### PR TITLE
Add resizable app panels

### DIFF
--- a/apps/ui/src/components/resize-handle/index.tsx
+++ b/apps/ui/src/components/resize-handle/index.tsx
@@ -1,0 +1,46 @@
+import { clsx } from 'clsx';
+import styles from './style.module.css';
+import type { KeyboardEventHandler, MouseEventHandler } from 'react';
+
+interface ResizeHandleProps {
+	className?: string;
+	label: string;
+	minWidth: number;
+	maxWidth: number;
+	width: number;
+	isResizing: boolean;
+	onResizeStart: MouseEventHandler< HTMLDivElement >;
+	onKeyDown: KeyboardEventHandler< HTMLDivElement >;
+}
+
+export function ResizeHandle( {
+	className,
+	label,
+	minWidth,
+	maxWidth,
+	width,
+	isResizing,
+	onResizeStart,
+	onKeyDown,
+}: ResizeHandleProps ) {
+	return (
+		<div
+			className={ clsx( styles.resizeHandle, className, isResizing && styles.resizing ) }
+			role="separator"
+			aria-label={ label }
+			aria-orientation="vertical"
+			aria-valuemin={ minWidth }
+			aria-valuemax={ maxWidth }
+			aria-valuenow={ width }
+			tabIndex={ 0 }
+			onMouseDown={ onResizeStart }
+			onKeyDown={ onKeyDown }
+		>
+			<span className={ styles.resizeHandleIndicator } aria-hidden="true" />
+		</div>
+	);
+}
+
+export function ResizeOverlay( { className }: { className?: string } ) {
+	return <div className={ clsx( styles.resizeOverlay, className ) } aria-hidden="true" />;
+}

