### PR TITLE
apps/ui: Implement contextual menus for desk canvas widgets

### DIFF
--- a/apps/ui/src/ui-desks/chrome/link-from-url-dialog.tsx
+++ b/apps/ui/src/ui-desks/chrome/link-from-url-dialog.tsx
@@ -12,10 +12,14 @@ import { useDesk } from '@/ui-desks/desk/provider';
 import { createUrlPastePayload } from '@/ui-desks/widgets/paste-handlers';
 
 interface LinkFromUrlDialogProps {
+	center?: {
+		x: number;
+		y: number;
+	};
 	onClose: () => void;
 }
 
-export function LinkFromUrlDialog( { onClose }: LinkFromUrlDialogProps ) {
+export function LinkFromUrlDialog( { center, onClose }: LinkFromUrlDialogProps ) {
 	const desk = useDesk();
 	const inputRef = useRef< HTMLInputElement | null >( null );
 	const [ text, setText ] = useState( '' );
@@ -34,7 +38,7 @@ export function LinkFromUrlDialog( { onClose }: LinkFromUrlDialogProps ) {
 		}
 
 		setError( null );
-		const didAdd = await desk.addPastedContent( payload );
+		const didAdd = await desk.addPastedContent( payload, center ? { center } : undefined );
 		if ( didAdd ) {
 			onClose();
 			return;

--- a/apps/ui/src/ui-desks/desk/canvas.tsx
+++ b/apps/ui/src/ui-desks/desk/canvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState, type MouseEvent } from 'react';
 import { Tldraw, type Editor, type TLComponents, type TldrawOptions } from 'tldraw';
 import 'tldraw/tldraw.css';
 import { deskShapeUtils } from '@/ui-desks/shapes/registry';
@@ -6,6 +6,11 @@ import {
 	StackAwareSelectionForeground,
 	StackCanvasOverlays,
 } from '@/ui-desks/stacks/canvas-components';
+import {
+	DeskCanvasContextMenu,
+	resolveDeskContextMenuState,
+	type DeskContextMenuState,
+} from './context-menu';
 import { DeskDrawingToolbar } from './drawing-toolbar';
 import { useDesk, useRegisterDeskEditor } from './provider';
 import styles from './style.module.css';
@@ -30,6 +35,8 @@ function DeskCanvasOverlays() {
 export function DeskCanvas() {
 	const { isLoading, isReadOnly, statusMessage } = useDesk();
 	const registerEditor = useRegisterDeskEditor();
+	const [ editor, setEditor ] = useState< Editor | null >( null );
+	const [ contextMenu, setContextMenu ] = useState< DeskContextMenuState | null >( null );
 	const canvasOptions = useMemo(
 		() =>
 			( {
@@ -40,6 +47,7 @@ export function DeskCanvas() {
 
 	const handleMount = useCallback(
 		( nextEditor: Editor ) => {
+			setEditor( nextEditor );
 			registerEditor( nextEditor );
 		},
 		[ registerEditor ]
@@ -47,16 +55,36 @@ export function DeskCanvas() {
 
 	useEffect( () => {
 		return () => {
+			setEditor( null );
+			setContextMenu( null );
 			registerEditor( null );
 		};
 	}, [ registerEditor ] );
+
+	const handleContextMenu = useCallback(
+		( event: MouseEvent< HTMLDivElement > ) => {
+			if ( ! editor || isReadOnly ) {
+				return;
+			}
+
+			const target = event.target as HTMLElement | null;
+			if ( target?.closest( '[data-ui-desks-context-menu]' ) ) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			setContextMenu( resolveDeskContextMenuState( editor, event.clientX, event.clientY ) );
+		},
+		[ editor, isReadOnly ]
+	);
 
 	if ( isLoading ) {
 		return <div className={ styles.loading } />;
 	}
 
 	return (
-		<div className={ styles.canvas }>
+		<div className={ styles.canvas } onContextMenu={ handleContextMenu }>
 			<Tldraw
 				hideUi
 				autoFocus
@@ -66,6 +94,13 @@ export function DeskCanvas() {
 				onMount={ handleMount }
 			/>
 			{ statusMessage && <div className={ styles.statusMessage }>{ statusMessage }</div> }
+			{ contextMenu && editor && (
+				<DeskCanvasContextMenu
+					editor={ editor }
+					state={ contextMenu }
+					onClose={ () => setContextMenu( null ) }
+				/>
+			) }
 		</div>
 	);
 }

--- a/apps/ui/src/ui-desks/desk/canvas.tsx
+++ b/apps/ui/src/ui-desks/desk/canvas.tsx
@@ -6,11 +6,8 @@ import {
 	StackAwareSelectionForeground,
 	StackCanvasOverlays,
 } from '@/ui-desks/stacks/canvas-components';
-import {
-	DeskCanvasContextMenu,
-	resolveDeskContextMenuState,
-	type DeskContextMenuState,
-} from './context-menu';
+import { DeskCanvasContextMenu } from './context-menu';
+import { resolveDeskContextMenuState, type DeskContextMenuState } from './context-menu-state';
 import { DeskDrawingToolbar } from './drawing-toolbar';
 import { useDesk, useRegisterDeskEditor } from './provider';
 import styles from './style.module.css';

--- a/apps/ui/src/ui-desks/desk/context-menu-state.ts
+++ b/apps/ui/src/ui-desks/desk/context-menu-state.ts
@@ -1,0 +1,59 @@
+import { getStackId } from '@/ui-desks/stacks/utils';
+import type { Editor, TLShape, TLShapeId } from 'tldraw';
+
+export type DeskContextMenuKind = 'empty' | 'single' | 'multi';
+
+export interface DeskContextMenuState {
+	kind: DeskContextMenuKind;
+	x: number;
+	y: number;
+	pagePoint: {
+		x: number;
+		y: number;
+	};
+	shapeIds: TLShapeId[];
+}
+
+export type ContextMenuResolverEditor = Pick<
+	Editor,
+	| 'getCurrentPageShapes'
+	| 'getSelectedShapeIds'
+	| 'getShapeAtPoint'
+	| 'screenToPage'
+	| 'setSelectedShapes'
+>;
+
+export function resolveDeskContextMenuState(
+	editor: ContextMenuResolverEditor,
+	x: number,
+	y: number
+): DeskContextMenuState {
+	const pagePoint = editor.screenToPage( { x, y } );
+	const shape = editor.getShapeAtPoint( pagePoint, {
+		hitInside: true,
+		renderingOnly: true,
+	} ) as TLShape | undefined;
+
+	if ( ! shape ) {
+		editor.setSelectedShapes( [] );
+		return { kind: 'empty', shapeIds: [], pagePoint, x, y };
+	}
+
+	const stackId = getStackId( shape );
+	if ( stackId ) {
+		const memberIds = editor
+			.getCurrentPageShapes()
+			.filter( ( member ) => getStackId( member ) === stackId )
+			.map( ( member ) => member.id );
+		editor.setSelectedShapes( memberIds );
+		return { kind: 'multi', shapeIds: memberIds, pagePoint, x, y };
+	}
+
+	const currentSelection = editor.getSelectedShapeIds();
+	if ( currentSelection.includes( shape.id ) && currentSelection.length > 1 ) {
+		return { kind: 'multi', shapeIds: currentSelection, pagePoint, x, y };
+	}
+
+	editor.setSelectedShapes( [ shape.id ] );
+	return { kind: 'single', shapeIds: [ shape.id ], pagePoint, x, y };
+}

--- a/apps/ui/src/ui-desks/desk/context-menu.module.css
+++ b/apps/ui/src/ui-desks/desk/context-menu.module.css
@@ -1,0 +1,143 @@
+.backdrop {
+	position: fixed;
+	inset: 0;
+	z-index: var(--ui-desks-z-context-menu-backdrop, 120);
+	background: transparent;
+}
+
+.menu {
+	position: fixed;
+	z-index: var(--ui-desks-z-context-menu, 121);
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	width: 240px;
+	max-width: calc(100vw - 16px);
+	max-height: min(420px, calc(100vh - 16px));
+	overflow-y: auto;
+	padding: 6px;
+	background: var(--ui-desks-material, #fff);
+	border-radius: var(--ui-desks-radius-control, 16px);
+	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	box-shadow: var(
+		--ui-desks-shadow-control-raised,
+		0 1px 2px rgba(15, 23, 42, 0.04),
+		0 18px 44px rgba(15, 23, 42, 0.1)
+	);
+	color: var(--ui-desks-text, #14171a);
+	animation: context-menu-rise 160ms cubic-bezier(0.32, 0.72, 0.24, 1);
+	transform-origin: top left;
+}
+
+.picker {
+	width: 300px;
+}
+
+.item {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	min-width: 0;
+	gap: 10px;
+	padding: 10px 12px;
+	border: 0;
+	border-radius: var(--ui-desks-radius-button, 12px);
+	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	background: transparent;
+	color: var(--ui-desks-text, #14171a);
+	font: inherit;
+	font-size: 13px;
+	line-height: 18px;
+	text-align: left;
+	cursor: pointer;
+	outline: none;
+	user-select: none;
+}
+
+.item:hover,
+.item:focus-visible,
+.item[data-active='true'] {
+	background: var(--ui-desks-control-hover, rgba(15, 23, 42, 0.07));
+}
+
+.item:disabled {
+	cursor: default;
+	opacity: 0.5;
+}
+
+.item > span {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.item > svg {
+	order: 2;
+	flex: 0 0 auto;
+	margin-left: auto;
+}
+
+.backItem {
+	color: var(--ui-desks-text-muted, rgba(15, 23, 42, 0.56));
+	font-size: 12px;
+}
+
+.chatIcon {
+	order: 2;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	margin-left: auto;
+	border-radius: 50%;
+	background: var(--wp-admin-theme-color, #3858e9);
+	color: #fff;
+	box-shadow: 0 6px 18px rgba(56, 88, 233, 0.28);
+}
+
+.separator {
+	height: 1px;
+	margin: 4px 6px;
+	background: var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+	border: 0;
+}
+
+.status {
+	padding: 12px;
+	color: var(--ui-desks-text-muted, rgba(15, 23, 42, 0.56));
+	font-size: 12px;
+	line-height: 16px;
+	text-align: center;
+}
+
+.postPickerItem {
+	padding-right: 12px;
+}
+
+.postPickerTitle {
+	flex: 1 1 auto;
+}
+
+.postPickerMeta {
+	flex: 0 0 auto;
+	margin-left: auto;
+	color: var(--ui-desks-text-muted, rgba(15, 23, 42, 0.56));
+	font-size: 12px;
+}
+
+@keyframes context-menu-rise {
+	from {
+		opacity: 0;
+		transform: translateY(2px) scale(0.99);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+}

--- a/apps/ui/src/ui-desks/desk/context-menu.test.ts
+++ b/apps/ui/src/ui-desks/desk/context-menu.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveDeskContextMenuState } from './context-menu';
+import type { Editor, TLShape, TLShapeId } from 'tldraw';
+
+describe( 'resolveDeskContextMenuState', () => {
+	it( 'clears selection for empty canvas menus', () => {
+		const editor = createEditorMock( {
+			shapes: [ createShape( 'shape:a' ) ],
+			hitShapeId: null,
+			selectedShapeIds: [ 'shape:a' as TLShapeId ],
+		} );
+
+		const state = resolveDeskContextMenuState( editor, 12, 24 );
+
+		expect( state ).toMatchObject( {
+			kind: 'empty',
+			shapeIds: [],
+			pagePoint: { x: 12, y: 24 },
+		} );
+		expect( editor.setSelectedShapes ).toHaveBeenCalledWith( [] );
+	} );
+
+	it( 'selects all stack members when right-clicking a stack member', () => {
+		const editor = createEditorMock( {
+			shapes: [
+				createShape( 'shape:a', 'stack-1' ),
+				createShape( 'shape:b', 'stack-1' ),
+				createShape( 'shape:c' ),
+			],
+			hitShapeId: 'shape:a',
+		} );
+
+		const state = resolveDeskContextMenuState( editor, 4, 8 );
+
+		expect( state.kind ).toBe( 'multi' );
+		expect( state.shapeIds ).toEqual( [ 'shape:a', 'shape:b' ] );
+		expect( editor.setSelectedShapes ).toHaveBeenCalledWith( [ 'shape:a', 'shape:b' ] );
+	} );
+
+	it( 'keeps an existing multi-selection when right-clicking inside it', () => {
+		const editor = createEditorMock( {
+			shapes: [ createShape( 'shape:a' ), createShape( 'shape:b' ), createShape( 'shape:c' ) ],
+			hitShapeId: 'shape:b',
+			selectedShapeIds: [ 'shape:a' as TLShapeId, 'shape:b' as TLShapeId ],
+		} );
+
+		const state = resolveDeskContextMenuState( editor, 4, 8 );
+
+		expect( state.kind ).toBe( 'multi' );
+		expect( state.shapeIds ).toEqual( [ 'shape:a', 'shape:b' ] );
+		expect( editor.setSelectedShapes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'selects the hit shape for single-shape menus', () => {
+		const editor = createEditorMock( {
+			shapes: [ createShape( 'shape:a' ), createShape( 'shape:b' ) ],
+			hitShapeId: 'shape:b',
+			selectedShapeIds: [ 'shape:a' as TLShapeId ],
+		} );
+
+		const state = resolveDeskContextMenuState( editor, 4, 8 );
+
+		expect( state.kind ).toBe( 'single' );
+		expect( state.shapeIds ).toEqual( [ 'shape:b' ] );
+		expect( editor.setSelectedShapes ).toHaveBeenCalledWith( [ 'shape:b' ] );
+	} );
+} );
+
+function createShape( id: string, stackId?: string ) {
+	return {
+		id: id as TLShapeId,
+		type: 'geo',
+		meta: stackId ? { deskStackId: stackId } : {},
+	} as TLShape;
+}
+
+function createEditorMock( {
+	shapes,
+	hitShapeId,
+	selectedShapeIds = [],
+}: {
+	shapes: TLShape[];
+	hitShapeId: string | null;
+	selectedShapeIds?: TLShapeId[];
+} ) {
+	let selection = selectedShapeIds;
+	const getShape = vi.fn( ( id: TLShapeId ) => shapes.find( ( shape ) => shape.id === id ) );
+	return {
+		getCurrentPageShapes: vi.fn( () => shapes ),
+		getSelectedShapeIds: vi.fn( () => selection ),
+		getShape,
+		getShapeAtPoint: vi.fn( () =>
+			hitShapeId ? getShape( hitShapeId as TLShapeId ) : undefined
+		),
+		screenToPage: vi.fn( ( point ) => point ),
+		setSelectedShapes: vi.fn( ( shapeIds: TLShapeId[] ) => {
+			selection = shapeIds;
+		} ),
+	} as unknown as Pick<
+		Editor,
+		| 'getCurrentPageShapes'
+		| 'getSelectedShapeIds'
+		| 'getShape'
+		| 'getShapeAtPoint'
+		| 'screenToPage'
+		| 'setSelectedShapes'
+	>;
+}

--- a/apps/ui/src/ui-desks/desk/context-menu.test.ts
+++ b/apps/ui/src/ui-desks/desk/context-menu.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { resolveDeskContextMenuState } from './context-menu';
+import { resolveDeskContextMenuState } from './context-menu-state';
 import type { Editor, TLShape, TLShapeId } from 'tldraw';
 
 describe( 'resolveDeskContextMenuState', () => {

--- a/apps/ui/src/ui-desks/desk/context-menu.tsx
+++ b/apps/ui/src/ui-desks/desk/context-menu.tsx
@@ -35,21 +35,9 @@ import { getCreatableWidgetDefinitions, getWidgetDefinition } from '@/ui-desks/w
 import { SITE_PREVIEW_WIDGET_TYPE } from '@/ui-desks/widgets/site-preview/types';
 import styles from './context-menu.module.css';
 import { useDesk } from './provider';
+import type { DeskContextMenuState } from './context-menu-state';
 import type { DeskWidget, DeskWidgetDefinition } from '@/ui-desks/widgets/types';
 import type { Editor, TLShape, TLShapeId } from 'tldraw';
-
-export type DeskContextMenuKind = 'empty' | 'single' | 'multi';
-
-export interface DeskContextMenuState {
-	kind: DeskContextMenuKind;
-	x: number;
-	y: number;
-	pagePoint: {
-		x: number;
-		y: number;
-	};
-	shapeIds: TLShapeId[];
-}
 
 type MenuMode = 'main' | 'show-as' | 'insert' | 'pick-post' | 'pick-page';
 
@@ -58,16 +46,6 @@ interface DeskCanvasContextMenuProps {
 	state: DeskContextMenuState;
 	onClose: () => void;
 }
-
-type ContextMenuResolverEditor = Pick<
-	Editor,
-	| 'getCurrentPageShapes'
-	| 'getSelectedShapeIds'
-	| 'getShape'
-	| 'getShapeAtPoint'
-	| 'screenToPage'
-	| 'setSelectedShapes'
->;
 
 const MENU_WIDTH = 240;
 const PICKER_WIDTH = 300;
@@ -674,41 +652,6 @@ function ContextMenuBackItem( { onClick }: { onClick: () => void } ) {
 
 function ContextMenuSeparator() {
 	return <div className={ styles.separator } role="separator" />;
-}
-
-export function resolveDeskContextMenuState(
-	editor: ContextMenuResolverEditor,
-	x: number,
-	y: number
-): DeskContextMenuState {
-	const pagePoint = editor.screenToPage( { x, y } );
-	const shape = editor.getShapeAtPoint( pagePoint, {
-		hitInside: true,
-		renderingOnly: true,
-	} ) as TLShape | undefined;
-
-	if ( ! shape ) {
-		editor.setSelectedShapes( [] );
-		return { kind: 'empty', shapeIds: [], pagePoint, x, y };
-	}
-
-	const stackId = getStackId( shape );
-	if ( stackId ) {
-		const memberIds = editor
-			.getCurrentPageShapes()
-			.filter( ( member ) => getStackId( member ) === stackId )
-			.map( ( member ) => member.id );
-		editor.setSelectedShapes( memberIds );
-		return { kind: 'multi', shapeIds: memberIds, pagePoint, x, y };
-	}
-
-	const currentSelection = editor.getSelectedShapeIds();
-	if ( currentSelection.includes( shape.id ) && currentSelection.length > 1 ) {
-		return { kind: 'multi', shapeIds: currentSelection, pagePoint, x, y };
-	}
-
-	editor.setSelectedShapes( [ shape.id ] );
-	return { kind: 'single', shapeIds: [ shape.id ], pagePoint, x, y };
 }
 
 function getMenuPosition( state: DeskContextMenuState, menuMode: MenuMode ) {

--- a/apps/ui/src/ui-desks/desk/context-menu.tsx
+++ b/apps/ui/src/ui-desks/desk/context-menu.tsx
@@ -1,0 +1,806 @@
+import { useEntityRecords, type Post as CoreDataPost } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
+import {
+	category,
+	chevronLeft,
+	chevronRight,
+	comment,
+	external,
+	group,
+	link,
+	pencil,
+	trash,
+	ungroup,
+	update,
+	verse,
+} from '@wordpress/icons';
+import { Icon } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import { useEffect, useMemo, useState, type MouseEvent, type ReactNode } from 'react';
+import { useConnector } from '@/data/core';
+import { useSites } from '@/data/queries/use-sites';
+import { SelectionChatDialog } from '@/ui-desks/chats/selection-chat-dialog';
+import { LinkFromUrlDialog } from '@/ui-desks/chrome/link-from-url-dialog';
+import { canvasShapeToDeskWidget } from '@/ui-desks/desk/tldraw-adapter';
+import { collapseStackInEditor, expandStackInEditor } from '@/ui-desks/stacks/editor-commands';
+import { createStackId, getStackId, isStackExpanded } from '@/ui-desks/stacks/utils';
+import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
+import { pageWidgetDefinition } from '@/ui-desks/widgets/page/definition';
+import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
+import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
+import { POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
+import { POST_COLLECTION_WIDGET_TYPE } from '@/ui-desks/widgets/post-collection/types';
+import { getCreatableWidgetDefinitions, getWidgetDefinition } from '@/ui-desks/widgets/registry';
+import { SITE_PREVIEW_WIDGET_TYPE } from '@/ui-desks/widgets/site-preview/types';
+import styles from './context-menu.module.css';
+import { useDesk } from './provider';
+import type { DeskWidget, DeskWidgetDefinition } from '@/ui-desks/widgets/types';
+import type { Editor, TLShape, TLShapeId } from 'tldraw';
+
+export type DeskContextMenuKind = 'empty' | 'single' | 'multi';
+
+export interface DeskContextMenuState {
+	kind: DeskContextMenuKind;
+	x: number;
+	y: number;
+	pagePoint: {
+		x: number;
+		y: number;
+	};
+	shapeIds: TLShapeId[];
+}
+
+type MenuMode = 'main' | 'show-as' | 'insert' | 'pick-post' | 'pick-page';
+
+interface DeskCanvasContextMenuProps {
+	editor: Editor;
+	state: DeskContextMenuState;
+	onClose: () => void;
+}
+
+type ContextMenuResolverEditor = Pick<
+	Editor,
+	| 'getCurrentPageShapes'
+	| 'getSelectedShapeIds'
+	| 'getShape'
+	| 'getShapeAtPoint'
+	| 'screenToPage'
+	| 'setSelectedShapes'
+>;
+
+const MENU_WIDTH = 240;
+const PICKER_WIDTH = 300;
+const MENU_MAX_HEIGHT = 420;
+const VIEWPORT_MARGIN = 8;
+
+export function DeskCanvasContextMenu( { editor, state, onClose }: DeskCanvasContextMenuProps ) {
+	const connector = useConnector();
+	const desk = useDesk();
+	const { data: sites, isLoading: isLoadingSites } = useSites();
+	const site = sites?.find( ( candidate ) => candidate.id === desk.siteId );
+	const isSiteRunning = Boolean( site?.running );
+	const singleShape =
+		state.kind === 'single' && state.shapeIds[ 0 ] ? editor.getShape( state.shapeIds[ 0 ] ) : null;
+	const singleWidget = singleShape ? canvasShapeToDeskWidget( singleShape ) : null;
+	const singleDefinition = singleWidget ? getWidgetDefinition( singleWidget.type ) : undefined;
+	const [ menuMode, setMenuMode ] = useState< MenuMode >( 'main' );
+	const [ isLinkDialogOpen, setIsLinkDialogOpen ] = useState( false );
+	const [ chatWidgets, setChatWidgets ] = useState< DeskWidget[] | null >( null );
+	const creatableWidgetDefinitions = getCreatableWidgetDefinitions().filter( ( definition ) =>
+		isWidgetAvailableInDeskContext( definition, Boolean( desk.siteId ) )
+	);
+	const canEditSingle = Boolean(
+		singleShape &&
+			singleWidget &&
+			canEditWidget( singleWidget, {
+				hasRunningSite: isSiteRunning,
+				hasSiteId: Boolean( desk.siteId ),
+			} )
+	);
+	const canFitSingle = Boolean(
+		singleWidget && singleDefinition?.getFittedShapeProps && state.kind === 'single'
+	);
+	const stackId = getSelectionStackId( editor, state.shapeIds );
+	const isStack = state.kind === 'multi' && Boolean( stackId );
+	const currentStackView =
+		stackId && isStackExpanded( editor.getShape( state.shapeIds[ 0 ] ) ) ? 'tiles' : 'stack';
+	const selectedWidgets = getWidgetsForShapeIds( editor, state.shapeIds );
+	const canChat = selectedWidgets.length > 0;
+
+	useEffect( () => {
+		setMenuMode( 'main' );
+		setIsLinkDialogOpen( false );
+		setChatWidgets( null );
+	}, [ state.x, state.y ] );
+
+	useEffect( () => {
+		function handleKeyDown( event: KeyboardEvent ) {
+			if ( event.key !== 'Escape' || isLinkDialogOpen || chatWidgets ) {
+				return;
+			}
+
+			if ( menuMode === 'pick-post' || menuMode === 'pick-page' ) {
+				setMenuMode( 'insert' );
+				return;
+			}
+
+			if ( menuMode !== 'main' ) {
+				setMenuMode( 'main' );
+				return;
+			}
+
+			onClose();
+		}
+
+		window.addEventListener( 'keydown', handleKeyDown );
+		return () => {
+			window.removeEventListener( 'keydown', handleKeyDown );
+		};
+	}, [ chatWidgets, isLinkDialogOpen, menuMode, onClose ] );
+
+	if ( isLinkDialogOpen ) {
+		return <LinkFromUrlDialog center={ state.pagePoint } onClose={ onClose } />;
+	}
+
+	if ( chatWidgets ) {
+		return <SelectionChatDialog widgets={ chatWidgets } onClose={ onClose } />;
+	}
+
+	const position = getMenuPosition( state, menuMode );
+
+	const closeAfter = ( action: () => void | Promise< void > ) => {
+		const result = action();
+		if ( result instanceof Promise ) {
+			void result.finally( onClose );
+			return;
+		}
+		onClose();
+	};
+
+	return (
+		<>
+			<button
+				type="button"
+				className={ styles.backdrop }
+				aria-label={ __( 'Close context menu' ) }
+				data-ui-desks-context-menu
+				onMouseDown={ onClose }
+				onContextMenu={ ( event ) => {
+					event.preventDefault();
+					onClose();
+				} }
+			/>
+			<div
+				className={ clsx(
+					styles.menu,
+					( menuMode === 'pick-post' || menuMode === 'pick-page' ) && styles.picker
+				) }
+				style={ position }
+				role="menu"
+				data-ui-desks-context-menu
+				onMouseDown={ ( event ) => event.stopPropagation() }
+				onContextMenu={ ( event ) => event.preventDefault() }
+			>
+				{ state.kind === 'single' && menuMode === 'main' && (
+					<>
+						{ canEditSingle && (
+							<ContextMenuItem onClick={ () => closeAfter( () => handleEditWidget() ) }>
+								<span>{ __( 'Edit' ) }</span>
+								<Icon icon={ pencil } />
+							</ContextMenuItem>
+						) }
+						{ canFitSingle && (
+							<ContextMenuItem
+								onClick={ () =>
+									closeAfter( async () => {
+										await desk.fitSelectedWidgetToContent();
+									} )
+								}
+							>
+								<span>
+									{ singleWidget?.type === NOTE_WIDGET_TYPE
+										? __( 'Fit text' )
+										: __( 'Fit to size' ) }
+								</span>
+								<Icon icon={ update } />
+							</ContextMenuItem>
+						) }
+						<ContextMenuItem onClick={ () => closeAfter( () => duplicateSelection() ) }>
+							<span>{ __( 'Duplicate' ) }</span>
+						</ContextMenuItem>
+						<ContextMenuItem
+							onClick={ () =>
+								closeAfter( () => {
+									editor.bringToFront( state.shapeIds );
+								} )
+							}
+						>
+							<span>{ __( 'Bring to front' ) }</span>
+						</ContextMenuItem>
+						<ChatMenuItem
+							disabled={ ! canChat }
+							onClick={ () => setChatWidgets( selectedWidgets ) }
+						/>
+						<ContextMenuSeparator />
+						<ContextMenuItem
+							onClick={ () =>
+								closeAfter( () => {
+									editor.deleteShapes( state.shapeIds );
+								} )
+							}
+						>
+							<span>{ __( 'Remove' ) }</span>
+							<Icon icon={ trash } />
+						</ContextMenuItem>
+					</>
+				) }
+				{ state.kind === 'multi' && ! isStack && menuMode === 'main' && (
+					<>
+						<ContextMenuItem
+							disabled={ ! desk.canAddWidgets }
+							onClick={ () => closeAfter( () => void desk.stackSelectedWidgets() ) }
+						>
+							<span>{ __( 'Create stack' ) }</span>
+							<Icon icon={ group } />
+						</ContextMenuItem>
+						<ChatMenuItem
+							disabled={ ! canChat }
+							onClick={ () => setChatWidgets( selectedWidgets ) }
+						/>
+						<ContextMenuSeparator />
+						<ContextMenuItem
+							onClick={ () =>
+								closeAfter( () => {
+									editor.deleteShapes( state.shapeIds );
+								} )
+							}
+						>
+							<span>{ __( 'Remove' ) }</span>
+							<Icon icon={ trash } />
+						</ContextMenuItem>
+					</>
+				) }
+				{ state.kind === 'multi' && isStack && menuMode === 'main' && (
+					<>
+						<ContextMenuItem onClick={ () => setMenuMode( 'show-as' ) }>
+							<span>{ __( 'Show as…' ) }</span>
+							<Icon icon={ chevronRight } />
+						</ContextMenuItem>
+						<ContextMenuItem
+							onClick={ () => closeAfter( () => void desk.unstackSelectedWidgets() ) }
+						>
+							<span>{ __( 'Unstack' ) }</span>
+							<Icon icon={ ungroup } />
+						</ContextMenuItem>
+						<ContextMenuItem onClick={ () => closeAfter( () => duplicateSelection() ) }>
+							<span>{ __( 'Duplicate' ) }</span>
+						</ContextMenuItem>
+						<ChatMenuItem
+							disabled={ ! canChat }
+							onClick={ () => setChatWidgets( selectedWidgets ) }
+						/>
+						<ContextMenuSeparator />
+						<ContextMenuItem
+							onClick={ () =>
+								closeAfter( () => {
+									editor.deleteShapes( state.shapeIds );
+								} )
+							}
+						>
+							<span>{ __( 'Remove' ) }</span>
+							<Icon icon={ trash } />
+						</ContextMenuItem>
+					</>
+				) }
+				{ state.kind === 'multi' && isStack && menuMode === 'show-as' && (
+					<>
+						<ContextMenuBackItem onClick={ () => setMenuMode( 'main' ) } />
+						<ContextMenuSeparator />
+						<ContextMenuItem
+							active={ currentStackView === 'stack' }
+							onClick={ () =>
+								closeAfter( () => {
+									if ( stackId ) {
+										collapseStackInEditor( editor, stackId );
+									}
+								} )
+							}
+						>
+							<span>{ __( 'Stack' ) }</span>
+							<Icon icon={ group } />
+						</ContextMenuItem>
+						<ContextMenuItem
+							active={ currentStackView === 'tiles' }
+							onClick={ () =>
+								closeAfter( () => {
+									if ( stackId ) {
+										expandStackInEditor( editor, stackId );
+									}
+								} )
+							}
+						>
+							<span>{ __( 'Tiles' ) }</span>
+							<Icon icon={ category } />
+						</ContextMenuItem>
+					</>
+				) }
+				{ state.kind === 'empty' && menuMode === 'main' && (
+					<>
+						<ContextMenuItem
+							disabled={ ! desk.canAddWidgets }
+							onClick={ () => setMenuMode( 'insert' ) }
+						>
+							<span>{ __( 'Insert…' ) }</span>
+							<Icon icon={ chevronRight } />
+						</ContextMenuItem>
+						<ContextMenuItem
+							disabled={ ! desk.canAddWidgets }
+							onClick={ () => closeAfter( () => void desk.startDrawing() ) }
+						>
+							<span>{ __( 'Draw' ) }</span>
+							<Icon icon={ verse } />
+						</ContextMenuItem>
+						<ContextMenuSeparator />
+						<ContextMenuItem
+							disabled={ ! desk.siteId || ! isSiteRunning }
+							onClick={ () =>
+								closeAfter( async () => {
+									if ( desk.siteId ) {
+										await connector.openSiteUrl( desk.siteId );
+									}
+								} )
+							}
+						>
+							<span>{ __( 'Go to site' ) }</span>
+							<Icon icon={ external } />
+						</ContextMenuItem>
+						<ContextMenuItem
+							disabled={ ! desk.siteId || ! isSiteRunning }
+							onClick={ () =>
+								closeAfter( async () => {
+									if ( desk.siteId ) {
+										await connector.openSiteUrl( desk.siteId, '/wp-admin/' );
+									}
+								} )
+							}
+						>
+							<span>{ __( 'Go to admin' ) }</span>
+							<Icon icon={ external } />
+						</ContextMenuItem>
+					</>
+				) }
+				{ state.kind === 'empty' && menuMode === 'insert' && (
+					<>
+						<ContextMenuBackItem onClick={ () => setMenuMode( 'main' ) } />
+						<ContextMenuSeparator />
+						{ creatableWidgetDefinitions.map( ( definition ) => (
+							<ContextMenuItem
+								key={ definition.type }
+								disabled={ isWidgetCreationDisabled(
+									definition,
+									desk.canAddWidgets,
+									isSiteRunning
+								) }
+								onClick={ () =>
+									closeAfter( () => {
+										desk.addWidget( definition.type, {
+											center: state.pagePoint,
+											shouldStartEditing: definition.shouldStartEditingOnCreate,
+										} );
+									} )
+								}
+							>
+								{ definition.icon && <Icon icon={ definition.icon } /> }
+								<span>{ definition.labels.add() }</span>
+							</ContextMenuItem>
+						) ) }
+						<ContextMenuItem
+							disabled={ ! desk.canAddWidgets }
+							onClick={ () => setIsLinkDialogOpen( true ) }
+						>
+							<Icon icon={ link } />
+							<span>{ __( 'New link from URL' ) }</span>
+						</ContextMenuItem>
+						<ContextMenuItem
+							disabled={ ! desk.canAddWidgets }
+							onClick={ () => closeAfter( () => void desk.startDrawing() ) }
+						>
+							<Icon icon={ verse } />
+							<span>{ __( 'New drawing' ) }</span>
+						</ContextMenuItem>
+						{ desk.siteId && (
+							<>
+								<ContextMenuItem
+									disabled={ isWidgetCreationDisabled(
+										postWidgetDefinition,
+										desk.canAddWidgets,
+										isSiteRunning
+									) }
+									onClick={ () => setMenuMode( 'pick-post' ) }
+								>
+									{ postWidgetDefinition.icon && <Icon icon={ postWidgetDefinition.icon } /> }
+									<span>{ postWidgetDefinition.labels.add() }</span>
+									<Icon icon={ chevronRight } />
+								</ContextMenuItem>
+								<ContextMenuItem
+									disabled={ isWidgetCreationDisabled(
+										pageWidgetDefinition,
+										desk.canAddWidgets,
+										isSiteRunning
+									) }
+									onClick={ () => setMenuMode( 'pick-page' ) }
+								>
+									{ pageWidgetDefinition.icon && <Icon icon={ pageWidgetDefinition.icon } /> }
+									<span>{ pageWidgetDefinition.labels.add() }</span>
+									<Icon icon={ chevronRight } />
+								</ContextMenuItem>
+							</>
+						) }
+					</>
+				) }
+				{ state.kind === 'empty' && ( menuMode === 'pick-post' || menuMode === 'pick-page' ) && (
+					<ExistingContentPickerMenuItems
+						type={ menuMode === 'pick-page' ? 'page' : 'post' }
+						canAddWidgets={ desk.canAddWidgets }
+						isLoadingSites={ isLoadingSites }
+						hasSite={ Boolean( site ) }
+						canQueryPosts={ isSiteRunning }
+						onBack={ () => setMenuMode( 'insert' ) }
+						onSelect={ ( id ) =>
+							closeAfter( () => {
+								desk.addWidget( menuMode === 'pick-page' ? PAGE_WIDGET_TYPE : POST_WIDGET_TYPE, {
+									center: state.pagePoint,
+									widgetProps: {
+										...( menuMode === 'pick-page'
+											? { pageId: id, tone: 'neutral' }
+											: { postId: id } ),
+									},
+									shouldStartEditing: false,
+								} );
+							} )
+						}
+					/>
+				) }
+			</div>
+		</>
+	);
+
+	function handleEditWidget() {
+		if ( ! singleShape || ! singleWidget ) {
+			return;
+		}
+
+		if (
+			singleWidget.type === NOTE_WIDGET_TYPE ||
+			singleWidget.type === SITE_PREVIEW_WIDGET_TYPE
+		) {
+			editor.setEditingShape( singleShape.id );
+			return;
+		}
+
+		if ( ! desk.siteId ) {
+			return;
+		}
+
+		if ( singleWidget.type === POST_WIDGET_TYPE && singleWidget.widgetProps.postId > 0 ) {
+			void connector.openSiteUrl(
+				desk.siteId,
+				`/wp-admin/post.php?post=${ singleWidget.widgetProps.postId }&action=edit`
+			);
+			return;
+		}
+
+		if ( singleWidget.type === PAGE_WIDGET_TYPE && singleWidget.widgetProps.pageId > 0 ) {
+			void connector.openSiteUrl(
+				desk.siteId,
+				`/wp-admin/post.php?post=${ singleWidget.widgetProps.pageId }&action=edit`
+			);
+			return;
+		}
+
+		if ( singleWidget.type === POST_COLLECTION_WIDGET_TYPE ) {
+			void connector.openSiteUrl( desk.siteId, '/wp-admin/edit.php' );
+		}
+	}
+
+	function duplicateSelection() {
+		const originalStackIds = getStackIdsForShapeIds( editor, state.shapeIds );
+		editor.duplicateShapes( state.shapeIds, { x: 24, y: 24 } );
+
+		if ( originalStackIds.size === 0 ) {
+			return;
+		}
+
+		const replacementStackIds = new Map(
+			Array.from( originalStackIds, ( originalStackId ) => [ originalStackId, createStackId() ] )
+		);
+		const duplicatedStackShapes = editor
+			.getSelectedShapeIds()
+			.map( ( shapeId ) => editor.getShape( shapeId ) )
+			.filter( ( shape ): shape is TLShape => Boolean( shape ) )
+			.map( ( shape ) => {
+				const originalStackId = getStackId( shape );
+				const nextStackId = originalStackId
+					? replacementStackIds.get( originalStackId )
+					: undefined;
+
+				if ( ! nextStackId ) {
+					return null;
+				}
+
+				return {
+					id: shape.id,
+					type: shape.type,
+					meta: {
+						...( shape.meta ?? {} ),
+						deskStackId: nextStackId,
+					},
+				};
+			} )
+			.filter( ( partial ): partial is NonNullable< typeof partial > => partial !== null );
+
+		if ( duplicatedStackShapes.length > 0 ) {
+			editor.updateShapes( duplicatedStackShapes );
+		}
+	}
+}
+
+function ExistingContentPickerMenuItems( {
+	type,
+	canAddWidgets,
+	isLoadingSites,
+	hasSite,
+	canQueryPosts,
+	onBack,
+	onSelect,
+}: {
+	type: 'post' | 'page';
+	canAddWidgets: boolean;
+	isLoadingSites: boolean;
+	hasSite: boolean;
+	canQueryPosts: boolean;
+	onBack: () => void;
+	onSelect: ( id: number ) => void;
+} ) {
+	const query = useMemo(
+		() => ( {
+			per_page: 20,
+			context: 'view',
+			orderby: type === 'page' ? 'menu_order' : 'date',
+			order: type === 'page' ? 'asc' : 'desc',
+			_fields: 'id,title,excerpt,status,date,link,slug',
+		} ),
+		[ type ]
+	);
+	const {
+		records,
+		isResolving,
+		status: resolutionStatus,
+	} = useEntityRecords< CoreDataPost >( 'postType', type, query, {
+		enabled: canQueryPosts,
+	} );
+
+	return (
+		<>
+			<ContextMenuBackItem onClick={ onBack } />
+			<ContextMenuSeparator />
+			{ isLoadingSites && <div className={ styles.status }>{ __( 'Checking site…' ) }</div> }
+			{ ! isLoadingSites && ! hasSite && (
+				<div className={ styles.status }>{ __( 'Site not found.' ) }</div>
+			) }
+			{ hasSite && ! canQueryPosts && (
+				<div className={ styles.status }>{ __( 'Site is not running.' ) }</div>
+			) }
+			{ canQueryPosts && isResolving && ! records && (
+				<div className={ styles.status }>
+					{ type === 'page' ? __( 'Loading pages…' ) : __( 'Loading posts…' ) }
+				</div>
+			) }
+			{ canQueryPosts && records && records.length === 0 && (
+				<div className={ styles.status }>
+					{ type === 'page' ? __( 'No pages found.' ) : __( 'No posts found.' ) }
+				</div>
+			) }
+			{ canQueryPosts && resolutionStatus === 'ERROR' && (
+				<div className={ styles.status }>
+					{ type === 'page' ? __( 'Unable to load pages.' ) : __( 'Unable to load posts.' ) }
+				</div>
+			) }
+			{ records?.map( ( record ) => {
+				const title = decodeEntities( record.title?.rendered ?? '' ).trim() || __( 'Untitled' );
+				return (
+					<ContextMenuItem
+						key={ record.id }
+						className={ styles.postPickerItem }
+						disabled={ ! canAddWidgets }
+						onClick={ () => onSelect( record.id ) }
+					>
+						<span className={ styles.postPickerTitle }>{ title }</span>
+						{ record.status && <span className={ styles.postPickerMeta }>{ record.status }</span> }
+					</ContextMenuItem>
+				);
+			} ) }
+		</>
+	);
+}
+
+function ContextMenuItem( {
+	children,
+	active = false,
+	disabled = false,
+	className,
+	onClick,
+}: {
+	children: ReactNode;
+	active?: boolean;
+	disabled?: boolean;
+	className?: string;
+	onClick: ( event: MouseEvent< HTMLButtonElement > ) => void;
+} ) {
+	return (
+		<button
+			type="button"
+			className={ clsx( styles.item, className ) }
+			role="menuitem"
+			disabled={ disabled }
+			data-active={ active ? 'true' : undefined }
+			onClick={ onClick }
+		>
+			{ children }
+		</button>
+	);
+}
+
+function ChatMenuItem( { disabled, onClick }: { disabled: boolean; onClick: () => void } ) {
+	return (
+		<ContextMenuItem disabled={ disabled } onClick={ onClick }>
+			<span>{ __( 'Start conversation…' ) }</span>
+			<span className={ styles.chatIcon } aria-hidden="true">
+				<Icon icon={ comment } size={ 20 } />
+			</span>
+		</ContextMenuItem>
+	);
+}
+
+function ContextMenuBackItem( { onClick }: { onClick: () => void } ) {
+	return (
+		<ContextMenuItem className={ styles.backItem } onClick={ onClick }>
+			<Icon icon={ chevronLeft } />
+			<span>{ __( 'Back' ) }</span>
+		</ContextMenuItem>
+	);
+}
+
+function ContextMenuSeparator() {
+	return <div className={ styles.separator } role="separator" />;
+}
+
+export function resolveDeskContextMenuState(
+	editor: ContextMenuResolverEditor,
+	x: number,
+	y: number
+): DeskContextMenuState {
+	const pagePoint = editor.screenToPage( { x, y } );
+	const shape = editor.getShapeAtPoint( pagePoint, {
+		hitInside: true,
+		renderingOnly: true,
+	} ) as TLShape | undefined;
+
+	if ( ! shape ) {
+		editor.setSelectedShapes( [] );
+		return { kind: 'empty', shapeIds: [], pagePoint, x, y };
+	}
+
+	const stackId = getStackId( shape );
+	if ( stackId ) {
+		const memberIds = editor
+			.getCurrentPageShapes()
+			.filter( ( member ) => getStackId( member ) === stackId )
+			.map( ( member ) => member.id );
+		editor.setSelectedShapes( memberIds );
+		return { kind: 'multi', shapeIds: memberIds, pagePoint, x, y };
+	}
+
+	const currentSelection = editor.getSelectedShapeIds();
+	if ( currentSelection.includes( shape.id ) && currentSelection.length > 1 ) {
+		return { kind: 'multi', shapeIds: currentSelection, pagePoint, x, y };
+	}
+
+	editor.setSelectedShapes( [ shape.id ] );
+	return { kind: 'single', shapeIds: [ shape.id ], pagePoint, x, y };
+}
+
+function getMenuPosition( state: DeskContextMenuState, menuMode: MenuMode ) {
+	if ( typeof window === 'undefined' ) {
+		return {
+			left: state.x,
+			top: state.y,
+		};
+	}
+
+	const width = menuMode === 'pick-post' || menuMode === 'pick-page' ? PICKER_WIDTH : MENU_WIDTH;
+	return {
+		left: Math.max(
+			VIEWPORT_MARGIN,
+			Math.min( state.x, window.innerWidth - width - VIEWPORT_MARGIN )
+		),
+		top: Math.max(
+			VIEWPORT_MARGIN,
+			Math.min( state.y, window.innerHeight - MENU_MAX_HEIGHT - VIEWPORT_MARGIN )
+		),
+	};
+}
+
+function getSelectionStackId( editor: Editor, shapeIds: TLShapeId[] ) {
+	if ( shapeIds.length < 2 ) {
+		return null;
+	}
+
+	const stackIds = new Set< string >();
+	for ( const shapeId of shapeIds ) {
+		const stackId = getStackId( editor.getShape( shapeId ) );
+		if ( ! stackId ) {
+			return null;
+		}
+		stackIds.add( stackId );
+	}
+
+	return stackIds.size === 1 ? stackIds.values().next().value : null;
+}
+
+function getStackIdsForShapeIds( editor: Editor, shapeIds: TLShapeId[] ) {
+	const stackIds = new Set< string >();
+	for ( const shapeId of shapeIds ) {
+		const stackId = getStackId( editor.getShape( shapeId ) );
+		if ( stackId ) {
+			stackIds.add( stackId );
+		}
+	}
+	return stackIds;
+}
+
+function getWidgetsForShapeIds( editor: Editor, shapeIds: TLShapeId[] ) {
+	return shapeIds
+		.map( ( shapeId ) => editor.getShape( shapeId ) )
+		.map( ( shape ) => ( shape ? canvasShapeToDeskWidget( shape ) : null ) )
+		.filter( ( widget ): widget is DeskWidget => widget !== null );
+}
+
+function canEditWidget(
+	widget: DeskWidget,
+	{ hasRunningSite, hasSiteId }: { hasRunningSite: boolean; hasSiteId: boolean }
+) {
+	if ( widget.type === NOTE_WIDGET_TYPE || widget.type === SITE_PREVIEW_WIDGET_TYPE ) {
+		return true;
+	}
+
+	if ( ! hasSiteId || ! hasRunningSite ) {
+		return false;
+	}
+
+	if ( widget.type === POST_WIDGET_TYPE ) {
+		return widget.widgetProps.postId > 0;
+	}
+
+	if ( widget.type === PAGE_WIDGET_TYPE ) {
+		return widget.widgetProps.pageId > 0;
+	}
+
+	return widget.type === POST_COLLECTION_WIDGET_TYPE;
+}
+
+function isWidgetAvailableInDeskContext(
+	definition: DeskWidgetDefinition,
+	hasSiteContext: boolean
+) {
+	return hasSiteContext || ! definition.requiresRunningSite;
+}
+
+function isWidgetCreationDisabled(
+	definition: DeskWidgetDefinition,
+	canAddWidgets: boolean,
+	isSiteRunning: boolean
+) {
+	return ! canAddWidgets || ( definition.requiresRunningSite && ! isSiteRunning );
+}


### PR DESCRIPTION
## Summary
- Add a custom desk canvas context menu with parity for empty canvas, single-widget, multi-selection, and stack-selection states
- Reuse the existing create-menu insertion flow for the Insert submenu, including adding existing posts/pages and link-from-URL creation at the cursor point
- Add selection chat access to the single-widget menu as well as multi-selection menus
- Support context-menu anchoring, dismissal, and focused resolver tests

## Testing
- `npm run typecheck` passed
- `npx eslint --fix` was run on the modified TypeScript files; CSS modules are ignored by the repo ESLint config
- Added focused unit coverage for context-menu state resolution
- Vitest coverage for the new menu test hit a pre-existing JSON import-attribute issue in the test environment