### PR TITLE
CLI code agent: support inline wpcom auth via STUDIO_WPCOM_TOKEN

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ WordPress Studio - Electron desktop app for managing local WordPress sites. Buil
 - **Auth**: `auth login|logout|status` - WordPress.com OAuth (tokens valid 2 weeks)
 - **Preview Sites**: See `apps/cli/commands/preview/`
 - **Local Sites**: See `apps/cli/commands/site/`
+- **Inline auth for `studio code`**: Set `STUDIO_WPCOM_TOKEN=<wpcom-access-token>` to authenticate a single `studio code` invocation without touching stored config. Intended for sandboxed/CI runs. Pins the AI provider to `wpcom` and hard-fails if the token is rejected.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,6 @@ WordPress Studio - Electron desktop app for managing local WordPress sites. Buil
 - **Auth**: `auth login|logout|status` - WordPress.com OAuth (tokens valid 2 weeks)
 - **Preview Sites**: See `apps/cli/commands/preview/`
 - **Local Sites**: See `apps/cli/commands/site/`
-- **Inline auth for `studio code`**: Set `STUDIO_WPCOM_TOKEN=<wpcom-access-token>` to authenticate a single `studio code` invocation without touching stored config. Intended for sandboxed/CI runs. Pins the AI provider to `wpcom` and hard-fails if the token is rejected.
 
 ## Architecture
 

--- a/apps/cli/ai/auth.ts
+++ b/apps/cli/ai/auth.ts
@@ -2,6 +2,7 @@ import {
 	AI_PROVIDER_PRIORITY,
 	DEFAULT_AI_PROVIDER,
 	getAiProviderDefinition,
+	hasInlineWpcomAuth,
 	type AiProviderId,
 } from 'cli/ai/providers';
 import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
@@ -49,6 +50,10 @@ export async function resolveUnavailableAiProvider(
 }
 
 export async function resolveInitialAiProvider(): Promise< AiProviderId > {
+	if ( hasInlineWpcomAuth() ) {
+		return 'wpcom';
+	}
+
 	const { aiProvider: savedProvider } = await readCliConfig();
 	if ( savedProvider ) {
 		const definition = getAiProviderDefinition( savedProvider );

--- a/apps/cli/ai/providers.ts
+++ b/apps/cli/ai/providers.ts
@@ -65,6 +65,14 @@ async function hasValidWpcomAuth(): Promise< boolean > {
 	return token !== null;
 }
 
+function readInlineWpcomToken(): string | null {
+	return process.env.STUDIO_WPCOM_TOKEN?.trim() || null;
+}
+
+export function hasInlineWpcomAuth(): boolean {
+	return readInlineWpcomToken() !== null;
+}
+
 function createBaseEnvironment(): Record< string, string > {
 	const env = { ...( process.env as Record< string, string > ) };
 
@@ -88,22 +96,23 @@ const AI_PROVIDER_DEFINITIONS: Record< AiProviderId, AiProviderDefinition > = {
 		id: 'wpcom',
 		autoFallbackWhenUnavailable: true,
 		isVisible: async () => true,
-		isReady: hasValidWpcomAuth,
+		isReady: async () => hasInlineWpcomAuth() || ( await hasValidWpcomAuth() ),
 		prepare: async () => {
-			if ( await hasValidWpcomAuth() ) {
+			if ( hasInlineWpcomAuth() || ( await hasValidWpcomAuth() ) ) {
 				return;
 			}
 
 			throw new LoggerError( __( 'WordPress.com login required. Use /login to authenticate.' ) );
 		},
 		resolveEnv: async () => {
-			const token = await readAuthToken();
-			if ( ! token ) {
+			const inlineToken = readInlineWpcomToken();
+			const accessToken = inlineToken ?? ( await readAuthToken() )?.accessToken;
+			if ( ! accessToken ) {
 				throw new LoggerError( __( 'WordPress.com login required. Use /login to authenticate.' ) );
 			}
 			const env = createBaseEnvironment();
 			env.ANTHROPIC_BASE_URL = getWpcomAiGatewayBaseUrl();
-			env.ANTHROPIC_AUTH_TOKEN = token.accessToken;
+			env.ANTHROPIC_AUTH_TOKEN = accessToken;
 			env.ANTHROPIC_CUSTOM_HEADERS = buildAnthropicCustomHeaders( {
 				'X-WPCOM-AI-Feature': WPCOM_AI_FEATURE_HEADER,
 			} );


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Used Claude Code to brainstorm the shape of the feature, draft the provider changes, and write this PR description. I reviewed the diff myself — it's a small, surgical change to the AI provider plumbing.

## Proposed Changes

- Add `STUDIO_WPCOM_TOKEN` env var for single-invocation auth to `studio code`. When set, the wpcom provider uses the inline token and skips `~/.studio/config.json` entirely.
- Pin the initial AI provider to `wpcom` when the inline token is present, so the provider picker doesn't block a non-interactive run.
- Hard-fail when the token is rejected: no fallback to stored creds, no interactive prompt. Sandbox runs should be loud when auth is wrong.
- Document the env var in `AGENTS.md`.

The motivation: sandbox and CI environments can't really run `auth login`, there's no browser and no config file to touch. So here: set `STUDIO_WPCOM_TOKEN` and the CLI picks it up for that one run. Nothing gets written to disk. If the var is unset, everything works like before — the stored-token flow runs as usual.

One important caveat for reviewers: the CLI routes AI requests through `/wpcom/v2/ai-api-proxy`, which allowlists Studio's `client_id=95109`. Tokens minted for other clients (e.g., via `/oauth2/token` with a different `client_id`) will 403 at the gateway. This env var helps anyone who already has a Studio-compatible token, but it does not bypass the proxy's client check.

## Testing Instructions

1. Build the CLI: `npm run cli:build`
2. Grab a Studio-compatible wpcom token. Easiest path: run `studio auth login` once, then read `authToken.accessToken` from `~/.studio/config.json`.
3. Clear the stored config or rename it so the CLI can't read it: `mv ~/.studio/config.json ~/.studio/config.json.bak`
4. Run the CLI with the env var set:
   ```bash
   STUDIO_WPCOM_TOKEN='<paste-token>' node apps/cli/dist/cli/main.mjs code "hey there"
   ```
5. Confirm the agent responds without prompting for login and without asking to pick a provider.
6. Run the CLI again without the env var set. Confirm it prompts for login as before (since the stored config is missing).
7. Restore the config file: `mv ~/.studio/config.json.bak ~/.studio/config.json`

Edge cases worth checking:

- Empty or whitespace-only value: `STUDIO_WPCOM_TOKEN='   '` → treated as unset, falls back to stored token.
- Both env var and stored token present: inline wins, the stored token is not read.
- Invalid token: expect a 401/403 from wpcom and a hard fail. No fallback, no retry.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

