### PR TITLE
apps/ui: give instant feedback when creating a new session

### DIFF
--- a/apps/ui/src/components/session-view/composer/index.tsx
+++ b/apps/ui/src/components/session-view/composer/index.tsx
@@ -9,6 +9,26 @@ import { EnvironmentPill } from './environment-pill';
 import styles from './style.module.css';
 import type { AiModelId, SyncSite } from '@/data/core';
 
+/**
+ * Structural placeholder that mirrors Composer's outer DOM (shell + textarea +
+ * toolbar + meta row) so the loading state can reserve the exact same vertical
+ * space. Heights track the real composer's CSS automatically — no magic
+ * numbers that drift when the composer changes.
+ */
+export function ComposerSkeleton() {
+	return (
+		<div className={ styles.root } aria-hidden="true">
+			<div className={ styles.shell }>
+				<textarea className={ styles.input } rows={ 2 } disabled tabIndex={ -1 } />
+				<div className={ styles.toolbar }>
+					<span className={ styles.pill } />
+				</div>
+			</div>
+			<div className={ styles.meta }>{ '\u00A0' }</div>
+		</div>
+	);
+}
+
 interface ComposerProps {
 	busy: boolean;
 	isInterrupting?: boolean;

--- a/apps/ui/src/components/session-view/composer/index.tsx
+++ b/apps/ui/src/components/session-view/composer/index.tsx
@@ -10,14 +10,15 @@ import styles from './style.module.css';
 import type { AiModelId, SyncSite } from '@/data/core';
 
 /**
- * Structural placeholder that mirrors Composer's outer DOM (shell + textarea +
- * toolbar + meta row) so the loading state can reserve the exact same vertical
- * space. Heights track the real composer's CSS automatically — no magic
- * numbers that drift when the composer changes.
+ * Invisible structural placeholder that mirrors Composer's outer DOM (shell +
+ * textarea + toolbar + meta row) so the loading state can reserve the exact
+ * same vertical space without rendering a visible composer. Heights track the
+ * real composer's CSS automatically — no magic numbers that drift when the
+ * composer changes.
  */
 export function ComposerSkeleton() {
 	return (
-		<div className={ styles.root } aria-hidden="true">
+		<div className={ styles.root } style={ { visibility: 'hidden' } } aria-hidden="true">
 			<div className={ styles.shell }>
 				<textarea className={ styles.input } rows={ 2 } disabled tabIndex={ -1 } />
 				<div className={ styles.toolbar }>

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -170,7 +170,6 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 				<div className={ styles.loadingAnimation }>
 					<EmptyBackground />
 				</div>
-				<div className={ styles.loadingLabel }>{ __( 'Loading…' ) }</div>
 			</div>
 		);
 	}

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -252,9 +252,7 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 				</div>
 			}
 			preview={
-				showPreview && ownerSite ? (
-					<SitePreview site={ ownerSite } sessionId={ sessionId } />
-				) : null
+				showPreview && ownerSite ? <SitePreview site={ ownerSite } sessionId={ sessionId } /> : null
 			}
 		>
 			{ isEmpty ? <EmptyBackground /> : null }

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -12,7 +12,7 @@ import {
 	type ReactNode,
 	type Ref,
 } from 'react';
-import { Composer } from '@/components/session-view/composer';
+import { Composer, ComposerSkeleton } from '@/components/session-view/composer';
 import { pickLiveSite } from '@/components/session-view/composer/environment-pill';
 import { Conversation } from '@/components/session-view/conversation';
 import { EmptyBackground } from '@/components/session-view/empty-background';
