### PR TITLE
Auth: Register wp-studio:// scheme on Linux

### DIFF
--- a/apps/studio/forge.config.ts
+++ b/apps/studio/forge.config.ts
@@ -83,6 +83,7 @@ const config: ForgeConfig = {
 				genericName: 'WordPress Studio',
 				categories: [ 'Utility' ],
 				name: 'studio',
+				bin: 'studio',
 				mimeType: [ 'x-scheme-handler/wp-studio' ],
 			},
 		} ),

--- a/apps/studio/forge.config.ts
+++ b/apps/studio/forge.config.ts
@@ -83,6 +83,7 @@ const config: ForgeConfig = {
 				genericName: 'WordPress Studio',
 				categories: [ 'Utility' ],
 				name: 'studio',
+				mimeType: [ 'x-scheme-handler/wp-studio' ],
 			},
 		} ),
 		new MakerSquirrel(

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -93,6 +93,12 @@ For easier access, you can create a desktop entry file that will add Studio to y
    update-desktop-database ~/.local/share/applications
    ```
 
+6. **Register Studio handler for `wp-studio://` links:**
+   ```bash
+   xdg-mime default studio.desktop x-scheme-handler/wp-studio
+   ```
+   Without this, browsers will still show "Open With… / No Apps Available" when WordPress.com OAuth redirects back to `wp-studio://`.
+
 Studio should now appear in your application launcher and can handle `wp-studio://` protocol URLs.
 
 ## Running with Wayland
@@ -155,4 +161,3 @@ The executable in `apps/studio/out/Studio-linux-x64/` will be updated with the n
 ## Contributing
 
 If you encounter Linux-specific issues or have suggestions for improving Linux support, please [open an issue](https://github.com/Automattic/studio/issues) or submit a pull request. Your feedback helps improve Studio for all Linux users!
-

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -161,3 +161,4 @@ The executable in `apps/studio/out/Studio-linux-x64/` will be updated with the n
 ## Contributing
 
 If you encounter Linux-specific issues or have suggestions for improving Linux support, please [open an issue](https://github.com/Automattic/studio/issues) or submit a pull request. Your feedback helps improve Studio for all Linux users!
+


### PR DESCRIPTION
## Related issues

- Fixes [STU-1629](https://linear.app/a8c/issue/STU-1629/linux-wp-studio-protocol-handler-not-registered-wpcom-login-redirect)

## How AI was used in this PR

Used Claude Code to locate the protocol registration path (`app.setAsDefaultProtocolClient` in `apps/studio/src/index.ts`), inspect the `@electron-forge/maker-deb` config surface to confirm `mimeType` is the supported option, and propose the minimal packaging change. I reviewed the diff and verified the approach against the existing `docs/linux.md` workaround before committing.

## Proposed Changes

- `apps/studio/forge.config.ts`: pass `mimeType: ['x-scheme-handler/wp-studio']` to `MakerDeb`. Electron Forge writes `MimeType=x-scheme-handler/wp-studio;` into the generated `.desktop` entry, and `dpkg` postinst runs `update-desktop-database` so the scheme is registered system-wide on DEB install.
- `docs/linux.md`: add a step telling source-built users to run `xdg-mime default studio.desktop x-scheme-handler/wp-studio`. Without this, browsers still show "Open With… / No Apps Available" on the `wp-studio://` callback even when the hand-crafted `.desktop` file declares the MimeType.

Why `setAsDefaultProtocolClient` alone wasn't enough on Linux: that Electron API ultimately shells out to `xdg-mime`, which only succeeds if there's a `.desktop` file on disk declaring the MimeType. Packaged DEB builds had no such entry, so the scheme silently failed to register.

## Testing Instructions

### DEB-packaged build (the primary fix)

1. On a Linux machine (or VM), `npm ci && npm run package`.
2. Go to `apps/studio/out/make/deb/arm64/studio*.deb`
3. Install the `.deb` (`sudo dpkg -i studio*.deb`), then from Firefox/Chrome open `wp-studio://test`.
   Expected: the browser launches Studio (no "Open With… / No Apps Available" dialog).
4. Run the full WordPress.com OAuth flow from the **Previews** tab and confirm the token is delivered back and login completes in-app.

### Source-built install

1. Follow the updated **Creating a Desktop Shortcut** steps in `docs/linux.md`, including the new `xdg-mime default studio.desktop x-scheme-handler/wp-studio` step.
2. Open `wp-studio://test` from a browser and confirm Studio is launched.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?