### PR TITLE
apps/ui: Add global desk settings for site name and toolbar layout

### DIFF
--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -188,8 +188,10 @@ export { getDefaultSiteDirectory, saveDefaultSiteDirectory };
 export { importSite, exportSite } from 'src/modules/import-export/lib/ipc-handlers';
 
 export {
+	getDeskSettings,
 	getSiteDeskConfig,
 	getUserDeskConfig,
+	saveDeskSettings,
 	saveSiteDeskConfig,
 	saveUserDeskConfig,
 } from 'src/modules/desks/lib/ipc-handlers';

--- a/apps/studio/src/modules/desks/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/desks/lib/ipc-handlers.ts
@@ -1,6 +1,8 @@
+import { normalizeDeskSettings } from '@studio/common/lib/desk-settings';
 import {
 	DESK_CONFIG_VERSION,
 	type DeskConfig,
+	type DeskSettings,
 	type DeskStack,
 	type DeskViewport,
 	type DeskWidgetBase,
@@ -95,6 +97,35 @@ export async function getUserDeskConfig(
 ): Promise< DeskConfig | undefined > {
 	const userData = await loadUserData();
 	return userData.desks?.user;
+}
+
+export async function getDeskSettings( _event: IpcMainInvokeEvent ): Promise< DeskSettings > {
+	const userData = await loadUserData();
+	return normalizeDeskSettings( userData.desks?.settings );
+}
+
+export async function saveDeskSettings(
+	_event: IpcMainInvokeEvent,
+	settings: DeskSettings
+): Promise< void > {
+	if ( ! isRecord( settings ) ) {
+		throw new Error( 'Invalid desk settings: expected an object.' );
+	}
+
+	const normalizedSettings = normalizeDeskSettings( settings );
+	await lockAppdata();
+	try {
+		const userData = await loadUserData();
+		await saveUserData( {
+			...userData,
+			desks: {
+				...userData.desks,
+				settings: normalizedSettings,
+			},
+		} );
+	} finally {
+		await unlockAppdata();
+	}
 }
 
 export async function saveUserDeskConfig(

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -221,6 +221,8 @@ const api: IpcApi = {
 		ipcRendererInvoke( 'answerAiAgentQuestion', runId, answers ),
 	setSessionEnvironment: ( sessionId, environment ) =>
 		ipcRendererInvoke( 'setSessionEnvironment', sessionId, environment ),
+	getDeskSettings: () => ipcRendererInvoke( 'getDeskSettings' ),
+	saveDeskSettings: ( settings ) => ipcRendererInvoke( 'saveDeskSettings', settings ),
 	getUserDeskConfig: () => ipcRendererInvoke( 'getUserDeskConfig' ),
 	saveUserDeskConfig: ( config ) => ipcRendererInvoke( 'saveUserDeskConfig', config ),
 	getSiteDeskConfig: ( siteId ) => ipcRendererInvoke( 'getSiteDeskConfig', siteId ),

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -6,6 +6,7 @@ import type {
 	ColorScheme,
 	Connector,
 	DeskConfig,
+	DeskSettings,
 	ExtractedBlueprintBundle,
 	FeaturedBlueprint,
 	InstalledApps,
@@ -596,6 +597,14 @@ export function createIpcConnector(): Connector {
 
 		async getInstalledApps(): Promise< InstalledApps > {
 			return ( await ipcApi.getInstalledAppsAndTerminals() ) as InstalledApps;
+		},
+
+		async getDeskSettings(): Promise< DeskSettings > {
+			return ( await ipcApi.getDeskSettings() ) as DeskSettings;
+		},
+
+		async saveDeskSettings( settings ): Promise< void > {
+			await ipcApi.saveDeskSettings( settings );
 		},
 
 		async getUserDeskConfig(): Promise< DeskConfig | undefined > {

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -8,6 +8,7 @@ export type {
 	Connector,
 	CreateSiteParams,
 	DeskConfig,
+	DeskSettings,
 	DeskWidgetBase,
 	ExtractedBlueprintBundle,
 	FeaturedBlueprint,

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -4,7 +4,7 @@ import type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessio
 import type { SupportedLocale } from '@studio/common/lib/locale';
 import type { SupportedEditor } from '@studio/common/lib/user-settings/editor';
 import type { SupportedTerminal } from '@studio/common/lib/user-settings/terminal';
-import type { DeskConfig } from '@studio/common/types/desk';
+import type { DeskConfig, DeskSettings } from '@studio/common/types/desk';
 import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
 import type { Snapshot } from '@studio/common/types/snapshot';
 import type { SyncSite } from '@studio/common/types/sync';
@@ -27,7 +27,7 @@ export type {
 export type { AiModelId } from '@studio/common/ai/models';
 export type { Snapshot } from '@studio/common/types/snapshot';
 export type { SyncSite } from '@studio/common/types/sync';
-export type { DeskConfig, DeskWidgetBase } from '@studio/common/types/desk';
+export type { DeskConfig, DeskSettings, DeskWidgetBase } from '@studio/common/types/desk';
 export type { SupportedEditor } from '@studio/common/lib/user-settings/editor';
 export type { SupportedTerminal } from '@studio/common/lib/user-settings/terminal';
 export type { SupportedLocale } from '@studio/common/lib/locale';
@@ -234,6 +234,8 @@ export interface Connector {
 	getInstalledApps(): Promise< InstalledApps >;
 
 	// Desks
+	getDeskSettings(): Promise< DeskSettings >;
+	saveDeskSettings( settings: DeskSettings ): Promise< void >;
 	getUserDeskConfig(): Promise< DeskConfig | undefined >;
 	saveUserDeskConfig( config: DeskConfig ): Promise< void >;
 	getSiteDeskConfig( siteId: string ): Promise< DeskConfig | undefined >;

--- a/apps/ui/src/data/queries/use-desk-config.ts
+++ b/apps/ui/src/data/queries/use-desk-config.ts
@@ -1,5 +1,6 @@
 import { createDefaultDeskSettings, normalizeDeskSettings } from '@studio/common/lib/desk-settings';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
 import { useConnector } from '@/data/core';
 import type { DeskConfig, DeskSettings } from '@/data/core';
 
@@ -56,4 +57,24 @@ export function useSaveDeskSettings() {
 			queryClient.setQueryData( deskSettingsQueryKey, settings );
 		},
 	} );
+}
+
+export function useUpdateDeskSettings() {
+	const { data: savedDeskSettings } = useDeskSettings();
+	const fallbackDeskSettings = useMemo( () => createDefaultDeskSettings(), [] );
+	const deskSettings = savedDeskSettings ?? fallbackDeskSettings;
+	const saveDeskSettings = useSaveDeskSettings();
+
+	return useCallback(
+		( patch: Partial< DeskSettings > ) => {
+			saveDeskSettings.mutate(
+				normalizeDeskSettings( {
+					...deskSettings,
+					...patch,
+					updatedAt: new Date().toISOString(),
+				} )
+			);
+		},
+		[ deskSettings, saveDeskSettings ]
+	);
 }

--- a/apps/ui/src/data/queries/use-desk-config.ts
+++ b/apps/ui/src/data/queries/use-desk-config.ts
@@ -1,7 +1,9 @@
+import { createDefaultDeskSettings, normalizeDeskSettings } from '@studio/common/lib/desk-settings';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useConnector } from '@/data/core';
-import type { DeskConfig } from '@/data/core';
+import type { DeskConfig, DeskSettings } from '@/data/core';
 
+const deskSettingsQueryKey = [ 'desk-settings' ] as const;
 const userDeskConfigQueryKey = [ 'desk-config', 'user' ] as const;
 const siteDeskConfigQueryKey = ( siteId: string ) => [ 'desk-config', 'site', siteId ] as const;
 const deskConfigQueryKey = ( siteId?: string ) =>
@@ -28,6 +30,30 @@ export function useSaveDeskConfig( siteId?: string ) {
 			).then( () => config ),
 		onSuccess: ( config ) => {
 			queryClient.setQueryData( deskConfigQueryKey( siteId ), config );
+		},
+	} );
+}
+
+export function useDeskSettings() {
+	const connector = useConnector();
+	return useQuery( {
+		queryKey: deskSettingsQueryKey,
+		queryFn: async () => normalizeDeskSettings( await connector.getDeskSettings() ),
+		placeholderData: () => createDefaultDeskSettings(),
+	} );
+}
+
+export function useSaveDeskSettings() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( settings: DeskSettings ) =>
+			connector.saveDeskSettings( settings ).then( () => settings ),
+		onMutate: ( settings ) => {
+			queryClient.setQueryData( deskSettingsQueryKey, settings );
+		},
+		onSuccess: ( settings ) => {
+			queryClient.setQueryData( deskSettingsQueryKey, settings );
 		},
 	} );
 }

--- a/apps/ui/src/ui-desks/chrome/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/index.tsx
@@ -1,12 +1,20 @@
+import { moveDeskToolbarButton } from '@studio/common/lib/desk-settings';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { clsx } from 'clsx';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useFullscreen } from '@/hooks/use-fullscreen';
 import { ChatsTrigger } from '../chats';
 import { DeskCreateMenu } from './create-menu';
+import { DeskSettingsButton } from './settings-button';
 import { DeskSiteMapButton } from './site-map-button';
 import styles from './style.module.css';
 import { DeskMenu } from './user-menu';
