### PR TITLE
Show a confirmation dialog before switching desks for moved chats

### DIFF
--- a/apps/ui/src/ui-desks/chats/provider.test.tsx
+++ b/apps/ui/src/ui-desks/chats/provider.test.tsx
@@ -1,0 +1,149 @@
+import '@testing-library/jest-dom/vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectorProvider } from '@/data/core';
+import { useChats } from './context';
+import { ChatsProvider } from './provider';
+import type { Connector } from '@/data/core';
+import type { AiSessionPlacementUpdatedEvent } from '@/data/core/types';
+
+const routerMock = vi.hoisted( () => ( {
+	navigate: vi.fn(),
+	search: { chats: true, session: 'session-1' } as Record< string, unknown >,
+} ) );
+
+vi.mock( '@tanstack/react-router', () => ( {
+	useNavigate: () => routerMock.navigate,
+	useSearch: () => routerMock.search,
+} ) );
+
+describe( 'ChatsProvider session placement changes', () => {
+	beforeEach( () => {
+		routerMock.navigate.mockReset();
+		routerMock.search = { chats: true, session: 'session-1' };
+	} );
+
+	it( 'asks before switching desks when the selected chat moves to another site', async () => {
+		const { emitPlacement } = renderProvider();
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'selected-session' ) ).toHaveTextContent( 'session-1' )
+		);
+		routerMock.navigate.mockClear();
+
+		emitPlacement( createPlacementEvent() );
+
+		expect(
+			await screen.findByRole( 'dialog', { name: 'Continue in the site desk?' } )
+		).toBeVisible();
+		expect( screen.getByText( /site desk for Created Site/ ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Switch desks' } ) ).toHaveFocus();
+		expect( routerMock.navigate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'switches to the new site desk when confirmed', async () => {
+		const { emitPlacement } = renderProvider();
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'selected-session' ) ).toHaveTextContent( 'session-1' )
+		);
+		routerMock.navigate.mockClear();
+
+		emitPlacement( createPlacementEvent() );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Switch desks' } ) );
+
+		expect( routerMock.navigate ).toHaveBeenCalledTimes( 1 );
+		const navigation = routerMock.navigate.mock.calls[ 0 ][ 0 ];
+		expect( navigation.to ).toBe( '/sites/$siteId' );
+		expect( navigation.params ).toEqual( { siteId: 'site-2' } );
+		expect( navigation.search( { existing: true } ) ).toEqual( {
+			existing: true,
+			chats: true,
+			session: 'session-1',
+		} );
+	} );
+
+	it( 'stays on the current desk by closing the chat sidebar', async () => {
+		const { emitPlacement } = renderProvider();
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'selected-session' ) ).toHaveTextContent( 'session-1' )
+		);
+		routerMock.navigate.mockClear();
+
+		emitPlacement( createPlacementEvent() );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Stay here' } ) );
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'selected-session' ) ).toHaveTextContent( 'none' )
+		);
+		expect(
+			screen.queryByRole( 'dialog', { name: 'Continue in the site desk?' } )
+		).not.toBeInTheDocument();
+		expect( routerMock.navigate ).toHaveBeenCalledTimes( 1 );
+		const navigation = routerMock.navigate.mock.calls[ 0 ][ 0 ];
+		expect( navigation.to ).toBe( '.' );
+		expect( navigation.search( { chats: true, session: 'session-1', existing: true } ) ).toEqual( {
+			chats: undefined,
+			session: undefined,
+			existing: true,
+		} );
+	} );
+} );
+
+function renderProvider( siteId?: string ) {
+	let placementListener: ( ( event: AiSessionPlacementUpdatedEvent ) => void ) | undefined;
+	const queryClient = new QueryClient( {
+		defaultOptions: {
+			queries: {
+				retry: false,
+			},
+		},
+	} );
+	const connector = {
+		onSessionPlacementUpdated: vi.fn( ( listener ) => {
+			placementListener = listener;
+			return vi.fn();
+		} ),
+		createSession: vi.fn(),
+	} as unknown as Connector;
+
+	render(
+		<QueryClientProvider client={ queryClient }>
+			<ConnectorProvider connector={ connector }>
+				<ChatsProvider siteId={ siteId }>
+					<SelectedSessionStatus />
+				</ChatsProvider>
+			</ConnectorProvider>
+		</QueryClientProvider>
+	);
+
+	return {
+		emitPlacement: ( event: AiSessionPlacementUpdatedEvent ) => {
+			if ( ! placementListener ) {
+				throw new Error( 'No placement listener registered.' );
+			}
+			act( () => {
+				placementListener?.( event );
+			} );
+		},
+	};
+}
+
+function SelectedSessionStatus() {
+	const { selectedSessionId } = useChats();
+	return <div data-testid="selected-session">{ selectedSessionId ?? 'none' }</div>;
+}
+
+function createPlacementEvent(): AiSessionPlacementUpdatedEvent {
+	return {
+		sessionId: 'session-1',
+		placement: {
+			kind: 'site',
+			siteId: 'site-2',
+			siteName: 'Created Site',
+			sitePath: '/sites/created-site',
+		},
+	};
+}

--- a/apps/ui/src/ui-desks/chats/provider.tsx
+++ b/apps/ui/src/ui-desks/chats/provider.tsx
@@ -1,7 +1,16 @@
 import { useNavigate, useSearch } from '@tanstack/react-router';
