### PR TITLE
Steer agent to use Jetpack Forms instead of raw HTML forms

### DIFF
--- a/apps/cli/ai/block-content-policy.ts
+++ b/apps/cli/ai/block-content-policy.ts
@@ -1,25 +1,34 @@
+import { PLUGIN_RECOMMENDATIONS } from './plugin-recommendations';
+
 const BLOCK_COMMENT_PATTERN = /<!--\s*\/?wp:[^>]*-->/g;
 const SINGLE_SCRIPT_PATTERN = /^<script(?:\s[^>]*)?>[\s\S]*<\/script>\s*$/i;
 const SINGLE_SVG_PATTERN = /^<svg(?:\s[^>]*)?>[\s\S]*<\/svg>\s*$/i;
-const FORM_MARKUP_PATTERN = /<(form|input|select|textarea|label|fieldset|legend|option)\b/i;
 const INTERACTION_MARKUP_PATTERN = /<(marquee)\b/i;
 
 export function getHtmlBlockPolicyIssues( content: string ): string[] {
 	const html = content.replace( BLOCK_COMMENT_PATTERN, '' ).trim();
-	if ( ! html || isAllowedHtmlBlockContent( html ) ) {
+	if ( ! html ) {
 		return [];
 	}
 
-	return [
-		'core/html contains markup that should use editable core blocks. Use core/group, core/columns, core/heading, core/paragraph, core/list, core/image, core/buttons, and theme CSS instead. Keep core/html only for inline SVG, form/input markup, interaction markup with no block equivalent, or a single script block.',
-	];
-}
-
-function isAllowedHtmlBlockContent( html: string ): boolean {
-	return (
+	if (
 		SINGLE_SCRIPT_PATTERN.test( html ) ||
 		SINGLE_SVG_PATTERN.test( html ) ||
-		FORM_MARKUP_PATTERN.test( html ) ||
 		INTERACTION_MARKUP_PATTERN.test( html )
-	);
+	) {
+		return [];
+	}
+
+	// Check plugin-specific patterns first so we return a targeted message.
+	for ( const recommendation of PLUGIN_RECOMMENDATIONS ) {
+		if ( recommendation.htmlPatterns && recommendation.htmlPolicyMessage ) {
+			if ( recommendation.htmlPatterns.some( ( pattern ) => pattern.test( html ) ) ) {
+				return [ recommendation.htmlPolicyMessage ];
+			}
+		}
+	}
+
+	return [
+		'core/html contains markup that should use editable core blocks. Use core/group, core/columns, core/heading, core/paragraph, core/list, core/image, core/buttons, and theme CSS instead. Keep core/html only for inline SVG, interaction markup with no block equivalent (marquee, cursor), or a single script block.',
+	];
 }

--- a/apps/cli/ai/plugin-recommendations.ts
+++ b/apps/cli/ai/plugin-recommendations.ts
@@ -44,9 +44,10 @@ export const PLUGIN_RECOMMENDATIONS: PluginRecommendation[] = [
 
 When the user asks for a contact form, feedback form, newsletter signup, survey, or any other interactive form, you MUST use Jetpack Forms — not raw HTML <form> elements.
 
-Install the plugin first if it is not already active:
+Install the plugin AND activate the \`contact-form\` Jetpack module first if not already active — both steps are required, otherwise the form blocks render as empty \`<div>\` elements on the frontend:
 \`\`\`
 wp_cli plugin install jetpack --activate
+wp_cli jetpack module activate contact-form
 \`\`\`
 
 Then build the form with blocks. Each field is a container block that holds a \`jetpack/label\` and a \`jetpack/input\` child. The submit button is a standard \`core/button\` (written as \`wp:button\` in block markup) placed directly inside the form container.

--- a/apps/cli/ai/plugin-recommendations.ts
+++ b/apps/cli/ai/plugin-recommendations.ts
@@ -85,47 +85,6 @@ The container jetpack/contact-form supports: "subject" (email subject line), "to
 		htmlPolicyMessage:
 			'core/html contains a <form> element. Use Jetpack Forms blocks instead: install the "jetpack" plugin and build the form with jetpack/contact-form and jetpack/field-* blocks. This keeps forms editable in the block editor and handles submission without custom backend code.',
 	},
-	{
-		name: 'WooCommerce',
-		pluginSlug: 'woocommerce',
-		blocks: [
-			'woocommerce/product-collection',
-			'woocommerce/all-products',
-			'woocommerce/featured-product',
-			'woocommerce/featured-category',
-			'woocommerce/cart',
-			'woocommerce/checkout',
-			'woocommerce/customer-account',
-			'woocommerce/mini-cart',
-			'woocommerce/product-search',
-			'woocommerce/product-categories',
-		],
-		guidance: `## E-commerce / Shops
-
-When the user asks for a shop, product listing, cart, checkout, or any e-commerce feature, you MUST use WooCommerce — not hand-coded product layouts.
-
-Install and activate WooCommerce first if it is not already active:
-\`\`\`
-wp_cli plugin install woocommerce --activate
-\`\`\`
-
-Then build shop pages using WooCommerce blocks:
-
-- **Product grid / shop page**: \`woocommerce/product-collection\` (modern, filter-aware) or \`woocommerce/all-products\` (legacy)
-- **Featured product highlight**: \`woocommerce/featured-product\` (requires a product ID)
-- **Cart page**: \`woocommerce/cart\`
-- **Checkout page**: \`woocommerce/checkout\`
-- **Mini-cart in header**: \`woocommerce/mini-cart\`
-- **Product search**: \`woocommerce/product-search\`
-- **Category navigation**: \`woocommerce/product-categories\`
-
-After activation, create a few demo products with WP-CLI so the user can see a real preview:
-\`\`\`
-wp_cli wc product create --name="Sample Product" --regular_price=29.99 --user=1
-\`\`\`
-
-Use WP-CLI's \`wc\` sub-commands (not \`post create\`) to manage products, orders, and coupons so all WooCommerce metadata is set correctly.`,
-	},
 ];
 
 /**

--- a/apps/cli/ai/plugin-recommendations.ts
+++ b/apps/cli/ai/plugin-recommendations.ts
@@ -36,7 +36,7 @@ export const PLUGIN_RECOMMENDATIONS: PluginRecommendation[] = [
 			'jetpack/field-checkbox-multiple',
 			'jetpack/field-radio',
 			'jetpack/field-select',
-			'jetpack/button',
+			'core/button',
 		],
 		guidance: `## Forms
 
@@ -54,7 +54,7 @@ Then build the form with blocks:
 <!-- wp:jetpack/field-name {"label":"Your name","required":true} /-->
 <!-- wp:jetpack/field-email {"label":"Email address","required":true} /-->
 <!-- wp:jetpack/field-textarea {"label":"Message","required":true} /-->
-<!-- wp:jetpack/button {"text":"Send message","lock":{"move":false,"remove":false}} /-->
+<!-- wp:core/button {"text":"Send message"} /-->
 <!-- /wp:jetpack/contact-form -->
 \`\`\`
 

--- a/apps/cli/ai/plugin-recommendations.ts
+++ b/apps/cli/ai/plugin-recommendations.ts
@@ -1,0 +1,117 @@
+export interface PluginRecommendation {
+	/** Human-readable plugin name. */
+	name: string;
+	/** WP-CLI installable slug (e.g. "jetpack"). */
+	pluginSlug: string;
+	/** Block names made available after activation. */
+	blocks: string[];
+	/**
+	 * Instruction injected into the system prompt.
+	 * Explain when to use this plugin and how to use its blocks.
+	 */
+	guidance: string;
+	/**
+	 * If set, HTML block content matching any of these patterns is flagged
+	 * by getHtmlBlockPolicyIssues() with htmlPolicyMessage instead of the
+	 * generic "use core blocks" message.
+	 */
+	htmlPatterns?: RegExp[];
+	/** Error message emitted when htmlPatterns match. */
+	htmlPolicyMessage?: string;
+}
+
+export const PLUGIN_RECOMMENDATIONS: PluginRecommendation[] = [
+	{
+		name: 'Jetpack Forms',
+		pluginSlug: 'jetpack',
+		blocks: [
+			'jetpack/contact-form',
+			'jetpack/field-name',
+			'jetpack/field-text',
+			'jetpack/field-email',
+			'jetpack/field-url',
+			'jetpack/field-telephone',
+			'jetpack/field-textarea',
+			'jetpack/field-checkbox',
+			'jetpack/field-checkbox-multiple',
+			'jetpack/field-radio',
+			'jetpack/field-select',
+			'jetpack/button',
+		],
+		guidance: `## Forms
+
+When the user asks for a contact form, feedback form, newsletter signup, survey, or any other interactive form, you MUST use Jetpack Forms — not raw HTML <form> elements.
+
+Install the plugin first if it is not already active:
+\`\`\`
+wp_cli plugin install jetpack --activate
+\`\`\`
+
+Then build the form with blocks:
+
+\`\`\`html
+<!-- wp:jetpack/contact-form {"subject":"Contact Us","to":"admin@example.com"} -->
+<!-- wp:jetpack/field-name {"label":"Your name","required":true} /-->
+<!-- wp:jetpack/field-email {"label":"Email address","required":true} /-->
+<!-- wp:jetpack/field-textarea {"label":"Message","required":true} /-->
+<!-- wp:jetpack/button {"text":"Send message","lock":{"move":false,"remove":false}} /-->
+<!-- /wp:jetpack/contact-form -->
+\`\`\`
+
+Available field types: jetpack/field-name, jetpack/field-text, jetpack/field-email, jetpack/field-url, jetpack/field-telephone, jetpack/field-textarea, jetpack/field-checkbox, jetpack/field-checkbox-multiple, jetpack/field-radio, jetpack/field-select.
+
+Every field block supports: "label" (string), "required" (boolean), "placeholder" (string), "id" (string for <label> association).
+The container jetpack/contact-form supports: "subject" (email subject line), "to" (recipient address or comma-separated list).`,
+		htmlPatterns: [ /<(form|input|select|textarea|fieldset)\b/i ],
+		htmlPolicyMessage:
+			'core/html contains a <form> element. Use Jetpack Forms blocks instead: install the "jetpack" plugin and build the form with jetpack/contact-form and jetpack/field-* blocks. This keeps forms editable in the block editor and handles submission without custom backend code.',
+	},
+	{
+		name: 'WooCommerce',
+		pluginSlug: 'woocommerce',
+		blocks: [
+			'woocommerce/product-grid',
+			'woocommerce/all-products',
+			'woocommerce/featured-product',
+			'woocommerce/featured-category',
+			'woocommerce/cart',
+			'woocommerce/checkout',
+			'woocommerce/customer-account',
+			'woocommerce/mini-cart',
+			'woocommerce/product-search',
+			'woocommerce/product-categories',
+		],
+		guidance: `## E-commerce / Shops
+
+When the user asks for a shop, product listing, cart, checkout, or any e-commerce feature, you MUST use WooCommerce — not hand-coded product layouts.
+
+Install and activate WooCommerce first if it is not already active:
+\`\`\`
+wp_cli plugin install woocommerce --activate
+\`\`\`
+
+Then build shop pages using WooCommerce blocks:
+
+- **Product grid / shop page**: \`woocommerce/product-grid\` or \`woocommerce/all-products\`
+- **Featured product highlight**: \`woocommerce/featured-product\` (requires a product ID)
+- **Cart page**: \`woocommerce/cart\`
+- **Checkout page**: \`woocommerce/checkout\`
+- **Mini-cart in header**: \`woocommerce/mini-cart\`
+- **Product search**: \`woocommerce/product-search\`
+- **Category navigation**: \`woocommerce/product-categories\`
+
+After activation, create a few demo products with WP-CLI so the user can see a real preview:
+\`\`\`
+wp_cli wc product create --name="Sample Product" --regular_price=29.99 --user=1
+\`\`\`
+
+Use WP-CLI's \`wc\` sub-commands (not \`post create\`) to manage products, orders, and coupons so all WooCommerce metadata is set correctly.`,
+	},
+];
+
+/**
+ * Returns the system-prompt section generated from all plugin recommendations.
+ */
+export function buildPluginRecommendationsSection(): string {
+	return PLUGIN_RECOMMENDATIONS.map( ( r ) => r.guidance ).join( '\n\n' );
+}

