### PR TITLE
apps/ui: Add dynamic post collection widgets to the desk UI

### DIFF
--- a/apps/ui/src/ui-desks/components/index.ts
+++ b/apps/ui/src/ui-desks/components/index.ts
@@ -1,5 +1,6 @@
 export { ActionButton } from './action-button';
 export { ControlButton, IconControlButton } from './control-button';
+export { LoadingPlaceholder } from './loading-placeholder';
 export { List, ListItem } from './list';
 export { Divider, Surface } from './surface';
 export * as Menu from './menu';

--- a/apps/ui/src/ui-desks/components/loading-placeholder/index.tsx
+++ b/apps/ui/src/ui-desks/components/loading-placeholder/index.tsx
@@ -1,0 +1,17 @@
+import { clsx } from 'clsx';
+import styles from './style.module.css';
+import type { ComponentPropsWithoutRef } from 'react';
+
+type LoadingPlaceholderProps = ComponentPropsWithoutRef< 'div' > & {
+	text?: string;
+};
+
+export function LoadingPlaceholder( { className, text, ...props }: LoadingPlaceholderProps ) {
+	return (
+		<div { ...props } className={ clsx( styles.placeholder, className ) }>
+			{ text && <div className={ styles.title }>{ text }</div> }
+			<div className={ styles.line } />
+			<div className={ styles.shortLine } />
+		</div>
+	);
+}

