### PR TITLE
CLI: Send X-WPCOM-Session-ID header on WPCOM AI proxy requests

### DIFF
--- a/apps/cli/ai/auth.ts
+++ b/apps/cli/ai/auth.ts
@@ -4,6 +4,7 @@ import {
 	getAiProviderDefinition,
 	hasInlineWpcomAuth,
 	type AiProviderId,
+	type ResolveAiEnvironmentOptions,
 } from 'cli/ai/providers';
 import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
 
@@ -89,7 +90,8 @@ export async function prepareAiProvider(
 }
 
 export async function resolveAiEnvironment(
-	provider: AiProviderId
+	provider: AiProviderId,
+	options?: ResolveAiEnvironmentOptions
 ): Promise< Record< string, string > > {
-	return getAiProviderDefinition( provider ).resolveEnv();
+	return getAiProviderDefinition( provider ).resolveEnv( options );
 }

--- a/apps/cli/ai/providers.ts
+++ b/apps/cli/ai/providers.ts
@@ -17,13 +17,17 @@ export const AI_PROVIDER_PRIORITY: AiProviderId[] = [ 'wpcom', 'anthropic-api-ke
 const DEFAULT_WPCOM_AI_GATEWAY_BASE_URL = 'https://public-api.wordpress.com/wpcom/v2/ai-api-proxy';
 const WPCOM_AI_FEATURE_HEADER = 'studio-assistant-anthropic';
 
+export interface ResolveAiEnvironmentOptions {
+	sessionId?: string;
+}
+
 export interface AiProviderDefinition {
 	id: AiProviderId;
 	autoFallbackWhenUnavailable: boolean;
 	isVisible: () => Promise< boolean >;
 	isReady: () => Promise< boolean >;
 	prepare: ( options?: { force?: boolean } ) => Promise< void >;
-	resolveEnv: () => Promise< Record< string, string > >;
+	resolveEnv: ( options?: ResolveAiEnvironmentOptions ) => Promise< Record< string, string > >;
 }
 
 async function resolveAnthropicApiKey( options?: {
@@ -105,7 +109,7 @@ const AI_PROVIDER_DEFINITIONS: Record< AiProviderId, AiProviderDefinition > = {
 
 			throw new LoggerError( __( 'WordPress.com login required. Use /login to authenticate.' ) );
 		},
-		resolveEnv: async () => {
+		resolveEnv: async ( options ) => {
 			const inlineToken = readInlineWpcomToken();
 			const accessToken = inlineToken ?? ( await readAuthToken() )?.accessToken;
 			if ( ! accessToken ) {
@@ -114,9 +118,13 @@ const AI_PROVIDER_DEFINITIONS: Record< AiProviderId, AiProviderDefinition > = {
 			const env = createBaseEnvironment();
 			env.ANTHROPIC_BASE_URL = getWpcomAiGatewayBaseUrl();
 			env.ANTHROPIC_AUTH_TOKEN = accessToken;
-			env.ANTHROPIC_CUSTOM_HEADERS = buildAnthropicCustomHeaders( {
+			const customHeaders: Record< string, string > = {
 				'X-WPCOM-AI-Feature': WPCOM_AI_FEATURE_HEADER,
-			} );
+			};
+			if ( options?.sessionId ) {
+				customHeaders[ 'X-WPCOM-Session-ID' ] = options.sessionId;
+			}
+			env.ANTHROPIC_CUSTOM_HEADERS = buildAnthropicCustomHeaders( customHeaders );
 			env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS = '1';
 			// The default agent retry count (10) causes the CLI to hang for
 			// minutes when the WPCOM proxy returns a 429 (e.g. usage cap

--- a/apps/cli/ai/tests/auth.test.ts
+++ b/apps/cli/ai/tests/auth.test.ts
@@ -109,6 +109,23 @@ describe( 'AI auth helpers', () => {
 		expect( env.ANTHROPIC_API_KEY ).toBeUndefined();
 	} );
 
+	it( 'includes the Studio AI session ID header when provided', async () => {
+		vi.mocked( readAuthToken ).mockResolvedValue( {
+			accessToken: 'wpcom-token',
+			displayName: 'User',
+			email: 'user@example.com',
+			expiresIn: 3600,
+			expirationTime: Date.now() + 3600_000,
+			id: 1,
+		} );
+
+		const env = await resolveAiEnvironment( 'wpcom', { sessionId: 'session-abc' } );
+
+		expect( env.ANTHROPIC_CUSTOM_HEADERS ).toBe(
+			'X-WPCOM-AI-Feature: studio-assistant-anthropic\nX-WPCOM-Session-ID: session-abc'
+		);
+	} );
+
 	it( 'prefers the saved provider', async () => {
 		vi.mocked( readCliConfig ).mockResolvedValue( {
 			version: 1,

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -414,7 +414,10 @@ export async function runCommand( options: {
 		retryAttempt = 0
 	): Promise< { status: TurnStatus; usage?: { numTurns: number; costUsd?: number } } > {
 		await maybeAutoSwitchProvider();
-		const env = await resolveAiEnvironment( currentProvider );
+		const recorder = await ensureSessionRecorder();
+		const env = await resolveAiEnvironment( currentProvider, {
+			sessionId: recorder?.sessionId,
+		} );
 
 		ui.beginAgentTurn();
 

--- a/apps/cli/commands/ai/tests/ai.test.ts
+++ b/apps/cli/commands/ai/tests/ai.test.ts
@@ -204,8 +204,16 @@ vi.mock( 'cli/ai/ui', () => ( {
 
 vi.mock( 'cli/ai/sessions/recorder', () => {
 	class MockAiSessionRecorder {
-		static create = vi.fn().mockResolvedValue( new MockAiSessionRecorder() );
-		static open = vi.fn().mockResolvedValue( new MockAiSessionRecorder() );
+		static create = vi
+			.fn()
+			.mockResolvedValue( new MockAiSessionRecorder( 'mock-session-created' ) );
+		static open = vi.fn( ( options: { sessionId: string } ) =>
+			Promise.resolve( new MockAiSessionRecorder( options.sessionId ) )
+		);
+		readonly sessionId: string;
+		constructor( sessionId: string = 'mock-session-created' ) {
+			this.sessionId = sessionId;
+		}
 		async recordSdkMessage() {}
 		async recordToolProgress() {}
 		async recordSessionCleared( ...args: unknown[] ) {
@@ -627,7 +635,9 @@ describe( 'CLI: studio code sessions command', () => {
 
 		await buildParser().parseAsync( [ 'ai', 'sessions', 'resume', 'latest' ] );
 
-		expect( resolveAiEnvironment ).toHaveBeenCalledWith( 'anthropic-api-key' );
+		expect( resolveAiEnvironment ).toHaveBeenCalledWith( 'anthropic-api-key', {
+			sessionId: 'session-latest',
+		} );
 		expect( ( AiSessionRecorder as typeof AiSessionRecorder ).open ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				sessionId: 'session-latest',


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Implementation was done with Claude Code. I checked the logs and reviewed the code.

## Proposed Changes

- Adds an `X-WPCOM-Session-ID` custom header to every request the `studio code` CLI makes to the WordPress.com AI proxy, alongside the existing `X-WPCOM-AI-Feature` header.
- The value is the Studio AI session recorder's UUID (the same ID used for session files under `~/Library/Application Support/Studio/sessions/`), so WPCOM can correlate multiple requests back to the same Studio conversation.
- Threads an optional `sessionId` through `resolveAiEnvironment` / the wpcom provider's `resolveEnv`. The header is only emitted when a recorder exists (i.e. session persistence is not disabled).

## Testing Instructions

1. Start a `studio code` session (CLI or desktop) and send a prompt.
2. Open Logstash, filter by `feature: studio-assistant-anthropic`, and check that `properties.session_id` is populated with the `studio code` session. You can use the following link 5fd435e7f90d2536111da67ff7eff216-logstash
4. Send a follow-up prompt in the same session — confirm `properties.session_id` is the same value.


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?