### PR TITLE
Generate CLI passwords without window

### DIFF
--- a/tools/common/lib/passwords.ts
+++ b/tools/common/lib/passwords.ts
@@ -1,7 +1,47 @@
-import { generatePassword } from '@automattic/generate-password';
 import { __ } from '@wordpress/i18n';
 
-export { generatePassword };
+const ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const DIGITS = '0123456789';
+const SPECIAL_CHARS = '!@#$%^&*()';
+const EXTRA_SPECIAL_CHARS = '-_ []{}<>~`+=,.;:/?|';
+
+/**
+ * Generates a cryptographically secure random password.
+ */
+export function generatePassword( {
+	length = 24,
+	useNumbers = true,
+	useSpecialChars = true,
+	useExtraSpecialChars = false,
+}: {
+	length?: number;
+	useNumbers?: boolean;
+	useSpecialChars?: boolean;
+	useExtraSpecialChars?: boolean;
+} = {} ): string {
+	let characterPool = ALPHABET;
+	if ( useNumbers ) {
+		characterPool += DIGITS;
+	}
+	if ( useSpecialChars ) {
+		characterPool += SPECIAL_CHARS;
+	}
+	if ( useExtraSpecialChars ) {
+		characterPool += EXTRA_SPECIAL_CHARS;
+	}
+
+	const randomNumber = new Uint8Array( 1 );
+	let password = '';
+
+	for ( let i = 0; i < length; i++ ) {
+		do {
+			globalThis.crypto.getRandomValues( randomNumber );
+		} while ( randomNumber[ 0 ] >= characterPool.length );
+		password += characterPool[ randomNumber[ 0 ] ];
+	}
+
+	return password;
+}
 
 /**
  * Generates a random, Base64-encoded password.


### PR DESCRIPTION
## Related issues

- Follow-up found while refreshing #3095 and running local Studio CLI benchmarks.

## Proposed Changes

- Replace the browser-only `@automattic/generate-password` wrapper usage with an equivalent runtime-neutral password generator.
- Use `globalThis.crypto.getRandomValues()` so password generation works in Node CLI and browser-capable runtimes.
- Preserve the existing exported `generatePassword()` and `createPassword()` APIs.

## Testing Instructions

- `npx vitest run tools/common/lib/tests/passwords.test.ts`
- `npm run lint -- tools/common/lib/passwords.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the CLI `window is not defined` failure and drafting the small runtime-neutral password generator patch. Chris remains responsible for review and merge.