### PR TITLE
Release 1.7.10 npm

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "wp-studio",
 	"author": "Automattic Inc.",
-	"version": "1.7.9",
+	"version": "1.7.10",
 	"productName": "Studio CLI",
 	"description": "WordPress Studio CLI",
 	"license": "GPL-2.0-or-later",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -3,7 +3,7 @@
 	"author": "Automattic Inc.",
 	"private": true,
 	"productName": "Studio",
-	"version": "1.7.9",
+	"version": "1.7.10",
 	"description": "Local WordPress development environment using Playgrounds",
 	"license": "GPL-2.0-or-later",
 	"main": "dist/main/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
 		},
 		"apps/cli": {
 			"name": "wp-studio",
-			"version": "1.7.9",
+			"version": "1.7.10",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -481,7 +481,7 @@
 		},
 		"apps/studio": {
 			"name": "studio-app",
-			"version": "1.7.9",
+			"version": "1.7.10",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@automattic/generate-password": "^0.1.0",
@@ -10178,7 +10178,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -10195,7 +10194,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -10212,7 +10210,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -10229,7 +10226,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -10246,7 +10242,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -10263,7 +10258,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -10280,7 +10274,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -10297,7 +10290,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -10314,7 +10306,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -10331,7 +10322,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}


### PR DESCRIPTION
## Related issue

Follow-up to #3126 (Release 1.7.9 npm).

## How AI was used in this PR

Opus 4.7 ran the version bump command, committed, pushed, and opened this PR.

## Proposed Changes

- Bump CLI version from 1.7.9 to 1.7.10 for both CLI (`wp-studio`) and App (`studio-app`).
- Lockfile updated accordingly.

## Testing Instructions

- Run `npm run cli:build` and verify `node apps/cli/dist/cli/main.mjs --version` reports `1.7.10`.
- Run `npm install` and confirm no lockfile drift.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?