### PR TITLE
Enable E2E tests on Linux

### DIFF
--- a/apps/studio/e2e/blueprints.test.ts
+++ b/apps/studio/e2e/blueprints.test.ts
@@ -19,10 +19,26 @@ test.describe( 'Blueprints', () => {
 
 		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
 		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 120_000 } );
+
+		// Run one site at a time to keep peak memory low on constrained hosts.
+		const sidebar = new MainSidebar( session.mainWindow );
+		await sidebar.getStopAllButton().click();
+		await expect( sidebar.locator.getByText( 'No sites running' ) ).toBeAttached( {
+			timeout: 60_000,
+		} );
 	} );
 
 	test.afterEach( async ( { page: _page }, testInfo ) => {
 		await session.reportMainProcessLogsOnFailure( testInfo );
+
+		const sidebar = new MainSidebar( session.mainWindow );
+		const stopAllButton = sidebar.getStopAllButton();
+		if ( await stopAllButton.isVisible().catch( () => false ) ) {
+			await stopAllButton.click();
+			await expect( sidebar.locator.getByText( 'No sites running' ) ).toBeAttached( {
+				timeout: 60_000,
+			} );
+		}
 	} );
 
 	test.afterAll( async () => {

--- a/apps/studio/e2e/blueprints.test.ts
+++ b/apps/studio/e2e/blueprints.test.ts
@@ -18,7 +18,7 @@ test.describe( 'Blueprints', () => {
 		await onboarding.closeWhatsNew();
 
 		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
-		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 120_000 } );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 
 		// Run one site at a time to keep peak memory low on constrained hosts.
 		const sidebar = new MainSidebar( session.mainWindow );

--- a/apps/studio/e2e/page-objects/main-sidebar.ts
+++ b/apps/studio/e2e/page-objects/main-sidebar.ts
@@ -18,7 +18,8 @@ export default class MainSidebar {
 	}
 
 	getStopAllButton() {
-		return this.locator.getByRole( 'button', { name: 'Stop all', exact: true } );
+		// The button is labeled "Stop" with one running site and "Stop all" with multiple.
+		return this.locator.getByRole( 'button', { name: /^Stop( all)?$/ } );
 	}
 
 	async openAddSiteModal() {

--- a/apps/studio/src/modules/cli/lib/linux-installation-manager.ts
+++ b/apps/studio/src/modules/cli/lib/linux-installation-manager.ts
@@ -229,7 +229,7 @@ export class LinuxCliInstallationManager implements StudioCliInstallationManager
 }
 
 export async function autoInstallLinuxCliIfNeeded(): Promise< void > {
-	if ( process.platform !== 'linux' || process.env.NODE_ENV !== 'production' ) {
+	if ( process.platform !== 'linux' || process.env.NODE_ENV !== 'production' || process.env.E2E ) {
 		return;
 	}
 


### PR DESCRIPTION
## Related issues

- Related to https://linear.app/a8c/issue/RSM-1856/review-and-fix-e2e-tests-on-linux

## How AI was used in this PR

Drafted with Claude Code under interactive review. The author pushed back on overstated claims (e.g. attributing the OOM to PHP WASM workers when only the symptom was verified) and on a speculative selector change that was reverted after confirming it was unnecessary. Each change here was vetted against the actual test runs and existing codebase conventions.

## Proposed Changes

- Add `process.env.E2E` guard to `autoInstallLinuxCliIfNeeded` so a packaged Linux build does not write to the host user's `~/.bashrc` or `~/.local/bin/studio` during E2E runs.
  - Verified by inspecting the bundle from `electron-vite build`: vite statically replaces `process.env.NODE_ENV` with `"production"`, so the existing `NODE_ENV !== 'production'` guard collapses to a dead `false` in the bundle (the same substitution applies to the full `package` flow, which just wraps the vite output). Without the new `process.env.E2E` term, the function would fire during E2E and call `installCli()`, which uses `os.homedir()` directly — and `E2E_HOME_PATH` does not override that.
  - The Mac/Windows installers use the same NODE_ENV-only guard pattern, but extending the fix to them is out of scope here: the analog has not been verified on those platforms from this Linux box, and shipping a guard on inference alone is the kind of thing this PR is trying to avoid.
- Reduce concurrent running sites in `blueprints.test.ts` to one at a time. The shared session previously accumulated 6+ running sites by the end of the file, which crashes memory-constrained hosts (e.g. local Linux VMs). Each blueprint test now runs with only its own site; the default onboarding site is stopped after `beforeAll`, and each newly created site is stopped after the test completes.
- Update `getStopAllButton` in `main-sidebar.ts` to match both "Stop" (single running site) and "Stop all" (multiple). The button text is conditional in `running-sites.tsx`; the existing locator only matched "Stop all" exactly, which made the new cleanup logic in blueprints unreliable when one site was running.

## Testing Instructions

1. Build the app: `npm run make`.
2. Install Playwright browsers: `npx playwright install chromium`.
3. Run the full suite: `npm run e2e`.
4. Expected outcome on Linux: 43 pass, 1 skipped (`import.test.ts` is skipped without the optional `e2e/imports/jetpack-backup.tar.gz` fixture). A few editor-iframe tests may flake on the first attempt and pass on Playwright's automatic retry.

Verified locally on Linux arm64 (Parallels VM). Mac/Windows behavior should be unchanged: the blueprints cleanup adds ~15-30s to that file's run time, otherwise no functional difference.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Mac and Windows E2E jobs still pass on CI.