### PR TITLE
Flag HTML block misuse during validation

### DIFF
--- a/apps/cli/ai/block-content-policy.ts
+++ b/apps/cli/ai/block-content-policy.ts
@@ -1,0 +1,25 @@
+const BLOCK_COMMENT_PATTERN = /<!--\s*\/?wp:[^>]*-->/g;
+const SINGLE_SCRIPT_PATTERN = /^<script(?:\s[^>]*)?>[\s\S]*<\/script>\s*$/i;
+const SINGLE_SVG_PATTERN = /^<svg(?:\s[^>]*)?>[\s\S]*<\/svg>\s*$/i;
+const FORM_MARKUP_PATTERN = /<(form|input|select|textarea|label|fieldset|legend|option)\b/i;
+const INTERACTION_MARKUP_PATTERN = /<(marquee)\b/i;
+
+export function getHtmlBlockPolicyIssues( content: string ): string[] {
+	const html = content.replace( BLOCK_COMMENT_PATTERN, '' ).trim();
+	if ( ! html || isAllowedHtmlBlockContent( html ) ) {
+		return [];
+	}
+
+	return [
+		'core/html contains markup that should use editable core blocks. Use core/group, core/columns, core/heading, core/paragraph, core/list, core/image, core/buttons, and theme CSS instead. Keep core/html only for inline SVG, form/input markup, interaction markup with no block equivalent, or a single script block.',
+	];
+}
+
+function isAllowedHtmlBlockContent( html: string ): boolean {
+	return (
+		SINGLE_SCRIPT_PATTERN.test( html ) ||
+		SINGLE_SVG_PATTERN.test( html ) ||
+		FORM_MARKUP_PATTERN.test( html ) ||
+		INTERACTION_MARKUP_PATTERN.test( html )
+	);
+}

--- a/apps/cli/ai/block-validator.ts
+++ b/apps/cli/ai/block-validator.ts
@@ -1,3 +1,4 @@
+import { getHtmlBlockPolicyIssues } from 'cli/ai/block-content-policy';
 import { EditorPage } from 'cli/ai/browser-utils';
 
 interface BlockValidationResult {
@@ -167,7 +168,7 @@ export async function validateBlocks(
 			/* eslint-enable @typescript-eslint/no-explicit-any */
 		}, content );
 
