### PR TITLE
apps/ui: Match scratchpad widget styling to the Desk reference

### DIFF
--- a/apps/ui/src/ui-desks/chats/conversation/index.tsx
+++ b/apps/ui/src/ui-desks/chats/conversation/index.tsx
@@ -568,17 +568,13 @@ function ScratchpadArtifactCard( {
 					) : null }
 				</div>
 				<div className={ styles.scratchpadArtifactThumbnail }>
-					{ widget.widgetProps.html ? (
-						<iframe
-							className={ styles.scratchpadArtifactFrame }
-							srcDoc={ widget.widgetProps.html }
-							sandbox="allow-scripts"
-							referrerPolicy="no-referrer"
-							title={ title }
-						/>
-					) : (
-						<div className={ styles.scratchpadArtifactEmpty }>{ __( 'Empty scratchpad' ) }</div>
-					) }
+					<iframe
+						className={ styles.scratchpadArtifactFrame }
+						srcDoc={ widget.widgetProps.html }
+						sandbox="allow-scripts"
+						referrerPolicy="no-referrer"
+						title={ title }
+					/>
 					<div className={ styles.scratchpadArtifactShield } aria-hidden="true" />
 				</div>
 			</div>

--- a/apps/ui/src/ui-desks/chats/conversation/style.module.css
+++ b/apps/ui/src/ui-desks/chats/conversation/style.module.css
@@ -347,19 +347,6 @@
 	pointer-events: none;
 }
 
-.scratchpadArtifactEmpty {
-	position: absolute;
-	inset: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	padding: 8px;
-	color: var(--ui-desks-muted, #6b7280);
-	font-size: 11px;
-	line-height: 14px;
-	text-align: center;
-}
-
 .scratchpadArtifactShield {
 	position: absolute;
 	inset: 0;

--- a/apps/ui/src/ui-desks/widget-actions/create-widget/index.test.ts
+++ b/apps/ui/src/ui-desks/widget-actions/create-widget/index.test.ts
@@ -140,6 +140,36 @@ describe( 'createDeskWidget', () => {
 		} );
 	} );
 