+import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useConnector } from '@/data/core';
 import { useCreateSession } from '@/data/queries/use-sessions';
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '../components';
 import {
 	ChatsContext,
 	type ChatPromptRequest,
@@ -12,6 +21,12 @@ import {
 } from './context';
 import { validateChatsSearch, type ChatsSearch } from './search';
 import type { DeskWidget } from '@/ui-desks/widgets/types';
+
+interface PendingPlacementSwitch {
+	sessionId: string;
+	siteId: string;
+	siteName: string;
+}
 
 function useChatsSearch() {
 	const search = validateChatsSearch( useSearch( { strict: false } ) as Record< string, unknown > );
@@ -63,6 +78,9 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 		ComposerWidgetDragPreview | undefined
 	>( undefined );
 	const [ isComposerWidgetDragTarget, setComposerWidgetDragTarget ] = useState( false );
+	const [ pendingPlacementSwitch, setPendingPlacementSwitch ] = useState<
+		PendingPlacementSwitch | undefined
+	>( undefined );
 
 	const setRouteSession = useCallback(
 		( sessionId: string | undefined ) => {
@@ -104,6 +122,21 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 		setAutoFocusSessionId( undefined );
 		setRouteSession( undefined );
 	}, [ setRouteSession ] );
+
+	const closeChatSidebar = useCallback( () => {
+		setSelectedSessionId( undefined );
+		setExpanded( false );
+		setAutoFocusSessionId( undefined );
+		setPendingPlacementSwitch( undefined );
+		void navigate( {
+			to: '.',
+			search: ( previous: ChatsSearch ) => ( {
+				...previous,
+				chats: undefined,
+				session: undefined,
+			} ),
+		} );
+	}, [ navigate ] );
 
 	const startNewChat = useCallback( async () => {
 		const session = await createSession.mutateAsync( siteId );
@@ -185,17 +218,45 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 			if ( event.placement.siteId === siteId ) {
 				return;
 			}
-			void navigate( {
-				to: '/sites/$siteId',
-				params: { siteId: event.placement.siteId },
-				search: ( previous: ChatsSearch ) => ( {
-					...previous,
-					chats: true,
-					session: event.sessionId,
-				} ),
+			setPendingPlacementSwitch( {
+				sessionId: event.sessionId,
+				siteId: event.placement.siteId,
+				siteName: event.placement.siteName,
 			} );
 		} );
-	}, [ connector, navigate, selectedSessionId, siteId ] );
+	}, [ connector, selectedSessionId, siteId ] );
+
+	useEffect( () => {
+		if ( pendingPlacementSwitch?.siteId === siteId ) {
+			setPendingPlacementSwitch( undefined );
+		}
+	}, [ pendingPlacementSwitch?.siteId, siteId ] );
+
+	useEffect( () => {
+		if (
+			pendingPlacementSwitch &&
+			selectedSessionId &&
+			pendingPlacementSwitch.sessionId !== selectedSessionId
+		) {
+			setPendingPlacementSwitch( undefined );
+		}
+	}, [ pendingPlacementSwitch, selectedSessionId ] );
+
+	const confirmPlacementSwitch = useCallback( () => {
+		if ( ! pendingPlacementSwitch ) {
+			return;
+		}
+		setPendingPlacementSwitch( undefined );
+		void navigate( {
+			to: '/sites/$siteId',
+			params: { siteId: pendingPlacementSwitch.siteId },
+			search: ( previous: ChatsSearch ) => ( {
+				...previous,
+				chats: true,
+				session: pendingPlacementSwitch.sessionId,
+			} ),
+		} );
+	}, [ navigate, pendingPlacementSwitch ] );
 
 	return (
 		<ChatsContext.Provider
@@ -223,6 +284,45 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 			} }
 		>
 			{ children }
+			{ pendingPlacementSwitch && (
+				<Dialog
+					ariaLabel={ __( 'Continue in the site desk?' ) }
+					onClose={ closeChatSidebar }
+					size="small"
+				>
+					<DialogHeader>
+						<DialogTitle>{ __( 'Continue in the site desk?' ) }</DialogTitle>
+					</DialogHeader>
+					<DialogContent>
+						<p>
+							{ pendingPlacementSwitch.siteName
+								? sprintf(
+										__(
+											'This chat is now connected to the site desk for %s. Switch desks to keep the conversation open, or stay here and close the chat sidebar.'
+										),
+										pendingPlacementSwitch.siteName
+								  )
+								: __(
+										'This chat is now connected to another site desk. Switch desks to keep the conversation open, or stay here and close the chat sidebar.'
+								  ) }
+						</p>
+					</DialogContent>
+					<DialogFooter>
+						<Button label={ __( 'Stay here' ) } onClick={ closeChatSidebar } variant="filled">
+							{ __( 'Stay here' ) }
+						</Button>
+						<Button
+							autoFocus
+							label={ __( 'Switch desks' ) }
+							onClick={ confirmPlacementSwitch }
+							tone="primary"
+							variant="filled"
+						>
+							{ __( 'Switch desks' ) }
+						</Button>
+					</DialogFooter>
+				</Dialog>
+			) }
 		</ChatsContext.Provider>
 	);
 }


### PR DESCRIPTION
## Summary
- Replaced the automatic desk switch with a confirmation dialog when an active chat session moves to another site desk.
- Added a “Stay here” path that closes the chat sidebar and clears the chat route state.
- Set initial focus to the primary “Switch desks” action so the dialog does not show a container focus ring.
- Added coverage for the switch, stay, and focus behavior in the chats provider test.

## Testing
- `npx eslint --fix apps/ui/src/ui-desks/chats/provider.tsx apps/ui/src/ui-desks/chats/provider.test.tsx`
- `npm test -- apps/ui/src/ui-desks/chats/provider.test.tsx`
- `npm run typecheck`