### PR TITLE
Studio Code: don't wipe in-progress typing on turn boundaries

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1331,7 +1331,6 @@ export class AiChatUI implements AiOutputAdapter {
 	}
 
 	waitForInput(): Promise< string > {
-		this.editor.setText( '' );
 		this.hideLoader();
 		this.showEditor();
 		if ( this.queuedPrompts.length > 0 ) {
@@ -1459,7 +1458,6 @@ export class AiChatUI implements AiOutputAdapter {
 	 * Begin an agent turn: hide editor, show loader, prepare response area.
 	 */
 	beginAgentTurn(): void {
-		this.editor.setText( '' );
 		this._inAgentTurn = true;
 		this.updateHints();
 		this.showLoader( randomThinkingMessage() );


### PR DESCRIPTION
## Related issues

- Related to: in-session bug report — while Studio Code's agent is running, text the user is typing into the prompt sometimes disappears (most often right when the agent finishes a turn).

## How AI was used in this PR

Investigated the `AiChatUI` lifecycle, identified the two `editor.setText('')` calls that fire across turn boundaries, and removed them after confirming pi-tui already clears the editor on submit.

## Proposed Changes

- Remove `this.editor.setText('')` from `AiChatUI.waitForInput()` and `AiChatUI.beginAgentTurn()` in `apps/cli/ai/ui.ts`.

The TUI editor stays focused while the agent runs, so users can keep typing during a turn. pi-tui's `Editor.submitValue()` already clears the editor synchronously when the user presses Enter, so the additional `setText('')` calls only ever fire on text the user typed during the async gap around turn start/end:

- **`waitForInput`** — runs after the agent returns control. If you typed (without pressing Enter) while the turn was finishing, those characters get wiped here. This is the case the bug report described.
- **`beginAgentTurn`** — runs after several `await`s in `runAgentTurn` (provider/env setup). Anything typed in that gap also gets wiped.

In both cases the editor is already empty in the normal flow (because `submitValue` cleared it), so removing these calls is a no-op except in the race window where the user's input was being lost.

## Testing Instructions

1. `npm run cli:build && node apps/cli/dist/cli/main.mjs` — start Studio Code.
2. Send any prompt that triggers a multi-step agent turn.
3. While the agent is running, start typing into the prompt (without pressing Enter).
4. Wait for the turn to complete.
5. **Before this PR:** the typed text disappears the moment the turn ends. **After this PR:** the text stays in the editor, ready to submit.
6. Sanity-check that the normal submit-and-clear flow still works (press Enter on a prompt → editor clears as expected).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Pre-existing typecheck errors on `trunk` are unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)