### PR TITLE
apps/ui: add Export entire site / Export database to site dropdown

### DIFF
--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -10,6 +10,8 @@ import { useSessions } from '@/data/queries/use-sessions';
 import {
 	useCopySite,
 	useDeleteSite,
+	useExportDatabase,
+	useExportFullSite,
 	useIsSiteStarting,
 	useIsSiteStopping,
 	useSites,
@@ -215,9 +217,12 @@ function SiteActionsMenu( { site }: { site: SiteDetails } ) {
 	const startSite = useStartSite();
 	const stopSite = useStopSite();
 	const copySite = useCopySite();
+	const exportFullSite = useExportFullSite();
+	const exportDatabase = useExportDatabase();
 	const isStarting = useIsSiteStarting( site.id );
 	const isStopping = useIsSiteStopping( site.id );
 	const busy = isStarting || isStopping;
+	const isExporting = exportFullSite.isPending || exportDatabase.isPending;
 	const [ deleteOpen, setDeleteOpen ] = useState( false );
 
 	return (
@@ -258,6 +263,13 @@ function SiteActionsMenu( { site }: { site: SiteDetails } ) {
 					</Menu.Item>
 					<Menu.Item disabled={ copySite.isPending } onClick={ () => copySite.mutate( site.id ) }>
 						{ copySite.isPending ? __( 'Copying…' ) : __( 'Copy site' ) }
+					</Menu.Item>
+					<Menu.Separator />
+					<Menu.Item disabled={ isExporting } onClick={ () => exportFullSite.mutate( site.id ) }>
+						{ exportFullSite.isPending ? __( 'Exporting…' ) : __( 'Export entire site' ) }
+					</Menu.Item>
+					<Menu.Item disabled={ isExporting } onClick={ () => exportDatabase.mutate( site.id ) }>
+						{ exportDatabase.isPending ? __( 'Exporting…' ) : __( 'Export database' ) }
 					</Menu.Item>
 					<Menu.Separator />
 					<Menu.Item onClick={ () => setDeleteOpen( true ) }>{ __( 'Delete site' ) }</Menu.Item>

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -1,3 +1,5 @@
+import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
+import { __ } from '@wordpress/i18n';
 import type { AgentRunEvent } from '../../agent-events';
 import type {
 	AiSessionSummary,
@@ -17,6 +19,60 @@ import type {
 	SyncSite,
 	UserPreferences,
 } from '../../types';
+
+function generateBackupFilename( siteName: string ): string {
+	const now = new Date();
+	const pad = ( n: number ) => String( n ).padStart( 2, '0' );
+	const timestamp =
+		`${ now.getFullYear() }-${ pad( now.getMonth() + 1 ) }-${ pad( now.getDate() ) }` +
+		`-${ pad( now.getHours() ) }-${ pad( now.getMinutes() ) }-${ pad( now.getSeconds() ) }`;
+	return sanitizeFolderName( `studio-backup-${ siteName }-${ timestamp }` );
+}
+
+type ExportRequest = {
+	site: SiteDetails;
+	backupFile: string;
+	includes: { database: boolean; wpContent: boolean };
+	phpVersion: string;
+};
+
+// Runs an export IPC call and surfaces the outcome through the same
+// main-process notification channels the legacy renderer uses: a native
+// success notification on completion, or the error message box (with a
+// "Show logs" affordance) on any failure.
+async function runExport(
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	ipcApi: any,
+	request: ExportRequest
+): Promise< string > {
+	const handleError = ( error?: unknown ) => {
+		ipcApi.showErrorMessageBox( {
+			title: __( 'Failed exporting site' ),
+			message: __(
+				'An error occurred while exporting the site. If this problem persists, please contact support.'
+			),
+			error,
+			showOpenLogs: true,
+		} );
+	};
+
+	let success = false;
+	try {
+		success = ( await ipcApi.exportSite( request ) ) as boolean;
+	} catch ( error ) {
+		handleError( error );
+		throw error;
+	}
+	if ( ! success ) {
+		handleError();
+		throw new Error( 'Export failed' );
+	}
+	ipcApi.showNotification( {
+		title: request.site.name,
+		body: __( 'Export completed' ),
+	} );
+	return request.backupFile;
+}
 
 /**
  * Creates a connector that delegates to the Electron IPC bridge.
@@ -301,6 +357,62 @@ export function createIpcConnector(): Connector {
 
 		async getXdebugEnabledSite() {
 			return ( await ipcApi.getXdebugEnabledSite() ) as SiteDetails | null;
+		},
+
+		async exportFullSite( siteId ): Promise< string | null > {
+			const sites = ( await ipcApi.getSiteDetails() ) as SiteDetails[];
+			const site = sites.find( ( candidate ) => candidate.id === siteId );
+			if ( ! site ) {
+				throw new Error( `Site ${ siteId } not found` );
+			}
+			const fileName = generateBackupFilename( site.name );
+			const backupFile = ( await ipcApi.showSaveAsDialog( {
+				title: __( 'Save backup file' ),
+				defaultPath: `${ fileName }.zip`,
+				filters: [
+					{
+						name: 'Compressed Backup Files',
+						extensions: [ 'tar.gz', 'tzg', 'zip' ],
+					},
+				],
+			} ) ) as string;
+			if ( ! backupFile ) {
+				return null;
+			}
+			return runExport( ipcApi, {
+				site,
+				backupFile,
+				includes: { database: true, wpContent: true },
+				phpVersion: site.phpVersion,
+			} );
+		},
+
+		async exportDatabase( siteId ): Promise< string | null > {
+			const sites = ( await ipcApi.getSiteDetails() ) as SiteDetails[];
+			const site = sites.find( ( candidate ) => candidate.id === siteId );
+			if ( ! site ) {
+				throw new Error( `Site ${ siteId } not found` );
+			}
+			const fileName = generateBackupFilename( site.name );
+			const backupFile = ( await ipcApi.showSaveAsDialog( {
+				title: __( 'Save database file' ),
+				defaultPath: `${ fileName }.sql`,
+				filters: [
+					{
+						name: 'SQL dump file',
+						extensions: [ 'sql' ],
+					},
+				],
+			} ) ) as string;
+			if ( ! backupFile ) {
+				return null;
+			}
+			return runExport( ipcApi, {
+				site,
+				backupFile,
+				includes: { database: true, wpContent: false },
+				phpVersion: site.phpVersion,
+			} );
 		},
 
 		// Preview snapshots

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -91,6 +91,14 @@ export interface Connector {
 	// it (or null) so the settings form can block a conflicting toggle.
 	getXdebugEnabledSite(): Promise< SiteDetails | null >;
 
+	// Exports a site as a full backup archive (files + database). Prompts the
+	// user for a destination via a save-as dialog; resolves with the chosen
+	// path on success, or `null` if the user cancelled the dialog.
+	exportFullSite( siteId: string ): Promise< string | null >;
+	// Exports only the site database as a .sql dump. Same dialog/cancel
+	// semantics as `exportFullSite`.
+	exportDatabase( siteId: string ): Promise< string | null >;
+
 	// Site-creation helpers — surface the same main-process capabilities the
 	// desktop app's add-site flow relies on (folder pickers, path validation,
 	// and domain lookups).

--- a/apps/ui/src/data/queries/use-sites.ts
+++ b/apps/ui/src/data/queries/use-sites.ts
@@ -51,6 +51,20 @@ export function useCopySite() {
 	} );
 }
 
+export function useExportFullSite() {
+	const connector = useConnector();
+	return useMutation( {
+		mutationFn: ( siteId: string ) => connector.exportFullSite( siteId ),
+	} );
+}
+
+export function useExportDatabase() {
+	const connector = useConnector();
+	return useMutation( {
+		mutationFn: ( siteId: string ) => connector.exportDatabase( siteId ),
+	} );
+}
+
 // Invalidation is awaited inside `mutationFn` (not `onSettled`) so
 // `isPending` stays true until `site.running` reflects the new state.
 export function useStartSite() {


### PR DESCRIPTION
## Related issues

- Related to: N/A

## How AI was used in this PR

Implemented end-to-end by Claude (menu wiring, connector methods, mutation hooks). I reviewed each change, exercised the happy path in-app, and verified the failure path by temporarily forcing `exportSite` to throw (then reverted). The `exportSite` main-process IPC handler was not touched — both new actions reuse the existing one the legacy Electron UI already uses.

## Proposed Changes

Brings back the two "Export…" actions the legacy Electron app exposes on every site, now available in the new apps/ui site-actions dropdown:

- **Export entire site** — opens a save-as dialog and produces a `.zip`/`.tar.gz` backup (`includes: { database: true, wpContent: true }`).
- **Export database** — opens a save-as dialog and produces a `.sql` dump (`includes: { database: true, wpContent: false }`).

Both actions go through the existing `exportSite` IPC handler in apps/studio, so the backup pipeline and event stream are unchanged. Outcomes are surfaced through the same channels the legacy renderer uses: a native OS notification on success, and an error message box with a **Show Logs** button on failure.

Implementation layout:
- `Connector` interface: added `exportFullSite(siteId)` / `exportDatabase(siteId)`.
- IPC connector: resolves the site, opens `showSaveAsDialog` with a sensible default filename (`studio-backup-<site>-<timestamp>.<ext>`), calls `ipcApi.exportSite`, and routes success/failure through a shared `runExport` helper.
- `useExportFullSite` / `useExportDatabase` React Query mutation hooks.
- `SiteActionsMenu` in the sidebar gets two new `Menu.Item`s (between Copy and Delete); each disables both while any export is in flight and shows "Exporting…" on the active one.

## Testing Instructions

1. `npm start` and pick any site in the sidebar.
2. Open the `⋯` dropdown → **Export entire site**.
3. Pick a save path. The menu item should display "Exporting…"; on completion a native OS notification fires ("*Site name* / Export completed") and a `.zip` is written.
4. Repeat with **Export database** — default filename should end in `.sql`, and only a SQL dump is written.
5. Failure path: temporarily add `throw new Error('forced');` at the top of `exportSite` in `apps/studio/src/ipc-handlers.ts`, fully restart the app, then trigger either export. Expect the "Failed exporting site" modal with a **Show Logs** button; after dismissing, the dropdown items re-enable. Revert the throw when done.
6. Cancelling the save dialog is a no-op (no notification, no error, no state change).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?