### PR TITLE
apps/ui: tidy site dropdown trigger and sidebar project spacing

### DIFF
--- a/apps/ui/src/components/project-list/index.tsx
+++ b/apps/ui/src/components/project-list/index.tsx
@@ -15,7 +15,6 @@ import {
 	useStopSite,
 } from '@/data/queries/use-sites';
 import { formatRelativeTime } from '@/lib/format-relative-time';
-import { getSiteDisplayUrl } from '@/lib/get-site-url';
 import styles from './style.module.css';
 import type { AiSessionSummary, SiteDetails } from '@/data/core';
 
@@ -25,16 +24,8 @@ type ProjectGroup = {
 	key: string;
 	site?: SiteDetails;
 	label: string;
-	subtitle?: string;
 	sessions: AiSessionSummary[];
 };
-
-function deriveSubtitle( site: SiteDetails ): string | undefined {
-	if ( site.customDomain || site.port > 0 ) {
-		return getSiteDisplayUrl( site );
-	}
-	return site.path.split( /[\\/]/ ).filter( Boolean ).pop();
-}
 
 function groupSessionsByOwner(
 	sites: SiteDetails[] | undefined,
@@ -62,7 +53,6 @@ function groupSessionsByOwner(
 		key: site.id,
 		site,
 		label: site.name,
-		subtitle: deriveSubtitle( site ),
 		sessions: sessionsByPath.get( site.path ) ?? [],
 	} ) );
 
