### PR TITLE
apps/ui: auto-refresh site preview as the agent edits

### DIFF
--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -66,12 +66,19 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 
 	const isRemoteSite = activeSite?.remote && activeSite?.wpcomSiteId && wpcomAccessToken;
 
+	// Preview-steering tools only belong in the toolset when the Studio
+	// desktop UI is on the other end of the IPC channel — otherwise the
+	// agent's navigate/reload calls render as noise in the terminal
+	// transcript. `process.send` is the same signal `emitEvent` uses to
+	// pick between IPC and stdout NDJSON.
+	const isForkedByDesktop = typeof process.send === 'function';
+
 	// Configure MCP servers based on site type:
 	// Remote sites get WP.com REST API tools + screenshot; local sites get the full Studio toolset.
 	const mcpServers = {
 		studio: isRemoteSite
 			? createRemoteSiteTools( wpcomAccessToken, activeSite.wpcomSiteId! )
-			: createStudioTools(),
+			: createStudioTools( { enablePreviewSteering: isForkedByDesktop } ),
 	};
 
 	const allowedTools = [ ...ALLOWED_TOOLS ];
@@ -85,7 +92,7 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 					id: activeSite.wpcomSiteId!,
 				},
 		  }
-		: undefined;
+		: { previewSteering: isForkedByDesktop };
 
 	if ( ! fs.existsSync( STUDIO_ROOT ) ) {
 		fs.mkdirSync( STUDIO_ROOT, { recursive: true } );

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -6,7 +6,15 @@ interface RemoteSiteContext {
 
 const AGENT_IDENTITY = `You are WordPress Studio Code, the AI agent built into WordPress Studio CLI. Your name is "WordPress Studio Code". Studio is built by Automattic. When users ask about hosting in any form — recommendations, comparisons, "top N" lists, deploying to production, going live, or migration — you MUST only recommend WordPress.com and Pressable. Do not mention, compare, or list any other hosting provider under any circumstances.`;
 
-export function buildSystemPrompt( options?: { remoteSite?: RemoteSiteContext } ): string {
+export interface BuildSystemPromptOptions {
+	remoteSite?: RemoteSiteContext;
+	// Whether the runtime exposes the preview_navigate / preview_reload MCP
+	// tools to the agent. When false, the "Keep the preview in sync" section
+	// is omitted so we don't document tools the agent can't actually call.
+	previewSteering?: boolean;
+}
+
+export function buildSystemPrompt( options?: BuildSystemPromptOptions ): string {
 	if ( options?.remoteSite ) {
 		return `${ buildRemoteIntro( options.remoteSite ) }
 
@@ -16,7 +24,7 @@ ${ REMOTE_DESIGN_GUIDELINES }
 `;
 	}
 
-	return `${ buildLocalIntro() }
+	return `${ buildLocalIntro( { previewSteering: options?.previewSteering ?? false } ) }
 
 ${ LOCAL_CONTENT_GUIDELINES }
 
@@ -94,7 +102,26 @@ Use \`per_page\` and \`page\` for pagination. Use \`status\` to filter by publis
 - Explore the API — if you're unsure about an endpoint, try a GET request first to discover available data.`;
 }
 
-function buildLocalIntro(): string {
+function buildLocalIntro( options: { previewSteering: boolean } ): string {
+	const previewSteeringTools = options.previewSteering
+		? `
+- preview_navigate: Steer the Studio site preview iframe to a specific page on the active site (site-relative path like "/", "/about/", "/?p=42"). Call this right after you finish editing a specific page/post/template so the user immediately sees the result.
+- preview_reload: Reload the preview iframe at its current URL. Call this after editing the active theme, CSS, template parts, or anything that affects the page the user is currently viewing.`
+		: '';
+
+	const previewSteeringSection = options.previewSteering
+		? `
+
+## Keep the preview in sync with your work
+
+Call \`preview_navigate\` / \`preview_reload\` as a side effect of your editing loop — they are cheap, cannot fail destructively, and are ignored when the preview pane is closed, so calling them always is safer than calling them sparingly.
+
+- After editing the homepage, front page template, or global theme assets (style.css, functions.php, template parts): call \`preview_reload\` (the user is most likely on "/").
+- After editing or creating a specific page or post: call \`preview_navigate\` with that page's path (e.g. \`/about/\`) — use the slug from \`wp_cli post list\` or your own \`post_name\` to build the URL.
+- After editing a single template like \`single-product.php\` or a CPT page: navigate to an example URL that uses that template.
+- Do not call these tools on a remote WordPress.com site.`
+		: '';
+
 	return `${ AGENT_IDENTITY } You manage and modify local WordPress sites using your Studio tools and generate content for these sites.
 
 IMPORTANT: You MUST use your mcp__studio__ tools to manage WordPress sites. Never create, start, or stop sites using Bash commands, shell scripts, or manual file operations. Never run \`wp\` commands via Bash — always use the wp_cli tool instead. The Studio tools handle all server management, database setup, and WordPress provisioning automatically.
@@ -153,7 +180,7 @@ One \`Write\` or \`Edit\` per turn (read-only \`site_info\`, \`site_list\`, \`wp
 - site_push: Push a local site to a WordPress.com site. Requires authentication (studio auth login). Specify the remote site URL or ID and sync options (all, sqls, uploads, plugins, themes, contents).
 - site_pull: Pull a WordPress.com site to a local site. Requires authentication. Specify the remote site URL or ID and sync options.
 - site_import: Import a backup file (.zip, .tar.gz, .sql, .wpress) into a local site.
-- site_export: Export a local site to a backup file. Supports full-site (.zip, .tar.gz) or database-only (.sql) exports.
+- site_export: Export a local site to a backup file. Supports full-site (.zip, .tar.gz) or database-only (.sql) exports.${ previewSteeringTools }${ previewSteeringSection }
 
 ## General rules
 

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import { emitEvent } from 'cli/ai/json-events';
 import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
 import {
 	Mode as PreviewDeleteMode,
@@ -10,7 +11,7 @@ import { readCliConfig } from 'cli/lib/cli-config/core';
 import { getSiteByFolder } from 'cli/lib/cli-config/sites';
 import { isServerRunning, sendWpCliCommand } from 'cli/lib/wordpress-server-manager';
 import { getProgressCallback, setProgressCallback } from 'cli/logger';
-import { studioToolDefinitions } from '../tools';
+import { resolveStudioToolDefinitions, studioToolDefinitions } from '../tools';
 
 vi.mock( 'cli/ai/block-validator', () => ( {
 	validateBlocks: vi.fn(),
@@ -18,6 +19,10 @@ vi.mock( 'cli/ai/block-validator', () => ( {
 
 vi.mock( 'cli/ai/browser-utils', () => ( {
 	getSharedBrowser: vi.fn(),
+} ) );
+
+vi.mock( 'cli/ai/json-events', () => ( {
+	emitEvent: vi.fn(),
 } ) );
 
 vi.mock( 'cli/commands/preview/create', () => ( {
@@ -126,8 +131,58 @@ describe( 'Studio AI MCP tools', () => {
 				'preview_list',
 				'preview_update',
 				'preview_delete',
+				'preview_navigate',
+				'preview_reload',
 			] )
 		);
+	} );
+
+	it( 'emits a preview navigate command with a normalized path', async () => {
+		const result = await getTool( 'preview_navigate' ).handler( { path: 'about/' } as never, null );
+
+		expect( emitEvent ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				type: 'preview.command',
+				kind: 'navigate',
+				path: '/about/',
+			} )
+		);
+		expect( result.isError ).toBeUndefined();
+		expect( getTextContent( result ) ).toContain( '/about/' );
+	} );
+
+	it( 'falls back to "/" when preview_navigate receives an empty path', async () => {
+		await getTool( 'preview_navigate' ).handler( { path: '   ' } as never, null );
+
+		expect( emitEvent ).toHaveBeenCalledWith(
+			expect.objectContaining( { kind: 'navigate', path: '/' } )
+		);
+	} );
+
+	it( 'emits a preview reload command', async () => {
+		const result = await getTool( 'preview_reload' ).handler( {} as never, null );
+
+		expect( emitEvent ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'preview.command', kind: 'reload' } )
+		);
+		expect( result.isError ).toBeUndefined();
+	} );
+
+	it( 'omits preview-steering tools when preview steering is disabled', () => {
+		const names = resolveStudioToolDefinitions().map( ( tool ) => tool.name );
+		expect( names ).not.toContain( 'preview_navigate' );
+		expect( names ).not.toContain( 'preview_reload' );
+		// Baseline Studio tools still present.
+		expect( names ).toContain( 'site_create' );
+		expect( names ).toContain( 'wp_cli' );
+	} );
+
+	it( 'includes preview-steering tools when enabled', () => {
+		const names = resolveStudioToolDefinitions( { enablePreviewSteering: true } ).map(
+			( tool ) => tool.name
+		);
+		expect( names ).toContain( 'preview_navigate' );
+		expect( names ).toContain( 'preview_reload' );
 	} );
 
 	it( 'creates previews for a resolved local site', async () => {

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -1091,11 +1091,13 @@ export interface CreateStudioToolsOptions {
 }
 
 export function resolveStudioToolDefinitions( options: CreateStudioToolsOptions = {} ) {
-	return options.enablePreviewSteering
-		? studioToolDefinitions
-		: studioToolDefinitions.filter(
-				( candidate ) => ! previewSteeringToolDefinitions.includes( candidate )
-		  );
+	if ( options.enablePreviewSteering ) {
+		return studioToolDefinitions;
+	}
+	const previewSteeringNames = new Set( previewSteeringToolDefinitions.map( ( t ) => t.name ) );
+	return studioToolDefinitions.filter(
+		( candidate ) => ! previewSteeringNames.has( candidate.name )
+	);
 }
 
 export function createStudioTools( options: CreateStudioToolsOptions = {} ) {

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -5,6 +5,7 @@ import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { z } from 'zod/v4';
 import { validateBlocks, type ValidationReport } from 'cli/ai/block-validator';
 import { getSharedBrowser } from 'cli/ai/browser-utils';
+import { emitEvent } from 'cli/ai/json-events';
 import { auditPerformance } from 'cli/ai/performance-audit';
 import { auditSeo } from 'cli/ai/seo-audit';
 import { createWpcomToolDefinitions } from 'cli/ai/wpcom-tools';
@@ -723,6 +724,59 @@ const takeScreenshotTool = tool(
 	}
 );
 
+// --- Preview orchestration tools ---
+
+function normalizePreviewPath( raw: string ): string {
+	const trimmed = raw.trim();
+	if ( ! trimmed ) {
+		return '/';
+	}
+	return trimmed.startsWith( '/' ) ? trimmed : `/${ trimmed }`;
+}
+
+const previewNavigateTool = tool(
+	'preview_navigate',
+	'Point the Studio site preview iframe at a specific page on the active site and reload it. ' +
+		'Use this after you finish editing a specific page, post, or template so the user immediately ' +
+		'sees the result of your change. Pass a site-relative path (e.g. "/", "/about/", ' +
+		'"/wp-admin/post.php?post=42&action=edit"). Does nothing when the preview pane is closed or ' +
+		'when running outside the Studio desktop app.',
+	{
+		path: z
+			.string()
+			.describe(
+				'Site-relative path to show in the preview, e.g. "/", "/about/", "/?p=123". Leading slash is added if missing.'
+			),
+	},
+	async ( args ) => {
+		const path = normalizePreviewPath( args.path );
+		emitEvent( {
+			type: 'preview.command',
+			timestamp: new Date().toISOString(),
+			kind: 'navigate',
+			path,
+		} );
+		return textResult( `Preview navigated to ${ path }.` );
+	}
+);
+
+const previewReloadTool = tool(
+	'preview_reload',
+	'Reload the Studio site preview iframe at its current URL. Use this after you edit the active ' +
+		'theme, CSS, template parts, or anything that affects the page the user is currently viewing, ' +
+		'so they see the updated result immediately. Does nothing when the preview pane is closed or ' +
+		'when running outside the Studio desktop app.',
+	{},
+	async () => {
+		emitEvent( {
+			type: 'preview.command',
+			timestamp: new Date().toISOString(),
+			kind: 'reload',
+		} );
+		return textResult( 'Preview reloaded.' );
+	}
+);
+
 // --- Taxonomist scripts installer ---
 
 const TAXONOMIST_SCRIPTS_DIR = 'tmp/taxonomist';
@@ -996,6 +1050,13 @@ const exportSiteTool = tool(
 	}
 );
 
+// Tools that only make sense when a Studio desktop UI is listening on the
+// other end of the agent event stream — they steer a preview iframe that
+// doesn't exist when the CLI runs standalone. Kept separate so plain-CLI
+// runs don't see (and the agent can't call) tools that would just produce
+// noise in the terminal transcript.
+const previewSteeringToolDefinitions = [ previewNavigateTool, previewReloadTool ];
+
 export const studioToolDefinitions = [
 	createSiteTool,
 	listSitesTool,
@@ -1017,13 +1078,31 @@ export const studioToolDefinitions = [
 	pullSiteTool,
 	importSiteTool,
 	exportSiteTool,
+	...previewSteeringToolDefinitions,
 ];
 
-export function createStudioTools() {
+export interface CreateStudioToolsOptions {
+	// Enable preview_navigate / preview_reload. Only meaningful when a
+	// Studio desktop UI is subscribed to the agent event stream — i.e. the
+	// CLI child was forked by the Studio main process (`process.send` is
+	// available). Defaults to false so standalone CLI runs don't advertise
+	// tools whose side effects would vanish into the void.
+	enablePreviewSteering?: boolean;
+}
+
+export function resolveStudioToolDefinitions( options: CreateStudioToolsOptions = {} ) {
+	return options.enablePreviewSteering
+		? studioToolDefinitions
+		: studioToolDefinitions.filter(
+				( candidate ) => ! previewSteeringToolDefinitions.includes( candidate )
+		  );
+}
+
+export function createStudioTools( options: CreateStudioToolsOptions = {} ) {
 	return createSdkMcpServer( {
 		name: 'studio',
 		version: '1.0.0',
-		tools: studioToolDefinitions,
+		tools: resolveStudioToolDefinitions( options ),
 	} );
 }
 

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -217,7 +217,9 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 					</div>
 				</div>
 			</div>
-			{ showPreview && ownerSite ? <SitePreview site={ ownerSite } /> : null }
+			{ showPreview && ownerSite ? (
+				<SitePreview site={ ownerSite } sessionId={ sessionId } />
+			) : null }
 		</div>
 	);
 }

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -10,6 +10,10 @@ import type { SiteDetails } from '@/data/core';
 
 interface SitePreviewProps {
 	site: SiteDetails;
+	// When present, the preview subscribes to the agent event stream for this
+	// session and reacts to `preview.command` events emitted by the agent's
+	// preview_navigate / preview_reload tools.
+	sessionId?: string;
 }
 
 // Isolated iframe + spinner so each URL change fully remounts the loading
@@ -44,10 +48,37 @@ function PreviewIframe( { src, title }: { src: string; title: string } ) {
 	);
 }
 
-export function SitePreview( { site }: SitePreviewProps ) {
+export function SitePreview( { site, sessionId }: SitePreviewProps ) {
 	const connector = useConnector();
 	const siteUrl = getSiteUrl( site );
 	const canPreview = site.running;
+	const [ currentPath, setCurrentPath ] = useState( '/' );
+	// Bumped on each `preview.command` (both navigate and reload) so the
+	// iframe remounts even when the resolved URL is identical to the current
+	// one — more reliable than calling `iframe.contentWindow.location.reload()`
+	// across the self-signed-HTTPS / custom-domain boundaries Studio supports.
+	const [ reloadNonce, setReloadNonce ] = useState( 0 );
+
+	useEffect( () => {
+		if ( ! sessionId ) {
+			return;
+		}
+		return connector.onAgentEvent( ( payload ) => {
+			if ( payload.sessionId !== sessionId ) {
+				return;
+			}
+			const event = payload.event;
+			if ( event.type !== 'preview.command' ) {
+				return;
+			}
+			if ( event.kind === 'navigate' ) {
+				setCurrentPath( event.path );
+			}
+			setReloadNonce( ( n ) => n + 1 );
+		} );
+	}, [ connector, sessionId ] );
+
+	const fullUrl = `${ siteUrl }${ currentPath }`;
 
 	return (
 		<aside className={ styles.root } aria-label={ __( 'Site preview' ) }>
@@ -66,12 +97,16 @@ export function SitePreview( { site }: SitePreviewProps ) {
 					icon={ external }
 					label={ __( 'Open site in browser' ) }
 					disabled={ ! canPreview }
-					onClick={ () => void connector.openExternalUrl( siteUrl ) }
+					onClick={ () => void connector.openExternalUrl( fullUrl ) }
 				/>
 			</div>
 			<div className={ styles.body }>
 				{ canPreview ? (
-					<PreviewIframe key={ siteUrl } src={ siteUrl } title={ site.name } />
+					<PreviewIframe
+						key={ `${ fullUrl }#${ reloadNonce }` }
+						src={ fullUrl }
+						title={ site.name }
+					/>
 				) : (
 					<div className={ styles.empty }>{ __( 'Start the site to see a live preview.' ) }</div>
 				) }

--- a/tools/common/ai/json-events.ts
+++ b/tools/common/ai/json-events.ts
@@ -1,5 +1,10 @@
 export type TurnCompletedStatus = 'success' | 'error' | 'paused' | 'max_turns';
 
+// Transient UI directives emitted by the agent's preview_* MCP tools to
+// steer the site preview iframe. They are not persisted to the session
+// JSONL — if no UI is listening (e.g. plain CLI runs) they are no-ops.
+export type PreviewCommand = { kind: 'navigate'; path: string } | { kind: 'reload' };
+
 export type JsonEvent =
 	| { type: 'message'; timestamp: string; message: unknown }
 	| { type: 'progress'; timestamp: string; message: string }
@@ -20,4 +25,5 @@ export type JsonEvent =
 			sessionId: string;
 			status: TurnCompletedStatus;
 			usage?: { numTurns: number; costUsd?: number };
-	  };
+	  }
+	| ( { type: 'preview.command'; timestamp: string } & PreviewCommand );

--- a/tools/common/ai/tools.ts
+++ b/tools/common/ai/tools.ts
@@ -20,6 +20,8 @@ export function getToolDisplayName( name: string ): string {
 		mcp__studio__wp_cli: __( 'Run WP-CLI' ),
 		mcp__studio__validate_blocks: __( 'Validate blocks' ),
 		mcp__studio__take_screenshot: __( 'Take screenshot' ),
+		mcp__studio__preview_navigate: __( 'Navigate preview' ),
+		mcp__studio__preview_reload: __( 'Reload preview' ),
 		Read: __( 'Read' ),
 		Write: __( 'Write' ),
 		Edit: __( 'Edit' ),
@@ -67,6 +69,8 @@ export function getToolDetail( name: string, input?: Record< string, unknown > )
 			return __( 'inline content' );
 		case 'mcp__studio__take_screenshot':
 			return typeof input.url === 'string' ? input.url : '';
+		case 'mcp__studio__preview_navigate':
+			return typeof input.path === 'string' ? input.path : '';
 		case 'Read':
 		case 'Write':
 		case 'Edit': {


### PR DESCRIPTION
## Related issues

- Related to the agent coding-session experience: the site preview next to each session was static, so users had to click refresh to see what the agent just did.

## How AI was used in this PR

Authored with Claude Code. The model drove the implementation end-to-end (architecture discussion → MCP tool design → renderer wiring → tests). I reviewed and steered at each step — asked for a detailed architecture of the most-reliable option, had it gate the tools for standalone CLI after I noticed the noisy tool-call messages, and flagged follow-ups rather than bundling them. Verification (typecheck, lint, 110 unit tests) was run locally.

## Proposed Changes

- **New MCP tools** (`apps/cli/ai/tools.ts`): `preview_navigate(path)` and `preview_reload()` — the agent calls these as a side effect of its editing loop. Handlers `emitEvent({ type: 'preview.command', ... })` and return synchronously.
- **Event pipeline**: added a `preview.command` variant to `JsonEvent` (`tools/common/ai/json-events.ts`). Events ride the existing CLI→main→renderer `ai-agent-event` channel — no new IPC surface.
- **Renderer subscriber** (`apps/ui/src/components/site-preview/index.tsx`): `SitePreview` now takes a `sessionId`, subscribes to `connector.onAgentEvent`, filters for matching `preview.command`s, and drives the iframe via `currentPath` + a `reloadNonce`. The nonce is baked into the iframe `key` so reloads force a remount — more reliable than `iframe.contentWindow.location.reload()` across self-signed certs / custom-domain boundaries.
- **Session wiring** (`apps/ui/src/components/session-view/index.tsx`): passes `sessionId` to `SitePreview`.
- **Standalone-CLI gating** (`apps/cli/ai/agent.ts`, `apps/cli/ai/tools.ts`, `apps/cli/ai/system-prompt.ts`): `enablePreviewSteering` is derived from `typeof process.send === 'function'` (the same signal `emitEvent` uses to pick IPC vs stdout). When the CLI runs standalone — not forked by the desktop app — the preview tools are filtered out of the MCP server and omitted from the system prompt, so the model never sees them and the terminal transcript doesn't show noisy "Reload preview" / "Navigate preview" entries.
- **Display names + details** (`tools/common/ai/tools.ts`): so the desktop transcript renders `Navigate preview /about/` nicely.
- **System-prompt guidance**: a new "Keep the preview in sync with your work" section (only emitted when preview-steering is enabled) nudges the model to call `preview_reload` after editing theme/CSS/homepage and `preview_navigate` after editing a specific page/post/template.
- **Tests**: 5 new cases in `apps/cli/ai/tests/tools.test.ts` covering navigate normalization, empty-path fallback, reload emission, and the gating behavior (with and without `enablePreviewSteering`).

### What isn't here yet
- **No fallback reload on `turn.completed`.** If the agent forgets to call the tools, nothing updates the preview. Intentionally left as a follow-up — want to see how good model compliance is on the system-prompt guidance first before layering a belt-and-suspenders reload in `run-manager`.
- **No replay on session reopen.** Preview commands are transient (not persisted in the JSONL); reopening a preview starts at \`/\`. The agent will re-navigate on its next relevant edit.
- **Remote WP.com sites**: explicitly excluded in the system prompt; the preview drawer only shows for local environments anyway.

## Testing Instructions

1. Pull this branch and run \`npm start\`.
2. In a coding session with a local site, open the preview drawer (top-right icon in session header).
3. Ask the agent to edit the front page of the theme — verify the preview reloads automatically after the edit.
4. Ask it to edit a specific page (e.g. "add a heading to the About page") — verify the preview navigates to \`/about/\` and reloads.
5. Close and reopen the drawer mid-session — verify it starts at \`/\` and will re-navigate on the next agent edit.
6. **Standalone CLI**: run \`node apps/cli/dist/cli/main.mjs code\` in a terminal, start a session, edit something. Verify no \`Reload preview\` / \`Navigate preview\` messages appear in the transcript.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
- [x] Tests pass (\`npm test\` — all 110 affected tests green).
- [x] Lint/format clean on modified files.