### PR TITLE
apps/cli: fix wp_cli post content apply failing silently in WASM

### DIFF
--- a/apps/cli/ai/eval-runner.ts
+++ b/apps/cli/ai/eval-runner.ts
@@ -57,9 +57,10 @@ function extractToolCalls( message: SDKMessage ) {
 			} ): block is { type: 'tool_use'; id: string; name: string; input: unknown } =>
 				block.type === 'tool_use'
 		)
-		.map( ( block: { id: string; name: string } ) => ( {
+		.map( ( block: { id: string; name: string; input: unknown } ) => ( {
 			id: block.id,
 			name: normalizeToolName( block.name ),
+			input: block.input,
 		} ) );
 }
 
@@ -140,7 +141,7 @@ async function runEval( input: EvalRunnerInput ) {
 	// Allow running inside a Claude Code session
 	delete env.CLAUDECODE;
 
-	const toolCalls: { id: string; name: string }[] = [];
+	const toolCalls: { id: string; name: string; input: unknown }[] = [];
 	const toolResults: {
 		toolUseId: string | null;
 		toolName: string | null;

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -158,7 +158,7 @@ One \`Write\` or \`Edit\` per turn (read-only \`site_info\`, \`site_list\`, \`wp
 **Long files (>~200 lines): skeleton first, then fill across Edits.**
 
 - \`style.css\`: skeleton = \`:root { ... }\` custom properties + 6–10 anchor comments \`/* === <concern> === */\` (e.g. \`reset\`, \`typography\`, \`hero\`, \`features\`, \`cta\`, \`footer\`, \`responsive\`), <2KB total. Fill one anchor per Edit (300–2000B each) — \`old_string\` is the anchor line, \`new_string\` is \`<anchor>\\n\\n<styles>\`.
-- Page content: create the page empty (\`wp_cli post create --post_content=""\`), write \`<theme>/page-content.html\` with \`<!-- section:<concern> -->\` anchors (<1KB), fill one anchor per Edit using only core blocks (never wrap in \`core/html\`), then apply once with \`wp_cli post update <id> --post_content-file=<absolute path>\`.
+- Page content: create the page empty (\`wp_cli post create --post_content=""\`), write \`<site>/tmp/page-<slug>.html\` (not inside the theme) with \`<!-- section:<concern> -->\` anchors (<1KB), fill one anchor per Edit using only core blocks (never wrap in \`core/html\`), then apply once with \`wp_cli eval '$content = file_get_contents(ABSPATH . "tmp/page-<slug>.html"); wp_update_post(["ID" => <id>, "post_content" => $content]); echo "ok";'\`. Do NOT use \`--post_content-file=<host path>\` — \`wp_cli\` runs inside the PHP-WASM filesystem (the host site directory is mounted at \`/wordpress/\`, so \`ABSPATH === "/wordpress/"\`) and cannot read host paths; \`--post_content-file=<host path>\` silently updates the post to empty content.
 
 ## Available Studio Tools (prefixed with mcp__studio__)
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -17,7 +17,7 @@ npm run eval:view
 - **identity** — Agent identifies itself correctly (verified by an LLM judge).
 - **site-creation** — Agent calls `site_create` and it succeeds.
 - **security** — Agent requests permission before writing outside `~/Studio`.
-- **single-page-build-turn-cadence** — Agent builds a simple one-page site and every individual turn takes less than 40s (wall-clock between successive assistant messages).
+- **single-page-build-turn-cadence** — Agent builds a simple one-page site. Asserts (a) every individual turn stays under 60s (wall-clock between successive assistant messages) and (b) no `wp_cli` call uses `--post_content-file=` (which silently fails inside PHP-WASM).
 
 ## Adding tests
 

--- a/eval/promptfoo.config.yaml
+++ b/eval/promptfoo.config.yaml
@@ -132,3 +132,26 @@ tests:
             }
             return { pass: true, score: 1, reason: `max turn ${max}ms across ${durations.length} turns` };
           });
+      # Regression: the "Page content" cadence used to tell the agent to apply
+      # page blocks via `wp_cli post update --post_content-file=<host path>`.
+      # `wp_cli` runs inside the PHP-WASM filesystem, so host paths silently
+      # resolve to empty content and the post is overwritten with nothing.
+      # The fix is `wp_cli eval` + `file_get_contents(ABSPATH . ...)` — this
+      # assertion fails if any wp_cli call reintroduces --post_content-file=.
+      - type: javascript
+        value: |
+          return import('node:fs').then(({ readFileSync }) => {
+            const marker = output.split(/\r?\n/).map(l => l.trim()).find(l => l.startsWith('EVAL_RUNNER_RESULT_FILE='));
+            if (!marker) return { pass: false, score: 0, reason: `no result-file marker on stdout; got: ${output.slice(0, 200)}` };
+            const d = JSON.parse(readFileSync(marker.slice('EVAL_RUNNER_RESULT_FILE='.length), 'utf8'));
+            const offending = (d.toolCalls || []).filter(t => {
+              if (t.name !== 'wp_cli') return false;
+              const cmd = t.input && typeof t.input.command === 'string' ? t.input.command : '';
+              return cmd.includes('--post_content-file=');
+            });
+            if (offending.length > 0) {
+              const sample = JSON.stringify(offending[0].input).slice(0, 300);
+              return { pass: false, score: 0, reason: `${offending.length} wp_cli call(s) used --post_content-file=, which silently fails inside PHP-WASM (first: ${sample})` };
+            }
+            return { pass: true, score: 1, reason: 'no wp_cli call used --post_content-file=' };
+          });


### PR DESCRIPTION
## Related issues

None. Follows up on the system-prompt portion of #3199; not a revert — a focused fix for one bug surfaced in agent session recordings.

## How AI was used in this PR

The AI agent's own session recordings surfaced this bug (an 18-turn debugging spiral over empty post content on FamilyFarm build). The fix was developed and validated by iterating over session audits to confirm that (a) `wp_cli` runs inside PHP-WASM, (b) host-absolute paths silently resolve to empty content, and (c) `ABSPATH === "/wordpress/"` maps back to the mounted host site directory.

The regression test assertion was also drafted alongside the fix so the bug can't silently creep back via prompt edits.

## Proposed Changes

- Replace the `wp_cli post update --post_content-file=<host path>` apply pattern in the Page-content cadence with `wp_cli eval` + `file_get_contents(ABSPATH . "tmp/page-<slug>.html")`. Host paths do not resolve inside PHP-WASM — `ABSPATH` (== `"/wordpress/"`) does, and the host site directory is mounted there.
- Move the scratch page-content file out of the theme folder into `<site>/tmp/page-<slug>.html` so transient authoring artefacts don't pollute exports / git.
- Add a one-line "why" note in the prompt so future edits don't revert the fix.
- Extend the agent eval runner to capture tool-call `input`, and add a regression assertion on the existing `single-page-build-turn-cadence` test that fails if any `wp_cli` call uses `--post_content-file=`.

## Testing Instructions

1. `npm run cli:build`
2. `npm run typecheck` (CLI workspace clean)
3. `npm test -- apps/cli/ai` — 110 tests should pass.
4. `node apps/cli/dist/cli/main.mjs ai` → prompt: "Build a farm one page site called MyFarm. Use elegant colors." Verify the tool-use trace:
   - `<site>/tmp/page-<slug>.html` is created (NOT `<theme>/page-content.html`).
   - The apply step is `wp_cli eval '$content = file_get_contents(ABSPATH . "tmp/page-<slug>.html"); wp_update_post([...]);'` — not `--post_content-file=`.
   - The final landing page has real content (not empty).
   - The agent does not spiral into a 15-20 turn debugging loop over empty post content.
5. (Optional) `npm run eval -- -n 1 --filter-description single-page-build-turn-cadence` to run the regression-assertion locally.

## Pre-merge Checklist

- [x] TypeScript clean (CLI workspace).
- [x] `npm test -- apps/cli/ai` passes (110/110).
- [x] Manual AI-agent build confirms the empty-post regression is gone.
- [x] Eval regression assertion added; would fail the single-page build test if the broken pattern re-enters the prompt.