### PR TITLE
Fix desktop Stop button stranding CLI subprocess in JSON mode

### DIFF
--- a/apps/cli/ai/output-adapter.ts
+++ b/apps/cli/ai/output-adapter.ts
@@ -48,13 +48,32 @@ export class JsonAdapter implements AiOutputAdapter {
 	onBeforeExit: ( () => Promise< void > ) | null = null;
 
 	private sessionId: string | undefined;
+	private ipcMessageListener: ( ( message: unknown ) => void ) | null = null;
 
 	start(): void {
-		// No-op in JSON mode
+		// When forked from Studio, route the parent's IPC `interrupt` message
+		// to onInterrupt. SIGTERM from the parent is swallowed by module-level
+		// handlers (e.g. wordpress-server-manager), so we can't rely on signals.
+		if ( typeof process.send !== 'function' ) {
+			return;
+		}
+		this.ipcMessageListener = ( message ) => {
+			if (
+				message &&
+				typeof message === 'object' &&
+				( message as { type?: string } ).type === 'interrupt'
+			) {
+				this.onInterrupt?.();
+			}
+		};
+		process.on( 'message', this.ipcMessageListener );
 	}
 
 	stop(): void {
-		// No-op in JSON mode
+		if ( this.ipcMessageListener ) {
+			process.off( 'message', this.ipcMessageListener );
+			this.ipcMessageListener = null;
+		}
 	}
 
 	showWelcome(): void {

--- a/apps/cli/ai/tests/output-adapter.test.ts
+++ b/apps/cli/ai/tests/output-adapter.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JsonAdapter } from 'cli/ai/output-adapter';
+
+describe( 'JsonAdapter IPC messaging', () => {
+	let originalSend: typeof process.send;
+	let listeners: Array< ( message: unknown ) => void >;
+	let originalOn: typeof process.on;
+	let originalOff: typeof process.off;
+
+	beforeEach( () => {
+		listeners = [];
+		originalSend = process.send;
+		originalOn = process.on.bind( process );
+		originalOff = process.off.bind( process );
+
+		( process as unknown as { send: typeof process.send } ).send = ( () =>
+			true ) as typeof process.send;
+
+		process.on = ( ( event: string, listener: ( message: unknown ) => void ) => {
+			if ( event === 'message' ) {
+				listeners.push( listener );
+				return process;
+			}
+			return originalOn( event as never, listener as never );
+		} ) as typeof process.on;
+
+		process.off = ( ( event: string, listener: ( message: unknown ) => void ) => {
+			if ( event === 'message' ) {
+				listeners = listeners.filter( ( l ) => l !== listener );
+				return process;
+			}
+			return originalOff( event as never, listener as never );
+		} ) as typeof process.off;
+	} );
+
+	afterEach( () => {
+		( process as unknown as { send: typeof process.send } ).send = originalSend;
+		process.on = originalOn;
+		process.off = originalOff;
+	} );
+
+	it( 'calls onInterrupt when the parent sends an interrupt message', () => {
+		const adapter = new JsonAdapter();
+		const onInterrupt = vi.fn();
+		adapter.onInterrupt = onInterrupt;
+
+		adapter.start();
+
+		expect( listeners ).toHaveLength( 1 );
+		listeners[ 0 ]( { type: 'interrupt' } );
+
+		expect( onInterrupt ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'ignores unrelated IPC messages', () => {
+		const adapter = new JsonAdapter();
+		const onInterrupt = vi.fn();
+		adapter.onInterrupt = onInterrupt;
+
+		adapter.start();
+
+		listeners[ 0 ]( { type: 'answer', answers: { foo: 'bar' } } );
+		listeners[ 0 ]( 'some-string' );
+		listeners[ 0 ]( null );
+		listeners[ 0 ]( { type: 'something-else' } );
+
+		expect( onInterrupt ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing when onInterrupt is not set', () => {
+		const adapter = new JsonAdapter();
+		adapter.start();
+
+		expect( () => listeners[ 0 ]( { type: 'interrupt' } ) ).not.toThrow();
+	} );
+
+	it( 'removes the IPC listener on stop', () => {
+		const adapter = new JsonAdapter();
+		adapter.onInterrupt = vi.fn();
+
+		adapter.start();
+		expect( listeners ).toHaveLength( 1 );
+
+		adapter.stop();
+		expect( listeners ).toHaveLength( 0 );
+	} );
+
+	it( 'does not install a listener when not running under a parent IPC channel', () => {
+		( process as unknown as { send: typeof process.send } ).send =
+			undefined as unknown as typeof process.send;
+
+		const adapter = new JsonAdapter();
+		adapter.onInterrupt = vi.fn();
+
+		adapter.start();
+
+		expect( listeners ).toHaveLength( 0 );
+	} );
+} );

--- a/apps/studio/src/modules/ai-agent/run-manager.ts
+++ b/apps/studio/src/modules/ai-agent/run-manager.ts
@@ -132,13 +132,31 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 	return { runId };
 }
 
+const INTERRUPT_FORCE_KILL_TIMEOUT_MS = 5000;
+
 export function interruptAgentRun( runId: string ): void {
 	const run = runsById.get( runId );
 	if ( ! run ) {
 		return;
 	}
 	run.interrupted = true;
-	run.child.kill();
+
+	// Prefer the graceful path: ask the child to interrupt via its Agent SDK
+	// query and exit cleanly. A SIGTERM would be swallowed by module-level
+	// handlers that aren't wired to the SDK, leaving the child running.
+	if ( run.child.connected ) {
+		run.child.send( { type: 'interrupt' } );
+		// Safety net: if the child doesn't exit in time, force-kill it so the
+		// renderer isn't stuck in a busy state.
+		setTimeout( () => {
+			if ( runsById.get( runId ) === run && ! run.child.killed ) {
+				run.child.kill( 'SIGKILL' );
+			}
+		}, INTERRUPT_FORCE_KILL_TIMEOUT_MS ).unref();
+		return;
+	}
+
+	run.child.kill( 'SIGKILL' );
 }
 
 export function answerAgentRun( runId: string, answers: Record< string, string > ): void {

--- a/apps/studio/src/modules/ai-agent/run-manager.ts
+++ b/apps/studio/src/modules/ai-agent/run-manager.ts
@@ -11,6 +11,7 @@ interface AgentRun {
 	child: ChildProcess;
 	webContents: WebContents;
 	interrupted: boolean;
+	interruptAttempts: number;
 }
 
 // Two subprocesses resuming the same session id would race on the JSONL
@@ -78,6 +79,7 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 		child,
 		webContents,
 		interrupted: false,
+		interruptAttempts: 0,
 	};
 
 	runsBySessionId.set( sessionId, run );
@@ -132,7 +134,7 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 	return { runId };
 }
 
-const INTERRUPT_FORCE_KILL_TIMEOUT_MS = 5000;
+const INTERRUPT_FORCE_KILL_TIMEOUT_MS = 2000;
 
 export function interruptAgentRun( runId: string ): void {
 	const run = runsById.get( runId );
@@ -140,14 +142,23 @@ export function interruptAgentRun( runId: string ): void {
 		return;
 	}
 	run.interrupted = true;
+	run.interruptAttempts += 1;
 
-	// Prefer the graceful path: ask the child to interrupt via its Agent SDK
-	// query and exit cleanly. A SIGTERM would be swallowed by module-level
-	// handlers that aren't wired to the SDK, leaving the child running.
+	// Second click escalates: the graceful path is in flight but evidently
+	// not landing fast enough, so skip the grace period.
+	if ( run.interruptAttempts > 1 ) {
+		run.child.kill( 'SIGKILL' );
+		return;
+	}
+
+	// First click: tell the child to interrupt via the Agent SDK and exit
+	// cleanly (so the session recorder flushes). SIGTERM is swallowed by
+	// module-level handlers that aren't wired to the SDK, so we use IPC.
 	if ( run.child.connected ) {
 		run.child.send( { type: 'interrupt' } );
-		// Safety net: if the child doesn't exit in time, force-kill it so the
-		// renderer isn't stuck in a busy state.
+		sendEvent( run, { type: 'run.interrupting', timestamp: nowIso() } );
+		// Safety net: if the graceful path doesn't land quickly, force-kill
+		// so the renderer can't get stuck in a busy state.
 		setTimeout( () => {
 			if ( runsById.get( runId ) === run && ! run.child.killed ) {
 				run.child.kill( 'SIGKILL' );

--- a/apps/studio/src/modules/ai-agent/types.ts
+++ b/apps/studio/src/modules/ai-agent/types.ts
@@ -6,6 +6,7 @@ export interface AgentRunEvent {
 	event:
 		| JsonEvent
 		| { type: 'run.started'; timestamp: string }
+		| { type: 'run.interrupting'; timestamp: string }
 		| { type: 'run.exited'; timestamp: string; status: 'success' | 'error'; code: number | null }
 		| { type: 'run.interrupted'; timestamp: string };
 }

--- a/apps/ui/src/components/session-view/composer/index.tsx
+++ b/apps/ui/src/components/session-view/composer/index.tsx
@@ -24,6 +24,7 @@ function PaperclipIcon() {
 
 interface ComposerProps {
 	busy: boolean;
+	isInterrupting?: boolean;
 	error: string | null;
 	onSend: ( prompt: string ) => Promise< void >;
 	onInterrupt: () => Promise< void >;
@@ -32,7 +33,13 @@ interface ComposerProps {
 const isMacPlatform =
 	typeof navigator !== 'undefined' && /mac/i.test( navigator.platform || navigator.userAgent );
 
-export function Composer( { busy, error, onSend, onInterrupt }: ComposerProps ) {
+export function Composer( {
+	busy,
+	isInterrupting = false,
+	error,
+	onSend,
+	onInterrupt,
+}: ComposerProps ) {
 	const [ value, setValue ] = useState( '' );
 
 	const send = useCallback( async () => {
@@ -117,7 +124,11 @@ export function Composer( { busy, error, onSend, onInterrupt }: ComposerProps ) 
 								type="button"
 								className={ styles.stopButton }
 								onClick={ () => void onInterrupt() }
-								aria-label={ __( 'Stop' ) }
+								aria-label={ isInterrupting ? __( 'Stopping' ) : __( 'Stop' ) }
+								aria-busy={ isInterrupting }
+								title={
+									isInterrupting ? __( 'Stopping… click again to force stop' ) : __( 'Stop' )
+								}
 							>
 								<span className={ styles.stopGlyph } aria-hidden="true" />
 							</button>

--- a/apps/ui/src/components/session-view/composer/style.module.css
+++ b/apps/ui/src/components/session-view/composer/style.module.css
@@ -159,6 +159,20 @@
 	filter: brightness(1.15);
 }
 
+.stopButton[aria-busy='true'] {
+	animation: stopPulse 1s ease-in-out infinite;
+}
+
+@keyframes stopPulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+}
+
 .stopGlyph {
 	width: 9px;
 	height: 9px;

--- a/apps/ui/src/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/components/session-view/conversation/index.tsx
@@ -29,7 +29,8 @@ type RenderItem =
 			key: string;
 			question: string;
 			options: Array< { label: string; description: string } >;
-	  };
+	  }
+	| { kind: 'interrupted-marker'; key: string };
 
 function eventsToRenderItems( events: AiSessionEvent[] ): RenderItem[] {
 	const relevant = filterEventsAfterLastClear( events );
@@ -97,6 +98,15 @@ function eventsToRenderItems( events: AiSessionEvent[] ): RenderItem[] {
 					question: event.question,
 					options: event.options,
 				} );
+				return;
+			}
+			case 'turn.closed': {
+				if ( event.status === 'interrupted' ) {
+					items.push( {
+						kind: 'interrupted-marker',
+						key: `${ eventIndex }:interrupted`,
+					} );
+				}
 				return;
 			}
 			default:
@@ -272,6 +282,12 @@ export function Conversation( {
 								pickedLabel={ pendingAnswers[ item.question ] }
 								onAnswer={ ( label ) => onAnswerQuestion( item.question, label ) }
 							/>
+						);
+					case 'interrupted-marker':
+						return (
+							<div key={ item.key } className={ styles.interruptedMarker } role="status">
+								{ __( 'Interrupted by you' ) }
+							</div>
 						);
 					default:
 						return null;

--- a/apps/ui/src/components/session-view/conversation/style.module.css
+++ b/apps/ui/src/components/session-view/conversation/style.module.css
@@ -157,3 +157,14 @@
 	color: var(--wpds-color-fg-content-accent, #2563eb);
 	opacity: 1;
 }
+
+.interruptedMarker {
+	align-self: center;
+	margin: var(--wpds-dimension-padding-sm) 0;
+	padding: 2px 10px;
+	border-radius: 9999px;
+	background-color: var(--wpds-color-bg-surface-neutral-weak);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-font-size-xs);
+	text-align: center;
+}

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -50,6 +50,7 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 	const {
 		isRunning,
 		hasActiveRun,
+		isInterrupting,
 		startedAt,
 		error: runError,
 		pendingQuestions,
@@ -112,6 +113,7 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 					<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
 					<Composer
 						busy={ composerBusy }
+						isInterrupting={ isInterrupting }
 						error={ runError }
 						onSend={ sendMessage }
 						onInterrupt={ interrupt }

--- a/apps/ui/src/data/core/agent-events.ts
+++ b/apps/ui/src/data/core/agent-events.ts
@@ -2,11 +2,14 @@ import type { JsonEvent } from '@studio/common/ai/json-events';
 
 // The subprocess lifecycle events layer on top of the shared JsonEvent
 // stream: `run.started` fires when the CLI child actually spawns,
-// `run.interrupted` before an explicit kill, and `run.exited` always on
-// subprocess termination (the status doubles as a coarse success signal).
+// `run.interrupting` right after the user requests a stop (for optimistic
+// UI feedback), `run.interrupted` before an explicit kill, and `run.exited`
+// always on subprocess termination (the status doubles as a coarse success
+// signal).
 export type AgentEvent =
 	| JsonEvent
 	| { type: 'run.started'; timestamp: string }
+	| { type: 'run.interrupting'; timestamp: string }
 	| { type: 'run.exited'; timestamp: string; status: 'success' | 'error'; code: number | null }
 	| { type: 'run.interrupted'; timestamp: string };
 

--- a/apps/ui/src/data/queries/use-agent-run.ts
+++ b/apps/ui/src/data/queries/use-agent-run.ts
@@ -30,6 +30,9 @@ export interface LiveAgentEvents {
 	// `run.exited`/`run.interrupted`, which can lag `turn.completed` by
 	// the persist-queue drain time.
 	hasActiveRun: boolean;
+	// User has clicked Stop and we're waiting for the child to wind down.
+	// Gives the Stop button immediate "Stopping…" feedback.
+	isInterrupting: boolean;
 	startedAt: number | null;
 	error: string | null;
 	pendingQuestions: PendingQuestion[];
@@ -57,6 +60,7 @@ interface State {
 	runId: string | null;
 	startedAt: number | null;
 	error: string | null;
+	isInterrupting: boolean;
 	pendingQuestions: PendingQuestion[];
 	pendingAnswers: Record< string, string >;
 	queuedPrompts: QueuedPrompt[];
@@ -67,6 +71,7 @@ const initialState: State = {
 	runId: null,
 	startedAt: null,
 	error: null,
+	isInterrupting: false,
 	pendingQuestions: [],
 	pendingAnswers: {},
 	queuedPrompts: [],
@@ -78,6 +83,7 @@ type Action =
 	| { type: 'error_set'; message: string | null }
 	| { type: 'turn_completed' }
 	| { type: 'run_ended' }
+	| { type: 'interrupt_requested' }
 	| { type: 'questions_added'; questions: PendingQuestion[] }
 	| { type: 'question_answered'; question: string; answer: string }
 	| { type: 'batch_dispatched' }
@@ -97,6 +103,7 @@ function reducer( state: State, action: Action ): State {
 				runId: action.runId,
 				startedAt: action.startedAt,
 				error: null,
+				isInterrupting: false,
 			};
 		case 'error_set':
 			return { ...state, error: action.message };
@@ -111,6 +118,8 @@ function reducer( state: State, action: Action ): State {
 			// Preserve the queue across run boundaries so staged follow-ups
 			// survive the transition. Everything else resets.
 			return { ...initialState, queuedPrompts: state.queuedPrompts };
+		case 'interrupt_requested':
+			return { ...state, isInterrupting: true };
 		case 'questions_added':
 			return {
 				...state,
@@ -142,7 +151,16 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 	const queryClient = useQueryClient();
 
 	const [ state, dispatch ] = useReducer( reducer, initialState );
-	const { phase, runId, startedAt, error, pendingQuestions, pendingAnswers, queuedPrompts } = state;
+	const {
+		phase,
+		runId,
+		startedAt,
+		error,
+		isInterrupting,
+		pendingQuestions,
+		pendingAnswers,
+		queuedPrompts,
+	} = state;
 
 	// Subscribed until `run.exited` so trailing events for a run whose turn
 	// has already completed still match the filter.
@@ -198,8 +216,25 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 				case 'turn.completed':
 					dispatch( { type: 'turn_completed' } );
 					return;
+				case 'run.interrupting':
+					dispatch( { type: 'interrupt_requested' } );
+					return;
 				case 'run.exited':
 				case 'run.interrupted':
+					if ( event.type === 'run.interrupted' ) {
+						// Append a synthetic `turn.closed` so the conversation view
+						// renders the "Interrupted by you" marker immediately. The
+						// CLI also persists a real `turn.closed` to the session file,
+						// so the marker survives a reload.
+						updateCache( ( events ) => [
+							...events,
+							{
+								type: 'turn.closed',
+								timestamp: event.timestamp,
+								status: 'interrupted',
+							},
+						] );
+					}
 					dispatch( { type: 'run_ended' } );
 					subscribedRunIdRef.current = null;
 					// Only refresh the sessions list (sidebar summaries, updatedAt).
@@ -323,6 +358,10 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 		if ( ! runId ) {
 			return;
 		}
+		// Optimistic feedback: the main-process `run.interrupting` event will
+		// also set this, but flipping state on the click keeps the button
+		// from lingering in its active style while the IPC is in flight.
+		dispatch( { type: 'interrupt_requested' } );
 		await connector.interruptAgentRun( runId );
 	}, [ connector, runId ] );
 
@@ -355,6 +394,7 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 	return {
 		isRunning: phase === 'running',
 		hasActiveRun: phase !== 'idle',
+		isInterrupting,
 		startedAt,
 		error,
 		pendingQuestions,


### PR DESCRIPTION
## How AI was used in this PR

Generated with Claude Code. A human verified the root-cause analysis, code changes, and tests.

## Proposed Changes

- **Root cause.** The desktop composer's Stop button fires `connector.interruptAgentRun(runId)`, which previously called `run.child.kill()` — sending `SIGTERM` to the forked CLI. [apps/cli/lib/wordpress-server-manager.ts:32-33](https://github.com/Automattic/studio/blob/trunk/apps/cli/lib/wordpress-server-manager.ts#L32-L33) registers a module-level `process.on('SIGTERM', …)` that only aborts an `AbortController` the Agent SDK's `query()` doesn't listen to. This module is imported transitively for every agent run, so Node's default "exit on `SIGTERM`" behavior is suppressed and the child process lives on. The main-process `child.on('exit', cleanup)` never fires, the renderer never receives `run.interrupted` / `run.exited`, and the composer stays busy forever.
- **Fix.** Introduce a Node IPC `{ type: 'interrupt' }` message (mirroring the existing `{ type: 'answer' }` pattern in `askUser`). `JsonAdapter.start()` subscribes to parent messages and routes `interrupt` to `onInterrupt`, which already runs `agentQuery.interrupt()` — the same graceful exit path used by the interactive CLI's ESC binding. `stop()` tears the listener down.
- **Main process.** `interruptAgentRun` now sends the IPC message when the child is still connected, with a 5 s `SIGKILL` safety timer (unref'd) in case the graceful path doesn't land — so the renderer can't get stuck.
- **Tests.** New `apps/cli/ai/tests/output-adapter.test.ts` covers the JsonAdapter IPC interrupt path: it fires `onInterrupt` for interrupt messages, ignores unrelated messages and non-object payloads, is a no-op when no parent IPC channel exists, and deregisters on `stop()`.

## Testing Instructions

1. In the Studio desktop app, start an agent run and press the Stop button while the agent is actively working. Verify the composer exits the busy state promptly and the run is marked interrupted.
2. Run the unit tests:
   - `npm test -- apps/cli/ai/tests/output-adapter.test.ts`
3. Run the full suite:
   - `npm test`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?