### PR TITLE
CLI: bump minimum Node.js version to 24

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -33,7 +33,7 @@ The Studio CLI lets you:
 
 ## Requirements
 
-`wp-studio` runs best on Node.js 24 or higher, which supports more recent V8 WASM APIs. Node.js 22 or higher is required. You can download the appropriate version from the [Node.js website](https://nodejs.org/en/download).
+`wp-studio` requires Node.js 24 or higher, which supports the V8 WASM APIs the CLI relies on. You can download the appropriate version from the [Node.js website](https://nodejs.org/en/download).
 
 ## Installation
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -16,7 +16,7 @@
 		"scripts/"
 	],
 	"engines": {
-		"node": ">=22.0.0"
+		"node": ">=24.0.0"
 	},
 	"repository": {
 		"type": "git",

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -69,7 +69,7 @@ export const baseConfig = defineConfig( {
 			formats: [ 'es' ],
 		},
 		outDir: 'dist/cli',
-		target: 'node22',
+		target: 'node24',
 		rollupOptions: {
 			output: {
 				format: 'es',

--- a/apps/studio/forge.config.ts
+++ b/apps/studio/forge.config.ts
@@ -249,7 +249,7 @@ const config: ForgeConfig = {
 			// AppX packages require AppExecutionAlias with an .exe target — batch files won't work.
 			if ( platform === 'win32' ) {
 				const pkgArch = arch === 'x64' ? 'x64' : 'arm64';
-				const target = `node22-win-${ pkgArch }`;
+				const target = `node24-win-${ pkgArch }`;
 				console.log( `Building CLI launcher executable for ${ target }...` );
 				await pkgExec( [
 					'bin/studio-cli-launcher.js',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"devEngines": {
 		"runtime": {
 			"name": "node",
-			"version": ">=22.0.0"
+			"version": ">=24.0.0"
 		},
 		"packageManager": {
 			"name": "npm",


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude Code located all references to the previous minimum (`engines.node`, `devEngines`, the Vite `target`, the yao-pkg target string, and the README copy), made the bumps, ran typecheck, and double-checked there were no remaining `node22` / `>=22.0.0` references in the repo.

## Proposed Changes

Bump the CLI's minimum supported Node.js version from **22** to **24**:

- `apps/cli/package.json` — `engines.node`: `>=22.0.0` → `>=24.0.0` (this is the source of truth that the build pipes into the `__MINIMUM_NODE_VERSION__` constant the CLI checks at startup in `apps/cli/index.ts`).
- `package.json` — root `devEngines.runtime.version`: `>=22.0.0` → `>=24.0.0`.
- `apps/cli/vite.config.base.ts` — Vite `build.target`: `node22` → `node24`.
- `apps/studio/forge.config.ts` — Windows AppX CLI launcher `@yao-pkg/pkg` target: `node22-win-${pkgArch}` → `node24-win-${pkgArch}`.
- `apps/cli/README.md` — Requirements copy now states Node 24 is required (it previously said "best on 24, 22 required").

The repo's `.nvmrc` is already `24.13.1` and `scripts/download-node-binary.ts` already falls back to `v24.13.1`, so contributors and the bundled Node binary that ships inside the desktop app are already on 24. This change aligns the CLI's user-facing minimum with what the project develops and ships against.

### Notes for reviewers

- This is a **breaking change for CLI npm consumers on Node 22**. After publish, `npx wp-studio@latest` on Node 22 will hit the existing version gate at `apps/cli/index.ts:34` and exit with the translated "requires Node.js 24 or newer" message. Worth highlighting in the next release notes.
- The JSPI capability check at `apps/cli/process-manager-daemon.ts:214` (`semver.gte(process.version, '24.0.0')`) becomes always-true after this bump. Left as-is to keep the diff minimal — happy to simplify the conditional in a follow-up if preferred.
- `@yao-pkg/pkg` is at `6.14.1` (per `package-lock.json`); the `node24-win-x64` / `node24-win-arm64` targets are supported in this version. A Windows AppX packaging smoke test would be a good extra check.

## Testing Instructions

- `npm run typecheck` — passes locally.
- On Node 22: run a built CLI (`npm run cli:build && node apps/cli/dist/cli/main.mjs --help`) and confirm it exits with the "requires Node.js 24 or newer" error.
- On Node 24+: run the CLI and confirm it starts normally and basic commands (e.g. `auth status`, `site list`) still work.
- Optional but recommended: run `npm run make:windows-x64` (or `make:windows-arm64`) to confirm the `node24-win-*` target builds the AppX CLI launcher executable cleanly.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Release notes / changelog updated to flag the breaking change for CLI consumers on Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)