-import type { ReactNode } from 'react';
+import type {
+	DeskSettings,
+	DeskToolbarButtonId,
+	DeskToolbarLayout,
+} from '@studio/common/types/desk';
+import type { Dispatch, DragEvent, ReactNode, SetStateAction } from 'react';
 
 interface DeskHeaderProps {
 	children: ReactNode;
@@ -31,29 +39,259 @@ interface DeskChromeProps {
 	siteId?: string;
 	siteMapOpen?: boolean;
 	siteMapPageCount?: number;
+	settings: DeskSettings;
+	settingsOpen: boolean;
+	editingToolbar: boolean;
 	onToggleSiteMap?: () => void;
+	onToggleSettings: () => void;
+	onChangeToolbarLayout: ( layout: DeskToolbarLayout ) => void;
 }
 
 export function DeskChrome( {
 	siteId,
 	siteMapOpen = false,
 	siteMapPageCount,
+	settings,
+	settingsOpen,
+	editingToolbar,
 	onToggleSiteMap,
+	onToggleSettings,
+	onChangeToolbarLayout,
 }: DeskChromeProps ) {
+	const [ dragState, setDragState ] = useState< ToolbarDragState >( EMPTY_DRAG_STATE );
+	const clearDragState = useCallback( () => setDragState( EMPTY_DRAG_STATE ), [] );
+
+	useEffect( () => {
+		window.addEventListener( 'dragend', clearDragState );
+		return () => window.removeEventListener( 'dragend', clearDragState );
+	}, [ clearDragState ] );
+
+	const renderButton = ( buttonId: DeskToolbarButtonId ) => {
+		switch ( buttonId ) {
+			case 'chat':
+				return <ChatsTrigger />;
+			case 'create':
+				return <DeskCreateMenu />;
+			case 'site-map':
+				return siteId && onToggleSiteMap ? (
+					<DeskSiteMapButton siteId={ siteId } open={ siteMapOpen } onToggle={ onToggleSiteMap } />
+				) : null;
+			case 'settings':
+				return <DeskSettingsButton open={ settingsOpen } onToggle={ onToggleSettings } />;
+		}
+	};
+
+	const reorderButton = (
+		buttonId: DeskToolbarButtonId,
+		side: keyof DeskToolbarLayout,
+		beforeButtonId: DeskToolbarButtonId | null
+	) => {
+		onChangeToolbarLayout(
+			moveDeskToolbarButton( settings.toolbarLayout, buttonId, side, beforeButtonId )
+		);
+	};
+
 	return (
 		<DeskHeader
 			centerChildren={ siteMapOpen ? <DeskSiteMapTitle pageCount={ siteMapPageCount } /> : null }
 			rightChildren={
-				siteId && onToggleSiteMap ? (
-					<DeskSiteMapButton siteId={ siteId } open={ siteMapOpen } onToggle={ onToggleSiteMap } />
-				) : null
+				<ToolbarRow
+					side="right"
+					buttonIds={ settings.toolbarLayout.right }
+					editing={ editingToolbar }
+					renderButton={ renderButton }
+					dragState={ dragState }
+					setDragState={ setDragState }
+					clearDragState={ clearDragState }
+					onReorder={ reorderButton }
+				/>
 			}
 		>
-			<DeskMenu siteId={ siteId } />
-			<ChatsTrigger />
-			<DeskCreateMenu />
+			<ToolbarRow
+				side="left"
+				buttonIds={ settings.toolbarLayout.left }
+				editing={ editingToolbar }
+				renderButton={ renderButton }
+				dragState={ dragState }
+				setDragState={ setDragState }
+				clearDragState={ clearDragState }
+				onReorder={ reorderButton }
+				leading={
+					<DeskMenu
+						siteId={ siteId }
+						disabled={ editingToolbar }
+						showSiteName={ settings.showSiteName }
+					/>
+				}
+			/>
 		</DeskHeader>
 	);
+}
+
+const DRAG_MIME = 'application/x-studio-desk-toolbar-button';
+
+interface ToolbarDragState {
+	draggedId: DeskToolbarButtonId | null;
+	insertBeforeId: DeskToolbarButtonId | null;
+	insertSide: keyof DeskToolbarLayout | null;
+}
+
+const EMPTY_DRAG_STATE: ToolbarDragState = {
+	draggedId: null,
+	insertBeforeId: null,
+	insertSide: null,
+};
+
+interface ToolbarRowProps {
+	side: keyof DeskToolbarLayout;
+	buttonIds: DeskToolbarButtonId[];
+	editing: boolean;
+	renderButton: ( buttonId: DeskToolbarButtonId ) => ReactNode;
+	onReorder: (
+		buttonId: DeskToolbarButtonId,
+		side: keyof DeskToolbarLayout,
+		beforeButtonId: DeskToolbarButtonId | null
+	) => void;
+	dragState: ToolbarDragState;
+	setDragState: Dispatch< SetStateAction< ToolbarDragState > >;
+	clearDragState: () => void;
+	leading?: ReactNode;
+}
+
+function ToolbarRow( {
+	side,
+	buttonIds,
+	editing,
+	renderButton,
+	onReorder,
+	dragState,
+	setDragState,
+	clearDragState,
+	leading,
+}: ToolbarRowProps ) {
+	const rowRef = useRef< HTMLDivElement | null >( null );
+
+	const getInsertionTarget = ( clientX: number ) => {
+		const row = rowRef.current;
+		if ( ! row ) {
+			return null;
+		}
+
+		const slots = row.querySelectorAll< HTMLElement >( `[data-toolbar-button-id]` );
+		for ( const slot of slots ) {
+			if ( slot.dataset.dragging === 'true' ) {
+				continue;
+			}
+
+			const id = slot.dataset.toolbarButtonId as DeskToolbarButtonId | undefined;
+			if ( ! id ) {
+				continue;
+			}
+
+			const rect = slot.getBoundingClientRect();
+			if ( clientX < rect.left + rect.width / 2 ) {
+				return id;
+			}
+		}
+
+		return null;
+	};
+
+	const onDragStart = ( event: DragEvent, buttonId: DeskToolbarButtonId ) => {
+		event.dataTransfer.setData( DRAG_MIME, buttonId );
+		event.dataTransfer.effectAllowed = 'move';
+		window.setTimeout( () => {
+			setDragState( { draggedId: buttonId, insertBeforeId: null, insertSide: null } );
+		}, 0 );
+	};
+
+	const onDragOver = ( event: DragEvent ) => {
+		if ( ! editing || ! event.dataTransfer.types.includes( DRAG_MIME ) ) {
+			return;
+		}
+
+		event.preventDefault();
+		event.dataTransfer.dropEffect = 'move';
+		const insertBeforeId = getInsertionTarget( event.clientX );
+		setDragState( ( previous ) =>
+			previous.insertBeforeId === insertBeforeId && previous.insertSide === side
+				? previous
+				: { ...previous, insertBeforeId, insertSide: side }
+		);
+	};
+
+	const onDrop = ( event: DragEvent ) => {
+		if ( ! editing ) {
+			return;
+		}
+
+		const buttonId = event.dataTransfer.getData( DRAG_MIME ) as DeskToolbarButtonId;
+		if ( ! buttonId ) {
+			return;
+		}
+
+		event.preventDefault();
+		onReorder( buttonId, side, getInsertionTarget( event.clientX ) );
+		clearDragState();
+	};
+
+	const isTarget = dragState.insertSide === side;
+	const slots: ReactNode[] = [];
+	let ghostInserted = false;
+
+	for ( const buttonId of buttonIds ) {
+		const button = renderButton( buttonId );
+		if ( ! button ) {
+			continue;
+		}
+
+		if (
+			isTarget &&
+			! ghostInserted &&
+			dragState.insertBeforeId === buttonId &&
+			dragState.draggedId !== buttonId
+		) {
+			slots.push( <DropGhost key="__ghost" /> );
+			ghostInserted = true;
+		}
+
+		const isDragged = dragState.draggedId === buttonId;
+		slots.push(
+			<div
+				key={ buttonId }
+				className={ styles.toolbarSlot }
+				data-toolbar-button-id={ buttonId }
+				data-dragging={ isDragged ? 'true' : 'false' }
+				draggable={ editing }
+				onDragStart={ ( event ) => onDragStart( event, buttonId ) }
+				onDragEnd={ clearDragState }
+			>
+				{ button }
+			</div>
+		);
+	}
+
+	if ( isTarget && ! ghostInserted ) {
+		slots.push( <DropGhost key="__ghost" /> );
+	}
+
+	return (
+		<div
+			ref={ rowRef }
+			className={ styles.toolbarRow }
+			data-side={ side }
+			data-editing={ editing ? 'true' : 'false' }
+			onDragOver={ onDragOver }
+			onDrop={ onDrop }
+		>
+			{ leading }
+			{ slots }
+		</div>
+	);
+}
+
+function DropGhost() {
+	return <div className={ clsx( styles.toolbarSlot, styles.toolbarDropGhost ) } aria-hidden />;
 }
 
 function DeskSiteMapTitle( { pageCount }: { pageCount?: number } ) {

--- a/apps/ui/src/ui-desks/chrome/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/index.tsx
@@ -1,19 +1,21 @@
-import { moveDeskToolbarButton } from '@studio/common/lib/desk-settings';
+import { createDefaultDeskSettings } from '@studio/common/lib/desk-settings';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { clsx } from 'clsx';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useDeskSettings, useUpdateDeskSettings } from '@/data/queries/use-desk-config';
 import { useFullscreen } from '@/hooks/use-fullscreen';
 import { ChatsTrigger } from '../chats';
 import { DeskCreateMenu } from './create-menu';
 import { DeskSettingsButton } from './settings-button';
 import { DeskSiteMapButton } from './site-map-button';
 import styles from './style.module.css';
+import {
+	moveDeskToolbarButton,
+	normalizeDeskToolbarSettings,
+	type DeskToolbarButtonId,
+	type DeskToolbarLayout,
+} from './toolbar-layout';
 import { DeskMenu } from './user-menu';
-import type {
-	DeskSettings,
-	DeskToolbarButtonId,
-	DeskToolbarLayout,
-} from '@studio/common/types/desk';
 import type { Dispatch, DragEvent, ReactNode, SetStateAction } from 'react';
 
 interface DeskHeaderProps {
@@ -39,25 +41,28 @@ interface DeskChromeProps {
 	siteId?: string;
 	siteMapOpen?: boolean;
 	siteMapPageCount?: number;
-	settings: DeskSettings;
 	settingsOpen: boolean;
 	editingToolbar: boolean;
 	onToggleSiteMap?: () => void;
 	onToggleSettings: () => void;
-	onChangeToolbarLayout: ( layout: DeskToolbarLayout ) => void;
 }
 
 export function DeskChrome( {
 	siteId,
 	siteMapOpen = false,
 	siteMapPageCount,
-	settings,
 	settingsOpen,
 	editingToolbar,
 	onToggleSiteMap,
 	onToggleSettings,
-	onChangeToolbarLayout,
 }: DeskChromeProps ) {
+	const { data: savedSettings } = useDeskSettings();
+	const fallbackSettings = useMemo( () => createDefaultDeskSettings(), [] );
+	const settings = useMemo(
+		() => normalizeDeskToolbarSettings( savedSettings ?? fallbackSettings ),
+		[ fallbackSettings, savedSettings ]
+	);
+	const updateDeskSettings = useUpdateDeskSettings();
 	const [ dragState, setDragState ] = useState< ToolbarDragState >( EMPTY_DRAG_STATE );
 	const clearDragState = useCallback( () => setDragState( EMPTY_DRAG_STATE ), [] );
 
@@ -86,9 +91,14 @@ export function DeskChrome( {
 		side: keyof DeskToolbarLayout,
 		beforeButtonId: DeskToolbarButtonId | null
 	) => {
-		onChangeToolbarLayout(
-			moveDeskToolbarButton( settings.toolbarLayout, buttonId, side, beforeButtonId )
-		);
+		updateDeskSettings( {
+			toolbarLayout: moveDeskToolbarButton(
+				settings.toolbarLayout,
+				buttonId,
+				side,
+				beforeButtonId
+			),
+		} );
 	};
 
 	return (

--- a/apps/ui/src/ui-desks/chrome/settings-button.tsx
+++ b/apps/ui/src/ui-desks/chrome/settings-button.tsx
@@ -1,0 +1,19 @@
+import { __ } from '@wordpress/i18n';
+import { cog } from '@wordpress/icons';
+import { IconControlButton } from '@/ui-desks/components';
+
+interface DeskSettingsButtonProps {
+	open: boolean;
+	onToggle: () => void;
+}
+
+export function DeskSettingsButton( { open, onToggle }: DeskSettingsButtonProps ) {
+	return (
+		<IconControlButton
+			icon={ cog }
+			label={ open ? __( 'Close desk settings' ) : __( 'Open desk settings' ) }
+			aria-pressed={ open }
+			onClick={ onToggle }
+		/>
+	);
+}

--- a/apps/ui/src/ui-desks/chrome/settings-modal.tsx
+++ b/apps/ui/src/ui-desks/chrome/settings-modal.tsx
@@ -1,65 +1,53 @@
+import { createDefaultDeskSettings } from '@studio/common/lib/desk-settings';
 import { __ } from '@wordpress/i18n';
-import { close } from '@wordpress/icons';
-import { Icon } from '@wordpress/ui';
-import { clsx } from 'clsx';
+import { Dialog, Field } from '@wordpress/ui';
+import { useMemo } from 'react';
+import { useDeskSettings, useUpdateDeskSettings } from '@/data/queries/use-desk-config';
+import { ActionButton } from '@/ui-desks/components';
 import styles from './style.module.css';
-import type { DeskSettings } from '@/data/core';
 
 interface DeskSettingsModalProps {
-	settings: DeskSettings;
-	onChange: ( patch: Partial< DeskSettings > ) => void;
-	onClose: () => void;
+	open: boolean;
+	onOpenChange: ( open: boolean ) => void;
 	onEditToolbar: () => void;
 }
 
-export function DeskSettingsModal( {
-	settings,
-	onChange,
-	onClose,
-	onEditToolbar,
-}: DeskSettingsModalProps ) {
+export function DeskSettingsModal( { open, onOpenChange, onEditToolbar }: DeskSettingsModalProps ) {
+	const { data: savedDeskSettings } = useDeskSettings();
+	const fallbackDeskSettings = useMemo( () => createDefaultDeskSettings(), [] );
+	const settings = savedDeskSettings ?? fallbackDeskSettings;
+	const updateDeskSettings = useUpdateDeskSettings();
+
 	return (
-		<div className={ styles.settingsBackdrop } onClick={ onClose }>
-			<div
-				className={ styles.settingsModal }
-				role="dialog"
-				aria-label={ __( 'Desk settings' ) }
-				onClick={ ( event ) => event.stopPropagation() }
-			>
-				<header className={ styles.settingsHeader }>
-					<h2>{ __( 'Settings' ) }</h2>
-					<button
-						type="button"
-						className={ styles.settingsCloseButton }
-						onClick={ onClose }
-						aria-label={ __( 'Close settings' ) }
-					>
-						<Icon icon={ close } size={ 20 } />
-					</button>
-				</header>
-				<div className={ styles.settingsBody }>
-					<label className={ styles.settingsToggleRow }>
-						<input
+		<Dialog.Root open={ open } onOpenChange={ onOpenChange }>
+			<Dialog.Popup size="small" className={ styles.settingsDialog }>
+				<Dialog.Header className={ styles.settingsHeader }>
+					<Dialog.Title>{ __( 'Settings' ) }</Dialog.Title>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
+				<Dialog.Content className={ styles.settingsBody }>
+					<Field.Root className={ styles.settingsToggleRow } render={ <div /> }>
+						<Field.Control
 							type="checkbox"
 							checked={ settings.showSiteName }
-							onChange={ ( event ) => onChange( { showSiteName: event.target.checked } ) }
+							onChange={ ( event ) => updateDeskSettings( { showSiteName: event.target.checked } ) }
 						/>
-						<span>{ __( 'Show site name' ) }</span>
-					</label>
-				</div>
-				<footer className={ styles.settingsFooter }>
-					<button
+						<Field.Label variant="plain">{ __( 'Show site name' ) }</Field.Label>
+					</Field.Root>
+				</Dialog.Content>
+				<Dialog.Footer className={ styles.settingsFooter }>
+					<ActionButton
 						type="button"
-						className={ clsx( styles.settingsFooterButton, styles.settingsFooterButtonPrimary ) }
+						className={ styles.settingsPrimaryAction }
 						onClick={ () => {
-							onClose();
+							onOpenChange( false );
 							onEditToolbar();
 						} }
 					>
 						{ __( 'Edit toolbar' ) }
-					</button>
-				</footer>
-			</div>
-		</div>
+					</ActionButton>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
 	);
 }

--- a/apps/ui/src/ui-desks/chrome/settings-modal.tsx
+++ b/apps/ui/src/ui-desks/chrome/settings-modal.tsx
@@ -1,0 +1,65 @@
+import { __ } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
+import { Icon } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import styles from './style.module.css';
+import type { DeskSettings } from '@/data/core';
+
+interface DeskSettingsModalProps {
+	settings: DeskSettings;
+	onChange: ( patch: Partial< DeskSettings > ) => void;
+	onClose: () => void;
+	onEditToolbar: () => void;
+}
+
+export function DeskSettingsModal( {
+	settings,
+	onChange,
+	onClose,
+	onEditToolbar,
+}: DeskSettingsModalProps ) {
+	return (
+		<div className={ styles.settingsBackdrop } onClick={ onClose }>
+			<div
+				className={ styles.settingsModal }
+				role="dialog"
+				aria-label={ __( 'Desk settings' ) }
+				onClick={ ( event ) => event.stopPropagation() }
+			>
+				<header className={ styles.settingsHeader }>
+					<h2>{ __( 'Settings' ) }</h2>
+					<button
+						type="button"
+						className={ styles.settingsCloseButton }
+						onClick={ onClose }
+						aria-label={ __( 'Close settings' ) }
+					>
+						<Icon icon={ close } size={ 20 } />
+					</button>
+				</header>
+				<div className={ styles.settingsBody }>
+					<label className={ styles.settingsToggleRow }>
+						<input
+							type="checkbox"
+							checked={ settings.showSiteName }
+							onChange={ ( event ) => onChange( { showSiteName: event.target.checked } ) }
+						/>
+						<span>{ __( 'Show site name' ) }</span>
+					</label>
+				</div>
+				<footer className={ styles.settingsFooter }>
+					<button
+						type="button"
+						className={ clsx( styles.settingsFooterButton, styles.settingsFooterButtonPrimary ) }
+						onClick={ () => {
+							onClose();
+							onEditToolbar();
+						} }
+					>
+						{ __( 'Edit toolbar' ) }
+					</button>
+				</footer>
+			</div>
+		</div>
+	);
+}

--- a/apps/ui/src/ui-desks/chrome/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/style.module.css
@@ -274,25 +274,12 @@
 	line-height: 14px;
 }
 
-.settingsBackdrop {
-	position: fixed;
-	inset: 0;
-	z-index: 50;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	padding: 24px;
-	background: rgba(15, 23, 42, 0.18);
-	backdrop-filter: blur(2px);
-	pointer-events: auto;
-}
+.settingsDialog {
+	--wp-ui-button-height: 36px;
 
-.settingsModal {
-	display: flex;
-	flex-direction: column;
 	width: min(440px, 92vw);
+	min-width: 0;
 	max-height: 80vh;
-	overflow: hidden;
 	color: var(--ui-desks-text, #14171a);
 	background: var(--ui-desks-material, #fff);
 	border-radius: 18px;
@@ -324,22 +311,10 @@
 	line-height: var(--wpds-typography-line-height-md);
 }
 
-.settingsCloseButton {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
+.settingsHeader [data-wp-ui-dialog-close-icon] {
 	width: 32px;
 	height: 32px;
-	padding: 0;
-	color: var(--ui-desks-text, #14171a);
-	background: transparent;
-	border: 0;
 	border-radius: var(--ui-desks-radius-button, 12px);
-	cursor: pointer;
-}
-
-.settingsCloseButton:hover {
-	background: var(--ui-desks-control-hover, rgba(15, 23, 42, 0.07));
 }
 
 .settingsBody {
@@ -348,7 +323,9 @@
 
 .settingsToggleRow {
 	display: flex;
+	width: fit-content;
 	align-items: center;
+	justify-content: flex-start;
 	gap: 10px;
 	color: var(--ui-desks-text, #14171a);
 	font-size: var(--wpds-typography-font-size-sm);
@@ -357,10 +334,12 @@
 	cursor: pointer;
 }
 
-.settingsToggleRow input {
+.settingsToggleRow input[type='checkbox'] {
+	flex: 0 0 auto;
 	width: 16px;
 	height: 16px;
 	margin: 0;
+	accent-color: var(--wp-admin-theme-color, #3858e9);
 	cursor: pointer;
 }
 
@@ -369,28 +348,22 @@
 	border-top: 1px solid var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
 }
 
-.settingsFooterButton {
+.settingsPrimaryAction {
+	--action-button-background: var(--ui-desks-text, #14171a);
+	--wp-ui-button-height: 36px;
+
 	height: 36px;
+	justify-content: center;
 	padding: 0 14px;
-	color: var(--ui-desks-text, #14171a);
-	font: inherit;
+	border-radius: var(--ui-desks-radius-button, 12px);
+	color: #fff;
 	font-size: var(--wpds-typography-font-size-sm);
 	font-weight: var(--wpds-typography-font-weight-medium, 500);
-	background: var(--ui-desks-control-hover, rgba(15, 23, 42, 0.07));
-	border: 0;
-	border-radius: var(--ui-desks-radius-button, 12px);
-	cursor: pointer;
+	line-height: var(--wpds-typography-line-height-sm);
 }
 
-.settingsFooterButton:hover {
-	background: rgba(15, 23, 42, 0.1);
-}
+.settingsPrimaryAction:hover:not(:disabled) {
+	--action-button-background: #000;
 
-.settingsFooterButtonPrimary {
-	background: var(--ui-desks-text, #14171a);
 	color: #fff;
-}
-
-.settingsFooterButtonPrimary:hover {
-	background: #000;
 }

--- a/apps/ui/src/ui-desks/chrome/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/style.module.css
@@ -35,6 +35,74 @@
 	pointer-events: auto;
 }
 
+.toolbarRow {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-md);
+}
+
+.toolbarRow[data-editing='true'] {
+	padding: 10px;
+	margin: -10px;
+	border-radius: 22px;
+	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	outline: 2px dashed rgba(159, 159, 159, 0.85);
+	outline-offset: -2px;
+}
+
+.toolbarSlot {
+	display: inline-flex;
+	align-items: center;
+}
+
+.toolbarSlot[draggable='true'] {
+	cursor: grab;
+}
+
+.toolbarSlot[draggable='true']:active {
+	cursor: grabbing;
+}
+
+.toolbarSlot[data-dragging='true'] {
+	display: none;
+}
+
+.toolbarRow[data-editing='true'] .toolbarSlot > * {
+	pointer-events: none;
+}
+
+.toolbarRow[data-editing='true'] .toolbarSlot:not(.toolbarDropGhost) > * {
+	animation: toolbar-jiggle 0.55s ease-in-out infinite;
+	transform-origin: center;
+	box-shadow:
+		0 2px 4px rgba(15, 23, 42, 0.06),
+		0 18px 32px rgba(15, 23, 42, 0.18);
+}
+
+.toolbarDropGhost {
+	box-sizing: border-box;
+	width: 52px;
+	height: 40px;
+	border: 2px dashed rgba(159, 159, 159, 0.6);
+	border-radius: var(--ui-desks-radius-control, 16px);
+	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	background: rgba(15, 23, 42, 0.04);
+	pointer-events: none;
+}
+
+@keyframes toolbar-jiggle {
+	0%,
+	100% {
+		transform: rotate(-3deg);
+	}
+
+	50% {
+		transform: rotate(3deg);
+	}
+}
+
 .rightActions {
 	position: fixed;
 	top: calc(var(--desk-titlebar-height) + var(--wpds-dimension-padding-sm));
@@ -204,4 +272,125 @@
 	color: rgba(15, 23, 42, 0.42);
 	font-size: 11px;
 	line-height: 14px;
+}
+
+.settingsBackdrop {
+	position: fixed;
+	inset: 0;
+	z-index: 50;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+	background: rgba(15, 23, 42, 0.18);
+	backdrop-filter: blur(2px);
+	pointer-events: auto;
+}
+
+.settingsModal {
+	display: flex;
+	flex-direction: column;
+	width: min(440px, 92vw);
+	max-height: 80vh;
+	overflow: hidden;
+	color: var(--ui-desks-text, #14171a);
+	background: var(--ui-desks-material, #fff);
+	border-radius: 18px;
+	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	box-shadow: var(
+		--ui-desks-shadow-control-raised,
+		0 1px 2px rgba(15, 23, 42, 0.04),
+		0 18px 44px rgba(15, 23, 42, 0.1)
+	);
+}
+
+.settingsHeader,
+.settingsFooter {
+	display: flex;
+	align-items: center;
+	padding: 14px 18px;
+}
+
+.settingsHeader {
+	justify-content: space-between;
+	border-bottom: 1px solid var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+}
+
+.settingsHeader h2 {
+	margin: 0;
+	font-size: var(--wpds-typography-font-size-md);
+	font-weight: var(--wpds-typography-font-weight-semibold, 600);
+	line-height: var(--wpds-typography-line-height-md);
+}
+
+.settingsCloseButton {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	padding: 0;
+	color: var(--ui-desks-text, #14171a);
+	background: transparent;
+	border: 0;
+	border-radius: var(--ui-desks-radius-button, 12px);
+	cursor: pointer;
+}
+
+.settingsCloseButton:hover {
+	background: var(--ui-desks-control-hover, rgba(15, 23, 42, 0.07));
+}
+
+.settingsBody {
+	padding: 16px 18px;
+}
+
+.settingsToggleRow {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	color: var(--ui-desks-text, #14171a);
+	font-size: var(--wpds-typography-font-size-sm);
+	font-weight: var(--wpds-typography-font-weight-medium, 500);
+	line-height: var(--wpds-typography-line-height-sm);
+	cursor: pointer;
+}
+
+.settingsToggleRow input {
+	width: 16px;
+	height: 16px;
+	margin: 0;
+	cursor: pointer;
+}
+
+.settingsFooter {
+	justify-content: flex-end;
+	border-top: 1px solid var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+}
+
+.settingsFooterButton {
+	height: 36px;
+	padding: 0 14px;
+	color: var(--ui-desks-text, #14171a);
+	font: inherit;
+	font-size: var(--wpds-typography-font-size-sm);
+	font-weight: var(--wpds-typography-font-weight-medium, 500);
+	background: var(--ui-desks-control-hover, rgba(15, 23, 42, 0.07));
+	border: 0;
+	border-radius: var(--ui-desks-radius-button, 12px);
+	cursor: pointer;
+}
+
+.settingsFooterButton:hover {
+	background: rgba(15, 23, 42, 0.1);
+}
+
+.settingsFooterButtonPrimary {
+	background: var(--ui-desks-text, #14171a);
+	color: #fff;
+}
+
+.settingsFooterButtonPrimary:hover {
+	background: #000;
 }

--- a/apps/ui/src/ui-desks/chrome/toolbar-layout.test.ts
+++ b/apps/ui/src/ui-desks/chrome/toolbar-layout.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DEFAULT_DESK_TOOLBAR_LAYOUT,
+	moveDeskToolbarButton,
+	normalizeDeskToolbarLayout,
+	normalizeDeskToolbarSettings,
+} from './toolbar-layout';
+
+describe( 'desk toolbar layout', () => {
+	it( 'normalizes toolbar layouts and appends missing buttons to the right side', () => {
+		expect(
+			normalizeDeskToolbarLayout( {
+				left: [ 'settings', 'chat', 'chat', 'unknown' ],
+				right: [ 'create' ],
+			} )
+		).toEqual( {
+			left: [ 'settings', 'chat' ],
+			right: [ 'create', 'site-map' ],
+		} );
+	} );
+
+	it( 'falls back to the default toolbar layout for invalid shapes', () => {
+		expect( normalizeDeskToolbarLayout( { left: [ 'chat' ], right: 'settings' } ) ).toEqual(
+			DEFAULT_DESK_TOOLBAR_LAYOUT
+		);
+	} );
+
+	it( 'normalizes persisted settings for toolbar rendering', () => {
+		expect(
+			normalizeDeskToolbarSettings( {
+				version: 1,
+				updatedAt: '2026-05-11T00:00:00.000Z',
+				showSiteName: true,
+				toolbarLayout: {
+					left: [ 'settings' ],
+					right: [ 'unknown', 'chat' ],
+				},
+			} )
+		).toEqual( {
+			version: 1,
+			updatedAt: '2026-05-11T00:00:00.000Z',
+			showSiteName: true,
+			toolbarLayout: {
+				left: [ 'settings' ],
+				right: [ 'chat', 'create', 'site-map' ],
+			},
+		} );
+	} );
+
+	it( 'moves a toolbar button between sides', () => {
+		expect(
+			moveDeskToolbarButton( DEFAULT_DESK_TOOLBAR_LAYOUT, 'settings', 'left', 'chat' )
+		).toEqual( {
+			left: [ 'settings', 'chat', 'create' ],
+			right: [ 'site-map' ],
+		} );
+	} );
+} );

--- a/apps/ui/src/ui-desks/chrome/toolbar-layout.ts
+++ b/apps/ui/src/ui-desks/chrome/toolbar-layout.ts
@@ -1,0 +1,96 @@
+import type {
+	DeskSettings,
+	DeskToolbarLayout as PersistedDeskToolbarLayout,
+} from '@studio/common/types/desk';
+
+export const DESK_TOOLBAR_BUTTONS = [ 'chat', 'create', 'site-map', 'settings' ] as const;
+
+export type DeskToolbarButtonId = ( typeof DESK_TOOLBAR_BUTTONS )[ number ];
+
+export interface DeskToolbarLayout {
+	left: DeskToolbarButtonId[];
+	right: DeskToolbarButtonId[];
+}
+
+export type DeskToolbarSettings = Omit< DeskSettings, 'toolbarLayout' > & {
+	toolbarLayout: DeskToolbarLayout;
+};
+
+export const DEFAULT_DESK_TOOLBAR_LAYOUT: DeskToolbarLayout = {
+	left: [ 'chat', 'create' ],
+	right: [ 'site-map', 'settings' ],
+};
+
+function cloneToolbarLayout( layout: DeskToolbarLayout ): DeskToolbarLayout {
+	return {
+		left: [ ...layout.left ],
+		right: [ ...layout.right ],
+	};
+}
+
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	return Boolean( value ) && typeof value === 'object' && ! Array.isArray( value );
+}
+
+function isDeskToolbarButtonId( value: unknown ): value is DeskToolbarButtonId {
+	return typeof value === 'string' && DESK_TOOLBAR_BUTTONS.includes( value as DeskToolbarButtonId );
+}
+
+export function normalizeDeskToolbarLayout( value: unknown ): DeskToolbarLayout {
+	if ( ! isRecord( value ) || ! Array.isArray( value.left ) || ! Array.isArray( value.right ) ) {
+		return cloneToolbarLayout( DEFAULT_DESK_TOOLBAR_LAYOUT );
+	}
+
+	const layout = value as Record< keyof PersistedDeskToolbarLayout, unknown[] >;
+	const next: DeskToolbarLayout = { left: [], right: [] };
+	const seen = new Set< DeskToolbarButtonId >();
+
+	for ( const side of [ 'left', 'right' ] as const ) {
+		for ( const buttonId of layout[ side ] ) {
+			if ( isDeskToolbarButtonId( buttonId ) && ! seen.has( buttonId ) ) {
+				next[ side ].push( buttonId );
+				seen.add( buttonId );
+			}
+		}
+	}
+
+	for ( const buttonId of DESK_TOOLBAR_BUTTONS ) {
+		if ( ! seen.has( buttonId ) ) {
+			next.right.push( buttonId );
+		}
+	}
+
+	return next;
+}
+
+export function normalizeDeskToolbarSettings( settings: DeskSettings ): DeskToolbarSettings {
+	return {
+		...settings,
+		toolbarLayout: normalizeDeskToolbarLayout( settings.toolbarLayout ),
+	};
+}
+
+export function moveDeskToolbarButton(
+	layout: PersistedDeskToolbarLayout,
+	buttonId: DeskToolbarButtonId,
+	side: keyof DeskToolbarLayout,
+	beforeButtonId: DeskToolbarButtonId | null
+): DeskToolbarLayout {
+	const next = normalizeDeskToolbarLayout( layout );
+	const left = next.left.filter( ( id ) => id !== buttonId );
+	const right = next.right.filter( ( id ) => id !== buttonId );
+	const target = side === 'left' ? left : right;
+
+	if ( beforeButtonId && beforeButtonId !== buttonId ) {
+		const index = target.indexOf( beforeButtonId );
+		if ( index >= 0 ) {
+			target.splice( index, 0, buttonId );
+		} else {
+			target.push( buttonId );
+		}
+	} else {
+		target.push( buttonId );
+	}
+
+	return { left, right };
+}

--- a/apps/ui/src/ui-desks/chrome/user-menu.tsx
+++ b/apps/ui/src/ui-desks/chrome/user-menu.tsx
@@ -17,13 +17,15 @@ const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
 
 interface DeskMenuProps {
 	siteId?: string;
+	disabled?: boolean;
+	showSiteName?: boolean;
 }
 
 function getSiteIconSeed( site: SiteDetails ) {
 	return `${ site.id }:${ site.name }:${ site.path }`;
 }
 
-export function DeskMenu( { siteId }: DeskMenuProps ) {
+export function DeskMenu( { siteId, disabled = false, showSiteName = true }: DeskMenuProps ) {
 	const navigate = useNavigate();
 	const connector = useConnector();
 	const { data: user } = useAuthUser();
@@ -60,6 +62,7 @@ export function DeskMenu( { siteId }: DeskMenuProps ) {
 	const trigger = siteId ? (
 		<ControlButton
 			className={ styles.siteTrigger }
+			disabled={ disabled }
 			label={ sprintf(
 				/* translators: %s: current site name. */
 				__( 'Desk menu. Current site is %s.' ),
@@ -72,13 +75,19 @@ export function DeskMenu( { siteId }: DeskMenuProps ) {
 				seed={ activeSiteIconSeed }
 				imageSrc={ activeSite?.siteIcon }
 			/>
-			<span className={ styles.siteName } title={ activeSiteName }>
-				{ activeSiteName }
-			</span>
+			{ showSiteName && (
+				<span className={ styles.siteName } title={ activeSiteName }>
+					{ activeSiteName }
+				</span>
+			) }
 			<Icon icon={ chevronDownSmall } size={ 20 } className={ styles.siteCaret } />
 		</ControlButton>
 	) : (
-		<ControlButton label={ __( 'Desk menu' ) } tooltipLabel={ user?.displayName }>
+		<ControlButton
+			disabled={ disabled }
+			label={ __( 'Desk menu' ) }
+			tooltipLabel={ user?.displayName }
+		>
 			{ user ? (
 				<Gravatar className={ styles.avatar } email={ user.email } isDark={ themeIsDark } />
 			) : (

--- a/apps/ui/src/ui-desks/components/action-button/index.tsx
+++ b/apps/ui/src/ui-desks/components/action-button/index.tsx
@@ -1,22 +1,30 @@
+import { Button } from '@wordpress/ui';
 import { clsx } from 'clsx';
+import { forwardRef } from 'react';
 import styles from './style.module.css';
-import type { ComponentPropsWithoutRef } from 'react';
+import type { ComponentProps, ElementRef } from 'react';
 
-type ActionButtonProps = ComponentPropsWithoutRef< 'button' > & {
+type ActionButtonProps = Omit< ComponentProps< typeof Button >, 'variant' | 'tone' | 'size' > & {
 	fullWidth?: boolean;
 };
 
-export function ActionButton( {
-	className,
-	fullWidth = false,
-	type = 'button',
-	...props
-}: ActionButtonProps ) {
-	return (
-		<button
-			{ ...props }
-			className={ clsx( styles.button, fullWidth && styles.fullWidth, className ) }
-			type={ type }
-		/>
-	);
-}
+export const ActionButton = forwardRef< ElementRef< typeof Button >, ActionButtonProps >(
+	function ActionButton(
+		{ className, fullWidth = false, nativeButton, render, type = 'button', ...props },
+		ref
+	) {
+		return (
+			<Button
+				ref={ ref }
+				variant="minimal"
+				tone="neutral"
+				size="small"
+				className={ clsx( styles.button, fullWidth && styles.fullWidth, className ) }
+				nativeButton={ nativeButton ?? ! render }
+				render={ render }
+				type={ type }
+				{ ...props }
+			/>
+		);
+	}
+);

--- a/apps/ui/src/ui-desks/components/action-button/index.tsx
+++ b/apps/ui/src/ui-desks/components/action-button/index.tsx
@@ -16,7 +16,7 @@ export const ActionButton = forwardRef< ElementRef< typeof Button >, ActionButto
 		return (
 			<Button
 				ref={ ref }
-				variant="minimal"
+				variant="unstyled"
 				tone="neutral"
 				size="small"
 				className={ clsx( styles.button, fullWidth && styles.fullWidth, className ) }

--- a/apps/ui/src/ui-desks/components/action-button/style.module.css
+++ b/apps/ui/src/ui-desks/components/action-button/style.module.css
@@ -8,8 +8,10 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: flex-start;
+	min-width: 0;
 	padding: 10px 12px;
 	border: 0;
+	border-color: transparent;
 	border-radius: var(--ui-desks-radius-button, 12px);
 	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
 	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));

--- a/apps/ui/src/ui-desks/desk/index.tsx
+++ b/apps/ui/src/ui-desks/desk/index.tsx
@@ -1,13 +1,21 @@
+import {
+	DEFAULT_DESK_TOOLBAR_LAYOUT,
+	createDefaultDeskSettings,
+	normalizeDeskSettings,
+} from '@studio/common/lib/desk-settings';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useDeskSettings, useSaveDeskSettings } from '@/data/queries/use-desk-config';
 import { Chats, ChatsProvider } from '../chats';
 import { DeskChrome } from '../chrome';
+import { DeskSettingsModal } from '../chrome/settings-modal';
 import { LoadingPlaceholder } from '../components';
 import { useSiteMapDeskConfig } from '../site-map/use-site-map-desk-config';
 import { DeskWidgetToolbar } from '../widgets/toolbar';
 import { DeskCanvas } from './canvas';
 import { DeskProvider } from './provider';
 import styles from './style.module.css';
+import type { DeskSettings, DeskToolbarLayout } from '@studio/common/types/desk';
 import type { ReactNode } from 'react';
 
 interface DeskProps {
@@ -75,19 +83,86 @@ function DeskShell( {
 	onToggleSiteMap?: () => void;
 	children: ReactNode;
 } ) {
+	const { data: savedDeskSettings } = useDeskSettings();
+	const fallbackDeskSettings = useMemo( () => createDefaultDeskSettings(), [] );
+	const deskSettings = savedDeskSettings ?? fallbackDeskSettings;
+	const saveDeskSettings = useSaveDeskSettings();
+	const [ settingsOpen, setSettingsOpen ] = useState( false );
+	const [ editingToolbar, setEditingToolbar ] = useState( false );
+
+	const updateDeskSettings = ( patch: Partial< DeskSettings > ) => {
+		saveDeskSettings.mutate(
+			normalizeDeskSettings( {
+				...deskSettings,
+				...patch,
+				updatedAt: new Date().toISOString(),
+			} )
+		);
+	};
+
+	const updateToolbarLayout = ( toolbarLayout: DeskToolbarLayout ) => {
+		updateDeskSettings( { toolbarLayout } );
+	};
+
 	return (
 		<ChatsProvider siteId={ siteId }>
 			<Chats siteId={ siteId } />
-			<main className={ styles.root } aria-label={ getDeskLabel( siteId ) } data-site-id={ siteId }>
+			<main
+				className={ styles.root }
+				aria-label={ getDeskLabel( siteId ) }
+				data-site-id={ siteId }
+				data-toolbar-editing={ editingToolbar ? 'true' : 'false' }
+			>
 				<DeskChrome
 					siteId={ siteId }
 					siteMapOpen={ siteMapOpen }
 					siteMapPageCount={ siteMapPageCount }
+					settings={ deskSettings }
+					settingsOpen={ settingsOpen }
+					editingToolbar={ editingToolbar }
 					onToggleSiteMap={ onToggleSiteMap }
+					onToggleSettings={ () => setSettingsOpen( ( open ) => ! open ) }
+					onChangeToolbarLayout={ updateToolbarLayout }
 				/>
 				{ children }
 				{ siteMapIsLoading && <SiteMapLoadingWidget /> }
 				<DeskWidgetToolbar />
+				{ settingsOpen && (
+					<DeskSettingsModal
+						settings={ deskSettings }
+						onChange={ updateDeskSettings }
+						onClose={ () => setSettingsOpen( false ) }
+						onEditToolbar={ () => setEditingToolbar( true ) }
+					/>
+				) }
+				{ editingToolbar && (
+					<>
+						<button
+							type="button"
+							className={ styles.toolbarEditBackdrop }
+							aria-label={ __( 'Exit toolbar editing' ) }
+							onClick={ () => setEditingToolbar( false ) }
+						/>
+						<div className={ styles.toolbarEditActions }>
+							<button
+								type="button"
+								className={ styles.toolbarEditButton }
+								onClick={ () => setEditingToolbar( false ) }
+							>
+								{ __( 'Done' ) }
+							</button>
+							<button
+								type="button"
+								className={ styles.toolbarEditButton }
+								onClick={ () =>
+									updateDeskSettings( { toolbarLayout: DEFAULT_DESK_TOOLBAR_LAYOUT } )
+								}
+							>
+								{ __( 'Reset' ) }
+							</button>
+						</div>
+					</>
+				) }
 			</main>
 		</ChatsProvider>
 	);

--- a/apps/ui/src/ui-desks/desk/index.tsx
+++ b/apps/ui/src/ui-desks/desk/index.tsx
@@ -1,21 +1,16 @@
-import {
-	DEFAULT_DESK_TOOLBAR_LAYOUT,
-	createDefaultDeskSettings,
-	normalizeDeskSettings,
-} from '@studio/common/lib/desk-settings';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useState } from 'react';
-import { useDeskSettings, useSaveDeskSettings } from '@/data/queries/use-desk-config';
+import { useState } from 'react';
+import { useUpdateDeskSettings } from '@/data/queries/use-desk-config';
 import { Chats, ChatsProvider } from '../chats';
 import { DeskChrome } from '../chrome';
 import { DeskSettingsModal } from '../chrome/settings-modal';
-import { LoadingPlaceholder } from '../components';
+import { DEFAULT_DESK_TOOLBAR_LAYOUT } from '../chrome/toolbar-layout';
+import { ActionButton, LoadingPlaceholder } from '../components';
 import { useSiteMapDeskConfig } from '../site-map/use-site-map-desk-config';
 import { DeskWidgetToolbar } from '../widgets/toolbar';
 import { DeskCanvas } from './canvas';
 import { DeskProvider } from './provider';
 import styles from './style.module.css';
-import type { DeskSettings, DeskToolbarLayout } from '@studio/common/types/desk';
 import type { ReactNode } from 'react';
 
 interface DeskProps {
@@ -83,26 +78,9 @@ function DeskShell( {
 	onToggleSiteMap?: () => void;
 	children: ReactNode;
 } ) {
-	const { data: savedDeskSettings } = useDeskSettings();
-	const fallbackDeskSettings = useMemo( () => createDefaultDeskSettings(), [] );
-	const deskSettings = savedDeskSettings ?? fallbackDeskSettings;
-	const saveDeskSettings = useSaveDeskSettings();
+	const updateDeskSettings = useUpdateDeskSettings();
 	const [ settingsOpen, setSettingsOpen ] = useState( false );
 	const [ editingToolbar, setEditingToolbar ] = useState( false );
-
-	const updateDeskSettings = ( patch: Partial< DeskSettings > ) => {
-		saveDeskSettings.mutate(
-			normalizeDeskSettings( {
-				...deskSettings,
-				...patch,
-				updatedAt: new Date().toISOString(),
-			} )
-		);
-	};
-
-	const updateToolbarLayout = ( toolbarLayout: DeskToolbarLayout ) => {
-		updateDeskSettings( { toolbarLayout } );
-	};
 
 	return (
 		<ChatsProvider siteId={ siteId }>
@@ -117,24 +95,19 @@ function DeskShell( {
 					siteId={ siteId }
 					siteMapOpen={ siteMapOpen }
 					siteMapPageCount={ siteMapPageCount }
-					settings={ deskSettings }
 					settingsOpen={ settingsOpen }
 					editingToolbar={ editingToolbar }
 					onToggleSiteMap={ onToggleSiteMap }
 					onToggleSettings={ () => setSettingsOpen( ( open ) => ! open ) }
-					onChangeToolbarLayout={ updateToolbarLayout }
 				/>
 				{ children }
 				{ siteMapIsLoading && <SiteMapLoadingWidget /> }
 				<DeskWidgetToolbar />
-				{ settingsOpen && (
-					<DeskSettingsModal
-						settings={ deskSettings }
-						onChange={ updateDeskSettings }
-						onClose={ () => setSettingsOpen( false ) }
-						onEditToolbar={ () => setEditingToolbar( true ) }
-					/>
-				) }
+				<DeskSettingsModal
+					open={ settingsOpen }
+					onOpenChange={ setSettingsOpen }
+					onEditToolbar={ () => setEditingToolbar( true ) }
+				/>
 				{ editingToolbar && (
 					<>
 						<button
@@ -144,14 +117,14 @@ function DeskShell( {
 							onClick={ () => setEditingToolbar( false ) }
 						/>
 						<div className={ styles.toolbarEditActions }>
-							<button
+							<ActionButton
 								type="button"
 								className={ styles.toolbarEditButton }
 								onClick={ () => setEditingToolbar( false ) }
 							>
 								{ __( 'Done' ) }
-							</button>
-							<button
+							</ActionButton>
+							<ActionButton
 								type="button"
 								className={ styles.toolbarEditButton }
 								onClick={ () =>
@@ -159,7 +132,7 @@ function DeskShell( {
 								}
 							>
 								{ __( 'Reset' ) }
-							</button>
+							</ActionButton>
 						</div>
 					</>
 				) }

--- a/apps/ui/src/ui-desks/desk/style.module.css
+++ b/apps/ui/src/ui-desks/desk/style.module.css
@@ -13,6 +13,63 @@
 	overflow: hidden;
 }
 
+.root[data-toolbar-editing='true'] .canvas {
+	filter: blur(8px) brightness(0.96);
+	transition: filter 220ms ease;
+}
+
+.toolbarEditBackdrop {
+	position: fixed;
+	inset: 0;
+	z-index: 19;
+	padding: 0;
+	background: rgba(15, 23, 42, 0.06);
+	border: 0;
+	cursor: zoom-out;
+}
+
+.toolbarEditActions {
+	position: fixed;
+	top: calc(46px + var(--wpds-dimension-padding-sm));
+	left: 50%;
+	z-index: 21;
+	display: flex;
+	gap: 8px;
+	transform: translateX(-50%);
+}
+
+.toolbarEditButton {
+	height: 40px;
+	padding: 0 16px;
+	color: var(--ui-desks-text, #14171a);
+	font: inherit;
+	font-size: var(--wpds-typography-font-size-sm);
+	font-weight: var(--wpds-typography-font-weight-medium, 500);
+	background: var(--ui-desks-material, #fff);
+	border: 0;
+	border-radius: var(--ui-desks-radius-control, 16px);
+	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	box-shadow: var(
+		--ui-desks-shadow-control,
+		0 1px 2px rgba(15, 23, 42, 0.04),
+		0 8px 24px rgba(15, 23, 42, 0.06)
+	);
+	cursor: pointer;
+	transition:
+		box-shadow 160ms ease,
+		transform 160ms ease;
+}
+
+.toolbarEditButton:hover {
+	box-shadow: var(
+		--ui-desks-shadow-control-raised,
+		0 1px 2px rgba(15, 23, 42, 0.04),
+		0 18px 44px rgba(15, 23, 42, 0.1)
+	);
+	transform: translateY(-1px);
+}
+
 .statusMessage {
 	position: absolute;
 	inset: 0;

--- a/apps/ui/src/ui-desks/desk/style.module.css
+++ b/apps/ui/src/ui-desks/desk/style.module.css
@@ -39,14 +39,12 @@
 }
 
 .toolbarEditButton {
+	--action-button-background: var(--ui-desks-material, #fff);
+
 	height: 40px;
 	padding: 0 16px;
-	color: var(--ui-desks-text, #14171a);
-	font: inherit;
-	font-size: var(--wpds-typography-font-size-sm);
-	font-weight: var(--wpds-typography-font-weight-medium, 500);
-	background: var(--ui-desks-material, #fff);
-	border: 0;
+	justify-content: center;
+	background-color: var(--action-button-background);
 	border-radius: var(--ui-desks-radius-control, 16px);
 	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
 	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
@@ -55,13 +53,14 @@
 		0 1px 2px rgba(15, 23, 42, 0.04),
 		0 8px 24px rgba(15, 23, 42, 0.06)
 	);
-	cursor: pointer;
 	transition:
 		box-shadow 160ms ease,
 		transform 160ms ease;
 }
 
 .toolbarEditButton:hover {
+	--action-button-background: var(--ui-desks-material, #fff);
+
 	box-shadow: var(
 		--ui-desks-shadow-control-raised,
 		0 1px 2px rgba(15, 23, 42, 0.04),

--- a/tools/common/lib/desk-settings.ts
+++ b/tools/common/lib/desk-settings.ts
@@ -1,14 +1,12 @@
 import {
 	DESK_SETTINGS_VERSION,
-	DESK_TOOLBAR_BUTTONS,
 	type DeskSettings,
-	type DeskToolbarButtonId,
 	type DeskToolbarLayout,
 } from '@studio/common/types/desk';
 
-export const DEFAULT_DESK_TOOLBAR_LAYOUT: DeskToolbarLayout = {
-	left: [ 'chat', 'create' ],
-	right: [ 'site-map', 'settings' ],
+const DEFAULT_DESK_TOOLBAR_LAYOUT: DeskToolbarLayout = {
+	left: [],
+	right: [],
 };
 
 function cloneToolbarLayout( layout: DeskToolbarLayout ): DeskToolbarLayout {
@@ -31,10 +29,6 @@ function isRecord( value: unknown ): value is Record< string, unknown > {
 	return Boolean( value ) && typeof value === 'object' && ! Array.isArray( value );
 }
 
-function isDeskToolbarButtonId( value: unknown ): value is DeskToolbarButtonId {
-	return typeof value === 'string' && DESK_TOOLBAR_BUTTONS.includes( value as DeskToolbarButtonId );
-}
-
 export function normalizeDeskToolbarLayout( value: unknown ): DeskToolbarLayout {
 	if ( ! isRecord( value ) || ! Array.isArray( value.left ) || ! Array.isArray( value.right ) ) {
 		return cloneToolbarLayout( DEFAULT_DESK_TOOLBAR_LAYOUT );
@@ -42,20 +36,14 @@ export function normalizeDeskToolbarLayout( value: unknown ): DeskToolbarLayout 
 
 	const layout = value as Record< keyof DeskToolbarLayout, unknown[] >;
 	const next: DeskToolbarLayout = { left: [], right: [] };
-	const seen = new Set< DeskToolbarButtonId >();
+	const seen = new Set< string >();
 
 	for ( const side of [ 'left', 'right' ] as const ) {
 		for ( const buttonId of layout[ side ] ) {
-			if ( isDeskToolbarButtonId( buttonId ) && ! seen.has( buttonId ) ) {
+			if ( typeof buttonId === 'string' && buttonId && ! seen.has( buttonId ) ) {
 				next[ side ].push( buttonId );
 				seen.add( buttonId );
 			}
-		}
-	}
-
-	for ( const buttonId of DESK_TOOLBAR_BUTTONS ) {
-		if ( ! seen.has( buttonId ) ) {
-			next.right.push( buttonId );
 		}
 	}
 
@@ -76,29 +64,4 @@ export function normalizeDeskSettings( value: unknown ): DeskSettings {
 			typeof value.showSiteName === 'boolean' ? value.showSiteName : defaults.showSiteName,
 		toolbarLayout: normalizeDeskToolbarLayout( value.toolbarLayout ),
 	};
-}
-
-export function moveDeskToolbarButton(
-	layout: DeskToolbarLayout,
-	buttonId: DeskToolbarButtonId,
-	side: keyof DeskToolbarLayout,
-	beforeButtonId: DeskToolbarButtonId | null
-): DeskToolbarLayout {
-	const next = normalizeDeskToolbarLayout( layout );
-	const left = next.left.filter( ( id ) => id !== buttonId );
-	const right = next.right.filter( ( id ) => id !== buttonId );
-	const target = side === 'left' ? left : right;
-
-	if ( beforeButtonId && beforeButtonId !== buttonId ) {
-		const index = target.indexOf( beforeButtonId );
-		if ( index >= 0 ) {
-			target.splice( index, 0, buttonId );
-		} else {
-			target.push( buttonId );
-		}
-	} else {
-		target.push( buttonId );
-	}
-
-	return { left, right };
 }

--- a/tools/common/lib/desk-settings.ts
+++ b/tools/common/lib/desk-settings.ts
@@ -1,0 +1,104 @@
+import {
+	DESK_SETTINGS_VERSION,
+	DESK_TOOLBAR_BUTTONS,
+	type DeskSettings,
+	type DeskToolbarButtonId,
+	type DeskToolbarLayout,
+} from '@studio/common/types/desk';
+
+export const DEFAULT_DESK_TOOLBAR_LAYOUT: DeskToolbarLayout = {
+	left: [ 'chat', 'create' ],
+	right: [ 'site-map', 'settings' ],
+};
+
+function cloneToolbarLayout( layout: DeskToolbarLayout ): DeskToolbarLayout {
+	return {
+		left: [ ...layout.left ],
+		right: [ ...layout.right ],
+	};
+}
+
+export function createDefaultDeskSettings( updatedAt = new Date().toISOString() ): DeskSettings {
+	return {
+		version: DESK_SETTINGS_VERSION,
+		updatedAt,
+		showSiteName: true,
+		toolbarLayout: cloneToolbarLayout( DEFAULT_DESK_TOOLBAR_LAYOUT ),
+	};
+}
+
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	return Boolean( value ) && typeof value === 'object' && ! Array.isArray( value );
+}
+
+function isDeskToolbarButtonId( value: unknown ): value is DeskToolbarButtonId {
+	return typeof value === 'string' && DESK_TOOLBAR_BUTTONS.includes( value as DeskToolbarButtonId );
+}
+
+export function normalizeDeskToolbarLayout( value: unknown ): DeskToolbarLayout {
+	if ( ! isRecord( value ) || ! Array.isArray( value.left ) || ! Array.isArray( value.right ) ) {
+		return cloneToolbarLayout( DEFAULT_DESK_TOOLBAR_LAYOUT );
+	}
+
+	const layout = value as Record< keyof DeskToolbarLayout, unknown[] >;
+	const next: DeskToolbarLayout = { left: [], right: [] };
+	const seen = new Set< DeskToolbarButtonId >();
+
+	for ( const side of [ 'left', 'right' ] as const ) {
+		for ( const buttonId of layout[ side ] ) {
+			if ( isDeskToolbarButtonId( buttonId ) && ! seen.has( buttonId ) ) {
+				next[ side ].push( buttonId );
+				seen.add( buttonId );
+			}
+		}
+	}
+
+	for ( const buttonId of DESK_TOOLBAR_BUTTONS ) {
+		if ( ! seen.has( buttonId ) ) {
+			next.right.push( buttonId );
+		}
+	}
+
+	return next;
+}
+
+export function normalizeDeskSettings( value: unknown ): DeskSettings {
+	const defaults = createDefaultDeskSettings();
+
+	if ( ! isRecord( value ) ) {
+		return defaults;
+	}
+
+	return {
+		version: DESK_SETTINGS_VERSION,
+		updatedAt: typeof value.updatedAt === 'string' ? value.updatedAt : defaults.updatedAt,
+		showSiteName:
+			typeof value.showSiteName === 'boolean' ? value.showSiteName : defaults.showSiteName,
+		toolbarLayout: normalizeDeskToolbarLayout( value.toolbarLayout ),
+	};
+}
+
+export function moveDeskToolbarButton(
+	layout: DeskToolbarLayout,
+	buttonId: DeskToolbarButtonId,
+	side: keyof DeskToolbarLayout,
+	beforeButtonId: DeskToolbarButtonId | null
+): DeskToolbarLayout {
+	const next = normalizeDeskToolbarLayout( layout );
+	const left = next.left.filter( ( id ) => id !== buttonId );
+	const right = next.right.filter( ( id ) => id !== buttonId );
+	const target = side === 'left' ? left : right;
+
+	if ( beforeButtonId && beforeButtonId !== buttonId ) {
+		const index = target.indexOf( beforeButtonId );
+		if ( index >= 0 ) {
+			target.splice( index, 0, buttonId );
+		} else {
+			target.push( buttonId );
+		}
+	} else {
+		target.push( buttonId );
+	}
+
+	return { left, right };
+}

--- a/tools/common/lib/tests/desk-settings.test.ts
+++ b/tools/common/lib/tests/desk-settings.test.ts
@@ -1,7 +1,5 @@
 import {
-	DEFAULT_DESK_TOOLBAR_LAYOUT,
 	createDefaultDeskSettings,
-	moveDeskToolbarButton,
 	normalizeDeskSettings,
 	normalizeDeskToolbarLayout,
 } from '../desk-settings';
@@ -12,26 +10,30 @@ describe( 'desk settings', () => {
 			version: 1,
 			updatedAt: '2026-05-11T00:00:00.000Z',
 			showSiteName: true,
-			toolbarLayout: DEFAULT_DESK_TOOLBAR_LAYOUT,
+			toolbarLayout: {
+				left: [],
+				right: [],
+			},
 		} );
 	} );
 
-	it( 'normalizes toolbar layouts and appends missing buttons to the right side', () => {
+	it( 'normalizes persisted toolbar layouts as deduped string arrays', () => {
 		expect(
 			normalizeDeskToolbarLayout( {
-				left: [ 'settings', 'chat', 'chat', 'unknown' ],
-				right: [ 'create' ],
+				left: [ 'settings', 'chat', 'chat', null, 'unknown' ],
+				right: [ 'create', 'settings', '' ],
 			} )
 		).toEqual( {
-			left: [ 'settings', 'chat' ],
-			right: [ 'create', 'site-map' ],
+			left: [ 'settings', 'chat', 'unknown' ],
+			right: [ 'create' ],
 		} );
 	} );
 
-	it( 'falls back to the default toolbar layout for invalid shapes', () => {
-		expect( normalizeDeskToolbarLayout( { left: [ 'chat' ], right: 'settings' } ) ).toEqual(
-			DEFAULT_DESK_TOOLBAR_LAYOUT
-		);
+	it( 'falls back to an empty toolbar layout for invalid persisted shapes', () => {
+		expect( normalizeDeskToolbarLayout( { left: [ 'chat' ], right: 'settings' } ) ).toEqual( {
+			left: [],
+			right: [],
+		} );
 	} );
 
 	it( 'normalizes saved settings', () => {
@@ -53,15 +55,6 @@ describe( 'desk settings', () => {
 				left: [ 'settings' ],
 				right: [ 'chat', 'create', 'site-map' ],
 			},
-		} );
-	} );
-
-	it( 'moves a toolbar button between sides', () => {
-		expect(
-			moveDeskToolbarButton( DEFAULT_DESK_TOOLBAR_LAYOUT, 'settings', 'left', 'chat' )
-		).toEqual( {
-			left: [ 'settings', 'chat', 'create' ],
-			right: [ 'site-map' ],
 		} );
 	} );
 } );

--- a/tools/common/lib/tests/desk-settings.test.ts
+++ b/tools/common/lib/tests/desk-settings.test.ts
@@ -1,0 +1,67 @@
+import {
+	DEFAULT_DESK_TOOLBAR_LAYOUT,
+	createDefaultDeskSettings,
+	moveDeskToolbarButton,
+	normalizeDeskSettings,
+	normalizeDeskToolbarLayout,
+} from '../desk-settings';
+
+describe( 'desk settings', () => {
+	it( 'creates default global desk settings', () => {
+		expect( createDefaultDeskSettings( '2026-05-11T00:00:00.000Z' ) ).toEqual( {
+			version: 1,
+			updatedAt: '2026-05-11T00:00:00.000Z',
+			showSiteName: true,
+			toolbarLayout: DEFAULT_DESK_TOOLBAR_LAYOUT,
+		} );
+	} );
+
+	it( 'normalizes toolbar layouts and appends missing buttons to the right side', () => {
+		expect(
+			normalizeDeskToolbarLayout( {
+				left: [ 'settings', 'chat', 'chat', 'unknown' ],
+				right: [ 'create' ],
+			} )
+		).toEqual( {
+			left: [ 'settings', 'chat' ],
+			right: [ 'create', 'site-map' ],
+		} );
+	} );
+
+	it( 'falls back to the default toolbar layout for invalid shapes', () => {
+		expect( normalizeDeskToolbarLayout( { left: [ 'chat' ], right: 'settings' } ) ).toEqual(
+			DEFAULT_DESK_TOOLBAR_LAYOUT
+		);
+	} );
+
+	it( 'normalizes saved settings', () => {
+		const settings = normalizeDeskSettings( {
+			version: 999,
+			updatedAt: '2026-05-11T00:00:00.000Z',
+			showSiteName: true,
+			toolbarLayout: {
+				left: [ 'settings' ],
+				right: [ 'chat', 'create', 'site-map' ],
+			},
+		} );
+
+		expect( settings ).toEqual( {
+			version: 1,
+			updatedAt: '2026-05-11T00:00:00.000Z',
+			showSiteName: true,
+			toolbarLayout: {
+				left: [ 'settings' ],
+				right: [ 'chat', 'create', 'site-map' ],
+			},
+		} );
+	} );
+
+	it( 'moves a toolbar button between sides', () => {
+		expect(
+			moveDeskToolbarButton( DEFAULT_DESK_TOOLBAR_LAYOUT, 'settings', 'left', 'chat' )
+		).toEqual( {
+			left: [ 'settings', 'chat', 'create' ],
+			right: [ 'site-map' ],
+		} );
+	} );
+} );

--- a/tools/common/types/desk.ts
+++ b/tools/common/types/desk.ts
@@ -1,13 +1,9 @@
 export const DESK_CONFIG_VERSION = 1;
 export const DESK_SETTINGS_VERSION = 1;
 
-export const DESK_TOOLBAR_BUTTONS = [ 'chat', 'create', 'site-map', 'settings' ] as const;
-
-export type DeskToolbarButtonId = ( typeof DESK_TOOLBAR_BUTTONS )[ number ];
-
 export interface DeskToolbarLayout {
-	left: DeskToolbarButtonId[];
-	right: DeskToolbarButtonId[];
+	left: string[];
+	right: string[];
 }
 
 export interface DeskSettings {

--- a/tools/common/types/desk.ts
+++ b/tools/common/types/desk.ts
@@ -1,4 +1,21 @@
 export const DESK_CONFIG_VERSION = 1;
+export const DESK_SETTINGS_VERSION = 1;
+
+export const DESK_TOOLBAR_BUTTONS = [ 'chat', 'create', 'site-map', 'settings' ] as const;
+
+export type DeskToolbarButtonId = ( typeof DESK_TOOLBAR_BUTTONS )[ number ];
+
+export interface DeskToolbarLayout {
+	left: DeskToolbarButtonId[];
+	right: DeskToolbarButtonId[];
+}
+
+export interface DeskSettings {
+	version: typeof DESK_SETTINGS_VERSION;
+	updatedAt: string;
+	showSiteName: boolean;
+	toolbarLayout: DeskToolbarLayout;
+}
 
 export interface DeskWidgetBase<
 	TType extends string = string,
@@ -38,6 +55,7 @@ export interface DeskConfig< TWidget extends DeskWidgetBase = DeskWidgetBase > {
 }
 
 export interface DesksConfig {
+	settings?: DeskSettings;
 	user?: DeskConfig;
 	sites?: Record< string, DeskConfig >;
 }


### PR DESCRIPTION
**Summary**
- Persist desk-wide settings in `app.json` under `desks.settings` and expose them through the IPC connector.
- Add a top-right settings button and modal on desks to toggle site-name display and enter toolbar edit mode.
- Support drag-and-drop reordering of toolbar buttons with the layout applied across all desks.
- Keep the user/site menu disabled while toolbar editing is active.

**Testing**
- Added unit coverage for desk-settings normalization, defaulting, and toolbar reordering.
- Ran lint/format on modified files, full typecheck, focused desk tests, and a UI production build successfully.