### PR TITLE
Add JSON import and export for desks

### DIFF
--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -208,9 +208,11 @@ export { getDefaultSiteDirectory, saveDefaultSiteDirectory };
 export { importSite, exportSite } from 'src/modules/import-export/lib/ipc-handlers';
 
 export {
+	exportDeskConfig,
 	getDeskSettings,
 	getSiteDeskConfig,
 	getUserDeskConfig,
+	importDeskConfig,
 	saveDeskSettings,
 	saveSiteDeskConfig,
 	saveUserDeskConfig,

--- a/apps/studio/src/modules/desks/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/desks/lib/ipc-handlers.ts
@@ -1,138 +1,34 @@
+import { BrowserWindow, dialog, type IpcMainInvokeEvent } from 'electron';
+import fsPromises from 'fs/promises';
+import nodePath from 'path';
+import { assertDeskConfig } from '@studio/common/lib/desk-config';
 import { normalizeDeskSettings } from '@studio/common/lib/desk-settings';
-import {
-	DESK_CONFIG_VERSION,
-	type DeskConnector,
-	type DeskConnectorEndpoint,
-	type DeskConfig,
-	type DeskSettings,
-	type DeskStack,
-	type DeskViewport,
-	type DeskWidgetBase,
-} from '@studio/common/types/desk';
+import { type DeskConfig, type DeskSettings } from '@studio/common/types/desk';
+import { __ } from '@wordpress/i18n';
 import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
-import type { IpcMainInvokeEvent } from 'electron';
 
 function isRecord( value: unknown ): value is Record< string, unknown > {
 	return Boolean( value ) && typeof value === 'object' && ! Array.isArray( value );
-}
-
-function isDeskWidget( value: unknown ): value is DeskWidgetBase {
-	if ( ! isRecord( value ) || ! isRecord( value.shapeProps ) || ! isRecord( value.widgetProps ) ) {
-		return false;
-	}
-	return (
-		typeof value.id === 'string' &&
-		typeof value.type === 'string' &&
-		typeof value.x === 'number' &&
-		typeof value.y === 'number' &&
-		typeof value.zIndex === 'string' &&
-		( value.rotation === undefined || typeof value.rotation === 'number' )
-	);
-}
-
-function isDeskStack( value: unknown ): value is DeskStack {
-	if ( ! isRecord( value ) || ! Array.isArray( value.memberIds ) ) {
-		return false;
-	}
-	return (
-		typeof value.id === 'string' &&
-		value.id.length > 0 &&
-		typeof value.x === 'number' &&
-		Number.isFinite( value.x ) &&
-		typeof value.y === 'number' &&
-		Number.isFinite( value.y ) &&
-		typeof value.zIndex === 'string' &&
-		value.memberIds.length >= 2 &&
-		value.memberIds.every( ( memberId ) => typeof memberId === 'string' )
-	);
-}
-
-function isDeskViewport( value: unknown ): value is DeskViewport {
-	if ( ! isRecord( value ) ) {
-		return false;
-	}
-
-	const { x, y, z } = value;
-	return (
-		typeof x === 'number' &&
-		Number.isFinite( x ) &&
-		typeof y === 'number' &&
-		Number.isFinite( y ) &&
-		typeof z === 'number' &&
-		Number.isFinite( z ) &&
-		z > 0
-	);
-}
-
-function isDeskConnectorEndpoint( value: unknown ): value is DeskConnectorEndpoint {
-	if ( ! isRecord( value ) || ! isRecord( value.normalizedAnchor ) ) {
-		return false;
-	}
-
-	const { x, y } = value.normalizedAnchor;
-	return (
-		typeof value.widgetId === 'string' &&
-		value.widgetId.length > 0 &&
-		typeof x === 'number' &&
-		Number.isFinite( x ) &&
-		x >= 0 &&
-		x <= 1 &&
-		typeof y === 'number' &&
-		Number.isFinite( y ) &&
-		y >= 0 &&
-		y <= 1
-	);
-}
-
-function isDeskConnector( value: unknown ): value is DeskConnector {
-	if ( ! isRecord( value ) ) {
-		return false;
-	}
-
-	return (
-		typeof value.id === 'string' &&
-		value.id.length > 0 &&
-		isDeskConnectorEndpoint( value.from ) &&
-		isDeskConnectorEndpoint( value.to ) &&
-		( value.bend === undefined ||
-			( typeof value.bend === 'number' && Number.isFinite( value.bend ) ) )
-	);
-}
-
-function assertDeskConfig( value: unknown ): asserts value is DeskConfig {
-	if ( ! isRecord( value ) ) {
-		throw new Error( 'Invalid desk config: expected an object.' );
-	}
-	if ( value.version !== DESK_CONFIG_VERSION ) {
-		throw new Error( `Invalid desk config: expected version ${ DESK_CONFIG_VERSION }.` );
-	}
-	if ( typeof value.updatedAt !== 'string' ) {
-		throw new Error( 'Invalid desk config: expected updatedAt string.' );
-	}
-	if ( ! Array.isArray( value.widgets ) || ! value.widgets.every( isDeskWidget ) ) {
-		throw new Error( 'Invalid desk config: expected widgets array.' );
-	}
-	if (
-		value.stacks !== undefined &&
-		( ! Array.isArray( value.stacks ) || ! value.stacks.every( isDeskStack ) )
-	) {
-		throw new Error( 'Invalid desk config: expected stacks array.' );
-	}
-	if ( value.viewport !== undefined && ! isDeskViewport( value.viewport ) ) {
-		throw new Error( 'Invalid desk config: expected viewport object.' );
-	}
-	if (
-		value.connectors !== undefined &&
-		( ! Array.isArray( value.connectors ) || ! value.connectors.every( isDeskConnector ) )
-	) {
-		throw new Error( 'Invalid desk config: expected connectors array.' );
-	}
 }
 
 function assertSiteId( siteId: unknown ): asserts siteId is string {
 	if ( typeof siteId !== 'string' || ! siteId ) {
 		throw new Error( 'Invalid site desk config: expected site id.' );
 	}
+}
+
+function getParentWindow( event: IpcMainInvokeEvent, channel: string ) {
+	const parentWindow = BrowserWindow.fromWebContents( event.sender );
+	if ( ! parentWindow ) {
+		throw new Error( `No window found for sender of ${ channel } message: ${ event.frameId }` );
+	}
+	return parentWindow;
+}
+
+function getDeskJsonFilename( suggestedFilename: string ) {
+	const fallbackFilename = 'studio-desk.json';
+	const basename = nodePath.basename( suggestedFilename || fallbackFilename );
+	return basename.toLowerCase().endsWith( '.json' ) ? basename : `${ basename }.json`;
 }
 
 export async function getUserDeskConfig(
@@ -169,6 +65,64 @@ export async function saveDeskSettings(
 	} finally {
 		await unlockAppdata();
 	}
+}
+
+export async function exportDeskConfig(
+	event: IpcMainInvokeEvent,
+	config: DeskConfig,
+	suggestedFilename: string
+): Promise< string | null > {
+	assertDeskConfig( config );
+
+	const { canceled, filePath } = await dialog.showSaveDialog(
+		getParentWindow( event, 'exportDeskConfig' ),
+		{
+			title: __( 'Export desk' ),
+			defaultPath: getDeskJsonFilename( suggestedFilename ),
+			filters: [
+				{
+					name: __( 'JSON files' ),
+					extensions: [ 'json' ],
+				},
+			],
+		}
+	);
+	if ( canceled || ! filePath ) {
+		return null;
+	}
+
+	const targetPath = filePath.toLowerCase().endsWith( '.json' ) ? filePath : `${ filePath }.json`;
+	await fsPromises.writeFile( targetPath, `${ JSON.stringify( config, null, 2 ) }\n`, 'utf8' );
+	return targetPath;
+}
+
+export async function importDeskConfig( event: IpcMainInvokeEvent ): Promise< DeskConfig | null > {
+	const { canceled, filePaths } = await dialog.showOpenDialog(
+		getParentWindow( event, 'importDeskConfig' ),
+		{
+			title: __( 'Import desk' ),
+			filters: [
+				{
+					name: __( 'JSON files' ),
+					extensions: [ 'json' ],
+				},
+			],
+			properties: [ 'openFile' ],
+		}
+	);
+	if ( canceled || ! filePaths[ 0 ] ) {
+		return null;
+	}
+
+	let parsedConfig: unknown;
+	try {
+		parsedConfig = JSON.parse( await fsPromises.readFile( filePaths[ 0 ], 'utf8' ) );
+	} catch {
+		throw new Error( 'Could not parse that file. Expected a Studio desk JSON export.' );
+	}
+
+	assertDeskConfig( parsedConfig );
+	return parsedConfig;
 }
 
 export async function saveUserDeskConfig(

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -227,6 +227,9 @@ const api: IpcApi = {
 		ipcRendererInvoke( 'setSessionEnvironment', sessionId, environment ),
 	getDeskSettings: () => ipcRendererInvoke( 'getDeskSettings' ),
 	saveDeskSettings: ( settings ) => ipcRendererInvoke( 'saveDeskSettings', settings ),
+	exportDeskConfig: ( config, suggestedFilename ) =>
+		ipcRendererInvoke( 'exportDeskConfig', config, suggestedFilename ),
+	importDeskConfig: () => ipcRendererInvoke( 'importDeskConfig' ),
 	getUserDeskConfig: () => ipcRendererInvoke( 'getUserDeskConfig' ),
 	saveUserDeskConfig: ( config ) => ipcRendererInvoke( 'saveUserDeskConfig', config ),
 	getSiteDeskConfig: ( siteId ) => ipcRendererInvoke( 'getSiteDeskConfig', siteId ),

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -635,6 +635,14 @@ export function createIpcConnector(): Connector {
 			await ipcApi.saveDeskSettings( settings );
 		},
 
+		async exportDeskConfig( config, suggestedFilename ): Promise< string | null > {
+			return ( await ipcApi.exportDeskConfig( config, suggestedFilename ) ) as string | null;
+		},
+
+		async importDeskConfig(): Promise< DeskConfig | null > {
+			return ( await ipcApi.importDeskConfig() ) as DeskConfig | null;
+		},
+
 		async getUserDeskConfig(): Promise< DeskConfig | undefined > {
 			return ( await ipcApi.getUserDeskConfig() ) as DeskConfig | undefined;
 		},

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -267,6 +267,8 @@ export interface Connector {
 	// Desks
 	getDeskSettings(): Promise< DeskSettings >;
 	saveDeskSettings( settings: DeskSettings ): Promise< void >;
+	exportDeskConfig( config: DeskConfig, suggestedFilename: string ): Promise< string | null >;
+	importDeskConfig(): Promise< DeskConfig | null >;
 	getUserDeskConfig(): Promise< DeskConfig | undefined >;
 	saveUserDeskConfig( config: DeskConfig ): Promise< void >;
 	getSiteDeskConfig( siteId: string ): Promise< DeskConfig | undefined >;

--- a/apps/ui/src/ui-desks/chrome/settings-modal/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/settings-modal/index.tsx
@@ -1,18 +1,26 @@
 import { createDefaultDeskSettings } from '@studio/common/lib/desk-settings';
+import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
 import { __ } from '@wordpress/i18n';
+import { download, upload } from '@wordpress/icons';
 import { Field } from '@wordpress/ui';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useConnector } from '@/data/core';
 import { useDeskSettings, useUpdateDeskSettings } from '@/data/queries/use-desk-config';
+import { useSites } from '@/data/queries/use-sites';
 import {
 	Button,
 	Dialog,
 	DialogCloseButton,
 	DialogContent,
+	DialogError,
 	DialogFooter,
 	DialogHeader,
+	DialogTip,
 	DialogTitle,
 } from '@/ui-desks/components';
+import { useDesk } from '@/ui-desks/desk/provider';
 import styles from './style.module.css';
+import type { DeskConfig } from '@/ui-desks/desk/types';
 
 interface DeskSettingsModalProps {
 	open: boolean;
@@ -21,10 +29,83 @@ interface DeskSettingsModalProps {
 }
 
 export function DeskSettingsModal( { open, onOpenChange, onEditToolbar }: DeskSettingsModalProps ) {
+	const connector = useConnector();
+	const desk = useDesk();
+	const { data: sites } = useSites();
 	const { data: savedDeskSettings } = useDeskSettings();
 	const fallbackDeskSettings = useMemo( () => createDefaultDeskSettings(), [] );
 	const settings = savedDeskSettings ?? fallbackDeskSettings;
 	const updateDeskSettings = useUpdateDeskSettings();
+	const [ status, setStatus ] = useState< { tone: 'success' | 'error'; message: string } | null >(
+		null
+	);
+	const [ isExporting, setIsExporting ] = useState( false );
+	const [ isImporting, setIsImporting ] = useState( false );
+	const activeSiteName = sites?.find( ( site ) => site.id === desk.siteId )?.name;
+	const isDeskDataActionDisabled =
+		desk.isReadOnly || desk.isLoading || ! desk.canAddWidgets || isExporting || isImporting;
+
+	useEffect( () => {
+		if ( ! open ) {
+			setStatus( null );
+		}
+	}, [ open ] );
+
+	const exportDesk = async () => {
+		const deskConfig = desk.getDeskConfigSnapshot();
+		if ( ! deskConfig ) {
+			setStatus( { tone: 'error', message: __( 'Could not export desk.' ) } );
+			return;
+		}
+
+		setStatus( null );
+		setIsExporting( true );
+		try {
+			const exportedPath = await connector.exportDeskConfig(
+				deskConfig,
+				getDeskExportFilename( activeSiteName )
+			);
+			if ( exportedPath ) {
+				setStatus( { tone: 'success', message: __( 'Desk exported.' ) } );
+			}
+		} catch ( error ) {
+			console.warn( 'Failed to export desk.', error );
+			setStatus( { tone: 'error', message: __( 'Could not export desk.' ) } );
+		} finally {
+			setIsExporting( false );
+		}
+	};
+
+	const importDesk = async () => {
+		setStatus( null );
+		setIsImporting( true );
+		try {
+			const deskConfig = await connector.importDeskConfig();
+			if ( ! deskConfig ) {
+				return;
+			}
+
+			if (
+				! window.confirm(
+					__( 'Replace the current desk with the imported file? This cannot be undone.' )
+				)
+			) {
+				return;
+			}
+
+			const didImport = await desk.replaceDeskConfig( deskConfig as DeskConfig );
+			setStatus(
+				didImport
+					? { tone: 'success', message: __( 'Desk imported.' ) }
+					: { tone: 'error', message: __( 'Could not import desk.' ) }
+			);
+		} catch ( error ) {
+			console.warn( 'Failed to import desk.', error );
+			setStatus( { tone: 'error', message: __( 'Could not import desk.' ) } );
+		} finally {
+			setIsImporting( false );
+		}
+	};
 
 	return (
 		<Dialog
@@ -47,6 +128,35 @@ export function DeskSettingsModal( { open, onOpenChange, onEditToolbar }: DeskSe
 					/>
 					<Field.Label variant="plain">{ __( 'Show site name' ) }</Field.Label>
 				</Field.Root>
+				<div className={ styles.settingsSection }>
+					<div className={ styles.settingsSectionTitle }>{ __( 'Desk data' ) }</div>
+					<div className={ styles.settingsActions }>
+						<Button
+							type="button"
+							icon={ download }
+							label={ __( 'Export desk' ) }
+							variant="quiet"
+							size="medium"
+							disabled={ isDeskDataActionDisabled }
+							onClick={ () => void exportDesk() }
+						>
+							{ isExporting ? __( 'Exporting...' ) : __( 'Export desk' ) }
+						</Button>
+						<Button
+							type="button"
+							icon={ upload }
+							label={ __( 'Import desk' ) }
+							variant="quiet"
+							size="medium"
+							disabled={ isDeskDataActionDisabled }
+							onClick={ () => void importDesk() }
+						>
+							{ isImporting ? __( 'Importing...' ) : __( 'Import desk' ) }
+						</Button>
+					</div>
+					{ status?.tone === 'error' && <DialogError>{ status.message }</DialogError> }
+					{ status?.tone === 'success' && <DialogTip>{ status.message }</DialogTip> }
+				</div>
 			</DialogContent>
 			<DialogFooter>
 				<Button
@@ -65,4 +175,10 @@ export function DeskSettingsModal( { open, onOpenChange, onEditToolbar }: DeskSe
 			</DialogFooter>
 		</Dialog>
 	);
+}
+
+function getDeskExportFilename( siteName?: string ) {
+	const stamp = new Date().toISOString().slice( 0, 10 );
+	const name = sanitizeFolderName( siteName ? `studio-desk-${ siteName }` : 'studio-desk-user' );
+	return `${ name || 'studio-desk' }-${ stamp }.json`;
 }

--- a/apps/ui/src/ui-desks/chrome/settings-modal/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/settings-modal/style.module.css
@@ -19,3 +19,24 @@
 	accent-color: var(--wp-admin-theme-color, #3858e9);
 	cursor: pointer;
 }
+
+.settingsSection {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	padding-top: 14px;
+	border-top: 1px solid var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+}
+
+.settingsSectionTitle {
+	color: var(--ui-desks-text, #14171a);
+	font-size: var(--wpds-typography-font-size-sm);
+	font-weight: var(--wpds-typography-font-weight-semibold, 600);
+	line-height: var(--wpds-typography-line-height-sm);
+}
+
+.settingsActions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}

--- a/apps/ui/src/ui-desks/desk/provider/context.ts
+++ b/apps/ui/src/ui-desks/desk/provider/context.ts
@@ -64,6 +64,8 @@ export interface DeskContextValue {
 	setFocusDesk: ( focusDesk: DeskFocusDesk ) => boolean;
 	getFocusDeskSnapshot: () => DeskFocusDesk | null;
 	stopFocusMode: () => boolean;
+	getDeskConfigSnapshot: () => DeskConfig | null;
+	replaceDeskConfig: ( config: DeskConfig ) => Promise< boolean >;
 }
 
 export interface AddDeskWidgetOptions {
@@ -124,6 +126,8 @@ const defaultDeskContext: DeskContextValue = {
 	setFocusDesk: () => false,
 	getFocusDeskSnapshot: () => null,
 	stopFocusMode: () => false,
+	getDeskConfigSnapshot: () => null,
+	replaceDeskConfig: () => Promise.resolve( false ),
 };
 
 export const DeskContext = createContext< DeskContextValue >( defaultDeskContext );

--- a/apps/ui/src/ui-desks/desk/provider/editor-state/index.ts
+++ b/apps/ui/src/ui-desks/desk/provider/editor-state/index.ts
@@ -90,19 +90,20 @@ export function hydrateEditorFromDesk(
 	desk: DeskConfig,
 	options: HydrateEditorOptions = {}
 ) {
+	const widgetShapes = desk.widgets.length > 0 ? deskConfigToCanvasShapes( desk ) : [];
+	const connectorShapes =
+		desk.widgets.length > 0 ? deskConfigToCanvasConnectorShapes( desk, widgetShapes ) : [];
+	const connectorBindings =
+		desk.widgets.length > 0 ? deskConfigToCanvasConnectorBindings( desk ) : [];
 	const existingShapes = editor.getCurrentPageShapes();
 	if ( existingShapes.length > 0 ) {
 		editor.run( () => editor.deleteShapes( existingShapes.map( ( shape ) => shape.id ) ), {
 			ignoreShapeLock: true,
 		} );
 	}
-	if ( desk.widgets.length > 0 ) {
-		const widgetShapes = deskConfigToCanvasShapes( desk );
-		editor.createShapes( [
-			...deskConfigToCanvasConnectorShapes( desk, widgetShapes ),
-			...widgetShapes,
-		] );
-		editor.createBindings( deskConfigToCanvasConnectorBindings( desk ) );
+	if ( widgetShapes.length > 0 ) {
+		editor.createShapes( [ ...connectorShapes, ...widgetShapes ] );
+		editor.createBindings( connectorBindings );
 	}
 	if ( desk.viewport ) {
 		editor.setCamera( desk.viewport, { immediate: true } );

--- a/apps/ui/src/ui-desks/desk/provider/index.tsx
+++ b/apps/ui/src/ui-desks/desk/provider/index.tsx
@@ -943,6 +943,79 @@ export function DeskProvider( {
 		};
 	}, [ editor, focusedWidgetId ] );
 
+	const getDeskConfigSnapshot = useCallback( () => {
+		if ( ! editor || ! isHydrated ) {
+			return null;
+		}
+
+		return createDeskConfigFromEditor( editor );
+	}, [ editor, isHydrated ] );
+
+	const replaceDeskConfig = useCallback(
+		async ( config: DeskConfig ) => {
+			if ( isReadOnly || ! editor || ! isHydrated ) {
+				return false;
+			}
+
+			const previousDeskConfig = createDeskConfigFromEditor( editor );
+			if ( saveTimerRef.current ) {
+				clearTimeout( saveTimerRef.current );
+				saveTimerRef.current = null;
+			}
+			if ( focusPersistenceResumeTimerRef.current ) {
+				clearTimeout( focusPersistenceResumeTimerRef.current );
+				focusPersistenceResumeTimerRef.current = null;
+			}
+
+			restoreFocusModeShapeState( editor, focusShapeRestoreRef.current );
+			focusShapeRestoreRef.current.clear();
+			focusShapeIdsRef.current = syncFocusDeskToEditor( editor, null, focusShapeIdsRef.current );
+			document
+				.querySelector( '[data-ui-desks-canvas]' )
+				?.removeAttribute( 'data-ui-desks-focus-mode' );
+			editor.setCameraOptions( { ...editor.getCameraOptions(), isLocked: false } );
+			focusDimmingActiveRef.current = false;
+			focusPersistencePausedRef.current = false;
+			focusRestoreCameraRef.current = null;
+			drawingStartShapeIdsRef.current = null;
+			hydratedRef.current = false;
+			setIsHydrated( false );
+			setSelectedWidgetToolbarItem( null );
+			setSelectedConnectorToolbarItem( null );
+			setSelectedWidgetConnectionTargets( [] );
+			setPendingConnectorSourceId( null );
+			setFocusModeState( null );
+			setFocusedWidget( null );
+			clearPressedStack();
+
+			let didImport = false;
+			try {
+				hydrateEditorFromDesk( editor, {
+					...config,
+					updatedAt: new Date().toISOString(),
+				} );
+				saveDeskConfig( createDeskConfigFromEditor( editor ) );
+				didImport = true;
+			} catch ( error ) {
+				console.warn( 'Failed to import desk config.', error );
+				hydrateEditorFromDesk( editor, previousDeskConfig );
+				saveDeskConfig( previousDeskConfig );
+			} finally {
+				hydratedRef.current = true;
+				setIsHydrated( true );
+				setSelectedWidgetToolbarItem(
+					getCurrentSelectedWidgetToolbarItem( editor, toolbarStateOptions )
+				);
+				setSelectedConnectorToolbarItem( getSelectedDeskConnectorToolbarItem( editor ) );
+				setSelectedWidgetConnectionTargets( getCurrentSelectedWidgetConnectionTargets( editor ) );
+				editor.focus();
+			}
+
+			return didImport;
+		},
+		[ clearPressedStack, editor, isHydrated, isReadOnly, saveDeskConfig, toolbarStateOptions ]
+	);
+
 	const value = useMemo(
 		() => ( {
 			siteId,
@@ -980,6 +1053,8 @@ export function DeskProvider( {
 			setFocusDesk,
 			getFocusDeskSnapshot,
 			stopFocusMode,
+			getDeskConfigSnapshot,
+			replaceDeskConfig,
 		} ),
 		[
 			addPastedContent,
@@ -993,6 +1068,7 @@ export function DeskProvider( {
 			focusedWidget,
 			focusedWidgetDefinition,
 			focusMode,
+			getDeskConfigSnapshot,
 			getFocusDeskSnapshot,
 			isHydrated,
 			isReadOnly,
@@ -1000,6 +1076,7 @@ export function DeskProvider( {
 			pendingConnectorSourceId,
 			pressStack,
 			pressedStackId,
+			replaceDeskConfig,
 			registerEditor,
 			removeSelectedConnector,
 			removeSelectedWidget,

--- a/apps/ui/src/ui-desks/desk/selection-toolbar/index.test.tsx
+++ b/apps/ui/src/ui-desks/desk/selection-toolbar/index.test.tsx
@@ -265,6 +265,8 @@ function createDeskContext( overrides: Partial< DeskContextValue > = {} ): DeskC
 		setFocusDesk: vi.fn(),
 		getFocusDeskSnapshot: vi.fn(),
 		stopFocusMode: vi.fn(),
+		getDeskConfigSnapshot: vi.fn(),
+		replaceDeskConfig: vi.fn().mockResolvedValue( false ),
 		...overrides,
 	};
 }

--- a/tools/common/lib/desk-config.ts
+++ b/tools/common/lib/desk-config.ts
@@ -1,0 +1,131 @@
+import {
+	DESK_CONFIG_VERSION,
+	type DeskConfig,
+	type DeskConnector,
+	type DeskConnectorEndpoint,
+	type DeskStack,
+	type DeskViewport,
+	type DeskWidgetBase,
+} from '../types/desk';
+
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	return Boolean( value ) && typeof value === 'object' && ! Array.isArray( value );
+}
+
+function isFiniteNumber( value: unknown ): value is number {
+	return typeof value === 'number' && Number.isFinite( value );
+}
+
+function isDeskWidget( value: unknown ): value is DeskWidgetBase {
+	if ( ! isRecord( value ) || ! isRecord( value.shapeProps ) || ! isRecord( value.widgetProps ) ) {
+		return false;
+	}
+
+	return (
+		typeof value.id === 'string' &&
+		value.id.length > 0 &&
+		typeof value.type === 'string' &&
+		value.type.length > 0 &&
+		isFiniteNumber( value.x ) &&
+		isFiniteNumber( value.y ) &&
+		typeof value.zIndex === 'string' &&
+		( value.rotation === undefined || isFiniteNumber( value.rotation ) )
+	);
+}
+
+function isDeskStack( value: unknown ): value is DeskStack {
+	if ( ! isRecord( value ) || ! Array.isArray( value.memberIds ) ) {
+		return false;
+	}
+
+	return (
+		typeof value.id === 'string' &&
+		value.id.length > 0 &&
+		isFiniteNumber( value.x ) &&
+		isFiniteNumber( value.y ) &&
+		typeof value.zIndex === 'string' &&
+		value.memberIds.length >= 2 &&
+		value.memberIds.every( ( memberId ) => typeof memberId === 'string' ) &&
+		( value.viewMode === undefined || value.viewMode === 'stack' || value.viewMode === 'tiles' )
+	);
+}
+
+function isDeskViewport( value: unknown ): value is DeskViewport {
+	if ( ! isRecord( value ) ) {
+		return false;
+	}
+
+	const { x, y, z } = value;
+	return isFiniteNumber( x ) && isFiniteNumber( y ) && isFiniteNumber( z ) && z > 0;
+}
+
+function isDeskConnectorEndpoint( value: unknown ): value is DeskConnectorEndpoint {
+	if ( ! isRecord( value ) || ! isRecord( value.normalizedAnchor ) ) {
+		return false;
+	}
+
+	const { x, y } = value.normalizedAnchor;
+	return (
+		typeof value.widgetId === 'string' &&
+		value.widgetId.length > 0 &&
+		isFiniteNumber( x ) &&
+		x >= 0 &&
+		x <= 1 &&
+		isFiniteNumber( y ) &&
+		y >= 0 &&
+		y <= 1
+	);
+}
+
+function isDeskConnector( value: unknown ): value is DeskConnector {
+	if ( ! isRecord( value ) ) {
+		return false;
+	}
+
+	return (
+		typeof value.id === 'string' &&
+		value.id.length > 0 &&
+		isDeskConnectorEndpoint( value.from ) &&
+		isDeskConnectorEndpoint( value.to ) &&
+		( value.bend === undefined || isFiniteNumber( value.bend ) )
+	);
+}
+
+export function assertDeskConfig( value: unknown ): asserts value is DeskConfig {
+	if ( ! isRecord( value ) ) {
+		throw new Error( 'Invalid desk config: expected an object.' );
+	}
+	if ( value.version !== DESK_CONFIG_VERSION ) {
+		throw new Error( `Invalid desk config: expected version ${ DESK_CONFIG_VERSION }.` );
+	}
+	if ( typeof value.updatedAt !== 'string' ) {
+		throw new Error( 'Invalid desk config: expected updatedAt string.' );
+	}
+	if ( ! Array.isArray( value.widgets ) || ! value.widgets.every( isDeskWidget ) ) {
+		throw new Error( 'Invalid desk config: expected widgets array.' );
+	}
+	if (
+		value.stacks !== undefined &&
+		( ! Array.isArray( value.stacks ) || ! value.stacks.every( isDeskStack ) )
+	) {
+		throw new Error( 'Invalid desk config: expected stacks array.' );
+	}
+	if ( value.viewport !== undefined && ! isDeskViewport( value.viewport ) ) {
+		throw new Error( 'Invalid desk config: expected viewport object.' );
+	}
+	if (
+		value.connectors !== undefined &&
+		( ! Array.isArray( value.connectors ) || ! value.connectors.every( isDeskConnector ) )
+	) {
+		throw new Error( 'Invalid desk config: expected connectors array.' );
+	}
+}
+
+export function isDeskConfig( value: unknown ): value is DeskConfig {
+	try {
+		assertDeskConfig( value );
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/tools/common/lib/tests/desk-config.test.ts
+++ b/tools/common/lib/tests/desk-config.test.ts
@@ -1,0 +1,108 @@
+import { assertDeskConfig, isDeskConfig } from '../desk-config';
+
+const validDesk = {
+	version: 1,
+	updatedAt: '2026-05-14T00:00:00.000Z',
+	viewport: {
+		x: 0,
+		y: 0,
+		z: 1,
+	},
+	widgets: [
+		{
+			id: 'note-1',
+			type: 'note',
+			x: 10,
+			y: 20,
+			zIndex: 'a1',
+			shapeProps: {
+				w: 240,
+				h: 180,
+			},
+			widgetProps: {
+				content: 'Hello',
+			},
+		},
+		{
+			id: 'note-2',
+			type: 'note',
+			x: 320,
+			y: 20,
+			zIndex: 'a2',
+			shapeProps: {},
+			widgetProps: {},
+		},
+	],
+	stacks: [
+		{
+			id: 'stack-1',
+			x: 10,
+			y: 20,
+			zIndex: 'a3',
+			memberIds: [ 'note-1', 'note-2' ],
+			viewMode: 'tiles',
+		},
+	],
+	connectors: [
+		{
+			id: 'connector-1',
+			from: {
+				widgetId: 'note-1',
+				normalizedAnchor: { x: 1, y: 0.5 },
+			},
+			to: {
+				widgetId: 'note-2',
+				normalizedAnchor: { x: 0, y: 0.5 },
+			},
+			bend: 72,
+		},
+	],
+};
+
+describe( 'desk config validation', () => {
+	it( 'accepts a structurally valid desk config', () => {
+		expect( isDeskConfig( validDesk ) ).toBe( true );
+		expect( () => assertDeskConfig( validDesk ) ).not.toThrow();
+	} );
+
+	it( 'rejects unsupported desk config versions', () => {
+		expect( () => assertDeskConfig( { ...validDesk, version: 999 } ) ).toThrow(
+			'Invalid desk config: expected version 1.'
+		);
+	} );
+
+	it( 'rejects invalid widget records', () => {
+		expect(
+			isDeskConfig( {
+				...validDesk,
+				widgets: [ { ...validDesk.widgets[ 0 ], shapeProps: [] } ],
+			} )
+		).toBe( false );
+	} );
+
+	it( 'rejects invalid stack view modes', () => {
+		expect(
+			isDeskConfig( {
+				...validDesk,
+				stacks: [ { ...validDesk.stacks[ 0 ], viewMode: 'grid' } ],
+			} )
+		).toBe( false );
+	} );
+
+	it( 'rejects connector anchors outside the normalized range', () => {
+		expect(
+			isDeskConfig( {
+				...validDesk,
+				connectors: [
+					{
+						...validDesk.connectors[ 0 ],
+						from: {
+							...validDesk.connectors[ 0 ].from,
+							normalizedAnchor: { x: 1.5, y: 0.5 },
+						},
+					},
+				],
+			} )
+		).toBe( false );
+	} );
+} );


### PR DESCRIPTION
## Summary
- Added `DeskConfig` JSON export/import through the Electron desk IPC layer, including file picker/save dialog handling and schema validation.
- Added desk data actions to the desks settings modal so users can export the current desk or import a saved JSON file.
- Added shared desk-config validation helpers and covered them with unit tests.

## Testing
- `npx eslint --fix` on the modified TS/TSX files
- `npm run typecheck`
- `npm test -- tools/common/lib/tests/desk-config.test.ts apps/ui/src/ui-desks/desk/selection-toolbar/index.test.tsx apps/ui/src/ui-desks/desk/tldraw-adapter/index.test.ts`
- `npm test -- apps/ui/src/ui-desks/desk/provider/editor-state/index.test.ts`