### PR TITLE
apps/ui: Add drawing widgets to the desk create flow

### DIFF
--- a/apps/ui/src/ui-desks/chrome/create-menu.tsx
+++ b/apps/ui/src/ui-desks/chrome/create-menu.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { useEntityRecords, type Post as CoreDataPost } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { chevronLeft, download, globe, link, plus } from '@wordpress/icons';
+import { chevronLeft, download, globe, link, plus, verse } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { useMemo, useState } from 'react';
 import { useSites } from '@/data/queries/use-sites';
@@ -72,6 +72,10 @@ export function DeskCreateMenu() {
 							>
 								<Icon icon={ link } />
 								<span>{ __( 'New link from URL' ) }</span>
+							</Menu.Item>
+							<Menu.Item disabled={ ! desk.canAddWidgets } onClick={ desk.startDrawing }>
+								<Icon icon={ verse } />
+								<span>{ __( 'New drawing' ) }</span>
 							</Menu.Item>
 							{ desk.siteId && (
 								<>

--- a/apps/ui/src/ui-desks/desk/canvas.tsx
+++ b/apps/ui/src/ui-desks/desk/canvas.tsx
@@ -6,6 +6,7 @@ import {
 	StackAwareSelectionForeground,
 	StackCanvasOverlays,
 } from '@/ui-desks/stacks/canvas-components';
+import { DeskDrawingToolbar } from './drawing-toolbar';
 import { useDesk, useRegisterDeskEditor } from './provider';
 import styles from './style.module.css';
 import { TldrawHoverStateSync } from './tldraw-hover-state-sync';
@@ -21,6 +22,7 @@ function DeskCanvasOverlays() {
 		<>
 			<TldrawHoverStateSync />
 			<StackCanvasOverlays />
+			<DeskDrawingToolbar />
 		</>
 	);
 }

--- a/apps/ui/src/ui-desks/desk/drawing-toolbar.tsx
+++ b/apps/ui/src/ui-desks/desk/drawing-toolbar.tsx
@@ -40,12 +40,12 @@ export function DeskDrawingToolbar() {
 			<ControlButton
 				className={ styles.drawingDoneButton }
 				disabled={ isFinishing }
-				label={ __( 'Done drawing' ) }
+				label={ __( 'Stop drawing' ) }
 				tooltipLabel={ false }
 				variant="toolbar"
 				onClick={ () => void handleFinishDrawing() }
 			>
-				{ __( 'Done' ) }
+				{ __( 'Stop drawing' ) }
 			</ControlButton>
 		</Surface>
 	);

--- a/apps/ui/src/ui-desks/desk/drawing-toolbar.tsx
+++ b/apps/ui/src/ui-desks/desk/drawing-toolbar.tsx
@@ -1,0 +1,52 @@
+import { __ } from '@wordpress/i18n';
+import { verse } from '@wordpress/icons';
+import { Icon } from '@wordpress/ui';
+import { useState } from 'react';
+import { useEditor, useValue } from 'tldraw';
+import { ControlButton, Surface } from '@/ui-desks/components';
+import { useDesk } from './provider';
+import styles from './style.module.css';
+
+export function DeskDrawingToolbar() {
+	const editor = useEditor();
+	const { finishDrawing } = useDesk();
+	const [ isFinishing, setIsFinishing ] = useState( false );
+	const isDrawing = useValue( 'desk-is-drawing', () => editor.getCurrentToolId() === 'draw', [
+		editor,
+	] );
+
+	const handleFinishDrawing = async () => {
+		setIsFinishing( true );
+		try {
+			await finishDrawing();
+		} finally {
+			setIsFinishing( false );
+		}
+	};
+
+	return (
+		<Surface
+			variant="glass"
+			className={ styles.drawingToolbar }
+			data-visible={ isDrawing ? 'true' : 'false' }
+			role="toolbar"
+			aria-label={ __( 'Drawing controls' ) }
+			aria-hidden={ ! isDrawing }
+			onPointerDown={ ( event ) => event.stopPropagation() }
+		>
+			<span className={ styles.drawingToolbarStatus }>
+				<Icon icon={ verse } size={ 20 } />
+			</span>
+			<ControlButton
+				className={ styles.drawingDoneButton }
+				disabled={ isFinishing }
+				label={ __( 'Done drawing' ) }
+				tooltipLabel={ false }
+				variant="toolbar"
+				onClick={ () => void handleFinishDrawing() }
+			>
+				{ __( 'Done' ) }
+			</ControlButton>
+		</Surface>
+	);
+}

--- a/apps/ui/src/ui-desks/desk/provider/context.ts
+++ b/apps/ui/src/ui-desks/desk/provider/context.ts
@@ -26,6 +26,8 @@ export interface DeskContextValue {
 		payload: WidgetPastePayload,
 		options?: AddDeskWidgetOptions
 	) => Promise< boolean >;
+	startDrawing: () => boolean;
+	finishDrawing: () => Promise< boolean >;
 	updateSelectedWidgetProps: ( widgetProps: Record< string, unknown > ) => boolean;
 	fitSelectedWidgetToContent: () => boolean;
 	stackSelectedWidgets: () => boolean;
@@ -67,6 +69,8 @@ const defaultDeskContext: DeskContextValue = {
 	pressStack: noopPressStack,
 	addWidget: () => false,
 	addPastedContent: () => Promise.resolve( false ),
+	startDrawing: () => false,
+	finishDrawing: async () => false,
 	updateSelectedWidgetProps: () => false,
 	fitSelectedWidgetToContent: () => false,
 	stackSelectedWidgets: () => false,

--- a/apps/ui/src/ui-desks/desk/provider/editor-state.ts
+++ b/apps/ui/src/ui-desks/desk/provider/editor-state.ts
@@ -1,4 +1,12 @@
-import { getIndexAbove, sortByIndex, type Editor, type JsonObject, type TLShape } from 'tldraw';
+import {
+	getIndexAbove,
+	sortByIndex,
+	type Editor,
+	type JsonObject,
+	type TLDrawShape,
+	type TLShape,
+	type TLShapeId,
+} from 'tldraw';
 import {
 	RECTANGLE_WIDGET_SHAPE_TYPE,
 	type RectangleWidgetShape,
@@ -16,6 +24,7 @@ import {
 } from '@/ui-desks/stacks/utils';
 import { BLOG_WIDGET_TYPE } from '@/ui-desks/widgets/blog/types';
 import { createDeskWidget } from '@/ui-desks/widgets/create-widget';
+import { DRAWING_WIDGET_TYPE } from '@/ui-desks/widgets/drawing/types';
 import { getFittedNoteHeight } from '@/ui-desks/widgets/note/text-sizing';
 import { isNoteWidgetProps, NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
 import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
@@ -65,6 +74,7 @@ const SITE_MAP_MAX_ZOOM = 0.76;
 const SITE_MAP_HORIZONTAL_PADDING = 96;
 const SITE_MAP_BOTTOM_PADDING = 96;
 const SITE_MAP_HOME_TOP = 126;
+const DRAWING_WIDGET_PADDING = 16;
 
 export function hydrateEditorFromDesk(
 	editor: Editor,
@@ -149,6 +159,47 @@ export function addWidgetToEditor(
 	}
 	editor.focus();
 	return true;
+}
+
+export async function convertDrawShapesToDrawingWidget(
+	editor: Editor,
+	drawShapes: TLDrawShape[]
+) {
+	if ( drawShapes.length === 0 ) {
+		return false;
+	}
+
+	const drawShapeIds = drawShapes.map( ( shape ) => shape.id );
+	const bounds = getCombinedShapePageBounds( editor, drawShapeIds );
+	if ( ! bounds ) {
+		return false;
+	}
+
+	const svg = await editor.getSvgString( drawShapeIds, {
+		background: false,
+		padding: DRAWING_WIDGET_PADDING,
+		preserveAspectRatio: 'xMidYMid meet',
+	} );
+	if ( ! svg ) {
+		return false;
+	}
+
+	editor.deleteShapes( drawShapeIds );
+
+	return addWidgetToEditor( editor, DRAWING_WIDGET_TYPE, 0, {
+		center: {
+			x: bounds.minX + bounds.w / 2,
+			y: bounds.minY + bounds.h / 2,
+		},
+		shapeProps: {
+			w: Math.max( 1, svg.width ),
+			h: Math.max( 1, svg.height ),
+		},
+		widgetProps: {
+			svg: svg.svg,
+		},
+		shouldStartEditing: false,
+	} );
 }
 
 export function updateSelectedWidgetPropsInEditor(
@@ -599,6 +650,10 @@ function getSiteMapWidgetShapes( editor: Editor ) {
 		.filter( ( shape ) => canvasShapeToDeskWidget( shape ) !== null );
 }
 
+export function isDrawShape( shape: TLShape ): shape is TLDrawShape {
+	return shape.type === 'draw';
+}
+
 function getInitialSiteMapZoom( editor: Editor ) {
 	const bounds = getSiteMapContentBounds( editor );
 	if ( ! bounds ) {
@@ -669,4 +724,39 @@ function getNextZIndexFromShapes( shapes: TLShape[] ) {
 
 export function createWidgetId() {
 	return globalThis.crypto?.randomUUID?.() ?? `widget-${ Date.now().toString( 36 ) }`;
+}
+
+function getCombinedShapePageBounds( editor: Editor, shapeIds: TLShapeId[] ) {
+	const bounds = shapeIds
+		.map( ( shapeId ) => editor.getShapePageBounds( shapeId ) )
+		.filter( ( shapeBounds ): shapeBounds is NonNullable< typeof shapeBounds > =>
+			Boolean( shapeBounds )
+		);
+
+	if ( bounds.length === 0 ) {
+		return null;
+	}
+
+	return bounds.reduce(
+		( currentBounds, nextBounds ) => ( {
+			minX: Math.min( currentBounds.minX, nextBounds.minX ),
+			minY: Math.min( currentBounds.minY, nextBounds.minY ),
+			maxX: Math.max( currentBounds.maxX, nextBounds.maxX ),
+			maxY: Math.max( currentBounds.maxY, nextBounds.maxY ),
+			w:
+				Math.max( currentBounds.maxX, nextBounds.maxX ) -
+				Math.min( currentBounds.minX, nextBounds.minX ),
+			h:
+				Math.max( currentBounds.maxY, nextBounds.maxY ) -
+				Math.min( currentBounds.minY, nextBounds.minY ),
+		} ),
+		{
+			minX: bounds[ 0 ].minX,
+			minY: bounds[ 0 ].minY,
+			maxX: bounds[ 0 ].maxX,
+			maxY: bounds[ 0 ].maxY,
+			w: bounds[ 0 ].w,
+			h: bounds[ 0 ].h,
+		}
+	);
 }

--- a/apps/ui/src/ui-desks/desk/provider/index.tsx
+++ b/apps/ui/src/ui-desks/desk/provider/index.tsx
@@ -32,6 +32,7 @@ import {
 } from './context';
 import {
 	addWidgetToEditor,
+	convertDrawShapesToDrawingWidget,
 	createWidgetId,
 	createDeskConfigFromEditor,
 	fitSelectedWidgetToContentInEditor,
@@ -39,6 +40,7 @@ import {
 	hasCameraChange,
 	hasPersistentDocumentChange,
 	hydrateEditorFromDesk,
+	isDrawShape,
 	removeSelectedWidgetFromEditor,
 	stackSelectedWidgetsInEditor,
 	unstackSelectedWidgetsInEditor,
@@ -85,6 +87,7 @@ export function DeskProvider( {
 	const hydratedRef = useRef( false );
 	const deskConfigKeyRef = useRef< string | undefined >( undefined );
 	const creationOffsetRef = useRef( 0 );
+	const drawingStartShapeIdsRef = useRef< Set< string > | null >( null );
 	const saveTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 	const { pressStack, clearPressedStack } = useStackPressAnimation( setPressedStackId );
 	const toolbarStateOptions = useMemo(
@@ -107,6 +110,7 @@ export function DeskProvider( {
 		hydratedRef.current = false;
 		setIsHydrated( false );
 		setSelectedWidgetToolbarItem( null );
+		drawingStartShapeIdsRef.current = null;
 	}, [ deskConfigKey ] );
 
 	useEffect( () => {
@@ -330,6 +334,7 @@ export function DeskProvider( {
 				setIsHydrated( false );
 				setSelectedWidgetToolbarItem( null );
 				clearPressedStack();
+				drawingStartShapeIdsRef.current = null;
 			}
 		},
 		[ clearPressedStack ]
@@ -381,6 +386,43 @@ export function DeskProvider( {
 		},
 		[ editor, isHydrated, isReadOnly, isRunningSite, siteId ]
 	);
+
+	const startDrawing = useCallback( () => {
+		if ( isReadOnly || ! editor || ! isHydrated ) {
+			return false;
+		}
+
+		drawingStartShapeIdsRef.current = new Set(
+			editor.getCurrentPageShapes().map( ( shape ) => shape.id )
+		);
+		editor.setCurrentTool( 'draw' );
+		editor.focus();
+		return true;
+	}, [ editor, isHydrated, isReadOnly ] );
+
+	const finishDrawing = useCallback( async () => {
+		if ( isReadOnly || ! editor || ! isHydrated ) {
+			return false;
+		}
+
+		const startingShapeIds = drawingStartShapeIdsRef.current ?? new Set< string >();
+		const drawShapes = editor
+			.getCurrentPageShapes()
+			.filter( isDrawShape )
+			.filter( ( shape ) => ! startingShapeIds.has( shape.id ) );
+
+		drawingStartShapeIdsRef.current = null;
+		editor.setCurrentTool( 'select' );
+
+		if ( drawShapes.length === 0 ) {
+			editor.focus();
+			return true;
+		}
+
+		const didConvertDrawing = await convertDrawShapesToDrawingWidget( editor, drawShapes );
+		editor.focus();
+		return didConvertDrawing;
+	}, [ editor, isHydrated, isReadOnly ] );
 
 	const updateSelectedWidgetProps = useCallback(
 		( widgetProps: Record< string, unknown > ) => {
@@ -462,6 +504,8 @@ export function DeskProvider( {
 			pressStack,
 			addWidget,
 			addPastedContent,
+			startDrawing,
+			finishDrawing,
 			updateSelectedWidgetProps,
 			fitSelectedWidgetToContent,
 			stackSelectedWidgets,
@@ -473,6 +517,7 @@ export function DeskProvider( {
 			addWidget,
 			editor,
 			fitSelectedWidgetToContent,
+			finishDrawing,
 			isHydrated,
 			isReadOnly,
 			isLoading,
@@ -482,6 +527,7 @@ export function DeskProvider( {
 			removeSelectedWidget,
 			selectedWidgetToolbarItem,
 			stackSelectedWidgets,
+			startDrawing,
 			siteId,
 			statusMessage,
 			unstackSelectedWidgets,

--- a/apps/ui/src/ui-desks/desk/style.module.css
+++ b/apps/ui/src/ui-desks/desk/style.module.css
@@ -81,6 +81,52 @@
 	pointer-events: none;
 }
 
+.drawingToolbar {
+	position: absolute;
+	bottom: 48px;
+	left: 50%;
+	z-index: 11;
+	gap: 8px;
+	padding: 6px 6px 6px 14px;
+	pointer-events: auto;
+	transform-origin: bottom center;
+	transition:
+		transform 260ms cubic-bezier( 0.32, 0.72, 0.24, 1 ),
+		opacity 220ms cubic-bezier( 0.32, 0.72, 0.24, 1 );
+}
+
+.drawingToolbar[data-visible='true'] {
+	opacity: 1;
+	transform: translate( -50%, 0 ) scale( 1 );
+}
+
+.drawingToolbar[data-visible='false'] {
+	opacity: 0;
+	pointer-events: none;
+	transform: translate( -50%, 4px ) scale( 0.99 );
+}
+
+.drawingToolbarStatus {
+	display: inline-flex;
+	align-items: center;
+	color: var(--ui-desks-muted, #6b7280);
+}
+
+.drawingDoneButton {
+	width: auto;
+	min-width: 64px;
+	padding: 0 14px;
+	color: #fff;
+	font-size: 13px;
+	font-weight: 500;
+	--control-button-background: var(--ui-desks-text, #14171a);
+	--control-button-foreground: #fff;
+}
+
+.drawingDoneButton:hover:not(:disabled) {
+	--control-button-background: #000;
+}
+
 .siteMapLoadingWidget {
 	--loading-placeholder-text-color: #14171a;
 	--loading-placeholder-line-color: #e5e7eb;

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
@@ -17,6 +17,7 @@ import {
 	resolvedDeskWidgetToCanvasShape,
 } from './tldraw-adapter';
 import type { DeskConfig } from './types';
+import type { DrawingWidget } from '@/ui-desks/widgets/drawing/types';
 import type { EmbedWidget } from '@/ui-desks/widgets/embed/types';
 import type { MediaWidget } from '@/ui-desks/widgets/media/types';
 import type { NoteWidget } from '@/ui-desks/widgets/note/types';
@@ -106,6 +107,44 @@ describe( 'tldraw adapter', () => {
 				tone: 'blue',
 			},
 		} );
+	} );
+
+	it( 'maps a drawing widget through the canvas shape adapter', () => {
+		const widget: DrawingWidget = {
+			id: 'drawing-1',
+			type: 'drawing',
+			x: 12,
+			y: 34,
+			zIndex: 'a3',
+			shapeProps: {
+				w: 320,
+				h: 240,
+			},
+			widgetProps: {
+				svg: '<svg viewBox="0 0 320 240" />',
+			},
+		};
+
+		const shape = deskWidgetToCanvasShape( widget ) as TLShape;
+
+		expect( shape ).toMatchObject( {
+			id: 'shape:drawing-1',
+			type: RECTANGLE_WIDGET_SHAPE_TYPE,
+			x: 12,
+			y: 34,
+			index: 'a3',
+			props: {
+				widgetType: 'drawing',
+				shapeProps: {
+					w: 320,
+					h: 240,
+				},
+				widgetProps: {
+					svg: '<svg viewBox="0 0 320 240" />',
+				},
+			},
+		} );
+		expect( canvasShapeToDeskWidget( shape ) ).toEqual( widget );
 	} );
 
 	it( 'maps a post widget through the canvas shape adapter', () => {

--- a/apps/ui/src/ui-desks/widgets/create-widget.test.ts
+++ b/apps/ui/src/ui-desks/widgets/create-widget.test.ts
@@ -203,6 +203,40 @@ describe( 'createDeskWidget', () => {
 		} );
 	} );
 
+	it( 'creates a drawing widget with supplied SVG props', () => {
+		const createdWidget = createDeskWidget( {
+			id: 'drawing-1',
+			type: 'drawing',
+			center: {
+				x: 400,
+				y: 300,
+			},
+			zIndex: 'a6',
+			shapeProps: {
+				w: 240,
+				h: 180,
+			},
+			widgetProps: {
+				svg: '<svg viewBox="0 0 240 180" />',
+			},
+		} );
+
+		expect( createdWidget ).toEqual( {
+			id: 'drawing-1',
+			type: 'drawing',
+			x: 280,
+			y: 210,
+			zIndex: 'a6',
+			shapeProps: {
+				w: 240,
+				h: 180,
+			},
+			widgetProps: {
+				svg: '<svg viewBox="0 0 240 180" />',
+			},
+		} );
+	} );
+
 	it( 'creates a media widget with supplied media props', () => {
 		const createdWidget = createDeskWidget( {
 			id: 'media-1',

--- a/apps/ui/src/ui-desks/widgets/drawing/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/drawing/component.tsx
@@ -1,0 +1,24 @@
+import { DRAWING_WIDGET_TYPE, type DrawingWidgetProps } from '@/ui-desks/widgets/drawing/types';
+import styles from './style.module.css';
+import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
+
+type DrawingWidgetComponentProps = DeskWidgetComponentProps< DrawingWidgetProps >;
+
+export function DrawingWidgetComponent( { id, widgetProps }: DrawingWidgetComponentProps ) {
+	return (
+		<div
+			className={ styles.drawing }
+			data-studio-desk-widget={ DRAWING_WIDGET_TYPE }
+			data-studio-desk-widget-id={ id }
+		>
+			{ widgetProps.svg && (
+				<img
+					alt=""
+					className={ styles.image }
+					draggable={ false }
+					src={ `data:image/svg+xml;charset=utf-8,${ encodeURIComponent( widgetProps.svg ) }` }
+				/>
+			) }
+		</div>
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/drawing/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/drawing/definition.ts
@@ -1,0 +1,35 @@
+import { __ } from '@wordpress/i18n';
+import { verse } from '@wordpress/icons';
+import { DrawingWidgetComponent } from '@/ui-desks/widgets/drawing/component';
+import {
+	DRAWING_WIDGET_TYPE,
+	isDrawingWidgetProps,
+	type DrawingWidget,
+} from '@/ui-desks/widgets/drawing/types';
+import type { WidgetDefinition } from '@/ui-desks/widgets/types';
+
+export const drawingWidgetDefinition = {
+	type: DRAWING_WIDGET_TYPE,
+	name: () => __( 'Drawing' ),
+	Component: DrawingWidgetComponent,
+	isWidgetProps: isDrawingWidgetProps,
+	labels: {
+		add: () => __( 'New drawing' ),
+	},
+	icon: verse,
+	isCreatable: false,
+	getSummary: () => __( 'Freehand drawing' ),
+	getIndicator: () => ( {
+		cornerRadius: 12,
+		stroke: '#6b7280',
+	} ),
+	getInitialWidget: () => ( {
+		shapeProps: {
+			w: 320,
+			h: 240,
+		},
+		widgetProps: {
+			svg: '',
+		},
+	} ),
+} satisfies WidgetDefinition< DrawingWidget >;

--- a/apps/ui/src/ui-desks/widgets/drawing/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/drawing/style.module.css
@@ -1,0 +1,16 @@
+.drawing {
+	box-sizing: border-box;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	background: transparent;
+}
+
+.image {
+	display: block;
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+	pointer-events: none;
+	user-select: none;
+}

--- a/apps/ui/src/ui-desks/widgets/drawing/types.ts
+++ b/apps/ui/src/ui-desks/widgets/drawing/types.ts
@@ -1,0 +1,22 @@
+import type { RectangleWidgetShapeProps } from '@/ui-desks/widgets/geometry';
+import type { DeskWidgetBase } from '@studio/common/types/desk';
+
+export const DRAWING_WIDGET_TYPE = 'drawing';
+
+export type DrawingWidgetProps = {
+	svg: string;
+};
+
+export type DrawingWidget = DeskWidgetBase<
+	typeof DRAWING_WIDGET_TYPE,
+	RectangleWidgetShapeProps,
+	DrawingWidgetProps
+>;
+
+export function isDrawingWidgetProps( props: unknown ): props is DrawingWidgetProps {
+	return (
+		Boolean( props ) &&
+		typeof props === 'object' &&
+		typeof ( props as Partial< DrawingWidgetProps > ).svg === 'string'
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/registry.ts
+++ b/apps/ui/src/ui-desks/widgets/registry.ts
@@ -1,5 +1,6 @@
 import { blogWidgetDefinition } from '@/ui-desks/widgets/blog/definition';
 import { bookmarkWidgetDefinition } from '@/ui-desks/widgets/bookmark/definition';
+import { drawingWidgetDefinition } from '@/ui-desks/widgets/drawing/definition';
 import { embedWidgetDefinition } from '@/ui-desks/widgets/embed/definition';
 import { loadingWidgetDefinition } from '@/ui-desks/widgets/loading/definition';
 import { mediaWidgetDefinition } from '@/ui-desks/widgets/media/definition';
@@ -14,6 +15,7 @@ export const widgetDefinitions = {
 	[ embedWidgetDefinition.type ]: embedWidgetDefinition,
 	[ bookmarkWidgetDefinition.type ]: bookmarkWidgetDefinition,
 	[ blogWidgetDefinition.type ]: blogWidgetDefinition,
+	[ drawingWidgetDefinition.type ]: drawingWidgetDefinition,
 	[ loadingWidgetDefinition.type ]: loadingWidgetDefinition,
 	[ noteWidgetDefinition.type ]: noteWidgetDefinition,
 	[ mediaWidgetDefinition.type ]: mediaWidgetDefinition,

--- a/apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts
+++ b/apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { DRAWING_WIDGET_TYPE } from '@/ui-desks/widgets/drawing/types';
 import { EMBED_WIDGET_TYPE } from '@/ui-desks/widgets/embed/types';
 import { MEDIA_WIDGET_TYPE } from '@/ui-desks/widgets/media/types';
 import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
@@ -91,6 +92,7 @@ describe( 'widget toolbar selection', () => {
 
 	it( 'returns the toolbar item for a single embed widget selection', () => {
 		const selectedItem = getSelectedWidgetToolbarItem( [ createEmbedWidget() ] );
+
 		expect( selectedItem ).toMatchObject( { kind: 'single-widget' } );
 		if ( selectedItem?.kind !== 'single-widget' ) {
 			throw new Error( 'Expected a single widget toolbar item.' );
@@ -99,6 +101,21 @@ describe( 'widget toolbar selection', () => {
 		expect( selectedItem.definition.controls?.[ 0 ]?.type ).toBe( 'custom' );
 		expect( selectedItem.widget.widgetProps ).toEqual( {
 			url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+		} );
+	} );
+
+	it( 'returns remove controls for a single drawing widget selection', () => {
+		const selectedItem = getSelectedWidgetToolbarItem( [ createDrawingWidget() ] );
+
+		expect( selectedItem ).toMatchObject( { kind: 'single-widget' } );
+		if ( selectedItem?.kind !== 'single-widget' ) {
+			throw new Error( 'Expected a single widget toolbar item.' );
+		}
+		expect( selectedItem.definition.type ).toBe( DRAWING_WIDGET_TYPE );
+		expect( selectedItem.definition.controls ).toBeUndefined();
+		expect( selectedItem.canRemove ).toBe( true );
+		expect( selectedItem.widget.widgetProps ).toEqual( {
+			svg: '<svg viewBox="0 0 320 240" />',
 		} );
 	} );
 
@@ -282,6 +299,23 @@ function createEmbedWidget(): DeskWidget {
 		},
 		widgetProps: {
 			url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+		},
+	};
+}
+
+function createDrawingWidget(): DeskWidget {
+	return {
+		id: 'drawing-1',
+		type: DRAWING_WIDGET_TYPE,
+		x: 0,
+		y: 0,
+		zIndex: 'a1',
+		shapeProps: {
+			w: 320,
+			h: 240,
+		},
+		widgetProps: {
+			svg: '<svg viewBox="0 0 320 240" />',
 		},
 	};
 }

--- a/apps/ui/src/ui-desks/widgets/toolbar-selection.ts
+++ b/apps/ui/src/ui-desks/widgets/toolbar-selection.ts
@@ -1,3 +1,4 @@
+import { DRAWING_WIDGET_TYPE } from '@/ui-desks/widgets/drawing/types';
 import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
 import type { DeskWidget } from '@/ui-desks/widgets/types';
 
@@ -52,11 +53,11 @@ export function getSelectedWidgetToolbarItem(
 
 	const [ widget ] = widgets;
 	const definition = getWidgetDefinition( widget.type );
-	if (
-		! definition ||
-		! definition.controls?.length ||
-		! definition.isWidgetProps( widget.widgetProps )
-	) {
+	if ( ! definition || ! definition.isWidgetProps( widget.widgetProps ) ) {
+		return null;
+	}
+
+	if ( ! definition.controls?.length && widget.type !== DRAWING_WIDGET_TYPE ) {
 		return null;
 	}
 

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -1,6 +1,7 @@
 import type { ControlConfig } from '@/ui-desks/controls/types';
 import type { BlogWidget } from '@/ui-desks/widgets/blog/types';
 import type { BookmarkWidget } from '@/ui-desks/widgets/bookmark/types';
+import type { DrawingWidget } from '@/ui-desks/widgets/drawing/types';
 import type { EmbedWidget } from '@/ui-desks/widgets/embed/types';
 import type { LoadingWidget } from '@/ui-desks/widgets/loading/types';
 import type { MediaWidget } from '@/ui-desks/widgets/media/types';
@@ -196,6 +197,7 @@ export interface WidgetDefinition< TWidget extends DeskWidgetBase = DeskWidgetBa
 export type DeskWidget =
 	| BookmarkWidget
 	| BlogWidget
+	| DrawingWidget
 	| EmbedWidget
 	| LoadingWidget
 	| NoteWidget
@@ -207,6 +209,7 @@ export type DeskWidget =
 export type DeskWidgetDefinition =
 	| WidgetDefinition< BookmarkWidget >
 	| WidgetDefinition< BlogWidget >
+	| WidgetDefinition< DrawingWidget >
 	| WidgetDefinition< EmbedWidget >
 	| WidgetDefinition< LoadingWidget >
 	| WidgetDefinition< NoteWidget >


### PR DESCRIPTION
## Summary
- Expose tldraw draw mode from the desk create menu and show a temporary drawing toolbar with a done action.
- Convert completed draw strokes into a single persistent `drawing` widget that stores the rendered SVG.
- Register the new widget type in the desk widget registry, selection logic, and canvas adapter tests.

## Testing
- `npx eslint --fix` on modified TypeScript files
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-desks/widgets/create-widget.test.ts apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts`
- `npm -w @studio/ui run build`