### PR TITLE
apps/cli: build WP sites incrementally

### DIFF
--- a/apps/cli/ai/plugin/skills/site-spec/SKILL.md
+++ b/apps/cli/ai/plugin/skills/site-spec/SKILL.md
@@ -27,6 +27,14 @@ After the user provides the name, use AskUserQuestion for:
 
 Call `site_create` with the provided name and use the layout preference to guide all subsequent design decisions.
 
+## After site_create returns
+
+Follow the **Working cadence** rules in your system prompt. The turn that immediately follows `site_create` is the single biggest source of perceived CLI hangs, so treat it carefully:
+
+1. Acknowledge the site is ready in one short sentence (≤ 2 lines of prose).
+2. Your **next** tool call must be either `site_info` (to confirm path, URL, and credentials) or a minimal first `Write` (≤ 50 lines). Do NOT scaffold a full theme, chain multiple `Write`/`Edit` calls, or produce a long design-plan essay in this turn.
+3. Build the site across many small turns after that — one `Write`/`Edit` per turn, large files grown incrementally via multiple `Edit` calls.
+
 ## When to Skip Discovery
 
 Do NOT ask questions if:

--- a/apps/cli/ai/plugin/skills/site-spec/SKILL.md
+++ b/apps/cli/ai/plugin/skills/site-spec/SKILL.md
@@ -29,7 +29,7 @@ Call `site_create` with the provided name and use the layout preference to guide
 
 ## After site_create returns
 
-Follow the **Working cadence** rules in your system prompt. The turn that immediately follows `site_create` is the single biggest source of perceived CLI hangs, so treat it carefully:
+The turn that immediately follows `site_create` is the single biggest source of perceived CLI hangs, so treat it carefully:
 
 1. Acknowledge the site is ready in one short sentence (≤ 2 lines of prose).
 2. Your **next** tool call must be either `site_info` (to confirm path, URL, and credentials) or a minimal first `Write` (≤ 50 lines). Do NOT scaffold a full theme, chain multiple `Write`/`Edit` calls, or produce a long design-plan essay in this turn.

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -122,6 +122,22 @@ Then continue with:
 5. **Check the misuse of HTML blocks**: Verify if HTML blocks were used as sections or not. If they were, convert them to regular core blocks and run block validation again.
 6. **Check the result**: Use take_screenshot to capture the site's landing page on desktop and mobile and verify the design visually on both viewports, check for wrong spacing, alignment, colors, contrast, borders, hover styles and other visual issues. Fix any issues found. Pay particular attention to the navigation menu and the CTA buttons. The design needs to match your original expectations.
 