@@ -196,13 +196,18 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 	}, [ sessionId, data, isRunning, queuedPrompts.length ] );
 
 	if ( isLoading ) {
-		// Use the same SessionFrame with empty placeholders so the
-		// EmptyBackground canvas sits in the exact same spot once the session
-		// data loads — otherwise the logo jumps and resizes mid-transition.
+		// Use the same SessionFrame with an empty header and a structural
+		// ComposerSkeleton so the scroll area has the exact same dimensions
+		// as the loaded view — otherwise the EmptyBackground canvas jumps
+		// mid-transition.
 		return (
 			<SessionFrame
 				header={ <div className={ styles.header } /> }
-				composer={ <div className={ clsx( styles.column, styles.composerPlaceholder ) } /> }
+				composer={
+					<div className={ styles.column }>
+						<ComposerSkeleton />
+					</div>
+				}
 			>
 				<EmptyBackground />
 			</SessionFrame>

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -165,7 +165,14 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 	}, [ sessionId, data, isRunning, queuedPrompts.length ] );
 
 	if ( isLoading ) {
-		return <div className={ styles.state }>{ __( 'Loading session…' ) }</div>;
+		return (
+			<div className={ clsx( styles.state, styles.loadingState ) }>
+				<div className={ styles.loadingAnimation }>
+					<EmptyBackground />
+				</div>
+				<div className={ styles.loadingLabel }>{ __( 'Loading…' ) }</div>
+			</div>
+		);
 	}
 
 	if ( error || ! data ) {

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -3,7 +3,15 @@ import { useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+	useCallback,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+	type ReactNode,
+	type Ref,
+} from 'react';
 import { Composer } from '@/components/session-view/composer';
 import { pickLiveSite } from '@/components/session-view/composer/environment-pill';
 import { Conversation } from '@/components/session-view/conversation';
@@ -87,6 +95,29 @@ function SessionHeader( {
 	);
 }
 
+interface SessionFrameProps {
+	header?: ReactNode;
+	composer?: ReactNode;
+	preview?: ReactNode;
+	scrollRef?: Ref< HTMLDivElement >;
+	children?: ReactNode;
+}
+
+function SessionFrame( { header, composer, preview, scrollRef, children }: SessionFrameProps ) {
+	return (
+		<div className={ styles.root }>
+			<div className={ styles.chatColumn }>
+				{ header }
+				<div ref={ scrollRef } className={ styles.scroll }>
+					{ children }
+				</div>
+				<div className={ styles.composerOuter }>{ composer }</div>
+			</div>
+			{ preview }
+		</div>
+	);
+}
+
 export function SessionView( { sessionId }: { sessionId: string } ) {
 	const { data, isLoading, error } = useSession( sessionId );
 	const connector = useConnector();
@@ -165,12 +196,16 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 	}, [ sessionId, data, isRunning, queuedPrompts.length ] );
 
 	if ( isLoading ) {
+		// Use the same SessionFrame with empty placeholders so the
+		// EmptyBackground canvas sits in the exact same spot once the session
+		// data loads — otherwise the logo jumps and resizes mid-transition.
 		return (
-			<div className={ clsx( styles.state, styles.loadingState ) }>
-				<div className={ styles.loadingAnimation }>
-					<EmptyBackground />
-				</div>
-			</div>
+			<SessionFrame
+				header={ <div className={ styles.header } /> }
+				composer={ <div className={ clsx( styles.column, styles.composerPlaceholder ) } /> }
+			>
+				<EmptyBackground />
+			</SessionFrame>
 		);
 	}
 
