### PR TITLE
apps/ui: Reduce desks button style overrides

### DIFF
--- a/apps/ui/src/ui-desks/chats/composer/index.tsx
+++ b/apps/ui/src/ui-desks/chats/composer/index.tsx
@@ -39,7 +39,7 @@ export function ComposerSkeleton() {
 							<span className={ clsx( styles.skeletonTool, styles.skeletonTextTool ) } />
 						</div>
 					</div>
-					<span className={ styles.sendButton } />
+					<span className={ clsx( styles.skeletonTool, styles.skeletonAction ) } />
 				</div>
 			</form>
 		</div>
@@ -268,7 +268,7 @@ export function Composer( {
 							>
 								<WidgetContextThumbnail widget={ widget } />
 								<Button
-									variant="quiet"
+									variant="filled"
 									size="xsmall"
 									className={ styles.removeAttachment }
 									icon={ closeSmall }
@@ -396,7 +396,8 @@ export function Composer( {
 						<div className={ styles.promptActions }>
 							{ busy ? (
 								<Button
-									variant="quiet"
+									tone="inverse"
+									variant="filled"
 									size="small"
 									className={ styles.stopButton }
 									label={ isInterrupting ? __( 'Stopping' ) : __( 'Stop' ) }
@@ -412,9 +413,9 @@ export function Composer( {
 							) : null }
 							<Button
 								type="submit"
-								variant="quiet"
+								tone="primary"
+								variant="filled"
 								size="small"
-								className={ styles.sendButton }
 								disabled={ ! canSend }
 								icon={ arrowUp }
 								label={ sendAriaLabel }

--- a/apps/ui/src/ui-desks/chats/composer/style.module.css
+++ b/apps/ui/src/ui-desks/chats/composer/style.module.css
@@ -43,22 +43,9 @@
 }
 
 .removeAttachment {
-	--button-background: rgba(255, 255, 255, 0.94);
-	--button-foreground: var(--ui-desks-muted, #6b7280);
-
 	position: absolute;
 	top: -8px;
 	right: -8px;
-	width: 22px;
-	height: 22px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	padding: 0;
-	border: 1px solid rgba(15, 23, 42, 0.1);
-	border-radius: 999px;
-	box-shadow: 0 3px 8px rgba(15, 23, 42, 0.12);
-	cursor: pointer;
 	opacity: 0;
 	transform: scale(0.92);
 	transition:
@@ -70,14 +57,6 @@
 .attachment:focus-within .removeAttachment {
 	opacity: 1;
 	transform: scale(1);
-}
-
-.removeAttachment:hover,
-.removeAttachment:focus-visible {
-	--button-background: rgba(255, 255, 255, 0.98);
-	--button-foreground: var(--ui-desks-text, #14171a);
-
-	border-color: rgba(15, 23, 42, 0.18);
 }
 
 .input {
@@ -157,6 +136,10 @@
 	width: 96px;
 }
 
+.skeletonAction {
+	width: 32px;
+}
+
 .iconTool {
 	width: 32px;
 	padding: 0;
@@ -173,7 +156,6 @@
 	max-width: 160px;
 }
 
-.sendButton,
 .stopButton {
 	width: 32px;
 	height: 32px;
@@ -190,42 +172,12 @@
 	transition: box-shadow 160ms ease, transform 160ms ease, opacity 140ms ease;
 }
 
-.sendButton {
-	--button-background: var(--ui-desks-focus, #3858e9);
-	--button-foreground: #fff;
-
-	box-shadow: 0 6px 18px rgba(56, 88, 233, 0.45);
-}
-
-.sendButton:hover:not(:disabled),
-.sendButton:focus-visible:not(:disabled) {
-	--button-background: var(--ui-desks-focus, #3858e9);
-
-	box-shadow: 0 8px 22px rgba(56, 88, 233, 0.55);
-	transform: translateY(-1px);
-}
-
-.sendButton:disabled {
-	cursor: default;
-	opacity: 0.42;
-	box-shadow: none;
-}
-
-.sendButton svg {
-	fill: #fff;
-}
-
 .stopButton {
-	--button-background: var(--ui-desks-text, #14171a);
-	--button-foreground: #fff;
-
 	box-shadow: 0 4px 14px rgba(15, 23, 42, 0.18);
 }
 
 .stopButton:hover,
 .stopButton:focus-visible {
-	--button-background: var(--ui-desks-text, #14171a);
-
 	box-shadow: 0 6px 18px rgba(15, 23, 42, 0.24);
 	transform: translateY(-1px);
 }

--- a/apps/ui/src/ui-desks/chats/queued-prompts/style.module.css
+++ b/apps/ui/src/ui-desks/chats/queued-prompts/style.module.css
@@ -32,35 +32,6 @@
 }
 
 .remove {
-	--button-background: transparent;
-	--button-foreground: var(--wpds-color-fg-content-neutral-weak);
-
-	appearance: none;
 	flex-shrink: 0;
-	width: 22px;
-	height: 22px;
 	margin: -2px -6px -2px 0;
-	border: 0;
-	border-radius: 50%;
-	padding: 0;
-	font: inherit;
-	font-size: 16px;
-	line-height: 1;
-	cursor: pointer;
-	opacity: 0.6;
-}
-
-.item:hover .remove,
-.remove:focus-visible {
-	opacity: 1;
-}
-
-.remove:hover,
-.remove:focus-visible {
-	--button-background: color-mix(
-		in srgb,
-		var(--wpds-color-fg-interactive-brand, #2563eb) 12%,
-		transparent
-	);
-	--button-foreground: var(--wpds-color-fg-content-neutral);
 }

--- a/apps/ui/src/ui-desks/chrome/settings-modal/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/settings-modal/index.tsx
@@ -52,7 +52,7 @@ export function DeskSettingsModal( { open, onOpenChange, onEditToolbar }: DeskSe
 				<Button
 					type="button"
 					label={ __( 'Edit toolbar' ) }
-					tone="primary"
+					tone="inverse"
 					variant="filled"
 					size="medium"
 					onClick={ () => {

--- a/apps/ui/src/ui-desks/components/button/index.tsx
+++ b/apps/ui/src/ui-desks/components/button/index.tsx
@@ -5,7 +5,7 @@ import styles from './style.module.css';
 import type { ComponentProps, ComponentPropsWithoutRef, ReactNode } from 'react';
 
 type ButtonVariant = 'chrome' | 'quiet' | 'filled';
-type ButtonTone = 'neutral' | 'primary';
+type ButtonTone = 'neutral' | 'primary' | 'inverse';
 type ButtonSize = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge';
 
 const ICON_SIZE_BY_BUTTON_SIZE: Record< ButtonSize, number > = {
@@ -50,7 +50,7 @@ export const Button = forwardRef< HTMLButtonElement, ButtonProps >( function But
 		styles.button,
 		styles[ variant ],
 		styles[ size ],
-		tone === 'primary' && styles.primary,
+		tone !== 'neutral' && styles[ tone ],
 		className
 	);
 	const resolvedTooltipSide = tooltipSide ?? ( variant === 'quiet' ? 'top' : 'bottom' );

--- a/apps/ui/src/ui-desks/components/button/style.module.css
+++ b/apps/ui/src/ui-desks/components/button/style.module.css
@@ -182,9 +182,20 @@
 	--button-foreground: #fff;
 }
 
+.filled.inverse,
+.chrome.inverse {
+	--button-background: var(--ui-desks-text, #14171a);
+	--button-foreground: #fff;
+}
+
 .filled.primary:hover:not(:disabled),
 .chrome.primary:hover:not(:disabled) {
 	--button-background: #2448e2;
+}
+
+.filled.inverse:hover:not(:disabled),
+.chrome.inverse:hover:not(:disabled) {
+	--button-background: #000;
 }
 
 .filled.primary[data-icon-only='true'] {

--- a/apps/ui/src/ui-desks/design-system.md
+++ b/apps/ui/src/ui-desks/design-system.md
@@ -27,7 +27,7 @@ Use variants by intent:
 - `quiet`: low-emphasis actions, icon-only utility actions, and controls that should visually recede until hovered or active.
 - `filled`: emphasized local actions, form actions, and primary dialog actions.
 
-Prefer `tone="primary"` when the action needs primary color treatment instead of overriding button colors locally.
+Prefer `tone` when the action needs a semantic color treatment instead of overriding button colors locally. Use `tone="primary"` for brand-colored primary actions and `tone="inverse"` for strong black/white actions.
 
 Local button classes are acceptable for layout constraints such as width, positioning, or contextual spacing. Avoid local classes that recreate button states, icon sizing, hover treatment, or disabled treatment. If the same visual override appears in multiple places, add a Button variant or a small shared wrapper instead.
 

--- a/apps/ui/src/ui-desks/desk/drawing-toolbar/index.tsx
+++ b/apps/ui/src/ui-desks/desk/drawing-toolbar/index.tsx
@@ -38,11 +38,11 @@ export function DeskDrawingToolbar() {
 				<Icon icon={ verse } size={ 20 } />
 			</span>
 			<Button
-				className={ styles.drawingDoneButton }
 				disabled={ isFinishing }
 				label={ __( 'Stop drawing' ) }
 				tooltipLabel={ false }
-				variant="quiet"
+				tone="inverse"
+				variant="filled"
 				size="medium"
 				onClick={ () => void handleFinishDrawing() }
 			>

--- a/apps/ui/src/ui-desks/desk/drawing-toolbar/style.module.css
+++ b/apps/ui/src/ui-desks/desk/drawing-toolbar/style.module.css
@@ -28,18 +28,3 @@
 	align-items: center;
 	color: var(--ui-desks-muted, #6b7280);
 }
-
-.drawingDoneButton {
-	width: auto;
-	min-width: 64px;
-	padding: 0 14px;
-	color: #fff;
-	font-size: 13px;
-	font-weight: 500;
-	--button-background: var(--ui-desks-text, #14171a);
-	--button-foreground: #fff;
-}
-
-.drawingDoneButton:hover:not(:disabled) {
-	--button-background: #000;
-}

--- a/apps/ui/src/ui-desks/desk/index.tsx
+++ b/apps/ui/src/ui-desks/desk/index.tsx
@@ -119,20 +119,18 @@ function DeskShell( {
 						<div className={ styles.toolbarEditActions }>
 							<Button
 								type="button"
-								className={ styles.toolbarEditButton }
 								label={ __( 'Done' ) }
-								variant="filled"
-								size="medium"
+								variant="chrome"
+								size="large"
 								onClick={ () => setEditingToolbar( false ) }
 							>
 								{ __( 'Done' ) }
 							</Button>
 							<Button
 								type="button"
-								className={ styles.toolbarEditButton }
 								label={ __( 'Reset' ) }
-								variant="filled"
-								size="medium"
+								variant="chrome"
+								size="large"
 								onClick={ () =>
 									updateDeskSettings( { toolbarLayout: DEFAULT_DESK_TOOLBAR_LAYOUT } )
 								}

--- a/apps/ui/src/ui-desks/desk/style.module.css
+++ b/apps/ui/src/ui-desks/desk/style.module.css
@@ -28,36 +28,6 @@
 	transform: translateX(-50%);
 }
 
-.toolbarEditButton {
-	--button-background: var(--ui-desks-material, #fff);
-
-	height: 40px;
-	padding: 0 16px;
-	justify-content: center;
-	border-radius: var(--ui-desks-radius-control, 16px);
-	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
-	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
-	box-shadow: var(
-		--ui-desks-shadow-control,
-		0 1px 2px rgba(15, 23, 42, 0.04),
-		0 8px 24px rgba(15, 23, 42, 0.06)
-	);
-	transition:
-		box-shadow 160ms ease,
-		transform 160ms ease;
-}
-
-.toolbarEditButton:hover {
-	--button-background: var(--ui-desks-material, #fff);
-
-	box-shadow: var(
-		--ui-desks-shadow-control-raised,
-		0 1px 2px rgba(15, 23, 42, 0.04),
-		0 18px 44px rgba(15, 23, 42, 0.1)
-	);
-	transform: translateY(-1px);
-}
-
 .siteMapLoadingWidget {
 	--loading-placeholder-text-color: #14171a;
 	--loading-placeholder-line-color: #e5e7eb;


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Codex helped audit the remaining desks button overrides and consolidate the low-risk styling into the shared `Button` component API. The touched files were reviewed locally and validation commands were run after the changes.

## Proposed Changes

- Add shared `tone="inverse"` support for black/white desks buttons.
- Move the settings `Edit toolbar`, drawing `Stop drawing`, and composer `Stop` buttons to shared `Button` styling.
- Move composer send to `tone="primary"` instead of local color overrides.
- Remove local visual CSS for composer send/remove, queued prompt remove, toolbar edit actions, and drawing toolbar actions where layout-only CSS is enough.
- Update `ui-desks/design-system.md` with guidance for `primary` and `inverse` button tone usage.

## Testing Instructions

- `npx eslint --fix apps/ui/src/ui-desks/chats/composer/index.tsx apps/ui/src/ui-desks/components/button/index.tsx apps/ui/src/ui-desks/desk/drawing-toolbar/index.tsx apps/ui/src/ui-desks/desk/index.tsx apps/ui/src/ui-desks/chrome/settings-modal/index.tsx`
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-desks`
- `git diff --check`

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
