### PR TITLE
apps/cli: polish "Selected site" announcement in AI chat

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -906,16 +906,16 @@ export class AiChatUI implements AiOutputAdapter {
 		const label = site.remote
 			? sprintf(
 					/* translators: %s: site name */
-					__( ' ✻ Selected site: %s (WordPress.com)' ),
+					__( ' Selected site: %s (WordPress.com)' ),
 					site.name
 			  )
 			: sprintf(
 					/* translators: %s: site name */
-					__( ' ✻ Selected site: %s' ),
+					__( ' Selected site: %s' ),
 					site.name
 			  );
 		if ( announce ) {
-			this.messages.addChild( new Text( `${ chalk.hex( '#5b8db8' )( label ) }\n`, 0, 0 ) );
+			this.messages.addChild( new Text( `\n${ chalk.hex( '#8839ef' )( label ) }\n`, 0, 0 ) );
 		}
 		if ( emitEvent ) {
 			this.siteSelectedCallback?.( site );


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Written with Claude Code. Small visual polish on the existing announcement rendered by the AI chat TUI in `apps/cli/ai/ui.ts`.

## Proposed Changes

- Add a blank line before the `Selected site: …` message so it no longer hugs the previous output.
- Drop the `✻` glyph from the label.
- Switch the label color from the muted blue `#5b8db8` to the purple `#8839ef` already used for the active-site name in the prompt border, for better legibility and a more cohesive look.

## Testing Instructions

1. `npm run cli:build && node apps/cli/dist/cli/main.mjs` (or the usual CLI entry).
2. Enter the AI chat and pick a site from the site picker.
3. Confirm the announcement reads ` Selected site: <name>` (no `✻`), appears with one blank line above it, and is rendered in the same purple as the site name shown in the prompt's top border.
4. Repeat with a WordPress.com site to verify the `(WordPress.com)` variant renders the same way.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?