### PR TITLE
apps/ui: add "Start from blueprint" onboarding flow

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -24,6 +24,7 @@
 		"@wordpress/react-i18n": "^4.41.0",
 		"@wordpress/theme": "0.10.0",
 		"@wordpress/ui": "0.10.0",
+		"@wp-playground/blueprints": "3.1.18",
 		"clsx": "^2.1.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/apps/ui/src/components/blueprint-selector/index.tsx
+++ b/apps/ui/src/components/blueprint-selector/index.tsx
@@ -1,0 +1,286 @@
+import { generateDefaultBlueprintDescription } from '@studio/common/lib/blueprint-settings';
+import { validateBlueprintData } from '@studio/common/lib/blueprint-validation';
+import { __, sprintf } from '@wordpress/i18n';
+import { external, upload } from '@wordpress/icons';
+import { Button, Icon } from '@wordpress/ui';
+import { useCallback, useRef, useState } from 'react';
+import { useConnector } from '@/data/core';
+import styles from './style.module.css';
+import type { FeaturedBlueprint } from '@/data/core';
+import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
+
+export interface PickedBlueprint {
+	title: string;
+	excerpt: string;
+	// `slug` is only populated for featured blueprints (used for stats server-side).
+	slug?: string;
+	blueprint: BlueprintV1Declaration;
+	// Absolute path to the extracted `blueprint.json` when the user uploaded a
+	// ZIP bundle — the CLI uses this to resolve relative asset references.
+	// Main process cleans up the enclosing temp dir once site creation runs.
+	filePath?: string;
+}
+
+interface BlueprintSelectorProps {
+	featured: FeaturedBlueprint[] | undefined;
+	isFeaturedLoading: boolean;
+	onPick: ( blueprint: PickedBlueprint ) => void;
+}
+
+const FILE_ACCEPT = 'application/json,.json,application/zip,.zip';
+
+export function BlueprintSelector( {
+	featured,
+	isFeaturedLoading,
+	onPick,
+}: BlueprintSelectorProps ) {
+	const connector = useConnector();
+	const fileInputRef = useRef< HTMLInputElement | null >( null );
+	const [ uploadError, setUploadError ] = useState< string | null >( null );
+	const [ isDraggingOver, setIsDraggingOver ] = useState( false );
+
+	const handleFeaturedClick = useCallback(
+		( item: FeaturedBlueprint ) => {
+			setUploadError( null );
+			onPick( {
+				slug: item.slug,
+				title: item.title,
+				excerpt: item.excerpt,
+				blueprint: item.blueprint,
+			} );
+		},
+		[ onPick ]
+	);
+
+	const handlePreviewClick = useCallback(
+		( event: React.MouseEvent< HTMLButtonElement >, item: FeaturedBlueprint ) => {
+			// Stop the click from bubbling to the card's pick handler — the
+			// user explicitly asked to preview, not to select.
+			event.stopPropagation();
+			if ( item.playgroundUrl ) {
+				void connector.openExternalUrl( item.playgroundUrl );
+			}
+		},
+		[ connector ]
+	);
+
+	/**
+	 * Validates parsed blueprint JSON and hands a `PickedBlueprint` to the
+	 * parent. Returns `true` on success so callers can tell whether to clean
+	 * up side-resources (extracted ZIP temp dirs, etc.).
+	 */
+	const acceptParsedBlueprint = useCallback(
+		async ( parsed: unknown, fileName: string, filePath?: string ): Promise< boolean > => {
+			// v2 blueprints need a different runner — block them up-front with a
+			// clear message rather than letting validation spit out a cryptic
+			// schema error. Matches the behavior of the desktop app.
+			if (
+				parsed &&
+				typeof parsed === 'object' &&
+				( parsed as { version?: number } ).version === 2
+			) {
+				setUploadError(
+					__( 'Blueprint v2 format is not supported yet. Please use Blueprint v1 format.' )
+				);
+				return false;
+			}
+			const validation = await validateBlueprintData( parsed );
+			if ( ! validation.valid ) {
+				setUploadError( validation.error );
+				return false;
+			}
+			const blueprint = parsed as BlueprintV1Declaration;
+			const meta = ( parsed as { meta?: { title?: string; description?: string } } ).meta;
+			const baseName = fileName.replace( /\.(json|zip)$/i, '' );
+			onPick( {
+				title: meta?.title || baseName,
+				excerpt: meta?.description || generateDefaultBlueprintDescription( blueprint ),
+				blueprint,
+				filePath,
+			} );
+			return true;
+		},
+		[ onPick ]
+	);
+
+	const handleFile = useCallback(
+		async ( file: File ) => {
+			setUploadError( null );
+			const lowerName = file.name.toLowerCase();
+			const isJson = file.type === 'application/json' || lowerName.endsWith( '.json' );
+			const isZip = file.type === 'application/zip' || lowerName.endsWith( '.zip' );
+
+			if ( isJson ) {
+				let parsed: unknown;
+				try {
+					parsed = JSON.parse( await file.text() );
+				} catch ( error ) {
+					setUploadError(
+						sprintf(
+							// translators: %s is the JSON parser error message.
+							__( 'Could not parse Blueprint JSON: %s' ),
+							error instanceof Error ? error.message : String( error )
+						)
+					);
+					return;
+				}
+				await acceptParsedBlueprint( parsed, file.name );
+				return;
+			}
+
+			if ( isZip ) {
+				// ZIP bundles have to be unpacked in the main process so the CLI
+				// can resolve relative asset references — we ship the extracted
+				// `blueprint.json` path along with the parsed JSON. Temp dir
+				// cleanup happens server-side once `createSite` runs; only the
+				// validation-failure branch here needs an explicit cleanup.
+				let tempDir: string | undefined;
+				try {
+					const zipPath = await connector.getFilePath( file );
+					if ( ! zipPath ) {
+						setUploadError(
+							__( 'Unable to resolve the ZIP file path. Try choosing the file via the button.' )
+						);
+						return;
+					}
+					const extracted = await connector.extractBlueprintBundle( zipPath );
+					tempDir = extracted.tempDir;
+					const ok = await acceptParsedBlueprint(
+						extracted.blueprintJson,
+						file.name,
+						extracted.blueprintJsonPath
+					);
+					if ( ! ok && tempDir ) {
+						void connector.cleanupBlueprintTempDir( tempDir );
+					}
+				} catch ( error ) {
+					if ( tempDir ) {
+						void connector.cleanupBlueprintTempDir( tempDir );
+					}
+					setUploadError(
+						error instanceof Error
+							? error.message
+							: __( 'Failed to load Blueprint ZIP file. Please try again.' )
+					);
+				}
+				return;
+			}
+
+			setUploadError( __( 'Please select a Blueprint JSON or ZIP bundle.' ) );
+		},
+		[ acceptParsedBlueprint, connector ]
+	);
+
+	const handleFileInputChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		const file = event.target.files?.[ 0 ];
+		if ( file ) {
+			void handleFile( file );
+		}
+		// Reset so re-picking the same file after an error re-fires `change`.
+		event.target.value = '';
+	};
+
+	const handleDrop = ( event: React.DragEvent< HTMLDivElement > ) => {
+		event.preventDefault();
+		setIsDraggingOver( false );
+		const file = event.dataTransfer.files[ 0 ];
+		if ( file ) {
+			void handleFile( file );
+		}
+	};
+
+	const handleDragOver = ( event: React.DragEvent< HTMLDivElement > ) => {
+		event.preventDefault();
+		if ( ! isDraggingOver ) setIsDraggingOver( true );
+	};
+
+	const handleDragLeave = () => {
+		setIsDraggingOver( false );
+	};
+
+	return (
+		<div className={ styles.root }>
+			<section className={ styles.section }>
+				<h2 className={ styles.sectionTitle }>{ __( 'Upload your own' ) }</h2>
+				<div
+					className={ `${ styles.dropzone } ${ isDraggingOver ? styles.dropzoneActive : '' }` }
+					onDragOver={ handleDragOver }
+					onDragLeave={ handleDragLeave }
+					onDrop={ handleDrop }
+				>
+					<Icon icon={ upload } />
+					<p className={ styles.dropzoneText }>
+						{ __( 'Drop a Blueprint JSON or ZIP bundle here, or' ) }
+					</p>
+					<Button
+						type="button"
+						variant="outline"
+						tone="neutral"
+						onClick={ () => fileInputRef.current?.click() }
+					>
+						{ __( 'Choose file…' ) }
+					</Button>
+					<input
+						ref={ fileInputRef }
+						type="file"
+						accept={ FILE_ACCEPT }
+						className={ styles.fileInput }
+						onChange={ handleFileInputChange }
+					/>
+				</div>
+				{ uploadError && <p className={ styles.uploadError }>{ uploadError }</p> }
+			</section>
+
+			<section className={ styles.section }>
+				<h2 className={ styles.sectionTitle }>{ __( 'Featured blueprints' ) }</h2>
+				{ isFeaturedLoading && (
+					<p className={ styles.featuredHint }>{ __( 'Loading featured blueprints…' ) }</p>
+				) }
+				{ ! isFeaturedLoading && ( ! featured || featured.length === 0 ) && (
+					<p className={ styles.featuredHint }>
+						{ __( 'No featured blueprints available right now.' ) }
+					</p>
+				) }
+				{ featured && featured.length > 0 && (
+					<ul className={ styles.grid }>
+						{ featured.map( ( item ) => (
+							<li key={ item.slug } className={ styles.cardWrapper }>
+								<button
+									type="button"
+									className={ styles.card }
+									onClick={ () => handleFeaturedClick( item ) }
+								>
+									{ item.image && (
+										<img className={ styles.cardImage } src={ item.image } alt="" loading="lazy" />
+									) }
+									<div className={ styles.cardBody }>
+										<h3 className={ styles.cardTitle }>{ item.title }</h3>
+										<p className={ styles.cardExcerpt }>{ item.excerpt }</p>
+									</div>
+								</button>
+								{ item.playgroundUrl && (
+									<Button
+										type="button"
+										variant="minimal"
+										tone="neutral"
+										size="small"
+										className={ styles.previewButton }
+										onClick={ ( event ) => handlePreviewClick( event, item ) }
+										aria-label={ sprintf(
+											// translators: %s is the blueprint title.
+											__( 'Preview %s in Playground' ),
+											item.title
+										) }
+									>
+										<Icon icon={ external } />
+										<span>{ __( 'Preview' ) }</span>
+									</Button>
+								) }
+							</li>
+						) ) }
+					</ul>
+				) }
+			</section>
+		</div>
+	);
+}

