### PR TITLE
apps/ui: Polish desk context menu status rows

### DIFF
--- a/apps/ui/src/ui-desks/desk/context-menu.module.css
+++ b/apps/ui/src/ui-desks/desk/context-menu.module.css
@@ -116,18 +116,47 @@
 }
 
 .postPickerItem {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 8px;
 	padding-right: 12px;
 }
 
+.postPickerContent {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	gap: 2px;
+	overflow: visible;
+	white-space: normal;
+}
+
+.postPickerTitle,
+.postPickerMeta {
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .postPickerTitle {
-	flex: 1 1 auto;
+	font-size: 13px;
+	line-height: 18px;
+	color: var(--ui-desks-text, #14171a);
 }
 
 .postPickerMeta {
-	flex: 0 0 auto;
-	margin-left: auto;
 	color: var(--ui-desks-text-muted, rgba(15, 23, 42, 0.56));
 	font-size: 12px;
+	line-height: 16px;
+}
+
+.postPickerStatusDot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	box-shadow: 0 0 0 2px var(--ui-desks-material, #fff);
 }
 
 @keyframes context-menu-rise {

--- a/apps/ui/src/ui-desks/desk/context-menu.tsx
+++ b/apps/ui/src/ui-desks/desk/context-menu.tsx
@@ -30,6 +30,7 @@ import { pageWidgetDefinition } from '@/ui-desks/widgets/page/definition';
 import { PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
 import { postWidgetDefinition } from '@/ui-desks/widgets/post/definition';
 import { POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
+import { CONTENT_CARD_STATUSES, getPostStatusInfo } from '@/ui-desks/widgets/post-status';
 import { getCreatableWidgetDefinitions, getWidgetDefinition } from '@/ui-desks/widgets/registry';
 import styles from './context-menu.module.css';
 import { useDesk } from './provider';
@@ -515,7 +516,8 @@ function ExistingContentPickerMenuItems( {
 	const query = useMemo(
 		() => ( {
 			per_page: 20,
-			context: 'view',
+			context: 'edit',
+			status: CONTENT_CARD_STATUSES,
 			orderby: type === 'page' ? 'menu_order' : 'date',
 			order: type === 'page' ? 'asc' : 'desc',
 			_fields: 'id,title,excerpt,status,date,link,slug',
@@ -558,6 +560,7 @@ function ExistingContentPickerMenuItems( {
 			) }
 			{ records?.map( ( record ) => {
 				const title = decodeEntities( record.title?.rendered ?? '' ).trim() || __( 'Untitled' );
+				const statusInfo = getPostStatusInfo( record.status );
 				return (
 					<ContextMenuItem
 						key={ record.id }
@@ -565,8 +568,20 @@ function ExistingContentPickerMenuItems( {
 						disabled={ ! canAddWidgets }
 						onClick={ () => onSelect( record.id ) }
 					>
-						<span className={ styles.postPickerTitle }>{ title }</span>
-						{ record.status && <span className={ styles.postPickerMeta }>{ record.status }</span> }
+						<span className={ styles.postPickerContent }>
+							<span className={ styles.postPickerTitle }>{ title }</span>
+							{ record.status && (
+								<span className={ styles.postPickerMeta }>{ statusInfo.label }</span>
+							) }
+						</span>
+						{ record.status && (
+							<span
+								className={ styles.postPickerStatusDot }
+								style={ { background: statusInfo.color } }
+								title={ statusInfo.label }
+								aria-label={ statusInfo.label }
+							/>
+						) }
 					</ContextMenuItem>
 				);
 			} ) }


### PR DESCRIPTION
## Related issues

- None

## How AI was used in this PR

Codex compared the desks-ui context-menu picker with the existing create-menu implementation, applied the small parity fix, and ran the checks listed below.

## Proposed Changes

- Use the shared post status metadata in the desk context-menu existing post/page picker.
- Show localized status labels and colored status dots instead of raw status text.
- Query the same content statuses as the create menu so drafts, pending, scheduled, and private content are represented consistently.

## Testing Instructions

- Open a desk for a running site.
- Right-click the canvas and choose Insert > Post or Insert > Page.
- Confirm each picker row shows the title, localized status label, and matching colored status dot.

Validated with:

- npx eslint --fix apps/ui/src/ui-desks/desk/context-menu.tsx apps/ui/src/ui-desks/desk/context-menu.module.css
- npm test -- apps/ui/src/ui-desks/desk/context-menu.test.ts apps/ui/src/ui-desks/widgets/post-status.test.ts
- npm run typecheck
- git diff --check

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?