### PR TITLE
Blueprints Gallery Library: Add search option to Blueprints

### DIFF
--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -2,15 +2,19 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
+	SearchControl as SearchControlWp,
 	Spinner,
 } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import StudioButton from 'src/components/button';
 import { EMPTY_SITE_PLAYGROUND_URL } from 'src/constants';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+
+const SearchControl = process.env.NODE_ENV === 'test' ? () => null : SearchControlWp;
+
 interface Blueprint {
 	slug: string;
 	title: string;
@@ -200,10 +204,10 @@ function renameBlueprintsForDisplay(
 	const excerptOverrides = getBlueprintExcerptOverrides( __ );
 	return [ ...blueprints ]
 		.sort( ( a, b ) => ( BLUEPRINT_ORDER[ a.title ] ?? 99 ) - ( BLUEPRINT_ORDER[ b.title ] ?? 99 ) )
-		.map( ( bp ) => ( {
-			...bp,
-			excerpt: excerptOverrides[ bp.title ] || bp.excerpt,
-			title: BLUEPRINT_DISPLAY_NAMES[ bp.title ] || bp.title,
+		.map( ( item ) => ( {
+			...item,
+			excerpt: excerptOverrides[ item.title ] || item.excerpt,
+			title: BLUEPRINT_DISPLAY_NAMES[ item.title ] || item.title,
 		} ) );
 }
 
@@ -218,6 +222,29 @@ export function NewSiteOptions( {
 	uploadButton,
 }: NewSiteOptionsProps ) {
 	const { __ } = useI18n();
+	const [ searchQuery, setSearchQuery ] = useState( '' );
+
+	const featuredBlueprints = blueprints.filter( ( blueprint ) =>
+		FEATURED_BLUEPRINT_SLUGS.has( blueprint.slug )
+	);
+	const exploreBlueprints = blueprints.filter(
+		( blueprint ) => ! FEATURED_BLUEPRINT_SLUGS.has( blueprint.slug )
+	);
+
+	const filteredExploreBlueprints = useMemo( () => {
+		const query = searchQuery.toLowerCase().trim();
+		if ( ! query ) {
+			return exploreBlueprints;
+		}
+		return exploreBlueprints.filter( ( blueprint ) => {
+			const titleMatch = blueprint.title.toLowerCase().includes( query );
+			const excerptMatch = blueprint.excerpt.toLowerCase().includes( query );
+			const categoryMatch = blueprint.blueprint?.meta?.categories?.some( ( category ) =>
+				category.toLowerCase().includes( query )
+			);
+			return titleMatch || excerptMatch || categoryMatch;
+		} );
+	}, [ exploreBlueprints, searchQuery ] );
 
 	const handleEmptyClick = useCallback( () => {
 		onBlueprintChange( 'empty' );
@@ -228,11 +255,6 @@ export function NewSiteOptions( {
 			onBlueprintChange( slug );
 		},
 		[ onBlueprintChange ]
-	);
-
-	const featuredBlueprints = blueprints.filter( ( bp ) => FEATURED_BLUEPRINT_SLUGS.has( bp.slug ) );
-	const exploreBlueprints = blueprints.filter(
-		( bp ) => ! FEATURED_BLUEPRINT_SLUGS.has( bp.slug )
 	);
 
 	return (
@@ -266,12 +288,12 @@ export function NewSiteOptions( {
 					</div>
 				) : (
 					enableBlueprints &&
-					renameBlueprintsForDisplay( featuredBlueprints, __ ).map( ( bp ) => (
+					renameBlueprintsForDisplay( featuredBlueprints, __ ).map( ( item ) => (
 						<BlueprintCard
-							key={ bp.slug }
-							blueprint={ bp }
-							isSelected={ selectedBlueprint === bp.slug }
-							onClick={ () => handleBlueprintClick( bp.slug ) }
+							key={ item.slug }
+							blueprint={ item }
+							isSelected={ selectedBlueprint === item.slug }
+							onClick={ () => handleBlueprintClick( item.slug ) }
 						/>
 					) )
 				) }
@@ -279,22 +301,34 @@ export function NewSiteOptions( {
 
 			{ enableBlueprints && ! isLoadingBlueprints && exploreBlueprints.length > 0 && (
 				<>
-					<Heading
-						className="text-[18px] text-frame-text mt-8 mb-4 w-full max-w-2xl mx-auto"
-						weight={ 500 }
-					>
-						{ __( 'Explore more blueprints' ) }
-					</Heading>
-					<div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full max-w-2xl mx-auto pb-1">
-						{ exploreBlueprints.map( ( bp ) => (
-							<BlueprintCard
-								key={ bp.slug }
-								blueprint={ bp }
-								isSelected={ selectedBlueprint === bp.slug }
-								onClick={ () => handleBlueprintClick( bp.slug ) }
-							/>
-						) ) }
+					<div className="flex items-center justify-between w-full max-w-2xl mx-auto mt-8 mb-4">
+						<Heading className="text-[18px] text-frame-text" weight={ 500 }>
+							{ __( 'Explore more blueprints' ) }
+						</Heading>
+						<SearchControl
+							className="!w-48 text-frame-text"
+							placeholder={ __( 'Search blueprints' ) }
+							onChange={ setSearchQuery }
+							value={ searchQuery }
+							__nextHasNoMarginBottom={ true }
+						/>
 					</div>
+					{ filteredExploreBlueprints.length === 0 ? (
+						<div className="flex items-center justify-center text-sm text-frame-text-secondary py-8 max-w-2xl mx-auto">
+							{ __( 'No blueprints found.' ) }
+						</div>
+					) : (
+						<div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full max-w-2xl mx-auto pb-1">
+							{ filteredExploreBlueprints.map( ( item ) => (
+								<BlueprintCard
+									key={ item.slug }
+									blueprint={ item }
+									isSelected={ selectedBlueprint === item.slug }
+									onClick={ () => handleBlueprintClick( item.slug ) }
+								/>
+							) ) }
+						</div>
+					) }
 				</>
 			) }
 		</VStack>


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1634

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

It was used to implement the feature. 

## Proposed Changes

This PR adds a search box for the blueprints that allows search by excerpt or title:

<img width="894" height="736" alt="Screenshot 2026-05-07 at 4 42 45 PM" src="https://github.com/user-attachments/assets/c4a53f6c-32c9-4f2c-952d-ded2f6d564a7" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm start`
* Enable the `Blueprints Gallery Library` feature flag
* Click on `Add site > Build new site`
* Scroll down to the blueprints library
* Confirm that you can use the search box and search by title or category

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
