### PR TITLE
apps/ui: Ignore multi-selected stack drags in connector handling

### DIFF
--- a/apps/ui/src/ui-desks/connectors/use-connector-interactions.ts
+++ b/apps/ui/src/ui-desks/connectors/use-connector-interactions.ts
@@ -14,6 +14,7 @@ import {
 	getConnectableShapeAtPagePoint,
 	getWidgetDropTargetAtPagePoint,
 	getWidgetShapeAtPagePoint,
+	isShapePartOfMultiSelection,
 } from './utils';
 import type {
 	ActiveWidgetDropFeedback,
@@ -379,7 +380,7 @@ export function useConnectorInteractions( {
 				const shape = getWidgetShapeAtPagePoint( editor, editor.inputs.currentPagePoint );
 				const widget = shape ? canvasShapeToDeskWidget( shape ) : null;
 				source =
-					widget && shape
+					widget && shape && ! isShapePartOfMultiSelection( editor, shape.id )
 						? {
 								shapeId: shape.id,
 								widget,
@@ -399,6 +400,11 @@ export function useConnectorInteractions( {
 			}
 
 			if ( ! source ) {
+				return;
+			}
+
+			if ( isShapePartOfMultiSelection( editor, source.shapeId ) ) {
+				cleanup();
 				return;
 			}
 

--- a/apps/ui/src/ui-desks/connectors/utils.test.ts
+++ b/apps/ui/src/ui-desks/connectors/utils.test.ts
@@ -8,8 +8,10 @@ import {
 	getDeskWidgetConnectionPillBg,
 	getDeskWidgetConnectionTitle,
 } from './context';
+import { isShapePartOfMultiSelection } from './utils';
 import type { DeskConfig } from '@/ui-desks/desk/types';
 import type { DeskWidget } from '@/ui-desks/widgets/types';
+import type { Editor, TLShapeId } from 'tldraw';
 
 vi.mock( '@wordpress/core-data', () => ( {
 	store: {},
@@ -66,6 +68,27 @@ describe( 'desk connections', () => {
 			source,
 		] );
 	} );
+
+	it( 'detects when a connector drag source is part of a multi-selection', () => {
+		const sourceShapeId = 'shape:source-note' as TLShapeId;
+		const otherShapeId = 'shape:other-note' as TLShapeId;
+
+		expect(
+			isShapePartOfMultiSelection(
+				createEditorSelection( [ sourceShapeId, otherShapeId ] ),
+				sourceShapeId
+			)
+		).toBe( true );
+		expect(
+			isShapePartOfMultiSelection( createEditorSelection( [ sourceShapeId ] ), sourceShapeId )
+		).toBe( false );
+		expect(
+			isShapePartOfMultiSelection(
+				createEditorSelection( [ otherShapeId, 'shape:third-note' as TLShapeId ] ),
+				sourceShapeId
+			)
+		).toBe( false );
+	} );
 } );
 
 function createNoteWidget( text: string, tone: NoteTone = 'yellow' ): DeskWidget {
@@ -101,5 +124,13 @@ function createSiteCardWidget(): DeskWidget {
 			siteId: 'site-1',
 			previewVisible: false,
 		},
+	};
+}
+
+function createEditorSelection(
+	selectedShapeIds: TLShapeId[]
+): Pick< Editor, 'getSelectedShapeIds' > {
+	return {
+		getSelectedShapeIds: () => selectedShapeIds,
 	};
 }

--- a/apps/ui/src/ui-desks/connectors/utils.ts
+++ b/apps/ui/src/ui-desks/connectors/utils.ts
@@ -104,6 +104,14 @@ export function getWidgetShapeAtPagePoint( editor: Editor, point: { x: number; y
 	} ) as TLShape | undefined;
 }
 
+export function isShapePartOfMultiSelection(
+	editor: Pick< Editor, 'getSelectedShapeIds' >,
+	shapeId: TLShapeId
+) {
+	const selectedShapeIds = editor.getSelectedShapeIds();
+	return selectedShapeIds.length > 1 && selectedShapeIds.includes( shapeId );
+}
+
 export function getConnectableShapeAtPagePoint(
 	editor: Editor,
 	point: { x: number; y: number },


### PR DESCRIPTION
## Summary
- Prevent connector/drop logic from treating multi-selected stack drags as single-widget connection gestures.
- Add a small utility to detect whether the active shape is part of a multi-selection.
- Cover the new selection check with a focused unit test.

## Testing
- `npx eslint --fix` on the touched UI files
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-desks/connectors/utils.test.ts`
- `git diff --check`