### PR TITLE
apps/ui: migrate to @wordpress/theme 0.11 token names

### DIFF
--- a/apps/ui/src/components/blueprint-selector/style.module.css
+++ b/apps/ui/src/components/blueprint-selector/style.module.css
@@ -18,7 +18,7 @@
 
 .featuredHint {
 	margin: 0;
-	color: var(--wpds-color-text-secondary, #666);
+	color: var(--wpds-color-fg-content-neutral-weak, #666);
 	font-size: 0.875rem;
 }
 
@@ -48,9 +48,9 @@
 	flex-direction: column;
 	width: 100%;
 	padding: 0;
-	border: 1px solid var(--wpds-color-border, #ddd);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral, #ddd);
 	border-radius: 8px;
-	background: var(--wpds-color-surface, #fff);
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 	cursor: pointer;
 	overflow: hidden;
 	text-align: left;
@@ -58,7 +58,7 @@
 }
 
 .card:hover {
-	border-color: var(--wpds-color-border-hover, #bbb);
+	border-color: var(--wpds-color-stroke-interactive-neutral, #bbb);
 }
 
 .previewButton {
@@ -93,7 +93,7 @@
 
 .cardExcerpt {
 	margin: 0;
-	color: var(--wpds-color-text-secondary, #666);
+	color: var(--wpds-color-fg-content-neutral-weak, #666);
 	font-size: 0.8125rem;
 	line-height: 1.4;
 	display: -webkit-box;

--- a/apps/ui/src/components/file-dropzone/style.module.css
+++ b/apps/ui/src/components/file-dropzone/style.module.css
@@ -11,16 +11,16 @@
 	justify-content: center;
 	gap: 8px;
 	padding: 32px 16px;
-	border: 1px dashed var(--wpds-color-border, #ccc);
+	border: 1px dashed var(--wpds-color-stroke-surface-neutral, #ccc);
 	border-radius: 8px;
-	background: var(--wpds-color-surface, #fff);
-	color: var(--wpds-color-text-secondary, #555);
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+	color: var(--wpds-color-fg-content-neutral-weak, #555);
 	text-align: center;
 }
 
 .dropzoneActive {
-	border-color: var(--wpds-color-border-hover, #888);
-	background: var(--wpds-color-surface-hover, #f7f7f7);
+	border-color: var(--wpds-color-stroke-interactive-neutral, #888);
+	background: var(--wpds-color-bg-interactive-neutral-weak-active, #f7f7f7);
 }
 
 .prompt {
@@ -31,7 +31,7 @@
 	margin: 0;
 	font-size: 15px;
 	font-weight: 500;
-	color: var(--wpds-color-text, #1e1e1e);
+	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 }
 
 .fileMeta {
@@ -39,7 +39,7 @@
 	align-items: center;
 	gap: 12px;
 	font-size: 13px;
-	color: var(--wpds-color-text-secondary, #666);
+	color: var(--wpds-color-fg-content-neutral-weak, #666);
 }
 
 .fileInput {

--- a/apps/ui/src/components/learn-more/style.module.css
+++ b/apps/ui/src/components/learn-more/style.module.css
@@ -3,7 +3,7 @@
 	border: none;
 	padding: 0;
 	font: inherit;
-	color: var(--wpds-color-text-link, #0075ff);
+	color: var(--wpds-color-fg-interactive-brand, #0075ff);
 	text-decoration: underline;
 	cursor: pointer;
 }

--- a/apps/ui/src/components/markdown/style.module.css
+++ b/apps/ui/src/components/markdown/style.module.css
@@ -1,6 +1,6 @@
 .root {
 	color: var(--wpds-color-fg-content-neutral);
-	font-size: var(--wpds-font-size-md);
+	font-size: var(--wpds-typography-font-size-md);
 	line-height: 1.65;
 	/* Subtle opentype improvements — lining numerals in tables, contextual
 	   alternates in prose. Falls back silently on fonts that don't support them. */
@@ -97,7 +97,7 @@
 }
 
 .a {
-	color: var(--wpds-color-fg-content-accent, #2563eb);
+	color: var(--wpds-color-fg-interactive-brand, #2563eb);
 	font-weight: 500;
 	text-decoration: underline;
 	text-decoration-thickness: 1px;
@@ -138,7 +138,7 @@
 	padding: 0.1em 0.35em;
 	border-radius: 4px;
 	background-color: var(--wpds-color-bg-surface-neutral-weak);
-	font-family: var(--wpds-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
 	font-size: 0.875em;
 	color: var(--wpds-color-fg-content-neutral);
 	/* Discourage code from breaking awkwardly across lines. */
@@ -150,7 +150,7 @@
 	padding: 0.875em 1em;
 	border-radius: var(--wpds-border-radius-md, 8px);
 	background-color: var(--wpds-color-bg-surface-neutral-weak);
-	font-family: var(--wpds-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
 	font-size: 0.85em;
 	line-height: 1.55;
 	overflow-x: auto;

--- a/apps/ui/src/components/menu/style.module.css
+++ b/apps/ui/src/components/menu/style.module.css
@@ -30,8 +30,8 @@
 	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
 	border-radius: var(--wpds-border-radius-sm);
 	color: var(--wpds-color-fg-content-neutral);
-	font-size: var(--wpds-font-size-sm);
-	line-height: var(--wpds-font-line-height-sm);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
 	cursor: var(--wpds-cursor-control);
 	outline: none;
 	user-select: none;

--- a/apps/ui/src/components/session-view/composer/style.module.css
+++ b/apps/ui/src/components/session-view/composer/style.module.css
@@ -15,7 +15,7 @@
 }
 
 .shell:focus-within {
-	border-color: var(--wpds-color-fg-content-accent, #2563eb);
+	border-color: var(--wpds-color-fg-interactive-brand, #2563eb);
 	box-shadow: 0 1px 2px rgb(0 0 0 / 6%), 0 6px 16px rgb(0 0 0 / 8%);
 }
 
@@ -25,7 +25,7 @@
 	border: 0;
 	background: transparent;
 	color: var(--wpds-color-fg-content-neutral);
-	font-size: var(--wpds-font-size-md);
+	font-size: var(--wpds-typography-font-size-md);
 	line-height: 1.5;
 	width: 100%;
 	resize: none;
@@ -99,7 +99,7 @@
 	background-color: transparent;
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font: inherit;
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	cursor: pointer;
 }
 
@@ -143,7 +143,7 @@
 }
 
 .sendButton {
-	background-color: var(--wpds-color-fg-content-accent, #2563eb);
+	background-color: var(--wpds-color-fg-interactive-brand, #2563eb);
 	color: #fff;
 }
 
@@ -197,7 +197,7 @@
 	margin-top: var(--wpds-dimension-padding-sm);
 	padding: 0 var(--wpds-dimension-padding-xs);
 	min-height: 16px;
-	font-size: var(--wpds-font-size-xs);
+	font-size: var(--wpds-typography-font-size-xs);
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
@@ -213,5 +213,5 @@
 
 .error {
 	color: var(--wpds-color-fg-content-error, #dc2626);
-	font-size: var(--wpds-font-size-xs);
+	font-size: var(--wpds-typography-font-size-xs);
 }

--- a/apps/ui/src/components/session-view/conversation/style.module.css
+++ b/apps/ui/src/components/session-view/conversation/style.module.css
@@ -19,12 +19,12 @@
 .userText {
 	align-self: flex-end;
 	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
-	background-color: color-mix(in srgb, var(--wpds-color-fg-content-accent, #2563eb) 10%, transparent);
+	background-color: color-mix(in srgb, var(--wpds-color-fg-interactive-brand, #2563eb) 10%, transparent);
 	/* Bottom-right tight so the bubble reads as originating from the user
 	   on the right; other corners round generously. */
 	border-radius: 18px 18px var(--wpds-border-radius-md, 8px) 18px;
 	max-width: 80%;
-	font-size: var(--wpds-font-size-md);
+	font-size: var(--wpds-typography-font-size-md);
 	line-height: 1.55;
 	color: var(--wpds-color-fg-content-neutral);
 	white-space: pre-wrap;
@@ -41,8 +41,8 @@
 	display: flex;
 	align-items: baseline;
 	gap: var(--wpds-dimension-padding-sm);
-	font-family: var(--wpds-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-	font-size: var(--wpds-font-size-sm);
+	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	font-size: var(--wpds-typography-font-size-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	padding: 2px 0;
 	min-width: 0;
@@ -60,8 +60,8 @@
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
 	border-left: 2px solid var(--wpds-color-stroke-surface-neutral);
 	color: var(--wpds-color-fg-content-neutral);
-	font-family: var(--wpds-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-	font-size: var(--wpds-font-size-xs);
+	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	font-size: var(--wpds-typography-font-size-xs);
 	line-height: 1.5;
 	white-space: pre-wrap;
 	word-wrap: break-word;
@@ -83,9 +83,9 @@
 	background: none;
 	border: none;
 	padding: 0;
-	color: var(--wpds-color-fg-content-accent, #2563eb);
+	color: var(--wpds-color-fg-interactive-brand, #2563eb);
 	font: inherit;
-	font-size: var(--wpds-font-size-xs);
+	font-size: var(--wpds-typography-font-size-xs);
 	cursor: pointer;
 }
 
@@ -133,7 +133,7 @@
 	background: none;
 	border: none;
 	padding: 0;
-	color: var(--wpds-color-fg-content-accent, #2563eb);
+	color: var(--wpds-color-fg-interactive-brand, #2563eb);
 	font: inherit;
 	cursor: pointer;
 }
@@ -154,7 +154,7 @@
 .questionOptionPicked,
 .questionOptionPicked:disabled {
 	font-weight: 600;
-	color: var(--wpds-color-fg-content-accent, #2563eb);
+	color: var(--wpds-color-fg-interactive-brand, #2563eb);
 	opacity: 1;
 }
 
@@ -165,6 +165,6 @@
 	border-radius: 9999px;
 	background-color: var(--wpds-color-bg-surface-neutral-weak);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-font-size-xs);
+	font-size: var(--wpds-typography-font-size-xs);
 	text-align: center;
 }

--- a/apps/ui/src/components/session-view/queued-prompts/style.module.css
+++ b/apps/ui/src/components/session-view/queued-prompts/style.module.css
@@ -15,11 +15,11 @@
 	/* Match the user bubble shape but lighter so staged follow-ups read as
 	   "drafted, not sent". Mirrors `.userText` (right-aligned, bottom-right
 	   tight corner). */
-	background-color: color-mix(in srgb, var(--wpds-color-fg-content-accent, #2563eb) 4%, transparent);
-	border: 1px dashed color-mix(in srgb, var(--wpds-color-fg-content-accent, #2563eb) 30%, transparent);
+	background-color: color-mix(in srgb, var(--wpds-color-fg-interactive-brand, #2563eb) 4%, transparent);
+	border: 1px dashed color-mix(in srgb, var(--wpds-color-fg-interactive-brand, #2563eb) 30%, transparent);
 	border-radius: 18px 18px var(--wpds-border-radius-md, 8px) 18px;
 	max-width: 80%;
-	font-size: var(--wpds-font-size-md);
+	font-size: var(--wpds-typography-font-size-md);
 	line-height: 1.55;
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
@@ -56,6 +56,6 @@
 
 .remove:hover,
 .remove:focus-visible {
-	background-color: color-mix(in srgb, var(--wpds-color-fg-content-accent, #2563eb) 12%, transparent);
+	background-color: color-mix(in srgb, var(--wpds-color-fg-interactive-brand, #2563eb) 12%, transparent);
 	color: var(--wpds-color-fg-content-neutral);
 }

--- a/apps/ui/src/components/session-view/style.module.css
+++ b/apps/ui/src/components/session-view/style.module.css
@@ -24,7 +24,7 @@
 	gap: var(--wpds-dimension-padding-sm);
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-2xl);
 	min-height: 46px;
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	color: var(--wpds-color-fg-content-neutral);
 	-webkit-app-region: drag;
 }

--- a/apps/ui/src/components/session-view/thinking-indicator/style.module.css
+++ b/apps/ui/src/components/session-view/thinking-indicator/style.module.css
@@ -3,7 +3,7 @@
 	flex-direction: column;
 	gap: 2px;
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	/* Reserves space so mounting / unmounting the inner content doesn't
 	   shift the surrounding layout. Holds ~one head line + one progress line. */
 	min-height: calc(1.5em * 2 + 2px);
@@ -19,7 +19,7 @@
 	width: 8px;
 	height: 8px;
 	border-radius: 50%;
-	background-color: var(--wpds-color-fg-content-accent, #2563eb);
+	background-color: var(--wpds-color-fg-interactive-brand, #2563eb);
 	animation: pulse 1.2s ease-in-out infinite;
 	flex-shrink: 0;
 }

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -16,7 +16,7 @@
 	gap: var(--wpds-dimension-padding-sm);
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-2xl);
 	min-height: 46px;
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	color: var(--wpds-color-fg-content-neutral);
 	-webkit-app-region: drag;
 }

--- a/apps/ui/src/components/sidebar-header/style.module.css
+++ b/apps/ui/src/components/sidebar-header/style.module.css
@@ -32,7 +32,7 @@
 .title {
 	flex: 1;
 	min-width: 0;
-	font-size: var(--wpds-font-size-md);
+	font-size: var(--wpds-typography-font-size-md);
 	font-weight: 600;
 	color: var(--wpds-color-fg-content-neutral);
 	overflow: hidden;

--- a/apps/ui/src/components/sidebar-nav/style.module.css
+++ b/apps/ui/src/components/sidebar-nav/style.module.css
@@ -25,8 +25,8 @@
 	width: 100%;
 	padding: 0 var(--wpds-dimension-padding-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-font-size-md);
-	font-weight: var(--wpds-font-weight-regular);
+	font-size: var(--wpds-typography-font-size-md);
+	font-weight: var(--wpds-typography-font-weight-regular);
 }
 
 .item:hover,
@@ -36,5 +36,5 @@
 
 .itemActive {
 	color: var(--wpds-color-fg-content-neutral);
-	font-weight: var(--wpds-font-weight-medium);
+	font-weight: var(--wpds-typography-font-weight-medium);
 }

--- a/apps/ui/src/components/site-dropdown/disconnect-site-dialog.module.css
+++ b/apps/ui/src/components/site-dropdown/disconnect-site-dialog.module.css
@@ -1,13 +1,13 @@
 .dialogText {
 	margin: 0;
-	font-size: var(--wpds-font-size-sm);
-	line-height: var(--wpds-font-line-height-sm);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
 .dialogError {
 	margin-top: var(--wpds-dimension-padding-sm);
-	font-size: var(--wpds-font-size-sm);
-	line-height: var(--wpds-font-line-height-sm);
-	color: var(--wpds-color-fg-content-critical, var(--wpds-color-fg-content-neutral));
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+	color: var(--wpds-color-fg-content-error, var(--wpds-color-fg-content-neutral));
 }

--- a/apps/ui/src/components/site-dropdown/dropdown-trigger.module.css
+++ b/apps/ui/src/components/site-dropdown/dropdown-trigger.module.css
@@ -50,13 +50,13 @@
 
 .env {
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 }
 
 .url {
 	color: var(--wpds-color-fg-content-neutral-weak);
 	opacity: 0.6;
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/apps/ui/src/components/site-dropdown/popover-row.module.css
+++ b/apps/ui/src/components/site-dropdown/popover-row.module.css
@@ -22,7 +22,7 @@
 	display: flex;
 	align-items: center;
 	gap: var(--wpds-dimension-padding-xs);
-	font-size: var(--wpds-font-size-md);
+	font-size: var(--wpds-typography-font-size-md);
 	line-height: 1.25;
 	font-weight: 500;
 	color: var(--wpds-color-fg-content-neutral);
@@ -30,7 +30,7 @@
 
 .sublabel {
 	margin-top: 4px;
-	font-size: var(--wpds-font-size-xs);
+	font-size: var(--wpds-typography-font-size-xs);
 	line-height: 1.3;
 	color: var(--wpds-color-fg-content-neutral-weak);
 	overflow: hidden;
@@ -40,6 +40,6 @@
 
 .action {
 	flex-shrink: 0;
-	color: var(--wpds-color-fg-content-accent);
-	font-size: var(--wpds-font-size-sm);
+	color: var(--wpds-color-fg-interactive-brand);
+	font-size: var(--wpds-typography-font-size-sm);
 }

--- a/apps/ui/src/components/site-dropdown/publish-picker-view.module.css
+++ b/apps/ui/src/components/site-dropdown/publish-picker-view.module.css
@@ -9,11 +9,11 @@
 	align-items: center;
 	gap: var(--wpds-dimension-padding-sm);
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
-	border-bottom: 1px solid var(--wpds-color-stroke-neutral-weak);
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 }
 
 .title {
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	font-weight: 500;
 	color: var(--wpds-color-fg-content-neutral);
 }
@@ -26,7 +26,7 @@
 .status {
 	padding: var(--wpds-dimension-padding-lg);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	text-align: center;
 }
 
@@ -53,18 +53,18 @@
 
 .item:hover,
 .item:focus-visible {
-	background-color: var(--wpds-color-bg-surface-neutral-hover);
+	background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
 	outline: none;
 }
 
 .itemName {
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	font-weight: 500;
 	color: var(--wpds-color-fg-content-neutral);
 }
 
 .itemUrl {
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -79,17 +79,17 @@
 	width: 100%;
 	background: transparent;
 	border: none;
-	border-top: 1px solid var(--wpds-color-stroke-neutral-weak);
+	border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-lg);
 	cursor: pointer;
 	font: inherit;
-	font-size: var(--wpds-font-size-sm);
-	color: var(--wpds-color-fg-content-accent);
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-interactive-brand);
 	text-align: left;
 }
 
 .create:hover,
 .create:focus-visible {
-	background-color: var(--wpds-color-bg-surface-neutral-hover);
+	background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
 	outline: none;
 }

--- a/apps/ui/src/components/site-dropdown/sync-activity-indicator.module.css
+++ b/apps/ui/src/components/site-dropdown/sync-activity-indicator.module.css
@@ -46,12 +46,12 @@
 .errorPopup {
 	max-width: 320px;
 	padding: var(--wpds-dimension-padding-md);
-	background: var(--wpds-color-bg-surface-strong, #ffffff);
-	border: 1px solid var(--wpds-color-stroke-neutral-weak);
-	border-radius: var(--wpds-dimension-radius-md);
-	box-shadow: var(--wpds-shadow-elevation-md);
+	background: var(--wpds-color-bg-surface-neutral-strong, #ffffff);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
+	border-radius: var(--wpds-border-radius-md);
+	box-shadow: var(--wpds-elevation-md);
 	color: var(--wpds-color-fg-content-neutral);
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	line-height: 1.4;
 	display: flex;
 	flex-direction: column;

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -39,9 +39,9 @@
 }
 
 .siteName {
-	font-size: var(--wpds-font-size-md);
+	font-size: var(--wpds-typography-font-size-md);
 	line-height: 1.2;
-	font-weight: var(--wpds-font-weight-regular);
+	font-weight: var(--wpds-typography-font-weight-regular);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -55,7 +55,7 @@
 
 .siteActive .siteName {
 	color: var(--wpds-color-fg-content-neutral);
-	font-weight: var(--wpds-font-weight-medium);
+	font-weight: var(--wpds-typography-font-weight-medium);
 }
 
 .siteActions {
@@ -84,7 +84,7 @@
 .empty {
 	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	margin: 0;
 }
 
@@ -105,8 +105,8 @@
 	height: 26px;
 	padding: 0 var(--wpds-dimension-padding-md) 0 var(--wpds-dimension-padding-xl);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-font-size-sm);
-	font-weight: var(--wpds-font-weight-regular);
+	font-size: var(--wpds-typography-font-size-sm);
+	font-weight: var(--wpds-typography-font-weight-regular);
 }
 
 /* Use ::after so we don't collide with the Button primitive's ::before
@@ -151,8 +151,8 @@
 
 .dialogText {
 	margin: 0;
-	font-size: var(--wpds-font-size-sm);
-	line-height: var(--wpds-font-line-height-sm);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
@@ -161,15 +161,15 @@
 	align-items: center;
 	gap: var(--wpds-dimension-padding-sm);
 	margin-top: var(--wpds-dimension-padding-sm);
-	font-size: var(--wpds-font-size-sm);
-	line-height: var(--wpds-font-line-height-sm);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
 	color: var(--wpds-color-fg-content-neutral);
 	cursor: var(--wpds-cursor-control);
 }
 
 .dialogError {
 	margin-top: var(--wpds-dimension-padding-sm);
-	font-size: var(--wpds-font-size-sm);
-	line-height: var(--wpds-font-line-height-sm);
-	color: var(--wpds-color-fg-content-critical, var(--wpds-color-fg-content-neutral));
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+	color: var(--wpds-color-fg-content-error, var(--wpds-color-fg-content-neutral));
 }

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -8,7 +8,7 @@
 		calc(var(--wpds-dimension-padding-md) * 2) 0;
 	background-color: var(--wpds-color-bg-surface-neutral);
 	border: 1px solid var(--wpds-color-stroke-surface-neutral);
-	border-radius: var(--wpds-dimension-radius-lg, 12px);
+	border-radius: var(--wpds-border-radius-lg, 12px);
 	overflow: hidden;
 	box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
 }
@@ -45,7 +45,7 @@
 }
 
 .trafficLightActive {
-	background-color: var(--wpds-color-fg-content-accent, #2563eb);
+	background-color: var(--wpds-color-fg-interactive-brand, #2563eb);
 }
 
 .headerSpacer {
@@ -75,7 +75,7 @@
 	height: 20px;
 	border-radius: 50%;
 	border: 2px solid var(--wpds-color-stroke-surface-neutral);
-	border-top-color: var(--wpds-color-fg-content-accent, #2563eb);
+	border-top-color: var(--wpds-color-fg-interactive-brand, #2563eb);
 	animation: sitePreviewSpin 0.8s linear infinite;
 }
 
@@ -100,6 +100,6 @@
 	justify-content: center;
 	padding: var(--wpds-dimension-padding-xl);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	text-align: center;
 }

--- a/apps/ui/src/components/site-settings-view/style.module.css
+++ b/apps/ui/src/components/site-settings-view/style.module.css
@@ -16,7 +16,7 @@
 	gap: var(--wpds-dimension-padding-sm);
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-2xl);
 	min-height: 46px;
-	font-size: var(--wpds-font-size-sm);
+	font-size: var(--wpds-typography-font-size-sm);
 	color: var(--wpds-color-fg-content-neutral);
 	-webkit-app-region: drag;
 }

--- a/apps/ui/src/components/tabs/style.module.css
+++ b/apps/ui/src/components/tabs/style.module.css
@@ -32,7 +32,7 @@
 	padding-block: var(--wpds-dimension-padding-lg) !important;
 	height: auto !important;
 	flex: 0 0 auto;
-	font-size: var(--wpds-font-size-md);
+	font-size: var(--wpds-typography-font-size-md);
 	font-weight: 400;
 	color: var(--wpds-color-fg-content-neutral-weak);
 }

--- a/apps/ui/src/components/user-menu/style.module.css
+++ b/apps/ui/src/components/user-menu/style.module.css
@@ -31,7 +31,7 @@
 
 .userTrigger {
 	flex: 1;
-	font-weight: var(--wpds-font-weight-regular);
+	font-weight: var(--wpds-typography-font-weight-regular);
 }
 
 .userName {
@@ -51,7 +51,7 @@
 
 .email {
 	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
-	font-size: var(--wpds-font-size-xs);
+	font-size: var(--wpds-typography-font-size-xs);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -15,9 +15,9 @@
 body {
 	margin: 0;
 	padding: 0;
-	font-family: var(--wpds-font-family-body);
-	font-size: var(--wpds-font-size-md);
-	line-height: var(--wpds-font-line-height-md);
+	font-family: var(--wpds-typography-font-family-body);
+	font-size: var(--wpds-typography-font-size-md);
+	line-height: var(--wpds-typography-line-height-md);
 	background-color: var(--wpds-color-bg-surface-neutral);
 	color: var(--wpds-color-fg-content-neutral);
 	color-scheme: light dark;
@@ -35,40 +35,40 @@ h3,
 h4,
 h5,
 h6 {
-	font-family: var(--wpds-font-family-heading);
-	font-weight: var(--wpds-font-weight-regular);
+	font-family: var(--wpds-typography-font-family-heading);
+	font-weight: var(--wpds-typography-font-weight-regular);
 	color: var(--wpds-color-fg-content-neutral);
 	margin: 0;
 }
 
 h1 {
-	font-size: var(--wpds-font-size-2xl);
-	line-height: var(--wpds-font-line-height-2xl);
+	font-size: var(--wpds-typography-font-size-2xl);
+	line-height: var(--wpds-typography-line-height-2xl);
 }
 
 h2 {
-	font-size: var(--wpds-font-size-xl);
-	line-height: var(--wpds-font-line-height-xl);
+	font-size: var(--wpds-typography-font-size-xl);
+	line-height: var(--wpds-typography-line-height-xl);
 }
 
 h3 {
-	font-size: var(--wpds-font-size-lg);
-	line-height: var(--wpds-font-line-height-lg);
+	font-size: var(--wpds-typography-font-size-lg);
+	line-height: var(--wpds-typography-line-height-lg);
 }
 
 h4 {
-	font-size: var(--wpds-font-size-md);
-	line-height: var(--wpds-font-line-height-md);
+	font-size: var(--wpds-typography-font-size-md);
+	line-height: var(--wpds-typography-line-height-md);
 }
 
 h5 {
-	font-size: var(--wpds-font-size-sm);
-	line-height: var(--wpds-font-line-height-sm);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
 }
 
 h6 {
-	font-size: var(--wpds-font-size-xs);
-	line-height: var(--wpds-font-line-height-xs);
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
 }
 
 /* Interactive elements inside drag-region ancestors (title bars, section

--- a/apps/ui/src/router/layout-onboarding/style.module.css
+++ b/apps/ui/src/router/layout-onboarding/style.module.css
@@ -10,7 +10,7 @@
 }
 
 .subtitle {
-	color: var(--wpds-color-text-secondary, #666);
+	color: var(--wpds-color-fg-content-neutral-weak, #666);
 	margin: 0 0 32px;
 }
 
@@ -25,16 +25,16 @@
 	text-align: left;
 	padding: 24px;
 	width: 240px;
-	border: 1px solid var(--wpds-color-border, #ddd);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral, #ddd);
 	border-radius: 8px;
 	cursor: pointer;
 	color: inherit;
 	text-decoration: none;
-	background: var(--wpds-color-surface, #fff);
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 }
 
 .card:hover {
-	border-color: var(--wpds-color-border-hover, #bbb);
+	border-color: var(--wpds-color-stroke-interactive-neutral, #bbb);
 }
 
 .cardDisabled {
@@ -48,7 +48,7 @@
 }
 
 .cardBody {
-	color: var(--wpds-color-text-secondary, #666);
+	color: var(--wpds-color-fg-content-neutral-weak, #666);
 	font-size: 0.875rem;
 }
 
@@ -59,5 +59,5 @@
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
-	color: var(--wpds-color-text-secondary, #555);
+	color: var(--wpds-color-fg-content-neutral-weak, #555);
 }


### PR DESCRIPTION
## Related issues

- Related to #3223 (the Dependabot PR that bumped `@wordpress/theme` from 0.10.0 to 0.11.0)

## How AI was used in this PR

Claude Code performed the migration. For each stale token, I cross-referenced the new token list in `node_modules/@wordpress/theme/build-module/prebuilt/js/design-tokens.mjs` and the fallback values in `design-token-fallbacks.mjs`, matching visual intent rather than doing blind string replacement. Ambiguous tokens (`--wpds-color-border`, `--wpds-color-text`, `--wpds-color-surface-hover`, etc.) were mapped by comparing the old fallback values in-context to the new fallback values and picking the token that best matched the original intent.

## Proposed Changes

The 0.11 release of `@wordpress/theme` renamed a large number of design tokens. Its postcss plugin (`postcss-ds-token-fallbacks`) now throws `Unknown design token` on any unrecognized name, so `npm start` hard-fails until every reference is migrated.

This PR migrates every `var(--wpds-*)` reference in `apps/ui/src/**/*.css` to the new names. It is a **pure CSS migration** — no JS/TS files or configuration are touched.

**Mechanical renames** (apply uniformly to every size/variant suffix):

| Old prefix | New prefix |
| --- | --- |
| `--wpds-font-size-*` | `--wpds-typography-font-size-*` |
| `--wpds-font-family-*` | `--wpds-typography-font-family-*` |
| `--wpds-font-line-height-*` | `--wpds-typography-line-height-*` |
| `--wpds-font-weight-*` | `--wpds-typography-font-weight-*` |
| `--wpds-dimension-radius-*` | `--wpds-border-radius-*` |
| `--wpds-shadow-elevation-md` | `--wpds-elevation-md` |
| `--wpds-color-fg-content-critical` | `--wpds-color-fg-content-error` |
| `--wpds-color-stroke-neutral-weak` | `--wpds-color-stroke-surface-neutral-weak` |
| `--wpds-color-bg-surface-strong` | `--wpds-color-bg-surface-neutral-strong` |

**Ambiguous renames** (resolved by matching the old fallback value and usage intent):

| Old token (old fallback) | New token (new fallback) | Reasoning |
| --- | --- | --- |
| `--wpds-color-border` (#ccc/#ddd) | `--wpds-color-stroke-surface-neutral` (#dbdbdb) | Static decorative border |
| `--wpds-color-border-hover` (#888/#bbb) | `--wpds-color-stroke-interactive-neutral` (#8d8d8d) | Border on interactive hover |
| `--wpds-color-surface` (#fff) | `--wpds-color-bg-surface-neutral-strong` (#ffffff) | Static card/panel background |
| `--wpds-color-surface-hover` (#f7f7f7) | `--wpds-color-bg-interactive-neutral-weak-active` (#ededed) | Interactive hover background |
| `--wpds-color-bg-surface-neutral-hover` | `--wpds-color-bg-interactive-neutral-weak-active` (#ededed) | Same — row/menu hover |
| `--wpds-color-text` (#1e1e1e) | `--wpds-color-fg-content-neutral` (#1e1e1e) | Body text (exact match) |
| `--wpds-color-text-secondary` (#555/#666) | `--wpds-color-fg-content-neutral-weak` (#707070) | Secondary/muted text |
| `--wpds-color-text-link` (#0075ff) | `--wpds-color-fg-interactive-brand` (admin theme color) | Link color |
| `--wpds-color-fg-content-accent` (#2563eb) | `--wpds-color-fg-interactive-brand` (admin theme color) | Accent/brand color |

25 files changed in `apps/ui/src`.

## Testing Instructions

- [ ] `npm start` launches without any `[postcss] Unknown design token: ...` errors.
- [ ] Visually inspect surfaces that exercised the ambiguous tokens: file dropzone hover state, blueprint selector cards, site list rows, publish picker dropdown, thinking indicator / composer accent color, disconnect-site dialog critical color, onboarding layout cards, learn-more links, sync activity indicator badge (`--wpds-color-bg-surface-strong` → `--wpds-color-bg-surface-neutral-strong`).
- [ ] Hover states on file-dropzone, blueprint selector, onboarding cards, and publish-picker rows — should be subtly different from the resting background.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

---

Verified locally:
- `npm run build -w @studio/ui` produced `dist/assets/index-Cho0-sdX.css` (223KB) without postcss errors — this runs the same `dsTokenFallbacksPostcss` plugin the dev server uses.
- `npm run typecheck` passes.
- `npx eslint --fix` on the changed files is a no-op (CSS is not linted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)