### PR TITLE
Auto-select Studio site when `studio code` runs in its folder

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -444,6 +444,11 @@ export class AiChatUI implements AiOutputAdapter {
 		return this._activeSite;
 	}
 
+	set activeSite( site: SiteInfo | null ) {
+		this._activeSite = site;
+		this.editor.activeSiteName = site?.name ?? null;
+	}
+
 	private refreshPromptChrome(): void {
 		this.editor.invalidate();
 	}

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -23,6 +23,7 @@ import { AI_CHAT_SLASH_COMMANDS, type SlashCommandContext } from 'cli/ai/slash-c
 import { AiChatUI } from 'cli/ai/ui';
 import { runCommand as runLoginCommand } from 'cli/commands/auth/login';
 import { readCliConfig } from 'cli/lib/cli-config/core';
+import { findSiteByFolder } from 'cli/lib/cli-config/sites';
 import { Logger, LoggerError, setProgressCallback } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -751,6 +752,15 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				}
 
 				const sitePath = typeof argv.path === 'string' ? argv.path : undefined;
+				let activeSite: { name: string; path: string } | undefined;
+				if ( sitePath && typedArgv.siteName ) {
+					activeSite = { name: typedArgv.siteName, path: sitePath };
+				} else if ( sitePath ) {
+					const matchedSite = await findSiteByFolder( sitePath );
+					if ( matchedSite ) {
+						activeSite = { name: matchedSite.name, path: matchedSite.path };
+					}
+				}
 				await runCommand( {
 					adapter,
 					initialMessage: typedArgv.message,
@@ -758,10 +768,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					noSessionPersistence,
 					autoApprove: typedArgv.autoApprove,
 					showLegacyCommandNotice: argv._[ 0 ] === 'ai',
-					activeSite:
-						sitePath && typedArgv.siteName
-							? { name: typedArgv.siteName, path: sitePath }
-							: undefined,
+					activeSite,
 				} );
 			} catch ( error ) {
 				if ( error instanceof LoggerError ) {

--- a/apps/cli/lib/cli-config/sites.ts
+++ b/apps/cli/lib/cli-config/sites.ts
@@ -26,6 +26,11 @@ export async function getSiteByFolder( siteFolder: string ): Promise< SiteData >
 	return site;
 }
 
+export async function findSiteByFolder( siteFolder: string ): Promise< SiteData | undefined > {
+	const config = await readCliConfig();
+	return config.sites.find( ( site ) => arePathsEqual( site.path, siteFolder ) );
+}
+
 export function getSiteUrl( site: SiteData ): string {
 	if ( site.url ) {
 		return site.url;


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude Code wrote the implementation end-to-end based on a short conversation with the author. The author reviewed the diff before submission.

## Proposed Changes

- `studio code` now auto-attaches an existing Studio site as the active site when the CLI is launched from that site's exact folder. No `--site-name` / `--path` required.
- Matching is **exact path only** (via the existing `arePathsEqual` inode-aware helper). Nested subdirectories of a site folder are intentionally not matched.
- Explicit `--site-name` still takes precedence over the auto-match — existing behavior is preserved.
- Adds a missing `activeSite` setter on `AiChatUI`. The `AiOutputAdapter` interface declares `activeSite` as read-write and `JsonAdapter` implements it as a plain field, but `AiChatUI` only had a getter. `runCommand` assigns `ui.activeSite = …`, which silently worked only in `--json` mode and threw in interactive mode (`Cannot set property activeSite of #<AiChatUI> which has only a getter`). The existing `--site-name` code path hit the same bug — this fix covers both.

### Files

- `apps/cli/lib/cli-config/sites.ts` — new `findSiteByFolder` helper (returns `undefined` instead of throwing like `getSiteByFolder`).
- `apps/cli/commands/ai/index.ts` — look up a matching site by cwd when `--site-name` is not provided.
- `apps/cli/ai/ui.ts` — `activeSite` setter that updates `_activeSite` and `editor.activeSiteName` so the prompt chrome renders the site name on first paint.

## Testing Instructions

1. `npm run cli:build`
2. Create (or pick) an existing Studio site, note its absolute path (e.g. `~/Studio/my-site`).
3. `cd` into that folder and run `node apps/cli/dist/cli/main.mjs code`.
   - **Expected:** the active site shows in the prompt chrome (site name) without passing any flags. `/browser`, tool calls, etc. target that site.
4. `cd` into a subdirectory of the site (e.g. `~/Studio/my-site/wp-content`) and run the same command.
   - **Expected:** no site is attached (exact-path match only).
5. `cd` into a random folder that isn't a Studio site and run the command.
   - **Expected:** no site is attached; agent still starts normally.
6. From any folder, pass `--site-name=SomeOtherSite --path=/path/to/other`.
   - **Expected:** explicit values win; auto-match does not run.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
- [x] Does this introduce changes that need to be communicated externally (e.g. in release notes, the app description, or on the website)?  No
- [ ] Have you tested in multiple environments (e.g. macOS, Windows, Linux)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)