### PR TITLE
Build for Linux in Buildkite + EC2 + Docker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -165,7 +165,20 @@ steps:
         agents:
           queue: default
         command: |
-          .buildkite/commands/install-node-dependencies.sh
+          set -eu
+
+          # The container has no SSH keys / known_hosts, use anonymous HTTPS
+          git remote set-url origin https://github.com/Automattic/studio.git
+
+          apt-get -o Acquire::Retries=3 update
+          apt-get install -y --no-install-recommends fakeroot
+
+          # `--maxsockets 1` works around npm/cli#4652 (ECONNRESETs on Linux);
+          # see install-node-dependencies.sh for the original rationale.
+          # TODO: restore the Buildkite npm cache used on Mac/Windows. The
+          # toolkit's cache helpers live on the host, so wiring them around a
+          # Docker step needs extra plumbing or a persistent agent volume.
+          npm ci --unsafe-perm --no-audit --no-progress --maxsockets 1
 
           node ./scripts/prepare-dev-build-version.mjs
 
@@ -175,7 +188,16 @@ steps:
           npm run make:linux-{{matrix}}
         artifact_paths:
           - apps/studio/out/make/deb/**/*.deb
-        plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
+        plugins:
+          # Amazon Linux on the `default` queue lacks `dpkg`/`fakeroot`
+          # required by electron-forge's MakerDeb, so we build inside a
+          # Debian container that has them. Image tag is derived from
+          # `.nvmrc` (see shared-pipeline-vars) so Linux drifts in lockstep
+          # with the Mac/Windows agents (which install Node via NVM).
+          - $DOCKER_PLUGIN:
+              image: "$NODE_DOCKER_IMAGE"
+              propagate-environment: true
+              mount-buildkite-agent: true
         matrix:
           - x64
           - arm64

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -7,7 +7,11 @@
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
 CI_TOOLKIT_VERSION='6.1.0'
 NVM_PLUGIN_VERSION='0.6.0'
+DOCKER_PLUGIN_VERSION='v5.13.0'
+NODE_VERSION=$(sed 's/^v//' .nvmrc)
 
 export IMAGE_ID="$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_VERSION"
 export NVM_PLUGIN="automattic/nvm#$NVM_PLUGIN_VERSION"
+export DOCKER_PLUGIN="docker#$DOCKER_PLUGIN_VERSION"
+export NODE_DOCKER_IMAGE="node:${NODE_VERSION}-bookworm"


### PR DESCRIPTION
AINFRA-2352

## Related issues

- Related to [RSM-1314](https://linear.app/a8c/issue/RSM-1314) — Linux release prep
- Builds on top of #3326 (`make:linux-x64`/`make:linux-arm64` scripts)

## How AI was used in this PR

AI-assisted throughout. Claude inspected the existing `.buildkite/pipeline.yml`, surveyed the `buildkite-ci` Terraform repo to map available queues, and cross-referenced pipelines in other projects to identify the right pattern. A self-review pass added the Linux ECONNRESET workaround, dynamic Node image derivation from `.nvmrc`, and the shell/apt hardening below.

## Proposed Changes

Adds a \`📦 Build for Linux\` group to \`.buildkite/pipeline.yml\`, mirroring the existing Mac and Windows groups: input gate (skipped on \`trunk\` and tagged release builds), group dependency on the input, and a 2-arch matrix (\`x64\`, \`arm64\`) that runs \`npm run make:linux-{{matrix}}\` and uploads the resulting \`.deb\`.

- **Build runs inside a Node Docker container.** Amazon Linux is RPM-based; \`dpkg\` isn't in its default repos and \`fakeroot\` is only available via EPEL. Both are hard prerequisites of \`electron-forge\`'s \`MakerDeb\`. Wrapping the step in a Debian container — using the Buildkite Docker plugin, an established A8C pattern — sidesteps the AMI mismatch cleanly.

- **Image is derived from \`.nvmrc\`.** \`shared-pipeline-vars\` reads \`.nvmrc\` and exports \`NODE_DOCKER_IMAGE=\"node:\${VERSION}-bookworm\"\`, which \`pipeline.yml\` references as \`\$NODE_DOCKER_IMAGE\`. Bumping \`.nvmrc\` moves the Linux container in lockstep with the NVM-installed Node on Mac/Windows agents, so \`\$NVM_PLUGIN\` isn't needed on this step.

- **\`git remote set-url origin https://...\` inside the container.** The host buildkite-agent clones over SSH and \`prepare-dev-build-version.mjs\` calls \`git fetch --tags --force\`. The container has no \`~/.ssh/known_hosts\` or deploy key, so SSH hangs on the host-key prompt. Studio is a public repo, so swapping to anonymous HTTPS for the in-container fetch is the simplest fix and avoids exposing the agent's deploy key inside the container.

- **Inline shell hardening.** \`set -euo pipefail\` at the top of the command; \`apt-get -o Acquire::Retries=3 update\` to ride out flaky Debian mirrors; \`npm ci --maxsockets 1\` to avoid the npm/cli#4652 ECONNRESETs that \`install-node-dependencies.sh\` already documents on Linux.

- Adds \`DOCKER_PLUGIN=\"docker#5.13.0\"\` and \`NODE_DOCKER_IMAGE\` to \`.buildkite/shared-pipeline-vars\`.

### Known follow-up

The Linux step currently does not restore the Buildkite npm cache that \`install-node-dependencies.sh\` provides on Mac/Windows. The toolkit's cache helpers run on the host, so wiring them around a Docker step needs either two pipeline steps (host install → container build) or a persistent host volume mounted into the container — both larger than the scope here. Tracked as a TODO in \`pipeline.yml\`.

## Testing Instructions

1. Open this PR (or rebuild on Buildkite if a build already exists).
2. Confirm the \`🚦 Build for Linux?\` input step appears alongside the existing Mac/Windows input gates.
3. Click \"yes\" — the matrix should fan out to two jobs: \`🔨 Linux Dev Build - x64\` and \`🔨 Linux Dev Build - arm64\`.
4. Both should pick up an agent on the \`default\` queue, pull the \`node:<.nvmrc>-bookworm\` image, install \`fakeroot\`, run \`npm ci\`, and produce a \`.deb\` artifact:
   - \`apps/studio/out/make/deb/x64/studio_<version>_amd64.deb\`
   - \`apps/studio/out/make/deb/arm64/studio_<version>_arm64.deb\`
5. Download each artifact and run \`dpkg-deb -I <file>\` to confirm metadata, and \`dpkg-deb -x <file> /tmp/extracted && file /tmp/extracted/opt/Studio/studio\` to confirm the binary architecture matches.

Note: \`Distribute Dev Builds\` (\`.buildkite/pipeline.yml:205\`) is intentionally not yet wired to depend on the Linux group — Linux distribution via Fastlane is out of scope for this PR. The \`.deb\` artifacts are reachable directly from the Buildkite build page.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Linux x64 dev build succeeds end-to-end on Buildkite.
- [ ] Linux arm64 dev build succeeds end-to-end on Buildkite.
- [ ] Resulting \`.deb\` files install cleanly on a target Debian/Ubuntu system (smoke test).