### PR TITLE
apps/ui: Align stack fan layout with the reference desk algorithm

### DIFF
--- a/apps/ui/src/ui-desks/desk/provider/editor-state/index.ts
+++ b/apps/ui/src/ui-desks/desk/provider/editor-state/index.ts
@@ -703,7 +703,7 @@ function getDerivedWidgetAnchor( shapes: TLShape[] ): DerivedWidgetAnchor | null
 	}
 
 	return {
-		...getStackAnchorFromMember( firstShape, order ),
+		...getStackAnchorFromMember( firstShape, order, shapes.length ),
 		zIndex: getStackZIndexFromMember( firstShape.index, order ),
 	};
 }

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter/index.test.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter/index.test.ts
@@ -494,9 +494,9 @@ describe( 'tldraw adapter', () => {
 
 		expect( firstStackMember ).toMatchObject( {
 			id: 'shape:note-1',
-			x: 100,
-			y: 200,
-			rotation: 0,
+			x: 95,
+			y: 196,
+			rotation: -0.026,
 			meta: {
 				deskStackId: 'stack-1',
 				deskStackOrder: 0,
@@ -506,9 +506,9 @@ describe( 'tldraw adapter', () => {
 		} );
 		expect( secondStackMember ).toMatchObject( {
 			id: 'shape:note-2',
-			x: 110,
-			y: 208,
-			rotation: 0.052,
+			x: 105,
+			y: 204,
+			rotation: 0.026,
 			meta: {
 				deskStackId: 'stack-1',
 				deskStackOrder: 1,
@@ -710,8 +710,8 @@ describe( 'tldraw adapter', () => {
 		const shapes = [
 			{
 				...deskWidgetToCanvasShape( createNoteWidget( 'note-1' ) ),
-				x: 100,
-				y: 200,
+				x: 95,
+				y: 196,
 				index: 'a5',
 				meta: {
 					deskStackId: 'stack-1',
@@ -720,8 +720,8 @@ describe( 'tldraw adapter', () => {
 			},
 			{
 				...deskWidgetToCanvasShape( createNoteWidget( 'note-2' ) ),
-				x: 110,
-				y: 208,
+				x: 105,
+				y: 204,
 				index: 'a4.999',
 				meta: {
 					deskStackId: 'stack-1',
@@ -858,8 +858,8 @@ describe( 'tldraw adapter', () => {
 					deskStackId: 'stack-1',
 					deskStackOrder: 0,
 					deskStackPushedBy: 'stack-2',
-					deskStackPushOriginX: 100,
-					deskStackPushOriginY: 200,
+					deskStackPushOriginX: 95,
+					deskStackPushOriginY: 196,
 				},
 			},
 			{
@@ -871,8 +871,8 @@ describe( 'tldraw adapter', () => {
 					deskStackId: 'stack-1',
 					deskStackOrder: 1,
 					deskStackPushedBy: 'stack-2',
-					deskStackPushOriginX: 110,
-					deskStackPushOriginY: 208,
+					deskStackPushOriginX: 105,
+					deskStackPushOriginY: 204,
 				},
 			},
 		] as unknown as TLShape[];
@@ -1029,9 +1029,9 @@ describe( 'tldraw adapter', () => {
 		} );
 
 		expect( shape ).toMatchObject( {
-			x: 110,
-			y: 208,
-			rotation: 0.052,
+			x: 105,
+			y: 204,
+			rotation: 0.026,
 			meta: {
 				deskStackId: 'stack-1',
 				deskStackOrder: 1,

--- a/apps/ui/src/ui-desks/desk/tldraw-adapter/index.ts
+++ b/apps/ui/src/ui-desks/desk/tldraw-adapter/index.ts
@@ -592,7 +592,8 @@ function canvasShapesToDeskStack( stackId: string, shapes: TLShape[] ): DeskStac
 				...firstMember.shape,
 				...getPersistedShapePosition( firstMember.shape ),
 			},
-			firstMember.order
+			firstMember.order,
+			sortedShapes.length
 		);
 
 	return {

--- a/apps/ui/src/ui-desks/stacks/editor-commands.ts
+++ b/apps/ui/src/ui-desks/stacks/editor-commands.ts
@@ -89,7 +89,10 @@ export function expandStackInEditor( editor: Editor, stackId: string ) {
 	}
 
 	const stack = getStackFromCollapsedMembers( members );
-	const expandedLayouts = getExpandedStackLayouts( members, stack );
+	const expandedLayouts = getExpandedStackLayouts( members, {
+		x: members[ 0 ].x,
+		y: members[ 0 ].y,
+	} );
 
 	editor.updateShapes(
 		members.map( ( shape ) => ( {
@@ -298,7 +301,7 @@ function getExpandedStackIds( editor: Editor ) {
 function getStackFromCollapsedMembers( members: TLShape[] ) {
 	const firstMember = members[ 0 ];
 	const firstOrder = getStackOrder( firstMember );
-	const anchor = getStackAnchorFromMember( firstMember, firstOrder );
+	const anchor = getStackAnchorFromMember( firstMember, firstOrder, members.length );
 
 	return {
 		id: getStackId( firstMember ) ?? createStackId(),

--- a/apps/ui/src/ui-desks/stacks/use-stack-shape-interaction.ts
+++ b/apps/ui/src/ui-desks/stacks/use-stack-shape-interaction.ts
@@ -2,7 +2,13 @@ import { useRef } from 'react';
 import { useEditor, useValue, type TLShape } from 'tldraw';
 import { useDesk } from '@/ui-desks/desk/provider/context';
 import { expandStackInEditor } from './editor-commands';
-import { getStackId, getStackOrder, getStackViewMode, isStackExpanded } from './utils';
+import {
+	getStackFanStep,
+	getStackId,
+	getStackOrder,
+	getStackViewMode,
+	isStackExpanded,
+} from './utils';
 import type { PointerEvent } from 'react';
 
 const STACK_HOVER_TRANSLATE = 8;
@@ -34,8 +40,7 @@ export function useStackShapeInteraction( shape: TLShape ) {
 	const members = stackId
 		? editor.getCurrentPageShapes().filter( ( member ) => getStackId( member ) === stackId )
 		: [];
-	const center = ( members.length - 1 ) / 2;
-	const step = order - center;
+	const step = getStackFanStep( order, members.length );
 	const hoverTranslate = isHovered ? step * STACK_HOVER_TRANSLATE : 0;
 	const hoverRotate = isHovered ? step * STACK_HOVER_ROTATE_DEG : 0;
 	const pressScale = isPressed ? 0.985 : 1;

--- a/apps/ui/src/ui-desks/stacks/use-stack-shape-interaction.ts
+++ b/apps/ui/src/ui-desks/stacks/use-stack-shape-interaction.ts
@@ -5,6 +5,9 @@ import { expandStackInEditor } from './editor-commands';
 import { getStackId, getStackOrder, getStackViewMode, isStackExpanded } from './utils';
 import type { PointerEvent } from 'react';
 
+const STACK_HOVER_TRANSLATE = 8;
+const STACK_HOVER_ROTATE_DEG = 3;
+
 export function useStackShapeInteraction( shape: TLShape ) {
 	const editor = useEditor();
 	const { isReadOnly, pressedStackId, pressStack } = useDesk();
@@ -33,8 +36,8 @@ export function useStackShapeInteraction( shape: TLShape ) {
 		: [];
 	const center = ( members.length - 1 ) / 2;
 	const step = order - center;
-	const hoverTranslate = isHovered ? step * 7 : 0;
-	const hoverRotate = isHovered ? step * 2.5 : 0;
+	const hoverTranslate = isHovered ? step * STACK_HOVER_TRANSLATE : 0;
+	const hoverRotate = isHovered ? step * STACK_HOVER_ROTATE_DEG : 0;
 	const pressScale = isPressed ? 0.985 : 1;
 
 	return {

--- a/apps/ui/src/ui-desks/stacks/utils.ts
+++ b/apps/ui/src/ui-desks/stacks/utils.ts
@@ -88,18 +88,34 @@ export function getStackOriginalZIndex( shape: TLShape | null | undefined ) {
 	return typeof meta?.deskStackOriginalZIndex === 'string' ? meta.deskStackOriginalZIndex : null;
 }
 
-export function getStackMemberLayout( stack: Pick< DeskStack, 'x' | 'y' >, order: number ) {
+function getStackFanStep( order: number, totalCount: number ) {
+	const center = ( Math.max( 1, totalCount ) - 1 ) / 2;
+	return order - center;
+}
+
+export function getStackMemberLayout(
+	stack: Pick< DeskStack, 'x' | 'y' | 'memberIds' >,
+	order: number
+) {
+	const step = getStackFanStep( order, stack.memberIds.length );
+
 	return {
-		x: stack.x + order * STACK_TRANSLATE_X,
-		y: stack.y + order * STACK_TRANSLATE_Y,
-		rotation: order * STACK_ROTATION,
+		x: stack.x + step * STACK_TRANSLATE_X,
+		y: stack.y + step * STACK_TRANSLATE_Y,
+		rotation: step * STACK_ROTATION,
 	};
 }
 
-export function getStackAnchorFromMember( shape: Pick< TLShape, 'x' | 'y' >, order: number ) {
+export function getStackAnchorFromMember(
+	shape: Pick< TLShape, 'x' | 'y' >,
+	order: number,
+	totalCount: number
+) {
+	const step = getStackFanStep( order, totalCount );
+
 	return {
-		x: shape.x - order * STACK_TRANSLATE_X,
-		y: shape.y - order * STACK_TRANSLATE_Y,
+		x: shape.x - step * STACK_TRANSLATE_X,
+		y: shape.y - step * STACK_TRANSLATE_Y,
 	};
 }
 

--- a/apps/ui/src/ui-desks/stacks/utils.ts
+++ b/apps/ui/src/ui-desks/stacks/utils.ts
@@ -88,7 +88,7 @@ export function getStackOriginalZIndex( shape: TLShape | null | undefined ) {
 	return typeof meta?.deskStackOriginalZIndex === 'string' ? meta.deskStackOriginalZIndex : null;
 }
 
-function getStackFanStep( order: number, totalCount: number ) {
+export function getStackFanStep( order: number, totalCount: number ) {
 	const center = ( Math.max( 1, totalCount ) - 1 ) / 2;
 	return order - center;
 }

--- a/apps/ui/src/ui-desks/widgets/post-collection/component/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/post-collection/component/style.module.css
@@ -24,12 +24,14 @@
 
 .loadingCard[data-layer='back'] {
 	background: #f6f7f7;
-	transform: translate(10px, 8px) rotate(2deg);
+	transform: translate(5px, 4px) rotate(1.5deg);
 	transform-origin: center;
 }
 
 .loadingCard[data-layer='front'] {
 	z-index: 1;
+	transform: translate(-5px, -4px) rotate(-1.5deg);
+	transform-origin: center;
 }
 
 .thumbnail {
@@ -60,12 +62,14 @@
 
 .thumbnailCard[data-layer='back'] {
 	background: #f6f7f7;
-	transform: translate(7px, 6px) rotate(2deg);
+	transform: translate(5px, 4px) rotate(1.5deg);
 	transform-origin: center;
 }
 
 .thumbnailCard[data-layer='front'] {
 	z-index: 1;
+	transform: translate(-5px, -4px) rotate(-1.5deg);
+	transform-origin: center;
 }
 
 .thumbnailLabel {


### PR DESCRIPTION
## Summary
- Center stack fan positioning around the stack midpoint so collapsed members tilt and offset symmetrically, matching the reference desk behavior more closely.
- Use the shared fan-step helper across stack layout, anchor reconstruction, hover motion, and derived stack persistence.
- Update the post-collection loading/thumbnail stack visuals to use the same centered fan treatment.
- Refresh adapter expectations to cover the new centered positions and rotations.

## Testing
- `npx eslint --fix` on the changed TypeScript files passed; the CSS module is ignored by the repo ESLint config.
- `npm run typecheck` passed.
- `npm test -- apps/ui/src/ui-desks/desk/tldraw-adapter/index.test.ts apps/ui/src/ui-desks/desk/provider/editor-state/index.test.ts apps/ui/src/ui-desks/desk/provider/resolvers.test.ts apps/ui/src/ui-desks/widgets/post-collection/definition/index.test.ts` passed.