### PR TITLE
apps/ui: Match post and page widgets to the reference desk design

### DIFF
--- a/apps/ui/src/ui-desks/widgets/page/component/index.tsx
+++ b/apps/ui/src/ui-desks/widgets/page/component/index.tsx
@@ -2,7 +2,7 @@ import { useEntityRecords, type Post as CoreDataPost } from '@wordpress/core-dat
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { LoadingPlaceholder } from '@/ui-desks/components';
-import { CONTENT_CARD_STATUSES, getPostStatusInfo } from '@/ui-desks/widget-actions/post-status';
+import { CONTENT_CARD_STATUSES } from '@/ui-desks/widget-actions/post-status';
 import {
 	getMediaDropPreviewPayload,
 	MediaDropPreview,
@@ -23,7 +23,6 @@ type EmbeddedFeaturedMedia = {
 	};
 };
 type PageCardRecord = CoreDataPost & {
-	status?: string;
 	slug?: string;
 	_embedded?: {
 		'wp:featuredmedia'?: EmbeddedFeaturedMedia[];
@@ -38,7 +37,7 @@ export function PageWidgetComponent( { id, widgetProps, dropFeedback }: PageWidg
 			context: 'edit',
 			status: CONTENT_CARD_STATUSES,
 			_embed: true,
-			_fields: 'id,title,excerpt,slug,status,featured_media,_links,_embedded',
+			_fields: 'id,title,excerpt,slug,featured_media,_links,_embedded',
 		} ),
 		[ widgetProps.pageId ]
 	);
@@ -72,7 +71,6 @@ export function PageWidgetComponent( { id, widgetProps, dropFeedback }: PageWidg
 	const title = getPageTitle( record, isResolving, hasError );
 	const excerpt = record?.excerpt?.rendered ?? '';
 	const slug = record?.slug ?? '';
-	const statusInfo = getPostStatusInfo( record?.status );
 	const featuredImage = getPageFeaturedImageUrl( record );
 	const ditherFilterId = getPageToneDitherFilterId( widgetProps.tone );
 	const headerFilterStyle =
@@ -108,18 +106,6 @@ export function PageWidgetComponent( { id, widgetProps, dropFeedback }: PageWidg
 			{ excerpt && (
 				<div className={ styles.body } dangerouslySetInnerHTML={ { __html: excerpt } } />
 			) }
-			{ record?.status && (
-				<div className={ styles.metadata }>
-					<span className={ styles.status } title={ statusInfo.label }>
-						<span
-							className={ styles.statusDot }
-							style={ { background: statusInfo.color } }
-							aria-hidden="true"
-						/>
-						<span className={ styles.statusLabel }>{ statusInfo.label }</span>
-					</span>
-				</div>
-			) }
 			{ slug && <div className={ styles.slug }>/{ slug }</div> }
 		</article>
 	);
@@ -135,7 +121,7 @@ export function PageWidgetThumbnailComponent( {
 			per_page: 1,
 			context: 'edit',
 			status: CONTENT_CARD_STATUSES,
-			_fields: 'id,title,slug,status',
+			_fields: 'id,title,slug',
 		} ),
 		[ widgetProps.pageId ]
 	);

--- a/apps/ui/src/ui-desks/widgets/page/component/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/page/component/style.module.css
@@ -108,42 +108,6 @@
 	margin-bottom: 0;
 }
 
