### PR TITLE
Animate sidebar thread groups

### DIFF
--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -1,7 +1,7 @@
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
-import { moreHorizontal, plus } from '@wordpress/icons';
-import { Button, Dialog, IconButton } from '@wordpress/ui';
+import { chevronDown, chevronRight, moreHorizontal, plus } from '@wordpress/icons';
+import { Button, Dialog, Icon, IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useMemo, useState } from 'react';
 import * as Menu from '@/components/menu';
@@ -88,7 +88,7 @@ function groupSessionsByOwner(
 	return groups;
 }
 
-function SessionItem( { session }: { session: AiSessionSummary } ) {
+function SessionItem( { session, isVisible }: { session: AiSessionSummary; isVisible: boolean } ) {
 	const label = session.firstPrompt?.trim() || __( '(No prompt yet)' );
 
 	return (
@@ -99,6 +99,7 @@ function SessionItem( { session }: { session: AiSessionSummary } ) {
 					<Link
 						to="/sessions/$sessionId"
 						params={ { sessionId: session.id } }
+						tabIndex={ isVisible ? undefined : -1 }
 						activeProps={ {
 							className: clsx( styles.sessionLink, styles.sessionLinkActive ),
 						} }
@@ -319,6 +320,9 @@ function SiteSection( {
 						onClick={ onToggle }
 						aria-expanded={ isOpen }
 					>
+						<span className={ styles.siteChevron } aria-hidden="true">
+							<Icon icon={ isOpen ? chevronDown : chevronRight } size={ 16 } />
+						</span>
 						<span className={ styles.siteName }>{ group.label }</span>
 					</SidebarButton>
 				</div>
@@ -329,12 +333,17 @@ function SiteSection( {
 					</div>
 				) : null }
 			</header>
-			{ isOpen && group.sessions.length > 0 ? (
-				<ul className={ styles.sessionList }>
-					{ group.sessions.map( ( session ) => (
-						<SessionItem key={ session.id } session={ session } />
-					) ) }
-				</ul>
+			{ group.sessions.length > 0 ? (
+				<div
+					className={ clsx( styles.sessionListFrame, isOpen && styles.sessionListFrameOpen ) }
+					aria-hidden={ ! isOpen }
+				>
+					<ul className={ styles.sessionList }>
+						{ group.sessions.map( ( session ) => (
+							<SessionItem key={ session.id } session={ session } isVisible={ isOpen } />
+						) ) }
+					</ul>
+				</div>
 			) : null }
 		</section>
 	);

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -320,10 +320,10 @@ function SiteSection( {
 						onClick={ onToggle }
 						aria-expanded={ isOpen }
 					>
+						<span className={ styles.siteName }>{ group.label }</span>
 						<span className={ styles.siteChevron } aria-hidden="true">
 							<Icon icon={ isOpen ? chevronDown : chevronRight } size={ 16 } />
 						</span>
-						<span className={ styles.siteName }>{ group.label }</span>
 					</SidebarButton>
 				</div>
 				{ group.site ? (

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -36,6 +36,7 @@
 .siteToggle {
 	max-width: 100%;
 	height: auto;
+	gap: var(--wpds-dimension-padding-xs);
 }
 
 .siteName {
@@ -47,6 +48,27 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	max-width: 100%;
+}
+
+.siteChevron {
+	display: grid;
+	place-items: center;
+	flex-shrink: 0;
+	width: 16px;
+	height: 16px;
+	color: var(--wpds-color-fg-content-neutral-weak);
+	opacity: 0;
+	transition: opacity 100ms ease, color 100ms ease;
+}
+
+.siteToggle:hover .siteChevron,
+.siteToggle:focus-visible .siteChevron {
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.siteHeader:hover .siteChevron,
+.siteHeader:focus-within .siteChevron {
+	opacity: 1;
 }
 
 .siteToggle:hover .siteName {
@@ -88,7 +110,31 @@
 	margin: 0;
 }
 
+.sessionListFrame {
+	display: grid;
+	grid-template-rows: 0fr;
+	opacity: 0;
+	pointer-events: none;
+	transition: grid-template-rows 160ms ease, opacity 120ms ease;
+}
+
+.sessionListFrameOpen {
+	grid-template-rows: 1fr;
+	opacity: 1;
+	pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.siteChevron,
+	.siteAction,
+	.sessionListFrame {
+		transition: none;
+	}
+}
+
 .sessionList {
+	overflow: hidden;
+	min-height: 0;
 	list-style: none;
 	padding: 0;
 	margin: 0 0 var(--wpds-dimension-padding-sm);

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -124,14 +124,6 @@
 	pointer-events: auto;
 }
 
-@media (prefers-reduced-motion: reduce) {
-	.siteChevron,
-	.siteAction,
-	.sessionListFrame {
-		transition: none;
-	}
-}
-
 .sessionList {
 	overflow: hidden;
 	min-height: 0;

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -125,3 +125,19 @@ a:focus:not(:focus-visible),
 	background-color: var(--wp-components-color-background, #fff);
 }
 
+/* Honor the user's reduced-motion preference across the entire app. Class-
+   scoped transitions out-specify a `*`-targeted rule, so `!important` is
+   needed to clamp them. Components that genuinely need to keep motion can
+   re-enable it with a more specific `!important` rule inside the same
+   media query. */
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
+}
+


### PR DESCRIPTION
Adds a smooth expand and collapse treatment for site conversation threads in the sidebar, plus a hover chevron that reflects each site group's open state.

## Proposed Changes

- Add a right/down chevron to each site row that appears on hover or keyboard focus.
- Keep populated thread lists mounted inside an animated wrapper so collapsing and expanding transitions smoothly.
- Remove collapsed thread links from keyboard tab order while they are visually hidden.
- Respect reduced-motion preferences for the new sidebar transitions.

## Testing Instructions

- Start the new UI and open the dashboard sidebar with at least one site that has conversation threads.
- Hover a site row and confirm the chevron appears pointing down when expanded and right when collapsed.
- Click the site row to collapse and expand its thread list, confirming the list animates smoothly in both directions.
- Confirm collapsed thread links are not reachable with Tab until the site row is expanded again.

## Automated Checks

- `npx eslint --fix apps/ui/src/components/site-list/index.tsx apps/ui/src/components/site-list/style.module.css` (CSS path is ignored by the ESLint config with a warning)
- `npm run typecheck`
- `npm test -- --project ui --passWithNoTests`
- `npm -w @studio/ui run build`

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?