### PR TITLE
Update AGENTS.md to reflect split config file layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,14 +58,16 @@ WordPress Studio - Electron desktop app for managing local WordPress sites. Buil
 
 **Files**: React components (PascalCase), utils (camelCase), tests (.test.ts/.tsx)
 **IPC Handlers** (`apps/studio/src/ipc-handlers.ts`): **MUST** `export async function handlerName(event, ...args): Promise<ReturnType>` | Handler names in `apps/studio/src/constants.ts` | All handlers MUST be async and return Promises
-**Storage**: **CRITICAL** - Always use file locking: `lockAppdata()` / `unlockAppdata()` to prevent data corruption
+**Storage**: **CRITICAL** - Always use file locking when writing config. Each config file has its own lockfile and helpers: `lockAppdata()` / `unlockAppdata()` for `app.json` (`apps/studio/src/storage/user-data.ts`), `lockCliConfig()` / `unlockCliConfig()` for `cli.json` (`apps/cli/lib/cli-config/core.ts`), and `lockSharedConfig()` / `unlockSharedConfig()` for `shared.json` (`tools/common/lib/shared-config.ts`).
 **i18n**: `@wordpress/i18n` (`__()` function), `tools/common/translations/`, `<I18nProvider>` (renderer), `loadTranslations()` (CLI)
 
 ## WordPress Studio Paths
 
-**App Data:**
-- macOS: `~/Library/Application Support/Studio/appdata-v1.json`
-- Windows: `%APPDATA%\Studio\appdata-v1.json` (expands to `C:\Users\<username>\AppData\Roaming\Studio\appdata-v1.json`)
+**App Data:** All platforms use `~/.studio/` (user's home directory). Resolve paths via the helpers in `tools/common/lib/well-known-paths.ts` (`getConfigDirectory`, `getSharedConfigPath`, `getAppConfigPath`, `getCliConfigPath`) rather than hardcoding.
+- `~/.studio/shared.json` — state shared between Desktop and CLI (e.g. locale)
+- `~/.studio/cli.json` — sites + snapshots (CLI-owned)
+- `~/.studio/app.json` — Desktop-only state (UI prefs, sync, per-site metadata, etc.)
+- Deprecated: pre-split builds used a single `appdata-v1.json` under the Electron platform path (macOS: `~/Library/Application Support/Studio/`, Windows: `%APPDATA%\Studio\`). On first launch the migration at `apps/studio/src/migrations/02-migrate-to-split-config.ts` splits it into the three files above and renames the original to `appdata-v1.deprecated.json`.
 
 **Logs:**
 - macOS: `~/Library/Logs/Studio/`
@@ -95,7 +97,7 @@ If you've built a substantial new feature — especially one generated with AI a
 
 **CRITICAL - WordPress Core Files**: Do NOT edit WordPress core files within site directories. Studio uses WordPress Playground (PHP WASM), and core modifications won't persist or function correctly.
 
-**CRITICAL - Appdata Locking**: Always wrap appdata file operations with `lockAppdata()` / `unlockAppdata()`. Concurrent writes will corrupt the database file.
+**CRITICAL - Config File Locking**: Each of the three config files has its own lockfile and helper pair — wrap writes accordingly. Use `lockAppdata()` / `unlockAppdata()` for `app.json`, `lockCliConfig()` / `unlockCliConfig()` for `cli.json`, and `lockSharedConfig()` / `unlockSharedConfig()` for `shared.json`. Concurrent unlocked writes will corrupt the file.
 
 **IMPORTANT - CLI Build Required**: Running CLI commands without first running `npm run cli:build` will execute stale/outdated code. Always build before testing CLI changes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ If you've built a substantial new feature — especially one generated with AI a
 
 **CRITICAL - WordPress Core Files**: Do NOT edit WordPress core files within site directories. Studio uses WordPress Playground (PHP WASM), and core modifications won't persist or function correctly.
 
-**CRITICAL - Config File Locking**: Each of the three config files has its own lockfile and helper pair — wrap writes accordingly. Use `lockAppdata()` / `unlockAppdata()` for `app.json`, `lockCliConfig()` / `unlockCliConfig()` for `cli.json`, and `lockSharedConfig()` / `unlockSharedConfig()` for `shared.json`. Concurrent unlocked writes will corrupt the file.
+**CRITICAL - Config File Locking**: Each config file has its own lockfile and helper pair — ensure that any write operation uses the correct pair for that specific file. Use `lockAppdata()` / `unlockAppdata()` for `app.json`, `lockCliConfig()` / `unlockCliConfig()` for `cli.json`, and `lockSharedConfig()` / `unlockSharedConfig()` for `shared.json`. Concurrent unlocked writes will corrupt the file.
 
 **IMPORTANT - CLI Build Required**: Running CLI commands without first running `npm run cli:build` will execute stale/outdated code. Always build before testing CLI changes.
 


### PR DESCRIPTION
## Related issues

- N/A (docs-only update)

## How AI was used in this PR

Claude Code drafted the changes. I verified the new layout against `tools/common/lib/well-known-paths.ts`, `apps/studio/src/migrations/02-migrate-to-split-config.ts`, and the three lock/unlock helpers (`lockAppdata`, `lockCliConfig`, `lockSharedConfig`) before editing.

## Proposed Changes

- Replace the stale single-file `appdata-v1.json` description in **WordPress Studio Paths → App Data** with the three-file layout under `~/.studio/` (`shared.json`, `cli.json`, `app.json`), and point at the helpers in `tools/common/lib/well-known-paths.ts` as the source of truth.
- Note that pre-split builds migrate the legacy file to `appdata-v1.deprecated.json` on first launch (via `apps/studio/src/migrations/02-migrate-to-split-config.ts`).
- Update **Storage** conventions and the **Config File Locking** pitfall so they cover all three lock/unlock helper pairs (`lockAppdata`/`unlockAppdata`, `lockCliConfig`/`unlockCliConfig`, `lockSharedConfig`/`unlockSharedConfig`) instead of only the appdata pair.

## Testing Instructions

- Docs-only change — no runtime behavior affected.
- Re-read the updated sections in `AGENTS.md` and confirm the three file paths, helper names, and migration reference match the current code.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (N/A — docs only)