-.metadata {
-	position: relative;
-	z-index: 1;
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	min-height: 18px;
-	margin-top: auto;
-	color: var(--page-tone-color);
-	font-size: 12px;
-	line-height: 1.3;
-	opacity: 0.72;
-}
-
-.status {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	min-width: 0;
-}
-
-.statusDot {
-	width: 8px;
-	height: 8px;
-	border-radius: 50%;
-	flex: 0 0 auto;
-	box-shadow: 0 0 0 2px #fff;
-}
-
-.statusLabel {
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
 .slug {
 	position: relative;
 	z-index: 1;
@@ -157,10 +121,6 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-}
-
-.metadata + .slug {
-	margin-top: 0;
 }
 
 .pageHeader {

--- a/apps/ui/src/ui-desks/widgets/post/component/index.tsx
+++ b/apps/ui/src/ui-desks/widgets/post/component/index.tsx
@@ -4,7 +4,7 @@ import { comment } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { LoadingPlaceholder } from '@/ui-desks/components';
-import { CONTENT_CARD_STATUSES, getPostStatusInfo } from '@/ui-desks/widget-actions/post-status';
+import { CONTENT_CARD_STATUSES } from '@/ui-desks/widget-actions/post-status';
 import {
 	getMediaDropPreviewPayload,
 	MediaDropPreview,
@@ -25,7 +25,6 @@ type EmbeddedFeaturedMedia = {
 	};
 };
 type PostCardRecord = CoreDataPost & {
-	status?: string;
 	_embedded?: {
 		'wp:featuredmedia'?: EmbeddedFeaturedMedia[];
 	};
@@ -39,7 +38,7 @@ export function PostWidgetComponent( { id, widgetProps, dropFeedback }: PostWidg
 			context: 'edit',
 			status: CONTENT_CARD_STATUSES,
 			_embed: true,
-			_fields: 'id,title,excerpt,status,featured_media,_links,_embedded',
+			_fields: 'id,title,excerpt,featured_media,_links,_embedded',
 		} ),
 		[ widgetProps.postId ]
 	);
@@ -74,8 +73,6 @@ export function PostWidgetComponent( { id, widgetProps, dropFeedback }: PostWidg
 	const excerpt = record?.excerpt?.rendered ?? '';
 	const featuredImage = getFeaturedImageUrl( record );
 	const showFeaturedImage = ! excerpt.trim() && Boolean( featuredImage );
-	const statusInfo = getPostStatusInfo( record?.status );
-	const showMetadata = Boolean( record?.status || commentCount > 0 );
 
 	return (
 		<article
@@ -95,30 +92,13 @@ export function PostWidgetComponent( { id, widgetProps, dropFeedback }: PostWidg
 			) : excerpt ? (
 				<div className={ styles.body } dangerouslySetInnerHTML={ { __html: excerpt } } />
 			) : null }
-			{ showMetadata && (
-				<div className={ styles.metadata }>
-					{ record?.status && (
-						<span className={ styles.status } title={ statusInfo.label }>
-							<span
-								className={ styles.statusDot }
-								style={ { background: statusInfo.color } }
-								aria-hidden="true"
-							/>
-							<span className={ styles.statusLabel }>{ statusInfo.label }</span>
-						</span>
-					) }
-					{ commentCount > 0 && (
-						<span
-							className={ styles.comments }
-							aria-label={ sprintf(
-								_n( '%d comment', '%d comments', commentCount ),
-								commentCount
-							) }
-						>
-							<Icon icon={ comment } />
-							<span>{ commentCount }</span>
-						</span>
-					) }
+			{ commentCount > 0 && (
+				<div
+					className={ styles.comments }
+					aria-label={ sprintf( _n( '%d comment', '%d comments', commentCount ), commentCount ) }
+				>
+					<Icon icon={ comment } size={ 24 } />
+					<span>{ commentCount }</span>
 				</div>
 			) }
 		</article>
@@ -135,7 +115,7 @@ export function PostWidgetThumbnailComponent( {
 			per_page: 1,
 			context: 'edit',
 			status: CONTENT_CARD_STATUSES,
-			_fields: 'id,title,status',
+			_fields: 'id,title',
 		} ),
 		[ widgetProps.postId ]
 	);

--- a/apps/ui/src/ui-desks/widgets/post/component/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/post/component/style.module.css
@@ -81,48 +81,17 @@
 	}
 }
 
-.metadata {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	min-height: 24px;
-	margin-top: auto;
-	color: #6b7280;
-	font-size: 12px;
-	line-height: 1.3;
-}
-
-.status,
 .comments {
+	position: absolute;
+	left: 26px;
+	bottom: 24px;
 	display: inline-flex;
 	align-items: center;
-	min-width: 0;
-}
-
-.status {
-	gap: 6px;
-}
-
-.statusDot {
-	width: 8px;
-	height: 8px;
-	border-radius: 50%;
-	flex: 0 0 auto;
-	box-shadow: 0 0 0 2px #fff;
-}
-
-.statusLabel {
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.comments {
 	gap: 4px;
-	margin-left: auto;
 	color: #6b7280;
-	font-size: 14px;
+	font-size: 16px;
+	pointer-events: none;
+	z-index: 1;
 }
 
 .comments svg {


### PR DESCRIPTION
## Summary
- Removed page status metadata so page cards render only the title, body, featured image, and slug, matching the reference design.
- Updated the post card to remove status rendering and move the comment count into a lower-left overlay, with the same icon sizing and placement as the reference.
- Trimmed the page and post REST field selections to stop requesting unused `status` data.

## Testing
- `npx eslint --fix` on the modified widget files passed, with the expected warning that CSS modules are ignored by the ESLint config.
- `npm run typecheck` was started and reached the workspace checks before the turn was interrupted.
- `npm test -- apps/ui/src/ui-desks/desk/tldraw-adapter/index.test.ts` passed.