--- a/apps/cli/ai/plugin-recommendations.ts
+++ b/apps/cli/ai/plugin-recommendations.ts
@@ -36,6 +36,8 @@ export const PLUGIN_RECOMMENDATIONS: PluginRecommendation[] = [
 			'jetpack/field-checkbox-multiple',
 			'jetpack/field-radio',
 			'jetpack/field-select',
+			'jetpack/label',
+			'jetpack/input',
 			'core/button',
 		],
 		guidance: `## Forms
@@ -47,20 +49,37 @@ Install the plugin first if it is not already active:
 wp_cli plugin install jetpack --activate
 \`\`\`
 
-Then build the form with blocks:
+Then build the form with blocks. Each field is a container block that holds a \`jetpack/label\` and a \`jetpack/input\` child. The submit button is a standard \`core/button\` (written as \`wp:button\` in block markup) placed directly inside the form container.
 
 \`\`\`html
-<!-- wp:jetpack/contact-form {"subject":"Contact Us","to":"admin@example.com"} -->
-<!-- wp:jetpack/field-name {"label":"Your name","required":true} /-->
-<!-- wp:jetpack/field-email {"label":"Email address","required":true} /-->
-<!-- wp:jetpack/field-textarea {"label":"Message","required":true} /-->
-<!-- wp:core/button {"text":"Send message"} /-->
+<!-- wp:jetpack/contact-form {"jetpackCRM":false,"variationName":"default","lock":{"remove":true,"move":true},"layout":{"type":"flex","flexWrap":"nowrap","orientation":"vertical","justifyContent":"left","verticalAlignment":"top"}} -->
+<div class="wp-block-jetpack-contact-form"><!-- wp:jetpack/field-name {"required":true,"fieldVariant":"name"} -->
+<div><!-- wp:jetpack/label {"label":"Name"} /-->
+
+<!-- wp:jetpack/input /--></div>
+<!-- /wp:jetpack/field-name -->
+
+<!-- wp:jetpack/field-email {"required":true} -->
+<div><!-- wp:jetpack/label {"label":"Email"} /-->
+
+<!-- wp:jetpack/input /--></div>
+<!-- /wp:jetpack/field-email -->
+
+<!-- wp:jetpack/field-textarea -->
+<div><!-- wp:jetpack/label {"label":"Message"} /-->
+
+<!-- wp:jetpack/input {"type":"textarea"} /--></div>
+<!-- /wp:jetpack/field-textarea -->
+
+<!-- wp:button {"tagName":"button","type":"submit","lock":{"move":false,"remove":true}} -->
+<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Contact us</button></div>
+<!-- /wp:button --></div>
 <!-- /wp:jetpack/contact-form -->
 \`\`\`
 
-Available field types: jetpack/field-name, jetpack/field-text, jetpack/field-email, jetpack/field-url, jetpack/field-telephone, jetpack/field-textarea, jetpack/field-checkbox, jetpack/field-checkbox-multiple, jetpack/field-radio, jetpack/field-select.
+Available field block types: jetpack/field-name, jetpack/field-text, jetpack/field-email, jetpack/field-url, jetpack/field-telephone, jetpack/field-textarea, jetpack/field-checkbox, jetpack/field-checkbox-multiple, jetpack/field-radio, jetpack/field-select.
 
-Every field block supports: "label" (string), "required" (boolean), "placeholder" (string), "id" (string for <label> association).
+Each field block is a container with two inner blocks: \`jetpack/label\` (accepts a "label" string attribute) and \`jetpack/input\` (accepts a "type" attribute — defaults to text; use "textarea" for jetpack/field-textarea). Top-level field attributes: "required" (boolean), "fieldVariant" (string, e.g. "name" for jetpack/field-name).
 The container jetpack/contact-form supports: "subject" (email subject line), "to" (recipient address or comma-separated list).`,
 		htmlPatterns: [ /<(form|input|select|textarea|fieldset)\b/i ],
 		htmlPolicyMessage:

