### PR TITLE
apps/ui: Add user desk chats panel

### DIFF
--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -215,14 +215,27 @@ export async function deleteAiSession(
 
 export async function createAiSession(
 	_event: IpcMainInvokeEvent,
-	siteId: string
+	siteId?: string
 ): Promise< AiSessionSummary > {
+	const sitesRoot = getAiSessionsRootDirectory();
+	if ( ! siteId ) {
+		const existing = await listAiSessionsFromStore( sitesRoot );
+		const emptyUserDeskSession = existing
+			.filter( ( session ) => ! session.ownerSitePath && ! session.firstPrompt )
+			.sort( ( a, b ) => Date.parse( b.updatedAt ) - Date.parse( a.updatedAt ) )[ 0 ];
+
+		if ( emptyUserDeskSession ) {
+			return emptyUserDeskSession;
+		}
+
+		return createAiSessionInStore( sitesRoot );
+	}
+
 	const server = SiteServer.get( siteId );
 	if ( ! server ) {
 		throw new Error( `Site not found: ${ siteId }` );
 	}
 	const sitePath = server.details.path;
-	const sitesRoot = getAiSessionsRootDirectory();
 
 	// Reuse the newest existing empty session for this site (one that has
 	// never received a user prompt) instead of creating another one. This

--- a/apps/ui/src/components/floating-surface-motion/style.module.css
+++ b/apps/ui/src/components/floating-surface-motion/style.module.css
@@ -1,0 +1,73 @@
+.motion {
+	--studio-floating-surface-width-duration: 0ms;
+	--studio-floating-surface-transform-duration: 180ms;
+	--studio-floating-surface-opacity-duration: 160ms;
+	--studio-floating-surface-easing: cubic-bezier(0.2, 0.8, 0.2, 1);
+
+	transform-origin: top left;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.motion {
+		transition:
+			width var(--studio-floating-surface-width-duration)
+				var(--studio-floating-surface-easing),
+			transform var(--studio-floating-surface-transform-duration)
+				var(--studio-floating-surface-easing),
+			opacity var(--studio-floating-surface-opacity-duration)
+				var(--studio-floating-surface-easing);
+	}
+
+	.motion[data-align='center'] {
+		transform-origin: top center;
+	}
+
+	.motion[data-align='end'] {
+		transform-origin: top right;
+	}
+
+	.motion[data-side='top'] {
+		transform-origin: bottom left;
+	}
+
+	.motion[data-side='top'][data-align='center'] {
+		transform-origin: bottom center;
+	}
+
+	.motion[data-side='top'][data-align='end'] {
+		transform-origin: bottom right;
+	}
+
+	.motion[data-side='left'] {
+		transform-origin: center right;
+	}
+
+	.motion[data-side='right'] {
+		transform-origin: center left;
+	}
+
+	.motion[data-instant] {
+		transition-duration: 0ms;
+	}
+
+	.motion[data-starting-style],
+	.motion[data-ending-style] {
+		opacity: 0;
+		transform: translateY(-4px) scale(0.96);
+	}
+
+	.motion[data-side='top'][data-starting-style],
+	.motion[data-side='top'][data-ending-style] {
+		transform: translateY(4px) scale(0.96);
+	}
+
+	.motion[data-side='left'][data-starting-style],
+	.motion[data-side='left'][data-ending-style] {
+		transform: translateX(4px) scale(0.96);
+	}
+
+	.motion[data-side='right'][data-starting-style],
+	.motion[data-side='right'][data-ending-style] {
+		transform: translateX(-4px) scale(0.96);
+	}
+}

--- a/apps/ui/src/components/menu/index.tsx
+++ b/apps/ui/src/components/menu/index.tsx
@@ -1,6 +1,7 @@
 import { Menu as BaseMenu } from '@base-ui/react/menu';
 import { privateApis } from '@wordpress/theme';
 import { forwardRef } from 'react';
+import motionStyles from '@/components/floating-surface-motion/style.module.css';
 import { unlock } from '@/lock-unlock';
 import styles from './style.module.css';
 import type { ComponentPropsWithoutRef, ElementRef, ReactNode } from 'react';
@@ -49,7 +50,9 @@ export function Popup( {
 					establish the density context here so icons inside the
 					popup render at 16px like the rest of the app. */ }
 				<ThemeProvider density="compact">
-					<BaseMenu.Popup className={ `${ styles.popup } ${ className ?? '' }` }>
+					<BaseMenu.Popup
+						className={ `${ styles.popup } ${ motionStyles.motion } ${ className ?? '' }` }
+					>
 						{ children }
 					</BaseMenu.Popup>
 				</ThemeProvider>

--- a/apps/ui/src/components/session-view/composer/index.tsx
+++ b/apps/ui/src/components/session-view/composer/index.tsx
@@ -2,11 +2,10 @@ import { AI_MODELS, getAiModelFamily, getAiModelLabel } from '@studio/common/ai/
 import { isStudioCustomEntryOfType } from '@studio/common/ai/sessions/entry-types';
 import { AI_SKILL_COMMANDS } from '@studio/common/ai/slash-commands';
 import { useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { arrowUp, chevronDownSmall } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
-import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import * as Menu from '@/components/menu';
 import { useConnector } from '@/data/core';
 import { SESSIONS_QUERY_KEY } from '@/data/queries/use-sessions';
@@ -55,6 +54,8 @@ interface ComposerProps {
 	// family swap; if absent we fall back to the in-place model change so the
 	// dropdown still works for unowned sessions.
 	ownerSiteId?: string;
+	onSwitchSession?: ( sessionId: string ) => void;
+	autoFocus?: boolean;
 }
 
 /**
@@ -83,6 +84,8 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 		liveSite,
 		entries,
 		ownerSiteId,
+		onSwitchSession,
+		autoFocus = false,
 	},
 	ref
 ) {
@@ -90,13 +93,18 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 	const textareaRef = useRef< HTMLTextAreaElement | null >( null );
 	const connector = useConnector();
 	const queryClient = useQueryClient();
-	const navigate = useNavigate();
 
 	// Cross-family swap state. We hold the picked model here while the
 	// confirmation dialog is open; nothing is persisted until the user
 	// confirms.
 	const [ pendingFamilyChange, setPendingFamilyChange ] = useState< AiModelId | null >( null );
 	const [ familySwitchInFlight, setFamilySwitchInFlight ] = useState( false );
+
+	useEffect( () => {
+		if ( autoFocus ) {
+			textareaRef.current?.focus();
+		}
+	}, [ autoFocus, sessionId ] );
 
 	useImperativeHandle(
 		ref,
@@ -224,11 +232,11 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 				.catch( () => undefined );
 			void queryClient.invalidateQueries( { queryKey: SESSIONS_QUERY_KEY } );
 			setPendingFamilyChange( null );
-			void navigate( { to: '/sessions/$sessionId', params: { sessionId: newSession.id } } );
+			onSwitchSession?.( newSession.id );
 		} finally {
 			setFamilySwitchInFlight( false );
 		}
-	}, [ connector, navigate, ownerSiteId, pendingFamilyChange, queryClient ] );
+	}, [ connector, onSwitchSession, ownerSiteId, pendingFamilyChange, queryClient ] );
 
 	const canSend = value.trim().length > 0;
 	const placeholder = busy

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -1,4 +1,5 @@
 import { resolveSessionModel } from '@studio/common/ai/models';
+import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
@@ -128,6 +129,7 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 }
 
 function SessionViewContent( { sessionId }: { sessionId: string } ) {
+	const navigate = useNavigate();
 	const { data, isLoading, error } = useSession( sessionId );
 	const { data: sites } = useSites();
 	const ownerSitePath = data?.summary.ownerSitePath;
@@ -249,6 +251,12 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 						liveSite={ liveSite }
 						entries={ data.entries }
 						ownerSiteId={ ownerSite?.id }
+						onSwitchSession={ ( nextSessionId ) =>
+							void navigate( {
+								to: '/sessions/$sessionId',
+								params: { sessionId: nextSessionId },
+							} )
+						}
 					/>
 				</div>
 			}

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -194,10 +194,9 @@ export interface Connector {
 	getSession( sessionId: string ): Promise< LoadedAiSession >;
 	deleteSession( sessionId: string ): Promise< void >;
 
-	// Create an empty session file attached to a site, so the new session
-	// appears in the sidebar immediately. The first prompt flows through
-	// `continueSession` as usual.
-	createSession( siteId: string ): Promise< AiSessionSummary >;
+	// Create an empty session file so it appears immediately. When `siteId`
+	// is omitted, the session is a user-desk chat with no owner site.
+	createSession( siteId?: string ): Promise< AiSessionSummary >;
 
 	// Continue an existing session by sending a new prompt. Returns a `runId`
 	// that identifies the in-flight agent run; live events for that run stream

--- a/apps/ui/src/data/queries/use-sessions.ts
+++ b/apps/ui/src/data/queries/use-sessions.ts
@@ -43,7 +43,7 @@ export function useCreateSession() {
 	const connector = useConnector();
 	const queryClient = useQueryClient();
 	return useMutation( {
-		mutationFn: ( siteId: string ) => connector.createSession( siteId ),
+		mutationFn: ( siteId?: string ) => connector.createSession( siteId ),
 		onSuccess: () => queryClient.invalidateQueries( { queryKey: SESSIONS_QUERY_KEY } ),
 	} );
 }

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -110,7 +110,7 @@ a:focus:not(:focus-visible),
    density only shrinks padding/gap tokens, not icon sizes. Override the
    svg width/height attributes with CSS until the design system exposes
    a density-aware icon token. Ideally this lives in ThemeProvider. */
-[data-wpds-density='compact'] svg {
+[data-wpds-density='compact'] [data-ui-mode='classic'] svg {
 	width: 16px;
 	height: 16px;
 }
@@ -140,4 +140,3 @@ a:focus:not(:focus-visible),
 		scroll-behavior: auto !important;
 	}
 }
-

--- a/apps/ui/src/ui-classic/app.tsx
+++ b/apps/ui/src/ui-classic/app.tsx
@@ -11,5 +11,9 @@ interface ClassicUiAppProps {
 export function ClassicUiApp( { connector }: ClassicUiAppProps ) {
 	const router = useMemo( () => createAppRouter( { queryClient, connector } ), [ connector ] );
 
-	return <RouterProvider router={ router } />;
+	return (
+		<div data-ui-mode="classic">
+			<RouterProvider router={ router } />
+		</div>
+	);
 }

--- a/apps/ui/src/ui-desks/app.tsx
+++ b/apps/ui/src/ui-desks/app.tsx
@@ -12,7 +12,7 @@ export function DesksUiApp() {
 				chatsOpen={ chatsOpen }
 				onToggleChats={ () => setChatsOpen( ( open ) => ! open ) }
 			/>
-			<UserDeskChats open={ chatsOpen } />
+			<UserDeskChats open={ chatsOpen } onOpenChange={ setChatsOpen } />
 			<UserDesk />
 		</div>
 	);

--- a/apps/ui/src/ui-desks/app.tsx
+++ b/apps/ui/src/ui-desks/app.tsx
@@ -1,10 +1,18 @@
+import { useState } from 'react';
+import { UserDeskChats } from './chats';
 import { DeskChrome } from './chrome';
 import { UserDesk } from './user-desk';
 
 export function DesksUiApp() {
+	const [ chatsOpen, setChatsOpen ] = useState( false );
+
 	return (
 		<>
-			<DeskChrome />
+			<DeskChrome
+				chatsOpen={ chatsOpen }
+				onToggleChats={ () => setChatsOpen( ( open ) => ! open ) }
+			/>
+			<UserDeskChats open={ chatsOpen } />
 			<UserDesk />
 		</>
 	);

--- a/apps/ui/src/ui-desks/app.tsx
+++ b/apps/ui/src/ui-desks/app.tsx
@@ -7,13 +7,13 @@ export function DesksUiApp() {
 	const [ chatsOpen, setChatsOpen ] = useState( false );
 
 	return (
-		<>
+		<div data-ui-mode="desks">
 			<DeskChrome
 				chatsOpen={ chatsOpen }
 				onToggleChats={ () => setChatsOpen( ( open ) => ! open ) }
 			/>
 			<UserDeskChats open={ chatsOpen } />
 			<UserDesk />
-		</>
+		</div>
 	);
 }

--- a/apps/ui/src/ui-desks/chats/index.tsx
+++ b/apps/ui/src/ui-desks/chats/index.tsx
@@ -3,7 +3,6 @@ import { Button } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useEffect, useMemo, useState } from 'react';
 import { useCreateSession, useSessions } from '@/data/queries/use-sessions';
-import { useFullscreen } from '@/hooks/use-fullscreen';
 import { formatRelativeTime } from '@/lib/format-relative-time';
 import { DeskSessionSurface } from './session-surface';
 import styles from './style.module.css';
@@ -26,7 +25,6 @@ function getSessionSubtitle( session: AiSessionSummary ) {
 }
 
 export function UserDeskChats( { open }: UserDeskChatsProps ) {
-	const isFullscreen = useFullscreen();
 	const { data: sessions } = useSessions();
 	const createSession = useCreateSession();
 	const [ selectedSessionId, setSelectedSessionId ] = useState< string | undefined >( undefined );
@@ -67,11 +65,7 @@ export function UserDeskChats( { open }: UserDeskChatsProps ) {
 
 	return (
 		<section
-			className={ clsx(
-				styles.panel,
-				expanded && styles.panelExpanded,
-				isFullscreen && styles.panelFullscreen
-			) }
+			className={ clsx( styles.panel, expanded && styles.panelExpanded ) }
 			aria-label={ __( 'Conversations' ) }
 		>
 			<div className={ styles.listPane }>

--- a/apps/ui/src/ui-desks/chats/index.tsx
+++ b/apps/ui/src/ui-desks/chats/index.tsx
@@ -1,0 +1,129 @@
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import { useEffect, useMemo, useState } from 'react';
+import { useCreateSession, useSessions } from '@/data/queries/use-sessions';
+import { useFullscreen } from '@/hooks/use-fullscreen';
+import { formatRelativeTime } from '@/lib/format-relative-time';
+import { DeskSessionSurface } from './session-surface';
+import styles from './style.module.css';
+import type { AiSessionSummary } from '@/data/core';
+
+interface UserDeskChatsProps {
+	open: boolean;
+}
+
+function getSessionTitle( session: AiSessionSummary ) {
+	return session.firstPrompt?.trim() || __( 'New chat' );
+}
+
+function getSessionSubtitle( session: AiSessionSummary ) {
+	if ( ! session.firstPrompt ) {
+		return __( 'Ask Studio Desk anything to get started.' );
+	}
+
+	return formatRelativeTime( session.updatedAt );
+}
+
+export function UserDeskChats( { open }: UserDeskChatsProps ) {
+	const isFullscreen = useFullscreen();
+	const { data: sessions } = useSessions();
+	const createSession = useCreateSession();
+	const [ selectedSessionId, setSelectedSessionId ] = useState< string | undefined >( undefined );
+	const [ expanded, setExpanded ] = useState( false );
+	const [ autoFocusSessionId, setAutoFocusSessionId ] = useState< string | undefined >( undefined );
+	const userDeskSessions = useMemo(
+		() =>
+			[ ...( sessions ?? [] ).filter( ( session ) => ! session.ownerSitePath ) ].sort(
+				( a, b ) => Date.parse( b.updatedAt ) - Date.parse( a.updatedAt )
+			),
+		[ sessions ]
+	);
+	const selectedSession = userDeskSessions.find( ( session ) => session.id === selectedSessionId );
+
+	useEffect( () => {
+		if ( selectedSessionId && ! selectedSession ) {
+			setSelectedSessionId( undefined );
+			setExpanded( false );
+		}
+	}, [ selectedSession, selectedSessionId ] );
+
+	if ( ! open ) {
+		return null;
+	}
+
+	const handleSelectSession = ( sessionId: string ) => {
+		setSelectedSessionId( sessionId );
+		setExpanded( true );
+		setAutoFocusSessionId( undefined );
+	};
+
+	const handleNewChat = async () => {
+		const session = await createSession.mutateAsync( undefined );
+		setSelectedSessionId( session.id );
+		setExpanded( true );
+		setAutoFocusSessionId( session.id );
+	};
+
+	return (
+		<section
+			className={ clsx(
+				styles.panel,
+				expanded && styles.panelExpanded,
+				isFullscreen && styles.panelFullscreen
+			) }
+			aria-label={ __( 'Conversations' ) }
+		>
+			<div className={ styles.listPane }>
+				<header className={ styles.header }>
+					<h2>{ __( 'Conversations' ) }</h2>
+				</header>
+				<div className={ styles.list }>
+					{ userDeskSessions.map( ( session ) => (
+						<button
+							key={ session.id }
+							type="button"
+							className={ clsx(
+								styles.sessionItem,
+								session.id === selectedSessionId && styles.sessionItemActive
+							) }
+							onClick={ () => handleSelectSession( session.id ) }
+						>
+							<span className={ styles.sessionTitle }>{ getSessionTitle( session ) }</span>
+							<span className={ styles.sessionSubtitle }>{ getSessionSubtitle( session ) }</span>
+						</button>
+					) ) }
+				</div>
+				<footer className={ styles.footer }>
+					<Button
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						className={ styles.newChatButton }
+						loading={ createSession.isPending }
+						loadingAnnouncement={ __( 'Creating chat' ) }
+						onClick={ () => void handleNewChat() }
+					>
+						{ __( '+ New chat' ) }
+					</Button>
+				</footer>
+			</div>
+			{ expanded ? (
+				<div className={ styles.chatPane }>
+					{ selectedSessionId ? (
+						<DeskSessionSurface
+							key={ selectedSessionId }
+							sessionId={ selectedSessionId }
+							onSwitchSession={ setSelectedSessionId }
+							autoFocus={ autoFocusSessionId === selectedSessionId }
+						/>
+					) : (
+						<div className={ styles.emptyChat }>
+							{ __( 'Ask Studio Desk anything to get started.' ) }
+						</div>
+					) }
+				</div>
+			) : null }
+		</section>
+	);
+}

--- a/apps/ui/src/ui-desks/chats/index.tsx
+++ b/apps/ui/src/ui-desks/chats/index.tsx
@@ -1,7 +1,9 @@
+import { Dialog } from '@base-ui/react/dialog';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useEffect, useMemo, useState } from 'react';
+import motionStyles from '@/components/floating-surface-motion/style.module.css';
 import { useCreateSession, useSessions } from '@/data/queries/use-sessions';
 import { formatRelativeTime } from '@/lib/format-relative-time';
 import { DeskSessionSurface } from './session-surface';
@@ -10,6 +12,7 @@ import type { AiSessionSummary } from '@/data/core';
 
 interface UserDeskChatsProps {
 	open: boolean;
+	onOpenChange: ( open: boolean ) => void;
 }
 
 function getSessionTitle( session: AiSessionSummary ) {
@@ -24,7 +27,7 @@ function getSessionSubtitle( session: AiSessionSummary ) {
 	return formatRelativeTime( session.updatedAt );
 }
 
-export function UserDeskChats( { open }: UserDeskChatsProps ) {
+export function UserDeskChats( { open, onOpenChange }: UserDeskChatsProps ) {
 	const { data: sessions } = useSessions();
 	const createSession = useCreateSession();
 	const [ selectedSessionId, setSelectedSessionId ] = useState< string | undefined >( undefined );
@@ -46,10 +49,6 @@ export function UserDeskChats( { open }: UserDeskChatsProps ) {
 		}
 	}, [ selectedSession, selectedSessionId ] );
 
-	if ( ! open ) {
-		return null;
-	}
-
 	const handleSelectSession = ( sessionId: string ) => {
 		setSelectedSessionId( sessionId );
 		setExpanded( true );
@@ -64,60 +63,73 @@ export function UserDeskChats( { open }: UserDeskChatsProps ) {
 	};
 
 	return (
-		<section
-			className={ clsx( styles.panel, expanded && styles.panelExpanded ) }
-			aria-label={ __( 'Conversations' ) }
+		<Dialog.Root
+			open={ open }
+			onOpenChange={ onOpenChange }
+			modal={ false }
+			disablePointerDismissal
 		>
-			<div className={ styles.listPane }>
-				<header className={ styles.header }>
-					<h2>{ __( 'Conversations' ) }</h2>
-				</header>
-				<div className={ styles.list }>
-					{ userDeskSessions.map( ( session ) => (
-						<button
-							key={ session.id }
-							type="button"
-							className={ clsx(
-								styles.sessionItem,
-								session.id === selectedSessionId && styles.sessionItemActive
-							) }
-							onClick={ () => handleSelectSession( session.id ) }
-						>
-							<span className={ styles.sessionTitle }>{ getSessionTitle( session ) }</span>
-							<span className={ styles.sessionSubtitle }>{ getSessionSubtitle( session ) }</span>
-						</button>
-					) ) }
-				</div>
-				<footer className={ styles.footer }>
-					<Button
-						variant="minimal"
-						tone="neutral"
-						size="small"
-						className={ styles.newChatButton }
-						loading={ createSession.isPending }
-						loadingAnnouncement={ __( 'Creating chat' ) }
-						onClick={ () => void handleNewChat() }
-					>
-						{ __( '+ New chat' ) }
-					</Button>
-				</footer>
-			</div>
-			{ expanded ? (
-				<div className={ styles.chatPane }>
-					{ selectedSessionId ? (
-						<DeskSessionSurface
-							key={ selectedSessionId }
-							sessionId={ selectedSessionId }
-							onSwitchSession={ setSelectedSessionId }
-							autoFocus={ autoFocusSessionId === selectedSessionId }
-						/>
-					) : (
-						<div className={ styles.emptyChat }>
-							{ __( 'Ask Studio Desk anything to get started.' ) }
+			<Dialog.Portal>
+				<Dialog.Popup
+					initialFocus={ false }
+					finalFocus={ false }
+					className={ clsx( styles.panel, motionStyles.motion, expanded && styles.panelExpanded ) }
+					aria-label={ __( 'Conversations' ) }
+				>
+					<div className={ styles.listPane }>
+						<header className={ styles.header }>
+							<h2>{ __( 'Conversations' ) }</h2>
+						</header>
+						<div className={ styles.list }>
+							{ userDeskSessions.map( ( session ) => (
+								<button
+									key={ session.id }
+									type="button"
+									className={ clsx(
+										styles.sessionItem,
+										session.id === selectedSessionId && styles.sessionItemActive
+									) }
+									onClick={ () => handleSelectSession( session.id ) }
+								>
+									<span className={ styles.sessionTitle }>{ getSessionTitle( session ) }</span>
+									<span className={ styles.sessionSubtitle }>
+										{ getSessionSubtitle( session ) }
+									</span>
+								</button>
+							) ) }
 						</div>
-					) }
-				</div>
-			) : null }
-		</section>
+						<footer className={ styles.footer }>
+							<Button
+								variant="minimal"
+								tone="neutral"
+								size="small"
+								className={ styles.newChatButton }
+								loading={ createSession.isPending }
+								loadingAnnouncement={ __( 'Creating chat' ) }
+								onClick={ () => void handleNewChat() }
+							>
+								{ __( '+ New chat' ) }
+							</Button>
+						</footer>
+					</div>
+					{ expanded ? (
+						<div className={ styles.chatPane }>
+							{ selectedSessionId ? (
+								<DeskSessionSurface
+									key={ selectedSessionId }
+									sessionId={ selectedSessionId }
+									onSwitchSession={ setSelectedSessionId }
+									autoFocus={ autoFocusSessionId === selectedSessionId }
+								/>
+							) : (
+								<div className={ styles.emptyChat }>
+									{ __( 'Ask Studio Desk anything to get started.' ) }
+								</div>
+							) }
+						</div>
+					) : null }
+				</Dialog.Popup>
+			</Dialog.Portal>
+		</Dialog.Root>
 	);
 }

--- a/apps/ui/src/ui-desks/chats/session-surface.tsx
+++ b/apps/ui/src/ui-desks/chats/session-surface.tsx
@@ -1,0 +1,171 @@
+import { resolveSessionModel } from '@studio/common/ai/models';
+import { isStudioCustomEntryOfType } from '@studio/common/ai/sessions/entry-types';
+import { __ } from '@wordpress/i18n';
+import { clsx } from 'clsx';
+import { useLayoutEffect, useMemo, useRef, type ReactNode, type Ref } from 'react';
+import { Composer, ComposerSkeleton } from '@/components/session-view/composer';
+import { pickLiveSite } from '@/components/session-view/composer/environment-pill';
+import { Conversation } from '@/components/session-view/conversation';
+import { EmptyBackground } from '@/components/session-view/empty-background';
+import { QueuedPrompts } from '@/components/session-view/queued-prompts';
+import sessionStyles from '@/components/session-view/style.module.css';
+import { useAgentRun } from '@/data/queries/use-agent-run';
+import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
+import { useSession, useSessionEffectiveEnvironment } from '@/data/queries/use-sessions';
+import { useSites } from '@/data/queries/use-sites';
+import { useSessionCommands } from '@/hooks/use-session-commands';
+import { SessionUIProvider } from '@/hooks/use-session-ui';
+
+interface DeskSessionSurfaceProps {
+	sessionId: string;
+	onSwitchSession: ( sessionId: string ) => void;
+	autoFocus?: boolean;
+}
+
+interface FrameProps {
+	composer?: ReactNode;
+	scrollRef?: Ref< HTMLDivElement >;
+	children?: ReactNode;
+}
+
+function Frame( { composer, scrollRef, children }: FrameProps ) {
+	return (
+		<div className={ sessionStyles.root }>
+			<div className={ sessionStyles.chatColumn }>
+				<div ref={ scrollRef } className={ sessionStyles.scroll }>
+					{ children }
+				</div>
+				<div className={ sessionStyles.composerOuter }>{ composer }</div>
+			</div>
+		</div>
+	);
+}
+
+function DeskSessionSurfaceContent( {
+	sessionId,
+	onSwitchSession,
+	autoFocus = false,
+}: DeskSessionSurfaceProps ) {
+	const { data, isLoading, error } = useSession( sessionId );
+	const { data: sites } = useSites();
+	const ownerSitePath = data?.summary.ownerSitePath;
+	const ownerSite = ownerSitePath
+		? sites?.find( ( candidate ) => candidate.path === ownerSitePath )
+		: undefined;
+	const { data: connectedSites } = useConnectedWpcomSites( ownerSite?.id );
+	const liveSite = pickLiveSite( connectedSites );
+	const effectiveEnvironment = useSessionEffectiveEnvironment( data?.summary, ownerSite?.id );
+	const {
+		isRunning,
+		hasActiveRun,
+		isInterrupting,
+		startedAt,
+		error: runError,
+		pendingQuestions,
+		pendingAnswers,
+		queuedPrompts,
+		sendMessage,
+		interrupt,
+		answerQuestion,
+		removeQueuedPrompt,
+	} = useAgentRun( sessionId );
+	const currentModel = useMemo(
+		() => resolveSessionModel( data?.entries ?? [] ),
+		[ data?.entries ]
+	);
+	const pendingQuestionTexts = useMemo(
+		() => new Set( pendingQuestions.map( ( question ) => question.question ) ),
+		[ pendingQuestions ]
+	);
+	const composerBusy = hasActiveRun || pendingQuestions.length > 0;
+	const isEmpty = useMemo(
+		() =>
+			! ( data?.entries ?? [] ).some( ( entry ) =>
+				isStudioCustomEntryOfType( entry, 'studio.user_prompt' )
+			),
+		[ data?.entries ]
+	);
+	const scrollRef = useRef< HTMLDivElement >( null );
+	useSessionCommands( sessionId );
+
+	useLayoutEffect( () => {
+		const node = scrollRef.current;
+		if ( ! node ) {
+			return;
+		}
+		node.scrollTop = node.scrollHeight;
+		const id = requestAnimationFrame( () => {
+			node.scrollTop = node.scrollHeight;
+		} );
+		return () => cancelAnimationFrame( id );
+	}, [ sessionId, data, isRunning, queuedPrompts.length ] );
+
+	if ( isLoading ) {
+		return (
+			<Frame
+				composer={
+					<div className={ sessionStyles.column }>
+						<ComposerSkeleton />
+					</div>
+				}
+			>
+				<EmptyBackground />
+			</Frame>
+		);
+	}
+
+	if ( error || ! data ) {
+		return (
+			<div className={ sessionStyles.state }>
+				<h1>{ __( 'Session not found' ) }</h1>
+				<p>{ sessionId }</p>
+			</div>
+		);
+	}
+
+	return (
+		<Frame
+			scrollRef={ scrollRef }
+			composer={
+				<div className={ sessionStyles.column }>
+					<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
+					<Composer
+						busy={ composerBusy }
+						isInterrupting={ isInterrupting }
+						error={ runError }
+						model={ currentModel }
+						onSend={ sendMessage }
+						onInterrupt={ interrupt }
+						sessionId={ sessionId }
+						effectiveEnvironment={ effectiveEnvironment }
+						liveSite={ liveSite }
+						entries={ data.entries }
+						ownerSiteId={ ownerSite?.id }
+						onSwitchSession={ onSwitchSession }
+						autoFocus={ autoFocus }
+					/>
+				</div>
+			}
+		>
+			{ isEmpty ? <EmptyBackground /> : null }
+			<div className={ clsx( sessionStyles.column, sessionStyles.conversationSpacing ) }>
+				<Conversation
+					data={ data }
+					isRunning={ isRunning }
+					startedAt={ startedAt }
+					pendingQuestions={ pendingQuestionTexts }
+					pendingAnswers={ pendingAnswers }
+					onAnswerQuestion={ answerQuestion }
+				/>
+			</div>
+		</Frame>
+	);
+}
+
+export function DeskSessionSurface( props: DeskSessionSurfaceProps ) {
+	return (
+		<SessionUIProvider>
+			<DeskSessionSurfaceContent { ...props } />
+		</SessionUIProvider>
+	);
+}

--- a/apps/ui/src/ui-desks/chats/style.module.css
+++ b/apps/ui/src/ui-desks/chats/style.module.css
@@ -18,8 +18,8 @@
 }
 
 .panelExpanded {
-	width: min(1040px, calc(100vw - 2 * var(--desk-chats-panel-gap)));
-	grid-template-columns: 340px minmax(0, 1fr);
+	width: min(960px, calc(100vw - 2 * var(--desk-chats-panel-gap)));
+	grid-template-columns: 320px minmax(0, 1fr);
 }
 
 .listPane {

--- a/apps/ui/src/ui-desks/chats/style.module.css
+++ b/apps/ui/src/ui-desks/chats/style.module.css
@@ -1,0 +1,130 @@
+.panel {
+	position: fixed;
+	top: calc(46px + var(--wpds-dimension-padding-lg));
+	left: 94px;
+	bottom: var(--wpds-dimension-padding-xl);
+	z-index: 15;
+	width: min(380px, calc(100vw - 94px - var(--wpds-dimension-padding-xl)));
+	display: grid;
+	grid-template-columns: minmax(0, 1fr);
+	overflow: hidden;
+	background: var(--wpds-color-bg-surface-neutral-strong);
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+	border-radius: var(--wpds-border-radius-lg);
+	box-shadow: var(--wpds-elevation-lg);
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.panelFullscreen {
+	left: var(--wpds-dimension-padding-xl);
+	width: min(380px, calc(100vw - 2 * var(--wpds-dimension-padding-xl)));
+}
+
+.panelExpanded {
+	width: min(1120px, calc(100vw - 94px - var(--wpds-dimension-padding-xl)));
+	grid-template-columns: 360px minmax(0, 1fr);
+}
+
+.panelExpanded.panelFullscreen {
+	width: min(1120px, calc(100vw - 2 * var(--wpds-dimension-padding-xl)));
+}
+
+.listPane {
+	display: flex;
+	min-width: 0;
+	min-height: 0;
+	flex-direction: column;
+}
+
+.panelExpanded .listPane {
+	border-right: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+}
+
+.header {
+	padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-xl)
+		var(--wpds-dimension-padding-sm);
+}
+
+.header h2 {
+	margin: 0;
+	font-size: var(--wpds-typography-font-size-lg);
+	line-height: var(--wpds-typography-line-height-lg);
+	font-weight: var(--wpds-typography-font-weight-medium);
+}
+
+.list {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
+}
+
+.sessionItem {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-xs);
+	padding: var(--wpds-dimension-padding-md);
+	border: 0;
+	border-radius: var(--wpds-border-radius-md);
+	background: transparent;
+	color: var(--wpds-color-fg-content-neutral);
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+
+.sessionItem:hover,
+.sessionItem:focus-visible,
+.sessionItemActive {
+	background: var(--wpds-color-bg-surface-neutral);
+	outline: none;
+}
+
+.sessionTitle,
+.sessionSubtitle {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.sessionTitle {
+	font-size: var(--wpds-typography-font-size-md);
+	line-height: var(--wpds-typography-line-height-md);
+	font-weight: var(--wpds-typography-font-weight-medium);
+}
+
+.sessionSubtitle {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+}
+
+.footer {
+	padding: var(--wpds-dimension-padding-md);
+	border-top: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+}
+
+.newChatButton {
+	width: 100%;
+	justify-content: flex-start;
+	background: var(--wpds-color-bg-surface-neutral);
+	border-color: transparent;
+}
+
+.chatPane {
+	min-width: 0;
+	min-height: 0;
+	position: relative;
+}
+
+.emptyChat {
+	height: 100%;
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
+	padding-top: calc(var(--wpds-dimension-padding-2xl) * 2);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-md);
+}

--- a/apps/ui/src/ui-desks/chats/style.module.css
+++ b/apps/ui/src/ui-desks/chats/style.module.css
@@ -1,10 +1,12 @@
 .panel {
+	--desk-chats-panel-gap: var(--wpds-dimension-padding-xl);
+
 	position: fixed;
 	top: calc(46px + var(--wpds-dimension-padding-lg));
-	left: 94px;
-	bottom: var(--wpds-dimension-padding-xl);
+	left: var(--desk-chats-panel-gap);
+	bottom: var(--desk-chats-panel-gap);
 	z-index: 15;
-	width: min(380px, calc(100vw - 94px - var(--wpds-dimension-padding-xl)));
+	width: min(380px, calc(100vw - 2 * var(--desk-chats-panel-gap)));
 	display: grid;
 	grid-template-columns: minmax(0, 1fr);
 	overflow: hidden;
@@ -15,18 +17,9 @@
 	color: var(--wpds-color-fg-content-neutral);
 }
 
-.panelFullscreen {
-	left: var(--wpds-dimension-padding-xl);
-	width: min(380px, calc(100vw - 2 * var(--wpds-dimension-padding-xl)));
-}
-
 .panelExpanded {
-	width: min(1120px, calc(100vw - 94px - var(--wpds-dimension-padding-xl)));
-	grid-template-columns: 360px minmax(0, 1fr);
-}
-
-.panelExpanded.panelFullscreen {
-	width: min(1120px, calc(100vw - 2 * var(--wpds-dimension-padding-xl)));
+	width: min(1040px, calc(100vw - 2 * var(--desk-chats-panel-gap)));
+	grid-template-columns: 340px minmax(0, 1fr);
 }
 
 .listPane {

--- a/apps/ui/src/ui-desks/chats/style.module.css
+++ b/apps/ui/src/ui-desks/chats/style.module.css
@@ -15,6 +15,9 @@
 	border-radius: var(--wpds-border-radius-lg);
 	box-shadow: var(--wpds-elevation-lg);
 	color: var(--wpds-color-fg-content-neutral);
+	--studio-floating-surface-width-duration: 240ms;
+	--studio-floating-surface-transform-duration: 220ms;
+	--studio-floating-surface-opacity-duration: 200ms;
 }
 
 .panelExpanded {

--- a/apps/ui/src/ui-desks/chrome/chats-button.tsx
+++ b/apps/ui/src/ui-desks/chrome/chats-button.tsx
@@ -1,0 +1,24 @@
+import { __ } from '@wordpress/i18n';
+import { comment } from '@wordpress/icons';
+import { IconButton } from '@wordpress/ui';
+import styles from './style.module.css';
+
+interface DeskChatsButtonProps {
+	open: boolean;
+	onToggle: () => void;
+}
+
+export function DeskChatsButton( { open, onToggle }: DeskChatsButtonProps ) {
+	return (
+		<IconButton
+			variant="minimal"
+			tone="neutral"
+			size="small"
+			className={ styles.trigger }
+			icon={ comment }
+			label={ open ? __( 'Hide conversations' ) : __( 'Show conversations' ) }
+			aria-pressed={ open }
+			onClick={ onToggle }
+		/>
+	);
+}

--- a/apps/ui/src/ui-desks/chrome/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/index.tsx
@@ -1,14 +1,21 @@
 import { clsx } from 'clsx';
 import { useFullscreen } from '@/hooks/use-fullscreen';
+import { DeskChatsButton } from './chats-button';
 import styles from './style.module.css';
 import { DeskUserMenu } from './user-menu';
 
-export function DeskChrome() {
+interface DeskChromeProps {
+	chatsOpen: boolean;
+	onToggleChats: () => void;
+}
+
+export function DeskChrome( { chatsOpen, onToggleChats }: DeskChromeProps ) {
 	const isFullscreen = useFullscreen();
 
 	return (
 		<div className={ clsx( styles.root, isFullscreen && styles.fullscreen ) }>
 			<DeskUserMenu />
+			<DeskChatsButton open={ chatsOpen } onToggle={ onToggleChats } />
 		</div>
 	);
 }

--- a/apps/ui/src/ui-desks/chrome/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/style.module.css
@@ -7,6 +7,9 @@
 	/* Matches the classic header's reserved macOS traffic-light space. */
 	left: 94px;
 	z-index: 20;
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-md);
 }
 
 .fullscreen {

--- a/apps/ui/src/ui-desks/chrome/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/style.module.css
@@ -17,15 +17,35 @@
 }
 
 .trigger {
+	--desk-chrome-button-background: var(--wpds-color-bg-surface-neutral-strong);
+	--desk-chrome-button-border: var(--wpds-color-stroke-surface-neutral-weak);
+	--desk-chrome-button-foreground: var(--wpds-color-fg-content-neutral);
+	--wp-ui-button-background-color: var(--desk-chrome-button-background);
+	--wp-ui-button-background-color-active: var(--desk-chrome-button-background);
+	--wp-ui-button-border-color: var(--desk-chrome-button-border);
+	--wp-ui-button-border-color-active: var(--desk-chrome-button-border);
+	--wp-ui-button-foreground-color: var(--desk-chrome-button-foreground);
+	--wp-ui-button-foreground-color-active: var(--desk-chrome-button-foreground);
+
 	width: var(--desk-user-menu-size);
 	height: var(--desk-user-menu-size);
 	min-width: var(--desk-user-menu-size);
 	padding: 0;
 	justify-content: center;
-	background: var(--wpds-color-bg-surface-neutral-strong);
-	border-color: var(--wpds-color-stroke-surface-neutral-weak);
+	background: var(--desk-chrome-button-background);
+	border-color: var(--desk-chrome-button-border);
 	border-radius: 50%;
 	box-shadow: var(--wpds-elevation-md);
+	color: var(--desk-chrome-button-foreground);
+}
+
+.trigger:hover,
+.trigger:focus,
+.trigger:active,
+.trigger[aria-pressed='true'] {
+	background: var(--desk-chrome-button-background);
+	border-color: var(--desk-chrome-button-border);
+	color: var(--desk-chrome-button-foreground);
 }
 
 .avatar,


### PR DESCRIPTION
## How AI was used in this PR

Codex implemented the initial user-desk chats surface, adapted existing session/composer pieces, and iterated on the floating panel animation. I reviewed the code paths, fixed a Base UI runtime issue by adding the required `Dialog.Portal`, and ran the local verification commands listed below.

## Proposed Changes

- Add a desks chrome chat button and floating user-desk conversations panel.
- Reuse existing session query/create flow for site-less user-desk chats.
- Reuse the classic session surface/composer in the expanded chats panel.
- Scope compact SVG sizing to classic UI so desks chrome icons retain their intended size.
- Add a shared floating-surface motion CSS module and apply it to generic menus and the chats sidebar.
- Render the chats sidebar as a non-modal Base UI `Dialog` so it uses the same open/close transition lifecycle without menu semantics.

## Testing Instructions

- Start Studio in desks UI mode.
- Click the chats button in the top-left chrome.
- Confirm the conversations panel opens with the shared scale/fade animation.
- Click `+ New chat` and confirm the panel expands, the composer appears, and the prompt can receive focus/input.
- Close and reopen the chats panel and confirm the app does not go blank or log `Base UI: <Dialog.Portal> is missing`.
- Open a generic menu, such as the user menu, and confirm it uses the same floating-surface animation.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

Validation run locally:

- `npx eslint --fix apps/ui/src/ui-desks/chrome/style.module.css apps/ui/src/ui-desks/chats/style.module.css`
- `npx eslint --fix apps/ui/src/ui-desks/chats/index.tsx apps/ui/src/components/menu/index.tsx apps/ui/src/ui-desks/app.tsx apps/ui/src/components/floating-surface-motion/style.module.css apps/ui/src/ui-desks/chats/style.module.css`
- `npm run typecheck`
- `npm test -- apps/ui/src`
- `npm -w @studio/ui run build`
- `git diff --check`

Note: CSS module files are ignored by the current ESLint config, so the CSS lint invocations report warnings for those files only.
