### PR TITLE
apps/ui: Add tiles mode for stack widgets and post collections

### DIFF
--- a/apps/ui/src/ui-desks/controls/registry.tsx
+++ b/apps/ui/src/ui-desks/controls/registry.tsx
@@ -1,10 +1,13 @@
 import { ColorControl } from './color';
+import { SelectControl } from './select';
 import type { ControlRendererProps } from './types';
 
 export function ControlRenderer( props: ControlRendererProps ) {
 	switch ( props.control.type ) {
 		case 'color':
 			return <ColorControl { ...props } control={ props.control } />;
+		case 'select':
+			return <SelectControl { ...props } control={ props.control } />;
 		case 'custom': {
 			const Component = props.control.Component;
 			return (

--- a/apps/ui/src/ui-desks/controls/select.tsx
+++ b/apps/ui/src/ui-desks/controls/select.tsx
@@ -1,0 +1,49 @@
+import { IconControlButton, Menu } from '@/ui-desks/components';
+import type { AnySelectControlConfig, ControlRendererProps } from './types';
+
+type SelectControlProps = ControlRendererProps & {
+	control: AnySelectControlConfig;
+};
+
+export function SelectControl( {
+	control,
+	isOpen,
+	setIsOpen,
+	updateProps,
+	props,
+}: SelectControlProps ) {
+	const currentValue =
+		typeof props[ control.property ] === 'string'
+			? ( props[ control.property ] as string )
+			: control.defaultValue;
+
+	return (
+		<Menu.Root modal={ false } open={ isOpen } orientation="horizontal" onOpenChange={ setIsOpen }>
+			<Menu.Trigger
+				render={
+					<IconControlButton
+						icon={ control.icon }
+						label={ control.label }
+						variant="toolbar"
+						aria-pressed={ isOpen }
+					/>
+				}
+			/>
+			<Menu.Popup side="top" align="center" sideOffset={ 18 }>
+				<Menu.RadioGroup
+					value={ currentValue }
+					onValueChange={ ( value ) => {
+						updateProps( { [ control.property ]: value } );
+						setIsOpen( false );
+					} }
+				>
+					{ control.options.map( ( option ) => (
+						<Menu.RadioItem key={ option.value } value={ option.value }>
+							{ option.label }
+						</Menu.RadioItem>
+					) ) }
+				</Menu.RadioGroup>
+			</Menu.Popup>
+		</Menu.Root>
+	);
+}

--- a/apps/ui/src/ui-desks/controls/types.ts
+++ b/apps/ui/src/ui-desks/controls/types.ts
@@ -1,4 +1,5 @@
-import type { ReactElement } from 'react';
+import type { Icon } from '@wordpress/ui';
+import type { ComponentProps, ReactElement } from 'react';
 
 export interface ColorControlOption< TValue extends string = string > {
 	value: TValue;
@@ -6,9 +7,18 @@ export interface ColorControlOption< TValue extends string = string > {
 	color: string;
 }
 
+export interface SelectControlOption< TValue extends string = string > {
+	value: TValue;
+	label: string;
+}
+
 type StringControlPropKey< TProps extends Record< string, unknown > > = {
-	[ TKey in Extract< keyof TProps, string > ]: TProps[ TKey ] extends string ? TKey : never;
+	[ TKey in Extract< keyof TProps, string > ]: NonNullable< TProps[ TKey ] > extends string
+		? TKey
+		: never;
 }[ Extract< keyof TProps, string > ];
+
+type ControlIcon = ComponentProps< typeof Icon >[ 'icon' ];
 
 export type ColorControlConfig<
 	TProps extends Record< string, unknown > = Record< string, string >,
@@ -19,6 +29,20 @@ export type ColorControlConfig<
 		property: TProperty;
 		label: string;
 		options: Array< ColorControlOption< Extract< TProps[ TProperty ], string > > >;
+	};
+}[ StringControlPropKey< TProps > ];
+
+export type SelectControlConfig<
+	TProps extends Record< string, unknown > = Record< string, string >,
+> = {
+	[ TProperty in StringControlPropKey< TProps > ]: {
+		type: 'select';
+		id: string;
+		property: TProperty;
+		label: string;
+		icon: ControlIcon;
+		defaultValue: Extract< NonNullable< TProps[ TProperty ] >, string >;
+		options: Array< SelectControlOption< Extract< NonNullable< TProps[ TProperty ] >, string > > >;
 	};
 }[ StringControlPropKey< TProps > ];
 
@@ -45,6 +69,7 @@ export interface CustomControlConfig<
 
 export type ControlConfig< TProps extends Record< string, unknown > = Record< string, string > > =
 	| ColorControlConfig< TProps >
+	| SelectControlConfig< TProps >
 	| CustomControlConfig< TProps >;
 
 export interface AnyColorControlConfig {
@@ -55,8 +80,19 @@ export interface AnyColorControlConfig {
 	options: Array< ColorControlOption< string > >;
 }
 
+export interface AnySelectControlConfig {
+	type: 'select';
+	id: string;
+	property: string;
+	label: string;
+	icon: ControlIcon;
+	defaultValue: string;
+	options: Array< SelectControlOption< string > >;
+}
+
 export type AnyControlConfig =
 	| AnyColorControlConfig
+	| AnySelectControlConfig
 	| CustomControlConfig< Record< string, unknown > >;
 
 export interface ControlRendererProps {

--- a/apps/ui/src/ui-desks/desk/provider/context.ts
+++ b/apps/ui/src/ui-desks/desk/provider/context.ts
@@ -1,5 +1,6 @@
 import { createContext, useContext } from 'react';
 import type { DeskConfig } from '../types';
+import type { StackViewMode } from '@/ui-desks/stacks/utils';
 import type { getSelectedWidgetToolbarItem } from '@/ui-desks/widgets/toolbar-selection';
 import type { WidgetPastePayload } from '@/ui-desks/widgets/types';
 import type { ReactNode } from 'react';
@@ -32,6 +33,7 @@ export interface DeskContextValue {
 	fitSelectedWidgetToContent: () => Promise< boolean >;
 	stackSelectedWidgets: () => boolean;
 	unstackSelectedWidgets: () => boolean;
+	setSelectedStackView: ( viewMode: StackViewMode ) => boolean;
 	removeSelectedWidget: () => boolean;
 }
 
@@ -75,6 +77,7 @@ const defaultDeskContext: DeskContextValue = {
 	fitSelectedWidgetToContent: () => Promise.resolve( false ),
 	stackSelectedWidgets: () => false,
 	unstackSelectedWidgets: () => false,
+	setSelectedStackView: () => false,
 	removeSelectedWidget: () => false,
 };
 

--- a/apps/ui/src/ui-desks/desk/provider/editor-state.ts
+++ b/apps/ui/src/ui-desks/desk/provider/editor-state.ts
@@ -13,6 +13,7 @@ import {
 	type RectangleWidgetShape,
 } from '@/ui-desks/shapes/rectangle-widget/types';
 import {
+	setStackViewInEditor,
 	stackSelectedWidgetsInEditor as stackSelectionInEditor,
 	unstackSelectedWidgetsInEditor as unstackSelectionInEditor,
 } from '@/ui-desks/stacks/editor-commands';
@@ -21,7 +22,9 @@ import {
 	getStackHome,
 	getStackId,
 	getStackOrder,
+	getStackViewMode,
 	getStackZIndexFromMember,
+	type StackViewMode,
 } from '@/ui-desks/stacks/utils';
 import { BLOG_WIDGET_TYPE } from '@/ui-desks/widgets/blog/types';
 import { createDeskWidget } from '@/ui-desks/widgets/create-widget';
@@ -65,6 +68,7 @@ interface DerivedWidgetAnchor {
 interface WidgetToolbarStateOptions {
 	canStack?: boolean;
 	canUnstack?: boolean;
+	canSetStackView?: boolean;
 	canRemove?: boolean;
 }
 
@@ -309,6 +313,20 @@ export function unstackSelectedWidgetsInEditor( editor: Editor ) {
 	);
 }
 
+export function setSelectedStackViewInEditor( editor: Editor, viewMode: StackViewMode ) {
+	const selection = getCurrentSelectedWidgetSelection( editor );
+	const stackId =
+		selection?.item.canSetStackView && selection.item.stackIds.length === 1
+			? selection.item.stackIds[ 0 ]
+			: null;
+
+	if ( ! stackId ) {
+		return false;
+	}
+
+	return setStackViewInEditor( editor, stackId, viewMode );
+}
+
 export function hasCameraChange( changes: CanvasStoreChanges ) {
 	const updatedRecords = Object.values( changes.updated ).map( ( [ , nextRecord ] ) => nextRecord );
 	const records = [
@@ -364,32 +382,31 @@ function getCurrentSelectedWidgetSelection(
 		return null;
 	}
 
-	const derivedSourceSelection = getDerivedSourceWidgetSelection(
-		editor,
-		shapes as TLShape[],
-		options
-	);
+	const typedShapes = shapes as TLShape[];
+	const derivedSourceSelection = getDerivedSourceWidgetSelection( editor, typedShapes, options );
 	if ( derivedSourceSelection ) {
 		return derivedSourceSelection;
 	}
 
-	const widgets = shapes.map( ( shape ) => canvasShapeToDeskWidget( shape as TLShape ) );
+	const widgets = typedShapes.map( ( shape ) => canvasShapeToDeskWidget( shape ) );
 	if ( widgets.some( ( widget ) => ! widget ) ) {
 		return null;
 	}
+	const hasDerivedShapes = typedShapes.some( isDerivedDeskCanvasRecord );
 
 	const stackIds = Array.from(
 		new Set(
-			( shapes as TLShape[] )
-				.map( getStackId )
-				.filter( ( stackId ): stackId is string => stackId !== null )
+			typedShapes.map( getStackId ).filter( ( stackId ): stackId is string => stackId !== null )
 		)
 	);
+	const selectedStackState = getSelectedStackState( editor, typedShapes );
 	const item = getSelectedWidgetToolbarItem( widgets as DeskWidget[], {
 		stackIds,
-		canStack: options.canStack,
-		canUnstack: options.canUnstack,
-		canRemove: options.canRemove,
+		stackViewMode: selectedStackState?.viewMode,
+		canStack: ( options.canStack ?? true ) && ! hasDerivedShapes,
+		canUnstack: ( options.canUnstack ?? true ) && ! hasDerivedShapes,
+		canSetStackView: options.canSetStackView,
+		canRemove: hasDerivedShapes ? false : options.canRemove,
 	} );
 	if ( ! item ) {
 		return null;
@@ -407,6 +424,45 @@ function isRectangleWidgetShape( shape: unknown ): shape is RectangleWidgetShape
 		typeof shape === 'object' &&
 		( shape as { type?: unknown } ).type === RECTANGLE_WIDGET_SHAPE_TYPE
 	);
+}
+
+function getSelectedStackState( editor: Editor, shapes: TLShape[] ) {
+	let stackId: string | null = null;
+
+	for ( const shape of shapes ) {
+		const nextStackId = getStackId( shape );
+		if ( ! nextStackId ) {
+			return null;
+		}
+
+		if ( stackId === null ) {
+			stackId = nextStackId;
+		} else if ( stackId !== nextStackId ) {
+			return null;
+		}
+	}
+
+	const firstShape = shapes[ 0 ];
+	if ( ! stackId || ! firstShape ) {
+		return null;
+	}
+
+	const selectedShapeIds = new Set( shapes.map( ( shape ) => shape.id ) );
+	const stackMemberIds = editor
+		.getCurrentPageShapes()
+		.filter( ( shape ) => getStackId( shape ) === stackId )
+		.map( ( shape ) => shape.id );
+	if (
+		stackMemberIds.length < 2 ||
+		stackMemberIds.some( ( shapeId ) => ! selectedShapeIds.has( shapeId ) )
+	) {
+		return null;
+	}
+
+	return {
+		id: stackId,
+		viewMode: getStackViewMode( firstShape ),
+	};
 }
 
 export function getCurrentDeskWidgets( editor: Editor ) {
@@ -478,6 +534,7 @@ function getDerivedShapePersistenceSignature( value: unknown ) {
 		deskStackHomeX: meta.deskStackHomeX,
 		deskStackHomeY: meta.deskStackHomeY,
 		deskStackHomeZIndex: meta.deskStackHomeZIndex,
+		deskStackViewMode: meta.deskStackViewMode,
 	} );
 }
 
@@ -486,6 +543,10 @@ function getDerivedSourceWidgetSelection(
 	shapes: TLShape[],
 	options: WidgetToolbarStateOptions = {}
 ) {
+	if ( ! isCompleteDerivedStackSelection( editor, shapes ) ) {
+		return null;
+	}
+
 	const sourceWidgetId = getDerivedSelectionSourceWidgetId( shapes );
 	if ( ! sourceWidgetId ) {
 		return null;
@@ -517,6 +578,37 @@ function getDerivedSourceWidgetSelection(
 		item,
 		shapes: [ sourceShape ],
 	};
+}
+
+function isCompleteDerivedStackSelection( editor: Editor, shapes: TLShape[] ) {
+	if ( shapes.length < 2 || shapes.some( ( shape ) => ! isDerivedDeskCanvasRecord( shape ) ) ) {
+		return false;
+	}
+
+	let stackId: string | null = null;
+	for ( const shape of shapes ) {
+		const nextStackId = getStackId( shape );
+		if ( ! nextStackId ) {
+			return false;
+		}
+
+		if ( stackId === null ) {
+			stackId = nextStackId;
+		} else if ( stackId !== nextStackId ) {
+			return false;
+		}
+	}
+
+	const selectedShapeIds = new Set( shapes.map( ( shape ) => shape.id ) );
+	const stackMemberIds = editor
+		.getCurrentPageShapes()
+		.filter( ( shape ) => getStackId( shape ) === stackId )
+		.map( ( shape ) => shape.id );
+
+	return (
+		stackMemberIds.length === selectedShapeIds.size &&
+		stackMemberIds.every( ( shapeId ) => selectedShapeIds.has( shapeId ) )
+	);
 }
 
 function getDerivedSelectionSourceWidgetId( shapes: TLShape[] ) {
@@ -571,6 +663,14 @@ function getDerivedWidgetAnchor( shapes: TLShape[] ): DerivedWidgetAnchor | null
 
 	const stackId = getStackId( firstShape );
 	if ( ! stackId ) {
+		return {
+			x: firstShape.x,
+			y: firstShape.y,
+			zIndex: firstShape.index,
+		};
+	}
+
+	if ( getStackViewMode( firstShape ) === 'tiles' ) {
 		return {
 			x: firstShape.x,
 			y: firstShape.y,

--- a/apps/ui/src/ui-desks/desk/provider/index.tsx
+++ b/apps/ui/src/ui-desks/desk/provider/index.tsx
@@ -42,6 +42,7 @@ import {
 	hydrateEditorFromDesk,
 	isDrawShape,
 	removeSelectedWidgetFromEditor,
+	setSelectedStackViewInEditor,
 	stackSelectedWidgetsInEditor,
 	unstackSelectedWidgetsInEditor,
 	updateSelectedWidgetPropsInEditor,
@@ -94,6 +95,7 @@ export function DeskProvider( {
 		() => ( {
 			canStack: ! isReadOnly,
 			canUnstack: ! isReadOnly,
+			canSetStackView: ! isReadOnly,
 			canRemove: ! isReadOnly,
 		} ),
 		[ isReadOnly ]
@@ -482,6 +484,25 @@ export function DeskProvider( {
 		return true;
 	}, [ editor, isHydrated, isReadOnly, toolbarStateOptions ] );
 
+	const setSelectedStackView = useCallback(
+		( viewMode: Parameters< typeof setSelectedStackViewInEditor >[ 1 ] ) => {
+			if (
+				isReadOnly ||
+				! editor ||
+				! isHydrated ||
+				! setSelectedStackViewInEditor( editor, viewMode )
+			) {
+				return false;
+			}
+
+			setSelectedWidgetToolbarItem(
+				getCurrentSelectedWidgetToolbarItem( editor, toolbarStateOptions )
+			);
+			return true;
+		},
+		[ editor, isHydrated, isReadOnly, toolbarStateOptions ]
+	);
+
 	const removeSelectedWidget = useCallback( () => {
 		if ( isReadOnly || ! editor || ! isHydrated || ! removeSelectedWidgetFromEditor( editor ) ) {
 			return false;
@@ -510,6 +531,7 @@ export function DeskProvider( {
 			fitSelectedWidgetToContent,
 			stackSelectedWidgets,
 			unstackSelectedWidgets,
+			setSelectedStackView,
 			removeSelectedWidget,
 		} ),
 		[
@@ -526,6 +548,7 @@ export function DeskProvider( {
 			registerEditor,
 			removeSelectedWidget,
 			selectedWidgetToolbarItem,
+			setSelectedStackView,
 			stackSelectedWidgets,
 			startDrawing,
 			siteId,

--- a/apps/ui/src/ui-desks/desk/provider/resolvers.ts
+++ b/apps/ui/src/ui-desks/desk/provider/resolvers.ts
@@ -9,7 +9,7 @@ import {
 	isDerivedDeskCanvasRecord,
 	resolvedDeskWidgetToCanvasShape,
 } from '@/ui-desks/desk/tldraw-adapter';
-import { isStackExpanded } from '@/ui-desks/stacks/utils';
+import { getStackViewMode, isStackExpanded } from '@/ui-desks/stacks/utils';
 import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
 import { getCurrentDeskWidgets } from './editor-state';
 import type {
@@ -294,7 +294,12 @@ function preserveExpandedStackMemberState(
 	existingShape: TLShape,
 	nextShape: TLShapePartial
 ): TLShapePartial {
-	if ( ! isStackExpanded( existingShape ) ) {
+	const nextViewMode = getStackViewMode( nextShape as TLShape );
+	const shouldPreserveTileState =
+		getStackViewMode( existingShape ) === 'tiles' && nextViewMode === 'tiles';
+	const shouldPreserveExpandedState = isStackExpanded( existingShape ) && nextViewMode === 'stack';
+
+	if ( ! shouldPreserveExpandedState && ! shouldPreserveTileState ) {
 		return nextShape;
 	}
 
@@ -395,7 +400,9 @@ function shouldUpdateShape( currentShape: TLShape, nextShape: TLShapePartial ) {
 
 function hasMatchingMeta( shape: TLShape, meta: TLShapePartial[ 'meta' ] ) {
 	const currentMeta = shape.meta as Record< string, unknown >;
-	return Object.entries( meta ?? {} ).every( ( [ key, value ] ) => currentMeta[ key ] === value );
+	return Object.entries( meta ?? {} ).every( ( [ key, value ] ) =>
+		value === null ? currentMeta[ key ] == null : currentMeta[ key ] === value
+	);
 }
 
 function isDerivedFromWidget( resolvedWidget: ResolvedDeskWidget, sourceWidgetId: string ) {

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter.test.ts
@@ -407,6 +407,7 @@ describe( 'tldraw adapter', () => {
 			meta: {
 				deskStackId: 'stack-1',
 				deskStackOrder: 0,
+				deskStackViewMode: null,
 				deskStackOriginalZIndex: 'a1',
 			},
 		} );
@@ -418,6 +419,7 @@ describe( 'tldraw adapter', () => {
 			meta: {
 				deskStackId: 'stack-1',
 				deskStackOrder: 1,
+				deskStackViewMode: null,
 				deskStackOriginalZIndex: 'a3',
 			},
 		} );
@@ -427,6 +429,61 @@ describe( 'tldraw adapter', () => {
 			'shape:note-2',
 			'shape:note-1',
 		] );
+	} );
+
+	it( 'projects tiled stack widgets from their persisted widget positions', () => {
+		const desk: DeskConfig = {
+			version: 1,
+			updatedAt: '2026-05-09T00:00:00.000Z',
+			widgets: [
+				{
+					...createNoteWidget( 'note-1' ),
+					x: 100,
+					y: 200,
+				},
+				{
+					...createNoteWidget( 'note-2' ),
+					x: 420,
+					y: 200,
+					zIndex: 'a3',
+				},
+			],
+			stacks: [
+				{
+					id: 'stack-1',
+					x: 100,
+					y: 200,
+					zIndex: 'a5',
+					memberIds: [ 'note-1', 'note-2' ],
+					viewMode: 'tiles',
+				},
+			],
+		};
+
+		const shapes = deskConfigToCanvasShapes( desk );
+		const firstStackMember = getCanvasShape( shapes, 'shape:note-1' );
+		const secondStackMember = getCanvasShape( shapes, 'shape:note-2' );
+
+		expect( firstStackMember ).toMatchObject( {
+			x: 100,
+			y: 200,
+			rotation: 0,
+			meta: {
+				deskStackId: 'stack-1',
+				deskStackOrder: 0,
+				deskStackViewMode: 'tiles',
+			},
+		} );
+		expect( secondStackMember ).toMatchObject( {
+			x: 420,
+			y: 200,
+			rotation: 0,
+			meta: {
+				deskStackId: 'stack-1',
+				deskStackOrder: 1,
+				deskStackViewMode: 'tiles',
+			},
+		} );
 	} );
 
 	it( 'maps desk connectors to locked arrow shapes and arrow bindings', () => {
@@ -547,6 +604,50 @@ describe( 'tldraw adapter', () => {
 				y: 200,
 				zIndex: 'a5',
 				memberIds: [ 'note-1', 'note-2' ],
+			},
+		] );
+	} );
+
+	it( 'extracts tiled stack geometry from actual member positions', () => {
+		const shapes = [
+			{
+				...deskWidgetToCanvasShape( createNoteWidget( 'note-1' ) ),
+				x: 100,
+				y: 200,
+				index: 'a5',
+				meta: {
+					deskStackId: 'stack-1',
+					deskStackOrder: 0,
+					deskStackViewMode: 'tiles',
+				},
+			},
+			{
+				...deskWidgetToCanvasShape( createNoteWidget( 'note-2' ) ),
+				x: 420,
+				y: 200,
+				index: 'a4.999',
+				meta: {
+					deskStackId: 'stack-1',
+					deskStackOrder: 1,
+					deskStackViewMode: 'tiles',
+				},
+			},
+		] as unknown as TLShape[];
+
+		expect( canvasShapeToDeskWidget( shapes[ 0 ] ) ).toMatchObject( {
+			id: 'note-1',
+			x: 100,
+			y: 200,
+			zIndex: 'a5',
+		} );
+		expect( canvasShapesToDeskStacks( shapes ) ).toEqual( [
+			{
+				id: 'stack-1',
+				x: 100,
+				y: 200,
+				zIndex: 'a5',
+				memberIds: [ 'note-1', 'note-2' ],
+				viewMode: 'tiles',
 			},
 		] );
 	} );
@@ -688,8 +789,9 @@ describe( 'tldraw adapter', () => {
 				studioDeskDerivedKey: 'post:42',
 			},
 		} );
+		expect( shape.index ).toBeUndefined();
 		expect( isPersistentDeskCanvasShape( shape ) ).toBe( false );
-		expect( canvasShapeToDeskWidget( shape ) ).toEqual( {
+		expect( canvasShapeToDeskWidget( { ...shape, index: 'a3' } as TLShape ) ).toEqual( {
 			...resolvedWidget.widget,
 			rotation: undefined,
 		} );
@@ -791,16 +893,16 @@ describe( 'tldraw adapter', () => {
 				memberIds: [ 'collection-1:post:41', 'collection-1:post:42' ],
 			},
 			order: 1,
-		} ) as TLShape;
+		} );
 
 		expect( shape ).toMatchObject( {
 			x: 110,
 			y: 208,
 			rotation: 0.052,
-			index: 'a6.999',
 			meta: {
 				deskStackId: 'stack-1',
 				deskStackOrder: 1,
+				deskStackViewMode: null,
 				deskStackOriginalZIndex: 'a3',
 				studioDeskOrigin: 'derived',
 				studioDeskPersist: false,
@@ -808,9 +910,10 @@ describe( 'tldraw adapter', () => {
 				studioDeskDerivedKey: 'post:42',
 			},
 		} );
+		expect( shape.index ).toBeUndefined();
 	} );
 
-	it( 'gives derived stack members distinct indices below non-numeric stack z-indexes', () => {
+	it( 'lets tldraw manage derived stack member indices', () => {
 		const resolvedWidget: ResolvedDeskWidget< PostWidget > = {
 			origin: {
 				kind: 'derived',
@@ -836,25 +939,16 @@ describe( 'tldraw adapter', () => {
 			id: 'stack-1',
 			x: 100,
 			y: 200,
-			zIndex: 'aF3j5',
-			memberIds: [ 'collection-1:post:40', 'collection-1:post:41', 'collection-1:post:42' ],
+			zIndex: 'any-stack-index',
+			memberIds: [ 'collection-1:post:41', 'collection-1:post:42' ],
 		};
-		const topShape = resolvedDeskWidgetToCanvasShape( resolvedWidget, {
-			stack,
-			order: 0,
-		} ) as TLShape;
-		const middleShape = resolvedDeskWidgetToCanvasShape( resolvedWidget, {
+
+		const shape = resolvedDeskWidgetToCanvasShape( resolvedWidget, {
 			stack,
 			order: 1,
-		} ) as TLShape;
-		const bottomShape = resolvedDeskWidgetToCanvasShape( resolvedWidget, {
-			stack,
-			order: 2,
-		} ) as TLShape;
+		} );
 
-		expect( new Set( [ topShape.index, middleShape.index, bottomShape.index ] ).size ).toBe( 3 );
-		expect( sortByIndex( middleShape, topShape ) ).toBeLessThan( 0 );
-		expect( sortByIndex( bottomShape, middleShape ) ).toBeLessThan( 0 );
+		expect( shape.index ).toBeUndefined();
 	} );
 
 	it( 'ignores unsupported canvas shapes', () => {

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter.ts
@@ -20,10 +20,10 @@ import {
 	getStackHome,
 	getStackId,
 	getStackMemberLayout,
-	getStackMemberZIndex,
 	getStackOriginalZIndex,
 	getStackPushOrigin,
 	getStackOrder,
+	getStackViewMode,
 	getStackZIndexFromMember,
 } from '@/ui-desks/stacks/utils';
 import { isRectangleWidgetShapeProps } from '@/ui-desks/widgets/geometry';
@@ -84,13 +84,11 @@ export function deskConfigToCanvasShapes( desk: DeskConfig ): TLShapePartial[] {
 			if ( ! stackMember ) {
 				continue;
 			}
-			shapes.push(
-				deskWidgetToCanvasShape(
-					widget,
-					stackMember,
-					memberIndices[ item.widgets.length - stackMember.order - 1 ]
-				)
-			);
+			const renderIndex =
+				stackMember.stack.viewMode === 'tiles'
+					? ( widget.zIndex as TLShapePartial[ 'index' ] )
+					: memberIndices[ item.widgets.length - stackMember.order - 1 ];
+			shapes.push( deskWidgetToCanvasShape( widget, stackMember, renderIndex ) );
 		}
 		indexCursor += item.widgets.length;
 	}
@@ -184,9 +182,7 @@ export function deskWidgetToCanvasShape(
 		throw new Error( `Unknown desk widget type: ${ widget.type }.` );
 	}
 
-	const stackLayout = stackMember
-		? getStackMemberLayout( stackMember.stack, stackMember.order )
-		: null;
+	const stackLayout = stackMember ? getCanvasStackMemberLayout( widget, stackMember ) : null;
 
 	return {
 		id: createShapeId( widget.id ),
@@ -194,13 +190,14 @@ export function deskWidgetToCanvasShape(
 		x: stackLayout?.x ?? widget.x,
 		y: stackLayout?.y ?? widget.y,
 		rotation: stackLayout?.rotation ?? widget.rotation ?? 0,
-		index:
-			renderIndex ??
-			( stackMember
-				? getStackMemberZIndex( stackMember.stack.zIndex, stackMember.order )
-				: ( widget.zIndex as TLShapePartial[ 'index' ] ) ),
+		index: renderIndex ?? ( widget.zIndex as TLShapePartial[ 'index' ] ),
 		meta: stackMember
-			? createStackMeta( stackMember.stack.id, stackMember.order, widget.zIndex )
+			? createStackMeta(
+					stackMember.stack.id,
+					stackMember.order,
+					widget.zIndex,
+					stackMember.stack.viewMode
+			  )
 			: undefined,
 		props: {
 			widgetType: widget.type,
@@ -214,13 +211,18 @@ export function resolvedDeskWidgetToCanvasShape(
 	resolvedWidget: ResolvedDeskWidget< DeskWidget >,
 	stackMember?: DeskStackMember
 ): TLShapePartial {
-	const shape = deskWidgetToCanvasShape( resolvedWidget.widget, stackMember );
+	const shape = deskWidgetToCanvasShape(
+		resolvedWidget.widget,
+		stackMember,
+		stackMember ? ( resolvedWidget.widget.zIndex as TLShapePartial[ 'index' ] ) : undefined
+	);
 	if ( resolvedWidget.origin.kind !== 'derived' ) {
 		return shape;
 	}
 
+	const { index: _index, ...shapeWithoutIndex } = shape;
 	return {
-		...shape,
+		...shapeWithoutIndex,
 		meta: {
 			...( shape.meta ?? {} ),
 			studioDeskOrigin: DERIVED_WIDGET_ORIGIN,
@@ -437,6 +439,18 @@ function getStackMembersByWidgetId( stacks: DeskStack[] | undefined ) {
 	return stackMembers;
 }
 
+function getCanvasStackMemberLayout( widget: DeskWidget, stackMember: DeskStackMember ) {
+	if ( stackMember.stack.viewMode === 'tiles' ) {
+		return {
+			x: widget.x,
+			y: widget.y,
+			rotation: widget.rotation ?? 0,
+		};
+	}
+
+	return getStackMemberLayout( stackMember.stack, stackMember.order );
+}
+
 function canvasShapesToDeskStack( stackId: string, shapes: TLShape[] ): DeskStack | null {
 	const sortedShapes = shapes
 		.map( ( shape ) => ( {
@@ -460,6 +474,18 @@ function canvasShapesToDeskStack( stackId: string, shapes: TLShape[] ): DeskStac
 	}
 
 	const firstMember = sortedShapes[ 0 ];
+	const viewMode = getStackViewMode( firstMember.shape );
+	if ( viewMode === 'tiles' ) {
+		return {
+			id: stackId,
+			x: firstMember.shape.x,
+			y: firstMember.shape.y,
+			zIndex: firstMember.shape.index,
+			memberIds: sortedShapes.map( ( { widget } ) => widget.id ),
+			viewMode,
+		};
+	}
+
 	const home = getStackHome( firstMember.shape );
 	const anchor =
 		home ??
@@ -481,6 +507,13 @@ function canvasShapesToDeskStack( stackId: string, shapes: TLShape[] ): DeskStac
 }
 
 function getPersistedShapePosition( shape: TLShape ) {
+	if ( getStackId( shape ) && getStackViewMode( shape ) === 'tiles' ) {
+		return {
+			x: shape.x,
+			y: shape.y,
+		};
+	}
+
 	const pushOrigin = getStackPushOrigin( shape );
 	if ( pushOrigin ) {
 		return {
@@ -497,6 +530,10 @@ function getPersistedShapePosition( shape: TLShape ) {
 
 function getPersistedShapeZIndex( shape: TLShape ) {
 	if ( getStackId( shape ) ) {
+		if ( getStackViewMode( shape ) === 'tiles' ) {
+			return shape.index;
+		}
+
 		return getStackOriginalZIndex( shape ) ?? shape.index;
 	}
 

--- a/apps/ui/src/ui-desks/desk/types.ts
+++ b/apps/ui/src/ui-desks/desk/types.ts
@@ -2,7 +2,12 @@ import type { DeskWidget } from '@/ui-desks/widgets/types';
 import type { DeskConfig as BaseDeskConfig } from '@studio/common/types/desk';
 
 export { DESK_CONFIG_VERSION } from '@studio/common/types/desk';
-export type { DeskStack, DeskViewport, DeskWidgetBase } from '@studio/common/types/desk';
+export type {
+	DeskStack,
+	DeskStackViewMode,
+	DeskViewport,
+	DeskWidgetBase,
+} from '@studio/common/types/desk';
 
 export interface DeskConnectorEndpoint {
 	widgetId: string;

--- a/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
+++ b/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
@@ -13,7 +13,7 @@ import {
 } from 'tldraw';
 import { getDeskCanvasRecordResolutionState } from '@/ui-desks/desk/tldraw-adapter';
 import { useStackShapeInteraction } from '@/ui-desks/stacks/use-stack-shape-interaction';
-import { getStackId, isStackExpanded } from '@/ui-desks/stacks/utils';
+import { getStackId, getStackViewMode, isStackExpanded } from '@/ui-desks/stacks/utils';
 import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
 import {
 	RECTANGLE_WIDGET_SHAPE_TYPE,
@@ -106,7 +106,11 @@ export class RectangleWidgetShapeUtil extends ShapeUtil< RectangleWidgetShape > 
 	}
 
 	override indicator( shape: RectangleWidgetShape ) {
-		if ( getStackId( shape ) && ! isStackExpanded( shape ) ) {
+		if (
+			getStackId( shape ) &&
+			! isStackExpanded( shape ) &&
+			getStackViewMode( shape ) !== 'tiles'
+		) {
 			return null;
 		}
 

--- a/apps/ui/src/ui-desks/stacks/canvas-components.tsx
+++ b/apps/ui/src/ui-desks/stacks/canvas-components.tsx
@@ -5,7 +5,7 @@ import {
 	useValue,
 } from 'tldraw';
 import { StackBadges } from './badges';
-import { getStackId, isStackExpanded } from './utils';
+import { getStackId, getStackViewMode, isStackExpanded } from './utils';
 
 export function StackCanvasOverlays() {
 	return <StackBadges />;
@@ -23,6 +23,7 @@ export function StackAwareSelectionForeground( props: TLSelectionForegroundProps
 
 			let selectedStackId: string | null = null;
 			let hasExpandedStackMember = false;
+			let hasTiledStackMember = false;
 			for ( const shapeId of selectedShapeIds ) {
 				const shape = editor.getShape( shapeId );
 				const stackId = getStackId( shape );
@@ -37,9 +38,10 @@ export function StackAwareSelectionForeground( props: TLSelectionForegroundProps
 				}
 
 				hasExpandedStackMember = hasExpandedStackMember || isStackExpanded( shape );
+				hasTiledStackMember = hasTiledStackMember || getStackViewMode( shape ) === 'tiles';
 			}
 
-			return selectedStackId !== null && ! hasExpandedStackMember;
+			return selectedStackId !== null && ! hasExpandedStackMember && ! hasTiledStackMember;
 		},
 		[ editor ]
 	);

--- a/apps/ui/src/ui-desks/stacks/editor-commands.ts
+++ b/apps/ui/src/ui-desks/stacks/editor-commands.ts
@@ -20,9 +20,12 @@ import {
 	getStackOrder,
 	getStackOriginalZIndex,
 	getStackPushOrigin,
+	getStackTileLayoutsFromCenter,
+	getStackViewMode,
 	getStackZIndexFromMember,
 	getWidgetIdFromShapeId,
 	isStackExpanded,
+	type StackViewMode,
 } from './utils';
 
 interface StackWidgetSelection {
@@ -77,7 +80,11 @@ export function stackSelectedWidgetsInEditor(
 
 export function expandStackInEditor( editor: Editor, stackId: string ) {
 	const members = getStackMembers( editor, stackId );
-	if ( members.length <= 1 || members.some( isStackExpanded ) ) {
+	if (
+		members.length <= 1 ||
+		members.some( isStackExpanded ) ||
+		getStackViewMode( members[ 0 ] ) === 'tiles'
+	) {
 		return false;
 	}
 
@@ -112,7 +119,11 @@ export function expandStackInEditor( editor: Editor, stackId: string ) {
 
 export function collapseStackInEditor( editor: Editor, stackId: string ) {
 	const members = getStackMembers( editor, stackId );
-	if ( members.length <= 1 || ! members.some( isStackExpanded ) ) {
+	if (
+		members.length <= 1 ||
+		! members.some( isStackExpanded ) ||
+		getStackViewMode( members[ 0 ] ) === 'tiles'
+	) {
 		return false;
 	}
 
@@ -149,6 +160,77 @@ export function collapseAllExpandedStacksInEditor( editor: Editor ) {
 		didCollapseStack = collapseStackInEditor( editor, stackId ) || didCollapseStack;
 	}
 	return didCollapseStack;
+}
+
+export function setStackViewInEditor( editor: Editor, stackId: string, viewMode: StackViewMode ) {
+	const members = getStackMembers( editor, stackId );
+	if ( members.length <= 1 ) {
+		return false;
+	}
+
+	const currentViewMode = getStackViewMode( members[ 0 ] );
+	if ( currentViewMode === viewMode ) {
+		return false;
+	}
+
+	const anchor = getStackAnchorCenter( members );
+	const restorePartials = getNeighborRestorePartials( editor, stackId );
+
+	if ( viewMode === 'tiles' ) {
+		editor.updateShapes(
+			members.map( ( shape ) => ( {
+				id: shape.id,
+				type: shape.type,
+				isLocked: false,
+				meta: {
+					...( shape.meta ?? {} ),
+					...clearExpandedStackMeta(),
+					deskStackViewMode: 'tiles',
+				},
+			} ) )
+		);
+
+		const tilePartials = getTiledStackPartials( members, anchor );
+		editor.animateShapes( withStackDimPartials( editor, [ ...tilePartials, ...restorePartials ] ), {
+			animation: { duration: STACK_ANIMATION_DURATION },
+		} );
+		return true;
+	}
+
+	const stack = {
+		id: stackId,
+		x: anchor.x - getShapeSize( members[ 0 ] ).w / 2,
+		y: anchor.y - getShapeSize( members[ 0 ] ).h / 2,
+		zIndex: getStackZIndexFromMember( members[ 0 ].index, getStackOrder( members[ 0 ] ) ),
+		memberIds: members.map( ( shape ) => getWidgetIdFromShapeId( shape.id ) ),
+	};
+
+	editor.updateShapes(
+		members.map( ( shape ) => ( {
+			id: shape.id,
+			type: shape.type,
+			isLocked: false,
+			meta: {
+				...( shape.meta ?? {} ),
+				deskStackViewMode: null,
+				...clearExpandedStackMeta(),
+			},
+		} ) )
+	);
+
+	const memberPartials = members.map( ( shape ) => {
+		const order = getStackOrder( shape );
+		return {
+			id: shape.id,
+			type: shape.type,
+			...getStackMemberLayout( stack, order ),
+		};
+	} );
+
+	editor.animateShapes( withStackDimPartials( editor, [ ...memberPartials, ...restorePartials ] ), {
+		animation: { duration: STACK_ANIMATION_DURATION },
+	} );
+	return true;
 }
 
 export function unstackSelectedWidgetsInEditor(
@@ -269,6 +351,26 @@ function getExpandedStackLayouts( members: TLShape[], stack: { x: number; y: num
 			y: startY + row * ( cellHeight + EXPANDED_STACK_GAP ) + ( cellHeight - size.h ) / 2,
 		};
 	} );
+}
+
+function getStackAnchorCenter( members: TLShape[] ) {
+	const firstMember = members[ 0 ];
+	const size = getShapeSize( firstMember );
+
+	return {
+		x: firstMember.x + size.w / 2,
+		y: firstMember.y + size.h / 2,
+	};
+}
+
+function getTiledStackPartials( members: TLShape[], center: { x: number; y: number } ) {
+	const layouts = getStackTileLayoutsFromCenter( members.map( getShapeSize ), center );
+
+	return members.map( ( shape, index ) => ( {
+		id: shape.id,
+		type: shape.type,
+		...layouts[ index ],
+	} ) );
 }
 
 function getExpandedStackDimensions( count: number ) {

--- a/apps/ui/src/ui-desks/stacks/use-stack-interactions.ts
+++ b/apps/ui/src/ui-desks/stacks/use-stack-interactions.ts
@@ -1,10 +1,11 @@
 import { useEffect, useRef } from 'react';
 import { collapseAllExpandedStacksInEditor, expandStackInEditor } from './editor-commands';
-import { getStackId, isStackExpanded } from './utils';
-import type { Editor, TLEventInfo } from 'tldraw';
+import { getStackId, getStackViewMode, isStackExpanded } from './utils';
+import type { Editor, TLEventInfo, TLShapeId } from 'tldraw';
 
 export function useStackInteractions( editor: Editor | null ) {
 	useStackDragSelection( editor );
+	useTiledStackDragSelection( editor );
 	useStackClickToOpen( editor );
 }
 
@@ -36,6 +37,116 @@ function useStackDragSelection( editor: Editor | null ) {
 		editor.on( 'event', selectStackMembersForDrag );
 		return () => {
 			editor.off( 'event', selectStackMembersForDrag );
+		};
+	}, [ editor ] );
+}
+
+function useTiledStackDragSelection( editor: Editor | null ) {
+	const restoreSelectionRef = useRef< TLShapeId[] | null >( null );
+	const activeMemberIdsRef = useRef< TLShapeId[] >( [] );
+	const movedShapeIdsRef = useRef( new Set< string >() );
+
+	useEffect( () => {
+		if ( ! editor ) {
+			return;
+		}
+
+		const movedShapeIds = movedShapeIdsRef.current;
+		const unsubscribeShapeChanges = editor.sideEffects.registerAfterChangeHandler(
+			'shape',
+			( previousShape, nextShape ) => {
+				if ( ! restoreSelectionRef.current || activeMemberIdsRef.current.length === 0 ) {
+					return;
+				}
+
+				if (
+					previousShape.x !== nextShape.x ||
+					previousShape.y !== nextShape.y ||
+					previousShape.rotation !== nextShape.rotation
+				) {
+					movedShapeIds.add( nextShape.id );
+				}
+			}
+		);
+
+		const handleTiledStackDragSelection = ( info: TLEventInfo ) => {
+			if ( info.type !== 'pointer' ) {
+				return;
+			}
+
+			if ( info.name === 'pointer_down' ) {
+				if ( info.button !== 0 || restoreSelectionRef.current ) {
+					return;
+				}
+
+				const hitShape = getShapeAtPointer( editor );
+				const stackId = getStackId( hitShape );
+				if ( ! hitShape || ! stackId || getStackViewMode( hitShape ) !== 'tiles' ) {
+					return;
+				}
+
+				const memberIds = editor
+					.getCurrentPageShapes()
+					.filter( ( shape ) => getStackId( shape ) === stackId )
+					.map( ( shape ) => shape.id );
+				if ( memberIds.length <= 1 ) {
+					return;
+				}
+
+				const selectedShapeIds = editor.getSelectedShapeIds();
+				const selectedStackMemberIds = selectedShapeIds.filter( ( shapeId ) =>
+					memberIds.includes( shapeId )
+				);
+				if ( selectedStackMemberIds.length === memberIds.length ) {
+					return;
+				}
+
+				restoreSelectionRef.current = selectedShapeIds.includes( hitShape.id )
+					? selectedShapeIds
+					: [ hitShape.id ];
+				activeMemberIdsRef.current = memberIds;
+				movedShapeIds.clear();
+				editor.setSelectedShapes( memberIds );
+				return;
+			}
+
+			if ( info.name === 'pointer_up' ) {
+				const restoreSelection = restoreSelectionRef.current;
+				if ( ! restoreSelection ) {
+					return;
+				}
+
+				restoreSelectionRef.current = null;
+				const existingMemberIds = activeMemberIdsRef.current.filter( ( shapeId ) =>
+					editor.getShape( shapeId )
+				);
+				const movedStack = existingMemberIds.some( ( shapeId ) => movedShapeIds.has( shapeId ) );
+				activeMemberIdsRef.current = [];
+				movedShapeIds.clear();
+
+				if ( movedStack ) {
+					if ( existingMemberIds.length > 0 ) {
+						editor.setSelectedShapes( existingMemberIds );
+					}
+					return;
+				}
+
+				const existingRestoreSelection = restoreSelection.filter( ( shapeId ) =>
+					editor.getShape( shapeId )
+				);
+				if ( existingRestoreSelection.length > 0 ) {
+					editor.setSelectedShapes( existingRestoreSelection );
+				}
+			}
+		};
+
+		editor.on( 'event', handleTiledStackDragSelection );
+		return () => {
+			restoreSelectionRef.current = null;
+			activeMemberIdsRef.current = [];
+			movedShapeIds.clear();
+			editor.off( 'event', handleTiledStackDragSelection );
+			unsubscribeShapeChanges();
 		};
 	}, [ editor ] );
 }
@@ -125,11 +236,22 @@ function useStackClickToOpen( editor: Editor | null ) {
 }
 
 function getCollapsedStackIdAtPointer( editor: Editor ) {
+	const stackId = getStackIdAtPointer( editor );
+	const hitShape = getShapeAtPointer( editor );
+	return stackId && ! isStackExpanded( hitShape ) && getStackViewMode( hitShape ) !== 'tiles'
+		? stackId
+		: null;
+}
+
+function getStackIdAtPointer( editor: Editor ) {
+	return getStackId( getShapeAtPointer( editor ) );
+}
+
+function getShapeAtPointer( editor: Editor ) {
 	const hitShape = editor.getShapeAtPoint( editor.inputs.currentPagePoint, {
 		hitInside: true,
 		renderingOnly: true,
 		margin: editor.options.hitTestMargin / editor.getZoomLevel(),
 	} );
-	const stackId = getStackId( hitShape );
-	return stackId && ! isStackExpanded( hitShape ) ? stackId : null;
+	return hitShape;
 }

--- a/apps/ui/src/ui-desks/stacks/use-stack-shape-interaction.ts
+++ b/apps/ui/src/ui-desks/stacks/use-stack-shape-interaction.ts
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import { useEditor, useValue, type TLShape } from 'tldraw';
 import { useDesk } from '@/ui-desks/desk/provider/context';
 import { expandStackInEditor } from './editor-commands';
-import { getStackId, getStackOrder, isStackExpanded } from './utils';
+import { getStackId, getStackOrder, getStackViewMode, isStackExpanded } from './utils';
 import type { PointerEvent } from 'react';
 
 export function useStackShapeInteraction( shape: TLShape ) {
@@ -11,17 +11,22 @@ export function useStackShapeInteraction( shape: TLShape ) {
 	const pointerDownPointRef = useRef< { x: number; y: number } | null >( null );
 	const stackId = getStackId( shape );
 	const isExpanded = isStackExpanded( shape );
+	const isTiles = getStackViewMode( shape ) === 'tiles';
 	const hoveredStackId = useValue(
 		'desk-stack-hovered-stack-id',
 		() => {
 			const hoveredShape = editor.getHoveredShape();
 			const hoveredShapeStackId = getStackId( hoveredShape );
-			return hoveredShapeStackId && ! isStackExpanded( hoveredShape ) ? hoveredShapeStackId : null;
+			return hoveredShapeStackId &&
+				! isStackExpanded( hoveredShape ) &&
+				getStackViewMode( hoveredShape ) !== 'tiles'
+				? hoveredShapeStackId
+				: null;
 		},
 		[ editor ]
 	);
-	const isHovered = Boolean( stackId ) && ! isExpanded && hoveredStackId === stackId;
-	const isPressed = Boolean( stackId ) && ! isExpanded && pressedStackId === stackId;
+	const isHovered = Boolean( stackId ) && ! isExpanded && ! isTiles && hoveredStackId === stackId;
+	const isPressed = Boolean( stackId ) && ! isExpanded && ! isTiles && pressedStackId === stackId;
 	const order = getStackOrder( shape );
 	const members = stackId
 		? editor.getCurrentPageShapes().filter( ( member ) => getStackId( member ) === stackId )
@@ -41,7 +46,7 @@ export function useStackShapeInteraction( shape: TLShape ) {
 			transition: 'transform 220ms ease',
 		},
 		onPointerDown: ( event: PointerEvent ) => {
-			if ( stackId && ! isExpanded ) {
+			if ( stackId && ! isExpanded && ! isTiles ) {
 				pressStack( stackId );
 				if ( isReadOnly ) {
 					pointerDownPointRef.current = {
@@ -54,7 +59,7 @@ export function useStackShapeInteraction( shape: TLShape ) {
 			}
 		},
 		onPointerUp: ( event: PointerEvent ) => {
-			if ( ! isReadOnly || ! stackId || isExpanded ) {
+			if ( ! isReadOnly || ! stackId || isExpanded || isTiles ) {
 				pointerDownPointRef.current = null;
 				return;
 			}

--- a/apps/ui/src/ui-desks/stacks/utils.ts
+++ b/apps/ui/src/ui-desks/stacks/utils.ts
@@ -1,14 +1,23 @@
-import { getIndicesAbove, getIndicesBelow, type TLShape, type TLShapePartial } from 'tldraw';
-import type { DeskStack } from '@/ui-desks/desk/types';
+import { getIndicesAbove, type TLShape, type TLShapePartial } from 'tldraw';
+import type { DeskStack, DeskStackViewMode } from '@/ui-desks/desk/types';
 
 export const STACK_TRANSLATE_X = 10;
 export const STACK_TRANSLATE_Y = 8;
 export const STACK_ROTATION = 0.052;
+export const STACK_TILE_GAP = 16;
 const STACK_Z_INDEX_STEP = 0.001;
+
+export type StackViewMode = DeskStackViewMode;
+
+export interface StackTileSize {
+	w: number;
+	h: number;
+}
 
 export interface DeskStackShapeMeta {
 	deskStackId?: unknown;
 	deskStackOrder?: unknown;
+	deskStackViewMode?: unknown;
 	deskStackExpanded?: unknown;
 	deskStackHomeX?: unknown;
 	deskStackHomeY?: unknown;
@@ -33,6 +42,11 @@ export function getStackOrder( shape: TLShape | null | undefined ) {
 export function isStackExpanded( shape: TLShape | null | undefined ) {
 	const meta = shape?.meta as DeskStackShapeMeta | undefined;
 	return meta?.deskStackExpanded === true;
+}
+
+export function getStackViewMode( shape: TLShape | null | undefined ): StackViewMode {
+	const meta = shape?.meta as DeskStackShapeMeta | undefined;
+	return meta?.deskStackViewMode === 'tiles' ? 'tiles' : 'stack';
 }
 
 export function getStackHome( shape: TLShape | null | undefined ) {
@@ -89,20 +103,89 @@ export function getStackAnchorFromMember( shape: Pick< TLShape, 'x' | 'y' >, ord
 	};
 }
 
-export function getStackMemberZIndex( zIndex: string, order: number ) {
-	const numericIndex = parseDeskZIndex( zIndex );
-	if ( numericIndex === null ) {
-		if ( order === 0 ) {
-			return zIndex as TLShapePartial[ 'index' ];
-		}
+export function getStackTileLayoutsFromCenter(
+	sizes: StackTileSize[],
+	center: { x: number; y: number }
+) {
+	const dimensions = getStackTileDimensions( sizes.length );
+	const cellWidth = Math.max( ...sizes.map( ( size ) => size.w ), 1 );
+	const cellHeight = Math.max( ...sizes.map( ( size ) => size.h ), 1 );
+	const totalWidth = dimensions.columns * cellWidth + ( dimensions.columns - 1 ) * STACK_TILE_GAP;
+	const totalHeight = dimensions.rows * cellHeight + ( dimensions.rows - 1 ) * STACK_TILE_GAP;
+	const startX = center.x - totalWidth / 2;
+	const startY = center.y - totalHeight / 2;
 
-		return (
-			getIndicesBelow( zIndex as TLShapePartial[ 'index' ], order ).at( 0 ) ??
-			( zIndex as TLShapePartial[ 'index' ] )
-		);
+	return sizes.map( ( size, index ) => {
+		const column = index % dimensions.columns;
+		const row = Math.floor( index / dimensions.columns );
+		const cellX = startX + column * ( cellWidth + STACK_TILE_GAP );
+		const cellY = startY + row * ( cellHeight + STACK_TILE_GAP );
+
+		return {
+			x: cellX + ( cellWidth - size.w ) / 2,
+			y: cellY + ( cellHeight - size.h ) / 2,
+			rotation: 0,
+		};
+	} );
+}
+
+function getStackTileCenterFromFirstTile(
+	sizes: StackTileSize[],
+	firstTile: { x: number; y: number }
+) {
+	const dimensions = getStackTileDimensions( sizes.length );
+	const firstSize = sizes[ 0 ] ?? { w: 1, h: 1 };
+	const cellWidth = Math.max( ...sizes.map( ( size ) => size.w ), firstSize.w, 1 );
+	const cellHeight = Math.max( ...sizes.map( ( size ) => size.h ), firstSize.h, 1 );
+	const totalWidth = dimensions.columns * cellWidth + ( dimensions.columns - 1 ) * STACK_TILE_GAP;
+	const totalHeight = dimensions.rows * cellHeight + ( dimensions.rows - 1 ) * STACK_TILE_GAP;
+
+	return {
+		x: firstTile.x - ( cellWidth - firstSize.w ) / 2 + totalWidth / 2,
+		y: firstTile.y - ( cellHeight - firstSize.h ) / 2 + totalHeight / 2,
+	};
+}
+
+export function getStackTileLayoutsFromFirstTile(
+	sizes: StackTileSize[],
+	firstTile: { x: number; y: number }
+) {
+	return getStackTileLayoutsFromCenter(
+		sizes,
+		getStackTileCenterFromFirstTile( sizes, firstTile )
+	);
+}
+
+function getStackTileDimensions( count: number ) {
+	if ( count <= 3 ) {
+		return {
+			rows: 1,
+			columns: Math.max( 1, count ),
+		};
+	}
+	if ( count <= 4 ) {
+		return {
+			rows: 2,
+			columns: 2,
+		};
+	}
+	if ( count <= 6 ) {
+		return {
+			rows: 2,
+			columns: 3,
+		};
+	}
+	if ( count <= 9 ) {
+		return {
+			rows: 3,
+			columns: 3,
+		};
 	}
 
-	return formatDeskZIndex( numericIndex - order * STACK_Z_INDEX_STEP ) as TLShapePartial[ 'index' ];
+	return {
+		rows: Math.ceil( count / 4 ),
+		columns: 4,
+	};
 }
 
 export function getStackZIndexFromMember( zIndex: string, order: number ) {
@@ -118,10 +201,16 @@ export function getStackZIndexFromMember( zIndex: string, order: number ) {
 	return formatDeskZIndex( numericIndex + order * STACK_Z_INDEX_STEP );
 }
 
-export function createStackMeta( stackId: string, order: number, originalZIndex?: string ) {
+export function createStackMeta(
+	stackId: string,
+	order: number,
+	originalZIndex?: string,
+	viewMode: StackViewMode = 'stack'
+) {
 	return {
 		deskStackId: stackId,
 		deskStackOrder: order,
+		deskStackViewMode: viewMode === 'tiles' ? 'tiles' : null,
 		...( originalZIndex ? { deskStackOriginalZIndex: originalZIndex } : {} ),
 	};
 }
@@ -166,6 +255,7 @@ export function clearStackMeta() {
 	return {
 		deskStackId: null,
 		deskStackOrder: null,
+		deskStackViewMode: null,
 		deskStackOriginalZIndex: null,
 		...clearExpandedStackMeta(),
 		...clearStackPushMeta(),

--- a/apps/ui/src/ui-desks/widgets/post-collection/definition.test.ts
+++ b/apps/ui/src/ui-desks/widgets/post-collection/definition.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { postCollectionWidgetDefinition } from './definition';
+import { POST_COLLECTION_WIDGET_TYPE, type PostCollectionWidget } from './types';
+import type { WidgetResolverContext } from '@/ui-desks/widgets/types';
+
+vi.mock( '@wordpress/core-data', () => ( {
+	store: {},
+} ) );
+
+vi.mock( '@/ui-desks/widgets/post-collection/edit-control', () => ( {
+	PostCollectionEditControl: () => null,
+} ) );
+
+vi.mock( '@/ui-desks/widgets/post/edit-control', () => ( {
+	PostEditControl: () => null,
+} ) );
+
+describe( 'post collection widget definition', () => {
+	it( 'keeps tiled post positions stable when resolving from a persisted first tile anchor', async () => {
+		const collection = createPostCollectionWidget( {
+			x: 100,
+			y: 200,
+			widgetProps: {
+				viewMode: 'tiles',
+			},
+		} );
+
+		const initialPositions = await resolvePostCollectionPositions( collection );
+		expect( initialPositions[ 0 ] ).toMatchObject( { x: 100, y: 200 } );
+
+		const reloadedCollection = {
+			...collection,
+			x: initialPositions[ 0 ].x,
+			y: initialPositions[ 0 ].y,
+		};
+
+		await expect( resolvePostCollectionPositions( reloadedCollection ) ).resolves.toEqual(
+			initialPositions
+		);
+	} );
+} );
+
+async function resolvePostCollectionPositions( collection: PostCollectionWidget ) {
+	const posts = [ 101, 102, 103, 104, 105 ].map( ( id ) => ( { id } ) );
+	const registry = {
+		resolveSelect: () => ( {
+			getEntityRecords: vi.fn().mockResolvedValue( posts ),
+		} ),
+	} as unknown as WidgetResolverContext[ 'registry' ];
+
+	const resolution = await postCollectionWidgetDefinition.resolver.resolve( collection, {
+		registry,
+	} );
+
+	return resolution.widgets.map( ( { widget } ) => ( {
+		x: widget.x,
+		y: widget.y,
+	} ) );
+}
+
+type PostCollectionWidgetOverrides = Partial< Omit< PostCollectionWidget, 'widgetProps' > > & {
+	widgetProps?: Partial< PostCollectionWidget[ 'widgetProps' ] >;
+};
+
+function createPostCollectionWidget(
+	overrides: PostCollectionWidgetOverrides = {}
+): PostCollectionWidget {
+	const widgetProps = {
+		query: {
+			postType: 'post' as const,
+			perPage: 5,
+			status: 'publish' as const,
+			orderby: 'date' as const,
+			order: 'desc' as const,
+		},
+		...overrides.widgetProps,
+	};
+
+	return {
+		id: 'collection-1',
+		type: POST_COLLECTION_WIDGET_TYPE,
+		x: 0,
+		y: 0,
+		zIndex: 'a1',
+		shapeProps: {
+			w: 1,
+			h: 1,
+		},
+		...overrides,
+		widgetProps,
+	};
+}

--- a/apps/ui/src/ui-desks/widgets/post-collection/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/post-collection/definition.ts
@@ -1,7 +1,7 @@
 import { store as coreDataStore, type Post as CoreDataPost } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
-import { post } from '@wordpress/icons';
-import { getIndicesAbove, type TLShapePartial } from 'tldraw';
+import { category, post } from '@wordpress/icons';
+import { getStackTileLayoutsFromFirstTile } from '@/ui-desks/stacks/utils';
 import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
 import { POST_WIDGET_TYPE, type PostWidget } from '@/ui-desks/widgets/post/types';
 import {
@@ -15,6 +15,7 @@ import {
 	POST_COLLECTION_WIDGET_TYPE,
 	type PostCollectionQuery,
 	type PostCollectionWidget,
+	type PostCollectionWidgetProps,
 } from './types';
 import type {
 	ResolvedDeskStack,
@@ -58,6 +59,13 @@ const COLLECTION_SOURCE_SHAPE_PROPS = {
 	h: 1,
 };
 const POST_CARD_SHAPE_PROPS = postWidgetDefinition.getInitialWidget().shapeProps;
+const STACK_VIEW_MODE_OPTIONS: Array< {
+	value: NonNullable< PostCollectionWidgetProps[ 'viewMode' ] >;
+	label: string;
+} > = [
+	{ value: 'stack', label: __( 'Stack' ) },
+	{ value: 'tiles', label: __( 'Tiles' ) },
+];
 
 export const postCollectionWidgetDefinition = {
 	type: POST_COLLECTION_WIDGET_TYPE,
@@ -66,6 +74,15 @@ export const postCollectionWidgetDefinition = {
 	thumbnail: PostCollectionThumbnailComponent,
 	loading: PostCollectionLoadingComponent,
 	controls: [
+		{
+			type: 'select',
+			id: 'view-mode',
+			property: 'viewMode',
+			label: __( 'Display' ),
+			icon: category,
+			defaultValue: 'stack',
+			options: STACK_VIEW_MODE_OPTIONS,
+		},
 		{
 			type: 'custom',
 			id: 'open-posts',
@@ -109,7 +126,7 @@ export const postCollectionWidgetDefinition = {
 			const posts =
 				( await getCoreDataResolvers( context ).getEntityRecords( 'postType', 'post', query ) ) ??
 				[];
-			const zIndices = getDerivedZIndices( widget.zIndex, posts.length + 1 );
+			const positions = getDerivedPostWidgetPositions( widget, posts.length );
 
 			return {
 				identity: {
@@ -117,12 +134,9 @@ export const postCollectionWidgetDefinition = {
 					posts,
 				},
 				widgets: posts.map( ( postRecord, index ) =>
-					createDerivedPostWidget( widget, postRecord.id, zIndices[ index ] )
+					createDerivedPostWidget( widget, postRecord.id, positions[ index ] )
 				),
-				stacks:
-					posts.length > 0
-						? [ createDerivedPostStack( widget, posts, zIndices[ posts.length ] ) ]
-						: [],
+				stacks: posts.length > 0 ? [ createDerivedPostStack( widget, posts ) ] : [],
 			};
 		},
 		invalidate: ( widget, previousIdentity, context ) => {
@@ -161,7 +175,7 @@ function getEntityRecordsQuery( query: PostCollectionQuery ): EntityRecordsQuery
 function createDerivedPostWidget(
 	collection: PostCollectionWidget,
 	postId: number,
-	zIndex: string
+	position: { x: number; y: number }
 ): ResolvedDeskWidget< PostWidget > {
 	return {
 		origin: {
@@ -172,9 +186,9 @@ function createDerivedPostWidget(
 		widget: {
 			id: `${ collection.id }:post:${ postId }`,
 			type: POST_WIDGET_TYPE,
-			x: collection.x,
-			y: collection.y,
-			zIndex,
+			x: position.x,
+			y: position.y,
+			zIndex: collection.zIndex,
 			shapeProps: POST_CARD_SHAPE_PROPS,
 			widgetProps: {
 				postId,
@@ -185,8 +199,7 @@ function createDerivedPostWidget(
 
 function createDerivedPostStack(
 	collection: PostCollectionWidget,
-	posts: CoreDataPost[],
-	zIndex: string
+	posts: CoreDataPost[]
 ): ResolvedDeskStack {
 	return {
 		origin: {
@@ -198,12 +211,27 @@ function createDerivedPostStack(
 			id: `post-collection:${ collection.id }`,
 			x: collection.x,
 			y: collection.y,
-			zIndex,
+			zIndex: collection.zIndex,
 			memberIds: posts.map( ( postRecord ) => `${ collection.id }:post:${ postRecord.id }` ),
+			...( collection.widgetProps.viewMode === 'tiles' ? { viewMode: 'tiles' as const } : {} ),
 		},
 	};
 }
 
-function getDerivedZIndices( zIndex: string, count: number ) {
-	return getIndicesAbove( zIndex as TLShapePartial[ 'index' ], count ) as string[];
+function getDerivedPostWidgetPositions( collection: PostCollectionWidget, count: number ) {
+	if ( collection.widgetProps.viewMode !== 'tiles' ) {
+		return Array.from( { length: count }, () => ( {
+			x: collection.x,
+			y: collection.y,
+		} ) );
+	}
+
+	const sizes = Array.from( { length: count }, () => POST_CARD_SHAPE_PROPS );
+	return getStackTileLayoutsFromFirstTile( sizes, {
+		x: collection.x,
+		y: collection.y,
+	} ).map( ( layout ) => ( {
+		x: layout.x,
+		y: layout.y,
+	} ) );
 }

--- a/apps/ui/src/ui-desks/widgets/post-collection/types.ts
+++ b/apps/ui/src/ui-desks/widgets/post-collection/types.ts
@@ -1,5 +1,5 @@
 import type { RectangleWidgetShapeProps } from '@/ui-desks/widgets/geometry';
-import type { DeskWidgetBase } from '@studio/common/types/desk';
+import type { DeskStackViewMode, DeskWidgetBase } from '@studio/common/types/desk';
 
 export const POST_COLLECTION_WIDGET_TYPE = 'post-collection';
 
@@ -17,6 +17,7 @@ export type PostCollectionQuery = {
 
 export type PostCollectionWidgetProps = {
 	query: PostCollectionQuery;
+	viewMode?: DeskStackViewMode;
 };
 
 export type PostCollectionWidget = DeskWidgetBase<
@@ -27,7 +28,16 @@ export type PostCollectionWidget = DeskWidgetBase<
 
 export function isPostCollectionWidgetProps( value: unknown ): value is PostCollectionWidgetProps {
 	const candidate = value as Partial< PostCollectionWidgetProps >;
-	return Boolean( value ) && typeof value === 'object' && isPostCollectionQuery( candidate.query );
+	return (
+		Boolean( value ) &&
+		typeof value === 'object' &&
+		isPostCollectionQuery( candidate.query ) &&
+		isPostCollectionViewMode( candidate.viewMode )
+	);
+}
+
+function isPostCollectionViewMode( value: unknown ): value is DeskStackViewMode | undefined {
+	return value === undefined || value === 'stack' || value === 'tiles';
 }
 
 function isPostCollectionQuery( value: unknown ): value is PostCollectionQuery {

--- a/apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts
+++ b/apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts
@@ -136,7 +136,8 @@ describe( 'widget toolbar selection', () => {
 			throw new Error( 'Expected a single widget toolbar item.' );
 		}
 		expect( selectedItem.definition.type ).toBe( POST_COLLECTION_WIDGET_TYPE );
-		expect( selectedItem.definition.controls?.[ 0 ]?.type ).toBe( 'custom' );
+		expect( selectedItem.definition.controls?.[ 0 ]?.type ).toBe( 'select' );
+		expect( selectedItem.definition.controls?.[ 1 ]?.type ).toBe( 'custom' );
 		expect( selectedItem.widget.widgetProps ).toEqual( {
 			query: {
 				postType: 'post',
@@ -180,6 +181,21 @@ describe( 'widget toolbar selection', () => {
 			canStack: false,
 			canUnstack: true,
 			stackIds: [ 'stack-1' ],
+		} );
+	} );
+
+	it( 'returns stack view controls for selections from a single stack', () => {
+		const widget = createNoteWidget();
+
+		expect(
+			getSelectedWidgetToolbarItem( [ widget, widget ], {
+				stackIds: [ 'stack-1' ],
+				stackViewMode: 'tiles',
+			} )
+		).toMatchObject( {
+			kind: 'multi-widget',
+			canSetStackView: true,
+			stackViewMode: 'tiles',
 		} );
 	} );
 

--- a/apps/ui/src/ui-desks/widgets/toolbar-selection.ts
+++ b/apps/ui/src/ui-desks/widgets/toolbar-selection.ts
@@ -1,19 +1,24 @@
 import { DRAWING_WIDGET_TYPE } from '@/ui-desks/widgets/drawing/types';
 import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
+import type { StackViewMode } from '@/ui-desks/stacks/utils';
 import type { DeskWidget } from '@/ui-desks/widgets/types';
 
 interface SelectedWidgetToolbarOptions {
 	stackIds?: string[];
+	stackViewMode?: StackViewMode;
 	canStack?: boolean;
 	canUnstack?: boolean;
+	canSetStackView?: boolean;
 	canRemove?: boolean;
 }
 
 interface SelectedWidgetToolbarBase {
 	widgets: DeskWidget[];
 	stackIds: string[];
+	stackViewMode?: StackViewMode;
 	canStack: boolean;
 	canUnstack: boolean;
+	canSetStackView: boolean;
 	canRemove: boolean;
 }
 
@@ -39,8 +44,13 @@ export function getSelectedWidgetToolbarItem(
 	const base = {
 		widgets,
 		stackIds,
+		stackViewMode: options.stackViewMode,
 		canStack: ( options.canStack ?? true ) && widgets.length >= 2 && stackIds.length === 0,
 		canUnstack: ( options.canUnstack ?? true ) && stackIds.length > 0,
+		canSetStackView:
+			( options.canSetStackView ?? true ) &&
+			stackIds.length === 1 &&
+			Boolean( options.stackViewMode ),
 		canRemove: options.canRemove ?? true,
 	};
 

--- a/apps/ui/src/ui-desks/widgets/toolbar.test.tsx
+++ b/apps/ui/src/ui-desks/widgets/toolbar.test.tsx
@@ -78,6 +78,7 @@ function createDeskContext( overrides: Partial< DeskContextValue > = {} ): DeskC
 		fitSelectedWidgetToContent: vi.fn().mockResolvedValue( false ),
 		stackSelectedWidgets: vi.fn(),
 		unstackSelectedWidgets: vi.fn(),
+		setSelectedStackView: vi.fn(),
 		removeSelectedWidget: vi.fn(),
 		...overrides,
 	};
@@ -105,6 +106,7 @@ function createSingleWidgetSelection(
 		stackIds: [],
 		canStack: false,
 		canUnstack: false,
+		canSetStackView: false,
 		canRemove: true,
 		widget,
 		definition: {

--- a/apps/ui/src/ui-desks/widgets/toolbar.tsx
+++ b/apps/ui/src/ui-desks/widgets/toolbar.tsx
@@ -1,5 +1,5 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { group, trash, ungroup, update } from '@wordpress/icons';
+import { category, group, trash, ungroup, update } from '@wordpress/icons';
 import { useEffect, useState } from 'react';
 import { ChatButton } from '@/ui-desks/chats/chat-button';
 import { SelectionChatDialog } from '@/ui-desks/chats/selection-chat-dialog';
@@ -7,10 +7,25 @@ import { Divider, IconControlButton, Surface } from '@/ui-desks/components';
 import { ControlRenderer } from '@/ui-desks/controls/registry';
 import { useDesk } from '@/ui-desks/desk/provider';
 import styles from './toolbar.module.css';
+import type { AnySelectControlConfig } from '@/ui-desks/controls/types';
+import type { StackViewMode } from '@/ui-desks/stacks/utils';
 import type { getSelectedWidgetToolbarItem } from '@/ui-desks/widgets/toolbar-selection';
 import type { DeskWidget } from '@/ui-desks/widgets/types';
 
 type SelectedWidgetToolbarItem = NonNullable< ReturnType< typeof getSelectedWidgetToolbarItem > >;
+
+const STACK_VIEW_MODE_CONTROL: AnySelectControlConfig = {
+	type: 'select',
+	id: 'stack-view-mode',
+	property: 'viewMode',
+	label: __( 'Display' ),
+	icon: category,
+	defaultValue: 'stack',
+	options: [
+		{ value: 'stack', label: __( 'Stack' ) },
+		{ value: 'tiles', label: __( 'Tiles' ) },
+	],
+};
 
 export function DeskWidgetToolbar() {
 	const {
@@ -18,6 +33,7 @@ export function DeskWidgetToolbar() {
 		fitSelectedWidgetToContent,
 		stackSelectedWidgets,
 		unstackSelectedWidgets,
+		setSelectedStackView,
 		updateSelectedWidgetProps,
 		removeSelectedWidget,
 	} = useDesk();
@@ -88,7 +104,24 @@ export function DeskWidgetToolbar() {
 							updateProps={ updateSelectedWidgetProps }
 						/>
 					) ) }
-				{ ( renderSelection.canStack || renderSelection.canUnstack ) && <Divider /> }
+				{ renderSelection.canSetStackView && (
+					<ControlRenderer
+						control={ STACK_VIEW_MODE_CONTROL }
+						isOpen={ openControlId === STACK_VIEW_MODE_CONTROL.id }
+						props={ { viewMode: renderSelection.stackViewMode ?? 'stack' } }
+						setIsOpen={ ( isOpen ) =>
+							setOpenControlId( isOpen ? STACK_VIEW_MODE_CONTROL.id : null )
+						}
+						updateProps={ ( nextProps ) => {
+							if ( isStackViewMode( nextProps.viewMode ) ) {
+								setSelectedStackView( nextProps.viewMode );
+							}
+						} }
+					/>
+				) }
+				{ ( renderSelection.canStack ||
+					renderSelection.canUnstack ||
+					renderSelection.canSetStackView ) && <Divider /> }
 				{ renderSelection.canStack && (
 					<IconControlButton
 						icon={ group }
@@ -124,4 +157,8 @@ export function DeskWidgetToolbar() {
 			) }
 		</>
 	);
+}
+
+function isStackViewMode( value: unknown ): value is StackViewMode {
+	return value === 'stack' || value === 'tiles';
 }

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -161,6 +161,11 @@ export interface WidgetResolver<
 	TWidget extends DeskWidgetBase = DeskWidgetBase,
 	TIdentity = unknown,
 > {
+	/**
+	 * Derived widgets should treat the source widget's x/y as the top-left origin of
+	 * the primary resolved shape. Persistence writes that same primary origin back
+	 * to the source widget, so center-based resolver layouts will drift on reload.
+	 */
 	resolve: (
 		widget: TWidget,
 		context: WidgetResolverContext

--- a/tools/common/types/desk.ts
+++ b/tools/common/types/desk.ts
@@ -34,12 +34,15 @@ export interface DeskViewport {
 	z: number;
 }
 
+export type DeskStackViewMode = 'stack' | 'tiles';
+
 export interface DeskStack {
 	id: string;
 	x: number;
 	y: number;
 	zIndex: string;
 	memberIds: string[];
+	viewMode?: DeskStackViewMode;
 }
 
 export interface DeskConfig< TWidget extends DeskWidgetBase = DeskWidgetBase > {


### PR DESCRIPTION
## Summary
- Add a built-in select control for widget display mode and expose tiles/stack switching in the toolbar.
- Support tiles mode end-to-end for stacks and post collections, including persistence, resolver output, and canvas hydration.
- Fix tile drag behavior so moving a tile selects and moves the full collection, while still allowing per-item toolbar editing.
- Stabilize tiled post collection reloads by treating the saved source position as the first tile's origin.
- Simplify stack tile handling by removing fragile z-index fallback logic and relying on tldraw for derived tile indices.

## Testing
- Added and updated unit coverage for tile layout stability, toolbar selection behavior, and tldraw adapter projections.
- Lint and formatting passed.
- Typecheck passed.
- Focused Vitest suite passed.