--- a/apps/cli/ai/plugin-recommendations.ts
+++ b/apps/cli/ai/plugin-recommendations.ts
@@ -70,7 +70,7 @@ The container jetpack/contact-form supports: "subject" (email subject line), "to
 		name: 'WooCommerce',
 		pluginSlug: 'woocommerce',
 		blocks: [
-			'woocommerce/product-grid',
+			'woocommerce/product-collection',
 			'woocommerce/all-products',
 			'woocommerce/featured-product',
 			'woocommerce/featured-category',
@@ -92,7 +92,7 @@ wp_cli plugin install woocommerce --activate
 
 Then build shop pages using WooCommerce blocks:
 
-- **Product grid / shop page**: \`woocommerce/product-grid\` or \`woocommerce/all-products\`
+- **Product grid / shop page**: \`woocommerce/product-collection\` (modern, filter-aware) or \`woocommerce/all-products\` (legacy)
 - **Featured product highlight**: \`woocommerce/featured-product\` (requires a product ID)
 - **Cart page**: \`woocommerce/cart\`
 - **Checkout page**: \`woocommerce/checkout\`

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -1,3 +1,5 @@
+import { buildPluginRecommendationsSection } from './plugin-recommendations';
+
 interface RemoteSiteContext {
 	name: string;
 	url: string;
@@ -32,7 +34,7 @@ ${ REMOTE_DESIGN_GUIDELINES }${ remoteSessionAddendum }
 
 	return `${ buildLocalIntro( { previewSteering: options?.previewSteering ?? false } ) }
 
-${ LOCAL_CONTENT_GUIDELINES }
+${ buildLocalContentGuidelines() }
 
 ${ LOCAL_DESIGN_GUIDELINES }${ remoteSessionAddendum }
 `;
@@ -244,14 +246,15 @@ const REMOTE_DESIGN_GUIDELINES = `## Design capabilities by plan
 - Custom CSS, global styles, plugin management, and advanced customization become available.
 - Check the specific plan to determine exact capabilities.`;
 
-const LOCAL_CONTENT_GUIDELINES = `## Block content guidelines
+// Evaluated lazily so unit tests that stub PLUGIN_RECOMMENDATIONS still work.
+function buildLocalContentGuidelines(): string {
+	return `## Block content guidelines
 
 - Only use \`core/html\` blocks for:
 	- Inline SVGs
-	- \`<form>\` elements and interactive inputs
 	- Animation/interaction markup with no block equivalent (marquee, cursor)
 	- A single \`<script>\` block at the bottom of the page for JS
-- Never use \`core/html\` to wrap text content, headings, layout sections, or lists.
+- Never use \`core/html\` to wrap text content, headings, layout sections, lists, or forms.
 - No decorative HTML comments (e.g. \`<!-- Hero Section -->\`, \`<!-- Features -->\`). Only block delimiter comments are allowed.
 - No custom class names on inner DOM elements — only on the outermost block wrapper via the \`className\` attribute.
 - No inline \`style\` or \`style\` block attributes for styling. Use \`className\` + \`style.css\` instead.
@@ -268,7 +271,10 @@ To break out of the content width, use these three patterns:
 - **Full-bleed section, full-bleed inner** (image grids, edge-to-edge galleries): outer AND inner \`core/group {"align":"full","layout":{"type":"default"}}\`. Children render at full viewport width.
 - **Standard constrained content**: omit \`align\` entirely and write blocks normally.
 
-The single most common failure is "I made a hero full-width but its inner content is narrow" — that's a missing \`align: "full"\` on the outer group or a mismatched inner \`layout\` type. Fix in markup, not in CSS.`;
+The single most common failure is "I made a hero full-width but its inner content is narrow" — that's a missing \`align: "full"\` on the outer group or a mismatched inner \`layout\` type. Fix in markup, not in CSS.
+
+${ buildPluginRecommendationsSection() }`;
+}
 
 const LOCAL_DESIGN_GUIDELINES = `## Design guidelines
 

--- a/apps/cli/ai/tests/block-content-policy.test.ts
+++ b/apps/cli/ai/tests/block-content-policy.test.ts
@@ -18,12 +18,13 @@ describe( 'HTML block content policy', () => {
 		).toEqual( [] );
 	} );
 
-	it( 'allows form markup', () => {
-		expect(
-			getHtmlBlockPolicyIssues(
-				'<!-- wp:html --><form><label>Email<input type="email" /></label></form><!-- /wp:html -->'
-			)
-		).toEqual( [] );
+	it( 'flags form markup with a Jetpack-specific message', () => {
+		const issues = getHtmlBlockPolicyIssues(
+			'<!-- wp:html --><form><label>Email<input type="email" /></label></form><!-- /wp:html -->'
+		);
+
+		expect( issues ).toHaveLength( 1 );
+		expect( issues[ 0 ] ).toContain( 'Jetpack Forms' );
 	} );
 
 	it( 'flags layout and text markup that should use core blocks', () => {


### PR DESCRIPTION
## Related issues

- Related to agent site-building improvements

## How AI was used in this PR

This PR was generated with Claude Code. The architecture and guidance text were written by AI and reviewed for correctness.

## Proposed Changes

Introduces a `plugin-recommendations.ts` registry so the agent knows which plugins to reach for rather than hand-rolling raw HTML. Each entry in the registry declares the plugin, its blocks, guidance text for the system prompt, and optional HTML patterns to flag in the block content policy. Adding new rules in the future (e.g. WooCommerce) requires only one object in the array — no other files change.

**This PR ships one rule: Jetpack Forms.**

When the agent is asked for any form (contact, feedback, newsletter, survey), it now:
1. Installs Jetpack if not already active
2. Builds the form with `jetpack/contact-form` and `jetpack/field-*` blocks using the exact composite markup Jetpack generates in the editor
3. Gets a targeted error from the block content policy if it falls back to a raw `<form>` element in a `core/html` block

**Files changed:**

- `apps/cli/ai/plugin-recommendations.ts` *(new)* — the recommendation registry
- `apps/cli/ai/block-content-policy.ts` — `<form>` HTML no longer silently passes; the policy loop iterates `PLUGIN_RECOMMENDATIONS` so any rule with `htmlPatterns` is enforced automatically
- `apps/cli/ai/system-prompt.ts` — local content guidelines now append all `guidance` strings from the registry

## Testing Instructions

- Ask the agent to "add a contact form" on a local site → it should install Jetpack and produce `jetpack/contact-form` block markup, not a `<form>` element
- Place a `<!-- wp:html -->…<form>…</form>…<!-- /wp:html -->` block in content and run `validate_blocks` → the policy should return the Jetpack-specific error message (not the generic "use core blocks" message)

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?