### PR TITLE
apps/cli: surface child-process crashes instead of silent 2-min timeout

### DIFF
--- a/apps/cli/lib/tests/wordpress-server-manager.test.ts
+++ b/apps/cli/lib/tests/wordpress-server-manager.test.ts
@@ -54,6 +54,10 @@ describe( 'WordPress Server Manager', () => {
 	} );
 
 	function setupIpcMocks(): void {
+		// Pretend the child process is alive so the startup-race guard in
+		// `waitForReadyMessage` doesn't short-circuit with a "child exited" error.
+		vi.mocked( daemonClient.isProcessRunning ).mockResolvedValue( mockProcessDescription );
+
 		// Emit "ready" repeatedly to avoid races where the listener is attached after one-shot emission.
 		const readyInterval = setInterval( () => {
 			mockBus.emit( 'process-message', {
@@ -128,6 +132,36 @@ describe( 'WordPress Server Manager', () => {
 
 			await expect( startWordPressServer( mockSiteData, mockLogger ) ).rejects.toThrow(
 				'Failed to start process'
+			);
+		} );
+
+		it( 'should surface an error when the child process exits before becoming ready', async () => {
+			// Race guard should not fire — pretend the process is still online when checked.
+			vi.mocked( daemonClient.isProcessRunning ).mockResolvedValue( mockProcessDescription );
+
+			// Do not emit `ready`; instead emit an `exit` event to simulate a crash during startup.
+			setTimeout( () => {
+				mockBus.emit( 'process-event', {
+					process: {
+						name: mockProcessDescription.name,
+						pm_id: mockProcessDescription.pmId,
+					},
+					event: 'exit',
+				} );
+			}, 10 );
+
+			await expect( startWordPressServer( mockSiteData, mockLogger ) ).rejects.toThrow(
+				/WordPress server child process exited before becoming ready/
+			);
+		} );
+
+		it( 'should surface an error when the child has already exited before listeners attach', async () => {
+			// Simulate the race where the child process has already exited by the time
+			// `startProcess` resolves — `isProcessRunning` returns undefined.
+			vi.mocked( daemonClient.isProcessRunning ).mockResolvedValue( undefined );
+
+			await expect( startWordPressServer( mockSiteData, mockLogger ) ).rejects.toThrow(
+				/WordPress server child process exited before becoming ready/
 			);
 		} );
 	} );

--- a/apps/cli/lib/tests/wordpress-server-manager.test.ts
+++ b/apps/cli/lib/tests/wordpress-server-manager.test.ts
@@ -54,10 +54,6 @@ describe( 'WordPress Server Manager', () => {
 	} );
 
 	function setupIpcMocks(): void {
-		// Pretend the child process is alive so the startup-race guard in
-		// `waitForReadyMessage` doesn't short-circuit with a "child exited" error.
-		vi.mocked( daemonClient.isProcessRunning ).mockResolvedValue( mockProcessDescription );
-
 		// Emit "ready" repeatedly to avoid races where the listener is attached after one-shot emission.
 		const readyInterval = setInterval( () => {
 			mockBus.emit( 'process-message', {
@@ -136,9 +132,6 @@ describe( 'WordPress Server Manager', () => {
 		} );
 
 		it( 'should surface an error when the child process exits before becoming ready', async () => {
-			// Race guard should not fire — pretend the process is still online when checked.
-			vi.mocked( daemonClient.isProcessRunning ).mockResolvedValue( mockProcessDescription );
-
 			// Do not emit `ready`; instead emit an `exit` event to simulate a crash during startup.
 			setTimeout( () => {
 				mockBus.emit( 'process-event', {
@@ -151,17 +144,50 @@ describe( 'WordPress Server Manager', () => {
 			}, 10 );
 
 			await expect( startWordPressServer( mockSiteData, mockLogger ) ).rejects.toThrow(
-				/WordPress server child process exited before becoming ready/
+				/exited before becoming ready/
 			);
 		} );
 
-		it( 'should surface an error when the child has already exited before listeners attach', async () => {
-			// Simulate the race where the child process has already exited by the time
-			// `startProcess` resolves — `isProcessRunning` returns undefined.
-			vi.mocked( daemonClient.isProcessRunning ).mockResolvedValue( undefined );
+		it( 'should include the child stderr tail in the error when the daemon provides it', async () => {
+			const stderrTail = 'SyntaxError: The requested module did not provide an export named X';
+
+			setTimeout( () => {
+				mockBus.emit( 'process-event', {
+					process: {
+						name: mockProcessDescription.name,
+						pm_id: mockProcessDescription.pmId,
+					},
+					event: 'exit',
+					stderrTail,
+				} );
+			}, 10 );
 
 			await expect( startWordPressServer( mockSiteData, mockLogger ) ).rejects.toThrow(
-				/WordPress server child process exited before becoming ready/
+				new RegExp( stderrTail.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ) )
+			);
+		} );
+
+		it( 'should catch exit events fired before startProcess resolves', async () => {
+			// Simulate an exit that fires while `startProcess` is still in flight, *before*
+			// the caller knows the pmId. Listeners must be attached ahead of startProcess for
+			// this to work.
+			vi.mocked( daemonClient.startProcess ).mockImplementation( async () => {
+				setTimeout( () => {
+					mockBus.emit( 'process-event', {
+						process: {
+							name: mockProcessDescription.name,
+							pm_id: mockProcessDescription.pmId,
+						},
+						event: 'exit',
+						stderrTail: 'early crash',
+					} );
+				}, 0 );
+				await new Promise( ( resolve ) => setTimeout( resolve, 20 ) );
+				return mockProcessDescription;
+			} );
+
+			await expect( startWordPressServer( mockSiteData, mockLogger ) ).rejects.toThrow(
+				/early crash/
 			);
 		} );
 	} );

--- a/apps/cli/lib/types/process-manager-ipc.ts
+++ b/apps/cli/lib/types/process-manager-ipc.ts
@@ -98,6 +98,9 @@ export const processEventSchema = z.object( {
 		z.literal( 'restart' ),
 		z.literal( 'stop' ),
 	] ),
+	// Tail of the child's stderr captured during this invocation. Only populated on `exit`
+	// events; undefined for any other event.
+	stderrTail: z.string().optional(),
 } );
 
 const daemonProcessEventSchema = z.object( {

--- a/apps/cli/lib/wordpress-server-manager.ts
+++ b/apps/cli/lib/wordpress-server-manager.ts
@@ -4,7 +4,6 @@
  * Manages WordPress server processes via process manager daemon. Each site runs in a separate
  * process that spawns Playground CLI.
  */
-import fs from 'fs';
 import path from 'path';
 import {
 	PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL,
@@ -21,7 +20,6 @@ import {
 	type DaemonBusEventMap,
 	sendMessageToProcess,
 } from 'cli/lib/daemon-client';
-import { PROCESS_MANAGER_LOGS_DIR } from 'cli/lib/paths';
 import { ProcessDescription } from 'cli/lib/types/process-manager-ipc';
 import { ServerConfig, ManagerMessagePayload } from 'cli/lib/types/wordpress-server-ipc';
 import { Logger } from 'cli/logger';
@@ -119,99 +117,121 @@ export async function startWordPressServer(
 		serverConfig.enableDebugDisplay = true;
 	}
 
-	const processDesc = await startProcess( processName, wordPressServerChildPath );
-	await waitForReadyMessage( processName, processDesc.pmId );
-	await sendMessage(
-		processDesc.pmId,
-		processName,
-		{
-			topic: 'start-server',
-			data: { config: serverConfig },
-		},
-		{ logger }
-	);
-
-	return processDesc;
-}
-
-const CHILD_STDERR_TAIL_BYTES = 4096;
-
-function readChildStderrTail( processName: string ): string {
-	const errorLogPath = path.join( PROCESS_MANAGER_LOGS_DIR, `${ processName }-error.log` );
+	const readyOrExit = await subscribeForReadyOrExit( processName );
 	try {
-		const { size } = fs.statSync( errorLogPath );
-		if ( size === 0 ) {
-			return '';
-		}
-		const readBytes = Math.min( size, CHILD_STDERR_TAIL_BYTES );
-		const buffer = Buffer.alloc( readBytes );
-		const fd = fs.openSync( errorLogPath, 'r' );
-		try {
-			fs.readSync( fd, buffer, 0, readBytes, size - readBytes );
-		} finally {
-			fs.closeSync( fd );
-		}
-		return buffer.toString( 'utf8' ).trimEnd();
-	} catch {
-		return '';
+		const processDesc = await startProcess( processName, wordPressServerChildPath );
+		await readyOrExit.waitFor( processDesc.pmId );
+		await sendMessage(
+			processDesc.pmId,
+			processName,
+			{
+				topic: 'start-server',
+				data: { config: serverConfig },
+			},
+			{ logger }
+		);
+
+		return processDesc;
+	} finally {
+		readyOrExit.dispose();
 	}
 }
 
-function buildChildExitedError( processName: string ): Error {
-	const errorLogPath = path.join( PROCESS_MANAGER_LOGS_DIR, `${ processName }-error.log` );
-	const tail = readChildStderrTail( processName );
-	let message = `WordPress server child process exited before becoming ready. See ${ errorLogPath }`;
-	if ( tail ) {
-		message += `\n${ tail }`;
+function buildChildExitedError( processName: string, stderrTail?: string ): Error {
+	let message = `WordPress server child process "${ processName }" exited before becoming ready.`;
+	if ( stderrTail?.trim() ) {
+		message += `\n${ stderrTail.trimEnd() }`;
 	}
 	return new Error( message );
 }
 
-async function waitForReadyMessage( processName: string, pmId: number ): Promise< void > {
+/**
+ * Attaches listeners to the daemon bus *before* the child process is started so we cannot miss
+ * an early `ready` or `exit` event. Events that arrive before the caller knows the pmId are
+ * buffered (filtered by processName) and replayed once `waitFor(pmId)` is called.
+ * Must be disposed via `dispose()` when done.
+ */
+async function subscribeForReadyOrExit( processName: string ): Promise< {
+	waitFor: ( pmId: number ) => Promise< void >;
+	dispose: () => void;
+} > {
 	const bus = await getDaemonBus();
 
-	let timeoutId: NodeJS.Timeout;
-	let readyHandler: ( packet: DaemonBusEventMap[ 'process-message' ] ) => void;
-	let exitHandler: ( event: DaemonBusEventMap[ 'process-event' ] ) => void;
-	let abortListener: () => void;
+	const pendingReady: Array< DaemonBusEventMap[ 'process-message' ] > = [];
+	const pendingExits: Array< DaemonBusEventMap[ 'process-event' ] > = [];
+	let onReady: () => void = () => {};
+	let onExit: ( stderrTail?: string ) => void = () => {};
+	let waiting = false;
 
-	return new Promise< void >( ( resolve, reject ) => {
-		timeoutId = setTimeout( () => {
-			reject( new Error( 'Timeout waiting for ready message from WordPress server child' ) );
-		}, PLAYGROUND_CLI_INACTIVITY_TIMEOUT );
-		readyHandler = ( packet ) => {
-			if ( packet.process.pm_id === pmId && packet.raw.topic === 'ready' ) {
-				resolve();
-			}
-		};
-		exitHandler = ( event ) => {
-			if ( event.process.pm_id === pmId && event.event === 'exit' ) {
-				reject( buildChildExitedError( processName ) );
-			}
-		};
-		abortListener = () => {
-			reject( new Error( 'Operation aborted' ) );
-		};
-		abortController.signal.addEventListener( 'abort', abortListener );
+	const messageHandler = ( packet: DaemonBusEventMap[ 'process-message' ] ) => {
+		if ( packet.process.name !== processName || packet.raw.topic !== 'ready' ) {
+			return;
+		}
+		if ( waiting ) {
+			onReady();
+		} else {
+			pendingReady.push( packet );
+		}
+	};
+	const eventHandler = ( event: DaemonBusEventMap[ 'process-event' ] ) => {
+		if ( event.process.name !== processName || event.event !== 'exit' ) {
+			return;
+		}
+		if ( waiting ) {
+			onExit( event.stderrTail );
+		} else {
+			pendingExits.push( event );
+		}
+	};
 
-		bus.on( 'process-message', readyHandler );
-		bus.on( 'process-event', exitHandler );
+	bus.on( 'process-message', messageHandler );
+	bus.on( 'process-event', eventHandler );
 
-		// Guard against the race where the child exits between `startProcess` resolving and
-		// our listeners being attached: if the process is no longer running now, surface the
-		// error immediately rather than waiting for the ready-message timeout.
-		void ( async () => {
-			const running = await isProcessRunning( processName );
-			if ( ! running ) {
-				reject( buildChildExitedError( processName ) );
+	const waitFor = ( pmId: number ): Promise< void > => {
+		waiting = true;
+
+		let timeoutId: NodeJS.Timeout;
+		let abortListener: () => void;
+
+		return new Promise< void >( ( resolve, reject ) => {
+			timeoutId = setTimeout( () => {
+				reject( new Error( 'Timeout waiting for ready message from WordPress server child' ) );
+			}, PLAYGROUND_CLI_INACTIVITY_TIMEOUT );
+			abortListener = () => {
+				reject( new Error( 'Operation aborted' ) );
+			};
+
+			onReady = () => resolve();
+			onExit = ( stderrTail ) => reject( buildChildExitedError( processName, stderrTail ) );
+
+			abortController.signal.addEventListener( 'abort', abortListener );
+
+			// Replay any events we buffered before pmId was known.
+			const bufferedExit = pendingExits.find( ( event ) => event.process.pm_id === pmId );
+			if ( bufferedExit ) {
+				onExit( bufferedExit.stderrTail );
+				return;
 			}
-		} )();
-	} ).finally( () => {
-		clearTimeout( timeoutId );
-		abortController.signal.removeEventListener( 'abort', abortListener );
-		bus.off( 'process-message', readyHandler );
-		bus.off( 'process-event', exitHandler );
-	} );
+			const bufferedReady = pendingReady.find( ( packet ) => packet.process.pm_id === pmId );
+			if ( bufferedReady ) {
+				onReady();
+			}
+		} ).finally( () => {
+			clearTimeout( timeoutId );
+			abortController.signal.removeEventListener( 'abort', abortListener );
+			// Release per-call handlers; the bus listeners stay until dispose().
+			onReady = () => {};
+			onExit = () => {};
+			waiting = false;
+		} );
+	};
+
+	const dispose = () => {
+		bus.off( 'process-message', messageHandler );
+		bus.off( 'process-event', eventHandler );
+	};
+
+	return { waitFor, dispose };
 }
 
 const messageActivityTrackers = new Map<
@@ -448,21 +468,26 @@ export async function runBlueprint(
 		serverConfig.enableDebugDisplay = true;
 	}
 
-	const processDesc = await startProcess( processName, wordPressServerChildPath );
+	const readyOrExit = await subscribeForReadyOrExit( processName );
 	try {
-		await waitForReadyMessage( processName, processDesc.pmId );
-		await sendMessage(
-			processDesc.pmId,
-			processName,
-			{
-				topic: 'run-blueprint',
-				data: { config: serverConfig },
-			},
-			{ logger }
-		);
+		const processDesc = await startProcess( processName, wordPressServerChildPath );
+		try {
+			await readyOrExit.waitFor( processDesc.pmId );
+			await sendMessage(
+				processDesc.pmId,
+				processName,
+				{
+					topic: 'run-blueprint',
+					data: { config: serverConfig },
+				},
+				{ logger }
+			);
+		} finally {
+			// Always stop the process after blueprint is applied
+			await stopProcess( processName );
+		}
 	} finally {
-		// Always stop the process after blueprint is applied
-		await stopProcess( processName );
+		readyOrExit.dispose();
 	}
 }
 

--- a/apps/cli/lib/wordpress-server-manager.ts
+++ b/apps/cli/lib/wordpress-server-manager.ts
@@ -4,6 +4,7 @@
  * Manages WordPress server processes via process manager daemon. Each site runs in a separate
  * process that spawns Playground CLI.
  */
+import fs from 'fs';
 import path from 'path';
 import {
 	PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL,
@@ -20,6 +21,7 @@ import {
 	type DaemonBusEventMap,
 	sendMessageToProcess,
 } from 'cli/lib/daemon-client';
+import { PROCESS_MANAGER_LOGS_DIR } from 'cli/lib/paths';
 import { ProcessDescription } from 'cli/lib/types/process-manager-ipc';
 import { ServerConfig, ManagerMessagePayload } from 'cli/lib/types/wordpress-server-ipc';
 import { Logger } from 'cli/logger';
@@ -118,7 +120,7 @@ export async function startWordPressServer(
 	}
 
 	const processDesc = await startProcess( processName, wordPressServerChildPath );
-	await waitForReadyMessage( processDesc.pmId );
+	await waitForReadyMessage( processName, processDesc.pmId );
 	await sendMessage(
 		processDesc.pmId,
 		processName,
@@ -132,11 +134,45 @@ export async function startWordPressServer(
 	return processDesc;
 }
 
-async function waitForReadyMessage( pmId: number ): Promise< void > {
+const CHILD_STDERR_TAIL_BYTES = 4096;
+
+function readChildStderrTail( processName: string ): string {
+	const errorLogPath = path.join( PROCESS_MANAGER_LOGS_DIR, `${ processName }-error.log` );
+	try {
+		const { size } = fs.statSync( errorLogPath );
+		if ( size === 0 ) {
+			return '';
+		}
+		const readBytes = Math.min( size, CHILD_STDERR_TAIL_BYTES );
+		const buffer = Buffer.alloc( readBytes );
+		const fd = fs.openSync( errorLogPath, 'r' );
+		try {
+			fs.readSync( fd, buffer, 0, readBytes, size - readBytes );
+		} finally {
+			fs.closeSync( fd );
+		}
+		return buffer.toString( 'utf8' ).trimEnd();
+	} catch {
+		return '';
+	}
+}
+
+function buildChildExitedError( processName: string ): Error {
+	const errorLogPath = path.join( PROCESS_MANAGER_LOGS_DIR, `${ processName }-error.log` );
+	const tail = readChildStderrTail( processName );
+	let message = `WordPress server child process exited before becoming ready. See ${ errorLogPath }`;
+	if ( tail ) {
+		message += `\n${ tail }`;
+	}
+	return new Error( message );
+}
+
+async function waitForReadyMessage( processName: string, pmId: number ): Promise< void > {
 	const bus = await getDaemonBus();
 
 	let timeoutId: NodeJS.Timeout;
 	let readyHandler: ( packet: DaemonBusEventMap[ 'process-message' ] ) => void;
+	let exitHandler: ( event: DaemonBusEventMap[ 'process-event' ] ) => void;
 	let abortListener: () => void;
 
 	return new Promise< void >( ( resolve, reject ) => {
@@ -148,16 +184,33 @@ async function waitForReadyMessage( pmId: number ): Promise< void > {
 				resolve();
 			}
 		};
+		exitHandler = ( event ) => {
+			if ( event.process.pm_id === pmId && event.event === 'exit' ) {
+				reject( buildChildExitedError( processName ) );
+			}
+		};
 		abortListener = () => {
 			reject( new Error( 'Operation aborted' ) );
 		};
 		abortController.signal.addEventListener( 'abort', abortListener );
 
 		bus.on( 'process-message', readyHandler );
+		bus.on( 'process-event', exitHandler );
+
+		// Guard against the race where the child exits between `startProcess` resolving and
+		// our listeners being attached: if the process is no longer running now, surface the
+		// error immediately rather than waiting for the ready-message timeout.
+		void ( async () => {
+			const running = await isProcessRunning( processName );
+			if ( ! running ) {
+				reject( buildChildExitedError( processName ) );
+			}
+		} )();
 	} ).finally( () => {
 		clearTimeout( timeoutId );
 		abortController.signal.removeEventListener( 'abort', abortListener );
 		bus.off( 'process-message', readyHandler );
+		bus.off( 'process-event', exitHandler );
 	} );
 }
 
@@ -397,7 +450,7 @@ export async function runBlueprint(
 
 	const processDesc = await startProcess( processName, wordPressServerChildPath );
 	try {
-		await waitForReadyMessage( processDesc.pmId );
+		await waitForReadyMessage( processName, processDesc.pmId );
 		await sendMessage(
 			processDesc.pmId,
 			processName,

--- a/apps/cli/process-manager-daemon.ts
+++ b/apps/cli/process-manager-daemon.ts
@@ -23,6 +23,11 @@ import { ManagerMessage } from 'cli/lib/types/wordpress-server-ipc';
 const SOCKET_TIMEOUT_MS = 2_500;
 const STOP_TIMEOUT_MS = 5_000;
 
+// In-memory tail of stderr kept per child so we can include the current invocation's error
+// output in the `exit` event. Bounded to avoid unbounded memory growth on chatty processes.
+const STDERR_BUFFER_MAX_LINES = 100;
+const STDERR_BUFFER_MAX_BYTES = 16 * 1024;
+
 type ManagedProcessBase = {
 	pmId: number;
 	name: string;
@@ -34,6 +39,8 @@ type ManagedProcessBase = {
 	stderrLogPath: string;
 	stdoutStream: WriteStream;
 	stderrStream: WriteStream;
+	stderrBuffer: string[];
+	stderrBufferBytes: number;
 	settled: boolean;
 };
 type ManagedProcessRunning = ManagedProcessBase & {
@@ -219,13 +226,17 @@ export class ProcessManagerDaemon {
 			stderrLogPath,
 			stdoutStream,
 			stderrStream,
+			stderrBuffer: [],
+			stderrBufferBytes: 0,
 			settled: false,
 		};
 
 		this.managedProcesses.set( pmId, managedProcess );
 
 		this.pipeOutputWithTimestamp( child.stdout, stdoutStream );
-		this.pipeOutputWithTimestamp( child.stderr, stderrStream );
+		this.pipeOutputWithTimestamp( child.stderr, stderrStream, ( line ) => {
+			this.recordStderrLine( managedProcess, line );
+		} );
 
 		child.on( 'message', ( raw ) => {
 			const event = daemonEventSchema.safeParse( {
@@ -242,7 +253,11 @@ export class ProcessManagerDaemon {
 		} );
 
 		child.on( 'error', ( error ) => {
-			writeTimestampedLines( stderrStream, error.stack ?? error.message );
+			const errorText = error.stack ?? error.message;
+			writeTimestampedLines( stderrStream, errorText );
+			for ( const line of errorText.split( '\n' ) ) {
+				this.recordStderrLine( managedProcess, line );
+			}
 			void this.handleProcessExit( managedProcess );
 		} );
 
@@ -300,11 +315,14 @@ export class ProcessManagerDaemon {
 		managedProcess.stdoutStream.end();
 		managedProcess.stderrStream.end();
 
+		const stderrTail = managedProcess.stderrBuffer.join( '\n' );
+
 		await this.broadcastEvent( {
 			type: 'process-event',
 			payload: {
 				process: { name: managedProcess.name, pm_id: managedProcess.pmId },
 				event: 'exit',
+				...( stderrTail ? { stderrTail } : {} ),
 			},
 		} );
 	}
@@ -336,7 +354,8 @@ export class ProcessManagerDaemon {
 
 	private pipeOutputWithTimestamp(
 		input: NodeJS.ReadableStream | null,
-		target: WriteStream
+		target: WriteStream,
+		onLine?: ( line: string ) => void
 	): void {
 		if ( ! input ) {
 			return;
@@ -349,7 +368,24 @@ export class ProcessManagerDaemon {
 
 		lineReader.on( 'line', ( line ) => {
 			void target.write( timestampLogLine( line ) );
+			onLine?.( line );
 		} );
+	}
+
+	private recordStderrLine( managedProcess: ManagedProcess, line: string ): void {
+		managedProcess.stderrBuffer.push( line );
+		managedProcess.stderrBufferBytes += Buffer.byteLength( line, 'utf8' ) + 1; // +1 for the joining newline
+
+		while (
+			managedProcess.stderrBuffer.length > STDERR_BUFFER_MAX_LINES ||
+			managedProcess.stderrBufferBytes > STDERR_BUFFER_MAX_BYTES
+		) {
+			const dropped = managedProcess.stderrBuffer.shift();
+			if ( dropped === undefined ) {
+				break;
+			}
+			managedProcess.stderrBufferBytes -= Buffer.byteLength( dropped, 'utf8' ) + 1;
+		}
 	}
 
 	private toProcessDescription( managedProcess: ManagedProcess ): ProcessDescription {

--- a/apps/cli/tests/daemon.test.ts
+++ b/apps/cli/tests/daemon.test.ts
@@ -121,6 +121,48 @@ describe( 'ProcessManagerDaemon', () => {
 		).toContain( 'fixture-stderr' );
 	} );
 
+	it( 'includes captured stderr in the exit event payload', async () => {
+		const child = new MockChildProcess();
+		spawnMock.mockReturnValue( child );
+		const { ProcessManagerDaemon } = await import( '../process-manager-daemon' );
+
+		const daemon = new ProcessManagerDaemon();
+		const daemonInternal = daemon as unknown as {
+			handleRequest: ( request: unknown ) => Promise< unknown >;
+			broadcastEvent: ( event: unknown ) => Promise< void >;
+		};
+		const broadcastSpy = vi
+			.spyOn( daemonInternal, 'broadcastEvent' )
+			.mockResolvedValue( undefined );
+
+		await daemonInternal.handleRequest( {
+			type: 'start-process',
+			requestId: '1',
+			processName: testProcessName,
+			scriptPath: '/tmp/test-child.js',
+			env: {},
+			args: [],
+		} );
+
+		child.stderr.write( 'SyntaxError: boom\n' );
+		child.stderr.write( '    at Module._compile\n' );
+		// Let readline consume the lines before triggering exit.
+		await new Promise( ( resolve ) => setTimeout( resolve, 25 ) );
+
+		child.emit( 'exit', 1 );
+		await new Promise( ( resolve ) => setTimeout( resolve, 25 ) );
+
+		const exitCall = broadcastSpy.mock.calls.find( ( [ event ] ) => {
+			const payload = ( event as { type: string; payload: { event: string } } ).payload;
+			return payload.event === 'exit';
+		} );
+
+		expect( exitCall ).toBeDefined();
+		const payload = ( exitCall![ 0 ] as { payload: { stderrTail?: string } } ).payload;
+		expect( payload.stderrTail ).toContain( 'SyntaxError: boom' );
+		expect( payload.stderrTail ).toContain( 'at Module._compile' );
+	} );
+
 	it( 'reuses duplicate starts, forwards messages, and resolves missing stops', async () => {
 		const child = new MockChildProcess();
 		spawnMock.mockReturnValue( child );


### PR DESCRIPTION
## Related issues

- Related to debugging local site start failures that surface as \"Failed to start WordPress server: Timeout waiting for ready message from WordPress server child\" after a 2-minute silent hang.

## How AI was used in this PR

Claude investigated a reproducible site-start failure by inspecting Studio logs, the daemon's pm2 log directory, and the child-process IPC flow. It identified the root cause (stale worktree `node_modules` + `wordpress-server-child.mjs` bundled against an incompatible `@php-wasm/cli-util`) and drafted this fix to make the failure actionable instead of silent. Reviewer focus: the new `process-event` subscription and the pre-listener race guard in `waitForReadyMessage`.

## Proposed Changes

- `waitForReadyMessage` now listens for `process-event` on the daemon bus and rejects with a helpful error when the child exits before sending `ready`.
- The error message includes the path to the child's stderr log plus the tail (up to 4 KB) of its contents — so users see the real stack trace (e.g. a `SyntaxError`) instead of a generic timeout.
- Added a race guard: immediately after attaching listeners we check `isProcessRunning(processName)`. If the child has already exited between `startProcess` resolving and our listeners attaching, we surface the error right away rather than waiting for the timeout.
- Unit tests cover both the exit-event path and the already-exited race path.

## Testing Instructions

Automated:

- `npm test -- apps/cli/lib/tests/wordpress-server-manager.test.ts` — 8 tests, all green.

Manual repro (simulates a crashing child):

1. `npm run cli:build`
2. Inject a fatal error at the top of the built child:
   \`\`\`
   printf 'throw new SyntaxError(\"forced crash for testing\");\n%s' \\
     \"\$(cat apps/cli/dist/cli/wordpress-server-child.mjs)\" \\
     > apps/cli/dist/cli/wordpress-server-child.mjs.tmp \\
     && mv apps/cli/dist/cli/wordpress-server-child.mjs.tmp \\
          apps/cli/dist/cli/wordpress-server-child.mjs
   \`\`\`
3. `node apps/cli/dist/cli/main.mjs site start <SITE_ID>`

**Before:** hangs ~2 minutes, then `Failed to start WordPress server: Timeout waiting for ready message…`
**After:** fails immediately with `WordPress server child process exited before becoming ready. See …/studio-site-<id>-error.log` plus the `SyntaxError: forced crash for testing` tail.

Restore with `npm run cli:build`.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?