### PR TITLE
apps/ui: add WordPress "W" particle animation as empty-session background

### DIFF
--- a/apps/ui/src/components/session-view/empty-background/index.tsx
+++ b/apps/ui/src/components/session-view/empty-background/index.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useRef } from 'react';
+import styles from './style.module.css';
+
+// Standard WordPress "W-in-a-circle" mark. Rendered offscreen in black so the
+// particle sampler below can threshold against pixel brightness.
+const WP_LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="280" height="280" viewBox="0 0 122.52 122.523"><path fill="black" d="M8.708,61.26c0,20.802,12.089,38.779,29.619,47.298L13.258,40.165C10.342,46.698,8.708,53.785,8.708,61.26z M96.74,58.608c0-6.495-2.333-10.993-4.334-14.494c-2.664-4.329-5.161-7.995-5.161-12.324c0-4.831,3.664-9.328,8.825-9.328c0.233,0,0.454,0.029,0.681,0.042c-9.35-8.566-21.807-13.796-35.489-13.796c-18.36,0-34.513,9.42-43.91,23.688c1.233,0.037,2.395,0.063,3.382,0.063c5.497,0,14.006-0.667,14.006-0.667c2.833-0.167,3.167,3.994,0.337,4.329c0,0-2.847,0.335-6.015,0.501l19.138,56.925L60.718,72.15l-8.181-22.414c-2.83-0.166-5.511-0.501-5.511-0.501c-2.832-0.166-2.5-4.496,0.332-4.329c0,0,8.679,0.667,13.843,0.667c5.496,0,14.006-0.667,14.006-0.667c2.835-0.167,3.168,3.994,0.337,4.329c0,0-2.853,0.335-6.015,0.501l18.992,56.494l5.242-17.517C95.948,70.801,96.74,64.348,96.74,58.608z M62.184,65.92l-15.768,45.817c4.708,1.384,9.687,2.141,14.846,2.141c6.12,0,11.989-1.058,17.452-2.979c-0.141-0.225-0.269-0.464-0.374-0.724L62.184,65.92z M107.376,36.151c0.23,1.707,0.36,3.538,0.36,5.51c0,5.438-1.018,11.551-4.081,19.192l-16.386,47.38c15.954-9.3,26.69-26.595,26.69-46.396C113.958,52.503,111.596,43.752,107.376,36.151z M61.262,0C27.477,0,0,27.476,0,61.26c0,33.787,27.477,61.263,61.262,61.263c33.783,0,61.265-27.476,61.265-61.263C122.526,27.476,95.045,0,61.262,0z M61.262,119.715c-32.23,0-58.453-26.223-58.453-58.455c0-32.23,26.222-58.451,58.453-58.451c32.229,0,58.45,26.221,58.45,58.451C119.712,93.492,93.491,119.715,61.262,119.715z"/></svg>`;
+
+const LOGO_SIZE = 280;
+const PAD = 100;
+const CANVAS_SIZE = LOGO_SIZE + PAD * 2;
+const SAMPLE_STEP = 5;
+const DOT_SIZE = 5;
+const REPEL_RADIUS = 120;
+const REPEL_MAX = 28;
+const PULL_RADIUS = 120;
+const PULL_MAX = 6;
+const COLOR = 'rgb(30, 95, 184)';
+
+type Particle = { x: number; y: number; hx: number; hy: number };
+
+export function EmptyBackground() {
+	const canvasRef = useRef< HTMLCanvasElement >( null );
+
+	useEffect( () => {
+		const canvas = canvasRef.current;
+		if ( ! canvas ) {
+			return;
+		}
+
+		const dpr = window.devicePixelRatio || 1;
+		canvas.width = CANVAS_SIZE * dpr;
+		canvas.height = CANVAS_SIZE * dpr;
+		canvas.style.width = `${ CANVAS_SIZE }px`;
+		canvas.style.height = `${ CANVAS_SIZE }px`;
+		const ctx = canvas.getContext( '2d' );
+		if ( ! ctx ) {
+			return;
+		}
+		ctx.scale( dpr, dpr );
+
+		const particles: Particle[] = [];
+		let mouseX = -9999;
+		let mouseY = -9999;
+		let hover = false;
+		let raf = 0;
+		let cancelled = false;
+
+		const off = document.createElement( 'canvas' );
+		off.width = LOGO_SIZE;
+		off.height = LOGO_SIZE;
+		const offCtx = off.getContext( '2d', { willReadFrequently: true } );
+		if ( ! offCtx ) {
+			return;
+		}
+
+		const img = new Image();
+		img.onload = () => {
+			if ( cancelled ) {
+				return;
+			}
+			const scale = Math.min( LOGO_SIZE / img.width, LOGO_SIZE / img.height ) * 0.92;
+			const drawW = img.width * scale;
+			const drawH = img.height * scale;
+			const insetX = ( LOGO_SIZE - drawW ) / 2;
+			const insetY = ( LOGO_SIZE - drawH ) / 2;
+
+			offCtx.clearRect( 0, 0, LOGO_SIZE, LOGO_SIZE );
+			offCtx.drawImage( img, insetX, insetY, drawW, drawH );
+			const { data } = offCtx.getImageData( 0, 0, LOGO_SIZE, LOGO_SIZE );
+
+			for ( let y = 0; y < LOGO_SIZE; y += SAMPLE_STEP ) {
+				for ( let x = 0; x < LOGO_SIZE; x += SAMPLE_STEP ) {
+					const idx = 4 * ( y * LOGO_SIZE + x );
+					const a = data[ idx + 3 ];
+					const brightness = ( data[ idx ] + data[ idx + 1 ] + data[ idx + 2 ] ) / 3;
+					if ( a > 128 && brightness < 140 ) {
+						particles.push( {
+							x: PAD + x,
+							y: PAD + y,
+							hx: PAD + x,
+							hy: PAD + y,
+						} );
+					}
+				}
+			}
+
+			const tick = () => {
+				ctx.clearRect( 0, 0, CANVAS_SIZE, CANVAS_SIZE );
+				ctx.fillStyle = COLOR;
+				for ( const pt of particles ) {
+					const dx = pt.x - mouseX;
+					const dy = pt.y - mouseY;
+					const d = Math.hypot( dx, dy ) || 0.0001;
+					const hdx = pt.hx - pt.x;
+					const hdy = pt.hy - pt.y;
+					const dh = Math.hypot( hdx, hdy ) || 0.0001;
+
+					const push = hover
+						? Math.max( 0, Math.min( REPEL_MAX, REPEL_MAX - ( d * REPEL_MAX ) / REPEL_RADIUS ) )
+						: 0;
+					const pull = Math.min( PULL_MAX, ( dh * PULL_MAX ) / PULL_RADIUS );
+
+					pt.x += ( dx / d ) * push + ( hdx / dh ) * pull;
+					pt.y += ( dy / d ) * push + ( hdy / dh ) * pull;
+
+					ctx.fillRect( pt.x - DOT_SIZE / 2, pt.y - DOT_SIZE / 2, DOT_SIZE, DOT_SIZE );
+				}
+				raf = requestAnimationFrame( tick );
+			};
+			tick();
+		};
+		img.src = `data:image/svg+xml;utf8,${ encodeURIComponent( WP_LOGO_SVG ) }`;
+
+		const onMove = ( event: MouseEvent ) => {
+			const rect = canvas.getBoundingClientRect();
+			mouseX = event.clientX - rect.left;
+			mouseY = event.clientY - rect.top;
+		};
+		const onEnter = () => {
+			hover = true;
+		};
+		const onLeave = () => {
+			hover = false;
+			mouseX = -9999;
+			mouseY = -9999;
+		};
+		canvas.addEventListener( 'mousemove', onMove );
+		canvas.addEventListener( 'mouseenter', onEnter );
+		canvas.addEventListener( 'mouseleave', onLeave );
+
+		return () => {
+			cancelled = true;
+			cancelAnimationFrame( raf );
+			canvas.removeEventListener( 'mousemove', onMove );
+			canvas.removeEventListener( 'mouseenter', onEnter );
+			canvas.removeEventListener( 'mouseleave', onLeave );
+		};
+	}, [] );
+
+	return (
+		<div className={ styles.root } aria-hidden="true">
+			<canvas ref={ canvasRef } className={ styles.canvas } />
+		</div>
+	);
+}

--- a/apps/ui/src/components/session-view/empty-background/style.module.css
+++ b/apps/ui/src/components/session-view/empty-background/style.module.css
@@ -1,0 +1,14 @@
+.root {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	pointer-events: none;
+}
+
+.canvas {
+	pointer-events: auto;
+	max-width: 100%;
+	max-height: 100%;
+}

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -6,6 +6,7 @@ import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 import { Composer } from '@/components/session-view/composer';
 import { pickLiveSite } from '@/components/session-view/composer/environment-pill';
 import { Conversation } from '@/components/session-view/conversation';
+import { EmptyBackground } from '@/components/session-view/empty-background';
 import { QueuedPrompts } from '@/components/session-view/queued-prompts';
 import { SiteDropdown } from '@/components/site-dropdown';
 import { useConnector } from '@/data/core';
@@ -109,6 +110,10 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 		[ pendingQuestions ]
 	);
 	const composerBusy = hasActiveRun || pendingQuestions.length > 0;
+	const isEmpty = useMemo(
+		() => ! ( data?.events ?? [] ).some( ( event ) => event.type === 'user.message' ),
+		[ data?.events ]
+	);
 	const scrollRef = useRef< HTMLDivElement >( null );
 
 	useLayoutEffect( () => {
@@ -140,6 +145,7 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 		<div className={ styles.root }>
 			<SessionHeader summary={ data.summary } />
 			<div ref={ scrollRef } className={ styles.scroll }>
+				{ isEmpty ? <EmptyBackground /> : null }
 				<div className={ clsx( styles.column, styles.conversationSpacing ) }>
 					<Conversation
 						data={ data }

--- a/apps/ui/src/components/session-view/style.module.css
+++ b/apps/ui/src/components/session-view/style.module.css
@@ -63,6 +63,7 @@
 	flex: 1;
 	min-height: 0;
 	overflow-y: auto;
+	position: relative;
 	padding: 0 var(--wpds-dimension-padding-xl);
 	/* Reserve scrollbar space symmetrically so the centered 760px column
 	   doesn't shift left when the scrollbar appears — keeping it aligned


### PR DESCRIPTION
## Related issues

- Related to the Studio Desktop UI exploration mockup

## How AI was used in this PR

The particle animation was adapted from a mockup that used a p5.js sketch. I re-implemented it with a plain `<canvas>` (no new dependencies) and wired it into `SessionView` behind the conversation column. The WordPress "W-in-a-circle" glyph is inlined as an SVG, sampled into particles, then animated with `requestAnimationFrame` — particles repel from the cursor on hover and ease back toward their home positions.

## Proposed Changes

- New `EmptyBackground` component at `apps/ui/src/components/session-view/empty-background/` — canvas that samples a WordPress logo SVG into ~1k blue dots and animates them with a mouse-repel + spring-to-home effect.
- `SessionView` renders it inside the scroll area only while the session has no `user.message` events (i.e. no prompt sent yet). As soon as the first prompt goes out, it disappears.
- `.scroll` gets `position: relative` so the absolutely-positioned background can sit behind the conversation column without affecting layout.

## Testing Instructions

1. `npm start`
2. Open the app and create a new chat on any site (sidebar → New chat, or `/sites/$siteId/new`).
3. The empty session view should show a blue, pixelated WordPress "W" roughly centered in the chat area.
4. Move the cursor over it — particles should push away from the cursor and settle back to their home positions after it leaves.
5. Send a prompt. The background should disappear as soon as the conversation has any message, and should not reappear for the rest of that session.
6. Navigating back to the empty state (another new chat) should show it again.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?