### PR TITLE
Update SQLite database integration to v3.0.0-rc.2

### DIFF
--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -59,7 +59,7 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.1';
+const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.2';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/releases/download/${ SQLITE_DATABASE_INTEGRATION_VERSION }/plugin-sqlite-database-integration.zip`;
 


### PR DESCRIPTION
## Related issues
https://github.com/WordPress/sqlite-database-integration/releases/tag/v3.0.0-rc.2

## Proposed Changes
- Bumps `SQLITE_DATABASE_INTEGRATION_VERSION` from `v3.0.0-rc.1` to `v3.0.0-rc.2` in `apps/studio/src/constants.ts`

**Upstream changelog:**
- Support MySQL `BINARY` operator
- Add support for `AUTO_INCREMENT` value management
- Add support for `DELETE` with `LIMIT` and `ORDER BY`

## Testing Instructions
- Create a new local site and verify it starts correctly
- Run existing tests: `npm test`

## Pre-merge Checklist
- [x] Changes are limited to the version bump
- [x] TypeScript check passes