--- a/apps/ui/src/components/resize-handle/style.module.css
+++ b/apps/ui/src/components/resize-handle/style.module.css
@@ -1,0 +1,34 @@
+.resizeHandle {
+	width: 15px;
+	z-index: 20;
+	display: flex;
+	align-items: center;
+	box-sizing: border-box;
+	cursor: col-resize;
+	outline: none;
+	-webkit-app-region: no-drag;
+}
+
+.resizeHandleIndicator {
+	width: 3px;
+	height: 48px;
+	border-radius: 999px;
+	background-color: var(--wpds-color-stroke-interactive-brand, #2563eb);
+	opacity: 0;
+	transition: opacity 120ms ease;
+}
+
+.resizeHandle:hover .resizeHandleIndicator,
+.resizeHandle:focus-visible .resizeHandleIndicator,
+.resizing .resizeHandleIndicator {
+	opacity: 1;
+}
+
+.resizeOverlay {
+	position: fixed;
+	inset: 0;
+	z-index: 1000;
+	cursor: col-resize;
+	user-select: none;
+	-webkit-app-region: no-drag;
+}

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -7,24 +7,53 @@ import { SidebarNav } from '@/components/sidebar-nav';
 import { SiteList } from '@/components/site-list';
 import { UserMenu } from '@/components/user-menu';
 import { useFullscreen } from '@/hooks/use-fullscreen';
+import { useResizablePanel } from '@/hooks/use-resizable-panel';
 import { SidebarCollapsedContext } from '@/hooks/use-sidebar-collapsed';
 import { drawerIcon } from '@/lib/icons';
+import { SIDEBAR_PANEL_CONFIG, SIDEBAR_PANEL_STORAGE_KEY } from '@/lib/resizable-panels';
 import styles from './style.module.css';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 export function SidebarLayout( { children }: { children: ReactNode } ) {
 	const [ collapsed, setCollapsed ] = useState( false );
 	const isFullscreen = useFullscreen();
+	const sidebarResize = useResizablePanel( {
+		config: SIDEBAR_PANEL_CONFIG,
+		edge: 'right',
+		storageKey: SIDEBAR_PANEL_STORAGE_KEY,
+	} );
+	const sidebarStyle = collapsed
+		? undefined
+		: ( { '--sidebar-width': `${ sidebarResize.width }px` } as CSSProperties );
 
 	return (
 		<SidebarCollapsedContext.Provider value={ collapsed }>
 			<div className={ styles.root }>
-				<aside className={ clsx( styles.sidebar, collapsed && styles.sidebarCollapsed ) }>
+				<aside
+					className={ clsx( styles.sidebar, collapsed && styles.sidebarCollapsed ) }
+					style={ sidebarStyle }
+				>
 					<SidebarHeader onToggleSidebar={ () => setCollapsed( true ) } />
 					<SidebarNav />
 					<SiteList />
 					<UserMenu />
 				</aside>
+				{ ! collapsed ? (
+					<div
+						className={ clsx( styles.resizeHandle, sidebarResize.isResizing && styles.resizing ) }
+						role="separator"
+						aria-label={ __( 'Resize sidebar' ) }
+						aria-orientation="vertical"
+						aria-valuemin={ sidebarResize.minWidth }
+						aria-valuemax={ sidebarResize.maxWidth }
+						aria-valuenow={ sidebarResize.width }
+						tabIndex={ 0 }
+						onMouseDown={ sidebarResize.handleResizeStart }
+						onKeyDown={ sidebarResize.handleKeyDown }
+					>
+						<span className={ styles.resizeHandleIndicator } aria-hidden="true" />
+					</div>
+				) : null }
 				<main className={ styles.main }>
 					{ collapsed ? (
 						<div
@@ -45,6 +74,7 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 					) : null }
 					{ children }
 				</main>
+				{ sidebarResize.isResizing ? <div className={ styles.resizeOverlay } /> : null }
 			</div>
 		</SidebarCollapsedContext.Provider>
 	);

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useState } from 'react';
+import { ResizeHandle, ResizeOverlay } from '@/components/resize-handle';
 import { SidebarHeader } from '@/components/sidebar-header';
 import { SidebarNav } from '@/components/sidebar-nav';
 import { SiteList } from '@/components/site-list';
@@ -39,20 +40,16 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 					<UserMenu />
 				</aside>
 				{ ! collapsed ? (
-					<div
-						className={ clsx( styles.resizeHandle, sidebarResize.isResizing && styles.resizing ) }
-						role="separator"
-						aria-label={ __( 'Resize sidebar' ) }
-						aria-orientation="vertical"
-						aria-valuemin={ sidebarResize.minWidth }
-						aria-valuemax={ sidebarResize.maxWidth }
-						aria-valuenow={ sidebarResize.width }
-						tabIndex={ 0 }
-						onMouseDown={ sidebarResize.handleResizeStart }
+					<ResizeHandle
+						className={ styles.resizeHandle }
+						label={ __( 'Resize sidebar' ) }
+						minWidth={ sidebarResize.minWidth }
+						maxWidth={ sidebarResize.maxWidth }
+						width={ sidebarResize.width }
+						isResizing={ sidebarResize.isResizing }
+						onResizeStart={ sidebarResize.handleResizeStart }
 						onKeyDown={ sidebarResize.handleKeyDown }
-					>
-						<span className={ styles.resizeHandleIndicator } aria-hidden="true" />
-					</div>
+					/>
 				) : null }
 				<main className={ styles.main }>
 					{ collapsed ? (
@@ -74,7 +71,7 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 					) : null }
 					{ children }
 				</main>
-				{ sidebarResize.isResizing ? <div className={ styles.resizeOverlay } /> : null }
+				{ sidebarResize.isResizing ? <ResizeOverlay /> : null }
 			</div>
 		</SidebarCollapsedContext.Provider>
 	);

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -1,10 +1,13 @@
 .root {
 	display: flex;
 	height: 100vh;
+	overflow: hidden;
 }
 
 .sidebar {
-	width: 320px;
+	width: var(--sidebar-width, 320px);
+	min-width: 240px;
+	max-width: 25vw;
 	flex-shrink: 0;
 	background-color: var(--wpds-color-bg-surface-neutral-weak);
 	border-right: 1px solid var(--wpds-color-stroke-surface-neutral);
@@ -20,12 +23,51 @@
 
 .sidebarCollapsed {
 	width: 0;
+	min-width: 0;
 }
 
 .main {
 	flex: 1;
+	min-width: 0;
 	overflow: auto;
 	position: relative;
+}
+
+.resizeHandle {
+	width: 10px;
+	margin-right: -5px;
+	margin-left: -5px;
+	flex-shrink: 0;
+	z-index: 20;
+	display: flex;
+	align-items: stretch;
+	justify-content: center;
+	cursor: col-resize;
+	outline: none;
+	-webkit-app-region: no-drag;
+}
+
+.resizeHandleIndicator {
+	width: 3px;
+	border-radius: 999px;
+	background-color: var(--wpds-color-stroke-interactive-brand, #2563eb);
+	opacity: 0;
+	transition: opacity 120ms ease;
+}
+
+.resizeHandle:hover .resizeHandleIndicator,
+.resizeHandle:focus-visible .resizeHandleIndicator,
+.resizing .resizeHandleIndicator {
+	opacity: 1;
+}
+
+.resizeOverlay {
+	position: fixed;
+	inset: 0;
+	z-index: 1000;
+	cursor: col-resize;
+	user-select: none;
+	-webkit-app-region: no-drag;
 }
 
 .floatingToggle {

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -34,41 +34,9 @@
 }
 
 .resizeHandle {
-	width: 15px;
 	flex-shrink: 0;
-	z-index: 20;
-	display: flex;
-	align-items: center;
 	justify-content: flex-start;
 	padding-left: 4px;
-	box-sizing: border-box;
-	cursor: col-resize;
-	outline: none;
-	-webkit-app-region: no-drag;
-}
-
-.resizeHandleIndicator {
-	width: 3px;
-	height: 48px;
-	border-radius: 999px;
-	background-color: var(--wpds-color-stroke-interactive-brand, #2563eb);
-	opacity: 0;
-	transition: opacity 120ms ease;
-}
-
-.resizeHandle:hover .resizeHandleIndicator,
-.resizeHandle:focus-visible .resizeHandleIndicator,
-.resizing .resizeHandleIndicator {
-	opacity: 1;
-}
-
-.resizeOverlay {
-	position: fixed;
-	inset: 0;
-	z-index: 1000;
-	cursor: col-resize;
-	user-select: none;
-	-webkit-app-region: no-drag;
 }
 
 .floatingToggle {

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -34,14 +34,14 @@
 }
 
 .resizeHandle {
-	width: 10px;
-	margin-right: -5px;
-	margin-left: -5px;
+	width: 15px;
 	flex-shrink: 0;
 	z-index: 20;
 	display: flex;
-	align-items: stretch;
-	justify-content: center;
+	align-items: center;
+	justify-content: flex-start;
+	padding-left: 4px;
+	box-sizing: border-box;
 	cursor: col-resize;
 	outline: none;
 	-webkit-app-region: no-drag;
@@ -49,6 +49,7 @@
 
 .resizeHandleIndicator {
 	width: 3px;
+	height: 48px;
 	border-radius: 999px;
 	background-color: var(--wpds-color-stroke-interactive-brand, #2563eb);
 	opacity: 0;

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -5,12 +5,15 @@ import { clsx } from 'clsx';
 import { useEffect, useRef, useState } from 'react';
 import { useConnector } from '@/data/core';
 import { useIsSiteStarting, useStartSite } from '@/data/queries/use-sites';
+import { useResizablePanel } from '@/hooks/use-resizable-panel';
 import { getSiteUrl } from '@/lib/get-site-url';
 import { playIcon } from '@/lib/icons';
+import { PREVIEW_PANEL_CONFIG, PREVIEW_PANEL_STORAGE_KEY } from '@/lib/resizable-panels';
 import { INSPECTOR_BRIDGE_PREFIX, INSPECTOR_PAGE_SCRIPT } from './inspector-script';
 import styles from './style.module.css';
 import type { Annotation } from './types';
 import type { SiteDetails } from '@/data/core';
+import type { CSSProperties } from 'react';
 
 export type { Annotation } from './types';
 
@@ -59,6 +62,14 @@ export function SitePreview( { site, sessionId, onAnnotationsDone }: SitePreview
 	const [ currentPath, setCurrentPath ] = useState( '/' );
 	const [ reloadNonce, setReloadNonce ] = useState( 0 );
 	const fullUrl = `${ siteUrl }${ currentPath }`;
+	const previewResize = useResizablePanel( {
+		config: PREVIEW_PANEL_CONFIG,
+		edge: 'left',
+		storageKey: PREVIEW_PANEL_STORAGE_KEY,
+	} );
+	const previewStyle = {
+		'--site-preview-width': `${ previewResize.width }px`,
+	} as CSSProperties;
 
 	useEffect( () => {
 		if ( ! sessionId ) return;
@@ -74,7 +85,21 @@ export function SitePreview( { site, sessionId, onAnnotationsDone }: SitePreview
 	}, [ connector, sessionId ] );
 
 	return (
-		<aside className={ styles.root } aria-label={ __( 'Site preview' ) }>
+		<aside className={ styles.root } style={ previewStyle } aria-label={ __( 'Site preview' ) }>
+			<div
+				className={ clsx( styles.resizeHandle, previewResize.isResizing && styles.resizing ) }
+				role="separator"
+				aria-label={ __( 'Resize site preview' ) }
+				aria-orientation="vertical"
+				aria-valuemin={ previewResize.minWidth }
+				aria-valuemax={ previewResize.maxWidth }
+				aria-valuenow={ previewResize.width }
+				tabIndex={ 0 }
+				onMouseDown={ previewResize.handleResizeStart }
+				onKeyDown={ previewResize.handleKeyDown }
+			>
+				<span className={ styles.resizeHandleIndicator } aria-hidden="true" />
+			</div>
 			<div className={ styles.header }>
 				<div className={ styles.trafficLights } aria-hidden="true">
 					<span className={ clsx( styles.trafficLight, styles.trafficLightActive ) } />
@@ -129,6 +154,7 @@ export function SitePreview( { site, sessionId, onAnnotationsDone }: SitePreview
 					</div>
 				) }
 			</div>
+			{ previewResize.isResizing ? <div className={ styles.resizeOverlay } /> : null }
 		</aside>
 	);
 }

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -3,6 +3,7 @@ import { external } from '@wordpress/icons';
 import { Button, IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useEffect, useRef, useState } from 'react';
+import { ResizeHandle, ResizeOverlay } from '@/components/resize-handle';
 import { useConnector } from '@/data/core';
 import { useIsSiteStarting, useStartSite } from '@/data/queries/use-sites';
 import { useResizablePanel } from '@/hooks/use-resizable-panel';
@@ -86,20 +87,16 @@ export function SitePreview( { site, sessionId, onAnnotationsDone }: SitePreview
 
 	return (
 		<aside className={ styles.root } style={ previewStyle } aria-label={ __( 'Site preview' ) }>
-			<div
-				className={ clsx( styles.resizeHandle, previewResize.isResizing && styles.resizing ) }
-				role="separator"
-				aria-label={ __( 'Resize site preview' ) }
-				aria-orientation="vertical"
-				aria-valuemin={ previewResize.minWidth }
-				aria-valuemax={ previewResize.maxWidth }
-				aria-valuenow={ previewResize.width }
-				tabIndex={ 0 }
-				onMouseDown={ previewResize.handleResizeStart }
+			<ResizeHandle
+				className={ styles.resizeHandle }
+				label={ __( 'Resize site preview' ) }
+				minWidth={ previewResize.minWidth }
+				maxWidth={ previewResize.maxWidth }
+				width={ previewResize.width }
+				isResizing={ previewResize.isResizing }
+				onResizeStart={ previewResize.handleResizeStart }
 				onKeyDown={ previewResize.handleKeyDown }
-			>
-				<span className={ styles.resizeHandleIndicator } aria-hidden="true" />
-			</div>
+			/>
 			<div className={ styles.header }>
 				<div className={ styles.trafficLights } aria-hidden="true">
 					<span className={ clsx( styles.trafficLight, styles.trafficLightActive ) } />
@@ -154,7 +151,7 @@ export function SitePreview( { site, sessionId, onAnnotationsDone }: SitePreview
 					</div>
 				) }
 			</div>
-			{ previewResize.isResizing ? <div className={ styles.resizeOverlay } /> : null }
+			{ previewResize.isResizing ? <ResizeOverlay /> : null }
 		</aside>
 	);
 }

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -21,40 +21,8 @@
 	top: 0;
 	bottom: 0;
 	left: -15px;
-	width: 15px;
-	z-index: 20;
-	display: flex;
-	align-items: center;
 	justify-content: flex-end;
 	padding-right: 4px;
-	box-sizing: border-box;
-	cursor: col-resize;
-	outline: none;
-	-webkit-app-region: no-drag;
-}
-
-.resizeHandleIndicator {
-	width: 3px;
-	height: 48px;
-	border-radius: 999px;
-	background-color: var(--wpds-color-stroke-interactive-brand, #2563eb);
-	opacity: 0;
-	transition: opacity 120ms ease;
-}
-
-.resizeHandle:hover .resizeHandleIndicator,
-.resizeHandle:focus-visible .resizeHandleIndicator,
-.resizing .resizeHandleIndicator {
-	opacity: 1;
-}
-
-.resizeOverlay {
-	position: fixed;
-	inset: 0;
-	z-index: 1000;
-	cursor: col-resize;
-	user-select: none;
-	-webkit-app-region: no-drag;
 }
 
 .header {

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -12,7 +12,7 @@
 	background-color: var(--wpds-color-bg-surface-neutral);
 	border: 1px solid var(--wpds-color-stroke-surface-neutral);
 	border-radius: var(--wpds-border-radius-lg, 12px);
-	overflow: hidden;
+	overflow: visible;
 	box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
 }
 
@@ -20,11 +20,14 @@
 	position: absolute;
 	top: 0;
 	bottom: 0;
-	left: 0;
-	width: 12px;
+	left: -15px;
+	width: 15px;
 	z-index: 20;
 	display: flex;
-	justify-content: center;
+	align-items: center;
+	justify-content: flex-end;
+	padding-right: 4px;
+	box-sizing: border-box;
 	cursor: col-resize;
 	outline: none;
 	-webkit-app-region: no-drag;
@@ -32,7 +35,7 @@
 
 .resizeHandleIndicator {
 	width: 3px;
-	margin: var(--wpds-dimension-padding-sm) 0;
+	height: 48px;
 	border-radius: 999px;
 	background-color: var(--wpds-color-stroke-interactive-brand, #2563eb);
 	opacity: 0;
@@ -63,6 +66,8 @@
 	flex-shrink: 0;
 	background-color: #fff;
 	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-top-left-radius: inherit;
+	border-top-right-radius: inherit;
 }
 
 .trafficLights {
@@ -99,6 +104,9 @@
 	display: flex;
 	position: relative;
 	background-color: #fff;
+	overflow: hidden;
+	border-bottom-right-radius: inherit;
+	border-bottom-left-radius: inherit;
 }
 
 .spinnerOverlay {

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -1,7 +1,10 @@
 .root {
 	display: flex;
 	flex-direction: column;
-	width: 520px;
+	position: relative;
+	width: var(--site-preview-width, 520px);
+	min-width: 360px;
+	max-width: 50vw;
 	flex-shrink: 0;
 	min-height: 0;
 	margin: calc(var(--wpds-dimension-padding-md) * 2) calc(var(--wpds-dimension-padding-md) * 2)
@@ -11,6 +14,44 @@
 	border-radius: var(--wpds-border-radius-lg, 12px);
 	overflow: hidden;
 	box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
+}
+
+.resizeHandle {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	width: 12px;
+	z-index: 20;
+	display: flex;
+	justify-content: center;
+	cursor: col-resize;
+	outline: none;
+	-webkit-app-region: no-drag;
+}
+
+.resizeHandleIndicator {
+	width: 3px;
+	margin: var(--wpds-dimension-padding-sm) 0;
+	border-radius: 999px;
+	background-color: var(--wpds-color-stroke-interactive-brand, #2563eb);
+	opacity: 0;
+	transition: opacity 120ms ease;
+}
+
+.resizeHandle:hover .resizeHandleIndicator,
+.resizeHandle:focus-visible .resizeHandleIndicator,
+.resizing .resizeHandleIndicator {
+	opacity: 1;
+}
+
+.resizeOverlay {
+	position: fixed;
+	inset: 0;
+	z-index: 1000;
+	cursor: col-resize;
+	user-select: none;
+	-webkit-app-region: no-drag;
 }
 
 .header {

--- a/apps/ui/src/hooks/use-resizable-panel.ts
+++ b/apps/ui/src/hooks/use-resizable-panel.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+	clampResizablePanelWidth,
+	getResizablePanelMaxWidth,
+	getStoredResizablePanelWidth,
+	getViewportWidth,
+	storeResizablePanelWidth,
+	type ResizablePanelConfig,
+} from '@/lib/resizable-panels';
+import type { KeyboardEvent, MouseEvent } from 'react';
+
+interface UseResizablePanelOptions {
+	config: ResizablePanelConfig;
+	edge: 'left' | 'right';
+	storageKey: string;
+}
+
+export function useResizablePanel( { config, edge, storageKey }: UseResizablePanelOptions ) {
+	const [ viewportWidth, setViewportWidth ] = useState( getViewportWidth );
+	const [ width, setWidth ] = useState( () =>
+		getStoredResizablePanelWidth( storageKey, config, getViewportWidth() )
+	);
+	const [ isResizing, setIsResizing ] = useState( false );
+	const dragStartX = useRef( 0 );
+	const dragStartWidth = useRef( 0 );
+
+	const maxWidth = useMemo(
+		() => getResizablePanelMaxWidth( viewportWidth, config ),
+		[ config, viewportWidth ]
+	);
+
+	const saveWidth = useCallback(
+		( nextWidth: number ) => {
+			const clampedWidth = clampResizablePanelWidth( nextWidth, config, getViewportWidth() );
+			setWidth( clampedWidth );
+			storeResizablePanelWidth( storageKey, clampedWidth );
+		},
+		[ config, storageKey ]
+	);
+
+	const handleResizeStart = useCallback(
+		( event: MouseEvent< HTMLElement > ) => {
+			if ( event.button !== 0 ) {
+				return;
+			}
+			event.preventDefault();
+			setIsResizing( true );
+			dragStartX.current = event.clientX;
+			dragStartWidth.current = width;
+		},
+		[ width ]
+	);
+
+	const handleKeyDown = useCallback(
+		( event: KeyboardEvent< HTMLElement > ) => {
+			const step = event.shiftKey ? 40 : 16;
+			if ( event.key === 'Home' ) {
+				event.preventDefault();
+				saveWidth( config.minWidth );
+				return;
+			}
+			if ( event.key === 'End' ) {
+				event.preventDefault();
+				saveWidth( maxWidth );
+				return;
+			}
+			if ( event.key !== 'ArrowLeft' && event.key !== 'ArrowRight' ) {
+				return;
+			}
+			event.preventDefault();
+			const direction = event.key === 'ArrowRight' ? 1 : -1;
+			const delta = edge === 'right' ? direction * step : direction * -step;
+			saveWidth( width + delta );
+		},
+		[ config.minWidth, edge, maxWidth, saveWidth, width ]
+	);
+
+	useEffect( () => {
+		const handleResize = () => {
+			const nextViewportWidth = getViewportWidth();
+			setViewportWidth( nextViewportWidth );
+			setWidth( ( currentWidth ) =>
+				clampResizablePanelWidth( currentWidth, config, nextViewportWidth )
+			);
+		};
+		window.addEventListener( 'resize', handleResize );
+		return () => window.removeEventListener( 'resize', handleResize );
+	}, [ config ] );
+
+	useEffect( () => {
+		if ( ! isResizing ) {
+			return;
+		}
+
+		let rafId: number | undefined;
+		const originalCursor = document.body.style.cursor;
+		const originalUserSelect = document.body.style.userSelect;
+		document.body.style.cursor = 'col-resize';
+		document.body.style.userSelect = 'none';
+
+		const handleMouseMove = ( event: globalThis.MouseEvent ) => {
+			if ( rafId ) {
+				cancelAnimationFrame( rafId );
+			}
+			rafId = requestAnimationFrame( () => {
+				const delta =
+					edge === 'right'
+						? event.clientX - dragStartX.current
+						: dragStartX.current - event.clientX;
+				setWidth(
+					clampResizablePanelWidth( dragStartWidth.current + delta, config, getViewportWidth() )
+				);
+			} );
+		};
+
+		const handleMouseUp = ( event: globalThis.MouseEvent ) => {
+			setIsResizing( false );
+			if ( rafId ) {
+				cancelAnimationFrame( rafId );
+			}
+			const delta =
+				edge === 'right' ? event.clientX - dragStartX.current : dragStartX.current - event.clientX;
+			saveWidth( dragStartWidth.current + delta );
+		};
+
+		document.addEventListener( 'mousemove', handleMouseMove );
+		document.addEventListener( 'mouseup', handleMouseUp );
+
+		return () => {
+			if ( rafId ) {
+				cancelAnimationFrame( rafId );
+			}
+			document.body.style.cursor = originalCursor;
+			document.body.style.userSelect = originalUserSelect;
+			document.removeEventListener( 'mousemove', handleMouseMove );
+			document.removeEventListener( 'mouseup', handleMouseUp );
+		};
+	}, [ config, edge, isResizing, saveWidth ] );
+
+	return {
+		width,
+		minWidth: config.minWidth,
+		maxWidth,
+		isResizing,
+		handleResizeStart,
+		handleKeyDown,
+	};
+}

--- a/apps/ui/src/lib/resizable-panels.test.ts
+++ b/apps/ui/src/lib/resizable-panels.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+	clampResizablePanelWidth,
+	getResizablePanelMaxWidth,
+	type ResizablePanelConfig,
+} from './resizable-panels';
+
+const config: ResizablePanelConfig = {
+	defaultWidth: 320,
+	minWidth: 240,
+	maxWidthRatio: 0.25,
+};
+
+describe( 'resizable panels', () => {
+	it( 'caps panel width to the configured viewport ratio', () => {
+		expect( clampResizablePanelWidth( 500, config, 1200 ) ).toBe( 300 );
+	} );
+
+	it( 'does not shrink below the configured minimum width', () => {
+		expect( clampResizablePanelWidth( 120, config, 1200 ) ).toBe( 240 );
+	} );
+
+	it( 'lets the minimum width win when the viewport ratio is smaller', () => {
+		expect( getResizablePanelMaxWidth( 800, config ) ).toBe( 240 );
+		expect( clampResizablePanelWidth( 320, config, 800 ) ).toBe( 240 );
+	} );
+} );

--- a/apps/ui/src/lib/resizable-panels.ts
+++ b/apps/ui/src/lib/resizable-panels.ts
@@ -1,0 +1,76 @@
+export interface ResizablePanelConfig {
+	defaultWidth: number;
+	minWidth: number;
+	maxWidthRatio: number;
+}
+
+export const SIDEBAR_PANEL_STORAGE_KEY = 'studio-ui-sidebar-width';
+export const PREVIEW_PANEL_STORAGE_KEY = 'studio-ui-preview-width';
+
+export const SIDEBAR_PANEL_CONFIG: ResizablePanelConfig = {
+	defaultWidth: 320,
+	minWidth: 240,
+	maxWidthRatio: 0.25,
+};
+
+export const PREVIEW_PANEL_CONFIG: ResizablePanelConfig = {
+	defaultWidth: 520,
+	minWidth: 360,
+	maxWidthRatio: 0.5,
+};
+
+export function getResizablePanelMaxWidth(
+	viewportWidth: number,
+	{ minWidth, maxWidthRatio }: ResizablePanelConfig
+): number {
+	return Math.max( minWidth, Math.floor( viewportWidth * maxWidthRatio ) );
+}
+
+export function clampResizablePanelWidth(
+	width: number,
+	config: ResizablePanelConfig,
+	viewportWidth: number
+): number {
+	const maxWidth = getResizablePanelMaxWidth( viewportWidth, config );
+	return Math.min( maxWidth, Math.max( config.minWidth, Math.round( width ) ) );
+}
+
+export function getViewportWidth(): number {
+	return typeof window === 'undefined' ? 0 : window.innerWidth;
+}
+
+export function getStoredResizablePanelWidth(
+	storageKey: string,
+	config: ResizablePanelConfig,
+	viewportWidth: number
+): number {
+	if ( typeof window === 'undefined' ) {
+		return clampResizablePanelWidth( config.defaultWidth, config, viewportWidth );
+	}
+
+	try {
+		const storedWidth = window.localStorage.getItem( storageKey );
+		if ( storedWidth ) {
+			const parsedWidth = Number( storedWidth );
+			if ( Number.isFinite( parsedWidth ) ) {
+				return clampResizablePanelWidth( parsedWidth, config, viewportWidth );
+			}
+		}
+	} catch {
+		// Ignore storage failures and fall back to the default width.
+	}
+
+	return clampResizablePanelWidth( config.defaultWidth, config, viewportWidth );
+}
+
+export function storeResizablePanelWidth( storageKey: string, width: number ): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	try {
+		window.localStorage.setItem( storageKey, String( width ) );
+	} catch {
+		// Ignore storage failures; resizing should still work for this session.
+	}
+}


### PR DESCRIPTION
Adds draggable resize controls to the new app UI sidebar and site preview panel, with viewport-based limits so neither panel can take over the window.

## Proposed Changes

- Add a reusable resizable-panel hook with mouse and keyboard resizing support.
- Make the left sidebar resizable with a minimum width and a maximum of 25% of the window.
- Make the site preview panel resizable with a minimum width and a maximum of 50% of the window.
- Persist panel widths locally and clamp restored values to the current viewport.

## Testing Instructions

- Start the new UI and verify the left sidebar can be resized by dragging its right edge.
- Confirm the sidebar cannot become very narrow and cannot grow beyond about one quarter of the window.
- Open a session with a local site preview, show the preview panel, and verify it can be resized by dragging its left edge.
- Confirm the preview panel cannot become very narrow and cannot grow beyond about half of the window.
- Focus each resize handle with the keyboard and verify ArrowLeft/ArrowRight, Home, and End adjust the panel widths.

## Automated Checks

- `npx eslint --fix apps/ui/src/components/sidebar-layout/index.tsx apps/ui/src/components/sidebar-layout/style.module.css apps/ui/src/components/site-preview/index.tsx apps/ui/src/components/site-preview/style.module.css apps/ui/src/hooks/use-resizable-panel.ts apps/ui/src/lib/resizable-panels.ts apps/ui/src/lib/resizable-panels.test.ts`
- `npm run typecheck`
- `npm test -- apps/ui/src/lib/resizable-panels.test.ts`

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?