### PR TITLE
Linux: support installing the Studio CLI

### DIFF
--- a/apps/studio/bin/studio-cli.sh
+++ b/apps/studio/bin/studio-cli.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-# The assumption is that this script lives in `/Applications/Studio.app/Contents/Resources/bin/studio-cli.sh`
+# In production, this script lives alongside `node` and the `cli/` directory under the Electron
+# app's resources directory:
+#   macOS: /Applications/Studio.app/Contents/Resources/bin/studio-cli.sh
+#   Linux: /opt/Studio/resources/bin/studio-cli.sh
 BIN_DIR=$(dirname "$(realpath "$0")")
 BUNDLED_NODE_EXECUTABLE="$BIN_DIR/node"
-CONTENTS_DIR=$(dirname "$(dirname "$BIN_DIR")")
-CLI_SCRIPT="$CONTENTS_DIR/Resources/cli/main.mjs"
+CLI_SCRIPT="$(dirname "$BIN_DIR")/cli/main.mjs"
 
 if [ -x "$BUNDLED_NODE_EXECUTABLE" ]; then
 	# Prevent node from printing warnings about NODE_OPTIONS being ignored

--- a/apps/studio/bin/studio-cli.sh
+++ b/apps/studio/bin/studio-cli.sh
@@ -3,7 +3,7 @@
 # In production, this script lives alongside `node` and the `cli/` directory under the Electron
 # app's resources directory:
 #   macOS: /Applications/Studio.app/Contents/Resources/bin/studio-cli.sh
-#   Linux: /opt/Studio/resources/bin/studio-cli.sh
+#   Linux: /usr/lib/studio/resources/bin/studio-cli.sh
 BIN_DIR=$(dirname "$(realpath "$0")")
 BUNDLED_NODE_EXECUTABLE="$BIN_DIR/node"
 CLI_SCRIPT="$(dirname "$BIN_DIR")/cli/main.mjs"

--- a/apps/studio/installers/desktop.ejs
+++ b/apps/studio/installers/desktop.ejs
@@ -2,7 +2,7 @@
 <% if (productName) { %>Name=<%= productName %>
 <% } %><% if (description) { %>Comment=<%= description %>
 <% } %><% if (genericName) { %>GenericName=<%= genericName %>
-<% } %><% if (name) { %>Exec=<%= name %> %U
+<% } %><% if (name) { %>Exec=/usr/bin/<%= name %> %U
 Icon=<%= name %>
 <% } %>Type=Application
 StartupNotify=true

--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -46,6 +46,7 @@ import {
 	stopCliEventsSubscriber,
 } from 'src/modules/cli/lib/cli-events-subscriber';
 import { isStudioCliInstalled } from 'src/modules/cli/lib/ipc-handlers';
+import { autoInstallLinuxCliIfNeeded } from 'src/modules/cli/lib/linux-installation-manager';
 import { autoInstallMacOSCliIfNeeded } from 'src/modules/cli/lib/macos-installation-manager';
 import { autoInstallWindowsCliIfNeeded } from 'src/modules/cli/lib/windows-installation-manager';
 import { stopAllProcesses as stopAllStudioCodeProcesses } from 'src/modules/studio-code';
@@ -343,6 +344,7 @@ async function appBoot() {
 
 		await autoInstallWindowsCliIfNeeded();
 		await autoInstallMacOSCliIfNeeded();
+		await autoInstallLinuxCliIfNeeded();
 
 		finishedInitialization = true;
 	} );

--- a/apps/studio/src/modules/cli/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/cli/lib/ipc-handlers.ts
@@ -1,6 +1,7 @@
 import { dialog } from 'electron';
 import { __ } from '@wordpress/i18n';
 import { getMainWindow } from 'src/main-window';
+import { LinuxCliInstallationManager } from 'src/modules/cli/lib/linux-installation-manager';
 import { MacOSCliInstallationManager } from 'src/modules/cli/lib/macos-installation-manager';
 import { WindowsCliInstallationManager } from 'src/modules/cli/lib/windows-installation-manager';
 
