### PR TITLE
Align chat sidebar loading state and column spacing

### DIFF
--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -54,7 +54,14 @@ import { isMultisite } from '@studio/common/lib/is-multisite';
 import { getAuthenticationUrl } from '@studio/common/lib/oauth';
 import { decodePassword, encodePassword } from '@studio/common/lib/passwords';
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
-import { readSharedConfig, updateSharedConfig } from '@studio/common/lib/shared-config';
+import {
+	deleteSharedSession,
+	readSharedConfig,
+	readSharedSession,
+	readSharedSessions,
+	updateSharedConfig,
+	updateSharedSession,
+} from '@studio/common/lib/shared-config';
 import { SYNC_IGNORE_DEFAULTS } from '@studio/common/lib/sync/constants';
 import { shouldExcludeFromSync } from '@studio/common/lib/sync/exclude-from-sync';
 import { shouldLimitDepth } from '@studio/common/lib/sync/tree-utils';
@@ -204,22 +211,57 @@ export {
 	studioCodeCheckProvider,
 } from 'src/modules/studio-code/ipc-handlers';
 
+function hydrateAiSessionSummary(
+	summary: AiSessionSummary,
+	metadata?: Pick< AiSessionSummary, 'starred' | 'archived' >
+): AiSessionSummary {
+	return {
+		...summary,
+		starred: metadata?.starred,
+		archived: metadata?.archived,
+	};
+}
+
+async function listHydratedAiSessions( rootDirectory: string ): Promise< AiSessionSummary[] > {
+	const [ sessions, sessionMetadata ] = await Promise.all( [
+		listAiSessionsFromStore( rootDirectory ),
+		readSharedSessions(),
+	] );
+	return sessions.map( ( session ) =>
+		hydrateAiSessionSummary( session, sessionMetadata[ session.id ] )
+	);
+}
+
+async function loadHydratedAiSession(
+	rootDirectory: string,
+	sessionIdOrPrefix: string
+): Promise< LoadedAiSession > {
+	const session = await loadAiSessionFromStore( rootDirectory, sessionIdOrPrefix );
+	const metadata = await readSharedSession( session.summary.id );
+	return {
+		...session,
+		summary: hydrateAiSessionSummary( session.summary, metadata ),
+	};
+}
+
 export async function listAiSessions( _event: IpcMainInvokeEvent ): Promise< AiSessionSummary[] > {
-	return listAiSessionsFromStore( getAiSessionsRootDirectory() );
+	return listHydratedAiSessions( getAiSessionsRootDirectory() );
 }
 
 export async function loadAiSession(
 	_event: IpcMainInvokeEvent,
 	sessionIdOrPrefix: string
 ): Promise< LoadedAiSession > {
-	return loadAiSessionFromStore( getAiSessionsRootDirectory(), sessionIdOrPrefix );
+	return loadHydratedAiSession( getAiSessionsRootDirectory(), sessionIdOrPrefix );
 }
 
 export async function deleteAiSession(
 	_event: IpcMainInvokeEvent,
 	sessionIdOrPrefix: string
 ): Promise< AiSessionSummary > {
-	return deleteAiSessionFromStore( getAiSessionsRootDirectory(), sessionIdOrPrefix );
+	const deleted = await deleteAiSessionFromStore( getAiSessionsRootDirectory(), sessionIdOrPrefix );
+	await deleteSharedSession( deleted.id );
+	return deleted;
 }
 
 export async function createAiSession(
@@ -228,16 +270,18 @@ export async function createAiSession(
 ): Promise< AiSessionSummary > {
 	const sitesRoot = getAiSessionsRootDirectory();
 	if ( ! siteId ) {
-		const existing = await listAiSessionsFromStore( sitesRoot );
+		const existing = await listHydratedAiSessions( sitesRoot );
 		const emptyUserDeskSession = existing
-			.filter( ( session ) => ! session.ownerSitePath && ! session.firstPrompt )
+			.filter(
+				( session ) => ! session.ownerSitePath && ! session.firstPrompt && ! session.archived
+			)
 			.sort( ( a, b ) => Date.parse( b.updatedAt ) - Date.parse( a.updatedAt ) )[ 0 ];
 
 		if ( emptyUserDeskSession ) {
 			return emptyUserDeskSession;
 		}
 
-		return createAiSessionInStore( sitesRoot );
+		return hydrateAiSessionSummary( await createAiSessionInStore( sitesRoot ) );
 	}
 
 	const server = SiteServer.get( siteId );
@@ -250,20 +294,38 @@ export async function createAiSession(
 	// never received a user prompt) instead of creating another one. This
 	// lets `/sites/$siteId/new` act as a stable "draft slot" per site — the
 	// UI can redirect to it eagerly without piling up orphan sessions.
-	const existing = await listAiSessionsFromStore( sitesRoot );
+	const existing = await listHydratedAiSessions( sitesRoot );
 	const emptyForSite = existing
-		.filter( ( session ) => session.ownerSitePath === sitePath && ! session.firstPrompt )
+		.filter(
+			( session ) =>
+				session.ownerSitePath === sitePath && ! session.firstPrompt && ! session.archived
+		)
 		.sort( ( a, b ) => Date.parse( b.updatedAt ) - Date.parse( a.updatedAt ) )[ 0 ];
 	if ( emptyForSite ) {
 		return emptyForSite;
 	}
 
-	return createAiSessionInStore( sitesRoot, {
-		site: {
-			name: server.details.name,
-			path: sitePath,
-		},
-	} );
+	return hydrateAiSessionSummary(
+		await createAiSessionInStore( sitesRoot, {
+			site: {
+				name: server.details.name,
+				path: sitePath,
+			},
+		} )
+	);
+}
+
+export async function updateAiSessionMetadata(
+	_event: IpcMainInvokeEvent,
+	sessionIdOrPrefix: string,
+	patch: Pick< AiSessionSummary, 'starred' | 'archived' >
+): Promise< AiSessionSummary > {
+	const { summary } = await loadAiSessionFromStore(
+		getAiSessionsRootDirectory(),
+		sessionIdOrPrefix
+	);
+	const metadata = await updateSharedSession( summary.id, patch );
+	return hydrateAiSessionSummary( summary, metadata );
 }
 
 /**
@@ -411,7 +473,10 @@ export async function setSessionEnvironment(
 			environment: 'live',
 			url: liveSite.url,
 			wpcomSiteId: liveSite.id,
-			summary: refreshed.summary,
+			summary: hydrateAiSessionSummary(
+				refreshed.summary,
+				await readSharedSession( refreshed.summary.id )
+			),
 		};
 	}
 
@@ -425,7 +490,10 @@ export async function setSessionEnvironment(
 	const refreshed = await loadAiSessionFromStore( getAiSessionsRootDirectory(), sessionId );
 	return {
 		environment: 'local',
-		summary: refreshed.summary,
+		summary: hydrateAiSessionSummary(
+			refreshed.summary,
+			await readSharedSession( refreshed.summary.id )
+		),
 	};
 }
 

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -212,6 +212,8 @@ const api: IpcApi = {
 	deleteAiSession: ( sessionIdOrPrefix ) =>
 		ipcRendererInvoke( 'deleteAiSession', sessionIdOrPrefix ),
 	createAiSession: ( siteId ) => ipcRendererInvoke( 'createAiSession', siteId ),
+	updateAiSessionMetadata: ( sessionIdOrPrefix, patch ) =>
+		ipcRendererInvoke( 'updateAiSessionMetadata', sessionIdOrPrefix, patch ),
 	continueAiSession: ( sessionId, prompt, options ) =>
 		ipcRendererInvoke( 'continueAiSession', sessionId, prompt, options ),
 	setAiSessionModel: ( sessionId, model ) =>

--- a/apps/ui/src/components/session-view/empty-background/index.tsx
+++ b/apps/ui/src/components/session-view/empty-background/index.tsx
@@ -31,8 +31,7 @@ export function EmptyBackground() {
 		const dpr = window.devicePixelRatio || 1;
 		canvas.width = CANVAS_SIZE * dpr;
 		canvas.height = CANVAS_SIZE * dpr;
-		canvas.style.width = `${ CANVAS_SIZE }px`;
-		canvas.style.height = `${ CANVAS_SIZE }px`;
+		canvas.style.setProperty( '--empty-background-canvas-size', `${ CANVAS_SIZE }px` );
 		const ctx = canvas.getContext( '2d' );
 		if ( ! ctx ) {
 			return;
@@ -181,8 +180,9 @@ export function EmptyBackground() {
 
 		const onMove = ( event: MouseEvent ) => {
 			const rect = canvas.getBoundingClientRect();
-			mouseX = event.clientX - rect.left;
-			mouseY = event.clientY - rect.top;
+			const scale = rect.width > 0 ? CANVAS_SIZE / rect.width : 1;
+			mouseX = ( event.clientX - rect.left ) * scale;
+			mouseY = ( event.clientY - rect.top ) * scale;
 		};
 		const onEnter = () => {
 			hover = true;

--- a/apps/ui/src/components/session-view/empty-background/style.module.css
+++ b/apps/ui/src/components/session-view/empty-background/style.module.css
@@ -8,7 +8,8 @@
 }
 
 .canvas {
+	display: block;
+	width: min(100%, var(--empty-background-canvas-size, 580px));
+	height: auto;
 	pointer-events: auto;
-	max-width: 100%;
-	max-height: 100%;
 }

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -208,7 +208,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 			<SessionFrame
 				header={ <div className={ styles.header } /> }
 				composer={
-					<div className={ styles.column }>
+					<div className={ styles.classicColumn }>
 						<ComposerSkeleton />
 					</div>
 				}
@@ -239,7 +239,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 				/>
 			}
 			composer={
-				<div className={ styles.column }>
+				<div className={ styles.classicColumn }>
 					<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
 					<Composer
 						busy={ composerBusy }
@@ -274,7 +274,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 			}
 		>
 			{ isEmpty ? <EmptyBackground /> : null }
-			<div className={ clsx( styles.column, styles.classicConversationSpacing ) }>
+			<div className={ clsx( styles.classicColumn, styles.classicConversationSpacing ) }>
 				<Conversation
 					data={ data }
 					isRunning={ isRunning }

--- a/apps/ui/src/components/session-view/style.module.css
+++ b/apps/ui/src/components/session-view/style.module.css
@@ -97,9 +97,9 @@
 	padding: 0 var(--wpds-dimension-padding-xl);
 }
 
-/* Shared 760px column used by both the conversation and composer so their
-   content edges line up at every viewport width. */
-.column {
+/* Classic session screen: keep the conversation + composer aligned to the
+   legacy 760px reading column. */
+.classicColumn {
 	max-width: 760px;
 	margin: 0 auto;
 }

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -517,6 +517,10 @@ export function createIpcConnector(): Connector {
 			await ipcApi.deleteAiSession( sessionId );
 		},
 
+		async updateSessionMetadata( sessionId, patch ): Promise< AiSessionSummary > {
+			return ( await ipcApi.updateAiSessionMetadata( sessionId, patch ) ) as AiSessionSummary;
+		},
+
 		async createSession( siteId ): Promise< AiSessionSummary > {
 			return ( await ipcApi.createAiSession( siteId ) ) as AiSessionSummary;
 		},

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -194,6 +194,10 @@ export interface Connector {
 	getSessions(): Promise< AiSessionSummary[] >;
 	getSession( sessionId: string ): Promise< LoadedAiSession >;
 	deleteSession( sessionId: string ): Promise< void >;
+	updateSessionMetadata(
+		sessionId: string,
+		patch: Pick< AiSessionSummary, 'starred' | 'archived' >
+	): Promise< AiSessionSummary >;
 
 	// Create an empty session file so it appears immediately. When `siteId`
 	// is omitted, the session is a user-desk chat with no owner site.

--- a/apps/ui/src/data/queries/use-sessions.ts
+++ b/apps/ui/src/data/queries/use-sessions.ts
@@ -48,6 +48,94 @@ export function useCreateSession() {
 	} );
 }
 
+function mergeSessionMetadata(
+	summary: AiSessionSummary,
+	patch: Pick< AiSessionSummary, 'starred' | 'archived' >
+): AiSessionSummary {
+	return {
+		...summary,
+		starred: patch.starred,
+		archived: patch.archived,
+	};
+}
+
+export function useUpdateSessionMetadata() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation<
+		AiSessionSummary,
+		Error,
+		{
+			sessionId: string;
+			patch: Pick< AiSessionSummary, 'starred' | 'archived' >;
+		},
+		{
+			previousSessions: AiSessionSummary[] | undefined;
+			previousSession: LoadedAiSession | undefined;
+		}
+	>( {
+		mutationFn: ( { sessionId, patch } ) => connector.updateSessionMetadata( sessionId, patch ),
+		onMutate: async ( { sessionId, patch } ) => {
+			const sessionKey = [ ...SESSIONS_QUERY_KEY, sessionId ];
+			await queryClient.cancelQueries( { queryKey: SESSIONS_QUERY_KEY } );
+
+			const previousSessions = queryClient.getQueryData< AiSessionSummary[] >( SESSIONS_QUERY_KEY );
+			const previousSession = queryClient.getQueryData< LoadedAiSession >( sessionKey );
+
+			queryClient.setQueryData< AiSessionSummary[] >(
+				SESSIONS_QUERY_KEY,
+				( current ) =>
+					current?.map( ( session ) =>
+						session.id === sessionId ? mergeSessionMetadata( session, patch ) : session
+					)
+			);
+			queryClient.setQueryData< LoadedAiSession >( sessionKey, ( current ) =>
+				current
+					? {
+							...current,
+							summary: mergeSessionMetadata( current.summary, patch ),
+					  }
+					: current
+			);
+
+			return { previousSessions, previousSession };
+		},
+		onError: ( _error, { sessionId }, context ) => {
+			if ( context?.previousSessions ) {
+				queryClient.setQueryData( SESSIONS_QUERY_KEY, context.previousSessions );
+			}
+			if ( context?.previousSession ) {
+				queryClient.setQueryData( [ ...SESSIONS_QUERY_KEY, sessionId ], context.previousSession );
+			}
+		},
+		onSuccess: ( summary ) => {
+			queryClient.setQueryData< AiSessionSummary[] >(
+				SESSIONS_QUERY_KEY,
+				( current ) =>
+					current?.map( ( session ) => ( session.id === summary.id ? summary : session ) )
+			);
+			queryClient.setQueryData< LoadedAiSession >(
+				[ ...SESSIONS_QUERY_KEY, summary.id ],
+				( current ) =>
+					current
+						? {
+								...current,
+								summary: {
+									...current.summary,
+									starred: summary.starred,
+									archived: summary.archived,
+								},
+						  }
+						: current
+			);
+		},
+		onSettled: ( _data, _error, { sessionId } ) => {
+			void queryClient.invalidateQueries( { queryKey: SESSIONS_QUERY_KEY } );
+			void queryClient.invalidateQueries( { queryKey: [ ...SESSIONS_QUERY_KEY, sessionId ] } );
+		},
+	} );
+}
+
 export function useSetSessionEnvironment(
 	sessionId: string | undefined,
 	// When available, the wpcom blog id of the live site the pill is about to

--- a/apps/ui/src/ui-desks/chats/index.tsx
+++ b/apps/ui/src/ui-desks/chats/index.tsx
@@ -1,18 +1,23 @@
 import { Dialog } from '@base-ui/react/dialog';
+import { createDefaultDeskSettings } from '@studio/common/lib/desk-settings';
 import { __ } from '@wordpress/i18n';
 import { clsx } from 'clsx';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import motionStyles from '@/components/floating-surface-motion/style.module.css';
+import { useDeskSettings } from '@/data/queries/use-desk-config';
 import { useSessions } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { useFullscreen } from '@/hooks/use-fullscreen';
 import { formatRelativeTime } from '@/lib/format-relative-time';
 import { ActionButton, List, ListItem } from '@/ui-desks/components';
 import { ChatsButton } from '../chrome/chats-button';
+import { getDeskToolbarButtonSide, normalizeDeskToolbarSettings } from '../chrome/toolbar-layout';
 import { useChats } from './context';
 import { SessionSurface } from './session-surface';
 import styles from './style.module.css';
+import { useChatPanelResize } from './use-chat-panel-resize';
 import type { AiSessionSummary } from '@/data/core';
+import type { CSSProperties } from 'react';
 
 export { ChatsProvider } from './provider';
 
@@ -53,19 +58,31 @@ export function Chats( { siteId }: ChatsProps ) {
 		startNewChat,
 		consumePendingPrompt,
 	} = useChats();
+	const { data: savedDeskSettings } = useDeskSettings();
 	const { data: sessions, isFetching: isFetchingSessions } = useSessions();
 	const { data: sites } = useSites();
 	const isFullscreen = useFullscreen();
+	const fallbackDeskSettings = useMemo( () => createDefaultDeskSettings(), [] );
+	const deskSettings = useMemo(
+		() => normalizeDeskToolbarSettings( savedDeskSettings ?? fallbackDeskSettings ),
+		[ fallbackDeskSettings, savedDeskSettings ]
+	);
+	const side = getDeskToolbarButtonSide( deskSettings.toolbarLayout, 'chat' );
+	const { width, isResizing, listCollapsed, collapseList, expandList, startResize } =
+		useChatPanelResize( side );
 	const site = siteId ? sites?.find( ( candidate ) => candidate.id === siteId ) : undefined;
 	const filteredSessions = siteId
 		? site?.path
-			? ( sessions ?? [] ).filter( ( session ) => session.ownerSitePath === site.path )
+			? ( sessions ?? [] ).filter(
+					( session ) => session.ownerSitePath === site.path && ! session.archived
+			  )
 			: []
-		: ( sessions ?? [] ).filter( ( session ) => ! session.ownerSitePath );
+		: ( sessions ?? [] ).filter( ( session ) => ! session.ownerSitePath && ! session.archived );
 	const chatSessions = [ ...filteredSessions ].sort(
 		( a, b ) => Date.parse( b.updatedAt ) - Date.parse( a.updatedAt )
 	);
 	const selectedSession = chatSessions.find( ( session ) => session.id === selectedSessionId );
+	const isListCollapsed = expanded && listCollapsed;
 
 	useEffect( () => {
 		if ( selectedSessionId && sessions && ! isFetchingSessions && ! selectedSession ) {
@@ -85,34 +102,48 @@ export function Chats( { siteId }: ChatsProps ) {
 						motionStyles.motion,
 						expanded && styles.panelExpanded
 					) }
+					data-side={ side }
+					data-expanded={ expanded ? 'true' : 'false' }
+					data-list-collapsed={ isListCollapsed ? 'true' : 'false' }
+					data-resizing={ isResizing ? 'true' : 'false' }
+					style={
+						expanded
+							? ( {
+									'--desk-chats-panel-width': `${ width }px`,
+							  } as CSSProperties )
+							: undefined
+					}
 					aria-label={ __( 'Conversations' ) }
 				>
-					<div className={ styles.listPane }>
-						<header className={ styles.header }>
-							<h2>{ __( 'Conversations' ) }</h2>
-						</header>
-						<List className={ styles.list }>
-							{ chatSessions.map( ( session ) => (
-								<ListItem
-									key={ session.id }
-									active={ session.id === selectedSessionId }
-									label={ getSessionTitle( session ) }
-									description={ getSessionSubtitle( session ) }
-									onClick={ () => selectSession( session.id ) }
-								/>
-							) ) }
-						</List>
-						<footer className={ styles.footer }>
-							<ActionButton
-								fullWidth
-								disabled={ isCreatingChat }
-								aria-busy={ isCreatingChat }
-								onClick={ () => void startNewChat() }
-							>
-								{ isCreatingChat ? __( 'Creating chat…' ) : __( '+ New chat' ) }
-							</ActionButton>
-						</footer>
-					</div>
+					{ ! isListCollapsed ? (
+						<div className={ styles.listPane }>
+							<header className={ styles.header }>
+								<h2>{ __( 'Conversations' ) }</h2>
+							</header>
+							<List className={ styles.list }>
+								{ chatSessions.map( ( session ) => (
+									<ListItem
+										key={ session.id }
+										active={ session.id === selectedSessionId }
+										label={ getSessionTitle( session ) }
+										description={ getSessionSubtitle( session ) }
+										onClick={ () => selectSession( session.id ) }
+									/>
+								) ) }
+							</List>
+							<footer className={ styles.footer }>
+								<ActionButton
+									fullWidth
+									disabled={ isCreatingChat }
+									aria-busy={ isCreatingChat }
+									onClick={ () => void startNewChat() }
+								>
+									{ isCreatingChat ? __( 'Creating chat…' ) : __( '+ New chat' ) }
+								</ActionButton>
+							</footer>
+							<div className={ styles.listDivider } aria-hidden />
+						</div>
+					) : null }
 					{ expanded ? (
 						<div className={ styles.chatPane }>
 							{ selectedSessionId ? (
@@ -120,6 +151,10 @@ export function Chats( { siteId }: ChatsProps ) {
 									key={ selectedSessionId }
 									siteId={ siteId }
 									sessionId={ selectedSessionId }
+									side={ side }
+									listCollapsed={ isListCollapsed }
+									onExpandList={ expandList }
+									onCollapseList={ collapseList }
 									onSwitchSession={ switchSession }
 									autoFocus={ autoFocusSessionId === selectedSessionId }
 									initialPrompt={
@@ -134,6 +169,14 @@ export function Chats( { siteId }: ChatsProps ) {
 							) }
 						</div>
 					) : null }
+					<div
+						className={ styles.resizeHandle }
+						onPointerDown={ startResize }
+						role="separator"
+						aria-orientation="vertical"
+						aria-label={ __( 'Resize conversations' ) }
+						aria-hidden={ ! expanded }
+					/>
 				</Dialog.Popup>
 			</Dialog.Portal>
 		</Dialog.Root>

--- a/apps/ui/src/ui-desks/chats/session-surface.tsx
+++ b/apps/ui/src/ui-desks/chats/session-surface.tsx
@@ -2,7 +2,7 @@ import { resolveSessionModel } from '@studio/common/ai/models';
 import { isStudioCustomEntryOfType } from '@studio/common/ai/sessions/entry-types';
 import { __ } from '@wordpress/i18n';
 import { box, chevronLeft, chevronRight, previous, starEmpty, starFilled } from '@wordpress/icons';
-import { Icon } from '@wordpress/ui';
+import { Button, Icon, IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useEffect, useLayoutEffect, useMemo, useRef, type ReactNode, type Ref } from 'react';
 import { Composer, ComposerSkeleton } from '@/components/session-view/composer';
@@ -202,55 +202,55 @@ function SessionSurfaceContent( {
 				<div className={ styles.conversationHeader }>
 					<div className={ styles.conversationHeaderSlot }>
 						{ listCollapsed ? (
-							<button
-								type="button"
+							<Button
+								variant="minimal"
+								tone="neutral"
+								size="small"
 								className={ styles.conversationBackButton }
 								onClick={ onExpandList }
 							>
 								<Icon icon={ side === 'left' ? chevronLeft : chevronRight } size={ 18 } />
 								<span>{ __( 'All chats' ) }</span>
-							</button>
+							</Button>
 						) : (
-							<button
-								type="button"
+							<IconButton
+								variant="minimal"
+								tone="neutral"
+								size="small"
 								className={ styles.conversationCollapseButton }
-								aria-label={ __( 'Collapse list' ) }
-								title={ __( 'Collapse list' ) }
+								icon={ previous }
+								label={ __( 'Collapse list' ) }
 								onClick={ onCollapseList }
-							>
-								<Icon icon={ previous } size={ 20 } />
-							</button>
+							/>
 						) }
 					</div>
 					<span className={ styles.conversationDate }>
 						{ formatChatDate( data.summary.createdAt ) }
 					</span>
 					<div className={ styles.conversationActions }>
-						<button
-							type="button"
+						<IconButton
+							variant="minimal"
+							tone="neutral"
+							size="small"
 							className={ styles.conversationAction }
-							aria-label={ __( 'Archive conversation' ) }
-							title={ __( 'Archive conversation' ) }
+							icon={ box }
+							label={ __( 'Archive conversation' ) }
 							disabled={ updateSessionMetadata.isPending }
 							onClick={ archiveConversation }
-						>
-							<Icon icon={ box } size={ 20 } />
-						</button>
-						<button
-							type="button"
+						/>
+						<IconButton
+							variant="minimal"
+							tone="neutral"
+							size="small"
 							className={ styles.conversationAction }
 							data-active={ data.summary.starred ? 'true' : 'false' }
-							aria-label={
-								data.summary.starred ? __( 'Unstar conversation' ) : __( 'Star conversation' )
-							}
-							title={
+							icon={ data.summary.starred ? starFilled : starEmpty }
+							label={
 								data.summary.starred ? __( 'Unstar conversation' ) : __( 'Star conversation' )
 							}
 							disabled={ updateSessionMetadata.isPending }
 							onClick={ toggleStar }
-						>
-							<Icon icon={ data.summary.starred ? starFilled : starEmpty } size={ 20 } />
-						</button>
+						/>
 					</div>
 				</div>
 			}

--- a/apps/ui/src/ui-desks/chats/session-surface.tsx
+++ b/apps/ui/src/ui-desks/chats/session-surface.tsx
@@ -1,6 +1,8 @@
 import { resolveSessionModel } from '@studio/common/ai/models';
 import { isStudioCustomEntryOfType } from '@studio/common/ai/sessions/entry-types';
 import { __ } from '@wordpress/i18n';
+import { box, chevronLeft, chevronRight, previous, starEmpty, starFilled } from '@wordpress/icons';
+import { Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useEffect, useLayoutEffect, useMemo, useRef, type ReactNode, type Ref } from 'react';
 import { Composer, ComposerSkeleton } from '@/components/session-view/composer';
@@ -11,7 +13,11 @@ import { QueuedPrompts } from '@/components/session-view/queued-prompts';
 import sessionStyles from '@/components/session-view/style.module.css';
 import { useAgentRun } from '@/data/queries/use-agent-run';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
-import { useSession, useSessionEffectiveEnvironment } from '@/data/queries/use-sessions';
+import {
+	useSession,
+	useSessionEffectiveEnvironment,
+	useUpdateSessionMetadata,
+} from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { useSessionCommands } from '@/hooks/use-session-commands';
 import { SessionUIProvider } from '@/hooks/use-session-ui';
@@ -21,6 +27,10 @@ import type { PendingChatPrompt } from './context';
 interface SessionSurfaceProps {
 	siteId?: string;
 	sessionId: string;
+	side: 'left' | 'right';
+	listCollapsed: boolean;
+	onExpandList: () => void;
+	onCollapseList: () => void;
 	onSwitchSession: ( sessionId: string ) => void;
 	autoFocus?: boolean;
 	initialPrompt?: PendingChatPrompt;
@@ -28,15 +38,31 @@ interface SessionSurfaceProps {
 }
 
 interface FrameProps {
+	header?: ReactNode;
 	composer?: ReactNode;
 	scrollRef?: Ref< HTMLDivElement >;
 	children?: ReactNode;
 }
 
-function Frame( { composer, scrollRef, children }: FrameProps ) {
+const chatDateFormatter = new Intl.DateTimeFormat( undefined, {
+	month: 'short',
+	day: 'numeric',
+	year: 'numeric',
+} );
+
+function formatChatDate( value: string ) {
+	const timestamp = Date.parse( value );
+	if ( Number.isNaN( timestamp ) ) {
+		return '';
+	}
+	return chatDateFormatter.format( new Date( timestamp ) );
+}
+
+function Frame( { header, composer, scrollRef, children }: FrameProps ) {
 	return (
 		<div className={ clsx( sessionStyles.root, styles.sessionSurface ) }>
 			<div className={ sessionStyles.chatColumn }>
+				{ header }
 				<div ref={ scrollRef } className={ sessionStyles.scroll }>
 					{ children }
 				</div>
@@ -49,6 +75,10 @@ function Frame( { composer, scrollRef, children }: FrameProps ) {
 function SessionSurfaceContent( {
 	siteId,
 	sessionId,
+	side,
+	listCollapsed,
+	onExpandList,
+	onCollapseList,
 	onSwitchSession,
 	autoFocus = false,
 	initialPrompt,
@@ -79,6 +109,7 @@ function SessionSurfaceContent( {
 		removeQueuedPrompt,
 	} = useAgentRun( sessionId );
 	const sentInitialPromptIdsRef = useRef< Set< string > >( new Set() );
+	const updateSessionMetadata = useUpdateSessionMetadata();
 	const currentModel = useMemo(
 		() => resolveSessionModel( data?.entries ?? [] ),
 		[ data?.entries ]
@@ -97,6 +128,20 @@ function SessionSurfaceContent( {
 	);
 	const scrollRef = useRef< HTMLDivElement >( null );
 	useSessionCommands( sessionId );
+
+	const toggleStar = () => {
+		void updateSessionMetadata.mutateAsync( {
+			sessionId,
+			patch: { starred: ! data?.summary.starred },
+		} );
+	};
+
+	const archiveConversation = () => {
+		void updateSessionMetadata.mutateAsync( {
+			sessionId,
+			patch: { archived: true },
+		} );
+	};
 
 	useEffect( () => {
 		if ( ! data || ! initialPrompt || initialPrompt.sessionId !== sessionId ) {
@@ -132,7 +177,7 @@ function SessionSurfaceContent( {
 		return (
 			<Frame
 				composer={
-					<div className={ sessionStyles.column }>
+					<div>
 						<ComposerSkeleton />
 					</div>
 				}
@@ -153,9 +198,65 @@ function SessionSurfaceContent( {
 
 	return (
 		<Frame
+			header={
+				<div className={ styles.conversationHeader }>
+					<div className={ styles.conversationHeaderSlot }>
+						{ listCollapsed ? (
+							<button
+								type="button"
+								className={ styles.conversationBackButton }
+								onClick={ onExpandList }
+							>
+								<Icon icon={ side === 'left' ? chevronLeft : chevronRight } size={ 18 } />
+								<span>{ __( 'All chats' ) }</span>
+							</button>
+						) : (
+							<button
+								type="button"
+								className={ styles.conversationCollapseButton }
+								aria-label={ __( 'Collapse list' ) }
+								title={ __( 'Collapse list' ) }
+								onClick={ onCollapseList }
+							>
+								<Icon icon={ previous } size={ 20 } />
+							</button>
+						) }
+					</div>
+					<span className={ styles.conversationDate }>
+						{ formatChatDate( data.summary.createdAt ) }
+					</span>
+					<div className={ styles.conversationActions }>
+						<button
+							type="button"
+							className={ styles.conversationAction }
+							aria-label={ __( 'Archive conversation' ) }
+							title={ __( 'Archive conversation' ) }
+							disabled={ updateSessionMetadata.isPending }
+							onClick={ archiveConversation }
+						>
+							<Icon icon={ box } size={ 20 } />
+						</button>
+						<button
+							type="button"
+							className={ styles.conversationAction }
+							data-active={ data.summary.starred ? 'true' : 'false' }
+							aria-label={
+								data.summary.starred ? __( 'Unstar conversation' ) : __( 'Star conversation' )
+							}
+							title={
+								data.summary.starred ? __( 'Unstar conversation' ) : __( 'Star conversation' )
+							}
+							disabled={ updateSessionMetadata.isPending }
+							onClick={ toggleStar }
+						>
+							<Icon icon={ data.summary.starred ? starFilled : starEmpty } size={ 20 } />
+						</button>
+					</div>
+				</div>
+			}
 			scrollRef={ scrollRef }
 			composer={
-				<div className={ sessionStyles.column }>
+				<div>
 					<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
 					<Composer
 						busy={ composerBusy }
@@ -176,7 +277,7 @@ function SessionSurfaceContent( {
 			}
 		>
 			{ isEmpty ? <EmptyBackground /> : null }
-			<div className={ sessionStyles.column }>
+			<div>
 				<Conversation
 					data={ data }
 					isRunning={ isRunning }

--- a/apps/ui/src/ui-desks/chats/style.module.css
+++ b/apps/ui/src/ui-desks/chats/style.module.css
@@ -201,33 +201,18 @@
 .conversationAction,
 .conversationBackButton,
 .conversationCollapseButton {
-	border: 0;
-	background: transparent;
 	color: var(--ui-desks-muted, #6b7280);
-	border-radius: 8px;
-	cursor: pointer;
-	transition:
-		background 140ms ease,
-		color 140ms ease,
-		opacity 120ms ease;
 	-webkit-app-region: no-drag;
 }
 
 .conversationAction,
 .conversationCollapseButton {
-	width: 32px;
-	height: 32px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
+	transition: opacity 120ms ease;
 }
 
 .conversationBackButton {
-	display: inline-flex;
-	align-items: center;
 	gap: 2px;
 	padding: 4px 8px 4px 4px;
-	font: inherit;
 	font-size: 12px;
 }
 
@@ -248,26 +233,4 @@
 .conversationAction[data-active='true']:focus-visible {
 	opacity: 1;
 	color: #f5b400;
-}
-
-.conversationAction:hover:not(:disabled),
-.conversationBackButton:hover,
-.conversationCollapseButton:hover,
-.conversationAction:focus-visible,
-.conversationBackButton:focus-visible,
-.conversationCollapseButton:focus-visible {
-	background: var(--ui-desks-control-hover, rgba(15, 23, 42, 0.07));
-	color: var(--ui-desks-text, #14171a);
-	outline: none;
-}
-
-.conversationAction:disabled {
-	cursor: default;
-	opacity: 0.45;
-}
-
-.conversationAction svg,
-.conversationBackButton svg,
-.conversationCollapseButton svg {
-	fill: currentColor;
 }

--- a/apps/ui/src/ui-desks/chats/style.module.css
+++ b/apps/ui/src/ui-desks/chats/style.module.css
@@ -3,6 +3,9 @@
 	--desk-chrome-button-size: 40px;
 	--desk-chrome-titlebar-height: 46px;
 	--desk-chrome-popup-offset: 8px;
+	--desk-chats-list-pane-width: 300px;
+	--desk-chats-panel-width: 760px;
+	--desk-chats-session-padding: 14px;
 
 	position: fixed;
 	top: calc(
@@ -12,9 +15,9 @@
 	left: var(--desk-chats-panel-gap);
 	bottom: var(--desk-chats-panel-gap);
 	z-index: 15;
-	width: min(380px, calc(100vw - 2 * var(--desk-chats-panel-gap)));
-	display: grid;
-	grid-template-columns: minmax(0, 1fr);
+	width: min(var(--desk-chats-list-pane-width), calc(100vw - 2 * var(--desk-chats-panel-gap)));
+	display: flex;
+	flex-direction: row;
 	overflow: hidden;
 	background: var(--ui-desks-glass, rgba(255, 255, 255, 0.85));
 	border: 1px solid var(--ui-desks-glass-border, rgba(255, 255, 255, 0.7));
@@ -27,16 +30,31 @@
 		0 18px 44px rgba(15, 23, 42, 0.1)
 	);
 	color: var(--ui-desks-text, #14171a);
+	transform-origin: top left;
 	-webkit-backdrop-filter: saturate(180%) blur(28px);
 	backdrop-filter: saturate(180%) blur(28px);
+	transition:
+		width 280ms cubic-bezier(0.32, 0.72, 0, 1),
+		transform 220ms cubic-bezier(0.32, 0.72, 0, 1),
+		opacity 200ms cubic-bezier(0.32, 0.72, 0, 1);
 	--studio-floating-surface-width-duration: 240ms;
 	--studio-floating-surface-transform-duration: 220ms;
 	--studio-floating-surface-opacity-duration: 200ms;
 }
 
 .panelExpanded {
-	width: min(960px, calc(100vw - 2 * var(--desk-chats-panel-gap)));
-	grid-template-columns: 320px minmax(0, 1fr);
+	width: min(var(--desk-chats-panel-width), calc(100vw - 2 * var(--desk-chats-panel-gap)));
+}
+
+.panel[data-resizing='true'] {
+	transition: none;
+}
+
+.panel[data-side='right'] {
+	left: auto;
+	right: var(--desk-chats-panel-gap);
+	transform-origin: top right;
+	flex-direction: row-reverse;
 }
 
 .panelFullscreen {
@@ -47,14 +65,34 @@
 }
 
 .listPane {
+	position: relative;
 	display: flex;
+	flex: 0 0 var(--desk-chats-list-pane-width);
+	width: var(--desk-chats-list-pane-width);
 	min-width: 0;
 	min-height: 0;
 	flex-direction: column;
 }
 
-.panelExpanded .listPane {
-	border-right: 1px solid var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+.listDivider {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	right: 0;
+	width: 1px;
+	background: var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 200ms ease;
+}
+
+.panelExpanded .listDivider {
+	opacity: 1;
+}
+
+.panel[data-side='right'] .listDivider {
+	right: auto;
+	left: 0;
 }
 
 .header {
@@ -80,8 +118,8 @@
 }
 
 .chatPane {
-	--desk-chats-session-edge-padding: 14px;
-
+	display: flex;
+	flex: 1;
 	min-width: 0;
 	min-height: 0;
 	position: relative;
@@ -89,7 +127,10 @@
 
 .sessionSurface {
 	box-sizing: border-box;
-	padding: var(--desk-chats-session-edge-padding);
+	width: 100%;
+	min-width: 0;
+	height: 100%;
+	padding: var(--desk-chats-session-padding);
 }
 
 .emptyChat {
@@ -100,4 +141,133 @@
 	padding-top: 48px;
 	color: var(--ui-desks-muted, #6b7280);
 	font-size: 13px;
+}
+
+.resizeHandle {
+	position: absolute;
+	top: 12px;
+	bottom: 12px;
+	right: -3px;
+	width: 8px;
+	cursor: ew-resize;
+	z-index: 2;
+	touch-action: none;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 200ms ease;
+}
+
+.panel[data-side='right'] .resizeHandle {
+	right: auto;
+	left: -3px;
+}
+
+.panel[data-expanded='true'] .resizeHandle {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.conversationHeader {
+	display: grid;
+	grid-template-columns: 1fr auto 1fr;
+	align-items: center;
+	padding: 0 0 var(--desk-chats-session-padding);
+	min-height: 32px;
+	flex: 0 0 auto;
+}
+
+.conversationHeaderSlot {
+	display: flex;
+	align-items: center;
+	justify-self: start;
+	min-height: 32px;
+}
+
+.conversationDate {
+	grid-column: 2;
+	text-align: center;
+	font-size: 12px;
+	color: var(--ui-desks-muted, #6b7280);
+}
+
+.conversationActions {
+	grid-column: 3;
+	justify-self: end;
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+}
+
+.conversationAction,
+.conversationBackButton,
+.conversationCollapseButton {
+	border: 0;
+	background: transparent;
+	color: var(--ui-desks-muted, #6b7280);
+	border-radius: 8px;
+	cursor: pointer;
+	transition:
+		background 140ms ease,
+		color 140ms ease,
+		opacity 120ms ease;
+	-webkit-app-region: no-drag;
+}
+
+.conversationAction,
+.conversationCollapseButton {
+	width: 32px;
+	height: 32px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.conversationBackButton {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+	padding: 4px 8px 4px 4px;
+	font: inherit;
+	font-size: 12px;
+}
+
+.conversationAction,
+.conversationCollapseButton {
+	opacity: 0;
+}
+
+.conversationHeader:hover .conversationAction,
+.conversationHeader:hover .conversationCollapseButton,
+.conversationHeader:focus-within .conversationAction,
+.conversationHeader:focus-within .conversationCollapseButton {
+	opacity: 1;
+}
+
+.conversationAction[data-active='true'],
+.conversationAction[data-active='true']:hover:not(:disabled),
+.conversationAction[data-active='true']:focus-visible {
+	opacity: 1;
+	color: #f5b400;
+}
+
+.conversationAction:hover:not(:disabled),
+.conversationBackButton:hover,
+.conversationCollapseButton:hover,
+.conversationAction:focus-visible,
+.conversationBackButton:focus-visible,
+.conversationCollapseButton:focus-visible {
+	background: var(--ui-desks-control-hover, rgba(15, 23, 42, 0.07));
+	color: var(--ui-desks-text, #14171a);
+	outline: none;
+}
+
+.conversationAction:disabled {
+	cursor: default;
+	opacity: 0.45;
+}
+
+.conversationAction svg,
+.conversationBackButton svg,
+.conversationCollapseButton svg {
+	fill: currentColor;
 }

--- a/apps/ui/src/ui-desks/chats/use-chat-panel-resize.ts
+++ b/apps/ui/src/ui-desks/chats/use-chat-panel-resize.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+
+export const CHAT_PANEL_EXPANDED_WIDTH = 760;
+export const CHAT_PANEL_COLLAPSED_WIDTH = 560;
+export const CHAT_PANEL_COLLAPSE_THRESHOLD = CHAT_PANEL_EXPANDED_WIDTH;
+export const CHAT_PANEL_MIN_WIDTH = 320;
+export const CHAT_PANEL_MAX_WIDTH = 1200;
+
+const CHAT_PANEL_STORAGE_KEY = 'ui-desks-chat-panel-width';
+const CHAT_PANEL_VIEWPORT_MARGIN = 36;
+
+function getViewportWidth() {
+	return typeof window === 'undefined' ? CHAT_PANEL_MAX_WIDTH : window.innerWidth;
+}
+
+export function clampChatPanelWidth( width: number, viewportWidth = getViewportWidth() ) {
+	return Math.max(
+		CHAT_PANEL_MIN_WIDTH,
+		Math.min( width, CHAT_PANEL_MAX_WIDTH, viewportWidth - CHAT_PANEL_VIEWPORT_MARGIN )
+	);
+}
+
+function readStoredChatPanelWidth() {
+	if ( typeof window === 'undefined' ) {
+		return CHAT_PANEL_EXPANDED_WIDTH;
+	}
+
+	const stored = window.localStorage.getItem( CHAT_PANEL_STORAGE_KEY );
+	const parsed = stored ? Number.parseInt( stored, 10 ) : Number.NaN;
+	return Number.isFinite( parsed ) ? parsed : CHAT_PANEL_EXPANDED_WIDTH;
+}
+
+function persistChatPanelWidth( width: number ) {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	window.localStorage.setItem( CHAT_PANEL_STORAGE_KEY, String( width ) );
+}
+
+export function useChatPanelResize( side: 'left' | 'right' ) {
+	const [ width, setWidth ] = useState( () =>
+		clampChatPanelWidth( readStoredChatPanelWidth(), getViewportWidth() )
+	);
+	const [ isResizing, setIsResizing ] = useState( false );
+
+	const updateWidth = useCallback( ( nextWidth: number ) => {
+		const clamped = clampChatPanelWidth( nextWidth, getViewportWidth() );
+		setWidth( clamped );
+		persistChatPanelWidth( clamped );
+	}, [] );
+
+	const collapseList = useCallback( () => {
+		updateWidth( CHAT_PANEL_COLLAPSED_WIDTH );
+	}, [ updateWidth ] );
+
+	const expandList = useCallback( () => {
+		updateWidth( CHAT_PANEL_EXPANDED_WIDTH );
+	}, [ updateWidth ] );
+
+	useEffect( () => {
+		const onResize = () => {
+			setWidth( ( current ) => {
+				const clamped = clampChatPanelWidth( current, getViewportWidth() );
+				persistChatPanelWidth( clamped );
+				return clamped;
+			} );
+		};
+
+		window.addEventListener( 'resize', onResize );
+		return () => window.removeEventListener( 'resize', onResize );
+	}, [] );
+
+	const startResize = useCallback(
+		( event: ReactPointerEvent< HTMLDivElement > ) => {
+			event.preventDefault();
+
+			const dragOriginX = event.clientX;
+			const startWidth = width;
+			const direction = side === 'left' ? 1 : -1;
+
+			setIsResizing( true );
+
+			const onPointerMove = ( pointerEvent: PointerEvent ) => {
+				const delta = ( pointerEvent.clientX - dragOriginX ) * direction;
+				updateWidth( startWidth + delta );
+			};
+
+			const onPointerUp = () => {
+				setIsResizing( false );
+				window.removeEventListener( 'pointermove', onPointerMove );
+				window.removeEventListener( 'pointerup', onPointerUp );
+			};
+
+			window.addEventListener( 'pointermove', onPointerMove );
+			window.addEventListener( 'pointerup', onPointerUp );
+		},
+		[ side, updateWidth, width ]
+	);
+
+	return {
+		width,
+		isResizing,
+		listCollapsed: width < CHAT_PANEL_COLLAPSE_THRESHOLD,
+		collapseList,
+		expandList,
+		startResize,
+	};
+}

--- a/apps/ui/src/ui-desks/chrome/toolbar-layout.test.ts
+++ b/apps/ui/src/ui-desks/chrome/toolbar-layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	DEFAULT_DESK_TOOLBAR_LAYOUT,
+	getDeskToolbarButtonSide,
 	moveDeskToolbarButton,
 	normalizeDeskToolbarLayout,
 	normalizeDeskToolbarSettings,
@@ -54,5 +55,18 @@ describe( 'desk toolbar layout', () => {
 			left: [ 'settings', 'chat', 'create' ],
 			right: [ 'site-map' ],
 		} );
+	} );
+
+	it( 'resolves the side for a toolbar button from normalized layout data', () => {
+		expect(
+			getDeskToolbarButtonSide(
+				{
+					left: [ 'settings' ],
+					right: [ 'chat', 'create' ],
+				},
+				'chat'
+			)
+		).toBe( 'right' );
+		expect( getDeskToolbarButtonSide( DEFAULT_DESK_TOOLBAR_LAYOUT, 'settings' ) ).toBe( 'right' );
 	} );
 } );

--- a/apps/ui/src/ui-desks/chrome/toolbar-layout.ts
+++ b/apps/ui/src/ui-desks/chrome/toolbar-layout.ts
@@ -70,6 +70,14 @@ export function normalizeDeskToolbarSettings( settings: DeskSettings ): DeskTool
 	};
 }
 
+export function getDeskToolbarButtonSide(
+	layout: PersistedDeskToolbarLayout,
+	buttonId: DeskToolbarButtonId
+): keyof DeskToolbarLayout {
+	const normalized = normalizeDeskToolbarLayout( layout );
+	return normalized.left.includes( buttonId ) ? 'left' : 'right';
+}
+
 export function moveDeskToolbarButton(
 	layout: PersistedDeskToolbarLayout,
 	buttonId: DeskToolbarButtonId,

--- a/tools/common/ai/sessions/types.ts
+++ b/tools/common/ai/sessions/types.ts
@@ -2,7 +2,12 @@ import type { SessionEntry } from '@mariozechner/pi-coding-agent';
 
 export type TurnStatus = 'success' | 'error' | 'max_turns' | 'interrupted';
 
-export interface AiSessionSummary {
+export interface AiSessionMetadata {
+	starred?: boolean;
+	archived?: boolean;
+}
+
+export interface AiSessionSummary extends AiSessionMetadata {
 	id: string;
 	filePath: string;
 	createdAt: string;

--- a/tools/common/lib/shared-config.ts
+++ b/tools/common/lib/shared-config.ts
@@ -25,12 +25,22 @@ export class SharedConfigVersionMismatchError extends Error {
 // increment SHARED_CONFIG_VERSION and add a data migration function.
 const SHARED_CONFIG_VERSION = 1;
 
+export const sharedSessionMetadataSchema = z
+	.object( {
+		starred: z.boolean().optional(),
+		archived: z.boolean().optional(),
+	} )
+	.loose();
+
+export type SharedSessionMetadata = z.infer< typeof sharedSessionMetadataSchema >;
+
 export const sharedConfigSchema = z
 	.object( {
 		version: z.literal( SHARED_CONFIG_VERSION ),
 		authToken: authTokenSchema.optional(),
 		locale: z.string().optional(),
 		selectedSkills: z.array( z.string() ).optional(),
+		sessions: z.record( z.string(), sharedSessionMetadataSchema ).optional(),
 		// WordPress.com sites connected to local sites, keyed by user id.
 		// Both Studio and the Studio CLI read and write this field through
 		// the helpers in `./connected-sites.ts`.
@@ -104,6 +114,77 @@ export async function updateSharedConfig( update: Partial< SharedConfig > ): Pro
 		const config = await readSharedConfig();
 		const updated = { ...config, ...update };
 		await saveSharedConfig( updated );
+	} finally {
+		await unlockSharedConfig();
+	}
+}
+
+function pruneSharedSessionMetadata( metadata: SharedSessionMetadata ): void {
+	if ( ! metadata.starred ) {
+		delete metadata.starred;
+	}
+	if ( ! metadata.archived ) {
+		delete metadata.archived;
+	}
+}
+
+function pruneEmptySharedSessions( config: SharedConfig ): void {
+	if ( ! config.sessions ) {
+		return;
+	}
+
+	for ( const [ sessionId, metadata ] of Object.entries( config.sessions ) ) {
+		pruneSharedSessionMetadata( metadata );
+		if ( Object.keys( metadata ).length === 0 ) {
+			delete config.sessions[ sessionId ];
+		}
+	}
+
+	if ( Object.keys( config.sessions ).length === 0 ) {
+		delete config.sessions;
+	}
+}
+
+export async function readSharedSessions(): Promise< Record< string, SharedSessionMetadata > > {
+	const config = await readSharedConfig();
+	return config.sessions ?? {};
+}
+
+export async function readSharedSession(
+	sessionId: string
+): Promise< SharedSessionMetadata | undefined > {
+	const sessions = await readSharedSessions();
+	return sessions[ sessionId ];
+}
+
+export async function updateSharedSession(
+	sessionId: string,
+	patch: Partial< SharedSessionMetadata >
+): Promise< SharedSessionMetadata | undefined > {
+	try {
+		await lockSharedConfig();
+		const config = await readSharedConfig();
+		config.sessions ??= {};
+		config.sessions[ sessionId ] ??= {};
+		Object.assign( config.sessions[ sessionId ], patch );
+		pruneEmptySharedSessions( config );
+		await saveSharedConfig( config );
+		return config.sessions?.[ sessionId ];
+	} finally {
+		await unlockSharedConfig();
+	}
+}
+
+export async function deleteSharedSession( sessionId: string ): Promise< void > {
+	try {
+		await lockSharedConfig();
+		const config = await readSharedConfig();
+		if ( ! config.sessions?.[ sessionId ] ) {
+			return;
+		}
+		delete config.sessions[ sessionId ];
+		pruneEmptySharedSessions( config );
+		await saveSharedConfig( config );
 	} finally {
 		await unlockSharedConfig();
 	}

--- a/tools/common/lib/tests/shared-config.test.ts
+++ b/tools/common/lib/tests/shared-config.test.ts
@@ -9,6 +9,10 @@ import {
 	lockSharedConfig,
 	unlockSharedConfig,
 	updateSharedConfig,
+	readSharedSession,
+	readSharedSessions,
+	updateSharedSession,
+	deleteSharedSession,
 	readAuthToken,
 	getCurrentUserId,
 	SharedConfigVersionMismatchError,
@@ -190,6 +194,84 @@ describe( 'Shared Config', () => {
 			const written = vi.mocked( writeFile ).mock.calls[ 0 ][ 1 ] as string;
 			const saved = JSON.parse( written );
 			expect( saved.locale ).toBe( 'fr' );
+		} );
+	} );
+
+	describe( 'shared sessions', () => {
+		it( 'reads persisted session metadata', async () => {
+			vi.mocked( readFile ).mockResolvedValue(
+				Buffer.from(
+					JSON.stringify( {
+						version: 1,
+						sessions: {
+							abc123: { starred: true },
+						},
+					} )
+				)
+			);
+
+			await expect( readSharedSessions() ).resolves.toEqual( {
+				abc123: { starred: true },
+			} );
+			await expect( readSharedSession( 'abc123' ) ).resolves.toEqual( { starred: true } );
+			await expect( readSharedSession( 'missing' ) ).resolves.toBeUndefined();
+		} );
+
+		it( 'updates session metadata in place', async () => {
+			vi.mocked( readFile ).mockResolvedValue( Buffer.from( JSON.stringify( { version: 1 } ) ) );
+
+			await expect( updateSharedSession( 'abc123', { starred: true } ) ).resolves.toEqual( {
+				starred: true,
+			} );
+
+			const written = vi.mocked( writeFile ).mock.calls[ 0 ][ 1 ] as string;
+			expect( JSON.parse( written ) ).toEqual( {
+				version: 1,
+				sessions: {
+					abc123: { starred: true },
+				},
+			} );
+		} );
+
+		it( 'prunes empty session metadata records', async () => {
+			vi.mocked( readFile ).mockResolvedValue(
+				Buffer.from(
+					JSON.stringify( {
+						version: 1,
+						sessions: {
+							abc123: { starred: true, archived: true },
+						},
+					} )
+				)
+			);
+
+			await expect(
+				updateSharedSession( 'abc123', {
+					starred: false,
+					archived: undefined,
+				} )
+			).resolves.toBeUndefined();
+
+			const written = vi.mocked( writeFile ).mock.calls[ 0 ][ 1 ] as string;
+			expect( JSON.parse( written ) ).toEqual( { version: 1 } );
+		} );
+
+		it( 'deletes stored session metadata', async () => {
+			vi.mocked( readFile ).mockResolvedValue(
+				Buffer.from(
+					JSON.stringify( {
+						version: 1,
+						sessions: {
+							abc123: { archived: true },
+						},
+					} )
+				)
+			);
+
+			await deleteSharedSession( 'abc123' );
+
+			const written = vi.mocked( writeFile ).mock.calls[ 0 ][ 1 ] as string;
+			expect( JSON.parse( written ) ).toEqual( { version: 1 } );
 		} );
 	} );
 


### PR DESCRIPTION
## Summary
- Kept the session loading artwork sized by width while preserving its aspect ratio and centering.
- Aligned the chat column padding so the header, conversation, and composer share the same horizontal inset.
- Ensured the session surface owns the full chat-column width during loading.

## Testing
- Local UI validation in the app.
- Typecheck passed.