### PR TITLE
Release 1.7.11 npm

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "wp-studio",
 	"author": "Automattic Inc.",
-	"version": "1.7.10",
+	"version": "1.7.11",
 	"productName": "Studio CLI",
 	"description": "WordPress Studio CLI",
 	"license": "GPL-2.0-or-later",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -3,7 +3,7 @@
 	"author": "Automattic Inc.",
 	"private": true,
 	"productName": "Studio",
-	"version": "1.7.10",
+	"version": "1.7.11",
 	"description": "Local WordPress development environment using Playgrounds",
 	"license": "GPL-2.0-or-later",
 	"main": "dist/main/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
 		},
 		"apps/cli": {
 			"name": "wp-studio",
-			"version": "1.7.10",
+			"version": "1.7.11",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -491,7 +491,7 @@
 		},
 		"apps/studio": {
 			"name": "studio-app",
-			"version": "1.7.10",
+			"version": "1.7.11",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@automattic/generate-password": "^0.1.0",


### PR DESCRIPTION
## Related issue

Follow-up to #3167 (Release 1.7.10 npm).

## How AI was used in this PR

Opus 4.7 ran the version bump command, committed, pushed, and opened this PR.

## Proposed Changes

- Bump CLI version from 1.7.10 to 1.7.11 for both CLI (`wp-studio`) and App (`studio-app`).
- Lockfile updated accordingly.

## Testing Instructions

- Run `npm run cli:build` and verify `node apps/cli/dist/cli/main.mjs --version` reports `1.7.11`.
- Run `npm install` and confirm no lockfile drift.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?