@@ -19,13 +20,17 @@ function getCliInstallationManager(): StudioCliInstallationManager {
 			return new MacOSCliInstallationManager();
 		case 'win32':
 			return new WindowsCliInstallationManager();
+		case 'linux':
+			return new LinuxCliInstallationManager();
 		default:
 			throw new Error( 'Studio CLI is not available on this platform.' );
 	}
 }
 
 function isPlatformSupported(): boolean {
-	return process.platform === 'darwin' || process.platform === 'win32';
+	return (
+		process.platform === 'darwin' || process.platform === 'win32' || process.platform === 'linux'
+	);
 }
 
 export async function isStudioCliInstalled(): Promise< boolean > {

--- a/apps/studio/src/modules/cli/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/cli/lib/ipc-handlers.ts
@@ -27,18 +27,9 @@ function getCliInstallationManager(): StudioCliInstallationManager {
 	}
 }
 
-function isPlatformSupported(): boolean {
-	return (
-		process.platform === 'darwin' || process.platform === 'win32' || process.platform === 'linux'
-	);
-}
-
 export async function isStudioCliInstalled(): Promise< boolean > {
-	if ( isPlatformSupported() ) {
-		const manager = getCliInstallationManager();
-		return await manager.isCliInstalled();
-	}
-	return false;
+	const manager = getCliInstallationManager();
+	return await manager.isCliInstalled();
 }
 
 export async function installStudioCli(): Promise< void > {
@@ -57,10 +48,8 @@ export async function installStudioCli(): Promise< void > {
 		}
 	}
 
-	if ( isPlatformSupported() ) {
-		const manager = getCliInstallationManager();
-		await manager.installCliWithConfirmation();
-	}
+	const manager = getCliInstallationManager();
+	await manager.installCliWithConfirmation();
 }
 
 export async function uninstallStudioCli(): Promise< void > {
@@ -79,8 +68,6 @@ export async function uninstallStudioCli(): Promise< void > {
 		}
 	}
 
-	if ( isPlatformSupported() ) {
-		const manager = getCliInstallationManager();
-		await manager.uninstallCliWithConfirmation();
-	}
+	const manager = getCliInstallationManager();
+	await manager.uninstallCliWithConfirmation();
 }

--- a/apps/studio/src/modules/cli/lib/linux-installation-manager.ts
+++ b/apps/studio/src/modules/cli/lib/linux-installation-manager.ts
@@ -17,7 +17,7 @@ const cliPackagedPath = path.join( binPath, 'studio-cli.sh' );
 
 // Production install path for the Studio DEB package. Used in development mode to detect
 // whether a production CLI is already installed alongside the running dev build.
