### PR TITLE
apps/ui: annotate toolbar for the site preview

### DIFF
--- a/apps/studio/electron.vite.config.new-ui.ts
+++ b/apps/studio/electron.vite.config.new-ui.ts
@@ -42,8 +42,15 @@ export default defineConfig( {
 	preload: {
 		build: {
 			externalizeDeps: { exclude: [ '@sentry/electron' ] },
-			lib: {
-				entry: resolve( __dirname, 'src/preload.ts' ),
+			rollupOptions: {
+				input: {
+					preload: resolve( __dirname, 'src/preload.ts' ),
+					'preview-preload': resolve( __dirname, 'src/preview-preload.ts' ),
+				},
+				output: {
+					entryFileNames: '[name].js',
+					format: 'cjs',
+				},
 			},
 		},
 	},

--- a/apps/studio/electron.vite.config.ts
+++ b/apps/studio/electron.vite.config.ts
@@ -53,8 +53,15 @@ export default defineConfig({
 	preload: {
 		build: {
 			externalizeDeps: { exclude: [ '@sentry/electron' ] },
-			lib: {
-				entry: resolve( __dirname, 'src/preload.ts' ),
+			rollupOptions: {
+				input: {
+					preload: resolve( __dirname, 'src/preload.ts' ),
+					'preview-preload': resolve( __dirname, 'src/preview-preload.ts' ),
+				},
+				output: {
+					entryFileNames: '[name].js',
+					format: 'cjs',
+				},
 			},
 		},
 	},

--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -49,6 +49,7 @@ import { isStudioCliInstalled } from 'src/modules/cli/lib/ipc-handlers';
 import { autoInstallMacOSCliIfNeeded } from 'src/modules/cli/lib/macos-installation-manager';
 import { autoInstallWindowsCliIfNeeded } from 'src/modules/cli/lib/windows-installation-manager';
 import { stopAllProcesses as stopAllStudioCodeProcesses } from 'src/modules/studio-code';
+import { isPreviewWebContents } from 'src/preview-view';
 import { getRunningSiteCount, SiteServer, stopAllServers } from 'src/site-server';
 import {
 	loadUserData,
@@ -158,16 +159,26 @@ async function appBoot() {
 	// be able to perform privileged operations.
 	app.enableSandbox();
 
-	// Prevent navigation to anywhere other than known locations
+	// Prevent navigation to anywhere other than known locations.
+	// The site preview's `WebContentsView` is exempt — it intentionally
+	// loads arbitrary user-owned WordPress URLs and registers itself in
+	// `isPreviewWebContents`.
 	app.on( 'web-contents-created', ( _event, contents ) => {
 		contents.on( 'will-navigate', ( event, navigationUrl ) => {
+			if ( isPreviewWebContents( contents.id ) ) return;
 			const { origin } = new URL( navigationUrl );
 			const allowedOrigins = [ new URL( getRendererUrl() ).origin ];
 			if ( ! allowedOrigins.includes( origin ) ) {
 				event.preventDefault();
 			}
 		} );
-		contents.setWindowOpenHandler( () => {
+		contents.setWindowOpenHandler( ( details ) => {
+			if ( isPreviewWebContents( contents.id ) ) {
+				// Site-preview popups (target="_blank", admin-bar links, …)
+				// load inside the preview's own webContents instead of
+				// spawning a detached BrowserWindow.
+				void contents.loadURL( details.url ).catch( () => undefined );
+			}
 			return { action: 'deny' };
 		} );
 	} );

--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -8,6 +8,8 @@ import {
 	Menu,
 	dialog,
 	MessageBoxSyncOptions,
+	shell,
+	type Event as ElectronEvent,
 } from 'electron';
 import path from 'path';
 import { pathToFileURL } from 'url';
@@ -49,7 +51,11 @@ import { isStudioCliInstalled } from 'src/modules/cli/lib/ipc-handlers';
 import { autoInstallMacOSCliIfNeeded } from 'src/modules/cli/lib/macos-installation-manager';
 import { autoInstallWindowsCliIfNeeded } from 'src/modules/cli/lib/windows-installation-manager';
 import { stopAllProcesses as stopAllStudioCodeProcesses } from 'src/modules/studio-code';
-import { isPreviewWebContents } from 'src/preview-view';
+import {
+	isPreviewNavigationAllowed,
+	isPreviewWebContents,
+	loadPreviewWebContentsURL,
+} from 'src/preview-view';
 import { getRunningSiteCount, SiteServer, stopAllServers } from 'src/site-server';
 import {
 	loadUserData,
@@ -69,6 +75,18 @@ function getRendererUrl(): string {
 	} else {
 		// For production file paths, convert to file:// URL
 		return pathToFileURL( path.join( __dirname, '../renderer/index.html' ) ).href;
+	}
+}
+
+function openExternalWebUrl( url: string ): void {
+	try {
+		const parsedUrl = new URL( url );
+		if ( ! [ 'http:', 'https:' ].includes( parsedUrl.protocol ) ) {
+			return;
+		}
+		void shell.openExternal( parsedUrl.toString() ).catch( () => undefined );
+	} catch {
+		// Ignore malformed URLs from untrusted pages.
 	}
 }
 
@@ -160,24 +178,47 @@ async function appBoot() {
 	app.enableSandbox();
 
 	// Prevent navigation to anywhere other than known locations.
-	// The site preview's `WebContentsView` is exempt — it intentionally
-	// loads arbitrary user-owned WordPress URLs and registers itself in
-	// `isPreviewWebContents`.
+	// The site preview's `WebContentsView` has its own site-scoped policy,
+	// since it intentionally loads local WordPress pages outside the renderer
+	// origin.
 	app.on( 'web-contents-created', ( _event, contents ) => {
+		const blockExternalPreviewNavigation = (
+			event: ElectronEvent,
+			navigationUrl: string
+		): boolean => {
+			if ( isPreviewWebContents( contents.id ) ) {
+				if ( ! isPreviewNavigationAllowed( contents.id, navigationUrl ) ) {
+					event.preventDefault();
+					openExternalWebUrl( navigationUrl );
+				}
+				return true;
+			}
+			return false;
+		};
+
 		contents.on( 'will-navigate', ( event, navigationUrl ) => {
-			if ( isPreviewWebContents( contents.id ) ) return;
+			if ( blockExternalPreviewNavigation( event, navigationUrl ) ) {
+				return;
+			}
 			const { origin } = new URL( navigationUrl );
 			const allowedOrigins = [ new URL( getRendererUrl() ).origin ];
 			if ( ! allowedOrigins.includes( origin ) ) {
 				event.preventDefault();
 			}
 		} );
+		contents.on( 'will-redirect', ( event, navigationUrl ) => {
+			blockExternalPreviewNavigation( event, navigationUrl );
+		} );
 		contents.setWindowOpenHandler( ( details ) => {
 			if ( isPreviewWebContents( contents.id ) ) {
 				// Site-preview popups (target="_blank", admin-bar links, …)
-				// load inside the preview's own webContents instead of
-				// spawning a detached BrowserWindow.
-				void contents.loadURL( details.url ).catch( () => undefined );
+				// load inside the preview only when they stay on the same site.
+				// External URLs leave the preview bridge and open in the browser.
+				void loadPreviewWebContentsURL( contents.id, details.url ).then( ( loaded ) => {
+					if ( ! loaded ) {
+						openExternalWebUrl( details.url );
+					}
+				} );
 			}
 			return { action: 'deny' };
 		} );

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -1867,55 +1867,86 @@ export async function isFullscreen( _event: IpcMainInvokeEvent ): Promise< boole
 	return window.isFullScreen();
 }
 
+function getSitePreviewBaseUrl( siteId: string ): { url: string; allowedOrigins: string[] } {
+	const server = SiteServer.get( siteId );
+	if ( ! server || ! server.details.running ) {
+		throw new Error( 'Cannot create preview for a site that is not running.' );
+	}
+
+	const details = server.details;
+	const baseUrl = details.customDomain
+		? `${ details.enableHttps ? 'https' : 'http' }://${ details.customDomain }`
+		: `http://localhost:${ details.port }`;
+
+	return {
+		url: baseUrl,
+		allowedOrigins: [ new URL( baseUrl ).origin ],
+	};
+}
+
+function resolveSitePreviewUrl( siteId: string, pathname: string = '/' ): string {
+	const { url: baseUrl, allowedOrigins } = getSitePreviewBaseUrl( siteId );
+	const resolvedUrl = new URL( pathname || '/', baseUrl );
+	if ( ! allowedOrigins.includes( resolvedUrl.origin ) ) {
+		throw new Error( 'Preview navigation blocked: path resolves outside the site origin.' );
+	}
+	return resolvedUrl.toString();
+}
+
 export async function createPreviewView(
-	_event: IpcMainInvokeEvent,
+	event: IpcMainInvokeEvent,
 	options: {
-		url: string;
+		siteId: string;
+		path?: string;
 		bounds: { x: number; y: number; width: number; height: number };
-		inspectorScript?: string;
+		enableInspector?: boolean;
 		borderRadius?: number;
 	}
 ): Promise< { viewId: string } > {
-	const { PreviewView, registerPreviewView } = await import( 'src/preview-view' );
+	const { PreviewView, registerPreviewView, disposePreviewViewsForOwner } = await import(
+		'src/preview-view'
+	);
 	const window = await getMainWindow();
-	const view = new PreviewView( window, options );
+	const { allowedOrigins } = getSitePreviewBaseUrl( options.siteId );
+	const view = new PreviewView( window, {
+		...options,
+		url: resolveSitePreviewUrl( options.siteId, options.path ),
+		allowedOrigins,
+		ownerWebContentsId: event.sender.id,
+	} );
 	registerPreviewView( view );
+	event.sender.once( 'destroyed', () => disposePreviewViewsForOwner( event.sender.id ) );
 	return { viewId: view.id };
 }
 
 export async function setPreviewViewBounds(
-	_event: IpcMainInvokeEvent,
+	event: IpcMainInvokeEvent,
 	viewId: string,
 	bounds: { x: number; y: number; width: number; height: number }
 ): Promise< void > {
 	const { getPreviewView } = await import( 'src/preview-view' );
-	getPreviewView( viewId )?.setBounds( bounds );
+	getPreviewView( viewId, event.sender.id )?.setBounds( bounds );
 }
 
-export async function loadPreviewViewURL(
-	_event: IpcMainInvokeEvent,
+export async function navigatePreviewView(
+	event: IpcMainInvokeEvent,
 	viewId: string,
-	url: string
+	path: string
 ): Promise< void > {
 	const { getPreviewView } = await import( 'src/preview-view' );
-	await getPreviewView( viewId )?.loadURL( url );
-}
-
-export async function sendPreviewViewCommand(
-	_event: IpcMainInvokeEvent,
-	viewId: string,
-	command: unknown
-): Promise< void > {
-	const { getPreviewView } = await import( 'src/preview-view' );
-	getPreviewView( viewId )?.sendInspectorCommand( command );
+	const view = getPreviewView( viewId, event.sender.id );
+	if ( ! view ) return;
+	await view.loadURL( resolveSitePreviewUrl( view.siteId, path ) );
 }
 
 export async function destroyPreviewView(
-	_event: IpcMainInvokeEvent,
+	event: IpcMainInvokeEvent,
 	viewId: string
 ): Promise< void > {
-	const { disposePreviewView } = await import( 'src/preview-view' );
-	disposePreviewView( viewId );
+	const { disposePreviewView, getPreviewView } = await import( 'src/preview-view' );
+	if ( getPreviewView( viewId, event.sender.id ) ) {
+		disposePreviewView( viewId );
+	}
 }
 
 export async function getAllCustomDomains(): Promise< string[] > {

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -1867,6 +1867,57 @@ export async function isFullscreen( _event: IpcMainInvokeEvent ): Promise< boole
 	return window.isFullScreen();
 }
 
+export async function createPreviewView(
+	_event: IpcMainInvokeEvent,
+	options: {
+		url: string;
+		bounds: { x: number; y: number; width: number; height: number };
+		inspectorScript?: string;
+		borderRadius?: number;
+	}
+): Promise< { viewId: string } > {
+	const { PreviewView, registerPreviewView } = await import( 'src/preview-view' );
+	const window = await getMainWindow();
+	const view = new PreviewView( window, options );
+	registerPreviewView( view );
+	return { viewId: view.id };
+}
+
+export async function setPreviewViewBounds(
+	_event: IpcMainInvokeEvent,
+	viewId: string,
+	bounds: { x: number; y: number; width: number; height: number }
+): Promise< void > {
+	const { getPreviewView } = await import( 'src/preview-view' );
+	getPreviewView( viewId )?.setBounds( bounds );
+}
+
+export async function loadPreviewViewURL(
+	_event: IpcMainInvokeEvent,
+	viewId: string,
+	url: string
+): Promise< void > {
+	const { getPreviewView } = await import( 'src/preview-view' );
+	await getPreviewView( viewId )?.loadURL( url );
+}
+
+export async function sendPreviewViewCommand(
+	_event: IpcMainInvokeEvent,
+	viewId: string,
+	command: unknown
+): Promise< void > {
+	const { getPreviewView } = await import( 'src/preview-view' );
+	getPreviewView( viewId )?.sendInspectorCommand( command );
+}
+
+export async function destroyPreviewView(
+	_event: IpcMainInvokeEvent,
+	viewId: string
+): Promise< void > {
+	const { disposePreviewView } = await import( 'src/preview-view' );
+	disposePreviewView( viewId );
+}
+
 export async function getAllCustomDomains(): Promise< string[] > {
 	return SiteServer.getAllDetails()
 		.map( ( site ) => site.customDomain )

--- a/apps/studio/src/ipc-utils.ts
+++ b/apps/studio/src/ipc-utils.ts
@@ -63,6 +63,10 @@ export interface IpcEvents {
 	'beta-features-updated': [ void ];
 	'ai-agent-event': [ AgentRunEvent ];
 	'studio-code-event': [ { siteId: string; event: StudioCodeEvent } ];
+	// Inspector events forwarded from a `WebContentsView`-backed site preview.
+	// Renderers subscribe through `ipcListener` and dispatch to the
+	// `viewId`-matching consumer (today: `SitePreview`'s annotate flow).
+	'preview-view:event': [ { viewId: string; payload: unknown } ];
 }
 
 export async function sendIpcEventToRenderer< T extends keyof IpcEvents >(

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -218,6 +218,13 @@ const api: IpcApi = {
 		ipcRendererInvoke( 'answerAiAgentQuestion', runId, answers ),
 	setSessionEnvironment: ( sessionId, environment ) =>
 		ipcRendererInvoke( 'setSessionEnvironment', sessionId, environment ),
+	createPreviewView: ( options ) => ipcRendererInvoke( 'createPreviewView', options ),
+	setPreviewViewBounds: ( viewId, bounds ) =>
+		ipcRendererInvoke( 'setPreviewViewBounds', viewId, bounds ),
+	loadPreviewViewURL: ( viewId, url ) => ipcRendererInvoke( 'loadPreviewViewURL', viewId, url ),
+	sendPreviewViewCommand: ( viewId, command ) =>
+		ipcRendererInvoke( 'sendPreviewViewCommand', viewId, command ),
+	destroyPreviewView: ( viewId ) => ipcRendererInvoke( 'destroyPreviewView', viewId ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -221,9 +221,7 @@ const api: IpcApi = {
 	createPreviewView: ( options ) => ipcRendererInvoke( 'createPreviewView', options ),
 	setPreviewViewBounds: ( viewId, bounds ) =>
 		ipcRendererInvoke( 'setPreviewViewBounds', viewId, bounds ),
-	loadPreviewViewURL: ( viewId, url ) => ipcRendererInvoke( 'loadPreviewViewURL', viewId, url ),
-	sendPreviewViewCommand: ( viewId, command ) =>
-		ipcRendererInvoke( 'sendPreviewViewCommand', viewId, command ),
+	navigatePreviewView: ( viewId, path ) => ipcRendererInvoke( 'navigatePreviewView', viewId, path ),
 	destroyPreviewView: ( viewId ) => ipcRendererInvoke( 'destroyPreviewView', viewId ),
 };
 

--- a/apps/studio/src/preview-inspector-script.ts
+++ b/apps/studio/src/preview-inspector-script.ts
@@ -1,14 +1,11 @@
 /**
- * Annotation inspector injected into the site preview's `<webview>`.
+ * Annotation inspector injected into the site preview's `WebContentsView`.
  *
  * Vanilla DOM in a Shadow DOM root — React isn't loaded in the cross-origin
  * WordPress page. Communicates with the host renderer via the
  * `window.__studioInspector` bridge exposed by
  * `apps/studio/src/preview-preload.ts`:
- *   - host -> guest: `{ type: 'set-picking', picking: boolean }`,
- *                    `{ type: 'clear' }`
- *   - guest -> host: `{ type: 'state', annotations, isPicking }`,
- *                    `{ type: 'pick-cancelled' }`
+ *   - guest -> host: `{ type: 'done', annotations }`
  *
  * Layout strategy: markers and the picking highlight use `position: absolute`
  * anchored at *document* coordinates (viewport rect + scroll offset). They

--- a/apps/studio/src/preview-preload.ts
+++ b/apps/studio/src/preview-preload.ts
@@ -1,9 +1,8 @@
 /**
  * Preload script attached to the `WebContentsView` that hosts the site
  * preview. Exposes a small bridge on `window.__studioInspector` so the
- * inspector page script (injected via `webContents.executeJavaScript`) can:
- *   - Receive commands from the host renderer (start/stop picking, clear, …)
- *   - Send annotation events back to the host renderer
+ * inspector page script (injected via `webContents.executeJavaScript`) can
+ * send annotation events back to the host renderer.
  *
  * The view has no host (it's a top-level web contents under
  * `mainWindow.contentView`), so events flow through the main process and
@@ -13,32 +12,9 @@
 
 import { contextBridge, ipcRenderer } from 'electron';
 
-const COMMAND_CHANNEL = 'studio-inspector:command';
 const EVENT_CHANNEL = 'studio-inspector:event';
 
-type CommandHandler = ( payload: unknown ) => void;
-
-const commandHandlers = new Set< CommandHandler >();
-
-ipcRenderer.on( COMMAND_CHANNEL, ( _event, payload: unknown ) => {
-	for ( const handler of commandHandlers ) {
-		try {
-			handler( payload );
-		} catch ( error ) {
-			// Swallow handler errors so a buggy injected script can't break the
-			// rest of the bridge.
-			console.error( 'studio-inspector handler error', error );
-		}
-	}
-} );
-
 contextBridge.exposeInMainWorld( '__studioInspector', {
-	onCommand( handler: CommandHandler ): () => void {
-		commandHandlers.add( handler );
-		return () => {
-			commandHandlers.delete( handler );
-		};
-	},
 	send( payload: unknown ): void {
 		ipcRenderer.send( EVENT_CHANNEL, payload );
 	},

--- a/apps/studio/src/preview-preload.ts
+++ b/apps/studio/src/preview-preload.ts
@@ -1,0 +1,45 @@
+/**
+ * Preload script attached to the `WebContentsView` that hosts the site
+ * preview. Exposes a small bridge on `window.__studioInspector` so the
+ * inspector page script (injected via `webContents.executeJavaScript`) can:
+ *   - Receive commands from the host renderer (start/stop picking, clear, …)
+ *   - Send annotation events back to the host renderer
+ *
+ * The view has no host (it's a top-level web contents under
+ * `mainWindow.contentView`), so events flow through the main process and
+ * are forwarded to the host renderer via `webContents.send` keyed by
+ * `viewId`. See `apps/studio/src/preview-view.ts`.
+ */
+
+import { contextBridge, ipcRenderer } from 'electron';
+
+const COMMAND_CHANNEL = 'studio-inspector:command';
+const EVENT_CHANNEL = 'studio-inspector:event';
+
+type CommandHandler = ( payload: unknown ) => void;
+
+const commandHandlers = new Set< CommandHandler >();
+
+ipcRenderer.on( COMMAND_CHANNEL, ( _event, payload: unknown ) => {
+	for ( const handler of commandHandlers ) {
+		try {
+			handler( payload );
+		} catch ( error ) {
+			// Swallow handler errors so a buggy injected script can't break the
+			// rest of the bridge.
+			console.error( 'studio-inspector handler error', error );
+		}
+	}
+} );
+
+contextBridge.exposeInMainWorld( '__studioInspector', {
+	onCommand( handler: CommandHandler ): () => void {
+		commandHandlers.add( handler );
+		return () => {
+			commandHandlers.delete( handler );
+		};
+	},
+	send( payload: unknown ): void {
+		ipcRenderer.send( EVENT_CHANNEL, payload );
+	},
+} );

--- a/apps/studio/src/preview-view.ts
+++ b/apps/studio/src/preview-view.ts
@@ -1,9 +1,9 @@
 /**
  * Wraps an Electron `WebContentsView` that hosts a Studio site preview.
  *
- * Replaces the deprecated `<webview>` tag in the renderer. The view is a
- * native overlay attached to the main window's `contentView`; the renderer
- * positions it by reporting the bounds of a placeholder `<div>` via IPC.
+ * Replaces the iframe renderer preview with a native overlay attached to the
+ * main window's `contentView`; the renderer positions it by reporting the
+ * bounds of a placeholder `<div>` via IPC.
  *
  * Inspector events emitted by `apps/studio/src/preview-preload.ts` flow
  * through `ipcMain` and are forwarded to the host renderer keyed by view id.
@@ -12,6 +12,7 @@
 import { randomUUID } from 'crypto';
 import { BrowserWindow, WebContentsView } from 'electron';
 import * as path from 'path';
+import { INSPECTOR_PAGE_SCRIPT } from 'src/preview-inspector-script';
 
 export interface PreviewViewBounds {
 	x: number;
@@ -21,26 +22,32 @@ export interface PreviewViewBounds {
 }
 
 export interface PreviewViewOptions {
+	siteId: string;
 	url: string;
+	allowedOrigins: string[];
 	bounds: PreviewViewBounds;
-	// JS source executed in the guest page after every successful navigation.
-	// Used to mount the annotate inspector inside the WordPress page.
-	inspectorScript?: string;
+	ownerWebContentsId: number;
+	enableInspector?: boolean;
 	// Native view corner radius in CSS pixels. WebContentsView paints over
 	// HTML and ignores parent CSS clipping; pass the same radius the React
 	// container uses so the preview's corners match its frame.
 	borderRadius?: number;
 }
 
+type InspectorEvent = {
+	type: 'done';
+	annotations?: unknown[];
+};
+
 const previewViews = new Map< string, PreviewView >();
 const previewWebContentsIds = new Set< number >();
+const previewViewIdsByWebContentsId = new Map< number, string >();
 
 /**
  * The app installs a global `will-navigate` handler in `index.ts` that
  * `preventDefault`s anything outside the renderer's origin. The site
- * preview is supposed to load arbitrary WordPress URLs, so its
- * `webContents` opts out of the policy via this set — the global handler
- * checks `isPreviewWebContents` and bails early for matching ids.
+ * preview is supposed to load Studio site URLs, so its `webContents` opts
+ * into a site-specific policy via this set and `isPreviewNavigationAllowed`.
  */
 export function isPreviewWebContents( id: number ): boolean {
 	return previewWebContentsIds.has( id );
@@ -48,15 +55,21 @@ export function isPreviewWebContents( id: number ): boolean {
 
 export class PreviewView {
 	public readonly id: string;
+	public readonly ownerWebContentsId: number;
+	public readonly siteId: string;
 	private readonly window: BrowserWindow;
 	private readonly view: WebContentsView;
-	private inspectorScript?: string;
+	private readonly allowedOrigins: Set< string >;
+	private readonly enableInspector: boolean;
 	private destroyed = false;
 
 	constructor( window: BrowserWindow, options: PreviewViewOptions ) {
 		this.id = randomUUID();
+		this.ownerWebContentsId = options.ownerWebContentsId;
+		this.siteId = options.siteId;
 		this.window = window;
-		this.inspectorScript = options.inspectorScript;
+		this.allowedOrigins = new Set( options.allowedOrigins );
+		this.enableInspector = options.enableInspector ?? false;
 
 		this.view = new WebContentsView( {
 			webPreferences: {
@@ -67,6 +80,7 @@ export class PreviewView {
 		} );
 
 		previewWebContentsIds.add( this.view.webContents.id );
+		previewViewIdsByWebContentsId.set( this.view.webContents.id, this.id );
 
 		window.contentView.addChildView( this.view );
 		this.view.setBounds( roundBounds( options.bounds ) );
@@ -84,6 +98,7 @@ export class PreviewView {
 		// `viewId` lets the host route to the matching `SitePreview` instance.
 		this.view.webContents.ipc.on( 'studio-inspector:event', ( _event, payload: unknown ) => {
 			if ( this.destroyed || this.window.isDestroyed() ) return;
+			if ( ! isInspectorEvent( payload ) ) return;
 			this.window.webContents.send( 'preview-view:event', {
 				viewId: this.id,
 				payload,
@@ -94,8 +109,9 @@ export class PreviewView {
 	}
 
 	private injectInspector(): void {
-		if ( this.destroyed || ! this.inspectorScript ) return;
-		this.view.webContents.executeJavaScript( this.inspectorScript, false ).catch( () => {
+		if ( this.destroyed || ! this.enableInspector ) return;
+		if ( ! this.isAllowedURL( this.view.webContents.getURL() ) ) return;
+		this.view.webContents.executeJavaScript( INSPECTOR_PAGE_SCRIPT, false ).catch( () => {
 			// Transient injection failures (e.g. frame swapped mid-eval)
 			// are recoverable on the next did-finish-load.
 		} );
@@ -108,18 +124,29 @@ export class PreviewView {
 
 	async loadURL( url: string ): Promise< void > {
 		if ( this.destroyed ) return;
+		if ( ! this.isAllowedURL( url ) ) {
+			throw new Error( 'Preview navigation blocked: URL is outside the site preview origin.' );
+		}
 		await this.view.webContents.loadURL( url ).catch( () => undefined );
 	}
 
-	sendInspectorCommand( command: unknown ): void {
-		if ( this.destroyed || this.view.webContents.isDestroyed() ) return;
-		this.view.webContents.send( 'studio-inspector:command', command );
+	isAllowedURL( url: string ): boolean {
+		try {
+			const parsed = new URL( url );
+			return (
+				[ 'http:', 'https:' ].includes( parsed.protocol ) &&
+				this.allowedOrigins.has( parsed.origin )
+			);
+		} catch {
+			return false;
+		}
 	}
 
 	destroy(): void {
 		if ( this.destroyed ) return;
 		this.destroyed = true;
 		previewWebContentsIds.delete( this.view.webContents.id );
+		previewViewIdsByWebContentsId.delete( this.view.webContents.id );
 		try {
 			this.window.contentView.removeChildView( this.view );
 		} catch {
@@ -130,6 +157,14 @@ export class PreviewView {
 			wc.close();
 		}
 	}
+}
+
+function isInspectorEvent( payload: unknown ): payload is InspectorEvent {
+	if ( ! payload || typeof payload !== 'object' ) return false;
+	const event = payload as InspectorEvent;
+	if ( event.type !== 'done' ) return false;
+	if ( event.annotations !== undefined && ! Array.isArray( event.annotations ) ) return false;
+	return true;
 }
 
 // Bounds passed to `setBounds` must be integers; sub-pixel values produce
@@ -147,8 +182,43 @@ export function registerPreviewView( view: PreviewView ): void {
 	previewViews.set( view.id, view );
 }
 
-export function getPreviewView( viewId: string ): PreviewView | undefined {
-	return previewViews.get( viewId );
+export function getPreviewView(
+	viewId: string,
+	ownerWebContentsId?: number
+): PreviewView | undefined {
+	const view = previewViews.get( viewId );
+	if ( ! view ) return undefined;
+	if ( ownerWebContentsId !== undefined && view.ownerWebContentsId !== ownerWebContentsId ) {
+		return undefined;
+	}
+	return view;
+}
+
+export function isPreviewNavigationAllowed( webContentsId: number, url: string ): boolean {
+	const viewId = previewViewIdsByWebContentsId.get( webContentsId );
+	if ( ! viewId ) return false;
+	return previewViews.get( viewId )?.isAllowedURL( url ) ?? false;
+}
+
+export async function loadPreviewWebContentsURL(
+	webContentsId: number,
+	url: string
+): Promise< boolean > {
+	const viewId = previewViewIdsByWebContentsId.get( webContentsId );
+	if ( ! viewId ) return false;
+	const view = previewViews.get( viewId );
+	if ( ! view || ! view.isAllowedURL( url ) ) return false;
+	await view.loadURL( url );
+	return true;
+}
+
+export function disposePreviewViewsForOwner( ownerWebContentsId: number ): void {
+	for ( const [ viewId, view ] of previewViews ) {
+		if ( view.ownerWebContentsId === ownerWebContentsId ) {
+			view.destroy();
+			previewViews.delete( viewId );
+		}
+	}
 }
 
 export function disposePreviewView( viewId: string ): void {

--- a/apps/studio/src/preview-view.ts
+++ b/apps/studio/src/preview-view.ts
@@ -1,0 +1,159 @@
+/**
+ * Wraps an Electron `WebContentsView` that hosts a Studio site preview.
+ *
+ * Replaces the deprecated `<webview>` tag in the renderer. The view is a
+ * native overlay attached to the main window's `contentView`; the renderer
+ * positions it by reporting the bounds of a placeholder `<div>` via IPC.
+ *
+ * Inspector events emitted by `apps/studio/src/preview-preload.ts` flow
+ * through `ipcMain` and are forwarded to the host renderer keyed by view id.
+ */
+
+import { randomUUID } from 'crypto';
+import { BrowserWindow, WebContentsView } from 'electron';
+import * as path from 'path';
+
+export interface PreviewViewBounds {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+export interface PreviewViewOptions {
+	url: string;
+	bounds: PreviewViewBounds;
+	// JS source executed in the guest page after every successful navigation.
+	// Used to mount the annotate inspector inside the WordPress page.
+	inspectorScript?: string;
+	// Native view corner radius in CSS pixels. WebContentsView paints over
+	// HTML and ignores parent CSS clipping; pass the same radius the React
+	// container uses so the preview's corners match its frame.
+	borderRadius?: number;
+}
+
+const previewViews = new Map< string, PreviewView >();
+const previewWebContentsIds = new Set< number >();
+
+/**
+ * The app installs a global `will-navigate` handler in `index.ts` that
+ * `preventDefault`s anything outside the renderer's origin. The site
+ * preview is supposed to load arbitrary WordPress URLs, so its
+ * `webContents` opts out of the policy via this set — the global handler
+ * checks `isPreviewWebContents` and bails early for matching ids.
+ */
+export function isPreviewWebContents( id: number ): boolean {
+	return previewWebContentsIds.has( id );
+}
+
+export class PreviewView {
+	public readonly id: string;
+	private readonly window: BrowserWindow;
+	private readonly view: WebContentsView;
+	private inspectorScript?: string;
+	private destroyed = false;
+
+	constructor( window: BrowserWindow, options: PreviewViewOptions ) {
+		this.id = randomUUID();
+		this.window = window;
+		this.inspectorScript = options.inspectorScript;
+
+		this.view = new WebContentsView( {
+			webPreferences: {
+				preload: path.resolve( __dirname, '../preload/preview-preload.js' ),
+				contextIsolation: true,
+				nodeIntegration: false,
+			},
+		} );
+
+		previewWebContentsIds.add( this.view.webContents.id );
+
+		window.contentView.addChildView( this.view );
+		this.view.setBounds( roundBounds( options.bounds ) );
+		if ( typeof options.borderRadius === 'number' ) {
+			this.view.setBorderRadius( Math.max( 0, Math.round( options.borderRadius ) ) );
+		}
+
+		// Re-inject the inspector after every successful navigation so the
+		// toolbar survives in-page link clicks and full reloads.
+		this.view.webContents.on( 'did-finish-load', () => {
+			this.injectInspector();
+		} );
+
+		// Forward inspector events to the host renderer (apps/ui). The
+		// `viewId` lets the host route to the matching `SitePreview` instance.
+		this.view.webContents.ipc.on( 'studio-inspector:event', ( _event, payload: unknown ) => {
+			if ( this.destroyed || this.window.isDestroyed() ) return;
+			this.window.webContents.send( 'preview-view:event', {
+				viewId: this.id,
+				payload,
+			} );
+		} );
+
+		void this.view.webContents.loadURL( options.url ).catch( () => undefined );
+	}
+
+	private injectInspector(): void {
+		if ( this.destroyed || ! this.inspectorScript ) return;
+		this.view.webContents.executeJavaScript( this.inspectorScript, false ).catch( () => {
+			// Transient injection failures (e.g. frame swapped mid-eval)
+			// are recoverable on the next did-finish-load.
+		} );
+	}
+
+	setBounds( bounds: PreviewViewBounds ): void {
+		if ( this.destroyed ) return;
+		this.view.setBounds( roundBounds( bounds ) );
+	}
+
+	async loadURL( url: string ): Promise< void > {
+		if ( this.destroyed ) return;
+		await this.view.webContents.loadURL( url ).catch( () => undefined );
+	}
+
+	sendInspectorCommand( command: unknown ): void {
+		if ( this.destroyed || this.view.webContents.isDestroyed() ) return;
+		this.view.webContents.send( 'studio-inspector:command', command );
+	}
+
+	destroy(): void {
+		if ( this.destroyed ) return;
+		this.destroyed = true;
+		previewWebContentsIds.delete( this.view.webContents.id );
+		try {
+			this.window.contentView.removeChildView( this.view );
+		} catch {
+			// Window may already be destroyed.
+		}
+		const wc = this.view.webContents as { close?: () => void; isDestroyed: () => boolean };
+		if ( ! wc.isDestroyed() && typeof wc.close === 'function' ) {
+			wc.close();
+		}
+	}
+}
+
+// Bounds passed to `setBounds` must be integers; sub-pixel values produce
+// blurry compositing edges and Electron will reject them on some platforms.
+function roundBounds( bounds: PreviewViewBounds ): PreviewViewBounds {
+	return {
+		x: Math.round( bounds.x ),
+		y: Math.round( bounds.y ),
+		width: Math.max( 0, Math.round( bounds.width ) ),
+		height: Math.max( 0, Math.round( bounds.height ) ),
+	};
+}
+
+export function registerPreviewView( view: PreviewView ): void {
+	previewViews.set( view.id, view );
+}
+
+export function getPreviewView( viewId: string ): PreviewView | undefined {
+	return previewViews.get( viewId );
+}
+
+export function disposePreviewView( viewId: string ): void {
+	const view = previewViews.get( viewId );
+	if ( ! view ) return;
+	view.destroy();
+	previewViews.delete( viewId );
+}

--- a/apps/ui/src/components/session-view/composer/index.tsx
+++ b/apps/ui/src/components/session-view/composer/index.tsx
@@ -3,7 +3,7 @@ import { AI_SKILL_COMMANDS } from '@studio/common/ai/slash-commands';
 import { __, sprintf } from '@wordpress/i18n';
 import { arrowUp, chevronDownSmall } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
-import { useCallback, useState } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import * as Menu from '@/components/menu';
 import { EnvironmentPill } from './environment-pill';
 import styles from './style.module.css';
@@ -46,22 +46,58 @@ interface ComposerProps {
 	liveSite?: SyncSite;
 }
 
+/**
+ * Imperative API surfaced via the Composer's forwarded ref. Lets parents
+ * (e.g. the annotate-toolbar hand-off) inject a draft without making the
+ * value a controlled prop — the latter would re-render the entire
+ * SessionView (and the heavy Conversation tree) on every keystroke.
+ */
+export interface ComposerHandle {
+	appendDraft( text: string ): void;
+}
+
 const isMacPlatform =
 	typeof navigator !== 'undefined' && /mac/i.test( navigator.platform || navigator.userAgent );
 
-export function Composer( {
-	busy,
-	isInterrupting = false,
-	error,
-	model,
-	onModelChange,
-	onSend,
-	onInterrupt,
-	sessionId,
-	effectiveEnvironment = 'local',
-	liveSite,
-}: ComposerProps ) {
+export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Composer(
+	{
+		busy,
+		isInterrupting = false,
+		error,
+		model,
+		onModelChange,
+		onSend,
+		onInterrupt,
+		sessionId,
+		effectiveEnvironment = 'local',
+		liveSite,
+	},
+	ref
+) {
 	const [ value, setValue ] = useState( '' );
+	const textareaRef = useRef< HTMLTextAreaElement | null >( null );
+
+	useImperativeHandle(
+		ref,
+		() => ( {
+			appendDraft( text ) {
+				if ( ! text ) return;
+				setValue( ( current ) =>
+					current.trim() ? `${ current.trimEnd() }\n\n${ text }` : text
+				);
+				// Defer focus to the next paint so the textarea reflects the
+				// new value before we move the caret to the end.
+				queueMicrotask( () => {
+					const node = textareaRef.current;
+					if ( ! node ) return;
+					node.focus();
+					const len = node.value.length;
+					node.setSelectionRange( len, len );
+				} );
+			},
+		} ),
+		[]
+	);
 
 	const send = useCallback( async () => {
 		const trimmed = value.trim();
@@ -91,6 +127,7 @@ export function Composer( {
 		<div className={ styles.root }>
 			<div className={ styles.shell }>
 				<textarea
+					ref={ textareaRef }
 					className={ styles.input }
 					placeholder={ placeholder }
 					value={ value }
@@ -214,4 +251,4 @@ export function Composer( {
 			</div>
 		</div>
 	);
-}
+} );

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -12,13 +12,18 @@ import {
 	type ReactNode,
 	type Ref,
 } from 'react';
-import { Composer, ComposerSkeleton } from '@/components/session-view/composer';
+import {
+	Composer,
+	ComposerSkeleton,
+	type ComposerHandle,
+} from '@/components/session-view/composer';
 import { pickLiveSite } from '@/components/session-view/composer/environment-pill';
 import { Conversation } from '@/components/session-view/conversation';
 import { EmptyBackground } from '@/components/session-view/empty-background';
 import { QueuedPrompts } from '@/components/session-view/queued-prompts';
 import { SiteDropdown } from '@/components/site-dropdown';
 import { SitePreview } from '@/components/site-preview';
+import { type Annotation } from '@/components/site-preview/types';
 import { useConnector } from '@/data/core';
 import { useAgentRun } from '@/data/queries/use-agent-run';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
@@ -103,6 +108,58 @@ interface SessionFrameProps {
 	children?: ReactNode;
 }
 
+/**
+ * Renders the annotation batch as a markdown prompt the user can review and
+ * (optionally) edit before sending. Annotations are grouped by the page they
+ * were taken on so the agent knows which URL to load before acting on each
+ * element. Within a group, each item carries the element's tag, nearby text
+ * and CSS selector — enough for the agent to locate the target without
+ * re-running the inspector.
+ */
+function formatAnnotationsAsPrompt( annotations: Annotation[] ): string {
+	const intro =
+		annotations.length === 1
+			? __( 'Apply this change from the site preview:' )
+			: // translators: %d is the number of annotations.
+			  __( 'Apply these %d changes from the site preview:' ).replace(
+					'%d',
+					String( annotations.length )
+			  );
+
+	// Group while preserving the order in which the user added the
+	// annotations, then merge consecutive runs that share a page so a
+	// chained sequence reads as a single section.
+	const groups: { page: string; items: Annotation[] }[] = [];
+	for ( const ann of annotations ) {
+		const page = ann.url || ann.pathname || '/';
+		const last = groups[ groups.length - 1 ];
+		if ( last && last.page === page ) {
+			last.items.push( ann );
+		} else {
+			groups.push( { page, items: [ ann ] } );
+		}
+	}
+
+	const lines: string[] = [ intro, '' ];
+	let counter = 1;
+	for ( const group of groups ) {
+		// translators: %s is the page URL or pathname.
+		lines.push( __( 'On %s:' ).replace( '%s', group.page ) );
+		for ( const ann of group.items ) {
+			const tag = ann.tag ?? 'element';
+			const nearby = ann.nearbyText ? ` — "${ ann.nearbyText.slice( 0, 80 ) }"` : '';
+			const selector = ann.selector ? `\n   Selector: \`${ ann.selector }\`` : '';
+			lines.push(
+				`${ counter }. \`<${ tag }>\`${ nearby }\n   Comment: ${ ann.comment }${ selector }`
+			);
+			counter += 1;
+		}
+		lines.push( '' );
+	}
+
+	return lines.join( '\n' ).trimEnd();
+}
+
 function SessionFrame( { header, composer, preview, scrollRef, children }: SessionFrameProps ) {
 	return (
 		<div className={ styles.root }>
@@ -179,9 +236,15 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 		[ data?.events ]
 	);
 	const scrollRef = useRef< HTMLDivElement >( null );
+	const composerRef = useRef< ComposerHandle | null >( null );
 	const [ previewOpen, setPreviewOpen ] = useState( false );
 	const canTogglePreview = !! ownerSite && effectiveEnvironment === 'local';
 	const showPreview = previewOpen && canTogglePreview;
+
+	const handleAnnotationsDone = useCallback( ( annotations: Annotation[] ) => {
+		if ( annotations.length === 0 ) return;
+		composerRef.current?.appendDraft( formatAnnotationsAsPrompt( annotations ) );
+	}, [] );
 
 	useLayoutEffect( () => {
 		const node = scrollRef.current;
@@ -238,6 +301,7 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 				<div className={ styles.column }>
 					<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
 					<Composer
+						ref={ composerRef }
 						busy={ composerBusy }
 						isInterrupting={ isInterrupting }
 						error={ runError }
@@ -252,7 +316,13 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 				</div>
 			}
 			preview={
-				showPreview && ownerSite ? <SitePreview site={ ownerSite } sessionId={ sessionId } /> : null
+				showPreview && ownerSite ? (
+					<SitePreview
+						site={ ownerSite }
+						sessionId={ sessionId }
+						onAnnotationsDone={ handleAnnotationsDone }
+					/>
+				) : null
 			}
 		>
 			{ isEmpty ? <EmptyBackground /> : null }

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -1,12 +1,18 @@
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
-import { IconButton } from '@wordpress/ui';
+import { Button, IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useConnector } from '@/data/core';
+import { useIsSiteStarting, useStartSite } from '@/data/queries/use-sites';
 import { getSiteUrl } from '@/lib/get-site-url';
+import { playIcon } from '@/lib/icons';
+import { INSPECTOR_PAGE_SCRIPT } from './inspector-page-script';
 import styles from './style.module.css';
+import type { Annotation } from './types';
 import type { SiteDetails } from '@/data/core';
+
+export type { Annotation } from './types';
 
 interface SitePreviewProps {
 	site: SiteDetails;
@@ -14,71 +20,39 @@ interface SitePreviewProps {
 	// session and reacts to `preview.command` events emitted by the agent's
 	// preview_navigate / preview_reload tools.
 	sessionId?: string;
+	// Called when the user clicks "Done" in the inspector toolbar (rendered
+	// inside the WebContentsView). Receives the full annotation payload.
+	onAnnotationsDone?: ( annotations: Annotation[] ) => void;
 }
 
-// Isolated iframe + spinner so each URL change fully remounts the loading
-// state. The parent-level `useEffect` we tried before missed `load` events
-// that fired before React's effect scheduler caught up, leaving the spinner
-// stuck.
-function PreviewIframe( { src, title }: { src: string; title: string } ) {
-	const [ loading, setLoading ] = useState( true );
-
-	// Safety net: some iframes (e.g. blocked by X-Frame-Options in certain
-	// WP configs) never fire `load`. Hide the spinner after a few seconds
-	// so it doesn't spin forever.
-	useEffect( () => {
-		const timer = setTimeout( () => setLoading( false ), 8000 );
-		return () => clearTimeout( timer );
-	}, [] );
-
-	return (
-		<>
-			<iframe
-				className={ styles.iframe }
-				src={ src }
-				title={ title }
-				onLoad={ () => setLoading( false ) }
-			/>
-			{ loading ? (
-				<div className={ styles.spinnerOverlay } aria-hidden="true">
-					<span className={ styles.spinner } />
-				</div>
-			) : null }
-		</>
-	);
+interface InspectorEvent {
+	type: 'done' | 'state' | 'pick-cancelled';
+	annotations?: Annotation[];
+	isPicking?: boolean;
 }
 
-export function SitePreview( { site, sessionId }: SitePreviewProps ) {
+export function SitePreview( { site, sessionId, onAnnotationsDone }: SitePreviewProps ) {
 	const connector = useConnector();
+	const startSite = useStartSite();
+	const isStarting = useIsSiteStarting( site.id );
 	const siteUrl = getSiteUrl( site );
 	const canPreview = site.running;
 	const [ currentPath, setCurrentPath ] = useState( '/' );
-	// Bumped on each `preview.command` (both navigate and reload) so the
-	// iframe remounts even when the resolved URL is identical to the current
-	// one — more reliable than calling `iframe.contentWindow.location.reload()`
-	// across the self-signed-HTTPS / custom-domain boundaries Studio supports.
 	const [ reloadNonce, setReloadNonce ] = useState( 0 );
+	const fullUrl = `${ siteUrl }${ currentPath }`;
 
 	useEffect( () => {
-		if ( ! sessionId ) {
-			return;
-		}
+		if ( ! sessionId ) return;
 		return connector.onAgentEvent( ( payload ) => {
-			if ( payload.sessionId !== sessionId ) {
-				return;
-			}
+			if ( payload.sessionId !== sessionId ) return;
 			const event = payload.event;
-			if ( event.type !== 'preview.command' ) {
-				return;
-			}
+			if ( event.type !== 'preview.command' ) return;
 			if ( event.kind === 'navigate' ) {
 				setCurrentPath( event.path );
 			}
 			setReloadNonce( ( n ) => n + 1 );
 		} );
 	}, [ connector, sessionId ] );
-
-	const fullUrl = `${ siteUrl }${ currentPath }`;
 
 	return (
 		<aside className={ styles.root } aria-label={ __( 'Site preview' ) }>
@@ -102,15 +76,166 @@ export function SitePreview( { site, sessionId }: SitePreviewProps ) {
 			</div>
 			<div className={ styles.body }>
 				{ canPreview ? (
-					<PreviewIframe
-						key={ `${ fullUrl }#${ reloadNonce }` }
-						src={ fullUrl }
-						title={ site.name }
-					/>
+					connector.previewView ? (
+						<WebContentsViewSurface
+							key={ `${ fullUrl }#${ reloadNonce }` }
+							url={ fullUrl }
+							previewView={ connector.previewView }
+							onAnnotationsDone={ onAnnotationsDone }
+						/>
+					) : (
+						// Non-Electron fallback: plain iframe, no inspector.
+						<iframe
+							key={ `${ fullUrl }#${ reloadNonce }` }
+							className={ styles.iframe }
+							src={ fullUrl }
+							title={ site.name }
+						/>
+					)
 				) : (
-					<div className={ styles.empty }>{ __( 'Start the site to see a live preview.' ) }</div>
+					<div className={ styles.empty }>
+						<p className={ styles.emptyText }>{ __( 'Start the site to see a live preview.' ) }</p>
+						<Button
+							variant="solid"
+							tone="brand"
+							loading={ isStarting }
+							loadingAnnouncement={ __( 'Starting site' ) }
+							onClick={ () => startSite.mutate( site.id ) }
+						>
+							<span className={ styles.startIcon } aria-hidden="true">
+								{ playIcon }
+							</span>
+							{ __( 'Start site' ) }
+						</Button>
+					</div>
 				) }
 			</div>
 		</aside>
+	);
+}
+
+interface WebContentsViewSurfaceProps {
+	url: string;
+	previewView: NonNullable< ReturnType< typeof useConnector >[ 'previewView' ] >;
+	onAnnotationsDone?: ( annotations: Annotation[] ) => void;
+}
+
+/**
+ * Mounts a Studio `WebContentsView` over the placeholder div, keeps its
+ * bounds in sync with the placeholder, and tears it down on unmount.
+ *
+ * The view is a native overlay — it always paints on top of HTML in the
+ * same window — so the inspector's toolbar UI lives inside the view's
+ * page (via `INSPECTOR_PAGE_SCRIPT`) rather than as a React overlay.
+ */
+function WebContentsViewSurface( {
+	url,
+	previewView,
+	onAnnotationsDone,
+}: WebContentsViewSurfaceProps ) {
+	const placeholderRef = useRef< HTMLDivElement | null >( null );
+	const viewIdRef = useRef< string | null >( null );
+	const [ ready, setReady ] = useState( false );
+	const onAnnotationsDoneRef = useRef( onAnnotationsDone );
+	useEffect( () => {
+		onAnnotationsDoneRef.current = onAnnotationsDone;
+	}, [ onAnnotationsDone ] );
+
+	// Lifecycle: create on mount, sync bounds, destroy on unmount. The
+	// `key` on the parent ensures we tear down + re-create whenever the URL
+	// changes (matches the old `<webview>` remount semantics).
+	useEffect( () => {
+		const node = placeholderRef.current;
+		if ( ! node ) return;
+
+		let cancelled = false;
+		let resizeObserver: ResizeObserver | null = null;
+		let scrollListener: ( () => void ) | null = null;
+		const initialBounds = node.getBoundingClientRect();
+		// WebContentsView ignores parent CSS clipping, so read the host
+		// container's border-radius and pass it down — the native view
+		// applies it via setBorderRadius. Falls back to 0 if unparseable.
+		const containerRadius = parseFloat(
+			window.getComputedStyle( node.closest( 'aside' ) ?? node ).borderRadius || '0'
+		);
+
+		void previewView
+			.create( {
+				url,
+				bounds: {
+					x: initialBounds.left,
+					y: initialBounds.top,
+					width: initialBounds.width,
+					height: initialBounds.height,
+				},
+				inspectorScript: INSPECTOR_PAGE_SCRIPT,
+				borderRadius: Number.isFinite( containerRadius ) ? containerRadius : 0,
+			} )
+			.then( ( { viewId } ) => {
+				if ( cancelled ) {
+					void previewView.destroy( viewId );
+					return;
+				}
+				viewIdRef.current = viewId;
+				setReady( true );
+
+				const syncBounds = () => {
+					if ( ! placeholderRef.current ) return;
+					const rect = placeholderRef.current.getBoundingClientRect();
+					void previewView.setBounds( viewId, {
+						x: rect.left,
+						y: rect.top,
+						width: rect.width,
+						height: rect.height,
+					} );
+				};
+
+				// `ResizeObserver` covers placeholder size changes (window
+				// resize, sidebar collapse, …). Window-level scroll covers
+				// the case where the placeholder moves without resizing.
+				resizeObserver = new ResizeObserver( syncBounds );
+				resizeObserver.observe( node );
+				scrollListener = syncBounds;
+				window.addEventListener( 'scroll', scrollListener, true );
+				window.addEventListener( 'resize', scrollListener );
+			} );
+
+		return () => {
+			cancelled = true;
+			resizeObserver?.disconnect();
+			if ( scrollListener ) {
+				window.removeEventListener( 'scroll', scrollListener, true );
+				window.removeEventListener( 'resize', scrollListener );
+			}
+			const viewId = viewIdRef.current;
+			viewIdRef.current = null;
+			if ( viewId ) {
+				void previewView.destroy( viewId );
+			}
+		};
+	}, [ previewView, url ] );
+
+	// Subscribe once for inspector events; route by viewId so the listener
+	// survives re-mounts under the same connector.
+	useEffect( () => {
+		return previewView.onEvent( ( { viewId, payload } ) => {
+			if ( viewId !== viewIdRef.current ) return;
+			const event = payload as InspectorEvent | null;
+			if ( ! event ) return;
+			if ( event.type === 'done' && event.annotations ) {
+				onAnnotationsDoneRef.current?.( event.annotations );
+			}
+		} );
+	}, [ previewView ] );
+
+	return (
+		<>
+			<div ref={ placeholderRef } className={ styles.iframe } />
+			{ ! ready ? (
+				<div className={ styles.spinnerOverlay } aria-hidden="true">
+					<span className={ styles.spinner } />
+				</div>
+			) : null }
+		</>
 	);
 }

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -7,7 +7,6 @@ import { useConnector } from '@/data/core';
 import { useIsSiteStarting, useStartSite } from '@/data/queries/use-sites';
 import { getSiteUrl } from '@/lib/get-site-url';
 import { playIcon } from '@/lib/icons';
-import { INSPECTOR_PAGE_SCRIPT } from './inspector-page-script';
 import styles from './style.module.css';
 import type { Annotation } from './types';
 import type { SiteDetails } from '@/data/core';
@@ -26,9 +25,8 @@ interface SitePreviewProps {
 }
 
 interface InspectorEvent {
-	type: 'done' | 'state' | 'pick-cancelled';
+	type: 'done';
 	annotations?: Annotation[];
-	isPicking?: boolean;
 }
 
 export function SitePreview( { site, sessionId, onAnnotationsDone }: SitePreviewProps ) {
@@ -78,8 +76,10 @@ export function SitePreview( { site, sessionId, onAnnotationsDone }: SitePreview
 				{ canPreview ? (
 					connector.previewView ? (
 						<WebContentsViewSurface
-							key={ `${ fullUrl }#${ reloadNonce }` }
-							url={ fullUrl }
+							key={ site.id }
+							siteId={ site.id }
+							path={ currentPath }
+							reloadNonce={ reloadNonce }
 							previewView={ connector.previewView }
 							onAnnotationsDone={ onAnnotationsDone }
 						/>
@@ -115,7 +115,9 @@ export function SitePreview( { site, sessionId, onAnnotationsDone }: SitePreview
 }
 
 interface WebContentsViewSurfaceProps {
-	url: string;
+	siteId: string;
+	path: string;
+	reloadNonce: number;
 	previewView: NonNullable< ReturnType< typeof useConnector >[ 'previewView' ] >;
 	onAnnotationsDone?: ( annotations: Annotation[] ) => void;
 }
@@ -126,24 +128,30 @@ interface WebContentsViewSurfaceProps {
  *
  * The view is a native overlay — it always paints on top of HTML in the
  * same window — so the inspector's toolbar UI lives inside the view's
- * page (via `INSPECTOR_PAGE_SCRIPT`) rather than as a React overlay.
+ * page rather than as a React overlay.
  */
 function WebContentsViewSurface( {
-	url,
+	siteId,
+	path,
+	reloadNonce,
 	previewView,
 	onAnnotationsDone,
 }: WebContentsViewSurfaceProps ) {
 	const placeholderRef = useRef< HTMLDivElement | null >( null );
 	const viewIdRef = useRef< string | null >( null );
+	const latestNavigationRef = useRef( { path, reloadNonce } );
 	const [ ready, setReady ] = useState( false );
 	const onAnnotationsDoneRef = useRef( onAnnotationsDone );
 	useEffect( () => {
 		onAnnotationsDoneRef.current = onAnnotationsDone;
 	}, [ onAnnotationsDone ] );
+	useEffect( () => {
+		latestNavigationRef.current = { path, reloadNonce };
+	}, [ path, reloadNonce ] );
 
-	// Lifecycle: create on mount, sync bounds, destroy on unmount. The
-	// `key` on the parent ensures we tear down + re-create whenever the URL
-	// changes (matches the old `<webview>` remount semantics).
+	// Lifecycle: create on mount, sync bounds, destroy on unmount. Navigation
+	// happens through a separate typed command so the main process keeps
+	// ownership of URL resolution and validation.
 	useEffect( () => {
 		const node = placeholderRef.current;
 		if ( ! node ) return;
@@ -158,17 +166,19 @@ function WebContentsViewSurface( {
 		const containerRadius = parseFloat(
 			window.getComputedStyle( node.closest( 'aside' ) ?? node ).borderRadius || '0'
 		);
+		const initialNavigation = latestNavigationRef.current;
 
 		void previewView
 			.create( {
-				url,
+				siteId,
+				path: initialNavigation.path,
 				bounds: {
 					x: initialBounds.left,
 					y: initialBounds.top,
 					width: initialBounds.width,
 					height: initialBounds.height,
 				},
-				inspectorScript: INSPECTOR_PAGE_SCRIPT,
+				enableInspector: true,
 				borderRadius: Number.isFinite( containerRadius ) ? containerRadius : 0,
 			} )
 			.then( ( { viewId } ) => {
@@ -178,6 +188,13 @@ function WebContentsViewSurface( {
 				}
 				viewIdRef.current = viewId;
 				setReady( true );
+				const latestNavigation = latestNavigationRef.current;
+				if (
+					latestNavigation.path !== initialNavigation.path ||
+					latestNavigation.reloadNonce !== initialNavigation.reloadNonce
+				) {
+					void previewView.navigate( viewId, latestNavigation.path );
+				}
 
 				const syncBounds = () => {
 					if ( ! placeholderRef.current ) return;
@@ -198,6 +215,11 @@ function WebContentsViewSurface( {
 				scrollListener = syncBounds;
 				window.addEventListener( 'scroll', scrollListener, true );
 				window.addEventListener( 'resize', scrollListener );
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setReady( true );
+				}
 			} );
 
 		return () => {
@@ -213,7 +235,13 @@ function WebContentsViewSurface( {
 				void previewView.destroy( viewId );
 			}
 		};
-	}, [ previewView, url ] );
+	}, [ previewView, siteId ] );
+
+	useEffect( () => {
+		const viewId = viewIdRef.current;
+		if ( ! viewId ) return;
+		void previewView.navigate( viewId, path );
+	}, [ path, previewView, reloadNonce ] );
 
 	// Subscribe once for inspector events; route by viewId so the listener
 	// survives re-mounts under the same connector.

--- a/apps/ui/src/components/site-preview/inspector-page-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-page-script.ts
@@ -1,0 +1,555 @@
+/**
+ * Annotation inspector injected into the site preview's `<webview>`.
+ *
+ * Vanilla DOM in a Shadow DOM root — React isn't loaded in the cross-origin
+ * WordPress page. Communicates with the host renderer via the
+ * `window.__studioInspector` bridge exposed by
+ * `apps/studio/src/preview-preload.ts`:
+ *   - host -> guest: `{ type: 'set-picking', picking: boolean }`,
+ *                    `{ type: 'clear' }`
+ *   - guest -> host: `{ type: 'state', annotations, isPicking }`,
+ *                    `{ type: 'pick-cancelled' }`
+ *
+ * Layout strategy: markers and the picking highlight use `position: absolute`
+ * anchored at *document* coordinates (viewport rect + scroll offset). They
+ * scroll with the page automatically — no scroll listener, no rAF loop. The
+ * popup uses `position: fixed` so it stays in the viewport.
+ */
+
+export const INSPECTOR_PAGE_SCRIPT =
+	String.raw`
+( () => {
+	const bridge = window.__studioInspector;
+	if ( ! bridge || typeof bridge.send !== 'function' ) {
+		return;
+	}
+	if ( window.__studioInspectorMounted ) {
+		return;
+	}
+	window.__studioInspectorMounted = true;
+
+	const HOST_ID = '__studio-inspector-host';
+
+	function buildSelector( el ) {
+		if ( ! el || el.nodeType !== 1 ) return '';
+		if ( el.id ) return '#' + CSS.escape( el.id );
+		const parts = [];
+		let node = el;
+		while ( node && node.nodeType === 1 && node !== document.documentElement ) {
+			let part = node.tagName.toLowerCase();
+			if ( node.classList && node.classList.length ) {
+				const classes = Array.from( node.classList )
+					.filter( ( c ) => ! c.startsWith( '__studio-' ) )
+					.slice( 0, 3 )
+					.map( ( c ) => '.' + CSS.escape( c ) )
+					.join( '' );
+				part += classes;
+			}
+			const parent = node.parentElement;
+			if ( parent ) {
+				const sameTagSiblings = Array.from( parent.children ).filter(
+					( c ) => c.tagName === node.tagName
+				);
+				if ( sameTagSiblings.length > 1 ) {
+					part += ':nth-of-type(' + ( sameTagSiblings.indexOf( node ) + 1 ) + ')';
+				}
+			}
+			parts.unshift( part );
+			node = parent;
+			if ( parts.length >= 6 ) break;
+		}
+		return parts.join( ' > ' );
+	}
+
+	function nearbyText( el ) {
+		const text = ( el.innerText || el.textContent || '' )
+			.replace( /\s+/g, ' ' )
+			.trim();
+		return text.length > 200 ? text.slice( 0, 200 ) + '…' : text;
+	}
+
+	function pickComputedStyles( el ) {
+		const cs = window.getComputedStyle( el );
+		const keys = [
+			'color', 'background-color', 'font-size', 'font-weight',
+			'font-family', 'line-height', 'padding', 'margin',
+			'border', 'display', 'width', 'height',
+		];
+		const out = {};
+		for ( const k of keys ) {
+			out[ k ] = cs.getPropertyValue( k );
+		}
+		return out;
+	}
+
+	function uid() {
+		return 'a_' + Math.random().toString( 36 ).slice( 2, 10 );
+	}
+
+	function documentRect( el ) {
+		const r = el.getBoundingClientRect();
+		return {
+			left: r.left + window.scrollX,
+			top: r.top + window.scrollY,
+			width: r.width,
+			height: r.height,
+		};
+	}
+
+	/* ------------------------------------------------------------------
+	 * Shadow DOM host. The host is \`position: absolute; top: 0; left: 0\`
+	 * with zero size — this anchors all absolutely-positioned descendants
+	 * at the document origin so their coordinates are document-relative
+	 * (and therefore scroll naturally with the page).
+	 * ---------------------------------------------------------------- */
+	const oldHost = document.getElementById( HOST_ID );
+	if ( oldHost ) oldHost.remove();
+	const host = document.createElement( 'div' );
+	host.id = HOST_ID;
+	host.style.cssText =
+		'all: initial; position: absolute; top: 0; left: 0; width: 0; height: 0; pointer-events: none; z-index: 2147483647;';
+	document.body.appendChild( host );
+	const root = host.attachShadow( { mode: 'open' } );
+
+	const style = document.createElement( 'style' );
+	style.textContent = ` +
+	'`' +
+	String.raw`
+		:host { all: initial; }
+		* { box-sizing: border-box; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+		.highlight {
+			position: absolute; pointer-events: none;
+			border: 2px solid #2563eb;
+			background: rgba(37,99,235,0.1);
+			border-radius: 2px;
+		}
+		.marker {
+			position: absolute; pointer-events: auto; cursor: pointer;
+			width: 22px; height: 22px;
+			background: #2563eb; color: #fff;
+			border: 2px solid #fff;
+			border-radius: 50%;
+			box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+			font: 700 11px/1 inherit;
+			display: inline-flex; align-items: center; justify-content: center;
+			transform: translate(-50%, -50%);
+		}
+		.popup {
+			position: fixed; width: 320px;
+			background: #1a1a1a; color: #fff;
+			border-radius: 12px;
+			box-shadow: 0 4px 24px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.08);
+			padding: 12px;
+			pointer-events: auto;
+			display: flex; flex-direction: column; gap: 8px;
+		}
+		.popup .target {
+			font-size: 11px; color: rgba(255,255,255,0.5);
+			overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+		}
+		.popup textarea {
+			width: 100%; min-height: 72px; resize: vertical;
+			background: rgba(255,255,255,0.05); color: #fff;
+			border: 1px solid rgba(255,255,255,0.15); border-radius: 8px;
+			padding: 8px; font: 13px/1.4 inherit; outline: none;
+		}
+		.popup textarea:focus { border-color: #2563eb; }
+		.popup .actions { display: flex; justify-content: flex-end; gap: 6px; }
+		.popup button {
+			padding: 6px 12px; border-radius: 16px; border: none;
+			font: 600 12px/1 inherit; cursor: pointer;
+		}
+		.popup .delete { background: transparent; color: rgba(255,255,255,0.5); margin-right: auto; }
+		.popup .delete:hover { color: #ef4444; }
+		.popup .cancel { background: transparent; color: rgba(255,255,255,0.7); }
+		.popup .cancel:hover { background: rgba(255,255,255,0.08); }
+		.popup .save { background: #fff; color: #1a1a1a; }
+		.popup .save[disabled] { opacity: 0.4; cursor: default; }
+		.toolbar {
+			position: fixed; bottom: 1.25rem; right: 1.25rem;
+			display: flex; align-items: center; gap: 6px;
+			background: #1a1a1a; color: #fff; border-radius: 22px;
+			padding: 6px;
+			box-shadow: 0 2px 8px rgba(0,0,0,0.2), 0 4px 16px rgba(0,0,0,0.1);
+			pointer-events: auto;
+		}
+		.toolbar button {
+			height: 32px; padding: 0 12px;
+			background: transparent; color: #fff;
+			border: none; border-radius: 16px;
+			font: 600 12px/1 inherit; cursor: pointer;
+			white-space: nowrap;
+		}
+		.toolbar button:hover { background: rgba(255,255,255,0.1); }
+		.toolbar button.active { background: #2563eb; color: #fff; }
+		.toolbar button.active:hover { background: #2563eb; }
+		.toolbar button.primary { background: #fff; color: #1a1a1a; }
+		.toolbar button.primary:hover { background: #f0f0f0; }
+		.toolbar button.primary[disabled] {
+			opacity: 0.5; cursor: default; background: #fff;
+		}
+		.toolbar .count {
+			min-width: 22px; height: 22px; padding: 0 6px;
+			display: inline-flex; align-items: center; justify-content: center;
+			background: rgba(255,255,255,0.15); color: #fff;
+			border-radius: 11px; font: 600 11px/1 inherit;
+		}
+	` +
+	'`' +
+	String.raw`;
+	root.appendChild( style );
+
+	/* ------------------------------------------------------------------
+	 * State + DOM
+	 * ---------------------------------------------------------------- */
+	let isPicking = false;
+	let hoveredEl = null;
+	let activePopup = null; /* { id?, target, comment, fromPicker? } */
+	let annotations = Array.isArray( window.__studioInspectorState )
+		? window.__studioInspectorState.slice()
+		: [];
+
+	const markerNodes = new Map(); /* id -> marker element */
+	let highlightNode = null;
+	let popupNode = null;
+	let toolbarNode = null;
+
+	function persistAnnotations() {
+		window.__studioInspectorState = annotations;
+	}
+
+	function syncMarkers() {
+		const ids = new Set( annotations.map( ( a ) => a.id ) );
+		for ( const [ id, marker ] of markerNodes ) {
+			if ( ! ids.has( id ) ) {
+				marker.remove();
+				markerNodes.delete( id );
+			}
+		}
+		annotations.forEach( ( ann, idx ) => {
+			let marker = markerNodes.get( ann.id );
+			if ( ! marker ) {
+				marker = document.createElement( 'div' );
+				marker.className = 'marker';
+				marker.addEventListener( 'click', ( e ) => {
+					e.stopPropagation();
+					const current = annotations.find( ( a ) => a.id === ann.id );
+					if ( current ) openPopupForAnnotation( current );
+				} );
+				/* Use the document-coord rect captured at save time so the
+				 * marker's position is fixed in document space and scrolls
+				 * with the page. No per-scroll repositioning needed. */
+				const box = ann.documentRect || ann.boundingBox || { left: 0, top: 0, width: 0, height: 0 };
+				marker.style.left = ( box.left + box.width ) + 'px';
+				marker.style.top = box.top + 'px';
+				root.appendChild( marker );
+				markerNodes.set( ann.id, marker );
+			}
+			marker.textContent = String( idx + 1 );
+			marker.title = ann.comment;
+		} );
+	}
+
+	function showHighlight( el ) {
+		if ( highlightNode ) {
+			highlightNode.remove();
+			highlightNode = null;
+		}
+		if ( ! el || ! isPicking ) return;
+		const r = documentRect( el );
+		highlightNode = document.createElement( 'div' );
+		highlightNode.className = 'highlight';
+		highlightNode.style.left = r.left + 'px';
+		highlightNode.style.top = r.top + 'px';
+		highlightNode.style.width = r.width + 'px';
+		highlightNode.style.height = r.height + 'px';
+		root.appendChild( highlightNode );
+	}
+
+	function showPopup() {
+		if ( popupNode ) {
+			popupNode.remove();
+			popupNode = null;
+		}
+		if ( activePopup ) {
+			popupNode = buildPopup( activePopup );
+			root.appendChild( popupNode );
+		}
+	}
+
+	function showToolbar() {
+		if ( toolbarNode ) {
+			toolbarNode.remove();
+			toolbarNode = null;
+		}
+		toolbarNode = document.createElement( 'div' );
+		toolbarNode.className = 'toolbar';
+
+		const pickBtn = document.createElement( 'button' );
+		pickBtn.textContent = isPicking ? 'Picking… click an element' : 'Annotate';
+		if ( isPicking ) pickBtn.className = 'active';
+		pickBtn.addEventListener( 'click', () => {
+			isPicking = ! isPicking;
+			if ( ! isPicking ) hoveredEl = null;
+			activePopup = null;
+			persistAnnotations();
+			render();
+		} );
+		toolbarNode.appendChild( pickBtn );
+
+		if ( annotations.length > 0 ) {
+			const count = document.createElement( 'span' );
+			count.className = 'count';
+			count.textContent = String( annotations.length );
+			count.title = annotations.length + ' annotation(s) pending';
+			toolbarNode.appendChild( count );
+		}
+
+		const doneBtn = document.createElement( 'button' );
+		doneBtn.className = 'primary';
+		doneBtn.textContent = 'Done';
+		doneBtn.disabled = annotations.length === 0;
+		doneBtn.addEventListener( 'click', () => {
+			if ( annotations.length === 0 ) return;
+			const sent = annotations.slice();
+			bridge.send( { type: 'done', annotations: sent } );
+			annotations = [];
+			activePopup = null;
+			isPicking = false;
+			hoveredEl = null;
+			persistAnnotations();
+			render();
+		} );
+		toolbarNode.appendChild( doneBtn );
+
+		root.appendChild( toolbarNode );
+	}
+
+	function render() {
+		syncMarkers();
+		showHighlight( hoveredEl );
+		showPopup();
+		showToolbar();
+	}
+
+	function buildPopup( state ) {
+		const popup = document.createElement( 'div' );
+		popup.className = 'popup';
+
+		/* Position the popup near the element using viewport coords (it's
+		 * \`position: fixed\` so it stays in the viewport). Falls back to
+		 * centre if the element can't be located. */
+		let el = null;
+		try {
+			el = state.target.selector ? document.querySelector( state.target.selector ) : null;
+		} catch {}
+		if ( el ) {
+			const r = el.getBoundingClientRect();
+			const popupWidth = 320;
+			const gap = 12;
+			const left = Math.min(
+				Math.max( 8, r.left + r.width / 2 - popupWidth / 2 ),
+				window.innerWidth - popupWidth - 8
+			);
+			let top = r.bottom + gap;
+			if ( top + 200 > window.innerHeight ) {
+				top = Math.max( 8, r.top - 200 - gap );
+			}
+			popup.style.left = left + 'px';
+			popup.style.top = top + 'px';
+		} else {
+			popup.style.left = '50%';
+			popup.style.top = '50%';
+			popup.style.transform = 'translate(-50%, -50%)';
+		}
+
+		const target = document.createElement( 'div' );
+		target.className = 'target';
+		target.textContent =
+			state.target.tag +
+			( state.target.nearbyText ? ' — ' + state.target.nearbyText : '' );
+		popup.appendChild( target );
+
+		const ta = document.createElement( 'textarea' );
+		ta.placeholder = 'What should change about this element?';
+		ta.value = state.comment || '';
+		ta.addEventListener( 'input', () => {
+			state.comment = ta.value;
+			save.disabled = ! state.comment.trim();
+		} );
+		popup.appendChild( ta );
+		setTimeout( () => ta.focus(), 0 );
+
+		const actions = document.createElement( 'div' );
+		actions.className = 'actions';
+
+		if ( state.id ) {
+			const del = document.createElement( 'button' );
+			del.className = 'delete';
+			del.textContent = 'Delete';
+			del.addEventListener( 'click', () => {
+				annotations = annotations.filter( ( a ) => a.id !== state.id );
+				activePopup = null;
+				persistAnnotations();
+				render();
+			} );
+			actions.appendChild( del );
+		}
+
+		const closePopup = () => {
+			activePopup = null;
+			/* Picking does NOT auto-resume after save/cancel. Auto-resume was
+			 * convenient for chaining annotations but it silently blocks every
+			 * link click in the page (the picking handler calls
+			 * preventDefault), making the preview feel broken. The user
+			 * re-enters picking mode via the Annotate button. */
+			isPicking = false;
+			hoveredEl = null;
+			persistAnnotations();
+			render();
+		};
+
+		const cancel = document.createElement( 'button' );
+		cancel.className = 'cancel';
+		cancel.textContent = 'Cancel';
+		cancel.addEventListener( 'click', closePopup );
+		actions.appendChild( cancel );
+
+		const save = document.createElement( 'button' );
+		save.className = 'save';
+		save.textContent = state.id ? 'Update' : 'Save';
+		save.disabled = ! ( state.comment && state.comment.trim() );
+		save.addEventListener( 'click', () => {
+			const trimmed = ( state.comment || '' ).trim();
+			if ( ! trimmed ) return;
+			if ( state.id ) {
+				annotations = annotations.map( ( a ) =>
+					a.id === state.id
+						? Object.assign( {}, a, { comment: trimmed, updatedAt: Date.now() } )
+						: a
+				);
+			} else {
+				annotations = annotations.concat( [
+					{
+						id: uid(),
+						comment: trimmed,
+						selector: state.target.selector,
+						tag: state.target.tag,
+						nearbyText: state.target.nearbyText,
+						boundingBox: state.target.boundingBox,
+						documentRect: state.target.documentRect,
+						computedStyles: state.target.computedStyles,
+						pathname: window.location.pathname,
+						url: window.location.href,
+						timestamp: Date.now(),
+					},
+				] );
+			}
+			closePopup();
+		} );
+		actions.appendChild( save );
+
+		popup.appendChild( actions );
+
+		popup.addEventListener( 'click', ( e ) => e.stopPropagation() );
+		popup.addEventListener( 'mousemove', ( e ) => e.stopPropagation() );
+
+		return popup;
+	}
+
+	function openPopupForAnnotation( ann ) {
+		isPicking = false;
+		hoveredEl = null;
+		activePopup = {
+			id: ann.id,
+			comment: ann.comment,
+			target: {
+				selector: ann.selector,
+				tag: ann.tag,
+				nearbyText: ann.nearbyText,
+				boundingBox: ann.boundingBox,
+				documentRect: ann.documentRect,
+				computedStyles: ann.computedStyles,
+			},
+		};
+		persistAnnotations();
+		render();
+	}
+
+	function openPopupForElement( el ) {
+		const viewport = el.getBoundingClientRect();
+		isPicking = false;
+		activePopup = {
+			fromPicker: true,
+			comment: '',
+			target: {
+				selector: buildSelector( el ),
+				tag: el.tagName.toLowerCase(),
+				nearbyText: nearbyText( el ),
+				boundingBox: { x: viewport.x, y: viewport.y, width: viewport.width, height: viewport.height },
+				documentRect: documentRect( el ),
+				computedStyles: pickComputedStyles( el ),
+			},
+		};
+		persistAnnotations();
+		render();
+	}
+
+	function isOurElement( el ) {
+		return !! ( el && el.closest && el.closest( '#' + HOST_ID ) );
+	}
+
+	/* ------------------------------------------------------------------
+	 * Picking interactions. Only the highlight is updated on mousemove —
+	 * markers are document-anchored and don't move with mouse position.
+	 * No scroll/resize listeners: markers and highlight live in document
+	 * coordinates and follow the page naturally.
+	 * ---------------------------------------------------------------- */
+	document.addEventListener(
+		'mousemove',
+		( e ) => {
+			if ( ! isPicking ) return;
+			if ( isOurElement( e.target ) ) {
+				if ( hoveredEl !== null ) {
+					hoveredEl = null;
+					showHighlight( null );
+				}
+				return;
+			}
+			if ( hoveredEl !== e.target ) {
+				hoveredEl = e.target;
+				showHighlight( hoveredEl );
+			}
+		},
+		true
+	);
+
+	document.addEventListener(
+		'click',
+		( e ) => {
+			if ( ! isPicking ) return;
+			if ( isOurElement( e.target ) ) return;
+			e.preventDefault();
+			e.stopPropagation();
+			openPopupForElement( e.target );
+		},
+		true
+	);
+
+	document.addEventListener( 'keydown', ( e ) => {
+		if ( e.key !== 'Escape' ) return;
+		if ( activePopup ) {
+			activePopup = null;
+			persistAnnotations();
+			render();
+		} else if ( isPicking ) {
+			isPicking = false;
+			hoveredEl = null;
+			persistAnnotations();
+			render();
+		}
+	} );
+
+	render();
+} )();
+`;

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -96,10 +96,28 @@
 .empty {
 	flex: 1;
 	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-md);
 	align-items: center;
 	justify-content: center;
 	padding: var(--wpds-dimension-padding-xl);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font-size: var(--wpds-typography-font-size-sm);
 	text-align: center;
+}
+
+.emptyText {
+	margin: 0;
+}
+
+.startIcon {
+	display: inline-flex;
+	width: 16px;
+	height: 16px;
+	margin-right: 4px;
+}
+
+.startIcon svg {
+	width: 100%;
+	height: 100%;
 }

--- a/apps/ui/src/components/site-preview/types.ts
+++ b/apps/ui/src/components/site-preview/types.ts
@@ -1,6 +1,5 @@
-// Subset of the inspector annotation that the host needs to know about.
-// The inspector (in `inspector-page-script.ts`) builds these and ships
-// them via the `done` event when the user clicks Done in the toolbar.
+// Annotation payload assembled by the React site-preview inspector. The
+// injected page runtime only supplies page-local target metadata.
 export interface Annotation {
 	id: string;
 	comment: string;

--- a/apps/ui/src/components/site-preview/types.ts
+++ b/apps/ui/src/components/site-preview/types.ts
@@ -1,0 +1,14 @@
+// Subset of the inspector annotation that the host needs to know about.
+// The inspector (in `inspector-page-script.ts`) builds these and ships
+// them via the `done` event when the user clicks Done in the toolbar.
+export interface Annotation {
+	id: string;
+	comment: string;
+	selector?: string;
+	tag?: string;
+	nearbyText?: string;
+	url?: string;
+	pathname?: string;
+	timestamp?: number;
+	[ key: string ]: unknown;
+}

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -626,11 +626,8 @@ export function createIpcConnector(): Connector {
 			async setBounds( viewId, bounds ) {
 				await ipcApi.setPreviewViewBounds( viewId, bounds );
 			},
-			async loadURL( viewId, url ) {
-				await ipcApi.loadPreviewViewURL( viewId, url );
-			},
-			async sendCommand( viewId, command ) {
-				await ipcApi.sendPreviewViewCommand( viewId, command );
+			async navigate( viewId, path ) {
+				await ipcApi.navigatePreviewView( viewId, path );
 			},
 			async destroy( viewId ) {
 				await ipcApi.destroyPreviewView( viewId );

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -619,6 +619,37 @@ export function createIpcConnector(): Connector {
 			ipcApi.openURL( url );
 		},
 
+		previewView: {
+			async create( options ) {
+				return ipcApi.createPreviewView( options );
+			},
+			async setBounds( viewId, bounds ) {
+				await ipcApi.setPreviewViewBounds( viewId, bounds );
+			},
+			async loadURL( viewId, url ) {
+				await ipcApi.loadPreviewViewURL( viewId, url );
+			},
+			async sendCommand( viewId, command ) {
+				await ipcApi.sendPreviewViewCommand( viewId, command );
+			},
+			async destroy( viewId ) {
+				await ipcApi.destroyPreviewView( viewId );
+			},
+			onEvent( listener ) {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const ipcListener = ( window as any ).ipcListener;
+				if ( ! ipcListener ) {
+					return () => undefined;
+				}
+				return ipcListener.subscribe(
+					'preview-view:event',
+					( _event: unknown, payload: { viewId: string; payload: unknown } ) => {
+						listener( payload );
+					}
+				);
+			},
+		},
+
 		// Window state
 		async isFullscreen(): Promise< boolean > {
 			return ipcApi.isFullscreen();

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -228,6 +228,13 @@ export interface Connector {
 	// External links
 	openExternalUrl( url: string ): Promise< void >;
 
+	// Site preview rendered as a native `WebContentsView` overlay. The
+	// renderer reports a placeholder div's bounds via `setBounds`, sends
+	// commands to the inspector, and subscribes to inspector events through
+	// `onEvent`. Connectors that don't have an Electron backing should
+	// expose `null` here; the renderer falls back to a plain `<iframe>`.
+	previewView: PreviewViewConnector | null;
+
 	// Window state (macOS fullscreen hides traffic lights, so the UI needs
 	// to reclaim the space we normally leave for them).
 	isFullscreen(): Promise< boolean >;
@@ -236,6 +243,34 @@ export interface Connector {
 	// Fires whenever a site is created, updated, started, stopped, or deleted.
 	// Consumers typically invalidate cached site data in response.
 	onSiteEvent( listener: () => void ): () => void;
+}
+
+export interface PreviewViewBounds {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+export interface PreviewViewEvent {
+	viewId: string;
+	payload: unknown;
+}
+
+export interface PreviewViewConnector {
+	create( options: {
+		url: string;
+		bounds: PreviewViewBounds;
+		inspectorScript?: string;
+		// CSS pixels — matches the React container's `border-radius` so the
+		// native overlay's corners line up with its frame.
+		borderRadius?: number;
+	} ): Promise< { viewId: string } >;
+	setBounds( viewId: string, bounds: PreviewViewBounds ): Promise< void >;
+	loadURL( viewId: string, url: string ): Promise< void >;
+	sendCommand( viewId: string, command: unknown ): Promise< void >;
+	destroy( viewId: string ): Promise< void >;
+	onEvent( listener: ( event: PreviewViewEvent ) => void ): () => void;
 }
 
 export type ColorScheme = 'system' | 'light' | 'dark';

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -229,10 +229,10 @@ export interface Connector {
 	openExternalUrl( url: string ): Promise< void >;
 
 	// Site preview rendered as a native `WebContentsView` overlay. The
-	// renderer reports a placeholder div's bounds via `setBounds`, sends
-	// commands to the inspector, and subscribes to inspector events through
-	// `onEvent`. Connectors that don't have an Electron backing should
-	// expose `null` here; the renderer falls back to a plain `<iframe>`.
+	// renderer reports a placeholder div's bounds via `setBounds`, navigates
+	// by site-relative path, and subscribes to inspector events through
+	// `onEvent`. Connectors that don't have an Electron backing should expose
+	// `null` here; the renderer falls back to a plain `<iframe>`.
 	previewView: PreviewViewConnector | null;
 
 	// Window state (macOS fullscreen hides traffic lights, so the UI needs
@@ -259,16 +259,16 @@ export interface PreviewViewEvent {
 
 export interface PreviewViewConnector {
 	create( options: {
-		url: string;
+		siteId: string;
+		path?: string;
 		bounds: PreviewViewBounds;
-		inspectorScript?: string;
+		enableInspector?: boolean;
 		// CSS pixels — matches the React container's `border-radius` so the
 		// native overlay's corners line up with its frame.
 		borderRadius?: number;
 	} ): Promise< { viewId: string } >;
 	setBounds( viewId: string, bounds: PreviewViewBounds ): Promise< void >;
-	loadURL( viewId: string, url: string ): Promise< void >;
-	sendCommand( viewId: string, command: unknown ): Promise< void >;
+	navigate( viewId: string, path: string ): Promise< void >;
 	destroy( viewId: string ): Promise< void >;
 	onEvent( listener: ( event: PreviewViewEvent ) => void ): () => void;
 }

--- a/apps/ui/src/lib/icons.tsx
+++ b/apps/ui/src/lib/icons.tsx
@@ -1,3 +1,9 @@
+export const playIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+		<path d="M8 5.5L18 12L8 18.5V5.5Z" fill="currentColor" />
+	</svg>
+);
+
 export const drawerIcon = (
 	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
 		<rect x="4" y="5" width="16" height="14" rx="1.5" stroke="currentColor" strokeWidth="1.5" />


### PR DESCRIPTION
## Related issues

- Builds on the design from #3243 (the `/annotate` skill in apps/cli) and ports the same idea into the apps/ui site preview, so users can annotate elements directly from the in-app preview and feed them straight into the chat composer.

## How AI was used in this PR

Heavy AI involvement — Claude Code drove the initial design + implementation across many iterations (iframe → `<webview>` → `WebContentsView`), and I worked through several real bugs with it (popup-closing race, scroll freeze, navigation-policy block, native overlay border-radius). Codex then reviewed and hardened the preview/inspector architecture. Worth a careful human read of:

- The native-view ↔ React renderer wiring in `apps/studio/src/preview-view.ts` + `apps/ui/src/components/site-preview/index.tsx`. Bounds tracking via `ResizeObserver`/`scroll`, view lifecycle, IPC routing of inspector events keyed by `viewId`, and replaying the latest requested path after async view creation.
- The preview navigation policy in `apps/studio/src/index.ts` + `apps/studio/src/preview-view.ts`. Preview `webContents` are scoped to the owning local site origin; external navigations/popups/redirects are blocked from loading in the privileged preview view and opened externally only for HTTP(S) URLs.
- The injected inspector runtime in `apps/studio/src/preview-inspector-script.ts`. Studio main owns this script; the renderer no longer passes executable code over IPC. The script is vanilla DOM in a Shadow DOM root and runs inside the WordPress page, so it needs to be defensive against theme CSS / global handlers.

## Proposed Changes

**Site preview rewrite (`apps/ui` + `apps/studio`)**
- Site preview now renders via Electron's `WebContentsView` instead of an `<iframe>` — needed for the annotate inspector to run inside the cross-origin WordPress page. The renderer renders a placeholder `<div>`; main process attaches the view to `mainWindow.contentView` and keeps its bounds in sync with the placeholder via IPC + `ResizeObserver` + `scroll`/`resize` listeners.
- Native-view corner rounding via `view.setBorderRadius` so the preview corners match the React container's `border-radius` (the native overlay otherwise ignores parent CSS clipping).
- New `Connector.previewView` slice (`create` / `setBounds` / `navigate` / `destroy` / `onEvent`) — connector-pattern friendly, with a plain `<iframe>` fallback for non-Electron connectors without inspector support.

**Preview security/lifecycle hardening**
- `createPreviewView` now takes validated data (`siteId`, `path`, bounds, feature flags) instead of renderer-supplied executable script source.
- Main process resolves preview URLs from `SiteServer`, validates paths against the local site origin/custom domain, and owns the inspector asset.
- Preview IPC commands are tied to the creating renderer `webContents.id`; commands from other renderers are ignored.
- Preview views are disposed when the owning renderer is destroyed, avoiding orphan native overlays after reloads/crashes/window teardown.
- Preview navigations, popups, and redirects are constrained to the allowed site origin. External HTTP(S) URLs open outside Studio; non-web or malformed URLs are ignored.
- Inspector injection checks the final committed preview URL before executing the script.

**Inspector (main-owned injected page script)**
- Toolbar at the bottom-right of the preview (Annotate / count badge / Done), styled to match #3243.
- `Annotate` toggles picking. While picking is on, the inspector intercepts clicks (capture phase, `preventDefault`) and opens a comment popup near the clicked element. Saving stores the annotation, closes the popup, and stops picking (no auto-resume — auto-resume silently blocked link navigation in the preview).
- Markers and highlight are positioned in document coordinates (`position: absolute`) so they scroll with the page with zero per-scroll JS — the earlier per-scroll rebuild approach froze the renderer on real WP pages.
- One inspector → host event: `{ type: 'done', annotations }` on Done click. The preload exposes only `window.__studioInspector.send(payload)`, and main validates the event shape before forwarding it to the host renderer.

**Composer integration (`apps/ui/src/components/session-view`)**
- `Composer` exposes an imperative `appendDraft(text)` via `forwardRef` + `useImperativeHandle`. SessionView holds a `composerRef` and calls `composerRef.current.appendDraft(formatAnnotationsAsPrompt(annotations))` when a batch arrives. **Not** a controlled `value` prop — that re-rendered the entire SessionView (and the heavy Conversation tree) on every keystroke and was producing visible UI freezes.
- `formatAnnotationsAsPrompt` groups annotations by page (preserving insertion order, merging consecutive same-page runs) so a batch from one page reads as one section, while navigate-annotate-navigate-annotate sequences keep each page's items under their own header. Each item carries the element tag + nearby text + CSS selector.

**Preview empty state**
- Adds a Start-site button to the empty state (`Start the site to see a live preview.`) using `useStartSite` — saves the user a trip to the sidebar to start the site.

**Files**

- New `apps/studio/src/preview-view.ts` — `PreviewView` class wrapping `WebContentsView` with owner tracking, allowed-origin navigation policy, lifecycle registry, and inspector event forwarding.
- New `apps/studio/src/preview-preload.ts` — small bridge exposing `window.__studioInspector.send(payload)` to the guest page; uses `ipcRenderer.send` with main-process validation and forwarding to the host renderer.
- New `apps/studio/src/preview-inspector-script.ts` — main-owned vanilla DOM inspector runtime, moved out of apps/ui so renderer IPC no longer carries executable source.
- New `apps/ui/src/components/site-preview/types.ts` — extracted `Annotation` interface.
- Modified `apps/studio/src/index.ts` — preview-specific navigation/redirect/window-open policy.
- Modified `apps/studio/src/ipc-handlers.ts` — `createPreviewView` / `setPreviewViewBounds` / `navigatePreviewView` / `destroyPreviewView` with site URL resolution and owner checks.
- Modified `apps/studio/electron.vite.config*.ts` — bundle the new `preview-preload.ts` as a second preload entry point.
- Modified `apps/ui/src/components/session-view/composer/index.tsx` — `forwardRef` + `appendDraft` imperative API.
- Modified `apps/ui/src/components/session-view/index.tsx` — wires `composerRef` and `formatAnnotationsAsPrompt` into the preview's `onAnnotationsDone`.

## Testing Instructions

1. `npm install`
2. `npm run start:new`
3. Open a session whose owner site is local + running (or start one from the new "Start site" button in the preview empty state).
4. Toggle the site preview on (header drawer icon).
5. Click `Annotate` in the bottom-right toolbar of the preview, click an element on the WordPress page, type a comment, click `Save`. Marker appears with a number badge.
6. (Optional) Click `Annotate` again to chain another, possibly after navigating to another page in the preview by clicking a link.
7. Click `Done`. The composer's draft is replaced/appended with a numbered list grouped by page, with element tag + nearby text + CSS selector for each annotation. Edit if needed and Cmd+Enter to send.
8. Verify: scrolling the preview is smooth (markers move with the page natively); link navigation works; existing markers re-anchor sensibly after navigation.
9. Verify navigation hardening: a same-site link should load in the preview; an external HTTP(S) link or popup should open in the system browser; non-web URLs should not load in the preview.

## Pre-merge Checklist

- [x] No TypeScript / lint errors for touched workspaces (`npm run typecheck -w apps/studio`, `npm run typecheck -w apps/ui`, `eslint --fix` on touched files).
- [x] Production builds (`vite build` for `@studio/ui`; `electron-vite build --config electron.vite.config.new-ui.ts`).
- [ ] Unit / E2E coverage — none added in this PR. The interaction surface lives inside an injected vanilla-DOM script + a native overlay, similar to #3243; reviewers may want to push for Playwright coverage before landing.
- [ ] Cross-platform (Windows/Linux) verification — only manually tested on macOS. The `WebContentsView` bounds-sync code uses `getBoundingClientRect`, which should match Electron's content coordinates on macOS but may need offset adjustments under Windows `titleBarOverlay`.
- [ ] Have you checked for TypeScript, React or other console errors?

## Notes for reviewers

- The toolbar lives inside the injected page script (Shadow DOM) rather than as a React component. `WebContentsView` is a native overlay that always paints on top of HTML in the same window, so HTML overlays are no longer possible. If the toolbar should integrate with apps/ui's i18n / theme, the path forward is to render it in the preview header instead (above the view's bounds) or move the inspector runtime into the local WordPress site/iframe architecture.
- About `<webview>`: the Electron docs at https://www.electronjs.org/docs/latest/api/webview-tag explicitly recommend against it (not formally deprecated, but discouraged). `WebContentsView` is one of the suggested alternatives.
- An iframe-only implementation would require injecting the inspector runtime into the local WordPress page itself and communicating back with `postMessage`; that may be a cleaner long-term architecture, but it is a larger redesign than this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
