### PR TITLE
apps/ui: Integrate scratchpad state with chat conversations

### DIFF
--- a/apps/ui/src/ui-desks/chats/context.tsx
+++ b/apps/ui/src/ui-desks/chats/context.tsx
@@ -39,7 +39,7 @@ export interface ChatsContextValue {
 	switchSession: ( sessionId: string ) => void;
 	clearSelection: () => void;
 	startNewChat: () => Promise< void >;
-	startChatWithPrompt: ( request: ChatPromptRequest ) => Promise< void >;
+	startChatWithPrompt: ( request: ChatPromptRequest ) => Promise< string >;
 	consumePendingPrompt: ( promptId: string ) => void;
 	attachWidgetsToComposer: ( widgets: DeskWidget[] ) => void;
 	consumeComposerWidgetAttachmentRequest: ( requestId: string ) => void;
@@ -85,7 +85,9 @@ function noopSetOpen() {}
 function noopSelectSession() {}
 function noopClearSelection() {}
 async function noopStartChat() {}
-async function noopStartChatWithPrompt() {}
+async function noopStartChatWithPrompt() {
+	return '';
+}
 function noopConsumePendingPrompt() {}
 function noopAttachWidgetsToComposer() {}
 function noopSetComposerWidgetDragPreview() {}

--- a/apps/ui/src/ui-desks/chats/conversation/index.test.ts
+++ b/apps/ui/src/ui-desks/chats/conversation/index.test.ts
@@ -149,6 +149,48 @@ describe( 'desks conversation render items', () => {
 			} )
 		);
 	} );
+
+	it( 'renders scratchpad artifacts as a preview card and adds synced run metadata', () => {
+		deskMocks.addWidget.mockReturnValue( true );
+
+		render(
+			createElement( ChatArtifact, {
+				artifact: {
+					version: STUDIO_CHAT_ARTIFACT_VERSION,
+					id: 'scratchpad-artifact',
+					widgets: [
+						{
+							type: 'scratchpad',
+							widgetProps: {
+								html: '<main><h1>Draft</h1></main>',
+								title: 'Landing page draft',
+								scope: 'page',
+								description: 'Tighten the hero.',
+							},
+						},
+					],
+				},
+			} )
+		);
+
+		expect( screen.getByText( 'Landing page draft' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Tighten the hero.' ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add to canvas' } ) );
+
+		expect( deskMocks.addWidget ).toHaveBeenCalledWith(
+			'scratchpad',
+			expect.objectContaining( {
+				widgetProps: expect.objectContaining( {
+					description: 'Tighten the hero.',
+					agentStatus: 'idle',
+					lastSyncedDescription: 'Tighten the hero.',
+				} ),
+				shouldStartEditing: false,
+			} )
+		);
+		expect( screen.getByRole( 'button', { name: 'Added' } ) ).toBeDisabled();
+	} );
 } );
 
 function assistantToolCallEntry( name: string ): SessionEntry {

--- a/apps/ui/src/ui-desks/chats/conversation/index.tsx
+++ b/apps/ui/src/ui-desks/chats/conversation/index.tsx
@@ -21,6 +21,12 @@ import { Markdown } from '@/components/markdown';
 import { Button } from '@/ui-desks/components';
 import { useDesk } from '@/ui-desks/desk/provider';
 import { createDeskWidget } from '@/ui-desks/widget-actions/create-widget';
+import {
+	SCRATCHPAD_WIDGET_TYPE,
+	isScratchpadWidgetProps,
+	type ScratchpadWidget,
+	type ScratchpadWidgetProps,
+} from '@/ui-desks/widgets/scratchpad/types';
 import { ThinkingIndicator } from '../thinking-indicator';
 import {
 	getWidgetDisplayLabel,
@@ -289,7 +295,7 @@ export function ChatArtifact( { artifact }: { artifact: StudioChatArtifactData }
 						center: { x: 0, y: 0 },
 						zIndex: 'a1',
 						shapeProps: widget.shapeProps,
-						widgetProps: widget.widgetProps,
+						widgetProps: normalizeChatArtifactWidgetProps( widget.type, widget.widgetProps ),
 					} )
 				)
 				.filter( ( widget ): widget is DeskWidget => widget !== null ),