--- a/apps/ui/src/ui-desks/components/loading-placeholder/style.module.css
+++ b/apps/ui/src/ui-desks/components/loading-placeholder/style.module.css
@@ -1,0 +1,43 @@
+.placeholder {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.title {
+	font-size: 13px;
+	line-height: 18px;
+	font-weight: 500;
+	color: var(--loading-placeholder-text-color, #50575e);
+}
+
+.line {
+	width: 68%;
+	height: 8px;
+	border-radius: 999px;
+	background: linear-gradient(
+		90deg,
+		var(--loading-placeholder-line-color, #f0f0f0) 0%,
+		var(--loading-placeholder-line-highlight-color, #fff) 45%,
+		var(--loading-placeholder-line-color, #f0f0f0) 90%
+	);
+	background-size: 220% 100%;
+	animation: shimmer 1.4s ease-in-out infinite;
+}
+
+.shortLine {
+	width: 44%;
+	height: 8px;
+	border-radius: 999px;
+	background: var(--loading-placeholder-line-color, #f0f0f0);
+}
+
+@keyframes shimmer {
+	0% {
+		background-position: 120% 0;
+	}
+
+	100% {
+		background-position: -120% 0;
+	}
+}

--- a/apps/ui/src/ui-desks/desk/provider/editor-state.ts
+++ b/apps/ui/src/ui-desks/desk/provider/editor-state.ts
@@ -23,6 +23,7 @@ import {
 	deskConfigToCanvasShapes,
 	deskWidgetToCanvasShape,
 	getDerivedDeskCanvasRecordSourceId,
+	hasOnlyDeskCanvasRecordResolutionStateChange,
 	isDerivedDeskCanvasRecord,
 	isPersistentDeskCanvasShape,
 } from '../tldraw-adapter';
@@ -193,6 +194,10 @@ export function hasPersistentDocumentChange( changes: CanvasStoreChanges ) {
 
 	return Object.values( changes.updated ).some( ( [ previousRecord, nextRecord ] ) => {
 		if ( isShapeRecord( previousRecord ) || isShapeRecord( nextRecord ) ) {
+			if ( hasOnlyDeskCanvasRecordResolutionStateChange( previousRecord, nextRecord ) ) {
+				return false;
+			}
+
 			if (
 				isDerivedDeskCanvasRecord( previousRecord ) ||
 				isDerivedDeskCanvasRecord( nextRecord )

--- a/apps/ui/src/ui-desks/desk/provider/editor-state.ts
+++ b/apps/ui/src/ui-desks/desk/provider/editor-state.ts
@@ -7,7 +7,13 @@ import {
 	stackSelectedWidgetsInEditor as stackSelectionInEditor,
 	unstackSelectedWidgetsInEditor as unstackSelectionInEditor,
 } from '@/ui-desks/stacks/editor-commands';
-import { getStackId } from '@/ui-desks/stacks/utils';
+import {
+	getStackAnchorFromMember,
+	getStackHome,
+	getStackId,
+	getStackOrder,
+	getStackZIndexFromMember,
+} from '@/ui-desks/stacks/utils';
 import { createDeskWidget } from '@/ui-desks/widgets/create-widget';
 import { getSelectedWidgetToolbarItem } from '@/ui-desks/widgets/toolbar-selection';
 import {
@@ -16,6 +22,9 @@ import {
 	canvasShapesToDeskStacks,
 	deskConfigToCanvasShapes,
 	deskWidgetToCanvasShape,
+	getDerivedDeskCanvasRecordSourceId,
+	isDerivedDeskCanvasRecord,
+	isPersistentDeskCanvasShape,
 } from '../tldraw-adapter';
 import { DESK_CONFIG_VERSION, type DeskConfig } from '../types';
 import type { SelectedWidgetToolbarItem, AddDeskWidgetOptions } from './context';
@@ -25,6 +34,12 @@ interface CanvasStoreChanges {
 	added: Record< string, unknown >;
 	updated: Record< string, readonly [ unknown, unknown ] >;
 	removed: Record< string, unknown >;
+}
+
+interface DerivedWidgetAnchor {
+	x: number;
+	y: number;
+	zIndex?: string;
 }
 
 export function hydrateEditorFromDesk( editor: Editor, desk: DeskConfig ) {
@@ -133,7 +148,7 @@ export function updateSelectedWidgetPropsInEditor(
 
 export function removeSelectedWidgetFromEditor( editor: Editor ) {
 	const selection = getCurrentSelectedWidgetSelection( editor );
-	if ( ! selection ) {
+	if ( ! selection || ! selection.item.canRemove ) {
 		return false;
 	}
 
@@ -167,6 +182,33 @@ export function hasCameraChange( changes: CanvasStoreChanges ) {
 	return records.some( isCameraRecord );
 }
 
+export function hasPersistentDocumentChange( changes: CanvasStoreChanges ) {
+	const addedOrRemovedRecords = [
+		...Object.values( changes.added ),
+		...Object.values( changes.removed ),
+	];
+	if ( addedOrRemovedRecords.some( isPersistentDocumentRecord ) ) {
+		return true;
+	}
+
+	return Object.values( changes.updated ).some( ( [ previousRecord, nextRecord ] ) => {
+		if ( isShapeRecord( previousRecord ) || isShapeRecord( nextRecord ) ) {
+			if (
+				isDerivedDeskCanvasRecord( previousRecord ) ||
+				isDerivedDeskCanvasRecord( nextRecord )
+			) {
+				return hasDerivedShapePersistenceChange( previousRecord, nextRecord );
+			}
+
+			return (
+				isPersistentDocumentRecord( previousRecord ) || isPersistentDocumentRecord( nextRecord )
+			);
+		}
+
+		return true;
+	} );
+}
+
 function getCurrentSelectedWidgetSelection( editor: Editor ) {
 	const selectedShapeIds = editor.getSelectedShapeIds();
 	if ( selectedShapeIds.length === 0 ) {
@@ -176,6 +218,11 @@ function getCurrentSelectedWidgetSelection( editor: Editor ) {
 	const shapes = selectedShapeIds.map( ( shapeId ) => editor.getShape( shapeId ) );
 	if ( shapes.some( ( shape ) => ! shape ) ) {
 		return null;
+	}
+
+	const derivedSourceSelection = getDerivedSourceWidgetSelection( editor, shapes as TLShape[] );
+	if ( derivedSourceSelection ) {
+		return derivedSourceSelection;
 	}
 
 	const widgets = shapes.map( ( shape ) => canvasShapeToDeskWidget( shape as TLShape ) );
@@ -201,11 +248,18 @@ function getCurrentSelectedWidgetSelection( editor: Editor ) {
 	};
 }
 
-function getCurrentDeskWidgets( editor: Editor ) {
-	return editor
-		.getCurrentPageShapes()
+export function getCurrentDeskWidgets( editor: Editor ) {
+	const shapes = editor.getCurrentPageShapes();
+	const derivedAnchors = getDerivedWidgetAnchorsBySourceId( shapes );
+
+	return shapes
+		.filter( isPersistentDeskCanvasShape )
 		.map( canvasShapeToDeskWidget )
-		.filter( ( widget ) => widget !== null );
+		.filter( ( widget ): widget is DeskWidget => widget !== null )
+		.map( ( widget ) => {
+			const anchor = derivedAnchors.get( widget.id );
+			return anchor ? { ...widget, ...anchor } : widget;
+		} );
 }
 
 function getCurrentDeskStacks( editor: Editor ) {
@@ -218,6 +272,155 @@ function isCameraRecord( value: unknown ) {
 		typeof value === 'object' &&
 		( value as { typeName?: unknown } ).typeName === 'camera'
 	);
+}
+
+function isShapeRecord( value: unknown ) {
+	return (
+		Boolean( value ) &&
+		typeof value === 'object' &&
+		( value as { typeName?: unknown } ).typeName === 'shape'
+	);
+}
+
+function isPersistentDocumentRecord( value: unknown ) {
+	if ( isShapeRecord( value ) ) {
+		return ! isDerivedDeskCanvasRecord( value );
+	}
+
+	return true;
+}
+
+function hasDerivedShapePersistenceChange( previousRecord: unknown, nextRecord: unknown ) {
+	if (
+		! isDerivedDeskCanvasRecord( previousRecord ) ||
+		! isDerivedDeskCanvasRecord( nextRecord )
+	) {
+		return false;
+	}
+
+	return (
+		getDerivedShapePersistenceSignature( previousRecord ) !==
+		getDerivedShapePersistenceSignature( nextRecord )
+	);
+}
+
+function getDerivedShapePersistenceSignature( value: unknown ) {
+	const shape = value as Partial< TLShape >;
+	const meta = ( shape.meta ?? {} ) as Record< string, unknown >;
+
+	return JSON.stringify( {
+		x: shape.x,
+		y: shape.y,
+		rotation: shape.rotation,
+		index: shape.index,
+		deskStackExpanded: meta.deskStackExpanded,
+		deskStackHomeX: meta.deskStackHomeX,
+		deskStackHomeY: meta.deskStackHomeY,
+		deskStackHomeZIndex: meta.deskStackHomeZIndex,
+	} );
+}
+
+function getDerivedSourceWidgetSelection( editor: Editor, shapes: TLShape[] ) {
+	const sourceWidgetId = getDerivedSelectionSourceWidgetId( shapes );
+	if ( ! sourceWidgetId ) {
+		return null;
+	}
+
+	const sourceShape = editor
+		.getCurrentPageShapes()
+		.find( ( shape ) => canvasShapeToDeskWidget( shape )?.id === sourceWidgetId );
+	if ( ! sourceShape ) {
+		return null;
+	}
+
+	const sourceWidget = canvasShapeToDeskWidget( sourceShape );
+	if ( ! sourceWidget ) {
+		return null;
+	}
+
+	const item = getSelectedWidgetToolbarItem( [ sourceWidget ], {
+		stackIds: [],
+		canRemove: false,
+	} );
+	if ( ! item ) {
+		return null;
+	}
+
+	return {
+		item,
+		shapes: [ sourceShape ],
+	};
+}
+
+function getDerivedSelectionSourceWidgetId( shapes: TLShape[] ) {
+	let sourceWidgetId: string | null = null;
+	for ( const shape of shapes ) {
+		const nextSourceWidgetId = getDerivedDeskCanvasRecordSourceId( shape );
+		if ( ! nextSourceWidgetId ) {
+			return null;
+		}
+
+		if ( sourceWidgetId === null ) {
+			sourceWidgetId = nextSourceWidgetId;
+		} else if ( sourceWidgetId !== nextSourceWidgetId ) {
+			return null;
+		}
+	}
+
+	return sourceWidgetId;
+}
+
+function getDerivedWidgetAnchorsBySourceId( shapes: TLShape[] ) {
+	const shapesBySourceId = new Map< string, TLShape[] >();
+	for ( const shape of shapes ) {
+		const sourceWidgetId = getDerivedDeskCanvasRecordSourceId( shape );
+		if ( ! sourceWidgetId ) {
+			continue;
+		}
+
+		shapesBySourceId.set( sourceWidgetId, [
+			...( shapesBySourceId.get( sourceWidgetId ) ?? [] ),
+			shape,
+		] );
+	}
+
+	return new Map(
+		Array.from( shapesBySourceId, ( [ sourceWidgetId, sourceShapes ] ) => [
+			sourceWidgetId,
+			getDerivedWidgetAnchor( sourceShapes ),
+		] ).filter( ( entry ): entry is [ string, DerivedWidgetAnchor ] => entry[ 1 ] !== null )
+	);
+}
+
+function getDerivedWidgetAnchor( shapes: TLShape[] ): DerivedWidgetAnchor | null {
+	const firstShape = [ ...shapes ].sort( ( first, second ) => {
+		const firstStackOrder = getStackOrder( first );
+		const secondStackOrder = getStackOrder( second );
+		return firstStackOrder - secondStackOrder || sortByIndex( second, first );
+	} )[ 0 ];
+	if ( ! firstShape ) {
+		return null;
+	}
+
+	const stackId = getStackId( firstShape );
+	if ( ! stackId ) {
+		return {
+			x: firstShape.x,
+			y: firstShape.y,
+			zIndex: firstShape.index,
+		};
+	}
+
+	const order = getStackOrder( firstShape );
+	const home = getStackHome( firstShape );
+	if ( home ) {
+		return home;
+	}
+
+	return {
+		...getStackAnchorFromMember( firstShape, order ),
+		zIndex: getStackZIndexFromMember( firstShape.index, order ),
+	};
 }
 
 function ensureContentVisible( editor: Editor ) {

--- a/apps/ui/src/ui-desks/desk/provider/index.tsx
+++ b/apps/ui/src/ui-desks/desk/provider/index.tsx
@@ -12,6 +12,7 @@ import {
 	createDeskConfigFromEditor,
 	getCurrentSelectedWidgetToolbarItem,
 	hasCameraChange,
+	hasPersistentDocumentChange,
 	hydrateEditorFromDesk,
 	removeSelectedWidgetFromEditor,
 	stackSelectedWidgetsInEditor,
@@ -19,6 +20,7 @@ import {
 	updateSelectedWidgetPropsInEditor,
 } from './editor-state';
 import { useDeskPersistence } from './persistence';
+import { useDeskWidgetResolvers } from './resolvers';
 import type { Editor } from 'tldraw';
 
 export { useDesk, useRegisterDeskEditor } from './context';
@@ -72,8 +74,10 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 		};
 
 		const unsubscribeDocument = editor.store.listen(
-			() => {
-				queueSave();
+			( { changes } ) => {
+				if ( hasPersistentDocumentChange( changes ) ) {
+					queueSave();
+				}
 				syncSelectedWidgetToolbarItem();
 			},
 			{ scope: 'document' }
@@ -204,6 +208,11 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 			updateSelectedWidgetProps,
 		]
 	);
+
+	useDeskWidgetResolvers( {
+		editor,
+		isEnabled: Boolean( siteId && isHydrated ),
+	} );
 
 	return <DeskContext.Provider value={ value }>{ children }</DeskContext.Provider>;
 }

--- a/apps/ui/src/ui-desks/desk/provider/resolvers.ts
+++ b/apps/ui/src/ui-desks/desk/provider/resolvers.ts
@@ -134,7 +134,7 @@ async function resolveDeskWidgets(
 				editor,
 				widget.id,
 				'loading',
-				definition.getInitialWidget().shapeProps
+				getLoadingShapeProps( definition, widget )
 			);
 		}
 
@@ -146,7 +146,12 @@ async function resolveDeskWidgets(
 			) ) as WidgetResolution;
 		} catch ( error ) {
 			if ( isInitialResolve ) {
-				setSourceWidgetResolutionState( editor, widget.id );
+				setSourceWidgetResolutionState(
+					editor,
+					widget.id,
+					undefined,
+					definition.getInitialWidget().shapeProps
+				);
 			}
 			console.warn( `Failed to resolve desk widget "${ widget.id }".`, error );
 			if ( ! previousState ) {
@@ -161,7 +166,12 @@ async function resolveDeskWidgets(
 			continue;
 		}
 		if ( isInitialResolve ) {
-			setSourceWidgetResolutionState( editor, widget.id );
+			setSourceWidgetResolutionState(
+				editor,
+				widget.id,
+				undefined,
+				definition.getInitialWidget().shapeProps
+			);
 		}
 		const widgets = resolution.widgets.filter(
 			( resolvedWidget ): resolvedWidget is ResolvedDeskWidget< DeskWidget > =>
@@ -210,6 +220,15 @@ function shouldResolveWidget(
 
 function getAuthoredDeskWidgets( editor: Editor ) {
 	return getCurrentDeskWidgets( editor );
+}
+
+function getLoadingShapeProps(
+	definition: NonNullable< ReturnType< typeof getWidgetDefinition > >,
+	widget: DeskWidget
+) {
+	return (
+		definition.getLoadingShapeProps?.( widget as never ) ?? definition.getInitialWidget().shapeProps
+	);
 }
 
 function reconcileResolvedWidgets(

--- a/apps/ui/src/ui-desks/desk/provider/resolvers.ts
+++ b/apps/ui/src/ui-desks/desk/provider/resolvers.ts
@@ -4,6 +4,8 @@ import {
 	canvasShapeToDeskWidget,
 	getDerivedDeskCanvasRecordKey,
 	getDerivedDeskCanvasRecordSourceId,
+	getDeskCanvasRecordMetaWithResolutionState,
+	hasOnlyDeskCanvasRecordResolutionStateChange,
 	isDerivedDeskCanvasRecord,
 	resolvedDeskWidgetToCanvasShape,
 } from '@/ui-desks/desk/tldraw-adapter';
@@ -16,6 +18,7 @@ import type {
 	ResolvedDeskWidget,
 	WidgetResolverContext,
 	WidgetResolution,
+	WidgetResolutionState,
 } from '@/ui-desks/widgets/types';
 import type { Editor, TLShape, TLShapePartial } from 'tldraw';
 
@@ -124,17 +127,15 @@ async function resolveDeskWidgets(
 		if ( previousState && ! shouldResolveWidget( definition, widget, previousState, context ) ) {
 			continue;
 		}
+		const isInitialResolve = ! previousState;
 
-		if ( ! previousState && getDerivedShapesForSource( editor, widget.id ).length === 0 ) {
-			const loadingResolution = getLoadingResolution( definition, widget );
-			if ( loadingResolution ) {
-				reconcileResolvedWidgets(
-					editor,
-					widget.id,
-					loadingResolution.widgets as Array< ResolvedDeskWidget< DeskWidget > >,
-					loadingResolution.stacks ?? []
-				);
-			}
+		if ( isInitialResolve && definition.loading ) {
+			setSourceWidgetResolutionState(
+				editor,
+				widget.id,
+				'loading',
+				definition.getInitialWidget().shapeProps
+			);
 		}
 
 		let resolution: WidgetResolution;
@@ -144,6 +145,9 @@ async function resolveDeskWidgets(
 				context
 			) ) as WidgetResolution;
 		} catch ( error ) {
+			if ( isInitialResolve ) {
+				setSourceWidgetResolutionState( editor, widget.id );
+			}
 			console.warn( `Failed to resolve desk widget "${ widget.id }".`, error );
 			if ( ! previousState ) {
 				deleteDerivedWidgetsForSource( editor, widget.id );
@@ -155,6 +159,9 @@ async function resolveDeskWidgets(
 		}
 		if ( ! getAuthoredDeskWidgets( editor ).some( ( candidate ) => candidate.id === widget.id ) ) {
 			continue;
+		}
+		if ( isInitialResolve ) {
+			setSourceWidgetResolutionState( editor, widget.id );
 		}
 		const widgets = resolution.widgets.filter(
 			( resolvedWidget ): resolvedWidget is ResolvedDeskWidget< DeskWidget > =>
@@ -203,13 +210,6 @@ function shouldResolveWidget(
 
 function getAuthoredDeskWidgets( editor: Editor ) {
 	return getCurrentDeskWidgets( editor );
-}
-
-function getLoadingResolution(
-	definition: NonNullable< ReturnType< typeof getWidgetDefinition > >,
-	widget: DeskWidget
-) {
-	return definition.resolver?.getLoadingResolution?.( widget as never );
 }
 
 function reconcileResolvedWidgets(
@@ -303,6 +303,33 @@ function deleteDerivedWidgetsForSource( editor: Editor, sourceWidgetId: string )
 	if ( shapes.length > 0 ) {
 		editor.deleteShapes( shapes.map( ( shape ) => shape.id ) );
 	}
+}
+
+function setSourceWidgetResolutionState(
+	editor: Editor,
+	sourceWidgetId: string,
+	resolutionState?: WidgetResolutionState,
+	shapeProps?: DeskWidget[ 'shapeProps' ]
+) {
+	const sourceShape = editor
+		.getCurrentPageShapes()
+		.find( ( shape ) => canvasShapeToDeskWidget( shape )?.id === sourceWidgetId );
+	if ( ! sourceShape ) {
+		return;
+	}
+
+	editor.updateShape( {
+		id: sourceShape.id,
+		type: sourceShape.type,
+		meta: getDeskCanvasRecordMetaWithResolutionState( sourceShape, resolutionState ),
+		...( shapeProps
+			? {
+					props: {
+						shapeProps,
+					},
+			  }
+			: {} ),
+	} );
 }
 
 function getDerivedShapesForSource( editor: Editor, sourceWidgetId: string ) {
@@ -401,17 +428,19 @@ function getResolvedStackMembers(
 }
 
 function hasResolverRelevantDocumentChange( changes: CanvasStoreChanges ) {
-	const records = [
-		...Object.values( changes.added ),
-		...Object.values( changes.removed ),
-		...Object.values( changes.updated ).flatMap( ( [ previousRecord, nextRecord ] ) => [
-			previousRecord,
-			nextRecord,
-		] ),
-	];
+	if (
+		[ ...Object.values( changes.added ), ...Object.values( changes.removed ) ].some(
+			( record ) => isShapeRecord( record ) && ! isDerivedDeskCanvasRecord( record )
+		)
+	) {
+		return true;
+	}
 
-	return records.some(
-		( record ) => isShapeRecord( record ) && ! isDerivedDeskCanvasRecord( record )
+	return Object.values( changes.updated ).some(
+		( [ previousRecord, nextRecord ] ) =>
+			! hasOnlyDeskCanvasRecordResolutionStateChange( previousRecord, nextRecord ) &&
+			( ( isShapeRecord( previousRecord ) && ! isDerivedDeskCanvasRecord( previousRecord ) ) ||
+				( isShapeRecord( nextRecord ) && ! isDerivedDeskCanvasRecord( nextRecord ) ) )
 	);
 }
 

--- a/apps/ui/src/ui-desks/desk/provider/resolvers.ts
+++ b/apps/ui/src/ui-desks/desk/provider/resolvers.ts
@@ -1,0 +1,424 @@
+import { useRegistry } from '@wordpress/data';
+import { useEffect, useRef } from 'react';
+import {
+	canvasShapeToDeskWidget,
+	getDerivedDeskCanvasRecordKey,
+	getDerivedDeskCanvasRecordSourceId,
+	isDerivedDeskCanvasRecord,
+	resolvedDeskWidgetToCanvasShape,
+} from '@/ui-desks/desk/tldraw-adapter';
+import { isStackExpanded } from '@/ui-desks/stacks/utils';
+import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
+import { getCurrentDeskWidgets } from './editor-state';
+import type {
+	DeskWidget,
+	ResolvedDeskStack,
+	ResolvedDeskWidget,
+	WidgetResolverContext,
+	WidgetResolution,
+} from '@/ui-desks/widgets/types';
+import type { Editor, TLShape, TLShapePartial } from 'tldraw';
+
+interface UseDeskWidgetResolversOptions {
+	editor: Editor | null;
+	isEnabled: boolean;
+}
+
+interface ResolvedWidgetState {
+	sourceWidget: DeskWidget;
+	identity: unknown;
+	widgets: Array< ResolvedDeskWidget< DeskWidget > >;
+	stacks: ResolvedDeskStack[];
+}
+
+interface CanvasStoreChanges {
+	added: Record< string, unknown >;
+	updated: Record< string, readonly [ unknown, unknown ] >;
+	removed: Record< string, unknown >;
+}
+
+const RESOLVE_DEBOUNCE_MS = 80;
+
+export function useDeskWidgetResolvers( { editor, isEnabled }: UseDeskWidgetResolversOptions ) {
+	const registry = useRegistry();
+	const resolvedStateRef = useRef( new Map< string, ResolvedWidgetState >() );
+
+	useEffect( () => {
+		if ( ! editor || ! isEnabled ) {
+			return;
+		}
+
+		const context: WidgetResolverContext = { registry };
+		let isCancelled = false;
+		let isRunning = false;
+		let shouldRunAgain = false;
+		let resolveTimer: ReturnType< typeof setTimeout > | null = null;
+
+		const runResolvers = async () => {
+			if ( isRunning ) {
+				shouldRunAgain = true;
+				return;
+			}
+
+			isRunning = true;
+			do {
+				shouldRunAgain = false;
+				await resolveDeskWidgets( editor, context, resolvedStateRef.current, () => isCancelled );
+			} while ( shouldRunAgain && ! isCancelled && ! editor.isDisposed );
+			isRunning = false;
+		};
+
+		const scheduleResolve = () => {
+			if ( resolveTimer ) {
+				clearTimeout( resolveTimer );
+			}
+			resolveTimer = setTimeout( () => {
+				resolveTimer = null;
+				void runResolvers();
+			}, RESOLVE_DEBOUNCE_MS );
+		};
+
+		const unsubscribeEditor = editor.store.listen(
+			( { changes } ) => {
+				if ( ! isRunning ) {
+					deleteSourceWidgetsForRemovedDerivedStacks( editor, changes );
+				}
+				if ( hasResolverRelevantDocumentChange( changes ) ) {
+					scheduleResolve();
+				}
+			},
+			{ scope: 'document' }
+		);
+		const unsubscribeRegistry = registry.subscribe( scheduleResolve );
+
+		scheduleResolve();
+
+		return () => {
+			isCancelled = true;
+			if ( resolveTimer ) {
+				clearTimeout( resolveTimer );
+			}
+			unsubscribeEditor();
+			unsubscribeRegistry();
+		};
+	}, [ editor, isEnabled, registry ] );
+}
+
+async function resolveDeskWidgets(
+	editor: Editor,
+	context: WidgetResolverContext,
+	resolvedState: Map< string, ResolvedWidgetState >,
+	isCancelled: () => boolean
+) {
+	const authoredWidgets = getAuthoredDeskWidgets( editor );
+	const activeResolverIds = new Set< string >();
+
+	for ( const widget of authoredWidgets ) {
+		const definition = getWidgetDefinition( widget.type );
+		if ( ! definition?.resolver ) {
+			continue;
+		}
+
+		activeResolverIds.add( widget.id );
+		const previousState = resolvedState.get( widget.id );
+		if ( previousState && ! shouldResolveWidget( definition, widget, previousState, context ) ) {
+			continue;
+		}
+
+		if ( ! previousState && getDerivedShapesForSource( editor, widget.id ).length === 0 ) {
+			const loadingResolution = getLoadingResolution( definition, widget );
+			if ( loadingResolution ) {
+				reconcileResolvedWidgets(
+					editor,
+					widget.id,
+					loadingResolution.widgets as Array< ResolvedDeskWidget< DeskWidget > >,
+					loadingResolution.stacks ?? []
+				);
+			}
+		}
+
+		let resolution: WidgetResolution;
+		try {
+			resolution = ( await definition.resolver.resolve(
+				widget as never,
+				context
+			) ) as WidgetResolution;
+		} catch ( error ) {
+			console.warn( `Failed to resolve desk widget "${ widget.id }".`, error );
+			if ( ! previousState ) {
+				deleteDerivedWidgetsForSource( editor, widget.id );
+			}
+			continue;
+		}
+		if ( isCancelled() || editor.isDisposed ) {
+			return;
+		}
+		if ( ! getAuthoredDeskWidgets( editor ).some( ( candidate ) => candidate.id === widget.id ) ) {
+			continue;
+		}
+		const widgets = resolution.widgets.filter(
+			( resolvedWidget ): resolvedWidget is ResolvedDeskWidget< DeskWidget > =>
+				isDerivedFromWidget( resolvedWidget, widget.id )
+		);
+		const stacks = ( resolution.stacks ?? [] ).filter( ( resolvedStack ) =>
+			isDerivedStackFromWidget( resolvedStack, widget.id, widgets )
+		);
+
+		reconcileResolvedWidgets( editor, widget.id, widgets, stacks );
+		resolvedState.set( widget.id, {
+			sourceWidget: widget,
+			identity: resolution.identity,
+			widgets,
+			stacks,
+		} );
+	}
+
+	for ( const sourceWidgetId of Array.from( resolvedState.keys() ) ) {
+		if ( activeResolverIds.has( sourceWidgetId ) ) {
+			continue;
+		}
+		deleteDerivedWidgetsForSource( editor, sourceWidgetId );
+		resolvedState.delete( sourceWidgetId );
+	}
+}
+
+function shouldResolveWidget(
+	definition: NonNullable< ReturnType< typeof getWidgetDefinition > >,
+	widget: DeskWidget,
+	previousState: ResolvedWidgetState,
+	context: WidgetResolverContext
+) {
+	if ( JSON.stringify( previousState.sourceWidget ) !== JSON.stringify( widget ) ) {
+		return true;
+	}
+
+	try {
+		return Boolean(
+			definition.resolver?.invalidate( widget as never, previousState.identity as never, context )
+		);
+	} catch {
+		return true;
+	}
+}
+
+function getAuthoredDeskWidgets( editor: Editor ) {
+	return getCurrentDeskWidgets( editor );
+}
+
+function getLoadingResolution(
+	definition: NonNullable< ReturnType< typeof getWidgetDefinition > >,
+	widget: DeskWidget
+) {
+	return definition.resolver?.getLoadingResolution?.( widget as never );
+}
+
+function reconcileResolvedWidgets(
+	editor: Editor,
+	sourceWidgetId: string,
+	widgets: Array< ResolvedDeskWidget< DeskWidget > >,
+	stacks: ResolvedDeskStack[] = []
+) {
+	const existingShapes = getDerivedShapesForSource( editor, sourceWidgetId );
+	const existingByKey = new Map(
+		existingShapes
+			.map( ( shape ) => [ getDerivedDeskCanvasRecordKey( shape ), shape ] as const )
+			.filter( ( entry ): entry is readonly [ string, TLShape ] => entry[ 0 ] !== null )
+	);
+	const nextKeys = new Set< string >();
+	const shapesToCreate: TLShapePartial[] = [];
+	const shapesToUpdate: TLShapePartial[] = [];
+	const stackMembers = getResolvedStackMembers( widgets, stacks );
+
+	for ( const resolvedWidget of widgets ) {
+		if ( resolvedWidget.origin.kind !== 'derived' ) {
+			continue;
+		}
+		nextKeys.add( resolvedWidget.origin.key );
+		const nextShape = resolvedDeskWidgetToCanvasShape(
+			resolvedWidget,
+			stackMembers.get( resolvedWidget.widget.id )
+		);
+		const existingShape = existingByKey.get( resolvedWidget.origin.key );
+
+		if ( existingShape ) {
+			const updateShape = preserveExpandedStackMemberState( existingShape, {
+				...nextShape,
+				id: existingShape.id,
+			} );
+			if ( shouldUpdateShape( existingShape, updateShape ) ) {
+				shapesToUpdate.push( updateShape );
+			}
+			continue;
+		}
+
+		if ( nextShape.id && editor.getShape( nextShape.id ) ) {
+			const existingShapeById = editor.getShape( nextShape.id ) as TLShape;
+			const updateShape = preserveExpandedStackMemberState( existingShapeById, nextShape );
+			if ( shouldUpdateShape( existingShapeById, updateShape ) ) {
+				shapesToUpdate.push( updateShape );
+			}
+			continue;
+		}
+
+		shapesToCreate.push( nextShape );
+	}
+
+	const shapesToDelete = existingShapes
+		.filter( ( shape ) => {
+			const key = getDerivedDeskCanvasRecordKey( shape );
+			return ! key || ! nextKeys.has( key );
+		} )
+		.map( ( shape ) => shape.id );
+
+	if ( shapesToDelete.length > 0 ) {
+		editor.deleteShapes( shapesToDelete );
+	}
+	if ( shapesToUpdate.length > 0 ) {
+		editor.updateShapes( shapesToUpdate );
+	}
+	if ( shapesToCreate.length > 0 ) {
+		editor.createShapes( shapesToCreate );
+	}
+}
+
+function preserveExpandedStackMemberState(
+	existingShape: TLShape,
+	nextShape: TLShapePartial
+): TLShapePartial {
+	if ( ! isStackExpanded( existingShape ) ) {
+		return nextShape;
+	}
+
+	return {
+		...nextShape,
+		x: existingShape.x,
+		y: existingShape.y,
+		rotation: existingShape.rotation,
+		index: existingShape.index,
+	};
+}
+
+function deleteDerivedWidgetsForSource( editor: Editor, sourceWidgetId: string ) {
+	const shapes = getDerivedShapesForSource( editor, sourceWidgetId );
+	if ( shapes.length > 0 ) {
+		editor.deleteShapes( shapes.map( ( shape ) => shape.id ) );
+	}
+}
+
+function getDerivedShapesForSource( editor: Editor, sourceWidgetId: string ) {
+	return editor
+		.getCurrentPageShapes()
+		.filter( ( shape ) => getDerivedDeskCanvasRecordSourceId( shape ) === sourceWidgetId );
+}
+
+function deleteSourceWidgetsForRemovedDerivedStacks( editor: Editor, changes: CanvasStoreChanges ) {
+	const sourceWidgetIds = new Set(
+		Object.values( changes.removed )
+			.map( getDerivedDeskCanvasRecordSourceId )
+			.filter( ( sourceWidgetId ): sourceWidgetId is string => sourceWidgetId !== null )
+	);
+	if ( sourceWidgetIds.size === 0 ) {
+		return;
+	}
+
+	const sourceShapeIds = Array.from( sourceWidgetIds ).flatMap( ( sourceWidgetId ) => {
+		if ( getDerivedShapesForSource( editor, sourceWidgetId ).length > 0 ) {
+			return [];
+		}
+
+		const sourceShape = editor
+			.getCurrentPageShapes()
+			.find( ( shape ) => canvasShapeToDeskWidget( shape )?.id === sourceWidgetId );
+		return sourceShape ? [ sourceShape.id ] : [];
+	} );
+
+	if ( sourceShapeIds.length > 0 ) {
+		editor.deleteShapes( sourceShapeIds );
+	}
+}
+
+function shouldUpdateShape( currentShape: TLShape, nextShape: TLShapePartial ) {
+	if (
+		( typeof nextShape.x === 'number' && currentShape.x !== nextShape.x ) ||
+		( typeof nextShape.y === 'number' && currentShape.y !== nextShape.y ) ||
+		( typeof nextShape.rotation === 'number' && currentShape.rotation !== nextShape.rotation ) ||
+		( nextShape.index && currentShape.index !== nextShape.index )
+	) {
+		return true;
+	}
+
+	if (
+		nextShape.props &&
+		JSON.stringify( currentShape.props ) !== JSON.stringify( nextShape.props )
+	) {
+		return true;
+	}
+
+	return Boolean( nextShape.meta && ! hasMatchingMeta( currentShape, nextShape.meta ) );
+}
+
+function hasMatchingMeta( shape: TLShape, meta: TLShapePartial[ 'meta' ] ) {
+	const currentMeta = shape.meta as Record< string, unknown >;
+	return Object.entries( meta ?? {} ).every( ( [ key, value ] ) => currentMeta[ key ] === value );
+}
+
+function isDerivedFromWidget( resolvedWidget: ResolvedDeskWidget, sourceWidgetId: string ) {
+	return (
+		resolvedWidget.origin.kind === 'derived' &&
+		resolvedWidget.origin.sourceWidgetId === sourceWidgetId
+	);
+}
+
+function isDerivedStackFromWidget(
+	resolvedStack: ResolvedDeskStack,
+	sourceWidgetId: string,
+	widgets: Array< ResolvedDeskWidget< DeskWidget > >
+) {
+	if ( resolvedStack.origin.sourceWidgetId !== sourceWidgetId ) {
+		return false;
+	}
+
+	const widgetIds = new Set( widgets.map( ( resolvedWidget ) => resolvedWidget.widget.id ) );
+	return resolvedStack.stack.memberIds.every( ( memberId ) => widgetIds.has( memberId ) );
+}
+
+function getResolvedStackMembers(
+	widgets: Array< ResolvedDeskWidget< DeskWidget > >,
+	stacks: ResolvedDeskStack[]
+) {
+	const stackMembers = new Map< string, { stack: ResolvedDeskStack[ 'stack' ]; order: number } >();
+	const widgetIds = new Set( widgets.map( ( resolvedWidget ) => resolvedWidget.widget.id ) );
+
+	for ( const { stack } of stacks ) {
+		stack.memberIds.forEach( ( memberId, order ) => {
+			if ( widgetIds.has( memberId ) ) {
+				stackMembers.set( memberId, { stack, order } );
+			}
+		} );
+	}
+
+	return stackMembers;
+}
+
+function hasResolverRelevantDocumentChange( changes: CanvasStoreChanges ) {
+	const records = [
+		...Object.values( changes.added ),
+		...Object.values( changes.removed ),
+		...Object.values( changes.updated ).flatMap( ( [ previousRecord, nextRecord ] ) => [
+			previousRecord,
+			nextRecord,
+		] ),
+	];
+
+	return records.some(
+		( record ) => isShapeRecord( record ) && ! isDerivedDeskCanvasRecord( record )
+	);
+}
+
+function isShapeRecord( value: unknown ) {
+	return (
+		Boolean( value ) &&
+		typeof value === 'object' &&
+		( value as { typeName?: unknown } ).typeName === 'shape'
+	);
+}

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
@@ -7,7 +7,9 @@ import {
 	canvasShapesToDeskStacks,
 	deskConfigToCanvasShapes,
 	deskWidgetToCanvasShape,
+	getDeskCanvasRecordMetaWithResolutionState,
 	getDeskCanvasRecordResolutionState,
+	hasOnlyDeskCanvasRecordResolutionStateChange,
 	isPersistentDeskCanvasShape,
 	resolvedDeskWidgetToCanvasShape,
 } from './tldraw-adapter';
@@ -456,7 +458,6 @@ describe( 'tldraw adapter', () => {
 				kind: 'derived',
 				sourceWidgetId: 'collection-1',
 				key: 'post:42',
-				state: 'loading',
 			},
 			widget: {
 				id: 'collection-1:post:42',
@@ -483,15 +484,47 @@ describe( 'tldraw adapter', () => {
 				studioDeskPersist: false,
 				studioDeskSourceWidgetId: 'collection-1',
 				studioDeskDerivedKey: 'post:42',
-				studioDeskResolutionState: 'loading',
 			},
 		} );
 		expect( isPersistentDeskCanvasShape( shape ) ).toBe( false );
-		expect( getDeskCanvasRecordResolutionState( shape ) ).toBe( 'loading' );
 		expect( canvasShapeToDeskWidget( shape ) ).toEqual( {
 			...resolvedWidget.widget,
 			rotation: undefined,
 		} );
+	} );
+
+	it( 'reads loading resolution state from canvas metadata', () => {
+		const shape = {
+			meta: getDeskCanvasRecordMetaWithResolutionState( {}, 'loading' ),
+		};
+
+		expect( getDeskCanvasRecordResolutionState( shape ) ).toBe( 'loading' );
+		expect(
+			getDeskCanvasRecordResolutionState( {
+				meta: getDeskCanvasRecordMetaWithResolutionState( shape ),
+			} )
+		).toBeUndefined();
+	} );
+
+	it( 'detects resolution state-only canvas metadata changes', () => {
+		const shape = {
+			id: 'shape:post-collection-1',
+			x: 40,
+			y: 50,
+			meta: {},
+		};
+		const loadingShape = {
+			...shape,
+			meta: getDeskCanvasRecordMetaWithResolutionState( shape, 'loading' ),
+		};
+
+		expect( hasOnlyDeskCanvasRecordResolutionStateChange( shape, loadingShape ) ).toBe( true );
+		expect(
+			hasOnlyDeskCanvasRecordResolutionStateChange( shape, {
+				...loadingShape,
+				x: 41,
+			} )
+		).toBe( false );
 	} );
 
 	it( 'maps derived stack members through stack metadata', () => {

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
@@ -7,14 +7,19 @@ import {
 	canvasShapesToDeskStacks,
 	deskConfigToCanvasShapes,
 	deskWidgetToCanvasShape,
+	getDeskCanvasRecordResolutionState,
+	isPersistentDeskCanvasShape,
+	resolvedDeskWidgetToCanvasShape,
 } from './tldraw-adapter';
 import type { DeskConfig } from './types';
 import type { NoteWidget } from '@/ui-desks/widgets/note/types';
 import type { PageWidget } from '@/ui-desks/widgets/page/types';
 import type { PostWidget } from '@/ui-desks/widgets/post/types';
 import type { SitePreviewWidget } from '@/ui-desks/widgets/site-preview/types';
+import type { ResolvedDeskWidget } from '@/ui-desks/widgets/types';
 
 vi.mock( '@wordpress/core-data', () => ( {
+	store: {},
 	useEntityRecord: () => ( { record: null, isResolving: false } ),
 	useEntityRecords: () => ( { records: null, isResolving: false, status: 'IDLE' } ),
 } ) );
@@ -443,6 +448,101 @@ describe( 'tldraw adapter', () => {
 				memberIds: [ 'note-1', 'note-2' ],
 			},
 		] );
+	} );
+
+	it( 'marks derived widgets as non-persistent canvas shapes', () => {
+		const resolvedWidget: ResolvedDeskWidget< PostWidget > = {
+			origin: {
+				kind: 'derived',
+				sourceWidgetId: 'collection-1',
+				key: 'post:42',
+				state: 'loading',
+			},
+			widget: {
+				id: 'collection-1:post:42',
+				type: 'post',
+				x: 40,
+				y: 50,
+				zIndex: 'a3',
+				shapeProps: {
+					w: 280,
+					h: 380,
+				},
+				widgetProps: {
+					postId: 42,
+				},
+			},
+		};
+
+		const shape = resolvedDeskWidgetToCanvasShape( resolvedWidget ) as TLShape;
+
+		expect( shape ).toMatchObject( {
+			id: 'shape:collection-1:post:42',
+			meta: {
+				studioDeskOrigin: 'derived',
+				studioDeskPersist: false,
+				studioDeskSourceWidgetId: 'collection-1',
+				studioDeskDerivedKey: 'post:42',
+				studioDeskResolutionState: 'loading',
+			},
+		} );
+		expect( isPersistentDeskCanvasShape( shape ) ).toBe( false );
+		expect( getDeskCanvasRecordResolutionState( shape ) ).toBe( 'loading' );
+		expect( canvasShapeToDeskWidget( shape ) ).toEqual( {
+			...resolvedWidget.widget,
+			rotation: undefined,
+		} );
+	} );
+
+	it( 'maps derived stack members through stack metadata', () => {
+		const resolvedWidget: ResolvedDeskWidget< PostWidget > = {
+			origin: {
+				kind: 'derived',
+				sourceWidgetId: 'collection-1',
+				key: 'post:42',
+			},
+			widget: {
+				id: 'collection-1:post:42',
+				type: 'post',
+				x: 40,
+				y: 50,
+				zIndex: 'a3',
+				shapeProps: {
+					w: 280,
+					h: 380,
+				},
+				widgetProps: {
+					postId: 42,
+				},
+			},
+		};
+
+		const shape = resolvedDeskWidgetToCanvasShape( resolvedWidget, {
+			stack: {
+				id: 'stack-1',
+				x: 100,
+				y: 200,
+				zIndex: 'a7',
+				memberIds: [ 'collection-1:post:41', 'collection-1:post:42' ],
+			},
+			order: 1,
+		} ) as TLShape;
+
+		expect( shape ).toMatchObject( {
+			x: 110,
+			y: 208,
+			rotation: 0.052,
+			index: 'a6.999',
+			meta: {
+				deskStackId: 'stack-1',
+				deskStackOrder: 1,
+				deskStackOriginalZIndex: 'a3',
+				studioDeskOrigin: 'derived',
+				studioDeskPersist: false,
+				studioDeskSourceWidgetId: 'collection-1',
+				studioDeskDerivedKey: 'post:42',
+			},
+		} );
 	} );
 
 	it( 'ignores unsupported canvas shapes', () => {

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter.ts
@@ -25,9 +25,23 @@ import {
 import { isRectangleWidgetShapeProps } from '@/ui-desks/widgets/geometry';
 import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
 import type { DeskConfig, DeskStack, DeskViewport } from '@/ui-desks/desk/types';
-import type { DeskWidget } from '@/ui-desks/widgets/types';
+import type {
+	DeskWidget,
+	ResolvedDeskWidget,
+	WidgetResolutionState,
+} from '@/ui-desks/widgets/types';
 
 const SHAPE_ID_PREFIX = 'shape:';
+const DERIVED_WIDGET_ORIGIN = 'derived';
+const DERIVED_WIDGET_PERSIST = false;
+
+interface DerivedWidgetMeta {
+	studioDeskOrigin?: typeof DERIVED_WIDGET_ORIGIN;
+	studioDeskPersist?: typeof DERIVED_WIDGET_PERSIST;
+	studioDeskSourceWidgetId?: string;
+	studioDeskDerivedKey?: string;
+	studioDeskResolutionState?: WidgetResolutionState;
+}
 
 interface DeskStackMember {
 	stack: DeskStack;
@@ -108,6 +122,30 @@ export function deskWidgetToCanvasShape(
 			widgetType: widget.type,
 			shapeProps: widget.shapeProps,
 			widgetProps: widget.widgetProps,
+		},
+	};
+}
+
+export function resolvedDeskWidgetToCanvasShape(
+	resolvedWidget: ResolvedDeskWidget< DeskWidget >,
+	stackMember?: DeskStackMember
+): TLShapePartial {
+	const shape = deskWidgetToCanvasShape( resolvedWidget.widget, stackMember );
+	if ( resolvedWidget.origin.kind !== 'derived' ) {
+		return shape;
+	}
+
+	return {
+		...shape,
+		meta: {
+			...( shape.meta ?? {} ),
+			studioDeskOrigin: DERIVED_WIDGET_ORIGIN,
+			studioDeskPersist: DERIVED_WIDGET_PERSIST,
+			studioDeskSourceWidgetId: resolvedWidget.origin.sourceWidgetId,
+			studioDeskDerivedKey: resolvedWidget.origin.key,
+			...( resolvedWidget.origin.state
+				? { studioDeskResolutionState: resolvedWidget.origin.state }
+				: {} ),
 		},
 	};
 }
@@ -197,7 +235,7 @@ export function canvasShapesToDeskStacks( shapes: TLShape[] ): DeskStack[] {
 	const shapesByStackId = new Map< string, TLShape[] >();
 
 	for ( const shape of shapes ) {
-		if ( canvasShapeToDeskWidget( shape ) === null ) {
+		if ( ! isPersistentDeskCanvasShape( shape ) || canvasShapeToDeskWidget( shape ) === null ) {
 			continue;
 		}
 
@@ -212,6 +250,39 @@ export function canvasShapesToDeskStacks( shapes: TLShape[] ): DeskStack[] {
 	return Array.from( shapesByStackId, ( [ stackId, stackShapes ] ) =>
 		canvasShapesToDeskStack( stackId, stackShapes )
 	).filter( ( stack ): stack is DeskStack => stack !== null );
+}
+
+export function isPersistentDeskCanvasShape( shape: TLShape ) {
+	return ! isDerivedDeskCanvasRecord( shape );
+}
+
+export function isDerivedDeskCanvasRecord( value: unknown ) {
+	const meta = getRecordMeta( value ) as DerivedWidgetMeta | null;
+	return (
+		meta?.studioDeskOrigin === DERIVED_WIDGET_ORIGIN &&
+		meta.studioDeskPersist === DERIVED_WIDGET_PERSIST
+	);
+}
+
+export function getDerivedDeskCanvasRecordSourceId( value: unknown ) {
+	const meta = getRecordMeta( value ) as DerivedWidgetMeta | null;
+	if ( ! isDerivedDeskCanvasRecord( value ) ) {
+		return null;
+	}
+	return typeof meta?.studioDeskSourceWidgetId === 'string' ? meta.studioDeskSourceWidgetId : null;
+}
+
+export function getDerivedDeskCanvasRecordKey( value: unknown ) {
+	const meta = getRecordMeta( value ) as DerivedWidgetMeta | null;
+	if ( ! isDerivedDeskCanvasRecord( value ) ) {
+		return null;
+	}
+	return typeof meta?.studioDeskDerivedKey === 'string' ? meta.studioDeskDerivedKey : null;
+}
+
+export function getDeskCanvasRecordResolutionState( value: unknown ) {
+	const meta = getRecordMeta( value ) as DerivedWidgetMeta | null;
+	return meta?.studioDeskResolutionState === 'loading' ? meta.studioDeskResolutionState : undefined;
 }
 
 export function canvasCameraToDeskViewport(
@@ -315,4 +386,13 @@ function isRectangleWidgetCanvasProps(
 		Boolean( candidate.widgetProps ) &&
 		typeof candidate.widgetProps === 'object'
 	);
+}
+
+function getRecordMeta( value: unknown ) {
+	if ( ! value || typeof value !== 'object' ) {
+		return null;
+	}
+
+	const meta = ( value as { meta?: unknown } ).meta;
+	return meta && typeof meta === 'object' ? ( meta as Record< string, unknown > ) : null;
 }

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter.ts
@@ -35,7 +35,7 @@ const SHAPE_ID_PREFIX = 'shape:';
 const DERIVED_WIDGET_ORIGIN = 'derived';
 const DERIVED_WIDGET_PERSIST = false;
 
-interface DerivedWidgetMeta {
+interface DeskCanvasMeta {
 	studioDeskOrigin?: typeof DERIVED_WIDGET_ORIGIN;
 	studioDeskPersist?: typeof DERIVED_WIDGET_PERSIST;
 	studioDeskSourceWidgetId?: string;
@@ -143,9 +143,6 @@ export function resolvedDeskWidgetToCanvasShape(
 			studioDeskPersist: DERIVED_WIDGET_PERSIST,
 			studioDeskSourceWidgetId: resolvedWidget.origin.sourceWidgetId,
 			studioDeskDerivedKey: resolvedWidget.origin.key,
-			...( resolvedWidget.origin.state
-				? { studioDeskResolutionState: resolvedWidget.origin.state }
-				: {} ),
 		},
 	};
 }
@@ -257,7 +254,7 @@ export function isPersistentDeskCanvasShape( shape: TLShape ) {
 }
 
 export function isDerivedDeskCanvasRecord( value: unknown ) {
-	const meta = getRecordMeta( value ) as DerivedWidgetMeta | null;
+	const meta = getRecordMeta( value ) as DeskCanvasMeta | null;
 	return (
 		meta?.studioDeskOrigin === DERIVED_WIDGET_ORIGIN &&
 		meta.studioDeskPersist === DERIVED_WIDGET_PERSIST
@@ -265,7 +262,7 @@ export function isDerivedDeskCanvasRecord( value: unknown ) {
 }
 
 export function getDerivedDeskCanvasRecordSourceId( value: unknown ) {
-	const meta = getRecordMeta( value ) as DerivedWidgetMeta | null;
+	const meta = getRecordMeta( value ) as DeskCanvasMeta | null;
 	if ( ! isDerivedDeskCanvasRecord( value ) ) {
 		return null;
 	}
@@ -273,7 +270,7 @@ export function getDerivedDeskCanvasRecordSourceId( value: unknown ) {
 }
 
 export function getDerivedDeskCanvasRecordKey( value: unknown ) {
-	const meta = getRecordMeta( value ) as DerivedWidgetMeta | null;
+	const meta = getRecordMeta( value ) as DeskCanvasMeta | null;
 	if ( ! isDerivedDeskCanvasRecord( value ) ) {
 		return null;
 	}
@@ -281,8 +278,33 @@ export function getDerivedDeskCanvasRecordKey( value: unknown ) {
 }
 
 export function getDeskCanvasRecordResolutionState( value: unknown ) {
-	const meta = getRecordMeta( value ) as DerivedWidgetMeta | null;
+	const meta = getRecordMeta( value ) as DeskCanvasMeta | null;
 	return meta?.studioDeskResolutionState === 'loading' ? meta.studioDeskResolutionState : undefined;
+}
+
+export function getDeskCanvasRecordMetaWithResolutionState(
+	value: unknown,
+	resolutionState?: WidgetResolutionState
+): TLShapePartial[ 'meta' ] {
+	const nextMeta = { ...( getRecordMeta( value ) ?? {} ) };
+	if ( resolutionState ) {
+		nextMeta.studioDeskResolutionState = resolutionState;
+	} else {
+		nextMeta.studioDeskResolutionState = null;
+	}
+	return nextMeta as TLShapePartial[ 'meta' ];
+}
+
+export function hasOnlyDeskCanvasRecordResolutionStateChange(
+	previousRecord: unknown,
+	nextRecord: unknown
+) {
+	return (
+		getDeskCanvasRecordResolutionState( previousRecord ) !==
+			getDeskCanvasRecordResolutionState( nextRecord ) &&
+		JSON.stringify( getRecordWithoutResolutionState( previousRecord ) ) ===
+			JSON.stringify( getRecordWithoutResolutionState( nextRecord ) )
+	);
 }
 
 export function canvasCameraToDeskViewport(
@@ -395,4 +417,15 @@ function getRecordMeta( value: unknown ) {
 
 	const meta = ( value as { meta?: unknown } ).meta;
 	return meta && typeof meta === 'object' ? ( meta as Record< string, unknown > ) : null;
+}
+
+function getRecordWithoutResolutionState( value: unknown ) {
+	if ( ! value || typeof value !== 'object' ) {
+		return value;
+	}
+
+	return {
+		...( value as Record< string, unknown > ),
+		meta: getDeskCanvasRecordMetaWithResolutionState( value ),
+	};
 }

--- a/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
+++ b/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
@@ -11,8 +11,12 @@ import {
 	type RecordProps,
 	type TLResizeInfo,
 } from 'tldraw';
+import {
+	getDeskCanvasRecordResolutionState,
+	isDerivedDeskCanvasRecord,
+} from '@/ui-desks/desk/tldraw-adapter';
 import { useStackShapeInteraction } from '@/ui-desks/stacks/use-stack-shape-interaction';
-import { getStackId, isStackExpanded } from '@/ui-desks/stacks/utils';
+import { getStackId, getStackOrder, isStackExpanded } from '@/ui-desks/stacks/utils';
 import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
 import {
 	RECTANGLE_WIDGET_SHAPE_TYPE,
@@ -174,6 +178,11 @@ function RectangleWidgetComponent( {
 				isEditing={ isEditing }
 				isHovered={ isHovered }
 				isSelected={ isSelected }
+				runtime={ {
+					isDerived: isDerivedDeskCanvasRecord( shape ),
+					resolutionState: getDeskCanvasRecordResolutionState( shape ),
+					stackOrder: getStackId( shape ) ? getStackOrder( shape ) : undefined,
+				} }
 				onWidgetPropsChange={ handleWidgetPropsChange }
 				onEditComplete={ () => editor.complete() }
 			/>

--- a/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
+++ b/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
@@ -11,19 +11,20 @@ import {
 	type RecordProps,
 	type TLResizeInfo,
 } from 'tldraw';
-import {
-	getDeskCanvasRecordResolutionState,
-	isDerivedDeskCanvasRecord,
-} from '@/ui-desks/desk/tldraw-adapter';
+import { getDeskCanvasRecordResolutionState } from '@/ui-desks/desk/tldraw-adapter';
 import { useStackShapeInteraction } from '@/ui-desks/stacks/use-stack-shape-interaction';
-import { getStackId, getStackOrder, isStackExpanded } from '@/ui-desks/stacks/utils';
+import { getStackId, isStackExpanded } from '@/ui-desks/stacks/utils';
 import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
 import {
 	RECTANGLE_WIDGET_SHAPE_TYPE,
 	type RectangleWidgetShape,
 	type RectangleWidgetShapeProps,
 } from './types';
-import type { DeskWidgetComponentProps, WidgetIndicator } from '@/ui-desks/widgets/types';
+import type {
+	DeskWidgetComponentProps,
+	DeskWidgetLoadingComponentProps,
+	WidgetIndicator,
+} from '@/ui-desks/widgets/types';
 import type { ComponentType } from 'react';
 
 type RegisteredWidgetDefinition = NonNullable< ReturnType< typeof getWidgetDefinition > >;
@@ -159,6 +160,11 @@ function RectangleWidgetComponent( {
 	const WidgetComponent = definition.Component as unknown as ComponentType<
 		DeskWidgetComponentProps< JsonObject >
 	>;
+	const LoadingComponent = definition.loading as
+		| ComponentType< DeskWidgetLoadingComponentProps< JsonObject > >
+		| undefined;
+	const isLoading = getDeskCanvasRecordResolutionState( shape ) === 'loading';
+	const widgetId = getWidgetIdFromShapeId( shape.id );
 
 	const handleWidgetPropsChange = ( widgetProps: JsonObject ) => {
 		editor.updateShape< RectangleWidgetShape >( {
@@ -172,20 +178,19 @@ function RectangleWidgetComponent( {
 
 	return (
 		<div style={ stackInteraction.style } onPointerDown={ stackInteraction.onPointerDown }>
-			<WidgetComponent
-				id={ getWidgetIdFromShapeId( shape.id ) }
-				widgetProps={ shape.props.widgetProps }
-				isEditing={ isEditing }
-				isHovered={ isHovered }
-				isSelected={ isSelected }
-				runtime={ {
-					isDerived: isDerivedDeskCanvasRecord( shape ),
-					resolutionState: getDeskCanvasRecordResolutionState( shape ),
-					stackOrder: getStackId( shape ) ? getStackOrder( shape ) : undefined,
-				} }
-				onWidgetPropsChange={ handleWidgetPropsChange }
-				onEditComplete={ () => editor.complete() }
-			/>
+			{ isLoading && LoadingComponent ? (
+				<LoadingComponent id={ widgetId } widgetProps={ shape.props.widgetProps } />
+			) : (
+				<WidgetComponent
+					id={ widgetId }
+					widgetProps={ shape.props.widgetProps }
+					isEditing={ isEditing }
+					isHovered={ isHovered }
+					isSelected={ isSelected }
+					onWidgetPropsChange={ handleWidgetPropsChange }
+					onEditComplete={ () => editor.complete() }
+				/>
+			) }
 		</div>
 	);
 }

--- a/apps/ui/src/ui-desks/widgets/create-widget.test.ts
+++ b/apps/ui/src/ui-desks/widgets/create-widget.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createDeskWidget } from './create-widget';
 
 vi.mock( '@wordpress/core-data', () => ( {
+	store: {},
 	useEntityRecord: () => ( { record: null, isResolving: false } ),
 	useEntityRecords: () => ( { records: null, isResolving: false, status: 'IDLE' } ),
 } ) );
@@ -134,6 +135,39 @@ describe( 'createDeskWidget', () => {
 			},
 			widgetProps: {
 				path: '/',
+			},
+		} );
+	} );
+
+	it( 'creates a post collection widget with default query props', () => {
+		const createdWidget = createDeskWidget( {
+			id: 'post-collection-1',
+			type: 'post-collection',
+			center: {
+				x: 500,
+				y: 400,
+			},
+			zIndex: 'a5',
+		} );
+
+		expect( createdWidget ).toEqual( {
+			id: 'post-collection-1',
+			type: 'post-collection',
+			x: 499.5,
+			y: 399.5,
+			zIndex: 'a5',
+			shapeProps: {
+				w: 1,
+				h: 1,
+			},
+			widgetProps: {
+				query: {
+					postType: 'post',
+					perPage: 5,
+					status: 'publish',
+					orderby: 'date',
+					order: 'desc',
+				},
 			},
 		} );
 	} );

--- a/apps/ui/src/ui-desks/widgets/create-widget.test.ts
+++ b/apps/ui/src/ui-desks/widgets/create-widget.test.ts
@@ -153,12 +153,12 @@ describe( 'createDeskWidget', () => {
 		expect( createdWidget ).toEqual( {
 			id: 'post-collection-1',
 			type: 'post-collection',
-			x: 360,
-			y: 210,
+			x: 499.5,
+			y: 399.5,
 			zIndex: 'a5',
 			shapeProps: {
-				w: 280,
-				h: 380,
+				w: 1,
+				h: 1,
 			},
 			widgetProps: {
 				query: {

--- a/apps/ui/src/ui-desks/widgets/create-widget.test.ts
+++ b/apps/ui/src/ui-desks/widgets/create-widget.test.ts
@@ -153,12 +153,12 @@ describe( 'createDeskWidget', () => {
 		expect( createdWidget ).toEqual( {
 			id: 'post-collection-1',
 			type: 'post-collection',
-			x: 499.5,
-			y: 399.5,
+			x: 360,
+			y: 210,
 			zIndex: 'a5',
 			shapeProps: {
-				w: 1,
-				h: 1,
+				w: 280,
+				h: 380,
 			},
 			widgetProps: {
 				query: {

--- a/apps/ui/src/ui-desks/widgets/page/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/page/component.tsx
@@ -1,6 +1,7 @@
 import { useEntityRecords, type Post as CoreDataPost } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import { LoadingPlaceholder } from '@/ui-desks/components';
 import styles from './style.module.css';
 import type { PageWidgetProps } from './types';
 import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
@@ -26,6 +27,22 @@ export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentPro
 	} );
 	const record = records?.[ 0 ] ?? null;
 	const hasError = resolutionStatus === 'ERROR';
+	const isLoading = isResolving && ! record;
+
+	if ( isLoading ) {
+		return (
+			<article
+				className={ styles.page }
+				data-tone={ widgetProps.tone }
+				data-is-loading="true"
+				data-studio-desk-widget="page"
+				data-studio-desk-widget-id={ id }
+				aria-busy="true"
+			>
+				<LoadingPlaceholder text={ __( 'Loading page' ) } />
+			</article>
+		);
+	}
 
 	const title = getPageTitle( record, isResolving, hasError );
 	const excerpt = record?.excerpt?.rendered ?? '';
@@ -35,7 +52,7 @@ export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentPro
 		<article
 			className={ styles.page }
 			data-tone={ widgetProps.tone }
-			data-is-loading={ isResolving && ! record ? 'true' : 'false' }
+			data-is-loading="false"
 			data-studio-desk-widget="page"
 			data-studio-desk-widget-id={ id }
 		>

--- a/apps/ui/src/ui-desks/widgets/page/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/page/style.module.css
@@ -9,6 +9,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
+	justify-content: flex-start;
 	margin: 0;
 	background: #fff;
 	border-radius: 18px;
@@ -18,6 +19,18 @@
 	color: var(--page-tone-color);
 	overflow: hidden;
 	font-family: inherit;
+}
+
+.page[data-is-loading='true'] {
+	--loading-placeholder-text-color: var(--page-tone-color);
+	--loading-placeholder-line-color: color-mix(in srgb, var(--page-tone-color) 20%, white);
+	--loading-placeholder-line-highlight-color: color-mix(
+		in srgb,
+		var(--page-tone-color) 6%,
+		white
+	);
+
+	justify-content: flex-end;
 }
 
 .page::before {

--- a/apps/ui/src/ui-desks/widgets/post-collection/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/post-collection/component.tsx
@@ -2,24 +2,28 @@ import { __ } from '@wordpress/i18n';
 import { LoadingPlaceholder } from '@/ui-desks/components';
 import styles from './style.module.css';
 import type { PostCollectionWidgetProps } from './types';
-import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
+import type {
+	DeskWidgetComponentProps,
+	DeskWidgetLoadingComponentProps,
+} from '@/ui-desks/widgets/types';
 
-export function PostCollectionWidgetComponent( {
-	runtime,
-}: DeskWidgetComponentProps< PostCollectionWidgetProps > ) {
-	if ( runtime.resolutionState !== 'loading' ) {
-		return null;
-	}
+export function PostCollectionWidgetComponent(
+	_props: DeskWidgetComponentProps< PostCollectionWidgetProps >
+) {
+	return null;
+}
 
-	const isFrontCard = runtime.stackOrder === 0;
-
+export function PostCollectionLoadingComponent(
+	_props: DeskWidgetLoadingComponentProps< PostCollectionWidgetProps >
+) {
 	return (
-		<section
-			className={ styles.loading }
-			data-front={ isFrontCard ? 'true' : 'false' }
-			aria-busy={ isFrontCard ? 'true' : undefined }
-		>
-			<LoadingPlaceholder text={ isFrontCard ? __( 'Loading posts' ) : undefined } />
+		<section className={ styles.loading } aria-busy="true">
+			<div className={ styles.loadingCard } data-layer="back" aria-hidden="true">
+				<LoadingPlaceholder />
+			</div>
+			<div className={ styles.loadingCard } data-layer="front">
+				<LoadingPlaceholder text={ __( 'Loading posts' ) } />
+			</div>
 		</section>
 	);
 }

--- a/apps/ui/src/ui-desks/widgets/post-collection/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/post-collection/component.tsx
@@ -1,0 +1,25 @@
+import { __ } from '@wordpress/i18n';
+import { LoadingPlaceholder } from '@/ui-desks/components';
+import styles from './style.module.css';
+import type { PostCollectionWidgetProps } from './types';
+import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
+
+export function PostCollectionWidgetComponent( {
+	runtime,
+}: DeskWidgetComponentProps< PostCollectionWidgetProps > ) {
+	if ( runtime.resolutionState !== 'loading' ) {
+		return null;
+	}
+
+	const isFrontCard = runtime.stackOrder === 0;
+
+	return (
+		<section
+			className={ styles.loading }
+			data-front={ isFrontCard ? 'true' : 'false' }
+			aria-busy={ isFrontCard ? 'true' : undefined }
+		>
+			<LoadingPlaceholder text={ isFrontCard ? __( 'Loading posts' ) : undefined } />
+		</section>
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/post-collection/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/post-collection/definition.ts
@@ -1,0 +1,240 @@
+import { store as coreDataStore, type Post as CoreDataPost } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { post } from '@wordpress/icons';
+import { POST_WIDGET_TYPE, type PostWidget } from '@/ui-desks/widgets/post/types';
+import { PostCollectionWidgetComponent } from '@/ui-desks/widgets/post-collection/component';
+import { PostCollectionEditControl } from '@/ui-desks/widgets/post-collection/edit-control';
+import {
+	isPostCollectionWidgetProps,
+	POST_COLLECTION_WIDGET_TYPE,
+	type PostCollectionQuery,
+	type PostCollectionWidget,
+} from './types';
+import type {
+	ResolvedDeskStack,
+	ResolvedDeskWidget,
+	WidgetDefinition,
+	WidgetResolverContext,
+} from '@/ui-desks/widgets/types';
+
+type EntityRecordsQuery = {
+	per_page: number;
+	status: 'publish' | 'draft' | Array< 'publish' | 'draft' >;
+	orderby: PostCollectionQuery[ 'orderby' ];
+	order: PostCollectionQuery[ 'order' ];
+	context: 'view' | 'edit';
+	_fields: string;
+};
+
+type CoreDataPostSelectors = {
+	getEntityRecords: (
+		kind: 'postType',
+		name: 'post',
+		query: EntityRecordsQuery
+	) => CoreDataPost[] | null;
+};
+
+type CoreDataPostResolvers = {
+	getEntityRecords: (
+		kind: 'postType',
+		name: 'post',
+		query: EntityRecordsQuery
+	) => Promise< CoreDataPost[] | null >;
+};
+
+type PostCollectionResolutionIdentity = {
+	query: EntityRecordsQuery;
+	posts: CoreDataPost[] | null;
+};
+
+const POST_CARD_WIDTH = 280;
+const POST_CARD_HEIGHT = 380;
+
+export const postCollectionWidgetDefinition = {
+	type: POST_COLLECTION_WIDGET_TYPE,
+	Component: PostCollectionWidgetComponent,
+	controls: [
+		{
+			type: 'custom',
+			id: 'open-posts',
+			Component: PostCollectionEditControl,
+		},
+	],
+	requiresRunningSite: true,
+	shouldStartEditingOnCreate: false,
+	isWidgetProps: isPostCollectionWidgetProps,
+	getIndicator: () => ( {
+		cornerRadius: 0,
+		stroke: 'transparent',
+	} ),
+	labels: {
+		add: () => __( 'New posts collection' ),
+	},
+	icon: post,
+	getInitialWidget: () => ( {
+		shapeProps: {
+			w: 1,
+			h: 1,
+		},
+		widgetProps: {
+			query: {
+				postType: 'post',
+				perPage: 5,
+				status: 'publish',
+				orderby: 'date',
+				order: 'desc',
+			},
+		},
+	} ),
+	resolver: {
+		getLoadingResolution: ( widget ) => {
+			const widgets = [ createLoadingWidget( widget, 0 ), createLoadingWidget( widget, 1 ) ];
+			return {
+				widgets,
+				stacks: [
+					{
+						origin: {
+							kind: 'derived',
+							sourceWidgetId: widget.id,
+							key: 'loading',
+							state: 'loading',
+						},
+						stack: {
+							id: `post-collection:${ widget.id }:loading`,
+							x: widget.x,
+							y: widget.y,
+							zIndex: getDerivedZIndex( widget.zIndex, widgets.length ),
+							memberIds: widgets.map( ( resolvedWidget ) => resolvedWidget.widget.id ),
+						},
+					},
+				],
+			};
+		},
+		resolve: async ( widget, context ) => {
+			const query = getEntityRecordsQuery( widget.widgetProps.query );
+			const posts =
+				( await getCoreDataResolvers( context ).getEntityRecords( 'postType', 'post', query ) ) ??
+				[];
+
+			return {
+				identity: {
+					query,
+					posts,
+				},
+				widgets: posts.map( ( postRecord, index ) =>
+					createDerivedPostWidget( widget, postRecord.id, index )
+				),
+				stacks: posts.length > 0 ? [ createDerivedPostStack( widget, posts ) ] : [],
+			};
+		},
+		invalidate: ( widget, previousIdentity, context ) => {
+			const previous = previousIdentity as PostCollectionResolutionIdentity;
+			const query = getEntityRecordsQuery( widget.widgetProps.query );
+			if ( JSON.stringify( query ) !== JSON.stringify( previous.query ) ) {
+				return true;
+			}
+
+			const posts = getCoreDataSelectors( context ).getEntityRecords( 'postType', 'post', query );
+			return posts !== previous.posts;
+		},
+	},
+} satisfies WidgetDefinition< PostCollectionWidget >;
+
+function getCoreDataSelectors( { registry }: WidgetResolverContext ): CoreDataPostSelectors {
+	return registry.select( coreDataStore ) as unknown as CoreDataPostSelectors;
+}
+
+function getCoreDataResolvers( { registry }: WidgetResolverContext ): CoreDataPostResolvers {
+	return registry.resolveSelect( coreDataStore ) as unknown as CoreDataPostResolvers;
+}
+
+function getEntityRecordsQuery( query: PostCollectionQuery ): EntityRecordsQuery {
+	const canIncludeDrafts = query.status === 'draft' || query.status === 'any';
+	return {
+		per_page: query.perPage,
+		status: query.status === 'any' ? [ 'publish', 'draft' ] : query.status,
+		orderby: query.orderby,
+		order: query.order,
+		context: canIncludeDrafts ? 'edit' : 'view',
+		_fields: 'id',
+	};
+}
+
+function createDerivedPostWidget(
+	collection: PostCollectionWidget,
+	postId: number,
+	index: number
+): ResolvedDeskWidget< PostWidget > {
+	return {
+		origin: {
+			kind: 'derived',
+			sourceWidgetId: collection.id,
+			key: `post:${ postId }`,
+		},
+		widget: {
+			id: `${ collection.id }:post:${ postId }`,
+			type: POST_WIDGET_TYPE,
+			x: collection.x,
+			y: collection.y,
+			zIndex: getDerivedZIndex( collection.zIndex, index ),
+			shapeProps: {
+				w: POST_CARD_WIDTH,
+				h: POST_CARD_HEIGHT,
+			},
+			widgetProps: {
+				postId,
+			},
+		},
+	};
+}
+
+function createLoadingWidget(
+	collection: PostCollectionWidget,
+	index: number
+): ResolvedDeskWidget< PostCollectionWidget > {
+	return {
+		origin: {
+			kind: 'derived',
+			sourceWidgetId: collection.id,
+			key: `loading:${ index }`,
+			state: 'loading',
+		},
+		widget: {
+			id: `${ collection.id }:loading:${ index }`,
+			type: POST_COLLECTION_WIDGET_TYPE,
+			x: collection.x,
+			y: collection.y,
+			zIndex: getDerivedZIndex( collection.zIndex, index ),
+			shapeProps: {
+				w: POST_CARD_WIDTH,
+				h: POST_CARD_HEIGHT,
+			},
+			widgetProps: collection.widgetProps,
+		},
+	};
+}
+
+function createDerivedPostStack(
+	collection: PostCollectionWidget,
+	posts: CoreDataPost[]
+): ResolvedDeskStack {
+	return {
+		origin: {
+			kind: 'derived',
+			sourceWidgetId: collection.id,
+			key: 'posts',
+		},
+		stack: {
+			id: `post-collection:${ collection.id }`,
+			x: collection.x,
+			y: collection.y,
+			zIndex: getDerivedZIndex( collection.zIndex, posts.length ),
+			memberIds: posts.map( ( postRecord ) => `${ collection.id }:post:${ postRecord.id }` ),
+		},
+	};
+}
+
+function getDerivedZIndex( zIndex: string, index: number ) {
+	const numericIndex = Number( zIndex.replace( /^a/, '' ) );
+	return `a${ Number.isFinite( numericIndex ) ? numericIndex + index + 1 : index + 1 }`;
+}

--- a/apps/ui/src/ui-desks/widgets/post-collection/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/post-collection/definition.ts
@@ -51,6 +51,10 @@ type PostCollectionResolutionIdentity = {
 	posts: CoreDataPost[] | null;
 };
 
+const COLLECTION_SOURCE_SHAPE_PROPS = {
+	w: 1,
+	h: 1,
+};
 const POST_CARD_SHAPE_PROPS = postWidgetDefinition.getInitialWidget().shapeProps;
 
 export const postCollectionWidgetDefinition = {
@@ -76,7 +80,7 @@ export const postCollectionWidgetDefinition = {
 	},
 	icon: post,
 	getInitialWidget: () => ( {
-		shapeProps: POST_CARD_SHAPE_PROPS,
+		shapeProps: COLLECTION_SOURCE_SHAPE_PROPS,
 		widgetProps: {
 			query: {
 				postType: 'post',
@@ -87,6 +91,7 @@ export const postCollectionWidgetDefinition = {
 			},
 		},
 	} ),
+	getLoadingShapeProps: () => POST_CARD_SHAPE_PROPS,
 	resolver: {
 		resolve: async ( widget, context ) => {
 			const query = getEntityRecordsQuery( widget.widgetProps.query );

--- a/apps/ui/src/ui-desks/widgets/post-collection/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/post-collection/definition.ts
@@ -1,8 +1,12 @@
 import { store as coreDataStore, type Post as CoreDataPost } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { post } from '@wordpress/icons';
+import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
 import { POST_WIDGET_TYPE, type PostWidget } from '@/ui-desks/widgets/post/types';
-import { PostCollectionWidgetComponent } from '@/ui-desks/widgets/post-collection/component';
+import {
+	PostCollectionLoadingComponent,
+	PostCollectionWidgetComponent,
+} from '@/ui-desks/widgets/post-collection/component';
 import { PostCollectionEditControl } from '@/ui-desks/widgets/post-collection/edit-control';
 import {
 	isPostCollectionWidgetProps,
@@ -47,12 +51,12 @@ type PostCollectionResolutionIdentity = {
 	posts: CoreDataPost[] | null;
 };
 
-const POST_CARD_WIDTH = 280;
-const POST_CARD_HEIGHT = 380;
+const POST_CARD_SHAPE_PROPS = postWidgetDefinition.getInitialWidget().shapeProps;
 
 export const postCollectionWidgetDefinition = {
 	type: POST_COLLECTION_WIDGET_TYPE,
 	Component: PostCollectionWidgetComponent,
+	loading: PostCollectionLoadingComponent,
 	controls: [
 		{
 			type: 'custom',
@@ -72,10 +76,7 @@ export const postCollectionWidgetDefinition = {
 	},
 	icon: post,
 	getInitialWidget: () => ( {
-		shapeProps: {
-			w: 1,
-			h: 1,
-		},
+		shapeProps: POST_CARD_SHAPE_PROPS,
 		widgetProps: {
 			query: {
 				postType: 'post',
@@ -87,29 +88,6 @@ export const postCollectionWidgetDefinition = {
 		},
 	} ),
 	resolver: {
-		getLoadingResolution: ( widget ) => {
-			const widgets = [ createLoadingWidget( widget, 0 ), createLoadingWidget( widget, 1 ) ];
-			return {
-				widgets,
-				stacks: [
-					{
-						origin: {
-							kind: 'derived',
-							sourceWidgetId: widget.id,
-							key: 'loading',
-							state: 'loading',
-						},
-						stack: {
-							id: `post-collection:${ widget.id }:loading`,
-							x: widget.x,
-							y: widget.y,
-							zIndex: getDerivedZIndex( widget.zIndex, widgets.length ),
-							memberIds: widgets.map( ( resolvedWidget ) => resolvedWidget.widget.id ),
-						},
-					},
-				],
-			};
-		},
 		resolve: async ( widget, context ) => {
 			const query = getEntityRecordsQuery( widget.widgetProps.query );
 			const posts =
@@ -177,39 +155,10 @@ function createDerivedPostWidget(
 			x: collection.x,
 			y: collection.y,
 			zIndex: getDerivedZIndex( collection.zIndex, index ),
-			shapeProps: {
-				w: POST_CARD_WIDTH,
-				h: POST_CARD_HEIGHT,
-			},
+			shapeProps: POST_CARD_SHAPE_PROPS,
 			widgetProps: {
 				postId,
 			},
-		},
-	};
-}
-
-function createLoadingWidget(
-	collection: PostCollectionWidget,
-	index: number
-): ResolvedDeskWidget< PostCollectionWidget > {
-	return {
-		origin: {
-			kind: 'derived',
-			sourceWidgetId: collection.id,
-			key: `loading:${ index }`,
-			state: 'loading',
-		},
-		widget: {
-			id: `${ collection.id }:loading:${ index }`,
-			type: POST_COLLECTION_WIDGET_TYPE,
-			x: collection.x,
-			y: collection.y,
-			zIndex: getDerivedZIndex( collection.zIndex, index ),
-			shapeProps: {
-				w: POST_CARD_WIDTH,
-				h: POST_CARD_HEIGHT,
-			},
-			widgetProps: collection.widgetProps,
 		},
 	};
 }

--- a/apps/ui/src/ui-desks/widgets/post-collection/edit-control.tsx
+++ b/apps/ui/src/ui-desks/widgets/post-collection/edit-control.tsx
@@ -1,0 +1,33 @@
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+import { useConnector } from '@/data/core';
+import { useSites } from '@/data/queries/use-sites';
+import { IconControlButton } from '@/ui-desks/components';
+import { useDesk } from '@/ui-desks/desk/provider';
+import type { PostCollectionWidgetProps } from './types';
+import type { ControlRenderContext } from '@/ui-desks/controls/types';
+
+export function PostCollectionEditControl( {
+	props,
+}: ControlRenderContext< PostCollectionWidgetProps > ) {
+	const connector = useConnector();
+	const { siteId } = useDesk();
+	const { data: sites } = useSites();
+	const site = sites?.find( ( currentSite ) => currentSite.id === siteId );
+	const canOpen = Boolean( siteId && site?.running && props.query.postType === 'post' );
+
+	return (
+		<IconControlButton
+			disabled={ ! canOpen }
+			icon={ external }
+			label={ __( 'Open posts' ) }
+			variant="toolbar"
+			onClick={ () => {
+				if ( ! siteId ) {
+					return;
+				}
+				void connector.openSiteUrl( siteId, '/wp-admin/edit.php' );
+			} }
+		/>
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/post-collection/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/post-collection/style.module.css
@@ -1,20 +1,33 @@
 .loading {
+	position: relative;
 	width: 100%;
 	height: 100%;
+	box-sizing: border-box;
+	color: #1e1e1e;
+	font-family: inherit;
+}
+
+.loadingCard {
+	position: absolute;
+	inset: 0;
 	box-sizing: border-box;
 	border: 1px solid #dcdcde;
 	border-radius: 14px;
 	background: #fff;
-	color: #1e1e1e;
 	display: flex;
 	flex-direction: column;
 	justify-content: flex-end;
 	padding: 18px;
 	box-shadow: 0 10px 24px rgb(0 0 0 / 8%);
 	overflow: hidden;
-	font-family: inherit;
 }
 
-.loading[data-front='false'] {
+.loadingCard[data-layer='back'] {
 	background: #f6f7f7;
+	transform: translate(10px, 8px) rotate(2deg);
+	transform-origin: center;
+}
+
+.loadingCard[data-layer='front'] {
+	z-index: 1;
 }

--- a/apps/ui/src/ui-desks/widgets/post-collection/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/post-collection/style.module.css
@@ -1,0 +1,20 @@
+.loading {
+	width: 100%;
+	height: 100%;
+	box-sizing: border-box;
+	border: 1px solid #dcdcde;
+	border-radius: 14px;
+	background: #fff;
+	color: #1e1e1e;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	padding: 18px;
+	box-shadow: 0 10px 24px rgb(0 0 0 / 8%);
+	overflow: hidden;
+	font-family: inherit;
+}
+
+.loading[data-front='false'] {
+	background: #f6f7f7;
+}

--- a/apps/ui/src/ui-desks/widgets/post-collection/types.ts
+++ b/apps/ui/src/ui-desks/widgets/post-collection/types.ts
@@ -1,0 +1,51 @@
+import type { RectangleWidgetShapeProps } from '@/ui-desks/widgets/geometry';
+import type { DeskWidgetBase } from '@studio/common/types/desk';
+
+export const POST_COLLECTION_WIDGET_TYPE = 'post-collection';
+
+export type PostCollectionStatus = 'publish' | 'draft' | 'any';
+export type PostCollectionOrderBy = 'date' | 'modified' | 'title';
+export type PostCollectionOrder = 'asc' | 'desc';
+
+export type PostCollectionQuery = {
+	postType: 'post';
+	perPage: number;
+	status: PostCollectionStatus;
+	orderby: PostCollectionOrderBy;
+	order: PostCollectionOrder;
+};
+
+export type PostCollectionWidgetProps = {
+	query: PostCollectionQuery;
+};
+
+export type PostCollectionWidget = DeskWidgetBase<
+	typeof POST_COLLECTION_WIDGET_TYPE,
+	RectangleWidgetShapeProps,
+	PostCollectionWidgetProps
+>;
+
+export function isPostCollectionWidgetProps( value: unknown ): value is PostCollectionWidgetProps {
+	const candidate = value as Partial< PostCollectionWidgetProps >;
+	return Boolean( value ) && typeof value === 'object' && isPostCollectionQuery( candidate.query );
+}
+
+function isPostCollectionQuery( value: unknown ): value is PostCollectionQuery {
+	const candidate = value as Partial< PostCollectionQuery >;
+	return (
+		Boolean( value ) &&
+		typeof value === 'object' &&
+		candidate.postType === 'post' &&
+		typeof candidate.perPage === 'number' &&
+		Number.isInteger( candidate.perPage ) &&
+		candidate.perPage >= 1 &&
+		candidate.perPage <= 20 &&
+		( candidate.status === 'publish' ||
+			candidate.status === 'draft' ||
+			candidate.status === 'any' ) &&
+		( candidate.orderby === 'date' ||
+			candidate.orderby === 'modified' ||
+			candidate.orderby === 'title' ) &&
+		( candidate.order === 'asc' || candidate.order === 'desc' )
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/post/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/post/component.tsx
@@ -1,6 +1,7 @@
 import { useEntityRecords, type Post as CoreDataPost } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import { LoadingPlaceholder } from '@/ui-desks/components';
 import styles from './style.module.css';
 import type { PostWidgetProps } from './types';
 import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
@@ -26,6 +27,21 @@ export function PostWidgetComponent( { id, widgetProps }: PostWidgetComponentPro
 	} );
 	const record = records?.[ 0 ] ?? null;
 	const hasError = resolutionStatus === 'ERROR';
+	const isLoading = isResolving && ! record;
+
+	if ( isLoading ) {
+		return (
+			<article
+				className={ styles.post }
+				data-is-loading="true"
+				data-studio-desk-widget="post"
+				data-studio-desk-widget-id={ id }
+				aria-busy="true"
+			>
+				<LoadingPlaceholder text={ __( 'Loading post' ) } />
+			</article>
+		);
+	}
 
 	const title = getPostTitle( record, isResolving, hasError );
 	const excerpt = record?.excerpt?.rendered ?? '';
@@ -33,7 +49,7 @@ export function PostWidgetComponent( { id, widgetProps }: PostWidgetComponentPro
 	return (
 		<article
 			className={ styles.post }
-			data-is-loading={ isResolving && ! record ? 'true' : 'false' }
+			data-is-loading="false"
 			data-studio-desk-widget="post"
 			data-studio-desk-widget-id={ id }
 		>

--- a/apps/ui/src/ui-desks/widgets/post/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/post/style.module.css
@@ -6,6 +6,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
+	justify-content: flex-start;
 	margin: 0;
 	background: #fff;
 	border-radius: 18px;
@@ -15,6 +16,12 @@
 	color: #14171a;
 	overflow: hidden;
 	font-family: inherit;
+}
+
+.post[data-is-loading='true'] {
+	justify-content: flex-end;
+	border: 1px solid #dcdcde;
+	box-shadow: 0 10px 24px rgb(0 0 0 / 8%);
 }
 
 .title {

--- a/apps/ui/src/ui-desks/widgets/registry.ts
+++ b/apps/ui/src/ui-desks/widgets/registry.ts
@@ -1,6 +1,7 @@
 import { noteWidgetDefinition } from '@/ui-desks/widgets/note/definition';
 import { pageWidgetDefinition } from '@/ui-desks/widgets/page/definition';
 import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
+import { postCollectionWidgetDefinition } from '@/ui-desks/widgets/post-collection/definition';
 import { sitePreviewWidgetDefinition } from '@/ui-desks/widgets/site-preview/definition';
 import type { DeskWidgetDefinition } from './types';
 
@@ -8,6 +9,7 @@ export const widgetDefinitions = {
 	[ noteWidgetDefinition.type ]: noteWidgetDefinition,
 	[ postWidgetDefinition.type ]: postWidgetDefinition,
 	[ pageWidgetDefinition.type ]: pageWidgetDefinition,
+	[ postCollectionWidgetDefinition.type ]: postCollectionWidgetDefinition,
 	[ sitePreviewWidgetDefinition.type ]: sitePreviewWidgetDefinition,
 } satisfies Record< string, DeskWidgetDefinition >;
 

--- a/apps/ui/src/ui-desks/widgets/site-preview/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/site-preview/component.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from 'react';
 import { useSites } from '@/data/queries/use-sites';
+import { LoadingPlaceholder } from '@/ui-desks/components';
 import { useDesk } from '@/ui-desks/desk/provider';
 import styles from './style.module.css';
 import { getSitePreviewUrl, urlLabelFor, withPreviewFlag } from './url';
@@ -23,12 +24,18 @@ export function SitePreviewWidgetComponent( {
 	const sitePreviewUrl = getSitePreviewUrl( site, widgetProps.path );
 	const previewFrameUrl = sitePreviewUrl ? withPreviewFlag( sitePreviewUrl ) : '';
 	const [ liveUrl, setLiveUrl ] = useState( sitePreviewUrl );
+	const [ isFrameLoading, setIsFrameLoading ] = useState( false );
 
 	useEffect( () => {
 		setLiveUrl( sitePreviewUrl );
 	}, [ sitePreviewUrl ] );
 
+	useEffect( () => {
+		setIsFrameLoading( Boolean( previewFrameUrl ) );
+	}, [ previewFrameUrl ] );
+
 	const handleIframeLoad = () => {
+		setIsFrameLoading( false );
 		try {
 			const href = iframeRef.current?.contentWindow?.location.href;
 			if ( href ) {
@@ -64,17 +71,30 @@ export function SitePreviewWidgetComponent( {
 			) }
 			<div className={ styles.preview } data-is-editing={ isEditing ? 'true' : 'false' }>
 				{ previewFrameUrl ? (
-					<iframe
-						ref={ iframeRef }
-						className={ styles.frame }
-						src={ previewFrameUrl }
-						title={ __( 'Site preview' ) }
-						sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
-						referrerPolicy="no-referrer"
-						onLoad={ handleIframeLoad }
-					/>
+					<>
+						<iframe
+							ref={ iframeRef }
+							className={ styles.frame }
+							src={ previewFrameUrl }
+							title={ __( 'Site preview' ) }
+							sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+							referrerPolicy="no-referrer"
+							onLoad={ handleIframeLoad }
+						/>
+						{ isFrameLoading && (
+							<div className={ styles.loading }>
+								<LoadingPlaceholder text={ __( 'Loading site preview' ) } />
+							</div>
+						) }
+					</>
 				) : (
-					<div className={ styles.empty }>{ emptyMessage }</div>
+					<div className={ isLoading ? styles.loading : styles.empty }>
+						{ isLoading ? (
+							<LoadingPlaceholder text={ __( 'Loading site preview' ) } />
+						) : (
+							emptyMessage
+						) }
+					</div>
 				) }
 				{ ! isEditing && <div className={ styles.shield } aria-hidden="true" /> }
 			</div>

--- a/apps/ui/src/ui-desks/widgets/site-preview/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/site-preview/style.module.css
@@ -67,6 +67,16 @@
 	text-align: center;
 }
 
+.loading {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: flex-end;
+	box-sizing: border-box;
+	padding: 24px;
+	background: #fff;
+}
+
 .shield {
 	position: absolute;
 	inset: 0;

--- a/apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts
+++ b/apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
 import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
 import { POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
+import { POST_COLLECTION_WIDGET_TYPE } from '@/ui-desks/widgets/post-collection/types';
 import { SITE_PREVIEW_WIDGET_TYPE } from '@/ui-desks/widgets/site-preview/types';
 import { getSelectedWidgetToolbarItem } from './toolbar-selection';
 import type { DeskWidget } from '@/ui-desks/widgets/types';
 
 vi.mock( '@wordpress/core-data', () => ( {
+	store: {},
 	useEntityRecord: () => ( { record: null, isResolving: false } ),
 	useEntityRecords: () => ( { records: null, isResolving: false, status: 'IDLE' } ),
 } ) );
@@ -20,6 +22,7 @@ describe( 'widget toolbar selection', () => {
 			throw new Error( 'Expected a single widget toolbar item.' );
 		}
 		expect( selectedItem.definition.type ).toBe( NOTE_WIDGET_TYPE );
+		expect( selectedItem.canRemove ).toBe( true );
 		expect( selectedItem.widget.widgetProps ).toEqual( {
 			text: 'Hello',
 			tone: 'yellow',
@@ -57,7 +60,6 @@ describe( 'widget toolbar selection', () => {
 
 	it( 'returns the toolbar item for a single site preview widget selection', () => {
 		const selectedItem = getSelectedWidgetToolbarItem( [ createSitePreviewWidget() ] );
-
 		expect( selectedItem ).toMatchObject( { kind: 'single-widget' } );
 		if ( selectedItem?.kind !== 'single-widget' ) {
 			throw new Error( 'Expected a single widget toolbar item.' );
@@ -66,6 +68,37 @@ describe( 'widget toolbar selection', () => {
 		expect( selectedItem.definition.controls?.[ 0 ]?.type ).toBe( 'custom' );
 		expect( selectedItem.widget.widgetProps ).toEqual( {
 			path: '/',
+		} );
+	} );
+
+	it( 'returns the toolbar item for a single post collection widget selection', () => {
+		const selectedItem = getSelectedWidgetToolbarItem( [ createPostCollectionWidget() ] );
+
+		expect( selectedItem ).toMatchObject( { kind: 'single-widget' } );
+		if ( selectedItem?.kind !== 'single-widget' ) {
+			throw new Error( 'Expected a single widget toolbar item.' );
+		}
+		expect( selectedItem.definition.type ).toBe( POST_COLLECTION_WIDGET_TYPE );
+		expect( selectedItem.definition.controls?.[ 0 ]?.type ).toBe( 'custom' );
+		expect( selectedItem.widget.widgetProps ).toEqual( {
+			query: {
+				postType: 'post',
+				perPage: 5,
+				status: 'publish',
+				orderby: 'date',
+				order: 'desc',
+			},
+		} );
+	} );
+
+	it( 'can disable removal for protected selections', () => {
+		const selectedItem = getSelectedWidgetToolbarItem( [ createPostCollectionWidget() ], {
+			canRemove: false,
+		} );
+
+		expect( selectedItem ).toMatchObject( {
+			kind: 'single-widget',
+			canRemove: false,
 		} );
 	} );
 
@@ -181,6 +214,29 @@ function createSitePreviewWidget(): DeskWidget {
 		},
 		widgetProps: {
 			path: '/',
+		},
+	};
+}
+
+function createPostCollectionWidget(): DeskWidget {
+	return {
+		id: 'collection-1',
+		type: POST_COLLECTION_WIDGET_TYPE,
+		x: 0,
+		y: 0,
+		zIndex: 'a1',
+		shapeProps: {
+			w: 1,
+			h: 1,
+		},
+		widgetProps: {
+			query: {
+				postType: 'post',
+				perPage: 5,
+				status: 'publish',
+				orderby: 'date',
+				order: 'desc',
+			},
 		},
 	};
 }

--- a/apps/ui/src/ui-desks/widgets/toolbar-selection.ts
+++ b/apps/ui/src/ui-desks/widgets/toolbar-selection.ts
@@ -3,6 +3,7 @@ import type { DeskWidget } from '@/ui-desks/widgets/types';
 
 interface SelectedWidgetToolbarOptions {
 	stackIds?: string[];
+	canRemove?: boolean;
 }
 
 interface SelectedWidgetToolbarBase {
@@ -10,6 +11,7 @@ interface SelectedWidgetToolbarBase {
 	stackIds: string[];
 	canStack: boolean;
 	canUnstack: boolean;
+	canRemove: boolean;
 }
 
 export type SelectedWidgetToolbarItem =
@@ -36,6 +38,7 @@ export function getSelectedWidgetToolbarItem(
 		stackIds,
 		canStack: widgets.length >= 2 && stackIds.length === 0,
 		canUnstack: stackIds.length > 0,
+		canRemove: options.canRemove ?? true,
 	};
 
 	if ( widgets.length !== 1 ) {

--- a/apps/ui/src/ui-desks/widgets/toolbar.tsx
+++ b/apps/ui/src/ui-desks/widgets/toolbar.tsx
@@ -85,13 +85,17 @@ export function DeskWidgetToolbar() {
 					onClick={ unstackSelectedWidgets }
 				/>
 			) }
-			<Divider />
-			<IconControlButton
-				icon={ trash }
-				label={ __( 'Remove widget selection' ) }
-				variant="toolbar"
-				onClick={ removeSelectedWidget }
-			/>
+			{ renderSelection.canRemove && (
+				<>
+					<Divider />
+					<IconControlButton
+						icon={ trash }
+						label={ __( 'Remove widget selection' ) }
+						variant="toolbar"
+						onClick={ removeSelectedWidget }
+					/>
+				</>
+			) }
 		</Surface>
 	);
 }

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -97,6 +97,7 @@ export interface WidgetDefinition< TWidget extends DeskWidgetBase = DeskWidgetBa
 	requiresRunningSite?: boolean;
 	shouldStartEditingOnCreate?: boolean;
 	getInitialWidget: () => Pick< TWidget, 'shapeProps' | 'widgetProps' >;
+	getLoadingShapeProps?: ( widget: TWidget ) => TWidget[ 'shapeProps' ];
 	getIndicator?: ( widgetProps: TWidget[ 'widgetProps' ] ) => WidgetIndicator;
 	resolver?: WidgetResolver< TWidget >;
 }

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -2,13 +2,23 @@ import type { ControlConfig } from '@/ui-desks/controls/types';
 import type { NoteWidget } from '@/ui-desks/widgets/note/types';
 import type { PageWidget } from '@/ui-desks/widgets/page/types';
 import type { PostWidget } from '@/ui-desks/widgets/post/types';
+import type { PostCollectionWidget } from '@/ui-desks/widgets/post-collection/types';
 import type { SitePreviewWidget } from '@/ui-desks/widgets/site-preview/types';
-import type { DeskWidgetBase } from '@studio/common/types/desk';
+import type { DeskStack, DeskWidgetBase } from '@studio/common/types/desk';
+import type { createRegistry } from '@wordpress/data';
 import type { ComponentProps, ComponentType, ReactElement } from 'react';
 
 export interface WidgetIndicator {
 	cornerRadius?: number;
 	stroke?: string;
+}
+
+export type WidgetResolutionState = 'loading';
+
+export interface DeskWidgetRuntimeState {
+	isDerived: boolean;
+	resolutionState?: WidgetResolutionState;
+	stackOrder?: number;
 }
 
 export interface DeskWidgetComponentProps<
@@ -19,6 +29,7 @@ export interface DeskWidgetComponentProps<
 	isEditing: boolean;
 	isHovered: boolean;
 	isSelected: boolean;
+	runtime: DeskWidgetRuntimeState;
 	onWidgetPropsChange: ( widgetProps: TWidgetProps ) => void;
 	onEditComplete: () => void;
 }
@@ -27,6 +38,53 @@ export type WidgetIcon = ReactElement< ComponentProps< 'svg' > >;
 
 export interface WidgetLabels {
 	add: () => string;
+}
+
+export type WidgetResolverRegistry = ReturnType< typeof createRegistry >;
+
+export interface WidgetResolverContext {
+	registry: WidgetResolverRegistry;
+}
+
+export type ResolvedDeskWidgetOrigin =
+	| { kind: 'authored' }
+	| {
+			kind: 'derived';
+			sourceWidgetId: string;
+			key: string;
+			state?: WidgetResolutionState;
+	  };
+
+export interface ResolvedDeskWidget< TWidget extends DeskWidgetBase = DeskWidgetBase > {
+	widget: TWidget;
+	origin: ResolvedDeskWidgetOrigin;
+}
+
+export interface ResolvedDeskStack {
+	stack: DeskStack;
+	origin: Extract< ResolvedDeskWidgetOrigin, { kind: 'derived' } >;
+}
+
+export interface WidgetResolution< TIdentity = unknown > {
+	widgets: ResolvedDeskWidget[];
+	stacks?: ResolvedDeskStack[];
+	identity: TIdentity;
+}
+
+export interface WidgetResolver<
+	TWidget extends DeskWidgetBase = DeskWidgetBase,
+	TIdentity = unknown,
+> {
+	resolve: (
+		widget: TWidget,
+		context: WidgetResolverContext
+	) => Promise< WidgetResolution< TIdentity > >;
+	getLoadingResolution?: ( widget: TWidget ) => Omit< WidgetResolution< never >, 'identity' >;
+	invalidate: (
+		widget: TWidget,
+		previousIdentity: TIdentity,
+		context: WidgetResolverContext
+	) => boolean;
 }
 
 export interface WidgetDefinition< TWidget extends DeskWidgetBase = DeskWidgetBase > {
@@ -41,11 +99,18 @@ export interface WidgetDefinition< TWidget extends DeskWidgetBase = DeskWidgetBa
 	shouldStartEditingOnCreate?: boolean;
 	getInitialWidget: () => Pick< TWidget, 'shapeProps' | 'widgetProps' >;
 	getIndicator?: ( widgetProps: TWidget[ 'widgetProps' ] ) => WidgetIndicator;
+	resolver?: WidgetResolver< TWidget >;
 }
 
-export type DeskWidget = NoteWidget | PostWidget | PageWidget | SitePreviewWidget;
+export type DeskWidget =
+	| NoteWidget
+	| PostWidget
+	| PageWidget
+	| PostCollectionWidget
+	| SitePreviewWidget;
 export type DeskWidgetDefinition =
 	| WidgetDefinition< NoteWidget >
 	| WidgetDefinition< PostWidget >
 	| WidgetDefinition< PageWidget >
+	| WidgetDefinition< PostCollectionWidget >
 	| WidgetDefinition< SitePreviewWidget >;

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -15,12 +15,6 @@ export interface WidgetIndicator {
 
 export type WidgetResolutionState = 'loading';
 
-export interface DeskWidgetRuntimeState {
-	isDerived: boolean;
-	resolutionState?: WidgetResolutionState;
-	stackOrder?: number;
-}
-
 export interface DeskWidgetComponentProps<
 	TWidgetProps extends Record< string, unknown > = Record< string, unknown >,
 > {
@@ -29,9 +23,15 @@ export interface DeskWidgetComponentProps<
 	isEditing: boolean;
 	isHovered: boolean;
 	isSelected: boolean;
-	runtime: DeskWidgetRuntimeState;
 	onWidgetPropsChange: ( widgetProps: TWidgetProps ) => void;
 	onEditComplete: () => void;
+}
+
+export interface DeskWidgetLoadingComponentProps<
+	TWidgetProps extends Record< string, unknown > = Record< string, unknown >,
+> {
+	id: string;
+	widgetProps: TWidgetProps;
 }
 
 export type WidgetIcon = ReactElement< ComponentProps< 'svg' > >;
@@ -52,7 +52,6 @@ export type ResolvedDeskWidgetOrigin =
 			kind: 'derived';
 			sourceWidgetId: string;
 			key: string;
-			state?: WidgetResolutionState;
 	  };
 
 export interface ResolvedDeskWidget< TWidget extends DeskWidgetBase = DeskWidgetBase > {
@@ -79,7 +78,6 @@ export interface WidgetResolver<
 		widget: TWidget,
 		context: WidgetResolverContext
 	) => Promise< WidgetResolution< TIdentity > >;
-	getLoadingResolution?: ( widget: TWidget ) => Omit< WidgetResolution< never >, 'identity' >;
 	invalidate: (
 		widget: TWidget,
 		previousIdentity: TIdentity,
@@ -90,6 +88,7 @@ export interface WidgetResolver<
 export interface WidgetDefinition< TWidget extends DeskWidgetBase = DeskWidgetBase > {
 	type: TWidget[ 'type' ];
 	Component: ComponentType< DeskWidgetComponentProps< TWidget[ 'widgetProps' ] > >;
+	loading?: ComponentType< DeskWidgetLoadingComponentProps< TWidget[ 'widgetProps' ] > >;
 	controls?: Array< ControlConfig< TWidget[ 'widgetProps' ] > >;
 	isWidgetProps: ( props: unknown ) => props is TWidget[ 'widgetProps' ];
 	labels: WidgetLabels;


### PR DESCRIPTION
## Summary
- Introduce a widget-domain resolver architecture so collection widgets can derive dynamic child widgets without exposing editor internals to widget definitions
- Add the post collection widget with loading, resolution, invalidation, and transparent rendering behavior that matches the prototype more closely
- Reuse a shared `LoadingPlaceholder` across post, page, and site preview widgets, and keep collection-derived widgets non-deletable in the toolbar
- Refine page loading so the placeholder sits inside the inset border and inherits the widget tone

## Testing
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-desks`
- Lint/format pass on the modified stylesheet files