### PR TITLE
Replace placeholder note widget with desk-style sticky note

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -23,6 +23,7 @@
 		"@wordpress/icons": "^13.0.0",
 		"@wordpress/private-apis": "^1.10.0",
 		"@wordpress/react-i18n": "^4.45.0",
+		"@wordpress/rich-text": "7.45.0",
 		"@wordpress/theme": "0.12.0",
 		"@wordpress/ui": "0.12.0",
 		"@wp-playground/blueprints": "3.1.28",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -18,6 +18,7 @@
 		"@tanstack/react-query-persist-client": "^5.96.2",
 		"@tanstack/react-router": "^1.120.14",
 		"@wordpress/components": "33.0.0",
+		"@wordpress/data": "^10.45.0",
 		"@wordpress/dataviews": "^14.2.0",
 		"@wordpress/i18n": "^6.18.0",
 		"@wordpress/icons": "^13.0.0",

--- a/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
+++ b/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
@@ -97,12 +97,20 @@ export class RectangleWidgetShapeUtil extends ShapeUtil< RectangleWidgetShape > 
 	}
 
 	override indicator( shape: RectangleWidgetShape ) {
+		const definition = getWidgetDefinition( shape.props.widgetType );
+		const indicator =
+			definition && definition.isWidgetProps( shape.props.widgetProps )
+				? definition.getIndicator?.( shape.props.widgetProps )
+				: undefined;
+
 		return (
 			<rect
 				width={ shape.props.shapeProps.w }
 				height={ shape.props.shapeProps.h }
-				rx={ 18 }
-				ry={ 18 }
+				rx={ indicator?.cornerRadius ?? 14 }
+				ry={ indicator?.cornerRadius ?? 14 }
+				fill="none"
+				stroke={ indicator?.stroke }
 			/>
 		);
 	}

--- a/apps/ui/src/ui-desks/user-desk/default-user-desk.ts
+++ b/apps/ui/src/ui-desks/user-desk/default-user-desk.ts
@@ -16,7 +16,7 @@ export const defaultUserDesk: DeskConfig = {
 			},
 			widgetProps: {
 				text: '',
-				tone: 'note',
+				tone: 'yellow',
 			},
 		},
 	],

--- a/apps/ui/src/ui-desks/user-desk/default-user-desk.ts
+++ b/apps/ui/src/ui-desks/user-desk/default-user-desk.ts
@@ -11,12 +11,12 @@ export const defaultUserDesk: DeskConfig = {
 			y: 120,
 			zIndex: 'a1',
 			shapeProps: {
-				w: 260,
-				h: 220,
+				w: 200,
+				h: 200,
 			},
 			widgetProps: {
 				text: '',
-				color: 'yellow',
+				tone: 'note',
 			},
 		},
 	],

--- a/apps/ui/src/ui-desks/user-desk/tldraw-adapter.test.ts
+++ b/apps/ui/src/ui-desks/user-desk/tldraw-adapter.test.ts
@@ -22,7 +22,7 @@ describe( 'tldraw adapter', () => {
 			},
 			widgetProps: {
 				text: 'Hello',
-				tone: 'note',
+				tone: 'yellow',
 			},
 		};
 
@@ -40,7 +40,7 @@ describe( 'tldraw adapter', () => {
 				},
 				widgetProps: {
 					text: 'Hello',
-					tone: 'note',
+					tone: 'yellow',
 				},
 			},
 		} );
@@ -62,7 +62,7 @@ describe( 'tldraw adapter', () => {
 				},
 				widgetProps: {
 					text: 'Updated',
-					tone: 'note-blue',
+					tone: 'blue',
 				},
 			},
 		} as unknown as TLShape;
@@ -80,7 +80,7 @@ describe( 'tldraw adapter', () => {
 			},
 			widgetProps: {
 				text: 'Updated',
-				tone: 'note-blue',
+				tone: 'blue',
 			},
 		} );
 	} );

--- a/apps/ui/src/ui-desks/user-desk/tldraw-adapter.test.ts
+++ b/apps/ui/src/ui-desks/user-desk/tldraw-adapter.test.ts
@@ -22,7 +22,7 @@ describe( 'tldraw adapter', () => {
 			},
 			widgetProps: {
 				text: 'Hello',
-				color: 'yellow',
+				tone: 'note',
 			},
 		};
 
