### PR TITLE
Fix WP-CLI post content parsing before porcelain flags

### DIFF
--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -360,4 +360,89 @@ describe( 'Studio AI MCP tools', () => {
 			'--post_content=Hello world',
 		] );
 	} );
+
+	it( 'keeps flags after quoted post_content out of the page content', async () => {
+		vi.mocked( isServerRunning ).mockResolvedValue( {
+			name: 'site-123',
+			pmId: 1,
+			status: 'online',
+			pid: 1234,
+		} );
+		vi.mocked( sendWpCliCommand ).mockResolvedValue( {
+			stdout: '123',
+			stderr: '',
+			exitCode: 0,
+		} );
+
+		await getTool( 'wp_cli' ).handler(
+			{
+				nameOrPath: 'My Site',
+				command:
+					'post create --post_type=page --post_title="About" --post_content="Hello world" --porcelain',
+			} as never,
+			null
+		);
+
+		expect( sendWpCliCommand ).toHaveBeenCalledWith( 'site-123', [
+			'post',
+			'create',
+			'--post_type=page',
+			'--post_title=About',
+			'--post_content=Hello world',
+			'--porcelain',
+		] );
+	} );
+
+	it( 'keeps porcelain after empty quoted post_content out of the page content', async () => {
+		vi.mocked( isServerRunning ).mockResolvedValue( {
+			name: 'site-123',
+			pmId: 1,
+			status: 'online',
+			pid: 1234,
+		} );
+		vi.mocked( sendWpCliCommand ).mockResolvedValue( {
+			stdout: '123',
+			stderr: '',
+			exitCode: 0,
+		} );
+
+		await getTool( 'wp_cli' ).handler(
+			{
+				nameOrPath: 'My Site',
+				command: 'post create --post_type=page --post_title="About" --post_content="" --porcelain',
+			} as never,
+			null
+		);
+
+		expect( sendWpCliCommand ).toHaveBeenCalledWith( 'site-123', [
+			'post',
+			'create',
+			'--post_type=page',
+			'--post_title=About',
+			'--post_content=',
+			'--porcelain',
+		] );
+	} );
+
+	it( 'rejects typographic dash options before dispatching to WP-CLI', async () => {
+		vi.mocked( isServerRunning ).mockResolvedValue( {
+			name: 'site-123',
+			pmId: 1,
+			status: 'online',
+			pid: 1234,
+		} );
+
+		const result = await getTool( 'wp_cli' ).handler(
+			{
+				nameOrPath: 'My Site',
+				command:
+					'post create --post_type=page --post_title="About" --post_content="Hello world" –porcelain',
+			} as never,
+			null
+		);
+
+		expect( sendWpCliCommand ).not.toHaveBeenCalled();
+		expect( result.isError ).toBe( true );
+		expect( getTextContent( result ) ).toContain( 'typographic dash' );
+	} );
 } );

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -92,22 +92,56 @@ function stripMatchingOuterQuotes( value: string ): string {
 	return value;
 }
 
+function splitPostContentCommandArgs( command: string, postContentIndex: number ): string[] {
+	const postContentMarker = '--post_content=';
+	const prefix = command.slice( 0, postContentIndex ).trim();
+	const postContentTail = command.slice( postContentIndex + postContentMarker.length ).trim();
+	const prefixArgs = splitBasicCommandArgs( prefix );
+
+	if ( ! postContentTail ) {
+		return [ ...prefixArgs, postContentMarker ];
+	}
+
+	const quote = postContentTail[ 0 ];
+	if ( quote === '"' || quote === "'" ) {
+		const closingQuoteIndex = postContentTail.indexOf( quote, 1 );
+		if ( closingQuoteIndex !== -1 ) {
+			const postContent = postContentTail.slice( 1, closingQuoteIndex );
+			const suffix = postContentTail.slice( closingQuoteIndex + 1 ).trim();
+			return [
+				...prefixArgs,
+				`${ postContentMarker }${ postContent }`,
+				...splitBasicCommandArgs( suffix ),
+			];
+		}
+	}
+
+	// Large block content is commonly emitted without shell quoting and should
+	// be treated as a single literal argument that consumes the rest of the command.
+	return [
+		...prefixArgs,
+		`${ postContentMarker }${ stripMatchingOuterQuotes( postContentTail ) }`,
+	];
+}
+
 function splitCommandArgs( command: string ): string[] {
 	const postContentMarker = '--post_content=';
 	const postContentIndex = command.indexOf( postContentMarker );
 
-	// Large block content is commonly emitted without shell quoting and should
-	// be treated as a single literal argument that consumes the rest of the command.
 	if ( postContentIndex !== -1 ) {
-		const prefix = command.slice( 0, postContentIndex ).trim();
-		const postContent = stripMatchingOuterQuotes(
-			command.slice( postContentIndex + postContentMarker.length ).trim()
-		);
-
-		return [ ...splitBasicCommandArgs( prefix ), `${ postContentMarker }${ postContent }` ];
+		return splitPostContentCommandArgs( command, postContentIndex );
 	}
 
 	return splitBasicCommandArgs( command );
+}
+
+function getUnsupportedWpCliOptionMessage( args: string[] ): string | null {
+	const unsupportedOption = args.find( ( arg ) => /^[\u2010-\u2015]\S+/.test( arg ) );
+	if ( ! unsupportedOption ) {
+		return null;
+	}
+
+	return `Unsupported WP-CLI option "${ unsupportedOption }": use ASCII hyphens, for example "--porcelain", not a typographic dash.`;
 }
 
 async function findSiteByName( name: string ): Promise< SiteData | undefined > {
@@ -518,6 +552,11 @@ const runWpCliTool = tool(
 				}
 
 				const wpCliArgs = splitCommandArgs( args.command );
+				const unsupportedOptionMessage = getUnsupportedWpCliOptionMessage( wpCliArgs );
+				if ( unsupportedOptionMessage ) {
+					return errorResult( unsupportedOptionMessage );
+				}
+
 				const unsupportedPostContentMessage = getUnsupportedWpCliPostContentMessage( wpCliArgs );
 				if ( unsupportedPostContentMessage ) {
 					return errorResult( unsupportedPostContentMessage );


### PR DESCRIPTION
I noticed the studio code agent sometimes includes things like "--porcelain" in the actual content of the pages, this PR should fix it.

## Summary
- Split quoted `--post_content` values so later WP-CLI flags are not absorbed into the post body
- Reject typographic dash options like `–porcelain` before dispatching the command
- Add regression coverage for quoted content followed by flags and for invalid dash input

## Testing
- Added unit test coverage for the parser and `wp_cli` tool behavior
- Lint and formatting passed
- Typecheck passed
- Targeted test file passed