### PR TITLE
Improve annotation submit workflow

### DIFF
--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -58,6 +58,7 @@ async function readAllStdin(): Promise< string > {
 export async function runCommand( options: {
 	adapter: AiOutputAdapter;
 	initialMessage?: string;
+	initialDisplayMessage?: string;
 	resumeSession?: LoadedAiSession;
 	resumeSessionId?: string;
 	noSessionPersistence?: boolean;
@@ -422,7 +423,8 @@ export async function runCommand( options: {
 
 	async function runAgentTurn(
 		prompt: string,
-		retryAttempt = 0
+		retryAttempt = 0,
+		displayMessage = prompt
 	): Promise< { status: TurnStatus } > {
 		await maybeAutoSwitchProvider();
 		const recorder = await ensureSessionRecorder();
@@ -455,7 +457,7 @@ export async function runCommand( options: {
 
 		await persist( ( recorder ) =>
 			recorder.recordUserMessage( {
-				text: prompt,
+				text: displayMessage,
 				source: 'prompt',
 				sitePath: site?.path,
 			} )
@@ -583,8 +585,9 @@ export async function runCommand( options: {
 	// JSON mode: single turn, then exit
 	if ( isJsonMode && options.initialMessage ) {
 		try {
-			ui.addUserMessage( options.initialMessage );
-			const result = await runAgentTurn( options.initialMessage );
+			const displayMessage = options.initialDisplayMessage ?? options.initialMessage;
+			ui.addUserMessage( displayMessage );
+			const result = await runAgentTurn( options.initialMessage, 0, displayMessage );
 			const jsonStatus = result.status === 'interrupted' ? 'error' : result.status;
 			( ui as JsonAdapter ).emitTurnCompleted( jsonStatus );
 		} catch ( error ) {
@@ -601,9 +604,10 @@ export async function runCommand( options: {
 
 	// Run initial message before entering the input loop
 	if ( options.initialMessage ) {
-		ui.addUserMessage( options.initialMessage );
+		const displayMessage = options.initialDisplayMessage ?? options.initialMessage;
+		ui.addUserMessage( displayMessage );
 		try {
-			await runAgentTurn( options.initialMessage );
+			await runAgentTurn( options.initialMessage, 0, displayMessage );
 		} catch ( error ) {
 			handleAgentTurnError( error );
 		}

--- a/apps/cli/commands/ai/sessions/resume.ts
+++ b/apps/cli/commands/ai/sessions/resume.ts
@@ -15,6 +15,7 @@ export async function runCommand(
 	options: {
 		noSessionPersistence?: boolean;
 		message?: string;
+		displayMessage?: string;
 		json?: boolean;
 	} = {}
 ): Promise< void > {
@@ -56,6 +57,7 @@ export async function runCommand(
 		resumeSession: session,
 		noSessionPersistence: options.noSessionPersistence === true,
 		initialMessage: options.message,
+		initialDisplayMessage: options.displayMessage,
 		activeSite: resolvedSite,
 	} );
 }
@@ -81,6 +83,11 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					default: false,
 					description: __( 'Output events as NDJSON to stdout (headless mode)' ),
 				} )
+				.option( 'display-message', {
+					type: 'string',
+					hidden: true,
+					description: __( 'Message to persist and display in the session transcript' ),
+				} )
 				.check( ( argv ) => {
 					if ( argv.json && ! argv.message ) {
 						throw new Error( __( '--json requires a message argument' ) );
@@ -93,6 +100,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				const typedArgv = argv as {
 					id?: string;
 					message?: string;
+					displayMessage?: string;
 					json?: boolean;
 					sessionPersistence?: boolean;
 				};
@@ -100,6 +108,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				await runCommand( typedArgv.id, {
 					noSessionPersistence,
 					message: typedArgv.message,
+					displayMessage: typedArgv.displayMessage,
 					json: typedArgv.json,
 				} );
 			} catch ( error ) {

--- a/apps/cli/commands/ai/tests/ai.test.ts
+++ b/apps/cli/commands/ai/tests/ai.test.ts
@@ -27,6 +27,8 @@ const {
 	recordSessionClearedMock,
 	recordSessionContextMock,
 	recordSiteSelectedMock,
+	recordUserMessageMock,
+	addUserMessageMock,
 	reportErrorMock,
 	setLoaderMessageMock,
 	waitForInputMock,
@@ -41,6 +43,8 @@ const {
 	recordSessionClearedMock: vi.fn(),
 	recordSessionContextMock: vi.fn(),
 	recordSiteSelectedMock: vi.fn(),
+	recordUserMessageMock: vi.fn(),
+	addUserMessageMock: vi.fn(),
 	reportErrorMock: vi.fn(),
 	setLoaderMessageMock: vi.fn(),
 	waitForInputMock: vi.fn(),
@@ -196,7 +200,9 @@ vi.mock( 'cli/ai/ui', () => ( {
 		} ) {
 			this.activeSite = site;
 		}
-		addUserMessage() {}
+		addUserMessage( ...args: unknown[] ) {
+			addUserMessageMock( ...args );
+		}
 		clearTranscript() {
 			clearTranscriptMock();
 		}
@@ -241,7 +247,9 @@ vi.mock( 'cli/ai/sessions/recorder', () => {
 		async recordSiteSelected( ...args: unknown[] ) {
 			return recordSiteSelectedMock( ...args );
 		}
-		async recordUserMessage() {}
+		async recordUserMessage( ...args: unknown[] ) {
+			return recordUserMessageMock( ...args );
+		}
 		async recordAgentQuestion() {}
 		async recordTurnClosed() {}
 		async recordAgentSessionId() {}
@@ -515,6 +523,44 @@ describe( 'CLI: studio code sessions command', () => {
 		expect( loadAiSession ).toHaveBeenCalledWith( expect.any( String ), 'session-latest' );
 		expect( ( AiSessionRecorder as typeof AiSessionRecorder ).open ).not.toHaveBeenCalled();
 		expect( process.exit ).toHaveBeenCalledWith( 0 );
+	} );
+
+	it( 'persists the display message when resuming with a hidden full message', async () => {
+		vi.mocked( loadAiSession ).mockResolvedValue( {
+			summary: {
+				id: 'session-id',
+				filePath: '/tmp/session-id.jsonl',
+				createdAt: '2026-03-11T11:00:00.000Z',
+				updatedAt: '2026-03-11T11:00:00.000Z',
+				linkedAgentSessionIds: [],
+				activeEnvironment: 'local',
+				eventCount: 1,
+			},
+			events: [],
+		} );
+
+		await buildParser().parseAsync( [
+			'ai',
+			'sessions',
+			'resume',
+			'session-id',
+			'Full annotation prompt',
+			'--json',
+			'--display-message',
+			'2 annotations submitted',
+		] );
+
+		expect( startAiAgent ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				prompt: 'Full annotation prompt',
+			} )
+		);
+		expect( recordUserMessageMock ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				text: '2 annotations submitted',
+				source: 'prompt',
+			} )
+		);
 	} );
 
 	it( 'deletes the latest session', async () => {

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -312,12 +312,14 @@ function expandSkillCommandPrompt( prompt: string ): string {
 export async function continueAiSession(
 	event: IpcMainInvokeEvent,
 	sessionId: string,
-	prompt: string
+	prompt: string,
+	options: { displayMessage?: string } = {}
 ): Promise< { runId: string } > {
 	await reconcileSessionEnvironmentBeforeRun( sessionId );
 	return startAgentRun( {
 		sessionId,
 		prompt: expandSkillCommandPrompt( prompt ),
+		displayMessage: options.displayMessage,
 		webContents: event.sender,
 	} );
 }

--- a/apps/studio/src/modules/ai-agent/run-manager.ts
+++ b/apps/studio/src/modules/ai-agent/run-manager.ts
@@ -38,11 +38,12 @@ function sendEvent( run: AgentRun, event: AgentRunEvent[ 'event' ] ): void {
 export interface StartAgentRunOptions {
 	sessionId: string;
 	prompt: string;
+	displayMessage?: string;
 	webContents: WebContents;
 }
 
 export function startAgentRun( options: StartAgentRunOptions ): { runId: string } {
-	const { sessionId, prompt, webContents } = options;
+	const { sessionId, prompt, displayMessage, webContents } = options;
 
 	if ( runsBySessionId.has( sessionId ) ) {
 		throw new Error( `A run is already in progress for session ${ sessionId }` );
@@ -50,19 +51,19 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 
 	const runId = crypto.randomUUID();
 	const cliPath = getCliPath();
-	const child = fork(
-		cliPath,
-		[ 'code', 'sessions', 'resume', sessionId, prompt, '--json', '--avoid-telemetry' ],
-		{
-			// Agent events arrive over the Node IPC channel (via `process.send`
-			// in the child). stdout/stderr are ignored — the child's
-			// `emitEvent` falls back to stdout only when IPC isn't available.
-			stdio: [ 'ignore', 'ignore', 'ignore', 'ipc' ],
-			execPath: getBundledNodeBinaryPath(),
-			execArgv: [ '--experimental-wasm-jspi' ],
-			env: { ...process.env },
-		}
-	);
+	const args = [ 'code', 'sessions', 'resume', sessionId, prompt, '--json', '--avoid-telemetry' ];
+	if ( displayMessage ) {
+		args.push( '--display-message', displayMessage );
+	}
+	const child = fork( cliPath, args, {
+		// Agent events arrive over the Node IPC channel (via `process.send`
+		// in the child). stdout/stderr are ignored — the child's
+		// `emitEvent` falls back to stdout only when IPC isn't available.
+		stdio: [ 'ignore', 'ignore', 'ignore', 'ipc' ],
+		execPath: getBundledNodeBinaryPath(),
+		execArgv: [ '--experimental-wasm-jspi' ],
+		env: { ...process.env },
+	} );
 
 	const run: AgentRun = {
 		runId,

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -211,8 +211,8 @@ const api: IpcApi = {
 	deleteAiSession: ( sessionIdOrPrefix ) =>
 		ipcRendererInvoke( 'deleteAiSession', sessionIdOrPrefix ),
 	createAiSession: ( siteId ) => ipcRendererInvoke( 'createAiSession', siteId ),
-	continueAiSession: ( sessionId, prompt ) =>
-		ipcRendererInvoke( 'continueAiSession', sessionId, prompt ),
+	continueAiSession: ( sessionId, prompt, options ) =>
+		ipcRendererInvoke( 'continueAiSession', sessionId, prompt, options ),
 	setAiSessionModel: ( sessionId, model ) =>
 		ipcRendererInvoke( 'setAiSessionModel', sessionId, model ),
 	interruptAiAgentRun: ( runId ) => ipcRendererInvoke( 'interruptAiAgentRun', runId ),

--- a/apps/ui/src/components/session-view/annotations.test.ts
+++ b/apps/ui/src/components/session-view/annotations.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { formatAnnotationsAsPrompt } from './annotations';
+import type { Annotation } from '@/components/site-preview/types';
+
+describe( 'formatAnnotationsAsPrompt', () => {
+	it( 'asks the agent to summarize, confirm, and use todos before editing', () => {
+		const annotations: Annotation[] = [
+			{
+				id: 'a_1',
+				comment: 'Make the hero heading smaller',
+				selector: 'main h1',
+				tag: 'h1',
+				nearbyText: 'Welcome to Studio',
+				url: 'http://studio.test/',
+				computedStyles: {
+					'font-size': '64px',
+				},
+			},
+		];
+
+		const prompt = formatAnnotationsAsPrompt( annotations );
+
+		expect( prompt ).toContain( 'The user submitted 1 visual annotation' );
+		expect( prompt ).toContain( 'First, reply with a markdown summary' );
+		expect( prompt ).toContain( 'Use `AskUserQuestion` for that confirmation' );
+		expect( prompt ).toContain( 'Do not edit files, run WP-CLI mutations, or change the site' );
+		expect( prompt ).toContain(
+			'call `TodoWrite` (the Todo tool) with one task for each confirmed annotation'
+		);
+		expect( prompt ).toContain( '- Selector: `main h1`' );
+		expect( prompt ).toContain( '"comment": "Make the hero heading smaller"' );
+	} );
+
+	it( 'keeps all annotations in their original order', () => {
+		const prompt = formatAnnotationsAsPrompt( [
+			{
+				id: 'a_1',
+				comment: 'Use more contrast',
+				tag: 'button',
+				nearbyText: 'Buy now',
+				pathname: '/pricing',
+			},
+			{
+				id: 'a_2',
+				comment: 'Add more spacing',
+				tag: 'section',
+				nearbyText: 'Testimonials',
+				pathname: '/about',
+			},
+		] );
+
+		expect( prompt.indexOf( '### 1. <button>' ) ).toBeLessThan(
+			prompt.indexOf( '### 2. <section>' )
+		);
+		expect( prompt ).toContain( 'The user submitted 2 visual annotations' );
+		expect( prompt ).toContain( '- Page: /pricing' );
+		expect( prompt ).toContain( '- Page: /about' );
+	} );
+} );

--- a/apps/ui/src/components/session-view/annotations.test.ts
+++ b/apps/ui/src/components/session-view/annotations.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { formatAnnotationsAsPrompt } from './annotations';
+import { formatAnnotationsAsPrompt, formatAnnotationsSubmittedMessage } from './annotations';
 import type { Annotation } from '@/components/site-preview/types';
 
 describe( 'formatAnnotationsAsPrompt', () => {
+	it( 'formats a compact submitted message for the visible transcript', () => {
+		expect( formatAnnotationsSubmittedMessage( 1 ) ).toBe( '1 annotation submitted' );
+		expect( formatAnnotationsSubmittedMessage( 2 ) ).toBe( '2 annotations submitted' );
+	} );
+
 	it( 'asks the agent to summarize, confirm, and use todos before editing', () => {
 		const annotations: Annotation[] = [
 			{

--- a/apps/ui/src/components/session-view/annotations.ts
+++ b/apps/ui/src/components/session-view/annotations.ts
@@ -1,7 +1,12 @@
+import { _n, sprintf } from '@wordpress/i18n';
 import type { Annotation } from '@/components/site-preview/types';
 
 function describeCount( count: number ): string {
 	return count === 1 ? '1 visual annotation' : `${ count } visual annotations`;
+}
+
+export function formatAnnotationsSubmittedMessage( count: number ): string {
+	return sprintf( _n( '%d annotation submitted', '%d annotations submitted', count ), count );
 }
 
 function truncateText( text: string, maxLength: number ): string {

--- a/apps/ui/src/components/session-view/annotations.ts
+++ b/apps/ui/src/components/session-view/annotations.ts
@@ -1,0 +1,68 @@
+import type { Annotation } from '@/components/site-preview/types';
+
+function describeCount( count: number ): string {
+	return count === 1 ? '1 visual annotation' : `${ count } visual annotations`;
+}
+
+function truncateText( text: string, maxLength: number ): string {
+	if ( text.length <= maxLength ) {
+		return text;
+	}
+	return `${ text.slice( 0, maxLength - 1 ) }...`;
+}
+
+function stringifyAnnotation( annotation: Annotation ): string {
+	return JSON.stringify( annotation, null, 2 );
+}
+
+/**
+ * Builds the submitted annotation prompt for the agent. The prompt mirrors the
+ * CLI `/annotate` workflow: summarize first, ask for confirmation, then create
+ * a TodoWrite list before making any site changes.
+ */
+export function formatAnnotationsAsPrompt( annotations: Annotation[] ): string {
+	const lines: string[] = [
+		`The user submitted ${ describeCount( annotations.length ) } from the site preview.`,
+		'',
+		'First, reply with a markdown summary of every requested change and ask the user to confirm before editing. Follow this shape:',
+		'',
+		"Here's what you asked me to change:",
+		'',
+		'1. <one-line description in your own words> - <visible element and nearby text>',
+		'   (your note: "<the user comment, verbatim>")',
+		'',
+		`Want me to go ahead with these ${ annotations.length } change(s)?`,
+		'',
+		'Use `AskUserQuestion` for that confirmation with options like "Yes, go ahead", "No, let me re-annotate", and "Skip some - I will tell you which". Do not edit files, run WP-CLI mutations, or change the site until the user explicitly confirms.',
+		'',
+		'After explicit confirmation, call `TodoWrite` (the Todo tool) with one task for each confirmed annotation, then keep that todo list updated as you complete the work.',
+		'',
+		'When summarizing for the user, identify elements by what is visible on the page rather than by selector. Use selectors and raw annotation data only for implementation.',
+		'',
+		'## Submitted Annotations',
+		'',
+	];
+
+	annotations.forEach( ( annotation, index ) => {
+		const tag = annotation.tag ? `<${ annotation.tag }>` : 'element';
+		const nearbyText =
+			typeof annotation.nearbyText === 'string' && annotation.nearbyText.trim()
+				? ` - "${ truncateText( annotation.nearbyText.trim(), 120 ) }"`
+				: '';
+		const page = annotation.url || annotation.pathname || '/';
+
+		lines.push(
+			`### ${ index + 1 }. ${ tag }${ nearbyText }`,
+			`- Page: ${ page }`,
+			`- Comment: ${ annotation.comment }`
+		);
+
+		if ( annotation.selector ) {
+			lines.push( `- Selector: \`${ annotation.selector }\`` );
+		}
+
+		lines.push( '', '```json', stringifyAnnotation( annotation ), '```', '' );
+	} );
+
+	return lines.join( '\n' ).trimEnd();
+}

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -12,7 +12,10 @@ import {
 	type ReactNode,
 	type Ref,
 } from 'react';
-import { formatAnnotationsAsPrompt } from '@/components/session-view/annotations';
+import {
+	formatAnnotationsAsPrompt,
+	formatAnnotationsSubmittedMessage,
+} from '@/components/session-view/annotations';
 import { Composer, ComposerSkeleton } from '@/components/session-view/composer';
 import { pickLiveSite } from '@/components/session-view/composer/environment-pill';
 import { Conversation } from '@/components/session-view/conversation';
@@ -188,7 +191,9 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 	const handleAnnotationsDone = useCallback(
 		( annotations: Annotation[] ) => {
 			if ( annotations.length === 0 ) return;
-			void sendMessage( formatAnnotationsAsPrompt( annotations ) );
+			void sendMessage( formatAnnotationsAsPrompt( annotations ), {
+				displayMessage: formatAnnotationsSubmittedMessage( annotations.length ),
+			} );
 		},
 		[ sendMessage ]
 	);

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -12,11 +12,8 @@ import {
 	type ReactNode,
 	type Ref,
 } from 'react';
-import {
-	Composer,
-	ComposerSkeleton,
-	type ComposerHandle,
-} from '@/components/session-view/composer';
+import { formatAnnotationsAsPrompt } from '@/components/session-view/annotations';
+import { Composer, ComposerSkeleton } from '@/components/session-view/composer';
 import { pickLiveSite } from '@/components/session-view/composer/environment-pill';
 import { Conversation } from '@/components/session-view/conversation';
 import { EmptyBackground } from '@/components/session-view/empty-background';
@@ -108,58 +105,6 @@ interface SessionFrameProps {
 	children?: ReactNode;
 }
 
-/**
- * Renders the annotation batch as a markdown prompt the user can review and
- * (optionally) edit before sending. Annotations are grouped by the page they
- * were taken on so the agent knows which URL to load before acting on each
- * element. Within a group, each item carries the element's tag, nearby text
- * and CSS selector — enough for the agent to locate the target without
- * re-running the inspector.
- */
-function formatAnnotationsAsPrompt( annotations: Annotation[] ): string {
-	const intro =
-		annotations.length === 1
-			? __( 'Apply this change from the site preview:' )
-			: // translators: %d is the number of annotations.
-			  __( 'Apply these %d changes from the site preview:' ).replace(
-					'%d',
-					String( annotations.length )
-			  );
-
-	// Group while preserving the order in which the user added the
-	// annotations, then merge consecutive runs that share a page so a
-	// chained sequence reads as a single section.
-	const groups: { page: string; items: Annotation[] }[] = [];
-	for ( const ann of annotations ) {
-		const page = ann.url || ann.pathname || '/';
-		const last = groups[ groups.length - 1 ];
-		if ( last && last.page === page ) {
-			last.items.push( ann );
-		} else {
-			groups.push( { page, items: [ ann ] } );
-		}
-	}
-
-	const lines: string[] = [ intro, '' ];
-	let counter = 1;
-	for ( const group of groups ) {
-		// translators: %s is the page URL or pathname.
-		lines.push( __( 'On %s:' ).replace( '%s', group.page ) );
-		for ( const ann of group.items ) {
-			const tag = ann.tag ?? 'element';
-			const nearby = ann.nearbyText ? ` — "${ ann.nearbyText.slice( 0, 80 ) }"` : '';
-			const selector = ann.selector ? `\n   Selector: \`${ ann.selector }\`` : '';
-			lines.push(
-				`${ counter }. \`<${ tag }>\`${ nearby }\n   Comment: ${ ann.comment }${ selector }`
-			);
-			counter += 1;
-		}
-		lines.push( '' );
-	}
-
-	return lines.join( '\n' ).trimEnd();
-}
-
 function SessionFrame( { header, composer, preview, scrollRef, children }: SessionFrameProps ) {
 	return (
 		<div className={ styles.root }>
@@ -236,15 +181,17 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 		[ data?.events ]
 	);
 	const scrollRef = useRef< HTMLDivElement >( null );
-	const composerRef = useRef< ComposerHandle | null >( null );
 	const [ previewOpen, setPreviewOpen ] = useState( false );
 	const canTogglePreview = !! ownerSite && effectiveEnvironment === 'local';
 	const showPreview = previewOpen && canTogglePreview;
 
-	const handleAnnotationsDone = useCallback( ( annotations: Annotation[] ) => {
-		if ( annotations.length === 0 ) return;
-		composerRef.current?.appendDraft( formatAnnotationsAsPrompt( annotations ) );
-	}, [] );
+	const handleAnnotationsDone = useCallback(
+		( annotations: Annotation[] ) => {
+			if ( annotations.length === 0 ) return;
+			void sendMessage( formatAnnotationsAsPrompt( annotations ) );
+		},
+		[ sendMessage ]
+	);
 
 	useLayoutEffect( () => {
 		const node = scrollRef.current;
@@ -301,7 +248,6 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 				<div className={ styles.column }>
 					<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
 					<Composer
-						ref={ composerRef }
 						busy={ composerBusy }
 						isInterrupting={ isInterrupting }
 						error={ runError }

--- a/apps/ui/src/components/session-view/queued-prompts/index.tsx
+++ b/apps/ui/src/components/session-view/queued-prompts/index.tsx
@@ -15,7 +15,7 @@ export function QueuedPrompts( { prompts, onRemove }: QueuedPromptsProps ) {
 		<div className={ styles.root } aria-label={ __( 'Queued follow-ups' ) }>
 			{ prompts.map( ( item ) => (
 				<div key={ item.id } className={ styles.item }>
-					<span className={ styles.text }>{ item.prompt }</span>
+					<span className={ styles.text }>{ item.displayMessage ?? item.prompt }</span>
 					<button
 						type="button"
 						className={ styles.remove }

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -20,8 +20,8 @@ interface SitePreviewProps {
 	// session and reacts to `preview.command` events emitted by the agent's
 	// preview_navigate / preview_reload tools.
 	sessionId?: string;
-	// Called when the user clicks "Done" in the inspector toolbar. Receives the
-	// full annotation payload assembled inside the webview's guest page.
+	// Called when the user clicks "Submit" in the inspector toolbar. Receives
+	// the full annotation payload assembled inside the webview's guest page.
 	onAnnotationsDone?: ( annotations: Annotation[] ) => void;
 }
 

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -313,11 +313,15 @@ export const INSPECTOR_PAGE_SCRIPT =
 			toolbarNode.appendChild( count );
 		}
 
-		const doneBtn = document.createElement( 'button' );
-		doneBtn.className = 'primary';
-		doneBtn.textContent = 'Done';
-		doneBtn.disabled = annotations.length === 0;
-		doneBtn.addEventListener( 'click', () => {
+		const submitBtn = document.createElement( 'button' );
+		submitBtn.className = 'primary';
+		submitBtn.textContent = 'Submit';
+		submitBtn.disabled = annotations.length === 0;
+		submitBtn.title =
+			annotations.length === 0
+				? 'Add at least one annotation first'
+				: 'Submit annotations to the agent';
+		submitBtn.addEventListener( 'click', () => {
 			if ( annotations.length === 0 ) return;
 			const sent = annotations.slice();
 			send( { type: 'done', annotations: sent } );
@@ -328,7 +332,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 			persistAnnotations();
 			render();
 		} );
-		toolbarNode.appendChild( doneBtn );
+		toolbarNode.appendChild( submitBtn );
 
 		root.appendChild( toolbarNode );
 	}

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -519,8 +519,10 @@ export function createIpcConnector(): Connector {
 			return ( await ipcApi.createAiSession( siteId ) ) as AiSessionSummary;
 		},
 
-		async continueSession( sessionId, prompt ): Promise< { runId: string } > {
-			return ( await ipcApi.continueAiSession( sessionId, prompt ) ) as { runId: string };
+		async continueSession( sessionId, prompt, options ): Promise< { runId: string } > {
+			return ( await ipcApi.continueAiSession( sessionId, prompt, options ) ) as {
+				runId: string;
+			};
 		},
 
 		async setSessionModel( sessionId, model ) {

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -191,7 +191,11 @@ export interface Connector {
 	// Continue an existing session by sending a new prompt. Returns a `runId`
 	// that identifies the in-flight agent run; live events for that run stream
 	// through `onAgentEvent`.
-	continueSession( sessionId: string, prompt: string ): Promise< { runId: string } >;
+	continueSession(
+		sessionId: string,
+		prompt: string,
+		options?: { displayMessage?: string }
+	): Promise< { runId: string } >;
 	// Persist a UI-driven model override for the session. The CLI picks this up
 	// on the next turn; the change survives reloads because it's written to the
 	// session JSONL.

--- a/apps/ui/src/data/queries/use-agent-run.ts
+++ b/apps/ui/src/data/queries/use-agent-run.ts
@@ -20,6 +20,11 @@ export interface PendingQuestion {
 export interface QueuedPrompt {
 	id: string;
 	prompt: string;
+	displayMessage?: string;
+}
+
+export interface SendMessageOptions {
+	displayMessage?: string;
 }
 
 export interface LiveAgentEvents {
@@ -43,7 +48,7 @@ export interface LiveAgentEvents {
 	// Follow-up prompts the user staged while a turn was in flight. FIFO:
 	// the head auto-dispatches when the current run ends.
 	queuedPrompts: QueuedPrompt[];
-	sendMessage: ( prompt: string ) => Promise< void >;
+	sendMessage: ( prompt: string, options?: SendMessageOptions ) => Promise< void >;
 	interrupt: () => Promise< void >;
 	answerQuestion: ( question: string, answer: string ) => void;
 	removeQueuedPrompt: ( id: string ) => void;
@@ -313,16 +318,17 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 	// idle) and the queue auto-dispatch effect. Throws on error so the direct
 	// caller can restore the composer draft; the queue path catches and clears.
 	const startRun = useCallback(
-		async ( prompt: string ) => {
+		async ( prompt: string, options: SendMessageOptions = {} ) => {
 			if ( ! sessionId ) {
 				throw new Error( 'No session selected' );
 			}
+			const displayMessage = options.displayMessage ?? prompt;
 			dispatch( { type: 'error_set', message: null } );
 
 			const optimisticEvent: AiSessionEvent = {
 				type: 'user.message',
 				timestamp: nowIso(),
-				text: prompt,
+				text: displayMessage,
 				source: 'prompt',
 			};
 			updateCache( ( events ) => [ ...events, optimisticEvent ] );
@@ -330,7 +336,9 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 
 			try {
 				await interruptRequestRef.current;
-				const { runId: newRunId } = await connector.continueSession( sessionId, prompt );
+				const { runId: newRunId } = await connector.continueSession( sessionId, prompt, {
+					displayMessage,
+				} );
 				if ( interruptPendingStartRef.current ) {
 					interruptPendingStartRef.current = false;
 					ignoredRunIdsRef.current.add( newRunId );
@@ -374,7 +382,7 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 		dispatchingQueuedRef.current = true;
 		void ( async () => {
 			try {
-				await startRun( next.prompt );
+				await startRun( next.prompt, { displayMessage: next.displayMessage } );
 				dispatch( { type: 'queue_shift' } );
 			} catch {
 				dispatch( { type: 'queue_clear' } );
@@ -385,15 +393,18 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 	}, [ phase, queuedPrompts, startRun ] );
 
 	const sendMessage = useCallback(
-		async ( prompt: string ) => {
+		async ( prompt: string, options: SendMessageOptions = {} ) => {
 			// Queue if anything is in flight, if we're waiting on question
 			// answers, or if earlier queued prompts haven't been dispatched yet
 			// (preserves FIFO order).
 			if ( phase !== 'idle' || pendingQuestions.length > 0 || queuedPrompts.length > 0 ) {
-				dispatch( { type: 'queue_append', prompt: { id: newId(), prompt } } );
+				dispatch( {
+					type: 'queue_append',
+					prompt: { id: newId(), prompt, displayMessage: options.displayMessage },
+				} );
 				return;
 			}
-			await startRun( prompt );
+			await startRun( prompt, options );
 		},
 		[ phase, pendingQuestions.length, queuedPrompts.length, startRun ]
 	);


### PR DESCRIPTION
Submits site preview annotations directly to the agent while keeping the visible session transcript compact. The agent still receives the full annotation payload and follows the confirmation-first workflow used by visual annotation sessions.

## Proposed Changes

- Rename the annotation toolbar primary action from Done to Submit.
- Send submitted annotations directly through the agent run path instead of inserting a composer draft.
- Show a compact visible transcript entry like `2 annotations submitted` while sending the full annotation prompt to the agent internally.
- Persist the compact transcript entry through the desktop-to-CLI resume path so reloads do not reveal the full annotation prompt.
- Build an annotation prompt that asks the agent to summarize in markdown, confirm with `AskUserQuestion`, and use `TodoWrite` after confirmation.
- Add focused tests for the generated annotation prompt and hidden/display resume message behavior.

## Testing Instructions

- Open a local session with a running site and show the site preview.
- Click Annotate, select one or more elements, add feedback, and click Submit.
- Verify the chat shows a compact entry such as `2 annotations submitted`, not the full annotation payload.
- Verify the agent presents a markdown summary with confirmation options before editing.
- After confirming, verify the agent creates a todo list before working through the annotation tasks.
- Reload or reopen the session and verify the compact annotation submission entry is still shown.

## Automated Checks

- `npx eslint --fix apps/cli/commands/ai/index.ts apps/cli/commands/ai/sessions/resume.ts apps/cli/commands/ai/tests/ai.test.ts apps/studio/src/ipc-handlers.ts apps/studio/src/modules/ai-agent/run-manager.ts apps/studio/src/preload.ts apps/ui/src/components/session-view/annotations.test.ts apps/ui/src/components/session-view/annotations.ts apps/ui/src/components/session-view/index.tsx apps/ui/src/components/session-view/queued-prompts/index.tsx apps/ui/src/data/core/connectors/ipc/index.ts apps/ui/src/data/core/types.ts apps/ui/src/data/queries/use-agent-run.ts`
- `npm run typecheck`
- `npm test -- apps/ui/src/components/session-view/annotations.test.ts apps/cli/commands/ai/tests/ai.test.ts`
- `npm run cli:build`
- `node apps/cli/dist/cli/main.mjs code sessions resume --help`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?