### PR TITLE
CLI: emit [] on stdout when site list --format=json finds no sites

### DIFF
--- a/apps/cli/commands/site/list.ts
+++ b/apps/cli/commands/site/list.ts
@@ -96,6 +96,9 @@ export async function runCommand( format: 'table' | 'json' ): Promise< void > {
 
 		if ( cliConfig.sites.length === 0 ) {
 			logger.reportSuccess( __( 'No sites found' ) );
+			if ( format === 'json' ) {
+				displaySiteList( { tableEntries: [], jsonEntries: [] }, format );
+			}
 			return;
 		}
 

--- a/apps/cli/commands/site/tests/list.test.ts
+++ b/apps/cli/commands/site/tests/list.test.ts
@@ -131,6 +131,15 @@ describe( 'CLI: studio site list', () => {
 			expect( disconnectFromDaemon ).toHaveBeenCalled();
 		} );
 
+		it( 'should output empty json array when no sites found', async () => {
+			vi.mocked( readCliConfig ).mockResolvedValue( emptyCliConfig );
+
+			await runCommand( 'json' );
+
+			expect( mockReportKeyValuePair ).toHaveBeenCalledWith( 'sites', '[]' );
+			expect( disconnectFromDaemon ).toHaveBeenCalled();
+		} );
+
 		it( 'should handle custom domain in site URL', async () => {
 			await runCommand( 'json' );
 


### PR DESCRIPTION
## How AI was used in this PR

Claude wrote the fix and the corresponding test. I reviewed and tested locally.

## Proposed Changes

NIT: `studio site list --format=json` returned early with no stdout output when zero sites were configured, so a scripted consumer received empty input and errored trying to parse it. Now the command emits `[]`, matching the contract of the non-empty case.

## Testing Instructions
0. Visual review should suffice, but:
1. `npm run cli:build`
2. Remove all sites
3. `node apps/cli/dist/cli/main.mjs site list --format=json`
4. Assert that you see an empty array - `[]`
5. `node apps/cli/dist/cli/main.mjs site list`
6. Assert that no regressions and you still see only `✔ No sites found`