### PR TITLE
Fix site creation assigning port 0 on first site

### DIFF
--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -399,6 +399,7 @@ export async function runCommand(
 		}
 
 		logger.reportKeyValuePair( 'id', siteDetails.id );
+		logger.reportKeyValuePair( 'port', String( siteDetails.port ) );
 		logger.reportKeyValuePair( 'running', String( siteDetails.running ) );
 		await emitCliEvent( { event: SITE_EVENTS.CREATED, data: { siteId: siteDetails.id } } );
 	} finally {

--- a/apps/studio/src/modules/cli/lib/cli-site-creator.ts
+++ b/apps/studio/src/modules/cli/lib/cli-site-creator.ts
@@ -16,13 +16,14 @@ const cliEventSchema = z.discriminatedUnion( 'action', [
 	} ),
 	z.object( {
 		action: z.literal( 'keyValuePair' ),
-		key: z.enum( [ 'id', 'running' ] ),
+		key: z.enum( [ 'id', 'running', 'port' ] ),
 		value: z.string(),
 	} ),
 ] );
 
 interface CreateSiteResult {
 	id: string;
+	port: number;
 	running: boolean;
 }
 
@@ -75,6 +76,11 @@ export async function createSiteViaCli( options: CreateSiteOptions ): Promise< C
 				const { key, value } = parsed.data;
 				if ( key === 'id' ) {
 					result.id = value;
+				} else if ( key === 'port' ) {
+					const parsedPort = Number.parseInt( value, 10 );
+					if ( Number.isFinite( parsedPort ) && parsedPort > 0 ) {
+						result.port = parsedPort;
+					}
 				} else if ( key === 'running' ) {
 					result.running = value === 'true';
 				}
