### PR TITLE
CLI: add eval-runner diagnostics

### DIFF
--- a/apps/cli/ai/eval-runner.ts
+++ b/apps/cli/ai/eval-runner.ts
@@ -55,6 +55,31 @@ type ToolResultBlock = {
 	content?: unknown;
 };
 
+type ToolCallRecord = {
+	id: string;
+	name: string;
+	input: unknown;
+};
+
+type ToolEvent = {
+	toolUseId: string;
+	toolName: string;
+	input: unknown;
+	startedAtMs: number;
+	endedAtMs?: number;
+	durationMs?: number;
+	isError?: boolean;
+	turnIndex: number;
+};
+
+type FirstToolError = {
+	toolUseId: string | null;
+	toolName: string | null;
+	input?: unknown;
+	error: string;
+	turnIndex: number;
+};
+
 function extractTextSegments( message: SDKMessage ): string[] {
 	if ( message.type !== 'assistant' ) {
 		return [];
@@ -115,36 +140,57 @@ function readInput(): EvalRunnerInput {
 }
 
 async function runEval( input: EvalRunnerInput ) {
+	const evalStartedAt = Date.now();
+	const elapsed = () => Date.now() - evalStartedAt;
+	const phaseTimingsMs: Record< string, number > = {};
+	let phaseStartedAt = Date.now();
+
 	let aiProvider: AiProviderId = await resolveInitialAiProvider();
+	phaseTimingsMs.resolve_initial_provider_ms = Date.now() - phaseStartedAt;
+
+	phaseStartedAt = Date.now();
 	aiProvider = ( await resolveUnavailableAiProvider( aiProvider ) ) ?? aiProvider;
+	phaseTimingsMs.resolve_unavailable_provider_ms = Date.now() - phaseStartedAt;
+
+	phaseStartedAt = Date.now();
+	const aiEnvironment = await resolveAiEnvironment( aiProvider );
+	phaseTimingsMs.resolve_ai_environment_ms = Date.now() - phaseStartedAt;
 
 	const env = {
 		...( process.env as Record< string, string > ),
-		...( await resolveAiEnvironment( aiProvider ) ),
+		...aiEnvironment,
 	};
 	// Allow running inside a Claude Code session
 	delete env.CLAUDECODE;
 
-	const toolCalls: { id: string; name: string; input: unknown }[] = [];
+	const toolCalls: ToolCallRecord[] = [];
 	const toolResults: {
 		toolUseId: string | null;
 		toolName: string | null;
 		isError: boolean;
 		text?: string;
 	}[] = [];
+	const toolEvents: ToolEvent[] = [];
 	const textSegments: string[] = [];
 	const toolNameById = new Map< string, string >();
+	const toolEventById = new Map< string, ToolEvent >();
+	let firstToolError: FirstToolError | null = null;
 	// Wall-clock per turn, measured between successive assistant messages.
 	const turnDurationsMs: number[] = [];
-	let turnStart = Date.now();
+	let turnIndex = 0;
 	let numTurns: number | null = null;
 	let success = false;
 
+	phaseStartedAt = Date.now();
 	const query = startAiAgent( {
 		prompt: input.prompt.trim(),
 		env,
 		maxTurns: input.maxTurns ?? 50,
 	} );
+	phaseTimingsMs.start_ai_agent_ms = Date.now() - phaseStartedAt;
+
+	const queryStartedAt = Date.now();
+	let turnStart = queryStartedAt;
 
 	const timeout = setTimeout( () => void query.interrupt(), input.timeoutMs ?? 300000 );
 
@@ -153,11 +199,24 @@ async function runEval( input: EvalRunnerInput ) {
 			if ( message.type === 'assistant' ) {
 				const now = Date.now();
 				turnDurationsMs.push( now - turnStart );
+				turnIndex += 1;
+				if ( turnIndex === 1 ) {
+					phaseTimingsMs.first_assistant_message_ms = now - queryStartedAt;
+				}
 				turnStart = now;
 			}
 			for ( const tc of extractToolCalls( message ) ) {
 				toolCalls.push( tc );
 				toolNameById.set( tc.id, tc.name );
+				const event: ToolEvent = {
+					toolUseId: tc.id,
+					toolName: tc.name,
+					input: tc.input,
+					startedAtMs: elapsed(),
+					turnIndex,
+				};
+				toolEvents.push( event );
+				toolEventById.set( tc.id, event );
 			}
 			textSegments.push( ...extractTextSegments( message ) );
 
@@ -165,6 +224,21 @@ async function runEval( input: EvalRunnerInput ) {
 				const tr = extractToolResult( message );
 				if ( tr ) {
 					const id = tr.toolUseId ?? message.parent_tool_use_id ?? null;
+					const event = id ? toolEventById.get( id ) : undefined;
+					if ( event ) {
+						event.endedAtMs = elapsed();
+						event.durationMs = event.endedAtMs - event.startedAtMs;
+						event.isError = tr.isError;
+					}
+					if ( tr.isError && ! firstToolError ) {
+						firstToolError = {
+							toolUseId: id,
+							toolName: id ? toolNameById.get( id ) ?? null : null,
+							...( event?.input ? { input: event.input } : {} ),
+							error: tr.text ?? 'Tool returned an error result.',
+							turnIndex,
+						};
+					}
 					toolResults.push( {
 						toolUseId: id,
 						toolName: id ? toolNameById.get( id ) ?? null : null,
@@ -182,8 +256,19 @@ async function runEval( input: EvalRunnerInput ) {
 	} finally {
 		clearTimeout( timeout );
 	}
+	phaseTimingsMs.total_eval_ms = elapsed();
 
-	return { success, numTurns, turnDurationsMs, toolCalls, toolResults, textSegments };
+	return {
+		success,
+		numTurns,
+		phaseTimingsMs,
+		turnDurationsMs,
+		toolCalls,
+		toolResults,
+		toolEvents,
+		firstToolError,
+		textSegments,
+	};
 }
 
 const RESULT_PREFIX = 'EVAL_RUNNER_RESULT_FILE=';


### PR DESCRIPTION
## Summary
- Add phase timing diagnostics to `eval-runner` so benchmark runs can separate provider resolution, runtime startup, first assistant latency, and total eval time.
- Add structured tool timing events and first-tool-error metadata while preserving the existing raw tool call/result/text output.

## Why
This makes Studio agent evals more useful for runtime and tool-path comparisons. The runner now exposes enough structure for benchmark tooling to verify that faster runs still did the expected work, instead of only comparing wall-clock totals.

This supports the eval-runner diagnostics work tracked in #3262.

## Benchmark context
I validated this with [Homeboy](https://github.com/Extra-Chill/homeboy), a local/CI benchmarking CLI I use to run repeatable workloads against pinned git worktrees (“rigs”). The shared Studio benchmark workloads live in the private [`chubes4/homeboy-rigs`](https://github.com/chubes4/homeboy-rigs) repo; the relevant rig update is [`chubes4/homeboy-rigs#7`](https://github.com/chubes4/homeboy-rigs/pull/7).

The important part for this PR is not Homeboy itself, but the contract it exercised: the eval runner now emits phase timings, tool-event counts, and tool durations that external eval tooling can assert on.

## Testing
- `npm run cli:build --silent`
- `npm -w wp-studio run typecheck`
- `homeboy bench --rig studio-agent-sdk-evaltiming --scenario studio-agent-runtime --iterations 5 --runs 3 --warmup 1 --json-summary --ignore-default-baseline`
- `homeboy bench --rig studio-agent-sdk-evaltiming --scenario studio-agent-site-info --iterations 5 --runs 3 --warmup 1 --json-summary --ignore-default-baseline`
- `homeboy bench --rig studio-agent-sdk-evaltiming --scenario studio-agent-runtime --scenario studio-agent-site-info --iterations 2 --runs 2 --warmup 1 --json-summary --ignore-default-baseline`
- `homeboy bench --rig studio-agent-sdk-evaltiming,studio-agent-pi-evaltiming --scenario studio-agent-runtime --iterations 2 --runs 2 --warmup 1 --json-summary --ignore-default-baseline`
- `homeboy bench --rig studio-agent-sdk-evaltiming,studio-agent-pi-evaltiming --scenario studio-agent-site-info --iterations 2 --runs 2 --warmup 1 --json-summary --ignore-default-baseline`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** drafting the eval-runner diagnostics change, running local validation, and preparing the PR summary. Chris directed the benchmarking scope and reviewed the findings.
