### PR TITLE
Improve Studio artifact guidance and screenshot presentation

### DIFF
--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -1,3 +1,7 @@
+import {
+	getStudioPresentationRulesPrompt,
+	getStudioWidgetPromptManifest,
+} from '@studio/common/ai/studio-widgets';
 import { buildPluginRecommendationsSection } from './plugin-recommendations';
 
 interface RemoteSiteContext {
@@ -111,12 +115,24 @@ Use \`per_page\` and \`page\` for pagination. Use \`status\` to filter by publis
 }
 
 function buildLocalIntro( options: { chatArtifactsEnabled: boolean } ): string {
-	const artifactSection = options.chatArtifactsEnabled
+	const automaticArtifactSection = options.chatArtifactsEnabled
 		? `
 
 ## Visual artifacts
 
-Studio tools may show visual artifacts automatically when they create something the UI can render, such as a new site, page, or post. No extra action is needed: these artifacts come from successful tool results, not from a separate artifact tool.`
+Studio tools may show visual artifacts automatically when they create something the UI can render, such as a new site, page, or post. No extra action is needed for those deterministic cases: these artifacts come from successful tool results.
+
+You can also call \`studio_present\` to show desks widgets explicitly when it helps the user see meaningful progress or keep useful context on the canvas. Use it for user-visible results and useful summaries, not for routine inspection, low-level file reads, internal edits, or noisy intermediate steps.
+
+Presentation rules:
+${ getStudioPresentationRulesPrompt() }
+
+Available desks widget types:
+${ getStudioWidgetPromptManifest() }`
+		: '';
+	const studioPresentToolBullet = options.chatArtifactsEnabled
+		? `
+- studio_present: Show one or more Studio desks widgets as inline visual artifacts.`
 		: '';
 
 	return `${ AGENT_IDENTITY } You manage and modify local WordPress sites using your Studio tools and generate content for these sites.
@@ -179,7 +195,8 @@ One \`Write\` or \`Edit\` per turn (read-only \`site_info\`, \`site_list\`, \`wp
 - site_push: Push a local site to a WordPress.com site. Requires authentication (studio auth login). Specify the remote site URL or ID and sync options (all, sqls, uploads, plugins, themes, contents).
 - site_pull: Pull a WordPress.com site to a local site. Requires authentication. Specify the remote site URL or ID and sync options.
 - site_import: Import a backup file (.zip, .tar.gz, .sql, .wpress) into a local site.
-- site_export: Export a local site to a backup file. Supports full-site (.zip, .tar.gz) or database-only (.sql) exports.${ artifactSection }
+- site_export: Export a local site to a backup file. Supports full-site (.zip, .tar.gz) or database-only (.sql) exports.
+${ studioPresentToolBullet }${ automaticArtifactSection }
 
 ## General rules
 

--- a/apps/cli/ai/tests/screenshot-helpers.test.ts
+++ b/apps/cli/ai/tests/screenshot-helpers.test.ts
@@ -1,0 +1,22 @@
+import { readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { saveScreenshotPngToTempFile } from '../tools/screenshot-helpers';
+
+describe( 'screenshot helpers', () => {
+	it( 'saves screenshots to a temporary local file', async () => {
+		const buffer = Buffer.from( 'not-really-a-png' );
+		const result = await saveScreenshotPngToTempFile( buffer, { viewportType: 'desktop' } );
+
+		try {
+			expect( result.path.startsWith( os.tmpdir() ) ).toBe( true );
+			expect( result.fileUrl.startsWith( 'file://' ) ).toBe( true );
+			expect( result.name ).toBe( 'screenshot-desktop.png' );
+			expect( result.mimeType ).toBe( 'image/png' );
+			await expect( readFile( result.path ) ).resolves.toEqual( buffer );
+		} finally {
+			await rm( path.dirname( result.path ), { recursive: true, force: true } );
+		}
+	} );
+} );

--- a/apps/cli/ai/tests/system-prompt.test.ts
+++ b/apps/cli/ai/tests/system-prompt.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { buildSystemPrompt } from '../system-prompt';
+
+describe( 'buildSystemPrompt', () => {
+	it( 'includes Studio presentation rules when chat artifacts are enabled', () => {
+		const prompt = buildSystemPrompt( { chatArtifactsEnabled: true } );
+
+		expect( prompt ).toContain( '## Visual artifacts' );
+		expect( prompt ).toContain( '- post-lists:' );
+		expect( prompt ).toContain( 'one post-collection widget' );
+		expect( prompt ).toContain( '- site-code-scratchpad:' );
+		expect( prompt ).toContain( 'note widget as a scratchpad-style summary' );
+		expect( prompt ).toContain( 'Use sd-artefact for standalone rendered HTML drafts' );
+		expect( prompt ).toContain( '- saved-local-media:' );
+		expect( prompt ).toContain( 'For generated SVGs, write a complete .svg file' );
+		expect( prompt ).toContain( 'Do not present generated SVG code as a drawing widget' );
+		expect( prompt ).not.toContain( '- drawing:' );
+		expect( prompt ).toContain( '- screenshot-local-media:' );
+		expect( prompt ).toContain( 'present the actual captured PNG' );
+		expect( prompt ).toContain( 'Do not substitute a site-preview widget for a screenshot' );
+		expect( prompt ).toContain( 'site-preview is for live previews, not captured screenshots' );
+	} );
+
+	it( 'omits Studio presentation rules when chat artifacts are disabled', () => {
+		const prompt = buildSystemPrompt( { chatArtifactsEnabled: false } );
+
+		expect( prompt ).not.toContain( '## Visual artifacts' );
+		expect( prompt ).not.toContain( '- site-code-scratchpad:' );
+		expect( prompt ).not.toContain( '- saved-local-media:' );
+		expect( prompt ).not.toContain( '- screenshot-local-media:' );
+		expect( prompt ).not.toContain( 'studio_present' );
+	} );
+} );

--- a/apps/cli/ai/tests/system-prompt.test.ts
+++ b/apps/cli/ai/tests/system-prompt.test.ts
@@ -9,7 +9,11 @@ describe( 'buildSystemPrompt', () => {
 		expect( prompt ).toContain( '- post-lists:' );
 		expect( prompt ).toContain( 'one post-collection widget' );
 		expect( prompt ).toContain( '- site-code-scratchpad:' );
-		expect( prompt ).toContain( 'note widget as a scratchpad-style summary' );
+		expect( prompt ).toContain( 'after any successful Write or Edit' );
+		expect( prompt ).toContain( 'creates or changes HTML, CSS, block markup' );
+		expect( prompt ).toContain( 'JSX/TSX markup' );
+		expect( prompt ).toContain( 'call studio_present with exactly one note widget' );
+		expect( prompt ).toContain( 'sections/selectors touched' );
 		expect( prompt ).toContain( 'Use sd-artefact for standalone rendered HTML drafts' );
 		expect( prompt ).toContain( '- saved-local-media:' );
 		expect( prompt ).toContain( 'For generated SVGs, write a complete .svg file' );

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { vi } from 'vitest';
+import { getSharedBrowser } from 'cli/ai/browser-utils';
 import { emitEvent } from 'cli/ai/json-events';
 import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
 import {
@@ -147,15 +148,213 @@ describe( 'Studio AI MCP tools', () => {
 		);
 	} );
 
-	it( 'does not expose a generic artifact tool', () => {
+	it( 'exposes the explicit presentation tool when chat artifacts are enabled', () => {
 		const names = resolveStudioToolDefinitions().map( ( tool ) => tool.name );
 		expect( names ).not.toContain( 'show_artifact' );
+		expect( names ).not.toContain( 'studio_present' );
 		const namesWithArtifacts = resolveStudioToolDefinitions( {
 			emitChatArtifacts: true,
 		} ).map( ( tool ) => tool.name );
+		const studioPresent = resolveStudioToolDefinitions( {
+			emitChatArtifacts: true,
+		} ).find( ( tool ) => tool.name === 'studio_present' );
 		expect( namesWithArtifacts ).not.toContain( 'show_artifact' );
+		expect( namesWithArtifacts ).toContain( 'studio_present' );
 		expect( namesWithArtifacts ).toContain( 'site_create' );
 		expect( namesWithArtifacts ).toContain( 'wp_cli' );
+		expect( studioPresent?.description ).toContain( '- site-code-scratchpad:' );
+		expect( studioPresent?.description ).toContain( '- saved-local-media:' );
+		expect( studioPresent?.description ).toContain(
+			'For generated SVGs, write a complete .svg file'
+		);
+		expect( studioPresent?.description ).not.toContain( '- drawing:' );
+	} );
+
+	it( 'guides screenshots toward captured media widgets instead of site previews', () => {
+		const takeScreenshot = resolveStudioToolDefinitions( {
+			emitChatArtifacts: true,
+		} ).find( ( tool ) => tool.name === 'take_screenshot' );
+		const studioPresent = resolveStudioToolDefinitions( {
+			emitChatArtifacts: true,
+		} ).find( ( tool ) => tool.name === 'studio_present' );
+		expect( takeScreenshot?.description ).toContain( 'actual captured PNG' );
+		expect( takeScreenshot?.description ).toContain(
+			'Do not use a site-preview widget as a substitute for the screenshot'
+		);
+		expect( studioPresent?.description ).toContain(
+			'Do not substitute a site-preview widget for a screenshot'
+		);
+	} );
+
+	it( 'keeps take_screenshot output compact while returning a media payload', async () => {
+		const screenshotBuffer = Buffer.from( 'fake-png' );
+		const page = {
+			emulateMedia: vi.fn(),
+			goto: vi.fn(),
+			waitForLoadState: vi.fn().mockResolvedValue( undefined ),
+			evaluate: vi.fn(),
+			addStyleTag: vi.fn(),
+			screenshot: vi.fn().mockResolvedValue( screenshotBuffer ),
+			close: vi.fn(),
+		};
+		const browser = {
+			newPage: vi.fn().mockResolvedValue( page ),
+		};
+		vi.mocked( getSharedBrowser ).mockResolvedValue( browser as never );
+
+		const result = await getTool( 'take_screenshot' ).rawHandler( {
+			url: 'http://localhost:8903/story-time',
+		} as never );
+		const text = getTextContent( result );
+		expect( text ).toContain( 'Screenshot captured (desktop).' );
+		expect( text ).toContain( 'mediaWidgetPayload=' );
+		expect( text ).not.toContain( 'When this screenshot is useful to show the user' );
+		expect( text ).not.toContain( 'Path:' );
+		expect( text ).not.toContain( 'File URL:' );
+		expect( result.content[ 1 ] ).toEqual( {
+			type: 'image',
+			data: screenshotBuffer.toString( 'base64' ),
+			mimeType: 'image/png',
+		} );
+
+		const payload = JSON.parse( text!.split( 'mediaWidgetPayload=' )[ 1 ] ) as {
+			widgetProps: { source: { path: string } };
+		};
+		await rm( path.dirname( payload.widgetProps.source.path ), { recursive: true, force: true } );
+	} );
+
+	it( 'emits explicit Studio widget artifacts from studio_present', async () => {
+		const tool = resolveStudioToolDefinitions( {
+			emitChatArtifacts: true,
+		} ).find( ( definition ) => definition.name === 'studio_present' );
+		expect( tool ).toBeDefined();
+
+		const result = await executeTool( tool!, {
+			message: 'Showing the draft plan.',
+			widgets: [
+				{
+					type: 'note',
+					widgetProps: { text: 'Draft the homepage hero next.', tone: 'yellow' },
+				},
+			],
+		} );
+
+		expect( emitEvent ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				type: 'chat.artifact',
+				artifact: expect.objectContaining( {
+					widgets: [
+						{
+							type: 'note',
+							widgetProps: { text: 'Draft the homepage hero next.', tone: 'yellow' },
+						},
+					],
+				} ),
+			} )
+		);
+		expect( getTextContent( result ) ).toBe( 'Showing the draft plan.' );
+	} );
+
+	it( 'accepts local SVG media widget artifacts from studio_present', async () => {
+		const tool = resolveStudioToolDefinitions( {
+			emitChatArtifacts: true,
+		} ).find( ( definition ) => definition.name === 'studio_present' );
+		expect( tool ).toBeDefined();
+
+		const localMediaWidget = {
+			type: 'media',
+			widgetProps: {
+				url: 'file:///tmp/rb-logo.svg',
+				mediaKind: 'image',
+				alt: 'RB logo SVG',
+				mediaId: null,
+				source: {
+					type: 'local',
+					path: '/tmp/rb-logo.svg',
+					name: 'rb-logo.svg',
+					mimeType: 'image/svg+xml',
+				},
+			},
+		};
+
+		await executeTool( tool!, {
+			widgets: [ localMediaWidget ],
+		} );
+
+		expect( emitEvent ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				type: 'chat.artifact',
+				artifact: expect.objectContaining( {
+					widgets: [ localMediaWidget ],
+				} ),
+			} )
+		);
+	} );
+
+	it( 'rejects drawing widget artifacts from studio_present', async () => {
+		const tool = resolveStudioToolDefinitions( {
+			emitChatArtifacts: true,
+		} ).find( ( definition ) => definition.name === 'studio_present' );
+		expect( tool ).toBeDefined();
+
+		await expect(
+			executeTool( tool!, {
+				widgets: [
+					{
+						type: 'drawing',
+						widgetProps: { svg: '<svg viewBox="0 0 100 100"></svg>' },
+					},
+				],
+			} )
+		).rejects.toThrow( 'Unsupported widget type "drawing"' );
+		expect( emitEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rejects invalid explicit Studio widget artifacts', async () => {
+		const tool = resolveStudioToolDefinitions( {
+			emitChatArtifacts: true,
+		} ).find( ( definition ) => definition.name === 'studio_present' );
+		expect( tool ).toBeDefined();
+
+		await expect(
+			executeTool( tool!, {
+				widgets: [
+					{
+						type: 'page',
+						widgetProps: { pageId: '123', tone: 'neutral' },
+					},
+				],
+			} )
+		).rejects.toThrow( 'Invalid widget at index 0' );
+		expect( emitEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rejects Studio widget artifacts with tiny shape props', async () => {
+		const tool = resolveStudioToolDefinitions( {
+			emitChatArtifacts: true,
+		} ).find( ( definition ) => definition.name === 'studio_present' );
+		expect( tool ).toBeDefined();
+
+		await expect(
+			executeTool( tool!, {
+				widgets: [
+					{
+						type: 'post-collection',
+						widgetProps: {
+							query: {
+								postType: 'post',
+								perPage: 5,
+								status: 'publish',
+								orderby: 'date',
+								order: 'desc',
+							},
+						},
+						shapeProps: { w: 1, h: 1 },
+					},
+				],
+			} )
+		).rejects.toThrow( 'shapeProps may only include numeric w and h between 80 and 3000' );
+		expect( emitEvent ).not.toHaveBeenCalled();
 	} );
 
 	describe( 'share_screenshot gating', () => {

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -174,15 +174,18 @@ describe( 'Studio AI MCP tools', () => {
 		expect( studioPresent?.description ).not.toContain( '- drawing:' );
 	} );
 
-	it( 'guides screenshots toward captured media widgets instead of site previews', () => {
+	it( 'keeps screenshot presentation guidance out of the screenshot tool description', () => {
 		const takeScreenshot = resolveStudioToolDefinitions( {
 			emitChatArtifacts: true,
 		} ).find( ( tool ) => tool.name === 'take_screenshot' );
 		const studioPresent = resolveStudioToolDefinitions( {
 			emitChatArtifacts: true,
 		} ).find( ( tool ) => tool.name === 'studio_present' );
-		expect( takeScreenshot?.description ).toContain( 'actual captured PNG' );
-		expect( takeScreenshot?.description ).toContain(
+		expect( takeScreenshot?.description ).toContain( 'ready-to-use media widget payload' );
+		expect( takeScreenshot?.description ).not.toContain(
+			'This does not automatically show the screenshot to the user'
+		);
+		expect( takeScreenshot?.description ).not.toContain(
 			'Do not use a site-preview widget as a substitute for the screenshot'
 		);
 		expect( studioPresent?.description ).toContain(

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -163,6 +163,10 @@ describe( 'Studio AI MCP tools', () => {
 		expect( namesWithArtifacts ).toContain( 'site_create' );
 		expect( namesWithArtifacts ).toContain( 'wp_cli' );
 		expect( studioPresent?.description ).toContain( '- site-code-scratchpad:' );
+		expect( studioPresent?.description ).toContain( 'after any successful Write or Edit' );
+		expect( studioPresent?.description ).toContain(
+			'call studio_present with exactly one note widget'
+		);
 		expect( studioPresent?.description ).toContain( '- saved-local-media:' );
 		expect( studioPresent?.description ).toContain(
 			'For generated SVGs, write a complete .svg file'

--- a/apps/cli/ai/tools/index.ts
+++ b/apps/cli/ai/tools/index.ts
@@ -19,6 +19,7 @@ import { shareScreenshotTool } from './share-screenshot';
 import { getSiteInfoTool } from './site-info';
 import { startSiteTool } from './start-site';
 import { stopSiteTool } from './stop-site';
+import { studioPresentTool } from './studio-present';
 import { takeScreenshotTool } from './take-screenshot';
 import { updatePreviewTool } from './update-preview';
 import { validateBlocksTool } from './validate-blocks';
@@ -73,7 +74,12 @@ export interface CreateStudioToolsOptions {
 export function resolveStudioToolDefinitions(
 	options: CreateStudioToolsOptions = {}
 ): AnyStudioAgentTool[] {
-	return studioToolDefinitions.flatMap( ( candidate ) => {
+	const definitions =
+		options.emitChatArtifacts === true
+			? [ ...studioToolDefinitions, studioPresentTool ]
+			: studioToolDefinitions;
+
+	return definitions.flatMap( ( candidate ) => {
 		if ( candidate.name === shareScreenshotTool.name && ! options.remoteSession ) {
 			return [];
 		}

--- a/apps/cli/ai/tools/screenshot-helpers.ts
+++ b/apps/cli/ai/tools/screenshot-helpers.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { getSharedBrowser } from 'cli/ai/browser-utils';
 
 /**
@@ -29,17 +33,16 @@ export const SHARE_VIEWPORTS = {
 export const SHARE_DEVICE_SCALE_FACTOR = 2;
 
 /**
- * Capture a PNG screenshot of `url` at the given viewport and return it as
- * a base64 string. Shared by both `take_screenshot` (full-page, intended for
- * the agent's own visual reasoning) and `share_screenshot` (configurable
- * fullPage + DPR, fire-and-forget delivery to the user via the remote
- * session bridge).
+ * Capture a PNG screenshot of `url` at the given viewport and return it as a
+ * Buffer. Shared by both `take_screenshot` and `share_screenshot`; callers
+ * decide whether to expose the image as base64, a temp local file, or an
+ * external media event.
  */
-export async function captureScreenshotPng(
+export async function captureScreenshotPngBuffer(
 	url: string,
 	viewport: { width: number; height: number },
 	options: { fullPage: boolean; deviceScaleFactor?: number }
-): Promise< string > {
+): Promise< Buffer > {
 	const browser = await getSharedBrowser();
 	const page = await browser.newPage( {
 		viewport,
@@ -103,8 +106,40 @@ export async function captureScreenshotPng(
 		} );
 
 		const buffer = await page.screenshot( { fullPage: options.fullPage, type: 'png' } );
-		return buffer.toString( 'base64' );
+		return Buffer.from( buffer );
 	} finally {
 		await page.close();
 	}
+}
+
+/**
+ * Capture a PNG screenshot of `url` at the given viewport and return it as
+ * a base64 string. Used by `share_screenshot`, where the remote-session
+ * media event carries image bytes directly.
+ */
+export async function captureScreenshotPng(
+	url: string,
+	viewport: { width: number; height: number },
+	options: { fullPage: boolean; deviceScaleFactor?: number }
+): Promise< string > {
+	const buffer = await captureScreenshotPngBuffer( url, viewport, options );
+	return buffer.toString( 'base64' );
+}
+
+export async function saveScreenshotPngToTempFile(
+	buffer: Buffer,
+	options: { viewportType: string }
+): Promise< { path: string; fileUrl: string; name: string; mimeType: 'image/png' } > {
+	const directory = await mkdtemp( path.join( os.tmpdir(), 'studio-screenshot-' ) );
+	const name = `screenshot-${ options.viewportType }.png`;
+	const filePath = path.join( directory, name );
+
+	await writeFile( filePath, buffer );
+
+	return {
+		path: filePath,
+		fileUrl: pathToFileURL( filePath ).href,
+		name,
+		mimeType: 'image/png',
+	};
 }

--- a/apps/cli/ai/tools/studio-present.ts
+++ b/apps/cli/ai/tools/studio-present.ts
@@ -1,0 +1,93 @@
+import {
+	getStudioPresentationRulesPrompt,
+	getStudioWidgetDraftValidationError,
+	getStudioWidgetPromptManifest,
+} from '@studio/common/ai/studio-widgets';
+import { Type } from 'typebox';
+import { defineTool } from './define-tool';
+import type { StudioChatArtifactWidgetDraft } from '@studio/common/ai/chat-artifacts';
+
+const MAX_WIDGETS_PER_PRESENTATION = 8;
+
+const description = `Shows Studio desk widgets as inline visual artifacts in the chat UI.
+Use this after a meaningful user-visible result, such as a created page, useful preview path, content summary, reference link, media item, or draft artefact.
+
+Presentation rules:
+${ getStudioPresentationRulesPrompt() }
+
+Available widget types:
+${ getStudioWidgetPromptManifest() }`;
+
+export const studioPresentTool = defineTool(
+	'studio_present',
+	description,
+	{
+		widgets: Type.Array(
+			Type.Object( {
+				type: Type.String( {
+					description: 'The Studio widget type to present.',
+				} ),
+				widgetProps: Type.Record( Type.String(), Type.Unknown(), {
+					description: 'Widget-specific props. Use the widget manifest in the tool description.',
+				} ),
+				shapeProps: Type.Optional(
+					Type.Record( Type.String(), Type.Unknown(), {
+						description: 'Optional widget dimensions. Only numeric w and h are supported.',
+					} )
+				),
+			} ),
+			{
+				description: 'One or more widgets to show in the chat artifact.',
+				minItems: 1,
+				maxItems: MAX_WIDGETS_PER_PRESENTATION,
+			}
+		),
+		message: Type.Optional(
+			Type.String( {
+				description: 'Optional concise summary of what is being presented.',
+			} )
+		),
+	},
+	async ( args ) => {
+		const widgets = validateWidgets( args.widgets );
+		return {
+			content: [
+				{
+					type: 'text' as const,
+					text:
+						args.message?.trim() ||
+						`Presented ${ widgets.length } Studio widget${ widgets.length === 1 ? '' : 's' }.`,
+				},
+			],
+			studioArtifacts: widgets,
+		};
+	}
+);
+
+function validateWidgets( widgets: unknown ): StudioChatArtifactWidgetDraft[] {
+	if ( ! Array.isArray( widgets ) ) {
+		throw new Error( 'widgets must be an array.' );
+	}
+
+	if ( widgets.length === 0 ) {
+		throw new Error( 'Pass at least one widget to present.' );
+	}
+
+	if ( widgets.length > MAX_WIDGETS_PER_PRESENTATION ) {
+		throw new Error( `Present at most ${ MAX_WIDGETS_PER_PRESENTATION } widgets at a time.` );
+	}
+
+	return widgets.map( ( widget, index ) => {
+		const validationError = getStudioWidgetDraftValidationError( widget );
+		if ( validationError ) {
+			throw new Error( `Invalid widget at index ${ index }: ${ validationError }` );
+		}
+
+		const draft = widget as StudioChatArtifactWidgetDraft;
+		return {
+			type: draft.type,
+			widgetProps: { ...draft.widgetProps },
+			...( draft.shapeProps ? { shapeProps: { ...draft.shapeProps } } : {} ),
+		};
+	} );
+}

--- a/apps/cli/ai/tools/take-screenshot.ts
+++ b/apps/cli/ai/tools/take-screenshot.ts
@@ -1,14 +1,19 @@
 import { Type } from 'typebox';
 import { emitProgress } from 'cli/logger';
 import { defineTool } from './define-tool';
-import { captureScreenshotPng, VIEWPORTS } from './screenshot-helpers';
+import {
+	captureScreenshotPngBuffer,
+	saveScreenshotPngToTempFile,
+	VIEWPORTS,
+} from './screenshot-helpers';
 
 export const takeScreenshotTool = defineTool(
 	'take_screenshot',
 	'Takes a full-page screenshot of a URL. Returns the screenshot as an image that you can analyze visually. ' +
+		'Also saves the screenshot as a temporary local PNG and returns a ready-to-use media widget payload. ' +
 		'Supports desktop and mobile viewports. Use this to verify the site looks correct after building it. ' +
-		'Note: this image is for your own visual reasoning only — the user does not see it. ' +
-		'Use `share_screenshot` instead when you want to deliver the rendered page to the user.',
+		'This does not automatically show the screenshot to the user. If the user asked to take, show, or capture a screenshot, call `studio_present` with the returned media widget payload so the user sees the actual captured PNG. Do not use a site-preview widget as a substitute for the screenshot. ' +
+		'Use `share_screenshot` instead only in remote sessions where you need to deliver the rendered page outside the Studio UI.',
 	{
 		url: Type.String( { description: 'The URL to screenshot' } ),
 		viewport: Type.Optional(
@@ -22,15 +27,38 @@ export const takeScreenshotTool = defineTool(
 		try {
 			const viewportType = args.viewport ?? 'desktop';
 			emitProgress( `Taking ${ viewportType } screenshot of ${ args.url }…` );
-			const base64 = await captureScreenshotPng( args.url, VIEWPORTS[ viewportType ], {
+			const buffer = await captureScreenshotPngBuffer( args.url, VIEWPORTS[ viewportType ], {
 				fullPage: true,
 			} );
+			const screenshotFile = await saveScreenshotPngToTempFile( buffer, { viewportType } );
+			const mediaWidgetPayload = {
+				type: 'media',
+				widgetProps: {
+					url: screenshotFile.fileUrl,
+					mediaKind: 'image',
+					alt: `Screenshot of ${ args.url } (${ viewportType })`,
+					mediaId: null,
+					source: {
+						type: 'local',
+						path: screenshotFile.path,
+						name: screenshotFile.name,
+						mimeType: screenshotFile.mimeType,
+					},
+				},
+			};
 			emitProgress( `Screenshot captured (${ viewportType })` );
 			return {
 				content: [
 					{
+						type: 'text' as const,
+						text: [
+							`Screenshot captured (${ viewportType }).`,
+							`mediaWidgetPayload=${ JSON.stringify( mediaWidgetPayload ) }`,
+						].join( '\n' ),
+					},
+					{
 						type: 'image' as const,
-						data: base64,
+						data: buffer.toString( 'base64' ),
 						mimeType: 'image/png',
 					},
 				],

--- a/apps/cli/ai/tools/take-screenshot.ts
+++ b/apps/cli/ai/tools/take-screenshot.ts
@@ -12,7 +12,6 @@ export const takeScreenshotTool = defineTool(
 	'Takes a full-page screenshot of a URL. Returns the screenshot as an image that you can analyze visually. ' +
 		'Also saves the screenshot as a temporary local PNG and returns a ready-to-use media widget payload. ' +
 		'Supports desktop and mobile viewports. Use this to verify the site looks correct after building it. ' +
-		'This does not automatically show the screenshot to the user. If the user asked to take, show, or capture a screenshot, call `studio_present` with the returned media widget payload so the user sees the actual captured PNG. Do not use a site-preview widget as a substitute for the screenshot. ' +
 		'Use `share_screenshot` instead only in remote sessions where you need to deliver the rendered page outside the Studio UI.',
 	{
 		url: Type.String( { description: 'The URL to screenshot' } ),

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -54,7 +54,9 @@ interface PiToolResultLike {
 	isError?: boolean;
 }
 
-function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {
+const HIDDEN_TOOL_ROWS = new Set( [ 'studio_present' ] );
+
+export function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {
 	// First pass: collect tool_call_id → tool_result pairings so each
 	// `toolCall` row can render its output inline.
 	const resultsByToolCallId = new Map< string, NormalizedToolResult >();
@@ -105,7 +107,8 @@ function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {
 				} else if (
 					block.type === 'toolCall' &&
 					typeof block.id === 'string' &&
-					typeof block.name === 'string'
+					typeof block.name === 'string' &&
+					! HIDDEN_TOOL_ROWS.has( block.name )
 				) {
 					items.push( {
 						kind: 'tool-use',

--- a/apps/ui/src/ui-desks/chats/conversation/index.test.ts
+++ b/apps/ui/src/ui-desks/chats/conversation/index.test.ts
@@ -1,7 +1,14 @@
 import { STUDIO_CHAT_ARTIFACT_VERSION } from '@studio/common/ai/chat-artifacts';
-import { describe, expect, it, vi } from 'vitest';
-import { entriesToRenderItems } from './index';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatArtifact, entriesToRenderItems } from './index';
 import type { SessionEntry } from '@mariozechner/pi-coding-agent';
+
+const deskMocks = vi.hoisted( () => ( {
+	addWidget: vi.fn(),
+	addWidgetAtScreenPoint: vi.fn(),
+} ) );
 
 vi.mock( '@/components/markdown', () => ( {
 	Markdown: () => null,
@@ -13,17 +20,34 @@ vi.mock( '@/ui-desks/components', () => ( {
 
 vi.mock( '@/ui-desks/desk/provider', () => ( {
 	useDesk: () => ( {
-		addWidget: vi.fn(),
-		addWidgetAtScreenPoint: vi.fn(),
+		addWidget: deskMocks.addWidget,
+		addWidgetAtScreenPoint: deskMocks.addWidgetAtScreenPoint,
 		canAddWidgets: true,
 	} ),
 } ) );
 
 vi.mock( '@/ui-desks/widget-actions/create-widget', () => ( {
-	createDeskWidget: () => null,
+	createDeskWidget: vi.fn(
+		( options: {
+			id: string;
+			type: string;
+			zIndex: string;
+			shapeProps?: Record< string, unknown >;
+			widgetProps?: Record< string, unknown >;
+		} ) => ( {
+			id: options.id,
+			type: options.type,
+			x: 0,
+			y: 0,
+			zIndex: options.zIndex,
+			shapeProps: { w: 120, h: 96, ...options.shapeProps },
+			widgetProps: options.widgetProps ?? {},
+		} )
+	),
 } ) );
 
 vi.mock( '@wordpress/icons', () => ( {
+	check: {},
 	plus: {},
 } ) );
 
@@ -37,10 +61,17 @@ vi.mock( '../thinking-indicator', () => ( {
 
 vi.mock( '../widget-context', () => ( {
 	summarizeWidgetList: () => '',
+	getWidgetDisplayLabel: ( widget: { type: string } ) => `${ widget.type } widget`,
+	WidgetContextThumbnail: () => null,
 	WidgetContextThumbnailList: () => null,
 } ) );
 
 describe( 'desks conversation render items', () => {
+	beforeEach( () => {
+		deskMocks.addWidget.mockReset();
+		deskMocks.addWidgetAtScreenPoint.mockReset();
+	} );
+
 	it( 'hides studio_present tool rows while keeping the artifact', () => {
 		const items = entriesToRenderItems( [
 			assistantToolCallEntry( 'studio_present' ),
@@ -66,6 +97,56 @@ describe( 'desks conversation render items', () => {
 					result: expect.objectContaining( { text: 'Success' } ),
 				} ),
 			] )
+		);
+	} );
+
+	it( 'adds widgets from multi-widget artifacts independently', () => {
+		deskMocks.addWidget.mockReturnValue( true );
+
+		render(
+			createElement( ChatArtifact, {
+				artifact: {
+					version: STUDIO_CHAT_ARTIFACT_VERSION,
+					id: 'artifact-2',
+					widgets: [
+						{
+							type: 'note',
+							widgetProps: { text: 'First note', tone: 'yellow' },
+						},
+						{
+							type: 'bookmark',
+							widgetProps: { url: 'https://example.com' },
+						},
+					],
+				},
+			} )
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Add widget 2 to canvas: bookmark widget' } )
+		);
+
+		expect( deskMocks.addWidget ).toHaveBeenCalledTimes( 1 );
+		expect( deskMocks.addWidget ).toHaveBeenCalledWith(
+			'bookmark',
+			expect.objectContaining( {
+				widgetProps: { url: 'https://example.com' },
+				shouldStartEditing: false,
+			} )
+		);
+		expect(
+			screen.getByRole( 'button', { name: 'Added widget 2 to canvas: bookmark widget' } )
+		).toBeDisabled();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add remaining' } ) );
+
+		expect( deskMocks.addWidget ).toHaveBeenCalledTimes( 2 );
+		expect( deskMocks.addWidget ).toHaveBeenLastCalledWith(
+			'note',
+			expect.objectContaining( {
+				widgetProps: { text: 'First note', tone: 'yellow' },
+				shouldStartEditing: false,
+			} )
 		);
 	} );
 } );

--- a/apps/ui/src/ui-desks/chats/conversation/index.test.ts
+++ b/apps/ui/src/ui-desks/chats/conversation/index.test.ts
@@ -1,0 +1,133 @@
+import { STUDIO_CHAT_ARTIFACT_VERSION } from '@studio/common/ai/chat-artifacts';
+import { describe, expect, it, vi } from 'vitest';
+import { entriesToRenderItems } from './index';
+import type { SessionEntry } from '@mariozechner/pi-coding-agent';
+
+vi.mock( '@/components/markdown', () => ( {
+	Markdown: () => null,
+} ) );
+
+vi.mock( '@/ui-desks/components', () => ( {
+	Button: () => null,
+} ) );
+
+vi.mock( '@/ui-desks/desk/provider', () => ( {
+	useDesk: () => ( {
+		addWidget: vi.fn(),
+		addWidgetAtScreenPoint: vi.fn(),
+		canAddWidgets: true,
+	} ),
+} ) );
+
+vi.mock( '@/ui-desks/widget-actions/create-widget', () => ( {
+	createDeskWidget: () => null,
+} ) );
+
+vi.mock( '@wordpress/icons', () => ( {
+	plus: {},
+} ) );
+
+vi.mock( '@wordpress/ui', () => ( {
+	Icon: () => null,
+} ) );
+
+vi.mock( '../thinking-indicator', () => ( {
+	ThinkingIndicator: () => null,
+} ) );
+
+vi.mock( '../widget-context', () => ( {
+	summarizeWidgetList: () => '',
+	WidgetContextThumbnailList: () => null,
+} ) );
+
+describe( 'desks conversation render items', () => {
+	it( 'hides studio_present tool rows while keeping the artifact', () => {
+		const items = entriesToRenderItems( [
+			assistantToolCallEntry( 'studio_present' ),
+			toolResultEntry( 'Presented 5 Studio widgets.' ),
+			chatArtifactEntry(),
+		] );
+
+		expect( items.some( ( item ) => item.kind === 'tool-use' ) ).toBe( false );
+		expect( items.some( ( item ) => item.kind === 'chat-artifact' ) ).toBe( true );
+	} );
+
+	it( 'keeps regular tool rows visible', () => {
+		const items = entriesToRenderItems( [
+			assistantToolCallEntry( 'wp_cli' ),
+			toolResultEntry( 'Success' ),
+		] );
+
+		expect( items ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					kind: 'tool-use',
+					name: 'wp_cli',
+					result: expect.objectContaining( { text: 'Success' } ),
+				} ),
+			] )
+		);
+	} );
+} );
+
+function assistantToolCallEntry( name: string ): SessionEntry {
+	return {
+		type: 'message',
+		id: `assistant-${ name }`,
+		parentId: null,
+		timestamp: '2026-05-13T00:00:00.000Z',
+		message: {
+			role: 'assistant',
+			content: [
+				{
+					type: 'toolCall',
+					id: 'tool-call-1',
+					name,
+					arguments: {},
+				},
+			],
+		},
+	} as unknown as SessionEntry;
+}
+
+function toolResultEntry( text: string ): SessionEntry {
+	return {
+		type: 'message',
+		id: 'tool-result',
+		parentId: null,
+		timestamp: '2026-05-13T00:00:01.000Z',
+		message: {
+			role: 'toolResult',
+			toolCallId: 'tool-call-1',
+			content: [ { type: 'text', text } ],
+		},
+	} as unknown as SessionEntry;
+}
+
+function chatArtifactEntry(): SessionEntry {
+	return {
+		type: 'custom',
+		id: 'artifact',
+		parentId: null,
+		timestamp: '2026-05-13T00:00:02.000Z',
+		customType: 'studio.chat_artifact',
+		data: {
+			version: STUDIO_CHAT_ARTIFACT_VERSION,
+			id: 'artifact-1',
+			widgets: [
+				{
+					type: 'post-collection',
+					widgetProps: {
+						query: {
+							postType: 'post',
+							perPage: 5,
+							status: 'publish',
+							orderby: 'date',
+							order: 'desc',
+						},
+					},
+				},
+			],
+		},
+	} as unknown as SessionEntry;
+}

--- a/apps/ui/src/ui-desks/chats/conversation/index.tsx
+++ b/apps/ui/src/ui-desks/chats/conversation/index.tsx
@@ -11,8 +11,8 @@ import {
 	getToolDisplayName,
 	type NormalizedToolResult,
 } from '@studio/common/ai/tools';
-import { __ } from '@wordpress/i18n';
-import { plus } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { check, plus } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useMemo, useState, type PointerEvent as ReactPointerEvent } from 'react';
@@ -22,7 +22,12 @@ import { Button } from '@/ui-desks/components';
 import { useDesk } from '@/ui-desks/desk/provider';
 import { createDeskWidget } from '@/ui-desks/widget-actions/create-widget';
 import { ThinkingIndicator } from '../thinking-indicator';
-import { summarizeWidgetList, WidgetContextThumbnailList } from '../widget-context';
+import {
+	getWidgetDisplayLabel,
+	summarizeWidgetList,
+	WidgetContextThumbnail,
+	WidgetContextThumbnailList,
+} from '../widget-context';
 import styles from './style.module.css';
 import type { LoadedAiSession } from '@/data/core';
 import type { DeskWidget } from '@/ui-desks/widgets/types';
@@ -268,9 +273,11 @@ function ToolUseRow( {
 	);
 }
 
-function ChatArtifact( { artifact }: { artifact: StudioChatArtifactData } ) {
+export function ChatArtifact( { artifact }: { artifact: StudioChatArtifactData } ) {
 	const { addWidget, addWidgetAtScreenPoint, canAddWidgets } = useDesk();
-	const [ added, setAdded ] = useState( false );
+	const [ addedWidgetIds, setAddedWidgetIds ] = useState< ReadonlySet< string > >(
+		() => new Set()
+	);
 	const [ dragState, setDragState ] = useState< ArtifactDragState | null >( null );
 	const widgets = useMemo(
 		() =>
@@ -294,36 +301,74 @@ function ChatArtifact( { artifact }: { artifact: StudioChatArtifactData } ) {
 	}
 
 	const summary = summarizeWidgetList( widgets );
+	const allAdded = widgets.every( ( widget ) => addedWidgetIds.has( widget.id ) );
+	const hasAddedSome = widgets.some( ( widget ) => addedWidgetIds.has( widget.id ) );
+	const markWidgetsAdded = ( widgetIds: string[] ) => {
+		if ( widgetIds.length === 0 ) {
+			return;
+		}
+
+		setAddedWidgetIds( ( previousIds ) => {
+			const nextIds = new Set( previousIds );
+			widgetIds.forEach( ( widgetId ) => nextIds.add( widgetId ) );
+			return nextIds;
+		} );
+	};
+	const insertWidgetOnCanvas = ( widget: DeskWidget, screenPoint?: { x: number; y: number } ) => {
+		const options = {
+			shapeProps: widget.shapeProps,
+			widgetProps: widget.widgetProps,
+			shouldStartEditing: false,
+		};
+		if ( screenPoint ) {
+			return addWidgetAtScreenPoint( widget.type, screenPoint, options );
+		}
+
+		return addWidget( widget.type, options );
+	};
+	const addWidgetToCanvas = ( widget: DeskWidget, screenPoint?: { x: number; y: number } ) => {
+		if ( addedWidgetIds.has( widget.id ) ) {
+			return false;
+		}
+
+		const didAdd = insertWidgetOnCanvas( widget, screenPoint );
+		if ( didAdd ) {
+			markWidgetsAdded( [ widget.id ] );
+		}
+		return didAdd;
+	};
 	const addWidgetsToCanvas = ( screenPoint?: { x: number; y: number } ) => {
-		let didAddAny = false;
+		const addedIds: string[] = [];
 		widgets.forEach( ( widget, index ) => {
-			const options = {
-				shapeProps: widget.shapeProps,
-				widgetProps: widget.widgetProps,
-				shouldStartEditing: false,
-			};
-			if ( screenPoint ) {
-				didAddAny =
-					addWidgetAtScreenPoint(
-						widget.type,
-						{
+			if ( addedWidgetIds.has( widget.id ) ) {
+				return;
+			}
+
+			const didAdd = insertWidgetOnCanvas(
+				widget,
+				screenPoint
+					? {
 							x: screenPoint.x + index * ARTIFACT_DRAG_SPACING,
 							y: screenPoint.y,
-						},
-						options
-					) || didAddAny;
-			} else {
-				didAddAny = addWidget( widget.type, options ) || didAddAny;
+					  }
+					: undefined
+			);
+			if ( didAdd ) {
+				addedIds.push( widget.id );
 			}
 		} );
-		if ( didAddAny ) {
-			setAdded( true );
-		}
-		return didAddAny;
+		markWidgetsAdded( addedIds );
+		return addedIds.length > 0;
 	};
 
 	const handlePointerDown = ( event: ReactPointerEvent< HTMLDivElement > ) => {
-		if ( event.button !== 0 || ! canAddWidgets || isInteractiveArtifactTarget( event.target ) ) {
+		const draggableWidgets = widgets.filter( ( widget ) => ! addedWidgetIds.has( widget.id ) );
+		if (
+			event.button !== 0 ||
+			! canAddWidgets ||
+			draggableWidgets.length === 0 ||
+			isInteractiveArtifactTarget( event.target )
+		) {
 			return;
 		}
 
@@ -343,7 +388,7 @@ function ChatArtifact( { artifact }: { artifact: StudioChatArtifactData } ) {
 
 		const syncDragState = ( pointerEvent: PointerEvent ) => {
 			setDragState( {
-				widgets,
+				widgets: draggableWidgets,
 				x: pointerEvent.clientX,
 				y: pointerEvent.clientY,
 				isOverCanvas: isCanvasDropTargetAtPoint( pointerEvent.clientX, pointerEvent.clientY ),
@@ -400,29 +445,93 @@ function ChatArtifact( { artifact }: { artifact: StudioChatArtifactData } ) {
 				onPointerDown={ handlePointerDown }
 				title={ summary }
 			>
-				<WidgetContextThumbnailList
-					widgets={ widgets }
-					className={ styles.artifactThumbnails }
-					ariaLabel={ summary }
-				/>
+				<div className={ styles.artifactThumbnails } aria-label={ summary }>
+					{ widgets.map( ( widget, index ) => {
+						const isAdded = addedWidgetIds.has( widget.id );
+						const widgetLabel = getWidgetDisplayLabel( widget );
+						const addLabel = getWidgetAddActionLabel( widget, index, isAdded );
+						return (
+							<div
+								key={ widget.id }
+								className={ styles.artifactThumbnail }
+								aria-label={ widgetLabel }
+								title={ widgetLabel }
+							>
+								<WidgetContextThumbnail widget={ widget } />
+								{ widgets.length > 1 && (
+									<button
+										type="button"
+										className={ styles.artifactThumbnailAdd }
+										disabled={ ! canAddWidgets || isAdded }
+										data-added={ isAdded ? 'true' : undefined }
+										title={ addLabel }
+										aria-label={ addLabel }
+										onClick={ ( event ) => {
+											event.stopPropagation();
+											addWidgetToCanvas( widget );
+										} }
+									>
+										<Icon icon={ isAdded ? check : plus } size={ 14 } />
+									</button>
+								) }
+							</div>
+						);
+					} ) }
+				</div>
 			</div>
 			<div className={ styles.artifactActions }>
-				<button
-					type="button"
-					className={ styles.artifactAction }
-					disabled={ ! canAddWidgets || added }
-					title={ summary }
-					onClick={ () => addWidgetsToCanvas() }
-				>
-					<Icon icon={ plus } size={ 16 } />
-					<span>{ added ? __( 'Added' ) : __( 'Add to canvas' ) }</span>
-				</button>
+				{ widgets.length > 1 ? (
+					<button
+						type="button"
+						className={ styles.artifactAction }
+						disabled={ ! canAddWidgets || allAdded }
+						title={ summary }
+						onClick={ () => addWidgetsToCanvas() }
+					>
+						<Icon icon={ plus } size={ 16 } />
+						<span>
+							{ allAdded
+								? __( 'Added all' )
+								: hasAddedSome
+								? __( 'Add remaining' )
+								: __( 'Add all' ) }
+						</span>
+					</button>
+				) : (
+					<button
+						type="button"
+						className={ styles.artifactAction }
+						disabled={ ! canAddWidgets || allAdded }
+						title={ summary }
+						onClick={ () => addWidgetToCanvas( widgets[ 0 ] ) }
+					>
+						<Icon icon={ plus } size={ 16 } />
+						<span>{ allAdded ? __( 'Added' ) : __( 'Add to canvas' ) }</span>
+					</button>
+				) }
 			</div>
 			{ dragState && typeof document !== 'undefined'
 				? createPortal( <ArtifactDragOverlay state={ dragState } />, document.body )
 				: null }
 		</div>
 	);
+}
+
+function getWidgetAddActionLabel( widget: DeskWidget, index: number, isAdded: boolean ) {
+	const widgetLabel = getWidgetDisplayLabel( widget );
+	return isAdded
+		? sprintf(
+				/* translators: 1: widget number in the artifact, 2: widget label. */
+				__( 'Added widget %1$d to canvas: %2$s' ),
+				index + 1,
+				widgetLabel
+		  )
+		: sprintf(
+				/* translators: 1: widget number in the artifact, 2: widget label. */
+				__( 'Add widget %1$d to canvas: %2$s' ),
+				index + 1,
+				widgetLabel
+		  );
 }
 
 function ArtifactDragOverlay( { state }: { state: ArtifactDragState } ) {

--- a/apps/ui/src/ui-desks/chats/conversation/index.tsx
+++ b/apps/ui/src/ui-desks/chats/conversation/index.tsx
@@ -67,7 +67,9 @@ interface PiToolResultLike {
 	isError?: boolean;
 }
 
-function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {
+const HIDDEN_TOOL_ROWS = new Set( [ 'studio_present' ] );
+
+export function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {
 	const resultsByToolCallId = new Map< string, NormalizedToolResult >();
 	for ( const entry of entries ) {
 		if ( entry.type !== 'message' ) continue;
@@ -116,7 +118,8 @@ function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {
 				} else if (
 					block.type === 'toolCall' &&
 					typeof block.id === 'string' &&
-					typeof block.name === 'string'
+					typeof block.name === 'string' &&
+					! HIDDEN_TOOL_ROWS.has( block.name )
 				) {
 					items.push( {
 						kind: 'tool-use',

--- a/apps/ui/src/ui-desks/chats/conversation/style.module.css
+++ b/apps/ui/src/ui-desks/chats/conversation/style.module.css
@@ -168,12 +168,75 @@
 .artifactThumbnails {
 	min-width: 0;
 	flex: 0 1 auto;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	gap: 8px;
+}
+
+.artifactThumbnail {
+	position: relative;
+	flex: 0 0 auto;
+}
+
+.artifactThumbnailAdd {
+	position: absolute;
+	top: -8px;
+	right: -8px;
+	width: 22px;
+	height: 22px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: 1px solid rgba(15, 23, 42, 0.1);
+	border-radius: 999px;
+	background: rgba(255, 255, 255, 0.94);
+	box-shadow: 0 3px 8px rgba(15, 23, 42, 0.12);
+	color: var(--ui-desks-muted, #6b7280);
+	cursor: pointer;
+	opacity: 0;
+	transform: scale(0.92);
+	transition:
+		opacity 120ms ease,
+		transform 120ms ease;
+	z-index: 1;
+}
+
+.artifactThumbnail:hover .artifactThumbnailAdd,
+.artifactThumbnail:focus-within .artifactThumbnailAdd,
+.artifactThumbnailAdd[data-added='true'] {
+	opacity: 1;
+	transform: scale(1);
+}
+
+.artifactThumbnailAdd:hover:not(:disabled),
+.artifactThumbnailAdd:focus-visible:not(:disabled) {
+	background: rgba(255, 255, 255, 0.98);
+	border-color: rgba(15, 23, 42, 0.18);
+	color: var(--ui-desks-text, #14171a);
+}
+
+.artifactThumbnailAdd:disabled:not([data-added='true']) {
+	cursor: default;
+	opacity: 0.55;
+}
+
+.artifactThumbnailAdd[data-added='true'] {
+	background: rgba(255, 255, 255, 0.98);
+	border-color: rgba(15, 23, 42, 0.18);
+	color: var(--ui-desks-text, #14171a);
+	cursor: default;
+	opacity: 1;
+	transform: scale(1);
 }
 
 .artifactActions {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	gap: 8px;
+	max-width: 100%;
 }
 
 .artifactAction {
@@ -193,6 +256,10 @@
 	padding: 6px 10px;
 	cursor: pointer;
 	transition: background 140ms ease;
+}
+
+.artifactAction span {
+	white-space: nowrap;
 }
 
 .artifactAction:hover:not(:disabled),

--- a/tools/common/ai/studio-widgets.ts
+++ b/tools/common/ai/studio-widgets.ts
@@ -1,0 +1,327 @@
+import type { StudioChatArtifactWidgetDraft } from './chat-artifacts';
+
+interface StudioWidgetSpec {
+	type: string;
+	description: string;
+	propsDescription: string;
+	example: StudioChatArtifactWidgetDraft;
+	validateWidgetProps: ( props: Record< string, unknown > ) => boolean;
+}
+
+interface StudioPresentationRule {
+	id: string;
+	description: string;
+}
+
+const PAGE_TONES = [ 'neutral', 'orange', 'red', 'violet', 'blue', 'sky', 'green' ] as const;
+const NOTE_TONES = [
+	'yellow',
+	'mint',
+	'blue',
+	'orange',
+	'violet',
+	'neon-yellow',
+	'neon-green',
+	'neon-violet',
+	'neon-orange',
+	'neon-blue',
+] as const;
+const NOTE_TEXT_SIZE_STEPS = [ 0, 1, 2, 3 ] as const;
+const ARTEFACT_SCOPES = [ 'page', 'pattern', 'block' ] as const;
+const MEDIA_KINDS = [ 'image', 'video' ] as const;
+const POST_COLLECTION_STATUSES = [ 'publish', 'draft', 'any' ] as const;
+const POST_COLLECTION_ORDER_BY = [ 'date', 'modified', 'title' ] as const;
+const POST_COLLECTION_ORDERS = [ 'asc', 'desc' ] as const;
+const STACK_VIEW_MODES = [ 'stack', 'tiles' ] as const;
+const MIN_WIDGET_SHAPE_SIZE = 80;
+
+export const STUDIO_PRESENTATION_RULES: StudioPresentationRule[] = [
+	{
+		id: 'meaningful-milestones',
+		description:
+			'Present widgets for meaningful user-visible progress, results, and durable context. Do not present routine inspection, low-level file reads, internal edits, or noisy intermediate steps.',
+	},
+	{
+		id: 'post-lists',
+		description:
+			'When showing latest, recent, top, feed, archive, query, or other post-list results, use one post-collection widget instead of multiple individual post widgets. Use multiple post widgets only for distinct hand-picked posts that need to be compared side by side.',
+	},
+	{
+		id: 'site-code-scratchpad',
+		description:
+			'During site creation or redesign work, after meaningful HTML, block markup, CSS, or theme-file edits, use a note widget as a scratchpad-style summary of changed files, sections/selectors, and design intent. Keep it compact and do not paste full files. Use sd-artefact for standalone rendered HTML drafts, and site-preview after a visible site or page milestone.',
+	},
+	{
+		id: 'saved-local-media',
+		description:
+			'When an image, video, SVG, logo, icon, illustration, or other visual asset is generated, written to, or discovered on disk, present it as a media widget using a file:// URL and local source metadata. For generated SVGs, write a complete .svg file to a local path first, then present that file. Use a temporary file when the user only wants to see the asset; save under the site or project only when they ask for a durable file. Do not present generated SVG code as a drawing widget.',
+	},
+	{
+		id: 'screenshot-local-media',
+		description:
+			'When the user asks to take, show, or capture a screenshot, present the actual captured PNG from take_screenshot as a media widget using the returned local-file payload. Do not substitute a site-preview widget for a screenshot; site-preview is for live previews, not captured screenshots. Do not present every internal verification screenshot.',
+	},
+];
+
+export const STUDIO_PRESENTABLE_WIDGET_SPECS: StudioWidgetSpec[] = [
+	{
+		type: 'site-preview',
+		description:
+			'A live preview of the current local site at a path or URL. Do not use this for captured screenshots; use a media widget for screenshot PNG files.',
+		propsDescription: '{ "path": "/" } where path is a relative path like "/about" or a URL.',
+		example: { type: 'site-preview', widgetProps: { path: '/' } },
+		validateWidgetProps: ( props ) => typeof props.path === 'string',
+	},
+	{
+		type: 'page',
+		description: 'A WordPress page card backed by an existing page ID.',
+		propsDescription:
+			'{ "pageId": 123, "tone": "neutral" } where tone is neutral, orange, red, violet, blue, sky, or green.',
+		example: { type: 'page', widgetProps: { pageId: 123, tone: 'neutral' } },
+		validateWidgetProps: ( props ) =>
+			isNonNegativeInteger( props.pageId ) && isOneOf( props.tone, PAGE_TONES ),
+	},
+	{
+		type: 'post',
+		description:
+			'A WordPress post card backed by an existing post ID. Use for a specific individual post, not for generic latest/recent post-list requests.',
+		propsDescription: '{ "postId": 123 }.',
+		example: { type: 'post', widgetProps: { postId: 123 } },
+		validateWidgetProps: ( props ) => isNonNegativeInteger( props.postId ),
+	},
+	{
+		type: 'post-collection',
+		description:
+			'A dynamic collection of recent or filtered WordPress posts. Prefer this for latest, recent, top, feed, archive, or other post-list requests.',
+		propsDescription:
+			'{ "query": { "postType": "post", "perPage": 5, "status": "publish", "orderby": "date", "order": "desc" }, "viewMode": "stack" }.',
+		example: {
+			type: 'post-collection',
+			widgetProps: {
+				query: {
+					postType: 'post',
+					perPage: 5,
+					status: 'publish',
+					orderby: 'date',
+					order: 'desc',
+				},
+				viewMode: 'stack',
+			},
+		},
+		validateWidgetProps: isPostCollectionWidgetProps,
+	},
+	{
+		type: 'note',
+		description:
+			'A sticky note for scratchpad-style plans, compact implementation summaries, decisions, or next steps.',
+		propsDescription:
+			'{ "text": "Short note text", "tone": "yellow", "textSize": 1 } where textSize is optional 0-3.',
+		example: { type: 'note', widgetProps: { text: 'Draft hero options', tone: 'yellow' } },
+		validateWidgetProps: ( props ) =>
+			typeof props.text === 'string' &&
+			isOneOf( props.tone, NOTE_TONES ) &&
+			( props.textSize === undefined || isOneOf( props.textSize, NOTE_TEXT_SIZE_STEPS ) ),
+	},
+	{
+		type: 'bookmark',
+		description: 'A link card for an external reference or useful URL.',
+		propsDescription: '{ "url": "https://example.com" } with an http or https URL.',
+		example: { type: 'bookmark', widgetProps: { url: 'https://wordpress.org' } },
+		validateWidgetProps: ( props ) => typeof props.url === 'string' && isHttpUrl( props.url ),
+	},
+	{
+		type: 'embed',
+		description: 'An embeddable URL preview for supported services.',
+		propsDescription: '{ "url": "https://www.youtube.com/watch?v=..." } with an http or https URL.',
+		example: { type: 'embed', widgetProps: { url: 'https://wordpress.tv' } },
+		validateWidgetProps: ( props ) => typeof props.url === 'string' && isHttpUrl( props.url ),
+	},
+	{
+		type: 'media',
+		description:
+			'An image or video card backed by a URL, including saved local image, video, or SVG files.',
+		propsDescription:
+			'{ "url": "https://example.com/image.jpg", "mediaKind": "image", "alt": "Alt text", "mediaId": 123 } where mediaId may be null. Local files, including SVGs, should use a file:// URL and source { "type": "local", "path": "/tmp/rb-logo.svg", "name": "rb-logo.svg", "mimeType": "image/svg+xml" }.',
+		example: {
+			type: 'media',
+			widgetProps: {
+				url: 'file:///tmp/rb-logo.svg',
+				mediaKind: 'image',
+				alt: 'RB logo SVG',
+				mediaId: null,
+				source: {
+					type: 'local',
+					path: '/tmp/rb-logo.svg',
+					name: 'rb-logo.svg',
+					mimeType: 'image/svg+xml',
+				},
+			},
+		},
+		validateWidgetProps: ( props ) =>
+			typeof props.url === 'string' &&
+			isMediaUrl( props.url ) &&
+			isOneOf( props.mediaKind, MEDIA_KINDS ) &&
+			typeof props.alt === 'string' &&
+			( props.source === undefined || isMediaWidgetSource( props.source ) ) &&
+			( props.mediaId === null || isNonNegativeInteger( props.mediaId ) ),
+	},
+	{
+		type: 'sd-artefact',
+		description: 'A rendered HTML artefact for a page, pattern, or block concept.',
+		propsDescription:
+			'{ "html": "<main>...</main>", "title": "Landing page draft", "scope": "page", "description": "Optional notes" } where scope is page, pattern, or block.',
+		example: {
+			type: 'sd-artefact',
+			widgetProps: {
+				html: '<main><h1>Draft</h1></main>',
+				title: 'Landing page draft',
+				scope: 'page',
+			},
+		},
+		validateWidgetProps: ( props ) =>
+			typeof props.html === 'string' &&
+			typeof props.title === 'string' &&
+			isOneOf( props.scope, ARTEFACT_SCOPES ) &&
+			( props.description === undefined || typeof props.description === 'string' ),
+	},
+];
+
+export function getStudioPresentableWidgetTypes(): string[] {
+	return STUDIO_PRESENTABLE_WIDGET_SPECS.map( ( spec ) => spec.type );
+}
+
+export function getStudioPresentationRulesPrompt(): string {
+	return STUDIO_PRESENTATION_RULES.map( ( rule ) => `- ${ rule.id }: ${ rule.description }` ).join(
+		'\n'
+	);
+}
+
+export function getStudioWidgetPromptManifest(): string {
+	return STUDIO_PRESENTABLE_WIDGET_SPECS.map(
+		( spec ) =>
+			`- ${ spec.type }: ${ spec.description } Props: ${
+				spec.propsDescription
+			} Example: ${ JSON.stringify( spec.example ) }`
+	).join( '\n' );
+}
+
+export function getStudioWidgetDraftValidationError( value: unknown ): string | null {
+	if ( ! isRecord( value ) ) {
+		return 'Widget must be an object.';
+	}
+
+	if ( typeof value.type !== 'string' ) {
+		return 'Widget type must be a string.';
+	}
+
+	if ( ! isRecord( value.widgetProps ) ) {
+		return `Widget "${ value.type }" must include widgetProps as an object.`;
+	}
+
+	if ( value.shapeProps !== undefined && ! isShapeProps( value.shapeProps ) ) {
+		return `Widget "${ value.type }" shapeProps may only include numeric w and h between ${ MIN_WIDGET_SHAPE_SIZE } and 3000.`;
+	}
+
+	const spec = STUDIO_PRESENTABLE_WIDGET_SPECS.find(
+		( candidate ) => candidate.type === value.type
+	);
+	if ( ! spec ) {
+		return `Unsupported widget type "${
+			value.type
+		}". Supported types: ${ getStudioPresentableWidgetTypes().join( ', ' ) }.`;
+	}
+
+	if ( ! spec.validateWidgetProps( value.widgetProps ) ) {
+		return `Invalid widgetProps for "${ spec.type }". Expected: ${ spec.propsDescription }`;
+	}
+
+	return null;
+}
+
+function isPostCollectionWidgetProps( props: Record< string, unknown > ): boolean {
+	if ( ! isRecord( props.query ) ) {
+		return false;
+	}
+
+	return (
+		props.query.postType === 'post' &&
+		isIntegerInRange( props.query.perPage, 1, 20 ) &&
+		isOneOf( props.query.status, POST_COLLECTION_STATUSES ) &&
+		isOneOf( props.query.orderby, POST_COLLECTION_ORDER_BY ) &&
+		isOneOf( props.query.order, POST_COLLECTION_ORDERS ) &&
+		( props.viewMode === undefined || isOneOf( props.viewMode, STACK_VIEW_MODES ) )
+	);
+}
+
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	return Boolean( value ) && typeof value === 'object' && ! Array.isArray( value );
+}
+
+function isNonNegativeInteger( value: unknown ): value is number {
+	return isIntegerInRange( value, 0, Number.MAX_SAFE_INTEGER );
+}
+
+function isIntegerInRange( value: unknown, min: number, max: number ): value is number {
+	return typeof value === 'number' && Number.isInteger( value ) && value >= min && value <= max;
+}
+
+function isOneOf< T extends readonly unknown[] >(
+	value: unknown,
+	values: T
+): value is T[ number ] {
+	return values.includes( value );
+}
+
+function isHttpUrl( value: string ): boolean {
+	try {
+		const url = new URL( value );
+		return url.protocol === 'http:' || url.protocol === 'https:';
+	} catch {
+		return false;
+	}
+}
+
+function isMediaUrl( value: string ): boolean {
+	try {
+		const url = new URL( value );
+		return url.protocol === 'http:' || url.protocol === 'https:' || url.protocol === 'file:';
+	} catch {
+		return false;
+	}
+}
+
+function isMediaWidgetSource( value: unknown ): boolean {
+	if ( ! isRecord( value ) ) {
+		return false;
+	}
+
+	if ( value.type === 'site' ) {
+		return true;
+	}
+
+	return (
+		value.type === 'local' &&
+		typeof value.path === 'string' &&
+		typeof value.name === 'string' &&
+		typeof value.mimeType === 'string'
+	);
+}
+
+function isShapeProps( value: unknown ): boolean {
+	if ( ! isRecord( value ) ) {
+		return false;
+	}
+
+	const keys = Object.keys( value );
+	if ( keys.some( ( key ) => key !== 'w' && key !== 'h' ) ) {
+		return false;
+	}
+
+	return keys.every(
+		( key ) =>
+			typeof value[ key ] === 'number' &&
+			Number.isFinite( value[ key ] ) &&
+			value[ key ] >= MIN_WIDGET_SHAPE_SIZE &&
+			value[ key ] <= 3000
+	);
+}

