### PR TITLE
apps/cli: add /rank-me-up on-page SEO audit skill

### DIFF
--- a/apps/cli/ai/plugin/skills/rank-me-up/SKILL.md
+++ b/apps/cli/ai/plugin/skills/rank-me-up/SKILL.md
@@ -116,8 +116,6 @@ Missing OG tags don't hurt rankings directly but kill click-through from social 
 
 **Only reach this section after running the "Check Active Plugins First" step and confirming no SEO plugin is active.**
 
-**Why Jetpack:** It's Automattic's official WordPress plugin and integrates natively with WordPress.com — the same platform users push Studio sites to via `site_push` and `preview_create`. Recommending Jetpack keeps the local dev experience aligned with production.
-
 **Install, activate, and enable the SEO module:**
 
 ```

--- a/apps/cli/ai/plugin/skills/rank-me-up/SKILL.md
+++ b/apps/cli/ai/plugin/skills/rank-me-up/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: rank-me-up
+description: Run an on-page SEO audit on a WordPress site and get actionable recommendations to improve search visibility.
+user-invokable: true
+---
+
+# SEO Audit
+
+Run an on-page SEO audit on a WordPress site to surface missing meta tags, broken heading structure, alt-text gaps, missing structured data, and indexing issues — then provide concrete, ordered fixes.
+
+## How to Run
+
+1. Determine which site to audit. If the user hasn't specified, ask them or use the site from the current context.
+2. Ensure the site is running (use `site_start` if needed).
+3. Call `rank_me_up` with the site name and path (defaults to `/`).
+4. **Inspect the SEO toolchain already on the site** (mandatory before suggesting plugin installs — see "Check Active Plugins First" below).
+5. Analyze the results using the interpretation guide.
+6. Present a prioritized list of fixes — most impactful first — with the specific change to make, routed through whatever plugin is already active.
+
+## Check Active Plugins First
+
+The audit only sees rendered HTML — it can't tell *why* a tag is missing. Before recommending an install, find out what's already wired up. Skipping this step leads to dumb suggestions like "install Jetpack" when Jetpack is already active and just needs a module enabled.
+
+**Step 1 — list active plugins:**
+
+```
+wp_cli: plugin list --status=active --field=name
+```
+
+Look for known SEO providers:
+
+| Slug | Plugin |
+|------|--------|
+| `jetpack` | Jetpack (preferred — see below) |
+| `wordpress-seo` | Yoast SEO |
+| `seo-by-rank-math` | Rank Math |
+| `all-in-one-seo-pack` | All in One SEO |
+| `wp-seopress` | SEOPress |
+| `the-seo-framework` | The SEO Framework |
+
+**Step 2 — if Jetpack is active, list its enabled modules** (Jetpack is modular; SEO features live in the `seo-tools` module and don't run unless that specific module is on):
+
+```
+wp_cli: jetpack module list
+```
+
+Then map the audit findings:
+
+- **Jetpack active + `seo-tools` module active** → don't install anything. Tell the user the issue is in *configuration* (e.g. empty default title format, missing per-post meta description). Point them at **Jetpack → Settings → Traffic → SEO Tools** in `wp-admin`.
+- **Jetpack active + `seo-tools` module inactive** → enable the module instead of installing a new plugin:
+  ```
+  wp_cli: jetpack module activate seo-tools
+  ```
+  Then re-run `rank_me_up` to confirm the tags appear.
+- **Another SEO plugin active** → don't recommend installing Jetpack on top of it (two SEO plugins fight over the same `<head>` tags). Surface the *settings page* for the active plugin instead — e.g. for Yoast: **SEO → Search Appearance**; for Rank Math: **Rank Math → Titles & Meta**.
+- **No SEO plugin active** → recommend installing Jetpack. See "Recommended SEO Plugin" below.
+
+**Also worth checking for non-plugin fixes:**
+
+```
+wp_cli: option get blog_public
+```
+
+If it returns `0`, the site has "Discourage search engines" enabled — no plugin can override that. Fix with `wp option update blog_public 1`.
+
+## Interpreting Results
+
+### Title and Meta Description
+
+| Field | Recommended | Issue |
+|-------|-------------|-------|
+| `title` | 30–60 chars | Missing, too short (< 20), or too long (> 70) gets truncated in SERPs |
+| `description` | 70–160 chars | Missing means Google generates one for you, often poorly |
+| `canonical` | Self-referencing absolute URL | Missing causes duplicate-content risk |
+| `robots` | absent or `index, follow` | `noindex` blocks the page from search results |
+| `viewport` | `width=device-width, initial-scale=1` | Missing breaks mobile usability ranking signal |
+| `htmlLang` | Present (e.g. `en-US`) | Missing hurts internationalization and accessibility |
+
+### Headings
+
+- **Exactly 1 `h1`** per page. 0 means the page has no clear topic; 2+ dilutes the signal.
+- **No skipped levels** (e.g. `h2 → h4`). Skipped levels confuse screen readers and weaken topical structure.
+- The `h1` text should reflect the page's primary search intent.
+
+### Images
+
+- Every `img` should have an `alt` attribute. `withoutAlt` (missing entirely) is worse than `emptyAlt` (decorative).
+- Empty `alt=""` is correct only for decorative images. Content images need descriptive alt text.
+- Use the `missingAltUrls` list to identify which images to fix first.
+
+### Social Tags (Open Graph & Twitter)
+
+Required for good link previews on social media:
+- **Open Graph**: `og:title`, `og:description`, `og:image`, `og:url`, `og:type`
+- **Twitter**: `twitter:card` (typically `summary_large_image`), `twitter:title`, `twitter:description`, `twitter:image`
+
+Missing OG tags don't hurt rankings directly but kill click-through from social shares.
+
+### Structured Data (JSON-LD)
+
+- `jsonLdCount: 0` means no rich-result eligibility. Add at minimum `WebSite` and `Organization` schema sitewide.
+- For specific page types, add `Article`, `Product`, `FAQPage`, `BreadcrumbList`, `LocalBusiness`, etc.
+
+### Resources
+
+- **`robotsTxtFound: false`**: WordPress generates a virtual one — usually fine, but a real file gives more control.
+- **`robotsTxtBlocksAll: true`**: CRITICAL — `Disallow: /` blocks all crawlers. Often a forgotten "Discourage search engines" setting in WP Admin → Reading.
+- **`sitemapFound: false`**: Install Jetpack and enable its SEO Tools module, or enable WP core's sitemap (`/wp-sitemap.xml`). See "Recommended SEO Plugin" below.
+
+### Links
+
+- Many `emptyText` links (anchors with no visible text, no `aria-label`, no alt-text image) hurt accessibility and SEO. Use the `emptyTextHrefs` list to fix.
+- A high `nofollow` count on internal links wastes link equity — internal links should generally be `dofollow`.
+
+## Recommended SEO Plugin: Jetpack
+
+**Only reach this section after running the "Check Active Plugins First" step and confirming no SEO plugin is active.**
+
+**Why Jetpack:** It's Automattic's official WordPress plugin and integrates natively with WordPress.com — the same platform users push Studio sites to via `site_push` and `preview_create`. Recommending Jetpack keeps the local dev experience aligned with production.
+
+**Install, activate, and enable the SEO module:**
+
+```
+wp_cli: plugin install jetpack --activate
+wp_cli: jetpack module activate seo-tools
+```
+
+**What the `seo-tools` module covers:**
+
+- Custom page title formats (front page, post, page, archive, etc.)
+- Custom meta descriptions per post/page
+- Open Graph + Twitter Card tags (including `twitter:card`, `og:image`, etc.)
+- XML sitemap at `/sitemap.xml` (auto-submitted to WordPress.com)
+- Verification tag support (Google, Bing, Pinterest, Yandex)
+
+**Plan note:** Jetpack's *Advanced SEO Tools* (custom title formats + per-post meta descriptions) require a paid Jetpack plan (Security, Complete, or the standalone Jetpack SEO add-on). Basic social meta + sitemap are available on the free tier. If the user is on free and needs per-post meta descriptions, tell them upfront so they can decide whether to upgrade.
+
+**Fallback:** Only suggest alternatives (Yoast SEO, Rank Math, AIOSEO) if the user explicitly rejects Jetpack.
+
+## Common WordPress Recommendations
+
+Based on the metrics, suggest specific actions. Route each fix through whatever you discovered in "Check Active Plugins First" — don't recommend installing a plugin that's already active or telling the user to configure one that isn't.
+
+- **Missing title/description**:
+  - *Jetpack active + `seo-tools` on*: user needs to *configure* title formats at **Jetpack → Settings → Traffic → SEO Tools** and fill meta descriptions per-post (paid plan required for per-post).
+  - *Jetpack active + `seo-tools` off*: `wp_cli: jetpack module activate seo-tools`.
+  - *Another SEO plugin active*: point to its title/meta settings page — don't install Jetpack on top.
+  - *Nothing active*: install Jetpack (see "Recommended SEO Plugin" above).
+  - *Plugins refused*: set the title via theme `wp_title()` and description via a `<meta>` tag in `header.php` / a block theme template part.
+- **Missing canonical**: Any SEO plugin (Jetpack, Yoast, Rank Math, AIOSEO) handles this automatically once active. Without one, add `<link rel="canonical" href="<?php echo esc_url( wp_get_canonical_url() ); ?>">` to the head.
+- **Wrong h1 count**: Audit the active block theme's templates — site title is often wrapped in an `h1` on every page. Use `h2` for the site title on inner pages, reserve `h1` for the page title. This is a theme fix; no SEO plugin will correct it.
+- **Missing alt text**: Content fix, not a plugin fix. Run `wp media list --field=ID` and update via `wp post update`, or train content editors to add alt text on upload.
+- **Missing OG / Twitter tags**:
+  - *Jetpack active + `seo-tools` on*: OG/Twitter should already be emitted — re-check the HTML; if still missing, inspect for a conflicting plugin stripping them.
+  - *Jetpack active + `seo-tools` off*: enable the module.
+  - *Another SEO plugin active*: enable its social-meta feature (Yoast: **SEO → Social**; Rank Math: **Rank Math → Titles & Meta → Social Meta**).
+  - *Nothing active*: install Jetpack, or hook into `wp_head` to emit tags manually.
+- **No JSON-LD**: WordPress core does not emit JSON-LD. Jetpack adds basic `WebSite` / `SearchAction` markup when the `seo-tools` module is on. For richer schemas (Product, FAQ, Article, BreadcrumbList) use a dedicated schema plugin (e.g. Yoast/Rank Math handle these) or custom `wp_head` output.
+- **`robotsTxtBlocksAll: true`**: Run `wp_cli: option update blog_public 1` to undo the "Discourage search engines" setting. No plugin can override this.
+- **Missing sitemap**: Verify `blog_public` is `1` first. Then check `/wp-sitemap.xml` (WP core since 5.5) or `/sitemap.xml` (Jetpack). If Jetpack is active but the sitemap is missing, enable the `seo-tools` module. If another SEO plugin is active, it may have disabled core sitemaps in favor of its own — check its sitemap settings.
+- **Missing viewport meta**: Theme bug — add `<meta name="viewport" content="width=device-width, initial-scale=1">` in the `<head>`. Not a plugin concern.
+- **Missing `htmlLang`**: Theme should output `<html <?php language_attributes(); ?>>` (block themes do this automatically; classic themes need it added). Not a plugin concern.
+
+## Important Notes
+
+- This is an **on-page audit of a local dev site**. It does NOT measure rankings, traffic, backlinks, or Core Web Vitals (use `need_for_speed` for performance signals).
+- Search engines won't crawl a local Studio site, so this is purely about preparing the site for production. Pair fixes with `site_push` or `preview_create` to validate on a public URL.
+- For content-quality SEO (keyword targeting, search intent, content depth), the audit can only flag structural gaps — not whether the content is *good*. Combine with editorial review.

--- a/apps/cli/ai/seo-audit.ts
+++ b/apps/cli/ai/seo-audit.ts
@@ -1,0 +1,429 @@
+/**
+ * On-page SEO audit module for WordPress sites.
+ *
+ * Loads a page in the shared Playwright browser and extracts on-page SEO
+ * signals from the rendered DOM (meta tags, headings, images, links, schema)
+ * along with the availability of robots.txt and sitemap.xml.
+ *
+ * This is a synthetic audit of a local site — it does not use Search Console
+ * data or rank tracking. Focus on structural fixes the user can apply.
+ */
+
+import { getSharedBrowser } from 'cli/ai/browser-utils';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MetaTagsAudit {
+	title: string | null;
+	titleLength: number;
+	description: string | null;
+	descriptionLength: number;
+	canonical: string | null;
+	robots: string | null;
+	viewport: string | null;
+	htmlLang: string | null;
+	charset: string | null;
+}
+
+export interface SocialTagsAudit {
+	openGraph: Record< string, string >;
+	twitter: Record< string, string >;
+}
+
+export interface HeadingsAudit {
+	counts: { h1: number; h2: number; h3: number; h4: number; h5: number; h6: number };
+	h1Texts: string[];
+	skippedLevels: string[];
+}
+
+export interface ImagesAudit {
+	total: number;
+	withAlt: number;
+	withoutAlt: number;
+	emptyAlt: number;
+	missingAltUrls: string[];
+}
+
+export interface LinksAudit {
+	totalInternal: number;
+	totalExternal: number;
+	nofollow: number;
+	emptyText: number;
+	emptyTextHrefs: string[];
+}
+
+export interface StructuredDataAudit {
+	jsonLdCount: number;
+	jsonLdTypes: string[];
+}
+
+export interface ResourcesAudit {
+	robotsTxtFound: boolean;
+	robotsTxtBlocksAll: boolean;
+	sitemapFound: boolean;
+	sitemapUrl: string | null;
+}
+
+export interface SeoMetrics {
+	url: string;
+	httpStatus: number;
+	wordCount: number;
+	meta: MetaTagsAudit;
+	social: SocialTagsAudit;
+	headings: HeadingsAudit;
+	images: ImagesAudit;
+	links: LinksAudit;
+	structuredData: StructuredDataAudit;
+	resources: ResourcesAudit;
+}
+
+export interface SeoAuditResult {
+	url: string;
+	timestamp: string;
+	metrics: SeoMetrics | null;
+	error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// In-page collection script
+// ---------------------------------------------------------------------------
+
+function collectSeoScript( origin: string ) {
+	function text( el: Element | null ): string {
+		return el?.textContent?.trim() ?? '';
+	}
+
+	function attr( selector: string, name: string ): string | null {
+		const el = document.querySelector( selector );
+		return el ? el.getAttribute( name ) : null;
+	}
+
+	const titleEl = document.querySelector( 'title' );
+	const titleText = text( titleEl );
+
+	const description = attr( 'meta[name="description" i]', 'content' );
+	const canonical = attr( 'link[rel="canonical" i]', 'href' );
+	const robots = attr( 'meta[name="robots" i]', 'content' );
+	const viewport = attr( 'meta[name="viewport" i]', 'content' );
+	const htmlLang = document.documentElement.getAttribute( 'lang' );
+	const charset =
+		document.characterSet ||
+		attr( 'meta[charset]', 'charset' ) ||
+		attr( 'meta[http-equiv="Content-Type" i]', 'content' );
+
+	const openGraph: Record< string, string > = {};
+	for ( const meta of Array.from(
+		document.querySelectorAll( 'meta[property^="og:" i]' )
+	) as HTMLMetaElement[] ) {
+		const property = meta.getAttribute( 'property' );
+		const content = meta.getAttribute( 'content' );
+		if ( property && content ) {
+			openGraph[ property.toLowerCase() ] = content;
+		}
+	}
+
+	const twitter: Record< string, string > = {};
+	for ( const meta of Array.from(
+		document.querySelectorAll( 'meta[name^="twitter:" i]' )
+	) as HTMLMetaElement[] ) {
+		const name = meta.getAttribute( 'name' );
+		const content = meta.getAttribute( 'content' );
+		if ( name && content ) {
+			twitter[ name.toLowerCase() ] = content;
+		}
+	}
+
+	const headingCounts = { h1: 0, h2: 0, h3: 0, h4: 0, h5: 0, h6: 0 };
+	const h1Texts: string[] = [];
+	const seenLevels: number[] = [];
+	const skippedLevels: string[] = [];
+
+	for ( const el of Array.from(
+		document.querySelectorAll( 'h1, h2, h3, h4, h5, h6' )
+	) as HTMLElement[] ) {
+		const level = Number( el.tagName.substring( 1 ) ) as 1 | 2 | 3 | 4 | 5 | 6;
+		const tag = el.tagName.toLowerCase() as keyof typeof headingCounts;
+		headingCounts[ tag ]++;
+		if ( level === 1 ) {
+			h1Texts.push( text( el ).slice( 0, 200 ) );
+		}
+		const previous = seenLevels[ seenLevels.length - 1 ];
+		if ( previous !== undefined && level > previous + 1 ) {
+			skippedLevels.push(
+				`${ tag } after h${ previous } (skipped ${ level - previous - 1 } level(s))`
+			);
+		}
+		seenLevels.push( level );
+	}
+
+	let imgTotal = 0;
+	let imgWithAlt = 0;
+	let imgWithoutAlt = 0;
+	let imgEmptyAlt = 0;
+	const missingAltUrls: string[] = [];
+	for ( const img of Array.from( document.querySelectorAll( 'img' ) ) as HTMLImageElement[] ) {
+		imgTotal++;
+		const alt = img.getAttribute( 'alt' );
+		if ( alt === null ) {
+			imgWithoutAlt++;
+			if ( missingAltUrls.length < 20 ) {
+				missingAltUrls.push( img.currentSrc || img.src || '(no src)' );
+			}
+		} else if ( alt.trim() === '' ) {
+			imgEmptyAlt++;
+		} else {
+			imgWithAlt++;
+		}
+	}
+
+	let internal = 0;
+	let external = 0;
+	let nofollow = 0;
+	let emptyText = 0;
+	const emptyTextHrefs: string[] = [];
+	for ( const a of Array.from( document.querySelectorAll( 'a[href]' ) ) as HTMLAnchorElement[] ) {
+		const href = a.getAttribute( 'href' ) ?? '';
+		if (
+			! href ||
+			href.startsWith( '#' ) ||
+			href.startsWith( 'mailto:' ) ||
+			href.startsWith( 'tel:' )
+		) {
+			continue;
+		}
+		let isExternal = false;
+		try {
+			const url = new URL( href, origin );
+			isExternal = url.origin !== origin;
+		} catch {
+			continue;
+		}
+		if ( isExternal ) {
+			external++;
+		} else {
+			internal++;
+		}
+		const rel = ( a.getAttribute( 'rel' ) ?? '' ).toLowerCase();
+		if ( rel.split( /\s+/ ).includes( 'nofollow' ) ) {
+			nofollow++;
+		}
+		const visibleText = ( a.textContent ?? '' ).trim();
+		const hasImage = a.querySelector( 'img[alt]:not([alt=""])' );
+		const ariaLabel = a.getAttribute( 'aria-label' )?.trim();
+		if ( ! visibleText && ! hasImage && ! ariaLabel ) {
+			emptyText++;
+			if ( emptyTextHrefs.length < 20 ) {
+				emptyTextHrefs.push( href );
+			}
+		}
+	}
+
+	const jsonLdTypes: string[] = [];
+	let jsonLdCount = 0;
+	for ( const script of Array.from(
+		document.querySelectorAll( 'script[type="application/ld+json"]' )
+	) ) {
+		jsonLdCount++;
+		try {
+			const parsed = JSON.parse( script.textContent ?? '' );
+			const items = Array.isArray( parsed ) ? parsed : [ parsed ];
+			for ( const item of items ) {
+				const graph = item?.[ '@graph' ];
+				const nodes = Array.isArray( graph ) ? graph : [ item ];
+				for ( const node of nodes ) {
+					const t = node?.[ '@type' ];
+					if ( typeof t === 'string' ) {
+						jsonLdTypes.push( t );
+					} else if ( Array.isArray( t ) ) {
+						for ( const v of t ) {
+							if ( typeof v === 'string' ) {
+								jsonLdTypes.push( v );
+							}
+						}
+					}
+				}
+			}
+		} catch {
+			// Ignore malformed JSON-LD blocks; we still report the count.
+		}
+	}
+
+	const wordCount = ( document.body.innerText || '' )
+		.trim()
+		.split( /\s+/ )
+		.filter( Boolean ).length;
+
+	return {
+		title: titleText || null,
+		description,
+		canonical,
+		robots,
+		viewport,
+		htmlLang,
+		charset,
+		openGraph,
+		twitter,
+		headingCounts,
+		h1Texts,
+		skippedLevels,
+		images: {
+			total: imgTotal,
+			withAlt: imgWithAlt,
+			withoutAlt: imgWithoutAlt,
+			emptyAlt: imgEmptyAlt,
+			missingAltUrls,
+		},
+		links: {
+			totalInternal: internal,
+			totalExternal: external,
+			nofollow,
+			emptyText,
+			emptyTextHrefs,
+		},
+		structuredData: { jsonLdCount, jsonLdTypes: Array.from( new Set( jsonLdTypes ) ) },
+		wordCount,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Robots.txt and sitemap detection
+// ---------------------------------------------------------------------------
+
+async function checkResource(
+	browser: Awaited< ReturnType< typeof getSharedBrowser > >,
+	url: string
+): Promise< { ok: boolean; body: string } > {
+	const context = await browser.newContext( { ignoreHTTPSErrors: true } );
+	try {
+		const response = await context.request.get( url, {
+			failOnStatusCode: false,
+			timeout: 10_000,
+		} );
+		const ok = response.status() >= 200 && response.status() < 400;
+		const body = ok ? await response.text() : '';
+		return { ok, body };
+	} catch {
+		return { ok: false, body: '' };
+	} finally {
+		await context.close();
+	}
+}
+
+function robotsBlocksAll( robotsTxt: string ): boolean {
+	const lines = robotsTxt.split( /\r?\n/ );
+	let inGlobalGroup = false;
+	for ( const line of lines ) {
+		const trimmed = line.split( '#' )[ 0 ].trim();
+		if ( ! trimmed ) {
+			continue;
+		}
+		const [ rawKey, ...rest ] = trimmed.split( ':' );
+		const key = rawKey.trim().toLowerCase();
+		const value = rest.join( ':' ).trim();
+		if ( key === 'user-agent' ) {
+			inGlobalGroup = value === '*';
+		} else if ( inGlobalGroup && key === 'disallow' && value === '/' ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+const AUDIT_VIEWPORT = { width: 1040, height: 1248 };
+
+export async function auditSeo( siteUrl: string, urlPath = '/' ): Promise< SeoAuditResult > {
+	const origin = siteUrl.replace( /\/+$/, '' );
+	const targetUrl = `${ origin }${ urlPath }`;
+
+	try {
+		const browser = await getSharedBrowser();
+		const page = await browser.newPage( {
+			viewport: AUDIT_VIEWPORT,
+			ignoreHTTPSErrors: true,
+		} );
+
+		try {
+			const response = await page.goto( targetUrl, {
+				waitUntil: 'networkidle',
+				timeout: 30_000,
+			} );
+
+			const httpStatus = response?.status() ?? 0;
+			const collected = await page.evaluate( collectSeoScript, origin );
+
+			const [ robotsResult, sitemapAtRoot, sitemapIndex ] = await Promise.all( [
+				checkResource( browser, `${ origin }/robots.txt` ),
+				checkResource( browser, `${ origin }/sitemap.xml` ),
+				checkResource( browser, `${ origin }/sitemap_index.xml` ),
+			] );
+
+			let sitemapUrl: string | null = null;
+			if ( sitemapAtRoot.ok ) {
+				sitemapUrl = `${ origin }/sitemap.xml`;
+			} else if ( sitemapIndex.ok ) {
+				sitemapUrl = `${ origin }/sitemap_index.xml`;
+			} else if ( robotsResult.ok ) {
+				const match = robotsResult.body.match( /^\s*Sitemap:\s*(\S+)/im );
+				if ( match ) {
+					sitemapUrl = match[ 1 ];
+				}
+			}
+
+			const metrics: SeoMetrics = {
+				url: targetUrl,
+				httpStatus,
+				wordCount: collected.wordCount,
+				meta: {
+					title: collected.title,
+					titleLength: collected.title?.length ?? 0,
+					description: collected.description,
+					descriptionLength: collected.description?.length ?? 0,
+					canonical: collected.canonical,
+					robots: collected.robots,
+					viewport: collected.viewport,
+					htmlLang: collected.htmlLang,
+					charset: collected.charset,
+				},
+				social: {
+					openGraph: collected.openGraph,
+					twitter: collected.twitter,
+				},
+				headings: {
+					counts: collected.headingCounts,
+					h1Texts: collected.h1Texts,
+					skippedLevels: collected.skippedLevels,
+				},
+				images: collected.images,
+				links: collected.links,
+				structuredData: collected.structuredData,
+				resources: {
+					robotsTxtFound: robotsResult.ok,
+					robotsTxtBlocksAll: robotsResult.ok && robotsBlocksAll( robotsResult.body ),
+					sitemapFound: sitemapUrl !== null,
+					sitemapUrl,
+				},
+			};
+
+			return {
+				url: targetUrl,
+				timestamp: new Date().toISOString(),
+				metrics,
+			};
+		} finally {
+			await page.close();
+		}
+	} catch ( error ) {
+		return {
+			url: targetUrl,
+			timestamp: new Date().toISOString(),
+			metrics: null,
+			error: error instanceof Error ? error.message : String( error ),
+		};
+	}
+}

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -295,4 +295,5 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 	},
 	{ name: 'taxonomist', description: __( 'Optimize category taxonomy with AI' ) },
 	{ name: 'need-for-speed', description: __( 'Run a performance audit on a site' ) },
+	{ name: 'rank-me-up', description: __( 'Run an on-page SEO audit on a site' ) },
 ];

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -138,6 +138,7 @@ Then continue with:
 - validate_blocks: Validate block content for correctness on a running site (runs each block through its save() function in a real browser). Requires a site name or path. Call after every file write/edit that contains block content.
 - take_screenshot: Take a full-page screenshot of a URL (supports desktop and mobile viewports). Use this to visually check the site after building it.
 - need_for_speed: Measure frontend performance metrics (TTFB, FCP, LCP, CLS, page weight, DOM size, JS/CSS/image/font asset breakdown) for a running site. Use this to identify performance bottlenecks and guide optimization.
+- rank_me_up: Run an on-page SEO audit (title/meta tags, headings, image alt text, OpenGraph/Twitter cards, JSON-LD structured data, robots.txt and sitemap.xml availability) for a running site. Use this to identify on-page SEO issues and guide fixes.
 - site_push: Push a local site to a WordPress.com site. Requires authentication (studio auth login). Specify the remote site URL or ID and sync options (all, sqls, uploads, plugins, themes, contents).
 - site_pull: Pull a WordPress.com site to a local site. Requires authentication. Specify the remote site URL or ID and sync options.
 - site_import: Import a backup file (.zip, .tar.gz, .sql, .wpress) into a local site.

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -6,6 +6,7 @@ import { z } from 'zod/v4';
 import { validateBlocks, type ValidationReport } from 'cli/ai/block-validator';
 import { getSharedBrowser } from 'cli/ai/browser-utils';
 import { auditPerformance } from 'cli/ai/performance-audit';
+import { auditSeo } from 'cli/ai/seo-audit';
 import { createWpcomToolDefinitions } from 'cli/ai/wpcom-tools';
 import { runCommand as runExportCommand } from 'cli/commands/export';
 import { runCommand as runImportCommand } from 'cli/commands/import';
@@ -794,6 +795,47 @@ const auditPerformanceTool = tool(
 	}
 );
 
+const auditSeoTool = tool(
+	'rank_me_up',
+	'Runs an on-page SEO audit on a WordPress site page. Returns title and meta description, ' +
+		'canonical/robots/viewport tags, Open Graph and Twitter cards, heading structure, image alt-text ' +
+		'coverage, internal/external link counts, JSON-LD structured data, and robots.txt/sitemap.xml ' +
+		'availability. The site must be running. Use this to identify on-page SEO issues.',
+	{
+		nameOrPath: z
+			.string()
+			.describe( 'The site name or file system path — the site must be running' ),
+		path: z
+			.string()
+			.optional()
+			.describe( 'URL path to audit (e.g., "/", "/about"). Defaults to "/".' ),
+	},
+	async ( args ) => {
+		try {
+			const site = await resolveSite( args.nameOrPath );
+			const siteUrl = getSiteUrl( site );
+			const urlPath = args.path ?? '/';
+
+			emitProgress( `Auditing SEO of ${ siteUrl }${ urlPath }…` );
+
+			const result = await auditSeo( siteUrl, urlPath );
+
+			if ( result.error ) {
+				emitProgress( `Audit failed: ${ result.error.slice( 0, 80 ) }` );
+				return errorResult( `SEO audit failed: ${ result.error }` );
+			}
+
+			emitProgress( `SEO audit complete for ${ urlPath }` );
+
+			return textResult( JSON.stringify( result, null, 2 ) );
+		} catch ( error ) {
+			return errorResult(
+				`SEO audit failed: ${ error instanceof Error ? error.message : String( error ) }`
+			);
+		}
+	}
+);
+
 const pushSiteTool = tool(
 	'site_push',
 	'Pushes a local WordPress site to a WordPress.com site. Requires WordPress.com authentication ' +
@@ -970,6 +1012,7 @@ export const studioToolDefinitions = [
 	takeScreenshotTool,
 	installTaxonomyScriptsTool,
 	auditPerformanceTool,
+	auditSeoTool,
 	pushSiteTool,
 	pullSiteTool,
 	importSiteTool,


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

This PR was generated with Claude Code. It mirrors the existing `need-for-speed` performance audit pattern: a Playwright-based audit module, an MCP tool, a slash-command entry, a line in the local system prompt, and a `SKILL.md`. Reviewers should focus on:

- Whether the Playwright `BrowserContext` lifecycle in `seo-audit.ts` matches the project's conventions (we use `browser.newContext()` + `context.close()` per request to check `robots.txt` / `sitemap.xml`, since Studio local sites use self-signed certs and Node's native `fetch()` would reject them).
- Whether the SKILL.md's Jetpack-first routing is the right default, and whether the "Check Active Plugins First" workflow is specific enough that the agent won't blindly suggest installs on top of an already-configured site.

## Proposed Changes

- Add `/rank-me-up` — a DOM-based on-page SEO audit for local Studio sites.
- New `apps/cli/ai/seo-audit.ts` module. Uses the shared Playwright browser to collect:
  - Meta: `title`, `description` (with lengths), `canonical`, `robots`, `viewport`, `htmlLang`, `charset`
  - Social: Open Graph + Twitter Card tags
  - Headings: counts per level, H1 text list, skipped-level detection
  - Images: total / with alt / without alt / empty alt, sample URLs missing alt
  - Links: internal/external counts, nofollow count, empty-text anchors
  - Structured data: JSON-LD count + `@type` list (including `@graph` walks)
  - Resources: `robots.txt` presence + `Disallow: /` detection, `sitemap.xml` / `sitemap_index.xml` / `Sitemap:` directive in robots.txt
  - Word count, HTTP status
- Register `rank_me_up` MCP tool in `apps/cli/ai/tools.ts` and add it to the local-mode system prompt alongside `need_for_speed`.
- Register `/rank-me-up` slash command.
- Add `apps/cli/ai/plugin/skills/rank-me-up/SKILL.md` with:
  - Mandatory "Check Active Plugins First" step (inspects active plugins + Jetpack modules via `wp plugin list` and `wp jetpack module list` before recommending anything)
  - Jetpack-first recommendation (`wp plugin install jetpack --activate` + `wp jetpack module activate seo-tools`), falling back to Yoast / Rank Math / AIOSEO only if the user rejects Jetpack
  - Four explicit routing branches for every plugin-sensitive fix (Jetpack+module on, Jetpack+module off, other SEO plugin active, nothing active)
  - Interpretation thresholds (title/description lengths, heading rules, etc.) and explicit flags for non-plugin fixes (h1 count, alt text, viewport, `htmlLang`, `blog_public`)

## Testing Instructions

1. `npm run cli:build`
2. Start a local site: `node apps/cli/dist/cli/main.mjs site start <site>`
3. Launch the agent and run `/rank-me-up` against the site.
4. Verify the audit returns structured JSON covering all categories above.
5. Try each plugin-state branch:
   - Site with no SEO plugin → agent should recommend installing Jetpack + activating `seo-tools`.
   - `wp plugin install jetpack --activate` but leave `seo-tools` off → agent should recommend `wp jetpack module activate seo-tools`, not a new install.
   - With Jetpack + `seo-tools` on → agent should point at **Jetpack → Settings → Traffic → SEO Tools** for configuration, not suggest installing anything.
   - With Yoast/Rank Math/AIOSEO active → agent should surface that plugin's settings page, not install Jetpack on top.
6. Confirm `need_for_speed` still works (no regression from sharing the Playwright browser).

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)