### PR TITLE
apps/ui: Render media thumbnails with img elements for local file URLs

### DIFF
--- a/apps/ui/src/ui-desks/widgets/media/component/index.test.tsx
+++ b/apps/ui/src/ui-desks/widgets/media/component/index.test.tsx
@@ -1,0 +1,36 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MediaWidgetThumbnailComponent } from './index';
+
+vi.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+describe( 'MediaWidgetThumbnailComponent', () => {
+	it( 'renders image thumbnails with an img element so local file URLs are not parsed as CSS URLs', () => {
+		const url = 'file:///Users/example/Pictures/Screenshot%20(1).png';
+		const { container } = render(
+			<MediaWidgetThumbnailComponent
+				id="media-1"
+				widgetProps={ {
+					url,
+					mediaKind: 'image',
+					alt: 'Screenshot (1).png',
+					mediaId: null,
+				} }
+				isEditing={ false }
+				isHovered={ false }
+				isSelected={ false }
+				onWidgetPropsChange={ vi.fn() }
+				onEditComplete={ vi.fn() }
+			/>
+		);
+
+		const image = container.querySelector( 'img' );
+
+		expect( image ).toBeInTheDocument();
+		expect( image ).toHaveAttribute( 'src', url );
+		expect( container.firstElementChild ).not.toHaveAttribute( 'style' );
+	} );
+} );

--- a/apps/ui/src/ui-desks/widgets/media/component/index.tsx
+++ b/apps/ui/src/ui-desks/widgets/media/component/index.tsx
@@ -76,14 +76,15 @@ export function MediaWidgetThumbnailComponent( {
 			data-kind={ widgetProps.mediaKind }
 			data-studio-desk-widget={ MEDIA_WIDGET_TYPE }
 			data-studio-desk-widget-id={ id }
-			style={
-				isImage
-					? {
-							backgroundImage: `url(${ widgetProps.url })`,
-					  }
-					: undefined
-			}
 		>
+			{ isImage && (
+				<img
+					className={ styles.thumbnailImage }
+					src={ widgetProps.url }
+					alt=""
+					draggable={ false }
+				/>
+			) }
 			{ ! isImage && (
 				<span className={ styles.thumbnailText }>
 					{ widgetProps.alt || widgetProps.url || __( 'Media' ) }

--- a/apps/ui/src/ui-desks/widgets/media/component/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/media/component/style.module.css
@@ -47,7 +47,6 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	padding: 8px;
 	background-color: rgba(15, 23, 42, 0.85);
 	background-position: center;
 	background-size: cover;
@@ -60,8 +59,18 @@
 	user-select: none;
 }
 
+.thumbnailImage {
+	display: block;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
 .thumbnailText {
+	box-sizing: border-box;
 	display: -webkit-box;
+	width: 100%;
+	padding: 8px;
 	font-size: 9px;
 	letter-spacing: 0;
 	line-height: 1.2;


### PR DESCRIPTION
## Summary
- Switched media thumbnails to render image previews with an `<img>` element instead of a CSS `backgroundImage`.
- Kept the text fallback for non-image media and moved its padding into the fallback branch so image thumbnails fill the frame.
- Added a regression test covering a local `file://` URL with parentheses in the filename.

## Testing
- `npx eslint --fix` on the touched media widget files
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-desks/widgets/media/component/index.test.tsx apps/ui/src/ui-desks/widget-actions/file-handlers/index.test.ts`