### PR TITLE
Blueprints Gallery Library: Improve Back button visibility

### DIFF
--- a/apps/studio/src/modules/add-site/components/stepper.tsx
+++ b/apps/studio/src/modules/add-site/components/stepper.tsx
@@ -50,12 +50,12 @@ export default function Stepper( {
 		<>
 			<div
 				aria-hidden="true"
-				className="absolute bottom-0 left-0 right-0 h-10 z-[5] pointer-events-none bg-gradient-to-t from-frame via-frame/90 to-transparent"
+				className="absolute bottom-0 left-0 right-0 h-20 z-[5] pointer-events-none bg-gradient-to-t from-frame via-frame to-transparent"
 			/>
 			{ leftSlot && <div className="absolute bottom-5 left-5 z-10">{ leftSlot }</div> }
 			<div className="absolute bottom-5 right-5 z-10 flex items-center gap-4">
 				{ currentPath && currentPath !== '/' && onBack && (
-					<Button variant="secondary" onClick={ onBack }>
+					<Button variant="secondary" onClick={ onBack } className="!bg-frame">
 						{ __( 'Back' ) }
 					</Button>
 				) }

--- a/apps/studio/src/modules/add-site/components/stepper.tsx
+++ b/apps/studio/src/modules/add-site/components/stepper.tsx
@@ -55,7 +55,7 @@ export default function Stepper( {
 			{ leftSlot && <div className="absolute bottom-5 left-5 z-10">{ leftSlot }</div> }
 			<div className="absolute bottom-5 right-5 z-10 flex items-center gap-4">
 				{ currentPath && currentPath !== '/' && onBack && (
-					<Button variant="tertiary" onClick={ onBack }>
+					<Button variant="secondary" onClick={ onBack }>
 						{ __( 'Back' ) }
 					</Button>
 				) }


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1669

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Not needed

## Proposed Changes

This PR improves the visibility of the `Back` button on the new blueprints library screen.

**Before**

<img width="954" height="724" alt="Screenshot 2026-05-08 at 11 05 34 AM" src="https://github.com/user-attachments/assets/cadc52d0-bee7-48bf-a5fa-351332075807" />

**After**

<img width="963" height="717" alt="Screenshot 2026-05-08 at 11 05 21 AM" src="https://github.com/user-attachments/assets/f55016c8-d590-4e86-9749-7c020bcbff59" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Enable the `Enable Blueprints Library` feature flag
* Click on `Add site` > `Build a new site`
* Confirm that the back button has the new design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
