### PR TITLE
Clean up Linux DEB filename for AppsCDN uploads

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -452,17 +452,23 @@ def get_windows_update_release_sha(arch: 'x64')
 end
 
 # `electron-installer-debian` writes one .deb per arch directory with the
-# version embedded in the filename (e.g. `studio_1.8.2~dev16_amd64.deb`), so
-# resolve it via glob rather than reconstructing the filename. The glob
-# matches the trailing `_<deb_arch>.deb` specifically — `create_versioned_file`
-# writes a sidecar copy alongside the original ending in `-<arch>-v<version>.deb`,
-# which this glob skips so retries don't see two `.deb` files.
+# version baked into the filename (e.g. `studio_1.8.2~dev16_amd64.deb`).
+# Renaming it to a clean `studio.deb` stem before upload lets
+# `create_versioned_file` produce a Mac-style `studio-<arch>-v<version>.deb`
+# filename — without the rename, it would mash the original arch+version
+# stamp with its own, yielding the unwieldy
+# `studio_1.8.2~dev16_amd64-x64-v1.8.2-dev16.deb`.
+# Idempotent so retries pick up the already-renamed file.
 def linux_deb_path(arch:)
   deb_arch = arch == 'x64' ? 'amd64' : arch
   dir = File.join(BUILDS_FOLDER, 'make', 'deb', arch)
+  clean_path = File.join(dir, 'studio.deb')
+  return clean_path if File.exist?(clean_path)
+
   matches = Dir.glob(File.join(dir, "studio_*_#{deb_arch}.deb"))
   UI.user_error!("Expected exactly 1 Linux #{arch} .deb in #{dir}, found #{matches.length}: #{matches.join(', ')}") unless matches.length == 1
-  matches.first
+  File.rename(matches.first, clean_path)
+  clean_path
 end
 
 def distribute_builds(


### PR DESCRIPTION
## Related issues
Follow-up to [#3464](https://github.com/Automattic/studio/pull/3464) (Linux dev build distribution).

## How AI was used in this PR
AI-assisted: spotted the duplicated arch/version in the uploaded filename while verifying the first trunk Distribute Dev Builds run, drafted the fix and PR body. Author reviewed.

## Proposed Changes

The Linux DEBs uploaded to AppsCDN by [build #16245](https://buildkite.com/automattic/studio/builds/16245) landed with names like:

- `studio_1.9.0dev51_amd64-x64-v1.9.0-dev51.deb`
- `studio_1.9.0dev51_arm64-arm64-v1.9.0-dev51.deb`

Both arch (`amd64` + `x64`) and version (`1.9.0dev51` + `v1.9.0-dev51`) appear twice. The cause: `electron-installer-debian` produces filenames like `studio_1.9.0~dev51_amd64.deb`, then `create_versioned_file` (in this Fastfile) blindly appends `-<arch>-v<version>` to the base name. For Mac the input is a clean `Studio.app.zip`, so the result is `studio-x64-v1.9.0.zip`; for Linux the input already carries arch+version, so the suffix is duplicated. WordPress's media library then strips the `~`, mashing the version slug.

This change renames the Linux DEB to a clean `studio.deb` stem in `linux_deb_path` before returning the path. `create_versioned_file` then produces the Mac-style `studio-<arch>-v<version>.deb` (e.g. `studio-x64-v1.9.0-dev51.deb`). The rename is idempotent — retries pick up the already-renamed file.

**Why this is cosmetic-only:**
- Version checking goes through the WPCOM `studio-app/updates` endpoint, which compares the `version` field in upload metadata (passed explicitly to `upload_file_to_apps_cdn`), not the filename.
- `apt`/`dpkg` install behavior reads the DEB's internal control file, not the filename.
- The CDN `media_url` is composed from `platform/version/build_number`, not the filename — only `Content-Disposition` after the 302 changes.

User-visible impact: the filename users see in their Downloads folder after clicking the in-app update button (#3465) becomes readable.

## Testing Instructions
- After this lands on trunk, watch the next Distribute Dev Builds run.
- Open the `cdn-link` annotation on the Distribute Dev Builds job.
- Click the **Linux - x64 (DEB)** and **Linux - ARM64 (DEB)** links and confirm the downloaded filenames look like `studio-x64-v<version>.deb` / `studio-arm64-v<version>.deb`.

## Pre-merge Checklist
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] CI is green.