### PR TITLE
apps/ui: Match desks chat loading behavior to TUI

### DIFF
--- a/apps/ui/src/ui-desks/chats/conversation/index.tsx
+++ b/apps/ui/src/ui-desks/chats/conversation/index.tsx
@@ -198,6 +198,16 @@ function findLatestProgressMessage( entries: SessionEntry[] ): string | null {
 	return null;
 }
 
+function findLatestToolUseKey( items: RenderItem[] ): string | null {
+	for ( let i = items.length - 1; i >= 0; i -= 1 ) {
+		const item = items[ i ];
+		if ( item.kind === 'tool-use' ) {
+			return item.key;
+		}
+	}
+	return null;
+}
+
 function UserMessage( { text }: { text: string } ) {
 	return (
 		<div className={ clsx( styles.messageGroup, styles.userGroup ) }>
@@ -734,6 +744,7 @@ export function Conversation( {
 		() => ( isRunning ? findLatestProgressMessage( entries ) : null ),
 		[ entries, isRunning ]
 	);
+	const thinkingMessageKey = useMemo( () => findLatestToolUseKey( items ), [ items ] );
 
 	return (
 		<div className={ styles.root }>
@@ -779,6 +790,7 @@ export function Conversation( {
 				<ThinkingIndicator
 					active={ isRunning && pendingQuestions.size === 0 }
 					startedAt={ startedAt }
+					messageKey={ thinkingMessageKey }
 					progressMessage={ progressMessage }
 				/>
 			</div>

--- a/apps/ui/src/ui-desks/chats/thinking-indicator/index.test.tsx
+++ b/apps/ui/src/ui-desks/chats/thinking-indicator/index.test.tsx
@@ -1,0 +1,75 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ThinkingIndicator } from './index';
+
+const thinkingMocks = vi.hoisted( () => ( {
+	randomThinkingMessage: vi.fn(),
+} ) );
+
+vi.mock( '@studio/common/ai/thinking-messages', () => ( {
+	randomThinkingMessage: thinkingMocks.randomThinkingMessage,
+} ) );
+
+describe( 'desks ThinkingIndicator', () => {
+	beforeEach( () => {
+		vi.useFakeTimers();
+		vi.setSystemTime( new Date( '2026-01-01T00:00:00Z' ) );
+		thinkingMocks.randomThinkingMessage.mockReset();
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+	} );
+
+	it( 'keeps the same thinking message while elapsed time updates', () => {
+		thinkingMocks.randomThinkingMessage.mockReturnValueOnce( 'Thinking once' );
+		thinkingMocks.randomThinkingMessage.mockReturnValue( 'Rotated message' );
+
+		render(
+			<ThinkingIndicator
+				active
+				startedAt={ Date.now() }
+				messageKey={ null }
+				progressMessage={ null }
+			/>
+		);
+
+		expect( screen.getByText( 'Thinking once' ) ).toBeVisible();
+
+		act( () => {
+			vi.advanceTimersByTime( 4000 );
+		} );
+
+		expect( screen.getByText( 'Thinking once' ) ).toBeVisible();
+		expect( screen.queryByText( 'Rotated message' ) ).not.toBeInTheDocument();
+		expect( thinkingMocks.randomThinkingMessage ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'refreshes the thinking message when the active run step changes', () => {
+		thinkingMocks.randomThinkingMessage
+			.mockReturnValueOnce( 'Initial thinking' )
+			.mockReturnValueOnce( 'Tool thinking' );
+		const startedAt = Date.now();
+
+		const { rerender } = render(
+			<ThinkingIndicator
+				active
+				startedAt={ startedAt }
+				messageKey={ null }
+				progressMessage={ null }
+			/>
+		);
+
+		rerender(
+			<ThinkingIndicator
+				active
+				startedAt={ startedAt }
+				messageKey="tool-call-1"
+				progressMessage={ null }
+			/>
+		);
+
+		expect( screen.getByText( 'Tool thinking' ) ).toBeVisible();
+		expect( thinkingMocks.randomThinkingMessage ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/apps/ui/src/ui-desks/chats/thinking-indicator/index.tsx
+++ b/apps/ui/src/ui-desks/chats/thinking-indicator/index.tsx
@@ -1,36 +1,43 @@
 import { randomThinkingMessage } from '@studio/common/ai/thinking-messages';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styles from './style.module.css';
 
 export function ThinkingIndicator( {
 	active,
 	startedAt,
+	messageKey,
 	progressMessage,
 }: {
 	active: boolean;
 	startedAt: number | null;
+	messageKey?: string | null;
 	progressMessage: string | null;
 } ) {
-	const [ message, setMessage ] = useState( () => randomThinkingMessage() );
+	const rotationKey = active && startedAt !== null ? `${ startedAt }:${ messageKey ?? '' }` : null;
+	const [ message, setMessage ] = useState( () =>
+		rotationKey === null ? '' : randomThinkingMessage()
+	);
 	const [ elapsedSeconds, setElapsedSeconds ] = useState( 0 );
+	const previousRotationKey = useRef( rotationKey );
 
 	useEffect( () => {
-		if ( ! active || startedAt === null ) {
+		if ( rotationKey === null || startedAt === null ) {
+			previousRotationKey.current = rotationKey;
+			setElapsedSeconds( 0 );
 			return;
 		}
-		setMessage( randomThinkingMessage() );
-		setElapsedSeconds( Math.floor( ( Date.now() - startedAt ) / 1000 ) );
-		const labelInterval = window.setInterval( () => {
+		if ( previousRotationKey.current !== rotationKey ) {
+			previousRotationKey.current = rotationKey;
 			setMessage( randomThinkingMessage() );
-		}, 4000 );
+		}
+		setElapsedSeconds( Math.floor( ( Date.now() - startedAt ) / 1000 ) );
 		const tickInterval = window.setInterval( () => {
 			setElapsedSeconds( Math.floor( ( Date.now() - startedAt ) / 1000 ) );
 		}, 1000 );
 		return () => {
-			window.clearInterval( labelInterval );
 			window.clearInterval( tickInterval );
 		};
-	}, [ active, startedAt ] );
+	}, [ rotationKey, startedAt ] );
 
 	return (
 		<div className={ styles.root } role="status" aria-live="polite">


### PR DESCRIPTION
## Summary
- Stop the desks-ui thinking label from rotating on a timer.
- Refresh the random thinking copy only when the active run step changes, which matches the TUI behavior.
- Add coverage for stable label timing and label refresh on step changes.

## Testing
- `npx eslint --fix` on the modified files.
- `npm test -- apps/ui/src/ui-desks/chats/thinking-indicator/index.test.tsx apps/ui/src/ui-desks/chats/conversation/index.test.ts`
- `npm run typecheck`