### PR TITLE
Always ask before stopping running sites on quit

### DIFF
--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -46,7 +46,6 @@ import {
 	startCliEventsSubscriber,
 	stopCliEventsSubscriber,
 } from 'src/modules/cli/lib/cli-events-subscriber';
-import { isStudioCliInstalled } from 'src/modules/cli/lib/ipc-handlers';
 import { autoInstallLinuxCliIfNeeded } from 'src/modules/cli/lib/linux-installation-manager';
 import { autoInstallMacOSCliIfNeeded } from 'src/modules/cli/lib/macos-installation-manager';
 import { autoInstallWindowsCliIfNeeded } from 'src/modules/cli/lib/windows-installation-manager';
@@ -444,7 +443,6 @@ async function appBoot() {
 
 			void ( async () => {
 				const userData = await loadUserData();
-				const isCliInstalled = await isStudioCliInstalled();
 
 				if ( userData.stopSitesOnQuit !== undefined ) {
 					shouldStopSitesOnQuit = userData.stopSitesOnQuit;
@@ -453,7 +451,7 @@ async function appBoot() {
 					return;
 				}
 
-				if ( ! isCliInstalled || process.env.E2E ) {
+				if ( process.env.E2E ) {
 					isQuittingConfirmed = true;
 					app.quit();
 					return;

--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -458,6 +458,7 @@ async function appBoot() {
 				}
 
 				const STOP_SITES_BUTTON_INDEX = 0;
+				const LEAVE_RUNNING_BUTTON_INDEX = 1;
 				const CANCEL_BUTTON_INDEX = 2;
 
 				const { response, checkboxChecked } = await dialog.showMessageBox( {
@@ -474,7 +475,7 @@ async function appBoot() {
 					buttons: [ __( 'Stop sites' ), __( 'Leave running' ), __( 'Cancel' ) ],
 					checkboxLabel: __( "Don't ask again" ),
 					cancelId: CANCEL_BUTTON_INDEX,
-					defaultId: STOP_SITES_BUTTON_INDEX,
+					defaultId: LEAVE_RUNNING_BUTTON_INDEX,
 				} );
 
 				if ( response === CANCEL_BUTTON_INDEX ) {


### PR DESCRIPTION
## Related issues

- Related to a Slack discussion where a user reported that closing the Studio desktop app silently stopped their running sites.

## How AI was used in this PR

- Used Claude to trace the close-on-quit flow, confirm the daemon's lifecycle is independent of the desktop app, and identify the root cause (the dialog gate). Reviewed the diff and architecture findings before committing.
- The code change itself is small (a few lines), but Claude also drafted this PR description based on the investigation. I read it through and edited where needed before posting.

## Proposed Changes

- Drop the `isStudioCliInstalled()` gate around the "running sites on quit" confirmation dialog in `apps/studio/src/index.ts`. The dialog now always shows when sites are running (unless the user has saved a preference, or when running E2E tests).
- Change the default button from **Stop sites** to **Leave running**, so the safer / less destructive option is the one selected by Enter.
- Remove the now-unused `isStudioCliInstalled` import.

### Why drop the CLI gate

`isStudioCliInstalled()` only returns `true` when the CLI symlink points to the *packaged* CLI installed via the app. Users who installed `studio` independently (e.g. via npm) failed this check, so the dialog was silently skipped and `shouldStopSitesOnQuit` defaulted to `true` — sites were stopped on quit without any confirmation.

Sites are actually managed by a long-lived **detached daemon** (`apps/cli/lib/daemon-client.ts`, spawned with `detached: true`, `stdio: 'ignore'`, `daemonProcess.unref()`) that survives the desktop app quit completely independently of CLI install state. Picking "Leave running" works regardless of whether the CLI is installed through the app, via npm, or not at all — so the gate was hiding a useful choice from users.

The gate's original intent (in #2314) was to spare GUI-only users from a new prompt, on the assumption that they wouldn't care about keeping sites running. But the capability is the same for everyone: closing the app shouldn't kill background processes the user started, and the dialog is also how users discover that sites can keep running.

### Why default to "Leave running"

Quitting the app is rarely a deliberate "stop everything" action — it's often Cmd+Q to free RAM, declutter, or by accident. Defaulting to the destructive option (`Stop sites`) means a single Enter keypress can terminate work that took non-trivial time to set up (long-running imports, in-progress dev sessions). `Leave running` is reversible — the user can always `studio site stop --all` later — while `Stop sites` is not.

## Testing Instructions

1. Start one or more sites in Studio.
2. Quit the app (Cmd+Q on macOS, or close the last window on Linux/Windows).
3. The "You have running sites" dialog should appear with **Stop sites / Leave running / Cancel**, with **Leave running** highlighted as the default. Pressing Enter should leave the sites running and quit.
4. Verify each path explicitly:
   - **Stop sites** → app quits, sites stop.
   - **Leave running** → app quits, sites continue running. Verify via `ps`/Activity Monitor that the daemon process under `~/.studio/daemon/` is still alive, and that the site URL still responds.
   - **Cancel** (or Esc) → app stays open.
5. Tick "Don't ask again", choose either option, then re-quit with running sites — the saved preference should be honored without showing the dialog. (Reset by clearing `stopSitesOnQuit` from `~/.studio/app.json` if needed.)
6. Confirm the dialog now appears regardless of whether the CLI was installed through the app or independently (e.g. uninstall the packaged CLI / install via npm).

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?