+	it( 'creates an empty scratchpad widget at the reference workbench size', () => {
+		const createdWidget = createDeskWidget( {
+			id: 'scratchpad-1',
+			type: 'scratchpad',
+			center: {
+				x: 700,
+				y: 500,
+			},
+			zIndex: 'a8',
+		} );
+
+		expect( createdWidget ).toEqual( {
+			id: 'scratchpad-1',
+			type: 'scratchpad',
+			x: 460,
+			y: 320,
+			zIndex: 'a8',
+			shapeProps: {
+				w: 480,
+				h: 360,
+			},
+			widgetProps: {
+				html: '',
+				title: '',
+				scope: 'block',
+				description: '',
+			},
+		} );
+	} );
+
 	it( 'ignores unsupported widget types', () => {
 		expect(
 			createDeskWidget( {

--- a/apps/ui/src/ui-desks/widgets/scratchpad/component/index.tsx
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/component/index.tsx
@@ -227,13 +227,13 @@ export function ScratchpadWidgetComponent( {
 				/>
 			) : widgetProps.reference ? (
 				<img
-					className={ styles.reference }
+					className={ `${ styles.frame } ${ styles.reference }` }
 					src={ widgetProps.reference.url }
 					alt={ widgetProps.reference.alt }
 					draggable={ false }
 				/>
 			) : (
-				<div className={ styles.empty }>{ __( 'Empty scratchpad' ) }</div>
+				<div className={ styles.empty } aria-hidden="true" />
 			) }
 			<div className={ styles.bottom }>
 				<div className={ styles.descriptionWrap }>
@@ -244,7 +244,7 @@ export function ScratchpadWidgetComponent( {
 						suppressContentEditableWarning
 						spellCheck={ false }
 						data-empty={ description ? 'false' : 'true' }
-						data-placeholder={ __( 'Describe what this scratchpad should become...' ) }
+						data-placeholder={ __( 'Describe what you’d like the agent to make…' ) }
 						onBlur={ () => {
 							updateDescription();
 							onEditComplete();
@@ -330,7 +330,7 @@ const SCRATCHPAD_STATUS_ICON = {
 
 const SCRATCHPAD_STATUS_LABEL: Record< Exclude< ScratchpadAgentStatus, 'idle' >, string > = {
 	pending: __( 'Run agent on this' ),
-	running: __( 'Agent working...' ),
+	running: __( 'Agent working…' ),
 	done: __( 'Done' ),
 };
 

--- a/apps/ui/src/ui-desks/widgets/scratchpad/component/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/component/style.module.css
@@ -6,15 +6,8 @@
 	box-sizing: border-box;
 	font-family: var(--wpds-typography-font-family-body);
 	background-color: #fff;
-	background-image:
-		radial-gradient(circle, #c9cbce 1px, transparent 1.1px),
-		radial-gradient(circle, #c9cbce 0.5px, transparent 0.6px);
-	background-size:
-		40px 40px,
-		10px 10px;
-	background-position:
-		0 0,
-		5px 5px;
+	background-image: radial-gradient(circle, #c9cbce 1px, transparent 1.1px);
+	background-size: 40px 40px;
 	border-radius: 18px;
 	overflow: hidden;
 }
@@ -27,12 +20,12 @@
 	box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
 }
 
-.frame,
-.reference,
-.empty {
+.frame {
+	display: block;
 	width: 100%;
 	flex: 1 1 0;
 	min-height: 0;
+	border: 0;
 	border-radius: 10px;
 	background: #fff;
 	box-shadow:
@@ -40,15 +33,9 @@
 		0 8px 20px rgba(15, 23, 42, 0.08);
 }
 
-.frame {
-	display: block;
-	border: 0;
-}
-
 .reference {
-	display: block;
-	object-fit: contain;
-	border: 0;
+	object-fit: cover;
+	opacity: 0.85;
 }
 
 .frameMedia {
@@ -73,12 +60,10 @@
 }
 
 .empty {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	color: #6b7280;
-	font-size: 13px;
-	line-height: 18px;
+	display: block;
+	width: 100%;
+	flex: 1 1 0;
+	min-height: 0;
 }
 
 .bottom {
@@ -102,10 +87,10 @@
 
 .description {
 	min-width: 0;
-	min-height: 20px;
+	min-height: 1.5em;
 	color: #6b7280;
 	font-size: 13px;
-	line-height: 20px;
+	line-height: 1.5;
 	text-align: left;
 	outline: none;
 	transition: color 140ms ease;
@@ -273,12 +258,7 @@
 	gap: 6px;
 	padding: 8px;
 	border-radius: 10px;
-	background-size:
-		16px 16px,
-		4px 4px;
-	background-position:
-		0 0,
-		2px 2px;
+	background-size: 16px 16px;
 	text-align: center;
 }
 

--- a/apps/ui/src/ui-desks/widgets/scratchpad/sizing.ts
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/sizing.ts
@@ -11,7 +11,7 @@ const SCRATCHPAD_VIEWPORTS: Record< ScratchpadScope, RectangleWidgetShapeProps >
 	block: { w: 480, h: 360 },
 };
 
-export const SCRATCHPAD_DEFAULT_SHAPE_PROPS = getScratchpadShapePropsForScope( 'block' );
+export const SCRATCHPAD_DEFAULT_SHAPE_PROPS = { ...SCRATCHPAD_VIEWPORTS.block };
 
 export function getScratchpadShapePropsForScope(
 	scope: ScratchpadScope
@@ -34,7 +34,7 @@ export async function getFittedScratchpadShapeProps( {
 	shapeProps: RectangleWidgetShapeProps;
 } ): Promise< RectangleWidgetShapeProps | null > {
 	if ( typeof document === 'undefined' || ! widgetProps.html ) {
-		return getScratchpadShapePropsForScope( widgetProps.scope );
+		return { ...SCRATCHPAD_DEFAULT_SHAPE_PROPS };
 	}
 
 	const viewport = SCRATCHPAD_VIEWPORTS[ widgetProps.scope ];


### PR DESCRIPTION
## Summary
- Removed the empty scratchpad placeholder card so the canvas and chat preview now use the same blank workbench treatment as the reference.
- Aligned scratchpad visuals with the Desk repo: single dotted background, cover-fit reference image treatment, and cleaner empty-frame sizing.
- Updated the default empty scratchpad size to the reference 480x360 block dimensions and added a regression test for that case.
- Tightened the scratchpad copy/status strings to match the reference wording more closely.

## Testing
- `npx eslint --fix` on the touched TypeScript files completed successfully.
- `npm test -- apps/ui/src/ui-desks/widgets/scratchpad/component/index.test.tsx apps/ui/src/ui-desks/chats/conversation/index.test.ts apps/ui/src/ui-desks/widget-actions/create-widget/index.test.ts` passed.
- `npm run typecheck` was started and was still running when the turn was interrupted, so full typecheck completion was not confirmed in this run.