### PR TITLE
Cleanup: Type agent JSON message events

### DIFF
--- a/apps/cli/ai/json-events.ts
+++ b/apps/cli/ai/json-events.ts
@@ -1,6 +1,10 @@
 import type { JsonEvent } from '@studio/common/ai/json-events';
 
-export type { JsonEvent, TurnCompletedStatus } from '@studio/common/ai/json-events';
+export {
+	type AgentMessageJsonEvent,
+	type JsonEvent,
+	type TurnCompletedStatus,
+} from '@studio/common/ai/json-events';
 
 export function emitEvent( event: JsonEvent ): void {
 	// When forked from the Studio main process the Node IPC channel is

--- a/apps/cli/ai/output-adapter.ts
+++ b/apps/cli/ai/output-adapter.ts
@@ -133,9 +133,8 @@ export class JsonAdapter implements AiOutputAdapter {
 
 	handleEvent( event: AgentSessionEvent ): void {
 		// Forward the event verbatim so the desktop main process can re-derive
-		// state without loading the JSONL itself. The wire keeps the legacy
-		// `'message'` envelope for compatibility with the renderer's parser,
-		// but the inner payload is now the native AgentSessionEvent.
+		// state without loading the JSONL itself. The wire keeps the existing
+		// `'message'` envelope, with a native AgentSessionEvent as the payload.
 		emitEvent( { type: 'message', timestamp: new Date().toISOString(), message: event } );
 	}
 

--- a/apps/cli/remote-session/tests/progress-streamer.test.ts
+++ b/apps/cli/remote-session/tests/progress-streamer.test.ts
@@ -81,7 +81,7 @@ describe( 'ProgressStreamer', () => {
 	it( 'ignores non-info / non-progress events', () => {
 		const { streamer, respond } = makeStreamer();
 		streamer.onEvent( { type: 'turn.started', timestamp: 't' } );
-		streamer.onEvent( { type: 'message', timestamp: 't', message: { type: 'result' } } );
+		streamer.onEvent( { type: 'message', timestamp: 't', message: { type: 'turn_start' } } );
 		streamer.onEvent( {
 			type: 'turn.completed',
 			timestamp: 't',

--- a/apps/cli/remote-session/turn-runner.ts
+++ b/apps/cli/remote-session/turn-runner.ts
@@ -1,5 +1,8 @@
 import { type ChildProcess, spawn } from 'child_process';
 import readline from 'readline';
+import { findLastAssistant } from '@studio/common/ai/session-events';
+import type { AgentMessage } from '@mariozechner/pi-agent-core';
+import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import type { JsonEvent, TurnCompletedStatus } from '@studio/common/ai/json-events';
 import type { RemoteSessionLogger } from 'cli/remote-session/logger';
 
@@ -59,25 +62,9 @@ const STALE_SESSION_PATTERNS = [
 	/resume.*session.*(failed|invalid)/i,
 ];
 
-// The CLI now wraps native pi `AgentSessionEvent` payloads inside the
-// `'message'` envelope; `agent_end` is the terminal event carrying the
-// full message tail. Pull the last assistant message's text + error
-// state from there. (The pre-pi-migration shape was a synthetic SDK
-// `result` message — replaced wholesale.)
-interface PiAgentEndEnvelope {
-	type?: unknown;
-	messages?: unknown;
-}
-
-interface PiAgentSessionEventLike {
-	type?: unknown;
-	message?: unknown;
-	messages?: unknown;
-	toolName?: unknown;
-	args?: unknown;
-	isError?: unknown;
-}
-
+// The CLI wraps native pi `AgentSessionEvent` payloads inside the `'message'`
+// envelope; `agent_end` is the terminal event carrying the full message tail.
+// Pull the last assistant message's text + error state from there.
 interface PiAgentMessageLike {
 	role?: unknown;
 	content?: unknown;
@@ -118,8 +105,8 @@ function previewToolInput( input: unknown ): string {
  * Extract concatenated text from a native pi assistant message. Used as a
  * fallback if the terminal `agent_end` arrives without final text.
  */
-function extractAssistantText( raw: unknown ): string {
-	const message = raw as PiAgentMessageLike | null | undefined;
+function extractAssistantText( raw: AgentMessage ): string {
+	const message = raw as PiAgentMessageLike;
 	if ( ! message || typeof message !== 'object' || message.role !== 'assistant' ) {
 		return '';
 	}
@@ -147,8 +134,8 @@ function extractAssistantText( raw: unknown ): string {
  * block (text snippet, tool call name+input preview, tool result error flag).
  * Empty array when the message has no useful content to summarize.
  */
-function summarizeAgentMessage( raw: unknown ): string[] {
-	const message = raw as PiAgentMessageLike | null | undefined;
+function summarizeAgentMessage( raw: AgentMessage ): string[] {
+	const message = raw as PiAgentMessageLike;
 	if ( ! message || typeof message !== 'object' ) {
 		return [];
 	}
@@ -198,11 +185,7 @@ function summarizeAgentMessage( raw: unknown ): string[] {
 	return lines;
 }
 
-function summarizeMessageContent( raw: unknown ): string[] {
-	const event = raw as PiAgentSessionEventLike | null | undefined;
-	if ( ! event || typeof event !== 'object' || typeof event.type !== 'string' ) {
-		return [];
-	}
+function summarizeMessageContent( event: AgentSessionEvent ): string[] {
 	if ( event.type === 'message_end' ) {
 		return summarizeAgentMessage( event.message );
 	}
@@ -219,9 +202,8 @@ function summarizeMessageContent( raw: unknown ): string[] {
 	return [];
 }
 
-function extractAssistantTextFromEvent( raw: unknown ): string {
-	const event = raw as PiAgentSessionEventLike | null | undefined;
-	if ( ! event || typeof event !== 'object' || event.type !== 'message_end' ) {
+function extractAssistantTextFromEvent( event: AgentSessionEvent ): string {
+	if ( event.type !== 'message_end' ) {
 		return '';
 	}
 	return extractAssistantText( event.message );
@@ -236,21 +218,11 @@ function extractResultPayload( event: Extract< JsonEvent, { type: 'message' } > 
 	isError: boolean;
 	stopReason?: string | null;
 } | null {
-	const wrapped = event.message as PiAgentEndEnvelope | null | undefined;
-	if ( ! wrapped || typeof wrapped !== 'object' || wrapped.type !== 'agent_end' ) {
+	const wrapped = event.message;
+	if ( wrapped.type !== 'agent_end' ) {
 		return null;
 	}
-	const messages = Array.isArray( wrapped.messages ) ? wrapped.messages : [];
-	let lastAssistant:
-		| { stopReason?: unknown; errorMessage?: unknown; content?: unknown }
-		| undefined;
-	for ( let i = messages.length - 1; i >= 0; i -= 1 ) {
-		const m = messages[ i ] as { role?: unknown };
-		if ( m && m.role === 'assistant' ) {
-			lastAssistant = m as typeof lastAssistant;
-			break;
-		}
-	}
+	const lastAssistant = findLastAssistant( wrapped.messages );
 	if ( ! lastAssistant ) {
 		return { isError: false };
 	}

--- a/apps/studio/src/components/studio-code-event-parser.ts
+++ b/apps/studio/src/components/studio-code-event-parser.ts
@@ -1,14 +1,13 @@
 import type { PermissionRequest } from './studio-code-ui-types';
+import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import type { StudioCodeEvent } from 'src/modules/studio-code/studio-code-event-types';
 
 // Translates the CLI's NDJSON wire format into reducer actions for
-// `studio-code-chat`. The CLI now wraps native pi `AgentSessionEvent`
-// payloads inside the legacy `{type:'message', message: <event>}` envelope,
-// so this parser pattern-matches against pi event shapes (`message_end`,
-// `turn_end`) rather than the prior SDK shapes. The other envelope-level
-// event types (`turn.started`, `turn.completed`, `question.asked`,
-// `progress`, `error`) come straight from `JsonAdapter.emit*` and stay
-// unchanged.
+// `studio-code-chat`. The CLI wraps native pi `AgentSessionEvent` payloads
+// inside the `{type:'message', message: <event>}` envelope, so this parser
+// pattern-matches against pi event shapes (`message_end`, `turn_end`). The
+// other envelope-level event types (`turn.started`, `turn.completed`,
+// `question.asked`, `progress`, `error`) come straight from `JsonAdapter.emit*`.
 
 interface PiTextContent {
 	type: 'text';
@@ -36,16 +35,10 @@ interface PiToolResultMessage {
 	isError?: boolean;
 }
 
-interface PiMessageEndEvent {
-	type: 'message_end';
-	message: PiAssistantMessage | { role: string };
-}
 interface PiTurnEndEvent {
 	type: 'turn_end';
 	toolResults?: PiToolResultMessage[];
 }
-
-type PiSessionEvent = PiMessageEndEvent | PiTurnEndEvent | { type: string };
 
 export type ParsedAction =
 	| { type: 'START_ASSISTANT_MESSAGE' }
@@ -66,13 +59,10 @@ function toolResultText( content: PiToolResultMessage[ 'content' ] ): string {
 		.join( '\n' );
 }
 
-function parseSessionMessage( raw: unknown ): ParsedAction[] {
-	const event = raw as PiSessionEvent | null | undefined;
-	if ( ! event || typeof event !== 'object' ) return [];
-
+function parseSessionMessage( event: AgentSessionEvent ): ParsedAction[] {
 	if ( event.type === 'message_end' ) {
-		const message = ( event as PiMessageEndEvent ).message;
-		if ( message?.role !== 'assistant' ) return [];
+		const message = event.message as PiAssistantMessage | { role?: string };
+		if ( message.role !== 'assistant' ) return [];
 		const actions: ParsedAction[] = [];
 		for ( const block of ( message as PiAssistantMessage ).content ?? [] ) {
 			if ( block.type === 'text' ) {

--- a/apps/studio/src/components/tests/studio-code-event-parser.test.ts
+++ b/apps/studio/src/components/tests/studio-code-event-parser.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { parseStudioCodeEvent } from '../studio-code-event-parser';
+import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import type { StudioCodeEvent } from 'src/modules/studio-code/studio-code-event-types';
 
 const ts = '2026-05-06T00:00:00.000Z';
 
 function envelope< T >( message: T ): StudioCodeEvent {
-	return { type: 'message', timestamp: ts, message: message as unknown } as StudioCodeEvent;
+	return { type: 'message', timestamp: ts, message: message as AgentSessionEvent };
 }
 
 describe( 'parseStudioCodeEvent — pi event shapes', () => {

--- a/apps/studio/src/modules/ai-agent/run-manager.ts
+++ b/apps/studio/src/modules/ai-agent/run-manager.ts
@@ -84,7 +84,7 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 	child.on( 'message', ( message ) => {
 		// The CLI's `Logger` also writes to this IPC channel with a different
 		// shape (`{ action, status, message }`) on error paths. Forward only
-		// messages that look like a JsonEvent.
+		// messages that look like the CLI JSON transport envelope.
 		if ( message && typeof message === 'object' && 'type' in message ) {
 			sendEvent( run, message as JsonEvent );
 		}

--- a/apps/ui/src/data/queries/use-agent-run.ts
+++ b/apps/ui/src/data/queries/use-agent-run.ts
@@ -286,10 +286,12 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 					} );
 					return;
 				case 'message': {
-					// `event.message` is an `AgentSessionEvent`; only the
-					// message-bearing variants need optimistic entries.
-					const inner = event.message as { type?: string; message?: { role?: string } } | undefined;
-					if ( inner?.type === 'message_end' && inner.message?.role === 'assistant' ) {
+					// Only message-bearing pi event variants need optimistic entries.
+					const inner = event.message;
+					if (
+						inner.type === 'message_end' &&
+						( inner.message as { role?: string } ).role === 'assistant'
+					) {
 						updateCache( ( entries ) => [
 							...entries,
 							{
@@ -300,8 +302,8 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 								message: inner.message,
 							} as unknown as SessionEntry,
 						] );
-					} else if ( inner?.type === 'turn_end' ) {
-						const toolResults = ( inner as { toolResults?: unknown[] } ).toolResults;
+					} else if ( inner.type === 'turn_end' ) {
+						const toolResults = inner.toolResults;
 						if ( Array.isArray( toolResults ) && toolResults.length > 0 ) {
 							updateCache( ( entries ) => [
 								...entries,

--- a/tools/common/ai/json-events.ts
+++ b/tools/common/ai/json-events.ts
@@ -1,3 +1,5 @@
+import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
+
 export type TurnCompletedStatus = 'success' | 'error' | 'paused' | 'max_turns';
 
 // Transient UI directives emitted by the agent's preview_* tools to
@@ -17,8 +19,14 @@ export interface MediaShareEvent {
 	caption?: string;
 }
 
+export interface AgentMessageJsonEvent {
+	type: 'message';
+	timestamp: string;
+	message: AgentSessionEvent;
+}
+
 export type JsonEvent =
-	| { type: 'message'; timestamp: string; message: unknown }
+	| AgentMessageJsonEvent
 	| { type: 'progress'; timestamp: string; message: string }
 	| { type: 'info'; timestamp: string; message: string }
 	| { type: 'error'; timestamp: string; message: string }


### PR DESCRIPTION
## Summary

Keeps the existing `studio code --json` wire format unchanged while making the `message` envelope explicitly carry a pi `AgentSessionEvent` instead of `unknown`.

## Changes

- Type the shared `JsonEvent` message payload as `AgentSessionEvent`.
- Remove local unknown pi-event casts from the app session rendering path, Studio Code parser, and remote-session turn runner.
- Reuse `findLastAssistant` in remote-session reply extraction instead of walking the transcript locally.
- Keep transport-boundary checks local to the IPC/stdout readers instead of adding shared JSON-event validation.

## Testing

- `npx eslint --fix tools/common/ai/json-events.ts apps/cli/ai/json-events.ts apps/cli/remote-session/media-streamer.ts apps/cli/remote-session/turn-runner.ts apps/studio/src/modules/ai-agent/run-manager.ts`
