### PR TITLE
apps/ui: Reset route when switching UI modes

### DIFF
--- a/apps/ui/src/app/use-ui-mode.ts
+++ b/apps/ui/src/app/use-ui-mode.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export type UiMode = 'classic' | 'desks';
 
@@ -39,6 +39,11 @@ function resetRouterPath() {
 	}
 
 	window.history.replaceState( window.history.state, '', '/' );
+	const event =
+		typeof PopStateEvent === 'function'
+			? new PopStateEvent( 'popstate', { state: window.history.state } )
+			: new Event( 'popstate' );
+	window.dispatchEvent( event );
 }
 
 function isEditableTarget( target: EventTarget | null ) {
@@ -56,15 +61,15 @@ function isEditableTarget( target: EventTarget | null ) {
 
 export function useUiMode() {
 	const [ mode, setModeState ] = useState< UiMode >( readStoredUiMode );
+	const modeRef = useRef( mode );
 
 	const setMode = useCallback( ( nextMode: UiMode ) => {
-		setModeState( ( currentMode ) => {
-			if ( currentMode !== nextMode ) {
-				resetRouterPath();
-			}
-			writeStoredUiMode( nextMode );
-			return nextMode;
-		} );
+		if ( modeRef.current !== nextMode ) {
+			resetRouterPath();
+		}
+		modeRef.current = nextMode;
+		writeStoredUiMode( nextMode );
+		setModeState( nextMode );
 	}, [] );
 
 	useEffect( () => {
@@ -80,17 +85,13 @@ export function useUiMode() {
 			}
 
 			event.preventDefault();
-			setModeState( ( currentMode ) => {
-				const nextMode = currentMode === 'classic' ? 'desks' : 'classic';
-				resetRouterPath();
-				writeStoredUiMode( nextMode );
-				return nextMode;
-			} );
+			const nextMode = modeRef.current === 'classic' ? 'desks' : 'classic';
+			setMode( nextMode );
 		}
 
 		window.addEventListener( 'keydown', handleKeyDown );
 		return () => window.removeEventListener( 'keydown', handleKeyDown );
-	}, [] );
+	}, [ setMode ] );
 
 	return { mode, setMode };
 }

--- a/apps/ui/src/app/use-ui-mode.ts
+++ b/apps/ui/src/app/use-ui-mode.ts
@@ -29,6 +29,18 @@ function writeStoredUiMode( mode: UiMode ) {
 	}
 }
 
