### PR TITLE
apps/ui: Sync site preview with connector and toolbar actions

### DIFF
--- a/apps/ui/src/ui-desks/connectors/use-connector-interactions.ts
+++ b/apps/ui/src/ui-desks/connectors/use-connector-interactions.ts
@@ -28,6 +28,7 @@ interface UseConnectorInteractionsOptions {
 	isReadOnly: boolean;
 	pendingConnectorSourceId: TLShapeId | null;
 	setPendingConnectorSourceId: ( shapeId: TLShapeId | null ) => void;
+	onConnectorComplete?: ( connection: WidgetConnectorCompleteIntent ) => void;
 	onCustomDrop?: ( drop: WidgetCustomDropIntent ) => void;
 }
 
@@ -37,6 +38,7 @@ export function useConnectorInteractions( {
 	isReadOnly,
 	pendingConnectorSourceId,
 	setPendingConnectorSourceId,
+	onConnectorComplete,
 	onCustomDrop,
 }: UseConnectorInteractionsOptions ) {
 	useEffect( () => {
@@ -110,7 +112,8 @@ export function useConnectorInteractions( {
 		}
 
 		const sourceShape = editor.getShape( pendingConnectorSourceId );
-		if ( ! sourceShape || ! canvasShapeToDeskWidget( sourceShape ) ) {
+		const sourceWidget = sourceShape ? canvasShapeToDeskWidget( sourceShape ) : null;
+		if ( ! sourceShape || ! sourceWidget ) {
 			setPendingConnectorSourceId( null );
 			return;
 		}
@@ -164,7 +167,8 @@ export function useConnectorInteractions( {
 
 			const point = editor.screenToPage( { x: event.clientX, y: event.clientY } );
 			const targetShape = getConnectableShapeAtPagePoint( editor, point, pendingConnectorSourceId );
-			if ( ! targetShape ) {
+			const targetWidget = targetShape ? canvasShapeToDeskWidget( targetShape ) : null;
+			if ( ! targetShape || ! targetWidget ) {
 				cancelConnection();
 				return;
 			}
@@ -177,6 +181,12 @@ export function useConnectorInteractions( {
 			}
 			editor.setSelectedShapes( [ arrowId ] );
 			editor.focus();
+			onConnectorComplete?.( {
+				sourceShapeId: pendingConnectorSourceId,
+				targetShapeId: targetShape.id,
+				sourceWidget,
+				targetWidget,
+			} );
 			setPendingConnectorSourceId( null );
 		};
 
@@ -199,7 +209,7 @@ export function useConnectorInteractions( {
 				editor.deleteShape( arrowId );
 			}
 		};
-	}, [ editor, pendingConnectorSourceId, setPendingConnectorSourceId ] );
+	}, [ editor, onConnectorComplete, pendingConnectorSourceId, setPendingConnectorSourceId ] );
 
 	useEffect( () => {
 		if ( ! editor || ! isHydrated || isReadOnly ) {
@@ -288,6 +298,12 @@ export function useConnectorInteractions( {
 							updateConnectorEnd( editor, connectorPreviewId, toPlainPoint( targetBounds.center ) );
 						}
 						restoreSourcePosition();
+						onConnectorComplete?.( {
+							sourceShapeId: source.shapeId,
+							targetShapeId: activeTarget.shapeId,
+							sourceWidget: source.widget,
+							targetWidget: activeTarget.widget,
+						} );
 					} else if ( activeTarget.handler.type === 'custom' ) {
 						restoreSourcePosition();
 						onCustomDrop?.( {
@@ -365,7 +381,14 @@ export function useConnectorInteractions( {
 			editor.off( 'event', handleEvent );
 			cleanup();
 		};
-	}, [ editor, isHydrated, isReadOnly, onCustomDrop ] );
+	}, [ editor, isHydrated, isReadOnly, onConnectorComplete, onCustomDrop ] );
+}
+
+export interface WidgetConnectorCompleteIntent {
+	sourceShapeId: TLShapeId;
+	targetShapeId: TLShapeId;
+	sourceWidget: DeskWidget;
+	targetWidget: DeskWidget;
 }
 
 export interface WidgetCustomDropIntent extends WidgetCustomDropActionIntent {

--- a/apps/ui/src/ui-desks/desk/provider/context.ts
+++ b/apps/ui/src/ui-desks/desk/provider/context.ts
@@ -20,6 +20,7 @@ export type SelectedWidgetToolbarItem = NonNullable<
 >;
 
 export type RegisterDeskEditor = ( editor: Editor | null ) => void;
+export type PreviewContentType = 'post' | 'page';
 
 export interface DeskContextValue {
 	siteId?: string;
@@ -52,6 +53,8 @@ export interface DeskContextValue {
 	updateSelectedWidgetProps: ( widgetProps: Record< string, unknown > ) => boolean;
 	canEditSelectedWidget: boolean;
 	editSelectedWidget: () => boolean;
+	canPreviewContentInSitePreview: boolean;
+	previewContentInSitePreview: ( type: PreviewContentType, id: number ) => Promise< boolean >;
 	fitSelectedWidgetToContent: () => Promise< boolean >;
 	stackSelectedWidgets: () => boolean;
 	unstackSelectedWidgets: () => boolean;
@@ -114,6 +117,8 @@ const defaultDeskContext: DeskContextValue = {
 	updateSelectedWidgetProps: () => false,
 	canEditSelectedWidget: false,
 	editSelectedWidget: () => false,
+	canPreviewContentInSitePreview: false,
+	previewContentInSitePreview: () => Promise.resolve( false ),
 	fitSelectedWidgetToContent: () => Promise.resolve( false ),
 	stackSelectedWidgets: () => false,
 	unstackSelectedWidgets: () => false,

--- a/apps/ui/src/ui-desks/desk/provider/index.tsx
+++ b/apps/ui/src/ui-desks/desk/provider/index.tsx
@@ -1,3 +1,5 @@
+import { store as coreDataStore } from '@wordpress/core-data';
+import { useRegistry } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -12,6 +14,7 @@ import {
 } from 'tldraw';
 import { useConnector } from '@/data/core';
 import { useSites } from '@/data/queries/use-sites';
+import { getSiteUrl } from '@/lib/get-site-url';
 import {
 	focusConnectedWidgetInEditor,
 	removeSelectedConnectorFromEditor,
@@ -19,6 +22,7 @@ import {
 } from '@/ui-desks/connectors/editor-commands';
 import {
 	useConnectorInteractions,
+	type WidgetConnectorCompleteIntent,
 	type WidgetCustomDropIntent,
 } from '@/ui-desks/connectors/use-connector-interactions';
 import {
@@ -54,11 +58,19 @@ import {
 } from '@/ui-desks/widget-actions/paste-handlers';
 import { LOADING_WIDGET_TYPE } from '@/ui-desks/widgets/loading/types';
 import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
+import { isPageWidgetProps, PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
+import { isPostWidgetProps, POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
 import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
+import { getSitePreviewPathFromContentLink } from '@/ui-desks/widgets/site-preview/preview-target';
+import {
+	isSitePreviewWidgetProps,
+	SITE_PREVIEW_WIDGET_TYPE,
+} from '@/ui-desks/widgets/site-preview/types';
 import {
 	DeskContext,
 	type AddDeskWidgetOptions,
 	type DeskProviderProps,
+	type PreviewContentType,
 	type SelectedWidgetToolbarItem,
 } from './context';
 import {
@@ -86,6 +98,7 @@ import type {
 	WidgetHandlerLoading,
 	WidgetHandlerResult,
 	WidgetPastePayload,
+	WidgetResolverRegistry,
 } from '@/ui-desks/widgets/types';
 
 export { useDesk, useRegisterDeskEditor } from './context';
@@ -99,6 +112,25 @@ interface FocusShapeRestoreSnapshot {
 	opacity: number;
 	isLocked: boolean;
 }
+
+interface CoreDataPreviewRecord {
+	id: number;
+	link?: string;
+}
+
+interface CoreDataPreviewResolvers {
+	getEntityRecord: (
+		kind: 'postType',
+		name: PreviewContentType,
+		key: number,
+		query: typeof CONTENT_PREVIEW_RECORD_QUERY
+	) => Promise< CoreDataPreviewRecord | undefined >;
+}
+
+const CONTENT_PREVIEW_RECORD_QUERY = {
+	context: 'edit',
+	_fields: 'id,link',
+} as const;
 
 export function DeskProvider( {
 	siteId,
@@ -121,6 +153,7 @@ export function DeskProvider( {
 	const desk = deskConfig ?? persistedDesk;
 	const isLoading = externalIsLoading ?? isLoadingPersistedDesk;
 	const connector = useConnector();
+	const registry = useRegistry();
 	const { data: sites } = useSites();
 	const site = sites?.find( ( candidate ) => candidate.id === siteId );
 	const isRunningSite = Boolean( siteId && site?.running );
@@ -193,6 +226,79 @@ export function DeskProvider( {
 		intent: customDropIntent,
 		closeMenu: closeCustomDropMenu,
 	} );
+	const canPreviewContentInSitePreview = Boolean(
+		! isReadOnly && editor && isHydrated && isRunningSite && getFirstSitePreviewShape( editor )
+	);
+	const previewContentInSitePreviewShape = useCallback(
+		async (
+			type: PreviewContentType,
+			id: number,
+			options: { targetShapeId?: TLShapeId; shouldFocus?: boolean } = {}
+		) => {
+			if ( id <= 0 || isReadOnly || ! editor || ! isHydrated || ! isRunningSite || ! site ) {
+				return false;
+			}
+
+			const targetShape = options.targetShapeId
+				? editor.getShape( options.targetShapeId )
+				: getFirstSitePreviewShape( editor );
+			const targetWidget = targetShape ? canvasShapeToDeskWidget( targetShape ) : null;
+			if (
+				! targetShape ||
+				targetWidget?.type !== SITE_PREVIEW_WIDGET_TYPE ||
+				! isSitePreviewWidgetProps( targetWidget.widgetProps )
+			) {
+				return false;
+			}
+
+			let record: CoreDataPreviewRecord | undefined;
+			try {
+				record = await getContentPreviewRecord( registry, type, id );
+			} catch ( error ) {
+				console.warn( `Unable to load ${ type } ${ id } for site preview.`, error );
+				return false;
+			}
+			if ( ! record?.link || editor.isDisposed ) {
+				return false;
+			}
+
+			const path = getSitePreviewPathFromContentLink( record.link, getSiteUrl( site ) );
+			const didUpdate = updateSitePreviewPathInEditor( editor, targetShape.id, path );
+			if ( didUpdate && options.shouldFocus ) {
+				const bounds = editor.getShapePageBounds( targetShape.id );
+				if ( bounds ) {
+					editor.zoomToBounds( bounds, { animation: { duration: 320 } } );
+				}
+			}
+			return didUpdate;
+		},
+		[ editor, isHydrated, isReadOnly, isRunningSite, registry, site ]
+	);
+	const previewContentInSitePreview = useCallback(
+		( type: PreviewContentType, id: number ) =>
+			previewContentInSitePreviewShape( type, id, { shouldFocus: true } ),
+		[ previewContentInSitePreviewShape ]
+	);
+	const handleConnectorComplete = useCallback(
+		( connection: WidgetConnectorCompleteIntent ) => {
+			if (
+				connection.targetWidget.type !== SITE_PREVIEW_WIDGET_TYPE ||
+				! isSitePreviewWidgetProps( connection.targetWidget.widgetProps )
+			) {
+				return;
+			}
+
+			const source = getContentPreviewSource( connection.sourceWidget );
+			if ( ! source ) {
+				return;
+			}
+
+			void previewContentInSitePreviewShape( source.type, source.id, {
+				targetShapeId: connection.targetShapeId,
+			} );
+		},
+		[ previewContentInSitePreviewShape ]
+	);
 
 	useStackInteractions( editor );
 	useConnectorInteractions( {
@@ -201,6 +307,7 @@ export function DeskProvider( {
 		isReadOnly,
 		pendingConnectorSourceId,
 		setPendingConnectorSourceId,
+		onConnectorComplete: handleConnectorComplete,
 		onCustomDrop: handleCustomDrop,
 	} );
 
@@ -1041,6 +1148,8 @@ export function DeskProvider( {
 			updateSelectedWidgetProps,
 			canEditSelectedWidget: Boolean( selectedWidgetEditAction ),
 			editSelectedWidget,
+			canPreviewContentInSitePreview,
+			previewContentInSitePreview,
 			fitSelectedWidgetToContent,
 			stackSelectedWidgets,
 			unstackSelectedWidgets,
@@ -1060,6 +1169,7 @@ export function DeskProvider( {
 			addPastedContent,
 			addWidget,
 			addWidgetAtScreenPoint,
+			canPreviewContentInSitePreview,
 			editor,
 			editSelectedWidget,
 			fitSelectedWidgetToContent,
@@ -1075,6 +1185,7 @@ export function DeskProvider( {
 			isLoading,
 			pendingConnectorSourceId,
 			pressStack,
+			previewContentInSitePreview,
 			pressedStackId,
 			replaceDeskConfig,
 			registerEditor,
@@ -1115,6 +1226,80 @@ export function DeskProvider( {
 			) }
 		</DeskContext.Provider>
 	);
+}
+
+function getContentPreviewSource(
+	widget: DeskWidget
+): { type: PreviewContentType; id: number } | null {
+	if (
+		widget.type === POST_WIDGET_TYPE &&
+		isPostWidgetProps( widget.widgetProps ) &&
+		widget.widgetProps.postId > 0
+	) {
+		return { type: 'post', id: widget.widgetProps.postId };
+	}
+
+	if (
+		widget.type === PAGE_WIDGET_TYPE &&
+		isPageWidgetProps( widget.widgetProps ) &&
+		widget.widgetProps.pageId > 0
+	) {
+		return { type: 'page', id: widget.widgetProps.pageId };
+	}
+
+	return null;
+}
+
+async function getContentPreviewRecord(
+	registry: WidgetResolverRegistry,
+	type: PreviewContentType,
+	id: number
+) {
+	return getCoreDataPreviewResolvers( registry ).getEntityRecord(
+		'postType',
+		type,
+		id,
+		CONTENT_PREVIEW_RECORD_QUERY
+	);
+}
+
+function getCoreDataPreviewResolvers( registry: WidgetResolverRegistry ) {
+	return registry.resolveSelect( coreDataStore ) as unknown as CoreDataPreviewResolvers;
+}
+
+function getFirstSitePreviewShape( editor: Editor ) {
+	return editor.getCurrentPageShapes().find( ( shape ) => {
+		const widget = canvasShapeToDeskWidget( shape );
+		return widget?.type === SITE_PREVIEW_WIDGET_TYPE;
+	} );
+}
+
+function updateSitePreviewPathInEditor( editor: Editor, shapeId: TLShapeId, path: string ) {
+	const shape = editor.getShape( shapeId );
+	const widget = shape ? canvasShapeToDeskWidget( shape ) : null;
+	if (
+		! shape ||
+		widget?.type !== SITE_PREVIEW_WIDGET_TYPE ||
+		! isSitePreviewWidgetProps( widget.widgetProps )
+	) {
+		return false;
+	}
+
+	if ( widget.widgetProps.path === path ) {
+		return true;
+	}
+
+	editor.updateShape< RectangleWidgetShape >( {
+		id: shape.id as RectangleWidgetShape[ 'id' ],
+		type: RECTANGLE_WIDGET_SHAPE_TYPE,
+		props: {
+			widgetProps: {
+				...widget.widgetProps,
+				path,
+			},
+		},
+	} );
+	return true;
 }
 
 function syncFocusDeskToEditor(

--- a/apps/ui/src/ui-desks/desk/selection-toolbar/index.test.tsx
+++ b/apps/ui/src/ui-desks/desk/selection-toolbar/index.test.tsx
@@ -253,6 +253,8 @@ function createDeskContext( overrides: Partial< DeskContextValue > = {} ): DeskC
 		updateSelectedWidgetProps: vi.fn(),
 		canEditSelectedWidget: false,
 		editSelectedWidget: vi.fn(),
+		canPreviewContentInSitePreview: false,
+		previewContentInSitePreview: vi.fn().mockResolvedValue( false ),
 		fitSelectedWidgetToContent: vi.fn().mockResolvedValue( false ),
 		stackSelectedWidgets: vi.fn(),
 		unstackSelectedWidgets: vi.fn(),

--- a/apps/ui/src/ui-desks/desk/selection-toolbar/selection/index.test.ts
+++ b/apps/ui/src/ui-desks/desk/selection-toolbar/selection/index.test.ts
@@ -41,7 +41,9 @@ describe( 'widget toolbar selection', () => {
 			throw new Error( 'Expected a single widget toolbar item.' );
 		}
 		expect( selectedItem.definition.type ).toBe( POST_WIDGET_TYPE );
-		expect( selectedItem.definition.controls ).toBeUndefined();
+		expect( selectedItem.definition.controls?.map( ( control ) => control.id ) ).toEqual( [
+			'preview-post-on-canvas',
+		] );
 		expect( selectedItem.definition.getEditAction ).toBeTypeOf( 'function' );
 		expect( selectedItem.widget.widgetProps ).toEqual( {
 			postId: 42,
@@ -57,6 +59,7 @@ describe( 'widget toolbar selection', () => {
 		}
 		expect( selectedItem.definition.type ).toBe( PAGE_WIDGET_TYPE );
 		expect( selectedItem.definition.controls?.[ 0 ]?.type ).toBe( 'color' );
+		expect( selectedItem.definition.controls?.[ 1 ]?.id ).toBe( 'preview-page-on-canvas' );
 		expect( selectedItem.widget.widgetProps ).toEqual( {
 			pageId: 84,
 			tone: 'blue',

--- a/apps/ui/src/ui-desks/widget-actions/drop-handlers/index.test.ts
+++ b/apps/ui/src/ui-desks/widget-actions/drop-handlers/index.test.ts
@@ -26,8 +26,19 @@ describe( 'widget drop handlers', () => {
 		expect( getWidgetDropHandler( createSitePreviewWidget(), createNoteWidget() ) ).toBeNull();
 	} );
 
-	it( 'does not return a handler when the target has no drop handlers', () => {
-		expect( getWidgetDropHandler( createNoteWidget(), createSitePreviewWidget() ) ).toBeNull();
+	it( 'does not return a handler for unsupported source and target pairs', () => {
+		expect( getWidgetDropHandler( createMediaWidget(), createSitePreviewWidget() ) ).toBeNull();
+	} );
+
+	it( 'returns a connector handler for post and page drops onto site previews', () => {
+		expect( getWidgetDropHandler( createPostWidget(), createSitePreviewWidget() ) ).toMatchObject( {
+			id: 'preview-site-content',
+			type: 'connector',
+		} );
+		expect( getWidgetDropHandler( createPageWidget(), createSitePreviewWidget() ) ).toMatchObject( {
+			id: 'preview-site-content',
+			type: 'connector',
+		} );
 	} );
 
 	it( 'returns custom media handlers for post, page, and scratchpad targets', () => {

--- a/apps/ui/src/ui-desks/widgets/page/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/page/definition.ts
@@ -6,6 +6,7 @@ import {
 	PageWidgetComponent,
 	PageWidgetThumbnailComponent,
 } from '@/ui-desks/widgets/page/component';
+import { PagePreviewControl } from '@/ui-desks/widgets/page/preview-control';
 import { isPageWidgetProps, PAGE_WIDGET_TYPE, type PageTone, type PageWidget } from './types';
 import type {
 	WidgetCustomDropActionContext,
@@ -45,6 +46,11 @@ export const pageWidgetDefinition = {
 			property: 'tone',
 			label: __( 'Color' ),
 			options: PAGE_TONE_OPTIONS,
+		},
+		{
+			type: 'custom',
+			id: 'preview-page-on-canvas',
+			Component: PagePreviewControl,
 		},
 	],
 	isCreatable: false,

--- a/apps/ui/src/ui-desks/widgets/page/preview-control.tsx
+++ b/apps/ui/src/ui-desks/widgets/page/preview-control.tsx
@@ -1,0 +1,23 @@
+import { __ } from '@wordpress/i18n';
+import { seen } from '@wordpress/icons';
+import { Button } from '@/ui-desks/components';
+import { useDesk } from '@/ui-desks/desk/provider/context';
+import type { PageWidgetProps } from './types';
+import type { ControlRenderContext } from '@/ui-desks/controls/types';
+
+export function PagePreviewControl( { props }: ControlRenderContext< PageWidgetProps > ) {
+	const { canPreviewContentInSitePreview, previewContentInSitePreview } = useDesk();
+
+	return (
+		<Button
+			icon={ seen }
+			label={ __( 'Preview on canvas' ) }
+			variant="quiet"
+			size="medium"
+			disabled={ props.pageId <= 0 || ! canPreviewContentInSitePreview }
+			onClick={ () => {
+				void previewContentInSitePreview( 'page', props.pageId );
+			} }
+		/>
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/post/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/post/definition.ts
@@ -6,6 +6,7 @@ import {
 	PostWidgetComponent,
 	PostWidgetThumbnailComponent,
 } from '@/ui-desks/widgets/post/component';
+import { PostPreviewControl } from '@/ui-desks/widgets/post/preview-control';
 import { isPostWidgetProps, POST_WIDGET_TYPE, type PostWidget } from './types';
 import type {
 	WidgetCustomDropActionContext,
@@ -30,6 +31,13 @@ export const postWidgetDefinition = {
 		edit: () => __( 'Edit in WP' ),
 	},
 	icon: post,
+	controls: [
+		{
+			type: 'custom',
+			id: 'preview-post-on-canvas',
+			Component: PostPreviewControl,
+		},
+	],
 	getInitialWidget: () => ( {
 		shapeProps: {
 			w: 280,

--- a/apps/ui/src/ui-desks/widgets/post/preview-control.tsx
+++ b/apps/ui/src/ui-desks/widgets/post/preview-control.tsx
@@ -1,0 +1,23 @@
+import { __ } from '@wordpress/i18n';
+import { seen } from '@wordpress/icons';
+import { Button } from '@/ui-desks/components';
+import { useDesk } from '@/ui-desks/desk/provider/context';
+import type { PostWidgetProps } from './types';
+import type { ControlRenderContext } from '@/ui-desks/controls/types';
+
+export function PostPreviewControl( { props }: ControlRenderContext< PostWidgetProps > ) {
+	const { canPreviewContentInSitePreview, previewContentInSitePreview } = useDesk();
+
+	return (
+		<Button
+			icon={ seen }
+			label={ __( 'Preview on canvas' ) }
+			variant="quiet"
+			size="medium"
+			disabled={ props.postId <= 0 || ! canPreviewContentInSitePreview }
+			onClick={ () => {
+				void previewContentInSitePreview( 'post', props.postId );
+			} }
+		/>
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/site-preview/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/site-preview/definition.ts
@@ -1,5 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
+import { isPageWidgetProps, PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
+import { isPostWidgetProps, POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
 import { SitePreviewAnnotateControl } from '@/ui-desks/widgets/site-preview/annotate-control';
 import {
 	SitePreviewAnnotationCancelControl,
@@ -64,6 +66,19 @@ export const sitePreviewWidgetDefinition = {
 	} ),
 	getSummary: ( widgetProps ) => widgetProps.path || '/',
 	getEditAction: () => ( { kind: 'canvas-editing' } ),
+	dropHandlers: [
+		{
+			id: 'preview-site-content',
+			type: 'connector',
+			sourceTypes: [ POST_WIDGET_TYPE, PAGE_WIDGET_TYPE ],
+			canHandle: ( sourceWidget, targetWidget ) =>
+				isSitePreviewWidgetProps( targetWidget.widgetProps ) &&
+				( ( isPostWidgetProps( sourceWidget.widgetProps ) &&
+					sourceWidget.widgetProps.postId > 0 ) ||
+					( isPageWidgetProps( sourceWidget.widgetProps ) &&
+						sourceWidget.widgetProps.pageId > 0 ) ),
+		},
+	],
 	focusModeControls: [
 		{
 			type: 'custom',

--- a/apps/ui/src/ui-desks/widgets/site-preview/preview-target.test.ts
+++ b/apps/ui/src/ui-desks/widgets/site-preview/preview-target.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getSitePreviewPathFromContentLink } from './preview-target';
+
+describe( 'getSitePreviewPathFromContentLink', () => {
+	it( 'stores only path, query, and hash for absolute content links', () => {
+		expect(
+			getSitePreviewPathFromContentLink( 'http://localhost:8881/about/team/?view=card#bio' )
+		).toBe( '/about/team/?view=card#bio' );
+	} );
+
+	it( 'removes the internal preview flag from content links', () => {
+		expect(
+			getSitePreviewPathFromContentLink(
+				'https://example.test/post/?studio_desk_preview=1&foo=bar'
+			)
+		).toBe( '/post/?foo=bar' );
+	} );
+
+	it( 'normalizes relative links against the provided site URL', () => {
+		expect( getSitePreviewPathFromContentLink( 'contact', 'http://localhost:8881' ) ).toBe(
+			'/contact'
+		);
+	} );
+} );

--- a/apps/ui/src/ui-desks/widgets/site-preview/preview-target.ts
+++ b/apps/ui/src/ui-desks/widgets/site-preview/preview-target.ts
@@ -1,0 +1,27 @@
+export function getSitePreviewPathFromContentLink( link: string, baseUrl?: string ) {
+	const trimmed = link.trim();
+	if ( ! trimmed ) {
+		return '';
+	}
+
+	try {
+		const previewUrl = new URL( trimmed, getBaseUrl( baseUrl ) );
+		previewUrl.searchParams.delete( 'studio_desk_preview' );
+		const query = previewUrl.searchParams.toString();
+		return `${ previewUrl.pathname || '/' }${ query ? `?${ query }` : '' }${ previewUrl.hash }`;
+	} catch {
+		return trimmed.startsWith( '/' ) ? trimmed : `/${ trimmed }`;
+	}
+}
+
+function getBaseUrl( baseUrl?: string ) {
+	if ( baseUrl ) {
+		return baseUrl.endsWith( '/' ) ? baseUrl : `${ baseUrl }/`;
+	}
+
+	if ( typeof window !== 'undefined' && window.location?.origin ) {
+		return window.location.origin;
+	}
+
+	return 'http://localhost/';
+}


### PR DESCRIPTION
## Summary
- Update connector completion so connecting a post or page to a site preview also updates the preview target path.
- Allow post and page widgets to connect directly to site previews via drag/drop.
- Add a canvas preview action to post and page widgets so they can point the first site preview at that content.
- Normalize preview paths before storing them so only path/query/hash are persisted.

## Testing
- `npx eslint --fix` on the touched files.
- `npm run typecheck` passed.
- Added and ran unit tests for preview-path normalization, connector drop handling, and selection-toolbar context defaults.