### PR TITLE
Include ai/plugin folder in npm build output to fix Studio Code skills

### DIFF
--- a/apps/cli/vite.config.npm.ts
+++ b/apps/cli/vite.config.npm.ts
@@ -1,9 +1,20 @@
 import { defineConfig, mergeConfig } from 'vite';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 import { baseConfig } from './vite.config.base';
 
 export default mergeConfig(
 	baseConfig,
 	defineConfig( {
+		plugins: [
+			viteStaticCopy( {
+				targets: [
+					{
+						src: 'ai/plugin',
+						dest: '.',
+					},
+				],
+			} ),
+		],
 		build: {
 			sourcemap: false,
 			rollupOptions: {


### PR DESCRIPTION
## Related issues

- Fixes pdtkmj-4wH-p2#comment-8784

## How AI was used in this PR

Diagnosed the missing skills bug with AI assistance, then narrowed the fix to the npm build config only to avoid side-effects on dev/prod builds.

## Proposed Changes

- Add `ai/plugin` to the `viteStaticCopy` targets in `apps/cli/vite.config.npm.ts` so the agent plugin (and its bundled skills: `taxonomist`, `site-spec`, `need-for-speed`) are copied into `dist/cli/plugin/` during `npm run cli:build:npm`.
- Without this, `apps/cli/ai/agent.ts` resolves the plugin path to a non-existent directory when the CLI is consumed from npm (e.g. via `npm link -w wp-studio`), and invoking slash commands like `/taxonomist` fails with `Unknown skill: taxonomist`.
- The dev build (`vite.config.dev.ts`) already does this; the prod build (`vite.config.prod.ts`) is intentionally left untouched since the Electron bundle has a separate skills pipeline.

## Testing Instructions

1. From the repo root, build and link the CLI:
   ```sh
   npm run cli:build:npm && chmod +x apps/cli/dist/cli/main.mjs
   npm link -w wp-studio
   ```
2. Verify the plugin directory was copied into the build output:
   ```sh
   ls apps/cli/dist/cli/plugin/skills
   # → need-for-speed  site-spec  taxonomist
   ```
3. Run `studio code` and then type `/taxonomist` — the skill should load instead of returning `Unknown skill: taxonomist`.
4. Unlink when done: `npm unlink -g wp-studio`.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?