### PR TITLE
Fix Windows build script for PowerShell 5.1

### DIFF
--- a/.buildkite/commands/build-for-windows.ps1
+++ b/.buildkite/commands/build-for-windows.ps1
@@ -28,7 +28,8 @@ if ($Architecture -notin $VALID_ARCHITECTURES) {
     Exit 1
 }
 
-If (@('1', 'true') -contains ($env:USE_AZURE_TRUSTED_SIGNING ?? '').Trim().ToLower()) {
+$useAzureTrustedSigning = "$($env:USE_AZURE_TRUSTED_SIGNING)".Trim().ToLower()
+If (@('1', 'true') -contains $useAzureTrustedSigning) {
     Write-Host "--- :lock: Setting up Azure Trusted Signing"
     $setupScript = (Get-Command setup_azure_trusted_signing.ps1 -ErrorAction Stop).Source
     & $setupScript


### PR DESCRIPTION
## Related issues

- Fixes [AINFRA-2344](https://linear.app/a8c/issue/AINFRA-2344)

## How AI was used in this PR

Investigation, root cause, and one-line fix produced by Claude Opus 4.7. Validated locally before pushing.

## Proposed Changes

The Windows Buildkite agents invoke `.buildkite/commands/build-for-windows.ps1` via `powershell` (Windows PowerShell 5.1), which does not support the `??` null-coalescing operator introduced in PowerShell 7.0.
The operator landed in #2995 and broke every Windows dev build on `trunk` since (15258, 15259, 15260, 15270, 15275 — both `x64` and `arm64`), failing at parser stage with `Unexpected token '??' in expression or statement.`.

This PR replaces the inline `??` with a 5.1-safe pre-assignment.
Stringifying `$env:USE_AZURE_TRUSTED_SIGNING` via `"$(...)"` yields `""` when the variable is unset, so the subsequent `.Trim().ToLower()` is safe without null-coalescing.

The release pipeline (`.buildkite/release-build-and-distribute.yml`) invokes the same script the same way, so this fix unbreaks both dev and release lanes.

## Testing Instructions

Local validation (works from macOS — no Windows VM needed):

`````sh
pwsh -NoProfile -Command "
  Import-Module PSScriptAnalyzer
  Invoke-ScriptAnalyzer -Path .buildkite/commands/build-for-windows.ps1 \
    -Settings @{ Rules = @{ PSUseCompatibleSyntax = @{ Enable = \$true; TargetVersions = @('5.1') } } } |
    Where-Object RuleName -eq 'PSUseCompatibleSyntax'
"
`````

Expected: zero `PSUseCompatibleSyntax` findings.
The same rule on the pre-fix line reports: *"The null-coalescing operator syntax `\$x ?? \$y` is not available by default in PowerShell versions 3,4,5,6"*.

The real proof is CI — the `Windows Dev Build - x64` and `Windows Dev Build - arm64` jobs should now reach the actual build steps instead of failing at script parse.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? — N/A; PowerShell-only change.