### PR TITLE
apps/studio: update MCP and agent skills docs links

### DIFF
--- a/apps/studio/src/lib/get-localized-link.ts
+++ b/apps/studio/src/lib/get-localized-link.ts
@@ -38,10 +38,10 @@ const DOCS_LINKS = {
 		en: 'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/',
 	},
 	docsMcp: {
-		en: 'https://developer.wordpress.com/docs/developer-tools/studio/mcp/',
+		en: 'https://developer.wordpress.com/docs/developer-tools/studio/mcp-on-studio/',
 	},
 	docsSkills: {
-		en: 'https://developer.wordpress.com/docs/developer-tools/studio/agent-skills/',
+		en: 'https://developer.wordpress.com/docs/developer-tools/studio/agent-skills-wordpress-studio/',
 	},
 } satisfies Record< `docs${ string }`, TranslatedLink >;
 


### PR DESCRIPTION
## Related issues

We added redirects in the docs site, but this PR will link the final links directly p1776777754963939-slack-C06DRMD6VPZ

## How AI was used in this PR

Used AI to locate the two links in `apps/studio/src/lib/get-localized-link.ts` and update them.

## Proposed Changes

- Update `docsMcp` URL to `https://developer.wordpress.com/docs/developer-tools/studio/mcp-on-studio/`
- Update `docsSkills` URL to `https://developer.wordpress.com/docs/developer-tools/studio/agent-skills-wordpress-studio/`

## Testing Instructions

- Open the app
- Go to the Global Settings
- Click on MCP and Skills and click on "Learn more" 
- Verify each link opens the new documentation URL in the browser, and it doesn't use a redirect.
- Run `npm test -- apps/studio/src/lib/tests/get-localized-link.test.ts` — all tests should pass.



https://github.com/user-attachments/assets/d157d117-6c19-45fb-be49-e41d54f1ba93


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?