### PR TITLE
remote-session: show agent output in attach (STU-1696)

### DIFF
--- a/apps/cli/remote-session/logger.ts
+++ b/apps/cli/remote-session/logger.ts
@@ -129,6 +129,14 @@ interface PersistedLogLine {
 	level?: unknown;
 	msg?: unknown;
 	meta?: unknown;
+	event?: unknown;
+	content?: unknown;
+}
+
+function formatEventForStdout( time: string, kind: string, content: string ): string {
+	const safe = safeForStdout( content ).replace( /\n/g, '\n  ' );
+	const safeKind = stripTerminalControls( kind );
+	return `[${ time }] ${ safeKind } ${ safe }\n`;
 }
 
 /**
@@ -147,12 +155,16 @@ export function formatLogLineForStdout( rawLine: string ): string {
 	} catch {
 		return `${ stripTerminalControls( trimmed ) }\n`;
 	}
-	const level = isLogLevel( parsed.level ) ? parsed.level : 'info';
-	const message = typeof parsed.msg === 'string' ? parsed.msg : '';
 	const time =
 		typeof parsed.t === 'string' && parsed.t.length >= 19
 			? parsed.t.slice( 11, 19 )
 			: new Date().toTimeString().slice( 0, 8 );
+	if ( typeof parsed.event === 'string' ) {
+		const content = typeof parsed.content === 'string' ? parsed.content : '';
+		return formatEventForStdout( time, parsed.event, content );
+	}
+	const level = isLogLevel( parsed.level ) ? parsed.level : 'info';
+	const message = typeof parsed.msg === 'string' ? parsed.msg : '';
 	const head = `[${ time }] ${ level } ${ safeForStdout( message ) }`;
 	if ( parsed.meta && typeof parsed.meta === 'object' ) {
 		const safeMeta = safeForStdout( JSON.stringify( parsed.meta ) );
@@ -220,23 +232,33 @@ export class RemoteSessionLogger {
 	}
 
 	/**
-	 * Write a single conversation-content line to stdout only (never the file).
-	 * Used to surface the actual subprocess event payloads — incoming user text,
-	 * progress messages, the final reply, paused questions — while attached.
-	 * Skipped when `mirrorToStdout` is off, so callers can sprinkle these freely
-	 * without affecting non-streaming runs.
+	 * Write a single conversation-content line — incoming user text, progress
+	 * messages, the final reply, paused questions. Persisted to the log file so
+	 * `remote-session attach` can replay them; also mirrored to stdout in
+	 * foreground mode for live viewing.
 	 */
 	event( kind: string, content: string ): void {
+		ensureLogDir( this.logPath );
+		rotateIfNeeded( this.logPath );
+
+		const line =
+			JSON.stringify( {
+				t: new Date().toISOString(),
+				event: kind,
+				content: redact( content ),
+			} ) + '\n';
+		try {
+			fs.appendFileSync( this.logPath, line, { encoding: 'utf8' } );
+		} catch {
+			// Logging is best-effort; never throw from here.
+		}
+
 		if ( ! this.mirrorToStdout ) {
 			return;
 		}
 		const time = new Date().toTimeString().slice( 0, 8 );
-		// Sanitize first so `\r` and other control bytes are gone before we
-		// indent newlines for multi-line content (questions, replies).
-		const safe = safeForStdout( content ).replace( /\n/g, '\n  ' );
-		const safeKind = stripTerminalControls( kind );
 		try {
-			process.stdout.write( `[${ time }] ${ safeKind } ${ safe }\n` );
+			process.stdout.write( formatEventForStdout( time, kind, content ) );
 		} catch {
 			// Best-effort; never throw from here.
 		}

--- a/apps/cli/remote-session/poll-loop.ts
+++ b/apps/cli/remote-session/poll-loop.ts
@@ -223,6 +223,15 @@ async function handleTurn(
 	const deliveredMedia = mediaSummary.posted > 0;
 
 	if ( reply === null && ! deliveredMedia ) {
+		deps.logger.warn( 'No reply produced; posting fallback', {
+			chat_id: target.chatId,
+			status: outcome.status,
+			exit_code: outcome.exitCode,
+			is_error: outcome.isError,
+			reply_text_chars: outcome.replyText?.length ?? 0,
+			questions: outcome.questions?.length ?? 0,
+			stderr_tail: outcome.stderrTail ? outcome.stderrTail.slice( -500 ) : '',
+		} );
 		await postBestEffort( deps, config, target, '⚠️ Local agent did not return a result.' );
 		return;
 	}

--- a/apps/cli/remote-session/tests/fixtures/mock-studio-code.mjs
+++ b/apps/cli/remote-session/tests/fixtures/mock-studio-code.mjs
@@ -6,6 +6,8 @@
 //   stale-resume   — writes a stale-session-looking line to stderr + exits non-zero
 //   hang           — never exits (tests timeout path)
 //   media-share    — emits a media.share + result + turn.completed success
+//   empty-result-with-text — assistant emits text, but result has empty `result`
+//                            field (reproduces the pi-runtime agent_end bug).
 
 const scenario = process.env.SCENARIO ?? 'success';
 const sessionId = process.env.SESSION_ID ?? 'sess-new';
@@ -133,6 +135,88 @@ function runMediaShare() {
 	process.exit( 0 );
 }
 
+function runEmptyResultWithText() {
+	emit( { type: 'turn.started', timestamp: ts() } );
+	// Assistant emits a tool call, then a text block with the actual answer.
+	emit( {
+		type: 'message',
+		timestamp: ts(),
+		message: {
+			type: 'assistant',
+			parent_tool_use_id: null,
+			uuid: 'a1',
+			session_id: sessionId,
+			message: {
+				id: 'm1',
+				type: 'message',
+				role: 'assistant',
+				model: 'claude',
+				content: [ { type: 'tool_use', id: 't1', name: 'site_list', input: {} } ],
+				stop_reason: 'tool_use',
+				stop_sequence: null,
+				usage: {},
+			},
+		},
+	} );
+	emit( {
+		type: 'message',
+		timestamp: ts(),
+		message: {
+			type: 'user',
+			parent_tool_use_id: null,
+			uuid: 'u1',
+			session_id: sessionId,
+			message: {
+				role: 'user',
+				content: [ { type: 'tool_result', tool_use_id: 't1', content: '[]', is_error: false } ],
+			},
+		},
+	} );
+	emit( {
+		type: 'message',
+		timestamp: ts(),
+		message: {
+			type: 'assistant',
+			parent_tool_use_id: null,
+			uuid: 'a2',
+			session_id: sessionId,
+			message: {
+				id: 'm2',
+				type: 'message',
+				role: 'assistant',
+				model: 'claude',
+				content: [ { type: 'text', text: 'Final answer from assistant.' } ],
+				stop_reason: 'end_turn',
+				stop_sequence: null,
+				usage: {},
+			},
+		},
+	} );
+	// Buggy result: empty `result` despite the assistant text above.
+	emit( {
+		type: 'message',
+		timestamp: ts(),
+		message: {
+			type: 'result',
+			subtype: 'success',
+			is_error: false,
+			result: '',
+			session_id: sessionId,
+			duration_ms: 10,
+			duration_api_ms: 5,
+			num_turns: 1,
+			stop_reason: 'end_turn',
+			total_cost_usd: 0,
+			usage: {},
+			modelUsage: {},
+			permission_denials: [],
+			uuid: 'r',
+		},
+	} );
+	emit( { type: 'turn.completed', timestamp: ts(), sessionId, status: 'success' } );
+	process.exit( 0 );
+}
+
 const handlers = {
 	success: runSuccess,
 	paused: runPaused,
@@ -140,6 +224,7 @@ const handlers = {
 	'stale-resume': runStaleResume,
 	hang: runHang,
 	'media-share': runMediaShare,
+	'empty-result-with-text': runEmptyResultWithText,
 };
 
 const handler = handlers[ scenario ];

--- a/apps/cli/remote-session/tests/logger.test.ts
+++ b/apps/cli/remote-session/tests/logger.test.ts
@@ -2,7 +2,12 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { RemoteSessionLogger, redact, stripTerminalControls } from 'cli/remote-session/logger';
+import {
+	RemoteSessionLogger,
+	formatLogLineForStdout,
+	redact,
+	stripTerminalControls,
+} from 'cli/remote-session/logger';
 
 describe( 'remote-session logger redaction', () => {
 	it( 'redacts Bearer tokens in arbitrary text', () => {
@@ -112,7 +117,7 @@ describe( 'RemoteSessionLogger writes', () => {
 		expect( fs.readFileSync( logPath, 'utf8' ) ).toMatch( /"msg":"hello Bearer \[redacted\]"/ );
 	} );
 
-	it( 'event() writes a single stdout line and never touches the file', () => {
+	it( 'event() persists to the log file and mirrors to stdout when enabled', () => {
 		const captured = captureStdout();
 		const logger = new RemoteSessionLogger( { logPath, mirrorToStdout: true } );
 		logger.event( 'reply', 'Just 1 site is running.\nLine two.' );
@@ -121,16 +126,28 @@ describe( 'RemoteSessionLogger writes', () => {
 		// Newlines in content are indented so each line stays grouped under its event.
 		expect( combined ).toMatch( /reply Just 1 site is running\.\n {2}Line two\./ );
 		expect( combined ).toMatch( /progress Authorization: Bearer \[redacted\]/ );
-		// File sink stays untouched by event().
-		expect( fs.existsSync( logPath ) ).toBe( false );
+		// File sink also receives the events (so attach can replay them).
+		const fileContent = fs.readFileSync( logPath, 'utf8' );
+		const lines = fileContent.split( '\n' ).filter( Boolean );
+		expect( lines ).toHaveLength( 2 );
+		const first = JSON.parse( lines[ 0 ] );
+		expect( first.event ).toBe( 'reply' );
+		expect( first.content ).toBe( 'Just 1 site is running.\nLine two.' );
+		const second = JSON.parse( lines[ 1 ] );
+		expect( second.event ).toBe( 'progress' );
+		expect( second.content ).toBe( 'Authorization: Bearer [redacted]' );
 	} );
 
-	it( 'event() is a no-op when mirrorToStdout is off', () => {
+	it( 'event() persists to the log file even when mirrorToStdout is off', () => {
 		const captured = captureStdout();
 		const logger = new RemoteSessionLogger( { logPath } );
-		logger.event( 'reply', 'should not appear' );
-		expect( captured.combined() ).not.toMatch( /should not appear/ );
-		expect( fs.existsSync( logPath ) ).toBe( false );
+		logger.event( 'reply', 'agent says hi' );
+		expect( captured.combined() ).not.toMatch( /agent says hi/ );
+		const lines = fs.readFileSync( logPath, 'utf8' ).split( '\n' ).filter( Boolean );
+		expect( lines ).toHaveLength( 1 );
+		const parsed = JSON.parse( lines[ 0 ] );
+		expect( parsed.event ).toBe( 'reply' );
+		expect( parsed.content ).toBe( 'agent says hi' );
 	} );
 
 	it( 'does not mirror to stdout by default', () => {
@@ -156,5 +173,31 @@ describe( 'RemoteSessionLogger writes', () => {
 		// JSON.stringify already escapes raw ESC bytes to the visible 6-char `\u001b` (literal backslash-u-0-0-1-b)
 		// sequence in meta, so the terminal sees inert text rather than active escapes.
 		expect( combined ).toContain( '\\u001b[31mred\\u001b[0m\\u0007' );
+	} );
+} );
+
+describe( 'formatLogLineForStdout', () => {
+	it( 'renders persisted event lines in [time] kind content shape', () => {
+		const line =
+			JSON.stringify( {
+				t: '2026-05-05T12:34:56.000Z',
+				event: 'reply',
+				content: 'Hello world.\nLine two.',
+			} ) + '\n';
+		const out = formatLogLineForStdout( line );
+		expect( out ).toBe( '[12:34:56] reply Hello world.\n  Line two.\n' );
+	} );
+
+	it( 'sanitizes terminal control sequences in event content', () => {
+		const line =
+			JSON.stringify( {
+				t: '2026-05-05T12:34:56.000Z',
+				event: 'progress',
+				content: '\x1b[2Jcleared',
+			} ) + '\n';
+		const out = formatLogLineForStdout( line );
+		// eslint-disable-next-line no-control-regex
+		expect( out ).not.toMatch( /[\x00-\x08\x0B-\x1F\x7F]/ );
+		expect( out ).toContain( 'progress cleared' );
 	} );
 } );

--- a/apps/cli/remote-session/tests/turn-runner.test.ts
+++ b/apps/cli/remote-session/tests/turn-runner.test.ts
@@ -50,6 +50,14 @@ describe( 'runTurn', () => {
 		expect( outcome.exitCode ).toBe( 1 );
 	} );
 
+	it( 'falls back to last assistant text when SDK result has empty result field', async () => {
+		const outcome = await run( 'empty-result-with-text' );
+		expect( outcome.status ).toBe( 'success' );
+		expect( outcome.isError ).toBe( false );
+		expect( outcome.replyText ).toBe( 'Final answer from assistant.' );
+		expect( outcome.exitCode ).toBe( 0 );
+	} );
+
 	it( 'detects a stale --resume-session via stderr pattern', async () => {
 		const outcome = await run( 'stale-resume', 'bogus-sess-id' );
 		expect( outcome.staleSession ).toBe( true );

--- a/apps/cli/remote-session/turn-runner.ts
+++ b/apps/cli/remote-session/turn-runner.ts
@@ -65,12 +65,128 @@ interface SdkResultLike {
 	session_id?: unknown;
 	is_error?: unknown;
 	errors?: unknown;
+	stop_reason?: unknown;
+	num_turns?: unknown;
+}
+
+interface SdkContentBlockLike {
+	type?: unknown;
+	text?: unknown;
+	name?: unknown;
+	input?: unknown;
+	tool_use_id?: unknown;
+	content?: unknown;
+	is_error?: unknown;
+}
+
+interface SdkAssistantOrUserLike {
+	type?: unknown;
+	message?: { content?: unknown } | null;
+}
+
+const STEP_TEXT_PREVIEW_CHARS = 200;
+const STEP_INPUT_PREVIEW_CHARS = 120;
+
+function previewToolInput( input: unknown ): string {
+	if ( ! input || typeof input !== 'object' ) {
+		return '';
+	}
+	let json: string;
+	try {
+		json = JSON.stringify( input );
+	} catch {
+		return '';
+	}
+	const oneLine = json.replace( /\s+/g, ' ' );
+	return oneLine.length > STEP_INPUT_PREVIEW_CHARS
+		? `${ oneLine.slice( 0, STEP_INPUT_PREVIEW_CHARS - 1 ) }…`
+		: oneLine;
+}
+
+/**
+ * Extract the concatenated text content from an SDK assistant message. Returns
+ * an empty string when the message is not from the assistant or contains no
+ * text blocks. Used as a fallback when the SDK result event arrives with an
+ * empty `result` field (see issue: pi runtime emits empty result on agent_end).
+ */
+function extractAssistantText( raw: unknown ): string {
+	const wrapped = raw as SdkAssistantOrUserLike | null | undefined;
+	if ( ! wrapped || typeof wrapped !== 'object' || wrapped.type !== 'assistant' ) {
+		return '';
+	}
+	const blocks = wrapped.message?.content;
+	if ( ! Array.isArray( blocks ) ) {
+		return '';
+	}
+	const parts: string[] = [];
+	for ( const block of blocks as SdkContentBlockLike[] ) {
+		if (
+			block &&
+			typeof block === 'object' &&
+			block.type === 'text' &&
+			typeof block.text === 'string'
+		) {
+			parts.push( block.text );
+		}
+	}
+	return parts.join( '' ).trim();
+}
+
+/**
+ * Extract a short, human-readable summary of an assistant or user SDK message
+ * for logging to the remote-session log file. Returns one line per content
+ * block (text snippet, tool_use name+input preview, tool_result is_error flag).
+ * Empty array when the message has no useful content to summarize.
+ */
+function summarizeMessageContent( raw: unknown ): string[] {
+	const wrapped = raw as SdkAssistantOrUserLike | null | undefined;
+	if ( ! wrapped || typeof wrapped !== 'object' ) {
+		return [];
+	}
+	const sdkType = typeof wrapped.type === 'string' ? wrapped.type : '';
+	if ( sdkType !== 'assistant' && sdkType !== 'user' ) {
+		return [];
+	}
+	const blocks = wrapped.message?.content;
+	if ( ! Array.isArray( blocks ) ) {
+		return [];
+	}
+	const lines: string[] = [];
+	for ( const block of blocks as SdkContentBlockLike[] ) {
+		if ( ! block || typeof block !== 'object' ) {
+			continue;
+		}
+		if ( block.type === 'text' && typeof block.text === 'string' ) {
+			const snippet = block.text.replace( /\s+/g, ' ' ).trim();
+			if ( snippet.length === 0 ) {
+				continue;
+			}
+			const truncated =
+				snippet.length > STEP_TEXT_PREVIEW_CHARS
+					? `${ snippet.slice( 0, STEP_TEXT_PREVIEW_CHARS - 1 ) }…`
+					: snippet;
+			lines.push( `text: ${ truncated }` );
+		} else if ( block.type === 'tool_use' ) {
+			const name = typeof block.name === 'string' ? block.name : '<unknown>';
+			const inputPreview = previewToolInput( block.input );
+			lines.push( inputPreview ? `tool_use: ${ name } ${ inputPreview }` : `tool_use: ${ name }` );
+		} else if ( block.type === 'tool_result' ) {
+			const errFlag = block.is_error === true ? ' (error)' : '';
+			lines.push( `tool_result${ errFlag }` );
+		} else if ( block.type === 'thinking' ) {
+			lines.push( 'thinking' );
+		}
+	}
+	return lines;
 }
 
 function extractResultPayload( event: Extract< JsonEvent, { type: 'message' } > ): {
 	sessionId?: string;
 	replyText?: string;
 	isError: boolean;
+	subtype?: string;
+	stopReason?: string | null;
+	numTurns?: number;
 } | null {
 	const wrapped = event.message as SdkResultLike | null | undefined;
 	if ( ! wrapped || typeof wrapped !== 'object' || wrapped.type !== 'result' ) {
@@ -78,6 +194,12 @@ function extractResultPayload( event: Extract< JsonEvent, { type: 'message' } > 
 	}
 	const isError = wrapped.is_error === true;
 	const sessionId = typeof wrapped.session_id === 'string' ? wrapped.session_id : undefined;
+	const subtype = typeof wrapped.subtype === 'string' ? wrapped.subtype : undefined;
+	const stopReason =
+		typeof wrapped.stop_reason === 'string' || wrapped.stop_reason === null
+			? ( wrapped.stop_reason as string | null )
+			: undefined;
+	const numTurns = typeof wrapped.num_turns === 'number' ? wrapped.num_turns : undefined;
 	let replyText: string | undefined;
 	if ( typeof wrapped.result === 'string' && wrapped.result.length > 0 ) {
 		replyText = wrapped.result;
@@ -89,7 +211,7 @@ function extractResultPayload( event: Extract< JsonEvent, { type: 'message' } > 
 			replyText = msgs;
 		}
 	}
-	return { sessionId, replyText, isError };
+	return { sessionId, replyText, isError, subtype, stopReason, numTurns };
 }
 
 function parseEvent( line: string ): JsonEvent | null {
@@ -197,12 +319,19 @@ export async function runTurn( options: TurnRunOptions ): Promise< TurnOutcome >
 	let stderrTail = '';
 	let timedOut = false;
 	let aborted = false;
+	const eventCounts: Record< string, number > = {};
+	let resultEventSeen = false;
+	let resultEventEmptyReply = false;
+	let nonJsonStdoutLines = 0;
+	let lastAssistantText = '';
+	let usedAssistantTextFallback = false;
 
 	const rl = readline.createInterface( { input: child.stdout! } );
 	rl.on( 'line', ( line ) => {
 		const event = parseEvent( line );
 		if ( ! event ) {
 			if ( line.trim().length > 0 ) {
+				nonJsonStdoutLines++;
 				logger?.debug( 'Subprocess stdout (non-JSON)', {
 					...logContext,
 					line: line.slice( 0, 500 ),
@@ -210,6 +339,7 @@ export async function runTurn( options: TurnRunOptions ): Promise< TurnOutcome >
 			}
 			return;
 		}
+		eventCounts[ event.type ] = ( eventCounts[ event.type ] ?? 0 ) + 1;
 		options.onEvent?.( event );
 
 		if ( event.type === 'progress' || event.type === 'info' ) {
@@ -220,13 +350,34 @@ export async function runTurn( options: TurnRunOptions ): Promise< TurnOutcome >
 
 		if ( event.type === 'message' ) {
 			const extracted = extractResultPayload( event );
+			if ( ! extracted ) {
+				const stepLines = summarizeMessageContent( event.message );
+				for ( const line of stepLines ) {
+					logger?.event( 'agent.step', line );
+				}
+				const assistantText = extractAssistantText( event.message );
+				if ( assistantText ) {
+					lastAssistantText = assistantText;
+				}
+			}
 			if ( extracted ) {
+				resultEventSeen = true;
 				if ( extracted.sessionId ) {
 					capturedSessionId = extracted.sessionId;
 				}
 				if ( extracted.replyText ) {
 					replyText = extracted.replyText;
 					logger?.event( extracted.isError ? 'reply.error' : 'reply', extracted.replyText );
+				} else {
+					resultEventEmptyReply = true;
+					logger?.warn( 'Result event had empty reply', {
+						...logContext,
+						is_error: extracted.isError,
+						session_id: extracted.sessionId,
+						subtype: extracted.subtype,
+						stop_reason: extracted.stopReason,
+						num_turns: extracted.numTurns,
+					} );
 				}
 				isError = isError || extracted.isError;
 				logger?.debug( 'Event: message/result', {
@@ -340,6 +491,26 @@ export async function runTurn( options: TurnRunOptions ): Promise< TurnOutcome >
 		};
 	}
 
+	// Workaround for pi-runtime bug: when the runtime yields `agent_end` it
+	// constructs the SDK result message with an empty `result` field even when
+	// the agent emitted a final assistant text block earlier in the turn. If we
+	// captured that text along the way, surface it as the reply instead of
+	// posting "did not return a result" to the user. See:
+	// docs/notes/empty-result-reply-fallback.md (Option A — fix at the source).
+	if (
+		resultEventEmptyReply &&
+		! isError &&
+		replyText === undefined &&
+		lastAssistantText.length > 0
+	) {
+		replyText = lastAssistantText;
+		usedAssistantTextFallback = true;
+		logger?.warn( 'Using last assistant text as reply (empty SDK result)', {
+			...logContext,
+			fallback_chars: lastAssistantText.length,
+		} );
+	}
+
 	const status: TurnOutcomeStatus = completedStatus ?? ( isError ? 'error' : 'error' );
 	const staleSession =
 		options.sessionId !== undefined && detectStaleSession( stderrTail, replyText, isError );
@@ -354,6 +525,12 @@ export async function runTurn( options: TurnRunOptions ): Promise< TurnOutcome >
 		questions: pausedQuestions?.length ?? 0,
 		stale_session: staleSession,
 		stderr_tail: stderrTail ? stderrTail.slice( -500 ) : '',
+		event_counts: eventCounts,
+		result_event_seen: resultEventSeen,
+		result_event_empty_reply: resultEventEmptyReply,
+		non_json_stdout_lines: nonJsonStdoutLines,
+		turn_completed_seen: completedStatus !== undefined,
+		used_assistant_text_fallback: usedAssistantTextFallback,
 	} );
 
 	return {


### PR DESCRIPTION
## Related issues

- Related to STU-1696

## How AI was used in this PR

Implementation, tests, and commit messages drafted with Claude Code. I drove the design (what to log, log shape, where the fallback goes), reproduced the empty-SDK-result bug live against the daemon to confirm the diagnosis, and reviewed each diff before committing. Reviewers should focus on the persisted-event log shape (`logger.ts`), the diagnostic fields on `Turn outcome`, and the empty-result workaround in `turn-runner.ts`.

## Proposed Changes

**1. Show agent output on `studio code remote-session attach`** (commit 1)

`RemoteSessionLogger.event()` now persists conversation events (progress, info, error, replies, questions) to the daemon log file in addition to the existing stdout-mirror path. `formatLogLineForStdout()` recognizes the new `{ t, event, content }` shape and renders it as `[time] kind content`. Result: when you attach to a running daemon, the conversation flow is visible alongside the polling logs.

**2. Diagnostics for "no response" turns** (commit 2)

Each non-result `message` event emits one `agent.step` line per content block (text snippet, `tool_use` with input preview, `tool_result`, `thinking`) so you can see exactly what the agent did. The `Turn outcome` info log gained `event_counts`, `result_event_seen`, `result_event_empty_reply`, `turn_completed_seen`, `non_json_stdout_lines`, plus `subtype` / `stop_reason` / `num_turns` on the new `Result event had empty reply` warn. The poll loop logs `No reply produced; posting fallback` before sending the user-facing fallback so the cause is captured in the log file.

**3. Workaround for empty SDK result** (commit 2)

While testing the new attach output, reproduced an issue where the agent finishes cleanly (`status: success`, `stop_reason: end_turn`, `num_turns: 1`) but the SDK `result` event arrives with `result: ""`, even though an assistant text block was streamed earlier in the turn. The remote-session loop was posting "⚠️ Local agent did not return a result." to Telegram even though the agent did answer. Root cause is in the pi runtime (it hardcodes the result text to `''` on `agent_end`). As a guard, the turn runner now captures the last assistant text seen during the turn and uses it as the reply when the result event has empty `replyText` and no error. The proper fix at the runtime source will follow.

## Testing Instructions

Automated:

- `npm test -- apps/cli/remote-session` — 111 tests pass (110 existing + 1 new for the empty-result fallback).
- `npm run typecheck` — clean.

Manual:

1. `npm run cli:build && node apps/cli/dist/cli/main.mjs code remote-session start --detach` (with a configured bot/chat).
2. In a second terminal: `node apps/cli/dist/cli/main.mjs code remote-session attach`.
3. Send a message from Telegram. You should see: `Polled message`, then a stream of `progress` / `agent.step` / `reply` event lines, then `Turn outcome` and `Posting reply`.
4. To exercise the workaround, send a single-tool one-turn question like _"How many local sites are currently running?"_. The reply should land in Telegram (previously it sometimes posted "⚠️ Local agent did not return a result."). The `Turn outcome` line will show `result_event_empty_reply: true` and `used_assistant_text_fallback: true`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?