### PR TITLE
apps/ui: Switch Studio’s new UI to desks mode by default

### DIFF
--- a/apps/studio/forge.config.ts
+++ b/apps/studio/forge.config.ts
@@ -1,3 +1,4 @@
+import { exec } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { MakerDeb } from '@electron-forge/maker-deb';
@@ -5,11 +6,9 @@ import { MakerDMG } from '@electron-forge/maker-dmg';
 import { MakerSquirrel } from '@electron-forge/maker-squirrel';
 import { MakerZIP } from '@electron-forge/maker-zip';
 import { AutoUnpackNativesPlugin } from '@electron-forge/plugin-auto-unpack-natives';
-import { isErrnoException } from '@studio/common/lib/is-errno-exception';
-import { exec } from 'child_process';
 import { exec as pkgExec } from '@yao-pkg/pkg';
-import type { ForgeConfig } from '@electron-forge/shared-types';
 import { windowsSign } from './windowsSign';
+import type { ForgeConfig } from '@electron-forge/shared-types';
 
 const repoRoot = path.resolve( __dirname, '../..' );
 
@@ -133,8 +132,7 @@ const config: ForgeConfig = {
 					: {
 							certificateFile: path.join( repoRoot, 'certificate.pfx' ),
 							certificatePassword: process.env.WINDOWS_CODE_SIGNING_CERT_PASSWORD,
-					  }
-				),
+					  } ),
 			},
 			[ 'win32' ]
 		),
