### PR TITLE
apps/ui: Hide the composer send button while an agent is running unless text is entered

### DIFF
--- a/apps/ui/src/ui-desks/chats/composer/index.test.tsx
+++ b/apps/ui/src/ui-desks/chats/composer/index.test.tsx
@@ -1,0 +1,154 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Composer } from './index';
+import type { ReactNode } from 'react';
+
+const composerMocks = vi.hoisted( () => ( {
+	onSend: vi.fn(),
+	onInterrupt: vi.fn(),
+	setQueryData: vi.fn(),
+	invalidateQueries: vi.fn(),
+	setSessionModel: vi.fn(),
+	createSession: vi.fn(),
+	consumeComposerWidgetAttachmentRequest: vi.fn(),
+} ) );
+
+vi.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+	sprintf: ( text: string, ...values: string[] ) =>
+		values.reduce(
+			( result, value, index ) =>
+				result.replace( `%${ index + 1 }$s`, value ).replace( '%s', value ),
+			text
+		),
+} ) );
+
+vi.mock( '@wordpress/icons', () => ( {
+	arrowUp: {},
+	chevronDownSmall: {},
+	closeSmall: {},
+	code: {},
+} ) );
+
+vi.mock( '@wordpress/ui', () => ( {
+	Icon: () => null,
+} ) );
+
+vi.mock( '@tanstack/react-query', () => ( {
+	useQueryClient: () => ( {
+		setQueryData: composerMocks.setQueryData,
+		invalidateQueries: composerMocks.invalidateQueries,
+	} ),
+} ) );
+
+vi.mock( '@/data/core', () => ( {
+	useConnector: () => ( {
+		setSessionModel: composerMocks.setSessionModel,
+		createSession: composerMocks.createSession,
+	} ),
+} ) );
+
+vi.mock( '@/ui-desks/chats/context', () => ( {
+	useChats: () => ( {
+		composerWidgetAttachmentRequest: undefined,
+		consumeComposerWidgetAttachmentRequest: composerMocks.consumeComposerWidgetAttachmentRequest,
+		isComposerWidgetDragTarget: false,
+	} ),
+} ) );
+
+vi.mock( '@/ui-desks/chats/widget-context', () => ( {
+	buildWidgetContextDisplayMessage: ( prompt: string ) => prompt,
+	buildWidgetContextPrompt: ( prompt: string ) => prompt,
+	getWidgetDisplayLabel: () => 'Widget',
+	MAX_VISIBLE_CHAT_WIDGETS: 3,
+	WidgetContextMoreThumbnail: () => null,
+	WidgetContextThumbnail: () => null,
+} ) );
+
+vi.mock( '@/ui-desks/components', async () => {
+	const React = await vi.importActual< typeof import('react') >( 'react' );
+	const passthrough = ( { children }: { children?: ReactNode } ) =>
+		React.createElement( React.Fragment, null, children );
+
+	return {
+		Button: ( {
+			children,
+			disabled,
+			label,
+			onClick,
+			type = 'button',
+			...props
+		}: {
+			children?: ReactNode;
+			disabled?: boolean;
+			label: string;
+			onClick?: () => void;
+			type?: 'button' | 'submit';
+		} ) =>
+			React.createElement(
+				'button',
+				{
+					...props,
+					'aria-label': label,
+					disabled,
+					onClick,
+					type,
+				},
+				children ?? label
+			),
+		Menu: {
+			Root: passthrough,
+			Trigger: ( { render }: { render: ReactNode } ) => render,
+			Popup: passthrough,
+			Item: ( { children, onClick }: { children?: ReactNode; onClick?: () => void } ) =>
+				React.createElement( 'button', { type: 'button', onClick }, children ),
+			RadioGroup: passthrough,
+			RadioItem: ( { children }: { children?: ReactNode } ) =>
+				React.createElement( 'div', null, children ),
+		},
+	};
+} );
+
+describe( 'desks chat Composer', () => {
+	beforeEach( () => {
+		composerMocks.onSend.mockReset().mockResolvedValue( undefined );
+		composerMocks.onInterrupt.mockReset().mockResolvedValue( undefined );
+		composerMocks.setQueryData.mockReset();
+		composerMocks.invalidateQueries.mockReset();
+		composerMocks.setSessionModel.mockReset().mockResolvedValue( undefined );
+		composerMocks.createSession.mockReset().mockResolvedValue( { id: 'new-session' } );
+		composerMocks.consumeComposerWidgetAttachmentRequest.mockReset();
+	} );
+
+	it( 'keeps the idle send button visible even when the prompt is empty', () => {
+		renderComposer( { busy: false } );
+
+		expect( screen.getByRole( 'button', { name: 'Send' } ) ).toBeDisabled();
+	} );
+
+	it( 'hides the queue button while busy until the user types a prompt', () => {
+		renderComposer( { busy: true } );
+
+		expect( screen.getByRole( 'button', { name: 'Stop' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Queue' } ) ).not.toBeInTheDocument();
+
+		fireEvent.change( screen.getByPlaceholderText( 'Ask Studio Desk…' ), {
+			target: { value: 'Follow up on this' },
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Queue' } ) ).toBeEnabled();
+	} );
+} );
+
+function renderComposer( { busy }: { busy: boolean } ) {
+	return render(
+		<Composer
+			busy={ busy }
+			error={ null }
+			model="claude-sonnet-4-6"
+			onSend={ composerMocks.onSend }
+			onInterrupt={ composerMocks.onInterrupt }
+		/>
+	);
+}

--- a/apps/ui/src/ui-desks/chats/composer/index.tsx
+++ b/apps/ui/src/ui-desks/chats/composer/index.tsx
@@ -247,6 +247,7 @@ export function Composer( {
 	}, [ connector, onSwitchSession, ownerSiteId, pendingFamilyChange, queryClient ] );
 
 	const canSend = value.trim().length > 0;
+	const showSendButton = ! busy || canSend;
 	const sendAriaLabel = busy ? __( 'Queue' ) : __( 'Send' );
 	const visibleContextWidgets = contextWidgets.slice( 0, MAX_VISIBLE_CHAT_WIDGETS );
 	const hiddenContextWidgetCount = contextWidgets.length - visibleContextWidgets.length;
@@ -411,16 +412,18 @@ export function Composer( {
 									<span className={ styles.stopGlyph } aria-hidden="true" />
 								</Button>
 							) : null }
-							<Button
-								type="submit"
-								tone="primary"
-								variant="filled"
-								size="small"
-								disabled={ ! canSend }
-								icon={ arrowUp }
-								label={ sendAriaLabel }
-								tooltipLabel={ false }
-							/>
+							{ showSendButton ? (
+								<Button
+									type="submit"
+									tone="primary"
+									variant="filled"
+									size="small"
+									disabled={ ! canSend }
+									icon={ arrowUp }
+									label={ sendAriaLabel }
+									tooltipLabel={ false }
+								/>
+							) : null }
 						</div>
 					</div>
 				</form>


### PR DESCRIPTION
## Summary
- Hide the desks composer submit button during an active agent run when the prompt is empty.
- Keep the button visible and switch it back to queue mode as soon as the user starts typing.
- Add focused composer tests for the idle and busy states.

## Testing
- `npx eslint --fix apps/ui/src/ui-desks/chats/composer/index.tsx apps/ui/src/ui-desks/chats/composer/index.test.tsx`
- `npm test -- apps/ui/src/ui-desks/chats/composer/index.test.tsx`
- `npm run typecheck`