### PR TITLE
apps/ui: wire into lint and vitest CI checks

### DIFF
--- a/apps/ui/src/components/create-site-form/index.tsx
+++ b/apps/ui/src/components/create-site-form/index.tsx
@@ -115,10 +115,7 @@ const { ValidatedInputControl } = unlock( componentsPrivateApis ) as {
  * Advanced toggle would falsely show "1 error found" until the user
  * expanded it and `PathField` mounted.
  */
-function usePathAutoGenerate(
-	data: FormData,
-	onChange: ( update: Partial< FormData > ) => void
-) {
+function usePathAutoGenerate( data: FormData, onChange: ( update: Partial< FormData > ) => void ) {
 	const { data: sites } = useSites();
 	const { generateProposedPath } = usePathValidator( sites );
 
@@ -185,14 +182,10 @@ function PathField( {
 			readOnly
 			onClick={ handleSelect }
 			className={ styles.pathControl }
-			customValidity={
-				errorMessage ? { type: 'invalid', message: errorMessage } : undefined
-			}
+			customValidity={ errorMessage ? { type: 'invalid', message: errorMessage } : undefined }
 			help={
 				<>
-					{ __(
-						'Select an empty directory or a directory with an existing WordPress site.'
-					) }{ ' ' }
+					{ __( 'Select an empty directory or a directory with an existing WordPress site.' ) }{ ' ' }
 					<LearnMoreLink docsLinksKey="docsSites" />
 				</>
 			}

--- a/apps/ui/src/components/markdown/index.tsx
+++ b/apps/ui/src/components/markdown/index.tsx
@@ -3,8 +3,8 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useConnector } from '@/data/core';
 import styles from './style.module.css';
-import type { Components } from 'react-markdown';
 import type { MouseEvent } from 'react';
+import type { Components } from 'react-markdown';
 
 const baseComponents: Components = {
 	h1: ( { children } ) => <h1 className={ styles.h1 }>{ children }</h1>,

--- a/apps/ui/vitest.config.ts
+++ b/apps/ui/vitest.config.ts
@@ -1,0 +1,20 @@
+import path from 'path';
+import { defineProject, mergeConfig } from 'vitest/config';
+import sharedConfig from '../../vitest.shared';
+
+export default mergeConfig(
+	sharedConfig,
+	defineProject( {
+		test: {
+			name: 'ui',
+			include: [ 'src/**/*.test.{ts,tsx}' ],
+			setupFiles: [ path.resolve( __dirname, './vitest.setup.ts' ) ],
+		},
+		resolve: {
+			alias: {
+				'@': path.resolve( __dirname, 'src' ),
+				'@studio/common': path.resolve( __dirname, '../../tools/common' ),
+			},
+		},
+	} )
+);

--- a/apps/ui/vitest.setup.ts
+++ b/apps/ui/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"cli:watch": "npm -w wp-studio run watch",
 		"app:install:bundle": "npm -w studio-app run install:bundle",
 		"compare:perf": "npm -w compare-perf run compare",
-		"lint": "eslint {apps/cli,apps/studio/src,apps/studio/e2e,tools/common}",
+		"lint": "eslint {apps/cli,apps/studio/src,apps/studio/e2e,apps/ui/src,tools/common}",
 		"typecheck": "npm run typecheck --workspaces --if-present && tsc -p scripts/tsconfig.json --noEmit",
 		"format": "npm run lint -- --fix",
 		"test": "vitest run",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig( {
 		projects: [
 			'./apps/cli/vitest.config.ts',
 			'./apps/studio/vitest.config.ts',
+			'./apps/ui/vitest.config.ts',
 			'./tools/common/vitest.config.ts',
 		],
 	},


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude Code drafted the config changes and auto-fixed the ESLint findings. I verified end-to-end by running the full `npm run lint`, `npm run typecheck -w @studio/ui`, and a temporary smoke test under the new vitest project (React + jsdom + `@testing-library/jest-dom`) before removing the smoke test.

## Proposed Changes

`apps/ui/src` was silently excluded from two CI gates that already covered `apps/studio/src`:

- `npm run lint` — the glob only included `{apps/cli,apps/studio/src,apps/studio/e2e,tools/common}`.
- `npm run test` — the root `vitest.config.ts` didn't list an `apps/ui` project, so any `*.test.tsx` added there would be silently ignored.

This PR closes both gaps:

- Add `apps/ui/src` to the `lint` script in `package.json`.
- Fix the 4 ESLint errors that surfaced once the config applied (3 `prettier/prettier` + 1 `import-x/order`, all `--fix`ed).
- Add `apps/ui/vitest.config.ts` and a minimal `apps/ui/vitest.setup.ts` that just imports `@testing-library/jest-dom/vitest`.
- Register the new project in the root `vitest.config.ts`.

Note: typecheck was already covered for `apps/ui` via `npm run typecheck --workspaces --if-present` (apps/ui has its own `typecheck` script).

Out of scope but flagged for later:
- Playwright's `testDir` is hard-coded to `apps/studio/e2e`; no E2E for apps/ui yet.
- `TEST_PATTERNS` in `.buildkite/commands/should-skip-job.sh` doesn't know about `apps/ui/**/*.test.ts` yet — only matters once tests exist there.

## Testing Instructions

- `npm run lint` passes with only a pre-existing warning in `apps/cli/lib/import-export/export/types.ts` (unrelated to this PR).
- `npm run typecheck -w @studio/ui` passes.
- `npm test` — the `ui` project runs and exits cleanly with no test files yet; adding a test file under `apps/ui/src/**/*.test.{ts,tsx}` picks it up (verified locally with a throwaway smoke test).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)