### PR TITLE
Studio Blueprints Gallery: add Live Preview button

### DIFF
--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -18,6 +18,7 @@ export const UPDATED_MESSAGE_DURATION_MS = 60000; // 1 minute
 export const AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
 export const MACOS_TRAFFIC_LIGHT_POSITION = { x: 20, y: 20 };
 export const WINDOWS_TITLEBAR_HEIGHT = 44;
+export const EMPTY_SITE_PLAYGROUND_URL = 'https://playground.wordpress.net/';
 export const ABOUT_WINDOW_WIDTH = 300;
 export const ABOUT_WINDOW_HEIGHT = 350;
 export const TELEX_HOSTNAME = 'telex.automattic.ai';

--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -175,13 +175,17 @@ const BLUEPRINT_DISPLAY_NAMES: Record< string, string > = {
 	Commerce: 'WooCommerce',
 };
 
-const BLUEPRINT_EXCERPT_OVERRIDES: Record< string, string > = {
-	'Quick Start':
-		'A WordPress.com-like environment with Business plan plugins and themes pre-installed.',
-	Commerce:
-		'Create your next online store with WooCommerce and its companion plugins pre-installed.',
-	Development: 'A streamlined environment for building and testing themes or plugins.',
-};
+function getBlueprintExcerptOverrides( __: ( text: string ) => string ): Record< string, string > {
+	return {
+		'Quick Start': __(
+			'A WordPress.com-like environment with Business plan plugins and themes pre-installed.'
+		),
+		Commerce: __(
+			'Create your next online store with WooCommerce and its companion plugins pre-installed.'
+		),
+		Development: __( 'A streamlined environment for building and testing themes or plugins.' ),
+	};
+}
 
 const BLUEPRINT_ORDER: Record< string, number > = {
 	'Quick Start': 1,
@@ -189,12 +193,16 @@ const BLUEPRINT_ORDER: Record< string, number > = {
 	Development: 3,
 };
 
-function renameBlueprintsForDisplay( blueprints: Blueprint[] ): Blueprint[] {
+function renameBlueprintsForDisplay(
+	blueprints: Blueprint[],
+	__: ( text: string ) => string
+): Blueprint[] {
+	const excerptOverrides = getBlueprintExcerptOverrides( __ );
 	return [ ...blueprints ]
 		.sort( ( a, b ) => ( BLUEPRINT_ORDER[ a.title ] ?? 99 ) - ( BLUEPRINT_ORDER[ b.title ] ?? 99 ) )
 		.map( ( bp ) => ( {
 			...bp,
-			excerpt: BLUEPRINT_EXCERPT_OVERRIDES[ bp.title ] || bp.excerpt,
+			excerpt: excerptOverrides[ bp.title ] || bp.excerpt,
 			title: BLUEPRINT_DISPLAY_NAMES[ bp.title ] || bp.title,
 		} ) );
 }
@@ -248,7 +256,7 @@ export function NewSiteOptions( {
 					</div>
 				) : (
 					enableBlueprints &&
-					renameBlueprintsForDisplay( blueprints ).map( ( bp ) => (
+					renameBlueprintsForDisplay( blueprints, __ ).map( ( bp ) => (
 						<BlueprintCard
 							key={ bp.slug }
 							blueprint={ bp }

--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -8,6 +8,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import StudioButton from 'src/components/button';
+import { EMPTY_SITE_PLAYGROUND_URL } from 'src/constants';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import type { AddSiteFlowType } from './options';
@@ -35,8 +36,6 @@ interface NewSiteOptionsProps {
 	onBlueprintChange: ( blueprintId: string ) => void;
 	blueprintFileError?: string;
 }
-
-const EMPTY_SITE_PLAYGROUND_URL = 'https://playground.wordpress.net/';
 
 function PreviewLink( { url }: { url: string } ) {
 	const { __ } = useI18n();

--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -4,10 +4,14 @@ import {
 	__experimentalText as Text,
 	Spinner,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
+import { ArrowIcon } from 'src/components/arrow-icon';
+import StudioButton from 'src/components/button';
 import { cx } from 'src/lib/cx';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import type { AddSiteFlowType } from './options';
+
 interface Blueprint {
 	slug: string;
 	title: string;
@@ -22,6 +26,7 @@ interface Blueprint {
 }
 
 interface NewSiteOptionsProps {
+	onOptionSelect: ( option: AddSiteFlowType ) => void;
 	enableBlueprints: boolean;
 	blueprints: Blueprint[];
 	isLoadingBlueprints: boolean;
@@ -29,6 +34,25 @@ interface NewSiteOptionsProps {
 	selectedBlueprint: string | null;
 	onBlueprintChange: ( blueprintId: string ) => void;
 	blueprintFileError?: string;
+}
+
+const EMPTY_SITE_PLAYGROUND_URL = 'https://playground.wordpress.net/';
+
+function PreviewLink( { url }: { url: string } ) {
+	const { __ } = useI18n();
+	return (
+		<StudioButton
+			variant="secondary"
+			onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+				e.stopPropagation();
+				getIpcApi().openURL( url );
+			} }
+			className="!absolute bottom-2 right-2 z-10 !px-2 !py-1 !h-auto !min-h-0 text-[11px] !bg-white/90 hover:!bg-white !text-a8c-gray-900 hover:!text-a8c-gray-900 !shadow-none whitespace-nowrap"
+		>
+			{ __( 'Live Preview' ) }
+			<ArrowIcon />
+		</StudioButton>
+	);
 }
 
 function EmptySiteCard( { isSelected, onClick }: { isSelected: boolean; onClick: () => void } ) {
@@ -80,6 +104,7 @@ function EmptySiteCard( { isSelected, onClick }: { isSelected: boolean; onClick:
 						fill="none"
 					/>
 				</svg>
+				<PreviewLink url={ EMPTY_SITE_PLAYGROUND_URL } />
 			</div>
 			<div className="px-3 pt-3 pb-3">
 				<Heading level={ 3 } className="text-[13px] text-frame-text mb-1" weight={ 500 }>
@@ -127,6 +152,7 @@ function BlueprintCard( {
 						{ blueprint.title }
 					</div>
 				) }
+				{ blueprint.playground_url && <PreviewLink url={ blueprint.playground_url } /> }
 			</div>
 			<div className="px-3 pt-3 pb-3">
 				<Heading level={ 3 } className="text-[13px] text-frame-text mb-1" weight={ 500 }>
@@ -150,15 +176,13 @@ const BLUEPRINT_DISPLAY_NAMES: Record< string, string > = {
 	Commerce: 'WooCommerce',
 };
 
-const getBlueprintExcerptOverrides = (): Record< string, string > => ( {
-	'Quick Start': __(
-		'A WordPress.com-like environment with Business plan plugins and themes pre-installed.'
-	),
-	Commerce: __(
-		'Create your next online store with WooCommerce and its companion plugins pre-installed.'
-	),
-	Development: __( 'A streamlined environment for building and testing themes or plugins.' ),
-} );
+const BLUEPRINT_EXCERPT_OVERRIDES: Record< string, string > = {
+	'Quick Start':
+		'A WordPress.com-like environment with Business plan plugins and themes pre-installed.',
+	Commerce:
+		'Create your next online store with WooCommerce and its companion plugins pre-installed.',
+	Development: 'A streamlined environment for building and testing themes or plugins.',
+};
 
 const BLUEPRINT_ORDER: Record< string, number > = {
 	'Quick Start': 1,
@@ -167,17 +191,17 @@ const BLUEPRINT_ORDER: Record< string, number > = {
 };
 
 function renameBlueprintsForDisplay( blueprints: Blueprint[] ): Blueprint[] {
-	const excerptOverrides = getBlueprintExcerptOverrides();
 	return [ ...blueprints ]
 		.sort( ( a, b ) => ( BLUEPRINT_ORDER[ a.title ] ?? 99 ) - ( BLUEPRINT_ORDER[ b.title ] ?? 99 ) )
 		.map( ( bp ) => ( {
 			...bp,
-			excerpt: excerptOverrides[ bp.title ] || bp.excerpt,
+			excerpt: BLUEPRINT_EXCERPT_OVERRIDES[ bp.title ] || bp.excerpt,
 			title: BLUEPRINT_DISPLAY_NAMES[ bp.title ] || bp.title,
 		} ) );
 }
 
 export function NewSiteOptions( {
+	onOptionSelect,
 	enableBlueprints,
 	blueprints,
 	isLoadingBlueprints,

--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -201,7 +201,6 @@ function renameBlueprintsForDisplay( blueprints: Blueprint[] ): Blueprint[] {
 }
 
 export function NewSiteOptions( {
-	onOptionSelect,
 	enableBlueprints,
 	blueprints,
 	isLoadingBlueprints,

--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -11,7 +11,6 @@ import StudioButton from 'src/components/button';
 import { EMPTY_SITE_PLAYGROUND_URL } from 'src/constants';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import type { AddSiteFlowType } from './options';
 
 interface Blueprint {
 	slug: string;
@@ -27,7 +26,6 @@ interface Blueprint {
 }
 
 interface NewSiteOptionsProps {
-	onOptionSelect: ( option: AddSiteFlowType ) => void;
 	enableBlueprints: boolean;
 	blueprints: Blueprint[];
 	isLoadingBlueprints: boolean;


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-1643

## How AI was used in this PR

No AI.


## Proposed Changes

- Adds a Live Preview button to blueprints on the **Build a new site** screen.

<img width="1844" height="1338" alt="image" src="https://github.com/user-attachments/assets/d832dfd9-a588-458a-9a4b-287d20fa1f9d" />

## Testing Instructions

- Open Studio
- Enable Blueprints Gallery feature flag
- Select ADD SITE → BUILD A NEW SITE
- Confirm appearance of Live Preview button
- Select any Live Preview button to open WordPress Playground

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