-		return report as ValidationReport;
+		return applyBlockContentPolicy( report as ValidationReport );
 	} catch ( error ) {
 		// If navigation or evaluation failed, discard the cached page so the
 		// next call gets a fresh one.
@@ -184,6 +185,33 @@ export async function validateBlocks(
 			}`,
 		};
 	}
+}
+
+function applyBlockContentPolicy( report: ValidationReport ): ValidationReport {
+	const results = report.results.map( ( result ) => {
+		if ( result.blockName !== 'core/html' ) {
+			return result;
+		}
+
+		const policyIssues = getHtmlBlockPolicyIssues( result.originalContent );
+		if ( policyIssues.length === 0 ) {
+			return result;
+		}
+
+		return {
+			...result,
+			isValid: false,
+			issues: [ ...result.issues, ...policyIssues ],
+		};
+	} );
+
+	const validBlocks = results.filter( ( result ) => result.isValid ).length;
+	return {
+		...report,
+		results,
+		validBlocks,
+		invalidBlocks: results.length - validBlocks,
+	};
 }
 
 /** Clean up all cached editor pages. */

--- a/apps/cli/ai/tests/block-content-policy.test.ts
+++ b/apps/cli/ai/tests/block-content-policy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { getHtmlBlockPolicyIssues } from 'cli/ai/block-content-policy';
+
+describe( 'HTML block content policy', () => {
+	it( 'allows inline SVG markup', () => {
+		expect(
+			getHtmlBlockPolicyIssues(
+				'<!-- wp:html --><svg viewBox="0 0 10 10"><path d="M0 0h10v10H0z" /></svg><!-- /wp:html -->'
+			)
+		).toEqual( [] );
+	} );
+
+	it( 'allows a single script block', () => {
+		expect(
+			getHtmlBlockPolicyIssues(
+				'<!-- wp:html --><script>document.body.classList.add("ready");</script><!-- /wp:html -->'
+			)
+		).toEqual( [] );
+	} );
+
+	it( 'allows form markup', () => {
+		expect(
+			getHtmlBlockPolicyIssues(
+				'<!-- wp:html --><form><label>Email<input type="email" /></label></form><!-- /wp:html -->'
+			)
+		).toEqual( [] );
+	} );
+
+	it( 'flags layout and text markup that should use core blocks', () => {
+		const issues = getHtmlBlockPolicyIssues(
+			'<!-- wp:html --><section class="hero"><h1>Auran</h1><p>Precision furniture.</p></section><!-- /wp:html -->'
+		);
+
+		expect( issues ).toHaveLength( 1 );
+		expect( issues[ 0 ] ).toContain( 'should use editable core blocks' );
+	} );
+} );

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -598,7 +598,7 @@ const runWpCliTool = tool(
 const validateBlocksTool = tool(
 	'validate_blocks',
 	"Validates WordPress block content by running each block through its save() function in the site's block editor (real browser). " +
-		'The site must be running. Returns per-block validation results with expected HTML for invalid blocks.',
+		'The site must be running. Also flags core/html blocks used for editable layout or text content. Returns per-block validation results with expected HTML for invalid blocks.',
 	{
 		nameOrPath: z
 			.string()

--- a/eval/promptfoo.config.yaml
+++ b/eval/promptfoo.config.yaml
@@ -137,3 +137,27 @@ tests:
             }
             return { pass: true, score: 1, reason: 'no wp_cli call used --post_content-file=' };
           });
+      - type: javascript
+        value: |
+          return import('node:fs').then(({ readFileSync }) => {
+            const marker = output.split(/\r?\n/).map(l => l.trim()).find(l => l.startsWith('EVAL_RUNNER_RESULT_FILE='));
+            if (!marker) return { pass: false, score: 0, reason: `no result-file marker on stdout; got: ${output.slice(0, 200)}` };
+            const d = JSON.parse(readFileSync(marker.slice('EVAL_RUNNER_RESULT_FILE='.length), 'utf8'));
+            const validationResults = (d.toolResults || []).filter(r => r.toolName === 'validate_blocks');
+            if (validationResults.length === 0) {
+              return { pass: false, score: 0, reason: 'validate_blocks was not called after building the page' };
+            }
+            const failures = validationResults.filter(r => {
+              const text = r.text || '';
+              return r.isError || /Invalid blocks:/i.test(text) || !/Validation:\s+\d+\/\d+\s+blocks valid/i.test(text);
+            });
+            if (failures.length > 0) {
+              return {
+                pass: false,
+                score: 0,
+                reason: `validate_blocks reported invalid or inconclusive output: ${(failures[0].text || JSON.stringify(failures[0])).slice(0, 500)}`,
+              };
+            }
+            const last = validationResults[validationResults.length - 1];
+            return { pass: true, score: 1, reason: `validate_blocks passed: ${(last.text || '').split(/\r?\n/)[0]}` };
+          });

--- a/eval/promptfoo.config.yaml
+++ b/eval/promptfoo.config.yaml
@@ -147,17 +147,15 @@ tests:
             if (validationResults.length === 0) {
               return { pass: false, score: 0, reason: 'validate_blocks was not called after building the page' };
             }
-            const failures = validationResults.filter(r => {
-              const text = r.text || '';
-              return r.isError || /Invalid blocks:/i.test(text) || !/Validation:\s+\d+\/\d+\s+blocks valid/i.test(text);
-            });
-            if (failures.length > 0) {
+            const last = validationResults[validationResults.length - 1];
+            const text = last.text || '';
+            const failed = last.isError || /Invalid blocks:/i.test(text) || !/Validation:\s+\d+\/\d+\s+blocks valid/i.test(text);
+            if (failed) {
               return {
                 pass: false,
                 score: 0,
-                reason: `validate_blocks reported invalid or inconclusive output: ${(failures[0].text || JSON.stringify(failures[0])).slice(0, 500)}`,
+                reason: `final validate_blocks result was invalid or inconclusive: ${(text || JSON.stringify(last)).slice(0, 500)}`,
               };
             }
-            const last = validationResults[validationResults.length - 1];
             return { pass: true, score: 1, reason: `validate_blocks passed: ${(last.text || '').split(/\r?\n/)[0]}` };
           });


### PR DESCRIPTION
Adds a content-policy pass to block validation so section-sized `core/html` blocks are reported as invalid and corrected during the agent validation loop.

## Proposed Changes

- Add a small HTML block content policy helper that allows inline SVG, form/input markup, interaction markup with no block equivalent, and single script blocks.
- Apply that policy inside `validate_blocks` so editable layout and text markup inside `core/html` fails validation with remediation guidance.
- Update the `validate_blocks` tool description and add unit coverage for allowed and disallowed HTML block uses.

## Testing Instructions

- Ask Studio Code to build a one-page site with a logo/client section and verify generated page sections use editable core blocks instead of wrapping text/layout content in `core/html`.
- Validate content containing `<!-- wp:html --><section><h1>Auran</h1><p>Precision furniture.</p></section><!-- /wp:html -->` and confirm `validate_blocks` reports a policy issue.
- Validate content containing a single inline SVG or script HTML block and confirm it remains allowed.

## Automated Checks

- `npx eslint --fix apps/cli/ai/block-content-policy.ts apps/cli/ai/block-validator.ts apps/cli/ai/tools.ts apps/cli/ai/tests/block-content-policy.test.ts`
- `npm run typecheck`
- `npm test -- apps/cli/ai/tests/block-content-policy.test.ts`
- `npm run cli:build`
- `node apps/cli/dist/cli/main.mjs --help`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?