### PR TITLE
Add Linux to the release build and distribution pipeline

### DIFF
--- a/.buildkite/release-build-and-distribute.yml
+++ b/.buildkite/release-build-and-distribute.yml
@@ -86,6 +86,46 @@ steps:
           - github_commit_status:
               context: All Windows Release Builds
 
+  - group: 📦 Build for Linux
+    key: release-linux
+    steps:
+      - label: 🔨 Linux Release Build - {{matrix}}
+        agents:
+          queue: default
+        command: |
+          set -eu
+
+          # The container has no SSH keys / known_hosts, use anonymous HTTPS
+          git remote set-url origin https://github.com/Automattic/studio.git
+
+          bash .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
+          apt-get -o Acquire::Retries=3 update
+          apt-get install -y --no-install-recommends fakeroot
+
+          # `--maxsockets 1` works around npm/cli#4652 (ECONNRESETs on Linux);
+          # see install-node-dependencies.sh for the original rationale.
+          npm ci --unsafe-perm --no-audit --no-progress --maxsockets 1
+
+          echo "--- :node: Building DEB"
+          npm run make:linux-{{matrix}}
+        artifact_paths:
+          - apps/studio/out/make/deb/**/*.deb
+        plugins:
+          # Same Docker-on-default-queue pattern as the dev Linux build group
+          # (see .buildkite/pipeline.yml): Amazon Linux on `default` lacks
+          # `dpkg`/`fakeroot`, so we build inside the Debian Node image.
+          - $DOCKER_PLUGIN:
+              image: "$NODE_DOCKER_IMAGE"
+              propagate-environment: true
+              mount-buildkite-agent: true
+        matrix:
+          - x64
+          - arm64
+        notify:
+          - github_commit_status:
+              context: All Linux Release Builds
+
   - label: ":rocket: Publish Release Builds"
     command: |
       echo "--- :robot_face: Use bot for Git operations"
@@ -99,6 +139,7 @@ steps:
       buildkite-agent artifact download "*.exe" .
       buildkite-agent artifact download "*.appx" .
       buildkite-agent artifact download "*.nupkg" .
+      buildkite-agent artifact download "*.deb" .
       buildkite-agent artifact download "*\\RELEASES" .
 
       .buildkite/commands/install-node-dependencies.sh
@@ -111,6 +152,7 @@ steps:
     depends_on:
       - step: release-mac
       - step: release-windows
+      - step: release-linux
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     notify:
       - github_commit_status:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -522,28 +522,26 @@ def distribute_builds(
     }
   }
 
-  # Linux is dev-only for now — the release pipeline produces only Mac/Windows
-  # artifacts. On Linux the .deb is the only artifact (it serves as both the
-  # update payload and the full installer); `install_type: 'Update'` matches
-  # the URL convention the WPCOM updates endpoint emits for the polling path.
-  if release_tag.nil?
-    update_builds[:linux_x64_deb] = {
-      binary_path: linux_deb_path(arch: 'x64'),
-      name: 'Linux - x64 (DEB)',
-      platform: 'Linux - x64',
-      arch: 'x64',
-      install_type: 'Update',
-      sha: commit_hash
-    }
-    update_builds[:linux_arm64_deb] = {
-      binary_path: linux_deb_path(arch: 'arm64'),
-      name: 'Linux - ARM64 (DEB)',
-      platform: 'Linux - ARM64',
-      arch: 'arm64',
-      install_type: 'Update',
-      sha: commit_hash
-    }
-  end
+  # On Linux the .deb is the only artifact — it serves as both the update
+  # payload and the full installer — so the same entry covers dev and release
+  # builds. `install_type: 'Update'` matches the URL convention the WPCOM
+  # updates endpoint emits for the in-app updater's polling path.
+  update_builds[:linux_x64_deb] = {
+    binary_path: linux_deb_path(arch: 'x64'),
+    name: 'Linux - x64 (DEB)',
+    platform: 'Linux - x64',
+    arch: 'x64',
+    install_type: 'Update',
+    sha: commit_hash
+  }
+  update_builds[:linux_arm64_deb] = {
+    binary_path: linux_deb_path(arch: 'arm64'),
+    name: 'Linux - ARM64 (DEB)',
+    platform: 'Linux - ARM64',
+    arch: 'arm64',
+    install_type: 'Update',
+    sha: commit_hash
+  }
 
   full_install_builds = {
     x64_dmg: {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -944,7 +944,7 @@ def create_draft_github_release(version:, release_tag:, builds:)
   notes = extract_release_notes(version: version)
 
   # Format download links from CDN URLs
-  download_link_keys = %i[x64_dmg arm64_dmg windows windows_arm64]
+  download_link_keys = %i[x64_dmg arm64_dmg windows windows_arm64 linux_x64_deb linux_arm64_deb]
   links = download_link_keys.filter_map do |key|
     build = builds[key]
     next unless build&.dig(:cdn_url)


### PR DESCRIPTION
## Related issues
Closes [RSM-2587](https://linear.app/a8c/issue/RSM-2587). Last remaining gate before a first Linux beta can ship.

## How AI was used in this PR
AI-assisted: drafted the Buildkite group, Fastfile change, and PR body following existing precedents (release-mac, release-windows, dev-linux). Author reviewed.

## Proposed Changes

Two coupled changes so release lanes produce and upload Linux DEBs alongside Mac/Windows:

**`.buildkite/release-build-and-distribute.yml`** — adds a `release-linux` group with an `x64`/`arm64` matrix, mirroring the structure of `release-mac` and `release-windows`. Uses the Docker-on-`default`-queue pattern Apps Infra established for the dev Linux build group (#3346): runs inside `$NODE_DOCKER_IMAGE` because Amazon Linux on the `default` queue lacks `dpkg`/`fakeroot` required by electron-forge's `MakerDeb`. The `Publish Release Builds` step now also downloads `*.deb` artifacts and depends on `release-linux`.

**`fastlane/Fastfile`** — lifts the `release_tag.nil?` gate around the `linux_x64_deb` / `linux_arm64_deb` entries in `update_builds`. On Linux the `.deb` is the only artifact (serves as both update payload and full installer), so the same entry covers dev and release builds. `install_type: 'Update'` keeps the URL convention compatible with the in-app updater's polling path (#3465).

## Testing Instructions

CI on this PR only validates parse/lint — the release pipeline doesn't run for regular PRs. The first real verification happens when a release is cut. After this lands:

1. When `code_freeze` / `new_beta_release` runs next, the triggered release pipeline should show a 📦 Build for Linux group running both x64 and arm64 builds in parallel with Mac/Windows.
2. Both Linux jobs should produce a `.deb` artifact at `apps/studio/out/make/deb/**/*.deb`.
3. The Publish Release Builds step should download all DEBs and `distribute_release_build` should upload them to AppsCDN. Linux DEB URLs should appear in the `cdn-link` annotation, the GitHub draft release, and the Slack notification.

## Pre-merge Checklist
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] CI is green.