@@ -40,7 +40,7 @@ describe( 'tldraw adapter', () => {
 				},
 				widgetProps: {
 					text: 'Hello',
-					color: 'yellow',
+					tone: 'note',
 				},
 			},
 		} );
@@ -62,7 +62,7 @@ describe( 'tldraw adapter', () => {
 				},
 				widgetProps: {
 					text: 'Updated',
-					color: 'blue',
+					tone: 'note-blue',
 				},
 			},
 		} as unknown as TLShape;
@@ -80,7 +80,7 @@ describe( 'tldraw adapter', () => {
 			},
 			widgetProps: {
 				text: 'Updated',
-				color: 'blue',
+				tone: 'note-blue',
 			},
 		} );
 	} );

--- a/apps/ui/src/ui-desks/widgets/note/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/note/component.tsx
@@ -1,6 +1,8 @@
+import { select, type AnyConfig, type StoreDescriptor } from '@wordpress/data';
 import {
 	__unstableUseRichText as useRichText,
 	registerFormatType,
+	store as richTextStore,
 	toggleFormat,
 	type RichTextValue,
 } from '@wordpress/rich-text';
@@ -11,6 +13,10 @@ import styles from './style.module.css';
 import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
 
 type NoteWidgetComponentProps = DeskWidgetComponentProps< NoteWidgetProps >;
