### PR TITLE
CLI: add eval-runner result diagnostics

### DIFF
--- a/apps/cli/ai/eval-runner.ts
+++ b/apps/cli/ai/eval-runner.ts
@@ -19,6 +19,7 @@ import {
 } from 'cli/ai/auth';
 import { runStudioAgentTurn } from 'cli/ai/runtimes/pi';
 import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
+import type { StopReason, Usage } from '@mariozechner/pi-ai';
 import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import type { AiProviderId } from 'cli/ai/providers';
 
@@ -27,6 +28,61 @@ interface EvalRunnerInput {
 	timeoutMs?: number;
 	model?: AiModelId;
 }
+
+// Tool names that indicate the agent did "real work" (mutated state, ran a
+// command, scaffolded files, etc.). Used as a heuristic to detect runs where
+// the agent reported success but produced no assistant text and never invoked
+// a state-changing tool — typically a "false success" failure mode where the
+// model trivially ended a turn without addressing the prompt.
+const MUTATING_TOOL_NAMES = new Set( [
+	'Write',
+	'Edit',
+	'Bash',
+	'wp_cli',
+	'site_create',
+	'site_delete',
+	'site_import',
+	'site_export',
+	'site_pull',
+	'site_push',
+	'site_start',
+	'site_stop',
+	'scaffold_theme',
+	'install_taxonomy_scripts',
+	'preview_create',
+	'preview_delete',
+	'preview_update',
+	'wpcom_request',
+] );
+
+// Cap individual text/tool-result strings inside the opt-in transcript so a
+// single huge tool output doesn't explode the eval artifact.
+const TRANSCRIPT_TEXT_MAX_LENGTH = 4000;
+
+function truncateText( value: string, maxLength = TRANSCRIPT_TEXT_MAX_LENGTH ): string {
+	return value.length > maxLength
+		? `${ value.slice( 0, maxLength ) }…[truncated ${ value.length - maxLength } chars]`
+		: value;
+}
+
+type TranscriptEvent = {
+	index: number;
+	type: AgentSessionEvent[ 'type' ];
+	turnIndex: number;
+	elapsedMs: number;
+	text?: string[];
+	toolCalls?: ToolCallRecord[];
+	toolResult?: {
+		toolUseId: string;
+		toolName: string | null;
+		isError: boolean;
+		text?: string;
+	};
+	stopReason?: StopReason;
+	errorMessage?: string;
+	compaction?: { reason: string; aborted?: boolean };
+	autoRetry?: { attempt: number; success?: boolean; error?: string };
+};
 
 function extractToolCalls( event: AgentSessionEvent ) {
 	if ( event.type !== 'message_end' || event.message.role !== 'assistant' ) {
@@ -168,8 +224,16 @@ async function runEval( input: EvalRunnerInput ) {
 	let numTurns = 0;
 	let numTurnsResult: number | null = null;
 	let success = false;
+	let interrupted = false;
 	let error: string | null = null;
 	let timedOut = false;
+	let resultStopReason: StopReason | null = null;
+	let resultText = '';
+	let resultErrorMessage: string | null = null;
+	let resultUsage: Usage | null = null;
+	const includeTranscript = process.env.STUDIO_EVAL_INCLUDE_TRANSCRIPT === '1';
+	const transcript: TranscriptEvent[] = [];
+	let transcriptIndex = 0;
 
 	phaseStartedAt = Date.now();
 	const session = SessionManager.inMemory( STUDIO_SITES_ROOT );
@@ -177,6 +241,15 @@ async function runEval( input: EvalRunnerInput ) {
 	let turnStart = queryStartedAt;
 
 	const handleEvent = ( event: AgentSessionEvent ): void => {
+		const transcriptEvent: TranscriptEvent | null = includeTranscript
+			? {
+					index: ++transcriptIndex,
+					type: event.type,
+					turnIndex,
+					elapsedMs: elapsed(),
+			  }
+			: null;
+
 		if ( event.type === 'message_end' && event.message.role === 'assistant' ) {
 			const now = Date.now();
 			turnDurationsMs.push( now - turnStart );
@@ -185,8 +258,16 @@ async function runEval( input: EvalRunnerInput ) {
 				phaseTimingsMs.first_assistant_message_ms = now - queryStartedAt;
 			}
 			turnStart = now;
+			if ( transcriptEvent ) {
+				transcriptEvent.turnIndex = turnIndex;
+				transcriptEvent.stopReason = event.message.stopReason;
+				if ( event.message.errorMessage ) {
+					transcriptEvent.errorMessage = event.message.errorMessage;
+				}
+			}
 		}
-		for ( const tc of extractToolCalls( event ) ) {
+		const messageToolCalls = extractToolCalls( event );
+		for ( const tc of messageToolCalls ) {
 			toolCalls.push( tc );
 			toolNameById.set( tc.id, tc.name );
 			const evt: ToolEvent = {
@@ -199,7 +280,14 @@ async function runEval( input: EvalRunnerInput ) {
 			toolEvents.push( evt );
 			toolEventById.set( tc.id, evt );
 		}
-		textSegments.push( ...extractTextSegments( event ) );
+		if ( transcriptEvent && messageToolCalls.length > 0 ) {
+			transcriptEvent.toolCalls = messageToolCalls;
+		}
+		const messageTextSegments = extractTextSegments( event );
+		textSegments.push( ...messageTextSegments );
+		if ( transcriptEvent && messageTextSegments.length > 0 ) {
+			transcriptEvent.text = messageTextSegments.map( ( segment ) => truncateText( segment ) );
+		}
 
 		if ( event.type === 'tool_execution_end' ) {
 			const tr = extractToolResult( event );
@@ -226,6 +314,14 @@ async function runEval( input: EvalRunnerInput ) {
 					isError: tr.isError,
 					...( tr.text ? { text: tr.text } : {} ),
 				} );
+				if ( transcriptEvent ) {
+					transcriptEvent.toolResult = {
+						toolUseId: id,
+						toolName: toolNameById.get( id ) ?? null,
+						isError: tr.isError,
+						...( tr.text ? { text: truncateText( tr.text ) } : {} ),
+					};
+				}
 			}
 		}
 
@@ -233,12 +329,62 @@ async function runEval( input: EvalRunnerInput ) {
 			numTurns += 1;
 		}
 
+		if ( event.type === 'compaction_start' || event.type === 'compaction_end' ) {
+			if ( transcriptEvent ) {
+				transcriptEvent.compaction = {
+					reason: event.reason,
+					...( event.type === 'compaction_end' ? { aborted: event.aborted } : {} ),
+				};
+			}
+		}
+
+		if ( event.type === 'auto_retry_start' ) {
+			if ( transcriptEvent ) {
+				transcriptEvent.autoRetry = {
+					attempt: event.attempt,
+					error: event.errorMessage,
+				};
+			}
+		}
+		if ( event.type === 'auto_retry_end' ) {
+			if ( transcriptEvent ) {
+				transcriptEvent.autoRetry = {
+					attempt: event.attempt,
+					success: event.success,
+					...( event.finalError ? { error: event.finalError } : {} ),
+				};
+			}
+		}
+
 		if ( event.type === 'agent_end' ) {
 			const lastAssistant = findLastAssistant( event.messages );
 			success =
 				! lastAssistant ||
 				( lastAssistant.stopReason !== 'error' && lastAssistant.stopReason !== 'aborted' );
+			interrupted = lastAssistant?.stopReason === 'aborted';
+			if ( lastAssistant ) {
+				resultStopReason = lastAssistant.stopReason;
+				resultErrorMessage = lastAssistant.errorMessage ?? null;
+				resultUsage = lastAssistant.usage;
+				resultText = lastAssistant.content
+					.filter( ( c ): c is { type: 'text'; text: string } => c.type === 'text' )
+					.map( ( c ) => c.text )
+					.join( '\n' )
+					.trim();
+			}
 			numTurnsResult = numTurns;
+			if ( transcriptEvent ) {
+				if ( resultStopReason ) {
+					transcriptEvent.stopReason = resultStopReason;
+				}
+				if ( resultErrorMessage ) {
+					transcriptEvent.errorMessage = resultErrorMessage;
+				}
+			}
+		}
+
+		if ( transcriptEvent ) {
+			transcript.push( transcriptEvent );
 		}
 	};
 
@@ -265,8 +411,15 @@ async function runEval( input: EvalRunnerInput ) {
 	}
 	phaseTimingsMs.total_eval_ms = elapsed();
 
+	const hasAnyAssistantText = textSegments.some( ( segment ) => segment.trim().length > 0 );
+	const hasSuccessfulMutatingTool = toolResults.some(
+		( tr ) => ! tr.isError && tr.toolName !== null && MUTATING_TOOL_NAMES.has( tr.toolName )
+	);
+	const producedNoUsefulOutput = success && ! hasAnyAssistantText && ! hasSuccessfulMutatingTool;
+
 	return {
 		success,
+		interrupted,
 		error,
 		timedOut,
 		numTurns: numTurnsResult,
@@ -277,6 +430,12 @@ async function runEval( input: EvalRunnerInput ) {
 		toolEvents,
 		firstToolError,
 		textSegments,
+		resultStopReason,
+		resultText,
+		resultErrorMessage,
+		resultUsage,
+		producedNoUsefulOutput,
+		...( includeTranscript ? { transcript } : {} ),
 	};
 }
 

--- a/apps/cli/ai/eval-runner.ts
+++ b/apps/cli/ai/eval-runner.ts
@@ -9,7 +9,6 @@
 import { writeFileSync, writeSync as fsWriteSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { SessionManager } from '@mariozechner/pi-coding-agent';
 import { isAiModelId, type AiModelId } from '@studio/common/ai/models';
 import { findLastAssistant } from '@studio/common/ai/session-events';
 import {
@@ -17,8 +16,6 @@ import {
 	resolveInitialAiProvider,
 	resolveUnavailableAiProvider,
 } from 'cli/ai/auth';
-import { runStudioAgentTurn } from 'cli/ai/runtimes/pi';
-import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
 import type { StopReason, Usage } from '@mariozechner/pi-ai';
 import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import type { AiProviderId } from 'cli/ai/providers';
@@ -187,6 +184,12 @@ async function runEval( input: EvalRunnerInput ) {
 	const elapsed = () => Date.now() - evalStartedAt;
 	const phaseTimingsMs: Record< string, number > = {};
 	let phaseStartedAt = Date.now();
+	process.env.STUDIO_SITES_ROOT ??= process.cwd();
+	const [ { SessionManager }, { runStudioAgentTurn }, { STUDIO_SITES_ROOT } ] = await Promise.all( [
+		import( '@mariozechner/pi-coding-agent' ),
+		import( 'cli/ai/runtimes/pi' ),
+		import( 'cli/lib/site-paths' ),
+	] );
 
 	let aiProvider: AiProviderId = await resolveInitialAiProvider();
 	phaseTimingsMs.resolve_initial_provider_ms = Date.now() - phaseStartedAt;

--- a/apps/cli/lib/site-paths.ts
+++ b/apps/cli/lib/site-paths.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import path from 'path';
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
 
-export const STUDIO_SITES_ROOT = path.join( os.homedir(), 'Studio' );
+export const STUDIO_SITES_ROOT = process.env.STUDIO_SITES_ROOT || path.join( os.homedir(), 'Studio' );
 
 export function getDefaultSitePath( siteName: string ): string {
 	const folderName = sanitizeFolderName( siteName );

--- a/apps/cli/lib/site-paths.ts
+++ b/apps/cli/lib/site-paths.ts
@@ -2,7 +2,8 @@ import os from 'os';
 import path from 'path';
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
 
-export const STUDIO_SITES_ROOT = process.env.STUDIO_SITES_ROOT || path.join( os.homedir(), 'Studio' );
+export const STUDIO_SITES_ROOT =
+	process.env.STUDIO_SITES_ROOT || path.join( os.homedir(), 'Studio' );
 
 export function getDefaultSitePath( siteName: string ): string {
 	const folderName = sanitizeFolderName( siteName );


### PR DESCRIPTION
## Summary

- Capture final SDK result metadata in eval-runner output: `resultStopReason`, `resultText`, `resultErrorMessage`, `resultUsage`, and `interrupted`. All derived from `findLastAssistant(event.messages)` on `agent_end` so they reflect the same source of truth as `success`.
- Add `producedNoUsefulOutput`, a heuristic that flags runs where the agent reported `success` but produced neither assistant text nor a successful mutating-tool call. The motivating failure mode is GPT-5.5 ending a turn after read-only tool calls (`site_list`, `site_info`) without writing anything or explaining anything — runs that classify as `success` today but produce no import report, no assistant text, and no `Write` / `wp_cli` activity.
- Add opt-in compact transcript diagnostics behind `STUDIO_EVAL_INCLUDE_TRANSCRIPT=1`. The transcript records every `AgentSessionEvent` (including `compaction_*` and `auto_retry_*`) with text / tool-result truncation, so default artifacts stay small while deeper debugging remains available when investigating model / runtime / harness regressions.

## Why

This continues the eval-runner observability work from #3273 and #3330. Those PRs made phase / tool timings, first tool errors, loop exceptions, and timeouts visible. This adds the final SDK result shape and an opt-in turn transcript so eval consumers can distinguish model behavior, pi-coding-agent harness continuation behavior, runner classification, and downstream benchmark quality gates.

The need surfaced while testing the Static Site Importer draft path in #3309 with the Studio site-build benchmark. GPT-5.5 repeatedly produced tool-only runs for built-in prompt variants (`restaurant`, `wordpress-is-dead`): `site_list` / `site_info` returned successfully, then the agent ended the turn with no assistant text, no `Write`, no `wp_cli`, and no import report. The eval runner classified the run as successful because the run terminated cleanly. With these diagnostics, those runs are now mechanically detectable as `producedNoUsefulOutput: true`.

## Replaces #3349

This PR replaces #3349, which was written against the pre-#3360 `SDKMessage` event model. After #3360 landed (`AI sessions: adopt pi-coding-agent SessionManager end-to-end`), the original PR could not be rebased — every event-handling code path it touched changed shape:

- `startAiAgent()` async iterator → `runStudioAgentTurn()` callback
- `SDKMessage` (`assistant` / `user` / `result`) → `AgentSessionEvent` (`message_end` / `tool_execution_end` / `turn_end` / `agent_end` / `compaction_*` / `auto_retry_*`)
- Final `result` SDKMessage with `subtype` / `stop_reason` / `result` / `is_error` / `errors` → no terminal `result` message at all; the canonical end-state lives on `findLastAssistant(event.messages).stopReason` plus the helper `getAgentEndTurnResult()` exposed by the new `@studio/common/ai/session-events` module

This rewrite is small (+161 / -2 lines, single file) and aligned with the new event surface. Closing #3349 in favor of this PR.

## Validation

- `npx eslint apps/cli/ai/eval-runner.ts` — clean
- `npm -w wp-studio run typecheck` — clean
- `npm run cli:build --silent` — clean, `apps/cli/dist/cli/eval-runner.mjs` produced
- **Direct smoke run** (no tools, identity prompt): all new fields populate correctly; `producedNoUsefulOutput: false` because the assistant produced text.
- **Single-tool eval** (`studio-agent-site-info.bench.mjs`, read-only `site_info`): tool calls and truncated tool results captured in transcript; `producedNoUsefulOutput: false`.
- **Multi-turn mutating run**: `Create a new Studio site named X. Then use wp_cli to set the blog title to Eval Validation. Confirm by saying done.` — agent called `site_create` and `wp_cli` across 3 turns, generated a real local Studio site (cleaned up afterward), `producedNoUsefulOutput: false`, `resultUsage` reported input / output / cache tokens and cost.
- **Read-only tool-only run**: `Use only site_list and respond with nothing else. Do not say anything.` — the agent called `site_list`, produced no text, `success: true`, `producedNoUsefulOutput: true`. This is the exact failure mode the heuristic is designed to flag.
- Existing `studio-agent-runtime.bench.mjs` and `studio-agent-site-info.bench.mjs` ran end-to-end against the new runner with no breakage. The benches don't yet consume the new fields; that's a separate change in the rig.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Rewriting the diagnostics layer against the new `AgentSessionEvent` / pi-coding-agent `SessionManager` model that landed in #3360, running the validation matrix above, and drafting this PR description. Chris reviewed the failure-mode evidence and remains responsible for the change.