### PR TITLE
CLI: silence noisy ENOENT log when daemon socket is absent

### DIFF
--- a/apps/cli/lib/daemon-client.ts
+++ b/apps/cli/lib/daemon-client.ts
@@ -295,7 +295,9 @@ export async function isProcessRunning(
 		const processes = await listProcesses();
 		return processes.find( ( p ) => p.name === processName && p.status === 'online' );
 	} catch ( error ) {
-		console.error( `Error checking if process ${ processName } is running:`, error );
+		if ( ! isRecoverableConnectError( error ) ) {
+			console.error( `Error checking if process ${ processName } is running:`, error );
+		}
 		return undefined;
 	}
 }


### PR DESCRIPTION
## Related issues

- Related to user-reported noise mid-session in `studio code`

## How AI was used in this PR

Investigated the source of an in-session log line, identified the over-eager `console.error` in `isProcessRunning`, and gated it behind the existing `isRecoverableConnectError` helper.

## Proposed Changes

- In `apps/cli/lib/daemon-client.ts`, suppress the `console.error` in `isProcessRunning()` for recoverable connect errors (`ENOENT`/`ECONNREFUSED`/`EPIPE`). Non-recoverable errors still log. The function continues to return `undefined` either way, so the agent's user-facing "Site is not running" message is unchanged.

### Why

When the process-manager daemon isn't running yet, attempting to connect to `~/.studio/daemon/daemon.sock` fails with `ENOENT`. `connectToDaemon()` already treats this as a recoverable condition and auto-spawns the daemon — but if the recovery path itself surfaces an error to `isProcessRunning`, that error gets logged as `Error checking if process studio-site-… is running: Error: connect ENOENT …`. This noise shows up mid-session in `studio code` (e.g. when the agent calls `wp_cli_run` and the site server isn't up yet), even though the situation is benign and the tool already returns a clear "Site is not running" message to the user.

## Testing Instructions

- Run `studio code` against a session where a site is not currently running, then ask the agent to run a WP-CLI command on that site (e.g. `Run wp eval ...`).
- Before this change: the session shows `Error checking if process studio-site-<id> is running: Error: connect ENOENT /Users/<you>/.studio/daemon/daemon.sock` immediately above the agent's `Site "<name>" is not running. Start it first using site_start.` message.
- After this change: only the `Site "<name>" is not running` message appears; no preceding `console.error` line.
- `npm test -- apps/cli/lib/tests/daemon-client.test.ts` continues to pass.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)