### PR TITLE
apps/ui: soften conversation surfaces and strengthen tool label

### DIFF
--- a/apps/ui/src/components/session-view/conversation/style.module.css
+++ b/apps/ui/src/components/session-view/conversation/style.module.css
@@ -59,7 +59,6 @@
 	margin: 0;
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
 	border-left: 2px solid var(--wpds-color-stroke-surface-neutral);
-	background-color: var(--wpds-color-bg-surface-neutral-strong);
 	color: var(--wpds-color-fg-content-neutral);
 	font-family: var(--wpds-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
 	font-size: var(--wpds-font-size-xs);
@@ -96,8 +95,8 @@
 }
 
 .toolLabel {
-	color: var(--wpds-color-fg-content-neutral-weak);
-	opacity: 0.7;
+	color: var(--wpds-color-fg-content-neutral);
+	font-weight: 600;
 	flex-shrink: 0;
 }
 

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -9,7 +9,7 @@ body {
 	font-family: var(--wpds-font-family-body);
 	font-size: var(--wpds-font-size-md);
 	line-height: var(--wpds-font-line-height-md);
-	background-color: var(--wpds-color-bg-surface-neutral-strong);
+	background-color: var(--wpds-color-bg-surface-neutral);
 	color: var(--wpds-color-fg-content-neutral);
 	color-scheme: light dark;
 }


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude Code made the CSS tweaks; I picked the tokens/styles and verified the result visually.

## Proposed Changes

- [apps/ui/src/index.css](apps/ui/src/index.css): switch `body` background from `--wpds-color-bg-surface-neutral-strong` (#fff) to `--wpds-color-bg-surface-neutral` (#f8f8f8) so the main area sits one step below the sidebar's `--wpds-color-bg-surface-neutral-weak` (#f0f0f0).
- [apps/ui/src/components/session-view/conversation/style.module.css](apps/ui/src/components/session-view/conversation/style.module.css):
  - Drop the solid white background on `.toolOutput` so it reads as an inline quote against the new surface; only the left border remains.
  - Strengthen `.toolLabel` (tool name caller) — use `--wpds-color-fg-content-neutral` at `font-weight: 600`, drop the 0.7 opacity.

## Testing Instructions

- `npm start`, open a session that has tool calls.
- Main area background should be slightly darker than sidebar's sidebar-weak, but lighter than previous pure white.
- Tool output panels should have no fill — only the left border separates them.
- Tool name (e.g. `Read`, `Bash`) at the start of each tool row should read noticeably bolder than before.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)