### PR TITLE
fix: pin @wp-playground/blueprints to exact version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,10 +25,6 @@ updates:
       - dependency-name: "wpcom"
       - dependency-name: "wpcom-*"
 
-      # WordPress Playground & PHP WASM
-      - dependency-name: "@wp-playground/*"
-      - dependency-name: "@php-wasm/*"
-
       # TypeScript ecosystem
       - dependency-name: "typescript"
       - dependency-name: "typescript-*"
@@ -165,11 +161,6 @@ updates:
           - "electron-playwright-helpers"
           - "electron-devtools-installer"
 
-      wp-playground-php-wasm:
-        patterns:
-          - "@wp-playground/*"
-          - "@php-wasm/*"
-
       wordpress:
         patterns:
           - "@wordpress/*"
@@ -279,6 +270,8 @@ updates:
       - dependency-name: "eslint-plugin-studio"
       - dependency-name: "winreg" # v1.2.5 has a known issue: https://github.com/fresc81/node-winreg/issues/65
       - dependency-name: "@types/glob" # glob@7 (transitive) has no bundled types; @types/glob@9 is a stub for glob@9+ only
+      - dependency-name: "@wp-playground/*" # must be pinned exactly and bumped manually in lockstep — version mismatches cause runtime failures and ~450 MB bundle bloat
+      - dependency-name: "@php-wasm/*" # must be pinned exactly and bumped manually in lockstep — version mismatches cause runtime failures and ~450 MB bundle bloat
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,8 @@ If you've built a substantial new feature — especially one generated with AI a
 
 **Port Conflicts**: Site servers dynamically allocate ports. Don't hardcode port numbers; use the port-finder utility.
 
+**CRITICAL - Playground/PHP-WASM Package Versions**: Always pin `@wp-playground/*` and `@php-wasm/*` packages to **exact versions** (no `^` or `~` ranges) in all `package.json` files. A caret range causes `install:bundle` to resolve a newer version when one publishes, creating a version conflict. npm then installs duplicate copies of all PHP WASM packages nested under the conflicting package's `node_modules/`. The `prune-php-wasm` vite plugin only removes top-level asyncify directories and misses nested copies, resulting in ~450 MB of bloat in the app bundle. More critically, different parts of Studio end up running mismatched Playground/PHP-WASM versions, which can cause subtle and hard-to-diagnose runtime failures in core site operations.
+
 ## Detailed Documentation
 
 For in-depth information, see these docs:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -33,7 +33,7 @@
 		"@php-wasm/util": "3.1.21",
 		"@vscode/sudo-prompt": "^9.3.2",
 		"@wordpress/i18n": "^6.14.0",
-		"@wp-playground/blueprints": "^3.1.21",
+		"@wp-playground/blueprints": "3.1.21",
 		"@wp-playground/cli": "3.1.21",
 		"@wp-playground/common": "3.1.21",
 		"@wp-playground/storage": "3.1.21",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -97,7 +97,7 @@
 		"@types/winreg": "^1.2.36",
 		"@types/yauzl": "^2.10.3",
 		"@vitejs/plugin-react": "^5.1.4",
-		"@wp-playground/blueprints": "^3.1.21",
+		"@wp-playground/blueprints": "3.1.21",
 		"electron": "^41.3.0",
 		"electron-devtools-installer": "^4.0.0",
 		"electron-vite": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
 				"@php-wasm/util": "3.1.21",
 				"@vscode/sudo-prompt": "^9.3.2",
 				"@wordpress/i18n": "^6.14.0",
-				"@wp-playground/blueprints": "^3.1.21",
+				"@wp-playground/blueprints": "3.1.21",
 				"@wp-playground/cli": "3.1.21",
 				"@wp-playground/common": "3.1.21",
 				"@wp-playground/storage": "3.1.21",
@@ -566,7 +566,7 @@
 				"@types/winreg": "^1.2.36",
 				"@types/yauzl": "^2.10.3",
 				"@vitejs/plugin-react": "^5.1.4",
-				"@wp-playground/blueprints": "^3.1.21",
+				"@wp-playground/blueprints": "3.1.21",
 				"electron": "^41.3.0",
 				"electron-devtools-installer": "^4.0.0",
 				"electron-vite": "^5.0.0",
@@ -28080,7 +28080,7 @@
 			"devDependencies": {
 				"@types/lockfile": "^1.0.4",
 				"@types/yauzl": "^2.10.3",
-				"@wp-playground/blueprints": "^3.1.21"
+				"@wp-playground/blueprints": "3.1.21"
 			}
 		},
 		"tools/common/node_modules/ignore": {

--- a/tools/common/package.json
+++ b/tools/common/package.json
@@ -23,6 +23,6 @@
 	"devDependencies": {
 		"@types/lockfile": "^1.0.4",
 		"@types/yauzl": "^2.10.3",
-		"@wp-playground/blueprints": "^3.1.21"
+		"@wp-playground/blueprints": "3.1.21"
 	}
 }


### PR DESCRIPTION
## Related issues

Follow-up to #3254.

## How AI was used in this PR

Fix identified by Claude while investigating a 455 MB app size regression shown in CodeVitals on trunk.

## Proposed Changes

Pins `@wp-playground/blueprints` to an exact version in all `package.json` files, consistent with how all other Playground/PHP-WASM packages are already pinned.

**Root cause of the regression:** `^3.1.20` on blueprints meant that when 3.1.21 published to npm, `install:bundle` (which runs `npm install --no-workspaces` inside `apps/cli`) resolved blueprints to 3.1.21. That version of blueprints depends on `@php-wasm/node@3.1.21`, but `apps/cli/package.json` pinned `@php-wasm/node@3.1.20` — so npm installed **both** versions, with the 3.1.21 copies nested under `blueprints/node_modules/`. The `prune-php-wasm` vite plugin only globs top-level `@php-wasm/node-*/asyncify/` paths, so the nested copies (8 PHP versions × ~58 MB each) were never pruned, adding ~466 MB to the app bundle.

## Testing Instructions

- CodeVitals app-size should stay at ~1450 MB, not jump to ~1907 MB after the next Playground release

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?