### PR TITLE
apps/ui: skill-command dropdown on composer "/" button

### DIFF
--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -1,3 +1,4 @@
+import { AI_SKILL_COMMANDS } from '@studio/common/ai/slash-commands';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import { __, sprintf } from '@wordpress/i18n';
 import { AI_MODELS, type AiModelId } from 'cli/ai/agent';
@@ -293,7 +294,5 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 		description: __( 'Exit the chat' ),
 		handler: async () => 'break',
 	},
-	{ name: 'taxonomist', description: __( 'Optimize category taxonomy with AI' ) },
-	{ name: 'need-for-speed', description: __( 'Run a performance audit on a site' ) },
-	{ name: 'rank-me-up', description: __( 'Run an on-page SEO audit on a site' ) },
+	...AI_SKILL_COMMANDS,
 ];

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -1,5 +1,6 @@
 import { listAiSessions } from '@studio/common/ai/sessions/store';
 import { type LoadedAiSession, type TurnStatus } from '@studio/common/ai/sessions/types';
+import { buildSkillInvocationPrompt } from '@studio/common/ai/slash-commands';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { DEFAULT_MODEL, startAiAgent, type AiModelId, type AskUserQuestion } from 'cli/ai/agent';
@@ -659,7 +660,7 @@ export async function runCommand( options: {
 					// Skill command — no handler, route to agent
 					ui.addUserMessage( prompt );
 					try {
-						await runAgentTurn( `Run the /${ cmd.name } skill using the Skill tool.` );
+						await runAgentTurn( buildSkillInvocationPrompt( cmd.name ) );
 					} catch ( error ) {
 						handleAgentTurnError( error );
 					}

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -27,6 +27,7 @@ import {
 	listAiSessions as listAiSessionsFromStore,
 	loadAiSession as loadAiSessionFromStore,
 } from '@studio/common/ai/sessions/store';
+import { AI_SKILL_COMMANDS, buildSkillInvocationPrompt } from '@studio/common/ai/slash-commands';
 import {
 	installSkillToSite,
 	removeSkillFromSite,
@@ -287,6 +288,22 @@ async function reconcileSessionEnvironmentBeforeRun( sessionId: string ): Promis
 	} );
 }
 
