### PR TITLE
apps/ui: add "Open WP admin" quick link with auto-login

### DIFF
--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -161,6 +161,14 @@ export function MainView( { site, onSetupClick, onDisconnectClick }: Props ) {
 		);
 	};
 
+	const handleOpenWpAdmin = () => {
+		const siteUrl = getSiteUrl( site );
+		const redirectTo = new URL( '/wp-admin/', siteUrl ).toString();
+		const autoLoginUrl = new URL( '/studio-auto-login', siteUrl );
+		autoLoginUrl.searchParams.set( 'redirect_to', redirectTo );
+		openExternal( autoLoginUrl.toString() );
+	};
+
 	return (
 		<>
 			<div className={ styles.rows }>
@@ -305,6 +313,9 @@ export function MainView( { site, onSetupClick, onDisconnectClick }: Props ) {
 				<Menu.Item onClick={ handleOpenInTerminal }>{ __( 'Open in terminal' ) }</Menu.Item>
 				<Menu.Item disabled={ ! site.running } onClick={ handleOpenPhpMyAdmin }>
 					{ __( 'Open phpMyAdmin' ) }
+				</Menu.Item>
+				<Menu.Item disabled={ ! site.running } onClick={ handleOpenWpAdmin }>
+					{ __( 'Open WP admin' ) }
 				</Menu.Item>
 			</div>
 		</>


### PR DESCRIPTION
## Related issues

- Related to: n/a (parity with desktop app)

## How AI was used in this PR

Implementation drafted with Claude Code. Reviewed the diff and verified the auto-login URL matches what the desktop app produces in `apps/studio/src/ipc-handlers.ts` (`openSiteURL` with default `autoLogin: true`).

## Proposed Changes

- Add an "Open WP admin" entry to the site dropdown in `apps/ui`, placed right after "Open phpMyAdmin", matching the existing "Open …" naming pattern of surrounding items.
- Route through the `/studio-auto-login?redirect_to=/wp-admin/` endpoint served by the `0-auto-login.php` mu-plugin (`tools/common/lib/mu-plugins.ts`) so users land already signed in, mirroring the desktop app's `WP admin` context-menu action.
- Disabled when the site is not running (same gating as the phpMyAdmin entry).

## Testing Instructions

- Start `apps/ui` against a running local site.
- Open the site dropdown — confirm "Open WP admin" appears directly under "Open phpMyAdmin".
- With the site stopped, the entry should be disabled.
- With the site running, click it — a new tab should open at `/studio-auto-login?redirect_to=…/wp-admin/` and land on the wp-admin dashboard with the user already signed in.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)