### PR TITLE
Add generic drop feedback for media card polish

### DIFF
--- a/apps/ui/src/ui-desks/connectors/use-connector-interactions.ts
+++ b/apps/ui/src/ui-desks/connectors/use-connector-interactions.ts
@@ -16,8 +16,11 @@ import {
 	getWidgetShapeAtPagePoint,
 } from './utils';
 import type {
+	ActiveWidgetDropFeedback,
 	DeskWidget,
 	WidgetCustomDropActionIntent,
+	WidgetDropFeedback,
+	WidgetDropFeedbackPhase,
 	WidgetDropHandler,
 } from '@/ui-desks/widgets/types';
 import type { Editor, TLArrowShape, TLEventInfo, TLShape, TLShapeId } from 'tldraw';
@@ -30,6 +33,7 @@ interface UseConnectorInteractionsOptions {
 	setPendingConnectorSourceId: ( shapeId: TLShapeId | null ) => void;
 	onConnectorComplete?: ( connection: WidgetConnectorCompleteIntent ) => void;
 	onCustomDrop?: ( drop: WidgetCustomDropIntent ) => void;
+	onDropFeedbackChange?: ( feedback: ActiveWidgetDropFeedback | null ) => void;
 }
 
 export function useConnectorInteractions( {
@@ -40,6 +44,7 @@ export function useConnectorInteractions( {
 	setPendingConnectorSourceId,
 	onConnectorComplete,
 	onCustomDrop,
+	onDropFeedbackChange,
 }: UseConnectorInteractionsOptions ) {
 	useEffect( () => {
 		if ( ! editor ) {
@@ -222,18 +227,113 @@ export function useConnectorInteractions( {
 			type: string;
 			x: number;
 			y: number;
+			opacity: number;
 		} | null = null;
 		let connectorPreviewId: TLArrowShape[ 'id' ] | null = null;
 		let activeTarget: WidgetDropTarget | null = null;
+		let activeDropFeedbackKey: string | null = null;
+		let hasSourceOpacityOverride = false;
 		let didDrag = false;
 		let completed = false;
 
-		const removeConnectorPreview = () => {
+		const getCustomDropFeedback = (
+			target: WidgetDropTarget | null,
+			phase: WidgetDropFeedbackPhase
+		): WidgetDropFeedback | null => {
+			if ( ! source || ! target || target.handler.type !== 'custom' ) {
+				return null;
+			}
+
+			return (
+				target.handler.getFeedback?.( {
+					sourceShapeId: source.shapeId,
+					targetShapeId: target.shapeId,
+					sourceWidget: source.widget,
+					targetWidget: target.widget,
+					screenPoint: getViewportScreenPoint( editor ),
+					phase,
+				} ) ?? null
+			);
+		};
+
+		const toActiveDropFeedback = (
+			target: WidgetDropTarget | null,
+			feedback: WidgetDropFeedback | null,
+			phase: WidgetDropFeedbackPhase
+		): ActiveWidgetDropFeedback | null => {
+			if ( ! target || ! feedback?.target ) {
+				return null;
+			}
+
+			return {
+				targetShapeId: target.shapeId,
+				feedback: {
+					...feedback.target,
+					phase,
+				},
+			};
+		};
+
+		const syncDropFeedback = (
+			target: WidgetDropTarget | null,
+			phase: WidgetDropFeedbackPhase
+		) => {
+			const feedback = getCustomDropFeedback( target, phase );
+			const activeFeedback = toActiveDropFeedback( target, feedback, phase );
+			const nextKey = activeFeedback
+				? `${ activeFeedback.targetShapeId }:${ activeFeedback.feedback.kind }:${ phase }`
+				: null;
+			if ( activeDropFeedbackKey !== nextKey ) {
+				activeDropFeedbackKey = nextKey;
+				onDropFeedbackChange?.( activeFeedback );
+			}
+			return feedback;
+		};
+
+		const setSourceOpacity = ( opacity: number ) => {
+			if ( ! source ) {
+				return;
+			}
+
+			const shape = editor.getShape( source.shapeId );
+			if ( ! shape || Math.abs( shape.opacity - opacity ) <= 0.001 ) {
+				return;
+			}
+
+			editor.updateShape( {
+				id: source.shapeId,
+				type: source.type as TLShape[ 'type' ],
+				opacity,
+			} );
+			hasSourceOpacityOverride = true;
+		};
+
+		const restoreSourceOpacity = () => {
+			if ( ! source || ! hasSourceOpacityOverride ) {
+				return;
+			}
+
+			const shape = editor.getShape( source.shapeId );
+			if ( shape && Math.abs( shape.opacity - source.opacity ) > 0.001 ) {
+				editor.updateShape( {
+					id: source.shapeId,
+					type: source.type as TLShape[ 'type' ],
+					opacity: source.opacity,
+				} );
+			}
+			hasSourceOpacityOverride = false;
+		};
+
+		const removeConnectorPreview = ( options: { preserveSourceOpacity?: boolean } = {} ) => {
 			if ( connectorPreviewId && editor.getShape( connectorPreviewId ) ) {
 				editor.deleteShape( connectorPreviewId );
 			}
 			connectorPreviewId = null;
 			activeTarget = null;
+			syncDropFeedback( null, 'hover' );
+			if ( ! options.preserveSourceOpacity ) {
+				restoreSourceOpacity();
+			}
 		};
 
 		const restoreSourcePosition = () => {
@@ -254,13 +354,18 @@ export function useConnectorInteractions( {
 			} );
 		};
 
-		const cleanup = () => {
+		const cleanup = ( options: { preserveSourceOpacity?: boolean } = {} ) => {
 			if ( ! completed ) {
-				removeConnectorPreview();
+				removeConnectorPreview( options );
+			}
+			if ( ! options.preserveSourceOpacity ) {
+				restoreSourceOpacity();
 			}
 			source = null;
 			connectorPreviewId = null;
 			activeTarget = null;
+			activeDropFeedbackKey = null;
+			hasSourceOpacityOverride = false;
 			didDrag = false;
 			completed = false;
 		};
@@ -275,10 +380,19 @@ export function useConnectorInteractions( {
 				const widget = shape ? canvasShapeToDeskWidget( shape ) : null;
 				source =
 					widget && shape
-						? { shapeId: shape.id, widget, type: shape.type, x: shape.x, y: shape.y }
+						? {
+								shapeId: shape.id,
+								widget,
+								type: shape.type,
+								x: shape.x,
+								y: shape.y,
+								opacity: shape.opacity,
+						  }
 						: null;
 				connectorPreviewId = null;
 				activeTarget = null;
+				syncDropFeedback( null, 'hover' );
+				hasSourceOpacityOverride = false;
 				didDrag = false;
 				completed = false;
 				return;
@@ -305,15 +419,27 @@ export function useConnectorInteractions( {
 							targetWidget: activeTarget.widget,
 						} );
 					} else if ( activeTarget.handler.type === 'custom' ) {
-						restoreSourcePosition();
-						onCustomDrop?.( {
+						const menuFeedback = getCustomDropFeedback( activeTarget, 'menu' );
+						const activeMenuFeedback = toActiveDropFeedback( activeTarget, menuFeedback, 'menu' );
+						const customDrop: WidgetCustomDropIntent = {
 							sourceShapeId: source.shapeId,
 							targetShapeId: activeTarget.shapeId,
 							sourceWidget: source.widget,
 							targetWidget: activeTarget.widget,
 							handler: activeTarget.handler,
 							screenPoint: getViewportScreenPoint( editor ),
-						} );
+							sourceOpacity: source.opacity,
+						};
+						restoreSourcePosition();
+						if ( typeof menuFeedback?.sourceOpacity === 'number' ) {
+							setSourceOpacity( menuFeedback.sourceOpacity );
+						} else {
+							restoreSourceOpacity();
+						}
+						cleanup( { preserveSourceOpacity: typeof menuFeedback?.sourceOpacity === 'number' } );
+						onDropFeedbackChange?.( activeMenuFeedback );
+						onCustomDrop?.( customDrop );
+						return;
 					}
 				}
 				cleanup();
@@ -340,17 +466,26 @@ export function useConnectorInteractions( {
 			restoreSourcePosition();
 
 			if ( target.handler.type !== 'connector' ) {
+				const customTarget = {
+					shapeId: target.shape.id,
+					widget: target.widget,
+					handler: target.handler,
+				};
+				const feedback = syncDropFeedback( customTarget, 'hover' );
 				if ( connectorPreviewId ) {
 					removeConnectorPreview();
-					activeTarget = {
-						shapeId: target.shape.id,
-						widget: target.widget,
-						handler: target.handler,
-					};
+					activeTarget = customTarget;
+					syncDropFeedback( activeTarget, 'hover' );
+				}
+				if ( typeof feedback?.sourceOpacity === 'number' ) {
+					setSourceOpacity( feedback.sourceOpacity );
+				} else {
+					restoreSourceOpacity();
 				}
 				return;
 			}
 
+			syncDropFeedback( null, 'hover' );
 			const targetBounds = editor.getShapePageBounds( target.shape.id );
 			if ( ! targetBounds ) {
 				removeConnectorPreview();
@@ -381,7 +516,7 @@ export function useConnectorInteractions( {
 			editor.off( 'event', handleEvent );
 			cleanup();
 		};
-	}, [ editor, isHydrated, isReadOnly, onConnectorComplete, onCustomDrop ] );
+	}, [ editor, isHydrated, isReadOnly, onConnectorComplete, onCustomDrop, onDropFeedbackChange ] );
 }
 
 export interface WidgetConnectorCompleteIntent {
@@ -393,6 +528,7 @@ export interface WidgetConnectorCompleteIntent {
 
 export interface WidgetCustomDropIntent extends WidgetCustomDropActionIntent {
 	handler: Extract< WidgetDropHandler, { type: 'custom' } >;
+	sourceOpacity: number;
 }
 
 interface WidgetDropTarget {

--- a/apps/ui/src/ui-desks/desk/provider/index.tsx
+++ b/apps/ui/src/ui-desks/desk/provider/index.tsx
@@ -48,6 +48,7 @@ import {
 import { useStackInteractions } from '@/ui-desks/stacks/use-stack-interactions';
 import { useStackPressAnimation } from '@/ui-desks/stacks/use-stack-press-animation';
 import { createDeskWidget } from '@/ui-desks/widget-actions/create-widget';
+import { WidgetDropFeedbackProvider } from '@/ui-desks/widget-actions/drop-feedback-context';
 import { DropActionMenu } from '@/ui-desks/widget-actions/drop-handlers/drop-action-menu';
 import { useWidgetCustomDropActions } from '@/ui-desks/widget-actions/drop-handlers/use-widget-custom-drop-actions';
 import { getWidgetEditAction } from '@/ui-desks/widget-actions/edit-action';
@@ -58,6 +59,7 @@ import {
 } from '@/ui-desks/widget-actions/paste-handlers';
 import { LOADING_WIDGET_TYPE } from '@/ui-desks/widgets/loading/types';
 import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
+import { PageDitherFilters } from '@/ui-desks/widgets/page/page-dither-filters';
 import { isPageWidgetProps, PAGE_WIDGET_TYPE } from '@/ui-desks/widgets/page/types';
 import { isPostWidgetProps, POST_WIDGET_TYPE } from '@/ui-desks/widgets/post/types';
 import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
@@ -95,6 +97,7 @@ import { useDeskWidgetResolvers } from './resolvers';
 import type { DeskFocusDesk, DeskFocusMode } from '@/ui-desks/focus-mode/types';
 import type {
 	DeskWidget,
+	ActiveWidgetDropFeedback,
 	WidgetHandlerLoading,
 	WidgetHandlerResult,
 	WidgetPastePayload,
@@ -175,6 +178,7 @@ export function DeskProvider( {
 	const [ customDropIntent, setCustomDropIntent ] = useState< WidgetCustomDropIntent | null >(
 		null
 	);
+	const [ dropFeedback, setDropFeedback ] = useState< ActiveWidgetDropFeedback | null >( null );
 	const hydratedRef = useRef( false );
 	const deskConfigKeyRef = useRef< string | undefined >( undefined );
 	const creationOffsetRef = useRef( 0 );
@@ -218,14 +222,40 @@ export function DeskProvider( {
 	const handleCustomDrop = useCallback( ( drop: WidgetCustomDropIntent ) => {
 		setCustomDropIntent( drop );
 	}, [] );
+	const restoreCustomDropSource = useCallback(
+		( drop: WidgetCustomDropIntent | null ) => {
+			if ( ! editor || ! drop ) {
+				return;
+			}
+
+			const shape = editor.getShape( drop.sourceShapeId );
+			if ( ! shape || Math.abs( shape.opacity - drop.sourceOpacity ) <= 0.001 ) {
+				return;
+			}
+
+			editor.updateShape( {
+				id: drop.sourceShapeId,
+				type: shape.type,
+				opacity: drop.sourceOpacity,
+			} );
+		},
+		[ editor ]
+	);
 	const closeCustomDropMenu = useCallback( () => {
+		restoreCustomDropSource( customDropIntent );
 		setCustomDropIntent( null );
-	}, [] );
+		setDropFeedback( null );
+	}, [ customDropIntent, restoreCustomDropSource ] );
 	const customDropActions = useWidgetCustomDropActions( {
 		editor,
 		intent: customDropIntent,
 		closeMenu: closeCustomDropMenu,
 	} );
+	useEffect( () => {
+		if ( customDropIntent && customDropActions.length === 0 ) {
+			closeCustomDropMenu();
+		}
+	}, [ closeCustomDropMenu, customDropActions.length, customDropIntent ] );
 	const canPreviewContentInSitePreview = Boolean(
 		! isReadOnly && editor && isHydrated && isRunningSite && getFirstSitePreviewShape( editor )
 	);
@@ -309,6 +339,7 @@ export function DeskProvider( {
 		setPendingConnectorSourceId,
 		onConnectorComplete: handleConnectorComplete,
 		onCustomDrop: handleCustomDrop,
+		onDropFeedbackChange: setDropFeedback,
 	} );
 
 	useEffect( () => {
@@ -1216,14 +1247,17 @@ export function DeskProvider( {
 
 	return (
 		<DeskContext.Provider value={ value }>
-			{ children }
-			{ customDropIntent && customDropActions.length > 0 && (
-				<DropActionMenu
-					screenPoint={ customDropIntent.screenPoint }
-					actions={ customDropActions }
-					onCancel={ closeCustomDropMenu }
-				/>
-			) }
+			<WidgetDropFeedbackProvider value={ dropFeedback }>
+				<PageDitherFilters />
+				{ children }
+				{ customDropIntent && customDropActions.length > 0 && (
+					<DropActionMenu
+						screenPoint={ customDropIntent.screenPoint }
+						actions={ customDropActions }
+						onCancel={ closeCustomDropMenu }
+					/>
+				) }
+			</WidgetDropFeedbackProvider>
 		</DeskContext.Provider>
 	);
 }

--- a/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
+++ b/apps/ui/src/ui-desks/shapes/rectangle-widget/shape-util.tsx
@@ -14,6 +14,7 @@ import {
 import { getDeskCanvasRecordResolutionState } from '@/ui-desks/desk/tldraw-adapter';
 import { useStackShapeInteraction } from '@/ui-desks/stacks/use-stack-shape-interaction';
 import { getStackId, getStackViewMode, isStackExpanded } from '@/ui-desks/stacks/utils';
+import { useWidgetDropFeedback } from '@/ui-desks/widget-actions/drop-feedback-context';
 import { DRAWING_WIDGET_TYPE } from '@/ui-desks/widgets/drawing/types';
 import { getWidgetDefinition } from '@/ui-desks/widgets/registry';
 import {
@@ -194,6 +195,7 @@ function RectangleWidgetComponent( {
 		| undefined;
 	const isLoading = getDeskCanvasRecordResolutionState( shape ) === 'loading';
 	const widgetId = getWidgetIdFromShapeId( shape.id );
+	const dropFeedback = useWidgetDropFeedback( shape.id );
 
 	const handleWidgetPropsChange = ( widgetProps: JsonObject ) => {
 		editor.updateShape< RectangleWidgetShape >( {
@@ -221,6 +223,7 @@ function RectangleWidgetComponent( {
 					isEditing={ isEditing }
 					isHovered={ isHovered }
 					isSelected={ isSelected }
+					dropFeedback={ dropFeedback }
 					onWidgetPropsChange={ handleWidgetPropsChange }
 					onEditComplete={ () => editor.complete() }
 				/>

--- a/apps/ui/src/ui-desks/widget-actions/drop-feedback-context.tsx
+++ b/apps/ui/src/ui-desks/widget-actions/drop-feedback-context.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import type { ActiveWidgetDropFeedback } from '@/ui-desks/widgets/types';
+import type { TLShapeId } from 'tldraw';
+
+const WidgetDropFeedbackContext = createContext< ActiveWidgetDropFeedback | null >( null );
+
+export function WidgetDropFeedbackProvider( {
+	value,
+	children,
+}: {
+	value: ActiveWidgetDropFeedback | null;
+	children: ReactNode;
+} ) {
+	return (
+		<WidgetDropFeedbackContext.Provider value={ value }>
+			{ children }
+		</WidgetDropFeedbackContext.Provider>
+	);
+}
+
+export function useWidgetDropFeedback( shapeId: TLShapeId | undefined ) {
+	const value = useContext( WidgetDropFeedbackContext );
+	if ( ! shapeId || value?.targetShapeId !== shapeId ) {
+		return null;
+	}
+
+	return value.feedback;
+}

--- a/apps/ui/src/ui-desks/widget-actions/drop-handlers/index.test.ts
+++ b/apps/ui/src/ui-desks/widget-actions/drop-handlers/index.test.ts
@@ -1,3 +1,4 @@
+import { createShapeId } from 'tldraw';
 import { describe, expect, it, vi } from 'vitest';
 import { MEDIA_WIDGET_TYPE } from '@/ui-desks/widgets/media/types';
 import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
@@ -73,6 +74,30 @@ describe( 'widget drop handlers', () => {
 		expect( scratchpadHandler?.type === 'custom' ? scratchpadHandler.getActions : null ).toEqual(
 			expect.any( Function )
 		);
+		expect( postHandler?.type === 'custom' ? postHandler.getFeedback : null ).toEqual(
+			expect.any( Function )
+		);
+		expect(
+			postHandler?.type === 'custom'
+				? postHandler.getFeedback?.( {
+						sourceShapeId: createShapeId( 'media-1' ),
+						targetShapeId: createShapeId( 'post-1' ),
+						sourceWidget: createMediaWidget( { mediaId: 123 } ),
+						targetWidget: createPostWidget(),
+						screenPoint: { x: 0, y: 0 },
+						phase: 'hover',
+				  } )
+				: null
+		).toMatchObject( {
+			sourceOpacity: 0,
+			target: {
+				kind: 'media-preview',
+				props: {
+					url: 'https://example.com/image.png',
+					mediaKind: 'image',
+				},
+			},
+		} );
 	} );
 
 	it( 'does not return post or page media actions for local-only media', () => {

--- a/apps/ui/src/ui-desks/widgets/media/drop-preview.tsx
+++ b/apps/ui/src/ui-desks/widgets/media/drop-preview.tsx
@@ -1,0 +1,81 @@
+import { isMediaKind, type MediaKind, type MediaWidgetProps } from './types';
+import type { WidgetDropFeedbackTarget } from '@/ui-desks/widgets/types';
+import type { CSSProperties } from 'react';
+
+export const MEDIA_DROP_PREVIEW_KIND = 'media-preview';
+
+export interface MediaDropPreviewPayload {
+	url: string;
+	alt: string;
+	mediaKind: MediaKind;
+}
+
+interface MediaDropPreviewProps {
+	media: MediaDropPreviewPayload;
+	className: string;
+	style?: CSSProperties;
+}
+
+export function MediaDropPreview( { media, className, style }: MediaDropPreviewProps ) {
+	if ( media.mediaKind === 'video' ) {
+		return (
+			<video
+				className={ className }
+				src={ media.url }
+				aria-label={ media.alt }
+				muted
+				loop
+				autoPlay
+				playsInline
+				draggable={ false }
+				style={ style }
+			/>
+		);
+	}
+
+	return (
+		<img
+			className={ className }
+			src={ media.url }
+			alt={ media.alt }
+			draggable={ false }
+			style={ style }
+		/>
+	);
+}
+
+export function createMediaDropPreviewTarget(
+	mediaProps: MediaWidgetProps
+): Omit< WidgetDropFeedbackTarget, 'phase' > {
+	return {
+		kind: MEDIA_DROP_PREVIEW_KIND,
+		props: {
+			url: mediaProps.url,
+			alt: mediaProps.alt,
+			mediaKind: mediaProps.mediaKind,
+		},
+	};
+}
+
+export function getMediaDropPreviewPayload(
+	feedback: WidgetDropFeedbackTarget | null | undefined
+): MediaDropPreviewPayload | null {
+	if ( feedback?.kind !== MEDIA_DROP_PREVIEW_KIND ) {
+		return null;
+	}
+
+	const props = feedback.props as Partial< MediaDropPreviewPayload >;
+	if (
+		typeof props.url !== 'string' ||
+		typeof props.alt !== 'string' ||
+		! isMediaKind( props.mediaKind )
+	) {
+		return null;
+	}
+
+	return {
+		url: props.url,
+		alt: props.alt,
+		mediaKind: props.mediaKind,
+	};
+}

--- a/apps/ui/src/ui-desks/widgets/page/component/index.tsx
+++ b/apps/ui/src/ui-desks/widgets/page/component/index.tsx
@@ -3,6 +3,11 @@ import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { LoadingPlaceholder } from '@/ui-desks/components';
 import { CONTENT_CARD_STATUSES, getPostStatusInfo } from '@/ui-desks/widget-actions/post-status';
+import {
+	getMediaDropPreviewPayload,
+	MediaDropPreview,
+} from '@/ui-desks/widgets/media/drop-preview';
+import { getPageToneDitherFilterId } from '@/ui-desks/widgets/page/tone';
 import styles from './style.module.css';
 import type { PageWidgetProps } from '../types';
 import type {
@@ -11,19 +16,29 @@ import type {
 } from '@/ui-desks/widgets/types';
 
 type PageWidgetComponentProps = DeskWidgetComponentProps< PageWidgetProps >;
+type EmbeddedFeaturedMedia = {
+	source_url?: string;
+	media_details?: {
+		sizes?: Record< string, { source_url?: string } >;
+	};
+};
 type PageCardRecord = CoreDataPost & {
 	status?: string;
 	slug?: string;
+	_embedded?: {
+		'wp:featuredmedia'?: EmbeddedFeaturedMedia[];
+	};
 };
 
-export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentProps ) {
+export function PageWidgetComponent( { id, widgetProps, dropFeedback }: PageWidgetComponentProps ) {
 	const query = useMemo(
 		() => ( {
 			include: [ widgetProps.pageId ],
 			per_page: 1,
 			context: 'edit',
 			status: CONTENT_CARD_STATUSES,
-			_fields: 'id,title,excerpt,slug,status',
+			_embed: true,
+			_fields: 'id,title,excerpt,slug,status,featured_media,_links,_embedded',
 		} ),
 		[ widgetProps.pageId ]
 	);
@@ -37,6 +52,7 @@ export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentPro
 	const record = records?.[ 0 ] ?? null;
 	const hasError = resolutionStatus === 'ERROR';
 	const isLoading = isResolving && ! record;
+	const morphMedia = getMediaDropPreviewPayload( dropFeedback );
 
 	if ( isLoading ) {
 		return (
@@ -57,6 +73,12 @@ export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentPro
 	const excerpt = record?.excerpt?.rendered ?? '';
 	const slug = record?.slug ?? '';
 	const statusInfo = getPostStatusInfo( record?.status );
+	const featuredImage = getPageFeaturedImageUrl( record );
+	const ditherFilterId = getPageToneDitherFilterId( widgetProps.tone );
+	const headerFilterStyle =
+		ditherFilterId && ( morphMedia?.mediaKind ?? 'image' ) === 'image'
+			? { filter: `url(#${ ditherFilterId })` }
+			: undefined;
 
 	return (
 		<article
@@ -66,6 +88,22 @@ export function PageWidgetComponent( { id, widgetProps }: PageWidgetComponentPro
 			data-studio-desk-widget="page"
 			data-studio-desk-widget-id={ id }
 		>
+			{ morphMedia ? (
+				<MediaDropPreview
+					media={ morphMedia }
+					className={ `${ styles.pageHeader } ${ styles.pageHeaderMorph }` }
+					style={ headerFilterStyle }
+				/>
+			) : featuredImage ? (
+				<img
+					key="featured"
+					className={ styles.pageHeader }
+					src={ featuredImage }
+					alt=""
+					draggable={ false }
+					style={ headerFilterStyle }
+				/>
+			) : null }
 			<h2 className={ styles.title } dangerouslySetInnerHTML={ { __html: title } } />
 			{ excerpt && (
 				<div className={ styles.body } dangerouslySetInnerHTML={ { __html: excerpt } } />
@@ -142,4 +180,19 @@ function getPageTitle(
 	}
 
 	return isResolving ? __( 'Loading page…' ) : __( 'Page unavailable' );
+}
+
+function getPageFeaturedImageUrl( pageRecord: PageCardRecord | null ): string | undefined {
+	const featured = pageRecord?._embedded?.[ 'wp:featuredmedia' ]?.[ 0 ];
+	if ( ! featured ) {
+		return undefined;
+	}
+
+	const sizes = featured.media_details?.sizes ?? {};
+	return (
+		sizes.medium_large?.source_url ??
+		sizes.large?.source_url ??
+		sizes.medium?.source_url ??
+		featured.source_url
+	);
 }

--- a/apps/ui/src/ui-desks/widgets/page/component/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/page/component/style.module.css
@@ -40,6 +40,7 @@
 	border: 3px solid var(--page-tone-color);
 	border-radius: 8px;
 	pointer-events: none;
+	z-index: 5;
 }
 
 .page[data-tone='orange'] {
@@ -67,6 +68,8 @@
 }
 
 .title {
+	position: relative;
+	z-index: 1;
 	margin: 0;
 	font-size: 22px;
 	line-height: 1.18;
@@ -77,6 +80,8 @@
 }
 
 .body {
+	position: relative;
+	z-index: 1;
 	max-height: 0;
 	min-height: 0;
 	margin: 0;
@@ -104,6 +109,8 @@
 }
 
 .metadata {
+	position: relative;
+	z-index: 1;
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -138,6 +145,8 @@
 }
 
 .slug {
+	position: relative;
+	z-index: 1;
 	margin-top: auto;
 	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
 	font-size: 15px;
@@ -152,6 +161,35 @@
 
 .metadata + .slug {
 	margin-top: 0;
+}
+
+.pageHeader {
+	display: block;
+	flex: 0 0 auto;
+	width: calc(100% + 64px);
+	height: 38%;
+	margin: -36px -32px 14px;
+	object-fit: cover;
+	border-radius: 18px 18px 0 0;
+	background: color-mix(in srgb, var(--page-tone-color) 8%, white);
+	image-rendering: pixelated;
+}
+
+.pageHeaderMorph {
+	animation: featured-morph-in 220ms cubic-bezier(0.34, 1.56, 0.64, 1);
+	transform-origin: center top;
+}
+
+@keyframes featured-morph-in {
+	from {
+		opacity: 0;
+		transform: scale(0.86);
+	}
+
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
 }
 
 .contextThumbnail {

--- a/apps/ui/src/ui-desks/widgets/page/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/page/definition.ts
@@ -1,28 +1,22 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { page } from '@wordpress/icons';
 import { getSiteContentMediaDropActions } from '@/ui-desks/widget-actions/drop-handlers/site-content-media-actions';
+import { createMediaDropPreviewTarget } from '@/ui-desks/widgets/media/drop-preview';
 import { isMediaWidgetProps, MEDIA_WIDGET_TYPE } from '@/ui-desks/widgets/media/types';
 import {
 	PageWidgetComponent,
 	PageWidgetThumbnailComponent,
 } from '@/ui-desks/widgets/page/component';
 import { PagePreviewControl } from '@/ui-desks/widgets/page/preview-control';
+import { PAGE_TONE_COLORS } from '@/ui-desks/widgets/page/tone';
 import { isPageWidgetProps, PAGE_WIDGET_TYPE, type PageTone, type PageWidget } from './types';
 import type {
 	WidgetCustomDropActionContext,
 	WidgetCustomDropActionIntent,
+	WidgetDropFeedback,
+	WidgetDropFeedbackIntent,
 	WidgetDefinition,
 } from '@/ui-desks/widgets/types';
-
-const PAGE_TONE_COLORS: Record< PageTone, string > = {
-	neutral: '#14171a',
-	orange: '#e86a00',
-	red: '#e5484d',
-	violet: '#8703e7',
-	blue: '#2200e0',
-	sky: '#0081f3',
-	green: '#00a96c',
-};
 
 const PAGE_TONE_OPTIONS: Array< { value: PageTone; label: string; color: string } > = [
 	{ value: 'neutral', label: __( 'Default' ), color: PAGE_TONE_COLORS.neutral },
@@ -101,10 +95,23 @@ export const pageWidgetDefinition = {
 				sourceWidget.widgetProps.mediaId !== null &&
 				isPageWidgetProps( targetWidget.widgetProps ) &&
 				targetWidget.widgetProps.pageId > 0,
+			getFeedback: getPageMediaDropFeedback,
 			getActions: getPageMediaDropActions,
 		},
 	],
 } satisfies WidgetDefinition< PageWidget >;
+
+function getPageMediaDropFeedback( intent: WidgetDropFeedbackIntent ): WidgetDropFeedback | null {
+	const mediaProps = intent.sourceWidget.widgetProps;
+	if ( ! isMediaWidgetProps( mediaProps ) ) {
+		return null;
+	}
+
+	return {
+		sourceOpacity: intent.phase === 'hover' ? 0 : 0.3,
+		target: createMediaDropPreviewTarget( mediaProps ),
+	};
+}
 
 function getPageMediaDropActions(
 	intent: WidgetCustomDropActionIntent,

--- a/apps/ui/src/ui-desks/widgets/page/page-dither-filters.tsx
+++ b/apps/ui/src/ui-desks/widgets/page/page-dither-filters.tsx
@@ -1,0 +1,127 @@
+import { useMemo } from 'react';
+import { getPageToneDitherFilterId, PAGE_TONE_COLORS } from './tone';
+import type { PageTone } from './types';
+
+let cachedDotTileUri: string | null = null;
+
+function getDotTileUri(): string {
+	if ( cachedDotTileUri !== null ) {
+		return cachedDotTileUri;
+	}
+	if ( typeof document === 'undefined' ) {
+		return '';
+	}
+
+	const size = 8;
+	const canvas = document.createElement( 'canvas' );
+	canvas.width = size;
+	canvas.height = size;
+	const context = canvas.getContext( '2d' );
+	if ( ! context ) {
+		return '';
+	}
+
+	context.fillStyle = '#000';
+	context.fillRect( 0, 0, size, size );
+	const gradient = context.createRadialGradient(
+		size / 2,
+		size / 2,
+		0,
+		size / 2,
+		size / 2,
+		size / 2
+	);
+	gradient.addColorStop( 0, '#fff' );
+	gradient.addColorStop( 1, '#000' );
+	context.fillStyle = gradient;
+	context.fillRect( 0, 0, size, size );
+	cachedDotTileUri = canvas.toDataURL( 'image/png' );
+	return cachedDotTileUri;
+}
+
+const DITHER_TONES = Object.keys( PAGE_TONE_COLORS ).filter(
+	( tone ): tone is Exclude< PageTone, 'neutral' > => tone !== 'neutral'
+);
+const INK_LIGHTEN = 0.25;
+
+export function PageDitherFilters() {
+	const tileUri = useMemo( () => getDotTileUri(), [] );
+
+	return (
+		<svg
+			width="0"
+			height="0"
+			style={ { position: 'absolute', pointerEvents: 'none' } }
+			aria-hidden="true"
+			focusable="false"
+		>
+			<defs>
+				{ DITHER_TONES.map( ( tone ) => {
+					const rgb = hexToRgbUnit( PAGE_TONE_COLORS[ tone ] );
+					const ink = lighten( rgb );
+					return (
+						<filter
+							key={ tone }
+							id={ getPageToneDitherFilterId( tone ) ?? undefined }
+							x="0"
+							y="0"
+							width="1"
+							height="1"
+							filterUnits="objectBoundingBox"
+							primitiveUnits="objectBoundingBox"
+							colorInterpolationFilters="sRGB"
+						>
+							<feColorMatrix
+								in="SourceGraphic"
+								type="matrix"
+								values="0.2126 0.7152 0.0722 0 0 0.2126 0.7152 0.0722 0 0 0.2126 0.7152 0.0722 0 0 0 0 0 1 0"
+								result="gray"
+							/>
+							<feImage
+								href={ tileUri }
+								x="0"
+								y="0"
+								width="0.018"
+								height="0.036"
+								result="ditherTile"
+							/>
+							<feTile in="ditherTile" result="tile" />
+							<feComposite
+								in="gray"
+								in2="tile"
+								operator="arithmetic"
+								k1="0"
+								k2="1"
+								k3="-1"
+								k4="0.55"
+								result="halftone"
+							/>
+							<feComponentTransfer in="halftone">
+								<feFuncR type="discrete" tableValues={ `${ ink[ 0 ] } 1` } />
+								<feFuncG type="discrete" tableValues={ `${ ink[ 1 ] } 1` } />
+								<feFuncB type="discrete" tableValues={ `${ ink[ 2 ] } 1` } />
+							</feComponentTransfer>
+						</filter>
+					);
+				} ) }
+			</defs>
+		</svg>
+	);
+}
+
+function hexToRgbUnit( hex: string ): [ number, number, number ] {
+	const value = hex.replace( '#', '' );
+	return [
+		parseInt( value.slice( 0, 2 ), 16 ) / 255,
+		parseInt( value.slice( 2, 4 ), 16 ) / 255,
+		parseInt( value.slice( 4, 6 ), 16 ) / 255,
+	];
+}
+
+function lighten( rgb: [ number, number, number ] ): [ number, number, number ] {
+	return rgb.map( ( channel ) => channel * ( 1 - INK_LIGHTEN ) + INK_LIGHTEN ) as [
+		number,
+		number,
+		number,
+	];
+}

--- a/apps/ui/src/ui-desks/widgets/page/tone.ts
+++ b/apps/ui/src/ui-desks/widgets/page/tone.ts
@@ -1,0 +1,19 @@
+import type { PageTone } from './types';
+
+export const PAGE_TONE_COLORS: Record< PageTone, string > = {
+	neutral: '#14171a',
+	orange: '#e86a00',
+	red: '#e5484d',
+	violet: '#8703e7',
+	blue: '#2200e0',
+	sky: '#0081f3',
+	green: '#00a96c',
+};
+
+export function getPageToneDitherFilterId( tone: PageTone ) {
+	if ( tone === 'neutral' ) {
+		return null;
+	}
+
+	return `ui-desks-page-dither-${ PAGE_TONE_COLORS[ tone ].slice( 1 ).toLowerCase() }`;
+}

--- a/apps/ui/src/ui-desks/widgets/post/component/index.tsx
+++ b/apps/ui/src/ui-desks/widgets/post/component/index.tsx
@@ -5,6 +5,10 @@ import { Icon } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { LoadingPlaceholder } from '@/ui-desks/components';
 import { CONTENT_CARD_STATUSES, getPostStatusInfo } from '@/ui-desks/widget-actions/post-status';
+import {
+	getMediaDropPreviewPayload,
+	MediaDropPreview,
+} from '@/ui-desks/widgets/media/drop-preview';
 import { useCommentCount } from '../use-comment-count';
 import styles from './style.module.css';
 import type { PostWidgetProps } from '../types';
@@ -27,7 +31,7 @@ type PostCardRecord = CoreDataPost & {
 	};
 };
 
-export function PostWidgetComponent( { id, widgetProps }: PostWidgetComponentProps ) {
+export function PostWidgetComponent( { id, widgetProps, dropFeedback }: PostWidgetComponentProps ) {
 	const query = useMemo(
 		() => ( {
 			include: [ widgetProps.postId ],
@@ -50,6 +54,7 @@ export function PostWidgetComponent( { id, widgetProps }: PostWidgetComponentPro
 	const hasError = resolutionStatus === 'ERROR';
 	const isLoading = isResolving && ! record;
 	const commentCount = useCommentCount( record ? widgetProps.postId : null );
+	const morphMedia = getMediaDropPreviewPayload( dropFeedback );
 
 	if ( isLoading ) {
 		return (
@@ -80,7 +85,12 @@ export function PostWidgetComponent( { id, widgetProps }: PostWidgetComponentPro
 			data-studio-desk-widget-id={ id }
 		>
 			<h2 className={ styles.title } dangerouslySetInnerHTML={ { __html: title } } />
-			{ showFeaturedImage && featuredImage ? (
+			{ morphMedia ? (
+				<MediaDropPreview
+					media={ morphMedia }
+					className={ `${ styles.featuredImage } ${ styles.featuredImageMorph }` }
+				/>
+			) : showFeaturedImage && featuredImage ? (
 				<img className={ styles.featuredImage } src={ featuredImage } alt="" draggable={ false } />
 			) : excerpt ? (
 				<div className={ styles.body } dangerouslySetInnerHTML={ { __html: excerpt } } />

--- a/apps/ui/src/ui-desks/widgets/post/component/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/post/component/style.module.css
@@ -64,6 +64,23 @@
 	background: #f3f4f6;
 }
 
+.featuredImageMorph {
+	animation: featured-morph-in 220ms cubic-bezier(0.34, 1.56, 0.64, 1);
+	transform-origin: center;
+}
+
+@keyframes featured-morph-in {
+	from {
+		opacity: 0;
+		transform: scale(0.86);
+	}
+
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
 .metadata {
 	display: flex;
 	align-items: center;

--- a/apps/ui/src/ui-desks/widgets/post/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/post/definition.ts
@@ -1,6 +1,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { post } from '@wordpress/icons';
 import { getSiteContentMediaDropActions } from '@/ui-desks/widget-actions/drop-handlers/site-content-media-actions';
+import { createMediaDropPreviewTarget } from '@/ui-desks/widgets/media/drop-preview';
 import { isMediaWidgetProps, MEDIA_WIDGET_TYPE } from '@/ui-desks/widgets/media/types';
 import {
 	PostWidgetComponent,
@@ -11,6 +12,8 @@ import { isPostWidgetProps, POST_WIDGET_TYPE, type PostWidget } from './types';
 import type {
 	WidgetCustomDropActionContext,
 	WidgetCustomDropActionIntent,
+	WidgetDropFeedback,
+	WidgetDropFeedbackIntent,
 	WidgetDefinition,
 } from '@/ui-desks/widgets/types';
 
@@ -70,10 +73,23 @@ export const postWidgetDefinition = {
 				sourceWidget.widgetProps.mediaId !== null &&
 				isPostWidgetProps( targetWidget.widgetProps ) &&
 				targetWidget.widgetProps.postId > 0,
+			getFeedback: getPostMediaDropFeedback,
 			getActions: getPostMediaDropActions,
 		},
 	],
 } satisfies WidgetDefinition< PostWidget >;
+
+function getPostMediaDropFeedback( intent: WidgetDropFeedbackIntent ): WidgetDropFeedback | null {
+	const mediaProps = intent.sourceWidget.widgetProps;
+	if ( ! isMediaWidgetProps( mediaProps ) ) {
+		return null;
+	}
+
+	return {
+		sourceOpacity: intent.phase === 'hover' ? 0 : 0.3,
+		target: createMediaDropPreviewTarget( mediaProps ),
+	};
+}
 
 function getPostMediaDropActions(
 	intent: WidgetCustomDropActionIntent,

--- a/apps/ui/src/ui-desks/widgets/scratchpad/component/index.tsx
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/component/index.tsx
@@ -7,6 +7,10 @@ import { useConnector } from '@/data/core';
 import { useChats } from '@/ui-desks/chats/context';
 import { focusOnDeskShape, useIncomingWidgetConnections } from '@/ui-desks/connectors/context';
 import {
+	getMediaDropPreviewPayload,
+	MediaDropPreview,
+} from '@/ui-desks/widgets/media/drop-preview';
+import {
 	SCRATCHPAD_WIDGET_TYPE,
 	type ScratchpadAgentStatus,
 	type ScratchpadScope,
@@ -24,6 +28,7 @@ export function ScratchpadWidgetComponent( {
 	id,
 	shapeId,
 	widgetProps,
+	dropFeedback,
 	isEditing,
 	isHovered,
 	isSelected,
@@ -41,6 +46,7 @@ export function ScratchpadWidgetComponent( {
 	const connectionSources = useIncomingWidgetConnections( editor, shapeId );
 	const lastSyncedDescription = widgetProps.lastSyncedDescription ?? description;
 	const agentStatus = widgetProps.agentStatus ?? 'idle';
+	const morphMedia = getMediaDropPreviewPayload( dropFeedback );
 
 	useEffect( () => {
 		widgetPropsRef.current = widgetProps;
@@ -201,7 +207,12 @@ export function ScratchpadWidgetComponent( {
 					{ widgetProps.title }
 				</div>
 			) }
-			{ widgetProps.html ? (
+			{ morphMedia ? (
+				<MediaDropPreview
+					media={ morphMedia }
+					className={ `${ styles.frame } ${ styles.frameMedia } ${ styles.frameMorph }` }
+				/>
+			) : widgetProps.html ? (
 				<iframe
 					className={ styles.frame }
 					title={ widgetProps.title || __( 'Scratchpad' ) }

--- a/apps/ui/src/ui-desks/widgets/scratchpad/component/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/component/style.module.css
@@ -51,6 +51,27 @@
 	border: 0;
 }
 
+.frameMedia {
+	object-fit: cover;
+}
+
+.frameMorph {
+	animation: featured-morph-in 220ms cubic-bezier(0.34, 1.56, 0.64, 1);
+	transform-origin: center;
+}
+
+@keyframes featured-morph-in {
+	from {
+		opacity: 0;
+		transform: scale(0.86);
+	}
+
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
 .empty {
 	display: flex;
 	align-items: center;

--- a/apps/ui/src/ui-desks/widgets/scratchpad/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/definition.ts
@@ -4,6 +4,7 @@ import {
 	RECTANGLE_WIDGET_SHAPE_TYPE,
 	type RectangleWidgetShape,
 } from '@/ui-desks/shapes/rectangle-widget/types';
+import { createMediaDropPreviewTarget } from '@/ui-desks/widgets/media/drop-preview';
 import { isMediaWidgetProps, MEDIA_WIDGET_TYPE } from '@/ui-desks/widgets/media/types';
 import {
 	ScratchpadWidgetComponent,
@@ -21,6 +22,8 @@ import {
 import type {
 	WidgetCustomDropActionContext,
 	WidgetCustomDropActionIntent,
+	WidgetDropFeedback,
+	WidgetDropFeedbackIntent,
 	WidgetDefinition,
 } from '@/ui-desks/widgets/types';
 import type { Editor, JsonObject } from 'tldraw';
@@ -61,10 +64,25 @@ export const scratchpadWidgetDefinition = {
 			type: 'custom',
 			sourceTypes: [ MEDIA_WIDGET_TYPE ],
 			canHandle: ( sourceWidget ) => isMediaWidgetProps( sourceWidget.widgetProps ),
+			getFeedback: getScratchpadMediaDropFeedback,
 			getActions: getScratchpadMediaDropActions,
 		},
 	],
 } satisfies WidgetDefinition< ScratchpadWidget >;
+
+function getScratchpadMediaDropFeedback(
+	intent: WidgetDropFeedbackIntent
+): WidgetDropFeedback | null {
+	const mediaProps = intent.sourceWidget.widgetProps;
+	if ( ! isMediaWidgetProps( mediaProps ) ) {
+		return null;
+	}
+
+	return {
+		sourceOpacity: intent.phase === 'hover' ? 0 : 0.3,
+		target: createMediaDropPreviewTarget( mediaProps ),
+	};
+}
 
 function getScratchpadMediaDropActions(
 	intent: WidgetCustomDropActionIntent,

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -15,7 +15,7 @@ import type { SitePreviewWidget } from '@/ui-desks/widgets/site-preview/types';
 import type { DeskStack, DeskWidgetBase } from '@studio/common/types/desk';
 import type { createRegistry } from '@wordpress/data';
 import type { ComponentProps, ComponentType, ReactElement } from 'react';
-import type { Editor, TLShapeId } from 'tldraw';
+import type { Editor, JsonObject, TLShapeId } from 'tldraw';
 
 export interface WidgetIndicator {
 	cornerRadius?: number;
@@ -23,6 +23,24 @@ export interface WidgetIndicator {
 }
 
 export type WidgetResolutionState = 'loading';
+
+export type WidgetDropFeedbackPhase = 'hover' | 'menu';
+
+export interface WidgetDropFeedbackTarget {
+	kind: string;
+	props: JsonObject;
+	phase: WidgetDropFeedbackPhase;
+}
+
+export interface ActiveWidgetDropFeedback {
+	targetShapeId: TLShapeId;
+	feedback: WidgetDropFeedbackTarget;
+}
+
+export interface WidgetDropFeedback {
+	sourceOpacity?: number;
+	target?: Omit< WidgetDropFeedbackTarget, 'phase' >;
+}
 
 export interface DeskWidgetComponentProps<
 	TWidgetProps extends Record< string, unknown > = Record< string, unknown >,
@@ -33,6 +51,7 @@ export interface DeskWidgetComponentProps<
 	isEditing: boolean;
 	isHovered: boolean;
 	isSelected: boolean;
+	dropFeedback?: WidgetDropFeedbackTarget | null;
 	onWidgetPropsChange: ( widgetProps: TWidgetProps ) => void;
 	onEditComplete: () => void;
 }
@@ -167,6 +186,10 @@ export interface WidgetCustomDropActionIntent {
 	};
 }
 
+export interface WidgetDropFeedbackIntent extends WidgetCustomDropActionIntent {
+	phase: WidgetDropFeedbackPhase;
+}
+
 export interface WidgetCustomDropActionContext {
 	editor: Editor;
 	registry: WidgetResolverRegistry;
@@ -188,6 +211,7 @@ export interface WidgetCustomDropHandler {
 	type: 'custom';
 	sourceTypes?: string[];
 	canHandle?: ( sourceWidget: DeskWidgetBase, targetWidget: DeskWidgetBase ) => boolean;
+	getFeedback?: ( intent: WidgetDropFeedbackIntent ) => WidgetDropFeedback | null;
 	getActions?: (
 		intent: WidgetCustomDropActionIntent,
 		context: WidgetCustomDropActionContext


### PR DESCRIPTION
## Summary
- Add a small generic drop-feedback API for custom widget drops so connector code stays generic
- Move the media preview/source-opacity behavior into the post, page, and scratchpad widget definitions
- Render page featured images with the colored halftone/dither treatment and add coverage for the new feedback contract

## Testing
- `npx eslint --fix` on the modified UI files passed, with only the repo’s existing CSS ignore warnings
- `npm run typecheck` passed
- `npm test -- apps/ui/src/ui-desks/widget-actions/drop-handlers/index.test.ts apps/ui/src/ui-desks/connectors/utils.test.ts apps/ui/src/ui-desks/widgets/scratchpad/component/index.test.tsx` passed
- `npm -w @studio/ui run build` passed