### PR TITLE
apps/ui: Add a chat intent for primary buttons and reuse it across desks

### DIFF
--- a/apps/ui/src/ui-desks/chats/chat-button/index.tsx
+++ b/apps/ui/src/ui-desks/chats/chat-button/index.tsx
@@ -10,6 +10,7 @@ export function ChatButton( { onClick }: ChatButtonProps ) {
 	return (
 		<Button
 			icon={ comment }
+			intent="chat"
 			label={ __( 'Chat about selection' ) }
 			size="medium"
 			tone="primary"

--- a/apps/ui/src/ui-desks/chats/composer/index.tsx
+++ b/apps/ui/src/ui-desks/chats/composer/index.tsx
@@ -415,6 +415,7 @@ export function Composer( {
 							{ showSendButton ? (
 								<Button
 									type="submit"
+									intent="chat"
 									tone="primary"
 									variant="filled"
 									size="small"

--- a/apps/ui/src/ui-desks/chats/selection-chat-dialog/index.tsx
+++ b/apps/ui/src/ui-desks/chats/selection-chat-dialog/index.tsx
@@ -79,6 +79,7 @@ export function SelectionChatDialog( { widgets, onClose }: SelectionChatDialogPr
 				/>
 				<Button
 					icon={ arrowUp }
+					intent="chat"
 					label={ isCreatingChat ? __( 'Creating chat' ) : __( 'Send' ) }
 					disabled={ ! canSubmit }
 					aria-busy={ isCreatingChat }

--- a/apps/ui/src/ui-desks/components/button/index.tsx
+++ b/apps/ui/src/ui-desks/components/button/index.tsx
@@ -7,6 +7,7 @@ import type { ComponentProps, ComponentPropsWithoutRef, ReactNode } from 'react'
 type ButtonVariant = 'chrome' | 'quiet' | 'filled';
 type ButtonTone = 'neutral' | 'primary' | 'inverse';
 type ButtonSize = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge';
+type ButtonIntent = 'default' | 'chat';
 
 const ICON_SIZE_BY_BUTTON_SIZE: Record< ButtonSize, number > = {
 	xsmall: 16,
@@ -19,6 +20,7 @@ const ICON_SIZE_BY_BUTTON_SIZE: Record< ButtonSize, number > = {
 type ButtonProps = Omit< ComponentPropsWithoutRef< 'button' >, 'children' > & {
 	children?: ReactNode;
 	icon?: ComponentProps< typeof Icon >[ 'icon' ];
+	intent?: ButtonIntent;
 	label: string;
 	size?: ButtonSize;
 	tone?: ButtonTone;
@@ -33,6 +35,7 @@ export const Button = forwardRef< HTMLButtonElement, ButtonProps >( function But
 		className,
 		disabled,
 		icon,
+		intent = 'default',
 		label,
 		size = 'large',
 		tone = 'neutral',
@@ -51,6 +54,7 @@ export const Button = forwardRef< HTMLButtonElement, ButtonProps >( function But
 		styles[ variant ],
 		styles[ size ],
 		tone !== 'neutral' && styles[ tone ],
+		intent !== 'default' && styles[ `${ intent }Intent` ],
 		className
 	);
 	const resolvedTooltipSide = tooltipSide ?? ( variant === 'quiet' ? 'top' : 'bottom' );

--- a/apps/ui/src/ui-desks/components/button/style.module.css
+++ b/apps/ui/src/ui-desks/components/button/style.module.css
@@ -198,11 +198,11 @@
 	--button-background: #000;
 }
 
-.filled.primary[data-icon-only='true'] {
+.filled.primary.chatIntent {
 	box-shadow: 0 6px 18px rgba(56, 88, 233, 0.45);
 }
 
-.filled.primary[data-icon-only='true']:hover:not(:disabled) {
+.filled.primary.chatIntent:hover:not(:disabled) {
 	--button-background: #3858e9;
 	box-shadow: 0 8px 22px rgba(56, 88, 233, 0.55);
 	transform: translateY(-1px);

--- a/apps/ui/src/ui-desks/design-system.md
+++ b/apps/ui/src/ui-desks/design-system.md
@@ -29,6 +29,8 @@ Use variants by intent:
 
 Prefer `tone` when the action needs a semantic color treatment instead of overriding button colors locally. Use `tone="primary"` for brand-colored primary actions and `tone="inverse"` for strong black/white actions.
 
+Use `intent="chat"` for primary actions that start, submit, or hand work to chat or the agent. The chat intent adds the shared blue glow only when combined with `variant="filled"` and `tone="primary"`.
+
 Local button classes are acceptable for layout constraints such as width, positioning, or contextual spacing. Avoid local classes that recreate button states, icon sizing, hover treatment, or disabled treatment. If the same visual override appears in multiple places, add a Button variant or a small shared wrapper instead.
 
 Raw `<button>` elements are acceptable for primitives that are not normal visible buttons, such as invisible backdrops, internal list/menu item primitives, or custom card-like controls that need their own component abstraction.

--- a/apps/ui/src/ui-desks/widgets/scratchpad/component/index.tsx
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/component/index.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, type KeyboardEvent, type PointerEvent }
 import { useEditor } from 'tldraw';
 import { useConnector } from '@/data/core';
 import { useChats } from '@/ui-desks/chats/context';
+import { Button } from '@/ui-desks/components';
 import { focusOnDeskShape, useIncomingWidgetConnections } from '@/ui-desks/connectors/context';
 import {
 	getMediaDropPreviewPayload,
@@ -276,18 +277,25 @@ export function ScratchpadWidgetComponent( {
 					) }
 				</div>
 				{ activeAgentStatus && (
-					<button
-						type="button"
-						className={ styles.statusButton }
+					<Button
+						icon={ SCRATCHPAD_STATUS_ICON[ activeAgentStatus ] }
+						intent={ activeAgentStatus === 'done' ? 'default' : 'chat' }
+						label={ SCRATCHPAD_STATUS_LABEL[ activeAgentStatus ] }
+						variant="filled"
+						tone={ activeAgentStatus === 'done' ? 'neutral' : 'primary' }
+						size="medium"
+						className={
+							activeAgentStatus === 'done'
+								? `${ styles.agentButton } ${ styles.agentButtonDone }`
+								: styles.agentButton
+						}
 						data-status={ activeAgentStatus }
-						disabled={ activeAgentStatus === 'running' || activeAgentStatus === 'done' }
-						aria-label={ SCRATCHPAD_STATUS_LABEL[ activeAgentStatus ] }
+						disabled={ activeAgentStatus !== 'pending' }
+						tooltipLabel={ false }
 						title={ SCRATCHPAD_STATUS_LABEL[ activeAgentStatus ] }
 						onClick={ handleRunAgent }
 						onPointerDown={ ( event ) => event.stopPropagation() }
-					>
-						<Icon icon={ SCRATCHPAD_STATUS_ICON[ activeAgentStatus ] } size={ 20 } />
-					</button>
+					/>
 				) }
 			</div>
 			{ ! isInteractive && <div className={ styles.shield } aria-hidden="true" /> }

--- a/apps/ui/src/ui-desks/widgets/scratchpad/component/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/component/style.module.css
@@ -165,48 +165,23 @@
 	pointer-events: none;
 }
 
-.statusButton {
+.agentButton {
 	flex: 0 0 auto;
-	width: 36px;
-	height: 36px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	padding: 0;
-	border: 0;
-	border-radius: 50%;
-	background: #3858e9;
-	color: #fff;
-	box-shadow: 0 6px 18px rgba(56, 88, 233, 0.45);
-	cursor: pointer;
-	transition:
-		background 160ms ease,
-		box-shadow 160ms ease,
-		transform 160ms ease;
 }
 
-.statusButton:hover:not(:disabled),
-.statusButton:focus-visible:not(:disabled) {
-	transform: translateY(-1px);
-	box-shadow: 0 8px 22px rgba(56, 88, 233, 0.55);
+.scratchpad .agentButton:disabled {
+	opacity: 1;
 }
 
-.statusButton:disabled {
-	cursor: default;
-}
-
-.statusButton[data-status='done'] {
-	background: #16a34a;
+.agentButton.agentButtonDone {
+	--button-background: #16a34a;
+	--button-foreground: #fff;
 	box-shadow: 0 6px 18px rgba(22, 163, 74, 0.45);
 }
 
-.statusButton[data-status='running'] svg {
+.agentButton[data-status='running'] svg {
 	animation: scratchpad-cog-spin 1.4s linear infinite;
 	transform-origin: 50% 50%;
-}
-
-.statusButton svg {
-	fill: currentColor;
 }
 
 @keyframes scratchpad-cog-spin {

--- a/apps/ui/src/ui-desks/widgets/site-preview/annotations/comment-dialog/index.tsx
+++ b/apps/ui/src/ui-desks/widgets/site-preview/annotations/comment-dialog/index.tsx
@@ -70,6 +70,7 @@ export function AnnotationCommentDialog( {
 				/>
 				<Button
 					type="submit"
+					intent="chat"
 					label={ __( 'Add annotation' ) }
 					variant="filled"
 					tone="primary"

--- a/apps/ui/src/ui-desks/widgets/site-preview/annotations/toolbar.tsx
+++ b/apps/ui/src/ui-desks/widgets/site-preview/annotations/toolbar.tsx
@@ -109,6 +109,7 @@ export function SitePreviewAnnotationSubmitControl(
 		<>
 			<Divider />
 			<Button
+				intent="chat"
 				label={ sprintf(
 					_n( 'Submit %d change', 'Submit %d changes', annotationCount ),
 					annotationCount


### PR DESCRIPTION
## Summary
- Added `intent="chat"` to the shared desks `Button` so the blue glow is driven by a semantic intent instead of local CSS.
- Applied the new intent to the chat, annotate, and scratchpad actions that represent chat/agent submission.
- Replaced the scratchpad’s custom primary button styling with the shared button and removed the duplicated blue-shadow rules.
- Documented the new intent in the desks design system.

## Testing
- `eslint --fix` ran on the modified files; CSS and Markdown were ignored by the ESLint config as expected.
- `npm run typecheck` passed.
- `npm test -- apps/ui/src/ui-desks/widgets/scratchpad/component/index.test.tsx` passed.