### PR TITLE
Write mu-plugins loader to site directory when using `native-php` runtime

### DIFF
--- a/apps/cli/commands/wp.ts
+++ b/apps/cli/commands/wp.ts
@@ -44,7 +44,7 @@ enum Mode {
 
 async function runNativePhpWpCliCommand( site: SiteData, args: string[] ): Promise< void > {
 	const phpVersion = validateNativePhpVersion( site.phpVersion );
-	await writeStudioMuPluginsForNativePhpRuntime( site.path );
+	await writeStudioMuPluginsForNativePhpRuntime( site.path, site.isWpAutoUpdating );
 	const child = spawn(
 		getPhpBinaryPath( phpVersion ),
 		[ getWpCliPharPath(), `--path=${ site.path }`, ...args ],

--- a/apps/cli/commands/wp.ts
+++ b/apps/cli/commands/wp.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { writeStudioMuPluginsForNativePhpRuntime } from '@studio/common/lib/mu-plugins';
 import { validateNativePhpVersion } from '@studio/common/lib/php-binary-metadata';
 import { __ } from '@wordpress/i18n';
 import { ArgumentsCamelCase } from 'yargs';
@@ -43,6 +44,7 @@ enum Mode {
 
 async function runNativePhpWpCliCommand( site: SiteData, args: string[] ): Promise< void > {
 	const phpVersion = validateNativePhpVersion( site.phpVersion );
+	await writeStudioMuPluginsForNativePhpRuntime( site.path );
 	const child = spawn(
 		getPhpBinaryPath( phpVersion ),
 		[ getWpCliPharPath(), `--path=${ site.path }`, ...args ],

--- a/apps/cli/lib/archive.ts
+++ b/apps/cli/lib/archive.ts
@@ -1,11 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import { createDeployIgnoreFilter } from '@studio/common/lib/deploy-ignore';
+import { STUDIO_LOADER_MU_PLUGIN_FILENAME } from '@studio/common/lib/mu-plugins';
 import { __ } from '@wordpress/i18n';
 import archiver, { EntryData } from 'archiver';
 import { LoggerError } from 'cli/logger';
 
 const ZIP_COMPRESSION_LEVEL = 9;
+const STUDIO_LOADER_ARCHIVE_PATH = `wp-content/mu-plugins/${ STUDIO_LOADER_MU_PLUGIN_FILENAME }`;
 
 export async function archiveSiteContent(
 	siteFolder: string,
@@ -33,7 +35,11 @@ export async function archiveSiteContent(
 			path.join( siteFolder, 'wp-content' ),
 			'wp-content',
 			( entry: EntryData ) => {
-				if ( deployIgnore.ignores( `wp-content/${ entry.name }` ) ) {
+				const archivePath = `wp-content/${ entry.name }`;
+				if ( archivePath === STUDIO_LOADER_ARCHIVE_PATH ) {
+					return false;
+				}
+				if ( deployIgnore.ignores( archivePath ) ) {
 					return false;
 				}
 				return entry;

--- a/apps/cli/lib/import-export/export/exporters/default-exporter.ts
+++ b/apps/cli/lib/import-export/export/exporters/default-exporter.ts
@@ -5,6 +5,10 @@ import path from 'path';
 import { ARCHIVER_OPTIONS, DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { generateBackupFilename } from '@studio/common/lib/generate-backup-filename';
 import { ExportEvents } from '@studio/common/lib/import-export-events';
+import {
+	LEGACY_MU_PLUGIN_FILENAMES,
+	STUDIO_LOADER_MU_PLUGIN_FILENAME,
+} from '@studio/common/lib/mu-plugins';
 import { parseJsonFromPhpOutput } from '@studio/common/lib/php-output-parser';
 import {
 	hasDefaultDbBlock,
@@ -26,6 +30,10 @@ import {
 } from '../types';
 import type { SiteData } from 'cli/lib/cli-config/core';
 
+const prefixedLegacyMuPluginNames = LEGACY_MU_PLUGIN_FILENAMES.map(
+	( name ) => `wp-content/mu-plugins/${ name }`
+);
+
 export class DefaultExporter extends ImportExportEventEmitter implements Exporter {
 	private archiveBuilder!: archiver.Archiver;
 	private backup: BackupContents;
@@ -37,16 +45,8 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 			'wp-content/database',
 			'wp-content/db.php',
 			'wp-content/debug.log',
-			'wp-content/mu-plugins/0-allowed-redirect-hosts.php',
-			'wp-content/mu-plugins/0-check-theme-availability.php',
-			'wp-content/mu-plugins/0-deactivate-jetpack-modules.php',
-			'wp-content/mu-plugins/0-dns-functions.php',
-			'wp-content/mu-plugins/0-permalinks.php',
-			'wp-content/mu-plugins/0-wp-config-constants-polyfill.php',
-			'wp-content/mu-plugins/0-sqlite.php',
-			'wp-content/mu-plugins/0-thumbnails.php',
-			'wp-content/mu-plugins/0-https-for-reverse-proxy.php',
-			'wp-content/mu-plugins/0-sqlite-command.php',
+			...prefixedLegacyMuPluginNames,
+			`wp-content/mu-plugins/${ STUDIO_LOADER_MU_PLUGIN_FILENAME }`,
 		];
 
 		return PATHS_TO_EXCLUDE.some( ( pathToExclude ) =>

--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -13,7 +13,11 @@ import {
 import { createSpawnHandler } from '@php-wasm/util';
 import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { IS_JSPI_AVAILABLE } from '@studio/common/lib/jspi';
-import { cleanupLegacyMuPlugins, getMuPlugins } from '@studio/common/lib/mu-plugins';
+import {
+	cleanupLegacyMuPlugins,
+	getMuPlugins,
+	writeStudioMuPluginsForNativePhpRuntime,
+} from '@studio/common/lib/mu-plugins';
 import { validateNativePhpVersion } from '@studio/common/lib/php-binary-metadata';
 import { LatestSupportedPHPVersion } from '@studio/common/types/php-versions';
 import { __ } from '@wordpress/i18n';
@@ -119,6 +123,7 @@ async function runNativeWpCliCommand(
 ): Promise< DisposableWpCliResponse > {
 	const nativeArgs = applyWpCliCommandOptions( 'native', args, options );
 	const phpVersion = validateNativePhpVersion( options.phpVersion ?? DEFAULT_PHP_VERSION );
+	await writeStudioMuPluginsForNativePhpRuntime( siteFolder );
 	const child = spawn(
 		getPhpBinaryPath( phpVersion ),
 		[ getWpCliPharPath(), `--path=${ siteFolder }`, ...nativeArgs ],

--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -117,18 +117,18 @@ async function ensureChildSpawned( child: ChildProcess ): Promise< void > {
 }
 
 async function runNativeWpCliCommand(
-	siteFolder: string,
+	site: SiteData,
 	args: string[],
 	options: RunWpCliCommandOptions = {}
 ): Promise< DisposableWpCliResponse > {
 	const nativeArgs = applyWpCliCommandOptions( 'native', args, options );
 	const phpVersion = validateNativePhpVersion( options.phpVersion ?? DEFAULT_PHP_VERSION );
-	await writeStudioMuPluginsForNativePhpRuntime( siteFolder );
+	await writeStudioMuPluginsForNativePhpRuntime( site.path, site.isWpAutoUpdating );
 	const child = spawn(
 		getPhpBinaryPath( phpVersion ),
-		[ getWpCliPharPath(), `--path=${ siteFolder }`, ...nativeArgs ],
+		[ getWpCliPharPath(), `--path=${ site.path }`, ...nativeArgs ],
 		{
-			cwd: siteFolder,
+			cwd: site.path,
 			stdio: [ 'ignore', 'pipe', 'pipe' ],
 		}
 	);
@@ -179,7 +179,7 @@ export async function runWpCliCommand(
 	const siteFolder = site.path;
 
 	if ( site.runtime === 'native-php' ) {
-		return runNativeWpCliCommand( siteFolder, args, options );
+		return runNativeWpCliCommand( site, args, options );
 	}
 
 	const phpVersion = options.phpVersion ?? validatePhpVersion( site.phpVersion );

--- a/apps/cli/lib/wordpress-server-manager.ts
+++ b/apps/cli/lib/wordpress-server-manager.ts
@@ -27,7 +27,6 @@ import { ProcessDescription } from 'cli/lib/types/process-manager-ipc';
 import { ServerConfig, ManagerMessagePayload } from 'cli/lib/types/wordpress-server-ipc';
 import { Logger } from 'cli/logger';
 import { validatePhpVersion } from './utils';
-import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
 import type { WordPressInstallMode } from '@wp-playground/wordpress';
 
 export const SITE_PROCESS_PREFIX = 'studio-site-';

--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -9,6 +9,7 @@
 import { ChildProcess, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { writeStudioMuPluginsForNativePhpRuntime } from '@studio/common/lib/mu-plugins';
 import { decodePassword } from '@studio/common/lib/passwords';
 import {
 	NativePhpSupportedVersion,
@@ -289,6 +290,8 @@ async function startServer( config: ServerConfig, signal: AbortSignal ): Promise
 	try {
 		stopSignal.throwIfAborted();
 		await ensureWpConfig( config.sitePath, phpVersion, stopSignal );
+		stopSignal.throwIfAborted();
+		await writeStudioMuPluginsForNativePhpRuntime( config.sitePath );
 		stopSignal.throwIfAborted();
 
 		const phpAddress = `localhost:${ config.port }`;

--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -291,7 +291,7 @@ async function startServer( config: ServerConfig, signal: AbortSignal ): Promise
 		stopSignal.throwIfAborted();
 		await ensureWpConfig( config.sitePath, phpVersion, stopSignal );
 		stopSignal.throwIfAborted();
-		await writeStudioMuPluginsForNativePhpRuntime( config.sitePath );
+		await writeStudioMuPluginsForNativePhpRuntime( config.sitePath, config.isWpAutoUpdating );
 		stopSignal.throwIfAborted();
 
 		const phpAddress = `localhost:${ config.port }`;

--- a/tools/common/lib/mu-plugins.ts
+++ b/tools/common/lib/mu-plugins.ts
@@ -5,33 +5,57 @@
  * available to WordPress instances. Shared between desktop app and CLI.
  */
 
-import { mkdtemp, readdir, unlink, writeFile } from 'fs/promises';
+import { mkdtemp, readdir, unlink, writeFile, mkdir, copyFile } from 'fs/promises';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import path from 'path';
 
 export interface MuPlugin {
 	filename: string;
 	content: string;
 }
 
+export type MuPluginRuntime = 'playground' | 'native-php';
+
 export interface MuPluginOptions {
 	isWpAutoUpdating?: boolean;
+	runtime?: MuPluginRuntime;
 }
 
 /**
- * Create a loader mu-plugin that loads the Studio mu-plugins
+ * MU-plugin filenames that should not be written for native PHP sites.
+ * These exist to work around behaviors specific to the Playground/PHP WASM
+ * runtime and have no equivalent purpose under native PHP.
+ */
+const NATIVE_PHP_EXCLUDED_MU_PLUGINS = new Set( [
+	'0-allowed-redirect-hosts.php',
+	'0-suppress-dns-get-record-warnings.php',
+	'0-http-request-timeout.php',
+] );
+
+/**
+ * Create a loader mu-plugin that loads the Studio mu-plugins.
+ *
+ * The loader is wired to the directory the rest of the mu-plugins live in.
+ * For the Playground runtime that's the fixed virtual-filesystem path the
+ * Studio mu-plugins are mounted at; for the native PHP runtime it's the
+ * on-disk directory created by `createMuPluginsDirectory()`. Routing
+ * through this loader keeps the user's `wp-content/mu-plugins/` empty (or
+ * close to it) regardless of runtime.
+ *
  * @returns The path to the loader mu-plugin
  */
-async function createLoaderMuPlugin(): Promise< string > {
+async function createLoaderMuPlugin( muPluginsDir: string ): Promise< string > {
 	try {
 		// Create a temporary file for the loader mu-plugin
-		const tempDir = await mkdtemp( join( tmpdir(), 'studio-loader-' ) );
-		const loaderPath = join( tempDir, '99-studio-loader.php' );
+		const tempDir = await mkdtemp( path.join( tmpdir(), 'studio-loader-' ) );
+		const loaderPath = path.join( tempDir, '99-studio-loader.php' );
+
+		const escapedMuPluginsDir = muPluginsDir.replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
 
 		const loaderContent = `<?php
 		/**
 		 * Studio MU-Plugins Loader
-		 * Loads Studio-specific mu-plugins from /internal/studio/mu-plugins/
+		 * Loads Studio-specific mu-plugins from a Studio-managed directory.
 		 */
 
 		// Define database constants if not already defined. It fixes the error
@@ -47,7 +71,7 @@ async function createLoaderMuPlugin(): Promise< string > {
 		// Set environment type to local if not already defined
 		if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) define( 'WP_ENVIRONMENT_TYPE', 'local' );
 
-		$studio_mu_plugins_dir = '/internal/studio/mu-plugins';
+		$studio_mu_plugins_dir = '${ escapedMuPluginsDir }';
 
 		if ( is_dir( $studio_mu_plugins_dir ) ) {
 			$files = glob( $studio_mu_plugins_dir . '/*.php' );
@@ -83,7 +107,7 @@ function getStandardMuPlugins( options: MuPluginOptions ): MuPlugin[] {
 		content: `<?php
 		// This is a temporary fix for a Query Manager plugin, which isn't rendered in wp-admin if sapi is "cli" (it's the case for wordpress-playground).
 		// See https://github.com/WordPress/wordpress-playground/pull/2424#issuecomment-3686951491
-		// It's not the best fix, but it's simple and for consistency it's the same as used in wordpress-playground (https://github.com/WordPress/wordpress-playground/pull/2415)		
+		// It's not the best fix, but it's simple and for consistency it's the same as used in wordpress-playground (https://github.com/WordPress/wordpress-playground/pull/2415)
 		define('QM_TESTS', true);
 		`,
 	} );
@@ -521,22 +545,26 @@ function getStandardMuPlugins( options: MuPluginOptions ): MuPlugin[] {
 		`,
 	} );
 
+	if ( options.runtime === 'native-php' ) {
+		return muPlugins.filter(
+			( plugin ) => ! NATIVE_PHP_EXCLUDED_MU_PLUGINS.has( plugin.filename )
+		);
+	}
+
 	return muPlugins;
 }
 
 async function createMuPluginsDirectory( options: MuPluginOptions ): Promise< string > {
 	try {
 		// Create a temporary directory for mu-plugins
-		const tempDir = await mkdtemp( join( tmpdir(), 'studio-mu-plugins-' ) );
+		const tempDir = await mkdtemp( path.join( tmpdir(), 'studio-mu-plugins-' ) );
 
 		// Get the standard mu-plugins
-		const muPlugins = getStandardMuPlugins( {
-			isWpAutoUpdating: options.isWpAutoUpdating,
-		} );
+		const muPlugins = getStandardMuPlugins( options );
 
 		// Write each mu-plugin file to the temporary directory
 		for ( const plugin of muPlugins ) {
-			const pluginPath = join( tempDir, plugin.filename );
+			const pluginPath = path.join( tempDir, plugin.filename );
 			await writeFile( pluginPath, plugin.content );
 		}
 		return tempDir;
@@ -546,24 +574,57 @@ async function createMuPluginsDirectory( options: MuPluginOptions ): Promise< st
 }
 
 /**
- * Get mu-plugins for a WordPress instance
- * @param options Configuration options for mu-plugins
- * @returns Array of paths: [studioMuPluginsHostPath, loaderMuPluginHostPath]
+ * Get mu-plugins for a WordPress instance.
+ *
+ * Returns `[studioMuPluginsHostPath, loaderMuPluginHostPath]` for both
+ * runtimes — only the loader's contents differ. For the `playground`
+ * runtime the loader requires plugins from the virtual-filesystem path
+ * the mu-plugins are mounted at. For the `native-php` runtime the loader
+ * requires plugins from the on-disk temp directory directly, so the
+ * caller only needs to drop the loader file into the site's
+ * `wp-content/mu-plugins/` for WordPress to pick it up.
  */
-export async function getMuPlugins( options: MuPluginOptions ) {
+export async function getMuPlugins( options: MuPluginOptions = {} ): Promise< [ string, string ] > {
 	const studioMuPluginsHostPath = await createMuPluginsDirectory( options );
-	const loaderMuPluginHostPath = await createLoaderMuPlugin();
+	const loaderMuPluginHostPath = await createLoaderMuPlugin(
+		options.runtime === 'native-php' ? studioMuPluginsHostPath : '/internal/studio/mu-plugins'
+	);
 
 	return [ studioMuPluginsHostPath, loaderMuPluginHostPath ];
 }
 
+export async function writeStudioMuPluginsForNativePhpRuntime(
+	siteFolder: string
+): Promise< void > {
+	const muPluginsDir = path.join( siteFolder, 'wp-content', 'mu-plugins' );
+	await mkdir( muPluginsDir, { recursive: true } );
+
+	// `getMuPlugins` writes the plugin files to a temp directory and produces
+	// a loader file that requires them. For the native PHP runtime we only
+	// copy the loader into wp-content/mu-plugins/ — WordPress auto-loads it
+	// at runtime and it pulls the rest in from the temp directory, keeping
+	// the user's mu-plugins/ nearly empty.
+	const [ , loaderHostPath ] = await getMuPlugins( { runtime: 'native-php' } );
+	await copyFile( loaderHostPath, path.join( muPluginsDir, STUDIO_LOADER_MU_PLUGIN_FILENAME ) );
+}
+
 /**
- * Legacy mu-plugin filenames that older Studio versions wrote directly into
- * wp-content/mu-plugins/. Newer versions inject these at runtime via the
- * PHP WASM virtual filesystem, so on-disk copies cause "Cannot redeclare"
- * PHP fatal errors. This list includes both current and retired filenames.
+ * Filename of the loader mu-plugin that the native PHP runtime drops into
+ * the site's `wp-content/mu-plugins/`. It's the only Studio-managed file
+ * that ever lands on disk during normal operation, so archive and export
+ * filters use this name to skip it.
  */
-const LEGACY_MU_PLUGIN_FILENAMES = [
+export const STUDIO_LOADER_MU_PLUGIN_FILENAME = '99-studio-loader.php';
+
+/**
+ * Mu-plugin filenames that older Studio versions wrote directly into
+ * `wp-content/mu-plugins/`. Newer versions keep these files in a temp
+ * directory and load them through `STUDIO_LOADER_MU_PLUGIN_FILENAME`, so
+ * any on-disk copies are leftovers we should clean up at startup. The
+ * list includes both currently-shipped and retired filenames so it can
+ * scrub anything previously installed by Studio.
+ */
+export const LEGACY_MU_PLUGIN_FILENAMES = [
 	// Current mu-plugins (from getStandardMuPlugins)
 	'0-allowed-redirect-hosts.php',
 	'0-auto-login.php',
@@ -601,7 +662,7 @@ const LEGACY_MU_PLUGIN_FILENAMES = [
  * @param sitePath - Absolute path to the WordPress site directory
  */
 export async function cleanupLegacyMuPlugins( sitePath: string ): Promise< void > {
-	const muPluginsDir = join( sitePath, 'wp-content', 'mu-plugins' );
+	const muPluginsDir = path.join( sitePath, 'wp-content', 'mu-plugins' );
 
 	let entries: string[];
 	try {
@@ -617,7 +678,7 @@ export async function cleanupLegacyMuPlugins( sitePath: string ): Promise< void 
 	await Promise.all(
 		filesToRemove.map( async ( name ) => {
 			try {
-				await unlink( join( muPluginsDir, name ) );
+				await unlink( path.join( muPluginsDir, name ) );
 			} catch {
 				// Best-effort: file may already be gone or locked
 			}

--- a/tools/common/lib/mu-plugins.ts
+++ b/tools/common/lib/mu-plugins.ts
@@ -594,7 +594,8 @@ export async function getMuPlugins( options: MuPluginOptions = {} ): Promise< [ 
 }
 
 export async function writeStudioMuPluginsForNativePhpRuntime(
-	siteFolder: string
+	siteFolder: string,
+	isWpAutoUpdating: MuPluginOptions[ 'isWpAutoUpdating' ]
 ): Promise< void > {
 	const muPluginsDir = path.join( siteFolder, 'wp-content', 'mu-plugins' );
 	await mkdir( muPluginsDir, { recursive: true } );
@@ -604,7 +605,7 @@ export async function writeStudioMuPluginsForNativePhpRuntime(
 	// copy the loader into wp-content/mu-plugins/ — WordPress auto-loads it
 	// at runtime and it pulls the rest in from the temp directory, keeping
 	// the user's mu-plugins/ nearly empty.
-	const [ , loaderHostPath ] = await getMuPlugins( { runtime: 'native-php' } );
+	const [ , loaderHostPath ] = await getMuPlugins( { isWpAutoUpdating, runtime: 'native-php' } );
 	await copyFile( loaderHostPath, path.join( muPluginsDir, STUDIO_LOADER_MU_PLUGIN_FILENAME ) );
 }
 

--- a/tools/common/lib/tests/mu-plugins.test.ts
+++ b/tools/common/lib/tests/mu-plugins.test.ts
@@ -1,8 +1,12 @@
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
-import { mkdtemp, readdir } from 'fs/promises';
+import { mkdtemp, readdir, readFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { cleanupLegacyMuPlugins } from '@studio/common/lib/mu-plugins';
+import {
+	cleanupLegacyMuPlugins,
+	STUDIO_LOADER_MU_PLUGIN_FILENAME,
+	writeStudioMuPluginsForNativePhpRuntime,
+} from '@studio/common/lib/mu-plugins';
 
 describe( 'cleanupLegacyMuPlugins', () => {
 	let sitePath: string;
@@ -82,5 +86,32 @@ describe( 'cleanupLegacyMuPlugins', () => {
 
 		const remaining = await readdir( muPluginsDir );
 		expect( remaining ).toHaveLength( 0 );
+	} );
+} );
+
+describe( 'writeStudioMuPluginsForNativePhpRuntime', () => {
+	let sitePath: string;
+
+	beforeEach( async () => {
+		sitePath = await mkdtemp( join( tmpdir(), 'studio-test-site-' ) );
+	} );
+
+	it( 'should preserve the auto-update setting for native PHP mu-plugins', async () => {
+		await writeStudioMuPluginsForNativePhpRuntime( sitePath, true );
+
+		const loaderPath = join(
+			sitePath,
+			'wp-content',
+			'mu-plugins',
+			STUDIO_LOADER_MU_PLUGIN_FILENAME
+		);
+		const loaderContent = await readFile( loaderPath, 'utf8' );
+		const muPluginsDir = loaderContent.match( /\$studio_mu_plugins_dir = '([^']+)';/ )?.[ 1 ];
+
+		expect( muPluginsDir ).toBeTruthy();
+
+		const generatedPlugins = await readdir( muPluginsDir as string );
+		expect( generatedPlugins ).toContain( '0-enable-auto-updates.php' );
+		expect( generatedPlugins ).not.toContain( '0-disable-auto-updates.php' );
 	} );
 } );


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes RSM-1154

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Given a clear implementation plan, Claude wrote the bulk of the code. I iterated on the result. 

## Proposed Changes

- For `native-php` sites, continue using the `getMuPlugins()` approach of creating a new temporary directory containing the plugins from `getStandardMuPlugins()`, and a loader PHP file that `require`s them.
- Write the loader PHP file to `wp-content/mu-plugins/99-studio-loader.php` on disk.
- This dance is done every time the site starts and on every WP-CLI invocation. The drawback is that we do more file I/O, but the upside is that `wp-content/mu-plugins` remains relatively clean. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `STUDIO_RUNTIME=native-php npm start`
2. Create a new site
3. Once the site has been created, click the `WP admin` button
4. Ensure that auto-login to wp-admin works as expected. This shows that the mu-plugins have loaded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
