### PR TITLE
apps/ui: Remove New chat from the ui-desks plus menu

### DIFF
--- a/apps/ui/src/ui-desks/chrome/create-menu.tsx
+++ b/apps/ui/src/ui-desks/chrome/create-menu.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { useEntityRecords, type Post as CoreDataPost } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { chevronLeft, comment, download, globe, plus } from '@wordpress/icons';
+import { chevronLeft, download, globe, plus } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { useMemo, useState } from 'react';
 import { useSites } from '@/data/queries/use-sites';
@@ -14,7 +14,6 @@ import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
 import { POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
 import { getCreatableWidgetDefinitions } from '@/ui-desks/widgets/registry';
 import styles from './style.module.css';
-import type { ChatsSearch } from '../chats/search';
 import type { DeskWidgetDefinition } from '@/ui-desks/widgets/types';
 
 export function DeskCreateMenu() {
@@ -27,17 +26,6 @@ export function DeskCreateMenu() {
 	const { data: sites } = useSites();
 	const site = sites?.find( ( candidate ) => candidate.id === desk.siteId );
 	const isSiteRunning = Boolean( site?.running );
-
-	const createChat = () => {
-		void navigate( {
-			to: '.',
-			search: ( previous: ChatsSearch ) => ( {
-				...previous,
-				chats: true,
-				newChat: Date.now(),
-			} ),
-		} );
-	};
 
 	const openCreateSite = () => {
 		void navigate( { to: '/onboarding' } );
@@ -110,10 +98,6 @@ export function DeskCreateMenu() {
 							</>
 						) }
 						{ ( creatableWidgetDefinitions.length > 0 || desk.siteId ) && <Menu.Separator /> }
-						<Menu.Item onClick={ createChat }>
-							<Icon icon={ comment } />
-							<span>{ __( 'New chat' ) }</span>
-						</Menu.Item>
 						<Menu.Item onClick={ openCreateSite }>
 							<Icon icon={ globe } />
 							<span>{ __( 'New site' ) }</span>


### PR DESCRIPTION
## Summary
- Removed the `New chat` item from the ui-desks create menu opened from the plus button.
- Cleaned up the unused chat navigation helper, icon import, and related search type import.

## Testing
- Lint and formatting passed for the modified file.
- Typecheck passed.
- `apps/ui/src/ui-desks` tests passed.