### PR TITLE
apps/ui: open sidebar plus and site actions menus to the left

### DIFF
--- a/apps/ui/src/components/sidebar-header/index.tsx
+++ b/apps/ui/src/components/sidebar-header/index.tsx
@@ -30,7 +30,7 @@ export function SidebarHeader( { onToggleSidebar }: Props ) {
 							/>
 						}
 					/>
-					<Menu.Popup side="bottom" align="start" className={ styles.popup }>
+					<Menu.Popup side="bottom" align="end" className={ styles.popup }>
 						<Menu.Item>
 							<Icon icon={ comment } />
 							<span>{ __( 'New chat' ) }</span>

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -179,7 +179,7 @@ export function SiteDropdown( { site, activeEnvironment = 'local' }: Props ) {
 						/>
 					}
 				/>
-				<Menu.Popup side="bottom" align="start" className={ styles.popup }>
+				<Menu.Popup side="bottom" align="end" className={ styles.popup }>
 					{ view === 'main' ? (
 						<MainView
 							site={ site }

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -179,7 +179,7 @@ export function SiteDropdown( { site, activeEnvironment = 'local' }: Props ) {
 						/>
 					}
 				/>
-				<Menu.Popup side="bottom" align="end" className={ styles.popup }>
+				<Menu.Popup side="bottom" align="start" className={ styles.popup }>
 					{ view === 'main' ? (
 						<MainView
 							site={ site }

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -235,7 +235,7 @@ function SiteActionsMenu( { site }: { site: SiteDetails } ) {
 						/>
 					}
 				/>
-				<Menu.Popup side="bottom" align="start">
+				<Menu.Popup side="bottom" align="end">
 					{ site.running ? (
 						<Menu.Item disabled={ busy } onClick={ () => stopSite.mutate( site.id ) }>
 							{ __( 'Stop site' ) }


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude Code located the relevant Base UI `Menu.Popup` usages in the sidebar and switched their `align` prop from `start` to `end` so the menus anchor on the trigger's right edge and open toward the left. A first pass also touched the `SiteDropdown` popup used in Site Settings; that change was reverted based on follow-up feedback — only the two menus inside the sidebar itself are changed.

## Proposed Changes

- `SidebarHeader` "Create new" (plus) menu: `Menu.Popup align="start"` → `align="end"` so it opens to the left of the trigger.
- `SiteActionsMenu` (three-dot button on each site row in the sidebar): same alignment change.

## Testing Instructions

- Run `npm start`.
- In the sidebar, click the `+` button at the top — the menu should open down-and-to-the-left, anchored to the button's right edge, staying fully inside the sidebar.
- Hover a site in the sidebar and click the three-dot actions button — the actions menu should similarly open down-and-to-the-left.
- Open a site's Site settings view and click the site dropdown in the header — this should still open to the right as before (this menu was intentionally left unchanged).

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)