### PR TITLE
apps/ui: Add site preview widgets

### DIFF
--- a/apps/ui/src/ui-desks/chrome/create-menu.tsx
+++ b/apps/ui/src/ui-desks/chrome/create-menu.tsx
@@ -20,7 +20,9 @@ import type { DeskWidgetDefinition } from '@/ui-desks/widgets/types';
 export function DeskCreateMenu() {
 	const navigate = useNavigate();
 	const desk = useDesk();
-	const creatableWidgetDefinitions = getCreatableWidgetDefinitions();
+	const creatableWidgetDefinitions = getCreatableWidgetDefinitions().filter( ( definition ) =>
+		isWidgetAvailableInDeskContext( definition, Boolean( desk.siteId ) )
+	);
 	const [ mode, setMode ] = useState< 'menu' | 'pick-post' | 'pick-page' >( 'menu' );
 	const { data: sites } = useSites();
 	const site = sites?.find( ( candidate ) => candidate.id === desk.siteId );
@@ -63,7 +65,11 @@ export function DeskCreateMenu() {
 									desk.canAddWidgets,
 									isSiteRunning
 								) }
-								onClick={ () => desk.addWidget( definition.type ) }
+								onClick={ () =>
+									desk.addWidget( definition.type, {
+										shouldStartEditing: definition.shouldStartEditingOnCreate,
+									} )
+								}
 							>
 								{ definition.icon && <Icon icon={ definition.icon } /> }
 								<span>{ definition.labels.add() }</span>
@@ -126,6 +132,13 @@ export function DeskCreateMenu() {
 			</Menu.Popup>
 		</Menu.Root>
 	);
