### PR TITLE
Update CLI and app versions to 1.8.2

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,33 @@
 Unreleased
 ==========
 
+1.8.2
+=====
+* Fixed an issue where multiple CLI progress line showed up in Studio Code #3286
+* CLI: stream remote-session activity to stdout while the REPL is blocked #3282
+* CLI: send screenshots from `studio code` to Telegram remote sessions #3272
+* Added Wapuu platformer easter egg #3270
+* Linux: trust root CA for HTTPS custom domains #3268
+* Linux: detect and launch third-party terminals #3278
+* Linux: don't default editor dropdown to VS Code when nothing is installed #3291
+* Enabled E2E tests on Linux #3295
+* Improved annotation submit workflow in `studio code` #3312
+* Silenced noisy ENOENT CLI log messages when daemon socket is absent #3322
+* Updated multiple dependencies, including WP Playground, PHP-WASM, and Electron
+
+1.8.1
+=====
+* Added Telegram remote-session bridge for studio code (PoC) #3196
+* Added /annotate skill with Studio inspector #3243
+* Added toolbar annotations to the site preview #3247
+* Removed Studio Code turn cap handling #3276
+* Switched Agent SDK to auto permission mode #3242
+* Flag HTML block misuse during validation #3267
+* Fixed AI CLI interrupt handling and immediate turn recovery #3263
+* Linux: support installing the Studio CLI #3269
+* Improved --format=json output when no sites are found #3220
+* Fixed WP-CLI post content parsing before porcelain flags #3264
+
 1.8.0
 =====
 * Added resizable sidebar #2853

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,14 +4,7 @@ Unreleased
 1.8.2
 =====
 * Fixed an issue where multiple CLI progress line showed up in Studio Code #3286
-* CLI: stream remote-session activity to stdout while the REPL is blocked #3282
-* CLI: send screenshots from `studio code` to Telegram remote sessions #3272
 * Added Wapuu platformer easter egg #3270
-* Linux: trust root CA for HTTPS custom domains #3268
-* Linux: detect and launch third-party terminals #3278
-* Linux: don't default editor dropdown to VS Code when nothing is installed #3291
-* Enabled E2E tests on Linux #3295
-* Improved annotation submit workflow in `studio code` #3312
 * Silenced noisy ENOENT CLI log messages when daemon socket is absent #3322
 * Updated multiple dependencies, including WP Playground, PHP-WASM, and Electron
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "wp-studio",
 	"author": "Automattic Inc.",
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"productName": "Studio CLI",
 	"description": "WordPress Studio CLI",
 	"license": "GPL-2.0-or-later",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -3,7 +3,7 @@
 	"author": "Automattic Inc.",
 	"private": true,
 	"productName": "Studio",
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"description": "Local WordPress development environment using Playgrounds",
 	"license": "GPL-2.0-or-later",
 	"main": "dist/main/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
 		},
 		"apps/cli": {
 			"name": "wp-studio",
-			"version": "1.8.1",
+			"version": "1.8.2",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -491,7 +491,7 @@
 		},
 		"apps/studio": {
 			"name": "studio-app",
-			"version": "1.8.1",
+			"version": "1.8.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@automattic/generate-password": "^0.1.0",


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- N/A

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

N/A

## Proposed Changes

I want to cut a new `wp-studio` release to npm. This PR does the following:

- Changes the `apps/cli` and `apps/studio` versions to 1.8.2. 
- Updates `RELEASE-NOTES.txt`. We hadn't added details for 1.8.1, so I included those, too (based on the [GitHub release](https://github.com/Automattic/studio/releases/tag/v1.8.1)).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review is sufficient

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
