### PR TITLE
CLI: route picospinner output to stderr so --format=json stays pipeable

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -1,3 +1,4 @@
+import 'cli/lib/picospinner-stderr-patch';
 import path from 'node:path';
 import { suppressPunycodeWarning } from '@studio/common/lib/suppress-punycode-warning';
 import { __, sprintf } from '@wordpress/i18n';

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -1,4 +1,3 @@
-import 'cli/lib/picospinner-stderr-patch';
 import path from 'node:path';
 import { suppressPunycodeWarning } from '@studio/common/lib/suppress-punycode-warning';
 import { __, sprintf } from '@wordpress/i18n';

--- a/apps/cli/lib/picospinner-stderr-patch.ts
+++ b/apps/cli/lib/picospinner-stderr-patch.ts
@@ -10,17 +10,8 @@ import { renderer } from 'picospinner';
  * avoids duplicating picospinner internals and survives upstream changes as
  * long as `render` and `onComponentFinish` remain the only write paths.
  */
-type PatchableRenderer = {
-	render: () => void;
-	onComponentFinish: () => void;
-};
 
 function redirectPicospinnerToStderr(): void {
-	const r = renderer as unknown as Partial< PatchableRenderer > | undefined;
-	if ( ! r || typeof r.render !== 'function' || typeof r.onComponentFinish !== 'function' ) {
-		return;
-	}
-
 	const withStdoutAsStderr = < T >( fn: () => T ): T => {
 		const originalWrite = process.stdout.write.bind( process.stdout );
 		process.stdout.write = process.stderr.write.bind(
@@ -33,11 +24,29 @@ function redirectPicospinnerToStderr(): void {
 		}
 	};
 
-	const originalRender = r.render.bind( r );
-	const originalOnComponentFinish = r.onComponentFinish.bind( r );
+	const originalRefresh = Spinner.prototype.refresh;
+	const originalSetDisplay = Spinner.prototype.setDisplay;
+	const originalStart = Spinner.prototype.start;
+	const originalStop = Spinner.prototype.stop;
 
-	r.render = () => withStdoutAsStderr( originalRender );
-	r.onComponentFinish = () => withStdoutAsStderr( originalOnComponentFinish );
+	Spinner.prototype.refresh = function (
+		this: Spinner,
+		...args: Parameters< Spinner[ 'refresh' ] >
+	) {
+		return withStdoutAsStderr( () => originalRefresh.apply( this, args ) );
+	};
+	Spinner.prototype.setDisplay = function (
+		this: Spinner,
+		...args: Parameters< Spinner[ 'setDisplay' ] >
+	) {
+		return withStdoutAsStderr( () => originalSetDisplay.apply( this, args ) );
+	};
+	Spinner.prototype.start = function ( this: Spinner, ...args: Parameters< Spinner[ 'start' ] > ) {
+		return withStdoutAsStderr( () => originalStart.apply( this, args ) );
+	};
+	Spinner.prototype.stop = function ( this: Spinner, ...args: Parameters< Spinner[ 'stop' ] > ) {
+		return withStdoutAsStderr( () => originalStop.apply( this, args ) );
+	};
 }
 
 redirectPicospinnerToStderr();

--- a/apps/cli/lib/picospinner-stderr-patch.ts
+++ b/apps/cli/lib/picospinner-stderr-patch.ts
@@ -1,14 +1,13 @@
-import { renderer } from 'picospinner';
+import { Spinner } from 'picospinner';
 
 /**
  * picospinner renders to stdout with no option to change the stream. Several CLI
  * commands emit machine-readable JSON on stdout (e.g. `site list --format=json`),
  * so mixing spinner frames into stdout breaks consumers like `| jq`.
  *
- * Wrap the renderer's two write-emitting methods so any `process.stdout.write`
- * calls they make are rerouted to stderr for the duration of the call. This
- * avoids duplicating picospinner internals and survives upstream changes as
- * long as `render` and `onComponentFinish` remain the only write paths.
+ * Wrap Spinner methods that render output so any `process.stdout.write` calls
+ * they make are rerouted to stderr for the duration of the call. This avoids
+ * duplicating picospinner internals or patching the private renderer.
  */
 
 function redirectPicospinnerToStderr(): void {

--- a/apps/cli/lib/picospinner-stderr-patch.ts
+++ b/apps/cli/lib/picospinner-stderr-patch.ts
@@ -16,7 +16,7 @@ type PatchableRenderer = {
 };
 
 function redirectPicospinnerToStderr(): void {
-	const r = renderer as Partial< PatchableRenderer > | undefined;
+	const r = renderer as unknown as Partial< PatchableRenderer > | undefined;
 	if ( ! r || typeof r.render !== 'function' || typeof r.onComponentFinish !== 'function' ) {
 		return;
 	}

--- a/apps/cli/lib/picospinner-stderr-patch.ts
+++ b/apps/cli/lib/picospinner-stderr-patch.ts
@@ -1,0 +1,43 @@
+import { renderer } from 'picospinner';
+
+/**
+ * picospinner renders to stdout with no option to change the stream. Several CLI
+ * commands emit machine-readable JSON on stdout (e.g. `site list --format=json`),
+ * so mixing spinner frames into stdout breaks consumers like `| jq`.
+ *
+ * Wrap the renderer's two write-emitting methods so any `process.stdout.write`
+ * calls they make are rerouted to stderr for the duration of the call. This
+ * avoids duplicating picospinner internals and survives upstream changes as
+ * long as `render` and `onComponentFinish` remain the only write paths.
+ */
+type PatchableRenderer = {
+	render: () => void;
+	onComponentFinish: () => void;
+};
+
+function redirectPicospinnerToStderr(): void {
+	const r = renderer as Partial< PatchableRenderer > | undefined;
+	if ( ! r || typeof r.render !== 'function' || typeof r.onComponentFinish !== 'function' ) {
+		return;
+	}
+
+	const withStdoutAsStderr = < T >( fn: () => T ): T => {
+		const originalWrite = process.stdout.write.bind( process.stdout );
+		process.stdout.write = process.stderr.write.bind(
+			process.stderr
+		) as typeof process.stdout.write;
+		try {
+			return fn();
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+	};
+
+	const originalRender = r.render.bind( r );
+	const originalOnComponentFinish = r.onComponentFinish.bind( r );
+
+	r.render = () => withStdoutAsStderr( originalRender );
+	r.onComponentFinish = () => withStdoutAsStderr( originalOnComponentFinish );
+}
+
+redirectPicospinnerToStderr();

--- a/apps/cli/logger.ts
+++ b/apps/cli/logger.ts
@@ -1,3 +1,4 @@
+import 'cli/lib/picospinner-stderr-patch';
 import { Spinner } from 'picospinner';
 
 const isIpcMode = Boolean( process.send );


### PR DESCRIPTION
## Related issues
Fixes STU-1637
Related to #3035 (ora → picospinner swap that introduced the regression)

## How AI was used in this PR

Assisted with investigation and writing code. We had a few iterations, I thoroughly reviewed and tested it.

## Proposed Changes

`ora` writes to stderr by default. `picospinner` hard-codes `process.stdout.write(...)` inside its `Renderer` and exposes no option to change the stream. As a result, shipping wp-studio@1.7.9 started emitting spinner frames on stdout, alongside the JSON payload of commands like `site list --format=json` — breaking `| jq` and any scripted consumer.

## Testing Instructions
1. `npm run cli:build`
2. `node apps/cli/dist/cli/main.mjs site list --format=json | jq`
3. Assert that you don't see errors (previously you would get `jq: parse error: Invalid numeric literal at line 1, column 3`)
4. `node apps/cli/dist/cli/main.mjs site list`
5. Assert that still works well