### PR TITLE
CLI: stream remote-session activity to stdout while the REPL is blocked

### DIFF
--- a/apps/cli/remote-session/index.ts
+++ b/apps/cli/remote-session/index.ts
@@ -16,7 +16,10 @@ export { RemoteSessionConfigError };
  */
 export async function runRemoteSession( overrides: RemoteSessionOverrides = {} ): Promise< void > {
 	const config = await loadRemoteSessionConfig( overrides );
-	const logger = new RemoteSessionLogger();
+	// The interactive REPL is blocked while attached, so stdout is free. Stream
+	// session activity (polled messages, turn outcomes, replies posted, errors)
+	// there alongside the structured log file, so the user can watch progress.
+	const logger = new RemoteSessionLogger( { mirrorToStdout: true } );
 	const logPath = getRemoteSessionLogPath();
 	logger.info( 'Remote session starting', {
 		base_url: config.base_url,

--- a/apps/cli/remote-session/logger.ts
+++ b/apps/cli/remote-session/logger.ts
@@ -146,4 +146,24 @@ export class RemoteSessionLogger {
 	error( message: string, meta?: Record< string, unknown > ): void {
 		this.write( 'error', message, meta );
 	}
+
+	/**
+	 * Write a single conversation-content line to stdout only (never the file).
+	 * Used to surface the actual subprocess event payloads — incoming user text,
+	 * progress messages, the final reply, paused questions — while attached.
+	 * Skipped when `mirrorToStdout` is off, so callers can sprinkle these freely
+	 * without affecting non-streaming runs.
+	 */
+	event( kind: string, content: string ): void {
+		if ( ! this.mirrorToStdout ) {
+			return;
+		}
+		const time = new Date().toTimeString().slice( 0, 8 );
+		const oneLine = redact( content ).replace( /\r?\n/g, '\n  ' );
+		try {
+			process.stdout.write( `[${ time }] ${ kind } ${ oneLine }\n` );
+		} catch {
+			// Best-effort; never throw from here.
+		}
+	}
 }

--- a/apps/cli/remote-session/logger.ts
+++ b/apps/cli/remote-session/logger.ts
@@ -68,11 +68,38 @@ function ensureLogDir( logPath: string ): void {
 	}
 }
 
+export interface RemoteSessionLoggerOptions {
+	/** Override the file path. Defaults to `~/.studio/remote-session.log`. */
+	logPath?: string;
+	/**
+	 * Also write a human-readable line to stdout for each non-suppressed call.
+	 * Used by `studio code --remote-session` so the user can watch session
+	 * activity in the terminal while the interactive REPL is blocked.
+	 */
+	mirrorToStdout?: boolean;
+}
+
+function formatStdoutLine(
+	level: LogLevel,
+	message: string,
+	meta?: Record< string, unknown >
+): string {
+	const time = new Date().toTimeString().slice( 0, 8 );
+	const head = `[${ time }] ${ level } ${ redact( message ) }`;
+	if ( ! meta ) {
+		return `${ head }\n`;
+	}
+	const redactedMeta = redact( JSON.stringify( meta ) );
+	return `${ head } ${ redactedMeta }\n`;
+}
+
 export class RemoteSessionLogger {
 	private logPath: string;
+	private mirrorToStdout: boolean;
 
-	constructor( logPath: string = getRemoteSessionLogPath() ) {
-		this.logPath = logPath;
+	constructor( options: RemoteSessionLoggerOptions = {} ) {
+		this.logPath = options.logPath ?? getRemoteSessionLogPath();
+		this.mirrorToStdout = options.mirrorToStdout ?? false;
 	}
 
 	private write( level: LogLevel, message: string, meta?: Record< string, unknown > ): void {
@@ -93,6 +120,14 @@ export class RemoteSessionLogger {
 			fs.appendFileSync( this.logPath, line, { encoding: 'utf8' } );
 		} catch {
 			// Logging is best-effort; never throw from here.
+		}
+
+		if ( this.mirrorToStdout ) {
+			try {
+				process.stdout.write( formatStdoutLine( level, message, meta ) );
+			} catch {
+				// Stdout mirroring is best-effort; never throw from here.
+			}
 		}
 	}
 

--- a/apps/cli/remote-session/logger.ts
+++ b/apps/cli/remote-session/logger.ts
@@ -21,6 +21,33 @@ export function redact( input: string ): string {
 		.replace( TOKEN_FIELD_PATTERN, '"token":"[redacted]"' );
 }
 
+// CSI (`\x1b[...`), OSC (`\x1b]...BEL` or `...ST`), and other 7-bit C1 escapes.
+const ANSI_ESCAPE_PATTERN =
+	// eslint-disable-next-line no-control-regex
+	/\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[@-_])/g;
+// All C0 control chars except `\t` (0x09) and `\n` (0x0A), plus DEL (0x7F).
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_PATTERN = /[\x00-\x08\x0B-\x1F\x7F]/g;
+
+/**
+ * Strip terminal control sequences from text destined for stdout. Telegram
+ * messages and agent output are untrusted and may embed ANSI escapes (colors,
+ * screen clears, cursor moves, OSC hyperlinks) that would otherwise manipulate
+ * the user's terminal — a log-spoofing / phishing risk. We keep `\t` and `\n`
+ * so multi-line replies still render with whitespace structure.
+ */
+export function stripTerminalControls( input: string ): string {
+	return input.replace( ANSI_ESCAPE_PATTERN, '' ).replace( CONTROL_CHAR_PATTERN, '' );
+}
+
+/**
+ * Apply both redaction and terminal-control sanitization. Use whenever text
+ * (operator-supplied or attacker-supplied) is being written to stdout.
+ */
+function safeForStdout( input: string ): string {
+	return stripTerminalControls( redact( input ) );
+}
+
 function shouldLogDebug(): boolean {
 	return process.env.STUDIO_REMOTE_DEBUG === '1';
 }
@@ -85,12 +112,16 @@ function formatStdoutLine(
 	meta?: Record< string, unknown >
 ): string {
 	const time = new Date().toTimeString().slice( 0, 8 );
-	const head = `[${ time }] ${ level } ${ redact( message ) }`;
+	const head = `[${ time }] ${ level } ${ safeForStdout( message ) }`;
 	if ( ! meta ) {
 		return `${ head }\n`;
 	}
-	const redactedMeta = redact( JSON.stringify( meta ) );
-	return `${ head } ${ redactedMeta }\n`;
+	// JSON.stringify already escapes control bytes inside string values
+	// (e.g. `"[2J"`), but we sanitize again defensively in case the
+	// shape ever changes. Redaction must run on the JSON so token fields
+	// matching `"token":"…"` are caught after serialization.
+	const safeMeta = safeForStdout( JSON.stringify( meta ) );
+	return `${ head } ${ safeMeta }\n`;
 }
 
 export class RemoteSessionLogger {
@@ -159,9 +190,12 @@ export class RemoteSessionLogger {
 			return;
 		}
 		const time = new Date().toTimeString().slice( 0, 8 );
-		const oneLine = redact( content ).replace( /\r?\n/g, '\n  ' );
+		// Sanitize first so `\r` and other control bytes are gone before we
+		// indent newlines for multi-line content (questions, replies).
+		const safe = safeForStdout( content ).replace( /\n/g, '\n  ' );
+		const safeKind = stripTerminalControls( kind );
 		try {
-			process.stdout.write( `[${ time }] ${ kind } ${ oneLine }\n` );
+			process.stdout.write( `[${ time }] ${ safeKind } ${ safe }\n` );
 		} catch {
 			// Best-effort; never throw from here.
 		}

--- a/apps/cli/remote-session/poll-loop.ts
+++ b/apps/cli/remote-session/poll-loop.ts
@@ -346,6 +346,9 @@ export async function runPollLoop( options: RunPollLoopOptions ): Promise< PollL
 					text_length: polled.text.length,
 					preview: text.slice( 0, 80 ),
 				} );
+				if ( text.length > 0 ) {
+					deps.logger.event( 'message', text );
+				}
 
 				if ( text.length === 0 ) {
 					// Empty text would cause `studio code --json` to fail its `.check()`

--- a/apps/cli/remote-session/tests/logger.test.ts
+++ b/apps/cli/remote-session/tests/logger.test.ts
@@ -153,7 +153,7 @@ describe( 'RemoteSessionLogger writes', () => {
 		expect( combined ).not.toMatch( /[\x00-\x08\x0B-\x1F\x7F]/ );
 		expect( combined ).toContain( 'message cleared' );
 		expect( combined ).toContain( 'click' );
-		// JSON.stringify already escapes raw ESC bytes to the visible 6-char ``
+		// JSON.stringify already escapes raw ESC bytes to the visible 6-char `\u001b` (literal backslash-u-0-0-1-b)
 		// sequence in meta, so the terminal sees inert text rather than active escapes.
 		expect( combined ).toContain( '\\u001b[31mred\\u001b[0m\\u0007' );
 	} );

--- a/apps/cli/remote-session/tests/logger.test.ts
+++ b/apps/cli/remote-session/tests/logger.test.ts
@@ -36,7 +36,7 @@ describe( 'RemoteSessionLogger writes', () => {
 	} );
 
 	it( 'writes one line per call with redacted content', () => {
-		const logger = new RemoteSessionLogger( logPath );
+		const logger = new RemoteSessionLogger( { logPath } );
 		logger.info( 'hello Bearer abc123', { token: 'visible-secret' } );
 		const content = fs.readFileSync( logPath, 'utf8' );
 		expect( content ).toMatch( /"msg":"hello Bearer \[redacted\]"/ );
@@ -48,7 +48,7 @@ describe( 'RemoteSessionLogger writes', () => {
 		const original = process.env.STUDIO_REMOTE_DEBUG;
 		try {
 			delete process.env.STUDIO_REMOTE_DEBUG;
-			const logger = new RemoteSessionLogger( logPath );
+			const logger = new RemoteSessionLogger( { logPath } );
 			logger.debug( 'should be suppressed' );
 			expect( fs.existsSync( logPath ) ).toBe( false );
 
@@ -62,5 +62,43 @@ describe( 'RemoteSessionLogger writes', () => {
 				process.env.STUDIO_REMOTE_DEBUG = original;
 			}
 		}
+	} );
+
+	it( 'mirrors non-debug entries to stdout when mirrorToStdout is set, with redaction', () => {
+		const writes: string[] = [];
+		const originalWrite = process.stdout.write.bind( process.stdout );
+		process.stdout.write = ( ( chunk: string | Uint8Array ) => {
+			writes.push( typeof chunk === 'string' ? chunk : Buffer.from( chunk ).toString( 'utf8' ) );
+			return true;
+		} ) as typeof process.stdout.write;
+		try {
+			const logger = new RemoteSessionLogger( { logPath, mirrorToStdout: true } );
+			logger.info( 'hello Bearer abc123', { token: 'visible-secret', chat_id: 42 } );
+			logger.warn( 'no meta here' );
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+		const combined = writes.join( '' );
+		expect( combined ).toMatch( /\binfo\b.*hello Bearer \[redacted\].*"chat_id":42/ );
+		expect( combined ).toMatch( /\bwarn\b.*no meta here/ );
+		expect( combined ).not.toMatch( /visible-secret/ );
+		// Sanity check: file path also got the line.
+		expect( fs.readFileSync( logPath, 'utf8' ) ).toMatch( /"msg":"hello Bearer \[redacted\]"/ );
+	} );
+
+	it( 'does not mirror to stdout by default', () => {
+		const writes: string[] = [];
+		const originalWrite = process.stdout.write.bind( process.stdout );
+		process.stdout.write = ( ( chunk: string | Uint8Array ) => {
+			writes.push( typeof chunk === 'string' ? chunk : Buffer.from( chunk ).toString( 'utf8' ) );
+			return true;
+		} ) as typeof process.stdout.write;
+		try {
+			const logger = new RemoteSessionLogger( { logPath } );
+			logger.info( 'silent on stdout' );
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+		expect( writes.join( '' ) ).not.toMatch( /silent on stdout/ );
 	} );
 } );

--- a/apps/cli/remote-session/tests/logger.test.ts
+++ b/apps/cli/remote-session/tests/logger.test.ts
@@ -86,6 +86,45 @@ describe( 'RemoteSessionLogger writes', () => {
 		expect( fs.readFileSync( logPath, 'utf8' ) ).toMatch( /"msg":"hello Bearer \[redacted\]"/ );
 	} );
 
+	it( 'event() writes a single stdout line and never touches the file', () => {
+		const writes: string[] = [];
+		const originalWrite = process.stdout.write.bind( process.stdout );
+		process.stdout.write = ( ( chunk: string | Uint8Array ) => {
+			writes.push( typeof chunk === 'string' ? chunk : Buffer.from( chunk ).toString( 'utf8' ) );
+			return true;
+		} ) as typeof process.stdout.write;
+		try {
+			const logger = new RemoteSessionLogger( { logPath, mirrorToStdout: true } );
+			logger.event( 'reply', 'Just 1 site is running.\nLine two.' );
+			logger.event( 'progress', 'Authorization: Bearer abc.def' );
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+		const combined = writes.join( '' );
+		// Newlines in content are indented so each line stays grouped under its event.
+		expect( combined ).toMatch( /reply Just 1 site is running\.\n {2}Line two\./ );
+		expect( combined ).toMatch( /progress Authorization: Bearer \[redacted\]/ );
+		// File sink stays untouched by event().
+		expect( fs.existsSync( logPath ) ).toBe( false );
+	} );
+
+	it( 'event() is a no-op when mirrorToStdout is off', () => {
+		const writes: string[] = [];
+		const originalWrite = process.stdout.write.bind( process.stdout );
+		process.stdout.write = ( ( chunk: string | Uint8Array ) => {
+			writes.push( typeof chunk === 'string' ? chunk : Buffer.from( chunk ).toString( 'utf8' ) );
+			return true;
+		} ) as typeof process.stdout.write;
+		try {
+			const logger = new RemoteSessionLogger( { logPath } );
+			logger.event( 'reply', 'should not appear' );
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+		expect( writes.join( '' ) ).not.toMatch( /should not appear/ );
+		expect( fs.existsSync( logPath ) ).toBe( false );
+	} );
+
 	it( 'does not mirror to stdout by default', () => {
 		const writes: string[] = [];
 		const originalWrite = process.stdout.write.bind( process.stdout );

--- a/apps/cli/remote-session/tests/logger.test.ts
+++ b/apps/cli/remote-session/tests/logger.test.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { RemoteSessionLogger, redact } from 'cli/remote-session/logger';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RemoteSessionLogger, redact, stripTerminalControls } from 'cli/remote-session/logger';
 
 describe( 'remote-session logger redaction', () => {
 	it( 'redacts Bearer tokens in arbitrary text', () => {
@@ -22,6 +22,21 @@ describe( 'remote-session logger redaction', () => {
 	} );
 } );
 
+describe( 'stripTerminalControls', () => {
+	it( 'removes ANSI CSI sequences and bare ESC bytes', () => {
+		expect( stripTerminalControls( '\x1b[2Jhello\x1b[31mworld\x1b[0m' ) ).toBe( 'helloworld' );
+		expect( stripTerminalControls( 'before\x1bafter' ) ).toBe( 'beforeafter' );
+	} );
+
+	it( 'removes OSC hyperlink sequences', () => {
+		expect( stripTerminalControls( '\x1b]8;;https://evil/\x07click\x1b]8;;\x07' ) ).toBe( 'click' );
+	} );
+
+	it( 'strips C0 and DEL but keeps tab and newline', () => {
+		expect( stripTerminalControls( 'a\x07b\x7fc\nd\te' ) ).toBe( 'abc\nd\te' );
+	} );
+} );
+
 describe( 'RemoteSessionLogger writes', () => {
 	let tmpDir: string;
 	let logPath: string;
@@ -33,7 +48,27 @@ describe( 'RemoteSessionLogger writes', () => {
 
 	afterEach( () => {
 		fs.rmSync( tmpDir, { recursive: true, force: true } );
+		vi.restoreAllMocks();
 	} );
+
+	function captureStdout(): { writes: string[]; combined: () => string } {
+		const writes: string[] = [];
+		// `process.stdout.write` has overloads: `(chunk, cb?)` and `(chunk, encoding?, cb?)`.
+		// Accept rest args and invoke any function-typed arg so internal Node/Vitest writers
+		// that supply a callback don't hang waiting for it.
+		vi.spyOn( process.stdout, 'write' ).mockImplementation( ( (
+			chunk: unknown,
+			...rest: unknown[]
+		) => {
+			writes.push(
+				typeof chunk === 'string' ? chunk : Buffer.from( chunk as Uint8Array ).toString( 'utf8' )
+			);
+			const cb = rest.find( ( arg ): arg is ( err?: Error ) => void => typeof arg === 'function' );
+			cb?.();
+			return true;
+		} ) as typeof process.stdout.write );
+		return { writes, combined: () => writes.join( '' ) };
+	}
 
 	it( 'writes one line per call with redacted content', () => {
 		const logger = new RemoteSessionLogger( { logPath } );
@@ -65,20 +100,11 @@ describe( 'RemoteSessionLogger writes', () => {
 	} );
 
 	it( 'mirrors non-debug entries to stdout when mirrorToStdout is set, with redaction', () => {
-		const writes: string[] = [];
-		const originalWrite = process.stdout.write.bind( process.stdout );
-		process.stdout.write = ( ( chunk: string | Uint8Array ) => {
-			writes.push( typeof chunk === 'string' ? chunk : Buffer.from( chunk ).toString( 'utf8' ) );
-			return true;
-		} ) as typeof process.stdout.write;
-		try {
-			const logger = new RemoteSessionLogger( { logPath, mirrorToStdout: true } );
-			logger.info( 'hello Bearer abc123', { token: 'visible-secret', chat_id: 42 } );
-			logger.warn( 'no meta here' );
-		} finally {
-			process.stdout.write = originalWrite;
-		}
-		const combined = writes.join( '' );
+		const captured = captureStdout();
+		const logger = new RemoteSessionLogger( { logPath, mirrorToStdout: true } );
+		logger.info( 'hello Bearer abc123', { token: 'visible-secret', chat_id: 42 } );
+		logger.warn( 'no meta here' );
+		const combined = captured.combined();
 		expect( combined ).toMatch( /\binfo\b.*hello Bearer \[redacted\].*"chat_id":42/ );
 		expect( combined ).toMatch( /\bwarn\b.*no meta here/ );
 		expect( combined ).not.toMatch( /visible-secret/ );
@@ -87,20 +113,11 @@ describe( 'RemoteSessionLogger writes', () => {
 	} );
 
 	it( 'event() writes a single stdout line and never touches the file', () => {
-		const writes: string[] = [];
-		const originalWrite = process.stdout.write.bind( process.stdout );
-		process.stdout.write = ( ( chunk: string | Uint8Array ) => {
-			writes.push( typeof chunk === 'string' ? chunk : Buffer.from( chunk ).toString( 'utf8' ) );
-			return true;
-		} ) as typeof process.stdout.write;
-		try {
-			const logger = new RemoteSessionLogger( { logPath, mirrorToStdout: true } );
-			logger.event( 'reply', 'Just 1 site is running.\nLine two.' );
-			logger.event( 'progress', 'Authorization: Bearer abc.def' );
-		} finally {
-			process.stdout.write = originalWrite;
-		}
-		const combined = writes.join( '' );
+		const captured = captureStdout();
+		const logger = new RemoteSessionLogger( { logPath, mirrorToStdout: true } );
+		logger.event( 'reply', 'Just 1 site is running.\nLine two.' );
+		logger.event( 'progress', 'Authorization: Bearer abc.def' );
+		const combined = captured.combined();
 		// Newlines in content are indented so each line stays grouped under its event.
 		expect( combined ).toMatch( /reply Just 1 site is running\.\n {2}Line two\./ );
 		expect( combined ).toMatch( /progress Authorization: Bearer \[redacted\]/ );
@@ -109,35 +126,35 @@ describe( 'RemoteSessionLogger writes', () => {
 	} );
 
 	it( 'event() is a no-op when mirrorToStdout is off', () => {
-		const writes: string[] = [];
-		const originalWrite = process.stdout.write.bind( process.stdout );
-		process.stdout.write = ( ( chunk: string | Uint8Array ) => {
-			writes.push( typeof chunk === 'string' ? chunk : Buffer.from( chunk ).toString( 'utf8' ) );
-			return true;
-		} ) as typeof process.stdout.write;
-		try {
-			const logger = new RemoteSessionLogger( { logPath } );
-			logger.event( 'reply', 'should not appear' );
-		} finally {
-			process.stdout.write = originalWrite;
-		}
-		expect( writes.join( '' ) ).not.toMatch( /should not appear/ );
+		const captured = captureStdout();
+		const logger = new RemoteSessionLogger( { logPath } );
+		logger.event( 'reply', 'should not appear' );
+		expect( captured.combined() ).not.toMatch( /should not appear/ );
 		expect( fs.existsSync( logPath ) ).toBe( false );
 	} );
 
 	it( 'does not mirror to stdout by default', () => {
-		const writes: string[] = [];
-		const originalWrite = process.stdout.write.bind( process.stdout );
-		process.stdout.write = ( ( chunk: string | Uint8Array ) => {
-			writes.push( typeof chunk === 'string' ? chunk : Buffer.from( chunk ).toString( 'utf8' ) );
-			return true;
-		} ) as typeof process.stdout.write;
-		try {
-			const logger = new RemoteSessionLogger( { logPath } );
-			logger.info( 'silent on stdout' );
-		} finally {
-			process.stdout.write = originalWrite;
-		}
-		expect( writes.join( '' ) ).not.toMatch( /silent on stdout/ );
+		const captured = captureStdout();
+		const logger = new RemoteSessionLogger( { logPath } );
+		logger.info( 'silent on stdout' );
+		expect( captured.combined() ).not.toMatch( /silent on stdout/ );
+	} );
+
+	it( 'sanitizes terminal control sequences from untrusted content on stdout', () => {
+		const captured = captureStdout();
+		const logger = new RemoteSessionLogger( { logPath, mirrorToStdout: true } );
+		// Raw ESC + CSI screen-clear, plus an OSC hyperlink wrapping evil text.
+		logger.event( 'message', '\x1b[2Jcleared\nhello\x1b]8;;https://evil/\x07click\x1b]8;;\x07' );
+		// info() goes through formatStdoutLine; its meta values must also be neutralized.
+		logger.info( 'Polled message', { preview: '\x1b[31mred\x1b[0m\x07' } );
+		const combined = captured.combined();
+		// No raw ESC, BEL, or other C0/DEL bytes (apart from \t/\n) leak through.
+		// eslint-disable-next-line no-control-regex
+		expect( combined ).not.toMatch( /[\x00-\x08\x0B-\x1F\x7F]/ );
+		expect( combined ).toContain( 'message cleared' );
+		expect( combined ).toContain( 'click' );
+		// JSON.stringify already escapes raw ESC bytes to the visible 6-char ``
+		// sequence in meta, so the terminal sees inert text rather than active escapes.
+		expect( combined ).toContain( '\\u001b[31mred\\u001b[0m\\u0007' );
 	} );
 } );

--- a/apps/cli/remote-session/tests/poll-loop.test.ts
+++ b/apps/cli/remote-session/tests/poll-loop.test.ts
@@ -71,7 +71,7 @@ function makeDeps(
 		readState,
 		writeSession,
 		clearSession,
-		logger: new RemoteSessionLogger( '/dev/null' ),
+		logger: new RemoteSessionLogger( { logPath: '/dev/null' } ),
 		sleep,
 		...overrides,
 	};

--- a/apps/cli/remote-session/tests/progress-streamer.test.ts
+++ b/apps/cli/remote-session/tests/progress-streamer.test.ts
@@ -38,7 +38,7 @@ function makeClock(): FakeClock {
 
 function makeStreamer( overrides: { intervalMs?: number; maxChars?: number } = {} ) {
 	const respond = vi.fn().mockResolvedValue( undefined );
-	const logger = new RemoteSessionLogger( '/dev/null' );
+	const logger = new RemoteSessionLogger( { logPath: '/dev/null' } );
 	const clock = makeClock();
 	const streamer = new ProgressStreamer( {
 		config: baseConfig,

--- a/apps/cli/remote-session/turn-runner.ts
+++ b/apps/cli/remote-session/turn-runner.ts
@@ -205,6 +205,12 @@ export async function runTurn( options: TurnRunOptions ): Promise< TurnOutcome >
 		}
 		options.onEvent?.( event );
 
+		if ( event.type === 'progress' || event.type === 'info' ) {
+			logger?.event( event.type, event.message );
+		} else if ( event.type === 'error' ) {
+			logger?.event( 'error', event.message );
+		}
+
 		if ( event.type === 'message' ) {
 			const extracted = extractResultPayload( event );
 			if ( extracted ) {
@@ -213,6 +219,7 @@ export async function runTurn( options: TurnRunOptions ): Promise< TurnOutcome >
 				}
 				if ( extracted.replyText ) {
 					replyText = extracted.replyText;
+					logger?.event( extracted.isError ? 'reply.error' : 'reply', extracted.replyText );
 				}
 				isError = isError || extracted.isError;
 				logger?.debug( 'Event: message/result', {
@@ -232,6 +239,12 @@ export async function runTurn( options: TurnRunOptions ): Promise< TurnOutcome >
 					description: o.description,
 				} ) ),
 			} ) );
+			for ( const q of pausedQuestions ) {
+				const optionLines = q.options
+					.map( ( o ) => `  - ${ o.label }: ${ o.description }` )
+					.join( '\n' );
+				logger?.event( 'question', `${ q.question }\n${ optionLines }` );
+			}
 			logger?.debug( 'Event: question.asked', {
 				...logContext,
 				questions: pausedQuestions.length,


### PR DESCRIPTION
## Related issues

- Fixes STU-1663

## How AI was used in this PR

Claude Code wrote the implementation and tests. I reviewed the logger changes, the stdout line format, and the redaction behavior, then ran typecheck/tests/lint locally to verify.

## Proposed Changes

When running `studio code --remote-session`, the REPL is blocked while the poll loop runs.

This PR mirrors the structured log to stdout while attached, so session activity shows up in the same terminal that is otherwise idle.

- `RemoteSessionLogger` now takes an options object (`{ logPath?, mirrorToStdout? }`). When `mirrorToStdout` is set, every non-suppressed log call also writes a human-readable line to stdout (`[HH:MM:SS] level message {meta-as-JSON}`) using the same redaction as the file sink. Stdout writes are best-effort and never throw.
- `runRemoteSession` constructs the logger with `{ mirrorToStdout: true }`. Debug-level lines stay suppressed unless `STUDIO_REMOTE_DEBUG=1`, matching the file behavior.
- The structured `~/.studio/remote-session.log` file continues to receive the full NDJSON record. No format change there.

## Testing Instructions

- `npm run cli:build`
- `STUDIO_ENABLE_REMOTE_SESSION=true node apps/cli/dist/cli/main.mjs code --remote-session`
- Send a message from Telegram and check that you see the log streaming to stdout
- `tail -f ~/.studio/remote-session.log` should still receive the full entries
- Without `--remote-session`, the regular interactive `studio code` REPL should produce no extra log lines on stdout.

| Telegram | Before | After |
|------|--------|--------|
| <img alt="CleanShot 2026-04-29 at 16 49 21@2x" src="https://github.com/user-attachments/assets/e4fcfb5d-5f8c-4e3b-8430-2f5f543f4f5e" /> | <img alt="CleanShot 2026-04-29 at 16 49 04@2x" src="https://github.com/user-attachments/assets/6d76190d-7dd7-46e0-9294-9c39ecc4fe34" /> | <img alt="CleanShot 2026-04-29 at 16 47 58@2x" src="https://github.com/user-attachments/assets/9c966596-8a4b-4d7b-9df8-7ae13fcb2c2b" /> | 


## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?