-const PROD_CLI_PACKAGED_PATH = '/opt/Studio/resources/bin/studio-cli.sh';
+const PROD_CLI_PACKAGED_PATH = '/usr/lib/studio/resources/bin/studio-cli.sh';
 
 const SUPPORTED_SHELLS = [ 'bash', 'zsh' ] as const;
 const SHELL_PROFILE_MAP: Record< ( typeof SUPPORTED_SHELLS )[ number ], string > = {

--- a/apps/studio/src/modules/cli/lib/linux-installation-manager.ts
+++ b/apps/studio/src/modules/cli/lib/linux-installation-manager.ts
@@ -1,0 +1,243 @@
+import { dialog } from 'electron';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as Sentry from '@sentry/electron/main';
+import { isErrnoException } from '@studio/common/lib/is-errno-exception';
+import { __, sprintf } from '@wordpress/i18n';
+import { getMainWindow } from 'src/main-window';
+import { StudioCliInstallationManager } from 'src/modules/cli/lib/ipc-handlers';
+import { getResourcesPath } from 'src/storage/paths';
+import { loadUserData, updateAppdata } from 'src/storage/user-data';
+
+const cliSymlinkPath = path.join( os.homedir(), '.local', 'bin', 'studio' );
+
+const binPath = path.join( getResourcesPath(), 'bin' );
+const cliPackagedPath = path.join( binPath, 'studio-cli.sh' );
+
+// Production install path for the Studio DEB package. Used in development mode to detect
+// whether a production CLI is already installed alongside the running dev build.
+const PROD_CLI_PACKAGED_PATH = '/opt/Studio/resources/bin/studio-cli.sh';
+
+const SUPPORTED_SHELLS = [ 'bash', 'zsh' ] as const;
+const SHELL_PROFILE_MAP: Record< ( typeof SUPPORTED_SHELLS )[ number ], string > = {
+	bash: '.bashrc',
+	zsh: '.zshrc',
+};
+const DEFAULT_PROFILE = SHELL_PROFILE_MAP[ 'bash' ];
+const PATH_DEFINITION = '$HOME/.local/bin';
+const PATH_EXPORT_LINE = `export PATH="${ PATH_DEFINITION }:$PATH"`;
+
+const ERROR_FILE_ALREADY_EXISTS = 'Studio CLI symlink path already occupied by non-symlink';
+
+export class LinuxCliInstallationManager implements StudioCliInstallationManager {
+	constructor() {
+		if ( process.platform !== 'linux' ) {
+			throw new Error( 'Use the appropriate installation manager for the current platform' );
+		}
+	}
+
+	async isCliInstalled(): Promise< boolean > {
+		const existingContent = await this.readShellProfileContent();
+
+		if ( ! existingContent.includes( PATH_DEFINITION ) ) {
+			return false;
+		}
+
+		return await this.doesSymlinkLeadToPackagedCli( cliSymlinkPath );
+	}
+
+	async installCliWithConfirmation(): Promise< void > {
+		try {
+			await this.installCli();
+		} catch ( error ) {
+			console.error( 'Failed to install CLI', error );
+
+			let message: string = __(
+				'There was an unknown error. Please check the logs for more information.'
+			);
+
+			if ( error instanceof Error ) {
+				if ( error.message === ERROR_FILE_ALREADY_EXISTS ) {
+					message = sprintf(
+						/* translators: 1: Installation path */
+						__(
+							'The installation path %1$s is already occupied by a file or directory. Please remove it and try again.'
+						),
+						cliSymlinkPath
+					);
+				} else {
+					Sentry.captureException( error );
+				}
+			} else {
+				Sentry.captureException( error );
+			}
+
+			const mainWindow = await getMainWindow();
+			await dialog.showMessageBox( mainWindow, {
+				type: 'error',
+				title: __( 'Failed to install CLI' ),
+				message,
+			} );
+		}
+	}
+
+	async uninstallCliWithConfirmation(): Promise< void > {
+		try {
+			await this.uninstallCli();
+			const mainWindow = await getMainWindow();
+			await dialog.showMessageBox( mainWindow, {
+				type: 'info',
+				title: __( 'CLI uninstalled' ),
+				message: __( 'The CLI has been uninstalled successfully.' ),
+			} );
+		} catch ( error ) {
+			Sentry.captureException( error );
+			console.error( 'Failed to uninstall CLI', error );
+
+			let message: string = __(
+				'There was an unknown error. Please check the logs for more information.'
+			);
+
+			if ( error instanceof Error ) {
+				message = error.message;
+			}
+
+			const mainWindow = await getMainWindow();
+			await dialog.showMessageBox( mainWindow, {
+				type: 'error',
+				title: __( 'Failed to uninstall CLI' ),
+				message,
+			} );
+		}
+	}
+
+	async autoInstallIfNeeded(): Promise< void > {
+		// Only auto-install on first launch. If the flag is already set but the CLI isn't
+		// installed, the user must have explicitly disabled it — respect their choice.
+		const userData = await loadUserData();
+		if ( userData.cliAutoInstalled ) {
+			return;
+		}
+
+		await this.installCli();
+		await updateAppdata( { cliAutoInstalled: true } );
+	}
+
+	private async installCli(): Promise< void > {
+		try {
+			const stats = await fs.promises.lstat( cliSymlinkPath );
+
+			if ( ! stats.isSymbolicLink() ) {
+				throw new Error( ERROR_FILE_ALREADY_EXISTS );
+			}
+		} catch ( error ) {
+			if ( isErrnoException( error ) && error.code === 'ENOENT' ) {
+				// File does not exist, which means we can proceed with the installation.
+			} else {
+				throw error;
+			}
+		}
+
+		if ( await this.isCliInstalled() ) {
+			return;
+		}
+
+		const directoryPath = path.dirname( cliSymlinkPath );
+
+		try {
+			await fs.promises.unlink( cliSymlinkPath );
+		} catch ( error ) {
+			if ( ! isErrnoException( error ) || error.code !== 'ENOENT' ) {
+				throw error;
+			}
+		}
+
+		await fs.promises.mkdir( directoryPath, { recursive: true } );
+		await fs.promises.symlink( cliPackagedPath, cliSymlinkPath );
+		await this.ensurePathInProfile();
+	}
+
+	private async uninstallCli(): Promise< void > {
+		try {
+			const stats = await fs.promises.lstat( cliSymlinkPath );
+
+			if ( ! stats.isSymbolicLink() ) {
+				throw new Error( ERROR_FILE_ALREADY_EXISTS );
+			}
+		} catch ( error ) {
+			if ( isErrnoException( error ) && error.code === 'ENOENT' ) {
+				return;
+			}
+			throw error;
+		}
+
+		await fs.promises.unlink( cliSymlinkPath );
+	}
+
+	private async ensurePathInProfile(): Promise< void > {
+		const existingContent = await this.readShellProfileContent();
+
+		if ( existingContent.includes( PATH_DEFINITION ) ) {
+			return;
+		}
+
+		const profilePath = this.getShellProfilePath();
+
+		const lineToAppend =
+			existingContent.endsWith( '\n' ) || existingContent === ''
+				? `${ PATH_EXPORT_LINE }\n`
+				: `\n${ PATH_EXPORT_LINE }\n`;
+
+		await fs.promises.writeFile( profilePath, existingContent + lineToAppend, 'utf-8' );
+	}
+
+	private getShellProfilePath(): string {
+		const shell = path.basename( os.userInfo().shell ?? process.env.SHELL ?? '' );
+		const supportedShell = SUPPORTED_SHELLS.find( ( candidate ) => candidate === shell );
+		const profileFile = supportedShell ? SHELL_PROFILE_MAP[ supportedShell ] : DEFAULT_PROFILE;
+		return path.join( os.homedir(), profileFile );
+	}
+
+	private async readShellProfileContent(): Promise< string > {
+		try {
+			return await fs.promises.readFile( this.getShellProfilePath(), 'utf-8' );
+		} catch ( error ) {
+			if ( isErrnoException( error ) && error.code === 'ENOENT' ) {
+				return '';
+			}
+			throw error;
+		}
+	}
+
+	private async doesSymlinkLeadToPackagedCli( symlinkPath: string ): Promise< boolean > {
+		try {
+			const symlinkDestination = await fs.promises.readlink( symlinkPath );
+
+			if (
+				process.env.NODE_ENV !== 'production' &&
+				symlinkDestination === PROD_CLI_PACKAGED_PATH
+			) {
+				return true;
+			}
+
+			return symlinkDestination === cliPackagedPath;
+		} catch {
+			return false;
+		}
+	}
+}
+
+export async function autoInstallLinuxCliIfNeeded(): Promise< void > {
+	if ( process.platform !== 'linux' || process.env.NODE_ENV !== 'production' ) {
+		return;
+	}
+
+	try {
+		const manager = new LinuxCliInstallationManager();
+		await manager.autoInstallIfNeeded();
+	} catch ( error ) {
+		console.error( 'Failed to auto-install Linux CLI', error );
+		Sentry.captureException( error );
+	}
+}

--- a/apps/studio/src/tests/index.test.ts
+++ b/apps/studio/src/tests/index.test.ts
@@ -64,6 +64,9 @@ vi.mock( 'src/modules/cli/lib/windows-installation-manager', () => ( {
 vi.mock( 'src/modules/cli/lib/macos-installation-manager', () => ( {
 	autoInstallMacOSCliIfNeeded: vi.fn().mockResolvedValue( undefined ),
 } ) );
+vi.mock( 'src/modules/cli/lib/linux-installation-manager', () => ( {
+	autoInstallLinuxCliIfNeeded: vi.fn().mockResolvedValue( undefined ),
+} ) );
 vi.mock( 'electron-devtools-installer', () => ( {
 	installExtension: vi.fn().mockResolvedValue( { id: 'test-extension' } ),
 	REACT_DEVELOPER_TOOLS: { id: 'fmkadmapgofadopljbjfkapdkoienihi' },


### PR DESCRIPTION
## Related issues

- Fixes [RSM-1316](https://linear.app/a8c/issue/RSM-1316)
- Fixes [RSM-1309](https://linear.app/a8c/issue/RSM-1309)

## How AI was used in this PR

Used Claude Code to scope the work, write the new `LinuxCliInstallationManager` (mirroring the macOS one), patch the path bug in `studio-cli.sh`, and run lint/typecheck/tests. Each change was reviewed before committing.

## Proposed Changes

- Add `LinuxCliInstallationManager` (`apps/studio/src/modules/cli/lib/linux-installation-manager.ts`) that symlinks `~/.local/bin/studio` → the bundled `studio-cli.sh` and appends `export PATH="$HOME/.local/bin:$PATH"` to `.bashrc` / `.zshrc`. Mirrors the macOS manager (no `/usr/local/bin` legacy cleanup needed — no prior Linux release shipped there).
- Wire the new manager into `getCliInstallationManager()` so the Preferences toggle and IPC handlers work on Linux. Drop the now-redundant `isPlatformSupported()` guard — every Electron-supported platform now has a manager, so the explicit `throw` in `getCliInstallationManager()` is the single source of truth.
- Call `autoInstallLinuxCliIfNeeded()` from `apps/studio/src/index.ts` so the CLI auto-installs on first launch (production builds only, matching the existing macOS/Windows behavior).
- Fix `apps/studio/bin/studio-cli.sh`: derive `CLI_SCRIPT` from `BIN_DIR` directly so it works on both macOS (`Resources/`) and Linux (`resources/`). The previous `CONTENTS_DIR/Resources/cli/main.mjs` path was mac-specific and would have broken on Linux even with a working installer.
- Add a vitest mock for the new module in `apps/studio/src/tests/index.test.ts`.
- Update `apps/studio/installers/desktop.ejs` to use an absolute path in `Exec=` (`/usr/bin/<%= name %>` instead of bare `<%= name %>`). Without this, clicking the dock icon would invoke the CLI symlink (`~/.local/bin/studio`) instead of the GUI launcher (`/usr/bin/studio`), because Ubuntu's `~/.profile` puts `~/.local/bin` ahead of `/usr/bin` on PATH for the desktop session. Same pattern VS Code uses (`Exec=/usr/share/code/code %F`).

## Testing Instructions

1. Build the DEB: `npm run make`.
2. Install it: `sudo apt install ./out/make/deb/<arch>/studio_*.deb`.
3. Reset state so the next launch counts as "first launch": `sudo rm -f ~/.local/bin/studio ~/.studio/app.json`. Then launch Studio from your distro's application launcher.
4. The first launch should create `~/.local/bin/studio` (a symlink to `/usr/lib/studio/resources/bin/studio-cli.sh`). We can check this with `ls -la ~/.local/bin/studio`.
5. We can also check if `export PATH="$HOME/.local/bin:$PATH"` is in `~/.bashrc` (or `~/.zshrc` if zsh is your shell): `grep -n '\.local/bin' ~/.bashrc`.
6. Open a **fresh** terminal so the new PATH export gets sourced, then run `studio --help`. The CLI help should print.
7. Run `studio preview list` (or any other CLI subcommand) to verify the bundled Node runtime and CLI bundle resolve correctly.
8. In Preferences, toggle the CLI off and Save. Verify the symlink was removed with `ls -l ~/.local/bin/studio` — it should report "No such file or directory". (Note: `which studio` may still resolve to `/usr/bin/studio`, which is the DEB-installed GUI launcher — that's expected and unrelated to the CLI.)
9. In Preferences, toggle the CLI back on and Save. In a fresh terminal (or after `hash -r` in the current one, since bash caches command paths), confirm `studio --help` works again.
10. Verify the dock/launcher icon still opens the GUI (not the CLI) while the CLI symlink is present at `~/.local/bin/studio`.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Manually validated the install / uninstall / auto-install flow on a Linux machine (DEB build).