@@ -88,11 +94,15 @@ export async function createSiteViaCli( options: CreateSiteOptions ): Promise< C
 
 		emitter.on( 'success', () => {
 			cleanupTempFile( blueprintTempPath );
-			if ( result.id ) {
-				resolve( { id: result.id, running: result.running ?? false } );
-			} else {
+			if ( ! result.id ) {
 				reject( new Error( 'CLI create site succeeded but no site ID received' ) );
+				return;
 			}
+			if ( ! result.port ) {
+				reject( new Error( 'CLI create site succeeded but no port received' ) );
+				return;
+			}
+			resolve( { id: result.id, port: result.port, running: result.running ?? false } );
 		} );
 
 		emitter.on( 'failure', ( { error } ) => {

--- a/apps/studio/src/modules/cli/lib/tests/cli-site-creator.test.ts
+++ b/apps/studio/src/modules/cli/lib/tests/cli-site-creator.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { executeCliCommand } from 'src/modules/cli/lib/execute-command';
+import { TypedEventEmitter } from 'src/modules/cli/lib/typed-event-emitter';
+import { createSiteViaCli } from '../cli-site-creator';
+
+vi.mock( 'src/modules/cli/lib/execute-command', () => ( {
+	executeCliCommand: vi.fn(),
+} ) );
+
+vi.mock( 'src/ipc-utils', () => ( {
+	sendIpcEventToRenderer: vi.fn(),
+} ) );
+
+type CliEventMap = Record< string, unknown >;
+
+function buildEmitter() {
+	const emitter = new TypedEventEmitter< CliEventMap >();
+	vi.mocked( executeCliCommand ).mockReturnValue( [
+		emitter,
+		// childProcess shape isn't read by createSiteViaCli for this test
+		{} as never,
+	] as never );
+	return emitter;
+}
+
+describe( 'createSiteViaCli', () => {
+	beforeEach( () => {
+		vi.mocked( executeCliCommand ).mockReset();
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	it( 'resolves with the port emitted by the CLI', async () => {
+		const emitter = buildEmitter();
+
+		const pending = createSiteViaCli( { path: '/tmp/site-port-emit' } );
+
+		emitter.emit( 'data', {
+			data: { action: 'keyValuePair', key: 'id', value: 'site-port-emit' },
+		} as never );
+		emitter.emit( 'data', {
+			data: { action: 'keyValuePair', key: 'port', value: '8765' },
+		} as never );
+		emitter.emit( 'data', {
+			data: { action: 'keyValuePair', key: 'running', value: 'true' },
+		} as never );
+		emitter.emit( 'success', { result: undefined } as never );
+
+		await expect( pending ).resolves.toEqual( {
+			id: 'site-port-emit',
+			port: 8765,
+			running: true,
+		} );
+	} );
+
+	it( 'rejects when the CLI succeeds without reporting a port', async () => {
+		const emitter = buildEmitter();
+
+		const pending = createSiteViaCli( { path: '/tmp/site-port-missing' } );
+
+		emitter.emit( 'data', {
+			data: { action: 'keyValuePair', key: 'id', value: 'site-port-missing' },
+		} as never );
+		emitter.emit( 'data', {
+			data: { action: 'keyValuePair', key: 'running', value: 'false' },
+		} as never );
+		emitter.emit( 'success', { result: undefined } as never );
+
+		await expect( pending ).rejects.toThrow( /no port received/i );
+	} );
+
+	it( 'rejects when the CLI emits port 0 (placeholder, never a real assignment)', async () => {
+		const emitter = buildEmitter();
+
+		const pending = createSiteViaCli( { path: '/tmp/site-port-zero' } );
+
+		emitter.emit( 'data', {
+			data: { action: 'keyValuePair', key: 'id', value: 'site-port-zero' },
+		} as never );
+		emitter.emit( 'data', {
+			data: { action: 'keyValuePair', key: 'port', value: '0' },
+		} as never );
+		emitter.emit( 'data', {
+			data: { action: 'keyValuePair', key: 'running', value: 'true' },
+		} as never );
+		emitter.emit( 'success', { result: undefined } as never );
+
+		await expect( pending ).rejects.toThrow( /no port received/i );
+	} );
+
+	it( 'rejects when the CLI succeeds without reporting an id', async () => {
+		const emitter = buildEmitter();
+
+		const pending = createSiteViaCli( { path: '/tmp/site-id-missing' } );
+
+		emitter.emit( 'data', {
+			data: { action: 'keyValuePair', key: 'port', value: '8765' },
+		} as never );
+		emitter.emit( 'data', {
+			data: { action: 'keyValuePair', key: 'running', value: 'true' },
+		} as never );
+		emitter.emit( 'success', { result: undefined } as never );
+
+		await expect( pending ).rejects.toThrow( /no site ID received/i );
+	} );
+} );

--- a/apps/studio/src/site-server.ts
+++ b/apps/studio/src/site-server.ts
@@ -181,8 +181,16 @@ export class SiteServer {
 
 		const result = await createSiteViaCli( { ...options, siteId } );
 
+		server.details.port = result.port;
 		if ( result.running ) {
-			server.details.running = true;
+			const url = getAbsoluteUrl( server.details );
+			const startedDetails: StartedSiteDetails = {
+				...server.details,
+				running: true,
+				url,
+			};
+			server.details = startedDetails;
+			server.server.url = url;
 		}
 
 		return { server, details: server.details };

--- a/apps/studio/src/tests/site-server.test.ts
+++ b/apps/studio/src/tests/site-server.test.ts
@@ -2,10 +2,15 @@
  * @vitest-environment node
  */
 import { vi } from 'vitest';
+import { createSiteViaCli } from 'src/modules/cli/lib/cli-site-creator';
 import { SiteServer } from 'src/site-server';
 
 // Electron's Node.js environment provides `btoa`/`atob`, but Vitest's does not
 vi.mock( '@studio/common/lib/passwords' );
+
+vi.mock( 'src/modules/cli/lib/cli-site-creator', () => ( {
+	createSiteViaCli: vi.fn(),
+} ) );
 
 // Mock the WordPress setup
 vi.mock( 'src/lib/wordpress-setup', () => ( {
@@ -73,6 +78,67 @@ vi.mock( 'src/modules/cli/lib/cli-server-process', () => {
 vi.mock( 'src/storage/user-data' );
 
 describe( 'SiteServer', () => {
+	describe( 'create', () => {
+		beforeEach( () => {
+			vi.mocked( createSiteViaCli ).mockReset();
+		} );
+
+		it( 'sets details.port from the CLI result instead of the placeholder 0', async () => {
+			vi.mocked( createSiteViaCli ).mockResolvedValue( {
+				id: 'create-port-1',
+				port: 8765,
+				running: false,
+			} );
+
+			const { server, details } = await SiteServer.create( {
+				siteId: 'create-port-1',
+				path: '/tmp/create-port-1',
+				name: 'create-port-1',
+			} );
+
+			expect( details.port ).toBe( 8765 );
+			expect( server.details.port ).toBe( 8765 );
+			expect( details.running ).toBe( false );
+		} );
+
+		it( 'transitions to StartedSiteDetails with a localhost URL when CLI reports running', async () => {
+			vi.mocked( createSiteViaCli ).mockResolvedValue( {
+				id: 'create-port-2',
+				port: 9100,
+				running: true,
+			} );
+
+			const { server, details } = await SiteServer.create( {
+				siteId: 'create-port-2',
+				path: '/tmp/create-port-2',
+				name: 'create-port-2',
+			} );
+
+			expect( details.running ).toBe( true );
+			expect( details.port ).toBe( 9100 );
+			if ( details.running ) {
+				expect( details.url ).toBe( 'http://localhost:9100' );
+			}
+			expect( server.server.url ).toBe( 'http://localhost:9100' );
+		} );
+
+		it( 'never returns a placeholder port 0 once the CLI has assigned a real port', async () => {
+			vi.mocked( createSiteViaCli ).mockResolvedValue( {
+				id: 'create-port-3',
+				port: 8881,
+				running: true,
+			} );
+
+			const { details } = await SiteServer.create( {
+				siteId: 'create-port-3',
+				path: '/tmp/create-port-3',
+				name: 'create-port-3',
+			} );
+
+			expect( details.port ).not.toBe( 0 );
+		} );
+	} );
+
 	describe( 'start', () => {
 		it( 'should throw if the server starts with a non-WordPress mode', async () => {
 			mockStartServer.mockRejectedValue(


### PR DESCRIPTION
## Related issues

- Fixes STU-1680

## How AI was used in this PR

Used an AI assistant to help trace the data flow between desktop main process and the CLI subprocess (`SiteServer.create` → `createSiteViaCli` → `reportKeyValuePair`), draft the fix, and scaffold the test cases. I reviewed all changes manually, ran the local test suite, and verified the typecheck for the affected workspaces.

## Proposed Changes

- `SiteServer.create` registered a placeholder `SiteDetails` with `port: 0` and never updated it after the CLI assigned a real port. The CLI only reported `id` and `running` back via `reportKeyValuePair`, so the placeholder leaked all the way to the renderer (visible as `http://localhost:0`) until the next app launch when `SiteServer.fetchAll()` reread `cli.json`. On a fresh machine, creating the very first site exposed the bug immediately.
- CLI now emits `port` as a `keyValuePair` alongside `id` and `running` (`apps/cli/commands/site/create.ts`).
- IPC schema accepts the new `port` key, parses it, and the success branch rejects when the CLI succeeds without a real (non-zero) port (`apps/studio/src/modules/cli/lib/cli-site-creator.ts`).
- `SiteServer.create` writes the real port into `details` and, when the site is running, transitions to `StartedSiteDetails` with a correct `http://localhost:<port>` url, also updating `server.server.url` (`apps/studio/src/site-server.ts`).
- Added unit tests covering port propagation and the new rejection paths.

## Testing Instructions

Reproduce the bug on `trunk` (pre-fix):

1. Quit Studio.
2. Move the Studio config aside to simulate a fresh machine: `mv ~/.studio ~/.studio.bak`.
3. Check out `trunk`, install, and run: `npm install && npm start`.
4. Click **Add site**, pick an empty folder, and create the site.
5. Inspect the resulting site URL in Site settings


Confirm the fix:

1. Reset state again: `rm -rf ~/.studio` (or move the backup aside).
2. Check out this branch, then `npm install && npm start`.
3. Click **Add site** and create a site.
4. The site URL now shows the real assigned port (e.g. `http://localhost:8881`), and opening the site in the browser works on the first try, with no restart needed.
5. Try the **Clone site** flow — the cloned site also receives a real port (the `updateSiteUrl` call at `ipc-handlers.ts:1058` no longer sees `localhost:0`).
7. Restore your config when finished: `mv ~/.studio.bak ~/.studio`.

**Before**

https://github.com/user-attachments/assets/a79eee2f-b39d-4471-a9b9-e96fc470bb83

**After**

https://github.com/user-attachments/assets/d6325aa7-2471-4335-8e4b-7b6a491167dc

## Pre-merge Checklist



- [x] Have you checked for TypeScript, React or other console errors?