@@ -198,8 +196,12 @@ const config: ForgeConfig = {
 			// may need to rerun `npm ci` from the repo root to reset the dependency tree after packaging.
 			await execAsync( 'npm run app:install:bundle' );
 
-			console.log( 'Downloading language packs ...' );
-			await execAsync( 'npm run download-language-packs' );
+			if ( process.env.SKIP_LANGUAGE_PACKS ) {
+				console.log( 'Skipping language packs because SKIP_LANGUAGE_PACKS is set ...' );
+			} else {
+				console.log( 'Downloading language packs ...' );
+				await execAsync( 'npm run download-language-packs' );
+			}
 
 			console.log( 'Building CLI (with bundled node_modules) ...' );
 			// NOTE: The `cli:package` script mutates the `apps/cli/node_modules` directory. You may need to
@@ -221,8 +223,7 @@ const config: ForgeConfig = {
 				// Refuse to delete anything unless the target arch is present *as a directory* —
 				// guards against a koffi naming/layout change silently nuking every prebuilt.
 				const targetIsDir =
-					fs.existsSync( koffiTargetPath ) &&
-					fs.statSync( koffiTargetPath ).isDirectory();
+					fs.existsSync( koffiTargetPath ) && fs.statSync( koffiTargetPath ).isDirectory();
 				if ( ! targetIsDir ) {
 					console.warn(
 						`Skipping koffi cleanup: no directory named ${ koffiTarget } in ${ koffiBuildDir }`
@@ -243,11 +244,7 @@ const config: ForgeConfig = {
 			// Clean up fs-ext-extra-prebuilt binaries (file format:
 			// fs-ext-{platform}-{arch}-{runtime}-{version}.node). The root postinstall
 			// already filtered by platform; this strips the unused arch for the target build.
-			const fsExtBinDir = path.join(
-				cliNodeModules,
-				'fs-ext-extra-prebuilt',
-				'binaries'
-			);
+			const fsExtBinDir = path.join( cliNodeModules, 'fs-ext-extra-prebuilt', 'binaries' );
 			const fsExtPrefix = `fs-ext-${ platform }-${ arch }-`;
 			if ( fs.existsSync( fsExtBinDir ) ) {
 				const fsExtFiles = fs.readdirSync( fsExtBinDir );

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -21,6 +21,7 @@
 		"make:macos-arm64": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && SKIP_DMG=true FILE_ARCHITECTURE=arm64 electron-forge make . --arch=arm64 --platform=darwin",
 		"make:linux-x64": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && electron-forge make . --arch=x64 --platform=linux",
 		"make:linux-arm64": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && electron-forge make . --arch=arm64 --platform=linux",
+		"make:new-ui": "electron-vite build --config ./electron.vite.config.new-ui.ts --outDir=dist && ts-node ../../scripts/build-new-ui-renderer.ts && electron-forge make .",
 		"install:bundle": "npm install --no-package-lock --no-progress --install-links --no-workspaces && patch-package && node ../../scripts/remove-fs-ext-other-platform-binaries.mjs",
 		"lint": "eslint src e2e",
 		"package": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && electron-forge package .",

--- a/apps/ui/src/app/router-history.ts
+++ b/apps/ui/src/app/router-history.ts
@@ -1,0 +1,9 @@
+import { createHashHistory, type RouterHistory } from '@tanstack/react-router';
+
+export function createPackagedRouterHistory(): RouterHistory | undefined {
+	if ( typeof window === 'undefined' || window.location.protocol !== 'file:' ) {
+		return undefined;
+	}
+
+	return createHashHistory();
+}

--- a/apps/ui/src/app/use-ui-mode.ts
+++ b/apps/ui/src/app/use-ui-mode.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 export type UiMode = 'classic' | 'desks';
 
 const UI_MODE_STORAGE_KEY = 'studio.uiMode';
+const DEFAULT_UI_MODE: UiMode = 'desks';
 
 function isUiMode( value: string | null ): value is UiMode {
 	return value === 'classic' || value === 'desks';
@@ -10,14 +11,14 @@ function isUiMode( value: string | null ): value is UiMode {
 
 function readStoredUiMode(): UiMode {
 	if ( typeof window === 'undefined' ) {
-		return 'classic';
+		return DEFAULT_UI_MODE;
 	}
 
 	try {
 		const storedMode = window.localStorage.getItem( UI_MODE_STORAGE_KEY );
-		return isUiMode( storedMode ) ? storedMode : 'classic';
+		return isUiMode( storedMode ) ? storedMode : DEFAULT_UI_MODE;
 	} catch {
-		return 'classic';
+		return DEFAULT_UI_MODE;
 	}
 }
 
@@ -31,6 +32,14 @@ function writeStoredUiMode( mode: UiMode ) {
 
 function resetRouteAndReload() {
 	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	if ( window.location.protocol === 'file:' ) {
+		if ( window.location.hash !== '#/' ) {
+			window.history.replaceState( window.history.state, '', '#/' );
+		}
+		window.location.reload();
 		return;
 	}
 

--- a/apps/ui/src/ui-classic/router/router.tsx
+++ b/apps/ui/src/ui-classic/router/router.tsx
@@ -1,4 +1,5 @@
 import { createRouter } from '@tanstack/react-router';
+import { createPackagedRouterHistory } from '@/app/router-history';
 import { dashboardLayoutRoute } from './layout-dashboard';
 import { onboardingLayoutRoute } from './layout-onboarding';
 import { rootRoute } from './layout-root';
@@ -36,5 +37,6 @@ export function createAppRouter( context: RouterContext ) {
 		routeTree,
 		context,
 		defaultPreload: 'intent',
+		history: createPackagedRouterHistory(),
 	} );
 }

--- a/apps/ui/src/ui-desks/app.tsx
+++ b/apps/ui/src/ui-desks/app.tsx
@@ -1,5 +1,6 @@
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { useMemo } from 'react';
+import { createPackagedRouterHistory } from '@/app/router-history';
 import {
 	desksOnboardingBlueprintRoute,
 	desksOnboardingCreateRoute,
@@ -23,6 +24,7 @@ export function createDesksRouter() {
 	return createRouter( {
 		routeTree,
 		defaultPreload: 'intent',
+		history: createPackagedRouterHistory(),
 	} );
 }
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,13 @@
+import path from 'node:path';
+import js from '@eslint/js';
 import { defineConfig, globalIgnores } from 'eslint/config';
 import pluginImport from 'eslint-plugin-import-x';
-import pluginStudio from 'eslint-plugin-studio';
+import pluginJestDom from 'eslint-plugin-jest-dom';
 import pluginPrettier from 'eslint-plugin-prettier/recommended';
+import pluginReactHooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 import tsEslint from 'typescript-eslint';
-import js from '@eslint/js';
-import pluginReactHooks from 'eslint-plugin-react-hooks';
-import pluginJestDom from 'eslint-plugin-jest-dom';
-import path from 'node:path';
+import pluginStudio from 'eslint-plugin-studio';
 
 export default defineConfig(
 	globalIgnores( [
@@ -39,7 +39,11 @@ export default defineConfig(
 			sourceType: 'commonjs',
 			parserOptions: {
 				projectService: {
-					allowDefaultProject: [ 'apps/studio/tailwind.config.js' ],
+					allowDefaultProject: [
+						'apps/studio/forge.config.ts',
+						'apps/studio/tailwind.config.js',
+						'eslint.config.mjs',
+					],
 				},
 			},
 		},

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"make:macos-arm64": "ts-node ./scripts/package-in-isolation.ts make:macos-arm64",
 		"make:linux-x64": "ts-node ./scripts/package-in-isolation.ts make:linux-x64",
 		"make:linux-arm64": "ts-node ./scripts/package-in-isolation.ts make:linux-arm64",
+		"make:new-ui": "ts-node ./scripts/package-in-isolation.ts make:new-ui",
 		"make:dmg-x64": "FILE_ARCHITECTURE=x64 node ./scripts/make-dmg.mjs",
 		"make:dmg-arm64": "FILE_ARCHITECTURE=arm64 node ./scripts/make-dmg.mjs",
 		"publish": "npm -w studio-app run publish",

--- a/scripts/build-new-ui-renderer.ts
+++ b/scripts/build-new-ui-renderer.ts
@@ -1,0 +1,53 @@
+import { spawnSync, type SpawnSyncOptions } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const repoRoot = path.resolve( __dirname, '..' );
+const studioRoot = path.join( repoRoot, 'apps', 'studio' );
+const uiRoot = path.join( repoRoot, 'apps', 'ui' );
+const rendererOut = path.join( studioRoot, 'dist', 'renderer' );
+
+function runOrFail( command: string, args: string[], cwd: string ) {
+	const options: SpawnSyncOptions = {
+		cwd,
+		stdio: 'inherit',
+		shell: process.platform === 'win32',
+	};
+
+	const result = spawnSync( command, args, options );
+	if ( result.status !== 0 ) {
+		process.exit( result.status ?? 1 );
+	}
+}
+
+function copyAboutMenuAssets() {
+	const aboutMenuDir = path.join( studioRoot, 'src', 'about-menu' );
+	fs.copyFileSync(
+		path.join( aboutMenuDir, 'about-menu.html' ),
+		path.join( rendererOut, 'about-menu.html' )
+	);
+	fs.copyFileSync(
+		path.join( aboutMenuDir, 'studio-app-icon.png' ),
+		path.join( rendererOut, 'studio-app-icon.png' )
+	);
+}
+
+fs.rmSync( rendererOut, { recursive: true, force: true } );
+
+runOrFail(
+	'npx',
+	[
+		'vite',
+		'build',
+		'--config',
+		'vite.config.ts',
+		'--base',
+		'./',
+		'--outDir',
+		path.relative( uiRoot, rendererOut ),
+		'--emptyOutDir',
+	],
+	uiRoot
+);
+
+copyAboutMenuAssets();


### PR DESCRIPTION
## Summary
- Default `apps/ui` to `desks` so fresh installs open the new UI instead of classic UI
- Add packaged-app router handling so `file://` loads use hash history and avoid the Not found screen
- Add a `make:new-ui` packaging path that builds the Electron app with the `apps/ui` renderer
- Skip bundled language-pack downloads when `SKIP_LANGUAGE_PACKS` is set, which unblocks local packaging in restricted network environments

## Testing
- `npx eslint --fix` on the modified files
- `npm run typecheck`
- `npm test -- apps/ui/src`
- Built the new UI app artifacts locally and verified the packaged ASAR contains the renderer entrypoint and file-mode routing fix