### PR TITLE
CLI: Add json format for auth status

### DIFF
--- a/apps/cli/commands/auth/status.ts
+++ b/apps/cli/commands/auth/status.ts
@@ -5,23 +5,46 @@ import { getUserInfo } from 'cli/lib/api';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
-export async function runCommand(): Promise< void > {
+export async function runCommand( format: 'text' | 'json' = 'text' ): Promise< void > {
 	const logger = new Logger< LoggerAction >();
 
-	logger.reportStart( LoggerAction.STATUS_CHECK, __( 'Checking authentication status…' ) );
+	if ( format !== 'json' ) {
+		logger.reportStart( LoggerAction.STATUS_CHECK, __( 'Checking authentication status…' ) );
+	}
 
 	try {
 		const token = await readAuthToken();
 
 		if ( ! token ) {
-			logger.reportError( new LoggerError( __( 'Authentication token is invalid or expired' ) ) );
+			if ( format === 'json' ) {
+				console.log( JSON.stringify( { authenticated: false }, null, 2 ) );
+			} else {
+				logger.reportError( new LoggerError( __( 'Authentication token is invalid or expired' ) ) );
+			}
 			return;
 		}
 
 		const userData = await getUserInfo( token.accessToken );
-		logger.reportSuccess(
-			sprintf( __( 'Authenticated with WordPress.com as `%s`' ), userData.username )
-		);
+
+		if ( format === 'json' ) {
+			console.log(
+				JSON.stringify(
+					{
+						authenticated: true,
+						id: userData.ID,
+						username: userData.username,
+						email: userData.email,
+						displayName: userData.display_name,
+					},
+					null,
+					2
+				)
+			);
+		} else {
+			logger.reportSuccess(
+				sprintf( __( 'Authenticated with WordPress.com as `%s`' ), userData.username )
+			);
+		}
 	} catch ( error ) {
 		if ( error instanceof LoggerError ) {
 			logger.reportError( error );
@@ -36,12 +59,19 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 		command: 'status',
 		describe: __( 'Check authentication status' ),
 		builder: ( yargs ) => {
-			return yargs.option( 'path', {
-				hidden: true,
-			} );
+			return yargs
+				.option( 'path', {
+					hidden: true,
+				} )
+				.option( 'format', {
+					type: 'string',
+					choices: [ 'text', 'json' ] as const,
+					default: 'text' as const,
+					description: __( 'Output format' ),
+				} );
 		},
-		handler: async () => {
-			await runCommand();
+		handler: async ( argv ) => {
+			await runCommand( argv.format );
 		},
 	} );
 };

--- a/apps/cli/commands/auth/tests/status.test.ts
+++ b/apps/cli/commands/auth/tests/status.test.ts
@@ -57,41 +57,103 @@ describe( 'Auth Status Command', () => {
 		vi.restoreAllMocks();
 	} );
 
-	it( 'should report success when authenticated', async () => {
-		await runCommand();
+	describe( 'text format (default)', () => {
+		it( 'should report success when authenticated', async () => {
+			await runCommand();
 
-		expect( mockReportStart ).toHaveBeenCalled();
-		expect( readAuthToken ).toHaveBeenCalled();
-		expect( getUserInfo ).toHaveBeenCalledWith( mockToken.accessToken );
-		expect( mockReportSuccess ).toHaveBeenCalledWith(
-			expect.stringContaining( 'Authenticated with WordPress.com as `testuser`' )
-		);
+			expect( mockReportStart ).toHaveBeenCalled();
+			expect( readAuthToken ).toHaveBeenCalled();
+			expect( getUserInfo ).toHaveBeenCalledWith( mockToken.accessToken );
+			expect( mockReportSuccess ).toHaveBeenCalledWith(
+				expect.stringContaining( 'Authenticated with WordPress.com as `testuser`' )
+			);
+		} );
+
+		it( 'should report error when token is invalid', async () => {
+			vi.mocked( readAuthToken ).mockResolvedValue( null );
+
+			await runCommand();
+
+			expect( mockReportError ).toHaveBeenCalled();
+			expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
+			expect( getUserInfo ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should forward LoggerError from getUserInfo', async () => {
+			const apiError = new LoggerError( 'API error' );
+			vi.mocked( getUserInfo ).mockRejectedValue( apiError );
+
+			await runCommand();
+
+			expect( mockReportError ).toHaveBeenCalledWith( apiError );
+		} );
+
+		it( 'should wrap unknown error when getUserInfo fails', async () => {
+			vi.mocked( getUserInfo ).mockRejectedValue( new Error( 'Unknown error' ) );
+
+			await runCommand();
+
+			expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
+		} );
 	} );
 
-	it( 'should report error when token is invalid', async () => {
-		vi.mocked( readAuthToken ).mockResolvedValue( null );
+	describe( 'json format', () => {
+		let consoleLogSpy: ReturnType< typeof vi.spyOn >;
 
-		await runCommand();
+		beforeEach( () => {
+			consoleLogSpy = vi.spyOn( console, 'log' ).mockImplementation( () => {} );
+		} );
 
-		expect( mockReportError ).toHaveBeenCalled();
-		expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
-		expect( getUserInfo ).not.toHaveBeenCalled();
-	} );
+		afterEach( () => {
+			consoleLogSpy.mockRestore();
+		} );
 
-	it( 'should forward LoggerError from getUserInfo', async () => {
-		const apiError = new LoggerError( 'API error' );
-		vi.mocked( getUserInfo ).mockRejectedValue( apiError );
+		it( 'should output authenticated JSON when token and user info are valid', async () => {
+			await runCommand( 'json' );
 
-		await runCommand();
+			expect( getUserInfo ).toHaveBeenCalledWith( mockToken.accessToken );
+			expect( consoleLogSpy ).toHaveBeenCalledWith(
+				JSON.stringify(
+					{
+						authenticated: true,
+						id: mockUserData.ID,
+						username: mockUserData.username,
+						email: mockUserData.email,
+						displayName: mockUserData.display_name,
+					},
+					null,
+					2
+				)
+			);
+			expect( mockReportSuccess ).not.toHaveBeenCalled();
+		} );
 
-		expect( mockReportError ).toHaveBeenCalledWith( apiError );
-	} );
+		it( 'should output unauthenticated JSON and set exit code when token is missing', async () => {
+			vi.mocked( readAuthToken ).mockResolvedValue( null );
 
-	it( 'should wrap unknown error when getUserInfo fails', async () => {
-		vi.mocked( getUserInfo ).mockRejectedValue( new Error( 'Unknown error' ) );
+			await runCommand( 'json' );
 
-		await runCommand();
+			expect( getUserInfo ).not.toHaveBeenCalled();
+			expect( consoleLogSpy ).toHaveBeenCalledWith(
+				JSON.stringify( { authenticated: false }, null, 2 )
+			);
+		} );
 
-		expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
+		it( 'should forward LoggerError from getUserInfo', async () => {
+			const apiError = new LoggerError( 'API error' );
+			vi.mocked( getUserInfo ).mockRejectedValue( apiError );
+
+			await runCommand( 'json' );
+
+			expect( mockReportError ).toHaveBeenCalledWith( apiError );
+		} );
+
+		it( 'should wrap unknown error when getUserInfo fails', async () => {
+			vi.mocked( getUserInfo ).mockRejectedValue( new Error( 'Unknown error' ) );
+
+			await runCommand( 'json' );
+
+			expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes STU-1638

## How AI was used in this PR

AI assisted with writing code and ensuring it's aligned with `site status`. We had a few iterations, I tested it, and reviewed it thoroughly.

## Proposed Changes

CLI supports i18n, so it's difficult to parse the output. I propose to add json output to handle it.

**Note:** I used "text | json". We typically use `table` but it doesn't fit in this case, that's why I decided to go with `text` as a universal approach and I would propose to go with `text` instead of `table` in other places in the future, to have consistency with the universal word to distinguish JSON vs human-readable format.

## Testing Instructions
1. Run `node apps/cli/dist/cli/main.mjs auth login`
2. Run `node apps/cli/dist/cli/main.mjs auth status`
3. Assert that no regression (`✔ Authenticated with WordPress.com as `nightnei``)
4. Run `node apps/cli/dist/cli/main.mjs auth status --format=json`
5. Assert you see json response
6. Run `node apps/cli/dist/cli/main.mjs auth logout`
7. Assert that `node apps/cli/dist/cli/main.mjs auth status` and `node apps/cli/dist/cli/main.mjs auth status --format=json` work well.