### PR TITLE
apps/ui: Add active site icons to the UI

### DIFF
--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -349,6 +349,11 @@ async function appBoot() {
 		await SiteServer.fetchAll();
 		await startCliEventsSubscriber();
 
+		// Sites already running at launch never hit the cli-events-subscriber's
+		// "transitioned to running" branch, so kick off icon fetches for them
+		// here. Don't await — the renderer picks up results via site-event.
+		void SiteServer.backfillRunningSiteIcons();
+
 		await createMainWindow();
 
 		const userData = await loadUserData();

--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -349,11 +349,6 @@ async function appBoot() {
 		await SiteServer.fetchAll();
 		await startCliEventsSubscriber();
 
-		// Sites already running at launch never hit the cli-events-subscriber's
-		// "transitioned to running" branch, so kick off icon fetches for them
-		// here. Don't await — the renderer picks up results via site-event.
-		void SiteServer.backfillRunningSiteIcons();
-
 		await createMainWindow();
 
 		const userData = await loadUserData();

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -616,13 +616,26 @@ function readProcessManagerLogs( siteId: string ): { stdout?: string[]; stderr?:
 export async function getSiteDetails( _event: IpcMainInvokeEvent ): Promise< SiteDetails[] > {
 	const sites = SiteServer.getAllDetails();
 	const userData = await loadUserData();
-	for ( const site of sites ) {
-		const appdataSite = userData.siteMetadata[ site.id ];
-		if ( appdataSite ) {
+	await Promise.all(
+		sites.map( async ( site ) => {
+			const appdataSite = userData.siteMetadata[ site.id ];
+			if ( ! appdataSite ) {
+				return;
+			}
 			site.sortOrder = appdataSite.sortOrder;
 			site.themeDetails = appdataSite.themeDetails;
-		}
-	}
+			site.siteIconPath = appdataSite.siteIconPath;
+
+			// Read the icon file from disk and hand the renderer a data URL.
+			// Keeping the base64 out of the persisted appdata avoids bloating
+			// app.json with image bytes.
+			if ( appdataSite.siteIconPath ) {
+				site.siteIcon = await getImageData( appdataSite.siteIconPath );
+			} else if ( appdataSite.siteIconPath === null ) {
+				site.siteIcon = null;
+			}
+		} )
+	);
 
 	return sites;
 }

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -707,6 +707,7 @@ export async function createSite(
 		// If the site is running after creation, fetch theme details and update thumbnail
 		if ( server.details.running ) {
 			void loadThemeDetails( event, server.details.id );
+			void loadSiteIcon( event, server.details.id );
 		}
 
 		return server.details;
@@ -891,6 +892,7 @@ export async function startServer( event: IpcMainInvokeEvent, id: string ): Prom
 
 	if ( server.details.running ) {
 		void loadThemeDetails( event, id );
+		void loadSiteIcon( event, id );
 	}
 
 	// Keep managed instruction files (STUDIO.md, CLAUDE.md) up-to-date
@@ -1275,6 +1277,29 @@ export async function loadThemeDetails(
 	}
 
 	return themeDetails;
+}
+
+// Mirror of loadThemeDetails for the Site Icon: fetch from the running
+// site's mu-plugin command and persist the resolved path so the renderer
+// can read it back from appdata via getSiteDetails.
+export async function loadSiteIcon(
+	_event: IpcMainInvokeEvent,
+	id: string
+): Promise< StartedSiteDetails[ 'siteIconPath' ] > {
+	const server = SiteServer.get( id );
+	if ( ! server ) {
+		throw new Error( 'Site not found.' );
+	}
+
+	const oldIconPath = server.details.siteIconPath;
+	const iconPath = await server.getSiteIcon();
+	const hasIconChanged = iconPath !== oldIconPath;
+
+	if ( hasIconChanged ) {
+		await server.persistSiteIcon();
+	}
+
+	return iconPath;
 }
 
 export async function getOnboardingData( _event: IpcMainInvokeEvent ): Promise< boolean > {

--- a/apps/studio/src/ipc-types.d.ts
+++ b/apps/studio/src/ipc-types.d.ts
@@ -31,6 +31,13 @@ interface StoppedSiteDetails {
 		supportsWidgets: boolean;
 		supportsMenus: boolean;
 	};
+	// Absolute filesystem path of the configured WordPress Site Icon.
+	// `null` means we've checked and the site has no icon configured;
+	// `undefined` means we've never fetched.
+	siteIconPath?: string | null;
+	// Data URL produced from `siteIconPath` for the renderer to display.
+	// Computed at the IPC boundary in `getSiteDetails`, never persisted.
+	siteIcon?: string | null;
 	isAddingSite?: boolean;
 	autoStart?: boolean;
 	latestCliPid?: number;

--- a/apps/studio/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/apps/studio/src/modules/cli/lib/cli-events-subscriber.ts
@@ -105,15 +105,7 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > 
 	if ( wasNotRunning && running ) {
 		void captureSiteThumbnail( siteId );
 		await server.getThemeDetails();
-
-		const previousIconPath = server.details.siteIconPath;
 		await server.getSiteIcon();
-		if ( server.details.siteIconPath !== previousIconPath ) {
-			await server.persistSiteIcon();
-			// Re-emit so the renderer's site list re-fetches and picks up the
-			// freshly-loaded icon.
-			void sendIpcEventToRenderer( 'site-event', event );
-		}
 	}
 } );
 

--- a/apps/studio/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/apps/studio/src/modules/cli/lib/cli-events-subscriber.ts
@@ -20,6 +20,7 @@ const STUDIO_ONLY_DETAIL_KEYS = [
 	'tlsKey',
 	'tlsCert',
 	'themeDetails',
+	'siteIconPath',
 	'sortOrder',
 	'isAddingSite',
 	'latestCliPid',
@@ -104,6 +105,15 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > 
 	if ( wasNotRunning && running ) {
 		void captureSiteThumbnail( siteId );
 		await server.getThemeDetails();
+
+		const previousIconPath = server.details.siteIconPath;
+		await server.getSiteIcon();
+		if ( server.details.siteIconPath !== previousIconPath ) {
+			await server.persistSiteIcon();
+			// Re-emit so the renderer's site list re-fetches and picks up the
+			// freshly-loaded icon.
+			void sendIpcEventToRenderer( 'site-event', event );
+		}
 	}
 } );
 

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -97,6 +97,7 @@ const api: IpcApi = {
 	showItemInFolder: ( path ) => ipcRendererSend( 'showItemInFolder', path ),
 	loadThemeDetails: ( id, emitLoadingEvent = true ) =>
 		ipcRendererInvoke( 'loadThemeDetails', id, emitLoadingEvent ),
+	loadSiteIcon: ( id ) => ipcRendererInvoke( 'loadSiteIcon', id ),
 	getThumbnailData: ( id ) => ipcRendererInvoke( 'getThumbnailData', id ),
 	getInstalledAppsAndTerminals: () => ipcRendererInvoke( 'getInstalledAppsAndTerminals' ),
 	importSite: ( siteId, importArchivePath, options ) =>

--- a/apps/studio/src/site-server.ts
+++ b/apps/studio/src/site-server.ts
@@ -471,6 +471,21 @@ export class SiteServer {
 		return this.details.siteIconPath;
 	}
 
+	async persistSiteIcon(): Promise< void > {
+		try {
+			await lockAppdata();
+			const userData = await loadUserData();
+			const siteId = this.details.id;
+			userData.siteMetadata[ siteId ] = {
+				...userData.siteMetadata[ siteId ],
+				siteIconPath: this.details.siteIconPath,
+			};
+			await saveUserData( userData );
+		} finally {
+			await unlockAppdata();
+		}
+	}
+
 	async hasSQLitePlugin(): Promise< boolean > {
 		const wpContentPath = nodePath.join( this.details.path, 'wp-content' );
 

--- a/apps/studio/src/site-server.ts
+++ b/apps/studio/src/site-server.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import { SQLITE_FILENAME } from '@studio/common/constants';
-import { siteListSchema, type SiteListItem } from '@studio/common/lib/cli-events';
+import { SITE_EVENTS, siteListSchema, type SiteListItem } from '@studio/common/lib/cli-events';
 import { parseJsonFromPhpOutput } from '@studio/common/lib/php-output-parser';
 import fsExtra from 'fs-extra';
 import { parse } from 'shell-quote';
@@ -11,6 +11,7 @@ import {
 	WP_CLI_DEFAULT_RESPONSE_TIMEOUT,
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT,
 } from 'src/constants';
+import { sendIpcEventToRenderer } from 'src/ipc-utils';
 import { CliServerProcess } from 'src/modules/cli/lib/cli-server-process';
 import { createSiteViaCli, type CreateSiteOptions } from 'src/modules/cli/lib/cli-site-creator';
 import { executeCliCommand } from 'src/modules/cli/lib/execute-command';
@@ -122,6 +123,44 @@ export class SiteServer {
 			.transform( ( val ) => JSON.parse( val ) )
 			.pipe( siteListSchema ),
 	} );
+
+	/**
+	 * Hydrate cached icon paths for running sites and fill any gaps by
+	 * fetching from the CLI. Necessary because `_events` only emits
+	 * transitions — sites that are already running when Studio launches
+	 * never trigger the cli-events-subscriber's running-transition branch,
+	 * so `getSiteIcon` would otherwise never run for them.
+	 */
+	static async backfillRunningSiteIcons(): Promise< void > {
+		const userData = await loadUserData();
+
+		await Promise.all(
+			Array.from( servers.values() ).map( async ( server ) => {
+				if ( ! server.details.running || deletedServers.includes( server.details.id ) ) {
+					return;
+				}
+
+				const cached = userData.siteMetadata[ server.details.id ]?.siteIconPath;
+				if ( cached !== undefined ) {
+					// Already resolved on a prior run (path or explicit "no icon").
+					// Trust the cache and let the next start cycle refresh it.
+					server.details.siteIconPath = cached;
+					return;
+				}
+
+				const previousPath = server.details.siteIconPath;
+				await server.getSiteIcon();
+				if ( server.details.siteIconPath !== previousPath ) {
+					await server.persistSiteIcon();
+					void sendIpcEventToRenderer( 'site-event', {
+						event: SITE_EVENTS.UPDATED,
+						siteId: server.details.id,
+						running: server.details.running,
+					} );
+				}
+			} )
+		);
+	}
 
 	static async fetchAll(): Promise< void > {
 		try {
@@ -430,6 +469,55 @@ export class SiteServer {
 			userData.siteMetadata[ siteId ] = {
 				...userData.siteMetadata[ siteId ],
 				themeDetails: this.details.themeDetails,
+			};
+			await saveUserData( userData );
+		} finally {
+			await unlockAppdata();
+		}
+	}
+
+	private static siteIconSchema = z.object( {
+		relativePath: z.string(),
+	} );
+
+	async getSiteIcon(): Promise< SiteDetails[ 'siteIconPath' ] > {
+		if ( ! this.details.running ) {
+			return this.details.siteIconPath;
+		}
+
+		try {
+			const { stdout, stderr, exitCode } = await this.executeWpCliCommand( [
+				'studio',
+				'get-site-icon',
+			] );
+
+			if ( exitCode !== 0 ) {
+				console.error( 'Failed to get site icon via WP-CLI', { exitCode, stdout, stderr } );
+				return this.details.siteIconPath;
+			}
+
+			const parsed = parseJsonFromPhpOutput( stdout );
+			if ( parsed === null ) {
+				this.details.siteIconPath = null;
+			} else {
+				const { relativePath } = SiteServer.siteIconSchema.parse( parsed );
+				this.details.siteIconPath = nodePath.join( this.details.path, relativePath );
+			}
+		} catch ( error ) {
+			console.error( 'Failed to get site icon:', error );
+		}
+
+		return this.details.siteIconPath;
+	}
+
+	async persistSiteIcon(): Promise< void > {
+		try {
+			await lockAppdata();
+			const userData = await loadUserData();
+			const siteId = this.details.id;
+			userData.siteMetadata[ siteId ] = {
+				...userData.siteMetadata[ siteId ],
+				siteIconPath: this.details.siteIconPath,
 			};
 			await saveUserData( userData );
 		} finally {

--- a/apps/studio/src/site-server.ts
+++ b/apps/studio/src/site-server.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import { SQLITE_FILENAME } from '@studio/common/constants';
-import { SITE_EVENTS, siteListSchema, type SiteListItem } from '@studio/common/lib/cli-events';
+import { siteListSchema, type SiteListItem } from '@studio/common/lib/cli-events';
 import { parseJsonFromPhpOutput } from '@studio/common/lib/php-output-parser';
 import fsExtra from 'fs-extra';
 import { parse } from 'shell-quote';
@@ -11,7 +11,6 @@ import {
 	WP_CLI_DEFAULT_RESPONSE_TIMEOUT,
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT,
 } from 'src/constants';
-import { sendIpcEventToRenderer } from 'src/ipc-utils';
 import { CliServerProcess } from 'src/modules/cli/lib/cli-server-process';
 import { createSiteViaCli, type CreateSiteOptions } from 'src/modules/cli/lib/cli-site-creator';
 import { executeCliCommand } from 'src/modules/cli/lib/execute-command';
@@ -123,44 +122,6 @@ export class SiteServer {
 			.transform( ( val ) => JSON.parse( val ) )
 			.pipe( siteListSchema ),
 	} );
-
-	/**
-	 * Hydrate cached icon paths for running sites and fill any gaps by
-	 * fetching from the CLI. Necessary because `_events` only emits
-	 * transitions — sites that are already running when Studio launches
-	 * never trigger the cli-events-subscriber's running-transition branch,
-	 * so `getSiteIcon` would otherwise never run for them.
-	 */
-	static async backfillRunningSiteIcons(): Promise< void > {
-		const userData = await loadUserData();
-
-		await Promise.all(
-			Array.from( servers.values() ).map( async ( server ) => {
-				if ( ! server.details.running || deletedServers.includes( server.details.id ) ) {
-					return;
-				}
-
-				const cached = userData.siteMetadata[ server.details.id ]?.siteIconPath;
-				if ( cached !== undefined ) {
-					// Already resolved on a prior run (path or explicit "no icon").
-					// Trust the cache and let the next start cycle refresh it.
-					server.details.siteIconPath = cached;
-					return;
-				}
-
-				const previousPath = server.details.siteIconPath;
-				await server.getSiteIcon();
-				if ( server.details.siteIconPath !== previousPath ) {
-					await server.persistSiteIcon();
-					void sendIpcEventToRenderer( 'site-event', {
-						event: SITE_EVENTS.UPDATED,
-						siteId: server.details.id,
-						running: server.details.running,
-					} );
-				}
-			} )
-		);
-	}
 
 	static async fetchAll(): Promise< void > {
 		try {
@@ -508,21 +469,6 @@ export class SiteServer {
 		}
 
 		return this.details.siteIconPath;
-	}
-
-	async persistSiteIcon(): Promise< void > {
-		try {
-			await lockAppdata();
-			const userData = await loadUserData();
-			const siteId = this.details.id;
-			userData.siteMetadata[ siteId ] = {
-				...userData.siteMetadata[ siteId ],
-				siteIconPath: this.details.siteIconPath,
-			};
-			await saveUserData( userData );
-		} finally {
-			await unlockAppdata();
-		}
 	}
 
 	async hasSQLitePlugin(): Promise< boolean > {

--- a/apps/studio/src/storage/storage-types.ts
+++ b/apps/studio/src/storage/storage-types.ts
@@ -13,6 +13,7 @@ export interface WindowBounds {
 
 export interface AppdataSiteData {
 	themeDetails?: SiteDetails[ 'themeDetails' ];
+	siteIconPath?: SiteDetails[ 'siteIconPath' ];
 	sortOrder?: number;
 }
 

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -22,6 +22,7 @@ import { Conversation } from '@/components/session-view/conversation';
 import { EmptyBackground } from '@/components/session-view/empty-background';
 import { QueuedPrompts } from '@/components/session-view/queued-prompts';
 import { SiteDropdown } from '@/components/site-dropdown';
+import { SiteIcon } from '@/components/site-icon';
 import { SitePreview } from '@/components/site-preview';
 import { type Annotation } from '@/components/site-preview/types';
 import { useConnector } from '@/data/core';
@@ -72,9 +73,14 @@ function SessionHeader( {
 		<div className={ styles.header }>
 			{ toggleSpacerClass ? <span className={ toggleSpacerClass } aria-hidden="true" /> : null }
 			{ site ? (
-				<SiteDropdown site={ site } activeEnvironment={ effectiveEnvironment } />
+				<SiteDropdown
+					site={ site }
+					activeEnvironment={ effectiveEnvironment }
+					showSiteIcon={ sidebarCollapsed }
+				/>
 			) : (
 				<>
+					{ sidebarCollapsed ? <SiteIcon className={ styles.headerSiteIcon } /> : null }
 					<span className={ styles.headerSite }>{ siteName }</span>
 					<span className={ styles.headerDot } aria-hidden="true" />
 					<span className={ styles.headerEnv }>

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -80,7 +80,9 @@ function SessionHeader( {
 				/>
 			) : (
 				<>
-					{ sidebarCollapsed ? <SiteIcon className={ styles.headerSiteIcon } /> : null }
+					{ sidebarCollapsed ? (
+						<SiteIcon className={ styles.headerSiteIcon } seed={ siteName } />
+					) : null }
 					<span className={ styles.headerSite }>{ siteName }</span>
 					<span className={ styles.headerDot } aria-hidden="true" />
 					<span className={ styles.headerEnv }>

--- a/apps/ui/src/components/session-view/style.module.css
+++ b/apps/ui/src/components/session-view/style.module.css
@@ -18,7 +18,6 @@
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
-
 .header {
 	display: flex;
 	align-items: center;
@@ -50,6 +49,10 @@
 
 .headerSite {
 	font-weight: 600;
+}
+
+.headerSiteIcon {
+	margin-inline-end: calc(-1 * var(--wpds-dimension-padding-xs));
 }
 
 .headerDot {

--- a/apps/ui/src/components/site-dropdown/dropdown-trigger.module.css
+++ b/apps/ui/src/components/site-dropdown/dropdown-trigger.module.css
@@ -2,6 +2,10 @@
 	gap: var(--wpds-dimension-padding-lg);
 }
 
+.siteIcon {
+	margin-inline-end: calc(-1 * var(--wpds-dimension-padding-sm));
+}
+
 .site {
 	font-weight: 600;
 }

--- a/apps/ui/src/components/site-dropdown/dropdown-trigger.tsx
+++ b/apps/ui/src/components/site-dropdown/dropdown-trigger.tsx
@@ -3,6 +3,7 @@ import { chevronDownSmall } from '@wordpress/icons';
 import { Button, Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { forwardRef } from 'react';
+import { SiteIcon } from '@/components/site-icon';
 import styles from './dropdown-trigger.module.css';
 import type { ComponentProps, ElementRef } from 'react';
 
@@ -14,11 +15,21 @@ type Props = Omit< ComponentProps< typeof Button >, 'children' > & {
 	status: SiteStatus;
 	statusLabel: string;
 	environment: 'local' | 'live';
+	showSiteIcon?: boolean;
 };
 
 export const DropdownTrigger = forwardRef< ElementRef< typeof Button >, Props >(
 	function DropdownTrigger(
-		{ siteName, siteUrl, status, statusLabel, environment, className, ...props },
+		{
+			siteName,
+			siteUrl,
+			status,
+			statusLabel,
+			environment,
+			showSiteIcon = false,
+			className,
+			...props
+		},
 		ref
 	) {
 		// In live mode the local server's running/stopped status is irrelevant
@@ -34,6 +45,7 @@ export const DropdownTrigger = forwardRef< ElementRef< typeof Button >, Props >(
 				className={ clsx( styles.trigger, className ) }
 				{ ...props }
 			>
+				{ showSiteIcon ? <SiteIcon className={ styles.siteIcon } /> : null }
 				<span className={ styles.site }>{ siteName }</span>
 				<span className={ styles.status }>
 					<span className={ clsx( styles.dot, dotClass ) } role="img" aria-label={ statusLabel } />

--- a/apps/ui/src/components/site-dropdown/dropdown-trigger.tsx
+++ b/apps/ui/src/components/site-dropdown/dropdown-trigger.tsx
@@ -17,6 +17,7 @@ type Props = Omit< ComponentProps< typeof Button >, 'children' > & {
 	environment: 'local' | 'live';
 	showSiteIcon?: boolean;
 	siteIconSeed?: string;
+	siteIconImage?: string | null;
 };
 
 export const DropdownTrigger = forwardRef< ElementRef< typeof Button >, Props >(
@@ -29,6 +30,7 @@ export const DropdownTrigger = forwardRef< ElementRef< typeof Button >, Props >(
 			environment,
 			showSiteIcon = false,
 			siteIconSeed,
+			siteIconImage,
 			className,
 			...props
 		},
@@ -51,6 +53,7 @@ export const DropdownTrigger = forwardRef< ElementRef< typeof Button >, Props >(
 					<SiteIcon
 						className={ styles.siteIcon }
 						seed={ siteIconSeed ?? `${ siteName }:${ siteUrl }` }
+						imageSrc={ siteIconImage }
 					/>
 				) : null }
 				<span className={ styles.site }>{ siteName }</span>

--- a/apps/ui/src/components/site-dropdown/dropdown-trigger.tsx
+++ b/apps/ui/src/components/site-dropdown/dropdown-trigger.tsx
@@ -16,6 +16,7 @@ type Props = Omit< ComponentProps< typeof Button >, 'children' > & {
 	statusLabel: string;
 	environment: 'local' | 'live';
 	showSiteIcon?: boolean;
+	siteIconSeed?: string;
 };
 
 export const DropdownTrigger = forwardRef< ElementRef< typeof Button >, Props >(
@@ -27,6 +28,7 @@ export const DropdownTrigger = forwardRef< ElementRef< typeof Button >, Props >(
 			statusLabel,
 			environment,
 			showSiteIcon = false,
+			siteIconSeed,
 			className,
 			...props
 		},
@@ -45,7 +47,12 @@ export const DropdownTrigger = forwardRef< ElementRef< typeof Button >, Props >(
 				className={ clsx( styles.trigger, className ) }
 				{ ...props }
 			>
-				{ showSiteIcon ? <SiteIcon className={ styles.siteIcon } /> : null }
+				{ showSiteIcon ? (
+					<SiteIcon
+						className={ styles.siteIcon }
+						seed={ siteIconSeed ?? `${ siteName }:${ siteUrl }` }
+					/>
+				) : null }
 				<span className={ styles.site }>{ siteName }</span>
 				<span className={ styles.status }>
 					<span className={ clsx( styles.dot, dotClass ) } role="img" aria-label={ statusLabel } />

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -18,9 +18,10 @@ type Props = {
 	// session's active environment (local vs. live) rather than always reading
 	// "Local". Outside a session context this defaults to local.
 	activeEnvironment?: 'local' | 'live';
+	showSiteIcon?: boolean;
 };
 
-export function SiteDropdown( { site, activeEnvironment = 'local' }: Props ) {
+export function SiteDropdown( { site, activeEnvironment = 'local', showSiteIcon = false }: Props ) {
 	const [ view, setView ] = useState< 'main' | 'picker' >( 'main' );
 	const [ menuOpen, setMenuOpen ] = useState( false );
 	const [ disconnectOpen, setDisconnectOpen ] = useState( false );
@@ -65,6 +66,7 @@ export function SiteDropdown( { site, activeEnvironment = 'local' }: Props ) {
 							status={ status }
 							statusLabel={ statusLabel }
 							environment={ activeEnvironment }
+							showSiteIcon={ showSiteIcon }
 						/>
 					}
 				/>

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -68,6 +68,7 @@ export function SiteDropdown( { site, activeEnvironment = 'local', showSiteIcon 
 							environment={ activeEnvironment }
 							showSiteIcon={ showSiteIcon }
 							siteIconSeed={ `${ site.id }:${ site.name }:${ site.path }` }
+							siteIconImage={ site.siteIcon }
 						/>
 					}
 				/>

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -67,6 +67,7 @@ export function SiteDropdown( { site, activeEnvironment = 'local', showSiteIcon 
 							statusLabel={ statusLabel }
 							environment={ activeEnvironment }
 							showSiteIcon={ showSiteIcon }
+							siteIconSeed={ `${ site.id }:${ site.name }:${ site.path }` }
 						/>
 					}
 				/>

--- a/apps/ui/src/components/site-icon/index.tsx
+++ b/apps/ui/src/components/site-icon/index.tsx
@@ -1,15 +1,55 @@
-import { globe } from '@wordpress/icons';
-import { Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import styles from './style.module.css';
-import type { ComponentPropsWithoutRef } from 'react';
+import type { ComponentPropsWithoutRef, CSSProperties } from 'react';
 
-type Props = ComponentPropsWithoutRef< 'span' >;
+type SiteIconStyle = CSSProperties & {
+	'--site-icon-color-a': string;
+	'--site-icon-color-b': string;
+	'--site-icon-color-c': string;
+	'--site-icon-color-d': string;
+	'--site-icon-position-a': string;
+	'--site-icon-position-b': string;
+	'--site-icon-position-c': string;
+};
 
-export function SiteIcon( { className, ...props }: Props ) {
+type Props = ComponentPropsWithoutRef< 'span' > & {
+	seed?: string;
+};
+
+function hashSeed( seed: string ): number {
+	let hash = 0;
+	for ( let index = 0; index < seed.length; index++ ) {
+		hash = ( hash << 5 ) - hash + seed.charCodeAt( index );
+		hash |= 0;
+	}
+	return Math.abs( hash );
+}
+
+function getMeshGradientStyle( seed = 'site' ): SiteIconStyle {
+	const hash = hashSeed( seed );
+	const hue = hash % 360;
+	const offset = ( hash >> 4 ) % 48;
+
+	return {
+		'--site-icon-color-a': `hsl(${ hue } 88% 58%)`,
+		'--site-icon-color-b': `hsl(${ ( hue + 92 + offset ) % 360 } 84% 62%)`,
+		'--site-icon-color-c': `hsl(${ ( hue + 188 + offset ) % 360 } 82% 54%)`,
+		'--site-icon-color-d': `hsl(${ ( hue + 276 + offset ) % 360 } 86% 66%)`,
+		'--site-icon-position-a': `${ 18 + ( hash % 34 ) }% ${ 20 + ( ( hash >> 3 ) % 30 ) }%`,
+		'--site-icon-position-b': `${ 58 + ( ( hash >> 6 ) % 28 ) }% ${ 16 + ( ( hash >> 9 ) % 36 ) }%`,
+		'--site-icon-position-c': `${ 30 + ( ( hash >> 12 ) % 40 ) }% ${
+			58 + ( ( hash >> 15 ) % 28 )
+		}%`,
+	};
+}
+
+export function SiteIcon( { className, seed, style, ...props }: Props ) {
 	return (
-		<span { ...props } className={ clsx( styles.root, className ) } aria-hidden="true">
-			<Icon icon={ globe } size={ 12 } />
-		</span>
+		<span
+			{ ...props }
+			className={ clsx( styles.root, className ) }
+			style={ { ...getMeshGradientStyle( seed ), ...style } }
+			aria-hidden="true"
+		/>
 	);
 }

--- a/apps/ui/src/components/site-icon/index.tsx
+++ b/apps/ui/src/components/site-icon/index.tsx
@@ -1,0 +1,15 @@
+import { globe } from '@wordpress/icons';
+import { Icon } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import styles from './style.module.css';
+import type { ComponentPropsWithoutRef } from 'react';
+
+type Props = ComponentPropsWithoutRef< 'span' >;
+
+export function SiteIcon( { className, ...props }: Props ) {
+	return (
+		<span { ...props } className={ clsx( styles.root, className ) } aria-hidden="true">
+			<Icon icon={ globe } size={ 12 } />
+		</span>
+	);
+}

--- a/apps/ui/src/components/site-icon/index.tsx
+++ b/apps/ui/src/components/site-icon/index.tsx
@@ -1,4 +1,5 @@
 import { clsx } from 'clsx';
+import { useState } from 'react';
 import styles from './style.module.css';
 import type { ComponentPropsWithoutRef, CSSProperties } from 'react';
 
@@ -14,6 +15,9 @@ type SiteIconStyle = CSSProperties & {
 
 type Props = ComponentPropsWithoutRef< 'span' > & {
 	seed?: string;
+	// Data URL for the configured WordPress Site Icon. Falls back to the
+	// procedural mesh gradient when missing or when the image fails to load.
+	imageSrc?: string | null;
 };
 
 function hashSeed( seed: string ): number {
@@ -43,13 +47,25 @@ function getMeshGradientStyle( seed = 'site' ): SiteIconStyle {
 	};
 }
 
-export function SiteIcon( { className, seed, style, ...props }: Props ) {
+export function SiteIcon( { className, seed, style, imageSrc, ...props }: Props ) {
+	const [ hasImageError, setHasImageError ] = useState( false );
+	const showImage = !! imageSrc && ! hasImageError;
+
 	return (
 		<span
 			{ ...props }
-			className={ clsx( styles.root, className ) }
-			style={ { ...getMeshGradientStyle( seed ), ...style } }
+			className={ clsx( styles.root, showImage && styles.rootWithImage, className ) }
+			style={ showImage ? style : { ...getMeshGradientStyle( seed ), ...style } }
 			aria-hidden="true"
-		/>
+		>
+			{ showImage && (
+				<img
+					className={ styles.image }
+					src={ imageSrc as string }
+					alt=""
+					onError={ () => setHasImageError( true ) }
+				/>
+			) }
+		</span>
 	);
 }

--- a/apps/ui/src/components/site-icon/style.module.css
+++ b/apps/ui/src/components/site-icon/style.module.css
@@ -5,9 +5,24 @@
 	width: 16px;
 	height: 16px;
 	border-radius: 4px;
-	color: var(--wpds-color-fg-content-neutral);
-	background: var(--wpds-color-bg-surface-neutral);
-	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	background: radial-gradient(
+			circle at var(--site-icon-position-a),
+			var(--site-icon-color-a) 0,
+			transparent 48%
+		),
+		radial-gradient(
+			circle at var(--site-icon-position-b),
+			var(--site-icon-color-b) 0,
+			transparent 46%
+		),
+		radial-gradient(
+			circle at var(--site-icon-position-c),
+			var(--site-icon-color-c) 0,
+			transparent 50%
+		),
+		linear-gradient(135deg, var(--site-icon-color-d), var(--site-icon-color-a));
+	border: 1px solid color-mix(in srgb, var(--site-icon-color-c) 36%, #0000);
 	flex-shrink: 0;
 	line-height: 0;
+	box-shadow: inset 0 0 0 1px rgb(255 255 255 / 18%);
 }

--- a/apps/ui/src/components/site-icon/style.module.css
+++ b/apps/ui/src/components/site-icon/style.module.css
@@ -25,4 +25,18 @@
 	flex-shrink: 0;
 	line-height: 0;
 	box-shadow: inset 0 0 0 1px rgb(255 255 255 / 18%);
+	overflow: hidden;
+}
+
+.image {
+	display: block;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.rootWithImage {
+	background: var(--wpds-color-bg-content-neutral, transparent);
+	border-color: color-mix(in srgb, var(--wpds-color-fg-content-neutral, currentColor) 12%, #0000);
+	box-shadow: none;
 }

--- a/apps/ui/src/components/site-icon/style.module.css
+++ b/apps/ui/src/components/site-icon/style.module.css
@@ -1,0 +1,13 @@
+.root {
+	display: inline-grid;
+	box-sizing: border-box;
+	place-items: center;
+	width: 16px;
+	height: 16px;
+	border-radius: 4px;
+	color: var(--wpds-color-fg-content-neutral);
+	background: var(--wpds-color-bg-surface-neutral);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	flex-shrink: 0;
+	line-height: 0;
+}

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -323,7 +323,10 @@ function SiteSection( {
 					>
 						{ group.site ? (
 							<span className={ styles.siteIconSlot } aria-hidden="true">
-								<SiteIcon seed={ `${ group.site.id }:${ group.site.name }:${ group.site.path }` } />
+								<SiteIcon
+									seed={ `${ group.site.id }:${ group.site.name }:${ group.site.path }` }
+									imageSrc={ group.site.siteIcon }
+								/>
 							</span>
 						) : null }
 						<span className={ styles.siteName }>{ group.label }</span>

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -323,7 +323,7 @@ function SiteSection( {
 					>
 						{ group.site ? (
 							<span className={ styles.siteIconSlot } aria-hidden="true">
-								<SiteIcon />
+								<SiteIcon seed={ `${ group.site.id }:${ group.site.name }:${ group.site.path }` } />
 							</span>
 						) : null }
 						<span className={ styles.siteName }>{ group.label }</span>

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -6,6 +6,7 @@ import { clsx } from 'clsx';
 import { useMemo, useState } from 'react';
 import * as Menu from '@/components/menu';
 import { SidebarButton } from '@/components/sidebar-button';
+import { SiteIcon } from '@/components/site-icon';
 import { useSessions } from '@/data/queries/use-sessions';
 import {
 	useCopySite,
@@ -320,6 +321,11 @@ function SiteSection( {
 						onClick={ onToggle }
 						aria-expanded={ isOpen }
 					>
+						{ group.site ? (
+							<span className={ styles.siteIconSlot } aria-hidden="true">
+								<SiteIcon />
+							</span>
+						) : null }
 						<span className={ styles.siteName }>{ group.label }</span>
 						<span className={ styles.siteChevron } aria-hidden="true">
 							<Icon icon={ isOpen ? chevronDown : chevronRight } size={ 16 } />

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -36,7 +36,34 @@
 .siteToggle {
 	max-width: 100%;
 	height: auto;
-	gap: var(--wpds-dimension-padding-xs);
+	gap: 0;
+}
+
+.siteIconSlot {
+	display: inline-grid;
+	place-items: center;
+	flex-shrink: 0;
+	inline-size: 0;
+	margin-inline-end: 0;
+	opacity: 0;
+	transform: translateX(-4px) scale(0.75);
+	transform-origin: left center;
+	overflow: hidden;
+	transition: inline-size 150ms ease, margin-inline-end 150ms ease, opacity 150ms ease,
+		transform 150ms ease;
+}
+
+.siteActive .siteIconSlot {
+	inline-size: 16px;
+	margin-inline-end: var(--wpds-dimension-padding-xs);
+	opacity: 1;
+	transform: translateX(0) scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.siteIconSlot {
+		transition: none;
+	}
 }
 
 .siteName {

--- a/apps/ui/src/components/site-settings-view/index.tsx
+++ b/apps/ui/src/components/site-settings-view/index.tsx
@@ -86,7 +86,7 @@ function SettingsHeader( { site }: { site: SiteDetails } ) {
 	return (
 		<div className={ styles.header }>
 			{ toggleSpacerClass ? <span className={ toggleSpacerClass } aria-hidden="true" /> : null }
-			<SiteDropdown site={ site } />
+			<SiteDropdown site={ site } showSiteIcon={ sidebarCollapsed } />
 		</div>
 	);
 }

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -48,6 +48,7 @@ export interface SiteDetails {
 		slug: string;
 		isBlockTheme: boolean;
 	};
+	siteIcon?: string | null;
 }
 
 export interface AuthUser {

--- a/tools/common/lib/mu-plugins.ts
+++ b/tools/common/lib/mu-plugins.ts
@@ -393,6 +393,42 @@ function getStandardMuPlugins( options: MuPluginOptions ): MuPlugin[] {
 			];
 			echo json_encode( $result );
 		} );
+
+		/**
+		 * Gets the path of the configured Site Icon relative to the
+		 * WordPress install root, or null when no Site Icon is set.
+		 *
+		 * The host (Studio) translates the WordPress-runtime path
+		 * (rooted at the /wordpress mount) into a real filesystem path
+		 * by joining the site folder with the returned relative path.
+		 *
+		 * ## EXAMPLES
+		 *
+		 *     wp studio get-site-icon
+		 *
+		 * @when after_wp_load
+		 */
+		WP_CLI::add_command( 'studio get-site-icon', function() {
+			$icon_id = (int) get_option( 'site_icon' );
+			if ( ! $icon_id ) {
+				echo json_encode( null );
+				return;
+			}
+
+			$path = get_attached_file( $icon_id );
+			if ( ! $path || ! file_exists( $path ) ) {
+				echo json_encode( null );
+				return;
+			}
+
+			// get_attached_file() returns paths rooted at /wordpress
+			// (Studio's PHP-runtime mount point). Strip the leading
+			// /wordpress so the host can resolve against the site dir.
+			$relative = preg_replace( '#^/wordpress/?#', '', $path );
+			echo json_encode( [
+				'relativePath' => ltrim( $relative, '/' ),
+			] );
+		} );
 		`,
 	} );
 


### PR DESCRIPTION
Adds active site icons to the sidebar list and collapsed site header so the current site remains identifiable in compact layouts.

## Proposed Changes

- Adds a reusable `SiteIcon` component for compact site identity in UI chrome.
- Shows the icon next to the active site title in the sidebar list with an animated transition.
- Shows the same icon in the site status dropdown header when the sidebar is collapsed on session and site settings views.

## Testing Instructions

- Open Studio with multiple sites and confirm the active site row in the sidebar shows its icon next to the site title.
- Switch between sites and confirm the icon transition does not shift the surrounding sidebar layout unexpectedly.
- Collapse the sidebar and confirm the session and site settings headers show the active site icon in the status dropdown trigger.
- Check a site without a custom icon and confirm the fallback icon still looks aligned and legible.

## Automated Checks

- `npx eslint --fix apps/ui/src/components/session-view/index.tsx apps/ui/src/components/session-view/style.module.css apps/ui/src/components/site-dropdown/dropdown-trigger.module.css apps/ui/src/components/site-dropdown/dropdown-trigger.tsx apps/ui/src/components/site-dropdown/index.tsx apps/ui/src/components/site-list/index.tsx apps/ui/src/components/site-list/style.module.css apps/ui/src/components/site-settings-view/index.tsx apps/ui/src/components/site-icon/index.tsx apps/ui/src/components/site-icon/style.module.css`
- `npm run typecheck`
- `npm test -- --passWithNoTests apps/ui/src/components/site-list apps/ui/src/components/site-dropdown apps/ui/src/components/session-view apps/ui/src/components/site-settings-view`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?