### PR TITLE
apps/ui: align and polish sidebar spacing, typography, and scroll behaviour

### DIFF
--- a/apps/ui/src/components/sidebar-header/style.module.css
+++ b/apps/ui/src/components/sidebar-header/style.module.css
@@ -9,12 +9,24 @@
 		var(--wpds-dimension-padding-sm) 94px;
 	min-height: 46px;
 	-webkit-app-region: drag;
+	/* Stay pinned while the sidebar scrolls. Opaque background so
+	   scrolling content doesn't bleed through. */
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	background-color: var(--wpds-color-bg-surface-neutral-weak);
 }
 
 /* In macOS fullscreen the traffic lights are hidden, so reclaim the
-   padding that was reserved for them. */
+   padding that was reserved for them and align the title with the
+   site list entries below — the site list outer padding is `xl + sm`
+   and each site label sits inside a button with another `sm` of
+   padding-inline, so its text starts at `xl + 2*sm` from the sidebar
+   edge. */
 .fullscreen {
-	padding-left: var(--wpds-dimension-padding-xl);
+	padding-left: calc(
+		var(--wpds-dimension-padding-xl) + 2 * var(--wpds-dimension-padding-sm)
+	);
 }
 
 .title {

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -21,10 +21,8 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 			<div className={ styles.root }>
 				<aside className={ clsx( styles.sidebar, collapsed && styles.sidebarCollapsed ) }>
 					<SidebarHeader onToggleSidebar={ () => setCollapsed( true ) } />
-					<div className={ styles.sidebarContent }>
-						<SidebarNav />
-						<SiteList />
-					</div>
+					<SidebarNav />
+					<SiteList />
 					<UserMenu />
 				</aside>
 				<main className={ styles.main }>

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -10,18 +10,16 @@
 	border-right: 1px solid var(--wpds-color-stroke-surface-neutral);
 	display: flex;
 	flex-direction: column;
-	overflow: hidden;
+	/* The sidebar itself scrolls so the scrollbar gutter affects the
+	   (sticky) header and footer identically to the middle content —
+	   avoiding the misalignment you get when the scrollbar lives on an
+	   inner wrapper. */
+	overflow-y: auto;
 	transition: width 150ms ease;
 }
 
 .sidebarCollapsed {
 	width: 0;
-}
-
-.sidebarContent {
-	flex: 1;
-	min-height: 0;
-	overflow-y: auto;
 }
 
 .main {
@@ -44,7 +42,7 @@
 }
 
 /* In macOS fullscreen the traffic lights are hidden, so the toggle can
-   sit at the main area's left edge. */
+   sit near the main area's left edge. */
 .floatingToggleFullscreen {
-	left: var(--wpds-dimension-padding-md);
+	left: var(--wpds-dimension-padding-xl);
 }

--- a/apps/ui/src/components/sidebar-nav/style.module.css
+++ b/apps/ui/src/components/sidebar-nav/style.module.css
@@ -1,6 +1,9 @@
 .root {
-	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-xl)
-		calc(var(--wpds-dimension-padding-xl) + var(--wpds-dimension-padding-md));
+	/* Top padding is `3xl`; the sidebar header already contributes an
+	   extra `sm` below its content, so bottom padding is `3xl + sm` to
+	   match the visible gap above. */
+	padding: var(--wpds-dimension-padding-3xl) var(--wpds-dimension-padding-xl)
+		calc(var(--wpds-dimension-padding-3xl) + var(--wpds-dimension-padding-sm));
 }
 
 .list {
@@ -9,15 +12,20 @@
 	margin: 0;
 	display: flex;
 	flex-direction: column;
-	gap: 2px;
+	gap: var(--wpds-dimension-padding-xs);
+}
+
+/* Make each row match the button's height exactly — otherwise the
+   inline-flex button leaves room for the parent's line-height. */
+.list > li {
+	display: flex;
 }
 
 .item {
 	width: 100%;
-	height: 26px;
 	padding: 0 var(--wpds-dimension-padding-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-font-size-md);
 	font-weight: var(--wpds-font-weight-regular);
 }
 

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -1,6 +1,6 @@
 .root {
-	padding: 0 calc(var(--wpds-dimension-padding-xl) + var(--wpds-dimension-padding-sm))
-		var(--wpds-dimension-padding-xl);
+	padding: 0 var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-xl)
+		calc(var(--wpds-dimension-padding-xl) + var(--wpds-dimension-padding-sm));
 	display: flex;
 	flex-direction: column;
 	gap: var(--wpds-dimension-padding-sm);
