### PR TITLE
apps/ui: Rename AI widget manifest from sd-artefact to scratchpad

### DIFF
--- a/apps/cli/ai/tests/system-prompt.test.ts
+++ b/apps/cli/ai/tests/system-prompt.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { buildSystemPrompt } from '../system-prompt';
 
 describe( 'buildSystemPrompt', () => {
+	const previousScratchpadWidgetType = 'sd-' + 'artefact';
+
 	it( 'includes Studio presentation rules when chat artifacts are enabled', () => {
 		const prompt = buildSystemPrompt( { chatArtifactsEnabled: true } );
 
@@ -14,7 +16,9 @@ describe( 'buildSystemPrompt', () => {
 		expect( prompt ).toContain( 'JSX/TSX markup' );
 		expect( prompt ).toContain( 'call studio_present with exactly one note widget' );
 		expect( prompt ).toContain( 'sections/selectors touched' );
-		expect( prompt ).toContain( 'Use sd-artefact for standalone rendered HTML drafts' );
+		expect( prompt ).toContain( 'Use scratchpad for standalone rendered HTML drafts' );
+		expect( prompt ).toContain( '- scratchpad:' );
+		expect( prompt ).not.toContain( previousScratchpadWidgetType );
 		expect( prompt ).toContain( '- saved-local-media:' );
 		expect( prompt ).toContain( 'For generated SVGs, write a complete .svg file' );
 		expect( prompt ).toContain( 'Do not present generated SVG code as a drawing widget' );

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -100,6 +100,7 @@ vi.mock( 'cli/lib/wordpress-server-manager', () => ( {
 } ) );
 
 describe( 'Studio AI MCP tools', () => {
+	const previousScratchpadWidgetType = 'sd-' + 'artefact';
 	const mockSite = {
 		id: 'site-123',
 		name: 'My Site',
@@ -169,6 +170,8 @@ describe( 'Studio AI MCP tools', () => {
 		expect( studioPresent?.description ).toContain(
 			'call studio_present with exactly one note widget'
 		);
+		expect( studioPresent?.description ).toContain( '- scratchpad:' );
+		expect( studioPresent?.description ).not.toContain( previousScratchpadWidgetType );
 		expect( studioPresent?.description ).toContain( '- saved-local-media:' );
 		expect( studioPresent?.description ).toContain(
 			'For generated SVGs, write a complete .svg file'

--- a/apps/cli/ai/tools/studio-present.ts
+++ b/apps/cli/ai/tools/studio-present.ts
@@ -10,7 +10,7 @@ import type { StudioChatArtifactWidgetDraft } from '@studio/common/ai/chat-artif
 const MAX_WIDGETS_PER_PRESENTATION = 8;
 
 const description = `Shows Studio desk widgets as inline visual artifacts in the chat UI.
-Use this after a meaningful user-visible result, such as a created page, useful preview path, content summary, reference link, media item, or draft artefact.
+Use this after a meaningful user-visible result, such as a created page, useful preview path, content summary, reference link, media item, or draft scratchpad.
 
 Presentation rules:
 ${ getStudioPresentationRulesPrompt() }

--- a/apps/ui/src/ui-desks/connectors/utils.ts
+++ b/apps/ui/src/ui-desks/connectors/utils.ts
@@ -199,8 +199,8 @@ export function getDeskWidgetConnectionLabel( widget: DeskWidget ) {
 			return typeof props.mediaKind === 'string' && props.mediaKind === 'video' ? 'Video' : 'Image';
 		case 'drawing':
 			return 'Drawing';
-		case 'sd-artefact':
-			return 'Artefact';
+		case 'scratchpad':
+			return 'Scratchpad';
 		case 'blog':
 			return 'Blog';
 		case 'post-collection':

--- a/tools/common/ai/studio-widgets.ts
+++ b/tools/common/ai/studio-widgets.ts
@@ -27,7 +27,7 @@ const NOTE_TONES = [
 	'neon-blue',
 ] as const;
 const NOTE_TEXT_SIZE_STEPS = [ 0, 1, 2, 3 ] as const;
-const ARTEFACT_SCOPES = [ 'page', 'pattern', 'block' ] as const;
+const SCRATCHPAD_SCOPES = [ 'page', 'pattern', 'block' ] as const;
 const MEDIA_KINDS = [ 'image', 'video' ] as const;
 const POST_COLLECTION_STATUSES = [ 'publish', 'draft', 'any' ] as const;
 const POST_COLLECTION_ORDER_BY = [ 'date', 'modified', 'title' ] as const;
@@ -49,7 +49,7 @@ export const STUDIO_PRESENTATION_RULES: StudioPresentationRule[] = [
 	{
 		id: 'site-code-scratchpad',
 		description:
-			'During site creation or redesign work, after any successful Write or Edit that creates or changes HTML, CSS, block markup, JSX/TSX markup, inline styles, theme.json design tokens, frontend JS behavior, or theme/plugin code that shapes markup or styling, call studio_present with exactly one note widget as a scratchpad summary. Include the changed file path or basename, the sections/selectors touched, and the design intent or next checkpoint. Keep it compact and do not paste full files. Skip only trivial mechanical edits, generated lockfiles, or config changes unrelated to HTML, CSS, layout, styling, or frontend behavior. Use sd-artefact for standalone rendered HTML drafts, and site-preview after a visible site or page milestone.',
+			'During site creation or redesign work, after any successful Write or Edit that creates or changes HTML, CSS, block markup, JSX/TSX markup, inline styles, theme.json design tokens, frontend JS behavior, or theme/plugin code that shapes markup or styling, call studio_present with exactly one note widget as a scratchpad summary. Include the changed file path or basename, the sections/selectors touched, and the design intent or next checkpoint. Keep it compact and do not paste full files. Skip only trivial mechanical edits, generated lockfiles, or config changes unrelated to HTML, CSS, layout, styling, or frontend behavior. Use scratchpad for standalone rendered HTML drafts, and site-preview after a visible site or page milestone.',
 	},
 	{
 		id: 'saved-local-media',
@@ -166,12 +166,12 @@ export const STUDIO_PRESENTABLE_WIDGET_SPECS: StudioWidgetSpec[] = [
 			( props.mediaId === null || isNonNegativeInteger( props.mediaId ) ),
 	},
 	{
-		type: 'sd-artefact',
-		description: 'A rendered HTML artefact for a page, pattern, or block concept.',
+		type: 'scratchpad',
+		description: 'A rendered HTML scratchpad for a page, pattern, or block concept.',
 		propsDescription:
 			'{ "html": "<main>...</main>", "title": "Landing page draft", "scope": "page", "description": "Optional notes" } where scope is page, pattern, or block.',
 		example: {
-			type: 'sd-artefact',
+			type: 'scratchpad',
 			widgetProps: {
 				html: '<main><h1>Draft</h1></main>',
 				title: 'Landing page draft',
@@ -181,7 +181,7 @@ export const STUDIO_PRESENTABLE_WIDGET_SPECS: StudioWidgetSpec[] = [
 		validateWidgetProps: ( props ) =>
 			typeof props.html === 'string' &&
 			typeof props.title === 'string' &&
-			isOneOf( props.scope, ARTEFACT_SCOPES ) &&
+			isOneOf( props.scope, SCRATCHPAD_SCOPES ) &&
 			( props.description === undefined || typeof props.description === 'string' ),
 	},
 ];


### PR DESCRIPTION
## Summary
- Updated the shared Studio widget manifest to publish `scratchpad` instead of `sd-artefact` for rendered HTML drafts.
- Aligned the `studio_present` guidance text and desk connector label to the renamed widget type.
- Updated CLI prompt tests to assert the new manifest text and guard against the old widget type.

## Testing
- `npx eslint --fix` on the modified files
- `npm test -- apps/cli/ai/tests/system-prompt.test.ts apps/cli/ai/tests/tools.test.ts`
- `npm run typecheck`