### PR TITLE
Improve Linux E2E diagnostics

### DIFF
--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -39,6 +39,7 @@ if [ "$PLATFORM" = "linux" ]; then
     libcairo2 \
     libxss1 \
     procps \
+    iproute2 \
     file
   npm ci --unsafe-perm --no-audit --no-progress --maxsockets 1
 else
@@ -177,7 +178,9 @@ if [ "$PLATFORM" = "linux" ]; then
     cd /workdir
     echo "STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES=${STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES:-0}"
     echo "STUDIO_PLAYGROUND_WORKERS=${STUDIO_PLAYGROUND_WORKERS:-auto}"
-    echo "SKIP_LINUX_E2E_NODE_SETCAP=${SKIP_LINUX_E2E_NODE_SETCAP:-0}"
+    echo "STUDIO_PLAYGROUND_VERBOSITY=${STUDIO_PLAYGROUND_VERBOSITY:-normal}"
+    echo "STUDIO_PLAYGROUND_DEBUG=${STUDIO_PLAYGROUND_DEBUG:-0}"
+    echo "STUDIO_INTERCEPT_PLAYGROUND_EXIT=${STUDIO_INTERCEPT_PLAYGROUND_EXIT:-0}"
     echo "Installing Playwright Chromium..."
     npx playwright install chromium
     echo "Running Playwright tests..."
@@ -198,15 +201,26 @@ if [ "$PLATFORM" = "linux" ]; then
       cat "$f" || true
     fi
   done
+  ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null || true
   ps -ef --forest 2>/dev/null | head -60 || true
   dmesg 2>/dev/null | tail -200 || true
 
-  if find /tmp -path '/tmp/studio-app-e2e-session-*/process-manager/logs/*.log' -print -quit | grep -q .; then
+  if [ "$test_exit" -ne 0 ]; then
+    echo '--- :memo: Process manager logs from failed Linux E2E'
+    find /tmp -path '/tmp/s-pm-*/logs/*.log' -exec sh -c '
+      for log_path do
+        echo "--- ${log_path} ---"
+        tail -400 "${log_path}" || true
+      done
+    ' sh {} + || true
+  fi
+
+  if find /tmp -path '/tmp/s-pm-*/logs/*.log' -print -quit | grep -q .; then
     echo '--- :file_folder: Copy process manager logs for artifact upload'
     mkdir -p /tmp/test-results/process-manager-logs
     (
       cd /tmp
-      find studio-app-e2e-session-*/process-manager/logs -type f -name '*.log' \
+      find s-pm-*/logs -type f -name '*.log' \
         -exec cp --parents {} /tmp/test-results/process-manager-logs/ \;
     ) || true
   fi

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -176,6 +176,7 @@ if [ "$PLATFORM" = "linux" ]; then
     set -euo pipefail
     cd /workdir
     echo "STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES=${STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES:-0}"
+    echo "STUDIO_PLAYGROUND_WORKERS=${STUDIO_PLAYGROUND_WORKERS:-auto}"
     echo "Installing Playwright Chromium..."
     npx playwright install chromium
     echo "Running Playwright tests..."

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -177,6 +177,7 @@ if [ "$PLATFORM" = "linux" ]; then
     cd /workdir
     echo "STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES=${STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES:-0}"
     echo "STUDIO_PLAYGROUND_WORKERS=${STUDIO_PLAYGROUND_WORKERS:-auto}"
+    echo "SKIP_LINUX_E2E_NODE_SETCAP=${SKIP_LINUX_E2E_NODE_SETCAP:-0}"
     echo "Installing Playwright Chromium..."
     npx playwright install chromium
     echo "Running Playwright tests..."

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -37,10 +37,31 @@ if [ "$PLATFORM" = "linux" ]; then
     libxrandr2 \
     libpango-1.0-0 \
     libcairo2 \
-    libxss1
+    libxss1 \
+    procps
   npm ci --unsafe-perm --no-audit --no-progress --maxsockets 1
 else
   bash .buildkite/commands/install-node-dependencies.sh
+fi
+
+if [ "$PLATFORM" = "linux" ]; then
+  echo '--- :mag: Linux container diagnostics'
+  uname -a
+  id
+  node --version
+  npm --version
+  df -h /dev/shm /tmp /workdir || true
+  for f in \
+    /sys/fs/cgroup/memory.max \
+    /sys/fs/cgroup/memory.current \
+    /sys/fs/cgroup/pids.max \
+    /sys/fs/cgroup/pids.current; do
+    if [ -f "$f" ]; then
+      echo "$f=$(cat "$f")"
+    fi
+  done
+  ulimit -a || true
+  free -h || true
 fi
 
 export IS_DEV_BUILD=true
@@ -91,11 +112,14 @@ if [ "$PLATFORM" = "linux" ]; then
   # doesn't run for `electron-forge package` output. Without this, custom-
   # domain HTTP/HTTPS tests fail to bind in the non-root test process.
   BUNDLED_NODE="apps/studio/out/Studio-linux-${ARCH}/resources/bin/node"
-  if [ -x "$BUNDLED_NODE" ]; then
+  if [ "${SKIP_LINUX_E2E_NODE_SETCAP:-0}" = "1" ]; then
+    echo '--- :shield: Skipping bundled node setcap for Linux E2E trial'
+  elif [ -x "$BUNDLED_NODE" ]; then
     echo '--- :shield: Grant cap_net_bind_service to bundled node'
     setcap 'cap_net_bind_service=+ep' "$BUNDLED_NODE" || \
       echo "warning: setcap failed on $BUNDLED_NODE; privileged-port tests may fail to bind." >&2
   fi
+  getcap "$BUNDLED_NODE" || true
 fi
 
 echo '--- :mag: Verify CLI build artifacts'
@@ -145,6 +169,7 @@ if [ "$PLATFORM" = "linux" ]; then
   su -s /bin/bash node -c '
     set -euo pipefail
     cd /workdir
+    echo "STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES=${STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES:-0}"
     echo "Installing Playwright Chromium..."
     npx playwright install chromium
     echo "Running Playwright tests..."
@@ -155,6 +180,13 @@ if [ "$PLATFORM" = "linux" ]; then
     xvfb-run -a -s "-screen 0 1920x1080x24" \
       npx playwright test --max-failures=1 --output=/tmp/test-results
   ' || test_exit=$?
+
+  if find /tmp -path '/tmp/studio-app-e2e-session-*/process-manager/logs/*.log' -print -quit | grep -q .; then
+    echo '--- :file_folder: Copy process manager logs for artifact upload'
+    mkdir -p /tmp/test-results/process-manager-logs
+    find /tmp -path '/tmp/studio-app-e2e-session-*/process-manager/logs/*.log' \
+      -exec cp --parents {} /tmp/test-results/process-manager-logs/ \; || true
+  fi
 
   if [ -d /tmp/test-results ]; then
     echo '--- :file_folder: Copy test results for artifact upload'

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -38,7 +38,8 @@ if [ "$PLATFORM" = "linux" ]; then
     libpango-1.0-0 \
     libcairo2 \
     libxss1 \
