### PR TITLE
Studio Blueprints Gallery: move block on ADD A SITE screen on one row

### DIFF
--- a/apps/studio/src/modules/add-site/components/options.tsx
+++ b/apps/studio/src/modules/add-site/components/options.tsx
@@ -182,7 +182,7 @@ export default function AddSiteOptions( {
 				{ __( 'Start fresh or bring an existing site into your Studio.' ) }
 			</Text>
 
-			<div className="flex gap-3 w-full max-w-[540px]">
+			<div className="flex gap-5 w-full max-w-[760px]">
 				<OptionCard
 					illustration={ <BuildNewSiteIllustration /> }
 					title={ __( 'Build a new site' ) }
@@ -201,11 +201,9 @@ export default function AddSiteOptions( {
 					onClick={ () => onOptionSelect( 'connect' ) }
 					disabled={ isOffline }
 				/>
-			</div>
-
-			<div className="w-full max-w-[540px] mt-3">
 				<ImportDropZone onValidated={ handleValidatedBackup } />
 			</div>
+
 		</VStack>
 	);
 }

--- a/apps/studio/src/modules/add-site/components/options.tsx
+++ b/apps/studio/src/modules/add-site/components/options.tsx
@@ -108,7 +108,7 @@ function ImportDropZone( { onValidated }: { onValidated: ( file: File ) => void 
 	return (
 		<div
 			className={ cx(
-				'group w-full border border-dashed rounded-xl p-6 text-center',
+				'group w-full border rounded-xl p-6 text-center',
 				'bg-frame/50 backdrop-blur-md transition-colors cursor-pointer',
 				isDragging
 					? 'border-frame-theme bg-frame-theme/5'

--- a/apps/studio/src/modules/add-site/components/options.tsx
+++ b/apps/studio/src/modules/add-site/components/options.tsx
@@ -203,7 +203,6 @@ export default function AddSiteOptions( {
 				/>
 				<ImportDropZone onValidated={ handleValidatedBackup } />
 			</div>
-
 		</VStack>
 	);
 }


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-1659

## How AI was used in this PR

No AI.



## Proposed Changes

- Puts all three blocks on the ADD A SITE screen on 1 row (instead of 2).

<img width="2100" height="1564" alt="image" src="https://github.com/user-attachments/assets/19a98b5b-979b-422d-aae3-d2e239236d35" />

## Testing Instructions

- Open Studio
- Enable Blueprints Gallery feature flag
- Select ADD SITE 
- Confirm that all 3 blocks on one row
- 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
