### PR TITLE
Share the app.json reader between Studio and the CLI

### DIFF
--- a/apps/studio/src/storage/tests/user-data.test.ts
+++ b/apps/studio/src/storage/tests/user-data.test.ts
@@ -9,18 +9,22 @@ import { vi } from 'vitest';
 import { loadUserData, lockAppdata, unlockAppdata, saveUserData } from 'src/storage/user-data';
 import { UserData } from '../storage-types';
 
-const { getUserDataFilePathMock, getAppConfigLockFilePathMock } = vi.hoisted( () => {
-	return {
-		getUserDataFilePathMock: vi.fn().mockReturnValue( '/path/to/app/.studio/app.json' ),
-		getAppConfigLockFilePathMock: vi.fn().mockReturnValue( '/path/to/app/.studio/app.json.lock' ),
-	};
-} );
+const { getUserDataFilePathMock, getAppConfigPathMock, getAppConfigLockFilePathMock } = vi.hoisted(
+	() => {
+		return {
+			getUserDataFilePathMock: vi.fn().mockReturnValue( '/path/to/app/.studio/app.json' ),
+			getAppConfigPathMock: vi.fn().mockReturnValue( '/path/to/app/.studio/app.json' ),
+			getAppConfigLockFilePathMock: vi.fn().mockReturnValue( '/path/to/app/.studio/app.json.lock' ),
+		};
+	}
+);
 
 vi.mock( 'fs' );
 vi.mock( 'src/storage/paths', () => ( {
 	getUserDataFilePath: getUserDataFilePathMock,
 } ) );