-    procps
+    procps \
+    file
   npm ci --unsafe-perm --no-audit --no-progress --maxsockets 1
 else
   bash .buildkite/commands/install-node-dependencies.sh
@@ -119,6 +120,11 @@ if [ "$PLATFORM" = "linux" ]; then
     setcap 'cap_net_bind_service=+ep' "$BUNDLED_NODE" || \
       echo "warning: setcap failed on $BUNDLED_NODE; privileged-port tests may fail to bind." >&2
   fi
+
+  echo '--- :mag: Bundled Node diagnostics'
+  file "$BUNDLED_NODE" || true
+  ldd "$BUNDLED_NODE" | head -20 || true
+  "$BUNDLED_NODE" --version || true
   getcap "$BUNDLED_NODE" || true
 fi
 
@@ -181,11 +187,26 @@ if [ "$PLATFORM" = "linux" ]; then
       npx playwright test --max-failures=1 --output=/tmp/test-results
   ' || test_exit=$?
 
+  echo '--- :mag: Linux post-test diagnostics'
+  for f in \
+    /sys/fs/cgroup/memory.events \
+    /sys/fs/cgroup/memory.peak; do
+    if [ -f "$f" ]; then
+      echo "$f:"
+      cat "$f" || true
+    fi
+  done
+  ps -ef --forest 2>/dev/null | head -60 || true
+  dmesg 2>/dev/null | tail -200 || true
+
   if find /tmp -path '/tmp/studio-app-e2e-session-*/process-manager/logs/*.log' -print -quit | grep -q .; then
     echo '--- :file_folder: Copy process manager logs for artifact upload'
     mkdir -p /tmp/test-results/process-manager-logs
-    find /tmp -path '/tmp/studio-app-e2e-session-*/process-manager/logs/*.log' \
-      -exec cp --parents {} /tmp/test-results/process-manager-logs/ \; || true
+    (
+      cd /tmp
+      find studio-app-e2e-session-*/process-manager/logs -type f -name '*.log' \
+        -exec cp --parents {} /tmp/test-results/process-manager-logs/ \;
+    ) || true
   fi
 
   if [ -d /tmp/test-results ]; then

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -110,6 +110,8 @@ steps:
       # TEMP(rsm-2593): trial toggle to isolate the Linux PHP-WASM child-process exit.
       # Keep setcap enabled for the first pass so this tests one variable at a time.
       STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES: "1"
+      # TEMP(rsm-2593): force the worker count above Playground's deadlock warning threshold.
+      STUDIO_PLAYGROUND_WORKERS: "6"
     # TEMP(rsm-2593): if: removed to force E2E on every push while iterating on Linux E2E setup. Revert before merge.
     notify:
       - github_commit_status:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -107,12 +107,12 @@ steps:
       - test-results/**/*error-context.md
     env:
       DEBUG: "pw:browser"
-      # TEMP(rsm-2593): trial toggles to isolate the Linux PHP-WASM child-process exit.
-      STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES: "1"
       # TEMP(rsm-2593): force the worker count above Playground's deadlock warning threshold.
       STUDIO_PLAYGROUND_WORKERS: "6"
-      # TEMP(rsm-2593): test whether setcap/AT_SECURE affects the packaged Node child.
-      SKIP_LINUX_E2E_NODE_SETCAP: "1"
+      # TEMP(rsm-2593): surface the swallowed Playground start-server failure in CI logs.
+      STUDIO_PLAYGROUND_VERBOSITY: "debug"
+      STUDIO_PLAYGROUND_DEBUG: "1"
+      STUDIO_INTERCEPT_PLAYGROUND_EXIT: "1"
     # TEMP(rsm-2593): if: removed to force E2E on every push while iterating on Linux E2E setup. Revert before merge.
     notify:
       - github_commit_status:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,7 @@ e2e_config: &e2e_config
   artifact_paths:
     - test-results/**/*.zip
     - test-results/**/*.png
+    - test-results/**/*.log
     - test-results/**/*error-context.md
   plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
   agents:
@@ -102,13 +103,17 @@ steps:
     artifact_paths:
       - test-results/**/*.zip
       - test-results/**/*.png
+      - test-results/**/*.log
       - test-results/**/*error-context.md
     env:
       DEBUG: "pw:browser"
+      # TEMP(rsm-2593): trial toggles to isolate the Linux PHP-WASM child-process exit.
+      SKIP_LINUX_E2E_NODE_SETCAP: "1"
+      STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES: "1"
     # TEMP(rsm-2593): if: removed to force E2E on every push while iterating on Linux E2E setup. Revert before merge.
     notify:
       - github_commit_status:
-          context: E2E Tests
+          context: E2E Tests / linux-x64
 
   - label: ":chart_with_upwards_trend: Performance Metrics"
     key: metrics

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -107,11 +107,12 @@ steps:
       - test-results/**/*error-context.md
     env:
       DEBUG: "pw:browser"
-      # TEMP(rsm-2593): trial toggle to isolate the Linux PHP-WASM child-process exit.
-      # Keep setcap enabled for the first pass so this tests one variable at a time.
+      # TEMP(rsm-2593): trial toggles to isolate the Linux PHP-WASM child-process exit.
       STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES: "1"
       # TEMP(rsm-2593): force the worker count above Playground's deadlock warning threshold.
       STUDIO_PLAYGROUND_WORKERS: "6"
+      # TEMP(rsm-2593): test whether setcap/AT_SECURE affects the packaged Node child.
+      SKIP_LINUX_E2E_NODE_SETCAP: "1"
     # TEMP(rsm-2593): if: removed to force E2E on every push while iterating on Linux E2E setup. Revert before merge.
     notify:
       - github_commit_status:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -107,8 +107,8 @@ steps:
       - test-results/**/*error-context.md
     env:
       DEBUG: "pw:browser"
-      # TEMP(rsm-2593): force the worker count above Playground's deadlock warning threshold.
-      STUDIO_PLAYGROUND_WORKERS: "6"
+      # TEMP(rsm-2593): test whether the Linux x64 Playground exit depends on worker pooling.
+      STUDIO_PLAYGROUND_WORKERS: "1"
       # TEMP(rsm-2593): surface the swallowed Playground start-server failure in CI logs.
       STUDIO_PLAYGROUND_VERBOSITY: "debug"
       STUDIO_PLAYGROUND_DEBUG: "1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -107,8 +107,8 @@ steps:
       - test-results/**/*error-context.md
     env:
       DEBUG: "pw:browser"
-      # TEMP(rsm-2593): trial toggles to isolate the Linux PHP-WASM child-process exit.
-      SKIP_LINUX_E2E_NODE_SETCAP: "1"
+      # TEMP(rsm-2593): trial toggle to isolate the Linux PHP-WASM child-process exit.
+      # Keep setcap enabled for the first pass so this tests one variable at a time.
       STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES: "1"
     # TEMP(rsm-2593): if: removed to force E2E on every push while iterating on Linux E2E setup. Revert before merge.
     notify:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -107,8 +107,8 @@ steps:
       - test-results/**/*error-context.md
     env:
       DEBUG: "pw:browser"
