### PR TITLE
apps/ui: Fix AI session site placement and restore active run state across navigation

### DIFF
--- a/apps/cli/ai/site-selection.ts
+++ b/apps/cli/ai/site-selection.ts
@@ -1,0 +1,13 @@
+import type { SiteInfo } from 'cli/ai/types';
+
+type LocalSiteSelectedCallback = ( site: SiteInfo ) => void | Promise< void >;
+
+let localSiteSelectedCallback: LocalSiteSelectedCallback | null = null;
+
+export function setLocalSiteSelectedCallback( callback: LocalSiteSelectedCallback | null ) {
+	localSiteSelectedCallback = callback;
+}
+
+export async function emitLocalSiteSelected( site: SiteInfo ): Promise< void > {
+	await localSiteSelectedCallback?.( site );
+}

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -132,7 +132,10 @@ IMPORTANT: For any generated content for the site, these three principles are ma
 
 For any request that involves a WordPress site, you MUST first determine which site to use:
 
-- **"Create" / "build" / "make" a site**: Run the \`site-spec\` skill to gather the site name and layout preference FIRST, then proceed with site creation. Do NOT call site_list first. Do NOT reuse or repurpose any existing site. Every new project gets a fresh site.
+- **Active site + ambiguous "create" / "build" / "make" / "design a site"**: Ask whether to update the active site or create a separate new site before calling site_create. Use AskUserQuestion when available with options like "Use current site" and "Create new site".
+- **Active site + explicit "new" / "separate" / "another" site**: Run the \`site-spec\` skill to gather the site name and layout preference FIRST, then call site_create.
+- **No active site + "create" / "build" / "make" a site**: Run the \`site-spec\` skill to gather the site name and layout preference FIRST, then call site_create.
+- **"Redesign" / "update" / "change this site"**: Reuse the active site.
 - **User names a specific existing site**: Call site_list to find it.
 - **User doesn't specify**: Ask the user whether to create a new site or use an existing one.
 - **Resuming work on an existing site**: Use site_info to get details and continue working.

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { vi } from 'vitest';
 import { emitEvent } from 'cli/ai/json-events';
+import { setLocalSiteSelectedCallback } from 'cli/ai/site-selection';
 import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
 import {
 	Mode as PreviewDeleteMode,
@@ -134,6 +135,7 @@ describe( 'Studio AI MCP tools', () => {
 
 	afterEach( () => {
 		setProgressCallback( null );
+		setLocalSiteSelectedCallback( null );
 	} );
 
 	it( 'includes preview tools in the MCP registry', () => {
@@ -209,11 +211,35 @@ describe( 'Studio AI MCP tools', () => {
 			expect.objectContaining( {
 				type: 'chat.artifact',
 				artifact: expect.objectContaining( {
-					widgets: [ { type: 'site-preview', widgetProps: { path: '/' } } ],
+					widgets: [
+						{
+							type: 'site-preview',
+							widgetProps: expect.objectContaining( {
+								path: '/',
+								siteId: 'site-123',
+								siteName: 'My Site',
+								sitePath: '/sites/my-site',
+							} ),
+						},
+					],
 				} ),
 			} )
 		);
+		expect( getTextContent( result ) ).toContain( '"id": "site-123"' );
 		expect( getTextContent( result ) ).toContain( '"name": "My Site"' );
+	} );
+
+	it( 'notifies JSON-mode callers when site_create selects the created site', async () => {
+		const onSiteSelected = vi.fn();
+		setLocalSiteSelectedCallback( onSiteSelected );
+
+		await getTool( 'site_create' ).rawHandler( { name: 'My Site' } as never );
+
+		expect( onSiteSelected ).toHaveBeenCalledWith( {
+			name: 'My Site',
+			path: '/sites/my-site',
+			running: true,
+		} );
 	} );
 
 	it( 'lists previews as JSON for a resolved local site', async () => {

--- a/apps/cli/ai/tools/create-site.ts
+++ b/apps/cli/ai/tools/create-site.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { Type } from 'typebox';
+import { emitLocalSiteSelected } from 'cli/ai/site-selection';
 import { runCommand as runCreateSiteCommand } from 'cli/commands/site/create';
 import { getSiteUrl } from 'cli/lib/cli-config/sites';
 import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
@@ -36,10 +37,16 @@ export const createSiteTool = defineTool(
 
 			const site = await resolveSite( args.name );
 			const url = getSiteUrl( site );
+			await emitLocalSiteSelected( {
+				name: site.name,
+				path: site.path,
+				running: true,
+			} );
 			return {
 				...textResult(
 					JSON.stringify(
 						{
+							id: site.id,
 							name: site.name,
 							path: site.path,
 							url,
@@ -52,7 +59,18 @@ export const createSiteTool = defineTool(
 						2
 					)
 				),
-				studioArtifacts: [ { type: 'site-preview', widgetProps: { path: '/' } } ],
+				studioArtifacts: [
+					{
+						type: 'site-preview',
+						widgetProps: {
+							path: '/',
+							siteId: site.id,
+							siteName: site.name,
+							sitePath: site.path,
+							url,
+						},
+					},
+				],
 			};
 		} catch ( error ) {
 			throw new Error(

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -26,6 +26,7 @@ import {
 	openStudioSession,
 } from 'cli/ai/sessions/pi-session';
 import { replaySessionHistory } from 'cli/ai/sessions/replay';
+import { setLocalSiteSelectedCallback } from 'cli/ai/site-selection';
 import { getActiveSlashCommands, type SlashCommandContext } from 'cli/ai/slash-commands';
 import { AiChatUI } from 'cli/ai/ui';
 import { runCommand as runLoginCommand } from 'cli/commands/auth/login';
@@ -198,6 +199,20 @@ export async function runCommand( options: {
 			} )
 		);
 	};
+
+	setLocalSiteSelectedCallback(
+		ui instanceof JsonAdapter
+			? async ( site ) => {
+					ui.activeSite = site;
+					await append( ( sm ) =>
+						appendStudioEntry( sm, 'studio.site_selected', {
+							siteName: site.name,
+							sitePath: site.path,
+						} )
+					);
+			  }
+			: null
+	);
 
 	if ( options.resumeSession ) {
 		ui.showInfo(
@@ -524,6 +539,7 @@ export async function runCommand( options: {
 			handleAgentTurnError( error );
 			( ui as JsonAdapter ).emitTurnCompleted( 'error', session?.getSessionId() ?? '' );
 		} finally {
+			setLocalSiteSelectedCallback( null );
 			ui.stop();
 			await closeSharedBrowser();
 		}

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -74,6 +74,13 @@ import {
 	WINDOWS_TITLEBAR_HEIGHT,
 } from 'src/constants';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
+import {
+	deleteAiSessionPlacement,
+	hydrateAiSessionSummaryWithPlacement,
+	readAiSessionPlacement,
+	readAiSessionPlacements,
+	setAiSessionSitePlacement,
+} from 'src/lib/ai-session-placement';
 import { getAiSessionsRootDirectory } from 'src/lib/ai-sessions';
 import { getBetaFeatures as getBetaFeaturesFromLib } from 'src/lib/beta-features';
 import { bumpStat, getBlueprintMetric, StatsGroup } from 'src/lib/bump-stats';
@@ -111,7 +118,12 @@ import {
 	removeSkillById,
 	type SkillStatus,
 } from 'src/modules/agent-instructions/lib/skills';
-import { answerAgentRun, interruptAgentRun, startAgentRun } from 'src/modules/ai-agent/run-manager';
+import {
+	answerAgentRun,
+	interruptAgentRun,
+	listActiveAgentRuns,
+	startAgentRun,
+} from 'src/modules/ai-agent/run-manager';
 import { editSiteViaCli, EditSiteOptions } from 'src/modules/cli/lib/cli-site-editor';
 import { isStudioCliInstalled } from 'src/modules/cli/lib/ipc-handlers';
 import { STABLE_BIN_DIR_PATH } from 'src/modules/cli/lib/windows-installation-manager';
@@ -137,6 +149,7 @@ import {
 } from 'src/storage/user-data';
 import { Blueprint } from 'src/stores/wpcom-api';
 import { captureSiteThumbnail } from './lib/capture-site-thumbnail';
+import type { ActiveAgentRun } from '@studio/common/ai/agent-events';
 import type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessions/types';
 import type { RawDirectoryEntry } from '@studio/common/types/sync-tree';
 import type { Ignore } from 'ignore';
@@ -223,12 +236,16 @@ function hydrateAiSessionSummary(
 }
 
 async function listHydratedAiSessions( rootDirectory: string ): Promise< AiSessionSummary[] > {
-	const [ sessions, sessionMetadata ] = await Promise.all( [
+	const [ sessions, sessionMetadata, placements ] = await Promise.all( [
 		listAiSessionsFromStore( rootDirectory ),
 		readSharedSessions(),
+		readAiSessionPlacements(),
 	] );
 	return sessions.map( ( session ) =>
-		hydrateAiSessionSummary( session, sessionMetadata[ session.id ] )
+		hydrateAiSessionSummary(
+			hydrateAiSessionSummaryWithPlacement( session, placements[ session.id ] ),
+			sessionMetadata[ session.id ]
+		)
 	);
 }
 
@@ -237,10 +254,16 @@ async function loadHydratedAiSession(
 	sessionIdOrPrefix: string
 ): Promise< LoadedAiSession > {
 	const session = await loadAiSessionFromStore( rootDirectory, sessionIdOrPrefix );
-	const metadata = await readSharedSession( session.summary.id );
+	const [ metadata, placement ] = await Promise.all( [
+		readSharedSession( session.summary.id ),
+		readAiSessionPlacement( session.summary.id ),
+	] );
 	return {
 		...session,
-		summary: hydrateAiSessionSummary( session.summary, metadata ),
+		summary: hydrateAiSessionSummary(
+			hydrateAiSessionSummaryWithPlacement( session.summary, placement ),
+			metadata
+		),
 	};
 }
 
@@ -261,6 +284,7 @@ export async function deleteAiSession(
 ): Promise< AiSessionSummary > {
 	const deleted = await deleteAiSessionFromStore( getAiSessionsRootDirectory(), sessionIdOrPrefix );
 	await deleteSharedSession( deleted.id );
+	await deleteAiSessionPlacement( deleted.id );
 	return deleted;
 }
 
@@ -305,14 +329,23 @@ export async function createAiSession(
 		return emptyForSite;
 	}
 
-	return hydrateAiSessionSummary(
-		await createAiSessionInStore( sitesRoot, {
-			site: {
-				name: server.details.name,
-				path: sitePath,
-			},
-		} )
-	);
+	const created = await createAiSessionInStore( sitesRoot, {
+		site: {
+			name: server.details.name,
+			path: sitePath,
+		},
+	} );
+	await setAiSessionSitePlacement( created.id, {
+		siteId: server.details.id,
+		siteName: server.details.name,
+		sitePath,
+	} );
+	return hydrateAiSessionSummaryWithPlacement( created, {
+		kind: 'site',
+		siteId: server.details.id,
+		siteName: server.details.name,
+		sitePath,
+	} );
 }
 
 export async function updateAiSessionMetadata(
@@ -324,8 +357,14 @@ export async function updateAiSessionMetadata(
 		getAiSessionsRootDirectory(),
 		sessionIdOrPrefix
 	);
-	const metadata = await updateSharedSession( summary.id, patch );
-	return hydrateAiSessionSummary( summary, metadata );
+	const [ metadata, placement ] = await Promise.all( [
+		updateSharedSession( summary.id, patch ),
+		readAiSessionPlacement( summary.id ),
+	] );
+	return hydrateAiSessionSummary(
+		hydrateAiSessionSummaryWithPlacement( summary, placement ),
+		metadata
+	);
 }
 
 /**
@@ -341,7 +380,7 @@ export async function updateAiSessionMetadata(
  */
 async function reconcileSessionEnvironmentBeforeRun( sessionId: string ): Promise< void > {
 	const root = getAiSessionsRootDirectory();
-	const { summary } = await loadAiSessionFromStore( root, sessionId );
+	const { summary } = await loadHydratedAiSession( root, sessionId );
 
 	if ( summary.activeEnvironment !== 'live' ) {
 		return;
@@ -402,6 +441,12 @@ export async function continueAiSession(
 	} );
 }
 
+export async function listActiveAiAgentRuns(
+	_event: IpcMainInvokeEvent
+): Promise< ActiveAgentRun[] > {
+	return listActiveAgentRuns();
+}
+
 export async function setAiSessionModel(
 	_event: IpcMainInvokeEvent,
 	sessionId: string,
@@ -434,7 +479,7 @@ export async function setSessionEnvironment(
 	sessionId: string,
 	environment: 'local' | 'live'
 ): Promise< SetSessionEnvironmentResult > {
-	const { summary } = await loadAiSessionFromStore( getAiSessionsRootDirectory(), sessionId );
+	const { summary } = await loadHydratedAiSession( getAiSessionsRootDirectory(), sessionId );
 
 	if ( ! summary.ownerSitePath || ! summary.ownerSiteName ) {
 		throw new Error( 'Cannot change environment: session has no owner site' );
@@ -459,24 +504,20 @@ export async function setSessionEnvironment(
 
 		await appendStudioEntry( getAiSessionsRootDirectory(), sessionId, 'studio.site_selected', {
 			siteName: liveSite.name,
-			// Keep the owner's path on remote picks too, so the renderer
-			// (which groups the sidebar by `ownerSitePath`) still resolves
-			// the session to its owner while the active environment is live.
+			// Keep the desktop placement path on remote picks too, so live/local
+			// environment flips still resolve against the same local site.
 			sitePath: summary.ownerSitePath,
 			remote: true,
 			url: liveSite.url,
 			wpcomSiteId: liveSite.id,
 		} );
 
-		const refreshed = await loadAiSessionFromStore( getAiSessionsRootDirectory(), sessionId );
+		const refreshed = await loadHydratedAiSession( getAiSessionsRootDirectory(), sessionId );
 		return {
 			environment: 'live',
 			url: liveSite.url,
 			wpcomSiteId: liveSite.id,
-			summary: hydrateAiSessionSummary(
-				refreshed.summary,
-				await readSharedSession( refreshed.summary.id )
-			),
+			summary: refreshed.summary,
 		};
 	}
 
@@ -487,13 +528,10 @@ export async function setSessionEnvironment(
 		url: 'url' in details ? details.url : undefined,
 	} );
 
-	const refreshed = await loadAiSessionFromStore( getAiSessionsRootDirectory(), sessionId );
+	const refreshed = await loadHydratedAiSession( getAiSessionsRootDirectory(), sessionId );
 	return {
 		environment: 'local',
-		summary: hydrateAiSessionSummary(
-			refreshed.summary,
-			await readSharedSession( refreshed.summary.id )
-		),
+		summary: refreshed.summary,
 	};
 }
 

--- a/apps/studio/src/ipc-utils.ts
+++ b/apps/studio/src/ipc-utils.ts
@@ -7,6 +7,7 @@ import { getMainWindow } from 'src/main-window';
 import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { JsonEvent as StudioCodeEvent } from '@studio/common/ai/json-events';
 import type { StoredAuthToken } from '@studio/common/lib/shared-config';
+import type { AiSessionPlacementUpdatedEvent } from 'src/lib/ai-session-placement';
 
 type SnapshotEventData = {
 	action: PreviewCommandLoggerAction;
@@ -62,6 +63,7 @@ export interface IpcEvents {
 	'refresh-app-globals': [ void ];
 	'beta-features-updated': [ void ];
 	'ai-agent-event': [ AgentRunEvent ];
+	'ai-session-placement-updated': [ AiSessionPlacementUpdatedEvent ];
 	'studio-code-event': [ { siteId: string; event: StudioCodeEvent } ];
 }
 

--- a/apps/studio/src/lib/ai-session-placement.ts
+++ b/apps/studio/src/lib/ai-session-placement.ts
@@ -1,0 +1,85 @@
+import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
+import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
+import type { AiSessionSitePlacement } from 'src/storage/storage-types';
+
+export type { AiSessionSitePlacement };
+
+export interface AiSessionPlacementUpdatedEvent {
+	sessionId: string;
+	placement: AiSessionSitePlacement;
+}
+
+export async function readAiSessionPlacements(): Promise<
+	Record< string, AiSessionSitePlacement >
+> {
+	const userData = await loadUserData();
+	return userData.aiSessionPlacements ?? {};
+}
+
+export async function readAiSessionPlacement(
+	sessionId: string
+): Promise< AiSessionSitePlacement | undefined > {
+	const placements = await readAiSessionPlacements();
+	return placements[ sessionId ];
+}
+
+export async function setAiSessionSitePlacement(
+	sessionId: string,
+	placement: Omit< AiSessionSitePlacement, 'kind' >
+): Promise< AiSessionSitePlacement > {
+	try {
+		await lockAppdata();
+		const userData = await loadUserData();
+		const nextPlacement: AiSessionSitePlacement = {
+			kind: 'site',
+			...placement,
+		};
+		await saveUserData( {
+			...userData,
+			aiSessionPlacements: {
+				...( userData.aiSessionPlacements ?? {} ),
+				[ sessionId ]: nextPlacement,
+			},
+		} );
+		return nextPlacement;
+	} finally {
+		await unlockAppdata();
+	}
+}
+
+export async function deleteAiSessionPlacement( sessionId: string ): Promise< void > {
+	try {
+		await lockAppdata();
+		const userData = await loadUserData();
+		if ( ! userData.aiSessionPlacements?.[ sessionId ] ) {
+			return;
+		}
+		const { [ sessionId ]: _deleted, ...remainingPlacements } = userData.aiSessionPlacements;
+		await saveUserData( {
+			...userData,
+			aiSessionPlacements:
+				Object.keys( remainingPlacements ).length > 0 ? remainingPlacements : undefined,
+		} );
+	} finally {
+		await unlockAppdata();
+	}
+}
+
+export function hydrateAiSessionSummaryWithPlacement(
+	summary: AiSessionSummary,
+	placement?: AiSessionSitePlacement
+): AiSessionSummary {
+	if ( ! placement ) {
+		return {
+			...summary,
+			ownerSitePath: undefined,
+			ownerSiteName: undefined,
+		};
+	}
+
+	return {
+		...summary,
+		ownerSitePath: placement.sitePath,
+		ownerSiteName: placement.siteName,
+	};
+}

--- a/apps/studio/src/lib/tests/ai-session-placement.test.ts
+++ b/apps/studio/src/lib/tests/ai-session-placement.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	deleteAiSessionPlacement,
+	hydrateAiSessionSummaryWithPlacement,
+	readAiSessionPlacements,
+	setAiSessionSitePlacement,
+} from 'src/lib/ai-session-placement';
+import { EMPTY_USER_DATA, type UserData } from 'src/storage/storage-types';
+import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
+import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
+
+vi.mock( 'src/storage/user-data', () => ( {
+	loadUserData: vi.fn(),
+	lockAppdata: vi.fn(),
+	saveUserData: vi.fn(),
+	unlockAppdata: vi.fn(),
+} ) );
+
+describe( 'ai session placement', () => {
+	let userData: UserData;
+
+	beforeEach( () => {
+		userData = structuredClone( EMPTY_USER_DATA );
+		vi.mocked( loadUserData ).mockImplementation( async () => structuredClone( userData ) );
+		vi.mocked( saveUserData ).mockImplementation( async ( nextUserData ) => {
+			userData = structuredClone( nextUserData );
+		} );
+		vi.mocked( lockAppdata ).mockResolvedValue( undefined );
+		vi.mocked( unlockAppdata ).mockResolvedValue( undefined );
+	} );
+
+	it( 'stores site placements in appdata', async () => {
+		const placement = await setAiSessionSitePlacement( 'session-1', {
+			siteId: 'site-1',
+			sitePath: '/sites/site-1',
+			siteName: 'Site One',
+		} );
+
+		expect( placement ).toEqual( {
+			kind: 'site',
+			siteId: 'site-1',
+			sitePath: '/sites/site-1',
+			siteName: 'Site One',
+		} );
+		await expect( readAiSessionPlacements() ).resolves.toEqual( {
+			'session-1': placement,
+		} );
+		expect( lockAppdata ).toHaveBeenCalled();
+		expect( unlockAppdata ).toHaveBeenCalled();
+	} );
+
+	it( 'removes empty placement maps after deletion', async () => {
+		await setAiSessionSitePlacement( 'session-1', {
+			siteId: 'site-1',
+			sitePath: '/sites/site-1',
+			siteName: 'Site One',
+		} );
+
+		await deleteAiSessionPlacement( 'session-1' );
+
+		expect( userData.aiSessionPlacements ).toBeUndefined();
+	} );
+
+	it( 'hydrates owner fields only from desktop placement', () => {
+		const summary = {
+			id: 'session-1',
+			filePath: '/sessions/session-1.jsonl',
+			createdAt: '2026-05-13T00:00:00.000Z',
+			updatedAt: '2026-05-13T00:00:00.000Z',
+			ownerSitePath: '/ignored/from-jsonl',
+			ownerSiteName: 'Ignored',
+			activeEnvironment: 'local',
+			eventCount: 1,
+		} satisfies AiSessionSummary;
+
+		expect( hydrateAiSessionSummaryWithPlacement( summary ) ).toMatchObject( {
+			ownerSitePath: undefined,
+			ownerSiteName: undefined,
+		} );
+		expect(
+			hydrateAiSessionSummaryWithPlacement( summary, {
+				kind: 'site',
+				siteId: 'site-1',
+				sitePath: '/sites/site-1',
+				siteName: 'Site One',
+			} )
+		).toMatchObject( {
+			ownerSitePath: '/sites/site-1',
+			ownerSiteName: 'Site One',
+		} );
+	} );
+} );

--- a/apps/studio/src/modules/ai-agent/run-manager.ts
+++ b/apps/studio/src/modules/ai-agent/run-manager.ts
@@ -1,7 +1,9 @@
 import crypto from 'crypto';
 import { fork, type ChildProcess } from 'node:child_process';
+import { setAiSessionSitePlacement } from 'src/lib/ai-session-placement';
 import { getBundledNodeBinaryPath, getCliPath } from 'src/storage/paths';
-import type { AgentRunEvent } from '@studio/common/ai/agent-events';
+import type { ActiveAgentRun, AgentRunEvent } from '@studio/common/ai/agent-events';
+import type { StudioChatArtifactData } from '@studio/common/ai/chat-artifacts';
 import type { JsonEvent } from '@studio/common/ai/json-events';
 import type { WebContents } from 'electron';
 
@@ -12,6 +14,8 @@ interface AgentRun {
 	webContents: WebContents;
 	interrupted: boolean;
 	interruptAttempts: number;
+	eventQueue: Promise< void >;
+	startedAt: number;
 }
 
 // Two subprocesses resuming the same session id would race on the JSONL
@@ -35,6 +39,72 @@ function sendEvent( run: AgentRun, event: AgentRunEvent[ 'event' ] ): void {
 	run.webContents.send( 'ai-agent-event', payload );
 }
 
+function getCreatedSiteFromArtifact( artifact: StudioChatArtifactData ):
+	| {
+			siteId: string;
+			sitePath: string;
+			siteName: string;
+	  }
+	| undefined {
+	for ( const widget of artifact.widgets ) {
+		if ( widget.type !== 'site-preview' ) {
+			continue;
+		}
+		const { siteId, sitePath, siteName } = widget.widgetProps;
+		if (
+			typeof siteId === 'string' &&
+			typeof sitePath === 'string' &&
+			typeof siteName === 'string'
+		) {
+			return { siteId, sitePath, siteName };
+		}
+	}
+	return undefined;
+}
+
+async function applySessionPlacementFromEvent( run: AgentRun, event: JsonEvent ): Promise< void > {
+	if ( event.type !== 'chat.artifact' ) {
+		return;
+	}
+	const createdSite = getCreatedSiteFromArtifact( event.artifact );
+	if ( ! createdSite ) {
+		return;
+	}
+	const placement = await setAiSessionSitePlacement( run.sessionId, createdSite );
+	if ( run.webContents.isDestroyed() ) {
+		return;
+	}
+	run.webContents.send( 'ai-session-placement-updated', {
+		sessionId: run.sessionId,
+		placement,
+	} );
+}
+
+async function sendQueuedJsonEvent( run: AgentRun, event: JsonEvent ): Promise< void > {
+	try {
+		await applySessionPlacementFromEvent( run, event );
+	} catch ( error ) {
+		sendEvent( run, {
+			type: 'error',
+			timestamp: nowIso(),
+			message: error instanceof Error ? error.message : 'Failed to update session placement',
+		} );
+	}
+	sendEvent( run, event );
+}
+
+function enqueueJsonEvent( run: AgentRun, event: JsonEvent ): void {
+	run.eventQueue = run.eventQueue
+		.then( () => sendQueuedJsonEvent( run, event ) )
+		.catch( ( error ) => {
+			sendEvent( run, {
+				type: 'error',
+				timestamp: nowIso(),
+				message: error instanceof Error ? error.message : 'Failed to forward agent event',
+			} );
+		} );
+}
+
 export interface StartAgentRunOptions {
 	sessionId: string;
 	prompt: string;
@@ -50,6 +120,7 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 	}
 
 	const runId = crypto.randomUUID();
+	const startedAt = Date.now();
 	const cliPath = getCliPath();
 	const args = [ 'code', 'sessions', 'resume', sessionId, prompt, '--json', '--avoid-telemetry' ];
 	if ( displayMessage ) {
@@ -72,6 +143,8 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 		webContents,
 		interrupted: false,
 		interruptAttempts: 0,
+		eventQueue: Promise.resolve(),
+		startedAt,
 	};
 
 	runsBySessionId.set( sessionId, run );
@@ -86,7 +159,7 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 		// shape (`{ action, status, message }`) on error paths. Forward only
 		// messages that look like the CLI JSON transport envelope.
 		if ( message && typeof message === 'object' && 'type' in message ) {
-			sendEvent( run, message as JsonEvent );
+			enqueueJsonEvent( run, message as JsonEvent );
 		}
 	} );
 
@@ -94,14 +167,16 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 		runsBySessionId.delete( sessionId );
 		runsById.delete( runId );
 
-		if ( run.interrupted ) {
-			sendEvent( run, { type: 'run.interrupted', timestamp: nowIso() } );
-		}
-		sendEvent( run, {
-			type: 'run.exited',
-			timestamp: nowIso(),
-			status: code === 0 ? 'success' : 'error',
-			code,
+		void run.eventQueue.finally( () => {
+			if ( run.interrupted ) {
+				sendEvent( run, { type: 'run.interrupted', timestamp: nowIso() } );
+			}
+			sendEvent( run, {
+				type: 'run.exited',
+				timestamp: nowIso(),
+				status: code === 0 ? 'success' : 'error',
+				code,
+			} );
 		} );
 	};
 
@@ -124,6 +199,15 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 	webContents.once( 'destroyed', abortOnDestroy );
 
 	return { runId };
+}
+
+export function listActiveAgentRuns(): ActiveAgentRun[] {
+	return Array.from( runsBySessionId.values() ).map( ( run ) => ( {
+		runId: run.runId,
+		sessionId: run.sessionId,
+		startedAt: run.startedAt,
+		phase: run.interrupted ? 'interrupting' : 'running',
+	} ) );
 }
 
 const INTERRUPT_FORCE_KILL_TIMEOUT_MS = 2000;

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -217,6 +217,7 @@ const api: IpcApi = {
 		ipcRendererInvoke( 'updateAiSessionMetadata', sessionIdOrPrefix, patch ),
 	continueAiSession: ( sessionId, prompt, options ) =>
 		ipcRendererInvoke( 'continueAiSession', sessionId, prompt, options ),
+	listActiveAiAgentRuns: () => ipcRendererInvoke( 'listActiveAiAgentRuns' ),
 	setAiSessionModel: ( sessionId, model ) =>
 		ipcRendererInvoke( 'setAiSessionModel', sessionId, model ),
 	interruptAiAgentRun: ( runId ) => ipcRendererInvoke( 'interruptAiAgentRun', runId ),

--- a/apps/studio/src/storage/storage-types.ts
+++ b/apps/studio/src/storage/storage-types.ts
@@ -17,6 +17,13 @@ export interface AppdataSiteData {
 	sortOrder?: number;
 }
 
+export interface AiSessionSitePlacement {
+	kind: 'site';
+	siteId: string;
+	sitePath: string;
+	siteName: string;
+}
+
 export interface UserData {
 	version: 1;
 	siteMetadata: Record< string, AppdataSiteData >;
@@ -36,6 +43,7 @@ export interface UserData {
 	cliAutoInstalled?: boolean;
 	wapuuScore?: number;
 	desks?: DesksConfig;
+	aiSessionPlacements?: Record< string, AiSessionSitePlacement >;
 }
 
 export interface PromptWindowsSpeedUpResult {

--- a/apps/ui/src/app/app-providers.tsx
+++ b/apps/ui/src/app/app-providers.tsx
@@ -3,6 +3,8 @@ import { defaultI18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
 import { privateApis } from '@wordpress/theme';
 import { ConnectorProvider, queryClient } from '@/data/core';
+import { AgentRunProvider } from '@/data/queries/use-agent-run';
+import { useSyncSessionsWithEvents } from '@/data/queries/use-sessions';
 import { useSyncSitesWithEvents } from '@/data/queries/use-sites';
 import { usePrefersColorScheme } from '@/hooks/use-prefers-color-scheme';
 import { useSyncConnectSiteListener } from '@/hooks/use-sync-connect-site-listener';
@@ -18,6 +20,7 @@ interface AppProvidersProps extends PropsWithChildren {
 
 function SiteEventsBridge() {
 	useSyncSitesWithEvents();
+	useSyncSessionsWithEvents();
 	useSyncConnectSiteListener();
 	return null;
 }
@@ -29,12 +32,14 @@ export function AppProviders( { children, connector }: AppProvidersProps ) {
 	return (
 		<ConnectorProvider connector={ connector }>
 			<QueryClientProvider client={ queryClient }>
-				<SiteEventsBridge />
-				<I18nProvider i18n={ defaultI18n }>
-					<ThemeProvider isRoot color={ themeColor } density="compact">
-						{ children }
-					</ThemeProvider>
-				</I18nProvider>
+				<AgentRunProvider>
+					<SiteEventsBridge />
+					<I18nProvider i18n={ defaultI18n }>
+						<ThemeProvider isRoot color={ themeColor } density="compact">
+							{ children }
+						</ThemeProvider>
+					</I18nProvider>
+				</AgentRunProvider>
 			</QueryClientProvider>
 		</ConnectorProvider>
 	);

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -1,7 +1,9 @@
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
 import { __ } from '@wordpress/i18n';
 import type {
+	ActiveAgentRun,
 	AiSessionSummary,
+	AiSessionPlacementUpdatedEvent,
 	AuthUser,
 	ColorScheme,
 	Connector,
@@ -536,6 +538,10 @@ export function createIpcConnector(): Connector {
 			};
 		},
 
+		async getActiveAgentRuns(): Promise< ActiveAgentRun[] > {
+			return ( await ipcApi.listActiveAiAgentRuns() ) as ActiveAgentRun[];
+		},
+
 		async setSessionModel( sessionId, model ) {
 			await ipcApi.setAiSessionModel( sessionId, model );
 		},
@@ -566,6 +572,15 @@ export function createIpcConnector(): Connector {
 			const ipcListener = ( window as any ).ipcListener;
 			return ipcListener.subscribe( 'ai-agent-event', ( _event: unknown, payload: AgentRunEvent ) =>
 				listener( payload )
+			);
+		},
+
+		onSessionPlacementUpdated( listener ) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const ipcListener = ( window as any ).ipcListener;
+			return ipcListener.subscribe(
+				'ai-session-placement-updated',
+				( _event: unknown, payload: AiSessionPlacementUpdatedEvent ) => listener( payload )
 			);
 		},
 

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -36,4 +36,4 @@ export type {
 	UserPreferences,
 	WritableUserPreferences,
 } from './types';
-export type { AgentEvent, AgentRunEvent } from '@studio/common/ai/agent-events';
+export type { ActiveAgentRun, AgentEvent, AgentRunEvent } from '@studio/common/ai/agent-events';

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -1,4 +1,4 @@
-import type { AgentRunEvent } from '@studio/common/ai/agent-events';
+import type { ActiveAgentRun, AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { AiModelId } from '@studio/common/ai/models';
 import type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessions/types';
 import type { SupportedLocale } from '@studio/common/lib/locale';
@@ -11,6 +11,7 @@ import type { SyncSite } from '@studio/common/types/sync';
 import type { SiteRestRequest, SiteRestResponse } from '@studio/common/types/wordpress-rest';
 import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
 
+export type { ActiveAgentRun, AgentRunEvent } from '@studio/common/ai/agent-events';
 export type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessions/types';
 export type { SessionEntry } from '@mariozechner/pi-coding-agent';
 export type {
@@ -33,6 +34,18 @@ export type { SupportedTerminal } from '@studio/common/lib/user-settings/termina
 export type { SupportedLocale } from '@studio/common/lib/locale';
 
 export type InstalledApps = Record< SupportedEditor | SupportedTerminal, boolean >;
+
+export interface AiSessionSitePlacement {
+	kind: 'site';
+	siteId: string;
+	sitePath: string;
+	siteName: string;
+}
+
+export interface AiSessionPlacementUpdatedEvent {
+	sessionId: string;
+	placement: AiSessionSitePlacement;
+}
 
 export interface SiteDetails {
 	id: string;
@@ -218,6 +231,7 @@ export interface Connector {
 		prompt: string,
 		options?: { displayMessage?: string }
 	): Promise< { runId: string } >;
+	getActiveAgentRuns(): Promise< ActiveAgentRun[] >;
 	// Persist a UI-driven model override for the session. The CLI picks this up
 	// on the next turn; the change survives reloads because it's written to the
 	// session JSONL.
@@ -225,6 +239,9 @@ export interface Connector {
 	interruptAgentRun( runId: string ): Promise< void >;
 	answerAgentQuestion( runId: string, answers: Record< string, string > ): Promise< void >;
 	onAgentEvent( listener: ( event: AgentRunEvent ) => void ): () => void;
+	onSessionPlacementUpdated(
+		listener: ( event: AiSessionPlacementUpdatedEvent ) => void
+	): () => void;
 
 	// Flip the session between acting on its owner site's local runtime vs.
 	// its linked WordPress.com live site. The owner site itself never changes.

--- a/apps/ui/src/data/queries/use-agent-run.tsx
+++ b/apps/ui/src/data/queries/use-agent-run.tsx
@@ -1,5 +1,14 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useReducer, useRef } from 'react';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useReducer,
+	useRef,
+	type PropsWithChildren,
+} from 'react';
 import { useConnector } from '@/data/core';
 import { SESSIONS_QUERY_KEY } from '@/data/queries/use-sessions';
 import type { AgentEvent, AgentRunEvent, LoadedAiSession, SessionEntry } from '@/data/core';
@@ -33,15 +42,15 @@ export interface SendMessageOptions {
 }
 
 export interface LiveAgentEvents {
-	// Agent loop is working — drives the thinking indicator. Clears at
+	// Agent loop is working - drives the thinking indicator. Clears at
 	// `turn.completed`, before the subprocess has finished winding down.
 	isRunning: boolean;
-	// Subprocess is still alive — blocks starting a new turn. Clears at
+	// Subprocess is still alive - blocks starting a new turn. Clears at
 	// `run.exited`/`run.interrupted`, which can lag `turn.completed` by
 	// the persist-queue drain time.
 	hasActiveRun: boolean;
 	// User has clicked Stop and we're waiting for the child to wind down.
-	// Gives the Stop button immediate "Stopping…" feedback.
+	// Gives the Stop button immediate "Stopping..." feedback.
 	isInterrupting: boolean;
 	startedAt: number | null;
 	error: string | null;
@@ -59,11 +68,10 @@ export interface LiveAgentEvents {
 	removeQueuedPrompt: ( id: string ) => void;
 }
 
-// `starting` → prompt was submitted and the subprocess run id is being created.
-// `running` → agent loop is working (thinking indicator shown).
-// `winding_down` → turn completed, subprocess still draining; composer
-// stays disabled so the user can't start a new turn mid-exit.
-// `idle` → no active run.
+// `starting` means the prompt was submitted and the subprocess run id is being created.
+// `running` means the agent loop is working (thinking indicator shown).
+// `winding_down` means the turn completed, but the subprocess is still draining.
+// `idle` means no active run.
 type RunPhase = 'idle' | 'starting' | 'running' | 'winding_down';
 
 interface State {
@@ -89,7 +97,7 @@ const initialState: State = {
 };
 
 type Action =
-	| { type: 'reset' }
+	| { type: 'hydrate_active_run'; runId: string; startedAt: number; interrupting: boolean }
 	| { type: 'send_pending'; startedAt: number }
 	| { type: 'send_start'; runId: string; startedAt: number }
 	| { type: 'error_set'; message: string | null }
@@ -106,8 +114,15 @@ type Action =
 
 function reducer( state: State, action: Action ): State {
 	switch ( action.type ) {
-		case 'reset':
-			return initialState;
+		case 'hydrate_active_run':
+			return {
+				...state,
+				phase: 'running',
+				runId: action.runId,
+				startedAt: action.startedAt,
+				error: null,
+				isInterrupting: action.interrupting,
+			};
 		case 'send_pending':
 			return {
 				...state,
@@ -175,47 +190,60 @@ function reducer( state: State, action: Action ): State {
 	}
 }
 
-export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
+type StatesBySession = Record< string, State >;
+
+type StoreAction = {
+	sessionId: string;
+	action: Action;
+};
+
+function storeReducer(
+	state: StatesBySession,
+	{ sessionId, action }: StoreAction
+): StatesBySession {
+	const previous = state[ sessionId ] ?? initialState;
+	const next = reducer( previous, action );
+	if ( next === previous ) {
+		return state;
+	}
+	return { ...state, [ sessionId ]: next };
+}
+
+function getTimestampMs( timestamp: string ): number {
+	const parsed = Date.parse( timestamp );
+	return Number.isNaN( parsed ) ? Date.now() : parsed;
+}
+
+interface AgentRunStore {
+	states: StatesBySession;
+	dispatchSession: ( sessionId: string, action: Action ) => void;
+	startRun: ( sessionId: string, prompt: string, options?: SendMessageOptions ) => Promise< void >;
+	interrupt: ( sessionId: string ) => Promise< void >;
+	answerQuestion: ( sessionId: string, question: string, answer: string ) => void;
+}
+
+const AgentRunContext = createContext< AgentRunStore | null >( null );
+
+export function AgentRunProvider( { children }: PropsWithChildren ) {
 	const connector = useConnector();
 	const queryClient = useQueryClient();
-
-	const [ state, dispatch ] = useReducer( reducer, initialState );
-	const {
-		phase,
-		runId,
-		startedAt,
-		error,
-		isInterrupting,
-		pendingQuestions,
-		pendingAnswers,
-		queuedPrompts,
-	} = state;
-
-	// Subscribed until `run.exited` so trailing events for a run whose turn
-	// has already completed still match the filter.
-	const subscribedRunIdRef = useRef< string | null >( null );
+	const [ states, dispatch ] = useReducer( storeReducer, {} );
+	const statesRef = useRef< StatesBySession >( states );
+	const subscribedRunIdsBySessionRef = useRef< Map< string, string > >( new Map() );
 	const ignoredRunIdsRef = useRef< Set< string > >( new Set() );
-	const interruptRequestRef = useRef< Promise< void > | null >( null );
-	const interruptPendingStartRef = useRef( false );
-	// Re-entry guard for the queue auto-dispatch effect. The effect's deps
-	// re-fire on every queue/phase change; without this guard a second render
-	// between the async start-call and `send_start` could kick off a duplicate
-	// run for the same queued prompt.
-	const dispatchingQueuedRef = useRef( false );
+	const interruptRequestsBySessionRef = useRef< Map< string, Promise< void > > >( new Map() );
+	const interruptPendingStartSessionIdsRef = useRef< Set< string > >( new Set() );
 
 	useEffect( () => {
-		dispatch( { type: 'reset' } );
-		subscribedRunIdRef.current = null;
-		ignoredRunIdsRef.current = new Set();
-		interruptRequestRef.current = null;
-		interruptPendingStartRef.current = false;
-	}, [ sessionId ] );
+		statesRef.current = states;
+	}, [ states ] );
+
+	const dispatchSession = useCallback( ( sessionId: string, action: Action ) => {
+		dispatch( { sessionId, action } );
+	}, [] );
 
 	const updateCache = useCallback(
-		( updater: ( entries: SessionEntry[] ) => SessionEntry[] ) => {
-			if ( ! sessionId ) {
-				return;
-			}
+		( sessionId: string, updater: ( entries: SessionEntry[] ) => SessionEntry[] ) => {
 			queryClient.setQueryData< LoadedAiSession >(
 				[ ...SESSIONS_QUERY_KEY, sessionId ],
 				( prev ) => {
@@ -228,45 +256,78 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 				}
 			);
 		},
-		[ queryClient, sessionId ]
+		[ queryClient ]
 	);
 
 	useEffect( () => {
-		if ( ! sessionId ) {
-			return;
-		}
-		const unsubscribe = connector.onAgentEvent( ( payload: AgentRunEvent ) => {
-			if ( payload.sessionId !== sessionId ) {
-				return;
-			}
+		let cancelled = false;
+
+		void connector
+			.getActiveAgentRuns()
+			.then( ( runs ) => {
+				if ( cancelled ) {
+					return;
+				}
+				for ( const run of runs ) {
+					subscribedRunIdsBySessionRef.current.set( run.sessionId, run.runId );
+					dispatchSession( run.sessionId, {
+						type: 'hydrate_active_run',
+						runId: run.runId,
+						startedAt: run.startedAt,
+						interrupting: run.phase === 'interrupting',
+					} );
+				}
+			} )
+			.catch( () => {
+				// A failed snapshot should not break normal live event handling.
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ connector, dispatchSession ] );
+
+	useEffect( () => {
+		return connector.onAgentEvent( ( payload: AgentRunEvent ) => {
 			if ( ignoredRunIdsRef.current.has( payload.runId ) ) {
 				if ( payload.event.type === 'run.exited' || payload.event.type === 'run.interrupted' ) {
 					ignoredRunIdsRef.current.delete( payload.runId );
 				}
 				return;
 			}
-			if ( subscribedRunIdRef.current && payload.runId !== subscribedRunIdRef.current ) {
+
+			const subscribedRunId = subscribedRunIdsBySessionRef.current.get( payload.sessionId );
+			if ( subscribedRunId && payload.runId !== subscribedRunId ) {
 				return;
 			}
 
 			const event: AgentEvent = payload.event;
 
 			switch ( event.type ) {
+				case 'run.started':
+					subscribedRunIdsBySessionRef.current.set( payload.sessionId, payload.runId );
+					dispatchSession( payload.sessionId, {
+						type: 'hydrate_active_run',
+						runId: payload.runId,
+						startedAt: getTimestampMs( event.timestamp ),
+						interrupting: false,
+					} );
+					return;
 				case 'error':
-					dispatch( { type: 'error_set', message: event.message } );
+					dispatchSession( payload.sessionId, { type: 'error_set', message: event.message } );
 					return;
 				case 'turn.completed':
-					dispatch( { type: 'turn_completed' } );
+					dispatchSession( payload.sessionId, { type: 'turn_completed' } );
 					return;
 				case 'run.interrupting':
-					dispatch( { type: 'interrupt_requested' } );
+					dispatchSession( payload.sessionId, { type: 'interrupt_requested' } );
 					return;
 				case 'run.exited':
 				case 'run.interrupted':
 					if ( event.type === 'run.interrupted' ) {
 						// Synthetic studio.turn_closed for immediate "Interrupted
 						// by you" rendering; the CLI also writes a real one.
-						updateCache( ( entries ) => [
+						updateCache( payload.sessionId, ( entries ) => [
 							...entries,
 							{
 								type: 'custom',
@@ -278,8 +339,8 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 							} as SessionEntry,
 						] );
 					}
-					dispatch( { type: 'run_ended' } );
-					subscribedRunIdRef.current = null;
+					dispatchSession( payload.sessionId, { type: 'run_ended' } );
+					subscribedRunIdsBySessionRef.current.delete( payload.sessionId );
 					// Refetch to replace optimistic entries with disk-backed ones.
 					void queryClient.invalidateQueries( {
 						queryKey: SESSIONS_QUERY_KEY,
@@ -292,7 +353,7 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 						inner.type === 'message_end' &&
 						( inner.message as { role?: string } ).role === 'assistant'
 					) {
-						updateCache( ( entries ) => [
+						updateCache( payload.sessionId, ( entries ) => [
 							...entries,
 							{
 								type: 'message',
@@ -305,7 +366,7 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 					} else if ( inner.type === 'turn_end' ) {
 						const toolResults = inner.toolResults;
 						if ( Array.isArray( toolResults ) && toolResults.length > 0 ) {
-							updateCache( ( entries ) => [
+							updateCache( payload.sessionId, ( entries ) => [
 								...entries,
 								...toolResults.map(
 									( tr ) =>
@@ -323,7 +384,7 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 					return;
 				}
 				case 'progress':
-					updateCache( ( entries ) => [
+					updateCache( payload.sessionId, ( entries ) => [
 						...entries,
 						{
 							type: 'custom',
@@ -336,7 +397,7 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 					] );
 					return;
 				case 'chat.artifact':
-					updateCache( ( entries ) => [
+					updateCache( payload.sessionId, ( entries ) => [
 						...entries,
 						{
 							type: 'custom',
@@ -350,7 +411,7 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 					return;
 				case 'question.asked':
 					if ( event.questions.length === 0 ) return;
-					updateCache( ( entries ) => [
+					updateCache( payload.sessionId, ( entries ) => [
 						...entries,
 						...event.questions.map(
 							( q ) =>
@@ -364,23 +425,19 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 								} ) as SessionEntry
 						),
 					] );
-					dispatch( { type: 'questions_added', questions: event.questions } );
+					dispatchSession( payload.sessionId, {
+						type: 'questions_added',
+						questions: event.questions,
+					} );
 					return;
 			}
 		} );
-		return unsubscribe;
-	}, [ connector, queryClient, sessionId, updateCache ] );
+	}, [ connector, dispatchSession, queryClient, updateCache ] );
 
-	// Core "start a new turn" path. Shared by direct sends (`sendMessage` when
-	// idle) and the queue auto-dispatch effect. Throws on error so the direct
-	// caller can restore the composer draft; the queue path catches and clears.
 	const startRun = useCallback(
-		async ( prompt: string, options: SendMessageOptions = {} ) => {
-			if ( ! sessionId ) {
-				throw new Error( 'No session selected' );
-			}
+		async ( sessionId: string, prompt: string, options: SendMessageOptions = {} ) => {
 			const displayMessage = options.displayMessage ?? prompt;
-			dispatch( { type: 'error_set', message: null } );
+			dispatchSession( sessionId, { type: 'error_set', message: null } );
 
 			const optimisticEntry: SessionEntry = {
 				type: 'custom',
@@ -390,46 +447,156 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 				customType: 'studio.user_prompt',
 				data: { text: displayMessage, source: 'prompt' },
 			} as SessionEntry;
-			updateCache( ( entries ) => [ ...entries, optimisticEntry ] );
-			dispatch( { type: 'send_pending', startedAt: Date.now() } );
+			updateCache( sessionId, ( entries ) => [ ...entries, optimisticEntry ] );
+			dispatchSession( sessionId, { type: 'send_pending', startedAt: Date.now() } );
 
 			try {
-				await interruptRequestRef.current;
+				await interruptRequestsBySessionRef.current.get( sessionId );
 				const { runId: newRunId } = await connector.continueSession( sessionId, prompt, {
 					displayMessage,
 				} );
-				if ( interruptPendingStartRef.current ) {
-					interruptPendingStartRef.current = false;
+				if ( interruptPendingStartSessionIdsRef.current.has( sessionId ) ) {
+					interruptPendingStartSessionIdsRef.current.delete( sessionId );
 					ignoredRunIdsRef.current.add( newRunId );
 					const interruptRequest = connector.interruptAgentRun( newRunId ).finally( () => {
-						if ( interruptRequestRef.current === interruptRequest ) {
-							interruptRequestRef.current = null;
+						if ( interruptRequestsBySessionRef.current.get( sessionId ) === interruptRequest ) {
+							interruptRequestsBySessionRef.current.delete( sessionId );
 						}
 					} );
-					interruptRequestRef.current = interruptRequest;
+					interruptRequestsBySessionRef.current.set( sessionId, interruptRequest );
 					return;
 				}
-				dispatch( { type: 'send_start', runId: newRunId, startedAt: Date.now() } );
-				subscribedRunIdRef.current = newRunId;
+				dispatchSession( sessionId, {
+					type: 'send_start',
+					runId: newRunId,
+					startedAt: Date.now(),
+				} );
+				subscribedRunIdsBySessionRef.current.set( sessionId, newRunId );
 			} catch ( err ) {
-				updateCache( ( entries ) => {
+				updateCache( sessionId, ( entries ) => {
 					const idx = entries.lastIndexOf( optimisticEntry );
 					if ( idx === -1 ) return entries;
 					return [ ...entries.slice( 0, idx ), ...entries.slice( idx + 1 ) ];
 				} );
 				const message = err instanceof Error ? err.message : String( err );
-				dispatch( { type: 'error_set', message } );
+				dispatchSession( sessionId, { type: 'error_set', message } );
 				throw err;
 			}
 		},
-		[ connector, sessionId, updateCache ]
+		[ connector, dispatchSession, updateCache ]
 	);
+
+	const interrupt = useCallback(
+		async ( sessionId: string ) => {
+			const state = statesRef.current[ sessionId ] ?? initialState;
+			if ( state.phase === 'idle' ) {
+				return;
+			}
+			const interruptedRunId = state.runId;
+			if ( interruptedRunId ) {
+				ignoredRunIdsRef.current.add( interruptedRunId );
+			} else {
+				interruptPendingStartSessionIdsRef.current.add( sessionId );
+			}
+			subscribedRunIdsBySessionRef.current.delete( sessionId );
+			updateCache( sessionId, ( entries ) => [
+				...entries,
+				{
+					type: 'custom',
+					id: shortEntryId(),
+					parentId: null,
+					timestamp: nowIso(),
+					customType: 'studio.turn_closed',
+					data: { status: 'interrupted' },
+				} as SessionEntry,
+			] );
+			// Optimistic feedback: the main-process `run.interrupting` event will
+			// also set this, but flipping state on the click keeps the button
+			// from lingering in its active style while the IPC is in flight.
+			dispatchSession( sessionId, { type: 'interrupt_requested' } );
+			if ( ! interruptedRunId ) {
+				return;
+			}
+			const interruptRequest = connector.interruptAgentRun( interruptedRunId ).finally( () => {
+				if ( interruptRequestsBySessionRef.current.get( sessionId ) === interruptRequest ) {
+					interruptRequestsBySessionRef.current.delete( sessionId );
+				}
+			} );
+			interruptRequestsBySessionRef.current.set( sessionId, interruptRequest );
+			await interruptRequest;
+		},
+		[ connector, dispatchSession, updateCache ]
+	);
+
+	const answerQuestion = useCallback(
+		( sessionId: string, question: string, answer: string ) => {
+			const state = statesRef.current[ sessionId ] ?? initialState;
+			if ( ! state.runId ) {
+				return;
+			}
+			const nextAnswers = { ...state.pendingAnswers, [ question ]: answer };
+			const complete = state.pendingQuestions.every(
+				( q ) => typeof nextAnswers[ q.question ] === 'string'
+			);
+			if ( complete ) {
+				dispatchSession( sessionId, { type: 'batch_dispatched' } );
+				void connector.answerAgentQuestion( state.runId, nextAnswers );
+			} else {
+				dispatchSession( sessionId, { type: 'question_answered', question, answer } );
+			}
+		},
+		[ connector, dispatchSession ]
+	);
+
+	const value = useMemo< AgentRunStore >(
+		() => ( {
+			states,
+			dispatchSession,
+			startRun,
+			interrupt,
+			answerQuestion,
+		} ),
+		[ answerQuestion, dispatchSession, interrupt, startRun, states ]
+	);
+
+	return <AgentRunContext.Provider value={ value }>{ children }</AgentRunContext.Provider>;
+}
+
+export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
+	const store = useContext( AgentRunContext );
+	if ( ! store ) {
+		throw new Error( 'useAgentRun must be used within AgentRunProvider' );
+	}
+
+	const {
+		states,
+		dispatchSession,
+		startRun,
+		interrupt: interruptRun,
+		answerQuestion: answerRunQuestion,
+	} = store;
+	const state = sessionId ? states[ sessionId ] ?? initialState : initialState;
+	const {
+		phase,
+		startedAt,
+		error,
+		isInterrupting,
+		pendingQuestions,
+		pendingAnswers,
+		queuedPrompts,
+	} = state;
+
+	// Re-entry guard for the queue auto-dispatch effect. The effect's deps
+	// re-fire on every queue/phase change; without this guard a second render
+	// between the async start-call and `send_start` could kick off a duplicate
+	// run for the same queued prompt.
+	const dispatchingQueuedRef = useRef( false );
 
 	// Auto-dispatch the head of the queue once the previous run ends. On
 	// success, shift; on failure, drop the whole queue so a broken backend
 	// doesn't cascade errors.
 	useEffect( () => {
-		if ( phase !== 'idle' || queuedPrompts.length === 0 ) {
+		if ( ! sessionId || phase !== 'idle' || queuedPrompts.length === 0 ) {
 			return;
 		}
 		if ( dispatchingQueuedRef.current ) {
@@ -439,96 +606,62 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 		dispatchingQueuedRef.current = true;
 		void ( async () => {
 			try {
-				await startRun( next.prompt, { displayMessage: next.displayMessage } );
-				dispatch( { type: 'queue_shift' } );
+				await startRun( sessionId, next.prompt, { displayMessage: next.displayMessage } );
+				dispatchSession( sessionId, { type: 'queue_shift' } );
 			} catch {
-				dispatch( { type: 'queue_clear' } );
+				dispatchSession( sessionId, { type: 'queue_clear' } );
 			} finally {
 				dispatchingQueuedRef.current = false;
 			}
 		} )();
-	}, [ phase, queuedPrompts, startRun ] );
+	}, [ dispatchSession, phase, queuedPrompts, sessionId, startRun ] );
 
 	const sendMessage = useCallback(
 		async ( prompt: string, options: SendMessageOptions = {} ) => {
+			if ( ! sessionId ) {
+				throw new Error( 'No session selected' );
+			}
 			// Queue if anything is in flight, if we're waiting on question
 			// answers, or if earlier queued prompts haven't been dispatched yet
 			// (preserves FIFO order).
 			if ( phase !== 'idle' || pendingQuestions.length > 0 || queuedPrompts.length > 0 ) {
-				dispatch( {
+				dispatchSession( sessionId, {
 					type: 'queue_append',
 					prompt: { id: newId(), prompt, displayMessage: options.displayMessage },
 				} );
 				return;
 			}
-			await startRun( prompt, options );
+			await startRun( sessionId, prompt, options );
 		},
-		[ phase, pendingQuestions.length, queuedPrompts.length, startRun ]
+		[ dispatchSession, phase, pendingQuestions.length, queuedPrompts.length, sessionId, startRun ]
 	);
 
 	const interrupt = useCallback( async () => {
-		if ( phase === 'idle' ) {
+		if ( ! sessionId ) {
 			return;
 		}
-		const interruptedRunId = runId;
-		if ( interruptedRunId ) {
-			ignoredRunIdsRef.current.add( interruptedRunId );
-		} else {
-			interruptPendingStartRef.current = true;
-		}
-		subscribedRunIdRef.current = null;
-		updateCache( ( entries ) => [
-			...entries,
-			{
-				type: 'custom',
-				id: shortEntryId(),
-				parentId: null,
-				timestamp: nowIso(),
-				customType: 'studio.turn_closed',
-				data: { status: 'interrupted' },
-			} as SessionEntry,
-		] );
-		// Optimistic feedback: the main-process `run.interrupting` event will
-		// also set this, but flipping state on the click keeps the button
-		// from lingering in its active style while the IPC is in flight.
-		dispatch( { type: 'interrupt_requested' } );
-		if ( ! interruptedRunId ) {
-			return;
-		}
-		const interruptRequest = connector.interruptAgentRun( interruptedRunId ).finally( () => {
-			if ( interruptRequestRef.current === interruptRequest ) {
-				interruptRequestRef.current = null;
-			}
-		} );
-		interruptRequestRef.current = interruptRequest;
-		await interruptRequest;
-	}, [ connector, phase, runId, updateCache ] );
+		await interruptRun( sessionId );
+	}, [ interruptRun, sessionId ] );
 
-	// Dispatch the batch once every question has an answer. Done inline here
-	// (rather than via a useEffect watching `pendingAnswers`) because the
-	// "all-answered → send" decision is a direct consequence of this click.
 	const answerQuestion = useCallback(
 		( question: string, answer: string ) => {
-			if ( ! runId ) {
+			if ( ! sessionId ) {
 				return;
 			}
-			const nextAnswers = { ...pendingAnswers, [ question ]: answer };
-			const complete = pendingQuestions.every(
-				( q ) => typeof nextAnswers[ q.question ] === 'string'
-			);
-			if ( complete ) {
-				dispatch( { type: 'batch_dispatched' } );
-				void connector.answerAgentQuestion( runId, nextAnswers );
-			} else {
-				dispatch( { type: 'question_answered', question, answer } );
-			}
+			answerRunQuestion( sessionId, question, answer );
 		},
-		[ connector, runId, pendingAnswers, pendingQuestions ]
+		[ answerRunQuestion, sessionId ]
 	);
 
-	const removeQueuedPrompt = useCallback( ( id: string ) => {
-		dispatch( { type: 'queue_remove', id } );
-	}, [] );
+	const removeQueuedPrompt = useCallback(
+		( id: string ) => {
+			if ( ! sessionId ) {
+				return;
+			}
+			dispatchSession( sessionId, { type: 'queue_remove', id } );
+		},
+		[ dispatchSession, sessionId ]
+	);
 
 	return {
 		isRunning: phase === 'starting' || phase === 'running',

--- a/apps/ui/src/data/queries/use-sessions.ts
+++ b/apps/ui/src/data/queries/use-sessions.ts
@@ -1,6 +1,6 @@
 import { deriveEffectiveEnvironment } from '@studio/common/ai/sessions/effective-site';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useConnector } from '@/data/core';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import type { AiSessionSummary, LoadedAiSession } from '@/data/core';
@@ -213,4 +213,17 @@ export function useSessionEffectiveEnvironment(
 		const connectedLiveIds = new Set( ( connectedSites ?? [] ).map( ( site ) => site.id ) );
 		return deriveEffectiveEnvironment( summary, ( blogId ) => connectedLiveIds.has( blogId ) );
 	}, [ summary, connectedSites ] );
+}
+
+export function useSyncSessionsWithEvents(): void {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	useEffect( () => {
+		return connector.onSessionPlacementUpdated( ( event ) => {
+			void queryClient.invalidateQueries( { queryKey: SESSIONS_QUERY_KEY } );
+			void queryClient.invalidateQueries( {
+				queryKey: [ ...SESSIONS_QUERY_KEY, event.sessionId ],
+			} );
+		} );
+	}, [ connector, queryClient ] );
 }

--- a/apps/ui/src/ui-desks/chats/panel/index.tsx
+++ b/apps/ui/src/ui-desks/chats/panel/index.tsx
@@ -79,7 +79,9 @@ export function Chats( { siteId }: ChatsProps ) {
 	const chatSessions = [ ...filteredSessions ].sort(
 		( a, b ) => Date.parse( b.updatedAt ) - Date.parse( a.updatedAt )
 	);
-	const selectedSession = chatSessions.find( ( session ) => session.id === selectedSessionId );
+	const selectedSession =
+		chatSessions.find( ( session ) => session.id === selectedSessionId ) ??
+		( sessions ?? [] ).find( ( session ) => session.id === selectedSessionId );
 	const isListCollapsed = expanded && listCollapsed;
 
 	useEffect( () => {

--- a/apps/ui/src/ui-desks/chats/provider.tsx
+++ b/apps/ui/src/ui-desks/chats/provider.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useConnector } from '@/data/core';
 import { useCreateSession } from '@/data/queries/use-sessions';
 import {
 	ChatsContext,
@@ -17,6 +18,7 @@ function useChatsSearch() {
 	const navigate = useNavigate();
 	const open = search.chats === true;
 	const createChatRequestId = search.newChat ?? 0;
+	const routeSessionId = search.session;
 
 	const setOpen = useCallback(
 		( nextOpen: boolean ) => {
@@ -25,13 +27,14 @@ function useChatsSearch() {
 				search: ( previous: ChatsSearch ) => ( {
 					...previous,
 					chats: nextOpen ? true : undefined,
+					session: nextOpen ? previous.session : undefined,
 				} ),
 			} );
 		},
 		[ navigate ]
 	);
 
-	return { open, setOpen, createChatRequestId };
+	return { open, setOpen, createChatRequestId, routeSessionId, navigate };
 }
 
 function createPendingPromptId() {
@@ -43,7 +46,8 @@ function createComposerWidgetAttachmentRequestId() {
 }
 
 export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
-	const { open, setOpen, createChatRequestId } = useChatsSearch();
+	const { open, setOpen, createChatRequestId, routeSessionId, navigate } = useChatsSearch();
+	const connector = useConnector();
 	const createSession = useCreateSession();
 	const lastCreateChatRequestId = useRef( createChatRequestId );
 	const [ selectedSessionId, setSelectedSessionId ] = useState< string | undefined >( undefined );
@@ -60,31 +64,55 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 	>( undefined );
 	const [ isComposerWidgetDragTarget, setComposerWidgetDragTarget ] = useState( false );
 
-	const selectSession = useCallback( ( sessionId: string ) => {
-		setSelectedSessionId( sessionId );
-		setExpanded( true );
-		setAutoFocusSessionId( undefined );
-	}, [] );
+	const setRouteSession = useCallback(
+		( sessionId: string | undefined ) => {
+			void navigate( {
+				to: '.',
+				search: ( previous: ChatsSearch ) => ( {
+					...previous,
+					chats: sessionId ? true : previous.chats,
+					session: sessionId,
+				} ),
+			} );
+		},
+		[ navigate ]
+	);
 
-	const switchSession = useCallback( ( sessionId: string ) => {
-		setSelectedSessionId( sessionId );
-		setExpanded( true );
-		setAutoFocusSessionId( sessionId );
-	}, [] );
+	const selectSession = useCallback(
+		( sessionId: string ) => {
+			setSelectedSessionId( sessionId );
+			setExpanded( true );
+			setAutoFocusSessionId( undefined );
+			setRouteSession( sessionId );
+		},
+		[ setRouteSession ]
+	);
+
+	const switchSession = useCallback(
+		( sessionId: string ) => {
+			setSelectedSessionId( sessionId );
+			setExpanded( true );
+			setAutoFocusSessionId( sessionId );
+			setRouteSession( sessionId );
+		},
+		[ setRouteSession ]
+	);
 
 	const clearSelection = useCallback( () => {
 		setSelectedSessionId( undefined );
 		setExpanded( false );
 		setAutoFocusSessionId( undefined );
-	}, [] );
+		setRouteSession( undefined );
+	}, [ setRouteSession ] );
 
 	const startNewChat = useCallback( async () => {
 		const session = await createSession.mutateAsync( siteId );
 		setSelectedSessionId( session.id );
 		setExpanded( true );
 		setAutoFocusSessionId( session.id );
+		setRouteSession( session.id );
 		setOpen( true );
-	}, [ createSession, setOpen, siteId ] );
+	}, [ createSession, setOpen, setRouteSession, siteId ] );
 
 	const startChatWithPrompt = useCallback(
 		async ( request: ChatPromptRequest ) => {
@@ -98,9 +126,10 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 				prompt: request.prompt,
 				displayMessage: request.displayMessage ?? request.prompt,
 			} );
+			setRouteSession( session.id );
 			setOpen( true );
 		},
-		[ createSession, setOpen, siteId ]
+		[ createSession, setOpen, setRouteSession, siteId ]
 	);
 
 	const consumePendingPrompt = useCallback( ( promptId: string ) => {
@@ -136,6 +165,36 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 		lastCreateChatRequestId.current = createChatRequestId;
 		void startNewChat();
 	}, [ createChatRequestId, startNewChat ] );
+
+	useEffect( () => {
+		if ( ! routeSessionId ) {
+			return;
+		}
+		setSelectedSessionId( routeSessionId );
+		setExpanded( true );
+		setAutoFocusSessionId( undefined );
+		setOpen( true );
+	}, [ routeSessionId, setOpen ] );
+
+	useEffect( () => {
+		return connector.onSessionPlacementUpdated( ( event ) => {
+			if ( event.sessionId !== selectedSessionId ) {
+				return;
+			}
+			if ( event.placement.siteId === siteId ) {
+				return;
+			}
+			void navigate( {
+				to: '/sites/$siteId',
+				params: { siteId: event.placement.siteId },
+				search: ( previous: ChatsSearch ) => ( {
+					...previous,
+					chats: true,
+					session: event.sessionId,
+				} ),
+			} );
+		} );
+	}, [ connector, navigate, selectedSessionId, siteId ] );
 
 	return (
 		<ChatsContext.Provider

--- a/apps/ui/src/ui-desks/chats/search.ts
+++ b/apps/ui/src/ui-desks/chats/search.ts
@@ -1,6 +1,7 @@
 export interface ChatsSearch {
 	chats?: boolean;
 	newChat?: number;
+	session?: string;
 }
 
 function parseChatsSearch( value: unknown ) {
@@ -16,5 +17,6 @@ export function validateChatsSearch( search: Record< string, unknown > ): ChatsS
 	return {
 		chats: parseChatsSearch( search.chats ) || undefined,
 		newChat: parseNewChatSearch( search.newChat ),
+		session: typeof search.session === 'string' && search.session ? search.session : undefined,
 	};
 }

--- a/tools/common/ai/agent-events.ts
+++ b/tools/common/ai/agent-events.ts
@@ -12,3 +12,10 @@ export interface AgentRunEvent {
 	sessionId: string;
 	event: AgentEvent;
 }
+
+export interface ActiveAgentRun {
+	runId: string;
+	sessionId: string;
+	startedAt: number;
+	phase: 'running' | 'interrupting';
+}

--- a/tools/common/ai/sessions/summary.ts
+++ b/tools/common/ai/sessions/summary.ts
@@ -77,8 +77,6 @@ export async function readAiSessionSummaryFromEntries(
 	const sessionId = header?.id ?? '';
 	let firstPrompt: string | undefined;
 	let assistantReplyPreview: string | undefined;
-	let ownerSitePath: string | undefined;
-	let ownerSiteName: string | undefined;
 	let selectedSiteName: string | undefined;
 	let activeEnvironment: 'local' | 'live' = 'local';
 	let lastSelectedWpcomSiteId: number | undefined;
@@ -103,12 +101,6 @@ export async function readAiSessionSummaryFromEntries(
 			const isLive = data.remote === true;
 			activeEnvironment = isLive ? 'live' : 'local';
 			lastSelectedWpcomSiteId = isLive ? data.wpcomSiteId : undefined;
-			// Anchor the owner on the first *local* site; remote-only sessions
-			// stay ownerless (sidebar Unassigned).
-			if ( ownerSitePath === undefined && ! isLive ) {
-				ownerSitePath = data.sitePath;
-				ownerSiteName = data.siteName;
-			}
 			continue;
 		}
 
@@ -138,8 +130,8 @@ export async function readAiSessionSummaryFromEntries(
 		updatedAt: updatedAt ?? createdAt ?? fallbackTimestamp,
 		firstPrompt,
 		assistantReplyPreview,
-		ownerSitePath,
-		ownerSiteName,
+		ownerSitePath: undefined,
+		ownerSiteName: undefined,
 		selectedSiteName,
 		activeEnvironment,
 		lastSelectedWpcomSiteId,

--- a/tools/common/ai/sessions/tests/create-session.test.ts
+++ b/tools/common/ai/sessions/tests/create-session.test.ts
@@ -14,15 +14,16 @@ describe( 'createAiSession', () => {
 		}
 	} );
 
-	it( 'writes a pi-format session JSONL with site.selected as the owner site', async () => {
+	it( 'writes a pi-format session JSONL with site.selected as the active site', async () => {
 		rootDirectory = await fs.mkdtemp( path.join( os.tmpdir(), 'studio-create-session-' ) );
 
 		const summary = await createAiSession( rootDirectory, {
 			site: { name: 'My Site', path: '/tmp/my-site' },
 		} );
 
-		expect( summary.ownerSitePath ).toBe( '/tmp/my-site' );
-		expect( summary.ownerSiteName ).toBe( 'My Site' );
+		expect( summary.ownerSitePath ).toBeUndefined();
+		expect( summary.ownerSiteName ).toBeUndefined();
+		expect( summary.selectedSiteName ).toBe( 'My Site' );
 		expect( summary.activeEnvironment ).toBe( 'local' );
 		expect( summary.firstPrompt ).toBeUndefined();
 

--- a/tools/common/ai/sessions/tests/environment.test.ts
+++ b/tools/common/ai/sessions/tests/environment.test.ts
@@ -43,7 +43,7 @@ describe( 'site.selected — environment flips', () => {
 		const { summary } = await loadAiSession( rootDirectory, created.id );
 		expect( summary.activeEnvironment ).toBe( 'live' );
 		expect( summary.lastSelectedWpcomSiteId ).toBe( 42 );
-		expect( summary.ownerSitePath ).toBe( '/tmp/my-site' );
+		expect( summary.ownerSitePath ).toBeUndefined();
 	} );
 
 	it( 'resolver preserves owner name/path when flipping to live', () => {

--- a/tools/common/ai/sessions/types.ts
+++ b/tools/common/ai/sessions/types.ts
@@ -14,16 +14,13 @@ export interface AiSessionSummary extends AiSessionMetadata {
 	updatedAt: string;
 	firstPrompt?: string;
 	assistantReplyPreview?: string;
-	// The first local site the session attached to. Acts as the session's owner
-	// in the UI sidebar. Undefined for sessions that only ever selected remote
-	// sites, or that never selected any site at all.
+	// Desktop-only placement, hydrated by the app from app.json. CLI session
+	// summaries do not infer ownership from active-site history.
 	ownerSitePath?: string;
 	ownerSiteName?: string;
-	// The most recently selected site during the session. May differ from the
-	// owner when the user switches between local and live (the owner stays
-	// anchored to the first local pick).
+	// The most recently selected execution target during the session.
 	selectedSiteName?: string;
-	// Side of the owner site the next turn acts on. `remote === true` → 'live'.
+	// Side of the current execution target the next turn acts on. `remote === true` → 'live'.
 	// Renderer's effective-env hook also checks `lastSelectedWpcomSiteId` against
 	// current connected sites for disconnect fall-back.
 	activeEnvironment: 'local' | 'live';


### PR DESCRIPTION
## Summary
- Treat CLI-only sessions as generic chats in the UI and move site placement into desktop-only metadata.
- Bind app-created site chats to the created site and automatically navigate the desk when a session moves to a different site.
- Recover active agent runs from the main process so the thinking indicator and live run state survive session switches and remounts.
- Update the AI prompt and create-site flow so ambiguous site requests ask for intent before creating a new site.

## Testing
- Added and updated unit tests for session summary hydration, environment flips, site placement storage, and `site_create` artifacts.
- Validated the shared run-state refactor with focused UI and CLI test coverage.
- `npx eslint --fix` and `npm run typecheck` passed.