### PR TITLE
apps/ui: auto-open site preview when the agent navigates

### DIFF
--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -3,15 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
-import {
-	useCallback,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-	useState,
-	type ReactNode,
-	type Ref,
-} from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, type ReactNode, type Ref } from 'react';
 import {
 	formatAnnotationsAsPrompt,
 	formatAnnotationsSubmittedMessage,
@@ -35,6 +27,8 @@ import {
 } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { useFullscreen } from '@/hooks/use-fullscreen';
+import { useSessionCommands } from '@/hooks/use-session-commands';
+import { SessionUIProvider, useSessionPreviewUI } from '@/hooks/use-session-ui';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
 import { drawerIcon } from '@/lib/icons';
 import styles from './style.module.css';
@@ -132,6 +126,14 @@ function SessionFrame( { header, composer, preview, scrollRef, children }: Sessi
 }
 
 export function SessionView( { sessionId }: { sessionId: string } ) {
+	return (
+		<SessionUIProvider>
+			<SessionViewContent sessionId={ sessionId } />
+		</SessionUIProvider>
+	);
+}
+
+function SessionViewContent( { sessionId }: { sessionId: string } ) {
 	const { data, isLoading, error } = useSession( sessionId );
 	const connector = useConnector();
 	const queryClient = useQueryClient();
@@ -192,9 +194,10 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 		[ data?.events ]
 	);
 	const scrollRef = useRef< HTMLDivElement >( null );
-	const [ previewOpen, setPreviewOpen ] = useState( false );
+	useSessionCommands( sessionId );
+	const preview = useSessionPreviewUI();
 	const canTogglePreview = !! ownerSite && effectiveEnvironment === 'local';
-	const showPreview = previewOpen && canTogglePreview;
+	const showPreview = preview.open && canTogglePreview;
 
 	const handleAnnotationsDone = useCallback(
 		( annotations: Annotation[] ) => {
@@ -253,7 +256,7 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 				<SessionHeader
 					summary={ data.summary }
 					previewOpen={ showPreview }
-					onTogglePreview={ () => setPreviewOpen( ( open ) => ! open ) }
+					onTogglePreview={ preview.toggle }
 					canTogglePreview={ canTogglePreview }
 				/>
 			}
@@ -278,7 +281,8 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 				showPreview && ownerSite ? (
 					<SitePreview
 						site={ ownerSite }
-						sessionId={ sessionId }
+						path={ preview.path }
+						reloadNonce={ preview.reloadNonce }
 						onAnnotationsDone={ handleAnnotationsDone }
 					/>
 				) : null

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -20,10 +20,13 @@ export type { Annotation } from './types';
 
 interface SitePreviewProps {
 	site: SiteDetails;
-	// When present, the preview subscribes to the agent event stream for this
-	// session and reacts to `preview.command` events emitted by the agent's
-	// preview_navigate / preview_reload tools.
-	sessionId?: string;
+	// Path to display within the previewed site, controlled by the parent so
+	// it can be updated by `preview.command` events even when the panel was
+	// previously collapsed.
+	path: string;
+	// Bumped by the parent to force a webview reload (e.g. on a `reload`
+	// preview command).
+	reloadNonce: number;
 	// Called when the user clicks "Submit" in the inspector toolbar. Receives
 	// the full annotation payload assembled inside the webview's guest page.
 	onAnnotationsDone?: ( annotations: Annotation[] ) => void;
@@ -54,15 +57,13 @@ const isElectron = (): boolean => {
 	return /\bElectron\//.test( navigator.userAgent );
 };
 
-export function SitePreview( { site, sessionId, onAnnotationsDone }: SitePreviewProps ) {
+export function SitePreview( { site, path, reloadNonce, onAnnotationsDone }: SitePreviewProps ) {
 	const connector = useConnector();
 	const startSite = useStartSite();
 	const isStarting = useIsSiteStarting( site.id );
 	const siteUrl = getSiteUrl( site );
 	const canPreview = site.running;
-	const [ currentPath, setCurrentPath ] = useState( '/' );
-	const [ reloadNonce, setReloadNonce ] = useState( 0 );
-	const fullUrl = `${ siteUrl }${ currentPath }`;
+	const fullUrl = `${ siteUrl }${ path }`;
 	const previewResize = useResizablePanel( {
 		config: PREVIEW_PANEL_CONFIG,
 		edge: 'left',
@@ -71,19 +72,6 @@ export function SitePreview( { site, sessionId, onAnnotationsDone }: SitePreview
 	const previewStyle = {
 		'--site-preview-width': `${ previewResize.width }px`,
 	} as CSSProperties;
-
-	useEffect( () => {
-		if ( ! sessionId ) return;
-		return connector.onAgentEvent( ( payload ) => {
-			if ( payload.sessionId !== sessionId ) return;
-			const event = payload.event;
-			if ( event.type !== 'preview.command' ) return;
-			if ( event.kind === 'navigate' ) {
-				setCurrentPath( event.path );
-			}
-			setReloadNonce( ( n ) => n + 1 );
-		} );
-	}, [ connector, sessionId ] );
 
 	return (
 		<aside className={ styles.root } style={ previewStyle } aria-label={ __( 'Site preview' ) }>

--- a/apps/ui/src/hooks/use-session-commands.ts
+++ b/apps/ui/src/hooks/use-session-commands.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useConnector } from '@/data/core';
+import { useSessionUIDispatch } from './use-session-ui';
+
+// Bridge from the chat event stream to SessionUI state. No state of its own —
+// purely the wiring that turns agent events into UI actions. Add a new
+// agent → UI behavior by handling its event type here and dispatching the
+// matching action defined in `use-session-ui`.
+export function useSessionCommands( sessionId: string ): void {
+	const connector = useConnector();
+	const dispatch = useSessionUIDispatch();
+
+	useEffect( () => {
+		return connector.onAgentEvent( ( payload ) => {
+			if ( payload.sessionId !== sessionId ) return;
+			const event = payload.event;
+			if ( event.type === 'preview.command' ) {
+				if ( event.kind === 'navigate' ) {
+					dispatch( { type: 'preview/navigate', path: event.path } );
+				} else if ( event.kind === 'reload' ) {
+					dispatch( { type: 'preview/reload' } );
+				}
+			}
+		} );
+	}, [ connector, sessionId, dispatch ] );
+}

--- a/apps/ui/src/hooks/use-session-ui.tsx
+++ b/apps/ui/src/hooks/use-session-ui.tsx
@@ -1,0 +1,128 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useReducer,
+	type Dispatch,
+	type ReactNode,
+} from 'react';
+
+// Session-scoped UI store. Holds the slices of UI state that the chat agent
+// can influence (preview panel today; future: composer, conversation pane,
+// modals, etc.) so that components can read/update them while a separate
+// bridge — `useSessionCommands` — translates agent events into actions.
+//
+// Add a new behavior by:
+//   1. Extending `SessionUIState` with the new slice.
+//   2. Adding action variants to `SessionUIAction` and reducer cases.
+//   3. Exposing a small consumer hook (like `useSessionPreviewUI`) for the UI.
+//   4. Wiring the agent event in `useSessionCommands` via `dispatch`.
+
+interface PreviewUIState {
+	open: boolean;
+	path: string;
+	reloadNonce: number;
+}
+
+export interface SessionUIState {
+	preview: PreviewUIState;
+}
+
+export type SessionUIAction =
+	| { type: 'preview/set-open'; value: boolean }
+	| { type: 'preview/toggle' }
+	| { type: 'preview/navigate'; path: string }
+	| { type: 'preview/reload' };
+
+const INITIAL_STATE: SessionUIState = {
+	preview: { open: false, path: '/', reloadNonce: 0 },
+};
+
+function reducer( state: SessionUIState, action: SessionUIAction ): SessionUIState {
+	switch ( action.type ) {
+		case 'preview/set-open':
+			return state.preview.open === action.value
+				? state
+				: { ...state, preview: { ...state.preview, open: action.value } };
+		case 'preview/toggle':
+			return { ...state, preview: { ...state.preview, open: ! state.preview.open } };
+		case 'preview/navigate':
+			return {
+				...state,
+				preview: {
+					...state.preview,
+					path: action.path,
+					reloadNonce: state.preview.reloadNonce + 1,
+					open: true,
+				},
+			};
+		case 'preview/reload':
+			return {
+				...state,
+				preview: {
+					...state.preview,
+					reloadNonce: state.preview.reloadNonce + 1,
+					open: true,
+				},
+			};
+	}
+}
+
+// Split contexts so that hooks which only need to dispatch (like
+// `useSessionCommands`) don't re-run on every state change.
+const SessionUIStateContext = createContext< SessionUIState | null >( null );
+const SessionUIDispatchContext = createContext< Dispatch< SessionUIAction > | null >( null );
+
+export function SessionUIProvider( { children }: { children: ReactNode } ) {
+	const [ state, dispatch ] = useReducer( reducer, INITIAL_STATE );
+	return (
+		<SessionUIDispatchContext.Provider value={ dispatch }>
+			<SessionUIStateContext.Provider value={ state }>{ children }</SessionUIStateContext.Provider>
+		</SessionUIDispatchContext.Provider>
+	);
+}
+
+function useSessionUIState(): SessionUIState {
+	const value = useContext( SessionUIStateContext );
+	if ( ! value ) {
+		throw new Error( 'useSessionUIState must be used within a SessionUIProvider' );
+	}
+	return value;
+}
+
+export function useSessionUIDispatch(): Dispatch< SessionUIAction > {
+	const value = useContext( SessionUIDispatchContext );
+	if ( ! value ) {
+		throw new Error( 'useSessionUIDispatch must be used within a SessionUIProvider' );
+	}
+	return value;
+}
+
+export interface SessionPreviewUI {
+	readonly open: boolean;
+	readonly path: string;
+	readonly reloadNonce: number;
+	setOpen: ( value: boolean ) => void;
+	toggle: () => void;
+}
+
+export function useSessionPreviewUI(): SessionPreviewUI {
+	const state = useSessionUIState();
+	const dispatch = useSessionUIDispatch();
+	const setOpen = useCallback(
+		( value: boolean ) => dispatch( { type: 'preview/set-open', value } ),
+		[ dispatch ]
+	);
+	const toggle = useCallback( () => dispatch( { type: 'preview/toggle' } ), [ dispatch ] );
+	return useMemo(
+		() => ( {
+			open: state.preview.open,
+			path: state.preview.path,
+			reloadNonce: state.preview.reloadNonce,
+			setOpen,
+			toggle,
+		} ),
+		[ state.preview.open, state.preview.path, state.preview.reloadNonce, setOpen, toggle ]
+	);
+}


### PR DESCRIPTION
## How AI was used in this PR

Built end-to-end with Claude Code in an exploratory back-and-forth: first a minimal fix (lift the agent-event subscription out of `SitePreview`), then an architectural pass to land a reusable shape for future *agent → UI* behaviors. Reviewers should sanity-check (a) that `useSessionCommands` is the only place agent events reach UI state, and (b) that the `SessionUIState` schema looks right as the place to grow new slices.

## Proposed Changes

When the agent calls `preview_navigate` / `preview_reload`, the site preview now auto-opens (it was previously dropped if the panel was collapsed) and lands at the requested path.

To get there, the wiring is reorganised into three small layers:

- `SessionUIProvider` + `useSessionPreviewUI` (`apps/ui/src/hooks/use-session-ui.tsx`) — session-scoped UI store backed by a typed reducer. `SessionUIState` is where future agent-driven UI slices plug in. State and dispatch contexts are split so dispatch-only consumers don't re-render on state changes.
- `useSessionCommands` (`apps/ui/src/hooks/use-session-commands.ts`) — a pure bridge: one subscription, no state of its own. Translates `preview.command` events into store actions. Adding a new agent → UI behavior is one `if (event.type === …) dispatch(…)` block.
- `SessionView` is now `<SessionUIProvider><SessionViewContent /></SessionUIProvider>`. `SitePreview` becomes a controlled view of `path` / `reloadNonce` and no longer subscribes to the agent stream itself.

The user-visible bug fix is the auto-open + correct-path behavior; the rest is the structure that makes the next such command (composer focus, modals, …) a one-slice extension.

## Testing Instructions

1. Start Studio with `npm start` and open a chat session whose owner site is local.
2. Collapse the site preview panel.
3. Ask the agent to navigate to a non-root path — e.g. *"open /wp-admin"*.
4. ✅ The preview panel should auto-open and load the requested path (not `/`).
5. Toggle the panel closed again and ask the agent to reload — it should re-open and reload.
6. Switch the session's environment to live (where `canTogglePreview` is false). Trigger a navigate from the agent. The store records the intent but the panel stays hidden; switching back to local opens it at the right path.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)