### PR TITLE
Add Dependabot cooldown of 1 day for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     schedule:
       interval: "weekly"
 
+    cooldown:
+      default-days: 1
+
     allow:
       # Automattic packages
       - dependency-name: "@automattic/*"


### PR DESCRIPTION
## Related issues

- N/A — follow-on to #3436

## How AI was used in this PR

Drafted with Claude Code: researched Dependabot's `cooldown` config (supported ecosystems, semantics around security updates), confirmed the change aligned with the `.npmrc` policy added in #3436, and made the single-line addition. I reviewed the diff and the GitHub docs reference myself before pushing.

## Proposed Changes

- Adds `cooldown.default-days: 1` to the npm entry in `.github/dependabot.yml`.

**Why:** #3436 added `.npmrc` with `min-release-age=1` so that `npm install` refuses any package released less than 1 day ago. Dependabot itself isn't aware of `min-release-age`, so it would still open PRs for packages released hours ago — those PRs then fail `npm install` in CI (or silently resolve to an older satisfying version), creating noise without a security benefit. Setting Dependabot's native `cooldown` to the same value keeps the two policies in lockstep.

**Notes for reviewers:**
- Security updates are explicitly **not** affected by `cooldown` — they continue to flow through immediately. Only routine version-update PRs are delayed.
- Not added to the `github-actions` entry because GitHub Actions is not in the list of ecosystems that support `cooldown` ([docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown--)).
- `1` mirrors the existing `.npmrc` value. PR #3436 framed `1` as "an uncontroversial starting point" — easy to raise later if we want stronger supply-chain protection (would want to raise both settings together).

## Testing Instructions

Dependabot config is parsed by GitHub, not locally executable. Verification is by inspection:

- [x] YAML parses cleanly; `cooldown` block is correctly nested under the npm `updates` entry.
- [ ] After merge, GitHub will surface config errors (if any) under **Insights → Dependency graph → Dependabot**.
- [ ] On the next weekly Dependabot run, PRs for packages released < 24h ago should be deferred. Dependabot annotates deferred updates in its PR descriptions / logs.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (N/A — config-only change)