### PR TITLE
apps/ui: Hide tldraw selection chrome and color selected drawings

### DIFF
--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -137,6 +137,19 @@ a:focus:not(:focus-visible),
 	height: 16px;
 }
 
+/* Desks uses each shape's indicator as the visible selection outline.
+   Hide tldraw's default selection box and handle glyphs while keeping the
+   underlying resize/rotate wrappers interactive. */
+[data-ui-mode='desks'] .tl-selection__fg__outline {
+	stroke: transparent;
+}
+
+[data-ui-mode='desks'] .tl-corner-handle,
+[data-ui-mode='desks'] .tl-mobile-rotate__fg,
+[data-ui-mode='desks'] .tl-text-handle {
+	opacity: 0;
+}
+
 /* @wordpress/components' ComboboxControl (used by DataForm's adaptive
    picker once a field has 10+ elements) leaves its wrapper without a
    background, so the body surface bleeds through around the inner input

--- a/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
+++ b/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
@@ -14,6 +14,7 @@ import {
 import { getDeskCanvasRecordResolutionState } from '@/ui-desks/desk/tldraw-adapter';
 import { useStackShapeInteraction } from '@/ui-desks/stacks/use-stack-shape-interaction';
 import { getStackId, getStackViewMode, isStackExpanded } from '@/ui-desks/stacks/utils';
+import { DRAWING_WIDGET_TYPE } from '@/ui-desks/widgets/drawing/types';
 import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
 import {
 	RECTANGLE_WIDGET_SHAPE_TYPE,
@@ -106,28 +107,52 @@ export class RectangleWidgetShapeUtil extends ShapeUtil< RectangleWidgetShape > 
 	}
 
 	override indicator( shape: RectangleWidgetShape ) {
-		if (
-			getStackId( shape ) &&
-			! isStackExpanded( shape ) &&
-			getStackViewMode( shape ) !== 'tiles'
-		) {
-			return null;
-		}
-
-		const definition = getWidgetDefinition( shape.props.widgetType );
-		const indicator = getWidgetIndicator( definition, shape.props.widgetProps );
-
-		return (
-			<rect
-				width={ shape.props.shapeProps.w }
-				height={ shape.props.shapeProps.h }
-				rx={ indicator?.cornerRadius ?? 14 }
-				ry={ indicator?.cornerRadius ?? 14 }
-				fill="none"
-				stroke={ indicator?.stroke }
-			/>
-		);
+		return <RectangleWidgetIndicator shape={ shape } />;
 	}
+}
+
+function RectangleWidgetIndicator( { shape }: { shape: RectangleWidgetShape } ) {
+	const editor = useEditor();
+	const isSelected = useValue(
+		`rectangle-widget-indicator-selected:${ shape.id }`,
+		() => editor.getSelectedShapeIds().includes( shape.id ),
+		[ editor, shape.id ]
+	);
+
+	if (
+		getStackId( shape ) &&
+		! isStackExpanded( shape ) &&
+		getStackViewMode( shape ) !== 'tiles'
+	) {
+		return null;
+	}
+
+	if ( shape.props.widgetType === DRAWING_WIDGET_TYPE ) {
+		return null;
+	}
+
+	const definition = getWidgetDefinition( shape.props.widgetType );
+	const indicator = getWidgetIndicator( definition, shape.props.widgetProps );
+
+	return (
+		<rect
+			width={ shape.props.shapeProps.w }
+			height={ shape.props.shapeProps.h }
+			rx={ indicator?.cornerRadius ?? 14 }
+			ry={ indicator?.cornerRadius ?? 14 }
+			fill="none"
+			stroke={ indicator?.stroke }
+			style={ { strokeWidth: indicatorStrokeWidth( isSelected ) } }
+		/>
+	);
+}
+
+const INDICATOR_STROKE_WIDTH_HOVER = 1.5;
+const INDICATOR_STROKE_WIDTH_SELECTED = 3;
+
+function indicatorStrokeWidth( isSelected: boolean ): string {
+	const width = isSelected ? INDICATOR_STROKE_WIDTH_SELECTED : INDICATOR_STROKE_WIDTH_HOVER;
+	return `calc(${ width }px * var(--tl-scale))`;
 }
 
 function getWidgetIndicator(

--- a/apps/ui/src/ui-desks/widgets/drawing/component.tsx
+++ b/apps/ui/src/ui-desks/widgets/drawing/component.tsx
@@ -1,23 +1,46 @@
 import { DRAWING_WIDGET_TYPE, type DrawingWidgetProps } from '@/ui-desks/widgets/drawing/types';
 import styles from './style.module.css';
 import type { DeskWidgetComponentProps } from '@/ui-desks/widgets/types';
+import type { CSSProperties } from 'react';
 
 type DrawingWidgetComponentProps = DeskWidgetComponentProps< DrawingWidgetProps >;
+const SELECTED_DRAWING_COLOR = '#6b7280';
 
-export function DrawingWidgetComponent( { id, widgetProps }: DrawingWidgetComponentProps ) {
+export function DrawingWidgetComponent( {
+	id,
+	isSelected,
+	widgetProps,
+}: DrawingWidgetComponentProps ) {
+	const svgSource = widgetProps.svg
+		? `data:image/svg+xml;charset=utf-8,${ encodeURIComponent( widgetProps.svg ) }`
+		: null;
+	const selectedImageStyle: CSSProperties | undefined = svgSource
+		? {
+				WebkitMaskImage: `url("${ svgSource }")`,
+				maskImage: `url("${ svgSource }")`,
+		  }
+		: undefined;
+
 	return (
 		<div
 			className={ styles.drawing }
 			data-studio-desk-widget={ DRAWING_WIDGET_TYPE }
 			data-studio-desk-widget-id={ id }
 		>
-			{ widgetProps.svg && (
-				<img
-					alt=""
-					className={ styles.image }
-					draggable={ false }
-					src={ `data:image/svg+xml;charset=utf-8,${ encodeURIComponent( widgetProps.svg ) }` }
-				/>
+			{ svgSource && (
+				<>
+					<img alt="" className={ styles.image } draggable={ false } src={ svgSource } />
+					{ isSelected && (
+						<div
+							aria-hidden="true"
+							className={ styles.selectedImage }
+							style={ {
+								...selectedImageStyle,
+								backgroundColor: SELECTED_DRAWING_COLOR,
+							} }
+						/>
+					) }
+				</>
 			) }
 		</div>
 	);

--- a/apps/ui/src/ui-desks/widgets/drawing/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/drawing/definition.ts
@@ -19,10 +19,6 @@ export const drawingWidgetDefinition = {
 	icon: verse,
 	isCreatable: false,
 	getSummary: () => __( 'Freehand drawing' ),
-	getIndicator: () => ( {
-		cornerRadius: 12,
-		stroke: '#6b7280',
-	} ),
 	getInitialWidget: () => ( {
 		shapeProps: {
 			w: 320,

--- a/apps/ui/src/ui-desks/widgets/drawing/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/drawing/style.module.css
@@ -1,5 +1,6 @@
 .drawing {
 	box-sizing: border-box;
+	position: relative;
 	width: 100%;
 	height: 100%;
 	overflow: hidden;
@@ -13,4 +14,19 @@
 	object-fit: contain;
 	pointer-events: none;
 	user-select: none;
+}
+
+.selectedImage {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	pointer-events: none;
+	user-select: none;
+	mask-position: center;
+	mask-repeat: no-repeat;
+	mask-size: contain;
+	-webkit-mask-position: center;
+	-webkit-mask-repeat: no-repeat;
+	-webkit-mask-size: contain;
 }


### PR DESCRIPTION
## Summary
- Hide tldraw’s default selection outline and handle glyphs in desks mode so shape indicators can serve as the visible selection treatment.
- Remove the drawing widget’s rectangle-style indicator and render the selected drawing as a colorized overlay of the SVG path itself.
- Keep the existing indicator stroke behavior for other widgets, with a slightly stronger stroke when selected.

## Testing
- `npx eslint --fix` on the touched UI files
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-desks`