### PR TITLE
Revert "Distribute Linux dev builds to AppsCDN" (#3363)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -240,7 +240,6 @@ steps:
       buildkite-agent artifact download "*.appx" .
       buildkite-agent artifact download "*.nupkg" .
       buildkite-agent artifact download "*\\RELEASES" .
-      buildkite-agent artifact download "*.deb" .
 
       .buildkite/commands/install-node-dependencies.sh
 
@@ -257,7 +256,6 @@ steps:
     depends_on:
       - step: dev-mac
       - step: dev-windows
-      - step: dev-linux
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     if: build.branch == 'trunk' && build.tag !~ /^v[0-9]+/
     notify:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -451,20 +451,6 @@ def get_windows_update_release_sha(arch: 'x64')
   sha1
 end
 
-# `electron-installer-debian` writes one .deb per arch directory with the
-# version embedded in the filename (e.g. `studio_1.8.2~dev16_amd64.deb`), so
-# resolve it via glob rather than reconstructing the filename. The glob
-# matches the trailing `_<deb_arch>.deb` specifically — `create_versioned_file`
-# writes a sidecar copy alongside the original ending in `-<arch>-v<version>.deb`,
-# which this glob skips so retries don't see two `.deb` files.
-def linux_deb_path(arch:)
-  deb_arch = arch == 'x64' ? 'amd64' : arch
-  dir = File.join(BUILDS_FOLDER, 'make', 'deb', arch)
-  matches = Dir.glob(File.join(dir, "studio_*_#{deb_arch}.deb"))
-  UI.user_error!("Expected exactly 1 Linux #{arch} .deb in #{dir}, found #{matches.length}: #{matches.join(', ')}") unless matches.length == 1
-  matches.first
-end
-
 def distribute_builds(
   commit_hash: last_git_commit[:abbreviated_commit_hash],
   build_number: get_required_env('BUILDKITE_BUILD_NUMBER'),
@@ -515,29 +501,6 @@ def distribute_builds(
       sha: get_windows_update_release_sha(arch: 'arm64')
     }
   }
-
-  # Linux is dev-only for now — the release pipeline produces only Mac/Windows
-  # artifacts. On Linux the .deb is the only artifact (it serves as both the
-  # update payload and the full installer); `install_type: 'Update'` matches
-  # the URL convention the WPCOM updates endpoint emits for the polling path.
-  if release_tag.nil?
-    update_builds[:linux_x64_deb] = {
-      binary_path: linux_deb_path(arch: 'x64'),
-      name: 'Linux - x64 (DEB)',
-      platform: 'Linux - x64',
-      arch: 'x64',
-      install_type: 'Update',
-      sha: commit_hash
-    }
-    update_builds[:linux_arm64_deb] = {
-      binary_path: linux_deb_path(arch: 'arm64'),
-      name: 'Linux - ARM64 (DEB)',
-      platform: 'Linux - ARM64',
-      arch: 'arm64',
-      install_type: 'Update',
-      sha: commit_hash
-    }
-  end
 
   full_install_builds = {
     x64_dmg: {


### PR DESCRIPTION
## Related issues

Reverts #3363. Restoring this once the upstream fix lands in the [`wordpress-mobile/release-toolkit`](https://github.com/wordpress-mobile/release-toolkit) plugin.

## How AI was used in this PR

AI-assisted: diagnosed the post-merge failure from the Buildkite log, identified the gap in the fastlane plugin's platform allowlist, and drafted this revert. Author reviewed.

## Why we're reverting

After #3363 merged, the next trunk build's `Distribute Dev Builds` step ([Buildkite #16073](https://buildkite.com/automattic/studio/builds/16073)) failed with:

```
Error setting value 'Linux - x64' for option 'platform'
You passed invalid parameters to 'upload_build_to_apps_cdn'.
Platform must be one of: Android, iOS, Mac - Silicon, Mac - Intel, Mac - Any,
Windows - x86, Windows - x64, Windows - ARM64,
Microsoft Store - x86, Microsoft Store - x64, Microsoft Store - ARM64
```

The `upload_build_to_apps_cdn` fastlane action (from the [`wordpress-mobile/release-toolkit`](https://github.com/wordpress-mobile/release-toolkit) gem, pinned at `~> 14.2`) has a **client-side** allowlist baked into its `VALID_PLATFORMS` constant (`lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb:31-43`). That list doesn't include `'Linux - x64'` or `'Linux - ARM64'`, so the action rejects our call before it ever reaches WPCOM.

The WPCOM-side allowlist updates (the enum + extension MIME types) are landed and correct — they handle the *server-side* validation. But the *client-side* validation in the fastlane plugin is a separate codebase that also needs to be updated. We missed that gap before merging.

Impact while #3363 was on trunk:
- Mac and Windows dev builds **did** upload to AppsCDN (they iterate first in the loop).
- Linux upload raised, terminating the loop before the `buildkite_annotate` summary fired.
- The `Distribute Dev Builds` step shows red despite Mac/Windows being in CDN — confusing for anyone watching trunk.
- Every subsequent trunk merge would hit the same failure, blocking the visible distribution annotation indefinitely.

Reverting restores the clean Mac/Windows distribution flow until the plugin gap is fixed upstream.

## Proposed Changes

Reverts the two-file change from #3363:
- `.buildkite/pipeline.yml`: drops `dev-linux` from `Distribute Dev Builds`'s `depends_on` and removes the `*.deb` artifact download.
- `fastlane/Fastfile`: removes the `linux_deb_path` helper, the `release_tag.nil?` block adding Linux entries to `update_builds`, and the related comment.

## Next steps after this lands

1. Open a PR against [`wordpress-mobile/release-toolkit`](https://github.com/wordpress-mobile/release-toolkit) adding `'Linux - x64'` and `'Linux - ARM64'` to `VALID_PLATFORMS` in `upload_build_to_apps_cdn.rb`. Precedent: their PR #672 added `'Microsoft Store - x64'` and `'Windows - x64'` to the same array.
2. Wait for the plugin's next gem release.
3. Bump the `Gemfile` to that version.
4. Re-apply #3363's changes (cherry-pick or fresh PR).
5. Re-verify on the next trunk distribute.

## Testing Instructions

1. Open the next trunk build after this merges.
2. Confirm `Distribute Dev Builds` step succeeds and the `buildkite_annotate` summary lists Mac and Windows (and only those) in the "🔗 Build available for ..." message.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Trunk's `Distribute Dev Builds` step succeeds again after this lands.