### PR TITLE
Studio Code: detach remote-session by default and add `attach` subcommand

### DIFF
--- a/apps/cli/commands/ai/remote-session.ts
+++ b/apps/cli/commands/ai/remote-session.ts
@@ -1,5 +1,6 @@
 import { getRemoteSessionLogPath } from '@studio/common/lib/well-known-paths';
 import { __, sprintf } from '@wordpress/i18n';
+import { DaemonNotRunningError, runAttach } from 'cli/remote-session/attach';
 import { loadRemoteSessionConfig } from 'cli/remote-session/config';
 import {
 	DaemonAlreadyRunningError,
@@ -51,7 +52,9 @@ async function runStart( argv: StartArgs ): Promise< void > {
 			process.stdout.write(
 				sprintf(
 					/* translators: 1: PID, 2: log file path */
-					__( 'Remote-session daemon started (PID %1$d). Logs: %2$s\n' ),
+					__(
+						'Remote-session daemon started (PID %1$d). Logs: %2$s\nRun `studio code remote-session attach` to follow them.\n'
+					),
 					result.pid,
 					getRemoteSessionLogPath()
 				)
@@ -156,6 +159,33 @@ async function runStop(): Promise< void > {
 	);
 }
 
+async function runAttachCommand(): Promise< void > {
+	const controller = new AbortController();
+	const onSignal = () => controller.abort();
+	process.on( 'SIGINT', onSignal );
+	process.on( 'SIGTERM', onSignal );
+	try {
+		await runAttach( { signal: controller.signal } );
+		if ( controller.signal.aborted ) {
+			process.stdout.write( __( 'Detached. Daemon is still running.\n' ) );
+		}
+	} catch ( error ) {
+		if ( error instanceof DaemonNotRunningError ) {
+			process.stderr.write(
+				__(
+					'Remote-session daemon is not running. Start it with `studio code remote-session start`.\n'
+				)
+			);
+			process.exitCode = 1;
+			return;
+		}
+		throw error;
+	} finally {
+		process.off( 'SIGINT', onSignal );
+		process.off( 'SIGTERM', onSignal );
+	}
+}
+
 export const registerRemoteSessionCommand = ( yargs: StudioArgv ) => {
 	return yargs.command(
 		'remote-session',
@@ -163,13 +193,17 @@ export const registerRemoteSessionCommand = ( yargs: StudioArgv ) => {
 		( remoteYargs ) => {
 			remoteYargs.command( {
 				command: 'start',
-				describe: __( 'Start the remote-session bridge (foreground or detached)' ),
+				describe: __(
+					'Start the remote-session bridge as a background daemon (use --no-detach to run in the foreground)'
+				),
 				builder: ( startYargs ) =>
 					startYargs
 						.option( 'detach', {
 							type: 'boolean',
-							default: false,
-							description: __( 'Run as a background daemon and return immediately' ),
+							default: true,
+							description: __(
+								'Run as a background daemon and return immediately (default). Use --no-detach to run attached in the foreground.'
+							),
 						} )
 						.option( 'remote-chat-id', {
 							type: 'number',
@@ -192,6 +226,13 @@ export const registerRemoteSessionCommand = ( yargs: StudioArgv ) => {
 				command: 'status',
 				describe: __( 'Show the remote-session daemon status' ),
 				handler: runStatus,
+			} );
+			remoteYargs.command( {
+				command: 'attach',
+				describe: __(
+					'Attach to a running remote-session daemon and stream its logs (Ctrl-C detaches)'
+				),
+				handler: runAttachCommand,
 			} );
 			remoteYargs
 				.version( false )

--- a/apps/cli/remote-session/attach.ts
+++ b/apps/cli/remote-session/attach.ts
@@ -1,0 +1,180 @@
+import fs from 'fs';
+import {
+	getRemoteSessionLogPath,
+	getRemoteSessionPidPath,
+} from '@studio/common/lib/well-known-paths';
+import { getDaemonStatus } from 'cli/remote-session/daemon';
+import { formatLogLineForStdout } from 'cli/remote-session/logger';
+
+const POLL_INTERVAL_MS = 250;
+const DAEMON_LIVENESS_INTERVAL_MS = 1000;
+/** Bytes of log history to replay on attach (tail-style). */
+const INITIAL_TAIL_BYTES = 16 * 1024;
+
+export class DaemonNotRunningError extends Error {
+	constructor() {
+		super( 'Remote-session daemon is not running.' );
+		this.name = 'DaemonNotRunningError';
+	}
+}
+
+export interface AttachOptions {
+	pidFile?: string;
+	logFile?: string;
+	out?: NodeJS.WritableStream;
+	signal?: AbortSignal;
+	pollIntervalMs?: number;
+	livenessIntervalMs?: number;
+	initialTailBytes?: number;
+}
+
+interface ReaderState {
+	offset: number;
+	carry: string;
+}
+
+function readNew( logFile: string, state: ReaderState ): string[] {
+	let stat: fs.Stats;
+	try {
+		stat = fs.statSync( logFile );
+	} catch {
+		return [];
+	}
+	const size = stat.size;
+	if ( size === state.offset ) {
+		return [];
+	}
+	if ( size < state.offset ) {
+		// File rotated or truncated.
+		state.offset = 0;
+		state.carry = '';
+	}
+	const fd = fs.openSync( logFile, 'r' );
+	try {
+		const length = size - state.offset;
+		const buf = Buffer.alloc( length );
+		fs.readSync( fd, buf, 0, length, state.offset );
+		state.offset = size;
+		const text = state.carry + buf.toString( 'utf8' );
+		const lastNl = text.lastIndexOf( '\n' );
+		if ( lastNl === -1 ) {
+			state.carry = text;
+			return [];
+		}
+		state.carry = text.slice( lastNl + 1 );
+		return text
+			.slice( 0, lastNl )
+			.split( '\n' )
+			.filter( ( line ) => line.length > 0 );
+	} finally {
+		fs.closeSync( fd );
+	}
+}
+
+function seekTail( logFile: string, tailBytes: number ): ReaderState {
+	let stat: fs.Stats;
+	try {
+		stat = fs.statSync( logFile );
+	} catch {
+		return { offset: 0, carry: '' };
+	}
+	if ( stat.size <= tailBytes ) {
+		return { offset: 0, carry: '' };
+	}
+	// Skip past the first partial line so we don't print a truncated entry.
+	const fd = fs.openSync( logFile, 'r' );
+	try {
+		const start = stat.size - tailBytes;
+		const buf = Buffer.alloc( tailBytes );
+		fs.readSync( fd, buf, 0, tailBytes, start );
+		const firstNl = buf.indexOf( 0x0a );
+		const safeStart = firstNl === -1 ? stat.size : start + firstNl + 1;
+		return { offset: safeStart, carry: '' };
+	} finally {
+		fs.closeSync( fd );
+	}
+}
+
+function isProcessAlive( pid: number ): boolean {
+	try {
+		process.kill( pid, 0 );
+		return true;
+	} catch ( error ) {
+		const code = ( error as NodeJS.ErrnoException ).code;
+		return code === 'EPERM';
+	}
+}
+
+/**
+ * Attach to a running remote-session daemon by streaming its log file to stdout.
+ * Returns when the abort signal fires (Ctrl-C) or when the daemon process exits.
+ * Does not stop the daemon — detaching the terminal is the only side effect.
+ */
+export async function runAttach( options: AttachOptions = {} ): Promise< void > {
+	const pidFile = options.pidFile ?? getRemoteSessionPidPath();
+	const logFile = options.logFile ?? getRemoteSessionLogPath();
+	const out = options.out ?? process.stdout;
+	const pollMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+	const livenessMs = options.livenessIntervalMs ?? DAEMON_LIVENESS_INTERVAL_MS;
+	const tailBytes = options.initialTailBytes ?? INITIAL_TAIL_BYTES;
+
+	const status = getDaemonStatus( pidFile );
+	if ( ! status.running || status.pid === undefined ) {
+		throw new DaemonNotRunningError();
+	}
+	const daemonPid = status.pid;
+
+	out.write( `Attached to remote-session daemon (PID ${ daemonPid }).\n` );
+	out.write( `Log: ${ logFile }\n` );
+	out.write( 'Press Ctrl-C to detach (daemon keeps running).\n' );
+
+	const state = seekTail( logFile, tailBytes );
+	// Drain whatever is already past the tail anchor before entering the loop.
+	for ( const line of readNew( logFile, state ) ) {
+		out.write( formatLogLineForStdout( line ) );
+	}
+
+	let lastLiveness = Date.now();
+	while ( true ) {
+		if ( options.signal?.aborted ) {
+			return;
+		}
+		await sleepAbortable( pollMs, options.signal );
+		if ( options.signal?.aborted ) {
+			return;
+		}
+		for ( const line of readNew( logFile, state ) ) {
+			out.write( formatLogLineForStdout( line ) );
+		}
+		const now = Date.now();
+		if ( now - lastLiveness >= livenessMs ) {
+			lastLiveness = now;
+			if ( ! isProcessAlive( daemonPid ) ) {
+				// Final drain before reporting exit.
+				for ( const line of readNew( logFile, state ) ) {
+					out.write( formatLogLineForStdout( line ) );
+				}
+				out.write( `Remote-session daemon (PID ${ daemonPid }) exited.\n` );
+				return;
+			}
+		}
+	}
+}
+
+function sleepAbortable( ms: number, signal?: AbortSignal ): Promise< void > {
+	return new Promise( ( resolve ) => {
+		if ( signal?.aborted ) {
+			resolve();
+			return;
+		}
+		const timer = setTimeout( () => {
+			signal?.removeEventListener( 'abort', onAbort );
+			resolve();
+		}, ms );
+		const onAbort = () => {
+			clearTimeout( timer );
+			resolve();
+		};
+		signal?.addEventListener( 'abort', onAbort, { once: true } );
+	} );
+}

--- a/apps/cli/remote-session/daemon.ts
+++ b/apps/cli/remote-session/daemon.ts
@@ -211,7 +211,17 @@ export async function startDaemon(
 		throw new Error( 'Cannot launch remote-session daemon: process.argv[1] is empty.' );
 	}
 
-	const args = [ cliEntry, 'code', 'remote-session', 'start', ...( options.extraArgs ?? [] ) ];
+	// `--no-detach` pins the child to foreground mode. Without it, the child
+	// would re-read the now-default `--detach=true` and try to spawn its own
+	// grandchild instead of running runRemoteSession + writing the PID file.
+	const args = [
+		cliEntry,
+		'code',
+		'remote-session',
+		'start',
+		'--no-detach',
+		...( options.extraArgs ?? [] ),
+	];
 	const env = {
 		...process.env,
 		...options.env,

--- a/apps/cli/remote-session/logger.ts
+++ b/apps/cli/remote-session/logger.ts
@@ -124,6 +124,47 @@ function formatStdoutLine(
 	return `${ head } ${ safeMeta }\n`;
 }
 
+interface PersistedLogLine {
+	t?: unknown;
+	level?: unknown;
+	msg?: unknown;
+	meta?: unknown;
+}
+
+/**
+ * Reformat one JSON log line (as written by RemoteSessionLogger) into the same
+ * human-readable shape used when mirroring to stdout. Falls back to the raw
+ * line (sanitized + newline-terminated) when parsing fails.
+ */
+export function formatLogLineForStdout( rawLine: string ): string {
+	const trimmed = rawLine.replace( /\r?\n$/, '' );
+	if ( trimmed.length === 0 ) {
+		return '\n';
+	}
+	let parsed: PersistedLogLine;
+	try {
+		parsed = JSON.parse( trimmed ) as PersistedLogLine;
+	} catch {
+		return `${ stripTerminalControls( trimmed ) }\n`;
+	}
+	const level = isLogLevel( parsed.level ) ? parsed.level : 'info';
+	const message = typeof parsed.msg === 'string' ? parsed.msg : '';
+	const time =
+		typeof parsed.t === 'string' && parsed.t.length >= 19
+			? parsed.t.slice( 11, 19 )
+			: new Date().toTimeString().slice( 0, 8 );
+	const head = `[${ time }] ${ level } ${ safeForStdout( message ) }`;
+	if ( parsed.meta && typeof parsed.meta === 'object' ) {
+		const safeMeta = safeForStdout( JSON.stringify( parsed.meta ) );
+		return `${ head } ${ safeMeta }\n`;
+	}
+	return `${ head }\n`;
+}
+
+function isLogLevel( value: unknown ): value is LogLevel {
+	return value === 'debug' || value === 'info' || value === 'warn' || value === 'error';
+}
+
 export class RemoteSessionLogger {
 	private logPath: string;
 	private mirrorToStdout: boolean;

--- a/apps/cli/remote-session/tests/attach.test.ts
+++ b/apps/cli/remote-session/tests/attach.test.ts
@@ -1,0 +1,199 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Writable } from 'stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DaemonNotRunningError, runAttach } from 'cli/remote-session/attach';
+
+class StringSink extends Writable {
+	chunks: string[] = [];
+	_write(
+		chunk: Buffer | string,
+		_encoding: BufferEncoding,
+		callback: ( error?: Error | null ) => void
+	) {
+		this.chunks.push( typeof chunk === 'string' ? chunk : chunk.toString( 'utf8' ) );
+		callback();
+	}
+	get text(): string {
+		return this.chunks.join( '' );
+	}
+}
+
+function jsonLine( msg: string, meta?: Record< string, unknown > ): string {
+	const entry: Record< string, unknown > = {
+		t: '2026-05-05T12:34:56.000Z',
+		level: 'info',
+		msg,
+	};
+	if ( meta ) {
+		entry.meta = meta;
+	}
+	return JSON.stringify( entry ) + '\n';
+}
+
+describe( 'remote-session attach', () => {
+	let tmpDir: string;
+	let pidFile: string;
+	let logFile: string;
+
+	beforeEach( () => {
+		tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-remote-attach-' ) );
+		pidFile = path.join( tmpDir, 'remote-session.pid' );
+		logFile = path.join( tmpDir, 'remote-session.log' );
+	} );
+
+	afterEach( () => {
+		fs.rmSync( tmpDir, { recursive: true, force: true } );
+	} );
+
+	async function reapedPid(): Promise< number > {
+		const child = spawn( process.execPath, [ '-e', 'process.exit(0)' ], { stdio: 'ignore' } );
+		const pid = child.pid;
+		if ( typeof pid !== 'number' ) {
+			throw new Error( 'Could not allocate a PID for the dead-process fixture' );
+		}
+		await new Promise< void >( ( resolve ) => child.once( 'exit', () => resolve() ) );
+		return pid;
+	}
+
+	it( 'throws DaemonNotRunningError when no PID file exists', async () => {
+		await expect( runAttach( { pidFile, logFile, out: new StringSink() } ) ).rejects.toBeInstanceOf(
+			DaemonNotRunningError
+		);
+	} );
+
+	it( 'throws DaemonNotRunningError when the PID file points to a dead process', async () => {
+		const dead = await reapedPid();
+		fs.writeFileSync( pidFile, `${ dead }\n`, 'utf8' );
+		await expect( runAttach( { pidFile, logFile, out: new StringSink() } ) ).rejects.toBeInstanceOf(
+			DaemonNotRunningError
+		);
+	} );
+
+	it( 'streams new log lines until the abort signal fires', async () => {
+		fs.writeFileSync( pidFile, `${ process.pid }\n`, 'utf8' );
+		fs.writeFileSync( logFile, '', 'utf8' );
+
+		const out = new StringSink();
+		const controller = new AbortController();
+		const promise = runAttach( {
+			pidFile,
+			logFile,
+			out,
+			signal: controller.signal,
+			pollIntervalMs: 20,
+			livenessIntervalMs: 10_000,
+			initialTailBytes: 0,
+		} );
+
+		// Append two log lines after the watcher is ticking.
+		await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+		fs.appendFileSync( logFile, jsonLine( 'first line' ), 'utf8' );
+		await new Promise( ( resolve ) => setTimeout( resolve, 80 ) );
+		fs.appendFileSync( logFile, jsonLine( 'second line', { foo: 'bar' } ), 'utf8' );
+		await new Promise( ( resolve ) => setTimeout( resolve, 80 ) );
+
+		controller.abort();
+		await promise;
+
+		expect( out.text ).toContain( 'first line' );
+		expect( out.text ).toContain( 'second line' );
+		expect( out.text ).toContain( '"foo":"bar"' );
+		expect( out.text ).toContain( `Attached to remote-session daemon (PID ${ process.pid })` );
+	} );
+
+	it( 'replays the tail of an existing log on attach', async () => {
+		fs.writeFileSync( pidFile, `${ process.pid }\n`, 'utf8' );
+		fs.writeFileSync( logFile, jsonLine( 'historical entry' ), 'utf8' );
+
+		const out = new StringSink();
+		const controller = new AbortController();
+		const promise = runAttach( {
+			pidFile,
+			logFile,
+			out,
+			signal: controller.signal,
+			pollIntervalMs: 20,
+			livenessIntervalMs: 10_000,
+		} );
+		await new Promise( ( resolve ) => setTimeout( resolve, 60 ) );
+		controller.abort();
+		await promise;
+
+		expect( out.text ).toContain( 'historical entry' );
+	} );
+
+	it( 'reports daemon exit when the daemon process dies', async () => {
+		// Spawn a real long-running child so we can kill it mid-attach.
+		const itPosix = process.platform === 'win32';
+		if ( itPosix ) {
+			return;
+		}
+		const child = spawn( process.execPath, [ '-e', 'setInterval(() => {}, 60000);' ], {
+			detached: true,
+			stdio: 'ignore',
+		} );
+		child.unref();
+		const childPid = child.pid;
+		if ( typeof childPid !== 'number' ) {
+			throw new Error( 'Could not spawn long-runner' );
+		}
+		fs.writeFileSync( pidFile, `${ childPid }\n`, 'utf8' );
+		fs.writeFileSync( logFile, '', 'utf8' );
+
+		const out = new StringSink();
+		const promise = runAttach( {
+			pidFile,
+			logFile,
+			out,
+			pollIntervalMs: 20,
+			livenessIntervalMs: 30,
+			initialTailBytes: 0,
+		} );
+
+		// Let attach establish, then kill the child and wait for the loop to notice.
+		await new Promise( ( resolve ) => setTimeout( resolve, 60 ) );
+		try {
+			process.kill( childPid, 'SIGKILL' );
+		} catch {
+			// already dead
+		}
+		await promise;
+
+		expect( out.text ).toContain( `Remote-session daemon (PID ${ childPid }) exited` );
+	}, 5000 );
+
+	it( 'recovers from log rotation (size shrinks)', async () => {
+		fs.writeFileSync( pidFile, `${ process.pid }\n`, 'utf8' );
+		// Pre-fill with several long entries so the file is larger than the
+		// post-rotation file we'll write later.
+		const preLines = Array.from( { length: 20 }, ( _, i ) =>
+			jsonLine( `pre-rotation-${ i }`, { padding: 'x'.repeat( 200 ) } )
+		).join( '' );
+		fs.writeFileSync( logFile, preLines, 'utf8' );
+
+		const out = new StringSink();
+		const controller = new AbortController();
+		const promise = runAttach( {
+			pidFile,
+			logFile,
+			out,
+			signal: controller.signal,
+			pollIntervalMs: 20,
+			livenessIntervalMs: 10_000,
+			initialTailBytes: 0,
+		} );
+
+		await new Promise( ( resolve ) => setTimeout( resolve, 60 ) );
+		// Simulate rotation: truncate and write fresh, much shorter content so
+		// size drops below the watcher's offset.
+		fs.writeFileSync( logFile, jsonLine( 'post-rotation' ), 'utf8' );
+		await new Promise( ( resolve ) => setTimeout( resolve, 80 ) );
+		controller.abort();
+		await promise;
+
+		expect( out.text ).toContain( 'post-rotation' );
+	} );
+} );

--- a/apps/cli/remote-session/tests/daemon.test.ts
+++ b/apps/cli/remote-session/tests/daemon.test.ts
@@ -165,6 +165,41 @@ describe( 'remote-session daemon helpers', () => {
 		} );
 
 		itPosix(
+			'startDaemon spawns the child with --no-detach so it runs in foreground mode',
+			async () => {
+				// Write a fake CLI entry that records its argv, then writes the
+				// PID file so startDaemon resolves cleanly.
+				const argvFile = path.join( tmpDir, 'argv.json' );
+				const fakeEntry = path.join( tmpDir, 'argv-recorder.cjs' );
+				fs.writeFileSync(
+					fakeEntry,
+					`const fs = require('fs');
+fs.writeFileSync(${ JSON.stringify( argvFile ) }, JSON.stringify(process.argv));
+fs.writeFileSync(${ JSON.stringify( pidFile ) }, String(process.pid) + '\\n', { mode: 0o600 });
+setInterval(() => {}, 60000);
+`,
+					'utf8'
+				);
+				try {
+					const result = await startDaemon( { cliEntry: fakeEntry, pidFileWaitMs: 5000 }, pidFile );
+					const argv = JSON.parse( fs.readFileSync( argvFile, 'utf8' ) ) as string[];
+					expect( argv ).toContain( '--no-detach' );
+					expect( argv ).toContain( 'remote-session' );
+					expect( argv ).toContain( 'start' );
+					// Cleanup the long-runner.
+					try {
+						process.kill( result.pid, 'SIGKILL' );
+					} catch {
+						// ignore
+					}
+				} finally {
+					fs.rmSync( pidFile, { force: true } );
+				}
+			},
+			15000
+		);
+
+		itPosix(
 			'startDaemon raises DaemonStartTimeoutError when the child never writes the PID file',
 			async () => {
 				// Spawn a child that exits immediately — it never has a chance to write the PID file.


### PR DESCRIPTION
## Related issues

- Fixes STU-1681

## How AI was used in this PR

Implementation written by Claude under direction. I reviewed the diff and verified behavior end-to-end against a live daemon (attach connects, formats logs, detaches on Ctrl-C without killing the daemon). Test design and edge cases (rotation, dead-PID, daemon-exit detection) were iterated on with the assistant.

## Proposed Changes

- Flip `studio code remote-session start` default from foreground to detached. The new behavior is "background daemon" by default; pass `--no-detach` to keep running attached in the foreground (same code path as before).
- Add `studio code remote-session attach`: connects to a running daemon, replays a 16 KB tail of `~/.studio/remote-session.log`, then streams new entries in the same human-readable format used when running foreground. Errors with exit 1 if no daemon is running. Ctrl-C / SIGTERM detach the terminal without stopping the daemon. Recovers from log rotation (size shrinks → reset offset) and reports daemon exit when the PID stops being live.
- Export `formatLogLineForStdout()` from `remote-session/logger.ts` so attach can reuse the existing JSON-to-human formatter and stay consistent with foreground output.

## Testing Instructions

CLI:

1. `npm run cli:build`
2. `STUDIO_REMOTE_SESSION_ENABLED=1 node apps/cli/dist/cli/main.mjs code remote-session start` — should print `Remote-session daemon started (PID …)` and return immediately.
3. `studio code remote-session status` — confirms the daemon is running.
4. `studio code remote-session attach` — should print the attach banner, replay the last bit of log, and stream new entries live. Press Ctrl-C: should print `Detached. Daemon is still running.`
5. `studio code remote-session status` — daemon should still be running after detaching.
6. `studio code remote-session stop` — terminates the daemon. Re-running `attach` should now error with `Remote-session daemon is not running.`
7. Foreground path: `studio code remote-session start --no-detach` — should still run attached and print activity to stdout as before.

Tests:

- `npm test -- apps/cli/remote-session/tests apps/cli/commands/ai/tests` (150 passing)
- `npm run typecheck`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?