### PR TITLE
Add site preview drawer to session view

### DIFF
--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -1,14 +1,16 @@
 import { resolveSessionModel } from '@studio/common/ai/models';
 import { useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
-import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Composer } from '@/components/session-view/composer';
 import { pickLiveSite } from '@/components/session-view/composer/environment-pill';
 import { Conversation } from '@/components/session-view/conversation';
 import { EmptyBackground } from '@/components/session-view/empty-background';
 import { QueuedPrompts } from '@/components/session-view/queued-prompts';
 import { SiteDropdown } from '@/components/site-dropdown';
+import { SitePreview } from '@/components/site-preview';
 import { useConnector } from '@/data/core';
 import { useAgentRun } from '@/data/queries/use-agent-run';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
@@ -20,10 +22,23 @@ import {
 import { useSites } from '@/data/queries/use-sites';
 import { useFullscreen } from '@/hooks/use-fullscreen';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
+import { drawerIcon } from '@/lib/icons';
 import styles from './style.module.css';
 import type { AiModelId, AiSessionSummary, LoadedAiSession } from '@/data/core';
 
-function SessionHeader( { summary }: { summary: AiSessionSummary } ) {
+interface SessionHeaderProps {
+	summary: AiSessionSummary;
+	previewOpen: boolean;
+	onTogglePreview: () => void;
+	canTogglePreview: boolean;
+}
+
+function SessionHeader( {
+	summary,
+	previewOpen,
+	onTogglePreview,
+	canTogglePreview,
+}: SessionHeaderProps ) {
 	const siteName = summary.ownerSiteName;
 	const sidebarCollapsed = useSidebarCollapsed();
 	const isFullscreen = useFullscreen();
@@ -54,6 +69,20 @@ function SessionHeader( { summary }: { summary: AiSessionSummary } ) {
 					</span>
 				</>
 			) }
+			<span className={ styles.headerSpacer } aria-hidden="true" />
+			{ canTogglePreview ? (
+				<div className={ styles.headerActions }>
+					<IconButton
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						icon={ drawerIcon }
+						label={ previewOpen ? __( 'Hide site preview' ) : __( 'Show site preview' ) }
+						aria-pressed={ previewOpen }
+						onClick={ onTogglePreview }
+					/>
+				</div>
+			) : null }
 		</div>
 	);
 }
@@ -119,6 +148,9 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 		[ data?.events ]
 	);
 	const scrollRef = useRef< HTMLDivElement >( null );
