### PR TITLE
Fix excessive word spacing on Linux caused by emoji-font fallback

### DIFF
--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -59,7 +59,13 @@ body {
 		BlinkMacSystemFont,
 		/* macOS/iOS system UI */ 'Segoe UI',
 		Roboto,
-		/* Windows + Android system UI */ 'Apple Color Emoji',
+		/* Windows + Android system UI */ Ubuntu,
+		Cantarell,
+		'Liberation Sans',
+		'DejaVu Sans',
+		/* Linux system UI — listed before emoji fonts so the space glyph
+		   resolves from a text font, not from Noto Color Emoji's wide space. */
+			'Apple Color Emoji',
 		'Segoe UI Emoji',
 		'Noto Color Emoji',
 		/* emoji */ 'Noto Sans',


### PR DESCRIPTION
## Related issues

- Fixes STU-1613

## How AI was used in this PR

AI-assisted: diagnosed the root cause (Chromium per-glyph font fallback picking up `Noto Color Emoji`'s wide U+0020 glyph on Linux because no text font earlier in the stack is installed there) and drafted the one-line insertion into the font stack. The change was reviewed by me before commit.

## Proposed Changes

- Add common Linux UI fonts (`Ubuntu`, `Cantarell`, `Liberation Sans`, `DejaVu Sans`) to the `body` font stack in `apps/studio/src/index.css`, positioned **before** the emoji fonts so a text font resolves first for the space glyph.
- No existing entries were removed or reordered — macOS and Windows resolution is unchanged because those platforms never walk past their native fonts (`-apple-system` / `BlinkMacSystemFont` / `Segoe UI`).

### Why this fixes it

Chromium does per-glyph fallback in declared order. On Linux, `-apple-system`, `BlinkMacSystemFont`, `Segoe UI`, and often `Roboto` aren't installed, so the first font that *is* installed used to be `Noto Color Emoji` — which has a very wide space glyph. Chromium would pick it up for U+0020 and stop, producing the gaps. The `Noto Sans` / `sans-serif` entries already at the tail of the stack were never consulted because resolution had already terminated. Inserting Linux text fonts before the emoji fonts gives Chromium a real text font to resolve the space from.

## Testing Instructions

- [ ] On Linux: launch `npm start` and visually confirm type still renders in the system font and there is no additional spacing.
- [ ] On macOS: launch `npm start` and visually confirm type still renders in the system font (SF Pro / -apple-system) — no regression.
- [ ] On Windows: launch and confirm text still renders in Segoe UI — no regression.

### Before / After

Before: 
<img width="2126" height="1448" alt="CleanShot 2026-04-22 at 19 23 10@2x" src="https://github.com/user-attachments/assets/6faab9b1-c349-4824-9465-fe832102e8db" />

After: normal inter-word spacing on Linux

<img width="2300" height="1452" alt="CleanShot 2026-04-22 at 19 18 14@2x" src="https://github.com/user-attachments/assets/955fd0f0-85b0-4187-9b8a-cbf1e966a841" />

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?