### PR TITLE
Add test for FORCE_SHOW_WHATS_NEW triggering What's New modal

### DIFF
--- a/apps/studio/src/stores/tests/app-version-api.test.ts
+++ b/apps/studio/src/stores/tests/app-version-api.test.ts
@@ -1,12 +1,22 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { vi } from 'vitest';
-import { FORCE_SHOW_WHATS_NEW } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { appVersionApi, selectIsNewVersion } from 'src/stores/app-version-api';
 
 vi.mock( 'src/lib/get-ipc-api', () => ( {
 	getIpcApi: vi.fn(),
 } ) );
+
+let mockForceShowWhatsNew = false;
+vi.mock( 'src/constants', async ( importOriginal ) => {
+	const actual = await importOriginal< typeof import('src/constants') >();
+	return {
+		...actual,
+		get FORCE_SHOW_WHATS_NEW() {
+			return mockForceShowWhatsNew;
+		},
+	};
+} );
 
 const mockIpcApi = {
 	getLastSeenVersion: vi.fn(),
@@ -28,6 +38,7 @@ const createTestStore = () => {
 describe( 'App Version API', () => {
 	beforeEach( () => {
 		vi.clearAllMocks();
+		mockForceShowWhatsNew = false;
 	} );
 
 	describe( 'getLastSeenVersion', () => {
@@ -84,17 +95,29 @@ describe( 'App Version API', () => {
 
 		it( 'should not trigger on a patch bump when FORCE_SHOW_WHATS_NEW is false', () => {
 			const result = selectIsNewVersion( createMockQueryResult( '1.2.0' ), '1.2.1' );
-			expect( result ).toBe( FORCE_SHOW_WHATS_NEW );
+			expect( result ).toBe( false );
 		} );
 
 		it( 'should not trigger on a minor bump when FORCE_SHOW_WHATS_NEW is false', () => {
 			const result = selectIsNewVersion( createMockQueryResult( '1.2.0' ), '1.3.0' );
-			expect( result ).toBe( FORCE_SHOW_WHATS_NEW );
+			expect( result ).toBe( false );
 		} );
 
 		it( 'should not trigger on a major bump when FORCE_SHOW_WHATS_NEW is false', () => {
 			const result = selectIsNewVersion( createMockQueryResult( '1.2.0' ), '2.0.0' );
-			expect( result ).toBe( FORCE_SHOW_WHATS_NEW );
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return true when FORCE_SHOW_WHATS_NEW is true and the version changed', () => {
+			mockForceShowWhatsNew = true;
+			const result = selectIsNewVersion( createMockQueryResult( '2.0.0' ), '2.1.0' );
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return false when FORCE_SHOW_WHATS_NEW is true but the version did not change', () => {
+			mockForceShowWhatsNew = true;
+			const result = selectIsNewVersion( createMockQueryResult( '3.0.0' ), '3.0.0' );
+			expect( result ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Related issues

- Related to #3203

## How AI was used in this PR

Claude Code drafted the new test cases and the mock-based approach for flipping `FORCE_SHOW_WHATS_NEW` per-case. I reviewed the diff, ran the suite locally, and confirmed the memoization edge case (unique version strings per test so `createSelector` does not return a cached result).

## Proposed Changes

- Mock `src/constants` in `apps/studio/src/stores/tests/app-version-api.test.ts` with a mutable getter so each test can set `FORCE_SHOW_WHATS_NEW` independently.
- Reset the flag to `false` in `beforeEach` to keep the existing tests deterministic.
- Replace `.toBe( FORCE_SHOW_WHATS_NEW )` assertions with explicit `.toBe( false )` now that the constant is controlled by the mock.
- Add two new cases covering the branches added in #3203:
  - `FORCE_SHOW_WHATS_NEW = true` + version changed → selector returns `true` (modal appears).
  - `FORCE_SHOW_WHATS_NEW = true` + version unchanged → selector returns `false`.

## Testing Instructions

- `npm test -- apps/studio/src/stores/tests/app-version-api.test.ts` — all 9 tests pass.
- `npm run typecheck` passes.
- `npx eslint --fix apps/studio/src/stores/tests/app-version-api.test.ts` reports no issues.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?