### PR TITLE
apps/ui: Align desks chrome buttons and tooltip behavior with macOS titlebar

### DIFF
--- a/apps/ui/src/ui-desks/chats/index.tsx
+++ b/apps/ui/src/ui-desks/chats/index.tsx
@@ -5,6 +5,7 @@ import { clsx } from 'clsx';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import motionStyles from '@/components/floating-surface-motion/style.module.css';
 import { useCreateSession, useSessions } from '@/data/queries/use-sessions';
+import { useFullscreen } from '@/hooks/use-fullscreen';
 import { formatRelativeTime } from '@/lib/format-relative-time';
 import { DeskSessionSurface } from './session-surface';
 import styles from './style.module.css';
@@ -30,6 +31,7 @@ function getSessionSubtitle( session: AiSessionSummary ) {
 
 export function UserDeskChats( { open, onOpenChange, createChatRequestId }: UserDeskChatsProps ) {
 	const { data: sessions } = useSessions();
+	const isFullscreen = useFullscreen();
 	const createSession = useCreateSession();
 	const lastCreateChatRequestId = useRef( createChatRequestId );
 	const [ selectedSessionId, setSelectedSessionId ] = useState< string | undefined >( undefined );
@@ -84,7 +86,12 @@ export function UserDeskChats( { open, onOpenChange, createChatRequestId }: User
 				<Dialog.Popup
 					initialFocus={ false }
 					finalFocus={ false }
-					className={ clsx( styles.panel, motionStyles.motion, expanded && styles.panelExpanded ) }
+					className={ clsx(
+						styles.panel,
+						isFullscreen && styles.panelFullscreen,
+						motionStyles.motion,
+						expanded && styles.panelExpanded
+					) }
 					aria-label={ __( 'Conversations' ) }
 				>
 					<div className={ styles.listPane }>

--- a/apps/ui/src/ui-desks/chats/style.module.css
+++ b/apps/ui/src/ui-desks/chats/style.module.css
@@ -1,8 +1,14 @@
 .panel {
 	--desk-chats-panel-gap: var(--wpds-dimension-padding-xl);
+	--desk-chrome-button-size: 40px;
+	--desk-chrome-titlebar-height: 46px;
+	--desk-chrome-popup-offset: 4px;
 
 	position: fixed;
-	top: calc(46px + var(--wpds-dimension-padding-lg));
+	top: calc(
+		var(--desk-chrome-titlebar-height) + var(--wpds-dimension-padding-sm) +
+			var(--desk-chrome-button-size) + var(--desk-chrome-popup-offset)
+	);
 	left: var(--desk-chats-panel-gap);
 	bottom: var(--desk-chats-panel-gap);
 	z-index: 15;
@@ -23,6 +29,13 @@
 .panelExpanded {
 	width: min(960px, calc(100vw - 2 * var(--desk-chats-panel-gap)));
 	grid-template-columns: 320px minmax(0, 1fr);
+}
+
+.panelFullscreen {
+	top: calc(
+		var(--desk-chats-panel-gap) + var(--desk-chrome-button-size) +
+			var(--desk-chrome-popup-offset)
+	);
 }
 
 .listPane {

--- a/apps/ui/src/ui-desks/chrome/chats-button.tsx
+++ b/apps/ui/src/ui-desks/chrome/chats-button.tsx
@@ -1,7 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { comment } from '@wordpress/icons';
-import { IconButton } from '@wordpress/ui';
-import styles from './style.module.css';
+import { DeskHeaderIconButton } from './header-button';
 
 interface DeskChatsButtonProps {
 	open: boolean;
@@ -10,11 +9,7 @@ interface DeskChatsButtonProps {
 
 export function DeskChatsButton( { open, onToggle }: DeskChatsButtonProps ) {
 	return (
-		<IconButton
-			variant="minimal"
-			tone="neutral"
-			size="small"
-			className={ styles.trigger }
+		<DeskHeaderIconButton
 			icon={ comment }
 			label={ open ? __( 'Hide conversations' ) : __( 'Show conversations' ) }
 			aria-pressed={ open }

--- a/apps/ui/src/ui-desks/chrome/create-menu.tsx
+++ b/apps/ui/src/ui-desks/chrome/create-menu.tsx
@@ -1,8 +1,9 @@
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { comment, download, globe, plus } from '@wordpress/icons';
-import { Icon, IconButton } from '@wordpress/ui';
+import { Icon } from '@wordpress/ui';
 import * as Menu from '@/components/menu';
+import { DeskHeaderIconButton } from './header-button';
 import styles from './style.module.css';
 
 export function DeskCreateMenu() {
@@ -26,16 +27,7 @@ export function DeskCreateMenu() {
 	return (
 		<Menu.Root modal={ false }>
 			<Menu.Trigger
-				render={
-					<IconButton
-						variant="minimal"
-						tone="neutral"
-						size="small"
-						className={ styles.trigger }
-						icon={ plus }
-						label={ __( 'Create new' ) }
-					/>
-				}
+				render={ <DeskHeaderIconButton icon={ plus } label={ __( 'Create new' ) } /> }
 			/>
 			<Menu.Popup side="bottom" align="start" className={ styles.popup }>
 				<Menu.Item onClick={ createChat }>

--- a/apps/ui/src/ui-desks/chrome/header-button.module.css
+++ b/apps/ui/src/ui-desks/chrome/header-button.module.css
@@ -1,0 +1,36 @@
+.trigger {
+	--desk-header-button-size: 40px;
+	--desk-header-button-background: var(--wpds-color-bg-surface-neutral-strong);
+	--desk-header-button-border: var(--wpds-color-stroke-surface-neutral-weak);
+	--desk-header-button-foreground: var(--wpds-color-fg-content-neutral);
+	--wp-ui-button-background-color: var(--desk-header-button-background);
+	--wp-ui-button-background-color-active: var(--desk-header-button-background);
+	--wp-ui-button-border-color: var(--desk-header-button-border);
+	--wp-ui-button-border-color-active: var(--desk-header-button-border);
+	--wp-ui-button-foreground-color: var(--desk-header-button-foreground);
+	--wp-ui-button-foreground-color-active: var(--desk-header-button-foreground);
+
+	width: var(--desk-header-button-size);
+	height: var(--desk-header-button-size);
+	min-width: var(--desk-header-button-size);
+	padding: 0;
+	justify-content: center;
+	background: var(--desk-header-button-background);
+	border-color: var(--desk-header-button-border);
+	border-radius: 50%;
+	box-shadow: var(--wpds-elevation-md);
+	color: var(--desk-header-button-foreground);
+}
+
+.trigger:hover,
+.trigger:focus,
+.trigger:active,
+.trigger[aria-pressed='true'] {
+	background: var(--desk-header-button-background);
+	border-color: var(--desk-header-button-border);
+	color: var(--desk-header-button-foreground);
+}
+
+.icon {
+	margin: -1px;
+}

--- a/apps/ui/src/ui-desks/chrome/header-button.tsx
+++ b/apps/ui/src/ui-desks/chrome/header-button.tsx
@@ -1,0 +1,69 @@
+import { Button, Icon, Tooltip } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import { forwardRef } from 'react';
+import styles from './header-button.module.css';
+import type { ComponentProps, ReactNode } from 'react';
+
+type DeskHeaderButtonProps = Omit< ComponentProps< typeof Button >, 'children' > & {
+	children: ReactNode;
+	label: string;
+	tooltipLabel?: string;
+};
+
+type DeskHeaderIconButtonProps = Omit< DeskHeaderButtonProps, 'children' > & {
+	icon: ComponentProps< typeof Icon >[ 'icon' ];
+};
+
+export const DeskHeaderButton = forwardRef< HTMLButtonElement, DeskHeaderButtonProps >(
+	function DeskHeaderButton(
+		{
+			children,
+			className,
+			disabled,
+			focusableWhenDisabled,
+			label,
+			size = 'small',
+			tooltipLabel = label,
+			tone = 'neutral',
+			variant = 'minimal',
+			...props
+		},
+		ref
+	) {
+		return (
+			<Tooltip.Provider delay={ 0 }>
+				<Tooltip.Root>
+					<Tooltip.Trigger
+						ref={ ref }
+						disabled={ disabled && ! focusableWhenDisabled }
+						render={
+							<Button
+								{ ...props }
+								aria-label={ label }
+								disabled={ disabled }
+								focusableWhenDisabled={ focusableWhenDisabled }
+								size={ size }
+								tone={ tone }
+								variant={ variant }
+							/>
+						}
+						className={ clsx( styles.trigger, className ) }
+					>
+						{ children }
+					</Tooltip.Trigger>
+					<Tooltip.Popup side="bottom">{ tooltipLabel }</Tooltip.Popup>
+				</Tooltip.Root>
+			</Tooltip.Provider>
+		);
+	}
+);
+
+export const DeskHeaderIconButton = forwardRef< HTMLButtonElement, DeskHeaderIconButtonProps >(
+	function DeskHeaderIconButton( { icon, ...props }, ref ) {
+		return (
+			<DeskHeaderButton ref={ ref } { ...props }>
+				<Icon icon={ icon } size={ 24 } className={ styles.icon } />
+			</DeskHeaderButton>
+		);
+	}
+);

--- a/apps/ui/src/ui-desks/chrome/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/index.tsx
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import { clsx } from 'clsx';
 import { useFullscreen } from '@/hooks/use-fullscreen';
 import { DeskChatsButton } from './chats-button';
@@ -15,9 +16,12 @@ export function DeskChrome( { chatsOpen, onToggleChats }: DeskChromeProps ) {
 
 	return (
 		<div className={ clsx( styles.root, isFullscreen && styles.fullscreen ) }>
-			<DeskUserMenu />
-			<DeskChatsButton open={ chatsOpen } onToggle={ onToggleChats } />
-			<DeskCreateMenu />
+			<span className={ styles.title }>{ __( 'Studio' ) }</span>
+			<div className={ styles.actions }>
+				<DeskUserMenu />
+				<DeskChatsButton open={ chatsOpen } onToggle={ onToggleChats } />
+				<DeskCreateMenu />
+			</div>
 		</div>
 	);
 }

--- a/apps/ui/src/ui-desks/chrome/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/style.module.css
@@ -1,53 +1,47 @@
 .root {
-	--desk-user-menu-size: 40px;
-	--desk-user-menu-y-nudge: 2px;
+	--desk-titlebar-height: 46px;
+	--desk-title-y-nudge: 3px;
+	--desk-macos-traffic-light-x: 20px;
 	--desk-chrome-edge-offset: var(--wpds-dimension-padding-xl);
 
 	position: fixed;
-	top: calc((46px - var(--desk-user-menu-size)) / 2 + var(--desk-user-menu-y-nudge));
-	/* Matches the classic header's reserved macOS traffic-light space. */
-	left: 94px;
+	top: 0;
+	left: 0;
 	z-index: 20;
+	pointer-events: none;
+}
+
+.title {
+	position: fixed;
+	top: var(--desk-title-y-nudge);
+	left: 94px;
+	display: flex;
+	align-items: center;
+	height: var(--desk-titlebar-height);
+	font-size: var(--wpds-typography-font-size-md);
+	font-weight: 600;
+	color: var(--wpds-color-fg-content-neutral);
+	pointer-events: auto;
+	-webkit-app-region: drag;
+}
+
+.actions {
+	position: fixed;
+	top: calc(var(--desk-titlebar-height) + var(--wpds-dimension-padding-sm));
+	left: var(--desk-macos-traffic-light-x);
 	display: flex;
 	align-items: center;
 	gap: var(--wpds-dimension-padding-md);
+	pointer-events: auto;
 }
 
-.fullscreen {
+.fullscreen .title {
+	display: none;
+}
+
+.fullscreen .actions {
 	top: var(--desk-chrome-edge-offset);
 	left: var(--desk-chrome-edge-offset);
-}
-
-.trigger {
-	--desk-chrome-button-background: var(--wpds-color-bg-surface-neutral-strong);
-	--desk-chrome-button-border: var(--wpds-color-stroke-surface-neutral-weak);
-	--desk-chrome-button-foreground: var(--wpds-color-fg-content-neutral);
-	--wp-ui-button-background-color: var(--desk-chrome-button-background);
-	--wp-ui-button-background-color-active: var(--desk-chrome-button-background);
-	--wp-ui-button-border-color: var(--desk-chrome-button-border);
-	--wp-ui-button-border-color-active: var(--desk-chrome-button-border);
-	--wp-ui-button-foreground-color: var(--desk-chrome-button-foreground);
-	--wp-ui-button-foreground-color-active: var(--desk-chrome-button-foreground);
-
-	width: var(--desk-user-menu-size);
-	height: var(--desk-user-menu-size);
-	min-width: var(--desk-user-menu-size);
-	padding: 0;
-	justify-content: center;
-	background: var(--desk-chrome-button-background);
-	border-color: var(--desk-chrome-button-border);
-	border-radius: 50%;
-	box-shadow: var(--wpds-elevation-md);
-	color: var(--desk-chrome-button-foreground);
-}
-
-.trigger:hover,
-.trigger:focus,
-.trigger:active,
-.trigger[aria-pressed='true'] {
-	background: var(--desk-chrome-button-background);
-	border-color: var(--desk-chrome-button-border);
-	color: var(--desk-chrome-button-foreground);
 }
 
 .avatar,

--- a/apps/ui/src/ui-desks/chrome/user-menu.tsx
+++ b/apps/ui/src/ui-desks/chrome/user-menu.tsx
@@ -1,12 +1,12 @@
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
 import { Gravatar } from '@/components/gravatar';
 import * as Menu from '@/components/menu';
 import { useConnector } from '@/data/core';
 import { useAuthUser, useLogin, useLogout } from '@/data/queries/use-auth-user';
 import { useUserPreferences } from '@/data/queries/use-user-preferences';
 import { usePrefersColorScheme } from '@/hooks/use-prefers-color-scheme';
+import { DeskHeaderButton } from './header-button';
 import styles from './style.module.css';
 
 const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
@@ -37,16 +37,12 @@ export function DeskUserMenu() {
 
 	if ( ! user ) {
 		return (
-			<Button
-				variant="minimal"
-				tone="neutral"
-				size="small"
-				className={ styles.trigger }
-				aria-label={ __( 'Log in with WordPress.com' ) }
+			<DeskHeaderButton
+				label={ __( 'Log in with WordPress.com' ) }
 				onClick={ () => login.mutate() }
 			>
 				<span className={ styles.loginAvatar } aria-hidden="true" />
-			</Button>
+			</DeskHeaderButton>
 		);
 	}
 
@@ -54,16 +50,9 @@ export function DeskUserMenu() {
 		<Menu.Root modal={ false }>
 			<Menu.Trigger
 				render={
-					<Button
-						variant="minimal"
-						tone="neutral"
-						size="small"
-						className={ styles.trigger }
-						aria-label={ __( 'User menu' ) }
-						title={ user.displayName }
-					>
+					<DeskHeaderButton label={ __( 'User menu' ) } tooltipLabel={ user.displayName }>
 						<Gravatar className={ styles.avatar } email={ user.email } isDark={ themeIsDark } />
-					</Button>
+					</DeskHeaderButton>
 				}
 			/>
 			<Menu.Popup side="bottom" align="start" className={ styles.popup }>


### PR DESCRIPTION
## Summary
- Reworked the desks chrome so the `Studio` title sits beside the macOS traffic lights and the action buttons render below them.
- Moved the shared circular header-button styling into a dedicated `DeskHeaderButton` wrapper and colocated CSS module.
- Forced desks header button tooltips to open below the buttons, matching the menu popup direction.
- Tightened the chats sidebar offset so it matches the same small popup gap instead of dropping too far below the header controls.

## Testing
- Lint and formatting passed with CSS-module ignore warnings only.
- `npm run typecheck` passed.
- `npm test -- apps/ui/src/ui-desks/user-desk/tldraw-adapter.test.ts` passed.
- `npm -w @studio/ui run build` passed.