### PR TITLE
apps/ui: add language switcher to Settings page

### DIFF
--- a/apps/ui/src/components/settings-view/index.tsx
+++ b/apps/ui/src/components/settings-view/index.tsx
@@ -1,3 +1,4 @@
+import { isSupportedLocale, supportedLocaleNames } from '@studio/common/lib/locale';
 import { SUPPORTED_EDITORS, supportedEditorConfig } from '@studio/common/lib/user-settings/editor';
 import { SUPPORTED_TERMINALS, terminalConfig } from '@studio/common/lib/user-settings/terminal';
 import { DataForm } from '@wordpress/dataviews';
@@ -5,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import * as Tabs from '@/components/tabs';
+import { persister } from '@/data/core/query-client';
 import { useInstalledApps } from '@/data/queries/use-installed-apps';
 import { useSaveUserPreferences, useUserPreferences } from '@/data/queries/use-user-preferences';
 import { useFullscreen } from '@/hooks/use-fullscreen';
@@ -14,6 +16,7 @@ import type {
 	ColorScheme,
 	InstalledApps,
 	SupportedEditor,
+	SupportedLocale,
 	SupportedTerminal,
 	UserPreferences,
 	WritableUserPreferences,
@@ -37,6 +40,14 @@ interface FormData {
 	editor: SupportedEditor | typeof UNSET;
 	terminal: SupportedTerminal | typeof UNSET;
 	colorScheme: ColorScheme;
+	locale: SupportedLocale;
+}
+
+// The saved locale can be any string the main process resolved (including ones
+// outside our catalog). Clamp to a SupportedLocale so the form control always
+// has a valid option selected.
+function resolveFormLocale( locale: string | undefined ): SupportedLocale {
+	return isSupportedLocale( locale ) ? locale : 'en';
 }
 
 function toFormData( prefs: UserPreferences ): FormData {
@@ -44,6 +55,7 @@ function toFormData( prefs: UserPreferences ): FormData {
 		editor: prefs.editor ?? UNSET,
 		terminal: prefs.terminal ?? UNSET,
 		colorScheme: prefs.colorScheme,
+		locale: resolveFormLocale( prefs.locale ),
 	};
 }
 
@@ -57,6 +69,7 @@ function diffFromSaved(
 	if ( nextEditor !== saved.editor ) patch.editor = nextEditor;
 	if ( nextTerminal !== saved.terminal ) patch.terminal = nextTerminal;
 	if ( next.colorScheme !== saved.colorScheme ) patch.colorScheme = next.colorScheme;
+	if ( next.locale !== resolveFormLocale( saved.locale ) ) patch.locale = next.locale;
 	return patch;
 }
 
@@ -85,6 +98,10 @@ const COLOR_SCHEME_ELEMENTS: { value: ColorScheme; label: string }[] = [
 	{ value: 'light', label: __( 'Light' ) },
 	{ value: 'dark', label: __( 'Dark' ) },
 ];
+
+const LOCALE_ELEMENTS: { value: SupportedLocale; label: string }[] = Object.entries(
+	supportedLocaleNames
+).map( ( [ value, label ] ) => ( { value: value as SupportedLocale, label } ) );
 
 function SettingsHeader() {
 	const sidebarCollapsed = useSidebarCollapsed();
@@ -139,6 +156,12 @@ export function SettingsView( {
 				label: __( 'Appearance' ),
 				elements: COLOR_SCHEME_ELEMENTS,
 			},
+			{
+				id: 'locale',
+				type: 'text',
+				label: __( 'Language' ),
+				elements: LOCALE_ELEMENTS,
+			},
 		],
 		[ installedApps ]
 	);
@@ -146,7 +169,15 @@ export function SettingsView( {
 	const preferencesForm = useMemo< Form >(
 		() => ( {
 			layout: { type: 'regular', labelPosition: 'top' },
-			fields: [ 'editor', 'terminal', 'colorScheme' ],
+			fields: [
+				{
+					id: 'apps',
+					layout: { type: 'row' },
+					children: [ 'editor', 'terminal' ],
+				},
+				'colorScheme',
+				'locale',
+			],
 		} ),
 		[]
 	);
@@ -166,7 +197,23 @@ export function SettingsView( {
 	const handleSubmit = ( event: FormEvent ) => {
 		event.preventDefault();
 		if ( ! canSubmit ) return;
-		savePreferences.mutate( patch );
+		// Translations are loaded once at bootstrap; the rest of the app imports
+		// `__` from `@wordpress/i18n` directly and doesn't subscribe to locale
+		// changes. Reload the window so every string re-renders in the new
+		// language after a successful save.
+		const localeChanged = 'locale' in patch;
+		savePreferences.mutate( patch, {
+			onSuccess: async () => {
+				if ( localeChanged ) {
+					// The persister is throttled (~1s), so a fresh `setQueryData`
+					// might not hit localStorage before we navigate. Drop the
+					// persisted cache so the next mount refetches preferences
+					// from the main process, which has the newly saved locale.
+					await persister.removeClient();
+					window.location.reload();
+				}
+			},
+		} );
 	};
 
 	return (

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -75,17 +75,6 @@
 	gap: var(--wpds-dimension-padding-xl);
 }
 
-/* DataForm's adaptive picker swaps to @wordpress/components' ComboboxControl
-   once a field has 10+ elements (e.g. the Language picker). Its wrapper
-   has no background, so the body surface bleeds through around the inner
-   input and suggestion rows. Force both to the same background the input
-   itself uses (`--wp-components-color-background`) so the control reads
-   as one solid field. */
-.form :global(.components-combobox-control__suggestions-container),
-.form :global(.components-form-token-field__suggestions-list) {
-	background-color: var(--wp-components-color-background, #fff);
-}
-
 .actions {
 	display: flex;
 	justify-content: flex-end;

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -75,6 +75,17 @@
 	gap: var(--wpds-dimension-padding-xl);
 }
 
+/* DataForm's adaptive picker swaps to @wordpress/components' ComboboxControl
+   once a field has 10+ elements (e.g. the Language picker). Its wrapper
+   has no background, so the body surface bleeds through around the inner
+   input and suggestion rows. Force both to the same background the input
+   itself uses (`--wp-components-color-background`) so the control reads
+   as one solid field. */
+.form :global(.components-combobox-control__suggestions-container),
+.form :global(.components-form-token-field__suggestions-list) {
+	background-color: var(--wp-components-color-background, #fff);
+}
+
 .actions {
 	display: flex;
 	justify-content: flex-end;

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -395,6 +395,9 @@ export function createIpcConnector(): Connector {
 			if ( 'colorScheme' in partial && partial.colorScheme ) {
 				writes.push( ipcApi.saveColorScheme( partial.colorScheme ) );
 			}
+			if ( 'locale' in partial && partial.locale ) {
+				writes.push( ipcApi.saveUserLocale( partial.locale ) );
+			}
 			await Promise.all( writes );
 		},
 

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -15,6 +15,7 @@ export type {
 	SiteDetails,
 	Snapshot,
 	SupportedEditor,
+	SupportedLocale,
 	SupportedTerminal,
 	SyncSite,
 	UserPreferences,

--- a/apps/ui/src/data/core/query-client.ts
+++ b/apps/ui/src/data/core/query-client.ts
@@ -20,7 +20,7 @@ export const queryClient = new QueryClient( {
 	},
 } );
 
-const persister = createSyncStoragePersister( {
+export const persister = createSyncStoragePersister( {
 	storage: typeof window !== 'undefined' ? window.localStorage : null,
 } );
 

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -1,6 +1,7 @@
 import type { AgentRunEvent } from './agent-events';
 import type { AiModelId } from '@studio/common/ai/models';
 import type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessions/types';
+import type { SupportedLocale } from '@studio/common/lib/locale';
 import type { SupportedEditor } from '@studio/common/lib/user-settings/editor';
 import type { SupportedTerminal } from '@studio/common/lib/user-settings/terminal';
 import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
@@ -17,6 +18,7 @@ export type { Snapshot } from '@studio/common/types/snapshot';
 export type { SyncSite } from '@studio/common/types/sync';
 export type { SupportedEditor } from '@studio/common/lib/user-settings/editor';
 export type { SupportedTerminal } from '@studio/common/lib/user-settings/terminal';
+export type { SupportedLocale } from '@studio/common/lib/locale';
 
 export type InstalledApps = Record< SupportedEditor | SupportedTerminal, boolean >;
 
@@ -202,16 +204,18 @@ export interface UserPreferences {
 	editor: SupportedEditor | null;
 	terminal: SupportedTerminal | null;
 	colorScheme: ColorScheme;
-	// Resolved locale string (e.g. "en", "fr-FR"). Read-only in v1 — there's
-	// no connector method for changing it yet.
+	// Resolved locale string (e.g. "en", "fr-FR"). May be any locale the main
+	// process resolves — including ones not in our translation catalog — so
+	// consumers should narrow with `isSupportedLocale` before acting on it.
 	locale: string | undefined;
 }
 
 // Subset of UserPreferences that callers can actually mutate. `locale` is
-// resolved by the OS / main process and has no setter, so excluding it from
-// the writable surface prevents accidental passes that would be silently
-// dropped by the connector.
-export type WritableUserPreferences = Omit< UserPreferences, 'locale' >;
+// typed as `SupportedLocale` on the write side because only locales we ship
+// translations for can be persisted.
+export type WritableUserPreferences = Omit< UserPreferences, 'locale' > & {
+	locale: SupportedLocale;
+};
 
 export interface CreateSiteParams {
 	name: string;

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -204,9 +204,6 @@ export interface UserPreferences {
 	editor: SupportedEditor | null;
 	terminal: SupportedTerminal | null;
 	colorScheme: ColorScheme;
-	// Resolved locale string (e.g. "en", "fr-FR"). May be any locale the main
-	// process resolves — including ones not in our translation catalog — so
-	// consumers should narrow with `isSupportedLocale` before acting on it.
 	locale: string | undefined;
 }
 

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -105,3 +105,13 @@ a:focus:not(:focus-visible),
 	height: 16px;
 }
 
+/* @wordpress/components' ComboboxControl (used by DataForm's adaptive
+   picker once a field has 10+ elements) leaves its wrapper without a
+   background, so the body surface bleeds through around the inner input
+   and suggestion rows. Force both to the same background the input
+   itself uses so the control reads as one solid field. */
+.components-combobox-control__suggestions-container,
+.components-form-token-field__suggestions-list {
+	background-color: var(--wp-components-color-background, #fff);
+}
+


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude Code drafted the plumbing (connector + form field + persister flush), the row grouping, and the combobox background override. I reviewed every diff, pushed back on the initial styling and cache strategies, and verified the behaviour end-to-end in the running app.

## Proposed Changes

- Wire the existing `saveUserLocale` main-process handler through the IPC connector's `setUserPreferences` fan-out so the Settings form can persist the app locale alongside editor/terminal/color-scheme.
- Make `locale` part of `WritableUserPreferences` (typed as `SupportedLocale`) while keeping the read side as `string | undefined` — the main process may resolve to locales outside our catalog, and the form clamps those down to `'en'` before submit.
- Add a "Language" field to the DataForm in `SettingsView`, sourced from `supportedLocaleNames`. Group editor + terminal on the same row via a DataForm `row` layout.
- Reload the window on locale save. Most of apps/ui imports `__` from `@wordpress/i18n` directly and doesn't subscribe to locale changes, so a reload is the only way every string picks up the new catalog.
- Flush the persisted query cache via `persister.removeClient()` before reloading. The `createSyncStoragePersister` wraps `persistClient` in a ~1s throttle, so a fresh `setQueryData` often hasn't hit localStorage before navigation; combined with `staleTime: Infinity` on `useUserPreferences`, the rehydrated cache would otherwise serve the stale locale back after reload.
- Scope an override in `settings-view/style.module.css` so `@wordpress/components`' ComboboxControl (what DataForm's adaptive picker swaps to for the 21-item Language field) picks up the same background as the input inside, instead of leaving the body surface to bleed through as an unthemed gray.

## Testing Instructions

- Open the app, go to Settings → Preferences.
- Confirm the editor and terminal selects sit side-by-side on the same row.
- Change the Language, click Save. The window reloads and every string renders in the new language. The Language field reflects the newly-saved locale (not the previous one).
- Open the Language picker and confirm the combobox wrapper + dropdown popup have a solid background matching the text input — no gray around the input chrome.
- Change editor / terminal / appearance and save; confirm no reload happens and the cached form state stays consistent.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?