+}
+
+function isWidgetAvailableInDeskContext(
+	definition: DeskWidgetDefinition,
+	hasSiteContext: boolean
+) {
+	return hasSiteContext || ! definition.requiresRunningSite;
 }
 
 function isWidgetCreationDisabled(

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
@@ -12,6 +12,7 @@ import type { DeskConfig } from './types';
 import type { NoteWidget } from '@/ui-desks/widgets/note/types';
 import type { PageWidget } from '@/ui-desks/widgets/page/types';
 import type { PostWidget } from '@/ui-desks/widgets/post/types';
+import type { SitePreviewWidget } from '@/ui-desks/widgets/site-preview/types';
 
 vi.mock( '@wordpress/core-data', () => ( {
 	useEntityRecord: () => ( { record: null, isResolving: false } ),
@@ -170,6 +171,47 @@ describe( 'tldraw adapter', () => {
 				widgetProps: {
 					pageId: 84,
 					tone: 'violet',
+				},
+			},
+		} );
+		expect( canvasShapeToDeskWidget( shape ) ).toEqual( {
+			...widget,
+			rotation: undefined,
+		} );
+	} );
+
+	it( 'maps a site preview widget through the canvas shape adapter', () => {
+		const widget: SitePreviewWidget = {
+			id: 'site-preview-1',
+			type: 'site-preview',
+			x: 80,
+			y: 90,
+			zIndex: 'a5',
+			shapeProps: {
+				w: 480,
+				h: 360,
+			},
+			widgetProps: {
+				path: '/',
+			},
+		};
+
+		const shape = deskWidgetToCanvasShape( widget ) as TLShape;
+
+		expect( shape ).toMatchObject( {
+			id: 'shape:site-preview-1',
+			type: RECTANGLE_WIDGET_SHAPE_TYPE,
+			x: 80,
+			y: 90,
+			index: 'a5',
+			props: {
+				widgetType: 'site-preview',
+				shapeProps: {
+					w: 480,
+					h: 360,
+				},
+				widgetProps: {
+					path: '/',
 				},
 			},
 		} );

--- a/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
+++ b/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
@@ -6,6 +6,7 @@ import {
 	resizeBox,
 	useEditor,
 	useIsEditing,
+	useValue,
 	type JsonObject,
 	type RecordProps,
 	type TLResizeInfo,
@@ -141,6 +142,16 @@ function RectangleWidgetComponent( {
 	const editor = useEditor();
 	const isEditing = useIsEditing( shape.id );
 	const stackInteraction = useStackShapeInteraction( shape );
+	const isHovered = useValue(
+		`rectangle-widget-is-hovered:${ shape.id }`,
+		() => editor.getHoveredShapeId() === shape.id,
+		[ editor, shape.id ]
+	);
+	const isSelected = useValue(
+		`rectangle-widget-is-selected:${ shape.id }`,
+		() => editor.getSelectedShapeIds().includes( shape.id ),
+		[ editor, shape.id ]
+	);
 	const WidgetComponent = definition.Component as unknown as ComponentType<
 		DeskWidgetComponentProps< JsonObject >
 	>;
@@ -161,6 +172,8 @@ function RectangleWidgetComponent( {
 				id={ getWidgetIdFromShapeId( shape.id ) }
 				widgetProps={ shape.props.widgetProps }
 				isEditing={ isEditing }
+				isHovered={ isHovered }
+				isSelected={ isSelected }
 				onWidgetPropsChange={ handleWidgetPropsChange }
 				onEditComplete={ () => editor.complete() }
 			/>

--- a/apps/ui/src/ui-desks/widgets/create-widget.test.ts
+++ b/apps/ui/src/ui-desks/widgets/create-widget.test.ts
@@ -110,4 +110,31 @@ describe( 'createDeskWidget', () => {
 			},
 		} );
 	} );
+
+	it( 'creates a site preview widget centered on the requested point', () => {
+		const createdWidget = createDeskWidget( {
+			id: 'site-preview-1',
+			type: 'site-preview',
+			center: {
+				x: 500,
+				y: 400,
+			},
+			zIndex: 'a5',
+		} );
+
+		expect( createdWidget ).toEqual( {
+			id: 'site-preview-1',
+			type: 'site-preview',
+			x: 220,
+			y: 190,
+			zIndex: 'a5',
+			shapeProps: {
+				w: 560,
+				h: 420,
+			},
+			widgetProps: {
+				path: '/',
+			},
+		} );
+	} );
 } );

--- a/apps/ui/src/ui-desks/widgets/registry.ts
+++ b/apps/ui/src/ui-desks/widgets/registry.ts
@@ -1,12 +1,14 @@
 import { noteWidgetDefinition } from '@/ui-desks/widgets/note/definition';
 import { pageWidgetDefinition } from '@/ui-desks/widgets/page/definition';
 import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
+import { sitePreviewWidgetDefinition } from '@/ui-desks/widgets/site-preview/definition';
 import type { DeskWidgetDefinition } from './types';
 
 export const widgetDefinitions = {
 	[ noteWidgetDefinition.type ]: noteWidgetDefinition,
 	[ postWidgetDefinition.type ]: postWidgetDefinition,
 	[ pageWidgetDefinition.type ]: pageWidgetDefinition,
+	[ sitePreviewWidgetDefinition.type ]: sitePreviewWidgetDefinition,
 } satisfies Record< string, DeskWidgetDefinition >;
 
 export function getWidgetDefinition( type: string ) {

--- a/apps/ui/src/ui-desks/widgets/site-preview/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/site-preview/component.tsx
@@ -1,0 +1,113 @@
+import { __ } from '@wordpress/i18n';
+import { useEffect, useRef, useState } from 'react';
+import { useSites } from '@/data/queries/use-sites';
+import { useDesk } from '@/ui-desks/desk/provider';
+import styles from './style.module.css';
+import { getSitePreviewUrl, urlLabelFor, withPreviewFlag } from './url';
+import type { SitePreviewWidgetProps } from './types';
+import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
+
+type SitePreviewWidgetComponentProps = DeskWidgetComponentProps< SitePreviewWidgetProps >;
+
+export function SitePreviewWidgetComponent( {
+	id,
+	widgetProps,
+	isEditing,
+	isHovered,
+	isSelected,
+}: SitePreviewWidgetComponentProps ) {
+	const iframeRef = useRef< HTMLIFrameElement | null >( null );
+	const { siteId } = useDesk();
+	const { data: sites, isLoading } = useSites();
+	const site = sites?.find( ( currentSite ) => currentSite.id === siteId );
+	const sitePreviewUrl = getSitePreviewUrl( site, widgetProps.path );
+	const previewFrameUrl = sitePreviewUrl ? withPreviewFlag( sitePreviewUrl ) : '';
+	const [ liveUrl, setLiveUrl ] = useState( sitePreviewUrl );
+
+	useEffect( () => {
+		setLiveUrl( sitePreviewUrl );
+	}, [ sitePreviewUrl ] );
+
+	const handleIframeLoad = () => {
+		try {
+			const href = iframeRef.current?.contentWindow?.location.href;
+			if ( href ) {
+				setLiveUrl( href );
+			}
+		} catch {
+			// Cross-origin navigation is expected for local sites in Electron.
+		}
+	};
+
+	const emptyMessage = getEmptyMessage( {
+		hasSiteId: Boolean( siteId ),
+		isLoading,
+		hasSite: Boolean( site ),
+		isRunning: Boolean( site?.running ),
+	} );
+	const urlLabel = urlLabelFor( liveUrl );
+
+	return (
+		<div
+			className={ styles.wrapper }
+			data-studio-desk-widget="site-preview"
+			data-studio-desk-widget-id={ id }
+		>
+			{ urlLabel && (
+				<div
+					className={ styles.url }
+					data-visible={ isHovered || isSelected ? 'true' : 'false' }
+					title={ urlLabel }
+				>
+					{ urlLabel }
+				</div>
+			) }
+			<div className={ styles.preview } data-is-editing={ isEditing ? 'true' : 'false' }>
+				{ previewFrameUrl ? (
+					<iframe
+						ref={ iframeRef }
+						className={ styles.frame }
+						src={ previewFrameUrl }
+						title={ __( 'Site preview' ) }
+						sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+						referrerPolicy="no-referrer"
+						onLoad={ handleIframeLoad }
+					/>
+				) : (
+					<div className={ styles.empty }>{ emptyMessage }</div>
+				) }
+				{ ! isEditing && <div className={ styles.shield } aria-hidden="true" /> }
+			</div>
+		</div>
+	);
+}
+
+function getEmptyMessage( {
+	hasSiteId,
+	isLoading,
+	hasSite,
+	isRunning,
+}: {
+	hasSiteId: boolean;
+	isLoading: boolean;
+	hasSite: boolean;
+	isRunning: boolean;
+} ) {
+	if ( ! hasSiteId ) {
+		return __( 'Site preview unavailable' );
+	}
+
+	if ( isLoading ) {
+		return __( 'Loading site…' );
+	}
+
+	if ( ! hasSite ) {
+		return __( 'Site not found.' );
+	}
+
+	if ( ! isRunning ) {
+		return __( 'Start the site to see a live preview.' );
+	}
+
+	return __( 'Site preview unavailable' );
+}

--- a/apps/ui/src/ui-desks/widgets/site-preview/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/site-preview/definition.ts
@@ -1,0 +1,43 @@
+import { __ } from '@wordpress/i18n';
+import { globe } from '@wordpress/icons';
+import { SitePreviewWidgetComponent } from '@/ui-desks/widgets/site-preview/component';
+import { SitePreviewOpenControl } from '@/ui-desks/widgets/site-preview/open-control';
+import {
+	isSitePreviewWidgetProps,
+	SITE_PREVIEW_WIDGET_TYPE,
+	type SitePreviewWidget,
+} from './types';
+import type { WidgetDefinition } from '@/ui-desks/widgets/types';
+
+export const sitePreviewWidgetDefinition = {
+	type: SITE_PREVIEW_WIDGET_TYPE,
+	Component: SitePreviewWidgetComponent,
+	controls: [
+		{
+			type: 'custom',
+			id: 'open-site-preview',
+			Component: SitePreviewOpenControl,
+		},
+	],
+	isCreatable: true,
+	requiresRunningSite: true,
+	shouldStartEditingOnCreate: false,
+	isWidgetProps: isSitePreviewWidgetProps,
+	getIndicator: () => ( {
+		cornerRadius: 18,
+		stroke: '#3858e9',
+	} ),
+	labels: {
+		add: () => __( 'New site preview' ),
+	},
+	icon: globe,
+	getInitialWidget: () => ( {
+		shapeProps: {
+			w: 560,
+			h: 420,
+		},
+		widgetProps: {
+			path: '/',
+		},
+	} ),
+} satisfies WidgetDefinition< SitePreviewWidget >;

--- a/apps/ui/src/ui-desks/widgets/site-preview/open-control.tsx
+++ b/apps/ui/src/ui-desks/widgets/site-preview/open-control.tsx
@@ -1,0 +1,36 @@
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+import { useConnector } from '@/data/core';
+import { useSites } from '@/data/queries/use-sites';
+import { IconControlButton } from '@/ui-desks/components';
+import { useDesk } from '@/ui-desks/desk/provider';
+import { getSitePreviewUrl } from './url';
+import type { SitePreviewWidgetProps } from './types';
+import type { ControlRenderContext } from '@/ui-desks/controls/types';
+
+export function SitePreviewOpenControl( {
+	props,
+}: ControlRenderContext< SitePreviewWidgetProps > ) {
+	const connector = useConnector();
+	const { siteId } = useDesk();
+	const { data: sites } = useSites();
+	const site = sites?.find( ( currentSite ) => currentSite.id === siteId );
+	const url = getSitePreviewUrl( site, props.path );
+	const canOpen = Boolean( url );
+
+	return (
+		<IconControlButton
+			icon={ external }
+			label={ __( 'Open site preview in browser' ) }
+			variant="toolbar"
+			disabled={ ! canOpen }
+			onClick={ () => {
+				if ( ! url ) {
+					return;
+				}
+
+				void connector.openExternalUrl( url );
+			} }
+		/>
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/site-preview/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/site-preview/style.module.css
@@ -1,0 +1,75 @@
+.wrapper {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	font-family: var(--wpds-typography-font-family-body);
+}
+
+.url {
+	position: absolute;
+	bottom: calc(100% + 18px);
+	left: 4px;
+	max-width: 100%;
+	color: #14171a;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+		monospace;
+	font-size: 13px;
+	line-height: 1.4;
+	letter-spacing: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	pointer-events: none;
+	user-select: none;
+	opacity: 0;
+	transition: opacity 200ms ease;
+}
+
+.url[data-visible='true'] {
+	opacity: 1;
+}
+
+.preview {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	background: #fff;
+	border-radius: 18px;
+	corner-shape: superellipse(1.42);
+	-webkit-corner-shape: superellipse(1.42);
+	box-shadow:
+		0 1px 2px rgba(15, 23, 42, 0.04),
+		0 18px 44px rgba(15, 23, 42, 0.09);
+	overflow: hidden;
+}
+
+.frame {
+	width: 133.3333%;
+	height: 133.3333%;
+	display: block;
+	border: 0;
+	background: #fff;
+	transform: scale(0.75);
+	transform-origin: top left;
+}
+
+.empty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	padding: 24px;
+	box-sizing: border-box;
+	color: #6b7280;
+	font-size: 13px;
+	line-height: 1.4;
+	text-align: center;
+}
+
+.shield {
+	position: absolute;
+	inset: 0;
+	background: transparent;
+	cursor: grab;
+}

--- a/apps/ui/src/ui-desks/widgets/site-preview/types.ts
+++ b/apps/ui/src/ui-desks/widgets/site-preview/types.ts
@@ -1,0 +1,22 @@
+import type { RectangleWidgetShapeProps } from '@/ui-desks/widgets/geometry';
+import type { DeskWidgetBase } from '@studio/common/types/desk';
+
+export const SITE_PREVIEW_WIDGET_TYPE = 'site-preview';
+
+export type SitePreviewWidgetProps = {
+	path: string;
+};
+
+export type SitePreviewWidget = DeskWidgetBase<
+	typeof SITE_PREVIEW_WIDGET_TYPE,
+	RectangleWidgetShapeProps,
+	SitePreviewWidgetProps
+>;
+
+export function isSitePreviewWidgetProps( value: unknown ): value is SitePreviewWidgetProps {
+	return (
+		Boolean( value ) &&
+		typeof value === 'object' &&
+		typeof ( value as Partial< SitePreviewWidgetProps > ).path === 'string'
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/site-preview/url.ts
+++ b/apps/ui/src/ui-desks/widgets/site-preview/url.ts
@@ -1,0 +1,46 @@
+import { getSiteUrl } from '@/lib/get-site-url';
+import type { SiteDetails } from '@/data/core';
+
+export function getSitePreviewUrl( site: SiteDetails | undefined, path: string ) {
+	if ( ! site?.running ) {
+		return '';
+	}
+
+	return resolvePreviewPath( getSiteUrl( site ), path );
+}
+
+export function withPreviewFlag( url: string ): string {
+	try {
+		const previewUrl = new URL( url, window.location.origin );
+		previewUrl.searchParams.set( 'studio_desk_preview', '1' );
+		return previewUrl.toString();
+	} catch {
+		return `${ url }${ url.includes( '?' ) ? '&' : '?' }studio_desk_preview=1`;
+	}
+}
+
+export function urlLabelFor( url: string ): string {
+	if ( ! url ) {
+		return '';
+	}
+
+	try {
+		const previewUrl = new URL( url, window.location.origin );
+		previewUrl.searchParams.delete( 'studio_desk_preview' );
+		const path = previewUrl.pathname === '/' ? '' : previewUrl.pathname;
+		const query = previewUrl.searchParams.toString();
+		return `${ previewUrl.host }${ path }${ query ? `?${ query }` : '' }${ previewUrl.hash }`;
+	} catch {
+		return url.replace( /^https?:\/\//, '' );
+	}
+}
+
+function resolvePreviewPath( siteUrl: string, path: string ) {
+	const trimmedPath = path.trim();
+	if ( /^https?:\/\//.test( trimmedPath ) ) {
+		return trimmedPath;
+	}
+
+	const normalizedPath = trimmedPath.startsWith( '/' ) ? trimmedPath : `/${ trimmedPath || '' }`;
+	return new URL( normalizedPath || '/', `${ siteUrl }/` ).toString();
+}

--- a/apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts
+++ b/apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
 import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
 import { POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
+import { SITE_PREVIEW_WIDGET_TYPE } from '@/ui-desks/widgets/site-preview/types';
 import { getSelectedWidgetToolbarItem } from './toolbar-selection';
 import type { DeskWidget } from '@/ui-desks/widgets/types';
 
@@ -51,6 +52,20 @@ describe( 'widget toolbar selection', () => {
 		expect( selectedItem.widget.widgetProps ).toEqual( {
 			pageId: 84,
 			tone: 'blue',
+		} );
+	} );
+
+	it( 'returns the toolbar item for a single site preview widget selection', () => {
+		const selectedItem = getSelectedWidgetToolbarItem( [ createSitePreviewWidget() ] );
+
+		expect( selectedItem ).toMatchObject( { kind: 'single-widget' } );
+		if ( selectedItem?.kind !== 'single-widget' ) {
+			throw new Error( 'Expected a single widget toolbar item.' );
+		}
+		expect( selectedItem.definition.type ).toBe( SITE_PREVIEW_WIDGET_TYPE );
+		expect( selectedItem.definition.controls?.[ 0 ]?.type ).toBe( 'custom' );
+		expect( selectedItem.widget.widgetProps ).toEqual( {
+			path: '/',
 		} );
 	} );
 
@@ -149,6 +164,23 @@ function createPageWidget(): DeskWidget {
 		widgetProps: {
 			pageId: 84,
 			tone: 'blue',
+		},
+	};
+}
+
+function createSitePreviewWidget(): DeskWidget {
+	return {
+		id: 'site-preview-1',
+		type: SITE_PREVIEW_WIDGET_TYPE,
+		x: 0,
+		y: 0,
+		zIndex: 'a1',
+		shapeProps: {
+			w: 480,
+			h: 360,
+		},
+		widgetProps: {
+			path: '/',
 		},
 	};
 }

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -2,6 +2,7 @@ import type { ControlConfig } from '@/ui-desks/controls/types';
 import type { NoteWidget } from '@/ui-desks/widgets/note/types';
 import type { PageWidget } from '@/ui-desks/widgets/page/types';
 import type { PostWidget } from '@/ui-desks/widgets/post/types';
+import type { SitePreviewWidget } from '@/ui-desks/widgets/site-preview/types';
 import type { DeskWidgetBase } from '@studio/common/types/desk';
 import type { ComponentProps, ComponentType, ReactElement } from 'react';
 
@@ -16,6 +17,8 @@ export interface DeskWidgetComponentProps<
 	id: string;
 	widgetProps: TWidgetProps;
 	isEditing: boolean;
+	isHovered: boolean;
+	isSelected: boolean;
 	onWidgetPropsChange: ( widgetProps: TWidgetProps ) => void;
 	onEditComplete: () => void;
 }
@@ -35,12 +38,14 @@ export interface WidgetDefinition< TWidget extends DeskWidgetBase = DeskWidgetBa
 	icon?: WidgetIcon;
 	isCreatable?: boolean;
 	requiresRunningSite?: boolean;
+	shouldStartEditingOnCreate?: boolean;
 	getInitialWidget: () => Pick< TWidget, 'shapeProps' | 'widgetProps' >;
 	getIndicator?: ( widgetProps: TWidget[ 'widgetProps' ] ) => WidgetIndicator;
 }
 
-export type DeskWidget = NoteWidget | PostWidget | PageWidget;
+export type DeskWidget = NoteWidget | PostWidget | PageWidget | SitePreviewWidget;
 export type DeskWidgetDefinition =
 	| WidgetDefinition< NoteWidget >
 	| WidgetDefinition< PostWidget >
-	| WidgetDefinition< PageWidget >;
+	| WidgetDefinition< PageWidget >
+	| WidgetDefinition< SitePreviewWidget >;


### PR DESCRIPTION
## Summary

- Adds site preview widget type
- Increased the default insertion size for site preview widgets to `560 x 420` while preserving the same aspect ratio.
- Updated the widget creation test to match the new centered placement and dimensions.

## Testing
- `npx eslint --fix apps/ui/src/ui-desks/widgets/site-preview/definition.ts apps/ui/src/ui-desks/widgets/create-widget.test.ts`
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-desks/widgets/create-widget.test.ts`