### PR TITLE
Studio Blueprints Gallery: Hide incompatible blueprints

### DIFF
--- a/apps/studio/src/stores/gallery-blueprints-api.ts
+++ b/apps/studio/src/stores/gallery-blueprints-api.ts
@@ -30,6 +30,9 @@ const galleryIndexEntrySchema = z.object( {
 
 const galleryIndexSchema = z.record( z.string(), galleryIndexEntrySchema );
 
+// Blueprints that are not compatible with Studio's PHP WASM runtime
+const HIDDEN_BLUEPRINT_SLUGS = new Set( [ 'brewcommerce', 'blocky-formats', 'beta-rc' ] );
+
 function transformGalleryIndex( raw: unknown ): GalleryBlueprint[] {
 	const parseResult = galleryIndexSchema.safeParse( raw );
 	if ( ! parseResult.success ) {
@@ -43,6 +46,9 @@ function transformGalleryIndex( raw: unknown ): GalleryBlueprint[] {
 			return [];
 		}
 		const slug = match[ 1 ];
+		if ( HIDDEN_BLUEPRINT_SLUGS.has( slug ) ) {
+			return [];
+		}
 		const blueprintUrl = `${ GITHUB_RAW_BASE_URL }blueprints/${ slug }/blueprint.json`;
 		const playgroundUrl = `${ PLAYGROUND_BASE_URL }?blueprint-url=${ encodeURIComponent(
 			blueprintUrl


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1709

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

It was not necessary, the fix is straightforward

## Proposed Changes

This PR hides some incompatible blueprints that come from the public blueprints library and that don't work well with Studio e.g `Coffee Shop`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Enable the `Enable Blueprints Gallery` feature flag on the top
* Click on `Add site > Build a new site`
* Scroll down to the blueprints library 
* Confirm that you can't see, for example, Coffee Shop blueprints 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
