### PR TITLE
Update SQLite Database Integration to v3.0.0-rc.1

### DIFF
--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -65,8 +65,6 @@ export async function runWpCliCommand(
 	try {
 		await php.setSapiName( 'cli' );
 
-		php.defineConstant( 'WP_SQLITE_AST_DRIVER', true );
-
 		php.mkdir( '/wordpress' );
 		await php.mount( '/wordpress', createNodeFsMountHandler( siteFolder ) );
 

--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -65,6 +65,10 @@ export async function runWpCliCommand(
 	try {
 		await php.setSapiName( 'cli' );
 
+		// Fallback for sites where DB_NAME was stripped from wp-config.php.
+		// The SQLite driver (v3+) requires a non-empty DB_NAME at runtime.
+		php.defineConstant( 'DB_NAME', 'wordpress' );
+
 		php.mkdir( '/wordpress' );
 		await php.mount( '/wordpress', createNodeFsMountHandler( siteFolder ) );
 

--- a/apps/cli/wordpress-server-child.ts
+++ b/apps/cli/wordpress-server-child.ts
@@ -183,6 +183,9 @@ async function getBaseRunCLIArgs(
 	const enableDebugDisplay = config.enableDebugDisplay ?? false;
 
 	const defaultConstants: Record< string, boolean | string > = {
+		// Fallback for sites where DB_NAME was stripped from wp-config.php.
+		// The SQLite driver (v3+) requires a non-empty DB_NAME at runtime.
+		DB_NAME: 'wordpress',
 		WP_DEBUG: enableDebugLog || enableDebugDisplay,
 		WP_DEBUG_LOG: enableDebugLog,
 		WP_DEBUG_DISPLAY: enableDebugDisplay,

--- a/apps/cli/wordpress-server-child.ts
+++ b/apps/cli/wordpress-server-child.ts
@@ -183,7 +183,6 @@ async function getBaseRunCLIArgs(
 	const enableDebugDisplay = config.enableDebugDisplay ?? false;
 
 	const defaultConstants: Record< string, boolean | string > = {
-		WP_SQLITE_AST_DRIVER: true,
 		WP_DEBUG: enableDebugLog || enableDebugDisplay,
 		WP_DEBUG_LOG: enableDebugLog,
 		WP_DEBUG_DISPLAY: enableDebugDisplay,

--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -56,7 +56,7 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.23';
+const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.1';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/releases/download/${ SQLITE_DATABASE_INTEGRATION_VERSION }/plugin-sqlite-database-integration.zip`;
 

--- a/tools/common/lib/sqlite-integration.ts
+++ b/tools/common/lib/sqlite-integration.ts
@@ -59,6 +59,7 @@ export abstract class SqliteIntegrationProvider {
 		await fs.promises.writeFile( path.join( wpContentPath, 'db.php' ), updatedContent );
 
 		const sqliteDestPath = path.join( wpContentPath, 'mu-plugins', sqliteDirname );
+		await fs.promises.rm( sqliteDestPath, { recursive: true, force: true } );
 		await fs.promises.cp( sqliteSourcePath, sqliteDestPath, {
 			recursive: true,
 			verbatimSymlinks: true,


### PR DESCRIPTION
## Related issues

- Related to https://github.com/WordPress/sqlite-database-integration/releases/tag/v3.0.0-rc.1

## How AI was used in this PR

Claude Code identified and applied all changes.

## Proposed Changes

- Bump `SQLITE_DATABASE_INTEGRATION_VERSION` from `v2.2.23` to `v3.0.0-rc.1`
- Remove `WP_SQLITE_AST_DRIVER: true` from `defaultConstants` in `wordpress-server-child.ts`
- Remove `php.defineConstant('WP_SQLITE_AST_DRIVER', true)` from `run-wp-cli-command.ts`
- Define `DB_NAME: 'wordpress'` at runtime in both `wordpress-server-child.ts` and `run-wp-cli-command.ts`

The `WP_SQLITE_AST_DRIVER` constant was a feature flag enabling the new AST-based driver in earlier versions. Starting with v3.0.0, the old driver has been removed and the flag is no longer needed.

SQLite v3.0.0 also removed the fallback for a missing `DB_NAME` — it now requires a non-empty value at runtime or it bails with "Error establishing a database connection". Studio strips the default MySQL constants (including `DB_NAME`) from `wp-config.php` after site creation, which previously worked because v2 had a `'database_name_here'` fallback. We fix this by explicitly defining `DB_NAME: 'wordpress'` as a runtime constant (the same value Playground's `ensureWpConfig` would set), so sites where `DB_NAME` was stripped still work correctly.

## Testing Instructions

- Create a new local site and verify it starts correctly on first launch (no "Error establishing a database connection")
- Restart an existing site and verify it still works
- Run a WP-CLI command (e.g. `wp option get siteurl`) and confirm it works

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?