@@ -9,7 +9,7 @@
 .sites {
 	display: flex;
 	flex-direction: column;
-	gap: 2px;
+	gap: var(--wpds-dimension-padding-xs);
 }
 
 .site {
@@ -19,7 +19,7 @@
 
 .siteHeader {
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
 	gap: var(--wpds-dimension-padding-xs);
 	min-width: 0;
 	padding-right: var(--wpds-dimension-padding-sm);
@@ -55,14 +55,14 @@
 
 .siteActive .siteName {
 	color: var(--wpds-color-fg-content-neutral);
-	font-weight: 600;
+	font-weight: var(--wpds-font-weight-medium);
 }
 
 .siteActions {
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
-	padding-top: 2px;
+	gap: var(--wpds-dimension-padding-xs);
 }
 
 .siteAction {
@@ -103,7 +103,7 @@
 .sessionLink {
 	width: 100%;
 	height: 26px;
-	padding: 0 var(--wpds-dimension-padding-sm) 0 var(--wpds-dimension-padding-lg);
+	padding: 0 var(--wpds-dimension-padding-md) 0 var(--wpds-dimension-padding-xl);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font-size: var(--wpds-font-size-sm);
 	font-weight: var(--wpds-font-weight-regular);

--- a/apps/ui/src/components/user-menu/style.module.css
+++ b/apps/ui/src/components/user-menu/style.module.css
@@ -1,6 +1,14 @@
 .root {
-	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-xl)
-		var(--wpds-dimension-padding-lg);
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-2xl)
+		var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-2xl);
+	/* Stay pinned at the bottom as the sidebar scrolls; `margin-top:
+	   auto` pushes it to the bottom in the flex column when content is
+	   shorter than the viewport. */
+	margin-top: auto;
+	position: sticky;
+	bottom: 0;
+	z-index: 1;
+	background-color: var(--wpds-color-bg-surface-neutral-weak);
 }
 
 .row {


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Iterative pairing on small CSS polish passes in the `apps/ui` sidebar: each change was proposed, reviewed visually, and nudged based on feedback (padding values, font sizes, scrollbar behaviour).

## Proposed Changes

**Alignment**
- In fullscreen the "Studio" title now aligns with the site labels below (`xl + 2*sm` from the sidebar's left edge) — reclaiming the traffic-light padding was not enough on its own.
- Site-list outer right padding bumped so the site-header action icons end at roughly the same horizontal position as the sidebar-header `+` / drawer icons.
- `.siteHeader` switched to `align-items: center` and the 2px `padding-top` on `.siteActions` removed; icons now line up with the site name without a manual nudge.
- Footer right padding bumped from `xl` to `2xl` so the appearance toggle ends at the same position as the header action icons; left padding bumped for symmetry, bottom padding increased to balance.

**Scrollbar**
- The sidebar itself (`.sidebar`) is now the scroll container, with `SidebarHeader` sticky at the top and `UserMenu` sticky at the bottom (opaque backgrounds + `z-index: 1`). The `.sidebarContent` wrapper was removed. Previously the scrollbar lived on an inner wrapper, which shifted only the middle section left when a scrollbar appeared while the header/footer stayed put — now the gutter shifts every row identically.
- `UserMenu` uses `margin-top: auto` so it still pins to the bottom when content is shorter than the sidebar.

**Typography & rhythm**
- Nav items now use `font-size: md` and `font-weight: medium` (active), matching the site labels. Removed the explicit `height: 26px` so nav rows collapse to the SidebarButton's intrinsic 24px; wrapped the `<li>` elements with `display: flex` so the inline-flex button doesn't leave line-height slack in the list item.
- Active site name weight switched from hardcoded `600` to the `--wpds-font-weight-medium` token to match the nav.
- Inter-item gap in both the nav list and the site list raised from `2px` to `var(--wpds-dimension-padding-xs)` (4px).
- `.sidebar-nav .root` vertical padding increased to `3xl` top / `3xl + sm` bottom so the visible gap below the header (which contributes its own `sm`) matches the gap before the first site.

**Collapsed toggle**
- The fullscreen floating toggle moved from `padding-md` (12px) to `padding-xl` (20px) so it isn't hugging the window edge.

## Testing Instructions

- `npm start` and open the sidebar.
- Toggle fullscreen and confirm "Studio" aligns with the site labels below.
- Add enough sites/sessions to trigger a scrollbar; confirm the header and footer stay pinned and nothing horizontally jumps when the scrollbar appears.
- Hover nav items, click through sites — active weight should match between the two sections.
- Collapse the sidebar (drawer icon) and check the floating show-sidebar button position in both windowed and fullscreen modes.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)