### PR TITLE
apps/ui: right-align user prompts in conversation view

### DIFF
--- a/apps/ui/src/components/session-view/conversation/style.module.css
+++ b/apps/ui/src/components/session-view/conversation/style.module.css
@@ -17,13 +17,13 @@
 }
 
 .userText {
-	align-self: flex-start;
+	align-self: flex-end;
 	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
 	background-color: color-mix(in srgb, var(--wpds-color-fg-content-accent, #2563eb) 10%, transparent);
-	/* Bottom-left tight so the bubble reads as originating from the speaker
-	   label above; other corners round generously. */
-	border-radius: 18px 18px 18px var(--wpds-border-radius-md, 8px);
-	max-width: 100%;
+	/* Bottom-right tight so the bubble reads as originating from the user
+	   on the right; other corners round generously. */
+	border-radius: 18px 18px var(--wpds-border-radius-md, 8px) 18px;
+	max-width: 80%;
 	font-size: var(--wpds-font-size-md);
 	line-height: 1.55;
 	color: var(--wpds-color-fg-content-neutral);


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Used Claude Code to flip the user-bubble alignment in the session conversation view.

## Proposed Changes

- User prompts in the session conversation now align to the right (\`align-self: flex-end\`) with a bottom-right tight corner and an 80% max-width, so they read as originating from the user side of the conversation instead of the assistant side.

## Testing Instructions

- Run \`npm start\`, open a session with existing prompts, and confirm user-prompt bubbles render on the right while assistant text remains on the left.
- Send a new prompt and verify the new bubble appears right-aligned as well.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?