### PR TITLE
apps/ui: use thin gray scrollbars globally

### DIFF
--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -21,6 +21,8 @@ body {
 	background-color: var(--wpds-color-bg-surface-neutral);
 	color: var(--wpds-color-fg-content-neutral);
 	color-scheme: light dark;
+	scrollbar-width: thin;
+	scrollbar-color: gray transparent;
 }
 
 /* Universal heading styles derived from the design system's font-size /


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Generated with Claude Code. The change is a two-line CSS addition to the global `body` rule; reviewed manually before commit.

## Proposed Changes

- Add `scrollbar-width: thin` and `scrollbar-color: gray transparent` to the global `body` rule in `apps/ui/src/index.css` so scrollable areas across the UI render with a subtler, less visually heavy scrollbar.

## Testing Instructions

- Run the apps/ui app and open any view with scrollable content (e.g. site list, settings, chat conversation).
- Confirm scrollbars render as thin gray tracks on transparent backgrounds in both light and dark mode.
- Verify on macOS (where overlay scrollbars are the default) that the change does not regress the native behavior, and on Windows/Linux that the thin scrollbar is applied.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)