### PR TITLE
apps/ui: Add page widgets to the desk UI

### DIFF
--- a/apps/ui/src/data/wordpress/provider.tsx
+++ b/apps/ui/src/data/wordpress/provider.tsx
@@ -1,7 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { RegistryProvider, createRegistry } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 import { useMemo, type ReactNode } from 'react';
 import { useConnector } from '@/data/core';
 import { createSiteApiFetchHandler } from './api-fetch';
@@ -16,18 +15,6 @@ export function WordPressDataProvider( { siteId, children }: WordPressDataProvid
 	const registry = useMemo( () => {
 		const nextRegistry = createRegistry();
 		nextRegistry.register( coreDataStore );
-		void nextRegistry.dispatch( coreDataStore ).addEntities( [
-			{
-				kind: 'postType',
-				name: 'post',
-				label: __( 'Posts' ),
-				baseURL: '/wp/v2/posts',
-				baseURLParams: { context: 'view' },
-				key: 'id',
-				plural: 'posts',
-				supportsPagination: true,
-			},
-		] );
 		return nextRegistry;
 	}, [] );
 

--- a/apps/ui/src/ui-desks/chrome/create-menu.tsx
+++ b/apps/ui/src/ui-desks/chrome/create-menu.tsx
@@ -8,6 +8,8 @@ import { useMemo, useState } from 'react';
 import { useSites } from '@/data/queries/use-sites';
 import { IconControlButton, Menu } from '@/ui-desks/components';
 import { useDesk } from '@/ui-desks/desk/provider';
+import { pageWidgetDefinition } from '@/ui-desks/widgets/page/definition';
+import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
 import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
 import { POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
 import { getCreatableWidgetDefinitions } from '@/ui-desks/widgets/registry';
@@ -19,7 +21,7 @@ export function DeskCreateMenu() {
 	const navigate = useNavigate();
 	const desk = useDesk();
 	const creatableWidgetDefinitions = getCreatableWidgetDefinitions();
-	const [ mode, setMode ] = useState< 'menu' | 'pick-post' >( 'menu' );
+	const [ mode, setMode ] = useState< 'menu' | 'pick-post' | 'pick-page' >( 'menu' );
 	const { data: sites } = useSites();
 	const site = sites?.find( ( candidate ) => candidate.id === desk.siteId );
 	const isSiteRunning = Boolean( site?.running );
@@ -49,7 +51,7 @@ export function DeskCreateMenu() {
 			<Menu.Popup
 				side="bottom"
 				align="start"
-				className={ `${ styles.popup } ${ mode === 'pick-post' ? styles.postPickerPopup : '' }` }
+				className={ `${ styles.popup } ${ mode !== 'menu' ? styles.postPickerPopup : '' }` }
 			>
 				{ mode === 'menu' ? (
 					<>
@@ -68,21 +70,38 @@ export function DeskCreateMenu() {
 							</Menu.Item>
 						) ) }
 						{ desk.siteId && (
-							<Menu.Item
-								disabled={ isWidgetCreationDisabled(
-									postWidgetDefinition,
-									desk.canAddWidgets,
-									isSiteRunning
-								) }
-								closeOnClick={ false }
-								onClick={ ( event ) => {
-									event.preventDefault();
-									setMode( 'pick-post' );
-								} }
-							>
-								{ postWidgetDefinition.icon && <Icon icon={ postWidgetDefinition.icon } /> }
-								<span>{ postWidgetDefinition.labels.add() }</span>
-							</Menu.Item>
+							<>
+								<Menu.Item
+									disabled={ isWidgetCreationDisabled(
+										postWidgetDefinition,
+										desk.canAddWidgets,
+										isSiteRunning
+									) }
+									closeOnClick={ false }
+									onClick={ ( event ) => {
+										event.preventDefault();
+										setMode( 'pick-post' );
+									} }
+								>
+									{ postWidgetDefinition.icon && <Icon icon={ postWidgetDefinition.icon } /> }
+									<span>{ postWidgetDefinition.labels.add() }</span>
+								</Menu.Item>
+								<Menu.Item
+									disabled={ isWidgetCreationDisabled(
+										pageWidgetDefinition,
+										desk.canAddWidgets,
+										isSiteRunning
+									) }
+									closeOnClick={ false }
+									onClick={ ( event ) => {
+										event.preventDefault();
+										setMode( 'pick-page' );
+									} }
+								>
+									{ pageWidgetDefinition.icon && <Icon icon={ pageWidgetDefinition.icon } /> }
+									<span>{ pageWidgetDefinition.labels.add() }</span>
+								</Menu.Item>
+							</>
 						) }
 						{ ( creatableWidgetDefinitions.length > 0 || desk.siteId ) && <Menu.Separator /> }
 						<Menu.Item onClick={ createChat }>
@@ -99,7 +118,10 @@ export function DeskCreateMenu() {
 						</Menu.Item>
 					</>
 				) : (
-					<PostPickerMenuItems onBack={ () => setMode( 'menu' ) } />
+					<ExistingContentPickerMenuItems
+						type={ mode === 'pick-page' ? 'page' : 'post' }
+						onBack={ () => setMode( 'menu' ) }
+					/>
 				) }
 			</Menu.Popup>
 		</Menu.Root>
@@ -114,7 +136,13 @@ function isWidgetCreationDisabled(
 	return ! canAddWidgets || ( definition.requiresRunningSite && ! isSiteRunning );
 }
 
-function PostPickerMenuItems( { onBack }: { onBack: () => void } ) {
+function ExistingContentPickerMenuItems( {
+	type,
+	onBack,
+}: {
+	type: 'post' | 'page';
+	onBack: () => void;
+} ) {
 	const desk = useDesk();
 	const { data: sites, isLoading: isLoadingSites } = useSites();
 	const site = sites?.find( ( candidate ) => candidate.id === desk.siteId );
@@ -123,18 +151,18 @@ function PostPickerMenuItems( { onBack }: { onBack: () => void } ) {
 		() => ( {
 			per_page: 20,
 			context: 'view',
-			orderby: 'date',
-			order: 'desc',
-			_fields: 'id,title,excerpt,status,date,link',
+			orderby: type === 'page' ? 'menu_order' : 'date',
+			order: type === 'page' ? 'asc' : 'desc',
+			_fields: 'id,title,excerpt,status,date,link,slug',
 		} ),
-		[]
+		[ type ]
 	);
 
 	const {
 		records,
 		isResolving,
 		status: resolutionStatus,
-	} = useEntityRecords< CoreDataPost >( 'postType', 'post', query, {
+	} = useEntityRecords< CoreDataPost >( 'postType', type, query, {
 		enabled: canQueryPosts,
 	} );
 
@@ -161,34 +189,40 @@ function PostPickerMenuItems( { onBack }: { onBack: () => void } ) {
 				<div className={ styles.postPickerStatus }>{ __( 'Site is not running.' ) }</div>
 			) }
 			{ canQueryPosts && isResolving && ! records && (
-				<div className={ styles.postPickerStatus }>{ __( 'Loading posts…' ) }</div>
+				<div className={ styles.postPickerStatus }>
+					{ type === 'page' ? __( 'Loading pages…' ) : __( 'Loading posts…' ) }
+				</div>
 			) }
 			{ canQueryPosts && records && records.length === 0 && (
-				<div className={ styles.postPickerStatus }>{ __( 'No posts found.' ) }</div>
+				<div className={ styles.postPickerStatus }>
+					{ type === 'page' ? __( 'No pages found.' ) : __( 'No posts found.' ) }
+				</div>
 			) }
 			{ canQueryPosts && resolutionStatus === 'ERROR' && (
-				<div className={ styles.postPickerStatus }>{ __( 'Unable to load posts.' ) }</div>
+				<div className={ styles.postPickerStatus }>
+					{ type === 'page' ? __( 'Unable to load pages.' ) : __( 'Unable to load posts.' ) }
+				</div>
 			) }
-			{ records?.map( ( postRecord ) => {
-				const title = decodeEntities( postRecord.title?.rendered ?? '' ).trim() || __( 'Untitled' );
+			{ records?.map( ( record ) => {
+				const title = decodeEntities( record.title?.rendered ?? '' ).trim() || __( 'Untitled' );
 				return (
 					<Menu.Item
-						key={ postRecord.id }
+						key={ record.id }
 						className={ styles.postPickerItem }
 						disabled={ ! desk.canAddWidgets }
 						onClick={ () =>
-							desk.addWidget( POST_WIDGET_TYPE, {
+							desk.addWidget( type === 'page' ? PAGE_WIDGET_TYPE : POST_WIDGET_TYPE, {
 								widgetProps: {
-									postId: postRecord.id,
+									...( type === 'page'
+										? { pageId: record.id, tone: 'neutral' }
+										: { postId: record.id } ),
 								},
 								shouldStartEditing: false,
 							} )
 						}
 					>
 						<span className={ styles.postPickerTitle }>{ title }</span>
-						{ postRecord.status && (
-							<span className={ styles.postPickerMeta }>{ postRecord.status }</span>
-						) }
+						{ record.status && <span className={ styles.postPickerMeta }>{ record.status }</span> }
 					</Menu.Item>
 				);
 			} ) }

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
@@ -6,6 +6,7 @@ import {
 	deskWidgetToCanvasShape,
 } from './tldraw-adapter';
 import type { NoteWidget } from '@/ui-desks/widgets/note/types';
+import type { PageWidget } from '@/ui-desks/widgets/page/types';
 import type { PostWidget } from '@/ui-desks/widgets/post/types';
 import type { TLShape } from 'tldraw';
 
@@ -123,6 +124,49 @@ describe( 'tldraw adapter', () => {
 				},
 				widgetProps: {
 					postId: 42,
+				},
+			},
+		} );
+		expect( canvasShapeToDeskWidget( shape ) ).toEqual( {
+			...widget,
+			rotation: undefined,
+		} );
+	} );
+
+	it( 'maps a page widget through the canvas shape adapter', () => {
+		const widget: PageWidget = {
+			id: 'page-1',
+			type: 'page',
+			x: 60,
+			y: 70,
+			zIndex: 'a4',
+			shapeProps: {
+				w: 280,
+				h: 380,
+			},
+			widgetProps: {
+				pageId: 84,
+				tone: 'violet',
+			},
+		};
+
+		const shape = deskWidgetToCanvasShape( widget ) as TLShape;
+
+		expect( shape ).toMatchObject( {
+			id: 'shape:page-1',
+			type: RECTANGLE_WIDGET_SHAPE_TYPE,
+			x: 60,
+			y: 70,
+			index: 'a4',
+			props: {
+				widgetType: 'page',
+				shapeProps: {
+					w: 280,
+					h: 380,
+				},
+				widgetProps: {
+					pageId: 84,
+					tone: 'violet',
 				},
 			},
 		} );

--- a/apps/ui/src/ui-desks/widgets/create-widget.test.ts
+++ b/apps/ui/src/ui-desks/widgets/create-widget.test.ts
@@ -78,4 +78,36 @@ describe( 'createDeskWidget', () => {
 			},
 		} );
 	} );
+
+	it( 'creates a page widget with supplied page props', () => {
+		const createdWidget = createDeskWidget( {
+			id: 'page-1',
+			type: 'page',
+			center: {
+				x: 500,
+				y: 400,
+			},
+			zIndex: 'a4',
+			widgetProps: {
+				pageId: 84,
+				tone: 'blue',
+			},
+		} );
+
+		expect( createdWidget ).toEqual( {
+			id: 'page-1',
+			type: 'page',
+			x: 360,
+			y: 210,
+			zIndex: 'a4',
+			shapeProps: {
+				w: 280,
+				h: 380,
+			},
+			widgetProps: {
+				pageId: 84,
+				tone: 'blue',
+			},
+		} );
+	} );
 } );

--- a/apps/ui/src/ui-desks/widgets/page/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/page/component.tsx
@@ -1,0 +1,61 @@
+import { useEntityRecords, type Post as CoreDataPost } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
+import styles from './style.module.css';
+import type { PageWidgetProps } from './types';
+import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
+
+type PageWidgetComponentProps = DeskWidgetComponentProps< PageWidgetProps >;
+
+export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentProps ) {
+	const query = useMemo(
+		() => ( {
+			include: [ widgetProps.pageId ],
+			per_page: 1,
+			context: 'view',
+			_fields: 'id,title,excerpt,slug',
+		} ),
+		[ widgetProps.pageId ]
+	);
+	const {
+		records,
+		isResolving,
+		status: resolutionStatus,
+	} = useEntityRecords< CoreDataPost >( 'postType', 'page', query, {
+		enabled: widgetProps.pageId > 0,
+	} );
+	const record = records?.[ 0 ] ?? null;
+	const hasError = resolutionStatus === 'ERROR';
+
+	const title = getPageTitle( record, isResolving, hasError );
+	const excerpt = record?.excerpt?.rendered ?? '';
+	const slug = record?.slug ?? '';
+
+	return (
+		<article
+			className={ styles.page }
+			data-tone={ widgetProps.tone }
+			data-is-loading={ isResolving && ! record ? 'true' : 'false' }
+			data-studio-desk-widget="page"
+			data-studio-desk-widget-id={ id }
+		>
+			<h2 className={ styles.title } dangerouslySetInnerHTML={ { __html: title } } />
+			{ excerpt && (
+				<div className={ styles.body } dangerouslySetInnerHTML={ { __html: excerpt } } />
+			) }
+			{ slug && <div className={ styles.slug }>/{ slug }</div> }
+		</article>
+	);
+}
+
+function getPageTitle( pageRecord: CoreDataPost | null, isResolving: boolean, hasError: boolean ) {
+	if ( pageRecord ) {
+		return pageRecord.title?.rendered || __( 'Untitled' );
+	}
+
+	if ( hasError ) {
+		return __( 'Unable to load page' );
+	}
+
+	return isResolving ? __( 'Loading page…' ) : __( 'Page unavailable' );
+}

--- a/apps/ui/src/ui-desks/widgets/page/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/page/definition.ts
@@ -1,0 +1,69 @@
+import { __ } from '@wordpress/i18n';
+import { page } from '@wordpress/icons';
+import { PageWidgetComponent } from '@/ui-desks/widgets/page/component';
+import { PageEditControl } from '@/ui-desks/widgets/page/edit-control';
+import { isPageWidgetProps, PAGE_WIDGET_TYPE, type PageTone, type PageWidget } from './types';
+import type { WidgetDefinition } from '@/ui-desks/widgets/types';
+
+const PAGE_TONE_COLORS: Record< PageTone, string > = {
+	neutral: '#14171a',
+	orange: '#e86a00',
+	red: '#e5484d',
+	violet: '#8703e7',
+	blue: '#2200e0',
+	sky: '#0081f3',
+	green: '#00a96c',
+};
+
+const PAGE_TONE_OPTIONS: Array< { value: PageTone; label: string; color: string } > = [
+	{ value: 'neutral', label: __( 'Default' ), color: PAGE_TONE_COLORS.neutral },
+	{ value: 'orange', label: __( 'Orange' ), color: PAGE_TONE_COLORS.orange },
+	{ value: 'red', label: __( 'Red' ), color: PAGE_TONE_COLORS.red },
+	{ value: 'violet', label: __( 'Violet' ), color: PAGE_TONE_COLORS.violet },
+	{ value: 'blue', label: __( 'Blue' ), color: PAGE_TONE_COLORS.blue },
+	{ value: 'sky', label: __( 'Sky' ), color: PAGE_TONE_COLORS.sky },
+	{ value: 'green', label: __( 'Green' ), color: PAGE_TONE_COLORS.green },
+];
+
+export const pageWidgetDefinition = {
+	type: PAGE_WIDGET_TYPE,
+	Component: PageWidgetComponent,
+	controls: [
+		{
+			type: 'color',
+			id: 'tone',
+			property: 'tone',
+			label: __( 'Color' ),
+			options: PAGE_TONE_OPTIONS,
+		},
+		{
+			type: 'custom',
+			id: 'edit-in-wp',
+			Component: PageEditControl,
+		},
+	],
+	isCreatable: false,
+	requiresRunningSite: true,
+	isWidgetProps: isPageWidgetProps,
+	getIndicator: ( widgetProps ) => {
+		const color = PAGE_TONE_COLORS[ widgetProps.tone ];
+		return {
+			cornerRadius: 18,
+			stroke: `color-mix(in srgb, ${ color } 50%, white)`,
+		};
+	},
+	labels: {
+		add: () => __( 'Add existing page…' ),
+	},
+	icon: page,
+	getInitialWidget: () => ( {
+		shapeProps: {
+			w: 280,
+			h: 380,
+		},
+		widgetProps: {
+			pageId: 0,
+			tone: 'neutral',
+		},
+	} ),
+} satisfies WidgetDefinition< PageWidget >;

--- a/apps/ui/src/ui-desks/widgets/page/edit-control.tsx
+++ b/apps/ui/src/ui-desks/widgets/page/edit-control.tsx
@@ -1,0 +1,35 @@
+import { __ } from '@wordpress/i18n';
+import { pencil } from '@wordpress/icons';
+import { useConnector } from '@/data/core';
+import { useSites } from '@/data/queries/use-sites';
+import { IconControlButton } from '@/ui-desks/components';
+import { useDesk } from '@/ui-desks/desk/provider';
+import type { PageWidgetProps } from './types';
+import type { ControlRenderContext } from '@/ui-desks/controls/types';
+
+export function PageEditControl( { props }: ControlRenderContext< PageWidgetProps > ) {
+	const connector = useConnector();
+	const { siteId } = useDesk();
+	const { data: sites } = useSites();
+	const site = sites?.find( ( currentSite ) => currentSite.id === siteId );
+	const canEdit = Boolean( siteId && site?.running && props.pageId > 0 );
+
+	return (
+		<IconControlButton
+			icon={ pencil }
+			label={ __( 'Edit in WP' ) }
+			variant="toolbar"
+			disabled={ ! canEdit }
+			onClick={ () => {
+				if ( ! siteId || props.pageId <= 0 ) {
+					return;
+				}
+
+				void connector.openSiteUrl(
+					siteId,
+					`/wp-admin/post.php?post=${ props.pageId }&action=edit`
+				);
+			} }
+		/>
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/page/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/page/style.module.css
@@ -1,0 +1,103 @@
+.page {
+	--page-tone-color: #14171a;
+
+	box-sizing: border-box;
+	position: relative;
+	width: 100%;
+	height: 100%;
+	padding: 36px 32px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	margin: 0;
+	background: #fff;
+	border-radius: 18px;
+	box-shadow:
+		0 1px 2px rgba(15, 23, 42, 0.04),
+		0 18px 44px rgba(15, 23, 42, 0.09);
+	color: var(--page-tone-color);
+	overflow: hidden;
+	font-family: inherit;
+}
+
+.page::before {
+	content: '';
+	position: absolute;
+	inset: 12px;
+	border: 3px solid var(--page-tone-color);
+	border-radius: 8px;
+	pointer-events: none;
+}
+
+.page[data-tone='orange'] {
+	--page-tone-color: #e86a00;
+}
+
+.page[data-tone='red'] {
+	--page-tone-color: #e5484d;
+}
+
+.page[data-tone='violet'] {
+	--page-tone-color: #8703e7;
+}
+
+.page[data-tone='blue'] {
+	--page-tone-color: #2200e0;
+}
+
+.page[data-tone='sky'] {
+	--page-tone-color: #0081f3;
+}
+
+.page[data-tone='green'] {
+	--page-tone-color: #00a96c;
+}
+
+.title {
+	margin: 0;
+	font-size: 22px;
+	line-height: 1.18;
+	font-weight: 600;
+	letter-spacing: 0;
+	color: var(--page-tone-color);
+	overflow-wrap: anywhere;
+}
+
+.body {
+	max-height: 0;
+	margin: 0;
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--page-tone-color);
+	overflow: hidden;
+	opacity: 0;
+	transition:
+		max-height 280ms cubic-bezier(0.32, 0.72, 0.24, 1),
+		opacity 240ms ease;
+}
+
+.page:hover .body {
+	max-height: 480px;
+	opacity: 1;
+}
+
+.body p {
+	margin: 0 0 8px;
+}
+
+.body p:last-child {
+	margin-bottom: 0;
+}
+
+.slug {
+	margin-top: auto;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+	font-size: 15px;
+	line-height: 1.4;
+	font-feature-settings: 'tnum' 1;
+	letter-spacing: 0;
+	color: var(--page-tone-color);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}

--- a/apps/ui/src/ui-desks/widgets/page/types.ts
+++ b/apps/ui/src/ui-desks/widgets/page/types.ts
@@ -1,0 +1,35 @@
+import type { RectangleWidgetShapeProps } from '@/ui-desks/widgets/geometry';
+import type { DeskWidgetBase } from '@studio/common/types/desk';
+
+export const PAGE_WIDGET_TYPE = 'page';
+
+export const PAGE_TONES = [ 'neutral', 'orange', 'red', 'violet', 'blue', 'sky', 'green' ] as const;
+
+export type PageTone = ( typeof PAGE_TONES )[ number ];
+
+export type PageWidgetProps = {
+	pageId: number;
+	tone: PageTone;
+};
+
+export type PageWidget = DeskWidgetBase<
+	typeof PAGE_WIDGET_TYPE,
+	RectangleWidgetShapeProps,
+	PageWidgetProps
+>;
+
+export function isPageWidgetProps( value: unknown ): value is PageWidgetProps {
+	const candidate = value as Partial< PageWidgetProps >;
+	return (
+		Boolean( value ) &&
+		typeof value === 'object' &&
+		typeof candidate.pageId === 'number' &&
+		Number.isInteger( candidate.pageId ) &&
+		candidate.pageId >= 0 &&
+		isPageTone( candidate.tone )
+	);
+}
+
+export function isPageTone( value: unknown ): value is PageTone {
+	return PAGE_TONES.includes( value as PageTone );
+}

--- a/apps/ui/src/ui-desks/widgets/registry.ts
+++ b/apps/ui/src/ui-desks/widgets/registry.ts
@@ -1,10 +1,12 @@
 import { noteWidgetDefinition } from '@/ui-desks/widgets/note/definition';
+import { pageWidgetDefinition } from '@/ui-desks/widgets/page/definition';
 import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
 import type { DeskWidgetDefinition } from './types';
 
 export const widgetDefinitions = {
 	[ noteWidgetDefinition.type ]: noteWidgetDefinition,
 	[ postWidgetDefinition.type ]: postWidgetDefinition,
+	[ pageWidgetDefinition.type ]: pageWidgetDefinition,
 } satisfies Record< string, DeskWidgetDefinition >;
 
 export function getWidgetDefinition( type: string ) {

--- a/apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts
+++ b/apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
+import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
 import { POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
 import { getSelectedWidgetToolbarItem } from './toolbar-selection';
 import type { DeskWidget } from '@/ui-desks/widgets/types';
@@ -27,6 +28,17 @@ describe( 'widget toolbar selection', () => {
 		expect( selectedItem?.definition.controls?.[ 0 ]?.type ).toBe( 'custom' );
 		expect( selectedItem?.widget.widgetProps ).toEqual( {
 			postId: 42,
+		} );
+	} );
+
+	it( 'returns the toolbar item for a single page widget selection', () => {
+		const selectedItem = getSelectedWidgetToolbarItem( [ createPageWidget() ] );
+
+		expect( selectedItem?.definition.type ).toBe( PAGE_WIDGET_TYPE );
+		expect( selectedItem?.definition.controls?.[ 0 ]?.type ).toBe( 'color' );
+		expect( selectedItem?.widget.widgetProps ).toEqual( {
+			pageId: 84,
+			tone: 'blue',
 		} );
 	} );
 
@@ -90,6 +102,24 @@ function createPostWidget(): DeskWidget {
 		},
 		widgetProps: {
 			postId: 42,
+		},
+	};
+}
+
+function createPageWidget(): DeskWidget {
+	return {
+		id: 'page-1',
+		type: PAGE_WIDGET_TYPE,
+		x: 0,
+		y: 0,
+		zIndex: 'a1',
+		shapeProps: {
+			w: 280,
+			h: 380,
+		},
+		widgetProps: {
+			pageId: 84,
+			tone: 'blue',
 		},
 	};
 }

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -1,5 +1,6 @@
 import type { ControlConfig } from '@/ui-desks/controls/types';
 import type { NoteWidget } from '@/ui-desks/widgets/note/types';
+import type { PageWidget } from '@/ui-desks/widgets/page/types';
 import type { PostWidget } from '@/ui-desks/widgets/post/types';
 import type { DeskWidgetBase } from '@studio/common/types/desk';
 import type { ComponentProps, ComponentType, ReactElement } from 'react';
@@ -38,5 +39,8 @@ export interface WidgetDefinition< TWidget extends DeskWidgetBase = DeskWidgetBa
 	getIndicator?: ( widgetProps: TWidget[ 'widgetProps' ] ) => WidgetIndicator;
 }
 
-export type DeskWidget = NoteWidget | PostWidget;
-export type DeskWidgetDefinition = WidgetDefinition< NoteWidget > | WidgetDefinition< PostWidget >;
+export type DeskWidget = NoteWidget | PostWidget | PageWidget;
+export type DeskWidgetDefinition =
+	| WidgetDefinition< NoteWidget >
+	| WidgetDefinition< PostWidget >
+	| WidgetDefinition< PageWidget >;


### PR DESCRIPTION
## Summary
- Add a new `page` desk widget that mirrors the existing post widget architecture
- Add an `Add existing page…` entry to the create menu and wire it to core-data page records
- Register the page widget in the widget registry and cover creation, selection, and canvas adapter behavior with tests
- Remove manual core-data entity registration and rely on core-data’s built-in post type entity loading

## Testing
- `npx eslint --fix` on the modified TypeScript files
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-desks/widgets/create-widget.test.ts apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts`