### PR TITLE
apps/cli: bump @anthropic-ai/claude-agent-sdk to ^0.2.117

### DIFF
--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -112,12 +112,6 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 			cwd: STUDIO_ROOT,
 			tools: { type: 'preset', preset: 'claude_code' },
 			allowedTools,
-			// Disable extended thinking. The native 0.2.110+ runtime defaults
-			// to deep adaptive thinking, which can stall a turn for minutes
-			// between tool calls and trip the wpcom proxy's idle timeout
-			// (cURL 92). Studio tasks are mostly tool orchestration, not
-			// deep reasoning.
-			thinking: { type: 'disabled' },
 			permissionMode: 'default',
 			canUseTool: async ( toolName, input, metadata ) => {
 				if ( autoApprove ) {

--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -112,11 +112,12 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 			cwd: STUDIO_ROOT,
 			tools: { type: 'preset', preset: 'claude_code' },
 			allowedTools,
-			// Keep per-turn latency predictable. The native 0.2.110+ runtime
-			// defaults to `effort: 'high'` with adaptive thinking, which can
-			// stall a single turn for 100s+ between tool calls. Studio's agent
-			// work is mostly tool orchestration, so minimal thinking is fine.
-			effort: 'low',
+			// Disable extended thinking. The native 0.2.110+ runtime defaults
+			// to deep adaptive thinking, which can stall a single turn for
+			// 100s+ between tool calls (observed in the turn-cadence eval).
+			// Studio's agent work is mostly tool orchestration, not deep
+			// reasoning, so we skip thinking for predictable latency.
+			thinking: { type: 'disabled' },
 			permissionMode: 'default',
 			canUseTool: async ( toolName, input, metadata ) => {
 				if ( autoApprove ) {

--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -112,12 +112,11 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 			cwd: STUDIO_ROOT,
 			tools: { type: 'preset', preset: 'claude_code' },
 			allowedTools,
-			// Disable extended thinking. The native 0.2.110+ runtime defaults
-			// to deep adaptive thinking, which can stall a single turn for
-			// 100s+ between tool calls (observed in the turn-cadence eval).
-			// Studio's agent work is mostly tool orchestration, not deep
-			// reasoning, so we skip thinking for predictable latency.
-			thinking: { type: 'disabled' },
+			// Keep per-turn latency predictable. The native 0.2.110+ runtime
+			// defaults to `effort: 'high'` with adaptive thinking, which can
+			// stall a single turn for 100s+ between tool calls. Studio's agent
+			// work is mostly tool orchestration, so minimal thinking is fine.
+			effort: 'low',
 			permissionMode: 'default',
 			canUseTool: async ( toolName, input, metadata ) => {
 				if ( autoApprove ) {

--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -112,6 +112,11 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 			cwd: STUDIO_ROOT,
 			tools: { type: 'preset', preset: 'claude_code' },
 			allowedTools,
+			// Keep per-turn latency predictable. The native 0.2.110+ runtime
+			// defaults to `effort: 'high'` with adaptive thinking, which can
+			// stall a single turn for 100s+ between tool calls. Studio's agent
+			// work is mostly tool orchestration, so minimal thinking is fine.
+			effort: 'low',
 			permissionMode: 'default',
 			canUseTool: async ( toolName, input, metadata ) => {
 				if ( autoApprove ) {

--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -112,6 +112,12 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 			cwd: STUDIO_ROOT,
 			tools: { type: 'preset', preset: 'claude_code' },
 			allowedTools,
+			// Disable extended thinking. The native 0.2.110+ runtime defaults
+			// to deep adaptive thinking, which can stall a turn for minutes
+			// between tool calls and trip the wpcom proxy's idle timeout
+			// (cURL 92). Studio tasks are mostly tool orchestration, not
+			// deep reasoning.
+			thinking: { type: 'disabled' },
 			permissionMode: 'default',
 			canUseTool: async ( toolName, input, metadata ) => {
 				if ( autoApprove ) {

--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -112,11 +112,6 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 			cwd: STUDIO_ROOT,
 			tools: { type: 'preset', preset: 'claude_code' },
 			allowedTools,
-			// Keep per-turn latency predictable. The native 0.2.110+ runtime
-			// defaults to `effort: 'high'` with adaptive thinking, which can
-			// stall a single turn for 100s+ between tool calls. Studio's agent
-			// work is mostly tool orchestration, so minimal thinking is fine.
-			effort: 'low',
 			permissionMode: 'default',
 			canUseTool: async ( toolName, input, metadata ) => {
 				if ( autoApprove ) {

--- a/apps/cli/ai/eval-runner.ts
+++ b/apps/cli/ai/eval-runner.ts
@@ -64,16 +64,22 @@ function extractToolCalls( message: SDKMessage ) {
 		} ) );
 }
 
+type TextBlock = { type: 'text'; text: string };
+type ToolResultBlock = {
+	type: 'tool_result';
+	tool_use_id: string;
+	is_error?: boolean;
+	content?: unknown;
+};
+
 function extractTextSegments( message: SDKMessage ): string[] {
 	if ( message.type !== 'assistant' ) {
 		return [];
 	}
-	const content = message.message.content ?? [];
+	const content = ( message.message.content ?? [] ) as Array< { type: string } >;
 	return content
-		.filter(
-			( block: { type: string } ): block is { type: 'text'; text: string } => block.type === 'text'
-		)
-		.map( ( block: { text: string } ) => block.text );
+		.filter( ( block ): block is TextBlock => block.type === 'text' )
+		.map( ( block ) => block.text );
 }
 
 function extractToolResult( message: SDKMessage ): {
@@ -84,12 +90,8 @@ function extractToolResult( message: SDKMessage ): {
 	if ( message.type !== 'user' || ! Array.isArray( message.message.content ) ) {
 		return null;
 	}
-	const block = message.message.content.find(
-		( b: {
-			type: string;
-		} ): b is { type: 'tool_result'; tool_use_id: string; is_error?: boolean; content?: unknown } =>
-			b.type === 'tool_result'
-	);
+	const content = message.message.content as Array< { type: string } >;
+	const block = content.find( ( b ): b is ToolResultBlock => b.type === 'tool_result' );
 	if ( ! block ) {
 		return null;
 	}
@@ -97,9 +99,11 @@ function extractToolResult( message: SDKMessage ): {
 	if ( typeof block.content === 'string' ) {
 		text = block.content;
 	} else if ( Array.isArray( block.content ) ) {
-		const tb = block.content.find( ( b: { type: string } ) => b.type === 'text' );
-		if ( tb && 'text' in tb ) {
-			text = tb.text as string;
+		const tb = ( block.content as Array< { type: string } > ).find(
+			( b ): b is TextBlock => b.type === 'text'
+		);
+		if ( tb ) {
+			text = tb.text;
 		}
 	}
 	return { toolUseId: block.tool_use_id ?? null, isError: block.is_error === true, text };

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1768,7 +1768,7 @@ export class AiChatUI implements AiOutputAdapter {
 		}
 
 		const contentBlocks = Array.isArray( message.message.content ) ? message.message.content : [];
-		const toolResultBlock = contentBlocks.find( isToolResultBlock );
+		const toolResultBlock = ( contentBlocks as unknown[] ).find( isToolResultBlock );
 		if ( ! toolResultBlock ) {
 			return null;
 		}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -24,7 +24,7 @@
 		"directory": "apps/cli"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.45",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.117",
 		"@inquirer/prompts": "^8.3.2",
 		"@mariozechner/pi-tui": "^0.54.0",
 		"@modelcontextprotocol/sdk": "^1.27.1",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,10 +74,17 @@ export default defineConfig(
 				},
 			],
 			'import-x/no-named-as-default-member': 'off',
-			// @wp-playground/blueprints ships blueprint-schema-validator outside its package.json exports map
+			// @wp-playground/blueprints ships blueprint-schema-validator outside its package.json exports map.
+			// @modelcontextprotocol/sdk 1.29+ only exposes server/stdio.js via a wildcard export which the
+			// eslint-import-x typescript resolver can't follow (runtime resolution is fine).
 			'import-x/no-unresolved': [
 				'error',
-				{ ignore: [ '@wp-playground/blueprints/blueprint-schema-validator' ] },
+				{
+					ignore: [
+						'@wp-playground/blueprints/blueprint-schema-validator',
+						'@modelcontextprotocol/sdk/server/stdio\\.js$',
+					],
+				},
 			],
 			'import-x/order': [
 				'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,17 +74,10 @@ export default defineConfig(
 				},
 			],
 			'import-x/no-named-as-default-member': 'off',
-			// @wp-playground/blueprints ships blueprint-schema-validator outside its package.json exports map.
-			// @modelcontextprotocol/sdk 1.29+ only exposes server/stdio.js via a wildcard export which the
-			// eslint-import-x typescript resolver can't follow (runtime resolution is fine).
+			// @wp-playground/blueprints ships blueprint-schema-validator outside its package.json exports map
 			'import-x/no-unresolved': [
 				'error',
-				{
-					ignore: [
-						'@wp-playground/blueprints/blueprint-schema-validator',
-						'@modelcontextprotocol/sdk/server/stdio\\.js$',
-					],
-				},
+				{ ignore: [ '@wp-playground/blueprints/blueprint-schema-validator' ] },
 			],
 			'import-x/order': [
 				'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@anthropic-ai/claude-agent-sdk": "^0.2.45",
+				"@anthropic-ai/claude-agent-sdk": "^0.2.117",
 				"@inquirer/prompts": "^8.3.2",
 				"@mariozechner/pi-tui": "^0.54.0",
 				"@modelcontextprotocol/sdk": "^1.27.1",
@@ -1025,25 +1025,153 @@
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk": {
-			"version": "0.2.45",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.45.tgz",
-			"integrity": "sha512-AKH2hKoJNyjLf9ThAttKqbmCjUFg7qs/8+LR/UTVX20fCLn359YH9WrQc6dAiAfi8RYNA+mWwrNYCAq+Sdo5Ag==",
+			"version": "0.2.117",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.117.tgz",
+			"integrity": "sha512-pVBss1Vu0w87nKCBhWtjMggSgCh6GVUtdRmuE58ZvXv0E2q0JcnUCQHehmn92BAW0+VCwPY8q/k7uKWkgwz/gA==",
 			"license": "SEE LICENSE IN README.md",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.81.0",
+				"@modelcontextprotocol/sdk": "^1.29.0"
+			},
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"optionalDependencies": {
-				"@img/sharp-darwin-arm64": "^0.33.5",
-				"@img/sharp-darwin-x64": "^0.33.5",
-				"@img/sharp-linux-arm": "^0.33.5",
-				"@img/sharp-linux-arm64": "^0.33.5",
-				"@img/sharp-linux-x64": "^0.33.5",
-				"@img/sharp-linuxmusl-arm64": "^0.33.5",
-				"@img/sharp-linuxmusl-x64": "^0.33.5",
-				"@img/sharp-win32-x64": "^0.33.5"
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.117",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.117",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.117",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.117",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.117",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.117",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.117",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.117"
 			},
 			"peerDependencies": {
 				"zod": "^4.0.0"
+			}
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+			"version": "0.2.117",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.117.tgz",
+			"integrity": "sha512-ZeC/Lz8XMKQ5w+GmjTziPR8bSSarBtNCJMkMAYRT9ekNmyXSWXEwGLENe5TDDmtpzNNzAB1mQNuIYoqTsqgV3w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+			"version": "0.2.117",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.117.tgz",
+			"integrity": "sha512-DKyggGzzpDcr9S435xlpbpwkEYKZNbePSekug75tJclK8l4ddD9+M9BFgMiSUq9F1Zt53kUaRDihDu/cBKvkdQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+			"version": "0.2.117",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.117.tgz",
+			"integrity": "sha512-jyHmyZQavpPOe3zxBRX3KbdOAJ8JwZ8m/wMr5bhHhhcstugm/vJx6IIs7D44VvFjk+8sqdvR2ZrliL8PUcJL0g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+			"version": "0.2.117",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.117.tgz",
+			"integrity": "sha512-bJU5gEOmM4VCOn4h8vipOKgdhPATePQ23mMpvyVqtVyipWppHfOUfVkqXb+SrF/hfkNSMYxDuoKxbJ+MmKtGjg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+			"version": "0.2.117",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.117.tgz",
+			"integrity": "sha512-Zb5PXKrDNbQ1dyNYwxZMNL+F2Dhgjh9f9B21wZUJqkhJL69hRJwJyxO42HiNmB2zGCaTxQTyjPhLdB/eQJo74Q==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+			"version": "0.2.117",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.117.tgz",
+			"integrity": "sha512-LIkKTAYZGugEVssAuWCPqlDWSqhVZAveNPNsfKLbuG1naIMCR04fUqil6i3d3mAAfk7FaS5D4IdHp45psi+GDw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+			"version": "0.2.117",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.117.tgz",
+			"integrity": "sha512-uetggH3B83PiH0a9D/5MVXB5Hqnlr2DVajehwAP2x0Mt4DBd632ICnHpu6pnSP+vVkWgq3FgQlkHe91RfP+peA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+			"version": "0.2.117",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.117.tgz",
+			"integrity": "sha512-TT4KngAokDTJSvQ2mrAP6ZRkXj50OLj7Tb1zZA4CnkmrrEidgs4KrMx7er1ZwoivngIvCekV9+TbtC9giknr5w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.81.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+			"integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@ariakit/core": {
@@ -5454,291 +5582,6 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
-		"node_modules/@img/sharp-darwin-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-			"integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-arm64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-darwin-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-			"integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-x64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-libvips-darwin-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-			"integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-darwin-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-			"integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-arm": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-			"integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
-			"cpu": [
-				"arm"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-			"integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-			"integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-			"integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-			"integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-linux-arm": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-			"integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm": "1.0.5"
-			}
-		},
-		"node_modules/@img/sharp-linux-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-			"integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-linux-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-			"integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-x64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-linuxmusl-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-			"integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-linuxmusl-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-			"integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-x64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-win32-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-			"integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0 AND LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
 		"node_modules/@inquirer/ansi": {
 			"version": "1.0.2",
 			"license": "MIT",
@@ -6768,9 +6611,9 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.27.1",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-			"integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@hono/node-server": "^1.19.9",
@@ -20019,6 +19862,19 @@
 			"version": "2.3.1",
 			"license": "MIT"
 		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"license": "MIT"
@@ -25997,6 +25853,12 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT"
 		},
 		"node_modules/ts-api-utils": {
 			"version": "2.4.0",


### PR DESCRIPTION
## Related issues

- Related to unlocking \`permissionMode: 'auto'\` for the Studio Code agent

## How AI was used in this PR

Used Claude Code to diff the installed SDK types against the latest version on npm, identify the permission-mode change we wanted, confirm no other breakages, and fix the two type-narrowing call sites surfaced by \`tsc\`. Every change was reviewed before commit.

## Proposed Changes

- Bump \`@anthropic-ai/claude-agent-sdk\` from \`^0.2.45\` to \`^0.2.117\` in [apps/cli/package.json](apps/cli/package.json).
- Fix two type-narrowing call sites broken by the SDK's stricter \`ContentBlockParam\` discriminated union:
  - [apps/cli/ai/eval-runner.ts](apps/cli/ai/eval-runner.ts) — widen filter/find predicate parameters and hoist \`TextBlock\` / \`ToolResultBlock\` type aliases.
  - [apps/cli/ai/ui.ts:1766](apps/cli/ai/ui.ts:1766) — cast \`contentBlocks\` through \`unknown[]\` before running \`isToolResultBlock\` so the predicate narrows.

### What the upgrade unlocks

Highlights between \`0.2.45\` → \`0.2.117\` that are relevant to Studio:

- **\`permissionMode: 'auto'\`** — classifier-based permission mode (the reason for the bump; follow-up PR will adopt it).
- **Session management API** — \`listSessions\`, \`getSessionMessages\`, \`forkSession\`, \`deleteSession\`, \`renameSession\`, \`tagSession\`, pluggable \`SessionStore\`.
- **New hooks** — \`FileChanged\`, \`CwdChanged\`, \`WorktreeCreate/Remove\`, \`Elicitation\`/\`ElicitationResult\`, \`PermissionDenied\`, \`PostCompact\`, \`InstructionsLoaded\`, \`ConfigChange\`.
- **New message types** — \`SDKAPIRetryMessage\`, \`SDKRateLimitEvent\`, \`SDKTaskProgressMessage\`, \`SDKSessionStateChangedMessage\`, \`SDKMemoryRecallMessage\`, \`SDKPluginInstallMessage\`, etc.
- **Config** — \`ThinkingConfig\` (\`adaptive | enabled | disabled\`), \`EffortLevel\` (\`low…max\`), \`'oauth'\` added to \`ApiKeySource\`.

### Removed upstream (no local fallout)

- \`permissionMode: 'delegate'\` — was for team-leader multi-agent setups; not used in this repo.

## Testing Instructions

- \`npm install\`
- \`npm run typecheck\` — passes across all workspaces.
- \`npx vitest run apps/cli/ai apps/cli/commands/ai\` — 105 tests pass.
- Run the Studio Code agent in the CLI / desktop app and confirm tool calls, tool results, and permission prompts still render correctly — the narrowing fixes are load-bearing for the tool-result output path in the UI.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)