@@ -303,6 +309,8 @@ export function ChatArtifact( { artifact }: { artifact: StudioChatArtifactData }
 	const summary = summarizeWidgetList( widgets );
 	const allAdded = widgets.every( ( widget ) => addedWidgetIds.has( widget.id ) );
 	const hasAddedSome = widgets.some( ( widget ) => addedWidgetIds.has( widget.id ) );
+	const scratchpadWidget =
+		widgets.length === 1 && isScratchpadWidget( widgets[ 0 ] ) ? widgets[ 0 ] : null;
 	const markWidgetsAdded = ( widgetIds: string[] ) => {
 		if ( widgetIds.length === 0 ) {
 			return;
@@ -439,82 +447,181 @@ export function ChatArtifact( { artifact }: { artifact: StudioChatArtifactData }
 
 	return (
 		<div className={ clsx( styles.messageGroup, styles.assistantGroup ) }>
-			<div
-				className={ styles.artifact }
-				data-dragging={ dragState ? 'true' : undefined }
-				onPointerDown={ handlePointerDown }
-				title={ summary }
-			>
-				<div className={ styles.artifactThumbnails } aria-label={ summary }>
-					{ widgets.map( ( widget, index ) => {
-						const isAdded = addedWidgetIds.has( widget.id );
-						const widgetLabel = getWidgetDisplayLabel( widget );
-						const addLabel = getWidgetAddActionLabel( widget, index, isAdded );
-						return (
-							<div
-								key={ widget.id }
-								className={ styles.artifactThumbnail }
-								aria-label={ widgetLabel }
-								title={ widgetLabel }
-							>
-								<WidgetContextThumbnail widget={ widget } />
-								{ widgets.length > 1 && (
-									<button
-										type="button"
-										className={ styles.artifactThumbnailAdd }
-										disabled={ ! canAddWidgets || isAdded }
-										data-added={ isAdded ? 'true' : undefined }
-										title={ addLabel }
-										aria-label={ addLabel }
-										onClick={ ( event ) => {
-											event.stopPropagation();
-											addWidgetToCanvas( widget );
-										} }
+			{ scratchpadWidget ? (
+				<ScratchpadArtifactCard
+					widget={ scratchpadWidget }
+					isAdded={ allAdded }
+					canAddWidgets={ canAddWidgets }
+					onAdd={ () => addWidgetToCanvas( scratchpadWidget ) }
+					onPointerDown={ handlePointerDown }
+				/>
+			) : (
+				<>
+					<div
+						className={ styles.artifact }
+						data-dragging={ dragState ? 'true' : undefined }
+						onPointerDown={ handlePointerDown }
+						title={ summary }
+					>
+						<div className={ styles.artifactThumbnails } aria-label={ summary }>
+							{ widgets.map( ( widget, index ) => {
+								const isAdded = addedWidgetIds.has( widget.id );
+								const widgetLabel = getWidgetDisplayLabel( widget );
+								const addLabel = getWidgetAddActionLabel( widget, index, isAdded );
+								return (
+									<div
+										key={ widget.id }
+										className={ styles.artifactThumbnail }
+										aria-label={ widgetLabel }
+										title={ widgetLabel }
 									>
-										<Icon icon={ isAdded ? check : plus } size={ 14 } />
-									</button>
-								) }
-							</div>
-						);
-					} ) }
-				</div>
-			</div>
-			<div className={ styles.artifactActions }>
-				{ widgets.length > 1 ? (
-					<button
-						type="button"
-						className={ styles.artifactAction }
-						disabled={ ! canAddWidgets || allAdded }
-						title={ summary }
-						onClick={ () => addWidgetsToCanvas() }
-					>
-						<Icon icon={ plus } size={ 16 } />
-						<span>
-							{ allAdded
-								? __( 'Added all' )
-								: hasAddedSome
-								? __( 'Add remaining' )
-								: __( 'Add all' ) }
-						</span>
-					</button>
-				) : (
-					<button
-						type="button"
-						className={ styles.artifactAction }
-						disabled={ ! canAddWidgets || allAdded }
-						title={ summary }
-						onClick={ () => addWidgetToCanvas( widgets[ 0 ] ) }
-					>
-						<Icon icon={ plus } size={ 16 } />
-						<span>{ allAdded ? __( 'Added' ) : __( 'Add to canvas' ) }</span>
-					</button>
-				) }
-			</div>
+										<WidgetContextThumbnail widget={ widget } />
+										{ widgets.length > 1 && (
+											<button
+												type="button"
+												className={ styles.artifactThumbnailAdd }
+												disabled={ ! canAddWidgets || isAdded }
+												data-added={ isAdded ? 'true' : undefined }
+												title={ addLabel }
+												aria-label={ addLabel }
+												onClick={ ( event ) => {
+													event.stopPropagation();
+													addWidgetToCanvas( widget );
+												} }
+											>
+												<Icon icon={ isAdded ? check : plus } size={ 14 } />
+											</button>
+										) }
+									</div>
+								);
+							} ) }
+						</div>
+					</div>
+					<div className={ styles.artifactActions }>
+						{ widgets.length > 1 ? (
+							<button
+								type="button"
+								className={ styles.artifactAction }
+								disabled={ ! canAddWidgets || allAdded }
+								title={ summary }
+								onClick={ () => addWidgetsToCanvas() }
+							>
+								<Icon icon={ plus } size={ 16 } />
+								<span>
+									{ allAdded
+										? __( 'Added all' )
+										: hasAddedSome
+										? __( 'Add remaining' )
+										: __( 'Add all' ) }
+								</span>
+							</button>
+						) : (
+							<button
+								type="button"
+								className={ styles.artifactAction }
+								disabled={ ! canAddWidgets || allAdded }
+								title={ summary }
+								onClick={ () => addWidgetToCanvas( widgets[ 0 ] ) }
+							>
+								<Icon icon={ plus } size={ 16 } />
+								<span>{ allAdded ? __( 'Added' ) : __( 'Add to canvas' ) }</span>
+							</button>
+						) }
+					</div>
+				</>
+			) }
 			{ dragState && typeof document !== 'undefined'
 				? createPortal( <ArtifactDragOverlay state={ dragState } />, document.body )
 				: null }
 		</div>
 	);
+}
+
+function ScratchpadArtifactCard( {
+	widget,
+	isAdded,
+	canAddWidgets,
+	onAdd,
+	onPointerDown,
+}: {
+	widget: ScratchpadWidget;
+	isAdded: boolean;
+	canAddWidgets: boolean;
+	onAdd: () => void;
+	onPointerDown: ( event: ReactPointerEvent< HTMLDivElement > ) => void;
+} ) {
+	const title = widget.widgetProps.title || __( 'Scratchpad' );
+	const description = widget.widgetProps.description?.trim();
+
+	return (
+		<>
+			<div
+				className={ styles.scratchpadArtifact }
+				data-scope={ widget.widgetProps.scope }
+				onPointerDown={ onPointerDown }
+				title={ getWidgetDisplayLabel( widget ) }
+			>
+				<div className={ styles.scratchpadArtifactBody }>
+					<span className={ styles.scratchpadArtifactTitle }>{ title }</span>
+					{ description ? (
+						<p className={ styles.scratchpadArtifactDescription }>{ description }</p>
+					) : null }
+				</div>
+				<div className={ styles.scratchpadArtifactThumbnail }>
+					{ widget.widgetProps.html ? (
+						<iframe
+							className={ styles.scratchpadArtifactFrame }
+							srcDoc={ widget.widgetProps.html }
+							sandbox="allow-scripts"
+							referrerPolicy="no-referrer"
+							title={ title }
+						/>
+					) : (
+						<div className={ styles.scratchpadArtifactEmpty }>{ __( 'Empty scratchpad' ) }</div>
+					) }
+					<div className={ styles.scratchpadArtifactShield } aria-hidden="true" />
+				</div>
+			</div>
+			<div className={ styles.artifactActions }>
+				<button
+					type="button"
+					className={ styles.artifactAction }
+					disabled={ ! canAddWidgets || isAdded }
+					title={ getWidgetDisplayLabel( widget ) }
+					onClick={ onAdd }
+				>
+					<Icon icon={ plus } size={ 16 } />
+					<span>{ isAdded ? __( 'Added' ) : __( 'Add to canvas' ) }</span>
+				</button>
+			</div>
+		</>
+	);
+}
+
+function normalizeChatArtifactWidgetProps(
+	type: string,
+	widgetProps: Record< string, unknown >
+): Record< string, unknown > {
+	if ( type !== SCRATCHPAD_WIDGET_TYPE || ! isScratchpadWidgetProps( widgetProps ) ) {
+		return widgetProps;
+	}
+
+	return normalizeScratchpadArtifactWidgetProps( widgetProps );
+}
+
+function normalizeScratchpadArtifactWidgetProps(
+	widgetProps: ScratchpadWidgetProps
+): ScratchpadWidgetProps {
+	const description = widgetProps.description ?? '';
+	return {
+		...widgetProps,
+		agentStatus: widgetProps.agentStatus ?? 'idle',
+		lastSyncedDescription: widgetProps.lastSyncedDescription ?? description,
+	};
+}
+
+function isScratchpadWidget( widget: DeskWidget ): widget is ScratchpadWidget {
+	return widget.type === SCRATCHPAD_WIDGET_TYPE && isScratchpadWidgetProps( widget.widgetProps );
 }
 
 function getWidgetAddActionLabel( widget: DeskWidget, index: number, isAdded: boolean ) {

--- a/apps/ui/src/ui-desks/chats/conversation/style.module.css
+++ b/apps/ui/src/ui-desks/chats/conversation/style.module.css
@@ -272,6 +272,101 @@
 	opacity: 0.55;
 }
 
+.scratchpadArtifact {
+	width: 100%;
+	max-width: 460px;
+	display: flex;
+	gap: 12px;
+	padding: 12px;
+	box-sizing: border-box;
+	background-color: #fff;
+	background-image: radial-gradient(circle, #c9cbce 1px, transparent 1.1px);
+	background-size: 40px 40px;
+	border: 1px solid rgba(15, 23, 42, 0.08);
+	border-radius: 14px;
+	cursor: grab;
+	user-select: none;
+	touch-action: none;
+}
+
+.scratchpadArtifact:active {
+	cursor: grabbing;
+}
+
+.scratchpadArtifactBody {
+	flex: 1 1 auto;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.scratchpadArtifactTitle {
+	color: var(--ui-desks-text, #14171a);
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 18px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.scratchpadArtifactDescription {
+	margin: 0;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 12px;
+	line-height: 1.4;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.scratchpadArtifactThumbnail {
+	position: relative;
+	flex: 0 0 auto;
+	width: 100px;
+	height: 70px;
+	border-radius: 8px;
+	overflow: hidden;
+	background: #fff;
+	box-shadow:
+		0 1px 0 rgba(15, 23, 42, 0.06),
+		0 4px 10px rgba(15, 23, 42, 0.08);
+}
+
+.scratchpadArtifactFrame {
+	position: absolute;
+	inset: 0;
+	width: calc(100% / 0.18);
+	height: calc(100% / 0.18);
+	border: 0;
+	background: #fff;
+	transform: scale(0.18);
+	transform-origin: top left;
+	pointer-events: none;
+}
+
+.scratchpadArtifactEmpty {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 8px;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 11px;
+	line-height: 14px;
+	text-align: center;
+}
+
+.scratchpadArtifactShield {
+	position: absolute;
+	inset: 0;
+	background: transparent;
+	cursor: inherit;
+}
+
 .artifactDragOverlay {
 	position: fixed;
 	z-index: 100000;

--- a/apps/ui/src/ui-desks/chats/provider.tsx
+++ b/apps/ui/src/ui-desks/chats/provider.tsx
@@ -128,6 +128,7 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 			} );
 			setRouteSession( session.id );
 			setOpen( true );
+			return session.id;
 		},
 		[ createSession, setOpen, setRouteSession, siteId ]
 	);

--- a/apps/ui/src/ui-desks/widgets/scratchpad/component/index.test.tsx
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/component/index.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ScratchpadWidgetComponent } from './index';
+
+const chatMocks = vi.hoisted( () => ( {
+	startChatWithPrompt: vi.fn(),
+	onAgentEvent: vi.fn(),
+} ) );
+
+vi.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+	sprintf: ( text: string, value: string ) => text.replace( '%s', value ),
+} ) );
+
+vi.mock( '@wordpress/icons', () => ( {
+	blockDefault: {},
+	check: {},
+	cog: {},
+	page: {},
+	redo: {},
+	reusableBlock: {},
+} ) );
+
+vi.mock( '@wordpress/ui', () => ( {
+	Icon: () => null,
+} ) );
+
+vi.mock( 'tldraw', () => ( {
+	useEditor: () => ( {} ),
+} ) );
+
+vi.mock( '@/data/core', () => ( {
+	useConnector: () => ( {
+		onAgentEvent: chatMocks.onAgentEvent,
+	} ),
+} ) );
+
+vi.mock( '@/ui-desks/chats/context', () => ( {
+	useChats: () => ( {
+		startChatWithPrompt: chatMocks.startChatWithPrompt,
+	} ),
+} ) );
+
+vi.mock( '@/ui-desks/connectors/context', () => ( {
+	focusOnDeskShape: vi.fn(),
+	useIncomingWidgetConnections: () => [],
+} ) );
+
+describe( 'ScratchpadWidgetComponent', () => {
+	beforeEach( () => {
+		chatMocks.startChatWithPrompt.mockReset().mockResolvedValue( 'session-1' );
+		chatMocks.onAgentEvent.mockReset().mockReturnValue( () => {} );
+	} );
+
+	it( 'starts a chat agent run from a pending scratchpad', async () => {
+		const onWidgetPropsChange = vi.fn();
+
+		render(
+			<ScratchpadWidgetComponent
+				id="scratchpad-1"
+				widgetProps={ {
+					html: '<main><h1>Draft</h1></main>',
+					title: 'Landing page draft',
+					scope: 'page',
+					description: 'Tighten the hero.',
+					agentStatus: 'pending',
+				} }
+				isEditing={ false }
+				isHovered={ false }
+				isSelected={ false }
+				onWidgetPropsChange={ onWidgetPropsChange }
+				onEditComplete={ vi.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Run agent on this' } ) );
+
+		await waitFor( () => {
+			expect( chatMocks.startChatWithPrompt ).toHaveBeenCalledTimes( 1 );
+		} );
+		expect( chatMocks.startChatWithPrompt ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				displayMessage: 'Run agent on scratchpad: Landing page draft\n\nTighten the hero.',
+				prompt: expect.stringContaining( 'call studio_present with exactly one scratchpad widget' ),
+			} )
+		);
+		expect( onWidgetPropsChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				agentStatus: 'running',
+			} )
+		);
+		expect( onWidgetPropsChange ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				agentStatus: 'running',
+				agentSessionId: 'session-1',
+			} )
+		);
+	} );
+} );

