### PR TITLE
Fix stale phpMyAdmin assets after Studio updates

### DIFF
--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -205,20 +205,29 @@ async function copyBundledAiInstructions() {
 }
 
 async function copyBundledPhpMyAdmin() {
-	await copySourceDirectoryIfNewerOrMissing( {
-		sourceDirectoryPath: path.join( getWpFilesPath(), 'phpmyadmin' ),
-		targetDirectoryPath: getPhpMyAdminPath(),
-		readSourceVersion: async () => {
-			const composerFilePath = path.join( getWpFilesPath(), 'phpmyadmin', 'composer.json' );
-			const composerFile = JSON.parse( fs.readFileSync( composerFilePath, 'utf8' ) );
-			return semver.coerce( composerFile.version );
-		},
-		readTargetVersion: async () => {
-			const composerFilePath = path.join( getPhpMyAdminPath(), 'composer.json' );
-			const composerFile = JSON.parse( fs.readFileSync( composerFilePath, 'utf8' ) );
-			return semver.coerce( composerFile.version );
-		},
-	} );
+	const sourcePhpMyAdminPath = path.join( getWpFilesPath(), 'phpmyadmin' );
+	if ( ! fs.existsSync( sourcePhpMyAdminPath ) ) {
+		return;
+	}
+
+	// The upstream `composer.json` version rarely changes, but we inject
+	// Playground-specific files (e.g. `DbiMysqli.php`) at build time that do change
+	// between Studio releases. Compare by size and mtime so those updates land.
+	const targetPhpMyAdminPath = getPhpMyAdminPath();
+	const isSourceDirectoryDifferent = await areDirectoriesDifferentBySizeAndMtime(
+		sourcePhpMyAdminPath,
+		targetPhpMyAdminPath
+	);
+	if ( ! isSourceDirectoryDifferent ) {
+		return;
+	}
+
+	try {
+		await fs.promises.rm( targetPhpMyAdminPath, { recursive: true, force: true } );
+	} catch {
+		// Do nothing if the target directory is missing or corrupted
+	}
+	await recursiveCopyDirectory( sourcePhpMyAdminPath, targetPhpMyAdminPath );
 }
 
 async function copyBundledLanguagePacks() {

--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -210,9 +210,9 @@ async function copyBundledPhpMyAdmin() {
 		return;
 	}
 
-	// The upstream `composer.json` version rarely changes, but we inject
-	// Playground-specific files (e.g. `DbiMysqli.php`) at build time that do change
-	// between Studio releases. Compare by size and mtime so those updates land.
+	// phpMyAdmin's composer.json version rarely changes, but Studio injects
+	// Playground-specific files (e.g. DbiMysqli.php) at build time that do.
+	// Compare by size and mtime so those updates land across releases.
 	const targetPhpMyAdminPath = getPhpMyAdminPath();
 	const isSourceDirectoryDifferent = await areDirectoriesDifferentBySizeAndMtime(
 		sourcePhpMyAdminPath,


### PR DESCRIPTION
## Related issues

- Fixes STU-1577

## How AI was used in this PR

Used Claude to locate the root cause (the bundled phpMyAdmin refresh keyed off `composer.json` version), propose the fix (switch to size/mtime comparison, matching sibling asset helpers), and run the test/typecheck/lint loop. I reviewed the diff and verified the fix end-to-end in a running Studio instance before opening the PR.

## Proposed Changes

- Replace the `composer.json` version comparison in `copyBundledPhpMyAdmin` with a size/mtime directory diff.
- The upstream phpMyAdmin `composer.json` "version" (5.2.3) rarely changes, but Studio injects Playground-specific files (e.g. `DbiMysqli.php`) at build time that do change across Studio releases. The version check was skipping the re-copy, leaving users with stale assets that still hard-coded `wp-content/mu-plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php` — a path that no longer exists in the current sqlite-database-integration layout.
- The new approach matches the pattern already used by `copyBundledLanguagePacks` and `copyBundledAiInstructions`.

## Testing Instructions

Prerequisite: Export a Studio site to a `.zip` file and import it to a new site.

**Before the fix**, opening phpMyAdmin for that site shows:

> Internal error in ./libraries/classes/Dbal/DbiMysqli.php#26
> ErrorException: require_once(/wordpress/wp-content/mu-plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php): Failed to open stream: No such file or directory

**With the fix**:

1. Build the CLI: `npm run cli:build`
2. Start Studio: `npm start`
3. Open phpMyAdmin on the affected site (hard-refresh the tab if the error page was cached).
4. phpMyAdmin loads normally — no error.

To simulate the stale state for testing without needing a fresh install, overwrite `~/.studio/server-files/phpmyadmin/libraries/classes/Dbal/DbiMysqli.php` with an older copy that still `require_onces` the legacy path,  for example add the following line to line 26:
```php
require_once('/wordpress/wp-content/mu-plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php');
```
then, run `npm start` in trunk and check you can reproduce the error. Then run `npm start` on this branch and check the error disappears when opening `phpMyAdmin` (remember to force refresh! `cmd+shift+R`)

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?