--- a/tools/common/ai/studio-widgets.ts
+++ b/tools/common/ai/studio-widgets.ts
@@ -49,7 +49,7 @@ export const STUDIO_PRESENTATION_RULES: StudioPresentationRule[] = [
 	{
 		id: 'site-code-scratchpad',
 		description:
-			'During site creation or redesign work, after meaningful HTML, block markup, CSS, or theme-file edits, use a note widget as a scratchpad-style summary of changed files, sections/selectors, and design intent. Keep it compact and do not paste full files. Use sd-artefact for standalone rendered HTML drafts, and site-preview after a visible site or page milestone.',
+			'During site creation or redesign work, after any successful Write or Edit that creates or changes HTML, CSS, block markup, JSX/TSX markup, inline styles, theme.json design tokens, frontend JS behavior, or theme/plugin code that shapes markup or styling, call studio_present with exactly one note widget as a scratchpad summary. Include the changed file path or basename, the sections/selectors touched, and the design intent or next checkpoint. Keep it compact and do not paste full files. Skip only trivial mechanical edits, generated lockfiles, or config changes unrelated to HTML, CSS, layout, styling, or frontend behavior. Use sd-artefact for standalone rendered HTML drafts, and site-preview after a visible site or page milestone.',
 	},
 	{
 		id: 'saved-local-media',


### PR DESCRIPTION
## Summary
- Add explicit Studio presentation rules and widget manifests so the agent can choose richer inline artifacts more consistently.
- Route screenshots through temporary local PNG media payloads and make the screenshot tool output more compact.
- Stop advertising `drawing` as a presentable widget and require generated SVG/logo assets to be written as local files and shown as `media`.
- Hide the explicit `studio_present` tool row from chat transcripts while keeping emitted artifacts visible.

## Testing
- Added and updated unit tests for the Studio prompt, screenshot helper, tool validation, and conversation rendering.
- Lint and formatting passed.
- Typecheck passed.
- Focused Vitest suite passed locally.