### PR TITLE
Fix Dependabot: add top-level packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"productName": "Studio",
 	"description": "Local WordPress development environment using Playgrounds",
 	"license": "GPL-2.0-or-later",
-	"packageManager": "npm@11.8.0",
+	"packageManager": "npm@11.13.0",
 	"devEngines": {
 		"runtime": {
 			"name": "node",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"productName": "Studio",
 	"description": "Local WordPress development environment using Playgrounds",
 	"license": "GPL-2.0-or-later",
+	"packageManager": "npm@11.8.0",
 	"devEngines": {
 		"runtime": {
 			"name": "node",


### PR DESCRIPTION
## Related issues

- Fixes Dependabot error: "Invalid package manager specification in package.json. The packageManager field must specify a valid semver version"

## How AI was used in this PR

Claude Code identified the root cause and applied the fix.

## Proposed Changes

- Added `"packageManager": "npm@11.8.0"` as a top-level string field in `package.json`

Dependabot requires the standard top-level `packageManager` string (e.g. `"npm@11.8.0"`) to resolve JS dependencies. It was erroring because it misread the object-shaped `devEngines.packageManager` as the `packageManager` field, which must be a plain semver string. Adding the correct field fixes the error and also satisfies corepack.

## Testing Instructions

- Dependabot should successfully create PRs after this merges

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?