### PR TITLE
apps/ui: Add richer post and page card metadata in desk UI

### DIFF
--- a/apps/ui/src/ui-desks/chrome/create-menu.tsx
+++ b/apps/ui/src/ui-desks/chrome/create-menu.tsx
@@ -12,6 +12,7 @@ import { pageWidgetDefinition } from '@/ui-desks/widgets/page/definition';
 import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
 import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
 import { POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
+import { getPostStatusInfo } from '@/ui-desks/widgets/post-status';
 import { getCreatableWidgetDefinitions } from '@/ui-desks/widgets/registry';
 import { LinkFromUrlDialog } from './link-from-url-dialog';
 import styles from './style.module.css';
@@ -163,7 +164,8 @@ function ExistingContentPickerMenuItems( {
 	const query = useMemo(
 		() => ( {
 			per_page: 20,
-			context: 'view',
+			context: 'edit',
+			status: [ 'publish', 'draft', 'pending', 'future', 'private' ],
 			orderby: type === 'page' ? 'menu_order' : 'date',
 			order: type === 'page' ? 'asc' : 'desc',
 			_fields: 'id,title,excerpt,status,date,link,slug',
@@ -218,6 +220,7 @@ function ExistingContentPickerMenuItems( {
 			) }
 			{ records?.map( ( record ) => {
 				const title = decodeEntities( record.title?.rendered ?? '' ).trim() || __( 'Untitled' );
+				const statusInfo = getPostStatusInfo( record.status );
 				return (
 					<Menu.Item
 						key={ record.id }
@@ -234,8 +237,20 @@ function ExistingContentPickerMenuItems( {
 							} )
 						}
 					>
-						<span className={ styles.postPickerTitle }>{ title }</span>
-						{ record.status && <span className={ styles.postPickerMeta }>{ record.status }</span> }
+						<span className={ styles.postPickerContent }>
+							<span className={ styles.postPickerTitle }>{ title }</span>
+							{ record.status && (
+								<span className={ styles.postPickerMeta }>{ statusInfo.label }</span>
+							) }
+						</span>
+						{ record.status && (
+							<span
+								className={ styles.postPickerStatusDot }
+								style={ { background: statusInfo.color } }
+								title={ statusInfo.label }
+								aria-label={ statusInfo.label }
+							/>
+						) }
 					</Menu.Item>
 				);
 			} ) }

--- a/apps/ui/src/ui-desks/chrome/create-menu.tsx
+++ b/apps/ui/src/ui-desks/chrome/create-menu.tsx
@@ -12,7 +12,7 @@ import { pageWidgetDefinition } from '@/ui-desks/widgets/page/definition';
 import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
 import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
 import { POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
-import { getPostStatusInfo } from '@/ui-desks/widgets/post-status';
+import { CONTENT_CARD_STATUSES, getPostStatusInfo } from '@/ui-desks/widgets/post-status';
 import { getCreatableWidgetDefinitions } from '@/ui-desks/widgets/registry';
 import { LinkFromUrlDialog } from './link-from-url-dialog';
 import styles from './style.module.css';
@@ -165,7 +165,7 @@ function ExistingContentPickerMenuItems( {
 		() => ( {
 			per_page: 20,
 			context: 'edit',
-			status: [ 'publish', 'draft', 'pending', 'future', 'private' ],
+			status: CONTENT_CARD_STATUSES,
 			orderby: type === 'page' ? 'menu_order' : 'date',
 			order: type === 'page' ? 'asc' : 'desc',
 			_fields: 'id,title,excerpt,status,date,link,slug',

--- a/apps/ui/src/ui-desks/chrome/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/style.module.css
@@ -235,7 +235,15 @@
 }
 
 .postPickerItem {
-	align-items: flex-start;
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 8px;
+}
+
+.postPickerContent {
+	display: flex;
+	min-width: 0;
 	flex-direction: column;
 	gap: 2px;
 }
@@ -258,6 +266,13 @@
 	font-size: var(--wpds-typography-font-size-xs);
 	line-height: var(--wpds-typography-line-height-xs);
 	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.postPickerStatusDot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9);
 }
 
 .email {

--- a/apps/ui/src/ui-desks/widgets/page/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/page/component.tsx
@@ -2,19 +2,24 @@ import { useEntityRecords, type Post as CoreDataPost } from '@wordpress/core-dat
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { LoadingPlaceholder } from '@/ui-desks/components';
+import { getPostStatusInfo } from '@/ui-desks/widgets/post-status';
 import styles from './style.module.css';
 import type { PageWidgetProps } from './types';
 import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
 
 type PageWidgetComponentProps = DeskWidgetComponentProps< PageWidgetProps >;
+type PageCardRecord = CoreDataPost & {
+	status?: string;
+	slug?: string;
+};
 
 export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentProps ) {
 	const query = useMemo(
 		() => ( {
 			include: [ widgetProps.pageId ],
 			per_page: 1,
-			context: 'view',
-			_fields: 'id,title,excerpt,slug',
+			context: 'edit',
+			_fields: 'id,title,excerpt,slug,status',
 		} ),
 		[ widgetProps.pageId ]
 	);
@@ -22,7 +27,7 @@ export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentPro
 		records,
 		isResolving,
 		status: resolutionStatus,
-	} = useEntityRecords< CoreDataPost >( 'postType', 'page', query, {
+	} = useEntityRecords< PageCardRecord >( 'postType', 'page', query, {
 		enabled: widgetProps.pageId > 0,
 	} );
 	const record = records?.[ 0 ] ?? null;
@@ -47,6 +52,7 @@ export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentPro
 	const title = getPageTitle( record, isResolving, hasError );
 	const excerpt = record?.excerpt?.rendered ?? '';
 	const slug = record?.slug ?? '';
+	const statusInfo = getPostStatusInfo( record?.status );
 
 	return (
 		<article
@@ -60,12 +66,28 @@ export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentPro
 			{ excerpt && (
 				<div className={ styles.body } dangerouslySetInnerHTML={ { __html: excerpt } } />
 			) }
+			{ record?.status && (
+				<div className={ styles.metadata }>
+					<span className={ styles.status } title={ statusInfo.label }>
+						<span
+							className={ styles.statusDot }
+							style={ { background: statusInfo.color } }
+							aria-hidden="true"
+						/>
+						<span className={ styles.statusLabel }>{ statusInfo.label }</span>
+					</span>
+				</div>
+			) }
 			{ slug && <div className={ styles.slug }>/{ slug }</div> }
 		</article>
 	);
 }
 
-function getPageTitle( pageRecord: CoreDataPost | null, isResolving: boolean, hasError: boolean ) {
+function getPageTitle(
+	pageRecord: PageCardRecord | null,
+	isResolving: boolean,
+	hasError: boolean
+) {
 	if ( pageRecord ) {
 		return pageRecord.title?.rendered || __( 'Untitled' );
 	}

--- a/apps/ui/src/ui-desks/widgets/page/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/page/component.tsx
@@ -2,7 +2,7 @@ import { useEntityRecords, type Post as CoreDataPost } from '@wordpress/core-dat
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { LoadingPlaceholder } from '@/ui-desks/components';
-import { getPostStatusInfo } from '@/ui-desks/widgets/post-status';
+import { CONTENT_CARD_STATUSES, getPostStatusInfo } from '@/ui-desks/widgets/post-status';
 import styles from './style.module.css';
 import type { PageWidgetProps } from './types';
 import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
@@ -19,6 +19,7 @@ export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentPro
 			include: [ widgetProps.pageId ],
 			per_page: 1,
 			context: 'edit',
+			status: CONTENT_CARD_STATUSES,
 			_fields: 'id,title,excerpt,slug,status',
 		} ),
 		[ widgetProps.pageId ]

--- a/apps/ui/src/ui-desks/widgets/page/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/page/style.module.css
@@ -78,6 +78,7 @@
 
 .body {
 	max-height: 0;
+	min-height: 0;
 	margin: 0;
 	font-size: 13px;
 	line-height: 1.5;
@@ -102,6 +103,40 @@
 	margin-bottom: 0;
 }
 
+.metadata {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-height: 18px;
+	margin-top: auto;
+	color: var(--page-tone-color);
+	font-size: 12px;
+	line-height: 1.3;
+	opacity: 0.72;
+}
+
+.status {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+}
+
+.statusDot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	flex: 0 0 auto;
+	box-shadow: 0 0 0 2px #fff;
+}
+
+.statusLabel {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .slug {
 	margin-top: auto;
 	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
@@ -113,4 +148,8 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+
+.metadata + .slug {
+	margin-top: 0;
 }

--- a/apps/ui/src/ui-desks/widgets/post-status.test.ts
+++ b/apps/ui/src/ui-desks/widgets/post-status.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getPostStatusInfo } from './post-status';
+
+describe( 'getPostStatusInfo', () => {
+	it( 'returns readable labels and dot colors for known WordPress statuses', () => {
+		expect( getPostStatusInfo( 'publish' ) ).toEqual( {
+			color: '#22c55e',
+			label: 'Published',
+		} );
+		expect( getPostStatusInfo( 'future' ) ).toEqual( {
+			color: '#3b82f6',
+			label: 'Scheduled',
+		} );
+		expect( getPostStatusInfo( 'auto-draft' ) ).toEqual( {
+			color: '#9ca3af',
+			label: 'Draft',
+		} );
+	} );
+
+	it( 'uses a neutral fallback for custom statuses', () => {
+		expect( getPostStatusInfo( 'needs-review' ) ).toEqual( {
+			color: '#9ca3af',
+			label: 'needs-review',
+		} );
+	} );
+} );

--- a/apps/ui/src/ui-desks/widgets/post-status.ts
+++ b/apps/ui/src/ui-desks/widgets/post-status.ts
@@ -1,0 +1,19 @@
+import { __ } from '@wordpress/i18n';
+
+export function getPostStatusInfo( status: string | undefined ): { color: string; label: string } {
+	switch ( status ) {
+		case 'publish':
+			return { color: '#22c55e', label: __( 'Published' ) };
+		case 'pending':
+			return { color: '#f59e0b', label: __( 'Pending review' ) };
+		case 'future':
+			return { color: '#3b82f6', label: __( 'Scheduled' ) };
+		case 'private':
+			return { color: '#a855f7', label: __( 'Private' ) };
+		case 'draft':
+		case 'auto-draft':
+			return { color: '#9ca3af', label: __( 'Draft' ) };
+		default:
+			return { color: '#9ca3af', label: status ?? __( 'Loading…' ) };
+	}
+}

--- a/apps/ui/src/ui-desks/widgets/post-status.ts
+++ b/apps/ui/src/ui-desks/widgets/post-status.ts
@@ -1,5 +1,7 @@
 import { __ } from '@wordpress/i18n';
 
+export const CONTENT_CARD_STATUSES = [ 'publish', 'draft', 'pending', 'future', 'private' ];
+
 export function getPostStatusInfo( status: string | undefined ): { color: string; label: string } {
 	switch ( status ) {
 		case 'publish':

--- a/apps/ui/src/ui-desks/widgets/post/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/post/component.tsx
@@ -4,7 +4,7 @@ import { comment } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { LoadingPlaceholder } from '@/ui-desks/components';
-import { getPostStatusInfo } from '@/ui-desks/widgets/post-status';
+import { CONTENT_CARD_STATUSES, getPostStatusInfo } from '@/ui-desks/widgets/post-status';
 import styles from './style.module.css';
 import { useCommentCount } from './use-comment-count';
 import type { PostWidgetProps } from './types';
@@ -30,6 +30,7 @@ export function PostWidgetComponent( { id, widgetProps }: PostWidgetComponentPro
 			include: [ widgetProps.postId ],
 			per_page: 1,
 			context: 'edit',
+			status: CONTENT_CARD_STATUSES,
 			_embed: true,
 			_fields: 'id,title,excerpt,status,featured_media,_links,_embedded',
 		} ),

--- a/apps/ui/src/ui-desks/widgets/post/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/post/component.tsx
@@ -1,20 +1,37 @@
 import { useEntityRecords, type Post as CoreDataPost } from '@wordpress/core-data';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { comment } from '@wordpress/icons';
+import { Icon } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { LoadingPlaceholder } from '@/ui-desks/components';
+import { getPostStatusInfo } from '@/ui-desks/widgets/post-status';
 import styles from './style.module.css';
+import { useCommentCount } from './use-comment-count';
 import type { PostWidgetProps } from './types';
 import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
 
 type PostWidgetComponentProps = DeskWidgetComponentProps< PostWidgetProps >;
+type EmbeddedFeaturedMedia = {
+	source_url?: string;
+	media_details?: {
+		sizes?: Record< string, { source_url?: string } >;
+	};
+};
+type PostCardRecord = CoreDataPost & {
+	status?: string;
+	_embedded?: {
+		'wp:featuredmedia'?: EmbeddedFeaturedMedia[];
+	};
+};
 
 export function PostWidgetComponent( { id, widgetProps }: PostWidgetComponentProps ) {
 	const query = useMemo(
 		() => ( {
 			include: [ widgetProps.postId ],
 			per_page: 1,
-			context: 'view',
-			_fields: 'id,title,excerpt',
+			context: 'edit',
+			_embed: true,
+			_fields: 'id,title,excerpt,status,featured_media,_links,_embedded',
 		} ),
 		[ widgetProps.postId ]
 	);
@@ -22,12 +39,13 @@ export function PostWidgetComponent( { id, widgetProps }: PostWidgetComponentPro
 		records,
 		isResolving,
 		status: resolutionStatus,
-	} = useEntityRecords< CoreDataPost >( 'postType', 'post', query, {
+	} = useEntityRecords< PostCardRecord >( 'postType', 'post', query, {
 		enabled: widgetProps.postId > 0,
 	} );
 	const record = records?.[ 0 ] ?? null;
 	const hasError = resolutionStatus === 'ERROR';
 	const isLoading = isResolving && ! record;
+	const commentCount = useCommentCount( record ? widgetProps.postId : null );
 
 	if ( isLoading ) {
 		return (
@@ -45,6 +63,10 @@ export function PostWidgetComponent( { id, widgetProps }: PostWidgetComponentPro
 
 	const title = getPostTitle( record, isResolving, hasError );
 	const excerpt = record?.excerpt?.rendered ?? '';
+	const featuredImage = getFeaturedImageUrl( record );
+	const showFeaturedImage = ! excerpt.trim() && Boolean( featuredImage );
+	const statusInfo = getPostStatusInfo( record?.status );
+	const showMetadata = Boolean( record?.status || commentCount > 0 );
 
 	return (
 		<article
@@ -54,14 +76,46 @@ export function PostWidgetComponent( { id, widgetProps }: PostWidgetComponentPro
 			data-studio-desk-widget-id={ id }
 		>
 			<h2 className={ styles.title } dangerouslySetInnerHTML={ { __html: title } } />
-			{ excerpt && (
+			{ showFeaturedImage && featuredImage ? (
+				<img className={ styles.featuredImage } src={ featuredImage } alt="" draggable={ false } />
+			) : excerpt ? (
 				<div className={ styles.body } dangerouslySetInnerHTML={ { __html: excerpt } } />
+			) : null }
+			{ showMetadata && (
+				<div className={ styles.metadata }>
+					{ record?.status && (
+						<span className={ styles.status } title={ statusInfo.label }>
+							<span
+								className={ styles.statusDot }
+								style={ { background: statusInfo.color } }
+								aria-hidden="true"
+							/>
+							<span className={ styles.statusLabel }>{ statusInfo.label }</span>
+						</span>
+					) }
+					{ commentCount > 0 && (
+						<span
+							className={ styles.comments }
+							aria-label={ sprintf(
+								_n( '%d comment', '%d comments', commentCount ),
+								commentCount
+							) }
+						>
+							<Icon icon={ comment } />
+							<span>{ commentCount }</span>
+						</span>
+					) }
+				</div>
 			) }
 		</article>
 	);
 }
 
-function getPostTitle( postRecord: CoreDataPost | null, isResolving: boolean, hasError: boolean ) {
+function getPostTitle(
+	postRecord: PostCardRecord | null,
+	isResolving: boolean,
+	hasError: boolean
+) {
 	if ( postRecord ) {
 		return postRecord.title?.rendered || __( 'Untitled' );
 	}
@@ -71,4 +125,19 @@ function getPostTitle( postRecord: CoreDataPost | null, isResolving: boolean, ha
 	}
 
 	return isResolving ? __( 'Loading post…' ) : __( 'Post unavailable' );
+}
+
+function getFeaturedImageUrl( postRecord: PostCardRecord | null ): string | undefined {
+	const featured = postRecord?._embedded?.[ 'wp:featuredmedia' ]?.[ 0 ];
+	if ( ! featured ) {
+		return undefined;
+	}
+
+	const sizes = featured.media_details?.sizes ?? {};
+	return (
+		sizes.medium_large?.source_url ??
+		sizes.medium?.source_url ??
+		sizes.large?.source_url ??
+		featured.source_url
+	);
 }

--- a/apps/ui/src/ui-desks/widgets/post/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/post/style.module.css
@@ -1,5 +1,6 @@
 .post {
 	box-sizing: border-box;
+	position: relative;
 	width: 100%;
 	height: 100%;
 	padding: 36px 32px;
@@ -36,6 +37,7 @@
 
 .body {
 	flex: 1;
+	min-height: 0;
 	margin: 0;
 	font-size: 13px;
 	line-height: 1.5;
@@ -49,4 +51,63 @@
 
 .body p:last-child {
 	margin-bottom: 0;
+}
+
+.featuredImage {
+	display: block;
+	flex: 1;
+	min-height: 0;
+	width: 100%;
+	margin: 12px 0 0;
+	border-radius: 18px;
+	object-fit: cover;
+	background: #f3f4f6;
+}
+
+.metadata {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	min-height: 24px;
+	margin-top: auto;
+	color: #6b7280;
+	font-size: 12px;
+	line-height: 1.3;
+}
+
+.status,
+.comments {
+	display: inline-flex;
+	align-items: center;
+	min-width: 0;
+}
+
+.status {
+	gap: 6px;
+}
+
+.statusDot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	flex: 0 0 auto;
+	box-shadow: 0 0 0 2px #fff;
+}
+
+.statusLabel {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.comments {
+	gap: 4px;
+	margin-left: auto;
+	color: #6b7280;
+	font-size: 14px;
+}
+
+.comments svg {
+	fill: currentColor;
 }

--- a/apps/ui/src/ui-desks/widgets/post/use-comment-count.ts
+++ b/apps/ui/src/ui-desks/widgets/post/use-comment-count.ts
@@ -1,0 +1,59 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from 'react';
+
+const cache = new Map< number, number >();
+const inflight = new Map< number, Promise< number > >();
+
+export function useCommentCount( postId: number | null ): number {
+	const [ count, setCount ] = useState( () => ( postId ? cache.get( postId ) ?? 0 : 0 ) );
+
+	useEffect( () => {
+		if ( ! postId ) {
+			setCount( 0 );
+			return;
+		}
+
+		if ( cache.has( postId ) ) {
+			setCount( cache.get( postId ) ?? 0 );
+			return;
+		}
+
+		setCount( 0 );
+
+		let cancelled = false;
+		let promise = inflight.get( postId );
+		if ( ! promise ) {
+			promise = fetchCommentCount( postId ).then( ( value ) => {
+				cache.set( postId, value );
+				inflight.delete( postId );
+				return value;
+			} );
+			inflight.set( postId, promise );
+		}
+
+		void promise.then( ( value ) => {
+			if ( ! cancelled ) {
+				setCount( value );
+			}
+		} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ postId ] );
+
+	return count;
+}
+
+async function fetchCommentCount( postId: number ): Promise< number > {
+	try {
+		const response = await apiFetch< unknown, false >( {
+			path: `/wp/v2/comments?post=${ postId }&per_page=1&status=approve`,
+			parse: false,
+		} );
+		const total = response.headers.get( 'X-WP-Total' );
+		return total ? Number.parseInt( total, 10 ) || 0 : 0;
+	} catch {
+		return 0;
+	}
+}

--- a/apps/ui/src/ui-desks/widgets/post/use-comment-count.ts
+++ b/apps/ui/src/ui-desks/widgets/post/use-comment-count.ts
@@ -1,59 +1,21 @@
-import apiFetch from '@wordpress/api-fetch';
-import { useEffect, useState } from 'react';
+import { useEntityRecords, type Comment as CoreDataComment } from '@wordpress/core-data';
+import { useMemo } from 'react';
 
-const cache = new Map< number, number >();
-const inflight = new Map< number, Promise< number > >();
+type CommentCountRecord = Pick< CoreDataComment, 'id' >;
 
 export function useCommentCount( postId: number | null ): number {
-	const [ count, setCount ] = useState( () => ( postId ? cache.get( postId ) ?? 0 : 0 ) );
+	const query = useMemo(
+		() => ( {
+			post: postId ?? 0,
+			per_page: 1,
+			status: 'approve',
+			_fields: 'id',
+		} ),
+		[ postId ]
+	);
+	const { totalItems } = useEntityRecords< CommentCountRecord >( 'root', 'comment', query, {
+		enabled: Boolean( postId ),
+	} );
 
-	useEffect( () => {
-		if ( ! postId ) {
-			setCount( 0 );
-			return;
-		}
-
-		if ( cache.has( postId ) ) {
-			setCount( cache.get( postId ) ?? 0 );
-			return;
-		}
-
-		setCount( 0 );
-
-		let cancelled = false;
-		let promise = inflight.get( postId );
-		if ( ! promise ) {
-			promise = fetchCommentCount( postId ).then( ( value ) => {
-				cache.set( postId, value );
-				inflight.delete( postId );
-				return value;
-			} );
-			inflight.set( postId, promise );
-		}
-
-		void promise.then( ( value ) => {
-			if ( ! cancelled ) {
-				setCount( value );
-			}
-		} );
-
-		return () => {
-			cancelled = true;
-		};
-	}, [ postId ] );
-
-	return count;
-}
-
-async function fetchCommentCount( postId: number ): Promise< number > {
-	try {
-		const response = await apiFetch< unknown, false >( {
-			path: `/wp/v2/comments?post=${ postId }&per_page=1&status=approve`,
-			parse: false,
-		} );
-		const total = response.headers.get( 'X-WP-Total' );
-		return total ? Number.parseInt( total, 10 ) || 0 : 0;
-	} catch {
-		return 0;
-	}
+	return totalItems ?? 0;
 }


### PR DESCRIPTION
## Summary
- Add status dots and human-readable status labels to post and page cards, plus the existing-content picker.
- Show approved comment counts on post cards and use featured-image fallback when a post has no excerpt.
- Fetch richer post/page fields from Core Data so the cards can render the extra metadata without extra widget plumbing.

## Testing
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-desks/widgets/post-status.test.ts apps/ui/src/ui-desks/widgets/create-widget.test.ts apps/ui/src/ui-desks/widgets/toolbar-selection.test.ts`
- `npx eslint --fix` on the modified TypeScript files; CSS files were reported as ignored by the repo ESLint config