### PR TITLE
apps/ui: add Open phpMyAdmin entry to site dropdown

### DIFF
--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -155,6 +155,12 @@ export function MainView( { site, onSetupClick, onDisconnectClick }: Props ) {
 		} );
 	};
 
+	const handleOpenPhpMyAdmin = () => {
+		openExternal(
+			`${ getSiteUrl( site ) }/phpmyadmin/index.php?route=/database/structure&db=wordpress`
+		);
+	};
+
 	return (
 		<>
 			<div className={ styles.rows }>
@@ -297,6 +303,9 @@ export function MainView( { site, onSetupClick, onDisconnectClick }: Props ) {
 				<Menu.Item onClick={ handleOpenFolder }>{ __( 'Open folder' ) }</Menu.Item>
 				<Menu.Item onClick={ handleOpenInEditor }>{ __( 'Open in editor' ) }</Menu.Item>
 				<Menu.Item onClick={ handleOpenInTerminal }>{ __( 'Open in terminal' ) }</Menu.Item>
+				<Menu.Item disabled={ ! site.running } onClick={ handleOpenPhpMyAdmin }>
+					{ __( 'Open phpMyAdmin' ) }
+				</Menu.Item>
 			</div>
 		</>
 	);


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude Code drafted the change end-to-end: located the phpMyAdmin integration in the legacy Electron UI (`apps/studio/src/components/content-tab-overview.tsx`), identified the matching dropdown in `apps/ui`, and followed the existing "Open folder / editor / terminal" pattern. I reviewed the diff and ran lint + typecheck locally.

## Proposed Changes

- Add an "Open phpMyAdmin" item to the site dropdown in `apps/ui`, placed alongside the existing Open folder / Open in editor / Open in terminal actions.
- The entry is disabled when the site is stopped, since phpMyAdmin is served by the site runtime itself.
- When enabled, it opens `{siteUrl}/phpmyadmin/index.php?route=/database/structure&db=wordpress` in the external browser via the existing `openExternalUrl` connector — matching the URL the legacy Electron UI has used.

## Testing Instructions

1. Start `apps/ui` with at least one local site.
2. Open a site's dropdown menu.
3. With the site **stopped**, confirm the "Open phpMyAdmin" item appears but is disabled.
4. Start the site, reopen the dropdown, and confirm the item is now enabled.
5. Click "Open phpMyAdmin" and confirm it opens the phpMyAdmin database structure view for the WordPress database in the browser.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?