### PR TITLE
apps/ui: Add sticky note text sizing and fit-text controls to desks UI

### DIFF
--- a/apps/ui/src/ui-desks/controls/registry.tsx
+++ b/apps/ui/src/ui-desks/controls/registry.tsx
@@ -10,6 +10,7 @@ export function ControlRenderer( props: ControlRendererProps ) {
 			return (
 				<Component
 					isOpen={ props.isOpen }
+					fitSelectedWidgetToContent={ props.fitSelectedWidgetToContent }
 					props={ props.props }
 					setIsOpen={ props.setIsOpen }
 					updateProps={ props.updateProps }

--- a/apps/ui/src/ui-desks/controls/types.ts
+++ b/apps/ui/src/ui-desks/controls/types.ts
@@ -27,6 +27,7 @@ export interface ControlRenderContext<
 > {
 	isOpen: boolean;
 	setIsOpen: ( isOpen: boolean ) => void;
+	fitSelectedWidgetToContent?: () => boolean;
 	updateProps: ( props: Record< string, unknown > ) => void;
 	props: TProps;
 }
@@ -63,6 +64,7 @@ export interface ControlRendererProps {
 	control: AnyControlConfig;
 	isOpen: boolean;
 	setIsOpen: ( isOpen: boolean ) => void;
+	fitSelectedWidgetToContent?: () => boolean;
 	updateProps: ( props: Record< string, unknown > ) => void;
 	props: Record< string, unknown >;
 }

--- a/apps/ui/src/ui-desks/desk/canvas.tsx
+++ b/apps/ui/src/ui-desks/desk/canvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { Tldraw, type Editor, type TLComponents, type TldrawOptions } from 'tldraw';
 import 'tldraw/tldraw.css';
 import { deskShapeUtils } from '@/ui-desks/shapes/registry';
@@ -9,10 +9,6 @@ import {
 import { useDesk, useRegisterDeskEditor } from './provider';
 import styles from './style.module.css';
 import { TldrawHoverStateSync } from './tldraw-hover-state-sync';
-
-const deskCanvasOptions = {
-	createTextOnCanvasDoubleClick: false,
-} satisfies Partial< TldrawOptions >;
 
 const deskCanvasComponents = {
 	ContextMenu: null,
@@ -30,8 +26,15 @@ function DeskCanvasOverlays() {
 }
 
 export function DeskCanvas() {
-	const { isLoading, statusMessage } = useDesk();
+	const { isLoading, isReadOnly, statusMessage } = useDesk();
 	const registerEditor = useRegisterDeskEditor();
+	const canvasOptions = useMemo(
+		() =>
+			( {
+				createTextOnCanvasDoubleClick: ! isReadOnly,
+			} ) satisfies Partial< TldrawOptions >,
+		[ isReadOnly ]
+	);
 
 	const handleMount = useCallback(
 		( nextEditor: Editor ) => {
@@ -55,7 +58,7 @@ export function DeskCanvas() {
 			<Tldraw
 				hideUi
 				autoFocus
-				options={ deskCanvasOptions }
+				options={ canvasOptions }
 				components={ deskCanvasComponents }
 				shapeUtils={ deskShapeUtils }
 				onMount={ handleMount }

--- a/apps/ui/src/ui-desks/desk/provider/context.ts
+++ b/apps/ui/src/ui-desks/desk/provider/context.ts
@@ -22,6 +22,7 @@ export interface DeskContextValue {
 	pressStack: ( stackId: string ) => void;
 	addWidget: ( type: string, options?: AddDeskWidgetOptions ) => boolean;
 	updateSelectedWidgetProps: ( widgetProps: Record< string, unknown > ) => boolean;
+	fitSelectedWidgetToContent: () => boolean;
 	stackSelectedWidgets: () => boolean;
 	unstackSelectedWidgets: () => boolean;
 	removeSelectedWidget: () => boolean;
@@ -61,6 +62,7 @@ const defaultDeskContext: DeskContextValue = {
 	pressStack: noopPressStack,
 	addWidget: () => false,
 	updateSelectedWidgetProps: () => false,
+	fitSelectedWidgetToContent: () => false,
 	stackSelectedWidgets: () => false,
 	unstackSelectedWidgets: () => false,
 	removeSelectedWidget: () => false,

--- a/apps/ui/src/ui-desks/desk/provider/editor-state.ts
+++ b/apps/ui/src/ui-desks/desk/provider/editor-state.ts
@@ -16,6 +16,8 @@ import {
 } from '@/ui-desks/stacks/utils';
 import { BLOG_WIDGET_TYPE } from '@/ui-desks/widgets/blog/types';
 import { createDeskWidget } from '@/ui-desks/widgets/create-widget';
+import { getFittedNoteHeight } from '@/ui-desks/widgets/note/text-sizing';
+import { isNoteWidgetProps, NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
 import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
 import { getSelectedWidgetToolbarItem } from '@/ui-desks/widgets/toolbar-selection';
 import {
@@ -185,6 +187,39 @@ export function updateSelectedWidgetPropsInEditor(
 	};
 }
 
+export function fitSelectedWidgetToContentInEditor( editor: Editor ) {
+	const selection = getCurrentSelectedWidgetSelection( editor );
+	if ( ! selection || selection.item.kind !== 'single-widget' ) {
+		return false;
+	}
+
+	const { item, shapes } = selection;
+	const [ shape ] = shapes;
+	if (
+		item.widget.type !== NOTE_WIDGET_TYPE ||
+		! isNoteWidgetProps( item.widget.widgetProps ) ||
+		! isRectangleWidgetShape( shape )
+	) {
+		return false;
+	}
+
+	const nextHeight = getFittedNoteHeight( item.widget.widgetProps, shape.props.shapeProps );
+	const centerY = shape.y + shape.props.shapeProps.h / 2;
+	editor.updateShape< RectangleWidgetShape >( {
+		id: shape.id,
+		type: RECTANGLE_WIDGET_SHAPE_TYPE,
+		y: centerY - nextHeight / 2,
+		props: {
+			shapeProps: {
+				...shape.props.shapeProps,
+				h: nextHeight,
+			},
+		},
+	} );
+
+	return true;
+}
+
 export function removeSelectedWidgetFromEditor( editor: Editor ) {
 	const selection = getCurrentSelectedWidgetSelection( editor );
 	if ( ! selection || ! selection.item.canRemove ) {
@@ -301,6 +336,14 @@ function getCurrentSelectedWidgetSelection(
 		item,
 		shapes: shapes as TLShape[],
 	};
+}
+
+function isRectangleWidgetShape( shape: unknown ): shape is RectangleWidgetShape {
+	return (
+		Boolean( shape ) &&
+		typeof shape === 'object' &&
+		( shape as { type?: unknown } ).type === RECTANGLE_WIDGET_SHAPE_TYPE
+	);
 }
 
 export function getCurrentDeskWidgets( editor: Editor ) {

--- a/apps/ui/src/ui-desks/desk/provider/index.tsx
+++ b/apps/ui/src/ui-desks/desk/provider/index.tsx
@@ -5,6 +5,7 @@ import {
 	getIndexAbove,
 	sortByIndex,
 	type Editor,
+	type TLShape,
 	type TLShapePartial,
 } from 'tldraw';
 import { useSites } from '@/data/queries/use-sites';
@@ -21,6 +22,7 @@ import { useStackPressAnimation } from '@/ui-desks/stacks/use-stack-press-animat
 import { createDeskWidget } from '@/ui-desks/widgets/create-widget';
 import { getWidgetFileHandler } from '@/ui-desks/widgets/file-handlers';
 import { LOADING_WIDGET_TYPE } from '@/ui-desks/widgets/loading/types';
+import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
 import {
 	DeskContext,
 	type AddDeskWidgetOptions,
@@ -31,6 +33,7 @@ import {
 	addWidgetToEditor,
 	createWidgetId,
 	createDeskConfigFromEditor,
+	fitSelectedWidgetToContentInEditor,
 	getCurrentSelectedWidgetToolbarItem,
 	hasCameraChange,
 	hasPersistentDocumentChange,
@@ -247,6 +250,22 @@ export function DeskProvider( {
 		};
 	}, [ editor, isHydrated, isReadOnly, isRunningSite, siteId ] );
 
+	useEffect( () => {
+		if ( ! editor || ! isHydrated || isReadOnly ) {
+			return;
+		}
+
+		return editor.sideEffects.registerAfterCreateHandler( 'shape', ( shape, source ) => {
+			if ( source !== 'user' || shape.type !== 'text' ) {
+				return;
+			}
+
+			queueMicrotask( () => {
+				replaceTextShapeWithNote( editor, shape );
+			} );
+		} );
+	}, [ editor, isHydrated, isReadOnly ] );
+
 	const registerEditor = useCallback(
 		( nextEditor: Editor | null ) => {
 			setEditor( nextEditor );
@@ -295,6 +314,22 @@ export function DeskProvider( {
 		[ editor, isHydrated, isReadOnly ]
 	);
 
+	const fitSelectedWidgetToContent = useCallback( () => {
+		if (
+			isReadOnly ||
+			! editor ||
+			! isHydrated ||
+			! fitSelectedWidgetToContentInEditor( editor )
+		) {
+			return false;
+		}
+
+		setSelectedWidgetToolbarItem(
+			getCurrentSelectedWidgetToolbarItem( editor, toolbarStateOptions )
+		);
+		return true;
+	}, [ editor, isHydrated, isReadOnly, toolbarStateOptions ] );
+
 	const stackSelectedWidgets = useCallback( () => {
 		if ( isReadOnly || ! editor || ! isHydrated || ! stackSelectedWidgetsInEditor( editor ) ) {
 			return false;
@@ -339,6 +374,7 @@ export function DeskProvider( {
 			pressStack,
 			addWidget,
 			updateSelectedWidgetProps,
+			fitSelectedWidgetToContent,
 			stackSelectedWidgets,
 			unstackSelectedWidgets,
 			removeSelectedWidget,
@@ -346,6 +382,7 @@ export function DeskProvider( {
 		[
 			addWidget,
 			editor,
+			fitSelectedWidgetToContent,
 			isHydrated,
 			isReadOnly,
 			isLoading,
@@ -368,6 +405,21 @@ export function DeskProvider( {
 	} );
 
 	return <DeskContext.Provider value={ value }>{ children }</DeskContext.Provider>;
+}
+
+function replaceTextShapeWithNote( editor: Editor, shape: TLShape ) {
+	if ( editor.isDisposed || ! editor.getShape( shape.id ) ) {
+		return;
+	}
+
+	editor.deleteShape( shape.id );
+	editor.setCurrentTool( 'select' );
+	addWidgetToEditor( editor, NOTE_WIDGET_TYPE, 0, {
+		center: {
+			x: shape.x,
+			y: shape.y,
+		},
+	} );
 }
 
 type HandledDroppedFile = {

--- a/apps/ui/src/ui-desks/widgets/note/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/note/component.tsx
@@ -7,6 +7,7 @@ import {
 	type RichTextValue,
 } from '@wordpress/rich-text';
 import { useCallback, useEffect, useRef, type KeyboardEvent, type PointerEvent } from 'react';
+import { getNoteTextSize } from '@/ui-desks/widgets/note/text-sizing';
 import { NOTE_WIDGET_TYPE, type NoteWidgetProps } from '@/ui-desks/widgets/note/types';
 import styles from './style.module.css';
 import type {
@@ -144,6 +145,7 @@ export function NoteWidgetComponent( {
 			className={ styles.note }
 			data-tone={ widgetProps.tone }
 			data-is-editing={ isEditing }
+			data-text-size={ getNoteTextSize( widgetProps ) }
 			data-studio-desk-widget={ NOTE_WIDGET_TYPE }
 			data-studio-desk-widget-id={ id }
 		>
@@ -170,6 +172,7 @@ export function NoteWidgetThumbnailComponent( {
 			className={ styles.note }
 			data-tone={ widgetProps.tone }
 			data-is-editing="false"
+			data-text-size={ getNoteTextSize( widgetProps ) }
 			data-studio-desk-widget={ NOTE_WIDGET_TYPE }
 			data-studio-desk-widget-id={ id }
 		>

--- a/apps/ui/src/ui-desks/widgets/note/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/note/definition.ts
@@ -4,6 +4,7 @@ import {
 	NoteWidgetComponent,
 	NoteWidgetThumbnailComponent,
 } from '@/ui-desks/widgets/note/component';
+import { NoteFitTextControl, NoteTextSizeControl } from '@/ui-desks/widgets/note/text-controls';
 import {
 	isNoteWidgetProps,
 	NOTE_WIDGET_TYPE,
@@ -43,6 +44,16 @@ export const noteWidgetDefinition = {
 	Component: NoteWidgetComponent,
 	thumbnail: NoteWidgetThumbnailComponent,
 	controls: [
+		{
+			type: 'custom',
+			id: 'text-size',
+			Component: NoteTextSizeControl,
+		},
+		{
+			type: 'custom',
+			id: 'fit-text',
+			Component: NoteFitTextControl,
+		},
 		{
 			type: 'color',
 			id: 'tone',

--- a/apps/ui/src/ui-desks/widgets/note/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/note/style.module.css
@@ -60,6 +60,27 @@
 	line-height: 1.5;
 }
 
+.note[data-text-size='1'] .editor,
+.note[data-text-size='1'] .thumbnail,
+.editor[data-text-size='1'] {
+	font-size: 18px;
+	line-height: 1.45;
+}
+
+.note[data-text-size='2'] .editor,
+.note[data-text-size='2'] .thumbnail,
+.editor[data-text-size='2'] {
+	font-size: 24px;
+	line-height: 1.4;
+}
+
+.note[data-text-size='3'] .editor,
+.note[data-text-size='3'] .thumbnail,
+.editor[data-text-size='3'] {
+	font-size: 32px;
+	line-height: 1.3;
+}
+
 .editor {
 	cursor: text;
 	user-select: text;

--- a/apps/ui/src/ui-desks/widgets/note/text-controls.tsx
+++ b/apps/ui/src/ui-desks/widgets/note/text-controls.tsx
@@ -1,0 +1,46 @@
+import { __ } from '@wordpress/i18n';
+import { plus, reset, update } from '@wordpress/icons';
+import { IconControlButton } from '@/ui-desks/components';
+import { getNoteTextSize } from './text-sizing';
+import { NOTE_TEXT_SIZE_COUNT, type NoteWidgetProps } from './types';
+import type { ControlRenderContext } from '@/ui-desks/controls/types';
+
+export function NoteTextSizeControl( {
+	props,
+	updateProps,
+}: ControlRenderContext< NoteWidgetProps > ) {
+	const textSize = getNoteTextSize( props );
+
+	return (
+		<>
+			<IconControlButton
+				icon={ reset }
+				label={ __( 'Decrease text size' ) }
+				variant="toolbar"
+				disabled={ textSize <= 0 }
+				onClick={ () => updateProps( { textSize: textSize - 1 } ) }
+			/>
+			<IconControlButton
+				icon={ plus }
+				label={ __( 'Increase text size' ) }
+				variant="toolbar"
+				disabled={ textSize >= NOTE_TEXT_SIZE_COUNT - 1 }
+				onClick={ () => updateProps( { textSize: textSize + 1 } ) }
+			/>
+		</>
+	);
+}
+
+export function NoteFitTextControl( {
+	fitSelectedWidgetToContent,
+}: ControlRenderContext< NoteWidgetProps > ) {
+	return (
+		<IconControlButton
+			icon={ update }
+			label={ __( 'Fit text' ) }
+			variant="toolbar"
+			disabled={ ! fitSelectedWidgetToContent }
+			onClick={ fitSelectedWidgetToContent }
+		/>
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/note/text-sizing.ts
+++ b/apps/ui/src/ui-desks/widgets/note/text-sizing.ts
@@ -1,0 +1,48 @@
+import styles from './style.module.css';
+import { NOTE_TEXT_SIZE_COUNT, type NoteWidgetProps } from './types';
+import type { RectangleWidgetShapeProps } from '@/ui-desks/widgets/geometry';
+
+const NOTE_MIN_FIT_HEIGHT = 80;
+
+export function getNoteTextSize( widgetProps: NoteWidgetProps ) {
+	const textSize = widgetProps.textSize;
+	if ( typeof textSize !== 'number' ) {
+		return 0;
+	}
+
+	return Math.min( NOTE_TEXT_SIZE_COUNT - 1, Math.max( 0, Math.floor( textSize ) ) );
+}
+
+export function getFittedNoteHeight(
+	widgetProps: NoteWidgetProps,
+	shapeProps: RectangleWidgetShapeProps
+) {
+	if ( typeof document === 'undefined' ) {
+		return shapeProps.h;
+	}
+
+	const probe = document.createElement( 'div' );
+	probe.style.cssText =
+		'position:absolute;top:-99999px;left:0;visibility:hidden;pointer-events:none;';
+
+	const note = document.createElement( 'div' );
+	note.className = styles.note;
+	note.dataset.tone = widgetProps.tone;
+	note.dataset.isEditing = 'false';
+	note.style.width = `${ shapeProps.w }px`;
+	note.style.height = 'auto';
+
+	const content = document.createElement( 'div' );
+	content.className = styles.editor;
+	content.dataset.textSize = String( getNoteTextSize( widgetProps ) );
+	content.style.minHeight = '0';
+	content.innerHTML = widgetProps.text || '&nbsp;';
+
+	note.appendChild( content );
+	probe.appendChild( note );
+	document.body.appendChild( probe );
+	const measuredHeight = Math.ceil( note.getBoundingClientRect().height );
+	document.body.removeChild( probe );
+
+	return Math.max( measuredHeight, NOTE_MIN_FIT_HEIGHT );
+}

--- a/apps/ui/src/ui-desks/widgets/note/types.ts
+++ b/apps/ui/src/ui-desks/widgets/note/types.ts
@@ -3,6 +3,9 @@ import type { DeskWidgetBase } from '@studio/common/types/desk';
 
 export const NOTE_WIDGET_TYPE = 'note';
 
+export const NOTE_TEXT_SIZE_STEPS = [ 0, 1, 2, 3 ] as const;
+export const NOTE_TEXT_SIZE_COUNT = NOTE_TEXT_SIZE_STEPS.length;
+
 export const NOTE_TONES = [
 	'yellow',
 	'mint',
@@ -17,10 +20,12 @@ export const NOTE_TONES = [
 ] as const;
 
 export type NoteTone = ( typeof NOTE_TONES )[ number ];
+export type NoteTextSize = ( typeof NOTE_TEXT_SIZE_STEPS )[ number ];
 
 export type NoteWidgetProps = {
 	text: string;
 	tone: NoteTone;
+	textSize?: NoteTextSize;
 };
 
 export type NoteWidget = DeskWidgetBase<
@@ -34,10 +39,19 @@ export function isNoteWidgetProps( value: unknown ): value is NoteWidgetProps {
 		Boolean( value ) &&
 		typeof value === 'object' &&
 		typeof ( value as Partial< NoteWidgetProps > ).text === 'string' &&
-		isNoteTone( ( value as Partial< NoteWidgetProps > ).tone )
+		isNoteTone( ( value as Partial< NoteWidgetProps > ).tone ) &&
+		isOptionalNoteTextSize( ( value as Partial< NoteWidgetProps > ).textSize )
 	);
 }
 
 export function isNoteTone( value: unknown ): value is NoteTone {
 	return NOTE_TONES.includes( value as NoteTone );
+}
+
+export function isNoteTextSize( value: unknown ): value is NoteTextSize {
+	return NOTE_TEXT_SIZE_STEPS.includes( value as NoteTextSize );
+}
+
+function isOptionalNoteTextSize( value: unknown ): value is NoteTextSize | undefined {
+	return value === undefined || isNoteTextSize( value );
 }

--- a/apps/ui/src/ui-desks/widgets/toolbar.tsx
+++ b/apps/ui/src/ui-desks/widgets/toolbar.tsx
@@ -15,6 +15,7 @@ type SelectedWidgetToolbarItem = NonNullable< ReturnType< typeof getSelectedWidg
 export function DeskWidgetToolbar() {
 	const {
 		selectedWidgetToolbarItem,
+		fitSelectedWidgetToContent,
 		stackSelectedWidgets,
 		unstackSelectedWidgets,
 		updateSelectedWidgetProps,
@@ -67,6 +68,7 @@ export function DeskWidgetToolbar() {
 						<ControlRenderer
 							key={ control.id }
 							control={ control }
+							fitSelectedWidgetToContent={ fitSelectedWidgetToContent }
 							isOpen={ openControlId === control.id }
 							props={ renderSelection.widget.widgetProps }
 							setIsOpen={ ( isOpen ) => setOpenControlId( isOpen ? control.id : null ) }


### PR DESCRIPTION
## Summary
- Added 4-step sticky note text sizing with persisted `textSize` metadata and UI controls.
- Added `Fit text` for notes by measuring rendered content and resizing the note height around it.
- Restored empty-canvas double-click note creation by swapping tldraw’s default text shape into a sticky note.
- Wired note controls through the desk toolbar and kept existing note color/rich-text behavior intact.

## Testing
- `npm run typecheck` passed.
- Focused Vitest coverage passed for desk widget creation, toolbar selection, and tldraw adapter behavior.
- Lint/format were run on the touched files; CSS formatting was normalized separately because ESLint ignores CSS modules.