### PR TITLE
apps/ui: redesign prompt composer

### DIFF
--- a/apps/ui/src/components/session-view/composer/index.tsx
+++ b/apps/ui/src/components/session-view/composer/index.tsx
@@ -1,6 +1,26 @@
 import { __ } from '@wordpress/i18n';
+import { arrowUp, chevronDownSmall } from '@wordpress/icons';
+import { Icon } from '@wordpress/ui';
 import { useCallback, useState } from 'react';
 import styles from './style.module.css';
+
+function PaperclipIcon() {
+	return (
+		<svg
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.6"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M21 11.5 12.5 20a5.5 5.5 0 0 1-7.78-7.78l9.2-9.2a3.5 3.5 0 0 1 4.95 4.95l-9.2 9.2a1.5 1.5 0 0 1-2.12-2.12l8.49-8.49" />
+		</svg>
+	);
+}
 
 interface ComposerProps {
 	busy: boolean;
@@ -8,6 +28,9 @@ interface ComposerProps {
 	onSend: ( prompt: string ) => Promise< void >;
 	onInterrupt: () => Promise< void >;
 }
+
+const isMacPlatform =
+	typeof navigator !== 'undefined' && /mac/i.test( navigator.platform || navigator.userAgent );
 
 export function Composer( { busy, error, onSend, onInterrupt }: ComposerProps ) {
 	const [ value, setValue ] = useState( '' );
@@ -29,43 +52,94 @@ export function Composer( { busy, error, onSend, onInterrupt }: ComposerProps ) 
 		}
 	}, [ value, onSend ] );
 
+	const canSend = value.trim().length > 0;
 	const placeholder = busy
 		? __( 'Queue a follow-up instruction…' )
 		: __( 'Set your next instruction…' );
-	const sendLabel = busy ? __( 'Queue' ) : __( 'Send' );
+	const sendAriaLabel = busy ? __( 'Queue' ) : __( 'Send' );
+	const modKey = isMacPlatform ? '⌘' : 'Ctrl';
 
 	return (
 		<div className={ styles.root }>
-			<textarea
-				className={ styles.input }
-				placeholder={ placeholder }
-				value={ value }
-				onChange={ ( event ) => setValue( event.target.value ) }
-				onKeyDown={ ( event ) => {
-					if ( event.key === 'Enter' && ( event.metaKey || event.ctrlKey ) ) {
-						event.preventDefault();
-						void send();
-					}
-				} }
-				rows={ 3 }
-			/>
-			<div className={ styles.footer }>
-				{ error ? <span className={ styles.error }>{ error }</span> : null }
-				<div className={ styles.actions }>
-					{ busy ? (
-						<button type="button" className={ styles.button } onClick={ () => void onInterrupt() }>
-							{ __( 'Stop' ) }
+			<div className={ styles.shell }>
+				<textarea
+					className={ styles.input }
+					placeholder={ placeholder }
+					value={ value }
+					onChange={ ( event ) => setValue( event.target.value ) }
+					onKeyDown={ ( event ) => {
+						if ( event.key === 'Enter' && ( event.metaKey || event.ctrlKey ) ) {
+							event.preventDefault();
+							void send();
+						}
+					} }
+					rows={ 2 }
+				/>
+				<div className={ styles.toolbar }>
+					<div className={ styles.leftActions }>
+						<button
+							type="button"
+							className={ styles.iconButton }
+							aria-label={ __( 'Attach file' ) }
+							disabled
+						>
+							<PaperclipIcon />
 						</button>
-					) : null }
-					<button
-						type="button"
-						className={ styles.button }
-						onClick={ () => void send() }
-						disabled={ ! value.trim() }
-					>
-						{ sendLabel }
-					</button>
+						<button
+							type="button"
+							className={ `${ styles.iconButton } ${ styles.glyphButton }` }
+							aria-label={ __( 'Commands' ) }
+							disabled
+						>
+							/
+						</button>
+						<button
+							type="button"
+							className={ `${ styles.iconButton } ${ styles.glyphButton }` }
+							aria-label={ __( 'Mention' ) }
+							disabled
+						>
+							@
+						</button>
+					</div>
+					<div className={ styles.rightActions }>
+						<button type="button" className={ styles.pill } disabled>
+							<span className={ styles.pillDot } aria-hidden="true" />
+							<span>{ __( 'Local' ) }</span>
+							<Icon icon={ chevronDownSmall } size={ 16 } />
+						</button>
+						<button type="button" className={ styles.pill } disabled>
+							<span>{ __( 'Claude Sonnet 4.5' ) }</span>
+							<Icon icon={ chevronDownSmall } size={ 16 } />
+						</button>
+						{ busy ? (
+							<button
+								type="button"
+								className={ styles.stopButton }
+								onClick={ () => void onInterrupt() }
+								aria-label={ __( 'Stop' ) }
+							>
+								<span className={ styles.stopGlyph } aria-hidden="true" />
+							</button>
+						) : null }
+						<button
+							type="button"
+							className={ styles.sendButton }
+							onClick={ () => void send() }
+							disabled={ ! canSend }
+							aria-label={ sendAriaLabel }
+						>
+							<Icon icon={ arrowUp } size={ 18 } />
+						</button>
+					</div>
 				</div>
+			</div>
+			<div className={ styles.meta }>
+				<span className={ styles.metaHint }>
+					{ modKey }↩ { __( 'to send' ) } · shift↩ { __( 'for newline' ) }
+				</span>
+				{ error ? <span className={ styles.error }>{ error }</span> : null }
+				<span className={ styles.metaUses }>{ __( 'Uses 1 message' ) }</span>
 			</div>
 		</div>
 	);

