### PR TITLE
apps/ui: Add read-only site map view to desk

### DIFF
--- a/apps/ui/src/data/queries/use-desk-config.ts
+++ b/apps/ui/src/data/queries/use-desk-config.ts
@@ -7,12 +7,13 @@ const siteDeskConfigQueryKey = ( siteId: string ) => [ 'desk-config', 'site', si
 const deskConfigQueryKey = ( siteId?: string ) =>
 	siteId ? siteDeskConfigQueryKey( siteId ) : userDeskConfigQueryKey;
 
-export function useDeskConfig( siteId?: string ) {
+export function useDeskConfig( siteId?: string, enabled = true ) {
 	const connector = useConnector();
 	return useQuery( {
 		queryKey: deskConfigQueryKey( siteId ),
 		queryFn: () =>
 			siteId ? connector.getSiteDeskConfig( siteId ) : connector.getUserDeskConfig(),
+		enabled,
 	} );
 }
 

--- a/apps/ui/src/ui-desks/chrome/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/index.tsx
@@ -1,37 +1,68 @@
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { clsx } from 'clsx';
 import { useFullscreen } from '@/hooks/use-fullscreen';
 import { DeskChatsTrigger } from '../chats';
 import { DeskCreateMenu } from './create-menu';
+import { DeskSiteMapButton } from './site-map-button';
 import styles from './style.module.css';
 import { DeskMenu } from './user-menu';
 import type { ReactNode } from 'react';
 
 interface DeskHeaderProps {
 	children: ReactNode;
+	centerChildren?: ReactNode;
+	rightChildren?: ReactNode;
 }
 
-export function DeskHeader( { children }: DeskHeaderProps ) {
+export function DeskHeader( { children, centerChildren, rightChildren }: DeskHeaderProps ) {
 	const isFullscreen = useFullscreen();
 
 	return (
 		<div className={ clsx( styles.root, isFullscreen && styles.fullscreen ) }>
 			<span className={ styles.title }>{ __( 'Studio' ) }</span>
 			<div className={ styles.actions }>{ children }</div>
+			{ centerChildren && <div className={ styles.centerActions }>{ centerChildren }</div> }
+			{ rightChildren && <div className={ styles.rightActions }>{ rightChildren }</div> }
 		</div>
 	);
 }
 
 interface DeskChromeProps {
 	siteId?: string;
+	siteMapOpen?: boolean;
+	siteMapPageCount?: number;
+	onToggleSiteMap?: () => void;
 }
 
-export function DeskChrome( { siteId }: DeskChromeProps ) {
+export function DeskChrome( {
+	siteId,
+	siteMapOpen = false,
+	siteMapPageCount,
+	onToggleSiteMap,
+}: DeskChromeProps ) {
 	return (
-		<DeskHeader>
+		<DeskHeader
+			centerChildren={ siteMapOpen ? <DeskSiteMapTitle pageCount={ siteMapPageCount } /> : null }
+			rightChildren={
+				siteId && onToggleSiteMap ? (
+					<DeskSiteMapButton siteId={ siteId } open={ siteMapOpen } onToggle={ onToggleSiteMap } />
+				) : null
+			}
+		>
 			<DeskMenu siteId={ siteId } />
 			<DeskChatsTrigger />
 			<DeskCreateMenu />
 		</DeskHeader>
+	);
+}
+
+function DeskSiteMapTitle( { pageCount }: { pageCount?: number } ) {
+	return (
+		<div className={ styles.siteMapTitle }>
+			<h1>{ __( 'Site map' ) }</h1>
+			{ pageCount !== undefined && (
+				<span>{ sprintf( _n( '%d page', '%d pages', pageCount ), pageCount ) }</span>
+			) }
+		</div>
 	);
 }

--- a/apps/ui/src/ui-desks/chrome/site-map-button.tsx
+++ b/apps/ui/src/ui-desks/chrome/site-map-button.tsx
@@ -1,0 +1,44 @@
+import { __ } from '@wordpress/i18n';
+import { category } from '@wordpress/icons';
+import { useSites } from '@/data/queries/use-sites';
+import { IconControlButton } from '@/ui-desks/components';
+
+interface DeskSiteMapButtonProps {
+	siteId: string;
+	open: boolean;
+	onToggle: () => void;
+}
+
+export function DeskSiteMapButton( { siteId, open, onToggle }: DeskSiteMapButtonProps ) {
+	const { data: sites, isLoading } = useSites();
+	const site = sites?.find( ( candidate ) => candidate.id === siteId );
+	const canOpen = Boolean( site?.running );
+	const disabled = ! open && ( isLoading || ! canOpen );
+
+	return (
+		<IconControlButton
+			icon={ category }
+			label={ __( 'Site map' ) }
+			tooltipLabel={ getTooltipLabel( isLoading, Boolean( site ), canOpen ) }
+			aria-pressed={ open }
+			disabled={ disabled }
+			onClick={ onToggle }
+		/>
+	);
+}
+
+function getTooltipLabel( isLoading: boolean, hasSite: boolean, canOpen: boolean ) {
+	if ( isLoading ) {
+		return __( 'Checking site…' );
+	}
+
+	if ( ! hasSite ) {
+		return __( 'Site map unavailable' );
+	}
+
+	if ( ! canOpen ) {
+		return __( 'Start the site to view its site map' );
+	}
+
+	return __( 'Site map' );
+}

--- a/apps/ui/src/ui-desks/chrome/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/style.module.css
@@ -35,6 +35,28 @@
 	pointer-events: auto;
 }
 
+.rightActions {
+	position: fixed;
+	top: calc(var(--desk-titlebar-height) + var(--wpds-dimension-padding-sm));
+	right: var(--desk-chrome-edge-offset);
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-md);
+	pointer-events: auto;
+}
+
+.centerActions {
+	position: fixed;
+	top: calc(var(--desk-titlebar-height) + var(--wpds-dimension-padding-sm));
+	left: 50%;
+	display: flex;
+	align-items: center;
+	height: 36px;
+	max-width: min(360px, calc(100vw - 320px));
+	transform: translateX(-50%);
+	pointer-events: none;
+}
+
 .fullscreen .title {
 	display: none;
 }
@@ -42,6 +64,44 @@
 .fullscreen .actions {
 	top: var(--desk-chrome-edge-offset);
 	left: var(--desk-chrome-edge-offset);
+}
+
+.fullscreen .rightActions {
+	top: var(--desk-chrome-edge-offset);
+}
+
+.fullscreen .centerActions {
+	top: var(--desk-chrome-edge-offset);
+}
+
+.siteMapTitle {
+	display: flex;
+	min-width: 0;
+	align-items: baseline;
+	justify-content: center;
+	gap: 8px;
+	color: var(--wpds-color-fg-content-neutral);
+	text-align: center;
+	white-space: nowrap;
+}
+
+.siteMapTitle h1,
+.siteMapTitle span {
+	margin: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.siteMapTitle h1 {
+	font-size: var(--wpds-typography-font-size-md);
+	font-weight: var(--wpds-typography-font-weight-semibold, 600);
+	line-height: var(--wpds-typography-line-height-md);
+}
+
+.siteMapTitle span {
+	color: var(--wpds-color-fg-content-neutral-weak, rgba(15, 23, 42, 0.55));
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
 }
 
 .siteTrigger {

--- a/apps/ui/src/ui-desks/desk/canvas.tsx
+++ b/apps/ui/src/ui-desks/desk/canvas.tsx
@@ -30,7 +30,7 @@ function DeskCanvasOverlays() {
 }
 
 export function DeskCanvas() {
-	const { isLoading } = useDesk();
+	const { isLoading, statusMessage } = useDesk();
 	const registerEditor = useRegisterDeskEditor();
 
 	const handleMount = useCallback(
@@ -60,6 +60,7 @@ export function DeskCanvas() {
 				shapeUtils={ deskShapeUtils }
 				onMount={ handleMount }
 			/>
+			{ statusMessage && <div className={ styles.statusMessage }>{ statusMessage }</div> }
 		</div>
 	);
 }

--- a/apps/ui/src/ui-desks/desk/index.tsx
+++ b/apps/ui/src/ui-desks/desk/index.tsx
@@ -1,6 +1,9 @@
 import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
 import { DeskChats } from '../chats';
 import { DeskChrome } from '../chrome';
+import { LoadingPlaceholder } from '../components';
+import { useSiteMapDeskConfig } from '../site-map/use-site-map-desk-config';
 import { DeskWidgetToolbar } from '../widgets/toolbar';
 import { DeskCanvas } from './canvas';
 import { DeskProvider } from './provider';
@@ -12,8 +15,12 @@ interface DeskProps {
 }
 
 export function Desk( { siteId }: DeskProps ) {
+	if ( siteId ) {
+		return <SiteDesk siteId={ siteId } />;
+	}
+
 	return (
-		<DeskProvider key={ siteId ?? 'user' } siteId={ siteId }>
+		<DeskProvider key="user" siteId={ siteId }>
 			<DeskShell siteId={ siteId }>
 				<DeskCanvas />
 			</DeskShell>
@@ -21,16 +28,72 @@ export function Desk( { siteId }: DeskProps ) {
 	);
 }
 
-function DeskShell( { siteId, children }: DeskProps & { children: ReactNode } ) {
+function SiteDesk( { siteId }: Required< DeskProps > ) {
+	const [ siteMapOpen, setSiteMapOpen ] = useState( false );
+	const siteMap = useSiteMapDeskConfig( siteId, siteMapOpen );
+	const providerKey = siteMapOpen ? `${ siteId }:site-map:${ siteMap.signature }` : siteId;
+
+	return (
+		<DeskProvider
+			key={ providerKey }
+			siteId={ siteId }
+			deskConfig={ siteMapOpen ? siteMap.config : undefined }
+			deskConfigKey={ providerKey }
+			initialViewportMode={ siteMapOpen ? 'site-map' : undefined }
+			isLoading={ siteMapOpen ? siteMap.isLoading : undefined }
+			isReadOnly={ siteMapOpen }
+			statusMessage={ siteMapOpen ? siteMap.message : undefined }
+		>
+			<DeskShell
+				siteId={ siteId }
+				siteMapOpen={ siteMapOpen }
+				siteMapIsLoading={ siteMapOpen && siteMap.isLoading }
+				siteMapPageCount={ siteMapOpen && ! siteMap.isLoading ? siteMap.pageCount : undefined }
+				onToggleSiteMap={ () => setSiteMapOpen( ( open ) => ! open ) }
+			>
+				<DeskCanvas />
+			</DeskShell>
+		</DeskProvider>
+	);
+}
+
+function DeskShell( {
+	siteId,
+	siteMapOpen,
+	siteMapIsLoading,
+	siteMapPageCount,
+	onToggleSiteMap,
+	children,
+}: DeskProps & {
+	siteMapOpen?: boolean;
+	siteMapIsLoading?: boolean;
+	siteMapPageCount?: number;
+	onToggleSiteMap?: () => void;
+	children: ReactNode;
+} ) {
 	return (
 		<>
 			<DeskChats siteId={ siteId } />
 			<main className={ styles.root } aria-label={ getDeskLabel( siteId ) } data-site-id={ siteId }>
-				<DeskChrome siteId={ siteId } />
+				<DeskChrome
+					siteId={ siteId }
+					siteMapOpen={ siteMapOpen }
+					siteMapPageCount={ siteMapPageCount }
+					onToggleSiteMap={ onToggleSiteMap }
+				/>
 				{ children }
+				{ siteMapIsLoading && <SiteMapLoadingWidget /> }
 				<DeskWidgetToolbar />
 			</main>
 		</>
+	);
+}
+
+function SiteMapLoadingWidget() {
+	return (
+		<div className={ styles.siteMapLoadingWidget } aria-live="polite">
+			<LoadingPlaceholder text={ __( 'Loading site map' ) } />
+		</div>
 	);
 }
 

--- a/apps/ui/src/ui-desks/desk/index.tsx
+++ b/apps/ui/src/ui-desks/desk/index.tsx
@@ -19,9 +19,13 @@ export function Desk( { siteId }: DeskProps ) {
 		return <SiteDesk siteId={ siteId } />;
 	}
 
+	return <UserDesk />;
+}
+
+function UserDesk() {
 	return (
-		<DeskProvider key="user" siteId={ siteId }>
-			<DeskShell siteId={ siteId }>
+		<DeskProvider key="user">
+			<DeskShell>
 				<DeskCanvas />
 			</DeskShell>
 		</DeskProvider>

--- a/apps/ui/src/ui-desks/desk/provider/context.ts
+++ b/apps/ui/src/ui-desks/desk/provider/context.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from 'react';
+import type { DeskConfig } from '../types';
 import type { getSelectedWidgetToolbarItem } from '@/ui-desks/widgets/toolbar-selection';
 import type { ReactNode } from 'react';
 import type { Editor } from 'tldraw';
@@ -12,6 +13,8 @@ export type RegisterDeskEditor = ( editor: Editor | null ) => void;
 export interface DeskContextValue {
 	siteId?: string;
 	isLoading: boolean;
+	isReadOnly: boolean;
+	statusMessage?: string;
 	canAddWidgets: boolean;
 	selectedWidgetToolbarItem: SelectedWidgetToolbarItem | null;
 	pressedStackId: string | null;
@@ -33,11 +36,19 @@ export interface AddDeskWidgetOptions {
 export interface DeskProviderProps {
 	siteId?: string;
 	children: ReactNode;
+	deskConfig?: DeskConfig;
+	deskConfigKey?: string;
+	initialViewportMode?: 'site-map';
+	isLoading?: boolean;
+	isReadOnly?: boolean;
+	statusMessage?: string;
 }
 
 const defaultDeskContext: DeskContextValue = {
 	siteId: undefined,
 	isLoading: true,
+	isReadOnly: false,
+	statusMessage: undefined,
 	canAddWidgets: false,
 	selectedWidgetToolbarItem: null,
 	pressedStackId: null,

--- a/apps/ui/src/ui-desks/desk/provider/editor-state.ts
+++ b/apps/ui/src/ui-desks/desk/provider/editor-state.ts
@@ -14,12 +14,16 @@ import {
 	getStackOrder,
 	getStackZIndexFromMember,
 } from '@/ui-desks/stacks/utils';
+import { BLOG_WIDGET_TYPE } from '@/ui-desks/widgets/blog/types';
 import { createDeskWidget } from '@/ui-desks/widgets/create-widget';
+import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
 import { getSelectedWidgetToolbarItem } from '@/ui-desks/widgets/toolbar-selection';
 import {
 	canvasCameraToDeskViewport,
 	canvasShapeToDeskWidget,
 	canvasShapesToDeskStacks,
+	deskConfigToCanvasConnectorBindings,
+	deskConfigToCanvasConnectorShapes,
 	deskConfigToCanvasShapes,
 	deskWidgetToCanvasShape,
 	getDerivedDeskCanvasRecordSourceId,
@@ -43,16 +47,46 @@ interface DerivedWidgetAnchor {
 	zIndex?: string;
 }
 
-export function hydrateEditorFromDesk( editor: Editor, desk: DeskConfig ) {
+interface WidgetToolbarStateOptions {
+	canStack?: boolean;
+	canUnstack?: boolean;
+	canRemove?: boolean;
+}
+
+interface HydrateEditorOptions {
+	initialViewportMode?: 'site-map';
+}
+
+const SITE_MAP_DEFAULT_ZOOM = 0.72;
+const SITE_MAP_MIN_ZOOM = 0.4;
+const SITE_MAP_MAX_ZOOM = 0.76;
+const SITE_MAP_HORIZONTAL_PADDING = 96;
+const SITE_MAP_BOTTOM_PADDING = 96;
+const SITE_MAP_HOME_TOP = 126;
+
+export function hydrateEditorFromDesk(
+	editor: Editor,
+	desk: DeskConfig,
+	options: HydrateEditorOptions = {}
+) {
 	const existingShapes = editor.getCurrentPageShapes();
 	if ( existingShapes.length > 0 ) {
-		editor.deleteShapes( existingShapes.map( ( shape ) => shape.id ) );
+		editor.run( () => editor.deleteShapes( existingShapes.map( ( shape ) => shape.id ) ), {
+			ignoreShapeLock: true,
+		} );
 	}
 	if ( desk.widgets.length > 0 ) {
-		editor.createShapes( deskConfigToCanvasShapes( desk ) );
+		const widgetShapes = deskConfigToCanvasShapes( desk );
+		editor.createShapes( [
+			...deskConfigToCanvasConnectorShapes( desk, widgetShapes ),
+			...widgetShapes,
+		] );
+		editor.createBindings( deskConfigToCanvasConnectorBindings( desk ) );
 	}
 	if ( desk.viewport ) {
 		editor.setCamera( desk.viewport, { immediate: true } );
+	} else if ( options.initialViewportMode === 'site-map' && desk.widgets.length > 0 ) {
+		setInitialSiteMapCamera( editor );
 	} else if ( desk.widgets.length > 0 ) {
 		ensureContentVisible( editor );
 	}
@@ -70,8 +104,11 @@ export function createDeskConfigFromEditor( editor: Editor ): DeskConfig {
 	};
 }
 
-export function getCurrentSelectedWidgetToolbarItem( editor: Editor ) {
-	return getCurrentSelectedWidgetSelection( editor )?.item ?? null;
+export function getCurrentSelectedWidgetToolbarItem(
+	editor: Editor,
+	options: WidgetToolbarStateOptions = {}
+) {
+	return getCurrentSelectedWidgetSelection( editor, options )?.item ?? null;
 }
 
 export function addWidgetToEditor(
@@ -214,7 +251,10 @@ export function hasPersistentDocumentChange( changes: CanvasStoreChanges ) {
 	} );
 }
 
-function getCurrentSelectedWidgetSelection( editor: Editor ) {
+function getCurrentSelectedWidgetSelection(
+	editor: Editor,
+	options: WidgetToolbarStateOptions = {}
+) {
 	const selectedShapeIds = editor.getSelectedShapeIds();
 	if ( selectedShapeIds.length === 0 ) {
 		return null;
@@ -225,7 +265,11 @@ function getCurrentSelectedWidgetSelection( editor: Editor ) {
 		return null;
 	}
 
-	const derivedSourceSelection = getDerivedSourceWidgetSelection( editor, shapes as TLShape[] );
+	const derivedSourceSelection = getDerivedSourceWidgetSelection(
+		editor,
+		shapes as TLShape[],
+		options
+	);
 	if ( derivedSourceSelection ) {
 		return derivedSourceSelection;
 	}
@@ -242,7 +286,12 @@ function getCurrentSelectedWidgetSelection( editor: Editor ) {
 				.filter( ( stackId ): stackId is string => stackId !== null )
 		)
 	);
-	const item = getSelectedWidgetToolbarItem( widgets as DeskWidget[], { stackIds } );
+	const item = getSelectedWidgetToolbarItem( widgets as DeskWidget[], {
+		stackIds,
+		canStack: options.canStack,
+		canUnstack: options.canUnstack,
+		canRemove: options.canRemove,
+	} );
 	if ( ! item ) {
 		return null;
 	}
@@ -325,7 +374,11 @@ function getDerivedShapePersistenceSignature( value: unknown ) {
 	} );
 }
 
-function getDerivedSourceWidgetSelection( editor: Editor, shapes: TLShape[] ) {
+function getDerivedSourceWidgetSelection(
+	editor: Editor,
+	shapes: TLShape[],
+	options: WidgetToolbarStateOptions = {}
+) {
 	const sourceWidgetId = getDerivedSelectionSourceWidgetId( shapes );
 	if ( ! sourceWidgetId ) {
 		return null;
@@ -345,6 +398,8 @@ function getDerivedSourceWidgetSelection( editor: Editor, shapes: TLShape[] ) {
 
 	const item = getSelectedWidgetToolbarItem( [ sourceWidget ], {
 		stackIds: [],
+		canStack: options.canStack,
+		canUnstack: options.canUnstack,
 		canRemove: false,
 	} );
 	if ( ! item ) {
@@ -443,6 +498,121 @@ function ensureContentVisible( editor: Editor ) {
 	if ( ! hasVisibleShape ) {
 		editor.zoomToFit( { animation: { duration: 0 } } );
 	}
+}
+
+function setInitialSiteMapCamera( editor: Editor ) {
+	const homeShape = getSiteMapHomeShape( editor );
+	const homeBounds = homeShape ? editor.getShapePageBounds( homeShape.id ) : null;
+	if ( ! homeBounds ) {
+		ensureContentVisible( editor );
+		return;
+	}
+
+	const screenBounds = editor.getViewportScreenBounds();
+	const zoom = getInitialSiteMapZoom( editor );
+	const homeCenterX = ( homeBounds.minX + homeBounds.maxX ) / 2;
+
+	editor.setCamera(
+		{
+			x: screenBounds.w / 2 / zoom - homeCenterX,
+			y: getSiteMapHomeScreenTop( screenBounds.h ) / zoom - homeBounds.minY,
+			z: zoom,
+		},
+		{ immediate: true }
+	);
+}
+
+function getSiteMapHomeShape( editor: Editor ) {
+	const pageShapes = getSiteMapPageShapes( editor );
+	return pageShapes
+		.map( ( shape ) => ( { shape, bounds: editor.getShapePageBounds( shape.id ) } ) )
+		.filter(
+			(
+				item
+			): item is {
+				shape: TLShape;
+				bounds: NonNullable< ReturnType< Editor[ 'getShapePageBounds' ] > >;
+			} => Boolean( item.bounds )
+		)
+		.sort(
+			( first, second ) =>
+				first.bounds.minY - second.bounds.minY ||
+				first.bounds.minX - second.bounds.minX ||
+				sortByIndex( first.shape, second.shape )
+		)[ 0 ]?.shape;
+}
+
+function getSiteMapPageShapes( editor: Editor ) {
+	return getSiteMapWidgetShapes( editor ).filter( ( shape ) => {
+		const widget = canvasShapeToDeskWidget( shape );
+		return widget?.type === PAGE_WIDGET_TYPE || widget?.type === BLOG_WIDGET_TYPE;
+	} );
+}
+
+function getSiteMapWidgetShapes( editor: Editor ) {
+	return editor
+		.getCurrentPageShapes()
+		.filter( ( shape ) => canvasShapeToDeskWidget( shape ) !== null );
+}
+
+function getInitialSiteMapZoom( editor: Editor ) {
+	const bounds = getSiteMapContentBounds( editor );
+	if ( ! bounds ) {
+		return SITE_MAP_DEFAULT_ZOOM;
+	}
+
+	const screenBounds = editor.getViewportScreenBounds();
+	const availableWidth = Math.max( 320, screenBounds.w - SITE_MAP_HORIZONTAL_PADDING * 2 );
+	const availableHeight = Math.max(
+		320,
+		screenBounds.h - getSiteMapHomeScreenTop( screenBounds.h ) - SITE_MAP_BOTTOM_PADDING
+	);
+	const fitZoom = Math.min( availableWidth / bounds.w, availableHeight / bounds.h );
+
+	return clamp( Math.min( SITE_MAP_DEFAULT_ZOOM, fitZoom ), SITE_MAP_MIN_ZOOM, SITE_MAP_MAX_ZOOM );
+}
+
+function getSiteMapContentBounds( editor: Editor ) {
+	const bounds = getSiteMapWidgetShapes( editor )
+		.map( ( shape ) => editor.getShapePageBounds( shape.id ) )
+		.filter( ( shapeBounds ): shapeBounds is NonNullable< typeof shapeBounds > =>
+			Boolean( shapeBounds )
+		);
+
+	if ( bounds.length === 0 ) {
+		return null;
+	}
+
+	return bounds.reduce(
+		( currentBounds, nextBounds ) => ( {
+			minX: Math.min( currentBounds.minX, nextBounds.minX ),
+			minY: Math.min( currentBounds.minY, nextBounds.minY ),
+			maxX: Math.max( currentBounds.maxX, nextBounds.maxX ),
+			maxY: Math.max( currentBounds.maxY, nextBounds.maxY ),
+			w:
+				Math.max( currentBounds.maxX, nextBounds.maxX ) -
+				Math.min( currentBounds.minX, nextBounds.minX ),
+			h:
+				Math.max( currentBounds.maxY, nextBounds.maxY ) -
+				Math.min( currentBounds.minY, nextBounds.minY ),
+		} ),
+		{
+			minX: bounds[ 0 ].minX,
+			minY: bounds[ 0 ].minY,
+			maxX: bounds[ 0 ].maxX,
+			maxY: bounds[ 0 ].maxY,
+			w: bounds[ 0 ].w,
+			h: bounds[ 0 ].h,
+		}
+	);
+}
+
+function getSiteMapHomeScreenTop( screenHeight: number ) {
+	return Math.min( SITE_MAP_HOME_TOP, Math.max( 104, screenHeight * 0.18 ) );
+}
+
+function clamp( value: number, min: number, max: number ) {
+	return Math.min( max, Math.max( min, value ) );
 }
 
 function getHighestShapeIndex( shapes: Pick< TLShape, 'index' >[] ) {

--- a/apps/ui/src/ui-desks/desk/provider/index.tsx
+++ b/apps/ui/src/ui-desks/desk/provider/index.tsx
@@ -105,22 +105,9 @@ export function DeskProvider( {
 				return previousShape;
 			}
 		);
-		const handleKeyDown = ( event: KeyboardEvent ) => {
-			if (
-				( event.key !== 'Backspace' && event.key !== 'Delete' ) ||
-				isEditableKeyboardTarget( event.target )
-			) {
-				return;
-			}
 
-			event.preventDefault();
-			event.stopPropagation();
-		};
-
-		window.addEventListener( 'keydown', handleKeyDown, { capture: true } );
 		return () => {
 			stopShapeChanges();
-			window.removeEventListener( 'keydown', handleKeyDown, { capture: true } );
 		};
 	}, [ editor, isReadOnly ] );
 
@@ -299,17 +286,4 @@ export function DeskProvider( {
 	} );
 
 	return <DeskContext.Provider value={ value }>{ children }</DeskContext.Provider>;
-}
-
-function isEditableKeyboardTarget( target: EventTarget | null ) {
-	if ( ! target || ! ( target instanceof HTMLElement ) ) {
-		return false;
-	}
-
-	return (
-		target.isContentEditable ||
-		target.tagName === 'INPUT' ||
-		target.tagName === 'TEXTAREA' ||
-		target.tagName === 'SELECT'
-	);
 }

--- a/apps/ui/src/ui-desks/desk/provider/index.tsx
+++ b/apps/ui/src/ui-desks/desk/provider/index.tsx
@@ -25,19 +25,57 @@ import type { Editor } from 'tldraw';
 
 export { useDesk, useRegisterDeskEditor } from './context';
 
-export function DeskProvider( { siteId, children }: DeskProviderProps ) {
-	const { desk, isLoading, saveDeskConfig } = useDeskPersistence( siteId );
+export function DeskProvider( {
+	siteId,
+	children,
+	deskConfig,
+	deskConfigKey,
+	initialViewportMode,
+	isLoading: externalIsLoading,
+	isReadOnly = false,
+	statusMessage,
+}: DeskProviderProps ) {
+	const hasExternalDeskConfig = Boolean( deskConfig );
+	const {
+		desk: persistedDesk,
+		isLoading: isLoadingPersistedDesk,
+		saveDeskConfig,
+	} = useDeskPersistence( siteId, {
+		enabled: ! hasExternalDeskConfig,
+	} );
+	const desk = deskConfig ?? persistedDesk;
+	const isLoading = externalIsLoading ?? isLoadingPersistedDesk;
 	const [ editor, setEditor ] = useState< Editor | null >( null );
 	const [ isHydrated, setIsHydrated ] = useState( false );
 	const [ selectedWidgetToolbarItem, setSelectedWidgetToolbarItem ] =
 		useState< SelectedWidgetToolbarItem | null >( null );
 	const [ pressedStackId, setPressedStackId ] = useState< string | null >( null );
 	const hydratedRef = useRef( false );
+	const deskConfigKeyRef = useRef< string | undefined >( undefined );
 	const creationOffsetRef = useRef( 0 );
 	const saveTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 	const { pressStack, clearPressedStack } = useStackPressAnimation( setPressedStackId );
+	const toolbarStateOptions = useMemo(
+		() => ( {
+			canStack: ! isReadOnly,
+			canUnstack: ! isReadOnly,
+			canRemove: ! isReadOnly,
+		} ),
+		[ isReadOnly ]
+	);
 
 	useStackInteractions( editor );
+
+	useEffect( () => {
+		if ( deskConfigKeyRef.current === deskConfigKey ) {
+			return;
+		}
+
+		deskConfigKeyRef.current = deskConfigKey;
+		hydratedRef.current = false;
+		setIsHydrated( false );
+		setSelectedWidgetToolbarItem( null );
+	}, [ deskConfigKey ] );
 
 	useEffect( () => {
 		if ( ! editor || isLoading || hydratedRef.current ) {
@@ -45,10 +83,46 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 		}
 
 		hydratedRef.current = true;
-		hydrateEditorFromDesk( editor, desk );
+		hydrateEditorFromDesk( editor, desk, { initialViewportMode } );
 		setIsHydrated( true );
-		setSelectedWidgetToolbarItem( getCurrentSelectedWidgetToolbarItem( editor ) );
-	}, [ desk, editor, isLoading ] );
+		setSelectedWidgetToolbarItem(
+			getCurrentSelectedWidgetToolbarItem( editor, toolbarStateOptions )
+		);
+	}, [ desk, editor, initialViewportMode, isLoading, toolbarStateOptions ] );
+
+	useEffect( () => {
+		if ( ! editor || ! isReadOnly ) {
+			return;
+		}
+
+		const stopShapeChanges = editor.sideEffects.registerBeforeChangeHandler(
+			'shape',
+			( previousShape, nextShape ) => {
+				if ( ! editor.inputs.isDragging ) {
+					return nextShape;
+				}
+
+				return previousShape;
+			}
+		);
+		const handleKeyDown = ( event: KeyboardEvent ) => {
+			if (
+				( event.key !== 'Backspace' && event.key !== 'Delete' ) ||
+				isEditableKeyboardTarget( event.target )
+			) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+		};
+
+		window.addEventListener( 'keydown', handleKeyDown, { capture: true } );
+		return () => {
+			stopShapeChanges();
+			window.removeEventListener( 'keydown', handleKeyDown, { capture: true } );
+		};
+	}, [ editor, isReadOnly ] );
 
 	useEffect( () => {
 		if ( ! editor ) {
@@ -56,7 +130,7 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 		}
 
 		const queueSave = () => {
-			if ( ! hydratedRef.current ) {
+			if ( isReadOnly || ! hydratedRef.current ) {
 				return;
 			}
 
@@ -70,7 +144,9 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 			}, 500 );
 		};
 		const syncSelectedWidgetToolbarItem = () => {
-			setSelectedWidgetToolbarItem( getCurrentSelectedWidgetToolbarItem( editor ) );
+			setSelectedWidgetToolbarItem(
+				getCurrentSelectedWidgetToolbarItem( editor, toolbarStateOptions )
+			);
 		};
 
 		const unsubscribeDocument = editor.store.listen(
@@ -100,7 +176,7 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 			unsubscribeDocument();
 			unsubscribeSession();
 		};
-	}, [ editor, saveDeskConfig ] );
+	}, [ editor, isReadOnly, saveDeskConfig, toolbarStateOptions ] );
 
 	const registerEditor = useCallback(
 		( nextEditor: Editor | null ) => {
@@ -117,7 +193,7 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 
 	const addWidget = useCallback(
 		( type: string, options?: AddDeskWidgetOptions ) => {
-			if ( ! editor || ! isHydrated ) {
+			if ( isReadOnly || ! editor || ! isHydrated ) {
 				return false;
 			}
 
@@ -127,12 +203,12 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 			}
 			return didAddWidget;
 		},
-		[ editor, isHydrated ]
+		[ editor, isHydrated, isReadOnly ]
 	);
 
 	const updateSelectedWidgetProps = useCallback(
 		( widgetProps: Record< string, unknown > ) => {
-			if ( ! editor || ! isHydrated ) {
+			if ( isReadOnly || ! editor || ! isHydrated ) {
 				return false;
 			}
 
@@ -147,41 +223,47 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 			setSelectedWidgetToolbarItem( nextSelectedWidgetToolbarItem );
 			return true;
 		},
-		[ editor, isHydrated ]
+		[ editor, isHydrated, isReadOnly ]
 	);
 
 	const stackSelectedWidgets = useCallback( () => {
-		if ( ! editor || ! isHydrated || ! stackSelectedWidgetsInEditor( editor ) ) {
+		if ( isReadOnly || ! editor || ! isHydrated || ! stackSelectedWidgetsInEditor( editor ) ) {
 			return false;
 		}
 
-		setSelectedWidgetToolbarItem( getCurrentSelectedWidgetToolbarItem( editor ) );
+		setSelectedWidgetToolbarItem(
+			getCurrentSelectedWidgetToolbarItem( editor, toolbarStateOptions )
+		);
 		return true;
-	}, [ editor, isHydrated ] );
+	}, [ editor, isHydrated, isReadOnly, toolbarStateOptions ] );
 
 	const unstackSelectedWidgets = useCallback( () => {
-		if ( ! editor || ! isHydrated || ! unstackSelectedWidgetsInEditor( editor ) ) {
+		if ( isReadOnly || ! editor || ! isHydrated || ! unstackSelectedWidgetsInEditor( editor ) ) {
 			return false;
 		}
 
-		setSelectedWidgetToolbarItem( getCurrentSelectedWidgetToolbarItem( editor ) );
+		setSelectedWidgetToolbarItem(
+			getCurrentSelectedWidgetToolbarItem( editor, toolbarStateOptions )
+		);
 		return true;
-	}, [ editor, isHydrated ] );
+	}, [ editor, isHydrated, isReadOnly, toolbarStateOptions ] );
 
 	const removeSelectedWidget = useCallback( () => {
-		if ( ! editor || ! isHydrated || ! removeSelectedWidgetFromEditor( editor ) ) {
+		if ( isReadOnly || ! editor || ! isHydrated || ! removeSelectedWidgetFromEditor( editor ) ) {
 			return false;
 		}
 
 		setSelectedWidgetToolbarItem( null );
 		return true;
-	}, [ editor, isHydrated ] );
+	}, [ editor, isHydrated, isReadOnly ] );
 
 	const value = useMemo(
 		() => ( {
 			siteId,
 			isLoading,
-			canAddWidgets: Boolean( editor ) && isHydrated,
+			isReadOnly,
+			statusMessage,
+			canAddWidgets: ! isReadOnly && Boolean( editor ) && isHydrated,
 			selectedWidgetToolbarItem,
 			pressedStackId,
 			registerEditor,
@@ -196,6 +278,7 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 			addWidget,
 			editor,
 			isHydrated,
+			isReadOnly,
 			isLoading,
 			pressStack,
 			pressedStackId,
@@ -204,6 +287,7 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 			selectedWidgetToolbarItem,
 			stackSelectedWidgets,
 			siteId,
+			statusMessage,
 			unstackSelectedWidgets,
 			updateSelectedWidgetProps,
 		]
@@ -215,4 +299,17 @@ export function DeskProvider( { siteId, children }: DeskProviderProps ) {
 	} );
 
 	return <DeskContext.Provider value={ value }>{ children }</DeskContext.Provider>;
+}
+
+function isEditableKeyboardTarget( target: EventTarget | null ) {
+	if ( ! target || ! ( target instanceof HTMLElement ) ) {
+		return false;
+	}
+
+	return (
+		target.isContentEditable ||
+		target.tagName === 'INPUT' ||
+		target.tagName === 'TEXTAREA' ||
+		target.tagName === 'SELECT'
+	);
 }

--- a/apps/ui/src/ui-desks/desk/provider/persistence.ts
+++ b/apps/ui/src/ui-desks/desk/provider/persistence.ts
@@ -3,17 +3,22 @@ import { useDeskConfig, useSaveDeskConfig } from '@/data/queries/use-desk-config
 import { defaultUserDesk } from '../default-desk';
 import { DESK_CONFIG_VERSION, type DeskConfig } from '../types';
 
-export function useDeskPersistence( siteId?: string ) {
-	const { data: savedDesk, isLoading } = useDeskConfig( siteId );
+interface DeskPersistenceOptions {
+	enabled?: boolean;
+}
+
+export function useDeskPersistence( siteId?: string, options: DeskPersistenceOptions = {} ) {
+	const enabled = options.enabled ?? true;
+	const { data: savedDesk, isLoading } = useDeskConfig( siteId, enabled );
 	const { mutate: saveDeskConfig } = useSaveDeskConfig( siteId );
 	const defaultDesk = useMemo( () => createDefaultDeskConfig( siteId ), [ siteId ] );
 	const desk = ( savedDesk as DeskConfig | undefined ) ?? defaultDesk;
 
 	useEffect( () => {
-		if ( ! isLoading && ! savedDesk ) {
+		if ( enabled && ! isLoading && ! savedDesk ) {
 			saveDeskConfig( defaultDesk );
 		}
-	}, [ defaultDesk, isLoading, savedDesk, saveDeskConfig ] );
+	}, [ defaultDesk, enabled, isLoading, savedDesk, saveDeskConfig ] );
 
 	return {
 		desk,

--- a/apps/ui/src/ui-desks/desk/provider/resolvers.ts
+++ b/apps/ui/src/ui-desks/desk/provider/resolvers.ts
@@ -146,12 +146,7 @@ async function resolveDeskWidgets(
 			) ) as WidgetResolution;
 		} catch ( error ) {
 			if ( isInitialResolve ) {
-				setSourceWidgetResolutionState(
-					editor,
-					widget.id,
-					undefined,
-					definition.getInitialWidget().shapeProps
-				);
+				setSourceWidgetResolutionState( editor, widget.id, undefined, widget.shapeProps );
 			}
 			console.warn( `Failed to resolve desk widget "${ widget.id }".`, error );
 			if ( ! previousState ) {
@@ -166,12 +161,7 @@ async function resolveDeskWidgets(
 			continue;
 		}
 		if ( isInitialResolve ) {
-			setSourceWidgetResolutionState(
-				editor,
-				widget.id,
-				undefined,
-				definition.getInitialWidget().shapeProps
-			);
+			setSourceWidgetResolutionState( editor, widget.id, undefined, widget.shapeProps );
 		}
 		const widgets = resolution.widgets.filter(
 			( resolvedWidget ): resolvedWidget is ResolvedDeskWidget< DeskWidget > =>

--- a/apps/ui/src/ui-desks/desk/style.module.css
+++ b/apps/ui/src/ui-desks/desk/style.module.css
@@ -6,10 +6,57 @@
 
 .canvas,
 .loading {
+	position: relative;
 	width: 100vw;
 	height: 100vh;
 	background: var(--ui-desks-bg, rgb(232, 234, 235));
 	overflow: hidden;
+}
+
+.statusMessage {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--wpds-color-fg-content-neutral-weak, rgba(15, 23, 42, 0.55));
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+	pointer-events: none;
+}
+
+.siteMapLoadingWidget {
+	--loading-placeholder-text-color: #14171a;
+	--loading-placeholder-line-color: #e5e7eb;
+	--loading-placeholder-line-highlight-color: #fff;
+
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	z-index: 8;
+	box-sizing: border-box;
+	width: 280px;
+	height: 380px;
+	padding: 36px 32px;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	transform: translate(-50%, -50%);
+	color: #14171a;
+	background: #fff;
+	border-radius: 18px;
+	box-shadow:
+		0 1px 2px rgba(15, 23, 42, 0.04),
+		0 18px 44px rgba(15, 23, 42, 0.09);
+	pointer-events: none;
+}
+
+.siteMapLoadingWidget::before {
+	content: '';
+	position: absolute;
+	inset: 12px;
+	border: 3px solid #14171a;
+	border-radius: 8px;
 }
 
 .canvas :global(.tl-background) {

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
@@ -5,6 +5,8 @@ import {
 	canvasCameraToDeskViewport,
 	canvasShapeToDeskWidget,
 	canvasShapesToDeskStacks,
+	deskConfigToCanvasConnectorBindings,
+	deskConfigToCanvasConnectorShapes,
 	deskConfigToCanvasShapes,
 	deskWidgetToCanvasShape,
 	getDeskCanvasRecordMetaWithResolutionState,
@@ -297,6 +299,76 @@ describe( 'tldraw adapter', () => {
 		] );
 	} );
 
+	it( 'maps desk connectors to locked arrow shapes and arrow bindings', () => {
+		const desk: DeskConfig = {
+			version: 1,
+			updatedAt: '2026-05-09T00:00:00.000Z',
+			widgets: [
+				{
+					...createNoteWidget(),
+					id: 'parent',
+					zIndex: 'a2',
+				},
+				{
+					...createNoteWidget(),
+					id: 'child',
+					zIndex: 'a3',
+				},
+			],
+			connectors: [
+				{
+					id: 'parent-to-child',
+					from: {
+						widgetId: 'parent',
+						normalizedAnchor: { x: 0.5, y: 1 },
+					},
+					to: {
+						widgetId: 'child',
+						normalizedAnchor: { x: 0.5, y: 0 },
+					},
+					bend: 24,
+				},
+			],
+		};
+		const widgetShapes = deskConfigToCanvasShapes( desk );
+		const connectorShapes = deskConfigToCanvasConnectorShapes( desk, widgetShapes );
+		const connectorShape = getCanvasShape( connectorShapes, 'shape:connector:parent-to-child' );
+		const parentShape = getCanvasShape( widgetShapes, 'shape:parent' );
+		const bindings = deskConfigToCanvasConnectorBindings( desk );
+
+		expect( connectorShape ).toMatchObject( {
+			id: 'shape:connector:parent-to-child',
+			type: 'arrow',
+			isLocked: true,
+			meta: {
+				studioDeskOrigin: 'derived',
+				studioDeskPersist: false,
+				studioDeskConnector: true,
+			},
+			props: {
+				arrowheadStart: 'none',
+				arrowheadEnd: 'none',
+				bend: 24,
+			},
+		} );
+		expect( sortByIndex( connectorShape, parentShape ) ).toBeLessThan( 0 );
+		expect( bindings ).toEqual( [
+			expect.objectContaining( {
+				type: 'arrow',
+				fromId: 'shape:connector:parent-to-child',
+				toId: 'shape:parent',
+				props: expect.objectContaining( { terminal: 'start' } ),
+			} ),
+			expect.objectContaining( {
+				type: 'arrow',
+				fromId: 'shape:connector:parent-to-child',
+				toId: 'shape:child',
+				props: expect.objectContaining( { terminal: 'end' } ),
+			} ),
+		] );
+		expect( isPersistentDeskCanvasShape( connectorShape as TLShape ) ).toBe( false );
+	} );
+
 	it( 'persists a stacked widget original z-index instead of the stack z-index', () => {
 		const shape = {
 			...deskWidgetToCanvasShape( createNoteWidget( 'note-1' ) ),
@@ -576,6 +648,53 @@ describe( 'tldraw adapter', () => {
 				studioDeskDerivedKey: 'post:42',
 			},
 		} );
+	} );
+
+	it( 'gives derived stack members distinct indices below non-numeric stack z-indexes', () => {
+		const resolvedWidget: ResolvedDeskWidget< PostWidget > = {
+			origin: {
+				kind: 'derived',
+				sourceWidgetId: 'collection-1',
+				key: 'post:42',
+			},
+			widget: {
+				id: 'collection-1:post:42',
+				type: 'post',
+				x: 40,
+				y: 50,
+				zIndex: 'aC5ns',
+				shapeProps: {
+					w: 280,
+					h: 380,
+				},
+				widgetProps: {
+					postId: 42,
+				},
+			},
+		};
+		const stack = {
+			id: 'stack-1',
+			x: 100,
+			y: 200,
+			zIndex: 'aF3j5',
+			memberIds: [ 'collection-1:post:40', 'collection-1:post:41', 'collection-1:post:42' ],
+		};
+		const topShape = resolvedDeskWidgetToCanvasShape( resolvedWidget, {
+			stack,
+			order: 0,
+		} ) as TLShape;
+		const middleShape = resolvedDeskWidgetToCanvasShape( resolvedWidget, {
+			stack,
+			order: 1,
+		} ) as TLShape;
+		const bottomShape = resolvedDeskWidgetToCanvasShape( resolvedWidget, {
+			stack,
+			order: 2,
+		} ) as TLShape;
+
+		expect( new Set( [ topShape.index, middleShape.index, bottomShape.index ] ).size ).toBe( 3 );
+		expect( sortByIndex( middleShape, topShape ) ).toBeLessThan( 0 );
+		expect( sortByIndex( bottomShape, middleShape ) ).toBeLessThan( 0 );
 	} );
 
 	it( 'ignores unsupported canvas shapes', () => {

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter.ts
@@ -1,8 +1,12 @@
 import {
 	createShapeId,
 	getIndicesAbove,
+	getIndicesBelow,
 	sortByIndex,
 	type TLCamera,
+	type TLArrowBinding,
+	type TLArrowShape,
+	type TLBindingCreate,
 	type TLShape,
 	type TLShapePartial,
 } from 'tldraw';
@@ -32,8 +36,10 @@ import type {
 } from '@/ui-desks/widgets/types';
 
 const SHAPE_ID_PREFIX = 'shape:';
+const CONNECTOR_SHAPE_ID_PREFIX = 'connector:';
 const DERIVED_WIDGET_ORIGIN = 'derived';
 const DERIVED_WIDGET_PERSIST = false;
+const CONNECTOR_COLOR = 'grey';
 
 interface DeskCanvasMeta {
 	studioDeskOrigin?: typeof DERIVED_WIDGET_ORIGIN;
@@ -41,6 +47,7 @@ interface DeskCanvasMeta {
 	studioDeskSourceWidgetId?: string;
 	studioDeskDerivedKey?: string;
 	studioDeskResolutionState?: WidgetResolutionState;
+	studioDeskConnector?: boolean;
 }
 
 interface DeskStackMember {
@@ -88,6 +95,82 @@ export function deskConfigToCanvasShapes( desk: DeskConfig ): TLShapePartial[] {
 	}
 
 	return shapes;
+}
+
+export function deskConfigToCanvasConnectorShapes(
+	desk: DeskConfig,
+	widgetShapes = deskConfigToCanvasShapes( desk )
+): TLShapePartial< TLArrowShape >[] {
+	if ( ! desk.connectors?.length ) {
+		return [];
+	}
+
+	const lowestWidgetIndex = getLowestShapeIndex( widgetShapes );
+	const connectorIndices = lowestWidgetIndex
+		? getIndicesBelow( lowestWidgetIndex, desk.connectors.length )
+		: getIndicesAbove( null, desk.connectors.length );
+
+	return desk.connectors.map( ( connector, index ) => ( {
+		id: createShapeId( `${ CONNECTOR_SHAPE_ID_PREFIX }${ connector.id }` ),
+		type: 'arrow',
+		index: connectorIndices[ index ],
+		isLocked: true,
+		opacity: 0.72,
+		meta: {
+			studioDeskOrigin: DERIVED_WIDGET_ORIGIN,
+			studioDeskPersist: DERIVED_WIDGET_PERSIST,
+			studioDeskConnector: true,
+		},
+		props: {
+			kind: 'arc',
+			color: CONNECTOR_COLOR,
+			dash: 'solid',
+			size: 'm',
+			bend: connector.bend ?? 24,
+			arrowheadStart: 'none',
+			arrowheadEnd: 'none',
+			start: { x: 0, y: 0 },
+			end: { x: 2, y: 0 },
+		},
+	} ) );
+}
+
+export function deskConfigToCanvasConnectorBindings(
+	desk: DeskConfig
+): TLBindingCreate< TLArrowBinding >[] {
+	if ( ! desk.connectors?.length ) {
+		return [];
+	}
+
+	return desk.connectors.flatMap( ( connector ) => {
+		const arrowId = createShapeId( `${ CONNECTOR_SHAPE_ID_PREFIX }${ connector.id }` );
+		return [
+			{
+				type: 'arrow' as const,
+				fromId: arrowId,
+				toId: createShapeId( connector.from.widgetId ),
+				props: {
+					terminal: 'start' as const,
+					normalizedAnchor: connector.from.normalizedAnchor,
+					isExact: false,
+					isPrecise: false,
+					snap: 'none' as const,
+				},
+			},
+			{
+				type: 'arrow' as const,
+				fromId: arrowId,
+				toId: createShapeId( connector.to.widgetId ),
+				props: {
+					terminal: 'end' as const,
+					normalizedAnchor: connector.to.normalizedAnchor,
+					isExact: false,
+					isPrecise: false,
+					snap: 'none' as const,
+				},
+			},
+		];
+	} );
 }
 
 export function deskWidgetToCanvasShape(
@@ -200,6 +283,16 @@ function getTopLevelDeskItems( desk: DeskConfig ) {
 			{ index: second.zIndex as TLShape[ 'index' ] }
 		)
 	);
+}
+
+function getLowestShapeIndex( shapes: TLShapePartial[] ) {
+	return [ ...shapes ]
+		.filter(
+			( shape ): shape is TLShapePartial & { index: NonNullable< TLShapePartial[ 'index' ] > } =>
+				Boolean( shape.index )
+		)
+		.sort( sortByIndex )
+		.at( 0 )?.index;
 }
 
 export function canvasShapeToDeskWidget( shape: TLShape ): DeskWidget | null {

--- a/apps/ui/src/ui-desks/desk/types.ts
+++ b/apps/ui/src/ui-desks/desk/types.ts
@@ -4,4 +4,21 @@ import type { DeskConfig as BaseDeskConfig } from '@studio/common/types/desk';
 export { DESK_CONFIG_VERSION } from '@studio/common/types/desk';
 export type { DeskStack, DeskViewport, DeskWidgetBase } from '@studio/common/types/desk';
 
-export type DeskConfig = BaseDeskConfig< DeskWidget >;
+export interface DeskConnectorEndpoint {
+	widgetId: string;
+	normalizedAnchor: {
+		x: number;
+		y: number;
+	};
+}
+
+export interface DeskConnector {
+	id: string;
+	from: DeskConnectorEndpoint;
+	to: DeskConnectorEndpoint;
+	bend?: number;
+}
+
+export type DeskConfig = BaseDeskConfig< DeskWidget > & {
+	connectors?: DeskConnector[];
+};

--- a/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
+++ b/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
@@ -177,7 +177,11 @@ function RectangleWidgetComponent( {
 	};
 
 	return (
-		<div style={ stackInteraction.style } onPointerDown={ stackInteraction.onPointerDown }>
+		<div
+			style={ stackInteraction.style }
+			onPointerDown={ stackInteraction.onPointerDown }
+			onPointerUp={ stackInteraction.onPointerUp }
+		>
 			{ isLoading && LoadingComponent ? (
 				<LoadingComponent id={ widgetId } widgetProps={ shape.props.widgetProps } />
 			) : (

--- a/apps/ui/src/ui-desks/site-map/desk-config.test.ts
+++ b/apps/ui/src/ui-desks/site-map/desk-config.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import { createSiteMapDeskConfig, getSiteMapDeskConfigSignature } from './desk-config';
+
+describe( 'createSiteMapDeskConfig', () => {
+	it( 'lays pages out as a parent-child tree of page widgets', () => {
+		const desk = createSiteMapDeskConfig(
+			[
+				{ id: 3, parent: 1, menu_order: 2, title: { rendered: 'About' } },
+				{ id: 1, parent: 0, menu_order: 1, title: { rendered: 'Home' } },
+				{ id: 2, parent: 1, menu_order: 1, title: { rendered: 'Contact' } },
+			],
+			{ show_on_front: 'page', page_on_front: 1 }
+		);
+
+		const home = desk.widgets.find( ( widget ) => widget.id === 'site-map-page-1' );
+		const contact = desk.widgets.find( ( widget ) => widget.id === 'site-map-page-2' );
+		const about = desk.widgets.find( ( widget ) => widget.id === 'site-map-page-3' );
+		const pages = desk.widgets.filter( ( widget ) => widget.type === 'page' );
+		const pageConnectors = desk.connectors?.filter(
+			( connector ) => connector.to.widgetId !== 'site-map-post-collection'
+		);
+
+		expect( pages ).toHaveLength( 3 );
+		expect( home ).toMatchObject( {
+			type: 'page',
+			y: 0,
+			shapeProps: {
+				w: 280,
+				h: 380,
+			},
+			widgetProps: {
+				pageId: 1,
+				tone: 'sky',
+			},
+		} );
+		expect( contact?.y ).toBeGreaterThan( home?.y ?? 0 );
+		expect( about?.y ).toBe( contact?.y );
+		expect( contact?.x ).toBeLessThan( about?.x ?? 0 );
+		expect( contact?.type === 'page' ? contact.widgetProps.tone : undefined ).toBe( 'neutral' );
+		expect( pageConnectors ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					from: expect.objectContaining( { widgetId: 'site-map-page-1' } ),
+					to: expect.objectContaining( { widgetId: 'site-map-page-2' } ),
+				} ),
+				expect.objectContaining( {
+					from: expect.objectContaining( { widgetId: 'site-map-page-1' } ),
+					to: expect.objectContaining( { widgetId: 'site-map-page-3' } ),
+				} ),
+			] )
+		);
+	} );
+
+	it( 'promotes pages with missing parents to roots', () => {
+		const desk = createSiteMapDeskConfig(
+			[
+				{ id: 1, parent: 999, title: { rendered: 'Orphan' } },
+				{ id: 2, parent: 1, title: { rendered: 'Child' } },
+			],
+			{ show_on_front: 'page' }
+		);
+
+		const orphan = desk.widgets.find( ( widget ) => widget.id === 'site-map-page-1' );
+		const child = desk.widgets.find( ( widget ) => widget.id === 'site-map-page-2' );
+
+		expect( orphan?.y ).toBe( 0 );
+		expect( orphan?.type === 'page' ? orphan.widgetProps.tone : undefined ).toBe( 'sky' );
+		expect( child?.y ).toBeGreaterThan( orphan?.y ?? 0 );
+	} );
+
+	it( 'uses the static front page as the parent for other root pages', () => {
+		const desk = createSiteMapDeskConfig(
+			[
+				{ id: 1, parent: 0, title: { rendered: 'Home' } },
+				{ id: 2, parent: 0, title: { rendered: 'About' } },
+				{ id: 3, parent: 0, title: { rendered: 'Contact' } },
+				{ id: 4, parent: 2, title: { rendered: 'Team' } },
+			],
+			{ show_on_front: 'page', page_on_front: 1 }
+		);
+
+		const home = desk.widgets.find( ( widget ) => widget.id === 'site-map-page-1' );
+		const about = desk.widgets.find( ( widget ) => widget.id === 'site-map-page-2' );
+		const contact = desk.widgets.find( ( widget ) => widget.id === 'site-map-page-3' );
+		const team = desk.widgets.find( ( widget ) => widget.id === 'site-map-page-4' );
+
+		expect( home?.y ).toBe( 0 );
+		expect( about?.y ).toBeGreaterThan( home?.y ?? 0 );
+		expect( contact?.y ).toBe( about?.y );
+		expect( team?.y ).toBeGreaterThan( about?.y ?? 0 );
+		expect( desk.connectors ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					from: expect.objectContaining( { widgetId: 'site-map-page-1' } ),
+					to: expect.objectContaining( { widgetId: 'site-map-page-2' } ),
+				} ),
+				expect.objectContaining( {
+					from: expect.objectContaining( { widgetId: 'site-map-page-1' } ),
+					to: expect.objectContaining( { widgetId: 'site-map-page-3' } ),
+				} ),
+				expect.objectContaining( {
+					from: expect.objectContaining( { widgetId: 'site-map-page-2' } ),
+					to: expect.objectContaining( { widgetId: 'site-map-page-4' } ),
+				} ),
+			] )
+		);
+	} );
+
+	it( 'returns an empty desk config when there are no pages', () => {
+		expect( createSiteMapDeskConfig( [], null ) ).toEqual( {
+			version: 1,
+			updatedAt: '1970-01-01T00:00:00.000Z',
+			widgets: [],
+		} );
+	} );
+
+	it( 'adds recent posts as a post collection widget', () => {
+		const desk = createSiteMapDeskConfig( [ { id: 1, parent: 0, title: { rendered: 'Home' } } ], {
+			show_on_front: 'page',
+		} );
+
+		const postCollection = desk.widgets.find( ( widget ) => widget.type === 'post-collection' );
+
+		expect( desk.widgets ).toHaveLength( 3 );
+		expect( postCollection ).toMatchObject( {
+			id: 'site-map-post-collection',
+			shapeProps: {
+				w: 280,
+				h: 380,
+			},
+			widgetProps: {
+				query: {
+					postType: 'post',
+					perPage: 5,
+					status: 'publish',
+					orderby: 'date',
+					order: 'desc',
+				},
+			},
+		} );
+		expect( postCollection?.x ).toBeGreaterThan(
+			desk.widgets.find( ( widget ) => widget.id === 'site-map-page-1' )?.x ?? 0
+		);
+	} );
+
+	it( 'adds a Blog widget as the posts collection parent for a posts homepage', () => {
+		const desk = createSiteMapDeskConfig( [ { id: 1, parent: 0, title: { rendered: 'About' } } ], {
+			show_on_front: 'posts',
+		} );
+
+		const blog = desk.widgets.find( ( widget ) => widget.id === 'site-map-blog' );
+		const page = desk.widgets.find( ( widget ) => widget.id === 'site-map-page-1' );
+		const postCollection = desk.widgets.find(
+			( widget ) => widget.id === 'site-map-post-collection'
+		);
+
+		expect( blog ).toMatchObject( {
+			type: 'blog',
+			y: 0,
+			widgetProps: {
+				title: 'Blog',
+			},
+		} );
+		expect( page?.y ).toBeGreaterThan( blog?.y ?? 0 );
+		expect( postCollection?.y ).toBe( blog?.y );
+		expect( desk.connectors ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					from: expect.objectContaining( { widgetId: 'site-map-blog' } ),
+					to: expect.objectContaining( { widgetId: 'site-map-page-1' } ),
+				} ),
+				expect.objectContaining( {
+					from: expect.objectContaining( { widgetId: 'site-map-blog' } ),
+					to: expect.objectContaining( { widgetId: 'site-map-post-collection' } ),
+				} ),
+			] )
+		);
+	} );
+
+	it( 'shows Blog and the posts collection even when a posts homepage has no pages', () => {
+		const desk = createSiteMapDeskConfig( [], { show_on_front: 'posts' } );
+
+		expect( desk.widgets.map( ( widget ) => widget.id ) ).toEqual( [
+			'site-map-blog',
+			'site-map-post-collection',
+		] );
+		expect( desk.connectors ).toHaveLength( 1 );
+		expect( desk.connectors?.[ 0 ] ).toMatchObject( {
+			from: { widgetId: 'site-map-blog' },
+			to: { widgetId: 'site-map-post-collection' },
+		} );
+	} );
+
+	it( 'includes hierarchy fields in the signature', () => {
+		const first = getSiteMapDeskConfigSignature(
+			[
+				{ id: 1, parent: 0, title: { rendered: 'Home' } },
+				{ id: 2, parent: 1, title: { rendered: 'About' } },
+			],
+			{ show_on_front: 'page' }
+		);
+		const second = getSiteMapDeskConfigSignature(
+			[
+				{ id: 1, parent: 0, title: { rendered: 'Home' } },
+				{ id: 2, parent: 0, title: { rendered: 'About' } },
+			],
+			{ show_on_front: 'page' }
+		);
+
+		expect( first ).not.toBe( second );
+	} );
+
+	it( 'includes front page settings in the signature', () => {
+		const pages = [ { id: 1, parent: 0, title: { rendered: 'Home' } } ];
+
+		expect( getSiteMapDeskConfigSignature( pages, { show_on_front: 'page' } ) ).not.toBe(
+			getSiteMapDeskConfigSignature( pages, { show_on_front: 'posts' } )
+		);
+	} );
+} );

--- a/apps/ui/src/ui-desks/site-map/desk-config.ts
+++ b/apps/ui/src/ui-desks/site-map/desk-config.ts
@@ -1,0 +1,514 @@
+import { getIndicesAbove } from 'tldraw';
+import { DESK_CONFIG_VERSION, type DeskConfig, type DeskConnector } from '@/ui-desks/desk/types';
+import { BLOG_WIDGET_TYPE, type BlogWidget } from '@/ui-desks/widgets/blog/types';
+import { PAGE_WIDGET_TYPE, type PageTone, type PageWidget } from '@/ui-desks/widgets/page/types';
+import {
+	POST_COLLECTION_WIDGET_TYPE,
+	type PostCollectionWidget,
+} from '@/ui-desks/widgets/post-collection/types';
+
+export interface SiteMapPage {
+	id: number;
+	parent?: number | null;
+	menu_order?: number;
+	slug?: string;
+	title?: {
+		rendered?: string;
+	};
+}
+
+export interface SiteMapSettings {
+	show_on_front?: string;
+	page_on_front?: number;
+	page_for_posts?: number;
+}
+
+type SiteMapLayoutNode = {
+	id: number;
+	kind: 'page' | 'blog';
+	parent: number;
+	menu_order: number;
+	slug?: string;
+	title?: {
+		rendered?: string;
+	};
+};
+
+const BLOG_NODE_ID = -1;
+const BLOG_WIDGET_ID = 'site-map-blog';
+const POST_COLLECTION_WIDGET_ID = 'site-map-post-collection';
+const PAGE_WIDTH = 280;
+const PAGE_HEIGHT = 380;
+const COLUMN_GAP = 96;
+const ROW_GAP = 136;
+const STATIC_UPDATED_AT = '1970-01-01T00:00:00.000Z';
+
+export const emptySiteMapDeskConfig: DeskConfig = {
+	version: DESK_CONFIG_VERSION,
+	updatedAt: STATIC_UPDATED_AT,
+	widgets: [],
+};
+
+export function createSiteMapDeskConfig(
+	pages: SiteMapPage[],
+	settings?: SiteMapSettings | null
+): DeskConfig {
+	const layoutNodes = createLayoutNodes( normalizePages( pages ), settings );
+	if ( layoutNodes.length === 0 ) {
+		return emptySiteMapDeskConfig;
+	}
+
+	const positions = layoutPages( layoutNodes );
+	const zIndices = getIndicesAbove( null, layoutNodes.length + 1 );
+	const widgets = layoutNodes
+		.map( ( node, index ) => createNodeWidget( node, positions, zIndices[ index ] ) )
+		.filter( ( widget ): widget is PageWidget | BlogWidget => widget !== null );
+
+	if ( widgets.length === 0 ) {
+		return emptySiteMapDeskConfig;
+	}
+
+	const postCollection = createPostCollectionWidget( positions, zIndices[ widgets.length ] );
+	const connectors = createConnectors( layoutNodes );
+
+	return {
+		version: DESK_CONFIG_VERSION,
+		updatedAt: STATIC_UPDATED_AT,
+		widgets: [ ...widgets, postCollection ],
+		...( connectors.length > 0 ? { connectors } : {} ),
+	};
+}
+
+export function getSiteMapDeskConfigSignature(
+	pages: SiteMapPage[] | null | undefined,
+	settings?: SiteMapSettings | null
+) {
+	const settingsSignature = [
+		settings?.show_on_front ?? '',
+		settings?.page_on_front ?? 0,
+		settings?.page_for_posts ?? 0,
+	].join( ':' );
+	const pagesSignature = normalizePages( pages ?? [] )
+		.map(
+			( page ) =>
+				`${ page.id }:${ page.parent ?? 0 }:${ page.menu_order ?? 0 }:${
+					page.slug ?? ''
+				}:${ getPageTitle( page ) }`
+		)
+		.join( '|' );
+
+	return `${ settingsSignature }|${ pagesSignature }`;
+}
+
+function createNodeWidget(
+	node: SiteMapLayoutNode,
+	positions: Map< number, { x: number; y: number } >,
+	zIndex: string
+): PageWidget | BlogWidget | null {
+	const position = positions.get( node.id );
+	if ( ! position ) {
+		return null;
+	}
+
+	if ( node.kind === 'blog' ) {
+		return createBlogWidget( node, position, zIndex );
+	}
+
+	return {
+		id: getNodeWidgetId( node ),
+		type: PAGE_WIDGET_TYPE,
+		x: position.x,
+		y: position.y,
+		zIndex,
+		shapeProps: {
+			w: PAGE_WIDTH,
+			h: PAGE_HEIGHT,
+		},
+		widgetProps: {
+			pageId: node.id,
+			tone: getPageTone( node ),
+		},
+	};
+}
+
+function createBlogWidget(
+	node: SiteMapLayoutNode,
+	position: { x: number; y: number },
+	zIndex: string
+): BlogWidget {
+	return {
+		id: BLOG_WIDGET_ID,
+		type: BLOG_WIDGET_TYPE,
+		x: position.x,
+		y: position.y,
+		zIndex,
+		shapeProps: {
+			w: PAGE_WIDTH,
+			h: PAGE_HEIGHT,
+		},
+		widgetProps: {
+			title: 'Blog',
+			...( node.slug ? { slug: node.slug } : {} ),
+		},
+	};
+}
+
+function createPostCollectionWidget(
+	positions: Map< number, { x: number; y: number } >,
+	zIndex: string
+): PostCollectionWidget {
+	const origin = getPostCollectionOrigin( positions );
+
+	return {
+		id: POST_COLLECTION_WIDGET_ID,
+		type: POST_COLLECTION_WIDGET_TYPE,
+		x: origin.x,
+		y: origin.y,
+		zIndex,
+		shapeProps: {
+			w: PAGE_WIDTH,
+			h: PAGE_HEIGHT,
+		},
+		widgetProps: {
+			query: {
+				postType: 'post',
+				perPage: 5,
+				status: 'publish',
+				orderby: 'date',
+				order: 'desc',
+			},
+		},
+	};
+}
+
+function createLayoutNodes( pages: SiteMapPage[], settings?: SiteMapSettings | null ) {
+	const blogNode = createBlogNode( pages, settings );
+	const droppedPostsPageId =
+		blogNode && settings?.show_on_front === 'page' ? getExistingPostsPageId( pages, settings ) : 0;
+	const homeNodeId = getHomeNodeId( pages, settings );
+	const nodes: SiteMapLayoutNode[] = [];
+
+	if ( blogNode ) {
+		nodes.push( blogNode );
+	}
+
+	for ( const page of pages ) {
+		if ( page.id === droppedPostsPageId ) {
+			continue;
+		}
+
+		nodes.push( {
+			id: page.id,
+			kind: 'page',
+			parent: getLayoutPageParent( page, droppedPostsPageId, homeNodeId ),
+			menu_order: page.menu_order ?? 0,
+			slug: page.slug,
+			title: page.title,
+		} );
+	}
+
+	return repairMissingParents( nodes ).sort( compareNodes );
+}
+
+function createBlogNode(
+	pages: SiteMapPage[],
+	settings?: SiteMapSettings | null
+): SiteMapLayoutNode | null {
+	if ( ! settings?.show_on_front ) {
+		return null;
+	}
+
+	if ( isPostsHome( settings ) ) {
+		return {
+			id: BLOG_NODE_ID,
+			kind: 'blog',
+			parent: 0,
+			menu_order: -1,
+			title: { rendered: 'Blog' },
+		};
+	}
+
+	const postsPageId = getExistingPostsPageId( pages, settings );
+	const postsPage = postsPageId ? pages.find( ( page ) => page.id === postsPageId ) : undefined;
+	if ( postsPage ) {
+		return {
+			id: BLOG_NODE_ID,
+			kind: 'blog',
+			parent: getBlogParentId( pages, settings, postsPage ),
+			menu_order: postsPage.menu_order ?? 0,
+			slug: postsPage.slug,
+			title: { rendered: 'Blog' },
+		};
+	}
+
+	return {
+		id: BLOG_NODE_ID,
+		kind: 'blog',
+		parent: getStaticFrontPageId( pages, settings ) ?? 0,
+		menu_order: Number.MAX_SAFE_INTEGER,
+		slug: 'blog',
+		title: { rendered: 'Blog' },
+	};
+}
+
+function getLayoutPageParent(
+	page: SiteMapPage,
+	droppedPostsPageId: number,
+	homeNodeId: number | null
+) {
+	const parentId = page.parent ?? 0;
+	if ( page.id === homeNodeId ) {
+		return 0;
+	}
+
+	if ( droppedPostsPageId !== 0 && parentId === droppedPostsPageId ) {
+		return BLOG_NODE_ID;
+	}
+
+	return parentId === 0 && homeNodeId !== null ? homeNodeId : parentId;
+}
+
+function getHomeNodeId( pages: SiteMapPage[], settings?: SiteMapSettings | null ) {
+	if ( isPostsHome( settings ) ) {
+		return BLOG_NODE_ID;
+	}
+
+	if ( settings?.show_on_front === 'page' ) {
+		return getStaticFrontPageId( pages, settings );
+	}
+
+	return null;
+}
+
+function getExistingPostsPageId( pages: SiteMapPage[], settings: SiteMapSettings ) {
+	const postsPageId = getPositiveId( settings.page_for_posts );
+	return postsPageId && pages.some( ( page ) => page.id === postsPageId ) ? postsPageId : 0;
+}
+
+function getBlogParentId(
+	pages: SiteMapPage[],
+	settings: SiteMapSettings,
+	postsPage: SiteMapPage
+) {
+	const staticFrontPageId = getStaticFrontPageId( pages, settings );
+	const parentId = postsPage.parent ?? 0;
+	return parentId === 0 && staticFrontPageId ? staticFrontPageId : parentId;
+}
+
+function getStaticFrontPageId( pages: SiteMapPage[], settings: SiteMapSettings ) {
+	const staticFrontPageId = getPositiveId( settings.page_on_front );
+	return staticFrontPageId && pages.some( ( page ) => page.id === staticFrontPageId )
+		? staticFrontPageId
+		: null;
+}
+
+function repairMissingParents( nodes: SiteMapLayoutNode[] ) {
+	const nodeIds = new Set( nodes.map( ( node ) => node.id ) );
+	return nodes.map( ( node ) =>
+		node.parent !== 0 && ! nodeIds.has( node.parent ) ? { ...node, parent: 0 } : node
+	);
+}
+
+function createConnectors( nodes: SiteMapLayoutNode[] ): DeskConnector[] {
+	const widgetIdsByNodeId = new Map(
+		nodes.map( ( node ) => [ node.id, getNodeWidgetId( node ) ] )
+	);
+	const connectors = nodes.flatMap( ( node ): DeskConnector[] => {
+		if ( node.parent === 0 ) {
+			return [];
+		}
+
+		const parentWidgetId = widgetIdsByNodeId.get( node.parent );
+		const childWidgetId = widgetIdsByNodeId.get( node.id );
+		if ( ! parentWidgetId || ! childWidgetId ) {
+			return [];
+		}
+
+		return [
+			{
+				id: `${ parentWidgetId }-to-${ childWidgetId }`,
+				from: {
+					widgetId: parentWidgetId,
+					normalizedAnchor: { x: 0.5, y: 1 },
+				},
+				to: {
+					widgetId: childWidgetId,
+					normalizedAnchor: { x: 0.5, y: 0 },
+				},
+				bend: 24,
+			},
+		];
+	} );
+
+	if ( widgetIdsByNodeId.has( BLOG_NODE_ID ) ) {
+		connectors.push( {
+			id: `${ BLOG_WIDGET_ID }-to-${ POST_COLLECTION_WIDGET_ID }`,
+			from: {
+				widgetId: BLOG_WIDGET_ID,
+				normalizedAnchor: { x: 1, y: 0.5 },
+			},
+			to: {
+				widgetId: POST_COLLECTION_WIDGET_ID,
+				normalizedAnchor: { x: 0, y: 0.5 },
+			},
+			bend: 24,
+		} );
+	}
+
+	return connectors;
+}
+
+function normalizePages( pages: SiteMapPage[] ) {
+	const pagesById = new Map< number, SiteMapPage >();
+
+	for ( const page of pages ) {
+		if ( Number.isInteger( page.id ) && page.id > 0 ) {
+			pagesById.set( page.id, page );
+		}
+	}
+
+	const knownIds = new Set( pagesById.keys() );
+	return Array.from( pagesById.values() )
+		.map( ( page ) => ( {
+			...page,
+			parent: normalizeParentId( page, knownIds ),
+			menu_order: page.menu_order ?? 0,
+		} ) )
+		.sort( comparePages );
+}
+
+function normalizeParentId( page: SiteMapPage, knownIds: Set< number > ) {
+	const parentId = page.parent ?? 0;
+	if ( parentId === page.id || parentId <= 0 || ! knownIds.has( parentId ) ) {
+		return 0;
+	}
+
+	return parentId;
+}
+
+function layoutPages( nodes: SiteMapLayoutNode[] ) {
+	const childrenByParent = new Map< number, SiteMapLayoutNode[] >();
+	const positions = new Map< number, { x: number; y: number } >();
+	const placedIds = new Set< number >();
+
+	for ( const node of nodes ) {
+		childrenByParent.set( node.parent, [ ...( childrenByParent.get( node.parent ) ?? [] ), node ] );
+	}
+	for ( const children of childrenByParent.values() ) {
+		children.sort( compareNodes );
+	}
+
+	let cursor = 0;
+	for ( const root of childrenByParent.get( 0 ) ?? [] ) {
+		cursor += placePage( root, 0, cursor, new Set() ) + COLUMN_GAP;
+	}
+
+	for ( const node of nodes ) {
+		if ( ! placedIds.has( node.id ) ) {
+			cursor += placePage( node, 0, cursor, new Set() ) + COLUMN_GAP;
+		}
+	}
+
+	return positions;
+
+	function placePage( node: SiteMapLayoutNode, depth: number, leftX: number, path: Set< number > ) {
+		if ( placedIds.has( node.id ) || path.has( node.id ) ) {
+			return 0;
+		}
+
+		const nextPath = new Set( path );
+		nextPath.add( node.id );
+		const children = getSafeChildren( node.id, nextPath );
+		const widthInLeaves = Math.max( 1, getLeafCount( node.id, path ) );
+		const width = widthInLeaves * ( PAGE_WIDTH + COLUMN_GAP ) - COLUMN_GAP;
+
+		positions.set( node.id, {
+			x: leftX + width / 2 - PAGE_WIDTH / 2,
+			y: depth * ( PAGE_HEIGHT + ROW_GAP ),
+		} );
+		placedIds.add( node.id );
+
+		let childCursor = leftX;
+		for ( const child of children ) {
+			const childWidth = placePage( child, depth + 1, childCursor, nextPath );
+			childCursor += childWidth + COLUMN_GAP;
+		}
+
+		return width;
+	}
+
+	function getLeafCount( nodeId: number, path: Set< number > ): number {
+		if ( path.has( nodeId ) ) {
+			return 1;
+		}
+
+		const nextPath = new Set( path );
+		nextPath.add( nodeId );
+		const children = getSafeChildren( nodeId, nextPath );
+		if ( children.length === 0 ) {
+			return 1;
+		}
+
+		return children.reduce( ( count, child ) => count + getLeafCount( child.id, nextPath ), 0 );
+	}
+
+	function getSafeChildren( parentId: number, path: Set< number > ) {
+		return ( childrenByParent.get( parentId ) ?? [] ).filter(
+			( child ) => ! path.has( child.id ) && ! placedIds.has( child.id )
+		);
+	}
+}
+
+function getPageTone( node: SiteMapLayoutNode ): PageTone {
+	return node.parent === 0 ? 'sky' : 'neutral';
+}
+
+function getPostCollectionOrigin( positions: Map< number, { x: number; y: number } > ) {
+	const pagePositions = Array.from( positions.values() );
+	const rightEdge = Math.max( ...pagePositions.map( ( position ) => position.x ) ) + PAGE_WIDTH;
+	const blogPosition = positions.get( BLOG_NODE_ID );
+
+	return {
+		x: Math.max(
+			( blogPosition?.x ?? 0 ) + PAGE_WIDTH + COLUMN_GAP * 2,
+			rightEdge + COLUMN_GAP * 2
+		),
+		y: blogPosition?.y ?? Math.min( ...pagePositions.map( ( position ) => position.y ) ),
+	};
+}
+
+function getNodeWidgetId( node: SiteMapLayoutNode ) {
+	return node.kind === 'blog' ? BLOG_WIDGET_ID : `site-map-page-${ node.id }`;
+}
+
+function isPostsHome( settings?: SiteMapSettings | null ) {
+	return settings?.show_on_front === 'posts';
+}
+
+function getPositiveId( value: number | undefined ) {
+	return typeof value === 'number' && Number.isInteger( value ) && value > 0 ? value : 0;
+}
+
+function compareNodes( first: SiteMapLayoutNode, second: SiteMapLayoutNode ) {
+	return (
+		( first.menu_order ?? 0 ) - ( second.menu_order ?? 0 ) ||
+		getNodeTitle( first ).localeCompare( getNodeTitle( second ) ) ||
+		first.id - second.id
+	);
+}
+
+function comparePages( first: SiteMapPage, second: SiteMapPage ) {
+	return (
+		( first.menu_order ?? 0 ) - ( second.menu_order ?? 0 ) ||
+		getPageTitle( first ).localeCompare( getPageTitle( second ) ) ||
+		first.id - second.id
+	);
+}
+
+function getNodeTitle( node: SiteMapLayoutNode ) {
+	return node.title?.rendered ?? '';
+}
+
+function getPageTitle( page: SiteMapPage ) {
+	return page.title?.rendered ?? '';
+}

--- a/apps/ui/src/ui-desks/site-map/use-site-map-desk-config.test.tsx
+++ b/apps/ui/src/ui-desks/site-map/use-site-map-desk-config.test.tsx
@@ -1,0 +1,175 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BLOG_WIDGET_TYPE } from '@/ui-desks/widgets/blog/types';
+import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
+import { POST_COLLECTION_WIDGET_TYPE } from '@/ui-desks/widgets/post-collection/types';
+import { useSiteMapDeskConfig } from './use-site-map-desk-config';
+import type { SiteMapPage, SiteMapSettings } from './desk-config';
+
+type SiteFixture = {
+	id: string;
+	running: boolean;
+};
+
+type CoreDataResolutionStatus = 'IDLE' | 'RESOLVING' | 'SUCCESS' | 'ERROR';
+type CoreDataResolutionStateStatus = 'resolving' | 'finished' | 'error' | undefined;
+
+const mockState = vi.hoisted( () => ( {
+	sites: [] as SiteFixture[] | undefined,
+	isLoadingSites: false,
+	pages: [] as SiteMapPage[] | null,
+	isResolvingPages: false,
+	pagesStatus: 'SUCCESS' as CoreDataResolutionStatus,
+	rootIndexSettings: undefined as SiteMapSettings | undefined,
+	rootIndexResolutionStatus: 'finished' as CoreDataResolutionStateStatus,
+	entityRecordsArgs: undefined as unknown[] | undefined,
+	entityRecordsOptions: undefined as unknown,
+	entityRecordArgs: undefined as unknown[] | undefined,
+	resolutionStateArgs: undefined as unknown[] | undefined,
+} ) );
+
+vi.mock( '@wordpress/core-data', () => ( {
+	store: {},
+	useEntityRecords: ( ...args: unknown[] ) => {
+		mockState.entityRecordsArgs = args;
+		mockState.entityRecordsOptions = args[ 3 ];
+
+		return {
+			records: mockState.pages,
+			isResolving: mockState.isResolvingPages,
+			status: mockState.pagesStatus,
+		};
+	},
+} ) );
+
+vi.mock( '@wordpress/data', () => ( {
+	useSelect: ( mapSelect: ( select: ( store: unknown ) => unknown ) => unknown ) =>
+		mapSelect( () => ( {
+			getEntityRecord: ( ...args: unknown[] ) => {
+				mockState.entityRecordArgs = args;
+				return mockState.rootIndexSettings;
+			},
+			getResolutionState: ( ...args: unknown[] ) => {
+				mockState.resolutionStateArgs = args;
+
+				return mockState.rootIndexResolutionStatus
+					? { status: mockState.rootIndexResolutionStatus }
+					: undefined;
+			},
+		} ) ),
+} ) );
+
+vi.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+vi.mock( '@/data/queries/use-sites', () => ( {
+	useSites: () => ( {
+		data: mockState.sites,
+		isLoading: mockState.isLoadingSites,
+	} ),
+} ) );
+
+describe( 'useSiteMapDeskConfig', () => {
+	beforeEach( () => {
+		mockState.sites = [ { id: 'site-1', running: true } ];
+		mockState.isLoadingSites = false;
+		mockState.pages = [];
+		mockState.isResolvingPages = false;
+		mockState.pagesStatus = 'SUCCESS';
+		mockState.rootIndexSettings = undefined;
+		mockState.rootIndexResolutionStatus = 'finished';
+		mockState.entityRecordsArgs = undefined;
+		mockState.entityRecordsOptions = undefined;
+		mockState.entityRecordArgs = undefined;
+		mockState.resolutionStateArgs = undefined;
+	} );
+
+	it( 'loads front page settings from the root index core-data entity', () => {
+		mockState.rootIndexSettings = { show_on_front: 'page', page_on_front: 1 };
+		mockState.pages = [
+			{ id: 1, parent: 0, menu_order: 0, title: { rendered: 'Home' }, slug: 'home' },
+			{ id: 2, parent: 0, menu_order: 1, title: { rendered: 'About' }, slug: 'about' },
+		];
+
+		const { result } = renderHook( () => useSiteMapDeskConfig( 'site-1', true ) );
+
+		expect( mockState.entityRecordsArgs?.slice( 0, 3 ) ).toEqual( [
+			'postType',
+			'page',
+			expect.objectContaining( {
+				per_page: 100,
+				orderby: 'menu_order',
+				_fields: 'id,parent,menu_order,title,slug,status',
+			} ),
+		] );
+		expect( mockState.entityRecordsOptions ).toEqual( { enabled: true } );
+		expect( mockState.entityRecordArgs ).toEqual( [ 'root', '__unstableBase' ] );
+		expect( mockState.resolutionStateArgs ).toEqual( [
+			'getEntityRecord',
+			[ 'root', '__unstableBase' ],
+		] );
+		expect( result.current.message ).toBeUndefined();
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.pageCount ).toBe( 3 );
+		expect( result.current.config.connectors ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					from: expect.objectContaining( { widgetId: 'site-map-page-1' } ),
+					to: expect.objectContaining( { widgetId: 'site-map-page-2' } ),
+				} ),
+			] )
+		);
+	} );
+
+	it( 'builds a Blog widget from latest-posts front page settings without page records', () => {
+		mockState.rootIndexSettings = { show_on_front: 'posts' };
+		mockState.pages = [];
+
+		const { result } = renderHook( () => useSiteMapDeskConfig( 'site-1', true ) );
+
+		expect( result.current.message ).toBeUndefined();
+		expect( result.current.pageCount ).toBe( 1 );
+		expect( result.current.config.widgets.map( ( widget ) => widget.type ) ).toEqual( [
+			BLOG_WIDGET_TYPE,
+			POST_COLLECTION_WIDGET_TYPE,
+		] );
+		expect( result.current.config.connectors ).toEqual( [
+			expect.objectContaining( {
+				from: expect.objectContaining( { widgetId: 'site-map-blog' } ),
+				to: expect.objectContaining( { widgetId: 'site-map-post-collection' } ),
+			} ),
+		] );
+	} );
+
+	it( 'keeps core-data queries disabled until the selected site is running', () => {
+		mockState.sites = [ { id: 'site-1', running: false } ];
+		mockState.rootIndexResolutionStatus = undefined;
+		mockState.pages = null;
+
+		const { result } = renderHook( () => useSiteMapDeskConfig( 'site-1', true ) );
+
+		expect( mockState.entityRecordsOptions ).toEqual( { enabled: false } );
+		expect( mockState.entityRecordArgs ).toBeUndefined();
+		expect( mockState.resolutionStateArgs ).toBeUndefined();
+		expect( result.current.config.widgets ).toEqual( [] );
+		expect( result.current.message ).toBe( 'Start the site to view its site map.' );
+	} );
+
+	it( 'reports loading while the root index settings request is resolving', () => {
+		mockState.pages = [
+			{ id: 1, parent: 0, menu_order: 0, title: { rendered: 'Home' }, slug: 'home' },
+		];
+		mockState.rootIndexSettings = undefined;
+		mockState.rootIndexResolutionStatus = 'resolving';
+
+		const { result } = renderHook( () => useSiteMapDeskConfig( 'site-1', true ) );
+
+		expect( result.current.isLoading ).toBe( true );
+		expect( result.current.message ).toBeUndefined();
+		expect( result.current.pageCount ).toBe( 1 );
+		expect(
+			result.current.config.widgets.some( ( widget ) => widget.type === PAGE_WIDGET_TYPE )
+		).toBe( true );
+	} );
+} );

--- a/apps/ui/src/ui-desks/site-map/use-site-map-desk-config.ts
+++ b/apps/ui/src/ui-desks/site-map/use-site-map-desk-config.ts
@@ -1,0 +1,197 @@
+import {
+	store as coreDataStore,
+	useEntityRecords,
+	type Post as CoreDataPost,
+} from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
+import { useSites } from '@/data/queries/use-sites';
+import { BLOG_WIDGET_TYPE } from '@/ui-desks/widgets/blog/types';
+import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
+import {
+	createSiteMapDeskConfig,
+	emptySiteMapDeskConfig,
+	getSiteMapDeskConfigSignature,
+	type SiteMapPage,
+	type SiteMapSettings,
+} from './desk-config';
+
+type CoreDataPage = CoreDataPost & {
+	parent?: number;
+	menu_order?: number;
+	slug?: string;
+};
+
+type CoreDataBase = SiteMapSettings;
+type CoreDataResolutionStatus = 'IDLE' | 'RESOLVING' | 'SUCCESS' | 'ERROR';
+type CoreDataResolutionState =
+	| {
+			status: 'resolving' | 'finished';
+	  }
+	| {
+			status: 'error';
+			error: Error | unknown;
+	  };
+
+const SITE_MAP_PAGE_QUERY = {
+	per_page: 100,
+	context: 'view',
+	orderby: 'menu_order',
+	order: 'asc',
+	_fields: 'id,parent,menu_order,title,slug,status',
+} as const;
+const ROOT_INDEX_ENTITY_ARGS: [ string, string ] = [ 'root', '__unstableBase' ];
+
+export function useSiteMapDeskConfig( siteId: string | undefined, enabled: boolean ) {
+	const { data: sites, isLoading: isLoadingSites } = useSites();
+	const site = sites?.find( ( candidate ) => candidate.id === siteId );
+	const canQueryPages = Boolean( enabled && site?.running );
+	const {
+		records,
+		isResolving,
+		status: resolutionStatus,
+	} = useEntityRecords< CoreDataPage >( 'postType', 'page', SITE_MAP_PAGE_QUERY, {
+		enabled: canQueryPages,
+	} );
+	const { settings, isResolvingSettings, settingsStatus } = useRootIndexSettings( canQueryPages );
+	const pages = useMemo( () => ( records ?? [] ).map( recordToSiteMapPage ), [ records ] );
+	const signature = useMemo(
+		() => getSiteMapDeskConfigSignature( pages, settings ),
+		[ pages, settings ]
+	);
+	const config = useMemo( () => createSiteMapDeskConfig( pages, settings ), [ pages, settings ] );
+	const pageCount = useMemo( () => getVisiblePageCount( config ), [ config ] );
+	const isLoading = Boolean(
+		enabled &&
+			( isLoadingSites ||
+				( canQueryPages &&
+					( ( isResolving && ! records ) || ( isResolvingSettings && ! settings ) ) ) )
+	);
+	const message = getSiteMapMessage( {
+		enabled,
+		hasContent: config.widgets.length > 0,
+		hasSite: Boolean( site ),
+		isLoading,
+		pageCount: pages.length,
+		resolutionStatus,
+		settingsStatus,
+		siteIsRunning: Boolean( site?.running ),
+	} );
+
+	return {
+		config: enabled ? config : emptySiteMapDeskConfig,
+		isLoading,
+		message,
+		pageCount,
+		signature,
+	};
+}
+
+function getVisiblePageCount( config: ReturnType< typeof createSiteMapDeskConfig > ) {
+	return config.widgets.filter(
+		( widget ) => widget.type === PAGE_WIDGET_TYPE || widget.type === BLOG_WIDGET_TYPE
+	).length;
+}
+
+function useRootIndexSettings( enabled: boolean ) {
+	return useSelect(
+		( select ) => {
+			if ( ! enabled ) {
+				return {
+					settings: undefined,
+					isResolvingSettings: false,
+					settingsStatus: 'IDLE' as CoreDataResolutionStatus,
+				};
+			}
+
+			const coreData = select( coreDataStore );
+			const settings = coreData.getEntityRecord( ...ROOT_INDEX_ENTITY_ARGS ) as
+				| CoreDataBase
+				| undefined;
+			const resolutionState = coreData.getResolutionState(
+				'getEntityRecord',
+				ROOT_INDEX_ENTITY_ARGS
+			) as CoreDataResolutionState | undefined;
+			const settingsStatus = getCoreDataResolutionStatus( resolutionState?.status );
+
+			return {
+				settings,
+				isResolvingSettings:
+					! settings && ( settingsStatus === 'IDLE' || settingsStatus === 'RESOLVING' ),
+				settingsStatus,
+			};
+		},
+		[ enabled ]
+	);
+}
+
+function getCoreDataResolutionStatus(
+	status: CoreDataResolutionState[ 'status' ] | undefined
+): CoreDataResolutionStatus {
+	if ( status === 'resolving' ) {
+		return 'RESOLVING';
+	}
+
+	if ( status === 'finished' ) {
+		return 'SUCCESS';
+	}
+
+	if ( status === 'error' ) {
+		return 'ERROR';
+	}
+
+	return 'IDLE';
+}
+
+function recordToSiteMapPage( record: CoreDataPage ): SiteMapPage {
+	return {
+		id: record.id,
+		parent: record.parent ?? 0,
+		menu_order: record.menu_order ?? 0,
+		slug: record.slug,
+		title: record.title,
+	};
+}
+
+function getSiteMapMessage( {
+	enabled,
+	hasContent,
+	hasSite,
+	isLoading,
+	pageCount,
+	resolutionStatus,
+	settingsStatus,
+	siteIsRunning,
+}: {
+	enabled: boolean;
+	hasContent: boolean;
+	hasSite: boolean;
+	isLoading: boolean;
+	pageCount: number;
+	resolutionStatus: string;
+	settingsStatus: string;
+	siteIsRunning: boolean;
+} ) {
+	if ( ! enabled || isLoading ) {
+		return undefined;
+	}
+
+	if ( ! hasSite ) {
+		return __( 'Site not found.' );
+	}
+
+	if ( ! siteIsRunning ) {
+		return __( 'Start the site to view its site map.' );
+	}
+
+	if ( resolutionStatus === 'ERROR' || settingsStatus === 'ERROR' ) {
+		return __( 'Unable to load site map.' );
+	}
+
+	if ( pageCount === 0 && ! hasContent ) {
+		return __( 'No pages found.' );
+	}
+
+	return undefined;
+}

--- a/apps/ui/src/ui-desks/stacks/use-stack-shape-interaction.ts
+++ b/apps/ui/src/ui-desks/stacks/use-stack-shape-interaction.ts
@@ -1,10 +1,14 @@
+import { useRef } from 'react';
 import { useEditor, useValue, type TLShape } from 'tldraw';
 import { useDesk } from '@/ui-desks/desk/provider/context';
+import { expandStackInEditor } from './editor-commands';
 import { getStackId, getStackOrder, isStackExpanded } from './utils';
+import type { PointerEvent } from 'react';
 
 export function useStackShapeInteraction( shape: TLShape ) {
 	const editor = useEditor();
-	const { pressedStackId, pressStack } = useDesk();
+	const { isReadOnly, pressedStackId, pressStack } = useDesk();
+	const pointerDownPointRef = useRef< { x: number; y: number } | null >( null );
 	const stackId = getStackId( shape );
 	const isExpanded = isStackExpanded( shape );
 	const hoveredStackId = useValue(
@@ -36,10 +40,47 @@ export function useStackShapeInteraction( shape: TLShape ) {
 			transformOrigin: 'center',
 			transition: 'transform 220ms ease',
 		},
-		onPointerDown: () => {
+		onPointerDown: ( event: PointerEvent ) => {
 			if ( stackId && ! isExpanded ) {
 				pressStack( stackId );
+				if ( isReadOnly ) {
+					pointerDownPointRef.current = {
+						x: event.clientX,
+						y: event.clientY,
+					};
+					event.preventDefault();
+					event.stopPropagation();
+				}
+			}
+		},
+		onPointerUp: ( event: PointerEvent ) => {
+			if ( ! isReadOnly || ! stackId || isExpanded ) {
+				pointerDownPointRef.current = null;
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			if ( didPointerMove( pointerDownPointRef.current, event ) ) {
+				pointerDownPointRef.current = null;
+				return;
+			}
+
+			pointerDownPointRef.current = null;
+			if ( expandStackInEditor( editor, stackId ) ) {
+				editor.setSelectedShapes( [] );
 			}
 		},
 	};
+}
+
+function didPointerMove( origin: { x: number; y: number } | null, event: PointerEvent ) {
+	if ( ! origin ) {
+		return true;
+	}
+
+	const deltaX = event.clientX - origin.x;
+	const deltaY = event.clientY - origin.y;
+	return Math.hypot( deltaX, deltaY ) > 6;
 }

--- a/apps/ui/src/ui-desks/stacks/utils.ts
+++ b/apps/ui/src/ui-desks/stacks/utils.ts
@@ -1,5 +1,5 @@
+import { getIndicesAbove, getIndicesBelow, type TLShape, type TLShapePartial } from 'tldraw';
 import type { DeskStack } from '@/ui-desks/desk/types';
-import type { TLShape, TLShapePartial } from 'tldraw';
 
 export const STACK_TRANSLATE_X = 10;
 export const STACK_TRANSLATE_Y = 8;
@@ -92,7 +92,14 @@ export function getStackAnchorFromMember( shape: Pick< TLShape, 'x' | 'y' >, ord
 export function getStackMemberZIndex( zIndex: string, order: number ) {
 	const numericIndex = parseDeskZIndex( zIndex );
 	if ( numericIndex === null ) {
-		return zIndex as TLShapePartial[ 'index' ];
+		if ( order === 0 ) {
+			return zIndex as TLShapePartial[ 'index' ];
+		}
+
+		return (
+			getIndicesBelow( zIndex as TLShapePartial[ 'index' ], order ).at( 0 ) ??
+			( zIndex as TLShapePartial[ 'index' ] )
+		);
 	}
 
 	return formatDeskZIndex( numericIndex - order * STACK_Z_INDEX_STEP ) as TLShapePartial[ 'index' ];
@@ -101,7 +108,11 @@ export function getStackMemberZIndex( zIndex: string, order: number ) {
 export function getStackZIndexFromMember( zIndex: string, order: number ) {
 	const numericIndex = parseDeskZIndex( zIndex );
 	if ( numericIndex === null ) {
-		return zIndex;
+		if ( order === 0 ) {
+			return zIndex;
+		}
+
+		return getIndicesAbove( zIndex as TLShapePartial[ 'index' ], order ).at( -1 ) ?? zIndex;
 	}
 
 	return formatDeskZIndex( numericIndex + order * STACK_Z_INDEX_STEP );

--- a/apps/ui/src/ui-desks/widgets/blog/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/blog/component.tsx
@@ -1,0 +1,31 @@
+import styles from '@/ui-desks/widgets/page/style.module.css';
+import type { BlogWidgetProps } from './types';
+import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
+
+type BlogWidgetComponentProps = DeskWidgetComponentProps< BlogWidgetProps >;
+
+export function BlogWidgetComponent( { id, widgetProps }: BlogWidgetComponentProps ) {
+	const slug = formatSlug( widgetProps.slug );
+
+	return (
+		<article
+			className={ styles.page }
+			data-tone="violet"
+			data-is-loading="false"
+			data-studio-desk-widget="blog"
+			data-studio-desk-widget-id={ id }
+		>
+			<h2 className={ styles.title }>{ widgetProps.title }</h2>
+			{ slug && <div className={ styles.slug }>{ slug }</div> }
+		</article>
+	);
+}
+
+function formatSlug( slug: string | undefined ) {
+	if ( ! slug ) {
+		return '';
+	}
+
+	const trimmedSlug = slug.replace( /^\/+|\/+$/g, '' );
+	return trimmedSlug ? `/${ trimmedSlug }` : '/';
+}

--- a/apps/ui/src/ui-desks/widgets/blog/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/blog/definition.ts
@@ -1,0 +1,32 @@
+import { __ } from '@wordpress/i18n';
+import { page } from '@wordpress/icons';
+import { BlogWidgetComponent } from '@/ui-desks/widgets/blog/component';
+import { BLOG_WIDGET_TYPE, isBlogWidgetProps, type BlogWidget } from './types';
+import type { WidgetDefinition } from '@/ui-desks/widgets/types';
+
+const BLOG_COLOR = '#8703e7';
+
+export const blogWidgetDefinition = {
+	type: BLOG_WIDGET_TYPE,
+	Component: BlogWidgetComponent,
+	isCreatable: false,
+	requiresRunningSite: true,
+	isWidgetProps: isBlogWidgetProps,
+	getIndicator: () => ( {
+		cornerRadius: 18,
+		stroke: `color-mix(in srgb, ${ BLOG_COLOR } 50%, white)`,
+	} ),
+	labels: {
+		add: () => __( 'Blog' ),
+	},
+	icon: page,
+	getInitialWidget: () => ( {
+		shapeProps: {
+			w: 280,
+			h: 380,
+		},
+		widgetProps: {
+			title: __( 'Blog' ),
+		},
+	} ),
+} satisfies WidgetDefinition< BlogWidget >;

--- a/apps/ui/src/ui-desks/widgets/blog/types.ts
+++ b/apps/ui/src/ui-desks/widgets/blog/types.ts
@@ -1,0 +1,25 @@
+import type { RectangleWidgetShapeProps } from '@/ui-desks/widgets/geometry';
+import type { DeskWidgetBase } from '@studio/common/types/desk';
+
+export const BLOG_WIDGET_TYPE = 'blog';
+
+export type BlogWidgetProps = {
+	title: string;
+	slug?: string;
+};
+
+export type BlogWidget = DeskWidgetBase<
+	typeof BLOG_WIDGET_TYPE,
+	RectangleWidgetShapeProps,
+	BlogWidgetProps
+>;
+
+export function isBlogWidgetProps( value: unknown ): value is BlogWidgetProps {
+	const candidate = value as Partial< BlogWidgetProps >;
+	return (
+		Boolean( value ) &&
+		typeof value === 'object' &&
+		typeof candidate.title === 'string' &&
+		( candidate.slug === undefined || typeof candidate.slug === 'string' )
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/post-collection/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/post-collection/definition.ts
@@ -1,6 +1,7 @@
 import { store as coreDataStore, type Post as CoreDataPost } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { post } from '@wordpress/icons';
+import { getIndicesAbove, type TLShapePartial } from 'tldraw';
 import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
 import { POST_WIDGET_TYPE, type PostWidget } from '@/ui-desks/widgets/post/types';
 import {
@@ -98,6 +99,7 @@ export const postCollectionWidgetDefinition = {
 			const posts =
 				( await getCoreDataResolvers( context ).getEntityRecords( 'postType', 'post', query ) ) ??
 				[];
+			const zIndices = getDerivedZIndices( widget.zIndex, posts.length + 1 );
 
 			return {
 				identity: {
@@ -105,9 +107,12 @@ export const postCollectionWidgetDefinition = {
 					posts,
 				},
 				widgets: posts.map( ( postRecord, index ) =>
-					createDerivedPostWidget( widget, postRecord.id, index )
+					createDerivedPostWidget( widget, postRecord.id, zIndices[ index ] )
 				),
-				stacks: posts.length > 0 ? [ createDerivedPostStack( widget, posts ) ] : [],
+				stacks:
+					posts.length > 0
+						? [ createDerivedPostStack( widget, posts, zIndices[ posts.length ] ) ]
+						: [],
 			};
 		},
 		invalidate: ( widget, previousIdentity, context ) => {
@@ -146,7 +151,7 @@ function getEntityRecordsQuery( query: PostCollectionQuery ): EntityRecordsQuery
 function createDerivedPostWidget(
 	collection: PostCollectionWidget,
 	postId: number,
-	index: number
+	zIndex: string
 ): ResolvedDeskWidget< PostWidget > {
 	return {
 		origin: {
@@ -159,7 +164,7 @@ function createDerivedPostWidget(
 			type: POST_WIDGET_TYPE,
 			x: collection.x,
 			y: collection.y,
-			zIndex: getDerivedZIndex( collection.zIndex, index ),
+			zIndex,
 			shapeProps: POST_CARD_SHAPE_PROPS,
 			widgetProps: {
 				postId,
@@ -170,7 +175,8 @@ function createDerivedPostWidget(
 
 function createDerivedPostStack(
 	collection: PostCollectionWidget,
-	posts: CoreDataPost[]
+	posts: CoreDataPost[],
+	zIndex: string
 ): ResolvedDeskStack {
 	return {
 		origin: {
@@ -182,13 +188,12 @@ function createDerivedPostStack(
 			id: `post-collection:${ collection.id }`,
 			x: collection.x,
 			y: collection.y,
-			zIndex: getDerivedZIndex( collection.zIndex, posts.length ),
+			zIndex,
 			memberIds: posts.map( ( postRecord ) => `${ collection.id }:post:${ postRecord.id }` ),
 		},
 	};
 }
 
-function getDerivedZIndex( zIndex: string, index: number ) {
-	const numericIndex = Number( zIndex.replace( /^a/, '' ) );
-	return `a${ Number.isFinite( numericIndex ) ? numericIndex + index + 1 : index + 1 }`;
+function getDerivedZIndices( zIndex: string, count: number ) {
+	return getIndicesAbove( zIndex as TLShapePartial[ 'index' ], count ) as string[];
 }

--- a/apps/ui/src/ui-desks/widgets/registry.ts
+++ b/apps/ui/src/ui-desks/widgets/registry.ts
@@ -1,3 +1,4 @@
+import { blogWidgetDefinition } from '@/ui-desks/widgets/blog/definition';
 import { noteWidgetDefinition } from '@/ui-desks/widgets/note/definition';
 import { pageWidgetDefinition } from '@/ui-desks/widgets/page/definition';
 import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
@@ -6,6 +7,7 @@ import { sitePreviewWidgetDefinition } from '@/ui-desks/widgets/site-preview/def
 import type { DeskWidgetDefinition } from './types';
 
 export const widgetDefinitions = {
+	[ blogWidgetDefinition.type ]: blogWidgetDefinition,
 	[ noteWidgetDefinition.type ]: noteWidgetDefinition,
 	[ postWidgetDefinition.type ]: postWidgetDefinition,
 	[ pageWidgetDefinition.type ]: pageWidgetDefinition,

--- a/apps/ui/src/ui-desks/widgets/toolbar-selection.ts
+++ b/apps/ui/src/ui-desks/widgets/toolbar-selection.ts
@@ -3,6 +3,8 @@ import type { DeskWidget } from '@/ui-desks/widgets/types';
 
 interface SelectedWidgetToolbarOptions {
 	stackIds?: string[];
+	canStack?: boolean;
+	canUnstack?: boolean;
 	canRemove?: boolean;
 }
 
@@ -36,8 +38,8 @@ export function getSelectedWidgetToolbarItem(
 	const base = {
 		widgets,
 		stackIds,
-		canStack: widgets.length >= 2 && stackIds.length === 0,
-		canUnstack: stackIds.length > 0,
+		canStack: ( options.canStack ?? true ) && widgets.length >= 2 && stackIds.length === 0,
+		canUnstack: ( options.canUnstack ?? true ) && stackIds.length > 0,
 		canRemove: options.canRemove ?? true,
 	};
 

--- a/apps/ui/src/ui-desks/widgets/toolbar.tsx
+++ b/apps/ui/src/ui-desks/widgets/toolbar.tsx
@@ -11,6 +11,7 @@ type SelectedWidgetToolbarItem = NonNullable< ReturnType< typeof getSelectedWidg
 
 export function DeskWidgetToolbar() {
 	const {
+		isReadOnly,
 		selectedWidgetToolbarItem,
 		stackSelectedWidgets,
 		unstackSelectedWidgets,
@@ -33,7 +34,11 @@ export function DeskWidgetToolbar() {
 	}
 
 	const controls =
-		renderSelection.kind === 'single-widget' ? renderSelection.definition.controls : undefined;
+		renderSelection.kind === 'single-widget'
+			? renderSelection.definition.controls?.filter(
+					( control ) => ! isReadOnly || control.type === 'custom'
+			  )
+			: undefined;
 	const canRenderControls =
 		renderSelection.kind === 'single-widget' &&
 		Boolean( controls?.length ) &&

--- a/apps/ui/src/ui-desks/widgets/toolbar.tsx
+++ b/apps/ui/src/ui-desks/widgets/toolbar.tsx
@@ -11,7 +11,6 @@ type SelectedWidgetToolbarItem = NonNullable< ReturnType< typeof getSelectedWidg
 
 export function DeskWidgetToolbar() {
 	const {
-		isReadOnly,
 		selectedWidgetToolbarItem,
 		stackSelectedWidgets,
 		unstackSelectedWidgets,
@@ -34,11 +33,7 @@ export function DeskWidgetToolbar() {
 	}
 
 	const controls =
-		renderSelection.kind === 'single-widget'
-			? renderSelection.definition.controls?.filter(
-					( control ) => ! isReadOnly || control.type === 'custom'
-			  )
-			: undefined;
+		renderSelection.kind === 'single-widget' ? renderSelection.definition.controls : undefined;
 	const canRenderControls =
 		renderSelection.kind === 'single-widget' &&
 		Boolean( controls?.length ) &&

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -1,4 +1,5 @@
 import type { ControlConfig } from '@/ui-desks/controls/types';
+import type { BlogWidget } from '@/ui-desks/widgets/blog/types';
 import type { NoteWidget } from '@/ui-desks/widgets/note/types';
 import type { PageWidget } from '@/ui-desks/widgets/page/types';
 import type { PostWidget } from '@/ui-desks/widgets/post/types';
@@ -103,12 +104,14 @@ export interface WidgetDefinition< TWidget extends DeskWidgetBase = DeskWidgetBa
 }
 
 export type DeskWidget =
+	| BlogWidget
 	| NoteWidget
 	| PostWidget
 	| PageWidget
 	| PostCollectionWidget
 	| SitePreviewWidget;
 export type DeskWidgetDefinition =
+	| WidgetDefinition< BlogWidget >
 	| WidgetDefinition< NoteWidget >
 	| WidgetDefinition< PostWidget >
 	| WidgetDefinition< PageWidget >


### PR DESCRIPTION
## Summary
- Add a site map mode behind the header button that loads an alternate read-only desk config
- Render pages as page widgets, posts as a single post collection, and synthetic Blog nodes where needed
- Add parent/child connectors, site-map-specific title/count UI, and a centered loading state
- Keep widget selection and stack opening available while blocking moves, adds, removes, and persistence in site map mode

## Testing
- Added and updated unit coverage for site map config, connector rendering, and stack z-index behavior
- Ran the desk UI test suite and typecheck successfully
- Verified linting and formatting for modified files