### PR TITLE
Keep post collections visible after loading and restore toolbar delete behavior

### DIFF
--- a/apps/ui/src/ui-desks/desk/provider/editor-state/index.test.ts
+++ b/apps/ui/src/ui-desks/desk/provider/editor-state/index.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+	deskWidgetToCanvasShape,
+	resolvedDeskWidgetToCanvasShape,
+} from '@/ui-desks/desk/tldraw-adapter';
+import {
 	RECTANGLE_WIDGET_SHAPE_TYPE,
 	type RectangleWidgetShape,
 } from '@/ui-desks/shapes/rectangle-widget/types';
-import { fitSelectedWidgetToContentInEditor } from './index';
-import type { Editor } from 'tldraw';
+import {
+	fitSelectedWidgetToContentInEditor,
+	getCurrentSelectedWidgetToolbarItem,
+	removeSelectedWidgetFromEditor,
+} from './index';
+import type { DeskWidget, ResolvedDeskWidget } from '@/ui-desks/widgets/types';
+import type { Editor, TLShape, TLShapeId } from 'tldraw';
 
 vi.mock( '@wordpress/core-data', () => ( {
 	store: {},
@@ -142,6 +151,42 @@ describe( 'editor state widget fitting', () => {
 	} );
 } );
 
+describe( 'editor state widget removal', () => {
+	it( 'allows toolbar removal for a complete derived post collection stack selection', () => {
+		const { editor } = createEditorWithPostCollectionDerivedSelection();
+
+		const item = getCurrentSelectedWidgetToolbarItem( editor );
+
+		expect( item ).toMatchObject( {
+			kind: 'single-widget',
+			canRemove: true,
+			widget: {
+				id: 'collection-1',
+				type: 'post-collection',
+			},
+		} );
+	} );
+
+	it( 'removes the selected derived post collection stack members from the toolbar', () => {
+		const { editor, derivedShapes, deletedShapeIds } =
+			createEditorWithPostCollectionDerivedSelection();
+
+		expect( removeSelectedWidgetFromEditor( editor ) ).toBe( true );
+		expect( deletedShapeIds ).toEqual( [ derivedShapes.map( ( shape ) => shape.id ) ] );
+	} );
+
+	it( 'keeps toolbar removal disabled when a complete derived selection cannot be removed', () => {
+		const { editor } = createEditorWithPostCollectionDerivedSelection();
+
+		const item = getCurrentSelectedWidgetToolbarItem( editor, { canRemove: false } );
+
+		expect( item ).toMatchObject( {
+			kind: 'single-widget',
+			canRemove: false,
+		} );
+	} );
+} );
+
 function createEditorWithSelectedShape( shape: RectangleWidgetShape ) {
 	const updates: unknown[] = [];
 	const editor = {
@@ -155,4 +200,75 @@ function createEditorWithSelectedShape( shape: RectangleWidgetShape ) {
 	} as unknown as Editor;
 
 	return { editor, updates };
+}
+
+function createEditorWithPostCollectionDerivedSelection() {
+	const sourceShape = deskWidgetToCanvasShape( {
+		id: 'collection-1',
+		type: 'post-collection',
+		x: 40,
+		y: 50,
+		zIndex: 'a1',
+		shapeProps: {
+			w: 1,
+			h: 1,
+		},
+		widgetProps: {
+			query: {
+				postType: 'post',
+				perPage: 5,
+				status: 'publish',
+				orderby: 'date',
+				order: 'desc',
+			},
+		},
+	} as DeskWidget ) as TLShape;
+	const stack = {
+		id: 'post-collection:collection-1',
+		x: 40,
+		y: 50,
+		zIndex: 'a1',
+		memberIds: [ 'collection-1:post:41', 'collection-1:post:42' ],
+	};
+	const derivedShapes = [ 41, 42 ].map(
+		( postId, order ) =>
+			resolvedDeskWidgetToCanvasShape(
+				{
+					origin: {
+						kind: 'derived',
+						sourceWidgetId: 'collection-1',
+						key: `post:${ postId }`,
+					},
+					widget: {
+						id: `collection-1:post:${ postId }`,
+						type: 'post',
+						x: 40,
+						y: 50,
+						zIndex: `a${ order + 2 }`,
+						shapeProps: {
+							w: 280,
+							h: 380,
+						},
+						widgetProps: {
+							postId,
+						},
+					},
+				} as ResolvedDeskWidget< DeskWidget >,
+				{ stack, order }
+			) as TLShape
+	);
+	const shapes = [ sourceShape, ...derivedShapes ];
+	const selectedShapeIds = derivedShapes.map( ( shape ) => shape.id );
+	const deletedShapeIds: TLShapeId[][] = [];
+	const editor = {
+		isDisposed: false,
+		getSelectedShapeIds: () => selectedShapeIds,
+		getShape: ( shapeId: TLShapeId ) => shapes.find( ( shape ) => shape.id === shapeId ),
+		getCurrentPageShapes: () => shapes,
+		deleteShapes: ( shapeIds: TLShapeId[] ) => {
+			deletedShapeIds.push( shapeIds );
+		},
+	} as unknown as Editor;
+
+	return { editor, derivedShapes, deletedShapeIds };
 }

--- a/apps/ui/src/ui-desks/desk/provider/editor-state/index.ts
+++ b/apps/ui/src/ui-desks/desk/provider/editor-state/index.ts
@@ -73,6 +73,12 @@ interface WidgetToolbarStateOptions {
 	canRemove?: boolean;
 }
 
+interface CurrentSelectedWidgetSelection {
+	item: SelectedWidgetToolbarItem;
+	shapes: TLShape[];
+	removalShapes?: TLShape[];
+}
+
 interface HydrateEditorOptions {
 	initialViewportMode?: 'site-map';
 }
@@ -296,7 +302,8 @@ export function removeSelectedWidgetFromEditor( editor: Editor ) {
 		return false;
 	}
 
-	editor.deleteShapes( selection.shapes.map( ( shape ) => shape.id ) );
+	const shapesToRemove = selection.removalShapes ?? selection.shapes;
+	editor.deleteShapes( shapesToRemove.map( ( shape ) => shape.id ) );
 	return true;
 }
 
@@ -374,7 +381,7 @@ export function hasPersistentDocumentChange( changes: CanvasStoreChanges ) {
 function getCurrentSelectedWidgetSelection(
 	editor: Editor,
 	options: WidgetToolbarStateOptions = {}
-) {
+): CurrentSelectedWidgetSelection | null {
 	const selectedShapeIds = editor.getSelectedShapeIds();
 	if ( selectedShapeIds.length === 0 ) {
 		return null;
@@ -551,7 +558,7 @@ function getDerivedSourceWidgetSelection(
 	editor: Editor,
 	shapes: TLShape[],
 	options: WidgetToolbarStateOptions = {}
-) {
+): CurrentSelectedWidgetSelection | null {
 	if ( ! isCompleteDerivedStackSelection( editor, shapes ) ) {
 		return null;
 	}
@@ -577,7 +584,7 @@ function getDerivedSourceWidgetSelection(
 		stackIds: [],
 		canStack: options.canStack,
 		canUnstack: options.canUnstack,
-		canRemove: false,
+		canRemove: options.canRemove,
 	} );
 	if ( ! item ) {
 		return null;
@@ -586,6 +593,7 @@ function getDerivedSourceWidgetSelection(
 	return {
 		item,
 		shapes: [ sourceShape ],
+		removalShapes: shapes,
 	};
 }
 

--- a/apps/ui/src/ui-desks/desk/provider/resolvers.test.ts
+++ b/apps/ui/src/ui-desks/desk/provider/resolvers.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	deskWidgetToCanvasShape,
+	resolvedDeskWidgetToCanvasShape,
+} from '@/ui-desks/desk/tldraw-adapter';
+import { selectDerivedWidgetsForSelectedSource } from './resolvers';
+import type { DeskWidget, ResolvedDeskWidget } from '@/ui-desks/widgets/types';
+import type { Editor, TLShape } from 'tldraw';
+
+vi.mock( '@wordpress/core-data', () => ( {
+	store: {},
+} ) );
+
+describe( 'desk widget resolvers', () => {
+	it( 'moves selection from a resolved source widget to its derived widgets', () => {
+		const { editor, derivedShapes, setSelectedShapes } = createPostCollectionResolverEditor( {
+			selectSource: true,
+		} );
+
+		selectDerivedWidgetsForSelectedSource( editor, 'collection-1' );
+
+		expect( setSelectedShapes ).toHaveBeenCalledWith( derivedShapes.map( ( shape ) => shape.id ) );
+	} );
+
+	it( 'keeps the current selection when it is no longer only the source widget', () => {
+		const { editor, setSelectedShapes } = createPostCollectionResolverEditor( {
+			selectSource: false,
+		} );
+
+		selectDerivedWidgetsForSelectedSource( editor, 'collection-1' );
+
+		expect( setSelectedShapes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps the source selected until derived widgets exist', () => {
+		const { editor, setSelectedShapes } = createPostCollectionResolverEditor( {
+			selectSource: true,
+			includeDerivedShapes: false,
+		} );
+
+		selectDerivedWidgetsForSelectedSource( editor, 'collection-1' );
+
+		expect( setSelectedShapes ).not.toHaveBeenCalled();
+	} );
+} );
+
+function createPostCollectionResolverEditor( {
+	selectSource,
+	includeDerivedShapes = true,
+}: {
+	selectSource: boolean;
+	includeDerivedShapes?: boolean;
+} ) {
+	const sourceShape = deskWidgetToCanvasShape( {
+		id: 'collection-1',
+		type: 'post-collection',
+		x: 40,
+		y: 50,
+		zIndex: 'a1',
+		shapeProps: {
+			w: 1,
+			h: 1,
+		},
+		widgetProps: {
+			query: {
+				postType: 'post',
+				perPage: 5,
+				status: 'publish',
+				orderby: 'date',
+				order: 'desc',
+			},
+		},
+	} as DeskWidget ) as TLShape;
+	const stack = {
+		id: 'post-collection:collection-1',
+		x: 40,
+		y: 50,
+		zIndex: 'a1',
+		memberIds: [ 'collection-1:post:41', 'collection-1:post:42' ],
+	};
+	const derivedShapes = [ 41, 42 ].map(
+		( postId, order ) =>
+			resolvedDeskWidgetToCanvasShape(
+				{
+					origin: {
+						kind: 'derived',
+						sourceWidgetId: 'collection-1',
+						key: `post:${ postId }`,
+					},
+					widget: {
+						id: `collection-1:post:${ postId }`,
+						type: 'post',
+						x: 40,
+						y: 50,
+						zIndex: `a${ order + 2 }`,
+						shapeProps: {
+							w: 280,
+							h: 380,
+						},
+						widgetProps: {
+							postId,
+						},
+					},
+				} as ResolvedDeskWidget< DeskWidget >,
+				{ stack, order }
+			) as TLShape
+	);
+	const shapes = includeDerivedShapes ? [ sourceShape, ...derivedShapes ] : [ sourceShape ];
+	const selectedShapeIds = selectSource
+		? [ sourceShape.id ]
+		: derivedShapes.map( ( shape ) => shape.id );
+	const setSelectedShapes = vi.fn();
+	const editor = {
+		getCurrentPageShapes: () => shapes,
+		getSelectedShapeIds: () => selectedShapeIds,
+		setSelectedShapes,
+	} as unknown as Editor;
+
+	return { editor, derivedShapes, setSelectedShapes };
+}

--- a/apps/ui/src/ui-desks/desk/provider/resolvers.ts
+++ b/apps/ui/src/ui-desks/desk/provider/resolvers.ts
@@ -288,6 +288,28 @@ function reconcileResolvedWidgets(
 	if ( shapesToCreate.length > 0 ) {
 		editor.createShapes( shapesToCreate );
 	}
+	selectDerivedWidgetsForSelectedSource( editor, sourceWidgetId );
+}
+
+export function selectDerivedWidgetsForSelectedSource( editor: Editor, sourceWidgetId: string ) {
+	const sourceShape = editor
+		.getCurrentPageShapes()
+		.find( ( shape ) => canvasShapeToDeskWidget( shape )?.id === sourceWidgetId );
+	if ( ! sourceShape ) {
+		return;
+	}
+
+	const selectedShapeIds = editor.getSelectedShapeIds();
+	if ( selectedShapeIds.length !== 1 || selectedShapeIds[ 0 ] !== sourceShape.id ) {
+		return;
+	}
+
+	const derivedShapeIds = getDerivedShapesForSource( editor, sourceWidgetId ).map(
+		( shape ) => shape.id
+	);
+	if ( derivedShapeIds.length > 0 ) {
+		editor.setSelectedShapes( derivedShapeIds );
+	}
 }
 
 function preserveExpandedStackMemberState(


### PR DESCRIPTION
## Summary
- Keep the post collection selection on the resolved derived posts instead of leaving it on the invisible 1x1 source anchor after load.
- Allow the toolbar delete button to remove a complete derived post collection selection, matching the context menu behavior.
- Add regression coverage for the selection handoff and derived-selection removal path.

## Testing
- `npx eslint --fix` on the modified files.
- `npm test -- apps/ui/src/ui-desks/desk/provider/editor-state/index.test.ts apps/ui/src/ui-desks/desk/provider/resolvers.test.ts`
- `npm run typecheck`