--- a/apps/ui/src/components/session-view/composer/style.module.css
+++ b/apps/ui/src/components/session-view/composer/style.module.css
@@ -3,69 +3,193 @@
 	flex-direction: column;
 }
 
-.input {
-	min-height: 88px;
-	padding: var(--wpds-dimension-padding-md);
+.shell {
+	display: flex;
+	flex-direction: column;
 	border: 1px solid var(--wpds-color-stroke-surface-neutral);
-	border-radius: var(--wpds-border-radius-md, 8px);
+	border-radius: 16px;
 	background-color: var(--wpds-color-bg-surface-neutral-strong);
+	padding: var(--wpds-dimension-padding-lg);
+	box-shadow: 0 1px 2px rgb(0 0 0 / 4%), 0 4px 12px rgb(0 0 0 / 6%);
+	transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.shell:focus-within {
+	border-color: var(--wpds-color-fg-content-accent, #2563eb);
+	box-shadow: 0 1px 2px rgb(0 0 0 / 6%), 0 6px 16px rgb(0 0 0 / 8%);
+}
+
+.input {
+	min-height: 48px;
+	padding: var(--wpds-dimension-padding-xs) 0;
+	border: 0;
+	background: transparent;
 	color: var(--wpds-color-fg-content-neutral);
 	font-size: var(--wpds-font-size-md);
 	line-height: 1.5;
 	width: 100%;
-	resize: vertical;
+	resize: none;
 	font-family: inherit;
 	box-sizing: border-box;
+	outline: none;
 }
 
-.input:focus-visible {
-	outline: 2px solid var(--wpds-color-fg-content-accent, #2563eb);
-	outline-offset: -1px;
+.input::placeholder {
+	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
-.input:disabled {
-	opacity: 0.6;
-	cursor: not-allowed;
+.toolbar {
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-padding-sm);
+	padding-top: var(--wpds-dimension-padding-xs);
 }
 
-.footer {
+.leftActions,
+.rightActions {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
-	gap: var(--wpds-dimension-padding-md);
-	margin-top: var(--wpds-dimension-padding-sm);
-	min-height: 28px;
+	gap: var(--wpds-dimension-padding-xs);
 }
 
-.error {
-	color: var(--wpds-color-fg-content-error, #dc2626);
-	font-size: var(--wpds-font-size-sm);
-}
-
-.actions {
-	display: flex;
-	gap: var(--wpds-dimension-padding-sm);
-	margin-left: auto;
-}
-
-.button {
-	appearance: none;
+.iconButton {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	padding: 0;
 	border: 1px solid var(--wpds-color-stroke-surface-neutral);
-	border-radius: var(--wpds-border-radius-md, 8px);
-	padding: 6px 14px;
-	background-color: var(--wpds-color-bg-surface-neutral);
+	border-radius: var(--wpds-border-radius-sm, 4px);
+	background-color: transparent;
 	color: var(--wpds-color-fg-content-neutral);
+	cursor: pointer;
+	font: inherit;
+}
+
+.iconButton svg {
+	width: 14px;
+	height: 14px;
+}
+
+.glyphButton {
+	font-size: 11px;
+	line-height: 1;
+}
+
+.iconButton:hover:not(:disabled),
+.iconButton:focus-visible:not(:disabled) {
+	background-color: var(--wpds-color-bg-surface-neutral);
+}
+
+.iconButton:disabled {
+	cursor: not-allowed;
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	height: 28px;
+	padding: 0 var(--wpds-dimension-padding-sm);
+	border: 0;
+	border-radius: var(--wpds-border-radius-sm, 4px);
+	background-color: transparent;
+	color: var(--wpds-color-fg-content-neutral-weak);
 	font: inherit;
 	font-size: var(--wpds-font-size-sm);
 	cursor: pointer;
 }
 
-.button:hover:not(:disabled),
-.button:focus-visible:not(:disabled) {
-	background-color: var(--wpds-color-bg-surface-neutral-strong);
+.pill:hover:not(:disabled),
+.pill:focus-visible:not(:disabled) {
+	background-color: var(--wpds-color-bg-surface-neutral);
 }
 
-.button:disabled {
-	opacity: 0.5;
+.pill:disabled {
+	cursor: default;
+}
+
+.pillDot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background-color: #16a34a;
+	flex-shrink: 0;
+}
+
+.sendButton,
+.stopButton {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	margin-left: 4px;
+	border: 0;
+	border-radius: 50%;
+	cursor: pointer;
+}
+
+.sendButton {
+	background-color: var(--wpds-color-fg-content-accent, #2563eb);
+	color: #fff;
+}
+
+.sendButton:hover:not(:disabled),
+.sendButton:focus-visible:not(:disabled) {
+	filter: brightness(0.92);
+}
+
+.sendButton:disabled {
+	opacity: 0.4;
 	cursor: not-allowed;
+}
+
+.stopButton {
+	background-color: var(--wpds-color-fg-content-neutral);
+	color: var(--wpds-color-bg-surface-neutral-strong);
+}
+
+.stopButton:hover,
+.stopButton:focus-visible {
+	filter: brightness(1.15);
+}
+
+.stopGlyph {
+	width: 9px;
+	height: 9px;
+	border-radius: 1px;
+	background-color: currentColor;
+	pointer-events: none;
+}
+
+.meta {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-padding-md);
+	margin-top: var(--wpds-dimension-padding-sm);
+	padding: 0 var(--wpds-dimension-padding-xs);
+	min-height: 16px;
+	font-size: var(--wpds-font-size-xs);
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.metaHint {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.metaUses {
+	margin-left: auto;
+}
+
+.error {
+	color: var(--wpds-color-fg-content-error, #dc2626);
+	font-size: var(--wpds-font-size-xs);
 }


### PR DESCRIPTION
## Related issues

- Related to design polish of the AI session view

## How AI was used in this PR

Claude (Opus 4.7) drove the redesign end-to-end from a screenshot reference: the composer shell structure, the left icon-button group (attach / slash / mention), the toolbar pills (Local + model), and the primary-accent send/queue circle with its secondary dark stop circle. I reviewed and iterated on the visual result — border radius, padding, shadow depth, button sizing and vertical alignment — and had Claude merge the design on top of the queued-prompts behavior from #3146 during a rebase.

## Proposed Changes

Reworks [apps/ui/src/components/session-view/composer/index.tsx](apps/ui/src/components/session-view/composer/index.tsx) and [style.module.css](apps/ui/src/components/session-view/composer/style.module.css):

- Single rounded shell (16px radius, layered soft shadow, focus-within accent border) wrapping a borderless textarea and a flex toolbar — replaces the previous bordered textarea + separate button row.
- Left toolbar: small 22×22 square icon buttons for attach (inline paperclip SVG since `@wordpress/icons` doesn't export one), `/`, and `@`. Rendered disabled for now — these are visual placeholders; wiring them up is out of scope for a visual redesign.
- Right toolbar: `Local` pill (green dot + chevron), `Claude Sonnet 4.5` pill (chevron), a dark stop circle (visible only while `busy`), and a primary accent-blue circular send button that flips its aria-label between "Send" and "Queue" depending on `busy`. Preserves the queued-prompts behavior introduced in #3146 where the send button stays enabled during a run so users can stage follow-ups.
- Meta line below the shell: platform-aware keyboard hint (⌘↩ on macOS, Ctrl↩ otherwise) and a "Uses 1 message" indicator.
- Toolbar uses `align-items: flex-end` so the smaller icon buttons sit at the same baseline as the pills/send circle, balancing the padding visually against the shell edges.

## Testing Instructions

- Open a session and confirm the composer renders as a single rounded card with the toolbar laid out as described.
- Type — the send circle lights up (accent blue) and is clickable. Focus the textarea — shell border goes accent and the shadow deepens slightly.
- Start a run. While the agent is working, confirm the stop circle appears to the left of the send circle, the placeholder reads "Queue a follow-up instruction…", and the textarea still accepts input (follow-up prompts queue).
- Resize the window — the shell/meta row stays centered in the 760px column and aligns with the conversation content above.
- Verify on Windows/Linux that the keyboard hint reads "Ctrl↩" instead of "⌘↩".

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you verified the change works on macOS, Windows, and Linux?