### PR TITLE
CLI: add eval-runner result diagnostics

### DIFF
--- a/apps/cli/ai/eval-runner.ts
+++ b/apps/cli/ai/eval-runner.ts
@@ -79,6 +79,33 @@ type FirstToolError = {
 	turnIndex: number;
 };
 
+type TranscriptEvent = {
+	index: number;
+	type: SDKMessage[ 'type' ];
+	turnIndex: number;
+	elapsedMs: number;
+	text?: string[];
+	toolCalls?: ToolCallRecord[];
+	toolResult?: {
+		toolUseId: string | null;
+		toolName: string | null;
+		isError: boolean;
+		text?: string;
+	};
+	stopReason?: string | null;
+	result?: string;
+	subtype?: string;
+	isError?: boolean;
+	errors?: string[];
+	numTurns?: number;
+};
+
+function truncateText( value: string, maxLength = 4000 ): string {
+	return value.length > maxLength
+		? `${ value.slice( 0, maxLength ) }…[truncated ${ value.length - maxLength } chars]`
+		: value;
+}
+
 function extractTextSegments( message: SDKMessage ): string[] {
 	if ( message.type !== 'assistant' ) {
 		return [];
@@ -176,6 +203,8 @@ async function runEval( input: EvalRunnerInput ) {
 	}[] = [];
 	const toolEvents: ToolEvent[] = [];
 	const textSegments: string[] = [];
+	const transcript: TranscriptEvent[] = [];
+	const includeTranscript = process.env.STUDIO_EVAL_INCLUDE_TRANSCRIPT === '1';
 	const toolNameById = new Map< string, string >();
 	const toolEventById = new Map< string, ToolEvent >();
 	let firstToolError: FirstToolError | null = null;
@@ -186,6 +215,12 @@ async function runEval( input: EvalRunnerInput ) {
 	let success = false;
 	let error: string | null = null;
 	let timedOut = false;
+	let resultStopReason: string | null = null;
+	let resultText = '';
+	let resultSubtype: string | null = null;
+	let resultIsError = false;
+	let resultErrors: string[] = [];
+	let messageIndex = 0;
 
 	phaseStartedAt = Date.now();
 	const query = startAiAgent( {
@@ -205,45 +240,68 @@ async function runEval( input: EvalRunnerInput ) {
 
 	try {
 		for await ( const message of query ) {
+			messageIndex += 1;
+			const event: TranscriptEvent = {
+				index: messageIndex,
+				type: message.type,
+				turnIndex,
+				elapsedMs: elapsed(),
+			};
 			if ( message.type === 'assistant' ) {
 				const now = Date.now();
 				turnDurationsMs.push( now - turnStart );
 				turnIndex += 1;
+				event.turnIndex = turnIndex;
 				if ( turnIndex === 1 ) {
 					phaseTimingsMs.first_assistant_message_ms = now - queryStartedAt;
 				}
 				turnStart = now;
+				event.stopReason = message.message.stop_reason ?? null;
 			}
-			for ( const tc of extractToolCalls( message ) ) {
+			const messageToolCalls = extractToolCalls( message );
+			if ( messageToolCalls.length ) {
+				event.toolCalls = messageToolCalls;
+			}
+			for ( const tc of messageToolCalls ) {
 				toolCalls.push( tc );
 				toolNameById.set( tc.id, tc.name );
-				const event: ToolEvent = {
+				const toolEvent: ToolEvent = {
 					toolUseId: tc.id,
 					toolName: tc.name,
 					input: tc.input,
 					startedAtMs: elapsed(),
 					turnIndex,
 				};
-				toolEvents.push( event );
-				toolEventById.set( tc.id, event );
+				toolEvents.push( toolEvent );
+				toolEventById.set( tc.id, toolEvent );
 			}
-			textSegments.push( ...extractTextSegments( message ) );
+			const messageTextSegments = extractTextSegments( message );
+			if ( messageTextSegments.length ) {
+				event.text = messageTextSegments.map( ( text ) => truncateText( text ) );
+			}
+			textSegments.push( ...messageTextSegments );
 
 			if ( message.type === 'user' ) {
 				const tr = extractToolResult( message );
 				if ( tr ) {
 					const id = tr.toolUseId ?? message.parent_tool_use_id ?? null;
-					const event = id ? toolEventById.get( id ) : undefined;
-					if ( event ) {
-						event.endedAtMs = elapsed();
-						event.durationMs = event.endedAtMs - event.startedAtMs;
-						event.isError = tr.isError;
+					const toolEvent = id ? toolEventById.get( id ) : undefined;
+					if ( toolEvent ) {
+						toolEvent.endedAtMs = elapsed();
+						toolEvent.durationMs = toolEvent.endedAtMs - toolEvent.startedAtMs;
+						toolEvent.isError = tr.isError;
 					}
+					event.toolResult = {
+						toolUseId: id,
+						toolName: id ? toolNameById.get( id ) ?? null : null,
+						isError: tr.isError,
+						...( tr.text ? { text: truncateText( tr.text ) } : {} ),
+					};
 					if ( tr.isError && ! firstToolError ) {
 						firstToolError = {
 							toolUseId: id,
 							toolName: id ? toolNameById.get( id ) ?? null : null,
-							...( event?.input ? { input: event.input } : {} ),
+							...( toolEvent?.input ? { input: toolEvent.input } : {} ),
 							error: tr.text ?? 'Tool returned an error result.',
 							turnIndex,
 						};
@@ -260,6 +318,22 @@ async function runEval( input: EvalRunnerInput ) {
 			if ( message.type === 'result' ) {
 				success = message.subtype === 'success';
 				numTurns = message.num_turns ?? null;
+				resultStopReason = message.stop_reason ?? null;
+				resultText = message.result ?? '';
+				resultSubtype = message.subtype ?? null;
+				resultIsError = message.is_error === true;
+				resultErrors = Array.isArray( message.errors ) ? message.errors : [];
+				event.subtype = message.subtype;
+				event.isError = message.is_error;
+				event.stopReason = message.stop_reason ?? null;
+				event.result = truncateText( message.result ?? '' );
+				event.numTurns = message.num_turns;
+				if ( resultErrors.length ) {
+					event.errors = resultErrors;
+				}
+			}
+			if ( includeTranscript ) {
+				transcript.push( event );
 			}
 		}
 	} catch ( caught ) {
@@ -268,12 +342,21 @@ async function runEval( input: EvalRunnerInput ) {
 		clearTimeout( timeout );
 	}
 	phaseTimingsMs.total_eval_ms = elapsed();
+	if ( success && ! textSegments.length && ! resultText.trim() ) {
+		success = false;
+		error = 'Agent completed without assistant text or result output.';
+	}
 
 	return {
 		success,
 		error,
 		timedOut,
 		numTurns,
+		resultSubtype,
+		resultIsError,
+		resultStopReason,
+		resultText,
+		resultErrors,
 		phaseTimingsMs,
 		turnDurationsMs,
 		toolCalls,
@@ -281,6 +364,7 @@ async function runEval( input: EvalRunnerInput ) {
 		toolEvents,
 		firstToolError,
 		textSegments,
+		...( includeTranscript ? { transcript } : {} ),
 	};
 }
 


### PR DESCRIPTION
## Summary
- Capture final SDK result metadata in eval-runner output: `resultSubtype`, `resultIsError`, `resultStopReason`, `resultText`, and `resultErrors`.
- Treat empty successful completions as failed evals when the SDK reports success but the run produced neither assistant text nor final result text.
- Add opt-in compact transcript diagnostics behind `STUDIO_EVAL_INCLUDE_TRANSCRIPT=1`, with text/tool-result truncation to avoid bloating default artifacts.

## Why
This continues the eval-runner observability work from #3273 and #3330. Those PRs made phase/tool timings, first tool errors, loop exceptions, and timeouts visible. This adds the final SDK result shape and an opt-in turn transcript so eval consumers can distinguish model behavior, PI harness continuation behavior, runner classification, and downstream benchmark quality gates.

The need surfaced while testing the Static Site Importer draft path in #3309 with the Studio site-build benchmark. GPT-5.5 repeatedly produced tool-only runs for built-in prompt variants (`restaurant`, `wordpress-is-dead`): `site_list` / `site_info` returned successfully, then the SDK emitted `subtype: \"success\"`, `stopReason: \"end_turn\"`, and an empty `result`. No assistant text, `Write`, `wp_cli`, or import report was produced, but the eval runner classified the run as successful because it trusted `message.subtype === 'success'`.

With the local transcript diagnostics enabled, that failure shape was clear. The same diagnostics also helped compare Claude Sonnet 4.6 on the same SSI site-build flow: Claude generated source HTML and wrote files, then timed out while repairing generated helper-script errors before reaching import. Different failure mode, same need for better eval evidence.

This PR keeps the transcript opt-in so normal eval artifacts only gain a few scalar fields, while deeper debugging remains available when investigating model/runtime/harness regressions.

## Validation
- `npm install` to bootstrap the clean worktree.
- `npm run cli:build --silent` — passed.
- `npx eslint apps/cli/ai/eval-runner.ts` — passed.
- `npm -w wp-studio run typecheck` — passed.
- `git diff --check` — passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the eval-runner artifact gap during SSI benchmark runs, drafting the result metadata / opt-in transcript patch, running local validation, and preparing this PR body. Chris reviewed the failure evidence and PR framing.