### PR TITLE
Update SQLite database integration to v3.0.0-rc.3

### DIFF
--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -59,7 +59,7 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.2';
+const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.3';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/releases/download/${ SQLITE_DATABASE_INTEGRATION_VERSION }/plugin-sqlite-database-integration.zip`;
 


### PR DESCRIPTION
## Related issues

- Related to https://github.com/WordPress/sqlite-database-integration/releases/tag/v3.0.0-rc.3

## How AI was used in this PR

Used Claude Code to locate the version constant and bump it.

## Proposed Changes

- Bump `SQLITE_DATABASE_INTEGRATION_VERSION` from `v3.0.0-rc.2` to `v3.0.0-rc.3` in [apps/studio/src/constants.ts](apps/studio/src/constants.ts). The download URL is constructed from this constant, so no other changes are required.

## Testing Instructions

- Run `npm run download-wp-server-files` (or equivalent build step that downloads server files) and confirm the v3.0.0-rc.3 plugin zip is fetched from GitHub.
- Start a new local site and verify it boots cleanly with the updated SQLite database integration plugin.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?