### PR TITLE
apps/ui: create new session from sidebar plus button

### DIFF
--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -19,6 +19,7 @@ import os from 'os';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import {
+	createAiSession as createAiSessionInStore,
 	deleteAiSession as deleteAiSessionFromStore,
 	listAiSessions as listAiSessionsFromStore,
 	loadAiSession as loadAiSessionFromStore,
@@ -187,6 +188,22 @@ export async function deleteAiSession(
 	sessionIdOrPrefix: string
 ): Promise< AiSessionSummary > {
 	return deleteAiSessionFromStore( getAiSessionsRootDirectory(), sessionIdOrPrefix );
+}
+
+export async function createAiSession(
+	_event: IpcMainInvokeEvent,
+	siteId: string
+): Promise< AiSessionSummary > {
+	const server = SiteServer.get( siteId );
+	if ( ! server ) {
+		throw new Error( `Site not found: ${ siteId }` );
+	}
+	return createAiSessionInStore( getAiSessionsRootDirectory(), {
+		site: {
+			name: server.details.name,
+			path: server.details.path,
+		},
+	} );
 }
 
 export async function continueAiSession(

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -184,6 +184,7 @@ const api: IpcApi = {
 	loadAiSession: ( sessionIdOrPrefix ) => ipcRendererInvoke( 'loadAiSession', sessionIdOrPrefix ),
 	deleteAiSession: ( sessionIdOrPrefix ) =>
 		ipcRendererInvoke( 'deleteAiSession', sessionIdOrPrefix ),
+	createAiSession: ( siteId ) => ipcRendererInvoke( 'createAiSession', siteId ),
 	continueAiSession: ( sessionId, prompt ) =>
 		ipcRendererInvoke( 'continueAiSession', sessionId, prompt ),
 	interruptAiAgentRun: ( runId ) => ipcRendererInvoke( 'interruptAiAgentRun', runId ),

--- a/apps/ui/src/components/project-list/index.tsx
+++ b/apps/ui/src/components/project-list/index.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from '@tanstack/react-router';
+import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { moreHorizontal, plus } from '@wordpress/icons';
 import { IconButton } from '@wordpress/ui';
@@ -6,7 +6,7 @@ import { clsx } from 'clsx';
 import { useMemo, useState } from 'react';
 import * as Menu from '@/components/menu';
 import { SidebarButton } from '@/components/sidebar-button';
-import { useSessions } from '@/data/queries/use-sessions';
+import { useCreateSession, useSessions } from '@/data/queries/use-sessions';
 import {
 	useIsSiteStarting,
 	useIsSiteStopping,
@@ -118,6 +118,32 @@ function SessionItem( { session }: { session: AiSessionSummary } ) {
 	);
 }
 
+function NewSessionButton( { site }: { site: SiteDetails } ) {
+	const navigate = useNavigate();
+	const createSession = useCreateSession();
+
+	const handleClick = async () => {
+		if ( createSession.isPending ) {
+			return;
+		}
+		const summary = await createSession.mutateAsync( site.id );
+		await navigate( { to: '/sessions/$sessionId', params: { sessionId: summary.id } } );
+	};
+
+	return (
+		<IconButton
+			variant="minimal"
+			tone="neutral"
+			size="small"
+			icon={ plus }
+			label={ __( 'New session' ) }
+			className={ styles.projectAction }
+			onClick={ handleClick }
+			disabled={ createSession.isPending }
+		/>
+	);
+}
+
 function ProjectActionsMenu( { site }: { site: SiteDetails } ) {
 	const startSite = useStartSite();
 	const stopSite = useStopSite();
@@ -191,14 +217,7 @@ function ProjectSection( {
 				{ group.site ? (
 					<div className={ styles.projectActions }>
 						<ProjectActionsMenu site={ group.site } />
-						<IconButton
-							variant="minimal"
-							tone="neutral"
-							size="small"
-							icon={ plus }
-							label={ __( 'New session' ) }
-							className={ styles.projectAction }
-						/>
+						<NewSessionButton site={ group.site } />
 					</div>
 				) : null }
 			</header>

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -103,6 +103,10 @@ export function createIpcConnector(): Connector {
 			await ipcApi.deleteAiSession( sessionId );
 		},
 
+		async createSession( siteId ): Promise< AiSessionSummary > {
+			return ( await ipcApi.createAiSession( siteId ) ) as AiSessionSummary;
+		},
+
 		async continueSession( sessionId, prompt ): Promise< { runId: string } > {
 			return ( await ipcApi.continueAiSession( sessionId, prompt ) ) as { runId: string };
 		},

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -67,6 +67,11 @@ export interface Connector {
 	getSession( sessionId: string ): Promise< LoadedAiSession >;
 	deleteSession( sessionId: string ): Promise< void >;
 
+	// Create an empty session file attached to a site, so the new session
+	// appears in the sidebar immediately. The first prompt flows through
+	// `continueSession` as usual.
+	createSession( siteId: string ): Promise< AiSessionSummary >;
+
 	// Continue an existing session by sending a new prompt. Returns a `runId`
 	// that identifies the in-flight agent run; live events for that run stream
 	// through `onAgentEvent`.

--- a/apps/ui/src/data/queries/use-sessions.ts
+++ b/apps/ui/src/data/queries/use-sessions.ts
@@ -34,3 +34,12 @@ export function useDeleteSession() {
 		onSuccess: () => queryClient.invalidateQueries( { queryKey: SESSIONS_QUERY_KEY } ),
 	} );
 }
+
+export function useCreateSession() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( siteId: string ) => connector.createSession( siteId ),
+		onSuccess: () => queryClient.invalidateQueries( { queryKey: SESSIONS_QUERY_KEY } ),
+	} );
+}

--- a/tools/common/ai/sessions/store.ts
+++ b/tools/common/ai/sessions/store.ts
@@ -1,5 +1,8 @@
+import crypto from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
+import { buildAiSessionFileName } from './file-naming';
+import { getAiSessionsDirectoryForDate } from './paths';
 import { readAiSessionSummaryFromEvents } from './summary';
 import type { AiSessionEvent, AiSessionSummary, LoadedAiSession } from './types';
 
@@ -134,6 +137,54 @@ export async function loadAiSession(
 	const summary = await resolveSessionByIdOrPrefix( rootDirectory, sessionIdOrPrefix );
 	const events = await readAiSessionEventsFromFile( summary.filePath );
 	return { summary, events };
+}
+
+export async function createAiSession(
+	rootDirectory: string,
+	options: {
+		site: {
+			name: string;
+			path: string;
+			remote?: boolean;
+			url?: string;
+			wpcomSiteId?: number;
+		};
+	}
+): Promise< AiSessionSummary > {
+	const startedAt = new Date();
+	const sessionId = crypto.randomUUID();
+	const directory = getAiSessionsDirectoryForDate( rootDirectory, startedAt );
+	const fileName = buildAiSessionFileName( startedAt, sessionId );
+	const filePath = path.join( directory, fileName );
+
+	await fs.mkdir( directory, { recursive: true } );
+
+	const events: AiSessionEvent[] = [
+		{
+			type: 'session.started',
+			timestamp: startedAt.toISOString(),
+			version: 1,
+			sessionId,
+		},
+		{
+			type: 'site.selected',
+			timestamp: startedAt.toISOString(),
+			siteName: options.site.name,
+			sitePath: options.site.path,
+			remote: options.site.remote,
+			url: options.site.url,
+			wpcomSiteId: options.site.wpcomSiteId,
+		},
+	];
+
+	const serialized = events.map( ( event ) => JSON.stringify( event ) ).join( '\n' ) + '\n';
+	await fs.writeFile( filePath, serialized, { encoding: 'utf8' } );
+
+	const summary = await readAiSessionSummaryFromEvents( filePath, events );
+	if ( ! summary ) {
+		throw new Error( 'Failed to build summary for newly created session' );
+	}
+	return summary;
 }
 
 export async function deleteAiSession(

--- a/tools/common/ai/sessions/tests/create-session.test.ts
+++ b/tools/common/ai/sessions/tests/create-session.test.ts
@@ -1,0 +1,36 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createAiSession, listAiSessions, readAiSessionEventsFromFile } from '../store';
+
+describe( 'createAiSession', () => {
+	let rootDirectory: string | undefined;
+
+	afterEach( async () => {
+		if ( rootDirectory ) {
+			await fs.rm( rootDirectory, { recursive: true, force: true } );
+			rootDirectory = undefined;
+		}
+	} );
+
+	it( 'writes a discoverable session file with site.selected as the owner site', async () => {
+		rootDirectory = await fs.mkdtemp( path.join( os.tmpdir(), 'studio-create-session-' ) );
+
+		const summary = await createAiSession( rootDirectory, {
+			site: { name: 'My Site', path: '/tmp/my-site' },
+		} );
+
+		expect( summary.ownerSitePath ).toBe( '/tmp/my-site' );
+		expect( summary.ownerSiteName ).toBe( 'My Site' );
+		expect( summary.firstPrompt ).toBeUndefined();
+		expect( summary.eventCount ).toBe( 2 );
+
+		const listed = await listAiSessions( rootDirectory );
+		expect( listed.map( ( s ) => s.id ) ).toContain( summary.id );
+
+		const events = await readAiSessionEventsFromFile( summary.filePath );
+		expect( events[ 0 ].type ).toBe( 'session.started' );
+		expect( events[ 1 ].type ).toBe( 'site.selected' );
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Implemented via Claude Code (Opus 4.7). I reviewed the flow end-to-end: decided between a persist-on-click vs. in-memory draft approach, and confirmed the chosen approach matches the CLI's existing session lifecycle (the recorder creates a file as soon as a site is selected).

## Proposed Changes

- Adds a `createAiSession` helper to `@studio/common/ai/sessions/store` that writes a minimal JSONL session file containing `session.started` + `site.selected` events and returns the resulting `AiSessionSummary`.
- Exposes a new `createAiSession(siteId)` IPC handler in `apps/studio`, wired through the preload bridge.
- Extends the UI `Connector` interface with `createSession`, and adds a `useCreateSession` mutation that invalidates the sessions query on success.
- Wires the plus button next to each project in the sidebar (`apps/ui/src/components/project-list`) to call `createSession` and navigate to `/sessions/$sessionId`. The button disables while the create mutation is in flight.
- Adds a unit test for the new store helper.

The resulting session file is indistinguishable from one created by the CLI, so `listAiSessions` / `loadAiSession` / the sidebar grouping all work without special-casing a draft state. The first prompt flows through the existing `continueSession` path; the sidebar title refreshes on `run.exited` as it does today.

**Tradeoff:** clicking the plus button persists a session on disk immediately, so idle clicks can leave empty sessions around. If this becomes noticeable we can (a) hide zero-user-message sessions from the sidebar, or (b) auto-prune empty sessions on app start.

## Testing Instructions

- `npm start`
- In the sidebar, click the `+` button next to a project title.
- Verify a new session appears in the project's session list with the placeholder `(No prompt yet)`, and you're navigated into the new session view.
- Type a prompt and send it. Verify the agent responds and the sidebar title updates to your prompt text after the turn exits.
- Run `npx vitest run tools/common/ai/sessions/tests/create-session.test.ts` to confirm the store-level test passes.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?