--- a/apps/ui/src/components/blueprint-selector/style.module.css
+++ b/apps/ui/src/components/blueprint-selector/style.module.css
@@ -1,0 +1,139 @@
+.root {
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+}
+
+.section {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.sectionTitle {
+	font-size: 1rem;
+	font-weight: 600;
+	margin: 0;
+}
+
+.dropzone {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	padding: 32px 16px;
+	border: 1px dashed var(--wpds-color-border, #ccc);
+	border-radius: 8px;
+	background: var(--wpds-color-surface, #fff);
+	color: var(--wpds-color-text-secondary, #555);
+	text-align: center;
+}
+
+.dropzoneActive {
+	border-color: var(--wpds-color-border-hover, #888);
+	background: var(--wpds-color-surface-hover, #f7f7f7);
+}
+
+.dropzoneText {
+	margin: 0;
+}
+
+.fileInput {
+	display: none;
+}
+
+.uploadError {
+	padding: 8px 12px;
+	border-radius: 4px;
+	background: #fce8e8;
+	color: #7a1a1a;
+	font-size: 13px;
+	margin: 0;
+}
+
+.featuredHint {
+	margin: 0;
+	color: var(--wpds-color-text-secondary, #666);
+	font-size: 0.875rem;
+}
+
+.grid {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: grid;
+	/* Fixed 3-column layout — the parent onboarding page constrains width to
+	   match, and a narrower fallback kicks in for cramped viewports. */
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 16px;
+}
+
+@media (max-width: 640px) {
+	.grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+.cardWrapper {
+	position: relative;
+}
+
+.card {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	padding: 0;
+	border: 1px solid var(--wpds-color-border, #ddd);
+	border-radius: 8px;
+	background: var(--wpds-color-surface, #fff);
+	cursor: pointer;
+	overflow: hidden;
+	text-align: left;
+	color: inherit;
+}
+
+.card:hover {
+	border-color: var(--wpds-color-border-hover, #bbb);
+}
+
+.previewButton {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	gap: 4px;
+	background: rgba(255, 255, 255, 0.92);
+	backdrop-filter: blur(6px);
+	border-radius: 4px;
+}
+
+.cardImage {
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	object-fit: cover;
+	background: #f0f0f0;
+}
+
+.cardBody {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 12px 16px 16px;
+}
+
+.cardTitle {
+	font-size: 0.95rem;
+	font-weight: 600;
+	margin: 0;
+}
+
+.cardExcerpt {
+	margin: 0;
+	color: var(--wpds-color-text-secondary, #666);
+	font-size: 0.8125rem;
+	line-height: 1.4;
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}

--- a/apps/ui/src/components/create-site-form/index.tsx
+++ b/apps/ui/src/components/create-site-form/index.tsx
@@ -52,16 +52,18 @@ export interface CreateSiteFormValues {
 
 interface CreateSiteFormProps {
 	/**
-	 * Initial "Site name" value. Applied once when first provided, so the form
-	 * can seed a randomly-generated default without fighting user input on
-	 * subsequent re-renders.
+	 * Initial field values applied once when first defined — the form won't
+	 * fight user input after that. Lets callers seed a randomly-generated
+	 * site name, pre-fill a blueprint's admin credentials / versions, etc.,
+	 * without needing a controlled form.
 	 */
-	defaultName?: string;
+	initialValues?: Partial< CreateSiteFormValues >;
 	existingDomainNames: string[];
 	onSubmit: ( values: CreateSiteFormValues ) => void;
 	onCancel: () => void;
 	isSubmitting?: boolean;
 	submitError?: string;
+	submitLabel?: string;
 }
 
 interface FormData {
@@ -105,6 +107,31 @@ const { ValidatedInputControl } = unlock( componentsPrivateApis ) as {
 		className?: string;
 	} >;
 };
+
+function hasAnyValue( values: Partial< CreateSiteFormValues > ): boolean {
+	return Object.values( values ).some( ( value ) => value !== undefined && value !== '' );
+}
+
+/**
+ * Merges caller-supplied initial values into form state. Only fields the
+ * caller actually provided are overwritten — user edits to everything else
+ * survive an async initial-value arrival.
+ */
+function applyInitialValues( prev: FormData, values: Partial< CreateSiteFormValues > ): FormData {
+	const next: FormData = { ...prev };
+	if ( values.name !== undefined && ! prev.name ) next.name = values.name;
+	if ( values.phpVersion !== undefined ) next.phpVersion = values.phpVersion;
+	if ( values.wpVersion !== undefined ) next.wpVersion = values.wpVersion;
+	if ( values.adminUsername !== undefined ) next.adminUsername = values.adminUsername;
+	if ( values.adminPassword !== undefined ) next.adminPassword = values.adminPassword;
+	if ( values.adminEmail !== undefined ) next.adminEmail = values.adminEmail;
+	if ( values.customDomain ) {
+		next.useCustomDomain = true;
+		next.customDomain = values.customDomain;
+	}
+	if ( values.enableHttps !== undefined ) next.enableHttps = values.enableHttps;
+	return next;
+}
 
 /**
  * Runs the name→path auto-generation effect on behalf of the form. Called
@@ -253,37 +280,46 @@ function countAdvancedErrors( validity: FormValidity, form: Form ): number {
 }
 
 export function CreateSiteForm( {
-	defaultName,
+	initialValues,
 	existingDomainNames,
 	onSubmit,
 	onCancel,
 	isSubmitting,
 	submitError,
+	submitLabel,
 }: CreateSiteFormProps ) {
-	const [ data, setData ] = useState< FormData >( () => ( {
-		name: '',
-		path: '',
-		hasCustomPath: false,
-		pathError: '',
-		phpVersion: RecommendedPHPVersion,
-		wpVersion: DEFAULT_WORDPRESS_VERSION,
-		useCustomDomain: false,
-		customDomain: '',
-		enableHttps: false,
-		adminUsername: 'admin',
-		adminPassword: generatePassword(),
-		adminEmail: 'admin@localhost.com',
-	} ) );
+	const [ data, setData ] = useState< FormData >( () => {
+		const base: FormData = {
+			name: '',
+			path: '',
+			hasCustomPath: false,
+			pathError: '',
+			phpVersion: RecommendedPHPVersion,
+			wpVersion: DEFAULT_WORDPRESS_VERSION,
+			useCustomDomain: false,
+			customDomain: '',
+			enableHttps: false,
+			adminUsername: 'admin',
+			adminPassword: generatePassword(),
+			adminEmail: 'admin@localhost.com',
+		};
+		if ( ! initialValues ) return base;
+		// Synchronous seed — callers already holding the full initial snapshot
+		// (e.g. values extracted from a blueprint) get them applied before the
+		// first render so derived effects like name→path see the seeded name.
+		return applyInitialValues( base, initialValues );
+	} );
 
-	// Seed the site name from `defaultName` the first time it resolves, as
-	// long as the user hasn't typed anything yet. Fires once — subsequent
-	// `defaultName` churn shouldn't clobber user input.
-	const hasAppliedDefaultName = useRef( false );
+	// Re-apply `initialValues` the first time it resolves with a populated
+	// value. Handles the async case (e.g. `useProposedSiteName` returns after
+	// mount) without clobbering user edits on subsequent re-renders.
+	const hasAppliedInitialValues = useRef( initialValues ? hasAnyValue( initialValues ) : false );
 	useEffect( () => {
-		if ( hasAppliedDefaultName.current || ! defaultName ) return;
-		hasAppliedDefaultName.current = true;
-		setData( ( prev ) => ( prev.name ? prev : { ...prev, name: defaultName } ) );
-	}, [ defaultName ] );
+		if ( hasAppliedInitialValues.current || ! initialValues ) return;
+		if ( ! hasAnyValue( initialValues ) ) return;
+		hasAppliedInitialValues.current = true;
+		setData( ( prev ) => applyInitialValues( prev, initialValues ) );
+	}, [ initialValues ] );
 
 	const fields = useMemo< Field< FormData >[] >(
 		() => [
@@ -464,7 +500,7 @@ export function CreateSiteForm( {
 					loadingAnnouncement={ __( 'Creating site' ) }
 					data-testid="create-site-submit"
 				>
-					{ __( 'Create site' ) }
+					{ submitLabel ?? __( 'Create site' ) }
 				</Button>
 			</div>
 		</form>

--- a/apps/ui/src/components/onboarding-layout/index.tsx
+++ b/apps/ui/src/components/onboarding-layout/index.tsx
@@ -12,9 +12,19 @@ interface OnboardingLayoutProps {
 	 * the user isn't trapped in the flow.
 	 */
 	onClose?: () => void;
+	/**
+	 * Content width variant. Defaults to a narrow column (`'default'`) sized
+	 * for forms and short cards; `'wide'` is used by pages that host grids of
+	 * content (e.g. the blueprint selector).
+	 */
+	width?: 'default' | 'wide';
 }
 
-export function OnboardingLayout( { children, onClose }: OnboardingLayoutProps ) {
+export function OnboardingLayout( {
+	children,
+	onClose,
+	width = 'default',
+}: OnboardingLayoutProps ) {
 	return (
 		<Stack align="center" justify="center" className={ styles.root }>
 			{ onClose && (
@@ -28,7 +38,9 @@ export function OnboardingLayout( { children, onClose }: OnboardingLayoutProps )
 					onClick={ onClose }
 				/>
 			) }
-			<div className={ styles.content }>{ children }</div>
+			<div className={ `${ styles.content } ${ width === 'wide' ? styles.contentWide : '' }` }>
+				{ children }
+			</div>
 		</Stack>
 	);
 }

--- a/apps/ui/src/components/onboarding-layout/style.module.css
+++ b/apps/ui/src/components/onboarding-layout/style.module.css
@@ -9,6 +9,12 @@
 	padding: var(--wpds-dimension-padding-3xl);
 }
 
+/* `wide` variant — used by content-heavy onboarding pages like the blueprint
+   selector. Sized to fit a 3-column card grid (see `blueprint-selector`). */
+.contentWide {
+	max-width: 820px;
+}
+
 .close {
 	position: absolute;
 	top: 16px;

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -4,6 +4,8 @@ import type {
 	AuthUser,
 	ColorScheme,
 	Connector,
+	ExtractedBlueprintBundle,
+	FeaturedBlueprint,
 	InstalledApps,
 	LoadedAiSession,
 	ProposedSitePath,
@@ -153,6 +155,7 @@ export function createIpcConnector(): Connector {
 				adminUsername,
 				adminPassword,
 				adminEmail,
+				blueprint,
 			} = params;
 			return ( await ipcApi.createSite( path, {
 				siteName: name,
@@ -163,6 +166,7 @@ export function createIpcConnector(): Connector {
 				adminUsername,
 				adminPassword,
 				adminEmail,
+				blueprint,
 			} ) ) as SiteDetails;
 		},
 
@@ -218,6 +222,69 @@ export function createIpcConnector(): Connector {
 
 		async getAllCustomDomains(): Promise< string[] > {
 			return ( await ipcApi.getAllCustomDomains() ) as string[];
+		},
+
+		async getFeaturedBlueprints( locale ) {
+			const url = new URL( 'https://public-api.wordpress.com/wpcom/v2/studio-app/blueprints' );
+			if ( locale ) {
+				url.searchParams.set( 'locale', locale );
+			}
+			const response = await fetch( url.toString() );
+			if ( ! response.ok ) {
+				throw new Error( `Failed to fetch blueprints: ${ response.status }` );
+			}
+			const body = ( await response.json() ) as {
+				blueprints?: Array< {
+					slug?: string;
+					title?: string;
+					excerpt?: string;
+					image?: string;
+					playground_url?: string;
+					blueprint?: unknown;
+				} >;
+			};
+			// Drop any blueprint missing the fields the UI relies on rather
+			// than failing the whole request — matches the desktop app's
+			// tolerant `transformResponse` behaviour.
+			const list: FeaturedBlueprint[] = [];
+			for ( const item of body.blueprints ?? [] ) {
+				if (
+					typeof item.slug !== 'string' ||
+					typeof item.title !== 'string' ||
+					typeof item.excerpt !== 'string' ||
+					typeof item.image !== 'string' ||
+					typeof item.playground_url !== 'string' ||
+					! item.blueprint ||
+					typeof item.blueprint !== 'object'
+				) {
+					continue;
+				}
+				list.push( {
+					slug: item.slug,
+					title: item.title,
+					excerpt: item.excerpt,
+					image: item.image,
+					playgroundUrl: item.playground_url,
+					blueprint: item.blueprint as FeaturedBlueprint[ 'blueprint' ],
+				} );
+			}
+			return list;
+		},
+
+		async getFilePath( file ) {
+			// `webUtils.getPathForFile` is a synchronous preload-only API; the
+			// connector wraps it in a Promise to keep the surface uniform and
+			// to leave room for non-Electron connectors that might resolve the
+			// path asynchronously.
+			return ( ipcApi.getPathForFile( file ) as string ) ?? '';
+		},
+
+		async extractBlueprintBundle( zipFilePath ): Promise< ExtractedBlueprintBundle > {
+			return ( await ipcApi.extractBlueprintBundle( zipFilePath ) ) as ExtractedBlueprintBundle;
+		},
+
+		async cleanupBlueprintTempDir( tempDir ) {
+			await ipcApi.cleanupBlueprintTempDir( tempDir );
 		},
 
 		async startSite( id ) {

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -8,6 +8,8 @@ export type {
 	ColorScheme,
 	Connector,
 	CreateSiteParams,
+	ExtractedBlueprintBundle,
+	FeaturedBlueprint,
 	InstalledApps,
 	LoadedAiSession,
 	ProposedSitePath,

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -7,6 +7,7 @@ import type { SupportedTerminal } from '@studio/common/lib/user-settings/termina
 import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
 import type { Snapshot } from '@studio/common/types/snapshot';
 import type { SyncSite } from '@studio/common/types/sync';
+import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
 
 export type {
 	AiSessionSummary,
@@ -98,6 +99,24 @@ export interface Connector {
 	selectSiteFolder( defaultPath: string ): Promise< SelectedSiteFolder | null >;
 	comparePaths( path1: string, path2: string ): Promise< boolean >;
 	getAllCustomDomains(): Promise< string[] >;
+
+	// Featured blueprints gallery for the "Start from blueprint" onboarding
+	// flow. Sourced from the public wpcom/v2/studio-app/blueprints endpoint —
+	// no auth required, localized by the user's current UI locale.
+	getFeaturedBlueprints( locale?: string ): Promise< FeaturedBlueprint[] >;
+
+	// Resolves the absolute filesystem path of a File handle picked or dropped
+	// in the renderer. Returns an empty string when the underlying file lacks
+	// a real path (synthetic blobs, non-Electron environments).
+	getFilePath( file: File ): Promise< string >;
+
+	// Extracts a Blueprint ZIP bundle to a temp directory and returns the
+	// parsed `blueprint.json`. The caller is responsible for calling
+	// `cleanupBlueprintTempDir` if the extraction succeeds but the upload
+	// flow never reaches `createSite` — otherwise `createSite` cleans the
+	// temp directory automatically when it uses the extracted blueprint.
+	extractBlueprintBundle( zipFilePath: string ): Promise< ExtractedBlueprintBundle >;
+	cleanupBlueprintTempDir( tempDir: string ): Promise< void >;
 
 	// Preview snapshots (WordPress.com hosted previews of local sites)
 	getSnapshots(): Promise< Snapshot[] >;
@@ -218,6 +237,15 @@ export type WritableUserPreferences = Omit< UserPreferences, 'locale' > & {
 	locale: SupportedLocale;
 };
 
+export interface FeaturedBlueprint {
+	slug: string;
+	title: string;
+	excerpt: string;
+	image: string;
+	playgroundUrl: string;
+	blueprint: BlueprintV1Declaration;
+}
+
 export interface CreateSiteParams {
 	name: string;
 	path: string;
@@ -228,6 +256,22 @@ export interface CreateSiteParams {
 	adminUsername?: string;
 	adminPassword?: string;
 	adminEmail?: string;
+	// Optional blueprint payload. When present, `blueprint` is the parsed
+	// blueprint JSON; `slug` is set for featured blueprints (used for stats);
+	// `filePath` points at the extracted `blueprint.json` inside a ZIP bundle
+	// so the CLI can resolve relative asset references. Main process cleans
+	// up the temp dir automatically once `createSite` completes.
+	blueprint?: {
+		blueprint: BlueprintV1Declaration;
+		slug?: string;
+		filePath?: string;
+	};
+}
+
+export interface ExtractedBlueprintBundle {
+	blueprintJson: BlueprintV1Declaration;
+	blueprintJsonPath: string;
+	tempDir: string;
 }
 
 export interface ProposedSitePath {

--- a/apps/ui/src/data/queries/use-featured-blueprints.ts
+++ b/apps/ui/src/data/queries/use-featured-blueprints.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+import { useUserLocale } from './use-user-locale';
+
+const FEATURED_BLUEPRINTS_QUERY_KEY = [ 'featured-blueprints' ] as const;
+
+export function useFeaturedBlueprints() {
+	const connector = useConnector();
+	const locale = useUserLocale();
+	return useQuery( {
+		queryKey: [ ...FEATURED_BLUEPRINTS_QUERY_KEY, locale ?? 'en' ],
+		queryFn: () => connector.getFeaturedBlueprints( locale ),
+		// Featured blueprints rarely change — keep them fresh for an hour so
+		// re-opening the selector doesn't spam the public endpoint.
+		staleTime: 60 * 60 * 1000,
+	} );
+}

--- a/apps/ui/src/globals.d.ts
+++ b/apps/ui/src/globals.d.ts
@@ -1,0 +1,5 @@
+// Shared helpers in `@studio/common` import from this subpath, but the
+// package's `exports` map doesn't expose it. The vite configs alias the
+// runtime file explicitly — this declaration keeps the TypeScript bundler
+// resolver happy without a matching alias.
+declare module '@wp-playground/blueprints/blueprint-schema-validator';

--- a/apps/ui/src/router/layout-onboarding/index.tsx
+++ b/apps/ui/src/router/layout-onboarding/index.tsx
@@ -1,4 +1,4 @@
-import { createRoute, Outlet, useNavigate } from '@tanstack/react-router';
+import { createRoute, Outlet, useMatches, useNavigate } from '@tanstack/react-router';
 import { OnboardingLayout } from '@/components/onboarding-layout';
 import { useSites } from '@/data/queries/use-sites';
 import { rootRoute } from '../layout-root';
@@ -7,9 +7,23 @@ function OnboardingShell() {
 	const navigate = useNavigate();
 	const { data: sites } = useSites();
 	const hasSites = ( sites?.length ?? 0 ) > 0;
+	// Grid-heavy pages (onboarding home with its flow picker cards, and the
+	// blueprint selector's "select" step) need more horizontal room than the
+	// single-column form pages; thread the variant through here so each child
+	// route doesn't have to re-declare its own layout chrome. The blueprint
+	// "configure" step reuses the shared site form and should match the
+	// narrow "/onboarding/create" width.
+	const matches = useMatches();
+	const isWide = matches.some( ( match ) => {
+		if ( match.pathname === '/onboarding' ) return true;
+		if ( match.pathname !== '/onboarding/blueprint' ) return false;
+		const step = ( match.search as { step?: string } ).step;
+		return step !== 'configure';
+	} );
 	return (
 		<OnboardingLayout
 			onClose={ hasSites ? () => void navigate( { to: '/dashboard' } ) : undefined }
+			width={ isWide ? 'wide' : 'default' }
 		>
 			<Outlet />
 		</OnboardingLayout>

--- a/apps/ui/src/router/route-onboarding-blueprint/index.tsx
+++ b/apps/ui/src/router/route-onboarding-blueprint/index.tsx
@@ -1,0 +1,198 @@
+import {
+	extractFormValuesFromBlueprint,
+	updateBlueprintWithFormValues,
+} from '@studio/common/lib/blueprint-settings';
+import { createRoute, useNavigate } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { arrowLeft } from '@wordpress/icons';
+import { Button, Icon } from '@wordpress/ui';
+import { useCallback, useEffect, useState } from 'react';
+import { BlueprintSelector, type PickedBlueprint } from '@/components/blueprint-selector';
+import { CreateSiteForm } from '@/components/create-site-form';
+import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
+import { useFeaturedBlueprints } from '@/data/queries/use-featured-blueprints';
+import { useCreateSite } from '@/data/queries/use-sites';
+import { onboardingLayoutRoute } from '../layout-onboarding';
+import styles from '../layout-onboarding/style.module.css';
+import localStyles from './style.module.css';
+import type { CreateSiteFormValues } from '@/components/create-site-form';
+
+type Step = 'select' | 'configure';
+
+interface BlueprintSearch {
+	step?: Step;
+}
+
+function OnboardingBlueprintPage() {
+	const { step } = onboardingBlueprintRoute.useSearch();
+	const navigate = useNavigate();
+	const activeStep: Step = step === 'configure' ? 'configure' : 'select';
+
+	const featured = useFeaturedBlueprints();
+	const { data: existingDomainNames } = useExistingCustomDomains();
+	const createSite = useCreateSite();
+
+	// Picked blueprint lives in component state — survives navigation between
+	// steps but not a hard refresh. If the user lands on `step=configure` with
+	// no picked blueprint (refresh, direct URL), the effect below bounces them
+	// back to the selector.
+	const [ picked, setPicked ] = useState< PickedBlueprint | null >( null );
+	const [ submitError, setSubmitError ] = useState( '' );
+
+	useEffect( () => {
+		if ( activeStep === 'configure' && ! picked ) {
+			void navigate( {
+				to: '/onboarding/blueprint',
+				search: { step: 'select' },
+				replace: true,
+			} );
+		}
+	}, [ activeStep, picked, navigate ] );
+
+	const handlePick = useCallback(
+		( blueprint: PickedBlueprint ) => {
+			setPicked( blueprint );
+			setSubmitError( '' );
+			void navigate( {
+				to: '/onboarding/blueprint',
+				search: { step: 'configure' },
+			} );
+		},
+		[ navigate ]
+	);
+
+	const handleBackToSelect = useCallback( () => {
+		void navigate( {
+			to: '/onboarding/blueprint',
+			search: { step: 'select' },
+		} );
+	}, [ navigate ] );
+
+	const handleSubmit = async ( values: CreateSiteFormValues ) => {
+		if ( ! picked ) return;
+		setSubmitError( '' );
+		// Fold the user's edited form values back into the blueprint JSON so
+		// any steps that reference them (defineSiteUrl, login, setSiteOptions,
+		// preferredVersions) pick up the final values when the CLI runs it.
+		const mergedBlueprint = updateBlueprintWithFormValues( picked.blueprint, {
+			phpVersion: values.phpVersion,
+			wpVersion: values.wpVersion,
+			customDomain: values.customDomain,
+			enableHttps: values.enableHttps,
+			adminUsername: values.adminUsername,
+			adminPassword: values.adminPassword,
+			siteName: values.name,
+		} );
+		try {
+			const site = await createSite.mutateAsync( {
+				name: values.name,
+				path: values.path,
+				phpVersion: values.phpVersion,
+				wpVersion: values.wpVersion,
+				customDomain: values.customDomain,
+				enableHttps: values.enableHttps,
+				adminUsername: values.adminUsername || undefined,
+				adminPassword: values.adminPassword || undefined,
+				adminEmail: values.adminEmail || undefined,
+				blueprint: {
+					blueprint: mergedBlueprint,
+					slug: picked.slug,
+					filePath: picked.filePath,
+				},
+			} );
+			await navigate( { to: '/sites/$siteId/new', params: { siteId: site.id } } );
+		} catch ( error ) {
+			setSubmitError(
+				error instanceof Error
+					? error.message
+					: __( 'Failed to create site from Blueprint. Please try again.' )
+			);
+		}
+	};
+
+	if ( activeStep === 'select' ) {
+		return (
+			<div className={ styles.page }>
+				<h1 className={ styles.title }>{ __( 'Start from a Blueprint' ) }</h1>
+				<p className={ styles.subtitle }>
+					{ __(
+						'Pick a featured Blueprint or drop in your own to provision plugins, content, and settings.'
+					) }
+				</p>
+				<BlueprintSelector
+					featured={ featured.data }
+					isFeaturedLoading={ featured.isLoading }
+					onPick={ handlePick }
+				/>
+			</div>
+		);
+	}
+
+	// `step=configure` with no picked blueprint is handled by the effect
+	// above; render nothing in the intermediate frame to avoid a flash.
+	if ( ! picked ) return null;
+
+	const initialValues = mapBlueprintSettingsToFormValues(
+		extractFormValuesFromBlueprint( picked.blueprint ),
+		picked.title
+	);
+
+	return (
+		<div className={ styles.page }>
+			<Button
+				type="button"
+				variant="minimal"
+				tone="neutral"
+				className={ localStyles.backLink }
+				onClick={ handleBackToSelect }
+			>
+				<Icon icon={ arrowLeft } />
+				<span>{ __( 'Back to Blueprints' ) }</span>
+			</Button>
+			<h1 className={ styles.title }>{ picked.title }</h1>
+			{ picked.excerpt && <p className={ styles.subtitle }>{ picked.excerpt }</p> }
+			<CreateSiteForm
+				initialValues={ initialValues }
+				existingDomainNames={ existingDomainNames ?? [] }
+				onSubmit={ handleSubmit }
+				onCancel={ () => void navigate( { to: '/onboarding' } ) }
+				isSubmitting={ createSite.isPending }
+				submitError={ submitError }
+				submitLabel={ __( 'Create site from Blueprint' ) }
+			/>
+		</div>
+	);
+}
+
+/**
+ * Translates the settings extracted from a blueprint into the shape the form
+ * expects. PHP 7.2/7.3 are already filtered out upstream, but we still guard
+ * against older blueprints sneaking in an unsupported value.
+ */
+function mapBlueprintSettingsToFormValues(
+	settings: ReturnType< typeof extractFormValuesFromBlueprint >,
+	fallbackName: string
+): Partial< CreateSiteFormValues > {
+	return {
+		name: settings.siteName || fallbackName,
+		phpVersion: settings.phpVersion,
+		wpVersion: settings.wpVersion,
+		customDomain: settings.customDomain,
+		enableHttps: settings.enableHttps,
+		adminUsername: settings.adminUsername,
+		adminPassword: settings.adminPassword,
+	};
+}
+
+export const onboardingBlueprintRoute = createRoute( {
+	getParentRoute: () => onboardingLayoutRoute,
+	path: '/onboarding/blueprint',
+	validateSearch: ( search: Record< string, unknown > ): BlueprintSearch => {
+		const value = search.step;
+		if ( value === 'configure' || value === 'select' ) {
+			return { step: value };
+		}
+		return {};
+	},
+	component: OnboardingBlueprintPage,
+} );

--- a/apps/ui/src/router/route-onboarding-blueprint/style.module.css
+++ b/apps/ui/src/router/route-onboarding-blueprint/style.module.css
@@ -1,0 +1,8 @@
+.backLink {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	align-self: flex-start;
+	margin-bottom: 16px;
+	padding: 4px 8px 4px 4px;
+}

--- a/apps/ui/src/router/route-onboarding-create/index.tsx
+++ b/apps/ui/src/router/route-onboarding-create/index.tsx
@@ -48,7 +48,7 @@ function CreateSitePage() {
 				{ __( 'Choose a name and we\u2019ll scaffold a fresh WordPress site locally.' ) }
 			</p>
 			<CreateSiteForm
-				defaultName={ proposedName }
+				initialValues={ proposedName ? { name: proposedName } : undefined }
 				existingDomainNames={ existingDomainNames ?? [] }
 				onSubmit={ handleSubmit }
 				onCancel={ () => void navigate( { to: '/onboarding' } ) }

--- a/apps/ui/src/router/route-onboarding-home/index.tsx
+++ b/apps/ui/src/router/route-onboarding-home/index.tsx
@@ -17,6 +17,14 @@ function OnboardingHomePage() {
 						{ __( 'Start fresh with a blank site and build it with AI' ) }
 					</p>
 				</Link>
+				<Link to="/onboarding/blueprint" className={ styles.card }>
+					<h3 className={ styles.cardTitle }>{ __( 'Start from a blueprint' ) }</h3>
+					<p className={ styles.cardBody }>
+						{ __(
+							'Pick a featured blueprint or drop in your own to provision plugins, content, and settings.'
+						) }
+					</p>
+				</Link>
 				<div className={ `${ styles.card } ${ styles.cardDisabled }` }>
 					<h3 className={ styles.cardTitle }>{ __( 'Bring existing' ) }</h3>
 					<p className={ styles.cardBody }>

--- a/apps/ui/src/router/router.tsx
+++ b/apps/ui/src/router/router.tsx
@@ -5,6 +5,7 @@ import { rootRoute } from './layout-root';
 import { dashboardRoute } from './route-dashboard';
 import { indexRoute } from './route-index';
 import { newSessionRoute } from './route-new-session';
+import { onboardingBlueprintRoute } from './route-onboarding-blueprint';
 import { onboardingCreateRoute } from './route-onboarding-create';
 import { onboardingHomeRoute } from './route-onboarding-home';
 import { sessionDetailRoute } from './route-session-detail';
@@ -21,7 +22,11 @@ const routeTree = rootRoute.addChildren( [
 		siteSettingsRoute,
 		settingsRoute,
 	] ),
-	onboardingLayoutRoute.addChildren( [ onboardingHomeRoute, onboardingCreateRoute ] ),
+	onboardingLayoutRoute.addChildren( [
+		onboardingHomeRoute,
+		onboardingCreateRoute,
+		onboardingBlueprintRoute,
+	] ),
 ] );
 
 export function createAppRouter( context: RouterContext ) {

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -28,6 +28,15 @@ export default defineConfig( {
 	resolve: {
 		alias: {
 			'@': resolve( __dirname, 'src' ),
+			// `@wp-playground/blueprints` ships the schema validator as a sibling
+			// module that isn't listed in the package's `exports` map. Shared
+			// helpers in @studio/common (blueprint-validation.ts) import it via
+			// this subpath, so map it through explicitly — matches the apps/cli
+			// and apps/studio vite configs.
+			'@wp-playground/blueprints/blueprint-schema-validator': resolve(
+				__dirname,
+				'../../node_modules/@wp-playground/blueprints/blueprint-schema-validator.js'
+			),
 		},
 		dedupe: directDeps,
 	},

--- a/apps/ui/vitest.config.ts
+++ b/apps/ui/vitest.config.ts
@@ -14,6 +14,11 @@ export default mergeConfig(
 			alias: {
 				'@': path.resolve( __dirname, 'src' ),
 				'@studio/common': path.resolve( __dirname, '../../tools/common' ),
+				// See `vite.config.ts` for why this subpath needs an explicit alias.
+				'@wp-playground/blueprints/blueprint-schema-validator': path.resolve(
+					__dirname,
+					'../../node_modules/@wp-playground/blueprints/blueprint-schema-validator.js'
+				),
 			},
 		},
 	} )

--- a/package-lock.json
+++ b/package-lock.json
@@ -974,6 +974,7 @@
 				"@wordpress/react-i18n": "^4.41.0",
 				"@wordpress/theme": "0.10.0",
 				"@wordpress/ui": "0.10.0",
+				"@wp-playground/blueprints": "3.1.18",
 				"clsx": "^2.1.1",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -986,6 +987,470 @@
 				"@vitejs/plugin-react": "^5.1.4",
 				"typescript": "~5.9.3",
 				"vite": "^7.3.1"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/cli-util": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.18.tgz",
+			"integrity": "sha512-2UxVhKTrSZMcHKWAr31ZrQk27Dk0Hu0epjQmF/4Wjb3s+Pi41BvAvsWcBtZ0sJBgsTqAigTFt0E4Si03swtQrQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/util": "3.1.18",
+				"fast-xml-parser": "^5.5.1",
+				"jsonc-parser": "3.3.1"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/logger": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.18.tgz",
+			"integrity": "sha512-RcU4xMif62xcXaqRKcqoWmypNlAdoBdyTDxfQ7/OVWzPQBsURRROraW0rtst/aJY3BpHdDSphXrXk2fQ/7I84w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.18"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/node": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.18.tgz",
+			"integrity": "sha512-uyH4bFF8ufSdOwZm8+NtJ9t+wXuTf7qz7nkK5ctZT6smarkucQp4N3Hf3dnw0Dhzn9iGrmlzdWl6XvzZzf4wUQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/cli-util": "3.1.18",
+				"@php-wasm/logger": "3.1.18",
+				"@php-wasm/node-7-4": "3.1.18",
+				"@php-wasm/node-8-0": "3.1.18",
+				"@php-wasm/node-8-1": "3.1.18",
+				"@php-wasm/node-8-2": "3.1.18",
+				"@php-wasm/node-8-3": "3.1.18",
+				"@php-wasm/node-8-4": "3.1.18",
+				"@php-wasm/node-8-5": "3.1.18",
+				"@php-wasm/node-polyfills": "3.1.18",
+				"@php-wasm/universal": "3.1.18",
+				"@php-wasm/util": "3.1.18",
+				"@wp-playground/common": "3.1.18",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/node-7-4": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.18.tgz",
+			"integrity": "sha512-ktSKUxHCqGOy6sJhpI77wG/X+1joFX+ZJCP/YUAeULDXcSlYU3Beaa9FC6hY4jydOlyb7wEEbSRYVvTrlLj/lg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.18",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/node-8-0": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.18.tgz",
+			"integrity": "sha512-TOJ8iqWBF5T0cQmo610pw/m9DBkiHEdv4jTNSlg3BxVVbBBKHKx4WdAhEl4s/e7dEnHc4u51sjP+hxpNEY2xwQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.18",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/node-8-1": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.18.tgz",
+			"integrity": "sha512-wJynAXRIGR91ikrnnZ4awnGGfSJUHnshnN2XdQJheOP7eU8A0XCEvGUJsbLyBprXM9iucSMuVHgfG+0L90vsOw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.18",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/node-8-2": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.18.tgz",
+			"integrity": "sha512-m2uPuDiVb42wYP0rmZhrLAlo5VjkNrBzjkUe8cGKYH00rM0apJd7/ibSbL6OSJDNSWuWRvZMepKhDd5FDPL2NA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.18",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/node-8-3": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.18.tgz",
+			"integrity": "sha512-8XK/xYoE4diunIehXIETizWi90olzjop30cbvUxARt0mPQRotgCwx7jwkfxR7asa693CgHj5TFFsofvLKdWVPA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.18",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/node-8-4": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.18.tgz",
+			"integrity": "sha512-pgS2Y6fz/r0YQy6j+eXWLiaL0TO6hPf7k2FmZGjgZzoifzgErEcS8WMiZzWm4FHg3FqmO8iBTfDX9pj17s14+A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.18",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/node-8-5": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.18.tgz",
+			"integrity": "sha512-BNSYtKw9LfNLQlL9Df7PPU9dUv9erPKuPLO15irMLVXYOo+bzlMeshOVH2qxUc+0ncpVhaTvqfBueCXAVa145g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.18",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/progress": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.18.tgz",
+			"integrity": "sha512-j/789FUhwneUdBjngb1n1NY2Gq12BgXxKuXakQsYn+Xa1dhHrpB/8bCfBWECG0x5mRDCx0sOd/vfptopuKOzEw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.18",
+				"@php-wasm/node-polyfills": "3.1.18"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/scopes": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.18.tgz",
+			"integrity": "sha512-og+wLUv2BjZBR1L8fwD8+0Y/c7L7ZaAxJaGml892sHRpt90FPf4JcIwmN23srnNXcEltk93Wty/c22Fv5TYLxw==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/stream-compression": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.18.tgz",
+			"integrity": "sha512-/jNdiTBRBwtJSJo2L7Lk/FMKAXJVRh3cZIRiuPiPj0JZN68aeQlq8xuyOCBdgJk/kKVK4PSysNNi7Xtp0eeu6A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.18",
+				"@php-wasm/util": "3.1.18"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/universal": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.18.tgz",
+			"integrity": "sha512-hqMApb/1bewMs6cBwNKNMVrpQAlFE3BDQalRqdcoEfuKxe4muXyoYi1/x0fRpfPJJUCpHJU5sUW8XD807vDyYw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.18",
+				"@php-wasm/node-polyfills": "3.1.18",
+				"@php-wasm/progress": "3.1.18",
+				"@php-wasm/stream-compression": "3.1.18",
+				"@php-wasm/util": "3.1.18",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/util": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.18.tgz",
+			"integrity": "sha512-M26e1PxIRU5VTcuUpynlBNNpy8WWtbgiMi689+WZ9NIDeELek6SM+zAYmZ/YR7+0DoaYWwwB5iak8hj3DzQ3gw==",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@php-wasm/web-service-worker": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.18.tgz",
+			"integrity": "sha512-Ozhst3rhS5arAO5dS3QzBJpDE+CKtzN4ji3qj2f+abE68TG1ELYqmK6xEbMUqANHOjDqZe9ywo00vqxlwX2bBQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/scopes": "3.1.18",
+				"@php-wasm/universal": "3.1.18",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@wp-playground/blueprints": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.18.tgz",
+			"integrity": "sha512-dRVJMcvlcbw2Sw5sa9vPEUTJyyro3WxfS5KgjOCHq2CkxvtGeL35JDea9dQtlxefogBmKKScb+e6NAhNCucONA==",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.18",
+				"@php-wasm/node": "3.1.18",
+				"@php-wasm/node-polyfills": "3.1.18",
+				"@php-wasm/progress": "3.1.18",
+				"@php-wasm/scopes": "3.1.18",
+				"@php-wasm/stream-compression": "3.1.18",
+				"@php-wasm/universal": "3.1.18",
+				"@php-wasm/util": "3.1.18",
+				"@php-wasm/web-service-worker": "3.1.18",
+				"@wp-playground/common": "3.1.18",
+				"@wp-playground/storage": "3.1.18",
+				"@wp-playground/wordpress": "3.1.18",
+				"@zip.js/zip.js": "2.7.57",
+				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"clean-git-ref": "2.0.1",
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ignore": "5.3.2",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"minimisted": "2.0.1",
+				"octokit": "3.1.2",
+				"pako": "1.0.10",
+				"pify": "2.3.0",
+				"readable-stream": "3.6.2",
+				"sha.js": "2.4.12",
+				"simple-get": "4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@wp-playground/common": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.18.tgz",
+			"integrity": "sha512-0wmTNI/rNIgSEONzReODwXuZUvbd6PyUi92Q4xEo9p6nKkpFxco8nioWFkYCcCfDgO6V1lGK760pGiulReR3AQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.18",
+				"@php-wasm/util": "3.1.18",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/@wp-playground/storage": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.18.tgz",
+			"integrity": "sha512-YSRWigcn8MJ/+zoMnK5wD2he+qUMpOCBtSyXlgeIx4m2uJI1fdTdQ+A8JzUdTMHFUjfM5nJ9Ih0eTQvDbQskWw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/stream-compression": "3.1.18",
+				"@php-wasm/universal": "3.1.18",
+				"@php-wasm/util": "3.1.18",
+				"@zip.js/zip.js": "2.7.57",
+				"async-lock": "^1.4.1",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"ignore": "^5.1.4",
+				"ini": "4.1.2",
+				"minimisted": "^2.0.0",
+				"octokit": "3.1.2",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^3.4.0",
+				"sha.js": "^2.4.9",
+				"simple-get": "^4.0.1"
+			}
+		},
+		"apps/ui/node_modules/@wp-playground/storage/node_modules/diff3": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+			"license": "MIT"
+		},
+		"apps/ui/node_modules/@wp-playground/storage/node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"apps/ui/node_modules/@wp-playground/wordpress": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.18.tgz",
+			"integrity": "sha512-0fB5nt0rAqqGyysoi/byNoKfpH9Ibf4wNeZXeBIStVFibW3ypSWXRxldVWUA91Dlke9JivpnHYtb8rI13Cv/GA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.18",
+				"@php-wasm/node": "3.1.18",
+				"@php-wasm/universal": "3.1.18",
+				"@php-wasm/util": "3.1.18",
+				"@wp-playground/common": "3.1.18",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/ui/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"apps/ui/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"apps/ui/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"apps/ui/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"apps/ui/node_modules/pako": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"license": "(MIT AND Zlib)"
+		},
+		"apps/ui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"apps/ui/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"apps/ui/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -8693,6 +9158,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/@php-wasm/node-polyfills": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.18.tgz",
+			"integrity": "sha512-wOP4W1UHKEyJgSE+c/P+EtujMwSwQSYNudNPE45AAqnsDh5XDgSI9ahJF1evlsTmAs32m5E87lWkLqftPIpLVg==",
+			"license": "GPL-2.0-or-later"
 		},
 		"node_modules/@php-wasm/node/node_modules/cliui": {
 			"version": "8.0.1",
@@ -27811,7 +28282,6 @@
 		},
 		"node_modules/ws": {
 			"version": "8.18.3",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Built end-to-end with Claude Code. I iterated on the plan first — keeping routes as thin glue and making the create-site form the single reusable piece — then let it implement and verify. Reviewers should focus on:

- The `CreateSiteForm` prop rename (`defaultName` → `initialValues`) and the one-shot seed semantics — user edits must always win after first apply.
- The `OnboardingLayout` `width` variant + the route-matching logic in `layout-onboarding` that decides when to widen.
- `CreateSiteParams.blueprint` shape — it now forwards through to the existing main-process `createSite` handler, which already supports the field.

## Proposed Changes

Adds a **"Start from blueprint"** entry to the apps/ui onboarding flow, porting the equivalent capability from the existing Electron UI.

- **New route** `/onboarding/blueprint` with a `?step=select|configure` query param:
  - **Select step** renders `BlueprintSelector` — a three-column grid of featured blueprints (fetched from the public `wpcom/v2/studio-app/blueprints` endpoint, no auth required) plus a drag-and-drop zone that accepts `.json` and `.zip` blueprint bundles. Each featured card has a **Preview in Playground** button that opens the blueprint's `playground_url` via the existing `openExternalUrl` connector.
  - **Configure step** reuses the shared `CreateSiteForm`, pre-populated via `extractFormValuesFromBlueprint` from `@studio/common`. Submit merges the user's edits back into the blueprint JSON (`updateBlueprintWithFormValues`) before calling `createSite`.
- **Shared form generalization** — `CreateSiteForm`'s `defaultName?: string` prop becomes `initialValues?: Partial<CreateSiteFormValues>`, applied once with a ref-gated effect so user edits aren't clobbered by a late-arriving query result. A new optional `submitLabel` lets callers reword the submit button.
- **Connector surface** — `Connector` gains `getFeaturedBlueprints`, `getFilePath`, `extractBlueprintBundle`, `cleanupBlueprintTempDir`. All main-process handlers already existed in `apps/studio` — this is purely renderer-side plumbing. `CreateSiteParams` gains an optional `blueprint` field (parsed JSON + optional `slug`/`filePath`) that's forwarded through the existing IPC handler.
- **ZIP bundle support** — large bundles are unpacked in the main process (`extractBlueprintBundle`), and the extracted `blueprint.json` path travels with the `PickedBlueprint` so the CLI can resolve relative asset references. The main-process `createSite` handler already cleans up the temp directory in its `finally`; upload-side failures clean up explicitly.
- **Layout width variant** — `OnboardingLayout` now takes `width: 'default' | 'wide'`. The onboarding home (three-card flow picker) and the blueprint selector's select step use `wide` (820px, sized for a 3-column grid); the configure step falls back to the narrow 640px column so it matches `/onboarding/create` exactly.
- **Entry point** — the onboarding home gets a third "Start from a blueprint" card alongside "Create new" and the still-disabled "Bring existing".
- **Build plumbing** — `@wp-playground/blueprints` added to `apps/ui`'s deps; vite + vitest aliases map the package's sibling `blueprint-schema-validator` module (not in the package's `exports` map) to its on-disk path. A `globals.d.ts` declares the subpath for TS's bundler resolver.

Shared helpers (`validateBlueprintData`, `extractFormValuesFromBlueprint`, `updateBlueprintWithFormValues`, `generateDefaultBlueprintDescription`) all live in `tools/common` already — no duplication.

**Intentionally deferred for now:** blueprint deeplinks (`wp-studio://add-site?...`). The main-process handler still exists but apps/ui doesn't listen for it — can land in a follow-up PR without any main-process changes.

## Testing Instructions

1. `npm start` and reach the onboarding flow (zero sites state, or Dashboard → Add site).
2. Click **Start from a blueprint** on the onboarding home.
3. Verify the selector page:
   - Featured blueprints load in a three-column grid (requires network).
   - Each featured card has a **Preview** button in the top-right that opens its Playground URL in the default browser.
   - Clicking elsewhere on a card advances to the configure step.
4. Back at the selector, drop or pick a **Blueprint JSON file** — see [docs/blueprints](https://developer.wordpress.com/docs/developer-tools/studio/blueprints/) for samples. Confirm validation errors show inline for malformed / v2 / schema-invalid blueprints.
5. Drop or pick a **Blueprint ZIP bundle** (a zip containing `blueprint.json` at its root). Create one quickly:
   ```bash
   cat > /tmp/blueprint.json <<'BP'
   { "steps": [{ "step": "installPlugin", "pluginData": { "resource": "wordpress.org/plugins", "slug": "hello-dolly" } }] }
   BP
   cd /tmp && zip blueprint.zip blueprint.json
   ```
6. On the configure step:
   - Verify the site form is pre-populated where the blueprint sets values (PHP/WP versions, admin creds, custom domain).
   - The submit button reads "Create site from Blueprint".
   - Back button returns to the selector.
   - Hard-refresh on `?step=configure` bounces back to `?step=select`.
7. Submit and verify the site creates successfully, the blueprint steps run, and you land on the new-session route.
8. Confirm `/onboarding/create` (the non-blueprint path) still works unchanged.
9. Confirm the configure step is the same narrow width as `/onboarding/create`, and the selector step + onboarding home are wider.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
- [x] Does it pass the linter? (`npx eslint --fix <files>`)
- [x] Does typecheck pass? (`npm run typecheck`)
- [x] Do relevant tests pass? (65 shared `blueprint-validation` + `blueprint-settings` tests still green)
- [ ] Manual testing in the desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)