### PR TITLE
apps/studio: Show What's New modal only on first launch or when explicitly forced

### DIFF
--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -85,4 +85,7 @@ export const IPC_VOID_HANDLERS = < const >[
 ];
 
 // What's New
-export const FORCE_WHATS_NEW_WHEN_PATCH_CHANGED = true;
+// Flip to `true` when shipping new modal content so users who haven't seen the
+// current app version get the modal once. Keep at `false` otherwise — the modal
+// will only auto-show for first-time users of Studio.
+export const FORCE_SHOW_WHATS_NEW = false;

--- a/apps/studio/src/stores/app-version-api.ts
+++ b/apps/studio/src/stores/app-version-api.ts
@@ -1,8 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { BaseQueryFn } from '@reduxjs/toolkit/query';
 import { createApi, fetchBaseQuery, TypedUseQueryStateResult } from '@reduxjs/toolkit/query/react';
-import semver from 'semver';
-import { FORCE_WHATS_NEW_WHEN_PATCH_CHANGED } from 'src/constants';
+import { FORCE_SHOW_WHATS_NEW } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
 export const appVersionApi = createApi( {
@@ -45,36 +44,19 @@ type GetLastSeenVersionQueryResult = TypedUseQueryStateResult<
 	BaseQueryFn
 >;
 
-function isGreaterExceptPatch( versionA: string | undefined, versionB: string ): boolean {
-	if ( ! versionA ) {
-		return true;
-	}
-
-	if (
-		! semver.valid( versionA ) ||
-		! semver.valid( versionB ) ||
-		semver.gte( versionA, versionB )
-	) {
-		return false;
-	}
-
-	const a = semver.parse( versionA )!;
-	const b = semver.parse( versionB )!;
-
-	if (
-		a.major === b.major &&
-		a.minor === b.minor &&
-		( a.patch !== b.patch || a.prerelease?.length !== b.prerelease?.length )
-	) {
-		return FORCE_WHATS_NEW_WHEN_PATCH_CHANGED;
-	}
-	return true;
-}
-
+// The modal auto-shows only for first-time users (no stored `lastSeenVersion`)
+// or when `FORCE_SHOW_WHATS_NEW` is flipped to `true` and the user hasn't
+// dismissed it on the current app version yet. Patch/minor/major bumps alone
+// never trigger the modal — devs must opt in via the constant.
 export const selectIsNewVersion = createSelector(
 	[
 		( res: GetLastSeenVersionQueryResult ) => res.data,
-		( res: GetLastSeenVersionQueryResult, currentVersion: string ) => currentVersion,
+		( _res: GetLastSeenVersionQueryResult, currentVersion: string ) => currentVersion,
 	],
-	( lastSeenVersion, currentVersion ) => isGreaterExceptPatch( lastSeenVersion, currentVersion )
+	( lastSeenVersion, currentVersion ) => {
+		if ( ! lastSeenVersion ) {
+			return true;
+		}
+		return FORCE_SHOW_WHATS_NEW && lastSeenVersion !== currentVersion;
+	}
 );

--- a/apps/studio/src/stores/tests/app-version-api.test.ts
+++ b/apps/studio/src/stores/tests/app-version-api.test.ts
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { vi } from 'vitest';
-import { FORCE_WHATS_NEW_WHEN_PATCH_CHANGED } from 'src/constants';
+import { FORCE_SHOW_WHATS_NEW } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { appVersionApi, selectIsNewVersion } from 'src/stores/app-version-api';
 
@@ -72,94 +72,29 @@ describe( 'App Version API', () => {
 			error: undefined,
 		} );
 
-		it( 'should return true for a new major version', () => {
-			const lastSeenVersion = '1.2.0';
-			const currentVersion = '2.0.0';
-
-			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
-
+		it( 'should return true for a first-time user (no stored version)', () => {
+			const result = selectIsNewVersion( createMockQueryResult( undefined ), '1.2.0' );
 			expect( result ).toBe( true );
 		} );
 
-		it( 'should return true for a new minor version', () => {
-			const lastSeenVersion = '1.2.0';
-			const currentVersion = '1.3.0';
-
-			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
-
-			expect( result ).toBe( true );
-		} );
-
-		it( 'should return false for the same version', () => {
-			const lastSeenVersion = '1.2.0';
-			const currentVersion = '1.2.0';
-
-			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
-
+		it( 'should return false when the stored version matches the current version', () => {
+			const result = selectIsNewVersion( createMockQueryResult( '1.2.0' ), '1.2.0' );
 			expect( result ).toBe( false );
 		} );
 
-		it( "should return true or false depending on whether force what's new is enabled for a new patch version", () => {
-			const lastSeenVersion = '1.2.0';
-			const currentVersion = '1.2.1';
-
-			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
-
-			expect( result ).toBe( FORCE_WHATS_NEW_WHEN_PATCH_CHANGED );
+		it( 'should not trigger on a patch bump when FORCE_SHOW_WHATS_NEW is false', () => {
+			const result = selectIsNewVersion( createMockQueryResult( '1.2.0' ), '1.2.1' );
+			expect( result ).toBe( FORCE_SHOW_WHATS_NEW );
 		} );
 
-		it( 'should return true when going from a stable version to a prerelease version', () => {
-			const lastSeenVersion = '1.2.0';
-			const currentVersion = '1.3.0-beta1';
-
-			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
-
-			expect( result ).toBe( true );
+		it( 'should not trigger on a minor bump when FORCE_SHOW_WHATS_NEW is false', () => {
+			const result = selectIsNewVersion( createMockQueryResult( '1.2.0' ), '1.3.0' );
+			expect( result ).toBe( FORCE_SHOW_WHATS_NEW );
 		} );
 
-		it( "It should return true or false depending on whether force what's new is enabled when going from a prerelease version to a stable version.", () => {
-			const lastSeenVersion = '1.2.0-beta2';
-			const currentVersion = '1.2.0';
-
-			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
-
-			expect( result ).toBe( FORCE_WHATS_NEW_WHEN_PATCH_CHANGED );
-		} );
-
-		it( "Should return true or false depending on whether force what's new is enabled when going from a stable version to a prerelease version that increases only the patch.", () => {
-			const lastSeenVersion = '1.2.0';
-			const currentVersion = '1.2.1-beta1';
-
-			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
-
-			expect( result ).toBe( FORCE_WHATS_NEW_WHEN_PATCH_CHANGED );
-		} );
-
-		it( 'should return true for a new prerelease version', () => {
-			const lastSeenVersion = '1.2.0-beta1';
-			const currentVersion = '1.2.0-beta2';
-
-			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
-
-			expect( result ).toBe( true );
-		} );
-
-		it( 'should return true for undefined lastSeenVersion', () => {
-			const lastSeenVersion = undefined;
-			const currentVersion = '1.2.0';
-
-			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
-
-			expect( result ).toBe( true );
-		} );
-
-		it( 'should return false for invalid version formats', () => {
-			const lastSeenVersion = 'invalid';
-			const currentVersion = 'also-invalid';
-
-			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
-
-			expect( result ).toBe( false );
+		it( 'should not trigger on a major bump when FORCE_SHOW_WHATS_NEW is false', () => {
+			const result = selectIsNewVersion( createMockQueryResult( '1.2.0' ), '2.0.0' );
+			expect( result ).toBe( FORCE_SHOW_WHATS_NEW );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Related issues

- Related to https://github.com/Automattic/studio/pull/2920

## How AI was used in this PR

Claude Opus was used to brainstorm alternative strategies (content-key vs. boolean override), implement the chosen approach, and update tests. The author reviewed and validated the diff.

## Proposed Changes

- Replace `FORCE_WHATS_NEW_WHEN_PATCH_CHANGED` (default `true`) with a simpler `FORCE_SHOW_WHATS_NEW` constant (default `false`) in `apps/studio/src/constants.ts`.
- Drop semver comparison in `selectIsNewVersion` (`apps/studio/src/stores/app-version-api.ts`). The modal now auto-shows only when:
  1. The user has no stored `lastSeenVersion` (first-time launch), **or**
  2. `FORCE_SHOW_WHATS_NEW === true` **and** the stored version differs from the current app version.
- Patch, minor, and major version bumps alone no longer trigger the modal.
- Help menu → "What's New" still opens the modal on demand, regardless of the flag.
- Remove the now-unused `semver` import from this file (still used elsewhere).
- Update `selectIsNewVersion` tests to cover the new semantics.

### Release workflow

When shipping new modal content:

1. Edit `whatsNewPages` in `apps/studio/src/modules/whats-new/components/whats-new-modal.tsx`.
2. Set `FORCE_SHOW_WHATS_NEW = true` in `apps/studio/src/constants.ts`.
3. Bump the app version and ship. Each user sees the modal once; dismissing it writes the current version and suppresses re-shows.
4. After the release, flip the flag back to `false` so subsequent patch/minor bumps don't retrigger it.

## Testing Instructions

- Run \`npm test -- src/stores/tests/app-version-api.test.ts\` — 7/7 pass.
- Manual test with \`FORCE_SHOW_WHATS_NEW = false\` (default):
  - Fresh install (remove \`lastSeenVersion\` in \`~/.studio/app.json\`) → modal appears once, dismiss writes version.
  - Restart the app → modal does **not** reappear.
  - Manually edit \`~/.studio/app.json\` to bump \`lastSeenVersion\` (simulating a version bump) → modal still does **not** appear.
  - Help menu → "What's New" → modal opens.
- Manual dogfood with \`FORCE_SHOW_WHATS_NEW = true\`:
  - With a stored \`lastSeenVersion\` that differs from \`appVersion\` → modal appears once, dismiss writes current version, subsequent launches quiet until another version bump.


https://github.com/user-attachments/assets/23ea4237-0323-48c3-baca-877f256bdc31



## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?