--- a/apps/ui/src/ui-desks/widgets/scratchpad/component/index.tsx
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/component/index.tsx
@@ -1,10 +1,17 @@
-import { __ } from '@wordpress/i18n';
-import { blockDefault, page, reusableBlock } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { blockDefault, check, cog, page, redo, reusableBlock } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { useCallback, useEffect, useRef, type KeyboardEvent, type PointerEvent } from 'react';
 import { useEditor } from 'tldraw';
+import { useConnector } from '@/data/core';
+import { useChats } from '@/ui-desks/chats/context';
 import { focusOnDeskShape, useIncomingWidgetConnections } from '@/ui-desks/connectors/context';
-import { SCRATCHPAD_WIDGET_TYPE, type ScratchpadScope, type ScratchpadWidgetProps } from '../types';
+import {
+	SCRATCHPAD_WIDGET_TYPE,
+	type ScratchpadAgentStatus,
+	type ScratchpadScope,
+	type ScratchpadWidgetProps,
+} from '../types';
 import styles from './style.module.css';
 import type {
 	DeskWidgetComponentProps,
@@ -24,11 +31,32 @@ export function ScratchpadWidgetComponent( {
 	onEditComplete,
 }: ScratchpadWidgetComponentProps ) {
 	const editor = useEditor();
+	const connector = useConnector();
+	const { startChatWithPrompt } = useChats();
 	const descriptionRef = useRef< HTMLDivElement | null >( null );
+	const widgetPropsRef = useRef( widgetProps );
 	const labelVisible = isHovered || isSelected || isEditing;
 	const isInteractive = isEditing;
 	const description = widgetProps.description ?? '';
 	const connectionSources = useIncomingWidgetConnections( editor, shapeId );
+	const lastSyncedDescription = widgetProps.lastSyncedDescription ?? description;
+	const agentStatus = widgetProps.agentStatus ?? 'idle';
+
+	useEffect( () => {
+		widgetPropsRef.current = widgetProps;
+	}, [ widgetProps ] );
+
+	const patchWidgetProps = useCallback(
+		( patch: Partial< ScratchpadWidgetProps > ) => {
+			const nextWidgetProps = {
+				...widgetPropsRef.current,
+				...patch,
+			};
+			widgetPropsRef.current = nextWidgetProps;
+			onWidgetPropsChange( nextWidgetProps );
+		},
+		[ onWidgetPropsChange ]
+	);
 
 	useEffect( () => {
 		const descriptionElement = descriptionRef.current;
@@ -66,12 +94,73 @@ export function ScratchpadWidgetComponent( {
 		};
 	}, [ isEditing ] );
 
-	const updateDescription = useCallback( () => {
-		onWidgetPropsChange( {
-			...widgetProps,
-			description: descriptionRef.current?.textContent ?? '',
+	useEffect( () => {
+		if ( agentStatus !== 'running' || ! widgetProps.agentSessionId ) {
+			return;
+		}
+
+		return connector.onAgentEvent( ( payload ) => {
+			if ( payload.sessionId !== widgetProps.agentSessionId ) {
+				return;
+			}
+
+			if ( payload.event.type === 'run.exited' ) {
+				const liveDescription =
+					descriptionRef.current?.textContent ?? widgetPropsRef.current.description ?? '';
+				patchWidgetProps(
+					payload.event.status === 'success'
+						? {
+								agentStatus: 'done',
+								lastSyncedDescription: liveDescription,
+						  }
+						: { agentStatus: 'pending' }
+				);
+			} else if ( payload.event.type === 'run.interrupted' ) {
+				patchWidgetProps( { agentStatus: 'pending' } );
+			}
 		} );
-	}, [ onWidgetPropsChange, widgetProps ] );
+	}, [ agentStatus, connector, patchWidgetProps, widgetProps.agentSessionId ] );
+
+	const updateDescription = useCallback( () => {
+		const nextDescription = descriptionRef.current?.textContent ?? '';
+		if ( agentStatus === 'running' ) {
+			patchWidgetProps( { description: nextDescription } );
+			return;
+		}
+
+		patchWidgetProps( {
+			description: nextDescription,
+			agentStatus: getNextAgentStatusForDescription(
+				nextDescription,
+				lastSyncedDescription,
+				agentStatus
+			),
+		} );
+	}, [ agentStatus, lastSyncedDescription, patchWidgetProps ] );
+
+	const handleRunAgent = useCallback( async () => {
+		if ( agentStatus !== 'pending' ) {
+			return;
+		}
+
+		const nextDescription = descriptionRef.current?.textContent ?? description;
+		const runningProps: ScratchpadWidgetProps = {
+			...widgetPropsRef.current,
+			description: nextDescription,
+			agentStatus: 'running',
+		};
+		patchWidgetProps( runningProps );
+
+		try {
+			const sessionId = await startChatWithPrompt( {
+				prompt: buildScratchpadAgentPrompt( id, runningProps ),
+				displayMessage: buildScratchpadAgentDisplayMessage( runningProps ),
+			} );
+			patchWidgetProps( { agentSessionId: sessionId } );
+		} catch {
+			patchWidgetProps( { agentStatus: 'pending' } );
+		}
+	}, [ agentStatus, description, id, patchWidgetProps, startChatWithPrompt ] );
 
 	const handleDescriptionPointerDown = useCallback(
 		( event: PointerEvent< HTMLDivElement > ) => {
@@ -92,11 +181,13 @@ export function ScratchpadWidgetComponent( {
 		},
 		[ onEditComplete ]
 	);
+	const activeAgentStatus = agentStatus === 'idle' ? null : agentStatus;
 
 	return (
 		<div
 			className={ styles.scratchpad }
 			data-scope={ widgetProps.scope }
+			data-agent-status={ agentStatus }
 			data-is-editing={ isEditing ? 'true' : 'false' }
 			data-studio-desk-widget={ SCRATCHPAD_WIDGET_TYPE }
 			data-studio-desk-widget-id={ id }
@@ -122,6 +213,13 @@ export function ScratchpadWidgetComponent( {
 					style={ {
 						pointerEvents: isInteractive ? 'auto' : 'none',
 					} }
+				/>
+			) : widgetProps.reference ? (
+				<img
+					className={ styles.reference }
+					src={ widgetProps.reference.url }
+					alt={ widgetProps.reference.alt }
+					draggable={ false }
 				/>
 			) : (
 				<div className={ styles.empty }>{ __( 'Empty scratchpad' ) }</div>
@@ -166,6 +264,20 @@ export function ScratchpadWidgetComponent( {
 						</div>
 					) }
 				</div>
+				{ activeAgentStatus && (
+					<button
+						type="button"
+						className={ styles.statusButton }
+						data-status={ activeAgentStatus }
+						disabled={ activeAgentStatus === 'running' || activeAgentStatus === 'done' }
+						aria-label={ SCRATCHPAD_STATUS_LABEL[ activeAgentStatus ] }
+						title={ SCRATCHPAD_STATUS_LABEL[ activeAgentStatus ] }
+						onClick={ handleRunAgent }
+						onPointerDown={ ( event ) => event.stopPropagation() }
+					>
+						<Icon icon={ SCRATCHPAD_STATUS_ICON[ activeAgentStatus ] } size={ 20 } />
+					</button>
+				) }
 			</div>
 			{ ! isInteractive && <div className={ styles.shield } aria-hidden="true" /> }
 		</div>
@@ -197,4 +309,70 @@ function getScratchpadScopeIcon( scope: ScratchpadScope ) {
 		case 'block':
 			return blockDefault;
 	}
+}
+
+const SCRATCHPAD_STATUS_ICON = {
+	pending: redo,
+	running: cog,
+	done: check,
+} as const;
+
+const SCRATCHPAD_STATUS_LABEL: Record< Exclude< ScratchpadAgentStatus, 'idle' >, string > = {
+	pending: __( 'Run agent on this' ),
+	running: __( 'Agent working...' ),
+	done: __( 'Done' ),
+};
+
+function getNextAgentStatusForDescription(
+	description: string,
+	lastSyncedDescription: string,
+	currentStatus: ScratchpadAgentStatus
+): ScratchpadAgentStatus {
+	const isDirty = description.trim() !== lastSyncedDescription.trim();
+	if ( isDirty ) {
+		return 'pending';
+	}
+	if ( currentStatus === 'done' ) {
+		return 'done';
+	}
+	return 'idle';
+}
+
+function buildScratchpadAgentPrompt( widgetId: string, widgetProps: ScratchpadWidgetProps ) {
+	const request =
+		widgetProps.description?.trim() || __( 'Revise this scratchpad into a stronger version.' );
+	const context = {
+		widgetId,
+		type: SCRATCHPAD_WIDGET_TYPE,
+		widgetProps: {
+			html: widgetProps.html,
+			title: widgetProps.title,
+			scope: widgetProps.scope,
+			description: widgetProps.description,
+			reference: widgetProps.reference,
+		},
+	};
+
+	return [
+		'Use this Studio scratchpad as context.',
+		'Revise or rebuild it according to the user request in its description.',
+		'When you have a result worth showing, call studio_present with exactly one scratchpad widget that includes updated html, title, scope, and description.',
+		'',
+		JSON.stringify( context, null, 2 ),
+		'',
+		'User request:',
+		request,
+	].join( '\n' );
+}
+
+function buildScratchpadAgentDisplayMessage( widgetProps: ScratchpadWidgetProps ) {
+	const title = widgetProps.title || __( 'Untitled scratchpad' );
+	const request = widgetProps.description?.trim();
+	const heading = sprintf(
+		/* translators: %s: scratchpad title. */
+		__( 'Run agent on scratchpad: %s' ),
+		title
+	);
+
+	return request ? `${ heading }\n\n${ request }` : heading;
 }

--- a/apps/ui/src/ui-desks/widgets/scratchpad/component/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/component/style.module.css
@@ -28,6 +28,7 @@
 }
 
 .frame,
+.reference,
 .empty {
 	width: 100%;
 	flex: 1 1 0;
@@ -41,6 +42,12 @@
 
 .frame {
 	display: block;
+	border: 0;
+}
+
+.reference {
+	display: block;
+	object-fit: contain;
 	border: 0;
 }
 
@@ -73,7 +80,6 @@
 }
 
 .description {
-	flex: 1 1 auto;
 	min-width: 0;
 	min-height: 20px;
 	color: #6b7280;
@@ -93,10 +99,14 @@
 	cursor: text;
 }
 
-.description[data-empty='true']:not(:focus)::before {
-	content: attr(data-placeholder);
-	color: #6b7280;
-	pointer-events: none;
+.scratchpad[data-agent-status='running'] .description,
+.scratchpad[data-agent-status='running'] .description:hover,
+.scratchpad[data-agent-status='running'] .description:focus {
+	color: #3858e9;
+}
+
+.scratchpad[data-agent-status='done'] .description {
+	color: #14171a;
 }
 
 .using {
@@ -141,6 +151,62 @@
 
 .usingPeriod {
 	margin-left: -6px;
+}
+
+.description[data-empty='true']:not(:focus)::before {
+	content: attr(data-placeholder);
+	color: #6b7280;
+	pointer-events: none;
+}
+
+.statusButton {
+	flex: 0 0 auto;
+	width: 36px;
+	height: 36px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: 0;
+	border-radius: 50%;
+	background: #3858e9;
+	color: #fff;
+	box-shadow: 0 6px 18px rgba(56, 88, 233, 0.45);
+	cursor: pointer;
+	transition:
+		background 160ms ease,
+		box-shadow 160ms ease,
+		transform 160ms ease;
+}
+
+.statusButton:hover:not(:disabled),
+.statusButton:focus-visible:not(:disabled) {
+	transform: translateY(-1px);
+	box-shadow: 0 8px 22px rgba(56, 88, 233, 0.55);
+}
+
+.statusButton:disabled {
+	cursor: default;
+}
+
+.statusButton[data-status='done'] {
+	background: #16a34a;
+	box-shadow: 0 6px 18px rgba(22, 163, 74, 0.45);
+}
+
+.statusButton[data-status='running'] svg {
+	animation: scratchpad-cog-spin 1.4s linear infinite;
+	transform-origin: 50% 50%;
+}
+
+.statusButton svg {
+	fill: currentColor;
+}
+
+@keyframes scratchpad-cog-spin {
+	to {
+		transform: rotate(360deg);
+	}
 }
 
 .title {

--- a/apps/ui/src/ui-desks/widgets/scratchpad/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/definition.ts
@@ -85,17 +85,25 @@ function getScratchpadMediaDropActions(
 					const { buildWidgetContextDisplayMessage, buildWidgetContextPrompt } = await import(
 						'@/ui-desks/chats/widget-context'
 					);
-					updateScratchpadReference( context.editor, intent );
-					await context.startChatWithPrompt( {
-						prompt: buildWidgetContextPrompt( BUILD_SOMETHING_LIKE_THIS_PROMPT, [
-							intent.sourceWidget,
-							intent.targetWidget,
-						] ),
-						displayMessage: buildWidgetContextDisplayMessage( BUILD_SOMETHING_LIKE_THIS_PROMPT, [
-							intent.sourceWidget,
-							intent.targetWidget,
-						] ),
-					} );
+					updateScratchpadReference( context.editor, intent, { agentStatus: 'pending' } );
+					try {
+						const sessionId = await context.startChatWithPrompt( {
+							prompt: buildWidgetContextPrompt( BUILD_SOMETHING_LIKE_THIS_PROMPT, [
+								intent.sourceWidget,
+								intent.targetWidget,
+							] ),
+							displayMessage: buildWidgetContextDisplayMessage( BUILD_SOMETHING_LIKE_THIS_PROMPT, [
+								intent.sourceWidget,
+								intent.targetWidget,
+							] ),
+						} );
+						updateScratchpadReference( context.editor, intent, {
+							agentStatus: 'running',
+							agentSessionId: sessionId,
+						} );
+					} catch {
+						updateScratchpadReference( context.editor, intent, { agentStatus: 'pending' } );
+					}
 				} ),
 		},
 		{
@@ -106,7 +114,11 @@ function getScratchpadMediaDropActions(
 	];
 }
 
-function updateScratchpadReference( editor: Editor, intent: WidgetCustomDropActionIntent ) {
+function updateScratchpadReference(
+	editor: Editor,
+	intent: WidgetCustomDropActionIntent,
+	patch: Partial< ScratchpadWidget[ 'widgetProps' ] > = {}
+) {
 	const mediaProps = intent.sourceWidget.widgetProps;
 	const targetShape = editor.getShape( intent.targetShapeId ) as RectangleWidgetShape | undefined;
 	if (
@@ -133,6 +145,7 @@ function updateScratchpadReference( editor: Editor, intent: WidgetCustomDropActi
 					url: mediaProps.url,
 					alt: mediaProps.alt,
 				},
+				...patch,
 			} satisfies JsonObject,
 		},
 	} );

--- a/apps/ui/src/ui-desks/widgets/scratchpad/types.ts
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/types.ts
@@ -4,14 +4,19 @@ import type { DeskWidgetBase } from '@studio/common/types/desk';
 export const SCRATCHPAD_WIDGET_TYPE = 'scratchpad';
 
 export const SCRATCHPAD_SCOPES = [ 'page', 'pattern', 'block' ] as const;
+export const SCRATCHPAD_AGENT_STATUSES = [ 'idle', 'pending', 'running', 'done' ] as const;
 
 export type ScratchpadScope = ( typeof SCRATCHPAD_SCOPES )[ number ];
+export type ScratchpadAgentStatus = ( typeof SCRATCHPAD_AGENT_STATUSES )[ number ];
 
 export type ScratchpadWidgetProps = {
 	html: string;
 	title: string;
 	scope: ScratchpadScope;
 	description?: string;
+	lastSyncedDescription?: string;
+	agentStatus?: ScratchpadAgentStatus;
+	agentSessionId?: string;
 	reference?: ScratchpadReference;
 };
 
@@ -36,12 +41,20 @@ export function isScratchpadWidgetProps( value: unknown ): value is ScratchpadWi
 		typeof candidate.title === 'string' &&
 		isScratchpadScope( candidate.scope ) &&
 		( candidate.description === undefined || typeof candidate.description === 'string' ) &&
+		( candidate.lastSyncedDescription === undefined ||
+			typeof candidate.lastSyncedDescription === 'string' ) &&
+		( candidate.agentStatus === undefined || isScratchpadAgentStatus( candidate.agentStatus ) ) &&
+		( candidate.agentSessionId === undefined || typeof candidate.agentSessionId === 'string' ) &&
 		( candidate.reference === undefined || isScratchpadReference( candidate.reference ) )
 	);
 }
 
 export function isScratchpadScope( value: unknown ): value is ScratchpadScope {
 	return SCRATCHPAD_SCOPES.includes( value as ScratchpadScope );
+}
+
+export function isScratchpadAgentStatus( value: unknown ): value is ScratchpadAgentStatus {
+	return SCRATCHPAD_AGENT_STATUSES.includes( value as ScratchpadAgentStatus );
 }
 
 function isScratchpadReference( value: unknown ): value is ScratchpadReference {

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -172,7 +172,10 @@ export interface WidgetCustomDropActionContext {
 	registry: WidgetResolverRegistry;
 	runAction: ( action: () => void | Promise< unknown > ) => void;
 	saveEntityRecord: WidgetCoreDataSaveEntityRecord;
-	startChatWithPrompt: ( request: { prompt: string; displayMessage?: string } ) => Promise< void >;
+	startChatWithPrompt: ( request: {
+		prompt: string;
+		displayMessage?: string;
+	} ) => Promise< string >;
 }
 
 export interface WidgetCustomDropAction {


### PR DESCRIPTION
## Summary
- Connect scratchpad widgets to chat conversation state so notes persist alongside the active chat
- Update chat context and provider wiring to surface scratchpad data where conversations render
- Refine scratchpad component styling and types to match the new state flow
- Add and update tests covering conversation and scratchpad integration behavior

## Testing
- Updated unit tests for conversation and scratchpad components
- Not run (not requested)