### PR TITLE
apps/cli: add taste skill for better site design direction

### DIFF
--- a/apps/cli/ai/plugin/skills/site-spec/SKILL.md
+++ b/apps/cli/ai/plugin/skills/site-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: site-spec
-description: Gather the site name and layout preference before building a WordPress site. Run this before creating any new site.
+description: Gather the site name, layout preference, and aesthetic direction before building a WordPress site. Run this before creating any new site.
 user-invokable: true
 ---
 
@@ -10,9 +10,9 @@ Before creating a new WordPress site, gather the user's basic preferences throug
 
 ## How to Run
 
-Gather preferences through 2 rounds. Keep it concise.
+Gather preferences through 3 rounds. Keep it concise.
 
-**AskUserQuestion constraints**: Each call supports 1-4 questions, each with 2-4 options. An "Other" free-form option is automatically provided by the system — do NOT add one yourself. Keep option labels short (1-5 words). Only use AskUserQuestion for questions that have meaningful predefined options. For open-ended questions (like asking for a name), just ask in your text output — the user will type their answer in the prompt.
+**AskUserQuestion constraints**: Each call supports 1-4 questions, each with **exactly 2-4 options per question** (hard cap — cannot exceed 4). An "Other" free-form option is automatically provided by the system — do NOT add one yourself and do NOT count it toward your 4. Keep option labels short (1-5 words). Only use AskUserQuestion for questions that have meaningful predefined options. For open-ended questions (like asking for a name), just ask in your text output — the user will type their answer in the prompt.
 
 ### Round 1 — Name
 
@@ -20,16 +20,65 @@ Ask the user for their business/site name in your text output. **Stop here and w
 
 ### Round 2 — Layout
 
-After the user provides the name, use AskUserQuestion for:
-- One-page site or multi-page site? (e.g., single scrollable page with sections vs. separate pages for each area)
+After the user provides the name, use AskUserQuestion for Layout **only**:
+
+- **Question**: One-page site or multi-page site? (single scrollable page with sections vs. separate pages for each area)
+- **Options**: `One-page`, `Multi-page`
+
+Keep this as its own round — do not combine with other questions. Combining tends to cause option trimming.
+
+### Round 3 — Aesthetic Direction
+
+Before the AskUserQuestion call, **print the full menu of five directions in your text output** so the user sees all options, not just the clickable four. Example:
+
+> "What aesthetic direction should the site take? Five presets:
+> - **Minimalist** — restrained, calm, generous whitespace, precise type.
+> - **Soft** — warm, airy, expensive-feeling, spring-like motion, muted palette.
+> - **Editorial** — magazine-like, refined typography, measured asymmetry, serif display.
+> - **Brutalist** — raw, mechanical, sharp contrast, Swiss/monospace typography.
+> - **Maximalist** — bold, dense, kinetic motion, layered effects, playful chaos.
+>
+> Pick one below, or use 'Other' to describe a custom direction (retro-futurist, playful-toy, luxury-refined, etc.)."
+
+Then call AskUserQuestion with **all four clickable options, no fewer**:
+
+- **Question**: Which aesthetic direction?
+- **Options** (MUST include all four):
+  1. `Minimalist`
+  2. `Soft`
+  3. `Editorial`
+  4. `Maximalist`
+- **Header**: "Aesthetic"
+- The auto-provided "Other" catches Brutalist + anything freeform.
+
+**Do not drop options.** If you find yourself tempted to shrink the list to 3, you're wrong — the AskUserQuestion tool supports exactly 4 and the skill requires all 4.
+
+### Aesthetic → Taste Dial Mapping
+
+Use this when you load the `taste` skill later. The mapping is the skill's authoritative source — keep it in sync.
+
+- **Minimalist** → VARIANCE 3, MOTION 4, DENSITY 3
+- **Soft** → VARIANCE 4, MOTION 6, DENSITY 3
+- **Editorial** → VARIANCE 6, MOTION 6, DENSITY 5
+- **Brutalist** → VARIANCE 9, MOTION 7, DENSITY 6
+- **Maximalist** → VARIANCE 9, MOTION 9, DENSITY 7
+- **Other / freeform** — interpret the user's words literally: pick dials that match the mood they described. Don't silently fall back to a baseline.
 
 ## After Gathering Answers
 
-Call `site_create` with the provided name and use the layout preference to guide all subsequent design decisions.
+Produce the **Site Spec** internally before calling `site_create`. The spec must include:
+- Site name
+- Layout (one-page / multi-page)
+- Aesthetic direction (name + the three dial values)
+- A one-sentence aesthetic brief you'll hand to the taste skill (e.g. "Editorial luxury for an architecture studio — measured asymmetry, serif display, muted stone palette")
+
+Then call `site_create`. When you subsequently load the `taste` skill during the design-planning step, apply the dial preset from the aesthetic direction rather than the default baseline, and honor the brief throughout.
 
 ## When to Skip Discovery
 
 Do NOT ask questions if:
-- The user already provided the name and layout preference in the initial prompt. Proceed directly with site creation.
-- The user says "just build something" or "surprise me". Pick a bold creative direction yourself and proceed.
+- The user already provided the name, layout preference, and aesthetic direction in the initial prompt. Proceed directly with site creation.
+- The user says "just build something" or "surprise me". Pick a bold creative direction yourself (vary across generations — don't default to the same direction twice) and proceed.
 - The user explicitly asks to skip the setup or says they don't want questions.
+
+If the user provided *some* of the three inputs but not all, only ask about the missing ones.

--- a/apps/cli/ai/plugin/skills/taste/SKILL.md
+++ b/apps/cli/ai/plugin/skills/taste/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: taste
+description: High-agency design direction for WordPress block themes. Enforces bold aesthetic commitment, anti-slop rules, and Studio-specific constraints (block-only content, style.css, progressive-enhancement animations). Load this before planning or generating any design work.
+user-invokable: true
+---
+
+# Taste — WordPress Block Theme Design Skill
+
+Adapted from [taste-skill](https://github.com/Leonxlnx/taste-skill) for WordPress Studio. The aesthetic philosophy and anti-slop rules are preserved; the technical directives are rewritten for block themes (core blocks, `style.css`, progressive-enhancement JS) instead of React/Tailwind/Framer Motion.
+
+## 1. ACTIVE BASELINE CONFIGURATION
+
+- **DESIGN_VARIANCE**: 7 (1=Perfect Symmetry, 10=Artsy Chaos)
+- **MOTION_INTENSITY**: 6 (1=Static, 10=Cinematic scroll-telling)
+- **VISUAL_DENSITY**: 4 (1=Art Gallery/Airy, 10=Packed Data)
+
+**Instruction:** These are the default dials for any new site. Adapt them dynamically when the user expresses a direction ("make it quieter" → lower MOTION_INTENSITY and DESIGN_VARIANCE; "I want a dense dashboard feel" → raise VISUAL_DENSITY). Use these values as global parameters driving Sections 3-6.
+
+If the site-spec skill captured an explicit aesthetic direction (minimalist, soft, editorial, brutalist, maximalist), let that override the defaults:
+
+- **minimalist** → VARIANCE 3, MOTION 4, DENSITY 3
+- **soft** → VARIANCE 4, MOTION 6, DENSITY 3
+- **editorial** → VARIANCE 6, MOTION 6, DENSITY 5
+- **brutalist** → VARIANCE 9, MOTION 7, DENSITY 6
+- **maximalist** → VARIANCE 9, MOTION 9, DENSITY 7
+
+**MOTION floor = 4.** Every site gets at least a page-load fade cascade and scroll reveals on key sections. MOTION 1-3 is only used when the user explicitly requests a static or accessibility-minimal site.
+
+## 1b. CROSS-GENERATION VARIANCE (READ FIRST)
+
+Every site you build must feel meaningfully different from the last. Convergence on a single "safe" template across generations is the single biggest failure mode of AI design, and it is the primary reason this skill exists. Before settling on any choice, check whether it was used recently and pick something else if so.
+
+Vary deliberately across:
+
+- **Aesthetic direction** — if the user didn't specify one and the last site was minimalist, pick something else this time. Don't default to the same mood twice.
+- **Light vs. dark** — alternate. If the last site was a light cream theme, this one should lean dark (graphite, ink, midnight) or vice versa. Don't converge on light-by-default.
+- **Display font** — never reach for Space Grotesk, Inter, or any single font reflexively. Rotate across the preferred lists in Section 3 Rule 1. If the last site used Cabinet Grotesk, pick Fraunces, Editorial New, Clash Display, Satoshi, etc.
+- **Palette temperature** — alternate warm (cream, stone, brass, rose) and cool (graphite, slate, electric blue, forest) across generations.
+- **Hero paradigm** — see Section 8. Never pick the same paradigm back to back. Specifically: do not default to the asymmetric split hero.
+- **Layout signature** — zig-zag, bento, masonry, horizontal scroll, sticky stack, numbered list — rotate through these instead of converging.
+- **Implementation complexity** — match the aesthetic: maximalist needs elaborate motion and layering; minimalist needs restraint and precision; editorial needs typographic confidence over visual effects. Both ends require intentionality; the failure is timid middle-ground output.
+
+**Commit boldly.** Timid, generic output is a failure of this skill. If you find yourself reaching for the safe choice, pick the second-safest one instead.
+
+**Always use sophisticated scroll effects and page-load animations unless the user explicitly asks for a static site.** MOTION_INTENSITY floor is 4 — even the minimalist preset gets a page-load cascade and scroll reveals. Static (1-3) is opt-in only.
+
+## 2. STUDIO ARCHITECTURE & HARD CONSTRAINTS
+
+These are non-negotiable Studio/WordPress rules. Design decisions must work within them.
+
+- **Block themes only.** Never generate classic themes. All pages are assembled from core WordPress blocks.
+- **Core blocks only for structure and content.** `core/html` blocks are reserved for: inline SVGs, `<form>` elements and interactive inputs, animation/interaction markup with no block equivalent (marquee, cursor effects), and a single `<script>` block at the bottom of the page. Never use `core/html` to wrap text, headings, layout sections, or lists.
+- **All styling goes in the theme's `style.css`.** No inline `style` attributes. No `style` block attributes. No custom stylesheets. Target blocks via the `className` attribute set on the outermost wrapper.
+- **Register `style.css` as editor styles** in the theme's `functions.php` so the block editor matches the frontend.
+- **Progressive-enhancement animations.** CSS must define elements in their **final visible state** (full opacity, final position). Frontend JS adds the initial hidden state and scroll-triggered transitions. This guarantees elements render correctly in the block editor, which loads theme CSS but not custom JS.
+- **Respect `prefers-reduced-motion`.** Every animation or transition must be disabled or simplified inside `@media (prefers-reduced-motion: reduce) { … }`.
+- **Validate blocks after every write.** Invalid blocks break the editor; always run the validator and fix any reported issues.
+- **No emojis** anywhere in generated content.
+- **No decorative HTML comments** (e.g. `<!-- Hero Section -->`). Only block delimiter comments are allowed.
+
+## 3. DESIGN ENGINEERING DIRECTIVES (Bias Correction)
+
+LLMs have statistical biases toward specific UI clichés. Proactively construct premium interfaces using these engineered rules:
+
+**Rule 1: Deterministic Typography**
+
+- Pair a distinctive display font with a refined body font. Load both via Google Fonts (`@import` in `style.css` or enqueued properly in `functions.php`).
+- **ANTI-SLOP BANNED FONTS**: Inter, Roboto, Arial, Open Sans, Lato, system-ui default stacks. These are AI fallbacks.
+- **Preferred display fonts**: Fraunces, Cabinet Grotesk, Satoshi, Outfit, Geist, Instrument Serif, Tobi, Clash Display, Cormorant, Editorial New.
+- **Preferred body fonts**: Geist, Satoshi, Outfit, Source Serif Pro, Inter Display (distinct from Inter). Keep body line-height around 1.5-1.7, max line length 65ch.
+- **Display/Headlines**: Tight letter-spacing (`letter-spacing: -0.02em`), tight line-height (`line-height: 1` to `1.1`), scale of `clamp(2.5rem, 6vw, 5rem)` or larger for hero h1.
+- **NEVER converge on the same font across generations** (stop reaching for Space Grotesk by default).
+
+**Rule 2: Color Calibration**
+
+- **Max 1 accent color.** Saturation < 80% unless the aesthetic is explicitly maximalist.
+- **THE LILA BAN**: The "AI Purple/Blue gradient" aesthetic is BANNED. No purple-to-blue button glows, no default neon gradients.
+- **No pure black (`#000000`) or pure white (`#ffffff`)** for large surfaces. Use off-black (`#0a0a0a`, `#14110f`) and off-white (`#faf8f5`, `#f5f2ec`). Tinted neutrals communicate intentionality.
+- **Commit to one palette for the whole site.** Don't fluctuate between warm and cool grays within the same theme.
+- **Vary between light and dark themes across generations.** Don't default to light every time.
+
+**Rule 3: Layout Diversification**
+
+- **ANTI-CENTER BIAS**: When `DESIGN_VARIANCE > 4`, the generic "centered headline + subtitle + two CTAs" hero is BANNED. See Section 8's Hero Paradigms for the full menu of alternatives — **pick one at random**, don't default to the first entry, and don't pick the same paradigm you used in the previous generation.
+- **NO 3-EQUAL-CARD ROWS**: The generic "three equal cards in a row" feature block is BANNED. Alternatives include: 2-column zig-zag, asymmetric grid (e.g. `grid-template-columns: 2fr 1fr 1fr`), horizontal scroll, stacked full-width rows with dividers, bento tiles, numbered editorial list. **Randomize across them.**
+- **Grid over flex math**: Use CSS Grid (`display: grid`) for structural layouts, not flex with percentage calc widths.
+- **Viewport stability**: Use `min-height: 100dvh` for full-height sections, never `100vh` (mobile Safari jump bug).
+
+**Rule 4: Materiality and Anti-Card-Overuse**
+
+- **Cards only when elevation communicates hierarchy.** For `VISUAL_DENSITY > 6`, generic card boxes are BANNED. Group content using top borders, dividers, or negative space instead.
+- **Tinted shadows**: When a shadow is used, tint it toward the background hue rather than pure black. Prefer wide diffusion shadows (`0 20px 40px -15px rgba(20,17,15,0.08)`) over sharp drop shadows.
+
+**Rule 5: Interactive States**
+
+- Every interactive element must have hover, focus-visible, and active states. `:active` should give tactile feedback (`transform: translateY(1px)` or `scale(0.98)`).
+- Skeleton loaders (matching content dimensions) over generic spinners.
+- Empty states should be composed, not apologetic — explain how to populate the space.
+
+**Rule 6: Spatial Composition**
+
+- Section rhythm: large `section` gaps (`padding-block: clamp(6rem, 12vw, 10rem)`) create breathing room.
+- Content containment: max-width around `1400px` or `min(90vw, 1400px)`, centered.
+- Break the grid at least once per page (a full-bleed image, an element overlapping two sections, an oversized headline extending past the container).
+
+## 4. CREATIVE PROACTIVITY (Anti-Slop Implementation)
+
+Adapted for CSS + vanilla JS with progressive enhancement.
+
+- **"Liquid Glass" Refraction**: For glass surfaces, don't stop at `backdrop-filter: blur(…)`. Add a 1px inner top border (`border-top: 1px solid rgba(255,255,255,0.15)`) and an inset highlight (`box-shadow: inset 0 1px 0 rgba(255,255,255,0.1)`) to simulate physical edge refraction.
+- **Staggered reveals on page load**: Use `animation-delay: calc(var(--index) * 100ms)` with an index custom property on each child. Prefer a single orchestrated staggered load over many scattered micro-animations.
+- **Scroll-triggered reveals (progressive enhancement)**:
+  - CSS defines the final visible state (no `opacity: 0` by default).
+  - A short script at the page bottom adds a class (e.g. `.is-hidden`) to targets and removes it via `IntersectionObserver`, with CSS transitioning back to visible.
+  - This keeps content visible in the editor and for reduced-motion users.
+- **Perpetual micro-interactions (when MOTION_INTENSITY > 5)**: One subtle infinite animation per page section — a slow float on an accent badge, a shimmer on a CTA, a gradient drift on a hero background. Not five.
+- **Spring-like easing**: Favor `cubic-bezier(0.16, 1, 0.3, 1)` (expo out) or `cubic-bezier(0.34, 1.56, 0.64, 1)` (back out) over `ease` or `linear`.
+
+## 5. PERFORMANCE GUARDRAILS
+
+- **Hardware-accelerated properties only**: animate `transform` and `opacity`. Never animate `top`, `left`, `width`, `height`, or `margin` for motion effects.
+- **Grain/noise textures**: apply to fixed, pointer-events-none overlays (`position: fixed; inset: 0; pointer-events: none; z-index: 0`), never to scrolling containers.
+- **`will-change: transform`**: use sparingly and only on elements that will animate; remove after.
+- **No scroll event listeners**: use `IntersectionObserver` for reveal triggers and CSS `scroll-timeline` (where supported) or `requestAnimationFrame` for parallax.
+- **Font loading**: use `font-display: swap` to avoid layout shift.
+
+## 6. TECHNICAL REFERENCE (Dial Definitions)
+
+### DESIGN_VARIANCE (1-10)
+
+- **1-3 (Predictable)**: centered compositions, symmetrical 12-column grids, equal padding, rigid alignment.
+- **4-7 (Offset)**: overlapping elements (`margin-top: -2rem`), varied aspect ratios side by side (4:3 next to 16:9), left-aligned headers above center-aligned data rows, asymmetric whitespace.
+- **8-10 (Asymmetric)**: masonry, CSS Grid with fractional units (`2fr 1fr 1fr`), massive empty zones (`padding-inline-start: 20vw`), grid-breaking overlaps, diagonal flow.
+- **Mobile override**: for levels 4-10, any asymmetric layout above the `md` breakpoint MUST collapse to a strict single-column below 768px to prevent horizontal scroll.
+
+### MOTION_INTENSITY (1-10)
+
+- **1-3 (Static — opt-in only)**: used only when the user explicitly requests a static or accessibility-minimal site. Hover and focus transitions only (`transition: color 0.2s ease`). No page-load animations, no scroll reveals.
+- **4 (Restrained Motion — the minimum default)**: a single page-load fade+rise cascade on the hero (staggered `animation-delay`), one `IntersectionObserver`-driven reveal on subsequent sections, refined hover states with `cubic-bezier` easing. No perpetual loops, no parallax. This is the floor even for minimalist sites — motion is quiet, not absent.
+- **5-7 (Fluid CSS)**: staggered `animation-delay` cascades on load across multiple sections. Scroll reveals via `IntersectionObserver` on most content blocks. CSS-only infinite loops (float, shimmer) on one or two accent elements. `cubic-bezier` easing everywhere. Light parallax on backgrounds permitted at 7.
+- **8-10 (Advanced Choreography)**: complex scroll-triggered reveals, parallax layers, text-mask reveals, kinetic marquees, scroll-linked transforms. Use vanilla JS with `IntersectionObserver` and `requestAnimationFrame`.
+
+### VISUAL_DENSITY (1-10)
+
+- **1-3 (Art Gallery)**: generous section gaps (10rem+), large typography, sparse content per viewport, expensive feel.
+- **4-7 (Daily App)**: standard product-site spacing.
+- **8-10 (Cockpit)**: tight padding, dividers over card boxes, monospace for numeric data (`font-family: 'JetBrains Mono', 'Geist Mono', monospace` for figures).
+
+## 7. AI TELLS — FORBIDDEN PATTERNS
+
+Strictly avoid these generic AI design signatures unless explicitly requested:
+
+### Visual & CSS
+- **NO neon/outer glows** (`box-shadow: 0 0 40px hotpink`). Use inner borders or subtle tinted shadows.
+- **NO pure black or pure white** for large surfaces. Use tinted off-black / off-white.
+- **NO oversaturated accents**. Desaturate to < 80% to blend elegantly with neutrals.
+- **NO text-fill gradients on large headers** (`background-clip: text` with a purple-to-blue gradient is the tell).
+- **NO custom mouse cursors**. They break accessibility and feel dated.
+
+### Typography
+- **NO Inter, Roboto, Arial, or system-ui stacks** as display fonts.
+- **NO oversized screaming H1s**. Control hierarchy with weight, tracking, and color — not only scale.
+- **Serifs are for editorial/creative contexts**, not dashboards. Don't mix a serif display with a dashboard aesthetic.
+
+### Layout & Spacing
+- **NO 3-equal-card horizontal feature rows.** Use zig-zag, asymmetric, or scrollable layouts.
+- **NO centered hero with a subtitle below and two CTAs** as the default.
+- **NO default-to-split-screen hero.** Asymmetric 50/50 split heroes have become the new AI-slop fallback — pick from the full Hero Paradigms menu (Section 8) and actively vary across generations. If the previous site used a split, the next one must not.
+- **NO awkward floating elements** with unexplained gaps. Spacing is mathematically considered, not arbitrary.
+
+### Content & Data (The "Jane Doe" Effect)
+- **NO generic names**: "John Doe", "Sarah Chan", "Jane Doe", "Jack Su" are BANNED. Use realistic, contextual names.
+- **NO generic avatars**: no default SVG "egg" icons, no Lucide/user placeholder icons. Use specific styled placeholders or descriptive text.
+- **NO fake-round numbers**: `99.99%`, `50%`, `1,234` are tells. Use organic data (`47.2%`, `+1 (312) 847-1928`).
+- **NO startup-slop brand names**: "Acme", "Nexus", "SmartFlow", "FlowCorp". Invent premium, contextual brands tied to the site's domain.
+- **NO filler verbs**: "Elevate", "Seamless", "Unleash", "Empower", "Next-Gen". Write concrete sentences about the actual offer.
+
+### Images
+- **NO broken Unsplash links**. Use `https://picsum.photos/seed/{specific-seed}/800/600` for placeholders, or upload real images via `wp media import`.
+
+## 8. THE CREATIVE ARSENAL (Block-Theme-Friendly)
+
+High-end patterns adapted to core blocks + CSS. Pick 1-2 signature moves per site, not all of them.
+
+**CRITICAL — Anti-anchor protocol.** For every category below (Hero Paradigms, Navigation, Layouts & Grids, Typography Moves, Cards, Backgrounds), do NOT pick the first entry by default. **Randomize your selection across the full list** for every new site. Keep a mental note of which paradigms you used on the previous generation and actively avoid repeating them — if the last hero was an asymmetric split, the next one must be something else entirely. The goal is variance across generations, not convergence on any single "best" pattern. Reaching for the same layout twice in a row is a failure of the skill.
+
+### Hero Paradigms (randomize your pick — do not default to the first)
+- **Oversized display type**: a single massive headline (`clamp(5rem, 14vw, 12rem)`) with tight tracking, no subtitle. The headline IS the hero.
+- **Editorial masthead**: small label + oversized display headline + single supporting paragraph + meta row (date, author, category) styled like a magazine masthead. Often centered, sometimes with rules above/below.
+- **Asymmetric split**: text block taking 7 of 12 columns, image or secondary headline taking 5. Background fades stylistically toward the next section. (Use sparingly — this is the AI-default; only pick when it genuinely fits.)
+- **Full-bleed image with offset label**: a full-viewport image or video with a small, intentionally offset text block (bottom-left, top-right, etc.) containing title + one sentence. Deliberately quiet.
+- **Vertical list hero**: a single left-aligned stack — category label, massive multi-line headline, supporting paragraph, single CTA, no imagery at all. Brutally minimal.
+- **Numbered index hero**: hero is a numbered list of the site's core offers or services (01, 02, 03...), each a massive display-typography entry. The site-name or brand sits as a small caption.
+- **Marquee hero**: the hero IS an animated horizontal marquee of oversized type — product categories, service names, or a slogan repeating. No static headline.
+- **Split diagonal hero**: two full-height panels separated by a diagonal or skewed divider, each with its own typography, creating editorial tension.
+- **Quote hero**: an oversized pull-quote as the hero (client testimonial, founder statement, mission sentence) with the attribution small below. No product shot.
+- **Grid-of-cells hero**: the viewport is divided into a 2x3 or 3x3 grid of content cells (image, text, stat, quote, image, CTA) — a dense bento-style landing.
+
+### Navigation (randomize)
+- **Hamburger + full-screen overlay menu**: staggered link reveal, oversized typography, close button in an unexpected corner. Good for editorial and brutalist.
+- **Centered pill nav**: a floating, rounded nav bar centered near the top with a subtle glass effect.
+- **Sidebar nav**: a thin left-column vertical nav that persists as you scroll, freeing the top of the viewport for massive hero content.
+- **Logo-only with corner menu**: brand mark centered or cornered, a single "Menu" label that opens the overlay on click.
+- **Minimal horizontal nav**: logo left, 3-4 links right, single CTA. The default — use only when explicitly appropriate, not as a fallback.
+
+### Layouts & Grids (randomize)
+- **Zig-zag feature rows**: alternating image-left/image-right with `core/media-text` or a `core/columns` with flipped `order` per row.
+- **Horizontal scroll gallery**: a `core/group` with `display: flex; overflow-x: auto; scroll-snap-type: x mandatory` containing `core/image` children.
+- **Sticky scroll stack**: consecutive `core/cover` sections with `position: sticky; top: 0` creating a stacking reveal as the user scrolls.
+- **Numbered editorial list**: full-width rows separated by thin rules, each row prefixed with a large number (01, 02, 03), the row contents can be asymmetric.
+- **Vertical marquee columns**: two or three columns each scrolling slowly in opposite directions, each column a list of image or text tiles.
+- **Bento-style group**: a `core/group` with CSS Grid `grid-template-columns: 2fr 1fr 1fr` and varied row heights — asymmetric tile clusters.
+- **Masonry layout**: staggered grid without fixed row heights, for gallery or content index pages.
+
+### Typography Moves (randomize)
+- **Text mask reveal**: `background-clip: text` with an image or video background — used sparingly on one signature headline, not every heading.
+- **Circular text path**: SVG text-on-path inside `core/html`, often around a central logo or CTA.
+- **Kinetic marquee**: a `core/html` block with a CSS-animated infinite horizontal scroll of oversized display text.
+- **Letter-by-letter stagger reveal**: each letter of a hero headline animates in individually with a staggered delay on page load.
+- **Oversized serif pull-quotes**: section breaks use a massive italic serif quote (`clamp(3rem, 8vw, 6rem)`) as a visual punctuation between content blocks.
+- **Typographic grid**: a full-page layout built almost entirely from type at different scales — no imagery, hierarchy entirely through size, weight, and color.
+
+### Cards & Containers (randomize)
+- **Spotlight border card**: a card where a conic-gradient border animates on hover using `@property --angle`.
+- **Tilt card**: a single signature card that tilts on pointer move (vanilla JS, respects reduced-motion).
+- **Glass panel**: true frosted glass with backdrop-blur + inner refraction borders (see Section 4).
+- **Ink-rule dividers**: group content into rows separated by single 1px top borders (`border-top: 1px solid var(--neutral-border)`) — no backgrounds, no shadows, maximum restraint.
+- **Overlapping slab cards**: full-bleed color slabs that overlap each other vertically by 1-2rem, creating depth without shadows.
+
+### Backgrounds & Atmosphere (randomize)
+- **Noise overlay**: fixed, pointer-events-none, SVG `feTurbulence` pattern with low opacity. Adds texture without color.
+- **Ambient light spots**: absolutely-positioned blurred color blobs behind key sections (large `filter: blur(120px)`).
+- **Mesh gradient**: layered radial-gradients on a fixed background div, slowly animated.
+- **Geometric pattern repeat**: a subtle SVG pattern (dots, crosses, diagonals) tiled as a `background-image` on key sections.
+- **Single signature hue wash**: each section gets a different flat tinted background (warm cream, dusty rose, forest, graphite) with sharp transitions between them — no textures at all.
+
+## 9. WORKFLOW INTEGRATION
+
+When called during site construction, this skill pairs with the broader Studio workflow:
+
+1. **After site-spec**: pick up the aesthetic direction from the spec (minimalist / soft / editorial / brutalist / maximalist). Set dials accordingly. If the spec didn't capture one, commit to a bold direction yourself — don't design timidly by default.
+2. **Before writing theme files**: plan typography (2 fonts, chosen by name), palette (1 background, 1 foreground, 1 accent — all tinted), 1 signature move from the Creative Arsenal.
+3. **During implementation**: all styling in `style.css`, all animations progressive-enhanced, all motion inside `prefers-reduced-motion` guards.
+4. **After screenshot**: verify the site doesn't have any AI tells from Section 7. Specifically check: fonts aren't Inter/Roboto, hero isn't centered-with-two-CTAs, no three-equal-card row, no purple-blue gradient, no pure black/white, names aren't generic.
+
+## 10. FINAL PRE-FLIGHT CHECK
+
+Before considering a site complete, confirm:
+
+- [ ] Does the site commit to ONE clear aesthetic direction, executed with precision?
+- [ ] Are both fonts distinctive (not Inter, Roboto, Arial, or system defaults)?
+- [ ] Is there at most one saturated accent color, tied to the aesthetic?
+- [ ] Does the hero avoid the "centered headline + subtitle + two CTAs" cliché?
+- [ ] Did you pick the hero paradigm by varying from the last generation — and specifically not default to an asymmetric split hero?
+- [ ] Are feature rows varied (zig-zag, asymmetric, or scrollable) rather than three equal cards?
+- [ ] Do all animations define final state in CSS, with initial hidden state added by JS?
+- [ ] Is `@media (prefers-reduced-motion: reduce)` honored for every animation and transition?
+- [ ] Is all styling in `style.css` (no inline styles, no style block attributes)?
+- [ ] Are content names, brands, and numbers contextual rather than generic placeholders?
+- [ ] Did `validate_blocks` pass after the last write?
+- [ ] Does the mobile viewport collapse asymmetric layouts to single-column safely?

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -108,7 +108,7 @@ IMPORTANT: For any generated content for the site, these three principles are ma
 
 For any request that involves a WordPress site, you MUST first determine which site to use:
 
-- **"Create" / "build" / "make" a site**: Run the \`site-spec\` skill to gather the site name and layout preference FIRST, then proceed with site creation. Do NOT call site_list first. Do NOT reuse or repurpose any existing site. Every new project gets a fresh site.
+- **"Create" / "build" / "make" a site**: Run the \`site-spec\` skill to gather the site name, layout preference, and aesthetic direction FIRST, then proceed with site creation. Do NOT call site_list first. Do NOT reuse or repurpose any existing site. Every new project gets a fresh site.
 - **User names a specific existing site**: Call site_list to find it.
 - **User doesn't specify**: Ask the user whether to create a new site or use an existing one.
 - **Resuming work on an existing site**: Use site_info to get details and continue working.
@@ -116,7 +116,7 @@ For any request that involves a WordPress site, you MUST first determine which s
 Then continue with:
 
 1. **Get site details**: Use site_info to get the site path, URL, and credentials.
-2. **Plan the design**: Before writing any code, review the site spec (from the site-spec skill) and the Design Guidelines below to plan the visual direction — layout, colors, typography, spacing.
+2. **Plan the design**: Before writing any code, load the \`taste\` skill for full design direction (typography, color, motion, layout, anti-slop rules, and WordPress-specific constraints). Apply the dial preset matching the aesthetic direction captured in the site spec (minimalist / soft / editorial / brutalist / other) rather than the taste skill's default baseline. Then commit to a clear visual direction — 2 distinctive fonts, a tinted palette with one accent, and one signature move from the Creative Arsenal (randomize your pick — do not default to an asymmetric split hero or the first entry in any list).
 3. **Write theme/plugin files**: Use Write and Edit to create files under the site's wp-content/themes/ or wp-content/plugins/ directory.
 4. **Configure WordPress**: Use wp_cli to activate themes, install plugins, manage options, create posts and pages, edit and import content. The site must be running. Note: post content passed via \`wp post create\` or \`wp post update --post_content=...\` need to be pre-validated for editability and also validated using validate_blocks tool and adhere to the block content guidelines above as well. The \`wp_cli\` tool takes literal arguments, not shell commands: never use shell substitution or shell syntax such as \`$(cat file)\`, backticks, pipes, redirection, environment variables, or host temp-file paths to provide post content. Pass the literal content directly in \`--post_content=...\`, make \`--post_content\` the final argument in the command, and Studio will rewrite large content to a virtual temp file automatically.
 5. **Check the misuse of HTML blocks**: Verify if HTML blocks were used as sections or not. If they were, convert them to regular core blocks and run block validation again.
@@ -188,33 +188,4 @@ const LOCAL_CONTENT_GUIDELINES = `## Block content guidelines
 
 const LOCAL_DESIGN_GUIDELINES = `## Design guidelines
 
-**Important**: Always use sophisticated scroll effects and add animations unless specifically asked otherwise.
-
-Understand the context and commit to a BOLD aesthetic direction:
-- **Purpose**: What problem does this interface solve? Who uses it?
-- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
-- **Constraints**: Technical requirements (framework, performance, accessibility).
-- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
-
-**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
-
-Then implement working code (HTML/CSS/JS etc.) that is:
-- Production-grade and functional
-- Visually striking and memorable
-- Cohesive with a clear aesthetic point-of-view
-- Meticulously refined in every detail
-
-Focus on:
-- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
-- **Color & Theme**: Commit to a cohesive aesthetic. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
-- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
-- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
-- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
-
-NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
-
-Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
-
-**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
-
-Remember: You are capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.`;
+**All aesthetic direction is defined by the \`taste\` skill.** You MUST load it via the Skill tool before planning or generating any design work — it covers typography, color, motion, spatial composition, anti-slop rules, cross-generation variance, and the WordPress-specific constraints (progressive-enhancement animations, \`prefers-reduced-motion\`, \`style.css\` only) that apply to every site. Do not design from memory or generic defaults — always consult the taste skill first.`;


### PR DESCRIPTION
## Related issues

- Related to improving the design quality of sites generated by the Studio Code agent.

## How AI was used in this PR

Claude helped structure the taste skill (adapted from the upstream [taste-skill](https://github.com/Leonxlnx/taste-skill) project for WordPress block themes), wire it into the existing `site-spec` skill and system prompt, and iterate on the dial presets + anti-convergence rules after observing that the agent was defaulting to the same hero paradigm across generations.

## Proposed Changes

- **New `taste` skill** at `apps/cli/ai/plugin/skills/taste/SKILL.md` — consolidates all aesthetic direction (typography, color, motion, spatial composition, anti-slop rules, and WordPress-specific constraints) into a single on-demand skill. Loaded by the agent before any design-planning step, rather than living as always-on bullets in the system prompt.
- **System prompt `LOCAL_DESIGN_GUIDELINES` slimmed** to a single paragraph that instructs the agent to load the `taste` skill. Removes ~20 lines of inline design rules that now live in the skill.
- **`site-spec` skill gains an aesthetic-direction round** (Round 3) — user picks Minimalist / Soft / Editorial / Maximalist (or `Other` for freeform like Brutalist, retro-futurist, etc.). The skill lists all five presets in text output before the click question so the user sees the full menu, since AskUserQuestion hard-caps at 4 options. Each preset maps to an explicit dial configuration in the taste skill.
- **Anti-anchor protocol + cross-generation variance rules** in the taste skill to prevent convergence on the same hero paradigm, fonts, palettes, and layouts across generations (was producing "split-screen hero everywhere").
- **Motion floor set to 4** so every preset still ships with a page-load cascade and scroll reveals. MOTION 1-3 is now opt-in only ("static") — restores motion on minimalist and editorial sites which had regressed to hover-only.

## Testing Instructions

1. `npm run cli:build`
2. Run `node apps/cli/dist/cli/main.mjs` and ask the agent to build a WordPress site.
3. Verify the `site-spec` flow asks three rounds: name, layout, aesthetic — with five presets described in text and four clickable options (plus Other).
4. Verify the agent loads the `taste` skill before generating design code.
5. Build a few sites in a row with different aesthetics and confirm:
    - Heroes vary across generations (no default-to-asymmetric-split).
    - Fonts, palettes, and light/dark mode rotate.
    - Minimalist-preset sites still get page-load animations and scroll reveals (motion floor working).
    - Maximalist-preset sites use elaborate motion and layered backgrounds.
6. Sanity-check that block content still validates (`validate_blocks`) and that the existing WordPress-specific constraints (no custom HTML for layout, no inline styles, style.css only, `prefers-reduced-motion` respected) are preserved in the skill.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Did you test the site-spec flow end-to-end in the CLI?
- [ ] Did you verify design output across multiple aesthetic presets?
- [ ] Did you confirm block validation still passes for generated content?

🤖 Generated with [Claude Code](https://claude.com/claude-code)