-vi.mock( '@studio/common/lib/config-paths', () => ( {
+vi.mock( '@studio/common/lib/well-known-paths', () => ( {
+	getAppConfigPath: getAppConfigPathMock,
 	getAppConfigLockFilePath: getAppConfigLockFilePathMock,
 } ) );
 

--- a/apps/studio/src/storage/user-data.ts
+++ b/apps/studio/src/storage/user-data.ts
@@ -1,35 +1,31 @@
-import fs from 'fs';
-import nodePath from 'node:path';
 import * as Sentry from '@sentry/electron/main';
-import { LOCKFILE_STALE_TIME, LOCKFILE_WAIT_TIME } from '@studio/common/constants';
 import { isErrnoException } from '@studio/common/lib/is-errno-exception';
-import { lockFileAsync, unlockFileAsync } from '@studio/common/lib/lockfile';
-import { getAppConfigLockFilePath } from '@studio/common/lib/well-known-paths';
-import { readFile, writeFile } from 'atomically';
+import {
+	loadUserData as loadUserDataShared,
+	saveUserData as saveUserDataShared,
+	lockAppdata,
+	unlockAppdata,
+} from '@studio/common/lib/user-data';
 import { sanitizeUnstructuredData, sanitizeUserpath } from 'src/lib/sanitize-for-logging';
 import { getUserDataFilePath } from 'src/storage/paths';
 import { EMPTY_USER_DATA, type UserData, type WindowBounds } from 'src/storage/storage-types';
+
+export { lockAppdata, unlockAppdata };
 
 export async function loadUserData(): Promise< UserData > {
 	const filePath = getUserDataFilePath();
 
 	try {
-		const asString = await readFile( filePath, 'utf-8' );
-		try {
-			const parsed = JSON.parse( asString );
-			const { siteMetadata, ...data } = parsed;
-			return { ...data, version: 1, siteMetadata: siteMetadata ?? {} };
-		} catch ( err ) {
-			if ( err instanceof SyntaxError ) {
+		return await loadUserDataShared< UserData >( {
+			onInvalidJson: ( _err, fileContents ) => {
 				Sentry.addBreadcrumb( {
 					data: {
-						fileContents: sanitizeUnstructuredData( asString ),
+						fileContents: sanitizeUnstructuredData( fileContents ),
 						filePath: sanitizeUserpath( filePath ),
 					},
 				} );
-			}
-			throw err;
-		}
+			},
+		} );
 	} catch ( err ) {
 		if ( isErrnoException( err ) && err.code === 'ENOENT' ) {
 			return EMPTY_USER_DATA;
@@ -40,24 +36,8 @@ export async function loadUserData(): Promise< UserData > {
 }
 
 export async function saveUserData( data: UserData ): Promise< void > {
-	const filePath = getUserDataFilePath();
 	const persisted: UserData = { ...data };
-	const asString = JSON.stringify( persisted, null, 2 ) + '\n';
-	await writeFile( filePath, asString, 'utf-8' );
-}
-
-const LOCKFILE_PATH = getAppConfigLockFilePath();
-
-export async function lockAppdata() {
-	const dir = nodePath.dirname( LOCKFILE_PATH );
-	if ( ! fs.existsSync( dir ) ) {
-		fs.mkdirSync( dir, { recursive: true } );
-	}
-	return lockFileAsync( LOCKFILE_PATH, { stale: LOCKFILE_STALE_TIME, wait: LOCKFILE_WAIT_TIME } );
-}
-
-export async function unlockAppdata() {
-	return unlockFileAsync( LOCKFILE_PATH );
+	await saveUserDataShared( persisted );
 }
 
 type UserDataSafeKeys =

--- a/tools/common/lib/tests/user-data.test.ts
+++ b/tools/common/lib/tests/user-data.test.ts
@@ -1,0 +1,89 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+	loadUserData,
+	lockAppdata,
+	saveUserData,
+	unlockAppdata,
+} from '@studio/common/lib/user-data';
+import { getAppConfigPath } from '@studio/common/lib/well-known-paths';
+
+describe( 'user data', () => {
+	let configDirectory: string;
+
+	beforeEach( () => {
+		configDirectory = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-user-data-' ) );
+		process.env.DEV_CONFIG_DIR = configDirectory;
+	} );
+
+	afterEach( () => {
+		delete process.env.DEV_CONFIG_DIR;
+		fs.rmSync( configDirectory, { recursive: true, force: true } );
+	} );
+
+	it( 'returns defaults when app.json does not exist', async () => {
+		await expect( loadUserData() ).resolves.toEqual( {
+			version: 1,
+			siteMetadata: {},
+		} );
+	} );
+
+	it( 'normalizes version to 1 and defaults siteMetadata', async () => {
+		fs.writeFileSync(
+			getAppConfigPath(),
+			JSON.stringify( {
+				version: 42,
+				onboardingCompleted: true,
+			} )
+		);
+
+		await expect( loadUserData() ).resolves.toEqual( {
+			version: 1,
+			siteMetadata: {},
+			onboardingCompleted: true,
+		} );
+	} );
+
+	it( 'reads beta features from app.json', async () => {
+		fs.writeFileSync(
+			getAppConfigPath(),
+			JSON.stringify( {
+				version: 1,
+				siteMetadata: {},
+				betaFeatures: { pullReprint: true },
+			} )
+		);
+
+		const userData = await loadUserData();
+		expect( userData.betaFeatures?.pullReprint ).toBe( true );
+	} );
+
+	it( 'calls onInvalidJson and throws when app.json is malformed', async () => {
+		fs.writeFileSync( getAppConfigPath(), '{not json' );
+		const onInvalidJson = vi.fn();
+
+		await expect( loadUserData( { onInvalidJson } ) ).rejects.toThrow( SyntaxError );
+		expect( onInvalidJson ).toHaveBeenCalledOnce();
+		const [ err, fileContents, filePath ] = onInvalidJson.mock.calls[ 0 ];
+		expect( err ).toBeInstanceOf( SyntaxError );
+		expect( fileContents ).toBe( '{not json' );
+		expect( filePath ).toBe( getAppConfigPath() );
+	} );
+
+	it( 'round-trips data through saveUserData/loadUserData', async () => {
+		try {
+			await lockAppdata();
+			await saveUserData( {
+				version: 1,
+				siteMetadata: {},
+				betaFeatures: { pullReprint: true },
+			} );
+		} finally {
+			await unlockAppdata();
+		}
+
+		const userData = await loadUserData();
+		expect( userData.betaFeatures?.pullReprint ).toBe( true );
+	} );
+} );

--- a/tools/common/lib/user-data.ts
+++ b/tools/common/lib/user-data.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import nodePath from 'node:path';
+import { readFile, writeFile } from 'atomically';
+import { LOCKFILE_STALE_TIME, LOCKFILE_WAIT_TIME } from '../constants';
+import { isErrnoException } from './is-errno-exception';
+import { lockFileAsync, unlockFileAsync } from './lockfile';
+import { getAppConfigLockFilePath, getAppConfigPath } from './well-known-paths';
+
+export interface AppUserData {
+	version: 1;
+	siteMetadata: Record< string, unknown >;
+	betaFeatures?: Record< string, boolean >;
+	[ key: string ]: unknown;
+}
+
+export const EMPTY_APP_USER_DATA: AppUserData = {
+	version: 1,
+	siteMetadata: {},
+};
+
+export interface LoadUserDataOptions {
+	onInvalidJson?: ( error: SyntaxError, fileContents: string, filePath: string ) => void;
+}
+
+export async function loadUserData< T = AppUserData >(
+	options?: LoadUserDataOptions
+): Promise< T > {
+	const filePath = getAppConfigPath();
+
+	try {
+		const asString = await readFile( filePath, 'utf-8' );
+		try {
+			const parsed = JSON.parse( asString );
+			const { siteMetadata, ...data } = parsed;
+			return { ...data, version: 1, siteMetadata: siteMetadata ?? {} } as T;
+		} catch ( err ) {
+			if ( err instanceof SyntaxError ) {
+				options?.onInvalidJson?.( err, asString, filePath );
+			}
+			throw err;
+		}
+	} catch ( err ) {
+		if ( isErrnoException( err ) && err.code === 'ENOENT' ) {
+			return EMPTY_APP_USER_DATA as T;
+		}
+		throw err;
+	}
+}
+
+export async function saveUserData< T = AppUserData >( data: T ): Promise< void > {
+	const filePath = getAppConfigPath();
+	const asString = JSON.stringify( data, null, 2 ) + '\n';
+	await writeFile( filePath, asString, 'utf-8' );
+}
+
+const LOCKFILE_PATH = getAppConfigLockFilePath();
+
+export async function lockAppdata() {
+	const dir = nodePath.dirname( LOCKFILE_PATH );
+	if ( ! fs.existsSync( dir ) ) {
+		fs.mkdirSync( dir, { recursive: true } );
+	}
+	return lockFileAsync( LOCKFILE_PATH, { stale: LOCKFILE_STALE_TIME, wait: LOCKFILE_WAIT_TIME } );
+}
+
+export async function unlockAppdata() {
+	return unlockFileAsync( LOCKFILE_PATH );
+}


### PR DESCRIPTION
## Related issues

Unblocks #2939 (gating `studio pull-reprint` behind a beta flag read from `~/.studio/app.json`).

## Proposed Changes

Studio's desktop process owns `~/.studio/app.json` — site metadata, window bounds, beta feature toggles, etc. — via `loadUserData()` / `saveUserData()` in `apps/studio/src/storage/user-data.ts`. That module imports `@sentry/electron/main` to attach breadcrumbs on parse failures, which means anything outside Electron's main process (like the CLI) can't reuse it.

When the CLI needs to read the same file — for example, to check a beta flag set from the desktop app — the options are (a) duplicate the reader, (b) drop Electron/Sentry entirely, or (c) split the module.

This PR does (c): lifts the plain JSON read/write into `tools/common/lib/user-data.ts` and turns `apps/studio/src/storage/user-data.ts` into a thin wrapper that:
- re-exports `lockAppdata` / `unlockAppdata` from the shared module,
- keeps the typed `UserData` return,
- injects the Sentry breadcrumb through a new `onInvalidJson` callback the shared reader exposes.

No behavior change for Studio — same file path, same locking, same ENOENT defaults, same breadcrumbs. The CLI can now do `(await loadUserData()).betaFeatures?.pullReprint` from `@studio/common/lib/user-data` without pulling Electron into `tools/common`.

## Testing Instructions

- `npm run typecheck`
- `npx vitest run apps/studio/src/storage/tests/user-data.test.ts tools/common/lib/tests/user-data.test.ts` — 9 tests covering the existing desktop behavior plus a new integration test suite in `tools/common` (defaults on missing file, version normalization, beta features round-trip, `onInvalidJson` callback on malformed JSON, save/load round-trip).
- Launch the desktop app and confirm `~/.studio/app.json` is still read/written normally (create a site, toggle a setting, relaunch).

## Pre-merge Checklist

- [x] Tests added / updated
- [x] Typecheck clean (pre-existing `ignore` package errors unrelated to this change)
- [x] No behavior change for Studio
- [ ] Reviewed by @wojtekn and @sejas