### PR TITLE
Make sure blueprints validation does not happen in preflight

### DIFF
--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -42,7 +42,7 @@ interface NewSiteOptionsProps {
 	isLoadingGallery?: boolean;
 	galleryErrorMessage?: string;
 	onGalleryBlueprintSelect?: ( blueprint: GalleryBlueprint ) => void;
-	isSelectingGalleryBlueprint?: boolean;
+	selectedGalleryBlueprint?: string | null;
 	gallerySelectionError?: string;
 }
 
@@ -218,21 +218,20 @@ function renameBlueprintsForDisplay(
 
 function GalleryBlueprintCard( {
 	blueprint,
+	isSelected,
 	onClick,
-	disabled,
 }: {
 	blueprint: GalleryBlueprint;
+	isSelected: boolean;
 	onClick: () => void;
-	disabled: boolean;
 } ) {
 	return (
 		<button
 			onClick={ onClick }
-			disabled={ disabled }
 			className={ cx(
 				'flex flex-col h-full rounded-lg border overflow-hidden text-left transition-colors',
-				disabled
-					? 'opacity-50 cursor-not-allowed border-frame-border'
+				isSelected
+					? 'border-frame-theme ring-2 ring-offset-2 ring-frame-theme ring-offset-frame'
 					: 'border-frame-border hover:border-frame-text-secondary'
 			) }
 		>
@@ -278,7 +277,7 @@ export function NewSiteOptions( {
 	isLoadingGallery = false,
 	galleryErrorMessage,
 	onGalleryBlueprintSelect,
-	isSelectingGalleryBlueprint = false,
+	selectedGalleryBlueprint,
 	gallerySelectionError,
 }: NewSiteOptionsProps ) {
 	const { __ } = useI18n();
@@ -393,16 +392,10 @@ export function NewSiteOptions( {
 								<GalleryBlueprintCard
 									key={ blueprint.slug }
 									blueprint={ blueprint }
+									isSelected={ selectedGalleryBlueprint === blueprint.slug }
 									onClick={ () => onGalleryBlueprintSelect( blueprint ) }
-									disabled={ isSelectingGalleryBlueprint }
 								/>
 							) ) }
-						</div>
-					) }
-
-					{ isSelectingGalleryBlueprint && (
-						<div className="flex items-center justify-center py-4">
-							<Spinner />
 						</div>
 					) }
 				</>

--- a/apps/studio/src/modules/add-site/index.tsx
+++ b/apps/studio/src/modules/add-site/index.tsx
@@ -107,7 +107,7 @@ function NavigationContent( props: NavigationContentProps ) {
 	const { __ } = useI18n();
 	const { enableBlueprints } = useFeatureFlags();
 	const [ blueprintFileError, setBlueprintFileError ] = useState< string | undefined >();
-	const [ isSelectingGalleryBlueprint, setIsSelectingGalleryBlueprint ] = useState( false );
+	const [ selectedGalleryBlueprint, setSelectedGalleryBlueprint ] = useState< GalleryBlueprint | undefined >();
 	const [ gallerySelectionError, setGallerySelectionError ] = useState< string | undefined >();
 	const {
 		data: galleryBlueprints,
@@ -173,12 +173,6 @@ function NavigationContent( props: NavigationContentProps ) {
 		[ goTo ]
 	);
 
-	const handleBlueprintContinue = useCallback( () => {
-		if ( selectedBlueprint ) {
-			goTo( '/new/create' );
-		}
-	}, [ selectedBlueprint, goTo ] );
-
 	const handleBackupFileSelect = useCallback(
 		( file?: File ) => {
 			setFileForImport( file || null );
@@ -228,6 +222,7 @@ function NavigationContent( props: NavigationContentProps ) {
 		}
 		if ( location.path === '/new' ) {
 			setSelectedBlueprint();
+			setSelectedGalleryBlueprint( undefined );
 			setBlueprintPreferredVersions?.( undefined );
 			setBlueprintSuggestedSiteName?.( undefined );
 			setBlueprintFileError( undefined );
@@ -278,6 +273,7 @@ function NavigationContent( props: NavigationContentProps ) {
 
 	const handleBlueprintChange = useCallback(
 		( blueprintId: string ) => {
+			setSelectedGalleryBlueprint( undefined );
 			if ( blueprintId === 'empty' ) {
 				setSelectedBlueprint( {
 					slug: 'empty',
@@ -306,11 +302,19 @@ function NavigationContent( props: NavigationContentProps ) {
 	);
 
 	const handleGalleryBlueprintSelect = useCallback(
-		async ( gallery: GalleryBlueprint ) => {
-			setIsSelectingGalleryBlueprint( true );
+		( gallery: GalleryBlueprint ) => {
+			setSelectedGalleryBlueprint( gallery );
+			setSelectedBlueprint();
+			setGallerySelectionError( undefined );
+		},
+		[ setSelectedBlueprint ]
+	);
+
+	const handleBlueprintContinue = useCallback( async () => {
+		if ( selectedGalleryBlueprint ) {
 			setGallerySelectionError( undefined );
 			try {
-				const response = await fetch( gallery.blueprintUrl );
+				const response = await fetch( selectedGalleryBlueprint.blueprintUrl );
 				if ( ! response.ok ) {
 					throw new Error( __( 'Failed to download blueprint.' ) );
 				}
@@ -323,13 +327,13 @@ function NavigationContent( props: NavigationContentProps ) {
 				}
 
 				const blueprint = {
-					slug: `gallery:${ gallery.slug }`,
-					title: gallery.title,
-					excerpt: gallery.description,
-					image: gallery.screenshotUrl,
-					playground_url: gallery.playgroundUrl,
+					slug: `gallery:${ selectedGalleryBlueprint.slug }`,
+					title: selectedGalleryBlueprint.title,
+					excerpt: selectedGalleryBlueprint.description,
+					image: selectedGalleryBlueprint.screenshotUrl,
+					playground_url: selectedGalleryBlueprint.playgroundUrl,
 					blueprint: blueprintJson,
-					filePath: gallery.blueprintUrl,
+					filePath: selectedGalleryBlueprint.blueprintUrl,
 				} as Blueprint;
 
 				handleBlueprintFormValues( blueprint );
@@ -338,12 +342,13 @@ function NavigationContent( props: NavigationContentProps ) {
 				setGallerySelectionError(
 					error instanceof Error ? error.message : __( 'Failed to load blueprint.' )
 				);
-			} finally {
-				setIsSelectingGalleryBlueprint( false );
 			}
-		},
-		[ __, goTo, handleBlueprintFormValues ]
-	);
+			return;
+		}
+		if ( selectedBlueprint ) {
+			goTo( '/new/create' );
+		}
+	}, [ selectedBlueprint, selectedGalleryBlueprint, goTo, __, handleBlueprintFormValues ] );
 
 	// Build default values with blueprint preferred versions applied
 	const { data: wpVersions = [] } = useGetWordPressVersions( {
@@ -412,7 +417,7 @@ function NavigationContent( props: NavigationContentProps ) {
 						isLoadingGallery={ isLoadingGallery }
 						galleryErrorMessage={ galleryError ? __( 'Could not load blueprints.' ) : undefined }
 						onGalleryBlueprintSelect={ handleGalleryBlueprintSelect }
-						isSelectingGalleryBlueprint={ isSelectingGalleryBlueprint }
+						selectedGalleryBlueprint={ selectedGalleryBlueprint?.slug }
 						gallerySelectionError={ gallerySelectionError }
 					/>
 				</ScreenContent>
@@ -466,7 +471,7 @@ function NavigationContent( props: NavigationContentProps ) {
 				onCreateSubmit={ () => {
 					formRef.current?.requestSubmit();
 				} }
-				canSubmitBlueprint={ !! selectedBlueprint }
+				canSubmitBlueprint={ !! selectedBlueprint || !! selectedGalleryBlueprint }
 				canSubmitBlueprintDeeplink={ !! selectedBlueprint }
 				canSubmitPullRemote={ !! selectedRemoteSite }
 				canSubmitCreate={ canSubmit }

--- a/apps/studio/src/modules/add-site/index.tsx
+++ b/apps/studio/src/modules/add-site/index.tsx
@@ -107,7 +107,9 @@ function NavigationContent( props: NavigationContentProps ) {
 	const { __ } = useI18n();
 	const { enableBlueprints } = useFeatureFlags();
 	const [ blueprintFileError, setBlueprintFileError ] = useState< string | undefined >();
-	const [ selectedGalleryBlueprint, setSelectedGalleryBlueprint ] = useState< GalleryBlueprint | undefined >();
+	const [ selectedGalleryBlueprint, setSelectedGalleryBlueprint ] = useState<
+		GalleryBlueprint | undefined
+	>();
 	const [ gallerySelectionError, setGallerySelectionError ] = useState< string | undefined >();
 	const {
 		data: galleryBlueprints,


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1708

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->
It was used to update the feature


## Proposed Changes

This PR ensures that we validate blueprints when we create a site and not in preflight. This ensures that the blueprints from the public library and the blueprints from the API are validated in the same way.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio app with `npm start`
* Enable the `Enable Blueprints Gallery` blueprint feature flag
* Click on `Add site > Build a new site`
* Scroll to the `Explore more blueprints` section
* Confirm that you first need to select a blueprint and then proceed to site creation and it does not skip to site creation automatically right away

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