@@ -184,48 +219,50 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 	}
 
 	return (
-		<div className={ styles.root }>
-			<div className={ styles.chatColumn }>
+		<SessionFrame
+			scrollRef={ scrollRef }
+			header={
 				<SessionHeader
 					summary={ data.summary }
 					previewOpen={ showPreview }
 					onTogglePreview={ () => setPreviewOpen( ( open ) => ! open ) }
 					canTogglePreview={ canTogglePreview }
 				/>
-				<div ref={ scrollRef } className={ styles.scroll }>
-					{ isEmpty ? <EmptyBackground /> : null }
-					<div className={ clsx( styles.column, styles.conversationSpacing ) }>
-						<Conversation
-							data={ data }
-							isRunning={ isRunning }
-							startedAt={ startedAt }
-							pendingQuestions={ pendingQuestionTexts }
-							pendingAnswers={ pendingAnswers }
-							onAnswerQuestion={ answerQuestion }
-						/>
-					</div>
+			}
+			composer={
+				<div className={ styles.column }>
+					<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
+					<Composer
+						busy={ composerBusy }
+						isInterrupting={ isInterrupting }
+						error={ runError }
+						model={ currentModel }
+						onModelChange={ onModelChange }
+						onSend={ sendMessage }
+						onInterrupt={ interrupt }
+						sessionId={ sessionId }
+						effectiveEnvironment={ effectiveEnvironment }
+						liveSite={ liveSite }
+					/>
 				</div>
-				<div className={ styles.composerOuter }>
-					<div className={ styles.column }>
-						<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
-						<Composer
-							busy={ composerBusy }
-							isInterrupting={ isInterrupting }
-							error={ runError }
-							model={ currentModel }
-							onModelChange={ onModelChange }
-							onSend={ sendMessage }
-							onInterrupt={ interrupt }
-							sessionId={ sessionId }
-							effectiveEnvironment={ effectiveEnvironment }
-							liveSite={ liveSite }
-						/>
-					</div>
-				</div>
+			}
+			preview={
+				showPreview && ownerSite ? (
+					<SitePreview site={ ownerSite } sessionId={ sessionId } />
+				) : null
+			}
+		>
+			{ isEmpty ? <EmptyBackground /> : null }
+			<div className={ clsx( styles.column, styles.conversationSpacing ) }>
+				<Conversation
+					data={ data }
+					isRunning={ isRunning }
+					startedAt={ startedAt }
+					pendingQuestions={ pendingQuestionTexts }
+					pendingAnswers={ pendingAnswers }
+					onAnswerQuestion={ answerQuestion }
+				/>
 			</div>
-			{ showPreview && ownerSite ? (
-				<SitePreview site={ ownerSite } sessionId={ sessionId } />
-			) : null }
-		</div>
+		</SessionFrame>
 	);
 }