+// Expand a bare skill-command slash prompt (e.g. `/rank-me-up`) into the
+// instruction the agent actually acts on. Mirrors the CLI's interactive main
+// loop so UI clients can send the short form and get the same behaviour.
+function expandSkillCommandPrompt( prompt: string ): string {
+	const trimmed = prompt.trim();
+	if ( ! trimmed.startsWith( '/' ) ) {
+		return prompt;
+	}
+	const name = trimmed.slice( 1 );
+	const match = AI_SKILL_COMMANDS.find( ( cmd ) => cmd.name === name );
+	if ( ! match ) {
+		return prompt;
+	}
+	return buildSkillInvocationPrompt( name );
+}
+
 export async function continueAiSession(
 	event: IpcMainInvokeEvent,
 	sessionId: string,
@@ -295,7 +312,7 @@ export async function continueAiSession(
 	await reconcileSessionEnvironmentBeforeRun( sessionId );
 	return startAgentRun( {
 		sessionId,
-		prompt,
+		prompt: expandSkillCommandPrompt( prompt ),
 		webContents: event.sender,
 	} );
 }

--- a/apps/ui/src/components/session-view/composer/index.tsx
+++ b/apps/ui/src/components/session-view/composer/index.tsx
@@ -1,4 +1,5 @@
 import { AI_MODELS } from '@studio/common/ai/models';
+import { AI_SKILL_COMMANDS } from '@studio/common/ai/slash-commands';
 import { __, sprintf } from '@wordpress/i18n';
 import { arrowUp, chevronDownSmall } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
@@ -7,24 +8,6 @@ import * as Menu from '@/components/menu';
 import { EnvironmentPill } from './environment-pill';
 import styles from './style.module.css';
 import type { AiModelId, SyncSite } from '@/data/core';
-
-function PaperclipIcon() {
-	return (
-		<svg
-			width="16"
-			height="16"
-			viewBox="0 0 24 24"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.6"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-			aria-hidden="true"
-		>
-			<path d="M21 11.5 12.5 20a5.5 5.5 0 0 1-7.78-7.78l9.2-9.2a3.5 3.5 0 0 1 4.95 4.95l-9.2 9.2a1.5 1.5 0 0 1-2.12-2.12l8.49-8.49" />
-		</svg>
-	);
-}
 
 interface ComposerProps {
 	busy: boolean;
@@ -101,30 +84,34 @@ export function Composer( {
 				/>
 				<div className={ styles.toolbar }>
 					<div className={ styles.leftActions }>
-						<button
-							type="button"
-							className={ styles.iconButton }
-							aria-label={ __( 'Attach file' ) }
-							disabled
-						>
-							<PaperclipIcon />
-						</button>
-						<button
-							type="button"
-							className={ `${ styles.iconButton } ${ styles.glyphButton }` }
-							aria-label={ __( 'Commands' ) }
-							disabled
-						>
-							/
-						</button>
-						<button
-							type="button"
-							className={ `${ styles.iconButton } ${ styles.glyphButton }` }
-							aria-label={ __( 'Mention' ) }
-							disabled
-						>
-							@
-						</button>
+						<Menu.Root modal={ false }>
+							<Menu.Trigger
+								render={
+									<button
+										type="button"
+										className={ `${ styles.iconButton } ${ styles.glyphButton }` }
+										aria-label={ __( 'Commands' ) }
+									>
+										/
+									</button>
+								}
+							/>
+							<Menu.Popup side="top" align="start" className={ styles.commandsMenuPopup }>
+								{ AI_SKILL_COMMANDS.map( ( command ) => (
+									<Menu.Item
+										key={ command.name }
+										onClick={ () => {
+											void onSend( `/${ command.name }` );
+										} }
+									>
+										<span className={ styles.commandItem }>
+											<span className={ styles.commandName }>/{ command.name }</span>
+											<span className={ styles.commandDescription }>{ command.description }</span>
+										</span>
+									</Menu.Item>
+								) ) }
+							</Menu.Popup>
+						</Menu.Root>
 					</div>
 					<div className={ styles.rightActions }>
 						{ sessionId && liveSite ? (

--- a/apps/ui/src/components/session-view/composer/style.module.css
+++ b/apps/ui/src/components/session-view/composer/style.module.css
@@ -128,6 +128,27 @@
 	min-width: 140px;
 }
 
+.commandsMenuPopup {
+	min-width: 280px;
+}
+
+.commandItem {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.commandName {
+	font-family: var(--wpds-typography-font-family-mono, ui-monospace, monospace);
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.commandDescription {
+	font-size: var(--wpds-typography-font-size-xs);
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
 .sendButton,
 .stopButton {
 	display: inline-flex;

--- a/tools/common/ai/slash-commands.ts
+++ b/tools/common/ai/slash-commands.ts
@@ -1,0 +1,16 @@
+import { __ } from '@wordpress/i18n';
+
+export interface SkillSlashCommand {
+	name: string;
+	description: string;
+}
+
+export const AI_SKILL_COMMANDS: SkillSlashCommand[] = [
+	{ name: 'taxonomist', description: __( 'Optimize category taxonomy with AI' ) },
+	{ name: 'need-for-speed', description: __( 'Run a performance audit on a site' ) },
+	{ name: 'rank-me-up', description: __( 'Run an on-page SEO audit on a site' ) },
+];
+
+export function buildSkillInvocationPrompt( name: string ): string {
+	return `Run the /${ name } skill using the Skill tool.`;
+}


### PR DESCRIPTION
## Related issues

- Related to: make the composer's `/` button a live command picker

## How AI was used in this PR

Generated end-to-end by Claude Code. The assistant proposed a minimal scope (show only skill commands that route cleanly to the agent, skip CLI-only plumbing like `/login`, `/api-key`, `/provider`), implemented the shared metadata module + UI dropdown + main-process expansion, and surfaced one known caveat (reloaded sessions show the expanded prompt because the CLI's JSONL records it, matching existing CLI behaviour). Please sanity-check the main-process expansion and the transcript-display tradeoff.

## Proposed Changes

- Move skill-command metadata (`/taxonomist`, `/need-for-speed`, `/rank-me-up`) into a new shared module at `tools/common/ai/slash-commands.ts` so the UI and the CLI reference one list.
- Replace the disabled `/` placeholder button in the session composer with a `Menu.Root` dropdown that lists the three skill commands; clicking one sends `/<name>` through the normal `sendMessage` path (queues if a turn is in flight).
- Expand bare skill-command prompts (`/<name>`) to the canonical `Run the /<name> skill using the Skill tool.` instruction inside `continueAiSession` in the main process, matching the CLI's interactive main-loop behaviour.
- Drop the paperclip (attach-file) and `@` (mention) placeholder buttons from the composer toolbar since they were disabled and aren't wired up yet.

## Testing Instructions

- `npm start`, open a session with a site, and click the `/` button. Confirm the dropdown lists the three skill commands with names + descriptions.
- Click `/rank-me-up`. Verify the optimistic user message in the transcript reads `/rank-me-up` (not the expanded prompt) and that the agent starts running the skill.
- While a turn is running, open the dropdown and pick a command — it should queue behind the active run just like a typed follow-up.
- In the CLI (`studio code`), type `/taxonomist` and confirm the existing interactive behaviour is unchanged (short form shown, expanded prompt sent to the agent).

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)