### PR TITLE
apps/ui: add per-site settings page

### DIFF
--- a/apps/studio/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/apps/studio/src/modules/cli/lib/cli-events-subscriber.ts
@@ -13,13 +13,46 @@ import { captureSiteThumbnail } from 'src/lib/capture-site-thumbnail';
 import { executeCliCommand } from 'src/modules/cli/lib/execute-command';
 import { SiteServer } from 'src/site-server';
 
+// Fields owned by Studio that the CLI never emits and that must survive a
+// site-event merge (TLS material, renderer-computed theme info, sort order,
+// transient runtime flags).
+const STUDIO_ONLY_DETAIL_KEYS = [
+	'tlsKey',
+	'tlsCert',
+	'themeDetails',
+	'sortOrder',
+	'isAddingSite',
+	'latestCliPid',
+] as const satisfies readonly ( keyof SiteServer[ 'details' ] )[];
+
+function pickStudioOnlyDetails( details?: SiteServer[ 'details' ] ) {
+	if ( ! details ) {
+		return {} as Partial< SiteServer[ 'details' ] >;
+	}
+	const picked: Partial< SiteServer[ 'details' ] > = {};
+	for ( const key of STUDIO_ONLY_DETAIL_KEYS ) {
+		const value = details[ key ];
+		if ( value !== undefined ) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			( picked as any )[ key ] = value;
+		}
+	}
+	return picked;
+}
+
+// The CLI event is the authoritative snapshot for every field in the shared
+// `siteDetailsSchema`. JSON serialization drops `undefined` values, so a
+// field that's been cleared (e.g. `customDomain` after `site set --domain ''`)
+// arrives here as an absent key. Spreading `...existingDetails` first would
+// then preserve the stale value. Invert the merge: start from Studio-only
+// fields, then let the CLI payload set or omit everything else.
 function siteDetailsToServerDetails(
 	site: SiteDetails,
 	running: boolean,
 	existingDetails?: SiteServer[ 'details' ]
 ): SiteServer[ 'details' ] {
 	return {
-		...existingDetails,
+		...pickStudioOnlyDetails( existingDetails ),
 		...site,
 		running,
 	};

--- a/apps/ui/src/components/create-site-form/index.tsx
+++ b/apps/ui/src/components/create-site-form/index.tsx
@@ -1,14 +1,7 @@
 import { DEFAULT_WORDPRESS_VERSION } from '@studio/common/constants';
-import {
-	generateCustomDomainFromSiteName,
-	getDomainNameValidationError,
-} from '@studio/common/lib/domains';
-import {
-	generatePassword,
-	validateAdminEmail,
-	validateAdminUsername,
-} from '@studio/common/lib/passwords';
-import { RecommendedPHPVersion, SupportedPHPVersions } from '@studio/common/types/php-versions';
+import { generateCustomDomainFromSiteName } from '@studio/common/lib/domains';
+import { generatePassword } from '@studio/common/lib/passwords';
+import { RecommendedPHPVersion } from '@studio/common/types/php-versions';
 import {
 	CheckboxControl,
 	privateApis as componentsPrivateApis,
@@ -20,6 +13,16 @@ import { chevronDown, chevronRight } from '@wordpress/icons';
 import { Button, Icon } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LearnHowLink, LearnMoreLink } from '@/components/learn-more';
+import {
+	adminEmailField,
+	adminPasswordField,
+	adminUsernameField,
+	customDomainField,
+	phpVersionField,
+	siteNameField,
+	customDomainToggleField,
+	wpVersionField,
+} from '@/components/site-fields';
 import { usePathValidator } from '@/data/queries/use-create-site-helpers';
 import { useSites } from '@/data/queries/use-sites';
 import { unlock } from '@/lock-unlock';
@@ -80,11 +83,6 @@ interface FormData {
 	adminPassword: string;
 	adminEmail: string;
 }
-
-const PHP_VERSION_ELEMENTS = SupportedPHPVersions.map( ( version ) => ( {
-	value: version,
-	label: version,
-} ) );
 
 // ValidatedInputControl is the same private-API control DataForm's built-in
 // `text`/`email`/`password` Edit components use, so wiring the path field
@@ -289,12 +287,7 @@ export function CreateSiteForm( {
 
 	const fields = useMemo< Field< FormData >[] >(
 		() => [
-			{
-				id: 'name',
-				type: 'text',
-				label: __( 'Site name' ),
-				isValid: { required: true },
-			},
+			siteNameField< FormData >(),
 			{
 				id: 'path',
 				label: __( 'Local path' ),
@@ -304,63 +297,13 @@ export function CreateSiteForm( {
 					custom: ( item: FormData ) => item.pathError || null,
 				},
 			},
-			{
-				id: 'phpVersion',
-				type: 'text',
-				label: __( 'PHP version' ),
-				elements: PHP_VERSION_ELEMENTS,
-			},
-			{
-				id: 'wpVersion',
-				type: 'text',
-				label: __( 'WordPress version' ),
-				placeholder: DEFAULT_WORDPRESS_VERSION,
-			},
-			{
-				id: 'adminUsername',
-				type: 'text',
-				label: __( 'Admin username' ),
-				isValid: {
-					required: true,
-					custom: ( item: FormData ) => validateAdminUsername( item.adminUsername ) || null,
-				},
-			},
-			{
-				id: 'adminPassword',
-				type: 'password',
-				label: __( 'Admin password' ),
-				isValid: { required: true },
-			},
-			{
-				id: 'adminEmail',
-				type: 'email',
-				label: __( 'Admin email' ),
-				isValid: {
-					required: true,
-					custom: ( item: FormData ) => validateAdminEmail( item.adminEmail ) || null,
-				},
-			},
-			{
-				id: 'useCustomDomain',
-				type: 'boolean',
-				label: __( 'Use custom domain' ),
-				description: __( 'Your system password will be required to set up the domain.' ),
-			},
-			{
-				id: 'customDomain',
-				type: 'text',
-				label: __( 'Domain name' ),
-				isVisible: ( item: FormData ) => item.useCustomDomain,
-				isValid: {
-					custom: ( item: FormData ) => {
-						const value = item.customDomain || generateCustomDomainFromSiteName( item.name );
-						return (
-							getDomainNameValidationError( item.useCustomDomain, value, existingDomainNames ) ||
-							null
-						);
-					},
-				},
-			},
+			phpVersionField< FormData >(),
+			wpVersionField< FormData >( DEFAULT_WORDPRESS_VERSION ),
+			adminUsernameField< FormData >(),
+			adminPasswordField< FormData >(),
+			adminEmailField< FormData >(),
+			customDomainToggleField< FormData >(),
+			customDomainField< FormData >( existingDomainNames ),
 			{
 				id: 'enableHttps',
 				type: 'boolean',

--- a/apps/ui/src/components/site-fields/index.ts
+++ b/apps/ui/src/components/site-fields/index.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared DataForm field builders used by both the create-site form and the
+ * site-settings form. Field IDs are fixed (so consumers must use the matching
+ * keys in their form data), but the generic `T` parameter keeps per-form type
+ * safety when `isValid.custom` / `isVisible` need to read other fields on the
+ * same record.
+ */
+
+import {
+	generateCustomDomainFromSiteName,
+	getDomainNameValidationError,
+} from '@studio/common/lib/domains';
+import { validateAdminEmail, validateAdminUsername } from '@studio/common/lib/passwords';
+import { SupportedPHPVersions } from '@studio/common/types/php-versions';
+import { __ } from '@wordpress/i18n';
+import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
+import type { Field } from '@wordpress/dataviews';
+
+const PHP_VERSION_ELEMENTS = SupportedPHPVersions.map( ( version ) => ( {
+	value: version,
+	label: version,
+} ) );
+
+export function siteNameField< T extends { name: string } >(): Field< T > {
+	return {
+		id: 'name',
+		type: 'text',
+		label: __( 'Site name' ),
+		isValid: { required: true },
+	};
+}
+
+export function phpVersionField< T extends { phpVersion: SupportedPHPVersion } >(): Field< T > {
+	return {
+		id: 'phpVersion',
+		type: 'text',
+		label: __( 'PHP version' ),
+		elements: PHP_VERSION_ELEMENTS,
+	};
+}
+
+export function wpVersionField< T extends { wpVersion: string } >(
+	placeholder: string
+): Field< T > {
+	return {
+		id: 'wpVersion',
+		type: 'text',
+		label: __( 'WordPress version' ),
+		placeholder,
+	};
+}
+
+export function adminUsernameField< T extends { adminUsername: string } >(): Field< T > {
+	return {
+		id: 'adminUsername',
+		type: 'text',
+		label: __( 'Admin username' ),
+		isValid: {
+			required: true,
+			custom: ( item: T ) => validateAdminUsername( item.adminUsername ) || null,
+		},
+	};
+}
+
+export function adminPasswordField< T extends { adminPassword: string } >(): Field< T > {
+	return {
+		id: 'adminPassword',
+		type: 'password',
+		label: __( 'Admin password' ),
+		isValid: { required: true },
+	};
+}
+
+export function adminEmailField< T extends { adminEmail: string } >(): Field< T > {
+	return {
+		id: 'adminEmail',
+		type: 'email',
+		label: __( 'Admin email' ),
+		isValid: {
+			required: true,
+			custom: ( item: T ) => validateAdminEmail( item.adminEmail ) || null,
+		},
+	};
+}
+
+// Builds the "use custom domain" boolean field. Named `customDomainToggleField`
+// (not `useCustomDomainField`) so the react-hooks/rules-of-hooks rule doesn't
+// flag it as a hook.
+export function customDomainToggleField< T extends { useCustomDomain: boolean } >(): Field< T > {
+	return {
+		id: 'useCustomDomain',
+		type: 'boolean',
+		label: __( 'Use custom domain' ),
+		description: __( 'Your system password will be required to set up the domain.' ),
+	};
+}
+
+/**
+ * Builder for the domain-name text field. The existing-domains list is passed
+ * in (not read from a hook) so the same field definition works in both the
+ * create and settings forms — each form fetches the list with its own filter
+ * rules (e.g. settings excludes the current site's domain).
+ */
+export function customDomainField<
+	T extends { useCustomDomain: boolean; customDomain: string; name: string },
+>( existingDomainNames: string[] ): Field< T > {
+	return {
+		id: 'customDomain',
+		type: 'text',
+		label: __( 'Domain name' ),
+		isVisible: ( item: T ) => item.useCustomDomain,
+		isValid: {
+			custom: ( item: T ) => {
+				const value = item.customDomain || generateCustomDomainFromSiteName( item.name );
+				return (
+					getDomainNameValidationError( item.useCustomDomain, value, existingDomainNames ) || null
+				);
+			},
+		},
+	};
+}
+
+export function enableXdebugField< T extends { enableXdebug: boolean } >( {
+	conflictingSiteName,
+}: { conflictingSiteName?: string } = {} ): Field< T > {
+	return {
+		id: 'enableXdebug',
+		type: 'boolean',
+		label: __( 'Enable Xdebug' ),
+		description: conflictingSiteName
+			? /* translators: %s: other site's name */
+			  `${ __( 'Xdebug is enabled on another site:' ) } ${ conflictingSiteName }`
+			: __( 'Enable PHP debugging with Xdebug. Only one site can have Xdebug enabled at a time.' ),
+	};
+}
+
+export function enableDebugLogField< T extends { enableDebugLog: boolean } >(): Field< T > {
+	return {
+		id: 'enableDebugLog',
+		type: 'boolean',
+		label: __( 'Enable debug log' ),
+		description: __(
+			"Log PHP errors and warnings to a debug.log file in your site's wp-content directory."
+		),
+	};
+}
+
+export function enableDebugDisplayField< T extends { enableDebugDisplay: boolean } >(): Field< T > {
+	return {
+		id: 'enableDebugDisplay',
+		type: 'boolean',
+		label: __( 'Show errors in browser' ),
+		description: __( 'Display PHP errors and warnings directly in the browser.' ),
+	};
+}

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -124,6 +124,7 @@ function NewSessionButton( { site }: { site: SiteDetails } ) {
 }
 
 function SiteActionsMenu( { site }: { site: SiteDetails } ) {
+	const navigate = useNavigate();
 	const startSite = useStartSite();
 	const stopSite = useStopSite();
 	const isStarting = useIsSiteStarting( site.id );
@@ -154,6 +155,17 @@ function SiteActionsMenu( { site }: { site: SiteDetails } ) {
 						{ isStarting ? __( 'Starting…' ) : __( 'Start site' ) }
 					</Menu.Item>
 				) }
+				<Menu.Separator />
+				<Menu.Item
+					onClick={ () =>
+						void navigate( {
+							to: '/sites/$siteId/settings',
+							params: { siteId: site.id },
+						} )
+					}
+				>
+					{ __( 'Site settings' ) }
+				</Menu.Item>
 			</Menu.Popup>
 		</Menu.Root>
 	);

--- a/apps/ui/src/components/site-settings-view/index.tsx
+++ b/apps/ui/src/components/site-settings-view/index.tsx
@@ -1,0 +1,365 @@
+import { DEFAULT_WORDPRESS_VERSION } from '@studio/common/constants';
+import { generateCustomDomainFromSiteName } from '@studio/common/lib/domains';
+import { decodePassword, encodePassword } from '@studio/common/lib/passwords';
+import { RecommendedPHPVersion } from '@studio/common/types/php-versions';
+import { CheckboxControl } from '@wordpress/components';
+import { DataForm, useFormValidity } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { LearnHowLink } from '@/components/learn-more';
+import { SiteDropdown } from '@/components/site-dropdown';
+import {
+	adminEmailField,
+	adminPasswordField,
+	adminUsernameField,
+	customDomainField,
+	customDomainToggleField,
+	enableDebugDisplayField,
+	enableDebugLogField,
+	enableXdebugField,
+	phpVersionField,
+	siteNameField,
+	wpVersionField,
+} from '@/components/site-fields';
+import * as Tabs from '@/components/tabs';
+import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
+import { useSites, useUpdateSite, useXdebugEnabledSite } from '@/data/queries/use-sites';
+import { useFullscreen } from '@/hooks/use-fullscreen';
+import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
+import styles from './style.module.css';
+import type { SiteDetails } from '@/data/core';
+import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
+import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
+import type { FormEvent } from 'react';
+
+type TabId = 'general' | 'debugging';
+
+interface FormData {
+	name: string;
+	phpVersion: SupportedPHPVersion;
+	// Empty string means "auto-update" — we map that back to
+	// DEFAULT_WORDPRESS_VERSION when building the updated site payload.
+	wpVersion: string;
+	useCustomDomain: boolean;
+	customDomain: string;
+	enableHttps: boolean;
+	adminUsername: string;
+	adminPassword: string;
+	adminEmail: string;
+	enableXdebug: boolean;
+	enableDebugLog: boolean;
+	enableDebugDisplay: boolean;
+}
+
+function getEffectiveWpVersion( site: SiteDetails | undefined ): string {
+	// Mirrors the legacy apps/studio behavior: sites created before the auto-
+	// updating flag existed fall through to the default too.
+	return site?.isWpAutoUpdating !== false ? '' : DEFAULT_WORDPRESS_VERSION;
+}
+
+function initialFormData( site: SiteDetails ): FormData {
+	return {
+		name: site.name,
+		phpVersion: ( site.phpVersion as SupportedPHPVersion ) ?? RecommendedPHPVersion,
+		wpVersion: getEffectiveWpVersion( site ),
+		useCustomDomain: Boolean( site.customDomain ),
+		customDomain: site.customDomain ?? '',
+		enableHttps: site.enableHttps ?? false,
+		adminUsername: site.adminUsername ?? 'admin',
+		adminPassword: decodePassword( site.adminPassword ?? '' ) || 'password',
+		adminEmail: site.adminEmail || 'admin@localhost.com',
+		enableXdebug: site.enableXdebug ?? false,
+		enableDebugLog: site.enableDebugLog ?? false,
+		enableDebugDisplay: site.enableDebugDisplay ?? false,
+	};
+}
+
+function SettingsHeader( { site }: { site: SiteDetails } ) {
+	const sidebarCollapsed = useSidebarCollapsed();
+	const isFullscreen = useFullscreen();
+	const toggleSpacerClass = sidebarCollapsed
+		? isFullscreen
+			? styles.toggleSpacerFullscreen
+			: styles.toggleSpacer
+		: null;
+	return (
+		<div className={ styles.header }>
+			{ toggleSpacerClass ? <span className={ toggleSpacerClass } aria-hidden="true" /> : null }
+			<SiteDropdown site={ site } />
+		</div>
+	);
+}
+
+function EnableHttpsControl( { data: item, field, onChange }: DataFormControlProps< FormData > ) {
+	return (
+		<CheckboxControl
+			__nextHasNoMarginBottom
+			label={ field.label }
+			checked={ item.enableHttps }
+			onChange={ ( checked ) => onChange( { enableHttps: checked } ) }
+			help={
+				<>
+					{ __(
+						'You need to manually add the Studio root certificate authority to your keychain and trust it to enable HTTPS.'
+					) }{ ' ' }
+					<LearnHowLink docsLinksKey="docsSslInStudio" />
+				</>
+			}
+		/>
+	);
+}
+
+export function SiteSettingsView( {
+	siteId,
+	activeTab,
+	onTabChange,
+}: {
+	siteId: string;
+	activeTab: TabId;
+	onTabChange: ( tab: TabId ) => void;
+} ) {
+	const { data: sites, isLoading: sitesLoading } = useSites();
+	const site = sites?.find( ( candidate ) => candidate.id === siteId );
+
+	if ( sitesLoading ) {
+		return <div className={ styles.state }>{ __( 'Loading…' ) }</div>;
+	}
+
+	if ( ! site ) {
+		return (
+			<div className={ styles.state }>
+				<h1>{ __( 'Site not found' ) }</h1>
+				<p>{ siteId }</p>
+			</div>
+		);
+	}
+
+	return <SiteSettingsBody site={ site } activeTab={ activeTab } onTabChange={ onTabChange } />;
+}
+
+function SiteSettingsBody( {
+	site,
+	activeTab,
+	onTabChange,
+}: {
+	site: SiteDetails;
+	activeTab: TabId;
+	onTabChange: ( tab: TabId ) => void;
+} ) {
+	const { data: allDomains } = useExistingCustomDomains();
+	const existingDomainNames = useMemo(
+		() => ( allDomains ?? [] ).filter( ( domain ) => domain !== site.customDomain ),
+		[ allDomains, site.customDomain ]
+	);
+	const { data: xdebugEnabledSite } = useXdebugEnabledSite();
+	const xdebugConflictSiteName =
+		xdebugEnabledSite && xdebugEnabledSite.id !== site.id ? xdebugEnabledSite.name : undefined;
+
+	const updateSite = useUpdateSite();
+	const [ submitError, setSubmitError ] = useState< string | null >( null );
+
+	const [ data, setData ] = useState< FormData >( () => initialFormData( site ) );
+	// Re-seed the form when the underlying site changes — e.g. after a save,
+	// or after another window edits it. React Query returns a new `site`
+	// reference on every refetch, so object identity is enough.
+	useEffect( () => {
+		setData( initialFormData( site ) );
+		setSubmitError( null );
+	}, [ site ] );
+
+	const fields = useMemo< Field< FormData >[] >(
+		() => [
+			siteNameField< FormData >(),
+			phpVersionField< FormData >(),
+			wpVersionField< FormData >( DEFAULT_WORDPRESS_VERSION ),
+			adminUsernameField< FormData >(),
+			adminPasswordField< FormData >(),
+			adminEmailField< FormData >(),
+			customDomainToggleField< FormData >(),
+			customDomainField< FormData >( existingDomainNames ),
+			{
+				id: 'enableHttps',
+				type: 'boolean',
+				label: __( 'Enable HTTPS' ),
+				isVisible: ( item: FormData ) => item.useCustomDomain,
+				Edit: EnableHttpsControl,
+			},
+			enableXdebugField< FormData >( { conflictingSiteName: xdebugConflictSiteName } ),
+			enableDebugLogField< FormData >(),
+			enableDebugDisplayField< FormData >(),
+		],
+		[ existingDomainNames, xdebugConflictSiteName ]
+	);
+
+	const generalForm = useMemo< Form >(
+		() => ( {
+			layout: { type: 'regular', labelPosition: 'top' },
+			fields: [
+				'name',
+				{
+					id: 'versions',
+					layout: { type: 'row' },
+					children: [ 'phpVersion', 'wpVersion' ],
+				},
+				{
+					id: 'adminCredentials',
+					layout: { type: 'row' },
+					children: [ 'adminUsername', 'adminPassword' ],
+				},
+				'adminEmail',
+				'useCustomDomain',
+				'customDomain',
+				'enableHttps',
+			],
+		} ),
+		[]
+	);
+	const debuggingForm = useMemo< Form >(
+		() => ( {
+			layout: { type: 'regular', labelPosition: 'top' },
+			fields: [ 'enableXdebug', 'enableDebugLog', 'enableDebugDisplay' ],
+		} ),
+		[]
+	);
+	const fullForm = useMemo< Form >(
+		() => ( {
+			layout: { type: 'regular', labelPosition: 'top' },
+			fields: [ ...generalForm.fields!, ...debuggingForm.fields! ],
+		} ),
+		[ generalForm, debuggingForm ]
+	);
+
+	const { validity, isValid } = useFormValidity( data, fields, fullForm );
+
+	const handleChange = useCallback( ( update: Record< string, unknown > ) => {
+		setData( ( prev ) => {
+			const next: FormData = { ...prev, ...( update as Partial< FormData > ) };
+			// When the user toggles custom domain on for the first time, seed
+			// the input with a default derived from the current site name.
+			if ( ! prev.useCustomDomain && next.useCustomDomain && ! next.customDomain ) {
+				next.customDomain = generateCustomDomainFromSiteName( next.name );
+			}
+			return next;
+		} );
+	}, [] );
+
+	const initial = useMemo( () => initialFormData( site ), [ site ] );
+	const isUnchanged = useMemo(
+		() =>
+			( Object.keys( initial ) as Array< keyof FormData > ).every(
+				( key ) => initial[ key ] === data[ key ]
+			),
+		[ data, initial ]
+	);
+
+	const xdebugBlocked = data.enableXdebug && !! xdebugConflictSiteName && ! site.enableXdebug;
+	const canSubmit = isValid && ! isUnchanged && ! updateSite.isPending && ! xdebugBlocked;
+
+	const handleSubmit = ( event: FormEvent ) => {
+		event.preventDefault();
+		if ( ! canSubmit ) return;
+		setSubmitError( null );
+		const usedCustomDomain = data.useCustomDomain
+			? data.customDomain || generateCustomDomainFromSiteName( data.name )
+			: undefined;
+		const wpPinned = data.wpVersion.trim();
+		const updated: SiteDetails = {
+			...site,
+			name: data.name,
+			phpVersion: data.phpVersion,
+			isWpAutoUpdating: ! wpPinned,
+			customDomain: usedCustomDomain,
+			enableHttps: !! usedCustomDomain && data.enableHttps,
+			adminUsername: data.adminUsername,
+			adminPassword: encodePassword( data.adminPassword ),
+			adminEmail: data.adminEmail,
+			enableXdebug: data.enableXdebug,
+			enableDebugLog: data.enableDebugLog,
+			enableDebugDisplay: data.enableDebugDisplay,
+		};
+		updateSite.mutate(
+			{ site: updated, wpVersion: wpPinned || undefined },
+			{
+				onError: ( error ) => {
+					setSubmitError( ( error as Error ).message ?? __( 'Unable to save changes.' ) );
+				},
+			}
+		);
+	};
+
+	return (
+		<div className={ styles.root }>
+			<SettingsHeader site={ site } />
+			<Tabs.Root
+				selectedTabId={ activeTab }
+				onSelect={ ( tabId ) => {
+					if ( tabId && isSiteSettingsTab( tabId ) ) {
+						onTabChange( tabId );
+					}
+				} }
+			>
+				{ /* Title + tabs sit outside the scroll container so the tablist's
+					 border-bottom spans the full main-area width. Only the form
+					 content scrolls — tabs stay pinned. */ }
+				<div className={ styles.titleBlock }>
+					<h1>{ __( 'Site settings' ) }</h1>
+				</div>
+				<div className={ styles.tabsBar }>
+					<div className={ styles.tabsBarInner }>
+						<Tabs.List>
+							<Tabs.Tab tabId="general">{ __( 'General' ) }</Tabs.Tab>
+							<Tabs.Tab tabId="debugging">{ __( 'Debugging' ) }</Tabs.Tab>
+						</Tabs.List>
+					</div>
+				</div>
+
+				<div className={ styles.scroll }>
+					<div className={ styles.contentBlock }>
+						<form onSubmit={ handleSubmit } className={ styles.form }>
+							<Tabs.Panel tabId="general">
+								<DataForm< FormData >
+									data={ data }
+									fields={ fields }
+									form={ generalForm }
+									onChange={ handleChange }
+									validity={ validity }
+								/>
+							</Tabs.Panel>
+							<Tabs.Panel tabId="debugging">
+								<DataForm< FormData >
+									data={ data }
+									fields={ fields }
+									form={ debuggingForm }
+									onChange={ handleChange }
+									validity={ validity }
+								/>
+							</Tabs.Panel>
+
+							{ submitError && <div className={ styles.submitError }>{ submitError }</div> }
+
+							<div className={ styles.actions }>
+								<Button
+									type="submit"
+									variant="solid"
+									tone="brand"
+									disabled={ ! canSubmit }
+									loading={ updateSite.isPending }
+									loadingAnnouncement={ __( 'Saving settings' ) }
+								>
+									{ __( 'Save settings' ) }
+								</Button>
+							</div>
+						</form>
+					</div>
+				</div>
+			</Tabs.Root>
+		</div>
+	);
+}
+
+export function isSiteSettingsTab( value: string ): value is TabId {
+	return value === 'general' || value === 'debugging';
+}
+
+export type SiteSettingsTabId = TabId;

--- a/apps/ui/src/components/site-settings-view/style.module.css
+++ b/apps/ui/src/components/site-settings-view/style.module.css
@@ -1,0 +1,99 @@
+.root {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+}
+
+.state {
+	padding: var(--wpds-dimension-padding-xl);
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-2xl);
+	min-height: 46px;
+	font-size: var(--wpds-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral);
+	-webkit-app-region: drag;
+}
+
+.toggleSpacer {
+	display: block;
+	flex-shrink: 0;
+	width: calc(118px - var(--wpds-dimension-padding-xs));
+	height: 100%;
+	-webkit-app-region: no-drag;
+}
+
+.toggleSpacerFullscreen {
+	display: block;
+	flex-shrink: 0;
+	width: calc(var(--wpds-dimension-padding-md) + 24px - var(--wpds-dimension-padding-xs));
+	height: 100%;
+	-webkit-app-region: no-drag;
+}
+
+.titleBlock {
+	max-width: 760px;
+	margin: 0 auto;
+	padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-xl) 0;
+	width: 100%;
+}
+
+/* Full-width bar so the border-bottom spans the entire main area. The inner
+   wrapper centers the tablist over the same 760px column the form uses.
+   The shared `Tabs` component expects this 1px neutral baseline and lines its
+   active indicator up with it via `margin-bottom: -1px` on the tablist. */
+.tabsBar {
+	width: 100%;
+	/* Matches the sidebar's right border so the two feel like one continuous
+	   frame around the main area. */
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
+	margin-top: var(--wpds-dimension-padding-xl);
+}
+
+.tabsBarInner {
+	max-width: 760px;
+	margin: 0 auto;
+	padding: 0 var(--wpds-dimension-padding-xl);
+}
+
+/* Only the form content scrolls. The tabs and title sit above this container
+   so the tablist's border-bottom isn't clipped by scrollbar-gutter
+   reservations. */
+.scroll {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+}
+
+.contentBlock {
+	max-width: 760px;
+	margin: 0 auto;
+	padding: calc(var(--wpds-dimension-padding-2xl) * 1.5) var(--wpds-dimension-padding-xl)
+		var(--wpds-dimension-padding-2xl);
+}
+
+.form {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-xl);
+}
+
+.submitError {
+	padding: 10px 12px;
+	border-radius: 4px;
+	background: #fce8e8;
+	color: #7a1a1a;
+	font-size: 13px;
+}
+
+.actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--wpds-dimension-padding-sm);
+}

--- a/apps/ui/src/components/tabs/index.tsx
+++ b/apps/ui/src/components/tabs/index.tsx
@@ -1,0 +1,119 @@
+/**
+ * Thin wrapper around `@wordpress/components`' `Tabs` (which is still behind
+ * the private-apis lock) that applies our condensed, DS-token-driven look:
+ *
+ *   - 1px active-tab indicator in `fg-content-neutral` (matches active label).
+ *   - Inactive tabs in `fg-content-neutral-weak`; selected tab bumps to the
+ *     primary fg token + semibold.
+ *   - No inline padding so the active underline aligns with label text; the
+ *     list spaces tabs with a gap instead.
+ *   - `margin-bottom: -1px` on the list so the active indicator lands on top
+ *     of a sibling container's 1px border-bottom, reading as one line.
+ *
+ * Callers are still responsible for any outer layout (e.g. a full-width bar
+ * with a baseline border) — this module only owns the tabs' own styling.
+ *
+ * Use as:
+ *
+ *   import * as Tabs from '@/components/tabs';
+ *
+ *   <Tabs.Root selectedTabId={...} onSelect={...}>
+ *     <Tabs.List>
+ *       <Tabs.Tab tabId="general">General</Tabs.Tab>
+ *       <Tabs.Tab tabId="debugging">Debugging</Tabs.Tab>
+ *     </Tabs.List>
+ *     <Tabs.Panel tabId="general">...</Tabs.Panel>
+ *     <Tabs.Panel tabId="debugging">...</Tabs.Panel>
+ *   </Tabs.Root>
+ */
+
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { clsx } from 'clsx';
+import { forwardRef } from 'react';
+import { unlock } from '@/lock-unlock';
+import styles from './style.module.css';
+import type { ComponentPropsWithoutRef, ComponentType, ElementRef, ReactNode } from 'react';
+
+type RootProps = {
+	selectedTabId?: string | null;
+	onSelect?: ( tabId: string | null | undefined ) => void;
+	orientation?: 'horizontal' | 'vertical';
+	children: ReactNode;
+};
+
+type ListProps = {
+	className?: string;
+	children: ReactNode;
+};
+
+type TabProps = {
+	tabId: string;
+	className?: string;
+	children: ReactNode;
+	disabled?: boolean;
+};
+
+type PanelProps = {
+	tabId: string;
+	className?: string;
+	children: ReactNode;
+	focusable?: boolean;
+};
+
+type WpTabs = ComponentType< RootProps > & {
+	TabList: ComponentType< ListProps >;
+	Tab: ComponentType< TabProps >;
+	TabPanel: ComponentType< PanelProps >;
+};
+
+const { Tabs: WpTabs } = unlock( componentsPrivateApis ) as { Tabs: WpTabs };
+
+export const Root = WpTabs;
+
+export const List = forwardRef<
+	ElementRef< 'div' >,
+	ComponentPropsWithoutRef< typeof WpTabs.TabList >
+>( function List( { className, children, ...props }, ref ) {
+	// @wordpress/components TabList forwards refs to its underlying div.
+	const ListComponent = WpTabs.TabList as unknown as ComponentType<
+		ListProps & { ref?: React.Ref< HTMLDivElement > }
+	>;
+	return (
+		<ListComponent ref={ ref } className={ clsx( styles.list, className ) } { ...props }>
+			{ children }
+		</ListComponent>
+	);
+} );
+
+export const Tab = forwardRef<
+	ElementRef< 'button' >,
+	ComponentPropsWithoutRef< typeof WpTabs.Tab >
+>( function Tab( { className, children, ...props }, ref ) {
+	const TabComponent = WpTabs.Tab as unknown as ComponentType<
+		TabProps & { ref?: React.Ref< HTMLButtonElement > }
+	>;
+	return (
+		<TabComponent ref={ ref } className={ clsx( styles.tab, className ) } { ...props }>
+			{ children }
+		</TabComponent>
+	);
+} );
+
+export const Panel = forwardRef<
+	ElementRef< 'div' >,
+	ComponentPropsWithoutRef< typeof WpTabs.TabPanel >
+>( function Panel( { className, focusable = false, children, ...props }, ref ) {
+	const PanelComponent = WpTabs.TabPanel as unknown as ComponentType<
+		PanelProps & { ref?: React.Ref< HTMLDivElement > }
+	>;
+	return (
+		<PanelComponent
+			ref={ ref }
+			className={ clsx( styles.panel, className ) }
+			focusable={ focusable }
+			{ ...props }
+		>
+			{ children }
+		</PanelComponent>
+	);
+} );

--- a/apps/ui/src/components/tabs/style.module.css
+++ b/apps/ui/src/components/tabs/style.module.css
@@ -1,0 +1,51 @@
+/* The WP Tabs component draws its active-tab indicator from the tablist's
+   bottom edge upward. `margin-bottom: -1px` lets that indicator sit on top
+   of a sibling container's 1px border-bottom (when present) so the selected
+   tab's line reads as a continuation of the rest of the border. */
+.list {
+	margin-bottom: -1px;
+	gap: calc(var(--wpds-dimension-padding-lg) * 2);
+}
+
+/* Active-tab indicator: matches the selected-tab text color so the underline
+   and label read as a single accent. 1px to match a typical neutral baseline
+   — overriding the 2px theme-accent default the WP component ships with. */
+.list::before {
+	border-bottom-width: 1px !important;
+	border-bottom-color: var(--wpds-color-fg-content-neutral) !important;
+}
+
+/* Override WP Tabs defaults:
+   - No inline padding so the active-tab underline aligns with the label text
+     (the list's `gap` keeps tabs from touching).
+   - Compact vertical padding + medium font size replace the 48px tall default.
+   - `flex: 0 0 auto` stops tabs from stretching to fill the tablist, which
+     would otherwise widen the indicator beyond the text.
+   - Inactive tabs read as secondary (neutral-weak, regular); selected tab
+     uses the primary fg token + semibold.
+   WP applies `padding-inline`/`height` via an `[aria-orientation='horizontal']
+   &` rule with the same specificity as `.list .tab`, so emotion's runtime
+   stylesheet wins source-order. `!important` is the simplest, targeted way
+   to force our condensed sizing through. */
+.list .tab {
+	padding-inline: 0 !important;
+	padding-block: var(--wpds-dimension-padding-lg) !important;
+	height: auto !important;
+	flex: 0 0 auto;
+	font-size: var(--wpds-font-size-md);
+	font-weight: 400;
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.list .tab[aria-selected='true'] {
+	font-weight: 600;
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.list .tab:not([aria-disabled='true']):is(:hover, [data-focus-visible]) {
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.panel {
+	outline: none;
+}

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -137,6 +137,14 @@ export function createIpcConnector(): Connector {
 			await ipcApi.stopServer( id );
 		},
 
+		async updateSite( site, wpVersion ) {
+			await ipcApi.updateSite( site, wpVersion );
+		},
+
+		async getXdebugEnabledSite() {
+			return ( await ipcApi.getXdebugEnabledSite() ) as SiteDetails | null;
+		},
+
 		// Preview snapshots
 		async getSnapshots(): Promise< Snapshot[] > {
 			return ( await ipcApi.fetchSnapshots() ) as Snapshot[];

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -24,6 +24,15 @@ export interface SiteDetails {
 	customDomain?: string;
 	enableHttps?: boolean;
 	phpVersion: string;
+	isWpAutoUpdating?: boolean;
+	adminUsername?: string;
+	// Base64-encoded. Use encodePassword/decodePassword from
+	// @studio/common/lib/passwords when reading or writing.
+	adminPassword?: string;
+	adminEmail?: string;
+	enableXdebug?: boolean;
+	enableDebugLog?: boolean;
+	enableDebugDisplay?: boolean;
 	themeDetails?: {
 		name: string;
 		path: string;
@@ -58,6 +67,13 @@ export interface Connector {
 	deleteSite( id: string ): Promise< void >;
 	startSite( id: string ): Promise< void >;
 	stopSite( id: string ): Promise< void >;
+	// Persists edits from the site-settings screen via the CLI-backed main
+	// process handler. `wpVersion` is only forwarded when the user explicitly
+	// picked a pinned version — undefined means "keep auto-updating".
+	updateSite( site: SiteDetails, wpVersion?: string ): Promise< void >;
+	// Xdebug is exclusive across sites; returns the one site currently using
+	// it (or null) so the settings form can block a conflicting toggle.
+	getXdebugEnabledSite(): Promise< SiteDetails | null >;
 
 	// Site-creation helpers — surface the same main-process capabilities the
 	// desktop app's add-site flow relies on (folder pickers, path validation,

--- a/apps/ui/src/data/queries/use-sites.ts
+++ b/apps/ui/src/data/queries/use-sites.ts
@@ -1,7 +1,7 @@
 import { useIsMutating, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useConnector } from '@/data/core';
-import type { CreateSiteParams } from '@/data/core';
+import type { CreateSiteParams, SiteDetails } from '@/data/core';
 
 export const SITES_QUERY_KEY = [ 'sites' ] as const;
 
@@ -57,6 +57,41 @@ export function useStopSite() {
 			await connector.stopSite( id );
 			await queryClient.invalidateQueries( { queryKey: SITES_QUERY_KEY } );
 		},
+	} );
+}
+
+export interface UpdateSiteInput {
+	site: SiteDetails;
+	// Provided only when the user switched WP version; undefined means the
+	// site stays on its current auto-updating track.
+	wpVersion?: string;
+}
+
+export function useUpdateSite() {
+	const connector = useConnector();
+	return useMutation( {
+		mutationFn: async ( { site, wpVersion }: UpdateSiteInput ) => {
+			await connector.updateSite( site, wpVersion );
+			// Intentionally skip an immediate invalidateQueries here: the CLI
+			// edit and the site-updated event are emitted from two separate
+			// CLI processes, so the event is usually still in flight when the
+			// IPC call resolves. A refetch fired now races ahead of the
+			// handler in cli-events-subscriber and returns pre-event state,
+			// which flashes the old values back into the settings form.
+			// `useSyncSitesWithEvents` invalidates `SITES_QUERY_KEY` once the
+			// site-event lands, giving us a single refetch against fresh
+			// in-memory details.
+		},
+	} );
+}
+
+const XDEBUG_ENABLED_SITE_QUERY_KEY = [ 'xdebugEnabledSite' ] as const;
+
+export function useXdebugEnabledSite() {
+	const connector = useConnector();
+	return useQuery( {
+		queryKey: XDEBUG_ENABLED_SITE_QUERY_KEY,
+		queryFn: () => connector.getXdebugEnabledSite(),
 	} );
 }
 

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -14,6 +14,54 @@ body {
 	color-scheme: light dark;
 }
 
+/* Universal heading styles derived from the design system's font-size /
+   line-height ramp. Each level steps down one token (h1 = 2xl, h6 = xs),
+   keeping the rest of the type contract — family, weight, color, zero
+   margin — identical. Components can still override via their own class
+   where a specific context demands it, but bare `<h1>`…`<h6>` elements
+   pick up a consistent look for free. */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	font-family: var(--wpds-font-family-heading);
+	font-weight: var(--wpds-font-weight-regular);
+	color: var(--wpds-color-fg-content-neutral);
+	margin: 0;
+}
+
+h1 {
+	font-size: var(--wpds-font-size-2xl);
+	line-height: var(--wpds-font-line-height-2xl);
+}
+
+h2 {
+	font-size: var(--wpds-font-size-xl);
+	line-height: var(--wpds-font-line-height-xl);
+}
+
+h3 {
+	font-size: var(--wpds-font-size-lg);
+	line-height: var(--wpds-font-line-height-lg);
+}
+
+h4 {
+	font-size: var(--wpds-font-size-md);
+	line-height: var(--wpds-font-line-height-md);
+}
+
+h5 {
+	font-size: var(--wpds-font-size-sm);
+	line-height: var(--wpds-font-line-height-sm);
+}
+
+h6 {
+	font-size: var(--wpds-font-size-xs);
+	line-height: var(--wpds-font-line-height-xs);
+}
+
 /* Interactive elements inside drag-region ancestors (title bars, section
    headers) need to opt out so clicks and focus still land. Harmless where no
    drag region is active. `[data-base-ui-portal] *` covers the @base-ui Menu

--- a/apps/ui/src/router/layout-onboarding/style.module.css
+++ b/apps/ui/src/router/layout-onboarding/style.module.css
@@ -3,10 +3,10 @@
 	text-align: left;
 }
 
+/* Typography comes from the universal `h1` rule in index.css — this class
+   only layers on the layout spacing above the subtitle. */
 .title {
-	font-size: 2rem;
-	font-weight: 600;
-	margin: 0 0 8px;
+	margin-bottom: 8px;
 }
 
 .subtitle {

--- a/apps/ui/src/router/route-site-settings/index.tsx
+++ b/apps/ui/src/router/route-site-settings/index.tsx
@@ -1,0 +1,44 @@
+import { createRoute, useNavigate } from '@tanstack/react-router';
+import { isSiteSettingsTab, SiteSettingsView } from '@/components/site-settings-view';
+import { dashboardLayoutRoute } from '../layout-dashboard';
+import type { SiteSettingsTabId } from '@/components/site-settings-view';
+
+interface SiteSettingsSearch {
+	// Tab selection is a `search` param so opening the route defaults to
+	// General and deep-links like `?tab=debugging` stay human-readable.
+	tab?: SiteSettingsTabId;
+}
+
+function SiteSettingsPage() {
+	const { siteId } = siteSettingsRoute.useParams();
+	const { tab } = siteSettingsRoute.useSearch();
+	const navigate = useNavigate();
+	const activeTab: SiteSettingsTabId = tab ?? 'general';
+	return (
+		<SiteSettingsView
+			siteId={ siteId }
+			activeTab={ activeTab }
+			onTabChange={ ( next ) =>
+				void navigate( {
+					to: '/sites/$siteId/settings',
+					params: { siteId },
+					search: { tab: next },
+					replace: true,
+				} )
+			}
+		/>
+	);
+}
+
+export const siteSettingsRoute = createRoute( {
+	getParentRoute: () => dashboardLayoutRoute,
+	path: '/sites/$siteId/settings',
+	validateSearch: ( search: Record< string, unknown > ): SiteSettingsSearch => {
+		const value = search.tab;
+		if ( typeof value === 'string' && isSiteSettingsTab( value ) ) {
+			return { tab: value };
+		}
+		return {};
+	},
+	component: SiteSettingsPage,
+} );

--- a/apps/ui/src/router/router.tsx
+++ b/apps/ui/src/router/router.tsx
@@ -8,11 +8,17 @@ import { newSessionRoute } from './route-new-session';
 import { onboardingCreateRoute } from './route-onboarding-create';
 import { onboardingHomeRoute } from './route-onboarding-home';
 import { sessionDetailRoute } from './route-session-detail';
+import { siteSettingsRoute } from './route-site-settings';
 import type { RouterContext } from './layout-root';
 
 const routeTree = rootRoute.addChildren( [
 	indexRoute,
-	dashboardLayoutRoute.addChildren( [ dashboardRoute, newSessionRoute, sessionDetailRoute ] ),
+	dashboardLayoutRoute.addChildren( [
+		dashboardRoute,
+		newSessionRoute,
+		sessionDetailRoute,
+		siteSettingsRoute,
+	] ),
 	onboardingLayoutRoute.addChildren( [ onboardingHomeRoute, onboardingCreateRoute ] ),
 ] );
 


### PR DESCRIPTION
## Related issues

- Related to the apps/ui site-settings work in context of the new per-site UI.

## How AI was used in this PR

Built iteratively via Claude Code — scaffolded the settings page, shared field builders, and tabs wrapper, then iterated on the typography and tab styling against design feedback. The stale-state bug in the CLI events subscriber was found and fixed after a QA pass surfaced a "custom domain restored after save" symptom.

## Proposed Changes

- New `/sites/$siteId/settings` route in apps/ui, accessible from the sidebar site-actions menu. Top of the page reuses `SiteDropdown` for context; tabs (General + Debugging) sit above the scroll container so the tablist's border-bottom spans the full main-area width and aligns with the sidebar's right edge. Saves via `updateSite` IPC (CLI-backed `site set`).
- Shared `components/site-fields` DataForm field builders (name, php/wp version, admin credentials, custom domain, xdebug/debug log/debug display) used by both the onboarding create-site form and the new settings form.
- Shared `components/tabs` wrapper around `@wordpress/components`' private `Tabs` (unlocked the same way `ValidatedInputControl` is in create-site-form). Condensed styling with DS tokens: 1px neutral baseline (matches the sidebar border), 1px active indicator in `fg-content-neutral`, compact labels with no inline padding so the underline aligns with the text, `lg * 2` gap, medium font size, regular/semibold weight on inactive/active.
- Universal `h1`–`h6` rules in `index.css` using `--wpds-font-family-heading`, `--wpds-font-weight-regular`, `--wpds-color-fg-content-neutral`, and the `2xl → xs` size/line-height ramp. Onboarding `.title` class slimmed to layout spacing only so all page titles share the same type.
- `SiteDetails` in apps/ui expanded (`adminUsername`, `adminPassword` (base64), `adminEmail`, `enableXdebug`, `enableDebugLog`, `enableDebugDisplay`, `isWpAutoUpdating`) and `Connector` gained `updateSite` + `getXdebugEnabledSite`.
- **Bug fix in `cli-events-subscriber`**: `siteDetailsToServerDetails` spread `existingDetails` then `site`, but JSON serialization drops cleared optional fields (e.g. `customDomain` after `site set --domain ''`), so the absent key let the stale value survive in memory. Merge now pulls only Studio-only fields (tls/theme/sort/runtime flags) from `existingDetails` and lets the CLI payload be authoritative for everything else.
- `useUpdateSite` no longer invalidates queries immediately — the CLI edit and its `site-updated` event come from two different CLI processes, so a refetch fired the moment the IPC resolves races ahead of the event handler and re-seeds the form with pre-event data. `useSyncSitesWithEvents` picks up the invalidation once the event lands.

## Testing Instructions

- Open a local site from the sidebar, click the per-site kebab menu → **Site settings**. Verify the page shows the SiteDropdown at the top, the "Site settings" h1, and General / Debugging tabs.
- General tab: change site name, PHP version, admin credentials, toggle "Use custom domain" with and without HTTPS, save. Confirm site-list reflects the changes after save and that the form re-syncs without flashing the old values.
- **Custom domain clearing regression** — toggle off "Use custom domain" and save. Confirm the checkbox stays unchecked after the save completes (previously would visually "restore" the old domain) and that the underlying site config no longer has a custom domain.
- Debugging tab: toggle Xdebug. If another site already has it enabled, the save button should stay disabled and the field description should name that site.
- Toggle debug log + debug display and save; confirm persistence.
- Deep-link `/sites/$siteId/settings?tab=debugging` and confirm the Debugging tab is active on load.
- Verify onboarding page titles (`/onboarding`, `/onboarding/create`) render with the universal h1 style (regular weight, heading family) and no layout regression.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?