-      # TEMP(rsm-2593): test whether the Linux x64 Playground exit depends on worker pooling.
-      STUDIO_PLAYGROUND_WORKERS: "1"
+      # TEMP(rsm-2593): force the worker count above Playground's deadlock warning threshold.
+      STUDIO_PLAYGROUND_WORKERS: "6"
       # TEMP(rsm-2593): surface the swallowed Playground start-server failure in CI logs.
       STUDIO_PLAYGROUND_VERBOSITY: "debug"
       STUDIO_PLAYGROUND_DEBUG: "1"

--- a/apps/cli/lib/cli-args-sanitizer.ts
+++ b/apps/cli/lib/cli-args-sanitizer.ts
@@ -119,6 +119,7 @@ export function sanitizeRunCLIArgs( args: RunCLIArgs ): Record< string, unknown 
 		port: args.port,
 		debug: args.debug,
 		verbosity: args.verbosity,
+		workers: args.workers,
 		wordpressInstallMode: args.wordpressInstallMode,
 		skipSqliteSetup: args.skipSqliteSetup,
 		followSymlinks: args.followSymlinks,

--- a/apps/cli/lib/types/process-manager-ipc.ts
+++ b/apps/cli/lib/types/process-manager-ipc.ts
@@ -101,6 +101,8 @@ export const processEventSchema = z.object( {
 	// Tail of the child's stderr captured during this invocation. Only populated on `exit`
 	// events; undefined for any other event.
 	stderrTail: z.string().optional(),
+	exitCode: z.number().nullable().optional(),
+	signal: z.string().nullable().optional(),
 } );
 
 const daemonProcessEventSchema = z.object( {

--- a/apps/cli/lib/wordpress-server-manager.ts
+++ b/apps/cli/lib/wordpress-server-manager.ts
@@ -227,8 +227,28 @@ export async function startWordPressServer(
 	}
 }
 
-function buildChildExitedError( processName: string, stderrTail?: string ): Error {
-	let message = `Server child process "${ processName }" exited before becoming ready.`;
+function formatProcessExitDetails( exitCode?: number | null, signal?: string | null ): string {
+	const details = [];
+	if ( exitCode !== undefined && exitCode !== null ) {
+		details.push( `exit code ${ exitCode }` );
+	}
+	if ( signal ) {
+		details.push( `signal ${ signal }` );
+	}
+	return details.length ? ` (${ details.join( ', ' ) })` : '';
+}
+
+function buildChildExitedError(
+	processName: string,
+	context: string,
+	stderrTail?: string,
+	exitCode?: number | null,
+	signal?: string | null
+): Error {
+	let message = `Server child process "${ processName }" ${ context }${ formatProcessExitDetails(
+		exitCode,
+		signal
+	) }.`;
 	if ( stderrTail?.trim() ) {
 		message += `\n${ stderrTail.trimEnd() }`;
 	}
@@ -250,7 +270,7 @@ async function subscribeForReadyOrExit( processName: string ): Promise< {
 	const pendingReady: Array< DaemonBusEventMap[ 'process-message' ] > = [];
 	const pendingExits: Array< DaemonBusEventMap[ 'process-event' ] > = [];
 	let onReady: () => void = () => {};
-	let onExit: ( stderrTail?: string ) => void = () => {};
+	let onExit: ( event: DaemonBusEventMap[ 'process-event' ] ) => void = () => {};
 	let waiting = false;
 
 	const messageHandler = ( packet: DaemonBusEventMap[ 'process-message' ] ) => {
@@ -268,7 +288,7 @@ async function subscribeForReadyOrExit( processName: string ): Promise< {
 			return;
 		}
 		if ( waiting ) {
-			onExit( event.stderrTail );
+			onExit( event );
 		} else {
 			pendingExits.push( event );
 		}
@@ -292,14 +312,23 @@ async function subscribeForReadyOrExit( processName: string ): Promise< {
 			};
 
 			onReady = () => resolve();
-			onExit = ( stderrTail ) => reject( buildChildExitedError( processName, stderrTail ) );
+			onExit = ( event ) =>
+				reject(
+					buildChildExitedError(
+						processName,
+						'exited before becoming ready',
+						event.stderrTail,
+						event.exitCode,
+						event.signal
+					)
+				);
 
 			abortController.signal.addEventListener( 'abort', abortListener );
 
 			// Replay any events we buffered before pmId was known.
 			const bufferedExit = pendingExits.find( ( event ) => event.process.pm_id === pmId );
 			if ( bufferedExit ) {
-				onExit( bufferedExit.stderrTail );
+				onExit( bufferedExit );
 				return;
 			}
 			const bufferedReady = pendingReady.find( ( packet ) => packet.process.pm_id === pmId );
@@ -388,9 +417,21 @@ export async function sendMessage(
 		} );
 
 		processEventHandler = ( event ) => {
-			if ( event.process.name === processName && event.event === 'exit' ) {
+			if (
+				event.process.name === processName &&
+				event.process.pm_id === pmId &&
+				event.event === 'exit'
+			) {
 				exitRejectTimeoutId = setTimeout( () => {
-					reject( new Error( 'WordPress server process exited unexpectedly' ) );
+					reject(
+						buildChildExitedError(
+							processName,
+							`exited while handling message "${ message.topic }"`,
+							event.stderrTail,
+							event.exitCode,
+							event.signal
+						)
+					);
 				}, CHILD_EXIT_ERROR_GRACE_MS );
 			}
 		};

--- a/apps/cli/playground-server-child.ts
+++ b/apps/cli/playground-server-child.ts
@@ -117,6 +117,7 @@ console.warn = ( ...args: unknown[] ) => {
 
 const originalStdoutWrite = process.stdout.write.bind( process.stdout );
 const originalStderrWrite = process.stderr.write.bind( process.stderr );
+const maxCapturedPlaygroundOutputLength = 24_000;
 
 process.stdout.write = function ( ...args: Parameters< typeof originalStdoutWrite > ) {
 	process.send!( { topic: 'activity' } );
@@ -160,14 +161,50 @@ function logServerListeningDetails( server: RunCLIServer, args: RunCLIArgs, conf
 	);
 }
 
+function normalizeWrittenChunk( chunk: unknown ): string {
+	if ( typeof chunk === 'string' ) {
+		return chunk;
+	}
+
+	if ( Buffer.isBuffer( chunk ) ) {
+		return chunk.toString( 'utf8' );
+	}
+
+	return String( chunk ?? '' );
+}
+
+function appendCapturedOutput( output: string, chunk: unknown ): string {
+	const nextOutput = output + normalizeWrittenChunk( chunk );
+	return nextOutput.length > maxCapturedPlaygroundOutputLength
+		? nextOutput.slice( -maxCapturedPlaygroundOutputLength )
+		: nextOutput;
+}
+
+function formatCapturedOutput( label: string, output: string ): string {
+	const trimmedOutput = output.trim();
+	if ( ! trimmedOutput ) {
+		return '';
+	}
+
+	return `Captured ${ label } before process.exit:\n${ trimmedOutput }`;
+}
+
 class PlaygroundProcessExitError extends Error {
-	constructor( code: string | number | null | undefined, args: RunCLIArgs, exitStack?: string ) {
+	constructor(
+		code: string | number | null | undefined,
+		args: RunCLIArgs,
+		exitStack?: string,
+		capturedStdout?: string,
+		capturedStderr?: string
+	) {
 		super(
 			[
 				`Playground CLI called process.exit(${ String( code ?? 0 ) }) while running "${
 					args.command
 				}".`,
 				`Sanitized args: ${ JSON.stringify( sanitizeRunCLIArgs( args ) ) }`,
+				formatCapturedOutput( 'stdout', capturedStdout ?? '' ),
+				formatCapturedOutput( 'stderr', capturedStderr ?? '' ),
 				exitStack ? `process.exit call stack:\n${ exitStack }` : '',
 			]
 				.filter( Boolean )
@@ -183,17 +220,54 @@ async function runCliWithExitDiagnostics( args: RunCLIArgs ): Promise< RunCLISer
 	}
 
 	const originalProcessExit = process.exit;
+	const currentStdoutWrite = process.stdout.write.bind( process.stdout );
+	const currentStderrWrite = process.stderr.write.bind( process.stderr );
+	let capturedStdout = '';
+	let capturedStderr = '';
+
+	const onUncaughtExceptionMonitor = ( error: Error, origin: NodeJS.UncaughtExceptionOrigin ) => {
+		errorToConsole(
+			'[Playground] uncaughtExceptionMonitor:',
+			origin,
+			error.stack ?? error.message
+		);
+	};
+	const onUnhandledRejection = ( reason: unknown ) => {
+		errorToConsole(
+			'[Playground] unhandledRejection:',
+			reason instanceof Error ? reason.stack ?? reason.message : reason
+		);
+	};
+
+	process.stdout.write = function ( ...writeArgs: Parameters< typeof currentStdoutWrite > ) {
+		capturedStdout = appendCapturedOutput( capturedStdout, writeArgs[ 0 ] );
+		return currentStdoutWrite( ...writeArgs );
+	} as typeof process.stdout.write;
+
+	process.stderr.write = function ( ...writeArgs: Parameters< typeof currentStderrWrite > ) {
+		capturedStderr = appendCapturedOutput( capturedStderr, writeArgs[ 0 ] );
+		return currentStderrWrite( ...writeArgs );
+	} as typeof process.stderr.write;
+
 	process.exit = ( ( code?: string | number | null | undefined ) => {
 		throw new PlaygroundProcessExitError(
 			code,
 			args,
-			new Error( 'process.exit intercepted' ).stack
+			new Error( 'process.exit intercepted' ).stack,
+			capturedStdout,
+			capturedStderr
 		);
 	} ) as typeof process.exit;
+	process.on( 'uncaughtExceptionMonitor', onUncaughtExceptionMonitor );
+	process.on( 'unhandledRejection', onUnhandledRejection );
 
 	try {
 		return await runCLI( args );
 	} finally {
+		process.off( 'uncaughtExceptionMonitor', onUncaughtExceptionMonitor );
+		process.off( 'unhandledRejection', onUnhandledRejection );
+		process.stdout.write = currentStdoutWrite;
+		process.stderr.write = currentStderrWrite;
 		process.exit = originalProcessExit;
 	}
 }

--- a/apps/cli/playground-server-child.ts
+++ b/apps/cli/playground-server-child.ts
@@ -66,6 +66,30 @@ function getConfiguredPlaygroundWorkers(): RunCLIArgs[ 'workers' ] | undefined {
 	return undefined;
 }
 
+function getConfiguredPlaygroundVerbosity(): RunCLIArgs[ 'verbosity' ] | undefined {
+	const verbosity = process.env.STUDIO_PLAYGROUND_VERBOSITY;
+	if ( ! verbosity ) {
+		return undefined;
+	}
+
+	if ( verbosity === 'quiet' || verbosity === 'normal' || verbosity === 'debug' ) {
+		return verbosity;
+	}
+
+	console.warn(
+		`Ignoring STUDIO_PLAYGROUND_VERBOSITY=${ verbosity }; expected quiet, normal, or debug.`
+	);
+	return undefined;
+}
+
+function isPlaygroundDebugEnabled(): boolean {
+	return process.env.STUDIO_PLAYGROUND_DEBUG === '1';
+}
+
+function shouldInterceptPlaygroundExit(): boolean {
+	return process.env.STUDIO_INTERCEPT_PLAYGROUND_EXIT === '1';
+}
+
 // Intercept and prefix all console output from playground-cli
 const originalConsoleLog = console.log;
 const originalConsoleError = console.error;
@@ -110,6 +134,58 @@ function logToConsole( ...args: Parameters< typeof console.log > ) {
 
 function errorToConsole( ...args: Parameters< typeof console.error > ) {
 	originalConsoleError( `[Playground Server]`, ...args );
+}
+
+function formatServerAddress(
+	address: ReturnType< RunCLIServer[ 'server' ][ 'address' ] >
+): string {
+	if ( ! address ) {
+		return 'unavailable';
+	}
+
+	if ( typeof address === 'string' ) {
+		return address;
+	}
+
+	return `${ address.address }:${ address.port } (${ address.family })`;
+}
+
+function logServerListeningDetails( server: RunCLIServer, args: RunCLIArgs, config: ServerConfig ) {
+	logToConsole(
+		`Server listening for site ${ config.siteId }: serverUrl=${
+			server.serverUrl
+		}, address=${ formatServerAddress( server.server.address() ) }, configuredPort=${
+			config.port
+		}, siteUrl=${ args[ 'site-url' ] ?? 'default' }`
+	);
+}
+
+class PlaygroundProcessExitError extends Error {
+	constructor( code: string | number | null | undefined, args: RunCLIArgs ) {
+		super(
+			`Playground CLI called process.exit(${ String( code ?? 0 ) }) while running "${
+				args.command
+			}". Sanitized args: ${ JSON.stringify( sanitizeRunCLIArgs( args ) ) }`
+		);
+		this.name = 'PlaygroundProcessExitError';
+	}
+}
+
+async function runCliWithExitDiagnostics( args: RunCLIArgs ): Promise< RunCLIServer | void > {
+	if ( ! shouldInterceptPlaygroundExit() ) {
+		return runCLI( args );
+	}
+
+	const originalProcessExit = process.exit;
+	process.exit = ( ( code?: string | number | null | undefined ) => {
+		throw new PlaygroundProcessExitError( code, args );
+	} ) as typeof process.exit;
+
+	try {
+		return await runCLI( args );
+	} finally {
+		process.exit = originalProcessExit;
+	}
 }
 
 function escapePhpString( str: string ): string {
@@ -277,6 +353,7 @@ async function getBaseRunCLIArgs(
 	const enableDebugLog = config.enableDebugLog ?? false;
 	const enableDebugDisplay = config.enableDebugDisplay ?? false;
 	const configuredPlaygroundWorkers = getConfiguredPlaygroundWorkers();
+	const configuredPlaygroundVerbosity = getConfiguredPlaygroundVerbosity();
 
 	const defaultConstants: Record< string, boolean | string > = {
 		// Fallback for sites where DB_NAME was stripped from wp-config.php.
@@ -358,6 +435,8 @@ async function getBaseRunCLIArgs(
 		redis: IS_JSPI_AVAILABLE && arePlaygroundWasmServicesEnabled,
 		memcached: IS_JSPI_AVAILABLE && arePlaygroundWasmServicesEnabled,
 		...( configuredPlaygroundWorkers ? { workers: configuredPlaygroundWorkers } : {} ),
+		...( configuredPlaygroundVerbosity ? { verbosity: configuredPlaygroundVerbosity } : {} ),
+		...( isPlaygroundDebugEnabled() ? { debug: true } : {} ),
 	};
 
 	if ( config.wpVersion ) {
@@ -430,7 +509,12 @@ const startServer = wrapWithStartingPromise(
 			// entire child process. The daemon will restart it, but the
 			// error message is lost. Filed upstream:
 			// https://github.com/WordPress/wordpress-playground/issues/3520
-			server = await runCLI( args );
+			const cliServer = await runCliWithExitDiagnostics( args );
+			if ( ! cliServer ) {
+				throw new Error( 'Playground CLI server command returned without a server.' );
+			}
+			server = cliServer;
+			logServerListeningDetails( server, args, config );
 
 			stopSignal.throwIfAborted();
 
@@ -511,7 +595,7 @@ async function runBlueprint( config: ServerConfig, signal: AbortSignal ): Promis
 		signal.throwIfAborted();
 
 		const args = await getBaseRunCLIArgs( 'run-blueprint', config );
-		await runCLI( args );
+		await runCliWithExitDiagnostics( args );
 
 		signal.throwIfAborted();
 

--- a/apps/cli/playground-server-child.ts
+++ b/apps/cli/playground-server-child.ts
@@ -47,6 +47,9 @@ import {
 
 let server: RunCLIServer | null = null;
 let lastCliArgs: Record< string, unknown > | null = null;
+// Diagnostic kill switch for CI while investigating Linux x64 PHP-WASM child exits.
+const arePlaygroundWasmServicesEnabled =
+	process.env.STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES !== '1';
 
 // Intercept and prefix all console output from playground-cli
 const originalConsoleLog = console.log;
@@ -336,8 +339,8 @@ async function getBaseRunCLIArgs(
 		'site-url': config.absoluteUrl || `http://localhost:${ config.port }`,
 		blueprint: blueprintBundle,
 		wordpressInstallMode,
-		redis: IS_JSPI_AVAILABLE,
-		memcached: IS_JSPI_AVAILABLE,
+		redis: IS_JSPI_AVAILABLE && arePlaygroundWasmServicesEnabled,
+		memcached: IS_JSPI_AVAILABLE && arePlaygroundWasmServicesEnabled,
 	};
 
 	if ( config.wpVersion ) {

--- a/apps/cli/playground-server-child.ts
+++ b/apps/cli/playground-server-child.ts
@@ -161,11 +161,17 @@ function logServerListeningDetails( server: RunCLIServer, args: RunCLIArgs, conf
 }
 
 class PlaygroundProcessExitError extends Error {
-	constructor( code: string | number | null | undefined, args: RunCLIArgs ) {
+	constructor( code: string | number | null | undefined, args: RunCLIArgs, exitStack?: string ) {
 		super(
-			`Playground CLI called process.exit(${ String( code ?? 0 ) }) while running "${
-				args.command
-			}". Sanitized args: ${ JSON.stringify( sanitizeRunCLIArgs( args ) ) }`
+			[
+				`Playground CLI called process.exit(${ String( code ?? 0 ) }) while running "${
+					args.command
+				}".`,
+				`Sanitized args: ${ JSON.stringify( sanitizeRunCLIArgs( args ) ) }`,
+				exitStack ? `process.exit call stack:\n${ exitStack }` : '',
+			]
+				.filter( Boolean )
+				.join( '\n' )
 		);
 		this.name = 'PlaygroundProcessExitError';
 	}
@@ -178,7 +184,11 @@ async function runCliWithExitDiagnostics( args: RunCLIArgs ): Promise< RunCLISer
 
 	const originalProcessExit = process.exit;
 	process.exit = ( ( code?: string | number | null | undefined ) => {
-		throw new PlaygroundProcessExitError( code, args );
+		throw new PlaygroundProcessExitError(
+			code,
+			args,
+			new Error( 'process.exit intercepted' ).stack
+		);
 	} ) as typeof process.exit;
 
 	try {

--- a/apps/cli/playground-server-child.ts
+++ b/apps/cli/playground-server-child.ts
@@ -161,6 +161,17 @@ function logServerListeningDetails( server: RunCLIServer, args: RunCLIArgs, conf
 	);
 }
 
+function blueprintContainsWpCliStep( config: ServerConfig ): boolean {
+	const steps = config.blueprint?.contents?.steps;
+	return (
+		Array.isArray( steps ) &&
+		steps.some(
+			( step ) =>
+				typeof step === 'object' && step !== null && 'step' in step && step.step === 'wp-cli'
+		)
+	);
+}
+
 function normalizeWrittenChunk( chunk: unknown ): string {
 	if ( typeof chunk === 'string' ) {
 		return chunk;
@@ -403,6 +414,7 @@ async function getBaseRunCLIArgs(
 	} );
 
 	if ( ! useExactMountLayout ) {
+		const shouldMountBundledWpCli = ! blueprintContainsWpCliStep( config );
 		mountsBeforeInstall = [
 			...( config.mountsBeforeInstall ?? [
 				{
@@ -410,15 +422,25 @@ async function getBaseRunCLIArgs(
 					vfsPath: '/wordpress',
 				},
 			] ),
-			{
-				hostPath: getWpCliPharPath(),
-				vfsPath: '/tmp/wp-cli.phar',
-			},
+			...( shouldMountBundledWpCli
+				? [
+						{
+							hostPath: getWpCliPharPath(),
+							vfsPath: '/tmp/wp-cli.phar',
+						},
+				  ]
+				: [] ),
 			{
 				hostPath: getSqliteCommandPath(),
 				vfsPath: '/tmp/sqlite-command',
 			},
 		];
+
+		if ( ! shouldMountBundledWpCli ) {
+			logToConsole(
+				'Skipping bundled WP-CLI mount because Playground injects /tmp/wp-cli.phar for Blueprint wp-cli steps'
+			);
+		}
 	}
 
 	// Studio MU-plugins (auto-login, admin-api, etc.) must be mounted for

--- a/apps/cli/playground-server-child.ts
+++ b/apps/cli/playground-server-child.ts
@@ -51,6 +51,21 @@ let lastCliArgs: Record< string, unknown > | null = null;
 const arePlaygroundWasmServicesEnabled =
 	process.env.STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES !== '1';
 
+function getConfiguredPlaygroundWorkers(): RunCLIArgs[ 'workers' ] | undefined {
+	const workers = process.env.STUDIO_PLAYGROUND_WORKERS;
+	if ( ! workers ) {
+		return undefined;
+	}
+
+	const parsedWorkers = Number( workers );
+	if ( Number.isInteger( parsedWorkers ) && parsedWorkers > 0 ) {
+		return parsedWorkers;
+	}
+
+	console.warn( `Ignoring STUDIO_PLAYGROUND_WORKERS=${ workers }; expected a positive integer.` );
+	return undefined;
+}
+
 // Intercept and prefix all console output from playground-cli
 const originalConsoleLog = console.log;
 const originalConsoleError = console.error;
@@ -261,6 +276,7 @@ async function getBaseRunCLIArgs(
 
 	const enableDebugLog = config.enableDebugLog ?? false;
 	const enableDebugDisplay = config.enableDebugDisplay ?? false;
+	const configuredPlaygroundWorkers = getConfiguredPlaygroundWorkers();
 
 	const defaultConstants: Record< string, boolean | string > = {
 		// Fallback for sites where DB_NAME was stripped from wp-config.php.
@@ -341,6 +357,7 @@ async function getBaseRunCLIArgs(
 		wordpressInstallMode,
 		redis: IS_JSPI_AVAILABLE && arePlaygroundWasmServicesEnabled,
 		memcached: IS_JSPI_AVAILABLE && arePlaygroundWasmServicesEnabled,
+		...( configuredPlaygroundWorkers ? { workers: configuredPlaygroundWorkers } : {} ),
 	};
 
 	if ( config.wpVersion ) {

--- a/apps/cli/process-manager-daemon.ts
+++ b/apps/cli/process-manager-daemon.ts
@@ -162,7 +162,7 @@ export class ProcessManagerDaemon {
 				};
 			}
 			case 'stop-process':
-				await this.stopProcess( request.processName );
+				await this.stopProcess( request.processName, 'stop-process request' );
 				return {
 					type: 'result',
 					payload: {},
@@ -290,7 +290,10 @@ export class ProcessManagerDaemon {
 		return this.toProcessDescription( managedProcess );
 	}
 
-	private async stopProcess( processName: string ): Promise< void > {
+	private async stopProcess(
+		processName: string,
+		reason = 'stop-process request'
+	): Promise< void > {
 		const managedProcess = this.getManagedProcessByName( processName );
 
 		if ( ! managedProcess || managedProcess.settled ) {
@@ -299,7 +302,11 @@ export class ProcessManagerDaemon {
 
 		await new Promise< void >( ( resolve ) => {
 			const timeoutId = setTimeout( () => {
-				void this.signalProcessGroup( managedProcess, 'SIGKILL' );
+				void this.signalProcessGroup(
+					managedProcess,
+					'SIGKILL',
+					`${ reason }; stop timeout after ${ STOP_TIMEOUT_MS }ms`
+				);
 			}, STOP_TIMEOUT_MS );
 
 			managedProcess.child.once( 'exit', () => {
@@ -314,7 +321,7 @@ export class ProcessManagerDaemon {
 				resolve();
 			} );
 
-			void this.signalProcessGroup( managedProcess, 'SIGTERM' );
+			void this.signalProcessGroup( managedProcess, 'SIGTERM', reason );
 		} );
 	}
 
@@ -429,18 +436,21 @@ export class ProcessManagerDaemon {
 			if ( managedProcess.settled ) {
 				continue;
 			}
-			await this.signalProcessGroup( managedProcess, 'SIGKILL' );
+			await this.signalProcessGroup( managedProcess, 'SIGKILL', 'process manager exit cleanup' );
 		}
 	}
 
 	private async signalProcessGroup(
 		managedProcess: ManagedProcess,
-		signal: NodeJS.Signals
+		signal: NodeJS.Signals,
+		reason: string
 	): Promise< void > {
 		const pid = managedProcess.child.pid;
 		if ( ! pid ) {
 			return;
 		}
+
+		this.logProcessSignal( managedProcess, signal, reason );
 
 		if ( process.platform === 'win32' ) {
 			if ( signal === 'SIGKILL' ) {
@@ -490,6 +500,27 @@ export class ProcessManagerDaemon {
 		}
 	}
 
+	private logProcessSignal(
+		managedProcess: ManagedProcess,
+		signal: NodeJS.Signals,
+		reason: string
+	): void {
+		const stack = new Error().stack?.split( '\n' ).slice( 2 ).join( '\n' );
+		const message = [
+			`[process-manager] Sending ${ signal } to "${ managedProcess.name }" (pmId=${
+				managedProcess.pmId
+			}, pid=${ managedProcess.child.pid ?? 'unknown' }). Reason: ${ reason }.`,
+			stack ? `Signal source stack:\n${ stack }` : undefined,
+		]
+			.filter( Boolean )
+			.join( '\n' );
+
+		writeTimestampedLines( managedProcess.stderrStream, message );
+		for ( const line of message.split( '\n' ) ) {
+			this.recordStderrLine( managedProcess, line );
+		}
+	}
+
 	private async shutdown( reason?: string ): Promise< void > {
 		await this.beginShutdownByKillingChildren( reason );
 		await this.finalizeShutdownByClosingSocketServersAndExiting();
@@ -499,7 +530,7 @@ export class ProcessManagerDaemon {
 		const stopAllChildren = async (): Promise< void > => {
 			await Promise.allSettled(
 				Array.from( this.managedProcesses.values() ).map( ( managedProcess ) =>
-					this.stopProcess( managedProcess.name )
+					this.stopProcess( managedProcess.name, `daemon shutdown (${ reason ?? 'unknown' })` )
 				)
 			);
 

--- a/apps/cli/process-manager-daemon.ts
+++ b/apps/cli/process-manager-daemon.ts
@@ -51,6 +51,10 @@ type ManagedProcessStopped = ManagedProcessBase & {
 	status: 'stopped';
 };
 type ManagedProcess = ManagedProcessRunning | ManagedProcessStopped;
+type ProcessExitDetails = {
+	exitCode?: number | null;
+	signal?: NodeJS.Signals | null;
+};
 
 function formatLogDateTag( date: Date ): string {
 	const year = date.getFullYear();
@@ -271,8 +275,8 @@ export class ProcessManagerDaemon {
 			void this.handleProcessExit( managedProcess );
 		} );
 
-		child.on( 'exit', () => {
-			void this.handleProcessExit( managedProcess );
+		child.on( 'exit', ( exitCode, signal ) => {
+			void this.handleProcessExit( managedProcess, { exitCode, signal } );
 		} );
 
 		await this.broadcastEvent( {
@@ -314,7 +318,10 @@ export class ProcessManagerDaemon {
 		} );
 	}
 
-	private async handleProcessExit( managedProcess: ManagedProcess ) {
+	private async handleProcessExit(
+		managedProcess: ManagedProcess,
+		exitDetails: ProcessExitDetails = {}
+	) {
 		if ( managedProcess.settled ) {
 			return;
 		}
@@ -333,6 +340,8 @@ export class ProcessManagerDaemon {
 				process: { name: managedProcess.name, pm_id: managedProcess.pmId },
 				event: 'exit',
 				...( stderrTail ? { stderrTail } : {} ),
+				...( exitDetails.exitCode !== undefined ? { exitCode: exitDetails.exitCode } : {} ),
+				...( exitDetails.signal !== undefined ? { signal: exitDetails.signal } : {} ),
 			},
 		} );
 	}

--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -199,7 +199,14 @@ export class E2ESession {
 
 		const processManagerLogs = await this.getProcessManagerLogs();
 		if ( processManagerLogs ) {
-			await this.attachLogFile( testInfo, 'process-manager.log', processManagerLogs );
+			const processManagerReport = [
+				`Process manager logs for failed test: ${ testInfo.title }`,
+				'',
+				processManagerLogs,
+			].join( '\n' );
+
+			console.error( processManagerReport );
+			await this.attachLogFile( testInfo, 'process-manager.log', processManagerReport );
 		}
 	}
 

--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -18,8 +18,11 @@ export class E2ESession {
 	homePath: string;
 	cliConfigPath: string;
 	sharedConfigPath: string;
+	processManagerHomePath: string;
 	private mainProcessLogs: string[] = [];
 	private readonly maxMainProcessLogChunks = 500;
+	private readonly maxProcessManagerLogFiles = 20;
+	private readonly maxProcessManagerLogLines = 200;
 	private stdoutListener?: ( chunk: Buffer | string ) => void;
 	private stderrListener?: ( chunk: Buffer | string ) => void;
 	private childProcess?: ChildProcess;
@@ -30,6 +33,7 @@ export class E2ESession {
 		this.homePath = path.join( this.sessionPath, 'home' );
 		this.cliConfigPath = path.join( this.sessionPath, 'cliConfig' );
 		this.sharedConfigPath = path.join( this.sessionPath, 'sharedConfig' );
+		this.processManagerHomePath = path.join( this.sessionPath, 'process-manager' );
 	}
 
 	async launch( testEnv: NodeJS.ProcessEnv = {} ) {
@@ -37,6 +41,7 @@ export class E2ESession {
 		await fs.mkdir( this.homePath, { recursive: true } );
 		await fs.mkdir( this.cliConfigPath, { recursive: true } );
 		await fs.mkdir( this.sharedConfigPath, { recursive: true } );
+		await fs.mkdir( this.processManagerHomePath, { recursive: true } );
 
 		// Pre-create appdata file with beta features enabled for CLI testing
 		// Path must include 'Studio' subfolder to match Electron app's path structure
@@ -135,9 +140,14 @@ export class E2ESession {
 		// elements that are technically present but never become "visible".
 		// SwiftShader is the deterministic software GL driver Chromium ships
 		// for exactly this case.
+		//
+		// --disable-dev-shm-usage avoids Docker's small default /dev/shm
+		// mount. The Linux Buildkite step is already headless, so using /tmp
+		// for Chromium shared memory is a better tradeoff than intermittent
+		// renderer or helper-process exits under load.
 		const linuxFlags =
 			appInfo.platform === 'linux'
-				? [ '--no-sandbox', '--disable-gpu', '--use-gl=swiftshader' ]
+				? [ '--no-sandbox', '--disable-gpu', '--use-gl=swiftshader', '--disable-dev-shm-usage' ]
 				: [];
 
 		this.electronApp = await electron.launch( {
@@ -151,6 +161,7 @@ export class E2ESession {
 				E2E_HOME_PATH: this.homePath,
 				E2E_CLI_CONFIG_PATH: this.cliConfigPath,
 				E2E_SHARED_CONFIG_PATH: this.sharedConfigPath,
+				STUDIO_PROCESS_MANAGER_HOME: this.processManagerHomePath,
 			},
 			timeout: 60_000,
 		} );
@@ -176,6 +187,14 @@ export class E2ESession {
 			body: Buffer.from( report, 'utf8' ),
 			contentType: 'text/plain',
 		} );
+
+		const processManagerLogs = await this.getProcessManagerLogs();
+		if ( processManagerLogs ) {
+			await testInfo.attach( 'process-manager.log', {
+				body: Buffer.from( processManagerLogs, 'utf8' ),
+				contentType: 'text/plain',
+			} );
+		}
 	}
 
 	private startCapturingMainProcessLogs() {
@@ -219,5 +238,35 @@ export class E2ESession {
 
 	private getMainProcessLogs() {
 		return this.mainProcessLogs.join( '' ).trim();
+	}
+
+	private async getProcessManagerLogs() {
+		const logsDir = path.join( this.processManagerHomePath, 'logs' );
+		try {
+			if ( ! ( await fs.pathExists( logsDir ) ) ) {
+				return '';
+			}
+
+			const logFiles = ( await fs.readdir( logsDir ) )
+				.filter( ( entry ) => entry.endsWith( '.log' ) )
+				.sort()
+				.slice( -this.maxProcessManagerLogFiles );
+
+			const reports = await Promise.all(
+				logFiles.map( async ( logFile ) => {
+					const logPath = path.join( logsDir, logFile );
+					const content = await fs.readFile( logPath, 'utf8' );
+					const lines = content
+						.split( '\n' )
+						.filter( ( line ) => line.trim() )
+						.slice( -this.maxProcessManagerLogLines );
+					return [ `--- ${ logFile } ---`, ...lines ].join( '\n' );
+				} )
+			);
+
+			return reports.join( '\n\n' ).trim();
+		} catch {
+			return '';
+		}
 	}
 }

--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -183,18 +183,21 @@ export class E2ESession {
 		);
 
 		console.error( report );
-		await testInfo.attach( 'main-process.log', {
-			body: Buffer.from( report, 'utf8' ),
-			contentType: 'text/plain',
-		} );
+		await this.attachLogFile( testInfo, 'main-process.log', report );
 
 		const processManagerLogs = await this.getProcessManagerLogs();
 		if ( processManagerLogs ) {
-			await testInfo.attach( 'process-manager.log', {
-				body: Buffer.from( processManagerLogs, 'utf8' ),
-				contentType: 'text/plain',
-			} );
+			await this.attachLogFile( testInfo, 'process-manager.log', processManagerLogs );
 		}
+	}
+
+	private async attachLogFile( testInfo: TestInfo, name: string, content: string ) {
+		const logPath = testInfo.outputPath( name );
+		await fs.outputFile( logPath, content, 'utf8' );
+		await testInfo.attach( name, {
+			path: logPath,
+			contentType: 'text/plain',
+		} );
 	}
 
 	private startCapturingMainProcessLogs() {

--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -28,12 +28,13 @@ export class E2ESession {
 	private childProcess?: ChildProcess;
 
 	public constructor() {
-		this.sessionPath = path.join( tmpdir(), `studio-app-e2e-session-${ randomUUID() }` );
+		const sessionId = randomUUID();
+		this.sessionPath = path.join( tmpdir(), `studio-app-e2e-session-${ sessionId }` );
 		this.appDataPath = path.join( this.sessionPath, 'appData' );
 		this.homePath = path.join( this.sessionPath, 'home' );
 		this.cliConfigPath = path.join( this.sessionPath, 'cliConfig' );
 		this.sharedConfigPath = path.join( this.sessionPath, 'sharedConfig' );
-		this.processManagerHomePath = path.join( this.sessionPath, 'process-manager' );
+		this.processManagerHomePath = path.join( tmpdir(), `s-pm-${ sessionId.slice( 0, 12 ) }` );
 	}
 
 	async launch( testEnv: NodeJS.ProcessEnv = {} ) {
@@ -99,11 +100,16 @@ export class E2ESession {
 
 	async cleanup() {
 		await this.closeApp();
+		await this.removePathWithRetries( this.sessionPath );
+		await this.removePathWithRetries( this.processManagerHomePath );
+	}
+
+	private async removePathWithRetries( targetPath: string ) {
 		// Retry on ENOTEMPTY: CLI child processes (e.g. copying skills to server-files) may still be
 		// writing to the session directory briefly after the Electron process exits.
 		for ( let attempt = 0; attempt < 5; attempt++ ) {
 			try {
-				await rimraf( this.sessionPath );
+				await rimraf( targetPath );
 				return;
 			} catch ( error ) {
 				if ( ! isErrnoException( error ) || error.code !== 'ENOTEMPTY' || attempt === 4 ) {
@@ -147,7 +153,13 @@ export class E2ESession {
 		// renderer or helper-process exits under load.
 		const linuxFlags =
 			appInfo.platform === 'linux'
-				? [ '--no-sandbox', '--disable-gpu', '--use-gl=swiftshader', '--disable-dev-shm-usage' ]
+				? [
+						'--no-sandbox',
+						'--disable-gpu',
+						'--use-gl=swiftshader',
+						'--disable-dev-shm-usage',
+						'--host-resolver-rules=MAP localhost 127.0.0.1',
+				  ]
 				: [];
 
 		this.electronApp = await electron.launch( {

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -584,7 +584,8 @@ export async function removeWordPressSkillFromAllSites(
 }
 
 const DEBUG_LOG_MAX_LINES = 50;
-const PROCESS_MANAGER_HOME = nodePath.join( os.homedir(), '.studio', 'daemon' );
+const PROCESS_MANAGER_HOME =
+	process.env.STUDIO_PROCESS_MANAGER_HOME ?? nodePath.join( os.homedir(), '.studio', 'daemon' );
 const DEFAULT_ENCODED_PASSWORD = encodePassword( 'password' );
 
 function readLastLines( filePath: string, maxLines: number ): string[] | undefined {
@@ -605,14 +606,34 @@ function readWordPressDebugLog( sitePath: string ): string[] | undefined {
 	return readLastLines( debugLogPath, DEBUG_LOG_MAX_LINES );
 }
 
+function findProcessManagerLogPath( logsDir: string, siteId: string, stream: 'out' | 'error' ) {
+	const legacyPath = nodePath.join( logsDir, `studio-site-${ siteId }-${ stream }.log` );
+	if ( fs.existsSync( legacyPath ) ) {
+		return legacyPath;
+	}
+
+	try {
+		const prefix = `studio-site-${ siteId }-${ stream }-`;
+		const matches = fs
+			.readdirSync( logsDir )
+			.filter( ( entry ) => entry.startsWith( prefix ) && entry.endsWith( '.log' ) )
+			.sort();
+
+		const latest = matches.at( -1 );
+		return latest ? nodePath.join( logsDir, latest ) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 function readProcessManagerLogs( siteId: string ): { stdout?: string[]; stderr?: string[] } {
 	const logsDir = nodePath.join( PROCESS_MANAGER_HOME, 'logs' );
-	const stdoutPath = nodePath.join( logsDir, `studio-site-${ siteId }-out.log` );
-	const stderrPath = nodePath.join( logsDir, `studio-site-${ siteId }-error.log` );
+	const stdoutPath = findProcessManagerLogPath( logsDir, siteId, 'out' );
+	const stderrPath = findProcessManagerLogPath( logsDir, siteId, 'error' );
 
 	return {
-		stdout: readLastLines( stdoutPath, DEBUG_LOG_MAX_LINES ),
-		stderr: readLastLines( stderrPath, DEBUG_LOG_MAX_LINES ),
+		stdout: stdoutPath ? readLastLines( stdoutPath, DEBUG_LOG_MAX_LINES ) : undefined,
+		stderr: stderrPath ? readLastLines( stderrPath, DEBUG_LOG_MAX_LINES ) : undefined,
 	};
 }
 


### PR DESCRIPTION
## Related issues

- Related to RSM-2593
- Stacked on #3421

## How AI was used in this PR

Codex helped investigate the Linux Buildkite failure and prepare this diagnostic stack. I reviewed the diff and ran the verification commands below. Claude feedback was also considered and incorporated into the CI diagnostics.

## Proposed Changes

- Include process-manager exit code, signal, and stderr tail in WordPress server child exit errors.
- Read dated process-manager log files when building app-side error context.
- Isolate E2E process-manager state per session with STUDIO_PROCESS_MANAGER_HOME and attach process-manager logs on failure.
- Add Linux container diagnostics, bundled Node diagnostics, post-test cgroup/OOM diagnostics, and .log artifact upload paths for E2E failures.
- For this CI trial, disable the Redis/memcached JSPI-backed Playground services via STUDIO_DISABLE_PLAYGROUND_WASM_SERVICES=1 while keeping setcap enabled, so this tests one variable first.
- Keep SKIP_LINUX_E2E_NODE_SETCAP supported in the script as a follow-up A/B knob, but do not enable it by default in this PR revision.
- Give Linux E2E its own GitHub commit status context so a failed Linux run is not masked by another E2E platform.

## Testing Instructions

- npx eslint --fix .buildkite/pipeline.yml apps/cli/lib/types/process-manager-ipc.ts apps/cli/lib/wordpress-server-manager.ts apps/cli/playground-server-child.ts apps/cli/process-manager-daemon.ts apps/studio/e2e/e2e-helpers.ts apps/studio/src/ipc-handlers.ts
  - Note: ESLint reports that .buildkite/pipeline.yml is ignored by config; TypeScript files lint cleanly.
- bash -n .buildkite/commands/run-e2e-tests.sh
- npm run typecheck
- npm test -- apps/cli/tests/daemon.test.ts apps/cli/lib/tests/daemon-client.test.ts
- Let Buildkite run the Linux E2E step and inspect process-manager logs/artifacts if it still fails.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
