### PR TITLE
apps/ui: move Settings link from user menu to sidebar nav

### DIFF
--- a/apps/ui/src/components/sidebar-nav/index.tsx
+++ b/apps/ui/src/components/sidebar-nav/index.tsx
@@ -17,7 +17,7 @@ type NavItem = {
 function getItems(): NavItem[] {
 	return [
 		{ key: 'chat', label: __( 'Chat' ), icon: comment, to: '/dashboard' },
-		{ key: 'settings', label: __( 'Settings' ), icon: cog },
+		{ key: 'settings', label: __( 'Settings' ), icon: cog, to: '/settings' },
 		{ key: 'skills', label: __( 'Skills' ), icon: category },
 	];
 }

--- a/apps/ui/src/components/user-menu/index.tsx
+++ b/apps/ui/src/components/user-menu/index.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/ui';
 import { Gravatar } from '@/components/gravatar';
@@ -18,7 +17,6 @@ const REPORT_ISSUE_URL = 'https://github.com/Automattic/studio/issues/new/choose
 
 export function UserMenu() {
 	const connector = useConnector();
-	const navigate = useNavigate();
 	const { data: user } = useAuthUser();
 	const { data: preferences } = useUserPreferences();
 	const savePreferences = useSaveUserPreferences();
@@ -60,9 +58,6 @@ export function UserMenu() {
 							</Menu.Item>
 							<Menu.Item onClick={ () => openLink( REPORT_ISSUE_URL ) }>
 								{ __( 'Report an issue' ) }
-							</Menu.Item>
-							<Menu.Item onClick={ () => void navigate( { to: '/settings' } ) }>
-								{ __( 'Settings' ) }
 							</Menu.Item>
 							<Menu.Separator />
 							<Menu.Item onClick={ () => logout.mutate() }>{ __( 'Log out' ) }</Menu.Item>


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Authored end-to-end by Claude Opus 4.7, then verified by the author. Trivial wiring change — a single nav item got a route and a duplicate menu entry was removed.

## Proposed Changes

- Wire the sidebar's Settings item to the existing `/settings` route (it was previously a placeholder without a `to` prop).
- Remove the now-redundant Settings entry from the user menu dropdown, plus its unused `useNavigate` import.

## Testing Instructions

- `npm start`, click **Settings** in the left sidebar — it should navigate to the Settings page and show as active.
- Open the user menu (click your avatar/name in the sidebar) — the Settings item should no longer appear; Edit WordPress.com profile, Documentation, Report an issue, and Log out remain.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)