+	const [ previewOpen, setPreviewOpen ] = useState( false );
+	const canTogglePreview = !! ownerSite && effectiveEnvironment === 'local';
+	const showPreview = previewOpen && canTogglePreview;
 
 	useLayoutEffect( () => {
 		const node = scrollRef.current;
@@ -147,37 +179,45 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 
 	return (
 		<div className={ styles.root }>
-			<SessionHeader summary={ data.summary } />
-			<div ref={ scrollRef } className={ styles.scroll }>
-				{ isEmpty ? <EmptyBackground /> : null }
-				<div className={ clsx( styles.column, styles.conversationSpacing ) }>
-					<Conversation
-						data={ data }
-						isRunning={ isRunning }
-						startedAt={ startedAt }
-						pendingQuestions={ pendingQuestionTexts }
-						pendingAnswers={ pendingAnswers }
-						onAnswerQuestion={ answerQuestion }
-					/>
+			<div className={ styles.chatColumn }>
+				<SessionHeader
+					summary={ data.summary }
+					previewOpen={ showPreview }
+					onTogglePreview={ () => setPreviewOpen( ( open ) => ! open ) }
+					canTogglePreview={ canTogglePreview }
+				/>
+				<div ref={ scrollRef } className={ styles.scroll }>
+					{ isEmpty ? <EmptyBackground /> : null }
+					<div className={ clsx( styles.column, styles.conversationSpacing ) }>
+						<Conversation
+							data={ data }
+							isRunning={ isRunning }
+							startedAt={ startedAt }
+							pendingQuestions={ pendingQuestionTexts }
+							pendingAnswers={ pendingAnswers }
+							onAnswerQuestion={ answerQuestion }
+						/>
+					</div>
+				</div>
+				<div className={ styles.composerOuter }>
+					<div className={ styles.column }>
+						<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
+						<Composer
+							busy={ composerBusy }
+							isInterrupting={ isInterrupting }
+							error={ runError }
+							model={ currentModel }
+							onModelChange={ onModelChange }
+							onSend={ sendMessage }
+							onInterrupt={ interrupt }
+							sessionId={ sessionId }
+							effectiveEnvironment={ effectiveEnvironment }
+							liveSite={ liveSite }
+						/>
+					</div>
 				</div>
 			</div>
-			<div className={ styles.composerOuter }>
-				<div className={ styles.column }>
-					<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
-					<Composer
-						busy={ composerBusy }
-						isInterrupting={ isInterrupting }
-						error={ runError }
-						model={ currentModel }
-						onModelChange={ onModelChange }
-						onSend={ sendMessage }
-						onInterrupt={ interrupt }
-						sessionId={ sessionId }
-						effectiveEnvironment={ effectiveEnvironment }
-						liveSite={ liveSite }
-					/>
-				</div>
-			</div>
+			{ showPreview && ownerSite ? <SitePreview site={ ownerSite } /> : null }
 		</div>
 	);
 }

--- a/apps/ui/src/components/session-view/style.module.css
+++ b/apps/ui/src/components/session-view/style.module.css
@@ -1,7 +1,15 @@
 .root {
 	display: flex;
-	flex-direction: column;
+	flex-direction: row;
 	height: 100%;
+	min-height: 0;
+}
+
+.chatColumn {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-width: 0;
 	min-height: 0;
 }
 
@@ -59,6 +67,17 @@
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
+.headerSpacer {
+	flex: 1;
+}
+
+.headerActions {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-xs);
+	-webkit-app-region: no-drag;
+}
+
 .scroll {
 	flex: 1;
 	min-height: 0;
@@ -84,5 +103,5 @@
 }
 
 .composerOuter {
-	padding: 0 var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-xl);
+	padding: 0 calc(var(--wpds-dimension-padding-2xl) * 2) var(--wpds-dimension-padding-xl);
 }

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -1,0 +1,81 @@
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+import { IconButton } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import { useEffect, useState } from 'react';
+import { useConnector } from '@/data/core';
+import { getSiteUrl } from '@/lib/get-site-url';
+import styles from './style.module.css';
+import type { SiteDetails } from '@/data/core';
+
+interface SitePreviewProps {
+	site: SiteDetails;
+}
+
+// Isolated iframe + spinner so each URL change fully remounts the loading
+// state. The parent-level `useEffect` we tried before missed `load` events
+// that fired before React's effect scheduler caught up, leaving the spinner
+// stuck.
+function PreviewIframe( { src, title }: { src: string; title: string } ) {
+	const [ loading, setLoading ] = useState( true );
+
+	// Safety net: some iframes (e.g. blocked by X-Frame-Options in certain
+	// WP configs) never fire `load`. Hide the spinner after a few seconds
+	// so it doesn't spin forever.
+	useEffect( () => {
+		const timer = setTimeout( () => setLoading( false ), 8000 );
+		return () => clearTimeout( timer );
+	}, [] );
+
+	return (
+		<>
+			<iframe
+				className={ styles.iframe }
+				src={ src }
+				title={ title }
+				onLoad={ () => setLoading( false ) }
+			/>
+			{ loading ? (
+				<div className={ styles.spinnerOverlay } aria-hidden="true">
+					<span className={ styles.spinner } />
+				</div>
+			) : null }
+		</>
+	);
+}
+
+export function SitePreview( { site }: SitePreviewProps ) {
+	const connector = useConnector();
+	const siteUrl = getSiteUrl( site );
+	const canPreview = site.running;
+
+	return (
+		<aside className={ styles.root } aria-label={ __( 'Site preview' ) }>
+			<div className={ styles.header }>
+				<div className={ styles.trafficLights } aria-hidden="true">
+					<span className={ clsx( styles.trafficLight, styles.trafficLightActive ) } />
+					<span className={ styles.trafficLight } />
+					<span className={ styles.trafficLight } />
+				</div>
+				<span className={ styles.headerSpacer } aria-hidden="true" />
+				<span className={ styles.separator } aria-hidden="true" />
+				<IconButton
+					variant="minimal"
+					tone="neutral"
+					size="small"
+					icon={ external }
+					label={ __( 'Open site in browser' ) }
+					disabled={ ! canPreview }
+					onClick={ () => void connector.openExternalUrl( siteUrl ) }
+				/>
+			</div>
+			<div className={ styles.body }>
+				{ canPreview ? (
+					<PreviewIframe key={ siteUrl } src={ siteUrl } title={ site.name } />
+				) : (
+					<div className={ styles.empty }>{ __( 'Start the site to see a live preview.' ) }</div>
+				) }
+			</div>
+		</aside>
+	);
+}

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -1,0 +1,105 @@
+.root {
+	display: flex;
+	flex-direction: column;
+	width: 520px;
+	flex-shrink: 0;
+	min-height: 0;
+	margin: calc(var(--wpds-dimension-padding-md) * 2) calc(var(--wpds-dimension-padding-md) * 2)
+		calc(var(--wpds-dimension-padding-md) * 2) 0;
+	background-color: var(--wpds-color-bg-surface-neutral);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-dimension-radius-lg, 12px);
+	overflow: hidden;
+	box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-lg);
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-lg);
+	min-height: 32px;
+	flex-shrink: 0;
+	background-color: #fff;
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
+}
+
+.trafficLights {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+}
+
+.separator {
+	width: 1px;
+	height: 14px;
+	background-color: var(--wpds-color-stroke-surface-neutral);
+	opacity: 0.6;
+}
+
+.trafficLight {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background-color: var(--wpds-color-stroke-surface-neutral);
+}
+
+.trafficLightActive {
+	background-color: var(--wpds-color-fg-content-accent, #2563eb);
+}
+
+.headerSpacer {
+	flex: 1;
+}
+
+.body {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	position: relative;
+	background-color: #fff;
+}
+
+.spinnerOverlay {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	pointer-events: none;
+	background-color: rgba(255, 255, 255, 0.6);
+}
+
+.spinner {
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	border: 2px solid var(--wpds-color-stroke-surface-neutral);
+	border-top-color: var(--wpds-color-fg-content-accent, #2563eb);
+	animation: sitePreviewSpin 0.8s linear infinite;
+}
+
+@keyframes sitePreviewSpin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.iframe {
+	flex: 1;
+	width: 100%;
+	height: 100%;
+	border: 0;
+	background-color: #fff;
+}
+
+.empty {
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: var(--wpds-dimension-padding-xl);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-font-size-sm);
+	text-align: center;
+}


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Built iteratively with Claude Code — I drove the design (layout, padding, rounded card, decorative traffic lights, header separator, spinner) through a back-and-forth; Claude handled the code. I did not verify the change end-to-end in the running app, so reviewers should sanity-check the actual rendering in Studio.

## Proposed Changes

- New `SitePreview` component (`apps/ui/src/components/site-preview/`) — a floating rounded right-side pane with a window-style header (decorative traffic lights on the left, a faint separator and an "open in browser" button on the right) and an iframe body embedding `http://localhost:<port>`.
- Isolated `PreviewIframe` sub-component with its own `loading` state keyed by URL, so each URL change gets a clean spinner. 8 s safety timeout clears the spinner if `load` never fires (e.g. `X-Frame-Options` blocks framing).
- `SessionView` gets a drawer toggle in its header (same `drawerIcon` as the sidebar toggle) and a horizontal split: chat column on the left, preview card on the right. Toggle is only shown when the session points at a local (non-live) environment — we can't iframe a remote WPCOM site.
- Composer horizontal padding bumped (`xl` → `2xl × 2`) so the chat column feels less cramped next to the preview card.

### Design notes

- Toggle state is local to `SessionView` (per-session, not persisted across restarts) — intentional for a first pass.
- The preview card: `2× md` margin top/right/bottom, flush on the left, `12px` radius, 12 %/6 % layered shadow, 1 px neutral border.
- Header: white background, 32 px min-height, `lg` horizontal padding with `lg` flex gap so the button-to-edge distance matches the separator-to-button distance; 14 px vertical separator (not full-height).
- Traffic lights are decorative (7 px circles); the first one uses `--wpds-color-fg-content-accent`.

## Testing Instructions

1. `npm start` to launch Studio.
2. Open an existing session that owns a local site (or create one).
3. Click the drawer icon at the top-right of the session header — the site preview pane slides in on the right.
4. Verify the subtle spinner appears while the iframe loads, and disappears once the site renders.
5. Click the external-link icon in the preview header — the site should open in the system browser.
6. Toggle the drawer off/on again; stop and start the site server and verify the placeholder ("Start the site to see a live preview.") shows when the site isn't running.
7. Switch the session environment to "Live" (if a connected site is available) — the drawer toggle should disappear.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)