### PR TITLE
apps/ui, apps/cli: queue follow-up prompts during an active agent turn

### DIFF
--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -194,6 +194,7 @@ describe( 'AiChatUI.clearTranscript', () => {
 		ui.currentMarkdown = { someMarkdown: true };
 		ui.currentResponseText = 'in-progress';
 		ui.hideLoader = vi.fn();
+		ui.queuedPrompts = [];
 
 		ui.clearTranscript();
 

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -77,6 +77,18 @@ function formatToolOutputLines( lines: string[] ): string {
 		.join( '\n' );
 }
 
+// Faint variant of the user bubble used by `addUserMessage`, for prompts that
+// were staged during an active turn and haven't been dispatched yet.
+function formatQueuedPrompt( text: string ): string {
+	const lines = text.split( '\n' );
+	return lines
+		.map( ( line, i ) => {
+			const body = i === 0 ? '↳ ' + line + ' ' : '  ' + line + ' ';
+			return ' ' + chalk.bgHex( '#e8eef5' ).hex( '#5a6b7d' )( body );
+		} )
+		.join( '\n' );
+}
+
 class PromptEditor implements Component, Focusable {
 	private editor: Editor;
 	private borderColorFn: ( text: string ) => string;
@@ -365,6 +377,8 @@ export class AiChatUI implements AiOutputAdapter {
 	private editor: PromptEditor;
 	private loader: Loader;
 	private messages: Container;
+	private queuedContainer: Container;
+	private queuedPrompts: string[] = [];
 	private currentResponseText = '';
 	private currentMarkdown: Markdown | null = null;
 	private submitResolve: ( ( text: string ) => void ) | null = null;
@@ -476,6 +490,10 @@ export class AiChatUI implements AiOutputAdapter {
 		this.currentMarkdown = null;
 		this.currentResponseText = '';
 		this.messages.clear();
+		if ( this.queuedPrompts.length > 0 ) {
+			this.queuedPrompts = [];
+			this.renderQueuedContainer();
+		}
 		this.tui.requestRender();
 	}
 
@@ -496,6 +514,12 @@ export class AiChatUI implements AiOutputAdapter {
 
 		this.messages = new Container();
 		this.tui.addChild( this.messages );
+
+		// Always mounted just after `messages` and (once shown) just before the
+		// editor, so staged follow-up prompts render in that gap regardless of
+		// whether the loader is currently visible.
+		this.queuedContainer = new Container();
+		this.tui.addChild( this.queuedContainer );
 
 		this.loader = new Loader(
 			this.tui,
@@ -537,10 +561,21 @@ export class AiChatUI implements AiOutputAdapter {
 
 		this.editor.onSubmit = ( text ) => {
 			const trimmed = text.trim();
-			if ( trimmed && this.submitResolve ) {
+			if ( ! trimmed ) {
+				return;
+			}
+			if ( this.submitResolve ) {
 				const resolve = this.submitResolve;
 				this.submitResolve = null;
 				resolve( trimmed );
+				return;
+			}
+			// No waiter → we're mid-turn. Stage the prompt so it fires after
+			// the current run ends; `waitForInput` drains the head.
+			if ( this._inAgentTurn ) {
+				this.queuedPrompts.push( trimmed );
+				this.editor.setText( '' );
+				this.renderQueuedContainer();
 			}
 		};
 		// Ctrl+C to exit, Escape to interrupt/close picker, arrow keys for picker
@@ -648,6 +683,19 @@ export class AiChatUI implements AiOutputAdapter {
 				// Forward remaining input (up/down/enter) to SelectList
 				this.sitePickerSelectList.handleInput( data );
 				this.renderSitePicker();
+				return { consume: true };
+			}
+			// Backspace on an empty editor pops the most recent queued prompt.
+			// Mirrors the × discard affordance in the GUI — lightweight undo
+			// for staged follow-ups without adding a new keybinding.
+			if (
+				matchesKey( data, 'backspace' ) &&
+				this.editorVisible &&
+				this.queuedPrompts.length > 0 &&
+				this.editor.getText() === ''
+			) {
+				this.queuedPrompts.pop();
+				this.renderQueuedContainer();
 				return { consume: true };
 			}
 			if ( matchesKey( data, 'escape' ) && this.interruptCallback ) {
@@ -1203,6 +1251,11 @@ export class AiChatUI implements AiOutputAdapter {
 		this.editor.setText( '' );
 		this.hideLoader();
 		this.showEditor();
+		if ( this.queuedPrompts.length > 0 ) {
+			const next = this.queuedPrompts.shift()!;
+			this.renderQueuedContainer();
+			return Promise.resolve( next );
+		}
 		return new Promise( ( resolve ) => {
 			this.submitResolve = resolve;
 		} );
@@ -1219,6 +1272,15 @@ export class AiChatUI implements AiOutputAdapter {
 			} )
 			.join( '\n' );
 		this.messages.addChild( new Text( '\n' + formatted, 0, 0 ) );
+		this.tui.requestRender();
+	}
+
+	private renderQueuedContainer(): void {
+		this.queuedContainer.clear();
+		for ( const prompt of this.queuedPrompts ) {
+			this.queuedContainer.addChild( new Text( '\n' + formatQueuedPrompt( prompt ), 0, 0 ) );
+		}
+		this.updateHints();
 		this.tui.requestRender();
 	}
 
@@ -1240,12 +1302,16 @@ export class AiChatUI implements AiOutputAdapter {
 
 	private showLoader( message?: string ): void {
 		if ( ! this.loaderVisible ) {
-			// Ensure editor is removed first so loader appears above it
+			// Re-attach trailing children in order so the final stack is
+			// [..., loader, queuedContainer, editor?] — loader just above the
+			// staged follow-ups, which sit just above the editor.
 			const wasEditorVisible = this.editorVisible;
 			if ( wasEditorVisible ) {
 				this.tui.removeChild( this.editor );
 			}
+			this.tui.removeChild( this.queuedContainer );
 			this.tui.addChild( this.loader );
+			this.tui.addChild( this.queuedContainer );
 			if ( wasEditorVisible ) {
 				this.tui.addChild( this.editor );
 			}
@@ -1277,6 +1343,9 @@ export class AiChatUI implements AiOutputAdapter {
 			hints.push(
 				this.activeExpandablePreview.isExpanded ? __( 'ctrl+o collapse' ) : __( 'ctrl+o expand' )
 			);
+		}
+		if ( this.queuedPrompts.length > 0 ) {
+			hints.push( __( 'backspace to unqueue' ) );
 		}
 		hints.push( __( 'esc to interrupt' ) );
 		this.editor.hints = hints;

--- a/apps/ui/src/components/session-view/composer/index.tsx
+++ b/apps/ui/src/components/session-view/composer/index.tsx
@@ -3,18 +3,18 @@ import { useCallback, useState } from 'react';
 import styles from './style.module.css';
 
 interface ComposerProps {
-	disabled: boolean;
+	busy: boolean;
 	error: string | null;
 	onSend: ( prompt: string ) => Promise< void >;
 	onInterrupt: () => Promise< void >;
 }
 
-export function Composer( { disabled, error, onSend, onInterrupt }: ComposerProps ) {
+export function Composer( { busy, error, onSend, onInterrupt }: ComposerProps ) {
 	const [ value, setValue ] = useState( '' );
 
 	const send = useCallback( async () => {
 		const trimmed = value.trim();
-		if ( ! trimmed || disabled ) {
+		if ( ! trimmed ) {
 			return;
 		}
 		setValue( '' );
@@ -22,16 +22,23 @@ export function Composer( { disabled, error, onSend, onInterrupt }: ComposerProp
 			await onSend( trimmed );
 		} catch {
 			// Restore the draft so the user can retry; the parent surfaces the
-			// error message via `error`.
+			// error message via `error`. Queued sends never throw from onSend
+			// (the parent swallows the failure and clears the queue instead),
+			// so this path only trips for direct sends from the idle state.
 			setValue( trimmed );
 		}
-	}, [ value, disabled, onSend ] );
+	}, [ value, onSend ] );
+
+	const placeholder = busy
+		? __( 'Queue a follow-up instruction…' )
+		: __( 'Set your next instruction…' );
+	const sendLabel = busy ? __( 'Queue' ) : __( 'Send' );
 
 	return (
 		<div className={ styles.root }>
 			<textarea
 				className={ styles.input }
-				placeholder={ __( 'Set your next instruction…' ) }
+				placeholder={ placeholder }
 				value={ value }
 				onChange={ ( event ) => setValue( event.target.value ) }
 				onKeyDown={ ( event ) => {
@@ -40,26 +47,24 @@ export function Composer( { disabled, error, onSend, onInterrupt }: ComposerProp
 						void send();
 					}
 				} }
-				disabled={ disabled }
 				rows={ 3 }
 			/>
 			<div className={ styles.footer }>
 				{ error ? <span className={ styles.error }>{ error }</span> : null }
 				<div className={ styles.actions }>
-					{ disabled ? (
+					{ busy ? (
 						<button type="button" className={ styles.button } onClick={ () => void onInterrupt() }>
 							{ __( 'Stop' ) }
 						</button>
-					) : (
-						<button
-							type="button"
-							className={ styles.button }
-							onClick={ () => void send() }
-							disabled={ ! value.trim() }
-						>
-							{ __( 'Send' ) }
-						</button>
-					) }
+					) : null }
+					<button
+						type="button"
+						className={ styles.button }
+						onClick={ () => void send() }
+						disabled={ ! value.trim() }
+					>
+						{ sendLabel }
+					</button>
 				</div>
 			</div>
 		</div>

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx';
 import { useLayoutEffect, useMemo, useRef } from 'react';
 import { Composer } from '@/components/session-view/composer';
 import { Conversation } from '@/components/session-view/conversation';
+import { QueuedPrompts } from '@/components/session-view/queued-prompts';
 import { SiteDropdown } from '@/components/site-dropdown';
 import { useAgentRun } from '@/data/queries/use-agent-run';
 import { useSession } from '@/data/queries/use-sessions';
@@ -53,9 +54,11 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 		error: runError,
 		pendingQuestions,
 		pendingAnswers,
+		queuedPrompts,
 		sendMessage,
 		interrupt,
 		answerQuestion,
+		removeQueuedPrompt,
 	} = useAgentRun( sessionId );
 	const pendingQuestionTexts = useMemo(
 		() => new Set( pendingQuestions.map( ( q ) => q.question ) ),
@@ -106,8 +109,9 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 			</div>
 			<div className={ styles.composerOuter }>
 				<div className={ styles.column }>
+					<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
 					<Composer
-						disabled={ composerBusy }
+						busy={ composerBusy }
 						error={ runError }
 						onSend={ sendMessage }
 						onInterrupt={ interrupt }

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -77,7 +77,7 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 			node.scrollTop = node.scrollHeight;
 		} );
 		return () => cancelAnimationFrame( id );
-	}, [ sessionId, data, isRunning ] );
+	}, [ sessionId, data, isRunning, queuedPrompts.length ] );
 
 	if ( isLoading ) {
 		return <div className={ styles.state }>{ __( 'Loading session…' ) }</div>;

--- a/apps/ui/src/components/session-view/queued-prompts/index.tsx
+++ b/apps/ui/src/components/session-view/queued-prompts/index.tsx
@@ -1,0 +1,32 @@
+import { __ } from '@wordpress/i18n';
+import styles from './style.module.css';
+import type { QueuedPrompt } from '@/data/queries/use-agent-run';
+
+interface QueuedPromptsProps {
+	prompts: QueuedPrompt[];
+	onRemove: ( id: string ) => void;
+}
+
+export function QueuedPrompts( { prompts, onRemove }: QueuedPromptsProps ) {
+	if ( prompts.length === 0 ) {
+		return null;
+	}
+	return (
+		<div className={ styles.root } aria-label={ __( 'Queued follow-ups' ) }>
+			{ prompts.map( ( item ) => (
+				<div key={ item.id } className={ styles.item }>
+					<span className={ styles.text }>{ item.prompt }</span>
+					<button
+						type="button"
+						className={ styles.remove }
+						onClick={ () => onRemove( item.id ) }
+						aria-label={ __( 'Discard queued follow-up' ) }
+						title={ __( 'Discard queued follow-up' ) }
+					>
+						×
+					</button>
+				</div>
+			) ) }
+		</div>
+	);
+}

--- a/apps/ui/src/components/session-view/queued-prompts/style.module.css
+++ b/apps/ui/src/components/session-view/queued-prompts/style.module.css
@@ -7,17 +7,18 @@
 
 .item {
 	position: relative;
-	align-self: flex-start;
+	align-self: flex-end;
 	display: flex;
 	align-items: flex-start;
 	gap: var(--wpds-dimension-padding-sm);
 	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
 	/* Match the user bubble shape but lighter so staged follow-ups read as
-	   "drafted, not sent". */
+	   "drafted, not sent". Mirrors `.userText` (right-aligned, bottom-right
+	   tight corner). */
 	background-color: color-mix(in srgb, var(--wpds-color-fg-content-accent, #2563eb) 4%, transparent);
 	border: 1px dashed color-mix(in srgb, var(--wpds-color-fg-content-accent, #2563eb) 30%, transparent);
-	border-radius: 18px 18px 18px var(--wpds-border-radius-md, 8px);
-	max-width: 100%;
+	border-radius: 18px 18px var(--wpds-border-radius-md, 8px) 18px;
+	max-width: 80%;
 	font-size: var(--wpds-font-size-md);
 	line-height: 1.55;
 	color: var(--wpds-color-fg-content-neutral-weak);

--- a/apps/ui/src/components/session-view/queued-prompts/style.module.css
+++ b/apps/ui/src/components/session-view/queued-prompts/style.module.css
@@ -1,0 +1,60 @@
+.root {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-sm);
+	margin-bottom: var(--wpds-dimension-padding-md);
+}
+
+.item {
+	position: relative;
+	align-self: flex-start;
+	display: flex;
+	align-items: flex-start;
+	gap: var(--wpds-dimension-padding-sm);
+	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
+	/* Match the user bubble shape but lighter so staged follow-ups read as
+	   "drafted, not sent". */
+	background-color: color-mix(in srgb, var(--wpds-color-fg-content-accent, #2563eb) 4%, transparent);
+	border: 1px dashed color-mix(in srgb, var(--wpds-color-fg-content-accent, #2563eb) 30%, transparent);
+	border-radius: 18px 18px 18px var(--wpds-border-radius-md, 8px);
+	max-width: 100%;
+	font-size: var(--wpds-font-size-md);
+	line-height: 1.55;
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.text {
+	flex: 1;
+	min-width: 0;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+}
+
+.remove {
+	appearance: none;
+	flex-shrink: 0;
+	width: 22px;
+	height: 22px;
+	margin: -2px -6px -2px 0;
+	border: 0;
+	border-radius: 50%;
+	padding: 0;
+	background: transparent;
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font: inherit;
+	font-size: 16px;
+	line-height: 1;
+	cursor: pointer;
+	opacity: 0.6;
+}
+
+.item:hover .remove,
+.remove:focus-visible {
+	opacity: 1;
+}
+
+.remove:hover,
+.remove:focus-visible {
+	background-color: color-mix(in srgb, var(--wpds-color-fg-content-accent, #2563eb) 12%, transparent);
+	color: var(--wpds-color-fg-content-neutral);
+}

--- a/apps/ui/src/data/queries/use-agent-run.ts
+++ b/apps/ui/src/data/queries/use-agent-run.ts
@@ -8,9 +8,18 @@ function nowIso(): string {
 	return new Date().toISOString();
 }
 
+function newId(): string {
+	return `${ Date.now().toString( 36 ) }-${ Math.random().toString( 36 ).slice( 2, 10 ) }`;
+}
+
 export interface PendingQuestion {
 	question: string;
 	options: Array< { label: string; description: string } >;
+}
+
+export interface QueuedPrompt {
+	id: string;
+	prompt: string;
 }
 
 export interface LiveAgentEvents {
@@ -28,9 +37,13 @@ export interface LiveAgentEvents {
 	// The user can re-click an option to change their pick until every
 	// question is answered, at which point the batch is dispatched.
 	pendingAnswers: Record< string, string >;
+	// Follow-up prompts the user staged while a turn was in flight. FIFO:
+	// the head auto-dispatches when the current run ends.
+	queuedPrompts: QueuedPrompt[];
 	sendMessage: ( prompt: string ) => Promise< void >;
 	interrupt: () => Promise< void >;
 	answerQuestion: ( question: string, answer: string ) => void;
+	removeQueuedPrompt: ( id: string ) => void;
 }
 
 // `running` → agent loop is working (thinking indicator shown).
@@ -46,6 +59,7 @@ interface State {
 	error: string | null;
 	pendingQuestions: PendingQuestion[];
 	pendingAnswers: Record< string, string >;
+	queuedPrompts: QueuedPrompt[];
 }
 
 const initialState: State = {
@@ -55,6 +69,7 @@ const initialState: State = {
 	error: null,
 	pendingQuestions: [],
 	pendingAnswers: {},
+	queuedPrompts: [],
 };
 
 type Action =
@@ -65,7 +80,11 @@ type Action =
 	| { type: 'run_ended' }
 	| { type: 'questions_added'; questions: PendingQuestion[] }
 	| { type: 'question_answered'; question: string; answer: string }
-	| { type: 'batch_dispatched' };
+	| { type: 'batch_dispatched' }
+	| { type: 'queue_append'; prompt: QueuedPrompt }
+	| { type: 'queue_remove'; id: string }
+	| { type: 'queue_shift' }
+	| { type: 'queue_clear' };
 
 function reducer( state: State, action: Action ): State {
 	switch ( action.type ) {
@@ -89,7 +108,9 @@ function reducer( state: State, action: Action ): State {
 				pendingAnswers: {},
 			};
 		case 'run_ended':
-			return initialState;
+			// Preserve the queue across run boundaries so staged follow-ups
+			// survive the transition. Everything else resets.
+			return { ...initialState, queuedPrompts: state.queuedPrompts };
 		case 'questions_added':
 			return {
 				...state,
@@ -102,6 +123,17 @@ function reducer( state: State, action: Action ): State {
 			};
 		case 'batch_dispatched':
 			return { ...state, pendingQuestions: [], pendingAnswers: {} };
+		case 'queue_append':
+			return { ...state, queuedPrompts: [ ...state.queuedPrompts, action.prompt ] };
+		case 'queue_remove':
+			return {
+				...state,
+				queuedPrompts: state.queuedPrompts.filter( ( q ) => q.id !== action.id ),
+			};
+		case 'queue_shift':
+			return { ...state, queuedPrompts: state.queuedPrompts.slice( 1 ) };
+		case 'queue_clear':
+			return { ...state, queuedPrompts: [] };
 	}
 }
 
@@ -110,11 +142,16 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 	const queryClient = useQueryClient();
 
 	const [ state, dispatch ] = useReducer( reducer, initialState );
-	const { phase, runId, startedAt, error, pendingQuestions, pendingAnswers } = state;
+	const { phase, runId, startedAt, error, pendingQuestions, pendingAnswers, queuedPrompts } = state;
 
 	// Subscribed until `run.exited` so trailing events for a run whose turn
 	// has already completed still match the filter.
 	const subscribedRunIdRef = useRef< string | null >( null );
+	// Re-entry guard for the queue auto-dispatch effect. The effect's deps
+	// re-fire on every queue/phase change; without this guard a second render
+	// between the async start-call and `send_start` could kick off a duplicate
+	// run for the same queued prompt.
+	const dispatchingQueuedRef = useRef( false );
 
 	useEffect( () => {
 		dispatch( { type: 'reset' } );
@@ -206,7 +243,10 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 		return unsubscribe;
 	}, [ connector, queryClient, sessionId, updateCache ] );
 
-	const sendMessage = useCallback(
+	// Core "start a new turn" path. Shared by direct sends (`sendMessage` when
+	// idle) and the queue auto-dispatch effect. Throws on error so the direct
+	// caller can restore the composer draft; the queue path catches and clears.
+	const startRun = useCallback(
 		async ( prompt: string ) => {
 			if ( ! sessionId ) {
 				throw new Error( 'No session selected' );
@@ -241,6 +281,44 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 		[ connector, sessionId, updateCache ]
 	);
 
+	// Auto-dispatch the head of the queue once the previous run ends. On
+	// success, shift; on failure, drop the whole queue so a broken backend
+	// doesn't cascade errors.
+	useEffect( () => {
+		if ( phase !== 'idle' || queuedPrompts.length === 0 ) {
+			return;
+		}
+		if ( dispatchingQueuedRef.current ) {
+			return;
+		}
+		const next = queuedPrompts[ 0 ];
+		dispatchingQueuedRef.current = true;
+		void ( async () => {
+			try {
+				await startRun( next.prompt );
+				dispatch( { type: 'queue_shift' } );
+			} catch {
+				dispatch( { type: 'queue_clear' } );
+			} finally {
+				dispatchingQueuedRef.current = false;
+			}
+		} )();
+	}, [ phase, queuedPrompts, startRun ] );
+
+	const sendMessage = useCallback(
+		async ( prompt: string ) => {
+			// Queue if anything is in flight, if we're waiting on question
+			// answers, or if earlier queued prompts haven't been dispatched yet
+			// (preserves FIFO order).
+			if ( phase !== 'idle' || pendingQuestions.length > 0 || queuedPrompts.length > 0 ) {
+				dispatch( { type: 'queue_append', prompt: { id: newId(), prompt } } );
+				return;
+			}
+			await startRun( prompt );
+		},
+		[ phase, pendingQuestions.length, queuedPrompts.length, startRun ]
+	);
+
 	const interrupt = useCallback( async () => {
 		if ( ! runId ) {
 			return;
@@ -270,6 +348,10 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 		[ connector, runId, pendingAnswers, pendingQuestions ]
 	);
 
+	const removeQueuedPrompt = useCallback( ( id: string ) => {
+		dispatch( { type: 'queue_remove', id } );
+	}, [] );
+
 	return {
 		isRunning: phase === 'running',
 		hasActiveRun: phase !== 'idle',
@@ -277,8 +359,10 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 		error,
 		pendingQuestions,
 		pendingAnswers,
+		queuedPrompts,
 		sendMessage,
 		interrupt,
 		answerQuestion,
+		removeQueuedPrompt,
 	};
 }


### PR DESCRIPTION
## Related issues

Closes STU-1574

## How AI was used in this PR

Claude (Opus 4.7) wrote the code end-to-end based on research into how Claude Code, opencode, Cursor, Aider, and pi handle mid-turn input, and a walk-through of how the GUI (`useAgentRun`) and CLI (`AiChatUI`) currently block submits. I reviewed each diff before committing and asked for the queued-prompt visual to be restyled once before landing.

## Proposed Changes

Today both surfaces block new input while the agent is running — you have to wait for a turn to finish before typing the next instruction. This adds a queue on both sides so follow-ups can be staged mid-turn and auto-dispatch once the current run ends, with a way to discard them before they fire.

**apps/ui (`useAgentRun` + session-view)**
- New `queuedPrompts: QueuedPrompt[]` in the reducer with `queue_append` / `queue_remove` / `queue_shift` / `queue_clear` actions. `run_ended` now preserves the queue across run boundaries.
- Extracted the old direct-send body into an internal `startRun`. `sendMessage` queues whenever `phase !== 'idle'`, questions are pending, or the queue already has items (preserves FIFO). An effect auto-dispatches the head when `phase === 'idle'`, guarded by a `dispatchingQueuedRef` ref to prevent duplicate runs during the async window between start-call and `send_start`. On queued-dispatch failure the whole queue is cleared so a broken backend doesn't cascade errors.
- `Composer` stays enabled during a run: the primary button switches to "Queue" and a Stop button shows alongside it. Placeholder text swaps between "Set your next instruction…" and "Queue a follow-up instruction…".
- New `QueuedPrompts` component renders staged prompts above the composer as faint user-style bubbles (matching `.userText` shape: left-aligned, `18px 18px 18px 8px` corners, 4% accent tint, dashed border, muted text). Each bubble has an × to discard before it fires.

**apps/cli (`AiChatUI`, pi-tui)**
- Added `queuedPrompts: string[]` and a persistent `queuedContainer: Container` mounted between `messages` and the editor.
- `editor.onSubmit` now branches: if `submitResolve` is set (idle), resolve as before; if `_inAgentTurn` is true, push the prompt onto `queuedPrompts` and clear the editor.
- `waitForInput` drains `queuedPrompts.shift()` immediately when the queue is non-empty, so the existing `while (true) { waitForInput(); runAgentTurn(...) }` loop in `commands/ai/index.ts` picks up follow-ups without any change on the caller side. Queued slash commands still route correctly when dequeued.
- `showLoader` re-attaches trailing children in order `[loader, queuedContainer, editor]` so the thinking loader sits above staged bubbles, which sit above the editor.
- Backspace on an empty editor pops the most recent queued prompt (discard affordance). Hint bar surfaces `backspace to unqueue` whenever the queue is non-empty.
- Queued prompts render as `↳ text` with a muted slate-on-very-light-blue style (`#e8eef5` bg, `#5a6b7d` fg) — visually the CLI analogue of the dashed bubble in the GUI.
- `/clear` wipes the queue alongside the transcript.
- Interrupt (Esc / Stop) leaves the queue intact — matches Claude Code / opencode behavior; user can backspace-clear or × to drop individual items.

## Testing Instructions

### apps/ui

1. Open a session and send a prompt.
2. While the agent is running, type a follow-up and press Cmd/Ctrl+Enter (or click "Queue"). Expect a faint dashed bubble to appear above the composer.
3. Queue 2–3 more prompts. Order should be preserved.
4. Hover a bubble and click the × — that item should disappear.
5. Wait for the current turn to finish — remaining queued prompts should fire one after another, in order, each rendering as a normal user message in the conversation.
6. While a queued batch is running, click **Stop**. The current turn should be interrupted, but remaining queued items should continue to fire on the next run (this is intentional — discard with × to drop them).
7. Edge: queue something while the agent is asking a clarifying question. The queued item should wait until the batch is answered and the run fully exits, then dispatch.

### apps/cli

1. `npm run cli:build && node apps/cli/dist/cli/main.mjs` into an AI chat.
2. Send a prompt. While the agent is thinking, type another prompt and press Enter. The editor should clear and a faint bubble (`↳ …`) should appear just above the editor, below the loader.
3. Queue 2–3 more. The bubbles should stack in FIFO order.
4. With the editor empty, press **Backspace** — the most recent queued bubble should pop. Confirm the hint bar shows "backspace to unqueue" while the queue has items.
5. Let the turn finish — queued items should dispatch one by one automatically (each one shows up as a normal user bubble in the transcript and kicks off its own run).
6. While mid-turn with queued items, press **Esc** to interrupt. Confirm the queued items survive and start firing after the interrupt settles.
7. Run `/clear` while a queue exists — queue and transcript should both wipe.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
- [x] `npm run typecheck` clean for `apps/ui` and `apps/cli`.
- [x] `npm test -- apps/cli/ai/tests/ui.test.ts` (6/6) and `apps/cli/commands/ai/tests/ai.test.ts` (21/21) pass. The `clearTranscript` test needed a tiny stub for the new `queuedPrompts` field (tests use `Object.create(AiChatUI.prototype)` and stub only the fields they exercise).
- [ ] Manual UI verification — see Testing Instructions above. Worth eyeballing the CLI bubble colors on Terminal.app / iTerm2 since `#e8eef5`/`#5a6b7d` relies on truecolor for the muted look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)