@@ -210,9 +200,6 @@ function ProjectSection( {
 					>
 						<span className={ styles.projectName }>{ group.label }</span>
 					</SidebarButton>
-					{ group.subtitle ? (
-						<span className={ styles.projectSubtitle }>{ group.subtitle }</span>
-					) : null }
 				</div>
 				{ group.site ? (
 					<div className={ styles.projectActions }>

--- a/apps/ui/src/components/project-list/style.module.css
+++ b/apps/ui/src/components/project-list/style.module.css
@@ -9,7 +9,7 @@
 .projects {
 	display: flex;
 	flex-direction: column;
-	gap: var(--wpds-dimension-padding-xl);
+	gap: 2px;
 }
 
 .project {
@@ -22,7 +22,6 @@
 	align-items: flex-start;
 	gap: var(--wpds-dimension-padding-xs);
 	min-width: 0;
-	margin-bottom: var(--wpds-dimension-padding-xs);
 	padding-right: var(--wpds-dimension-padding-sm);
 }
 
@@ -59,19 +58,6 @@
 	font-weight: 600;
 }
 
-.projectSubtitle {
-	font-size: var(--wpds-font-size-xs);
-	line-height: 1;
-	color: var(--wpds-color-fg-content-neutral-weak);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	max-width: 100%;
-	opacity: 0.55;
-	padding: 0 var(--wpds-dimension-padding-sm);
-	margin-top: 4px;
-}
-
 .projectActions {
 	display: flex;
 	align-items: center;
@@ -105,7 +91,7 @@
 .sessionList {
 	list-style: none;
 	padding: 0;
-	margin: 0;
+	margin: 0 0 var(--wpds-dimension-padding-sm);
 	display: flex;
 	flex-direction: column;
 }

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -24,30 +24,36 @@ function stripProtocol( url: string ): string {
 	return url.replace( /^https?:\/\//, '' ).replace( /\/$/, '' );
 }
 
-type TriggerProps = Omit< ComponentProps< 'button' >, 'children' > & {
+type TriggerProps = Omit< ComponentProps< typeof Button >, 'children' > & {
 	siteName: string;
+	siteUrl: string;
 	status: SiteStatus;
 	statusLabel: string;
 };
 
-const DropdownTrigger = forwardRef< ElementRef< 'button' >, TriggerProps >(
-	function DropdownTrigger( { siteName, status, statusLabel, className, ...props }, ref ) {
+const DropdownTrigger = forwardRef< ElementRef< typeof Button >, TriggerProps >(
+	function DropdownTrigger( { siteName, siteUrl, status, statusLabel, className, ...props }, ref ) {
 		return (
-			<button
+			<Button
 				ref={ ref }
-				type="button"
-				className={ `${ styles.trigger } ${ className ?? '' }` }
+				variant="minimal"
+				tone="neutral"
+				size="small"
+				className={ clsx( styles.trigger, className ) }
 				{ ...props }
 			>
 				<span className={ styles.triggerSite }>{ siteName }</span>
-				<span
-					className={ clsx( styles.triggerDot, styles[ `triggerDot_${ status }` ] ) }
-					role="img"
-					aria-label={ statusLabel }
-				/>
-				<span className={ styles.triggerEnv }>{ __( 'Local' ) }</span>
+				<span className={ styles.triggerStatus }>
+					<span
+						className={ clsx( styles.triggerDot, styles[ `triggerDot_${ status }` ] ) }
+						role="img"
+						aria-label={ statusLabel }
+					/>
+					<span className={ styles.triggerEnv }>{ __( 'Local' ) }</span>
+				</span>
+				<span className={ styles.triggerUrl }>{ siteUrl }</span>
 				<Icon icon={ chevronDownSmall } />
-			</button>
+			</Button>
 		);
 	}
 );
@@ -159,7 +165,12 @@ export function SiteDropdown( { site }: Props ) {
 		<Menu.Root modal={ false }>
 			<Menu.Trigger
 				render={
-					<DropdownTrigger siteName={ site.name } status={ status } statusLabel={ statusLabel } />
+					<DropdownTrigger
+						siteName={ site.name }
+						siteUrl={ getSiteDisplayUrl( site ) }
+						status={ status }
+						statusLabel={ statusLabel }
+					/>
 				}
 			/>
 			<Menu.Popup side="bottom" align="start" className={ styles.popup }>

--- a/apps/ui/src/components/site-dropdown/style.module.css
+++ b/apps/ui/src/components/site-dropdown/style.module.css
@@ -1,26 +1,15 @@
 .trigger {
-	display: inline-flex;
-	align-items: center;
-	gap: var(--wpds-dimension-padding-sm);
-	background: transparent;
-	border: 0;
-	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
-	margin: 0;
-	border-radius: var(--wpds-border-radius-sm);
-	font: inherit;
-	font-size: var(--wpds-font-size-sm);
-	color: var(--wpds-color-fg-content-neutral);
-	cursor: var(--wpds-cursor-control);
-	-webkit-app-region: no-drag;
-}
-
-.trigger:hover,
-.trigger[data-popup-open] {
-	background: var(--wpds-color-bg-surface-neutral);
+	gap: var(--wpds-dimension-padding-lg);
 }
 
 .triggerSite {
 	font-weight: 600;
+}
+
+.triggerStatus {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-xs);
 }
 
 .triggerDot {
@@ -28,8 +17,6 @@
 	height: 6px;
 	border-radius: 50%;
 	flex-shrink: 0;
-	/* Matches the session header's dot spacing: extra room around the dot only. */
-	margin: 0 var(--wpds-dimension-padding-xs);
 }
 
 /* Hardcoded because `--wpds-color-fg-content-success` is #002900 (reads as
@@ -59,6 +46,17 @@
 
 .triggerEnv {
 	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-font-size-sm);
+}
+
+.triggerUrl {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	opacity: 0.6;
+	font-size: var(--wpds-font-size-sm);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
 }
 
 .popup {
@@ -105,7 +103,7 @@
 
 .rowSublabel {
 	margin-top: 4px;
-	font-size: var(--wpds-font-size-xs);
+	font-size: var(--wpds-font-size-sm);
 	line-height: 1.2;
 	color: var(--wpds-color-fg-content-neutral-weak);
 	overflow: hidden;


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Generated with Claude Code via iterative design feedback. All changes are CSS / small JSX refactors in \`apps/ui\` — no behavioral logic or IPC surface area changed. Reviewers should mainly eyeball the sidebar and the site dropdown trigger.

## Proposed Changes

- **Site dropdown trigger**: show the site URL inline next to the existing name + status dot + \"Local\" label, so the URL is visible without opening the popover.
- **Switch the trigger to \`Button\` from \`@wordpress/ui\`** (\`variant=\"minimal\" tone=\"neutral\" size=\"small\"\`) instead of a hand-rolled \`<button>\`. This fixes the hover state — the custom hover background used \`--wpds-color-bg-surface-neutral\`, which is the same token as \`body\`'s background, so the hover was invisible. Now hover/focus come from the design system.
- **Layout tweaks** on the trigger: group dot + \"Local\" in a single inline-flex span so they sit close, widen the gap between the three trigger groups (name / status / URL) to \`padding-lg\`, and drop \"Local\" + URL to \`--wpds-font-size-sm\` for a lighter visual weight. URL uses \`neutral-weak\` with \`opacity: 0.6\`.
- **Sidebar project list**: remove the URL subtitle from each project row (it's now in the trigger) and match the sidebar-nav's \`2px\` gap rhythm. Add a small bottom margin under an expanded project's session list so open projects have breathing room before the next project.

## Testing Instructions

- Run \`npm start\` and open the sidebar:
  - Site rows no longer show a URL subtitle and sit close together (same gap as Chat / Skills / etc.).
  - Expanding a project's sessions leaves a touch more space before the next project.
- Click on a site in the sidebar to open a session and look at the header:
  - Trigger reads: **Site name • Local ginzacoffee.test** with a status dot.
  - Hovering over the trigger now shows a visible hover background.
  - Opening the popover still shows the Local / Live / Preview rows as before.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)