### PR TITLE
Blueprints Gallery Library: Fix warnings while running add-site.test.tsx

### DIFF
--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -8,7 +8,6 @@ import {
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
-import StudioButton from 'src/components/button';
 import { EMPTY_SITE_PLAYGROUND_URL } from 'src/constants';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -42,17 +41,18 @@ interface NewSiteOptionsProps {
 function PreviewLink( { url }: { url: string } ) {
 	const { __ } = useI18n();
 	return (
-		<StudioButton
-			variant="secondary"
-			onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+		<a
+			href={ url }
+			onClick={ ( e: React.MouseEvent< HTMLAnchorElement > ) => {
+				e.preventDefault();
 				e.stopPropagation();
 				getIpcApi().openURL( url );
 			} }
-			className="!absolute bottom-2 right-2 z-10 !px-2 !py-1 !h-auto !min-h-0 text-[11px] !bg-white/90 hover:!bg-white !text-a8c-gray-900 hover:!text-a8c-gray-900 !shadow-none whitespace-nowrap"
+			className="!absolute bottom-2 right-2 z-10 inline-flex items-center gap-1 !px-2 !py-1 !h-auto !min-h-0 text-[11px] !bg-white/90 hover:!bg-white !text-a8c-gray-900 hover:!text-a8c-gray-900 !shadow-none whitespace-nowrap rounded-sm no-underline border border-a8c-gray-5"
 		>
 			{ __( 'Live Preview' ) }
 			<ArrowIcon />
-		</StudioButton>
+		</a>
 	);
 }
 


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1716

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

It was used to fix the test.



## Proposed Changes

This PR ensures that when you run the tests in `add-site.test.tsx`, the warning about the DOM structure is not present. It solves it by adjusting the DOM structure to the correct one. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Run `npm test -- apps/studio/src/modules/add-site/tests/add-site.test.tsx -t "Blueprint preferred versions"`
* Confirm that you can not see the warning about:

```Blueprint preferred versions differ from selected versions                                              
  Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>.                   
      at button
```

* Run the same test on trunk and confirm that the warning is not there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
