### PR TITLE
apps/ui: unify icon sizing via compact-density CSS rule

### DIFF
--- a/apps/ui/src/components/sidebar-header/index.tsx
+++ b/apps/ui/src/components/sidebar-header/index.tsx
@@ -30,15 +30,15 @@ export function SidebarHeader( { onToggleSidebar }: Props ) {
 					/>
 					<Menu.Popup side="bottom" align="start" className={ styles.popup }>
 						<Menu.Item>
-							<Icon icon={ comment } size={ 16 } />
+							<Icon icon={ comment } />
 							<span>{ __( 'New chat' ) }</span>
 						</Menu.Item>
 						<Menu.Item>
-							<Icon icon={ globe } size={ 16 } />
+							<Icon icon={ globe } />
 							<span>{ __( 'New site project' ) }</span>
 						</Menu.Item>
 						<Menu.Item>
-							<Icon icon={ download } size={ 16 } />
+							<Icon icon={ download } />
 							<span>{ __( 'Import from…' ) }</span>
 						</Menu.Item>
 					</Menu.Popup>

--- a/apps/ui/src/components/sidebar-nav/index.tsx
+++ b/apps/ui/src/components/sidebar-nav/index.tsx
@@ -42,7 +42,7 @@ export function SidebarNav() {
 								) : undefined
 							}
 						>
-							<Icon icon={ item.icon } size={ 16 } />
+							<Icon icon={ item.icon } />
 							<span>{ item.label }</span>
 						</SidebarButton>
 					</li>

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -46,7 +46,7 @@ const DropdownTrigger = forwardRef< ElementRef< 'button' >, TriggerProps >(
 					aria-label={ statusLabel }
 				/>
 				<span className={ styles.triggerEnv }>{ __( 'Local' ) }</span>
-				<Icon icon={ chevronDownSmall } size={ 18 } />
+				<Icon icon={ chevronDownSmall } />
 			</button>
 		);
 	}

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -38,12 +38,13 @@ a:focus:not(:focus-visible),
 	outline: none;
 }
 
-/* Default icons inside buttons and menu items to 75% scale — WP UI's Icon
-   primitive draws at 16px, which reads a bit large for dense sidebars and
-   menus. `a svg` covers Button primitives rendered as links via their
-   `render` prop. */
-button svg,
-a svg,
-[role^="menuitem"] svg {
-	transform: scale(0.75);
+/* Compact density: shrink icons to match the tighter spacing tokens.
+   @wordpress/icons draws SVGs at 24x24 by default; the theme's compact
+   density only shrinks padding/gap tokens, not icon sizes. Override the
+   svg width/height attributes with CSS until the design system exposes
+   a density-aware icon token. Ideally this lives in ThemeProvider. */
+[data-wpds-density='compact'] svg {
+	width: 16px;
+	height: 16px;
 }
+


### PR DESCRIPTION
## Related issues

- Related to sidebar icon size inconsistency

## How AI was used in this PR

Investigated the sidebar nav icon size mismatch with Claude, traced it to a combination of mismatched `size={...}` props and a global `transform: scale(0.75)` rule that didn't reclaim layout space, and replaced both with a single density-scoped CSS rule.

## Proposed Changes

- Drop the global `button svg, a svg, [role^="menuitem"] svg { transform: scale(0.75) }` rule in `apps/ui/src/index.css` — it left the svgs at their original 24px layout box, creating uneven padding, and missed `[role="button"]` elements entirely.
- Add a new density-scoped rule: `[data-wpds-density='compact'] svg { width: 16px; height: 16px }`. `ThemeProvider` stamps the `data-wpds-density` attribute, so the rule naturally turns off when density changes and has a clear home when the design system eventually exposes a density-aware icon token.
- Remove explicit `size={16}` / `size={18}` props from `sidebar-nav`, `sidebar-header`, and `site-dropdown` so icons inherit the `@wordpress/icons` default (24px) and the new CSS rule scales them consistently.

## Testing Instructions

- Run `npm run dev` in `apps/ui` (or start the UI through the usual harness).
- Verify the three sidebar-nav icons (Chat / Settings / Skills) visually match the surrounding IconButtons (plus, drawer toggle, theme toggle) in both collapsed and expanded sidebar states.
- Open the "Create new" menu in the sidebar header — the `comment`, `globe`, and `download` menu item icons should match the trigger icon size.
- Open the site dropdown — the chevron should look consistent with other icons (no longer slightly oversized).
- Toggle light/dark theme; icons should render the same size in both.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)