### PR TITLE
CLI: align PI runtime SDK stream contract

### DIFF
--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -271,7 +271,11 @@ function resolveModelEnvironment(
 		...( parseColonHeaderEnv( env.ANTHROPIC_CUSTOM_HEADERS ) ?? {} ),
 		...( authToken ? { Authorization: `Bearer ${ authToken }` } : {} ),
 	};
-	return { apiKey, baseURL, extraHeaders: Object.keys( extraHeaders ).length ? extraHeaders : undefined };
+	return {
+		apiKey,
+		baseURL,
+		extraHeaders: Object.keys( extraHeaders ).length ? extraHeaders : undefined,
+	};
 }
 
 /**

--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -71,6 +71,7 @@ const AGENTS_BY_SESSION = new Map< string, Agent >();
 // model breakdowns the same way the Claude Agent SDK did.
 interface RunUsage {
 	turns: number;
+	runtimeError: boolean;
 	denials: { tool_name: string; tool_use_id: string; tool_input: Record< string, unknown > }[];
 	usageByModel: Map<
 		string,
@@ -86,7 +87,7 @@ interface RunUsage {
 }
 
 function newRunUsage(): RunUsage {
-	return { turns: 0, denials: [], usageByModel: new Map() };
+	return { turns: 0, runtimeError: false, denials: [], usageByModel: new Map() };
 }
 
 export const piRuntime: AgentRuntime = {
@@ -120,7 +121,7 @@ async function* createMessageStream(
 	// any future feature-flagged model rollouts from blowing up the loop.
 	const family: AiModelFamily = isAiModelId( config.model )
 		? getAiModelFamily( config.model )
-		: config.model.startsWith( 'gpt' )
+		: String( config.model ).startsWith( 'gpt' )
 		? 'openai'
 		: 'anthropic';
 	yield makeSystemInit( sessionId, config.model );
@@ -153,11 +154,22 @@ async function* createMessageStream(
 		// stream is push-based via `subscribe()`, so we bridge to our
 		// generator with a simple queue.
 		const queue: SDKMessage[] = [];
+		const emittedAssistantMessageKeys = new Set< string >();
+		const emittedToolCallIds = new Set< string >();
+		const emittedToolResultIds = new Set< string >();
 		let resolveNext: ( () => void ) | null = null;
 		let done = false;
 
 		const unsubscribe = agent.subscribe( ( event ) => {
-			for ( const msg of translateEvent( event, sessionId, config.model, usage ) ) {
+			for ( const msg of translateEvent(
+				event,
+				sessionId,
+				config.model,
+				usage,
+				emittedAssistantMessageKeys,
+				emittedToolCallIds,
+				emittedToolResultIds
+			) ) {
 				queue.push( msg );
 			}
 			if ( event.type === 'agent_end' ) {
@@ -195,9 +207,11 @@ async function* createMessageStream(
 			await saveSidecar( config.sessionFilePath, agent.state.messages ).catch( () => undefined );
 		}
 
-		// Emit the success result *after* persistence so the UI's "Done"
+		// Emit the result *after* persistence so the UI's "Done"
 		// message lines up with the durable state on disk.
-		yield makeResultSuccess( sessionId, config.model, start, usage );
+		yield usage.runtimeError
+			? makeResultError( sessionId, config.model, start, usage )
+			: makeResultSuccess( sessionId, config.model, start, usage );
 	} catch ( error ) {
 		if ( controller.signal.aborted ) {
 			yield makeResultError( sessionId, config.model, start, usage );
@@ -252,8 +266,12 @@ function resolveModelEnvironment(
 	// sensible default `baseUrl` of https://api.anthropic.com, so we only
 	// override when one is supplied.
 	const baseURL = env.ANTHROPIC_BASE_URL?.trim() || 'https://api.anthropic.com';
-	const extraHeaders = parseColonHeaderEnv( env.ANTHROPIC_CUSTOM_HEADERS );
-	return { apiKey, baseURL, extraHeaders };
+	const authToken = env.ANTHROPIC_AUTH_TOKEN?.trim();
+	const extraHeaders = {
+		...( parseColonHeaderEnv( env.ANTHROPIC_CUSTOM_HEADERS ) ?? {} ),
+		...( authToken ? { Authorization: `Bearer ${ authToken }` } : {} ),
+	};
+	return { apiKey, baseURL, extraHeaders: Object.keys( extraHeaders ).length ? extraHeaders : undefined };
 }
 
 /**
@@ -507,10 +525,13 @@ function buildBeforeToolCall(): (
  * Maps pi's AgentEvent stream into the synthetic SDKMessage shape the UI
  * (ui.ts) already knows how to render. The important events:
  *
+ * - `tool_execution_start` / `tool_execution_end` emit tool-use and tool-result
+ *   SDKMessages as the work happens, so the UI/recorder can measure real tool
+ *   duration instead of reconstructing it from bundled end-of-turn artifacts.
  * - `turn_end` emits one assistant message (possibly with tool calls) plus
- *   tool results. We yield one `SDKAssistantMessage` per tool-call block and
- *   one `SDKUserMessage` per tool result. We also accumulate per-turn usage
- *   here so the synthetic `result` message can report real numbers.
+ *   tool results. We use it as a fallback for artifacts not already emitted by
+ *   the streaming tool execution events, and accumulate per-turn usage here so
+ *   the synthetic `result` message can report real numbers.
  * - `message_end` covers the pure-text case (no tools).
  * - `agent_end` we treat as a no-op for emission; the success result is
  *   synthesized after persistence, in `createMessageStream`.
@@ -519,45 +540,67 @@ function* translateEvent(
 	event: AgentEvent,
 	sessionId: string,
 	currentModel: AiModelId,
-	usage: RunUsage
+	usage: RunUsage,
+	emittedAssistantMessageKeys: Set< string >,
+	emittedToolCallIds: Set< string >,
+	emittedToolResultIds: Set< string >
 ): Generator< SDKMessage, void, void > {
-	if ( event.type === 'message_end' ) {
-		const msg = event.message;
-		if ( msg.role !== 'assistant' ) return;
-		recordUsage( msg, usage );
-		const text = extractAssistantText( msg );
-		const thinkingBlocks = extractThinkingBlocks( msg );
-		const toolCalls = msg.content.filter(
-			( block ): block is Extract< typeof block, { type: 'toolCall' } > => block.type === 'toolCall'
+	if ( event.type === 'tool_execution_start' ) {
+		if ( emittedToolCallIds.has( event.toolCallId ) ) {
+			return;
+		}
+		emittedToolCallIds.add( event.toolCallId );
+		yield makeAssistantToolUse(
+			sessionId,
+			currentModel,
+			event.toolCallId,
+			event.toolName,
+			( event.args as Record< string, unknown > ) ?? {}
 		);
-		// Yield thinking content first so the desktop UI can render the
-		// "thinking" affordance before any text or tool calls land. Each
-		// thinking block becomes its own assistant SDKMessage with a single
-		// `thinking` content block — matches the Claude Agent SDK shape that
-		// the UI already knows how to render.
-		for ( const block of thinkingBlocks ) {
-			yield makeAssistantThinking( sessionId, currentModel, block.thinking, block.signature );
+		return;
+	}
+	if ( event.type === 'tool_execution_end' ) {
+		if ( emittedToolResultIds.has( event.toolCallId ) ) {
+			return;
 		}
-		if ( text ) {
-			yield makeAssistantText( sessionId, currentModel, text );
-		} else if ( toolCalls.length === 0 && thinkingBlocks.length === 0 ) {
-			// Empty turn fallback: nothing to render. Skip silently — the
-			// `result` message still closes the turn so the UI doesn't hang.
-		}
-		for ( const block of toolCalls ) {
-			yield makeAssistantToolUse(
-				sessionId,
-				currentModel,
-				block.id,
-				block.name,
-				( block.arguments as Record< string, unknown > ) ?? {}
-			);
-		}
+		emittedToolResultIds.add( event.toolCallId );
+		yield makeToolResult(
+			sessionId,
+			event.toolCallId,
+			extractToolResultText( event.result ),
+			Boolean( event.isError )
+		);
+		return;
+	}
+	if ( event.type === 'message_end' ) {
+		yield* emitAssistantMessage(
+			event.message,
+			sessionId,
+			currentModel,
+			usage,
+			emittedAssistantMessageKeys,
+			emittedToolCallIds
+		);
 		return;
 	}
 	if ( event.type === 'turn_end' ) {
 		usage.turns += 1;
+		const maybeMessage = ( event as { message?: AgentMessage } ).message;
+		if ( maybeMessage ) {
+			yield* emitAssistantMessage(
+				maybeMessage,
+				sessionId,
+				currentModel,
+				usage,
+				emittedAssistantMessageKeys,
+				emittedToolCallIds
+			);
+		}
 		for ( const toolResult of event.toolResults ) {
+			if ( emittedToolResultIds.has( toolResult.toolCallId ) ) {
+				continue;
+			}
+			emittedToolResultIds.add( toolResult.toolCallId );
 			const text = extractToolResultText( toolResult );
 			if ( toolResult.isError ) {
 				// pi reports a permission denial as an error tool result with
@@ -578,6 +621,71 @@ function* translateEvent(
 		}
 		return;
 	}
+}
+
+function* emitAssistantMessage(
+	msg: AgentMessage,
+	sessionId: string,
+	currentModel: AiModelId,
+	usage: RunUsage,
+	emittedAssistantMessageKeys: Set< string >,
+	emittedToolCallIds: Set< string >
+): Generator< SDKMessage, void, void > {
+	if ( msg.role !== 'assistant' ) return;
+	const messageKey = assistantMessageKey( msg );
+	if ( emittedAssistantMessageKeys.has( messageKey ) ) {
+		return;
+	}
+	emittedAssistantMessageKeys.add( messageKey );
+	recordUsage( msg, usage );
+	if ( isAssistantError( msg ) ) {
+		usage.runtimeError = true;
+	}
+	const text = extractAssistantText( msg );
+	const thinkingBlocks = extractThinkingBlocks( msg );
+	const toolCalls = msg.content.filter(
+		( block ): block is Extract< typeof block, { type: 'toolCall' } > => block.type === 'toolCall'
+	);
+	// Yield thinking content first so the desktop UI can render the "thinking"
+	// affordance before any text or tool calls land.
+	for ( const block of thinkingBlocks ) {
+		yield makeAssistantThinking( sessionId, currentModel, block.thinking, block.signature );
+	}
+	if ( text ) {
+		yield makeAssistantText( sessionId, currentModel, text );
+	} else if ( toolCalls.length === 0 && thinkingBlocks.length === 0 ) {
+		// Empty turn fallback: nothing to render. Skip silently — the `result`
+		// message still closes the turn so the UI doesn't hang.
+	}
+	for ( const block of toolCalls ) {
+		if ( emittedToolCallIds.has( block.id ) ) {
+			continue;
+		}
+		emittedToolCallIds.add( block.id );
+		yield makeAssistantToolUse(
+			sessionId,
+			currentModel,
+			block.id,
+			block.name,
+			( block.arguments as Record< string, unknown > ) ?? {}
+		);
+	}
+}
+
+function assistantMessageKey( msg: AgentMessage ): string {
+	if ( msg.role !== 'assistant' ) {
+		return JSON.stringify( { role: msg.role } );
+	}
+	return JSON.stringify( {
+		role: msg.role,
+		content: msg.content,
+		model: 'model' in msg ? msg.model : undefined,
+		stopReason: 'stopReason' in msg ? msg.stopReason : undefined,
+	} );
+}
+
+function isAssistantError( msg: AgentMessage ): boolean {
+	return msg.role === 'assistant' && 'stopReason' in msg && msg.stopReason === 'error';
 }
 
 function recordUsage( msg: AssistantMessage, usage: RunUsage ): void {

--- a/apps/cli/ai/tests/pi-runtime.test.ts
+++ b/apps/cli/ai/tests/pi-runtime.test.ts
@@ -5,7 +5,17 @@ import type { AiModelId } from '@studio/common/ai/models';
 // Module-level capture so the model-swap test can inspect every Agent the
 // runtime instantiated across a sequence of `run()` calls.
 const constructedAgents: Array< {
-	state: { model: { id: string; api: string; provider: string }; messages: unknown[] };
+	options: {
+		getApiKey?: () => string;
+		initialState?: {
+			model?: { id?: string; api?: string; provider?: string; headers?: Record< string, string > };
+			messages?: unknown[];
+		};
+	};
+	state: {
+		model: { id: string; api: string; provider: string; headers?: Record< string, string > };
+		messages: unknown[];
+	};
 } > = [];
 
 // Tests can override the events the mock Agent emits per prompt(), to
@@ -27,11 +37,15 @@ let nextMockEvents: unknown[] | null = null;
 vi.mock( '@mariozechner/pi-agent-core', () => {
 	class MockAgent {
 		private listener?: ( event: unknown ) => void;
-		public state: { model: { id: string; api: string; provider: string }; messages: unknown[] };
+		public state: {
+			model: { id: string; api: string; provider: string; headers?: Record< string, string > };
+			messages: unknown[];
+		};
 		constructor(
 			public options: {
+				getApiKey?: () => string;
 				initialState?: {
-					model?: { id?: string; api?: string; provider?: string };
+					model?: { id?: string; api?: string; provider?: string; headers?: Record< string, string > };
 					messages?: unknown[];
 				};
 			}
@@ -41,6 +55,7 @@ vi.mock( '@mariozechner/pi-agent-core', () => {
 					id: options.initialState?.model?.id ?? '',
 					api: options.initialState?.model?.api ?? '',
 					provider: options.initialState?.model?.provider ?? '',
+					headers: options.initialState?.model?.headers,
 				},
 				messages: options.initialState?.messages?.slice() ?? [],
 			};
@@ -187,6 +202,211 @@ describe( 'unified pi runtime', () => {
 		expect( constructedAgents[ 0 ].state.model.api ).toBe( 'anthropic-messages' );
 		expect( constructedAgents[ 0 ].state.model.provider ).toBe( 'anthropic' );
 		expect( constructedAgents[ 0 ].state.model.id ).toBe( 'claude-opus-4-7' );
+		expect( constructedAgents[ 0 ].state.model.headers ).toMatchObject( {
+			Authorization: 'Bearer sk-test',
+			'X-WPCOM-AI-Feature': 'studio-assistant-anthropic',
+		} );
+		expect( constructedAgents[ 0 ].options.getApiKey?.() ).toBe( 'sk-test' );
+	} );
+
+	it( 'surfaces assistant text carried by turn_end.message', async () => {
+		nextMockEvents = [
+			{
+				type: 'turn_end',
+				message: {
+					role: 'assistant',
+					content: [ { type: 'text', text: 'turn end response' } ],
+					stopReason: 'stop',
+				},
+				toolResults: [],
+			},
+			{ type: 'agent_end', messages: [] },
+		];
+
+		const handle = piRuntime.run( {
+			prompt: 'hello',
+			env: {
+				ANTHROPIC_AUTH_TOKEN: 'sk-test',
+				ANTHROPIC_BASE_URL: 'https://proxy.example.com',
+			},
+			model: 'claude-sonnet-4-6',
+			maxTurns: 1,
+			resume: 'turn-end-message-' + Math.random(),
+		} );
+
+		const assistantTexts: string[] = [];
+		for await ( const m of handle ) {
+			if ( m.type === 'assistant' && Array.isArray( m.message.content ) ) {
+				const content = m.message.content as Array< { type: string; text?: string } >;
+				const text = content.find(
+					( block ): block is { type: 'text'; text: string } => block.type === 'text'
+				);
+				if ( text ) assistantTexts.push( text.text );
+			}
+		}
+
+		expect( assistantTexts ).toEqual( [ 'turn end response' ] );
+	} );
+
+	it( 'dedupes assistant messages repeated by message_end and turn_end.message', async () => {
+		const repeatedMessage = {
+			role: 'assistant',
+			content: [ { type: 'text', text: 'same response' } ],
+			stopReason: 'stop',
+		};
+		nextMockEvents = [
+			{ type: 'message_end', message: repeatedMessage },
+			{ type: 'turn_end', message: repeatedMessage, toolResults: [] },
+			{ type: 'agent_end', messages: [] },
+		];
+
+		const handle = piRuntime.run( {
+			prompt: 'hello',
+			env: {
+				ANTHROPIC_AUTH_TOKEN: 'sk-test',
+				ANTHROPIC_BASE_URL: 'https://proxy.example.com',
+			},
+			model: 'claude-sonnet-4-6',
+			maxTurns: 1,
+			resume: 'dedupe-' + Math.random(),
+		} );
+
+		let assistantCount = 0;
+		for await ( const m of handle ) {
+			if ( m.type === 'assistant' ) assistantCount += 1;
+		}
+
+		expect( assistantCount ).toBe( 1 );
+	} );
+
+	it( 'streams tool calls and results from execution events without turn_end duplicates', async () => {
+		const toolMessage = {
+			role: 'assistant',
+			content: [
+				{
+					type: 'toolCall',
+					id: 'tool-1',
+					name: 'site_info',
+					arguments: { nameOrPath: 'intelligence-chubes4' },
+				},
+			],
+			stopReason: 'toolCall',
+		};
+		nextMockEvents = [
+			{
+				type: 'tool_execution_start',
+				toolCallId: 'tool-1',
+				toolName: 'site_info',
+				args: { nameOrPath: 'intelligence-chubes4' },
+			},
+			{
+				type: 'tool_execution_end',
+				toolCallId: 'tool-1',
+				toolName: 'site_info',
+				args: { nameOrPath: 'intelligence-chubes4' },
+				result: { content: [ { type: 'text', text: '{"status":"Offline"}' } ] },
+				isError: false,
+			},
+			{
+				type: 'turn_end',
+				message: toolMessage,
+				toolResults: [
+					{
+						toolCallId: 'tool-1',
+						toolName: 'site_info',
+						content: [ { type: 'text', text: '{"status":"Offline"}' } ],
+						isError: false,
+					},
+				],
+			},
+			{ type: 'agent_end', messages: [] },
+		];
+
+		const handle = piRuntime.run( {
+			prompt: 'hello',
+			env: {
+				ANTHROPIC_AUTH_TOKEN: 'sk-test',
+				ANTHROPIC_BASE_URL: 'https://proxy.example.com',
+			},
+			model: 'claude-sonnet-4-6',
+			maxTurns: 1,
+			resume: 'stream-tool-events-' + Math.random(),
+		} );
+
+		const toolCalls: Array< { id: string; name: string; input: unknown } > = [];
+		const toolResults: Array< { id: string; text: string; isError: boolean } > = [];
+		for await ( const m of handle ) {
+			if ( m.type === 'assistant' && Array.isArray( m.message.content ) ) {
+				for ( const block of m.message.content ) {
+					if ( block.type === 'tool_use' ) {
+						toolCalls.push( { id: block.id, name: block.name, input: block.input } );
+					}
+				}
+			}
+			if ( m.type === 'user' && Array.isArray( m.message.content ) ) {
+				for ( const block of m.message.content ) {
+					if ( block.type === 'tool_result' ) {
+						toolResults.push( {
+							id: block.tool_use_id,
+							text: block.content,
+							isError: block.is_error,
+						} );
+					}
+				}
+			}
+		}
+
+		expect( toolCalls ).toEqual( [
+			{ id: 'tool-1', name: 'site_info', input: { nameOrPath: 'intelligence-chubes4' } },
+		] );
+		expect( toolResults ).toEqual( [
+			{ id: 'tool-1', text: '{"status":"Offline"}', isError: false },
+		] );
+	} );
+
+	it( 'treats pi assistant error stop reasons as failed results', async () => {
+		nextMockEvents = [
+			{
+				type: 'turn_end',
+				message: {
+					role: 'assistant',
+					content: [ { type: 'text', text: 'provider failed' } ],
+					stopReason: 'error',
+				},
+				toolResults: [],
+			},
+			{ type: 'agent_end', messages: [] },
+		];
+
+		const handle = piRuntime.run( {
+			prompt: 'hello',
+			env: {
+				ANTHROPIC_AUTH_TOKEN: 'sk-test',
+				ANTHROPIC_BASE_URL: 'https://proxy.example.com',
+			},
+			model: 'claude-sonnet-4-6',
+			maxTurns: 1,
+			resume: 'error-stop-' + Math.random(),
+		} );
+
+		const messages: Array< { type: string; subtype?: string; text?: string } > = [];
+		for await ( const m of handle ) {
+			if ( m.type === 'assistant' && Array.isArray( m.message.content ) ) {
+				const content = m.message.content as Array< { type: string; text?: string } >;
+				const text = content.find(
+					( block ): block is { type: 'text'; text: string } => block.type === 'text'
+				);
+				messages.push( { type: m.type, text: text?.text } );
+			} else {
+				messages.push( { type: m.type, subtype: 'subtype' in m ? m.subtype : undefined } );
+			}
+		}
+
+		expect( messages ).toEqual( [
+			{ type: 'system', subtype: 'init' },
+			{ type: 'assistant', text: 'provider failed' },
+			{ type: 'result', subtype: 'error_during_execution' },
+		] );
 	} );
 
 	// Regression: with reasoning enabled, models occasionally produce a turn

--- a/apps/cli/ai/tests/pi-runtime.test.ts
+++ b/apps/cli/ai/tests/pi-runtime.test.ts
@@ -45,7 +45,12 @@ vi.mock( '@mariozechner/pi-agent-core', () => {
 			public options: {
 				getApiKey?: () => string;
 				initialState?: {
-					model?: { id?: string; api?: string; provider?: string; headers?: Record< string, string > };
+					model?: {
+						id?: string;
+						api?: string;
+						provider?: string;
+						headers?: Record< string, string >;
+					};
 					messages?: unknown[];
 				};
 			}


### PR DESCRIPTION
## Summary
- Preserve Anthropic proxy auth headers when constructing the PI model.
- Surface assistant messages carried by `turn_end`, dedupe repeated assistant events, and treat PI `stopReason: "error"` as an SDK-style failed result.
- Stream tool-use and tool-result SDK messages from PI tool execution events so recorders/evals observe tool work as it happens instead of only at `turn_end`.

## Stack context
This is a **draft stacked PR** on top of Riad's PI runtime swap in #3246 (`unify-ai-runtimes-on-pi`). It is not intended to land independently of that PR.

It also builds on the eval-runner diagnostics that just landed in #3273. Those diagnostics made these runtime contract gaps visible in local SDK-vs-PI benchmarks: without these fixes, PI could look faster while failing to surface assistant output, provider errors, or tool execution in the SDK-shaped stream.

## Why
Studio's UI, recorder, and eval tooling still consume an SDK-shaped message stream. This patch keeps the unified PI runtime compatible with that contract while preserving the PI branch's runtime direction.

The main compatibility fixes are:

- WP.com Anthropic proxy auth needs the bearer token in model headers.
- `turn_end.message` may carry assistant output even when no separate `message_end` event fired.
- `stopReason: "error"` should produce an SDK-style failed result, not a successful empty run.
- Tool-use and tool-result messages should stream at execution start/end so evals and recorders can observe real tool work.

## Testing
- `npm test -- apps/cli/ai/tests/pi-runtime.test.ts`
- `npm -w wp-studio run typecheck`
- `npm run cli:build --silent`
- Local SDK-vs-PI rig benches using the shared `homeboy-rigs` eval scenarios:
  - `studio-agent-runtime`
  - `studio-agent-site-info`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** drafted the PI runtime contract fixes and regression tests, then ran local validation and benchmark comparisons. Chris directed the benchmarking scope and reviewed the findings.