--- a/apps/ui/src/components/session-view/style.module.css
+++ b/apps/ui/src/components/session-view/style.module.css
@@ -18,6 +18,29 @@
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
+.loadingState {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--wpds-dimension-padding-lg);
+}
+
+.loadingAnimation {
+	position: relative;
+	width: 580px;
+	height: 580px;
+	max-width: 100%;
+	max-height: 60vh;
+}
+
+.loadingLabel {
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
 .header {
 	display: flex;
 	align-items: center;

--- a/apps/ui/src/components/session-view/style.module.css
+++ b/apps/ui/src/components/session-view/style.module.css
@@ -22,23 +22,14 @@
 	flex: 1;
 	min-height: 0;
 	display: flex;
-	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	gap: var(--wpds-dimension-padding-lg);
 }
 
 .loadingAnimation {
 	position: relative;
-	width: 580px;
-	height: 580px;
-	max-width: 100%;
-	max-height: 60vh;
-}
-
-.loadingLabel {
-	font-size: var(--wpds-typography-font-size-sm);
-	color: var(--wpds-color-fg-content-neutral-weak);
+	width: min(580px, 90vw, 60vh);
+	aspect-ratio: 1 / 1;
 }
 
 .header {

--- a/apps/ui/src/components/session-view/style.module.css
+++ b/apps/ui/src/components/session-view/style.module.css
@@ -18,12 +18,6 @@
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
-/* Matches the minimum visible height of the real Composer's shell + toolbar so
-   the scroll area (and the EmptyBackground canvas centered inside it) keeps
-   the same dimensions during session loading. */
-.composerPlaceholder {
-	min-height: 114px;
-}
 
 .header {
 	display: flex;

--- a/apps/ui/src/components/session-view/style.module.css
+++ b/apps/ui/src/components/session-view/style.module.css
@@ -18,18 +18,11 @@
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
-.loadingState {
-	flex: 1;
-	min-height: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-}
-
-.loadingAnimation {
-	position: relative;
-	width: min(580px, 90vw, 60vh);
-	aspect-ratio: 1 / 1;
+/* Matches the minimum visible height of the real Composer's shell + toolbar so
+   the scroll area (and the EmptyBackground canvas centered inside it) keeps
+   the same dimensions during session loading. */
+.composerPlaceholder {
+	min-height: 114px;
 }
 
 .header {

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -114,6 +114,15 @@ function SessionItem( { session }: { session: AiSessionSummary } ) {
 
 function NewSessionButton( { site }: { site: SiteDetails } ) {
 	const navigate = useNavigate();
+	const [ isPending, setIsPending ] = useState( false );
+	const handleClick = async () => {
+		setIsPending( true );
+		try {
+			await navigate( { to: '/sites/$siteId/new', params: { siteId: site.id } } );
+		} finally {
+			setIsPending( false );
+		}
+	};
 	return (
 		<IconButton
 			variant="minimal"
@@ -122,7 +131,9 @@ function NewSessionButton( { site }: { site: SiteDetails } ) {
 			icon={ plus }
 			label={ __( 'New session' ) }
 			className={ styles.siteAction }
-			onClick={ () => void navigate( { to: '/sites/$siteId/new', params: { siteId: site.id } } ) }
+			loading={ isPending }
+			loadingAnnouncement={ __( 'Creating session' ) }
+			onClick={ handleClick }
 		/>
 	);
 }

--- a/apps/ui/src/router/route-new-session/index.tsx
+++ b/apps/ui/src/router/route-new-session/index.tsx
@@ -16,8 +16,9 @@ export const newSessionRoute = createRoute( {
 		const summary = await context.connector.createSession( params.siteId );
 		// Bypasses `useCreateSession`, so we need to invalidate the sessions
 		// list ourselves — otherwise the sidebar wouldn't reflect the new
-		// session on first render after the redirect.
-		await context.queryClient.invalidateQueries( { queryKey: SESSIONS_QUERY_KEY } );
+		// session on first render after the redirect. Fire-and-forget: the
+		// refetch can happen in the background while we redirect immediately.
+		void context.queryClient.invalidateQueries( { queryKey: SESSIONS_QUERY_KEY } );
 		throw redirect( { to: '/sessions/$sessionId', params: { sessionId: summary.id } } );
 	},
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -992,7 +992,7 @@
 				"@wordpress/private-apis": "^1.10.0",
 				"@wordpress/react-i18n": "^4.44.0",
 				"@wordpress/theme": "0.11.0",
-				"@wordpress/ui": "^0.11.0",
+				"@wordpress/ui": "0.11.0",
 				"@wp-playground/blueprints": "3.1.20",
 				"clsx": "^2.1.1",
 				"react": "^18.2.0",


### PR DESCRIPTION
## Related issues

- Related to internal UX report: clicking "New session" in the apps/ui sidebar sometimes feels unresponsive — nothing changes on screen for a moment before the new session view appears.

## How AI was used in this PR

Claude traced the click → render path (sidebar button → `newSessionRoute.beforeLoad` → `createSession` IPC → `invalidateQueries` → redirect → `SessionView` mount → `useSession` fetch), identified two issues in the path, and wrote the patch. I reviewed and confirmed the scope before committing.

## Proposed Changes

Two small, targeted changes to reduce perceived latency when starting a new session from the sidebar:

- **Don't block the redirect on the sidebar refresh.** `route-new-session`'s `beforeLoad` used to `await` `queryClient.invalidateQueries( SESSIONS_QUERY_KEY )` before throwing the redirect. That refetch only needs to land eventually (so the sidebar picks up the new session) — it doesn't need to complete before we navigate. Swapped to fire-and-forget with `void`.
- **Show pending feedback on the button.** `NewSessionButton` now tracks the `navigate()` promise in local state and forwards it to `IconButton`'s `loading` / `loadingAnnouncement` props, so the `+` icon swaps to a spinner the moment the user clicks. Previously the click had no visible acknowledgment until the redirect + `SessionView` mount completed.

The bigger remaining wait — `useSession()` fetching JSONL event history on `SessionView` mount — is not addressed here; if it's noticeable in practice, preloading session data into the TanStack Query cache inside `beforeLoad` would be the natural next step.

## Testing Instructions

1. `npm start`, open apps/ui.
2. In the sidebar, click the `+` (New session) icon next to any site.
3. Verify the `+` icon immediately becomes a spinner on click.
4. Verify the sidebar's sessions list still refreshes to include the new session after the redirect (no stale sidebar).
5. Click through a few times in a row — no duplicate sessions should be created (reuse-newest-empty behaviour in `createSession` is unchanged).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?