+## Working cadence
+
+Deliver work incrementally, one logical step per assistant turn. This is both a UX requirement and a quality lever:
+
+- **UX**: The CLI renders assistant messages as complete units. A single turn that emits thousands of tokens of code produces a silent spinner for many minutes and may trip upstream gateway timeouts.
+- **Quality**: Step 6 above (take_screenshot → fix issues) is your strongest quality loop and only works if you reach it after *small visible increments*, not after one mega-turn. Ambitious, polished builds come from many deliberate steps.
+
+Rules:
+
+- One \`Write\` or \`Edit\` per assistant turn. Stacking multiple file writes in one turn is the main thing to avoid. Read-only calls (\`site_info\`, \`site_list\`, \`wp_cli\` queries) can be combined.
+- For long files (full \`style.css\`, \`theme.json\`, multi-section templates), write a short skeleton first and grow it across later turns with \`Edit\`. If a single \`Write\` would exceed ~200 lines, split it.
+- Prose between tool calls: 1–3 sentences describing what you just did and what's next. Avoid long design-plan essays before tools fire — commit the plan by building and let screenshots refine it.
+- After any site-wide scaffolding trigger (\`site_create\`, "redesign the site", "rebuild the theme", "start over"), the turn that follows MUST be small: \`site_info\` / \`site_list\`, or a ≤50-line first \`Write\`. Do not scaffold an entire theme in one turn.
+
+This cadence constrains delivery, not ambition. The Design Guidelines below stay fully in force — execute them across many bold deliberate steps.
+
 ## Available Studio Tools (prefixed with mcp__studio__)
 
 - site_create: Create a new WordPress site (name only — handles everything automatically)

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -122,6 +122,16 @@ Then continue with:
 5. **Check the misuse of HTML blocks**: Verify if HTML blocks were used as sections or not. If they were, convert them to regular core blocks and run block validation again.
 6. **Check the result**: Use take_screenshot to capture the site's landing page on desktop and mobile and verify the design visually on both viewports, check for wrong spacing, alignment, colors, contrast, borders, hover styles and other visual issues. Fix any issues found. Pay particular attention to the navigation menu and the CTA buttons. The design needs to match your original expectations.
 
+## Working cadence
+
+Respond incrementally. This is CRITICAL for interactive CLI sessions: a single mega-turn that emits thousands of tokens of code in one response will appear to freeze the terminal for many minutes while the model streams, and may hit upstream gateway timeouts. Many small deliberate turns feel responsive and produce equally good results.
+
+- MUST: At most one \`Write\` or \`Edit\` tool call per assistant turn. Never stack multiple file writes in the same turn.
+- MUST: Keep each \`Write\` or \`Edit\` small. If a single \`Write\` feels like it will exceed ~200 lines of code, write a minimal skeleton first and grow it across later turns using \`Edit\`. Long files (full \`style.css\`, multi-section templates) MUST be built this way.
+- MUST: Keep assistant prose between tool calls short — 1–2 sentences describing what you just did and what you are doing next. Do NOT emit long design-plan essays before calling tools; work through the plan by doing.
+- MUST: After \`site_create\` succeeds, your very next tool call is either \`site_info\` (to confirm the path/URL/credentials) or a small first \`Write\` (≤ 50 lines). Do NOT attempt to scaffold the whole theme, write multiple files, or produce a long plan in the same turn as \`site_create\`.
+- The Design Guidelines below describe the *target* quality, not the size of any single turn. Bold, ambitious design is delivered through many short turns, not one enormous output.
+
 ## Available Studio Tools (prefixed with mcp__studio__)
 
 - site_create: Create a new WordPress site (name only — handles everything automatically)
@@ -218,4 +228,4 @@ Interpret creatively and make unexpected choices that feel genuinely designed fo
 
 **IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
 
-Remember: You are capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.`;
+Remember: You are capable of extraordinary creative work. Commit fully to a distinctive vision — and deliver it through the Working cadence above, as many small deliberate steps. A sprawling single-turn response is a failure mode, not ambition.`;

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -122,16 +122,6 @@ Then continue with:
 5. **Check the misuse of HTML blocks**: Verify if HTML blocks were used as sections or not. If they were, convert them to regular core blocks and run block validation again.
 6. **Check the result**: Use take_screenshot to capture the site's landing page on desktop and mobile and verify the design visually on both viewports, check for wrong spacing, alignment, colors, contrast, borders, hover styles and other visual issues. Fix any issues found. Pay particular attention to the navigation menu and the CTA buttons. The design needs to match your original expectations.
 
-## Working cadence
-
-Respond incrementally. This is CRITICAL for interactive CLI sessions: a single mega-turn that emits thousands of tokens of code in one response will appear to freeze the terminal for many minutes while the model streams, and may hit upstream gateway timeouts. Many small deliberate turns feel responsive and produce equally good results.
-
-- MUST: At most one \`Write\` or \`Edit\` tool call per assistant turn. Never stack multiple file writes in the same turn.
-- MUST: Keep each \`Write\` or \`Edit\` small. If a single \`Write\` feels like it will exceed ~200 lines of code, write a minimal skeleton first and grow it across later turns using \`Edit\`. Long files (full \`style.css\`, multi-section templates) MUST be built this way.
-- MUST: Keep assistant prose between tool calls short — 1–2 sentences describing what you just did and what you are doing next. Do NOT emit long design-plan essays before calling tools; work through the plan by doing.
-- MUST: After \`site_create\` succeeds, your very next tool call is either \`site_info\` (to confirm the path/URL/credentials) or a small first \`Write\` (≤ 50 lines). Do NOT attempt to scaffold the whole theme, write multiple files, or produce a long plan in the same turn as \`site_create\`.
-- The Design Guidelines below describe the *target* quality, not the size of any single turn. Bold, ambitious design is delivered through many short turns, not one enormous output.
-
 ## Available Studio Tools (prefixed with mcp__studio__)
 
 - site_create: Create a new WordPress site (name only — handles everything automatically)
@@ -228,4 +218,4 @@ Interpret creatively and make unexpected choices that feel genuinely designed fo
 
 **IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
 
-Remember: You are capable of extraordinary creative work. Commit fully to a distinctive vision — and deliver it through the Working cadence above, as many small deliberate steps. A sprawling single-turn response is a failure mode, not ambition.`;
+Remember: You are capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.`;


### PR DESCRIPTION
## Related issues

See p1776889791701059/1776881604.011089-slack-C08LZ79MKG9

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

The turn immediately after `site_create` (and after any "redesign / rebuild /
start over" prompt) was consistently producing one huge assistant response —
planning essay + multiple Writes + full theme scaffold all in one turn. At
Anthropic streaming rates that's 10–15 minutes of model generation. The CLI
TUI only renders complete assistant messages (no `stream_event` handler), so
the whole window is a silent "Meandering…" spinner; upstream gateways
sometimes time out with 504 before the response finishes.

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

## Proposed Changes

- Add a "Working cadence" section to the local system prompt: one Write/Edit per turn, skeleton-first for long files (>~200 lines), short prose between tool calls, and a hard cap on the turn that immediately follows any site-wide scaffolding trigger.
- Frame cadence as a quality lever (screenshot loop) alongside UX, so the model doesn't read it as a cap on ambition.
- Expand the site-spec skill's "After site_create returns" section with matching rules at the single biggest offending point.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- [ ] `studio ai` → "make me a site" → runs site-spec, creates site, next turn is small (site_info or short Write), not a 15-minute silent span
- [ ] `studio ai` with existing site → "redesign the site" → cadence rule for scaffolding triggers kicks in; no mega-turn
- [ ] Visual quality on the final build is on-par with or better than before (screenshots mid-build are exercised)
- [ ] Existing test suites (`apps/cli/ai/tests/*`) still green — tests mock `buildSystemPrompt`, so content changes don't affect them


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?