### PR TITLE
Suggestion: build a single Vite file

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -22,6 +22,9 @@ import { untildify } from 'cli/lib/utils';
 import { StudioArgv } from 'cli/types';
 
 const version = __STUDIO_CLI_VERSION__;
+const PROCESS_MANAGER_DAEMON_COMMAND = 'process-manager-daemon';
+const PROXY_DAEMON_COMMAND = 'proxy-daemon';
+const WORDPRESS_SERVER_CHILD_COMMAND = 'wordpress-server-child';
 
 suppressPunycodeWarning();
 
@@ -100,22 +103,47 @@ async function main() {
 		.middleware( async () => {
 			await setupServerFiles();
 		} )
-		.command( 'auth', __( 'Manage authentication' ), async ( authYargs ) => {
-			const [
-				{ registerCommand: registerAuthLoginCommand },
-				{ registerCommand: registerAuthLogoutCommand },
-				{ registerCommand: registerAuthStatusCommand },
-			] = await Promise.all( [
-				import( 'cli/commands/auth/login' ),
-				import( 'cli/commands/auth/logout' ),
-				import( 'cli/commands/auth/status' ),
-			] );
-
-			registerAuthLoginCommand( authYargs );
-			registerAuthLogoutCommand( authYargs );
-			registerAuthStatusCommand( authYargs );
-			authYargs.version( false ).demandCommand( 1, __( 'You must provide a valid auth command' ) );
+		.command( {
+			command: PROCESS_MANAGER_DAEMON_COMMAND,
+			describe: false,
+			handler: async () => {
+				const { runProcessManagerDaemon } = await import( 'cli/process-manager-daemon' );
+				await runProcessManagerDaemon();
+			},
+		} )
+		.command( {
+			command: PROXY_DAEMON_COMMAND,
+			describe: false,
+			handler: async () => {
+				const { runProxyDaemon } = await import( 'cli/proxy-daemon' );
+				await runProxyDaemon();
+			},
+		} )
+		.command( {
+			command: WORDPRESS_SERVER_CHILD_COMMAND,
+			describe: false,
+			handler: async () => {
+				const { startWordPressServerChildProcess } = await import( 'cli/wordpress-server-child' );
+				startWordPressServerChildProcess();
+			},
 		} );
+
+	studioArgv.command( 'auth', __( 'Manage authentication' ), async ( authYargs ) => {
+		const [
+			{ registerCommand: registerAuthLoginCommand },
+			{ registerCommand: registerAuthLogoutCommand },
+			{ registerCommand: registerAuthStatusCommand },
+		] = await Promise.all( [
+			import( 'cli/commands/auth/login' ),
+			import( 'cli/commands/auth/logout' ),
+			import( 'cli/commands/auth/status' ),
+		] );
+
+		registerAuthLoginCommand( authYargs );
+		registerAuthLogoutCommand( authYargs );
+		registerAuthStatusCommand( authYargs );
+		authYargs.version( false ).demandCommand( 1, __( 'You must provide a valid auth command' ) );
+	} );
 
 	const studioCodeCommandBuilder = async ( aiYargs: StudioArgv ) => {
 		const { registerCommand: registerAiCommand } = await import( 'cli/commands/ai' );

--- a/apps/cli/lib/daemon-client.ts
+++ b/apps/cli/lib/daemon-client.ts
@@ -28,6 +28,8 @@ import {
 import type { SocketEvent } from '@studio/common/lib/cli-events';
 
 const PROXY_PROCESS_NAME = 'studio-proxy';
+const PROCESS_MANAGER_DAEMON_COMMAND = 'process-manager-daemon';
+const PROXY_DAEMON_COMMAND = 'proxy-daemon';
 const CONNECTION_TIMEOUT_MS = 10_000;
 const PROCESS_MANAGER_LOCKFILE_PATH = path.join( PROCESS_MANAGER_HOME, 'pm-connection.lock' );
 export const SITE_EVENTS_SOCKET_PATH =
@@ -152,12 +154,15 @@ async function waitForDaemonReady() {
 }
 
 function spawnDaemonProcess() {
-	const daemonScriptPath = path.resolve( import.meta.dirname, 'process-manager-daemon.mjs' );
-	const daemonProcess = spawn( process.execPath, [ daemonScriptPath ], {
-		detached: true,
-		stdio: 'ignore',
-		windowsHide: true,
-	} );
+	const daemonProcess = spawn(
+		process.execPath,
+		[ path.resolve( import.meta.dirname, 'main.mjs' ), PROCESS_MANAGER_DAEMON_COMMAND ],
+		{
+			detached: true,
+			stdio: 'ignore',
+			windowsHide: true,
+		}
+	);
 	daemonProcess.unref();
 }
 
@@ -272,9 +277,9 @@ export async function sendMessageToProcess(
 }
 
 export async function startProxyProcess(): Promise< ProcessDescription > {
-	const proxyDaemonPath = path.resolve( import.meta.dirname, 'proxy-daemon.mjs' );
-
-	return startProcess( PROXY_PROCESS_NAME, proxyDaemonPath );
+	return startProcess( PROXY_PROCESS_NAME, path.resolve( import.meta.dirname, 'main.mjs' ), {}, [
+		PROXY_DAEMON_COMMAND,
+	] );
 }
 
 export async function isProxyProcessRunning(): Promise< ProcessDescription | undefined > {

--- a/apps/cli/lib/tests/wordpress-server-manager.test.ts
+++ b/apps/cli/lib/tests/wordpress-server-manager.test.ts
@@ -115,7 +115,9 @@ describe( 'WordPress Server Manager', () => {
 
 			expect( vi.mocked( daemonClient.startProcess ) ).toHaveBeenCalledWith(
 				'studio-site-test-site-id',
-				expect.stringContaining( 'wordpress-server-child.mjs' )
+				expect.stringContaining( 'main.mjs' ),
+				{},
+				[ 'wordpress-server-child' ]
 			);
 
 			expect( result ).toEqual( mockProcessDescription );

--- a/apps/cli/lib/wordpress-server-manager.ts
+++ b/apps/cli/lib/wordpress-server-manager.ts
@@ -25,6 +25,7 @@ import { ServerConfig, ManagerMessagePayload } from 'cli/lib/types/wordpress-ser
 import { Logger } from 'cli/logger';
 
 export const SITE_PROCESS_PREFIX = 'studio-site-';
+const WORDPRESS_SERVER_CHILD_COMMAND = 'wordpress-server-child';
 
 // Get an abort signal that's triggered on SIGINT/SIGTERM. This is useful for aborting and cleaning
 // up async operations.
@@ -59,10 +60,7 @@ export async function startWordPressServer(
 	logger: Logger< string >,
 	options?: StartServerOptions
 ): Promise< ProcessDescription > {
-	const wordPressServerChildPath = path.resolve(
-		import.meta.dirname,
-		'wordpress-server-child.mjs'
-	);
+	const cliEntrypointPath = path.resolve( import.meta.dirname, 'main.mjs' );
 	const processName = getProcessName( site.id );
 
 	const serverConfig: ServerConfig = {
@@ -117,7 +115,9 @@ export async function startWordPressServer(
 		serverConfig.enableDebugDisplay = true;
 	}
 
-	const processDesc = await startProcess( processName, wordPressServerChildPath );
+	const processDesc = await startProcess( processName, cliEntrypointPath, {}, [
+		WORDPRESS_SERVER_CHILD_COMMAND,
+	] );
 	await waitForReadyMessage( processDesc.pmId );
 	await sendMessage(
 		processDesc.pmId,
@@ -340,10 +340,7 @@ export async function runBlueprint(
 	logger: Logger< string >,
 	options: RunBlueprintOptions
 ): Promise< void > {
-	const wordPressServerChildPath = path.resolve(
-		import.meta.dirname,
-		'wordpress-server-child.mjs'
-	);
+	const cliEntrypointPath = path.resolve( import.meta.dirname, 'main.mjs' );
 	const processName = getProcessName( site.id );
 
 	const serverConfig: ServerConfig = {
@@ -395,7 +392,9 @@ export async function runBlueprint(
 		serverConfig.enableDebugDisplay = true;
 	}
 
-	const processDesc = await startProcess( processName, wordPressServerChildPath );
+	const processDesc = await startProcess( processName, cliEntrypointPath, {}, [
+		WORDPRESS_SERVER_CHILD_COMMAND,
+	] );
 	try {
 		await waitForReadyMessage( processDesc.pmId );
 		await sendMessage(

--- a/apps/cli/process-manager-daemon.ts
+++ b/apps/cli/process-manager-daemon.ts
@@ -406,7 +406,7 @@ export class ProcessManagerDaemon {
 	}
 }
 
-async function main() {
+export async function runProcessManagerDaemon() {
 	try {
 		const daemon = new ProcessManagerDaemon();
 		await daemon.start();
@@ -414,5 +414,3 @@ async function main() {
 		console.error( error );
 	}
 }
-
-void main();

--- a/apps/cli/proxy-daemon.ts
+++ b/apps/cli/proxy-daemon.ts
@@ -16,7 +16,7 @@
 
 import { startProxyServers } from 'cli/lib/proxy-server';
 
-async function main() {
+export async function runProxyDaemon() {
 	try {
 		console.log( '[Proxy Daemon] Starting WordPress Studio Proxy Daemon…' );
 		await startProxyServers();
@@ -25,5 +25,3 @@ async function main() {
 		process.exit( 1 );
 	}
 }
-
-void main();

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -127,9 +127,6 @@ export const baseConfig = defineConfig( {
 		lib: {
 			entry: {
 				main: resolve( __dirname, 'index.ts' ),
-				'process-manager-daemon': resolve( __dirname, 'process-manager-daemon.ts' ),
-				'proxy-daemon': resolve( __dirname, 'proxy-daemon.ts' ),
-				'wordpress-server-child': resolve( __dirname, 'wordpress-server-child.ts' ),
 			},
 			name: 'StudioCLI',
 			formats: [ 'es' ],
@@ -139,8 +136,8 @@ export const baseConfig = defineConfig( {
 		rollupOptions: {
 			output: {
 				format: 'es',
+				inlineDynamicImports: true,
 				entryFileNames: '[name].mjs',
-				chunkFileNames: '[name]-[hash].mjs',
 				paths: ( id ) => {
 					// Rewrite trailing-slash imports in output
 					if ( id.endsWith( '/' ) ) {

--- a/apps/cli/wordpress-server-child.ts
+++ b/apps/cli/wordpress-server-child.ts
@@ -42,44 +42,58 @@ import {
 
 let server: RunCLIServer | null = null;
 let lastCliArgs: Record< string, unknown > | null = null;
+let isWordPressServerChildStarted = false;
+let isIpcLoggingConfigured = false;
 
 // Intercept and prefix all console output from playground-cli
 const originalConsoleLog = console.log;
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 
-console.log = ( ...args: unknown[] ) => {
-	originalConsoleLog( '[playground-cli]', ...args );
-	const message = args.join( ' ' );
-	process.send!( { topic: 'activity' } );
-	const formattedMessage = formatPlaygroundCliMessage( message );
-	if ( formattedMessage !== message ) {
-		process.send!( { topic: 'console-message', message: formattedMessage } );
-	}
-};
-
-console.error = ( ...args: unknown[] ) => {
-	originalConsoleError( '[playground-cli]', ...args );
-	process.send!( { topic: 'activity' } );
-};
-
-console.warn = ( ...args: unknown[] ) => {
-	originalConsoleWarn( '[playground-cli]', ...args );
-	process.send!( { topic: 'activity' } );
-};
-
 const originalStdoutWrite = process.stdout.write.bind( process.stdout );
 const originalStderrWrite = process.stderr.write.bind( process.stderr );
 
-process.stdout.write = function ( ...args: Parameters< typeof originalStdoutWrite > ) {
-	process.send!( { topic: 'activity' } );
-	return originalStdoutWrite( ...args );
-} as typeof process.stdout.write;
+function reportActivity() {
+	process.send?.( { topic: 'activity' } );
+}
 
-process.stderr.write = function ( ...args: Parameters< typeof originalStderrWrite > ) {
-	process.send!( { topic: 'activity' } );
-	return originalStderrWrite( ...args );
-} as typeof process.stderr.write;
+function configureIpcLogging() {
+	if ( isIpcLoggingConfigured ) {
+		return;
+	}
+
+	console.log = ( ...args: unknown[] ) => {
+		originalConsoleLog( '[playground-cli]', ...args );
+		const message = args.join( ' ' );
+		reportActivity();
+		const formattedMessage = formatPlaygroundCliMessage( message );
+		if ( formattedMessage !== message ) {
+			process.send?.( { topic: 'console-message', message: formattedMessage } );
+		}
+	};
+
+	console.error = ( ...args: unknown[] ) => {
+		originalConsoleError( '[playground-cli]', ...args );
+		reportActivity();
+	};
+
+	console.warn = ( ...args: unknown[] ) => {
+		originalConsoleWarn( '[playground-cli]', ...args );
+		reportActivity();
+	};
+
+	process.stdout.write = function ( ...args: Parameters< typeof originalStdoutWrite > ) {
+		reportActivity();
+		return originalStdoutWrite( ...args );
+	} as typeof process.stdout.write;
+
+	process.stderr.write = function ( ...args: Parameters< typeof originalStderrWrite > ) {
+		reportActivity();
+		return originalStderrWrite( ...args );
+	} as typeof process.stderr.write;
+
+	isIpcLoggingConfigured = true;
+}
 
 function logToConsole( ...args: Parameters< typeof console.log > ) {
 	originalConsoleLog( `[WordPress Server Child]`, ...args );
@@ -568,9 +582,17 @@ async function ipcMessageHandler( packet: unknown ) {
 	}
 }
 
-if ( process.send ) {
+export function startWordPressServerChildProcess() {
+	if ( isWordPressServerChildStarted ) {
+		return;
+	}
+
+	if ( ! process.send ) {
+		throw new Error( 'process.send is not available' );
+	}
+
+	configureIpcLogging();
 	process.on( 'message', ipcMessageHandler );
 	process.send( { topic: 'ready' } );
-} else {
-	throw new Error( 'process.send is not available' );
+	isWordPressServerChildStarted = true;
 }


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Suggestions for https://github.com/Automattic/studio/pull/3064

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Codex was used for 90% of the implementation, with iterative directions from me. 

## Proposed Changes

- Change the Vite build to output a single JS file.
- Expose `process-manager-daemon`, `proxy-daemon`, and `wordpress-server-child` as yargs commands in `cli/index.ts` instead of building them as separate entries. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