+
+type RichTextFormatSelectors = {
+	getFormatType: ( name: string ) => unknown;
+};
 
 const NOTE_TEXT_FORMATS = [
 	{ name: 'core/bold', title: 'Bold', tagName: 'strong', shortcut: 'b' },
@@ -155,15 +161,15 @@ export function NoteWidgetComponent( { id, shapeType, widgetProps }: NoteWidgetC
 }
 
 function registerNoteFormats() {
-	const globalObject = globalThis as typeof globalThis & {
-		__studioNoteFormatsRegistered?: boolean;
-	};
-
-	if ( globalObject.__studioNoteFormatsRegistered ) {
-		return;
-	}
+	const { getFormatType } = select(
+		richTextStore as StoreDescriptor< AnyConfig >
+	) as unknown as RichTextFormatSelectors;
 
 	for ( const { name, title, tagName } of NOTE_TEXT_FORMATS ) {
+		if ( getFormatType( name ) ) {
+			continue;
+		}
+
 		registerFormatType( name, {
 			name,
 			title,
@@ -174,6 +180,4 @@ function registerNoteFormats() {
 			edit: () => null,
 		} );
 	}
-
-	globalObject.__studioNoteFormatsRegistered = true;
 }

--- a/apps/ui/src/ui-desks/widgets/note/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/note/component.tsx
@@ -1,21 +1,29 @@
+import { create, registerFormatType, toHTMLString } from '@wordpress/rich-text';
 import { useCallback, useEffect, useRef, type KeyboardEvent, type PointerEvent } from 'react';
-import {
-	getPointerInfo,
-	stopEventPropagation,
-	useEditor,
-	useIsEditing,
-	type TLUnknownShape,
-} from 'tldraw';
+import { useEditor, useIsEditing, type TLUnknownShape } from 'tldraw';
 import { NOTE_WIDGET_TYPE, type NoteWidgetProps } from '@/ui-desks/widgets/note/types';
 import styles from './style.module.css';
 import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
 
 type NoteWidgetComponentProps = DeskWidgetComponentProps< NoteWidgetProps >;
 
+registerCoreFormats();
+
 export function NoteWidgetComponent( { id, shapeType, widgetProps }: NoteWidgetComponentProps ) {
 	const editor = useEditor();
 	const isEditing = useIsEditing( id );
-	const textareaRef = useRef< HTMLTextAreaElement >( null );
+	const editorRef = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		const noteEditor = editorRef.current;
+		if ( ! noteEditor || isEditing ) {
+			return;
+		}
+
+		if ( noteEditor.innerHTML !== widgetProps.text ) {
+			noteEditor.innerHTML = widgetProps.text;
+		}
+	}, [ isEditing, widgetProps.text ] );
 
 	useEffect( () => {
 		if ( ! isEditing ) {
@@ -23,13 +31,18 @@ export function NoteWidgetComponent( { id, shapeType, widgetProps }: NoteWidgetC
 		}
 
 		const frame = window.requestAnimationFrame( () => {
-			const textarea = textareaRef.current;
-			if ( ! textarea ) {
+			const noteEditor = editorRef.current;
+			if ( ! noteEditor ) {
 				return;
 			}
 
-			textarea.focus();
-			textarea.select();
+			noteEditor.focus();
+			const range = document.createRange();
+			range.selectNodeContents( noteEditor );
+			range.collapse( false );
+			const selection = window.getSelection();
+			selection?.removeAllRanges();
+			selection?.addRange( range );
 		} );
 
 		return () => {
@@ -37,79 +50,107 @@ export function NoteWidgetComponent( { id, shapeType, widgetProps }: NoteWidgetC
 		};
 	}, [ isEditing ] );
 
-	const updateText = useCallback(
-		( text: string ) => {
-			if ( editor.getEditingShapeId() !== id ) {
-				return;
-			}
+	const commitText = useCallback( () => {
+		const noteEditor = editorRef.current;
+		if ( ! noteEditor ) {
+			return;
+		}
 
-			editor.updateShape< TLUnknownShape >( {
-				id,
-				type: shapeType,
-				props: {
-					widgetProps: {
-						...widgetProps,
-						text,
-					},
+		const value = create( { element: noteEditor } );
+		const text = toHTMLString( { value } );
+		if ( text === widgetProps.text ) {
+			return;
+		}
+
+		editor.updateShape< TLUnknownShape >( {
+			id,
+			type: shapeType,
+			props: {
+				widgetProps: {
+					...widgetProps,
+					text,
 				},
-			} );
-		},
-		[ editor, id, shapeType, widgetProps ]
-	);
+			},
+		} );
+	}, [ editor, id, shapeType, widgetProps ] );
 
 	const handlePointerDown = useCallback(
-		( event: PointerEvent< HTMLTextAreaElement > ) => {
-			const shape = editor.getShape( id );
-			if ( shape ) {
-				editor.dispatch( {
-					...getPointerInfo( event ),
-					type: 'pointer',
-					name: 'pointer_down',
-					target: 'shape',
-					shape,
-				} );
+		( event: PointerEvent< HTMLDivElement > ) => {
+			if ( isEditing ) {
+				event.stopPropagation();
 			}
-
-			stopEventPropagation( event );
 		},
-		[ editor, id ]
+		[ isEditing ]
 	);
 
 	const handleKeyDown = useCallback(
-		( event: KeyboardEvent< HTMLTextAreaElement > ) => {
+		( event: KeyboardEvent< HTMLDivElement > ) => {
 			event.stopPropagation();
 
-			if ( event.key === 'Enter' && ( event.metaKey || event.ctrlKey ) ) {
+			const isMod = event.metaKey || event.ctrlKey;
+			if ( ! isMod ) {
+				return;
+			}
+
+			if ( event.key === 'b' || event.key === 'i' ) {
 				event.preventDefault();
+				document.execCommand( event.key === 'b' ? 'bold' : 'italic' );
+				commitText();
+			} else if ( event.key === 'Enter' ) {
+				event.preventDefault();
+				commitText();
 				editor.complete();
 			}
 		},
-		[ editor ]
+		[ commitText, editor ]
 	);
 
 	return (
 		<div
 			className={ styles.note }
-			data-color={ widgetProps.color }
+			data-tone={ widgetProps.tone }
 			data-is-editing={ isEditing }
 			data-studio-desk-widget={ NOTE_WIDGET_TYPE }
 		>
-			{ isEditing ? (
-				<textarea
-					ref={ textareaRef }
-					className={ styles.textarea }
-					value={ widgetProps.text }
-					spellCheck
-					onChange={ ( event ) => updateText( event.currentTarget.value ) }
-					onKeyDown={ handleKeyDown }
-					onPointerDown={ handlePointerDown }
-					onBlur={ () => editor.complete() }
-				/>
-			) : widgetProps.text ? (
-				<div className={ styles.text }>{ widgetProps.text }</div>
-			) : (
-				<div className={ styles.placeholder }>Type a note...</div>
-			) }
+			<div
+				ref={ editorRef }
+				className={ styles.editor }
+				contentEditable={ isEditing }
+				suppressContentEditableWarning
+				spellCheck={ false }
+				onInput={ commitText }
+				onBlur={ () => {
+					commitText();
+					editor.complete();
+				} }
+				onKeyDown={ handleKeyDown }
+				onPointerDown={ handlePointerDown }
+				data-empty={ ! widgetProps.text ? 'true' : 'false' }
+				data-placeholder="Type a note..."
+			/>
 		</div>
 	);
+}
+
+function registerCoreFormats() {
+	const formats: Array< { name: string; title: string; tagName: string } > = [
+		{ name: 'core/bold', title: 'Bold', tagName: 'strong' },
+		{ name: 'core/italic', title: 'Italic', tagName: 'em' },
+	];
+
+	for ( const format of formats ) {
+		try {
+			registerFormatType( format.name, {
+				name: format.name,
+				title: format.title,
+				tagName: format.tagName,
+				className: null,
+				interactive: false,
+				object: false,
+				edit: () => null,
+			} );
+		} catch {
+			// The rich-text registry is global, so HMR can register these first.
+		}
+	}
 }

--- a/apps/ui/src/ui-desks/widgets/note/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/note/component.tsx
@@ -1,4 +1,9 @@
-import { create, registerFormatType, toHTMLString } from '@wordpress/rich-text';
+import {
+	__unstableUseRichText as useRichText,
+	registerFormatType,
+	toggleFormat,
+	type RichTextValue,
+} from '@wordpress/rich-text';
 import { useCallback, useEffect, useRef, type KeyboardEvent, type PointerEvent } from 'react';
 import { useEditor, useIsEditing, type TLUnknownShape } from 'tldraw';
 import { NOTE_WIDGET_TYPE, type NoteWidgetProps } from '@/ui-desks/widgets/note/types';
@@ -7,23 +12,56 @@ import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
 
 type NoteWidgetComponentProps = DeskWidgetComponentProps< NoteWidgetProps >;
 
-registerCoreFormats();
+const NOTE_TEXT_FORMATS = [
+	{ name: 'core/bold', title: 'Bold', tagName: 'strong', shortcut: 'b' },
+	{ name: 'core/italic', title: 'Italic', tagName: 'em', shortcut: 'i' },
+] as const;
+
+type NoteTextFormatName = ( typeof NOTE_TEXT_FORMATS )[ number ][ 'name' ];
+
+const NOTE_FORMAT_BY_SHORTCUT = Object.fromEntries(
+	NOTE_TEXT_FORMATS.map( ( format ) => [ format.shortcut, format.name ] )
+) as Record< string, NoteTextFormatName >;
+
+registerNoteFormats();
 
 export function NoteWidgetComponent( { id, shapeType, widgetProps }: NoteWidgetComponentProps ) {
 	const editor = useEditor();
 	const isEditing = useIsEditing( id );
-	const editorRef = useRef< HTMLDivElement >( null );
+	const editorRef = useRef< HTMLDivElement | null >( null );
 
-	useEffect( () => {
-		const noteEditor = editorRef.current;
-		if ( ! noteEditor || isEditing ) {
-			return;
-		}
+	const updateText = useCallback(
+		( text: string ) => {
+			editor.updateShape< TLUnknownShape >( {
+				id,
+				type: shapeType,
+				props: {
+					widgetProps: {
+						...widgetProps,
+						text,
+					},
+				},
+			} );
+		},
+		[ editor, id, shapeType, widgetProps ]
+	);
 
-		if ( noteEditor.innerHTML !== widgetProps.text ) {
-			noteEditor.innerHTML = widgetProps.text;
-		}
-	}, [ isEditing, widgetProps.text ] );
+	const richText = useRichText( {
+		value: widgetProps.text,
+		placeholder: 'Type a note...',
+		onChange: updateText,
+		onSelectionChange: () => undefined,
+		__unstableIsSelected: isEditing,
+	} );
+	const { ref: richTextRef, getValue: getRichTextValue, onChange: setRichTextValue } = richText;
+
+	const setEditorRef = useCallback(
+		( node: HTMLDivElement | null ) => {
+			editorRef.current = node;
+			richTextRef( node ?? undefined );
+		},
+		[ richTextRef ]
+	);
 
 	useEffect( () => {
 		if ( ! isEditing ) {
@@ -50,30 +88,6 @@ export function NoteWidgetComponent( { id, shapeType, widgetProps }: NoteWidgetC
 		};
 	}, [ isEditing ] );
 
-	const commitText = useCallback( () => {
-		const noteEditor = editorRef.current;
-		if ( ! noteEditor ) {
-			return;
-		}
-
-		const value = create( { element: noteEditor } );
-		const text = toHTMLString( { value } );
-		if ( text === widgetProps.text ) {
-			return;
-		}
-
-		editor.updateShape< TLUnknownShape >( {
-			id,
-			type: shapeType,
-			props: {
-				widgetProps: {
-					...widgetProps,
-					text,
-				},
-			},
-		} );
-	}, [ editor, id, shapeType, widgetProps ] );
-
 	const handlePointerDown = useCallback(
 		( event: PointerEvent< HTMLDivElement > ) => {
 			if ( isEditing ) {
@@ -81,6 +95,18 @@ export function NoteWidgetComponent( { id, shapeType, widgetProps }: NoteWidgetC
 			}
 		},
 		[ isEditing ]
+	);
+
+	const toggleTextFormat = useCallback(
+		( format: NoteTextFormatName ) => {
+			const value = getRichTextValue() as RichTextValue | undefined;
+			if ( ! value ) {
+				return;
+			}
+
+			setRichTextValue( toggleFormat( value, { type: format } ) );
+		},
+		[ getRichTextValue, setRichTextValue ]
 	);
 
 	const handleKeyDown = useCallback(
@@ -92,17 +118,19 @@ export function NoteWidgetComponent( { id, shapeType, widgetProps }: NoteWidgetC
 				return;
 			}
 
-			if ( event.key === 'b' || event.key === 'i' ) {
+			const format = NOTE_FORMAT_BY_SHORTCUT[ event.key.toLowerCase() ];
+			if ( format ) {
 				event.preventDefault();
-				document.execCommand( event.key === 'b' ? 'bold' : 'italic' );
-				commitText();
-			} else if ( event.key === 'Enter' ) {
+				toggleTextFormat( format );
+				return;
+			}
+
+			if ( event.key === 'Enter' ) {
 				event.preventDefault();
-				commitText();
 				editor.complete();
 			}
 		},
-		[ commitText, editor ]
+		[ editor, toggleTextFormat ]
 	);
 
 	return (
@@ -113,44 +141,39 @@ export function NoteWidgetComponent( { id, shapeType, widgetProps }: NoteWidgetC
 			data-studio-desk-widget={ NOTE_WIDGET_TYPE }
 		>
 			<div
-				ref={ editorRef }
+				ref={ setEditorRef }
 				className={ styles.editor }
 				contentEditable={ isEditing }
 				suppressContentEditableWarning
 				spellCheck={ false }
-				onInput={ commitText }
-				onBlur={ () => {
-					commitText();
-					editor.complete();
-				} }
+				onBlur={ () => editor.complete() }
 				onKeyDown={ handleKeyDown }
 				onPointerDown={ handlePointerDown }
-				data-empty={ ! widgetProps.text ? 'true' : 'false' }
-				data-placeholder="Type a note..."
 			/>
 		</div>
 	);
 }
 
-function registerCoreFormats() {
-	const formats: Array< { name: string; title: string; tagName: string } > = [
-		{ name: 'core/bold', title: 'Bold', tagName: 'strong' },
-		{ name: 'core/italic', title: 'Italic', tagName: 'em' },
-	];
+function registerNoteFormats() {
+	const globalObject = globalThis as typeof globalThis & {
+		__studioNoteFormatsRegistered?: boolean;
+	};
 
-	for ( const format of formats ) {
-		try {
-			registerFormatType( format.name, {
-				name: format.name,
-				title: format.title,
-				tagName: format.tagName,
-				className: null,
-				interactive: false,
-				object: false,
-				edit: () => null,
-			} );
-		} catch {
-			// The rich-text registry is global, so HMR can register these first.
-		}
+	if ( globalObject.__studioNoteFormatsRegistered ) {
+		return;
 	}
+
+	for ( const { name, title, tagName } of NOTE_TEXT_FORMATS ) {
+		registerFormatType( name, {
+			name,
+			title,
+			tagName,
+			interactive: false,
+			object: false,
+			className: null,
+			edit: () => null,
+		} );
+	}
+
+	globalObject.__studioNoteFormatsRegistered = true;
 }

--- a/apps/ui/src/ui-desks/widgets/note/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/note/definition.ts
@@ -9,16 +9,16 @@ import {
 import type { WidgetDefinition } from '@/ui-desks/widgets/types';
 
 const NOTE_TONE_STROKE: Record< NoteTone, string > = {
-	note: '#c4a300',
-	'note-mint': '#3ca56f',
-	'note-blue': '#2271b1',
-	'note-orange': '#c97223',
-	'note-violet': '#7b3fb6',
-	'note-neon-yellow': '#a18a00',
-	'note-neon-green': '#2e9e3a',
-	'note-neon-violet': '#6f2daa',
-	'note-neon-orange': '#b97917',
-	'note-neon-blue': '#1873c9',
+	yellow: '#c4a300',
+	mint: '#3ca56f',
+	blue: '#2271b1',
+	orange: '#c97223',
+	violet: '#7b3fb6',
+	'neon-yellow': '#a18a00',
+	'neon-green': '#2e9e3a',
+	'neon-violet': '#6f2daa',
+	'neon-orange': '#b97917',
+	'neon-blue': '#1873c9',
 };
 
 export const noteWidgetDefinition = {

--- a/apps/ui/src/ui-desks/widgets/note/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/note/definition.ts
@@ -3,13 +3,31 @@ import { NoteWidgetComponent } from '@/ui-desks/widgets/note/component';
 import {
 	isNoteWidgetProps,
 	NOTE_WIDGET_TYPE,
+	type NoteTone,
 	type NoteWidget,
 } from '@/ui-desks/widgets/note/types';
 import type { WidgetDefinition } from '@/ui-desks/widgets/types';
+
+const NOTE_TONE_STROKE: Record< NoteTone, string > = {
+	note: '#c4a300',
+	'note-mint': '#3ca56f',
+	'note-blue': '#2271b1',
+	'note-orange': '#c97223',
+	'note-violet': '#7b3fb6',
+	'note-neon-yellow': '#a18a00',
+	'note-neon-green': '#2e9e3a',
+	'note-neon-violet': '#6f2daa',
+	'note-neon-orange': '#b97917',
+	'note-neon-blue': '#1873c9',
+};
 
 export const noteWidgetDefinition = {
 	type: NOTE_WIDGET_TYPE,
 	shapeType: RECTANGLE_WIDGET_SHAPE_TYPE,
 	Component: NoteWidgetComponent,
 	isWidgetProps: isNoteWidgetProps,
+	getIndicator: ( widgetProps ) => ( {
+		cornerRadius: 14,
+		stroke: NOTE_TONE_STROKE[ widgetProps.tone ],
+	} ),
 } satisfies WidgetDefinition< NoteWidget >;

--- a/apps/ui/src/ui-desks/widgets/note/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/note/style.module.css
@@ -15,39 +15,39 @@
 	user-select: none;
 }
 
-.note[data-tone='note-mint'] {
+.note[data-tone='mint'] {
 	background: #d9f5e1;
 }
 
-.note[data-tone='note-blue'] {
+.note[data-tone='blue'] {
 	background: #c5deff;
 }
 
-.note[data-tone='note-orange'] {
+.note[data-tone='orange'] {
 	background: #ffd8b0;
 }
 
-.note[data-tone='note-violet'] {
+.note[data-tone='violet'] {
 	background: #e0c8ff;
 }
 
-.note[data-tone='note-neon-yellow'] {
+.note[data-tone='neon-yellow'] {
 	background: rgb(255, 236, 61);
 }
 
-.note[data-tone='note-neon-green'] {
+.note[data-tone='neon-green'] {
 	background: #6cda76;
 }
 
-.note[data-tone='note-neon-violet'] {
+.note[data-tone='neon-violet'] {
 	background: #be89ec;
 }
 
-.note[data-tone='note-neon-orange'] {
+.note[data-tone='neon-orange'] {
 	background: #f5b047;
 }
 
-.note[data-tone='note-neon-blue'] {
+.note[data-tone='neon-blue'] {
 	background: #52aeff;
 }
 

--- a/apps/ui/src/ui-desks/widgets/note/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/note/style.module.css
@@ -1,8 +1,10 @@
 .note {
 	width: 100%;
 	height: 100%;
-	padding: 24px;
-	border-radius: 18px;
+	padding: 9% 10%;
+	border-radius: 14px;
+	corner-shape: superellipse(1.42);
+	-webkit-corner-shape: superellipse(1.42);
 	background: #fff8c5;
 	box-shadow:
 		0 1px 2px rgba(15, 23, 42, 0.04),
@@ -13,47 +15,77 @@
 	user-select: none;
 }
 
-.note[data-color='blue'] {
-	background: #c5deff;
-}
-
-.note[data-color='green'] {
+.note[data-tone='note-mint'] {
 	background: #d9f5e1;
 }
 
-.note[data-color='pink'] {
-	background: #ffd2e7;
+.note[data-tone='note-blue'] {
+	background: #c5deff;
 }
 
-.text,
-.placeholder,
-.textarea {
+.note[data-tone='note-orange'] {
+	background: #ffd8b0;
+}
+
+.note[data-tone='note-violet'] {
+	background: #e0c8ff;
+}
+
+.note[data-tone='note-neon-yellow'] {
+	background: rgb(255, 236, 61);
+}
+
+.note[data-tone='note-neon-green'] {
+	background: #6cda76;
+}
+
+.note[data-tone='note-neon-violet'] {
+	background: #be89ec;
+}
+
+.note[data-tone='note-neon-orange'] {
+	background: #f5b047;
+}
+
+.note[data-tone='note-neon-blue'] {
+	background: #52aeff;
+}
+
+.editor {
+	min-height: 100%;
+	outline: none;
+	cursor: text;
+	color: #14171a;
 	font-size: 14px;
 	line-height: 1.5;
-	white-space: pre-wrap;
-	overflow-wrap: anywhere;
-}
-
-.text {
-	color: #14171a;
-}
-
-.placeholder {
-	color: rgba(20, 23, 26, 0.45);
-}
-
-.textarea {
-	display: block;
-	width: 100%;
-	height: 100%;
-	padding: 0;
-	border: 0;
-	outline: 0;
-	resize: none;
-	background: transparent;
-	color: #14171a;
-	font-family: inherit;
-	box-shadow: none;
-	box-sizing: border-box;
 	user-select: text;
+	-webkit-user-select: text;
+}
+
+.editor[contenteditable='false'] {
+	cursor: inherit;
+	user-select: none;
+	-webkit-user-select: none;
+}
+
+.editor[data-empty='true']:not(:focus)::before {
+	color: rgba(15, 23, 42, 0.35);
+	content: attr(data-placeholder);
+	pointer-events: none;
+}
+
+.editor p {
+	margin: 0 0 8px;
+}
+
+.editor p:last-child {
+	margin-bottom: 0;
+}
+
+.editor strong {
+	font-weight: 700;
+}
+
+.editor em {
+	font-style: italic;
 }

--- a/apps/ui/src/ui-desks/widgets/note/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/note/style.module.css
@@ -68,9 +68,9 @@
 	-webkit-user-select: none;
 }
 
-.editor[data-empty='true']:not(:focus)::before {
+.editor [data-rich-text-placeholder]::after {
 	color: rgba(15, 23, 42, 0.35);
-	content: attr(data-placeholder);
+	content: attr(data-rich-text-placeholder);
 	pointer-events: none;
 }
 

--- a/apps/ui/src/ui-desks/widgets/note/types.ts
+++ b/apps/ui/src/ui-desks/widgets/note/types.ts
@@ -3,11 +3,21 @@ import type { DeskWidgetBase } from '@studio/common/types/desk';
 
 export const NOTE_WIDGET_TYPE = 'note';
 
-export type NoteColor = 'yellow' | 'blue' | 'green' | 'pink';
+export type NoteTone =
+	| 'note'
+	| 'note-mint'
+	| 'note-blue'
+	| 'note-orange'
+	| 'note-violet'
+	| 'note-neon-yellow'
+	| 'note-neon-green'
+	| 'note-neon-violet'
+	| 'note-neon-orange'
+	| 'note-neon-blue';
 
 export type NoteWidgetProps = {
 	text: string;
-	color: NoteColor;
+	tone: NoteTone;
 };
 
 export type NoteWidget = DeskWidgetBase<
@@ -21,10 +31,21 @@ export function isNoteWidgetProps( value: unknown ): value is NoteWidgetProps {
 		Boolean( value ) &&
 		typeof value === 'object' &&
 		typeof ( value as Partial< NoteWidgetProps > ).text === 'string' &&
-		isNoteColor( ( value as Partial< NoteWidgetProps > ).color )
+		isNoteTone( ( value as Partial< NoteWidgetProps > ).tone )
 	);
 }
 
-function isNoteColor( value: unknown ): value is NoteColor {
-	return value === 'yellow' || value === 'blue' || value === 'green' || value === 'pink';
+export function isNoteTone( value: unknown ): value is NoteTone {
+	return (
+		value === 'note' ||
+		value === 'note-mint' ||
+		value === 'note-blue' ||
+		value === 'note-orange' ||
+		value === 'note-violet' ||
+		value === 'note-neon-yellow' ||
+		value === 'note-neon-green' ||
+		value === 'note-neon-violet' ||
+		value === 'note-neon-orange' ||
+		value === 'note-neon-blue'
+	);
 }

--- a/apps/ui/src/ui-desks/widgets/note/types.ts
+++ b/apps/ui/src/ui-desks/widgets/note/types.ts
@@ -3,17 +3,20 @@ import type { DeskWidgetBase } from '@studio/common/types/desk';
 
 export const NOTE_WIDGET_TYPE = 'note';
 
-export type NoteTone =
-	| 'note'
-	| 'note-mint'
-	| 'note-blue'
-	| 'note-orange'
-	| 'note-violet'
-	| 'note-neon-yellow'
-	| 'note-neon-green'
-	| 'note-neon-violet'
-	| 'note-neon-orange'
-	| 'note-neon-blue';
+export const NOTE_TONES = [
+	'yellow',
+	'mint',
+	'blue',
+	'orange',
+	'violet',
+	'neon-yellow',
+	'neon-green',
+	'neon-violet',
+	'neon-orange',
+	'neon-blue',
+] as const;
+
+export type NoteTone = ( typeof NOTE_TONES )[ number ];
 
 export type NoteWidgetProps = {
 	text: string;
@@ -36,16 +39,5 @@ export function isNoteWidgetProps( value: unknown ): value is NoteWidgetProps {
 }
 
 export function isNoteTone( value: unknown ): value is NoteTone {
-	return (
-		value === 'note' ||
-		value === 'note-mint' ||
-		value === 'note-blue' ||
-		value === 'note-orange' ||
-		value === 'note-violet' ||
-		value === 'note-neon-yellow' ||
-		value === 'note-neon-green' ||
-		value === 'note-neon-violet' ||
-		value === 'note-neon-orange' ||
-		value === 'note-neon-blue'
-	);
+	return NOTE_TONES.includes( value as NoteTone );
 }

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -3,6 +3,11 @@ import type { DeskWidgetBase } from '@studio/common/types/desk';
 import type { ComponentType } from 'react';
 import type { TLShapeId } from 'tldraw';
 
+export interface WidgetIndicator {
+	cornerRadius?: number;
+	stroke?: string;
+}
+
 export interface DeskWidgetComponentProps<
 	TWidgetProps extends Record< string, unknown > = Record< string, unknown >,
 > {
@@ -16,6 +21,7 @@ export interface WidgetDefinition< TWidget extends DeskWidgetBase = DeskWidgetBa
 	shapeType: string;
 	Component: ComponentType< DeskWidgetComponentProps< TWidget[ 'widgetProps' ] > >;
 	isWidgetProps: ( props: unknown ) => props is TWidget[ 'widgetProps' ];
+	getIndicator?: ( widgetProps: TWidget[ 'widgetProps' ] ) => WidgetIndicator;
 }
 
 export type DeskWidget = NoteWidget;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,6 +1014,7 @@
 				"@wordpress/icons": "^13.0.0",
 				"@wordpress/private-apis": "^1.10.0",
 				"@wordpress/react-i18n": "^4.45.0",
+				"@wordpress/rich-text": "7.45.0",
 				"@wordpress/theme": "0.12.0",
 				"@wordpress/ui": "0.12.0",
 				"@wp-playground/blueprints": "3.1.28",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1009,6 +1009,7 @@
 				"@tanstack/react-query-persist-client": "^5.96.2",
 				"@tanstack/react-router": "^1.120.14",
 				"@wordpress/components": "33.0.0",
+				"@wordpress/data": "^10.45.0",
 				"@wordpress/dataviews": "^14.2.0",
 				"@wordpress/i18n": "^6.18.0",
 				"@wordpress/icons": "^13.0.0",


### PR DESCRIPTION
## Summary
- Replaced the placeholder note widget with a desk-style sticky note built on `contentEditable` and `@wordpress/rich-text`
- Kept the existing widget architecture and persistence flow intact, while updating the note schema to use tones instead of the old color enum
- Matched the widget indicator styling to the note tone and updated the default user desk seed plus adapter tests

## Testing
- `npx eslint --fix` on the modified files
- `npm test -- apps/ui/src/ui-desks/user-desk/tldraw-adapter.test.ts`
- `npm run typecheck`
- `npm -w @studio/ui run build`