### PR TITLE
apps/ui: Remove padding from chat drag thumbnail preview

### DIFF
--- a/apps/ui/src/ui-desks/chats/panel/style.module.css
+++ b/apps/ui/src/ui-desks/chats/panel/style.module.css
@@ -182,22 +182,11 @@
 	top: var(--desk-widget-drag-preview-y);
 	z-index: 30;
 	pointer-events: none;
-	transform: translate(12px, 12px);
+	transform: translate(-50%, -50%);
 }
 
 .widgetDragPreviewThumbnails {
 	display: inline-flex;
 	flex-wrap: nowrap;
 	max-width: 260px;
-	padding: 10px;
-	border: 1px solid rgba(255, 255, 255, 0.72);
-	border-radius: 14px;
-	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
-	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
-	background: rgba(255, 255, 255, 0.86);
-	box-shadow:
-		0 1px 2px rgba(15, 23, 42, 0.04),
-		0 18px 44px rgba(15, 23, 42, 0.14);
-	-webkit-backdrop-filter: saturate(180%) blur(20px);
-	backdrop-filter: saturate(180%) blur(20px);
 }


### PR DESCRIPTION
## Summary
- Matched the desk chat drag preview more closely to the reference by removing the extra padded glass wrapper around dragged thumbnails.
- Centered the floating preview on the pointer so the cursor-following behavior lines up with the reference implementation.

## Testing
- `npm test -- apps/ui/src/ui-desks/chats/conversation/index.test.ts` passed.
- `npm run typecheck` was started after installing dependencies and reached the workspace typecheck phase; it did not surface any code errors before the session was interrupted.
- `npx eslint --fix apps/ui/src/ui-desks/chats/panel/style.module.css` reported the CSS file is ignored by the current ESLint config, so there was nothing to rewrite.