+function resetRouterPath() {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	if ( window.location.pathname === '/' && ! window.location.search && ! window.location.hash ) {
+		return;
+	}
+
+	window.history.replaceState( window.history.state, '', '/' );
+}
+
 function isEditableTarget( target: EventTarget | null ) {
 	if ( ! ( target instanceof HTMLElement ) ) {
 		return false;
@@ -46,8 +58,13 @@ export function useUiMode() {
 	const [ mode, setModeState ] = useState< UiMode >( readStoredUiMode );
 
 	const setMode = useCallback( ( nextMode: UiMode ) => {
-		setModeState( nextMode );
-		writeStoredUiMode( nextMode );
+		setModeState( ( currentMode ) => {
+			if ( currentMode !== nextMode ) {
+				resetRouterPath();
+			}
+			writeStoredUiMode( nextMode );
+			return nextMode;
+		} );
 	}, [] );
 
 	useEffect( () => {
@@ -65,6 +82,7 @@ export function useUiMode() {
 			event.preventDefault();
 			setModeState( ( currentMode ) => {
 				const nextMode = currentMode === 'classic' ? 'desks' : 'classic';
+				resetRouterPath();
 				writeStoredUiMode( nextMode );
 				return nextMode;
 			} );

--- a/apps/ui/src/app/use-ui-mode.ts
+++ b/apps/ui/src/app/use-ui-mode.ts
@@ -29,18 +29,6 @@ function writeStoredUiMode( mode: UiMode ) {
 	}
 }
 
-function resetRouterPath() {
-	if ( typeof window === 'undefined' ) {
-		return;
-	}
-
-	if ( window.location.pathname === '/' && ! window.location.search && ! window.location.hash ) {
-		return;
-	}
-
-	window.history.replaceState( window.history.state, '', '/' );
-}
-
 function isEditableTarget( target: EventTarget | null ) {
 	if ( ! ( target instanceof HTMLElement ) ) {
 		return false;
@@ -58,13 +46,8 @@ export function useUiMode() {
 	const [ mode, setModeState ] = useState< UiMode >( readStoredUiMode );
 
 	const setMode = useCallback( ( nextMode: UiMode ) => {
-		setModeState( ( currentMode ) => {
-			if ( currentMode !== nextMode ) {
-				resetRouterPath();
-			}
-			writeStoredUiMode( nextMode );
-			return nextMode;
-		} );
+		setModeState( nextMode );
+		writeStoredUiMode( nextMode );
 	}, [] );
 
 	useEffect( () => {
@@ -82,7 +65,6 @@ export function useUiMode() {
 			event.preventDefault();
 			setModeState( ( currentMode ) => {
 				const nextMode = currentMode === 'classic' ? 'desks' : 'classic';
-				resetRouterPath();
 				writeStoredUiMode( nextMode );
 				return nextMode;
 			} );

--- a/apps/ui/src/app/use-ui-mode.ts
+++ b/apps/ui/src/app/use-ui-mode.ts
@@ -29,6 +29,18 @@ function writeStoredUiMode( mode: UiMode ) {
 	}
 }
 
+function resetRouteAndReload() {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	if ( window.location.pathname !== '/' || window.location.search || window.location.hash ) {
+		window.history.replaceState( window.history.state, '', '/' );
+	}
+
+	window.location.reload();
+}
+
 function isEditableTarget( target: EventTarget | null ) {
 	if ( ! ( target instanceof HTMLElement ) ) {
 		return false;
@@ -45,10 +57,18 @@ function isEditableTarget( target: EventTarget | null ) {
 export function useUiMode() {
 	const [ mode, setModeState ] = useState< UiMode >( readStoredUiMode );
 
-	const setMode = useCallback( ( nextMode: UiMode ) => {
-		setModeState( nextMode );
-		writeStoredUiMode( nextMode );
-	}, [] );
+	const setMode = useCallback(
+		( nextMode: UiMode ) => {
+			if ( mode === nextMode ) {
+				return;
+			}
+
+			setModeState( nextMode );
+			writeStoredUiMode( nextMode );
+			resetRouteAndReload();
+		},
+		[ mode ]
+	);
 
 	useEffect( () => {
 		function handleKeyDown( event: KeyboardEvent ) {
@@ -63,16 +83,12 @@ export function useUiMode() {
 			}
 
 			event.preventDefault();
-			setModeState( ( currentMode ) => {
-				const nextMode = currentMode === 'classic' ? 'desks' : 'classic';
-				writeStoredUiMode( nextMode );
-				return nextMode;
-			} );
+			setMode( mode === 'classic' ? 'desks' : 'classic' );
 		}
 
 		window.addEventListener( 'keydown', handleKeyDown );
 		return () => window.removeEventListener( 'keydown', handleKeyDown );
-	}, [] );
+	}, [ mode, setMode ] );
 
 	return { mode, setMode };
 }

--- a/apps/ui/src/app/use-ui-mode.ts
+++ b/apps/ui/src/app/use-ui-mode.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export type UiMode = 'classic' | 'desks';
 
@@ -39,11 +39,6 @@ function resetRouterPath() {
 	}
 
 	window.history.replaceState( window.history.state, '', '/' );
-	const event =
-		typeof PopStateEvent === 'function'
-			? new PopStateEvent( 'popstate', { state: window.history.state } )
-			: new Event( 'popstate' );
-	window.dispatchEvent( event );
 }
 
 function isEditableTarget( target: EventTarget | null ) {
@@ -61,15 +56,15 @@ function isEditableTarget( target: EventTarget | null ) {
 
 export function useUiMode() {
 	const [ mode, setModeState ] = useState< UiMode >( readStoredUiMode );
-	const modeRef = useRef( mode );
 
 	const setMode = useCallback( ( nextMode: UiMode ) => {
-		if ( modeRef.current !== nextMode ) {
-			resetRouterPath();
-		}
-		modeRef.current = nextMode;
-		writeStoredUiMode( nextMode );
-		setModeState( nextMode );
+		setModeState( ( currentMode ) => {
+			if ( currentMode !== nextMode ) {
+				resetRouterPath();
+			}
+			writeStoredUiMode( nextMode );
+			return nextMode;
+		} );
 	}, [] );
 
 	useEffect( () => {
@@ -85,13 +80,17 @@ export function useUiMode() {
 			}
 
 			event.preventDefault();
-			const nextMode = modeRef.current === 'classic' ? 'desks' : 'classic';
-			setMode( nextMode );
+			setModeState( ( currentMode ) => {
+				const nextMode = currentMode === 'classic' ? 'desks' : 'classic';
+				resetRouterPath();
+				writeStoredUiMode( nextMode );
+				return nextMode;
+			} );
 		}
 
 		window.addEventListener( 'keydown', handleKeyDown );
 		return () => window.removeEventListener( 'keydown', handleKeyDown );
-	}, [ setMode ] );
+	}, [] );
 
 	return { mode, setMode };
 }

--- a/apps/ui/src/ui-desks/router/root.tsx
+++ b/apps/ui/src/ui-desks/router/root.tsx
@@ -1,10 +1,5 @@
-import { Navigate, createRootRoute, Outlet } from '@tanstack/react-router';
-
-function ResetToUserDesk() {
-	return <Navigate to="/" replace />;
-}
+import { createRootRoute, Outlet } from '@tanstack/react-router';
 
 export const desksRootRoute = createRootRoute< unknown >( {
 	component: () => <Outlet />,
-	notFoundComponent: ResetToUserDesk,
 } );

--- a/apps/ui/src/ui-desks/router/root.tsx
+++ b/apps/ui/src/ui-desks/router/root.tsx
@@ -1,5 +1,10 @@
-import { createRootRoute, Outlet } from '@tanstack/react-router';
+import { Navigate, createRootRoute, Outlet } from '@tanstack/react-router';
+
+function ResetToUserDesk() {
+	return <Navigate to="/" replace />;
+}
 
 export const desksRootRoute = createRootRoute< unknown >( {
 	component: () => <Outlet />,
+	notFoundComponent: ResetToUserDesk,
 } );


### PR DESCRIPTION
## How AI was used in this PR

Codex implemented the route reset behavior and verified the focused UI checks.

## Proposed Changes

- Reset the browser history path to `/` when switching between classic and desks UI modes.
- Preserve the current mode when the requested mode is unchanged.

## Testing Instructions

- Run `npm run typecheck`.
- Run `npm test -- apps/ui/src`.
- In the app, navigate away from `/`, switch UI mode, and confirm the new UI opens at `/`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?