### PR TITLE
apps/ui: switch sessions between local and linked live site

### DIFF
--- a/apps/cli/ai/sessions/recorder.ts
+++ b/apps/cli/ai/sessions/recorder.ts
@@ -95,6 +95,20 @@ export class AiSessionRecorder {
 		} );
 	}
 
+	async recordEnvironmentSelected( payload: {
+		environment: 'local' | 'live';
+		url?: string;
+		wpcomSiteId?: number;
+	} ): Promise< void > {
+		await this.appendEvent( {
+			type: 'environment.selected',
+			timestamp: toIsoTimestamp(),
+			environment: payload.environment,
+			url: payload.url,
+			wpcomSiteId: payload.wpcomSiteId,
+		} );
+	}
+
 	async recordUserMessage( options: {
 		text: string;
 		source: 'prompt' | 'ask_user';

--- a/apps/cli/ai/sessions/replay.ts
+++ b/apps/cli/ai/sessions/replay.ts
@@ -24,6 +24,31 @@ export function replaySessionHistory( ui: AiChatUI, events: AiSessionEvent[] ): 
 						running: false,
 						remote: event.remote === true,
 						url: typeof event.url === 'string' ? event.url : undefined,
+						wpcomSiteId: typeof event.wpcomSiteId === 'number' ? event.wpcomSiteId : undefined,
+					},
+					{ announce: true, emitEvent: false }
+				);
+				continue;
+			}
+
+			if ( event.type === 'environment.selected' ) {
+				// Environment flips never change the owner site — they only
+				// toggle whether the agent acts on the local runtime or the
+				// linked WordPress.com site. Preserve the name/path from the
+				// prior `site.selected`; only adjust the remote bits.
+				const current = ui.activeSite;
+				if ( ! current ) {
+					continue;
+				}
+				const isLive = event.environment === 'live';
+				ui.setActiveSite(
+					{
+						name: current.name,
+						path: current.path,
+						running: current.running,
+						remote: isLive,
+						url: isLive ? event.url : undefined,
+						wpcomSiteId: isLive ? event.wpcomSiteId : undefined,
 					},
 					{ announce: true, emitEvent: false }
 				);

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -51,7 +51,14 @@ export async function runCommand( options: {
 	noSessionPersistence?: boolean;
 	autoApprove?: boolean;
 	showLegacyCommandNotice?: boolean;
-	activeSite?: { name: string; path: string; running?: boolean };
+	activeSite?: {
+		name: string;
+		path: string;
+		running?: boolean;
+		remote?: boolean;
+		url?: string;
+		wpcomSiteId?: number;
+	};
 } ): Promise< void > {
 	const ui = options.adapter;
 	const isJsonMode = ui instanceof JsonAdapter;
@@ -66,6 +73,9 @@ export async function runCommand( options: {
 			name: options.activeSite.name,
 			path: options.activeSite.path,
 			running: options.activeSite.running ?? false,
+			remote: options.activeSite.remote,
+			url: options.activeSite.url,
+			wpcomSiteId: options.activeSite.wpcomSiteId,
 		};
 	}
 	ui.start();

--- a/apps/cli/commands/ai/sessions/resume.ts
+++ b/apps/cli/commands/ai/sessions/resume.ts
@@ -1,3 +1,4 @@
+import { resolveActiveSiteFromEvents } from '@studio/common/ai/sessions/active-site';
 import { listAiSessions, loadAiSession } from '@studio/common/ai/sessions/store';
 import { __ } from '@wordpress/i18n';
 import { JsonAdapter } from 'cli/ai/output-adapter';
@@ -43,12 +44,21 @@ export async function runCommand(
 
 	const session = await loadAiSession( getAiSessionsRootDirectory(), resolvedSessionIdOrPrefix );
 	const adapter: AiOutputAdapter = options.json ? new JsonAdapter() : new AiChatUI();
+
+	// JSON-mode resume has no replay loop (that only runs for AiChatUI), so the
+	// active site would stay null and the agent would fall back to local tools
+	// even if the session was flipped to live. Hydrate it explicitly from the
+	// event log instead.
+	const resolvedSite =
+		adapter instanceof JsonAdapter ? resolveActiveSiteFromEvents( session.events ) : undefined;
+
 	await runAiCommand( {
 		adapter,
 		resumeSession: session,
 		noSessionPersistence: options.noSessionPersistence === true,
 		initialMessage: options.message,
 		autoApprove: options.autoApprove,
+		activeSite: resolvedSite,
 	} );
 }
 

--- a/apps/cli/commands/ai/tests/ai.test.ts
+++ b/apps/cli/commands/ai/tests/ai.test.ts
@@ -364,6 +364,7 @@ describe( 'CLI: studio code sessions command', () => {
 				createdAt: '2026-03-11T11:00:00.000Z',
 				updatedAt: '2026-03-11T11:00:00.000Z',
 				linkedAgentSessionIds: [],
+				activeEnvironment: 'local',
 				eventCount: 1,
 			},
 			{
@@ -372,6 +373,7 @@ describe( 'CLI: studio code sessions command', () => {
 				createdAt: '2026-03-10T11:00:00.000Z',
 				updatedAt: '2026-03-10T11:00:00.000Z',
 				linkedAgentSessionIds: [],
+				activeEnvironment: 'local',
 				eventCount: 1,
 			},
 		] );
@@ -382,6 +384,7 @@ describe( 'CLI: studio code sessions command', () => {
 				createdAt: '2026-03-11T11:00:00.000Z',
 				updatedAt: '2026-03-11T11:00:00.000Z',
 				linkedAgentSessionIds: [],
+				activeEnvironment: 'local',
 				eventCount: 1,
 			},
 			events: [],
@@ -402,6 +405,7 @@ describe( 'CLI: studio code sessions command', () => {
 				createdAt: '2026-03-11T11:00:00.000Z',
 				updatedAt: '2026-03-11T11:00:00.000Z',
 				linkedAgentSessionIds: [],
+				activeEnvironment: 'local',
 				eventCount: 1,
 			},
 			{
@@ -410,6 +414,7 @@ describe( 'CLI: studio code sessions command', () => {
 				createdAt: '2026-03-10T11:00:00.000Z',
 				updatedAt: '2026-03-10T11:00:00.000Z',
 				linkedAgentSessionIds: [],
+				activeEnvironment: 'local',
 				eventCount: 1,
 			},
 		] );
@@ -419,6 +424,7 @@ describe( 'CLI: studio code sessions command', () => {
 			createdAt: '2026-03-11T11:00:00.000Z',
 			updatedAt: '2026-03-11T11:00:00.000Z',
 			linkedAgentSessionIds: [],
+			activeEnvironment: 'local',
 			eventCount: 1,
 		} );
 
@@ -436,6 +442,7 @@ describe( 'CLI: studio code sessions command', () => {
 				createdAt: '2026-03-11T11:00:00.000Z',
 				updatedAt: '2026-03-11T11:00:00.000Z',
 				linkedAgentSessionIds: [],
+				activeEnvironment: 'local',
 				eventCount: 1,
 			},
 		] );
@@ -446,6 +453,7 @@ describe( 'CLI: studio code sessions command', () => {
 				createdAt: '2026-03-11T11:00:00.000Z',
 				updatedAt: '2026-03-11T11:00:00.000Z',
 				linkedAgentSessionIds: [],
+				activeEnvironment: 'local',
 				eventCount: 1,
 			},
 			events: [],
@@ -579,6 +587,7 @@ describe( 'CLI: studio code sessions command', () => {
 				createdAt: '2026-03-11T11:00:00.000Z',
 				updatedAt: '2026-03-11T11:00:00.000Z',
 				linkedAgentSessionIds: [],
+				activeEnvironment: 'local',
 				eventCount: 2,
 			},
 		] );
@@ -589,6 +598,7 @@ describe( 'CLI: studio code sessions command', () => {
 				createdAt: '2026-03-11T11:00:00.000Z',
 				updatedAt: '2026-03-11T11:00:00.000Z',
 				linkedAgentSessionIds: [],
+				activeEnvironment: 'local',
 				eventCount: 2,
 			},
 			events: [

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -48,7 +48,11 @@ import { isMultisite } from '@studio/common/lib/is-multisite';
 import { getAuthenticationUrl } from '@studio/common/lib/oauth';
 import { decodePassword, encodePassword } from '@studio/common/lib/passwords';
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
-import { readSharedConfig, updateSharedConfig } from '@studio/common/lib/shared-config';
+import {
+	getCurrentUserId,
+	readSharedConfig,
+	updateSharedConfig,
+} from '@studio/common/lib/shared-config';
 import { shouldExcludeFromSync, shouldLimitDepth } from '@studio/common/lib/sync/tree-utils';
 import { isWordPressDevVersion } from '@studio/common/lib/wordpress-version-utils';
 import { __, sprintf, LocaleData, defaultI18n } from '@wordpress/i18n';
@@ -240,6 +244,78 @@ export async function setAiSessionModel(
 		timestamp: new Date().toISOString(),
 		model,
 	} );
+}
+
+export interface SetSessionEnvironmentResult {
+	environment: 'local' | 'live';
+	url?: string;
+	wpcomSiteId?: number;
+	summary: AiSessionSummary;
+}
+
+/**
+ * Flip a session between operating on its owner site's local runtime vs. the
+ * linked WordPress.com live site. The owner site itself never changes — this
+ * only toggles which environment the agent targets on the next turn.
+ *
+ * Resolves the live endpoint here rather than accepting it from the renderer
+ * so a buggy UI can't accidentally rebind the session to a different site.
+ */
+export async function setSessionEnvironment(
+	_event: IpcMainInvokeEvent,
+	sessionId: string,
+	environment: 'local' | 'live'
+): Promise< SetSessionEnvironmentResult > {
+	const { summary } = await loadAiSessionFromStore( getAiSessionsRootDirectory(), sessionId );
+
+	if ( ! summary.ownerSitePath || ! summary.ownerSiteName ) {
+		throw new Error( 'Cannot change environment: session has no owner site' );
+	}
+
+	let url: string | undefined;
+	let wpcomSiteId: number | undefined;
+
+	if ( environment === 'live' ) {
+		const ownerServer = SiteServer.getByPath( summary.ownerSitePath );
+		if ( ! ownerServer ) {
+			throw new Error(
+				`Cannot change environment: owner site is no longer available (${ summary.ownerSitePath })`
+			);
+		}
+
+		const currentUserId = await getCurrentUserId();
+		const userData = currentUserId ? await loadUserData() : undefined;
+		const connected = userData?.connectedWpcomSites?.[ currentUserId! ] ?? [];
+		const candidates = connected.filter( ( s ) => s.localSiteId === ownerServer.details.id );
+		// Prefer the production (non-staging) site to match the UI's
+		// `pickLiveSite` behavior in the site dropdown.
+		const liveSite = candidates.find( ( s ) => ! s.isStaging ) ?? candidates[ 0 ];
+
+		if ( ! liveSite ) {
+			throw new Error( 'Cannot switch to live: no linked WordPress.com site for this session' );
+		}
+
+		url = liveSite.url;
+		wpcomSiteId = liveSite.id;
+	}
+
+	await appendAiSessionEvent( getAiSessionsRootDirectory(), sessionId, {
+		type: 'environment.selected',
+		timestamp: new Date().toISOString(),
+		environment,
+		url,
+		wpcomSiteId,
+	} );
+
+	// Refresh the summary so the renderer can update without needing a second round-trip.
+	const refreshed = await loadAiSessionFromStore( getAiSessionsRootDirectory(), sessionId );
+
+	return {
+		environment,
+		url,
+		wpcomSiteId,
+		summary: refreshed.summary,
+	};
 }
 
 export async function interruptAiAgentRun(

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -205,6 +205,8 @@ const api: IpcApi = {
 	interruptAiAgentRun: ( runId ) => ipcRendererInvoke( 'interruptAiAgentRun', runId ),
 	answerAiAgentQuestion: ( runId, answers ) =>
 		ipcRendererInvoke( 'answerAiAgentQuestion', runId, answers ),
+	setSessionEnvironment: ( sessionId, environment ) =>
+		ipcRendererInvoke( 'setSessionEnvironment', sessionId, environment ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );

--- a/apps/ui/src/components/session-view/composer/environment-pill.tsx
+++ b/apps/ui/src/components/session-view/composer/environment-pill.tsx
@@ -1,0 +1,88 @@
+import { __ } from '@wordpress/i18n';
+import { chevronDownSmall } from '@wordpress/icons';
+import { Icon } from '@wordpress/ui';
+import * as Menu from '@/components/menu';
+import { useSetSessionEnvironment } from '@/data/queries/use-sessions';
+import styles from './style.module.css';
+import type { SyncSite } from '@/data/core';
+
+interface EnvironmentPillProps {
+	sessionId: string;
+	activeEnvironment: 'local' | 'live';
+	liveSite: SyncSite;
+	disabled?: boolean;
+}
+
+function pickLiveSite( connectedSites: SyncSite[] | undefined ): SyncSite | undefined {
+	if ( ! connectedSites || connectedSites.length === 0 ) {
+		return undefined;
+	}
+	return connectedSites.find( ( site ) => ! site.isStaging ) ?? connectedSites[ 0 ];
+}
+
+/**
+ * Toggle the active environment for the current session between local and the
+ * linked WordPress.com live site. The owner site itself never changes — this
+ * only swaps which tool set the next agent turn will use.
+ *
+ * The caller is expected to omit this pill entirely when no live site is
+ * linked; when a run is in flight it stays rendered but non-interactive so the
+ * user can still see the current env at a glance.
+ */
+export function EnvironmentPill( {
+	sessionId,
+	activeEnvironment,
+	disabled = false,
+}: EnvironmentPillProps ) {
+	const setEnvironment = useSetSessionEnvironment( sessionId );
+	const isLive = activeEnvironment === 'live';
+	const label = isLive ? __( 'Live' ) : __( 'Local' );
+
+	const onValueChange = ( value: string ) => {
+		if ( value !== 'local' && value !== 'live' ) {
+			return;
+		}
+		if ( value === activeEnvironment ) {
+			return;
+		}
+		setEnvironment.mutate( value );
+	};
+
+	if ( disabled ) {
+		return (
+			<button type="button" className={ styles.pill } disabled>
+				<span
+					className={ `${ styles.pillDot } ${ isLive ? styles.pillDotLive : '' }` }
+					aria-hidden="true"
+				/>
+				<span>{ label }</span>
+				<Icon icon={ chevronDownSmall } size={ 16 } />
+			</button>
+		);
+	}
+
+	return (
+		<Menu.Root modal={ false }>
+			<Menu.Trigger
+				render={
+					<button type="button" className={ styles.pill }>
+						<span
+							className={ `${ styles.pillDot } ${ isLive ? styles.pillDotLive : '' }` }
+							aria-hidden="true"
+						/>
+						<span>{ label }</span>
+						<Icon icon={ chevronDownSmall } size={ 16 } />
+					</button>
+				}
+			/>
+			<Menu.Popup side="top" align="end" className={ styles.envMenuPopup }>
+				<Menu.RadioGroup value={ activeEnvironment } onValueChange={ onValueChange }>
+					<Menu.RadioItem value="local">{ __( 'Local' ) }</Menu.RadioItem>
+					<Menu.RadioItem value="live">{ __( 'Live' ) }</Menu.RadioItem>
+				</Menu.RadioGroup>
+			</Menu.Popup>
+		</Menu.Root>
+	);
+}
+
+export { pickLiveSite };

--- a/apps/ui/src/components/session-view/composer/index.tsx
+++ b/apps/ui/src/components/session-view/composer/index.tsx
@@ -4,8 +4,9 @@ import { arrowUp, chevronDownSmall } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { useCallback, useState } from 'react';
 import * as Menu from '@/components/menu';
+import { EnvironmentPill } from './environment-pill';
 import styles from './style.module.css';
-import type { AiModelId } from '@/data/core';
+import type { AiModelId, SyncSite } from '@/data/core';
 
 function PaperclipIcon() {
 	return (
@@ -33,6 +34,12 @@ interface ComposerProps {
 	onModelChange: ( model: AiModelId ) => void;
 	onSend: ( prompt: string ) => Promise< void >;
 	onInterrupt: () => Promise< void >;
+	// Environment pill: only rendered when both a `sessionId` and a linked
+	// `liveSite` are available. Without a live link the pill is hidden
+	// entirely (there'd be nothing to flip to).
+	sessionId?: string;
+	activeEnvironment?: 'local' | 'live';
+	liveSite?: SyncSite;
 }
 
 const isMacPlatform =
@@ -46,6 +53,9 @@ export function Composer( {
 	onModelChange,
 	onSend,
 	onInterrupt,
+	sessionId,
+	activeEnvironment = 'local',
+	liveSite,
 }: ComposerProps ) {
 	const [ value, setValue ] = useState( '' );
 
@@ -117,11 +127,14 @@ export function Composer( {
 						</button>
 					</div>
 					<div className={ styles.rightActions }>
-						<button type="button" className={ styles.pill } disabled>
-							<span className={ styles.pillDot } aria-hidden="true" />
-							<span>{ __( 'Local' ) }</span>
-							<Icon icon={ chevronDownSmall } size={ 16 } />
-						</button>
+						{ sessionId && liveSite ? (
+							<EnvironmentPill
+								sessionId={ sessionId }
+								activeEnvironment={ activeEnvironment }
+								liveSite={ liveSite }
+								disabled={ busy }
+							/>
+						) : null }
 						<Menu.Root modal={ false }>
 							<Menu.Trigger
 								render={

--- a/apps/ui/src/components/session-view/composer/style.module.css
+++ b/apps/ui/src/components/session-view/composer/style.module.css
@@ -120,6 +120,14 @@
 	flex-shrink: 0;
 }
 
+.pillDotLive {
+	background-color: #2563eb;
+}
+
+.envMenuPopup {
+	min-width: 140px;
+}
+
 .sendButton,
 .stopButton {
 	display: inline-flex;

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -4,11 +4,13 @@ import { __ } from '@wordpress/i18n';
 import { clsx } from 'clsx';
 import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 import { Composer } from '@/components/session-view/composer';
+import { pickLiveSite } from '@/components/session-view/composer/environment-pill';
 import { Conversation } from '@/components/session-view/conversation';
 import { QueuedPrompts } from '@/components/session-view/queued-prompts';
 import { SiteDropdown } from '@/components/site-dropdown';
 import { useConnector } from '@/data/core';
 import { useAgentRun } from '@/data/queries/use-agent-run';
+import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import { SESSIONS_QUERY_KEY, useSession } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { useFullscreen } from '@/hooks/use-fullscreen';
@@ -26,6 +28,7 @@ function SessionHeader( { summary }: { summary: AiSessionSummary } ) {
 	}
 
 	const site = sites?.find( ( candidate ) => candidate.path === summary.ownerSitePath );
+	const activeEnvironment = summary.activeEnvironment ?? 'local';
 	const toggleSpacerClass = sidebarCollapsed
 		? isFullscreen
 			? styles.toggleSpacerFullscreen
@@ -36,12 +39,14 @@ function SessionHeader( { summary }: { summary: AiSessionSummary } ) {
 		<div className={ styles.header }>
 			{ toggleSpacerClass ? <span className={ toggleSpacerClass } aria-hidden="true" /> : null }
 			{ site ? (
-				<SiteDropdown site={ site } />
+				<SiteDropdown site={ site } activeEnvironment={ activeEnvironment } />
 			) : (
 				<>
 					<span className={ styles.headerSite }>{ siteName }</span>
 					<span className={ styles.headerDot } aria-hidden="true" />
-					<span className={ styles.headerEnv }>{ __( 'Local' ) }</span>
+					<span className={ styles.headerEnv }>
+						{ activeEnvironment === 'live' ? __( 'Live' ) : __( 'Local' ) }
+					</span>
 				</>
 			) }
 		</div>
@@ -52,6 +57,14 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 	const { data, isLoading, error } = useSession( sessionId );
 	const connector = useConnector();
 	const queryClient = useQueryClient();
+	const { data: sites } = useSites();
+	const ownerSitePath = data?.summary.ownerSitePath;
+	const ownerSite = ownerSitePath
+		? sites?.find( ( candidate ) => candidate.path === ownerSitePath )
+		: undefined;
+	const { data: connectedSites } = useConnectedWpcomSites( ownerSite?.id );
+	const liveSite = pickLiveSite( connectedSites );
+	const activeEnvironment: 'local' | 'live' = data?.summary.activeEnvironment ?? 'local';
 	const {
 		isRunning,
 		hasActiveRun,
@@ -149,6 +162,9 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 						onModelChange={ onModelChange }
 						onSend={ sendMessage }
 						onInterrupt={ interrupt }
+						sessionId={ sessionId }
+						activeEnvironment={ activeEnvironment }
+						liveSite={ liveSite }
 					/>
 				</div>
 			</div>

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -29,10 +29,19 @@ type TriggerProps = Omit< ComponentProps< typeof Button >, 'children' > & {
 	siteUrl: string;
 	status: SiteStatus;
 	statusLabel: string;
+	environment: 'local' | 'live';
 };
 
 const DropdownTrigger = forwardRef< ElementRef< typeof Button >, TriggerProps >(
-	function DropdownTrigger( { siteName, siteUrl, status, statusLabel, className, ...props }, ref ) {
+	function DropdownTrigger(
+		{ siteName, siteUrl, status, statusLabel, environment, className, ...props },
+		ref
+	) {
+		// In live mode the local server's running/stopped status is irrelevant
+		// to what the agent targets; use a dedicated dot color so the trigger
+		// visibly mirrors the environment pill.
+		const dotClass =
+			environment === 'live' ? styles.triggerDot_live : styles[ `triggerDot_${ status }` ];
 		return (
 			<Button
 				ref={ ref }
@@ -45,11 +54,13 @@ const DropdownTrigger = forwardRef< ElementRef< typeof Button >, TriggerProps >(
 				<span className={ styles.triggerSite }>{ siteName }</span>
 				<span className={ styles.triggerStatus }>
 					<span
-						className={ clsx( styles.triggerDot, styles[ `triggerDot_${ status }` ] ) }
+						className={ clsx( styles.triggerDot, dotClass ) }
 						role="img"
 						aria-label={ statusLabel }
 					/>
-					<span className={ styles.triggerEnv }>{ __( 'Local' ) }</span>
+					<span className={ styles.triggerEnv }>
+						{ environment === 'live' ? __( 'Live' ) : __( 'Local' ) }
+					</span>
 				</span>
 				<span className={ styles.triggerUrl }>{ siteUrl }</span>
 				<Icon icon={ chevronDownSmall } />
@@ -80,6 +91,10 @@ function PopoverRow( {
 
 type Props = {
 	site: SiteDetails;
+	// Optional: when rendered inside a session view, the dropdown reflects the
+	// session's active environment (local vs. live) rather than always reading
+	// "Local". Outside a session context these default to local.
+	activeEnvironment?: 'local' | 'live';
 };
 
 function ensureProtocol( url: string ): string {
@@ -113,7 +128,7 @@ function pickLatestSnapshot(
 		}, undefined );
 }
 
-export function SiteDropdown( { site }: Props ) {
+export function SiteDropdown( { site, activeEnvironment = 'local' }: Props ) {
 	const connector = useConnector();
 	const { data: snapshots } = useSnapshots();
 	const { data: connectedSites } = useConnectedWpcomSites( site.id );
@@ -170,6 +185,7 @@ export function SiteDropdown( { site }: Props ) {
 						siteUrl={ getSiteDisplayUrl( site ) }
 						status={ status }
 						statusLabel={ statusLabel }
+						environment={ activeEnvironment }
 					/>
 				}
 			/>

--- a/apps/ui/src/components/site-dropdown/style.module.css
+++ b/apps/ui/src/components/site-dropdown/style.module.css
@@ -34,6 +34,10 @@
 	animation: siteDotBlink 1s ease-in-out infinite;
 }
 
+.triggerDot_live {
+	background-color: #2563eb;
+}
+
 @keyframes siteDotBlink {
 	0%,
 	100% {

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -123,6 +123,19 @@ export function createIpcConnector(): Connector {
 			await ipcApi.answerAiAgentQuestion( runId, answers );
 		},
 
+		async setSessionEnvironment( sessionId, environment ) {
+			const result = ( await ipcApi.setSessionEnvironment( sessionId, environment ) ) as {
+				environment: 'local' | 'live';
+				url?: string;
+				wpcomSiteId?: number;
+			};
+			return {
+				environment: result.environment,
+				url: result.url,
+				wpcomSiteId: result.wpcomSiteId,
+			};
+		},
+
 		onAgentEvent( listener ) {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const ipcListener = ( window as any ).ipcListener;

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -86,6 +86,13 @@ export interface Connector {
 	answerAgentQuestion( runId: string, answers: Record< string, string > ): Promise< void >;
 	onAgentEvent( listener: ( event: AgentRunEvent ) => void ): () => void;
 
+	// Flip the session between acting on its owner site's local runtime vs.
+	// its linked WordPress.com live site. The owner site itself never changes.
+	setSessionEnvironment(
+		sessionId: string,
+		environment: 'local' | 'live'
+	): Promise< { environment: 'local' | 'live'; url?: string; wpcomSiteId?: number } >;
+
 	// Locale
 	getUserLocale(): Promise< string | undefined >;
 

--- a/apps/ui/src/data/queries/use-connected-wpcom-sites.ts
+++ b/apps/ui/src/data/queries/use-connected-wpcom-sites.ts
@@ -4,10 +4,11 @@ import { useConnector } from '@/data/core';
 export const connectedWpcomSitesQueryKey = ( localSiteId: string ) =>
 	[ 'connected-wpcom-sites', localSiteId ] as const;
 
-export function useConnectedWpcomSites( localSiteId: string ) {
+export function useConnectedWpcomSites( localSiteId: string | undefined ) {
 	const connector = useConnector();
 	return useQuery( {
-		queryKey: connectedWpcomSitesQueryKey( localSiteId ),
-		queryFn: () => connector.getConnectedWpcomSites( localSiteId ),
+		queryKey: connectedWpcomSitesQueryKey( localSiteId ?? '' ),
+		queryFn: () => connector.getConnectedWpcomSites( localSiteId! ),
+		enabled: !! localSiteId,
 	} );
 }

--- a/apps/ui/src/data/queries/use-sessions.ts
+++ b/apps/ui/src/data/queries/use-sessions.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useConnector } from '@/data/core';
+import type { LoadedAiSession } from '@/data/core';
 
 export const SESSIONS_QUERY_KEY = [ 'sessions' ] as const;
 
@@ -42,4 +43,48 @@ export function useCreateSession() {
 		mutationFn: ( siteId: string ) => connector.createSession( siteId ),
 		onSuccess: () => queryClient.invalidateQueries( { queryKey: SESSIONS_QUERY_KEY } ),
 	} );
+}
+
+export function useSetSessionEnvironment( sessionId: string | undefined ) {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	const sessionKey = [ ...SESSIONS_QUERY_KEY, sessionId ];
+	return useMutation< unknown, Error, 'local' | 'live', { previous: LoadedAiSession | undefined } >(
+		{
+			mutationFn: ( environment ) => {
+				if ( ! sessionId ) {
+					throw new Error( 'No session selected' );
+				}
+				return connector.setSessionEnvironment( sessionId, environment );
+			},
+			// Optimistically flip `activeEnvironment` so the pill (and anything
+			// else reading the summary) updates the moment the user clicks,
+			// rather than waiting for the IPC round-trip to the main process.
+			onMutate: async ( environment ) => {
+				if ( ! sessionId ) {
+					return { previous: undefined };
+				}
+				await queryClient.cancelQueries( { queryKey: sessionKey } );
+				const previous = queryClient.getQueryData< LoadedAiSession >( sessionKey );
+				if ( previous ) {
+					queryClient.setQueryData< LoadedAiSession >( sessionKey, {
+						...previous,
+						summary: { ...previous.summary, activeEnvironment: environment },
+					} );
+				}
+				return { previous };
+			},
+			onError: ( _error, _variables, context ) => {
+				if ( context?.previous ) {
+					queryClient.setQueryData( sessionKey, context.previous );
+				}
+			},
+			onSettled: () => {
+				// Reconcile against the server-side event log so the cache matches the
+				// JSONL truth, and refresh the sidebar list which shows env indicators.
+				void queryClient.invalidateQueries( { queryKey: sessionKey } );
+				void queryClient.invalidateQueries( { queryKey: SESSIONS_QUERY_KEY } );
+			},
+		}
+	);
 }

--- a/tools/common/ai/sessions/active-site.ts
+++ b/tools/common/ai/sessions/active-site.ts
@@ -1,0 +1,48 @@
+import type { AiSessionEvent } from './types';
+
+export interface ResolvedActiveSite {
+	name: string;
+	path: string;
+	remote: boolean;
+	url?: string;
+	wpcomSiteId?: number;
+}
+
+/**
+ * Walks a session's events and returns the site the next turn should act on.
+ * `site.selected` anchors the owner site; `environment.selected` flips the
+ * environment (local vs. linked live) without changing the owner. The CLI's
+ * JSON adapter has no replay loop, so it relies on this helper to hydrate
+ * `ui.activeSite` before dispatching a new turn.
+ */
+export function resolveActiveSiteFromEvents(
+	events: AiSessionEvent[]
+): ResolvedActiveSite | undefined {
+	let state: ResolvedActiveSite | undefined;
+
+	for ( const event of events ) {
+		if ( event.type === 'site.selected' ) {
+			state = {
+				name: event.siteName,
+				path: event.sitePath,
+				remote: event.remote === true,
+				url: event.url,
+				wpcomSiteId: event.wpcomSiteId,
+			};
+			continue;
+		}
+
+		if ( event.type === 'environment.selected' && state ) {
+			const isLive = event.environment === 'live';
+			state = {
+				name: state.name,
+				path: state.path,
+				remote: isLive,
+				url: isLive ? event.url : undefined,
+				wpcomSiteId: isLive ? event.wpcomSiteId : undefined,
+			};
+		}
+	}
+
+	return state;
+}

--- a/tools/common/ai/sessions/summary.ts
+++ b/tools/common/ai/sessions/summary.ts
@@ -18,6 +18,7 @@ export async function readAiSessionSummaryFromEvents(
 	let ownerSitePath: string | undefined;
 	let ownerSiteName: string | undefined;
 	let selectedSiteName: string | undefined;
+	let activeEnvironment: 'local' | 'live' = 'local';
 	let endReason: 'error' | 'stopped' | undefined;
 	let eventCount = 0;
 
@@ -45,6 +46,11 @@ export async function readAiSessionSummaryFromEvents(
 				ownerSitePath = event.sitePath;
 				ownerSiteName = event.siteName;
 			}
+			activeEnvironment = event.remote === true ? 'live' : 'local';
+		}
+
+		if ( event.type === 'environment.selected' ) {
+			activeEnvironment = event.environment;
 		}
 
 		if ( event.type === 'user.message' && event.source === 'prompt' && ! firstPrompt ) {
@@ -74,6 +80,7 @@ export async function readAiSessionSummaryFromEvents(
 		ownerSitePath,
 		ownerSiteName,
 		selectedSiteName,
+		activeEnvironment,
 		endReason,
 		eventCount,
 	};

--- a/tools/common/ai/sessions/tests/environment.test.ts
+++ b/tools/common/ai/sessions/tests/environment.test.ts
@@ -1,0 +1,114 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveActiveSiteFromEvents } from '../active-site';
+import { appendAiSessionEvent, createAiSession, loadAiSession } from '../store';
+import type { AiSessionEvent } from '../types';
+
+describe( 'environment.selected', () => {
+	let rootDirectory: string | undefined;
+
+	afterEach( async () => {
+		if ( rootDirectory ) {
+			await fs.rm( rootDirectory, { recursive: true, force: true } );
+			rootDirectory = undefined;
+		}
+	} );
+
+	it( 'summary defaults activeEnvironment to "local" when no flip has happened', async () => {
+		rootDirectory = await fs.mkdtemp( path.join( os.tmpdir(), 'studio-env-' ) );
+		const summary = await createAiSession( rootDirectory, {
+			site: { name: 'My Site', path: '/tmp/my-site' },
+		} );
+		expect( summary.activeEnvironment ).toBe( 'local' );
+	} );
+
+	it( 'summary reflects the latest environment.selected event', async () => {
+		rootDirectory = await fs.mkdtemp( path.join( os.tmpdir(), 'studio-env-' ) );
+		const created = await createAiSession( rootDirectory, {
+			site: { name: 'My Site', path: '/tmp/my-site' },
+		} );
+
+		await appendAiSessionEvent( rootDirectory, created.id, {
+			type: 'environment.selected',
+			timestamp: new Date().toISOString(),
+			environment: 'live',
+			url: 'https://mysite.example',
+			wpcomSiteId: 42,
+		} );
+
+		const { summary } = await loadAiSession( rootDirectory, created.id );
+		expect( summary.activeEnvironment ).toBe( 'live' );
+	} );
+
+	it( 'resolver preserves owner name/path when flipping to live', () => {
+		const events: AiSessionEvent[] = [
+			{
+				type: 'site.selected',
+				timestamp: '2026-04-20T10:00:00.000Z',
+				siteName: 'My Site',
+				sitePath: '/tmp/my-site',
+			},
+			{
+				type: 'environment.selected',
+				timestamp: '2026-04-20T10:01:00.000Z',
+				environment: 'live',
+				url: 'https://mysite.example',
+				wpcomSiteId: 42,
+			},
+		];
+
+		expect( resolveActiveSiteFromEvents( events ) ).toEqual( {
+			name: 'My Site',
+			path: '/tmp/my-site',
+			remote: true,
+			url: 'https://mysite.example',
+			wpcomSiteId: 42,
+		} );
+	} );
+
+	it( 'resolver clears live endpoint info when flipping back to local', () => {
+		const events: AiSessionEvent[] = [
+			{
+				type: 'site.selected',
+				timestamp: '2026-04-20T10:00:00.000Z',
+				siteName: 'My Site',
+				sitePath: '/tmp/my-site',
+			},
+			{
+				type: 'environment.selected',
+				timestamp: '2026-04-20T10:01:00.000Z',
+				environment: 'live',
+				url: 'https://mysite.example',
+				wpcomSiteId: 42,
+			},
+			{
+				type: 'environment.selected',
+				timestamp: '2026-04-20T10:02:00.000Z',
+				environment: 'local',
+			},
+		];
+
+		expect( resolveActiveSiteFromEvents( events ) ).toEqual( {
+			name: 'My Site',
+			path: '/tmp/my-site',
+			remote: false,
+			url: undefined,
+			wpcomSiteId: undefined,
+		} );
+	} );
+
+	it( 'resolver ignores environment.selected with no prior site.selected', () => {
+		const events: AiSessionEvent[] = [
+			{
+				type: 'environment.selected',
+				timestamp: '2026-04-20T10:00:00.000Z',
+				environment: 'live',
+				url: 'https://orphan.example',
+			},
+		];
+
+		expect( resolveActiveSiteFromEvents( events ) ).toBeUndefined();
+	} );
+} );

--- a/tools/common/ai/sessions/types.ts
+++ b/tools/common/ai/sessions/types.ts
@@ -40,6 +40,18 @@ export type AiSessionEvent =
 			wpcomSiteId?: number;
 	  }
 	| {
+			type: 'environment.selected';
+			timestamp: string;
+			// Which environment of the session's owner site is now active. The
+			// owner site itself never changes within a session — only whether
+			// tool calls target the local runtime or the linked live WordPress.com
+			// site. `url`/`wpcomSiteId` are resolved at record time so replay
+			// doesn't need to re-query WordPress.com.
+			environment: 'local' | 'live';
+			url?: string;
+			wpcomSiteId?: number;
+	  }
+	| {
 			type: 'user.message';
 			timestamp: string;
 			text: string;
@@ -88,6 +100,10 @@ export interface AiSessionSummary {
 	// The most recently selected site during the session. May differ from the owner
 	// if the user switched sites mid-session.
 	selectedSiteName?: string;
+	// Which environment of the owner site the next turn will act on. Derived
+	// from the latest `environment.selected` event, or falls back to `'live'`
+	// when the most recent `site.selected` marked the site as remote.
+	activeEnvironment: 'local' | 'live';
 	endReason?: 'error' | 'stopped';
 	eventCount: number;
 }


### PR DESCRIPTION
## Related issues

- Related to the work on the new Studio Code UI composer

## How AI was used in this PR

Implementation done with Claude Code in auto mode. Design iterated with me in the same session before coding started — the final shape (session-scoped flip, owner site never changes, IPC is the enforcement point, narrow `environment.selected` event for a clean audit log) was agreed up front. AI wrote the schema/event/IPC/UI wiring and the tests; I steered the UX simplifications (just "Local" / "Live" labels, hide pill when no live link, optimistic update, header dropdown reflects env).

**Review focus**: the IPC contract in `apps/studio/src/ipc-handlers.ts` (it must not be possible for the renderer to rebind a session to a different site) and the JSON-mode resume hydration in `apps/cli/commands/ai/sessions/resume.ts` (previously `ui.activeSite` stayed null in JSON mode because replay is gated to `AiChatUI`).

## Proposed Changes

Adds a session-scoped environment switch so the Studio Code UI can run the next agent turn against either the owner site's local runtime or its linked WordPress.com live site. The owner site itself never changes within a session — only whether `createStudioTools()` or `createRemoteSiteTools()` is used — and that constraint is enforced in the IPC, not the renderer.

- **New `environment.selected` session event** in the JSONL log, with summary-level `activeEnvironment: 'local' | 'live'` derived from the event stream.
- **`resolveActiveSiteFromEvents` helper** + JSON-mode resume hydration: in JSON mode the CLI has no replay loop (it only runs for `AiChatUI`), so `ui.activeSite` would otherwise stay null and the agent would fall back to local tools regardless of what the session file said. The resume path now derives it from the event log.
- **`setSessionEnvironment` IPC** takes only `(sessionId, 'local' | 'live')` — the live endpoint is resolved on the main side from the session's owner site via `pickLiveSite()`, so a renderer bug can't accidentally rebind to a different site.
- **Composer environment pill** (Local / Live) wired to an optimistic mutation. Hidden entirely when no live site is linked. Disabled (static) during an in-flight run.
- **Header `SiteDropdown` trigger** now reflects the active environment (dot color + label), matching the composer pill.

## Testing Instructions

1. **Local-only session** (no linked live site)
   - Open a Studio Code session on a site with no WordPress.com link.
   - Verify the composer shows no environment pill. The header dropdown trigger reads "Local".

2. **Site with a linked live site**
   - Open a session on a site that has a linked WordPress.com live site.
   - Verify the composer shows a "Local" pill with a green dot.
   - Click it, pick "Live". The dropdown closes immediately and the pill label flips to "Live" with a blue dot (optimistic update). The header dropdown trigger flips too.
   - Send a prompt. Verify the agent uses remote/WordPress.com tools (e.g. REST API calls).
   - Flip back to "Local". Verify the next turn uses local tools again.

3. **Resume persistence**
   - Flip to Live, send a turn, close the session, re-open it.
   - Verify the pill still shows "Live" after reload and the next turn still targets live.

4. **During a run**
   - Click the pill while a turn is in flight. Verify it's disabled (still shows current env, no interaction).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
- [x] Does the UI have clear visual feedback for every interaction?
- [x] Does the code have sufficient test coverage?
- [x] Have you added relevant docs to project's readme, or inline comments?

🤖 Generated with [Claude Code](https://claude.com/claude-code)