### PR TITLE
Linux: detect and launch third-party terminals

### DIFF
--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -116,6 +116,8 @@ import {
 	saveDefaultSiteDirectory,
 } from 'src/modules/user-settings/lib/ipc-handlers';
 import { linuxFindEditorPath } from 'src/modules/user-settings/lib/linux-editor-path';
+import { linuxFindTerminalPath } from 'src/modules/user-settings/lib/linux-terminal-path';
+import { SupportedTerminal } from 'src/modules/user-settings/lib/terminal';
 import { winFindEditorPath } from 'src/modules/user-settings/lib/win-editor-path';
 import { SiteServer, stopAllServers as triggerStopAllServers } from 'src/site-server';
 import { getSiteThumbnailPath } from 'src/storage/paths';
@@ -1362,7 +1364,46 @@ export async function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath
 			env,
 		} );
 	} else if ( platform === 'linux' ) {
-		return promiseExec( `gnome-terminal --working-directory=${ targetPath }` );
+		const escapedPath = targetPath.replace( /\\/g, '\\\\' ).replace( /"/g, '\\"' );
+
+		// Warp on Linux currently opens at its configured "new session"
+		// directory regardless of how it is launched — it ignores
+		// `--working-directory`, the `path=` URL scheme query, and the
+		// spawn cwd. Tracked upstream in warpdotdev/Warp#4974 and #6357.
+		// Best effort: launch with `cwd` set so we benefit if/when upstream
+		// adds support, and so a fresh launch (no daemon yet) at least has
+		// a chance of inheriting it.
+		const launchers: Record<
+			SupportedTerminal,
+			( () => { command: string; options?: ExecOptions } ) | null
+		> = {
+			terminal: () => ( {
+				command: `gnome-terminal --working-directory="${ escapedPath }"`,
+			} ),
+			warp: () => ( { command: 'warp-terminal', options: { cwd: targetPath } } ),
+			ghostty: () => ( {
+				command: `ghostty --working-directory="${ escapedPath }"`,
+			} ),
+			iterm: null,
+		};
+
+		const order: SupportedTerminal[] = [ preferredTerminal, 'terminal' ];
+		for ( const candidate of order ) {
+			const launcher = launchers[ candidate ];
+			if ( ! launcher ) {
+				continue;
+			}
+			const binary = await linuxFindTerminalPath( candidate );
+			if ( ! binary ) {
+				continue;
+			}
+			const { command, options } = launcher();
+			return promiseExec( command, options );
+		}
+
+		// Last-resort fallback that preserves prior behavior even if no
+		// supported terminal binary is on $PATH.
+		return promiseExec( `gnome-terminal --working-directory="${ escapedPath }"` );
 	} else {
 		console.error( 'Unsupported platform:', platform );
 		return;

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -1375,14 +1375,14 @@ export async function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath
 		// a chance of inheriting it.
 		const launchers: Record<
 			SupportedTerminal,
-			( () => { command: string; options?: ExecOptions } ) | null
+			( ( binary: string ) => { command: string; options?: ExecOptions } ) | null
 		> = {
-			terminal: () => ( {
-				command: `gnome-terminal --working-directory="${ escapedPath }"`,
+			terminal: ( binary ) => ( {
+				command: `"${ binary }" --working-directory="${ escapedPath }"`,
 			} ),
-			warp: () => ( { command: 'warp-terminal', options: { cwd: targetPath } } ),
-			ghostty: () => ( {
-				command: `ghostty --working-directory="${ escapedPath }"`,
+			warp: ( binary ) => ( { command: `"${ binary }"`, options: { cwd: targetPath } } ),
+			ghostty: ( binary ) => ( {
+				command: `"${ binary }" --working-directory="${ escapedPath }"`,
 			} ),
 			iterm: null,
 		};
@@ -1397,7 +1397,7 @@ export async function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath
 			if ( ! binary ) {
 				continue;
 			}
-			const { command, options } = launcher();
+			const { command, options } = launcher( binary );
 			return promiseExec( command, options );
 		}
 

--- a/apps/studio/src/lib/is-installed.ts
+++ b/apps/studio/src/lib/is-installed.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { findOnPath } from 'src/lib/find-on-path';
 import { SUPPORTED_EDITORS, supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
+import { SUPPORTED_TERMINALS, terminalConfig } from 'src/modules/user-settings/lib/terminal';
 
 type PlatformPaths = {
 	[ K in keyof InstalledApps ]: string[];
@@ -54,9 +55,9 @@ const installationPaths: Record< string, PlatformPaths > = {
 		warp: [ 'Warp.app' ],
 		ghostty: [ 'Ghostty.app' ],
 	},
-	// Linux editor detection is driven by `supportedEditorConfig.linuxCommands`
-	// (resolved via $PATH in `isInstalled`), so editors are intentionally
-	// omitted from this map. Only non-editor entries live here.
+	// Linux editor and terminal detection is driven by `linuxCommands`
+	// (resolved via $PATH in `isInstalled`), so those entries are intentionally
+	// omitted from this map. Only the non-resolvable iterm entry lives here.
 	linux: {
 		antigravity: [],
 		vscode: [],
@@ -68,7 +69,7 @@ const installationPaths: Record< string, PlatformPaths > = {
 		zed: [],
 		iterm: [],
 		terminal: [],
-		warp: [ '/usr/bin/warp' ],
+		warp: [],
 		ghostty: [],
 	},
 	win32: {
@@ -149,14 +150,27 @@ function isSupportedEditor(
 	return ( SUPPORTED_EDITORS as readonly string[] ).includes( key );
 }
 
+function isSupportedTerminal(
+	key: keyof InstalledApps
+): key is ( typeof SUPPORTED_TERMINALS )[ number ] {
+	return ( SUPPORTED_TERMINALS as readonly string[] ).includes( key );
+}
+
 export function isInstalled( key: keyof InstalledApps ): boolean {
 	const platform = process.platform;
 
-	// On Linux, editors live in many places (apt, snap, flatpak, ~/.local/bin, …).
-	// Resolve them against $PATH using the editor config instead of hardcoded paths.
-	if ( platform === 'linux' && isSupportedEditor( key ) ) {
-		const editor = supportedEditorConfig[ key ];
-		return editor.linuxCommands.some( ( command ) => findOnPath( command ) !== null );
+	// On Linux, editors and terminals live in many places (apt, snap, flatpak,
+	// ~/.local/bin, …). Resolve them against $PATH using their `linuxCommands`
+	// instead of hardcoded paths.
+	if ( platform === 'linux' ) {
+		if ( isSupportedEditor( key ) ) {
+			const editor = supportedEditorConfig[ key ];
+			return editor.linuxCommands.some( ( command ) => findOnPath( command ) !== null );
+		}
+		if ( isSupportedTerminal( key ) ) {
+			const terminal = terminalConfig[ key ];
+			return terminal.linuxCommands.some( ( command ) => findOnPath( command ) !== null );
+		}
 	}
 
 	const paths = installationPaths[ platform ]?.[ key ];

--- a/apps/studio/src/lib/tests/is-installed.test.ts
+++ b/apps/studio/src/lib/tests/is-installed.test.ts
@@ -210,9 +210,29 @@ describe( 'isInstalled', () => {
 			expect( isInstalled( 'zed' ) ).toBe( false );
 		} );
 
-		it( 'detects Warp via the hardcoded /usr/bin path (non-editor)', () => {
-			mockPaths = [ '/usr/bin/warp' ];
+		it( 'detects Warp installed via $PATH ($HOME/.local/bin)', () => {
+			mockPaths = [ '/mock/home/path/.local/bin/warp-terminal' ];
 			expect( isInstalled( 'warp' ) ).toBe( true );
+		} );
+
+		it( 'detects Warp installed via $PATH (/usr/bin)', () => {
+			mockPaths = [ '/usr/bin/warp-terminal' ];
+			expect( isInstalled( 'warp' ) ).toBe( true );
+		} );
+
+		it( 'returns false when Warp is not on $PATH', () => {
+			mockPaths = [];
+			expect( isInstalled( 'warp' ) ).toBe( false );
+		} );
+
+		it( 'detects Ghostty installed via $PATH', () => {
+			mockPaths = [ '/usr/bin/ghostty' ];
+			expect( isInstalled( 'ghostty' ) ).toBe( true );
+		} );
+
+		it( 'returns false when Ghostty is not on $PATH', () => {
+			mockPaths = [];
+			expect( isInstalled( 'ghostty' ) ).toBe( false );
 		} );
 
 		it( 'ignores a same-named directory on $PATH (not a regular file)', () => {

--- a/apps/studio/src/modules/user-settings/lib/linux-terminal-path.ts
+++ b/apps/studio/src/modules/user-settings/lib/linux-terminal-path.ts
@@ -1,0 +1,23 @@
+import { findOnPath } from 'src/lib/find-on-path';
+import { SupportedTerminal, terminalConfig } from 'src/modules/user-settings/lib/terminal';
+
+/**
+ * Finds the executable path for a given terminal on Linux by walking $PATH.
+ */
+export async function linuxFindTerminalPath(
+	terminalKey: SupportedTerminal
+): Promise< string | null > {
+	const terminal = terminalConfig[ terminalKey ];
+	if ( ! terminal?.linuxCommands?.length ) {
+		return null;
+	}
+
+	for ( const command of terminal.linuxCommands ) {
+		const found = findOnPath( command );
+		if ( found ) {
+			return found;
+		}
+	}
+
+	return null;
+}

--- a/tools/common/lib/user-settings/terminal.ts
+++ b/tools/common/lib/user-settings/terminal.ts
@@ -8,27 +8,32 @@ export type TerminalPlatform = 'darwin' | 'win32' | 'linux';
 export type TerminalConfig = {
 	name: string;
 	platforms: TerminalPlatform[];
+	linuxCommands: string[];
 };
 
 export const terminalConfig: Record< SupportedTerminal, TerminalConfig > = {
 	terminal: {
 		name: __( 'Terminal' ),
 		platforms: [ 'darwin', 'linux', 'win32' ],
+		linuxCommands: [ 'gnome-terminal' ],
 	},
 	iterm: {
 		// translators: "iTerm" is the brand name for a terminal app and does not need to be translated
 		name: __( 'iTerm' ),
 		platforms: [ 'darwin' ],
+		linuxCommands: [],
 	},
 	warp: {
 		// translators: "Warp" is the brand name for a terminal app and does not need to be translated
 		name: __( 'Warp' ),
 		platforms: [ 'darwin', 'win32', 'linux' ],
+		linuxCommands: [ 'warp-terminal' ],
 	},
 	ghostty: {
 		// translators: "Ghostty" is the brand name for a terminal app and does not need to be translated
 		name: __( 'Ghostty' ),
 		platforms: [ 'darwin', 'linux' ],
+		linuxCommands: [ 'ghostty' ],
 	},
 };
 


### PR DESCRIPTION
## Related issues

- Fixes [RSM-1310](https://linear.app/a8c/issue/RSM-1310/linux-third-party-terminals-eg-warp-not-detected-in-terminal)

## How AI was used in this PR

AI assisted with scoping the fix, drafting the PATH-walk lookup for terminals (mirroring the existing editor-detection pattern), and updating the unit tests. All code was reviewed and tested manually inside an Ubuntu Linux VM.

## Proposed Changes

- Extend `TerminalConfig` (`tools/common/lib/user-settings/terminal.ts`) with a `linuxCommands: string[]` field, populated for `terminal` (`gnome-terminal`), `warp` (`warp-terminal`), and `ghostty`.
- Detect supported terminals on Linux via `findOnPath` against `linuxCommands`, instead of the dead `/usr/bin/warp` hardcoded path. This mirrors what editors already do on Linux, so terminals installed via apt/snap/flatpak/`~/.local/bin` are picked up.
- Add `linuxFindTerminalPath` (analogue of the existing `linuxFindEditorPath`).
- Update `openTerminalAtPath` so the Linux branch resolves the user's preferred terminal binary on `$PATH` and launches it with the right working-directory invocation per terminal: `gnome-terminal --working-directory=`, `ghostty --working-directory=`, and `warp-terminal` (best effort, see Known limitation below). Falls back to `gnome-terminal` if no supported binary is found, preserving prior behavior.

### Known limitation: Warp on Linux

Warp on Linux currently does not honor any mechanism for opening at a specific directory — `--working-directory` is unsupported, the `path=` query param in the `warp://` URL scheme is ignored on Linux, and the spawn `cwd` is dropped because Warp behaves as a single-instance daemon. Warp uses its configured "new session" directory instead. Tracked upstream:

- [warpdotdev/Warp#4974](https://github.com/warpdotdev/Warp/issues/4974) — "Open terminal here" from Dolphin opens at root
- [warpdotdev/Warp#6357](https://github.com/warpdotdev/Warp/issues/6357) — Allow launching Warp in a specified working directory

This PR keeps Warp listed in the picker on Linux as a best-effort: detection works, Warp launches, and we set `cwd` so we benefit automatically once upstream lands cwd support. Will discuss with the team whether to keep it best-effort, hide Warp on Linux until upstream is fixed, or surface a UI notice.

## Testing Instructions

Inside an Ubuntu Linux VM (or any Linux distro):

1. Install Warp (`warp-terminal`) and/or Ghostty (`ghostty`).
2. Open Studio → Settings → General → Terminal application. Confirm Warp/Ghostty appear under "Available terminals" when installed and under "Not installed" when not.
3. Set Ghostty as the preferred terminal, then click "Open in terminal" on a site. Confirm Ghostty opens at the site directory.
4. Set Warp as the preferred terminal, click "Open in terminal". Confirm Warp opens (it will currently open at Warp's configured "new session" directory due to the upstream limitation above; this is the documented best-effort behavior).
5. Set Terminal (gnome-terminal) as the preferred terminal, click "Open in terminal". Confirm gnome-terminal opens at the site directory (regression check).
6. Run unit tests: `npm test -- apps/studio/src/lib/tests/is-installed.test.ts`.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?