### PR TITLE
Studio Blueprints Gallery: Add project feature flag

### DIFF
--- a/apps/studio/src/ipc-types.d.ts
+++ b/apps/studio/src/ipc-types.d.ts
@@ -89,6 +89,7 @@ type IpcApi = {
 
 interface FeatureFlags {
 	enableBlueprints: boolean;
+	enableBlueprintsGallery: boolean;
 	enableStudioCodeUi: boolean;
 }
 

--- a/apps/studio/src/lib/feature-flags.ts
+++ b/apps/studio/src/lib/feature-flags.ts
@@ -12,6 +12,12 @@ export const FEATURE_FLAGS: Record< keyof FeatureFlags, FeatureFlagDefinition > 
 		flag: 'enableBlueprints',
 		default: true,
 	},
+	enableBlueprintsGallery: {
+		label: 'Enable Blueprints Gallery',
+		env: 'ENABLE_BLUEPRINTS_GALLERY',
+		flag: 'enableBlueprintsGallery',
+		default: false,
+	},
 	enableStudioCodeUi: {
 		label: 'Enable Studio Code UI',
 		env: 'ENABLE_STUDIO_CODE_UI',


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1616

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

It was used to add a new feature flag.


## Proposed Changes

This PR adds a new feature flag for Blueprints Gallery Library project. The feature flag is `ENABLE_BLUEPRINTS_GALLERY`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff:

```diff --git a/apps/studio/src/hooks/use-feature-flags.tsx b/apps/studio/src/hooks/use-feature-flags.tsx
index b1c220ee3..abe60b91d 100644
--- a/apps/studio/src/hooks/use-feature-flags.tsx
+++ b/apps/studio/src/hooks/use-feature-flags.tsx
@@ -34,6 +34,10 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
        const { isAuthenticated, client } = useAuth();
        const [ apiFlags, setApiFlags ] = useState< Partial< FeatureFlags > >( {} );
 
+       useEffect( () => {
+               console.log( '[FeatureFlags] enableBlueprintsGallery:', featureFlags.enableBlueprintsGallery );
+       }, [ featureFlags.enableBlueprintsGallery ] );
+
        useIpcListener( 'refresh-app-globals', async () => {
                window.appGlobals = await getIpcApi().getAppGlobals();
                setFeatureFlags( {
```

* Start Studio with `npm start`
* Open the developer tools
* Confirm that the feature flag is marked as `false` in the logs
* Enable the new feature flag in the topbar
* Confirm that it is marked as `true`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
