### PR TITLE
apps/ui: wire composer model picker to switch agent models

### DIFF
--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { query, type Query } from '@anthropic-ai/claude-agent-sdk';
+import { AI_MODELS, DEFAULT_MODEL, type AiModelId } from '@studio/common/ai/models';
 import {
 	ALLOWED_TOOLS,
 	STUDIO_ROOT,
@@ -12,6 +13,7 @@ import { createRemoteSiteTools, createStudioTools } from 'cli/ai/tools';
 import type { SiteInfo } from 'cli/ai/ui';
 
 export type { AskUserQuestion } from 'cli/ai/security';
+export { AI_MODELS, DEFAULT_MODEL, type AiModelId };
 
 export interface AiAgentConfig {
 	prompt: string;
@@ -24,16 +26,6 @@ export interface AiAgentConfig {
 	wpcomAccessToken?: string;
 	onAskUser?: ( questions: AskUserQuestion[] ) => Promise< Record< string, string > >;
 }
-
-export const AI_MODELS = {
-	'claude-sonnet-4-6': 'Sonnet 4.6',
-	'claude-opus-4-6': 'Opus 4.6',
-	'claude-opus-4-7': 'Opus 4.7',
-} as const;
-
-export type AiModelId = keyof typeof AI_MODELS;
-
-export const DEFAULT_MODEL: AiModelId = 'claude-sonnet-4-6';
 
 // The Claude Agent SDK rejects internal pending promises (e.g. control
 // responses) when an agent turn is interrupted via ESC. These rejections

--- a/apps/cli/ai/sessions/context.ts
+++ b/apps/cli/ai/sessions/context.ts
@@ -1,13 +1,9 @@
-import { AI_MODELS, type AiModelId } from 'cli/ai/agent';
+import { isAiModelId, type AiModelId } from '@studio/common/ai/models';
 import { AI_PROVIDERS, type AiProviderId } from 'cli/ai/providers';
 import type { LoadedAiSession } from '@studio/common/ai/sessions/types';
 
 function isAiProviderId( value: string ): value is AiProviderId {
 	return Object.prototype.hasOwnProperty.call( AI_PROVIDERS, value );
-}
-
-function isAiModelId( value: string ): value is AiModelId {
-	return Object.prototype.hasOwnProperty.call( AI_MODELS, value );
 }
 
 export interface ResumeSessionContext {
@@ -36,6 +32,15 @@ export function resolveResumeSessionContext(
 			const sessionId = ( event.message as { session_id?: unknown } ).session_id;
 			if ( typeof sessionId === 'string' && sessionId.trim().length > 0 ) {
 				context.sessionId = sessionId;
+			}
+		}
+
+		// `session.model_selected` is a UI-side override (set from the
+		// composer dropdown). Prefer it over the per-turn `session.context`
+		// model so the user's pick wins on the next turn.
+		if ( ! context.model && event.type === 'session.model_selected' ) {
+			if ( isAiModelId( event.model ) ) {
+				context.model = event.model;
 			}
 		}
 

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -18,7 +18,9 @@ import https from 'node:https';
 import os from 'os';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
+import { isAiModelId } from '@studio/common/ai/models';
 import {
+	appendAiSessionEvent,
 	createAiSession as createAiSessionInStore,
 	deleteAiSession as deleteAiSessionFromStore,
 	listAiSessions as listAiSessionsFromStore,
@@ -222,6 +224,21 @@ export async function continueAiSession(
 		sessionId,
 		prompt,
 		webContents: event.sender,
+	} );
+}
+
+export async function setAiSessionModel(
+	_event: IpcMainInvokeEvent,
+	sessionId: string,
+	model: string
+): Promise< void > {
+	if ( ! isAiModelId( model ) ) {
+		throw new Error( `Unknown AI model: ${ model }` );
+	}
+	await appendAiSessionEvent( getAiSessionsRootDirectory(), sessionId, {
+		type: 'session.model_selected',
+		timestamp: new Date().toISOString(),
+		model,
 	} );
 }
 

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -200,6 +200,8 @@ const api: IpcApi = {
 	createAiSession: ( siteId ) => ipcRendererInvoke( 'createAiSession', siteId ),
 	continueAiSession: ( sessionId, prompt ) =>
 		ipcRendererInvoke( 'continueAiSession', sessionId, prompt ),
+	setAiSessionModel: ( sessionId, model ) =>
+		ipcRendererInvoke( 'setAiSessionModel', sessionId, model ),
 	interruptAiAgentRun: ( runId ) => ipcRendererInvoke( 'interruptAiAgentRun', runId ),
 	answerAiAgentQuestion: ( runId, answers ) =>
 		ipcRendererInvoke( 'answerAiAgentQuestion', runId, answers ),

--- a/apps/ui/src/components/session-view/composer/index.tsx
+++ b/apps/ui/src/components/session-view/composer/index.tsx
@@ -1,8 +1,11 @@
-import { __ } from '@wordpress/i18n';
+import { AI_MODELS } from '@studio/common/ai/models';
+import { __, sprintf } from '@wordpress/i18n';
 import { arrowUp, chevronDownSmall } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { useCallback, useState } from 'react';
+import * as Menu from '@/components/menu';
 import styles from './style.module.css';
+import type { AiModelId } from '@/data/core';
 
 function PaperclipIcon() {
 	return (
@@ -26,6 +29,8 @@ interface ComposerProps {
 	busy: boolean;
 	isInterrupting?: boolean;
 	error: string | null;
+	model: AiModelId;
+	onModelChange: ( model: AiModelId ) => void;
 	onSend: ( prompt: string ) => Promise< void >;
 	onInterrupt: () => Promise< void >;
 }
@@ -37,6 +42,8 @@ export function Composer( {
 	busy,
 	isInterrupting = false,
 	error,
+	model,
+	onModelChange,
 	onSend,
 	onInterrupt,
 }: ComposerProps ) {
@@ -115,10 +122,42 @@ export function Composer( {
 							<span>{ __( 'Local' ) }</span>
 							<Icon icon={ chevronDownSmall } size={ 16 } />
 						</button>
-						<button type="button" className={ styles.pill } disabled>
-							<span>{ __( 'Claude Sonnet 4.5' ) }</span>
-							<Icon icon={ chevronDownSmall } size={ 16 } />
-						</button>
+						<Menu.Root modal={ false }>
+							<Menu.Trigger
+								render={
+									<button
+										type="button"
+										className={ styles.pill }
+										aria-label={ __( 'Select model' ) }
+									>
+										<span>
+											{
+												/* translators: %s: model display name (e.g. "Sonnet 4.6") */
+												sprintf( __( 'Claude %s' ), AI_MODELS[ model ] )
+											}
+										</span>
+										<Icon icon={ chevronDownSmall } size={ 16 } />
+									</button>
+								}
+							/>
+							<Menu.Popup side="top" align="end">
+								<Menu.RadioGroup
+									value={ model }
+									onValueChange={ ( value ) => onModelChange( value as AiModelId ) }
+								>
+									{ ( Object.entries( AI_MODELS ) as [ AiModelId, string ][] ).map(
+										( [ id, label ] ) => (
+											<Menu.RadioItem key={ id } value={ id }>
+												{
+													/* translators: %s: model display name */
+													sprintf( __( 'Claude %s' ), label )
+												}
+											</Menu.RadioItem>
+										)
+									) }
+								</Menu.RadioGroup>
+							</Menu.Popup>
+						</Menu.Root>
 						{ busy ? (
 							<button
 								type="button"

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -1,17 +1,20 @@
+import { resolveSessionModel } from '@studio/common/ai/models';
+import { useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { clsx } from 'clsx';
-import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 import { Composer } from '@/components/session-view/composer';
 import { Conversation } from '@/components/session-view/conversation';
 import { QueuedPrompts } from '@/components/session-view/queued-prompts';
 import { SiteDropdown } from '@/components/site-dropdown';
+import { useConnector } from '@/data/core';
 import { useAgentRun } from '@/data/queries/use-agent-run';
-import { useSession } from '@/data/queries/use-sessions';
+import { SESSIONS_QUERY_KEY, useSession } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { useFullscreen } from '@/hooks/use-fullscreen';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
 import styles from './style.module.css';
-import type { AiSessionSummary } from '@/data/core';
+import type { AiModelId, AiSessionSummary, LoadedAiSession } from '@/data/core';
 
 function SessionHeader( { summary }: { summary: AiSessionSummary } ) {
 	const siteName = summary.ownerSiteName;
@@ -47,6 +50,8 @@ function SessionHeader( { summary }: { summary: AiSessionSummary } ) {
 
 export function SessionView( { sessionId }: { sessionId: string } ) {
 	const { data, isLoading, error } = useSession( sessionId );
+	const connector = useConnector();
+	const queryClient = useQueryClient();
 	const {
 		isRunning,
 		hasActiveRun,
@@ -61,6 +66,31 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 		answerQuestion,
 		removeQueuedPrompt,
 	} = useAgentRun( sessionId );
+	const currentModel = useMemo( () => resolveSessionModel( data?.events ?? [] ), [ data?.events ] );
+	// Optimistically append a `session.model_selected` event so the composer
+	// reflects the new pick immediately. The main process writes the same event
+	// to the JSONL; if that write fails we fall back to the prior state.
+	const onModelChange = useCallback(
+		( model: AiModelId ) => {
+			const timestamp = new Date().toISOString();
+			queryClient.setQueryData< LoadedAiSession >(
+				[ ...SESSIONS_QUERY_KEY, sessionId ],
+				( prev ) =>
+					prev
+						? {
+								...prev,
+								events: [ ...prev.events, { type: 'session.model_selected', timestamp, model } ],
+						  }
+						: prev
+			);
+			void connector.setSessionModel( sessionId, model ).catch( () => {
+				void queryClient.invalidateQueries( {
+					queryKey: [ ...SESSIONS_QUERY_KEY, sessionId ],
+				} );
+			} );
+		},
+		[ connector, queryClient, sessionId ]
+	);
 	const pendingQuestionTexts = useMemo(
 		() => new Set( pendingQuestions.map( ( q ) => q.question ) ),
 		[ pendingQuestions ]
@@ -115,6 +145,8 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 						busy={ composerBusy }
 						isInterrupting={ isInterrupting }
 						error={ runError }
+						model={ currentModel }
+						onModelChange={ onModelChange }
 						onSend={ sendMessage }
 						onInterrupt={ interrupt }
 					/>

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -111,6 +111,10 @@ export function createIpcConnector(): Connector {
 			return ( await ipcApi.continueAiSession( sessionId, prompt ) ) as { runId: string };
 		},
 
+		async setSessionModel( sessionId, model ) {
+			await ipcApi.setAiSessionModel( sessionId, model );
+		},
+
 		async interruptAgentRun( runId ) {
 			await ipcApi.interruptAiAgentRun( runId );
 		},

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -1,6 +1,7 @@
 export { ConnectorProvider, useConnector } from './connector-context';
 export { queryClient, persistPromise } from './query-client';
 export type {
+	AiModelId,
 	AiSessionEvent,
 	AiSessionSummary,
 	AuthUser,

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -1,4 +1,5 @@
 import type { AgentRunEvent } from './agent-events';
+import type { AiModelId } from '@studio/common/ai/models';
 import type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessions/types';
 import type { Snapshot } from '@studio/common/types/snapshot';
 import type { SyncSite } from '@studio/common/types/sync';
@@ -8,6 +9,7 @@ export type {
 	LoadedAiSession,
 	AiSessionEvent,
 } from '@studio/common/ai/sessions/types';
+export type { AiModelId } from '@studio/common/ai/models';
 export type { Snapshot } from '@studio/common/types/snapshot';
 export type { SyncSite } from '@studio/common/types/sync';
 
@@ -76,6 +78,10 @@ export interface Connector {
 	// that identifies the in-flight agent run; live events for that run stream
 	// through `onAgentEvent`.
 	continueSession( sessionId: string, prompt: string ): Promise< { runId: string } >;
+	// Persist a UI-driven model override for the session. The CLI picks this up
+	// on the next turn; the change survives reloads because it's written to the
+	// session JSONL.
+	setSessionModel( sessionId: string, model: AiModelId ): Promise< void >;
 	interruptAgentRun( runId: string ): Promise< void >;
 	answerAgentQuestion( runId: string, answers: Record< string, string > ): Promise< void >;
 	onAgentEvent( listener: ( event: AgentRunEvent ) => void ): () => void;

--- a/tools/common/ai/models.ts
+++ b/tools/common/ai/models.ts
@@ -1,0 +1,36 @@
+import type { AiSessionEvent } from './sessions/types';
+
+export const AI_MODELS = {
+	'claude-sonnet-4-6': 'Sonnet 4.6',
+	'claude-opus-4-6': 'Opus 4.6',
+	'claude-opus-4-7': 'Opus 4.7',
+} as const;
+
+export type AiModelId = keyof typeof AI_MODELS;
+
+export const DEFAULT_MODEL: AiModelId = 'claude-sonnet-4-6';
+
+export function isAiModelId( value: string ): value is AiModelId {
+	return Object.prototype.hasOwnProperty.call( AI_MODELS, value );
+}
+
+/**
+ * Derive the current model for a session from its events.
+ *
+ * Prefers the most recent `session.model_selected` override (written when the
+ * user picks a model from the UI) over the `session.context.model` that the
+ * CLI records per turn. Falls back to `DEFAULT_MODEL` for sessions that have
+ * neither — e.g. a brand-new session before the first turn runs.
+ */
+export function resolveSessionModel( events: AiSessionEvent[] ): AiModelId {
+	for ( let index = events.length - 1; index >= 0; index -= 1 ) {
+		const event = events[ index ];
+		if ( event.type === 'session.model_selected' && isAiModelId( event.model ) ) {
+			return event.model;
+		}
+		if ( event.type === 'session.context' && isAiModelId( event.model ) ) {
+			return event.model;
+		}
+	}
+	return DEFAULT_MODEL;
+}

--- a/tools/common/ai/sessions/store.ts
+++ b/tools/common/ai/sessions/store.ts
@@ -187,6 +187,17 @@ export async function createAiSession(
 	return summary;
 }
 
+export async function appendAiSessionEvent(
+	rootDirectory: string,
+	sessionIdOrPrefix: string,
+	event: AiSessionEvent
+): Promise< void > {
+	const summary = await resolveSessionByIdOrPrefix( rootDirectory, sessionIdOrPrefix );
+	await fs.appendFile( summary.filePath, `${ JSON.stringify( event ) }\n`, {
+		encoding: 'utf8',
+	} );
+}
+
 export async function deleteAiSession(
 	rootDirectory: string,
 	sessionIdOrPrefix: string

--- a/tools/common/ai/sessions/types.ts
+++ b/tools/common/ai/sessions/types.ts
@@ -19,6 +19,14 @@ export type AiSessionEvent =
 			model: string;
 	  }
 	| {
+			// User-initiated model override (e.g. the composer dropdown in the
+			// desktop UI). The CLI prefers this over `session.context.model` on
+			// resume so the next turn uses the selected model.
+			type: 'session.model_selected';
+			timestamp: string;
+			model: string;
+	  }
+	| {
 			type: 'session.cleared';
 			timestamp: string;
 	  }


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Wrote with Claude Code. All changes reviewed locally; typecheck + the AI-session unit tests pass. No manual browser verification yet — worth a quick smoke test with a real session before merging.

## Proposed Changes

- Turn the placeholder \"Claude Sonnet 4.5\" pill in the new `apps/ui` composer into a real model picker built on the existing `Menu.RadioGroup` primitive. Populated from the same `AI_MODELS` the CLI already uses (Sonnet 4.6, Opus 4.6, Opus 4.7).
- Extract the model constants (`AI_MODELS`, `AiModelId`, `DEFAULT_MODEL`, `isAiModelId`) plus a new `resolveSessionModel( events )` helper into `tools/common/ai/models.ts` so the UI and CLI share one source of truth. `apps/cli/ai/agent.ts` re-exports from the shared module for callers that still import from there.
- Add a new session event type `session.model_selected` — a UI-initiated override distinct from the per-turn `session.context` the CLI records. `resolveResumeSessionContext` (CLI) and `resolveSessionModel` (UI) both prefer the latest override over the context model, so the user's pick wins on the next turn.
- New IPC handler `setAiSessionModel( sessionId, model )` in the main process, which appends the override event via a new shared `appendAiSessionEvent` helper in `tools/common/ai/sessions/store.ts`. Exposed on the preload API and plumbed through the `Connector` interface as `setSessionModel`.
- `SessionView` derives the current model from the session's cached events and updates the query cache optimistically on pick, with rollback (via invalidation) if the IPC write fails.

Model choice persists to the session JSONL, so it survives app reloads.

## Testing Instructions

- Open a session in the new `apps/ui`. The model pill should now show the agent's current model (defaults to Sonnet 4.6 on a fresh session) instead of \"Claude Sonnet 4.5\".
- Click the pill — a radio menu should open with Sonnet 4.6, Opus 4.6, and Opus 4.7. Pick a different model.
- Send a prompt. The turn should run on the selected model. Confirm by inspecting the session JSONL (`~/Library/Application Support/Studio/ai-sessions/...`) — you should see a `session.model_selected` event and subsequent `session.context` events using the chosen model.
- Reload the app and reopen the session. The composer should restore the last-picked model.
- Regression: existing sessions with no `session.model_selected` event should still show the model from their last `session.context` event (or the default for brand-new sessions).

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)