### PR TITLE
apps/ui: Refine chat archive button alignment in the sidebar

### DIFF
--- a/apps/ui/src/ui-desks/chats/panel/index.tsx
+++ b/apps/ui/src/ui-desks/chats/panel/index.tsx
@@ -1,11 +1,13 @@
 import { Dialog } from '@base-ui/react/dialog';
 import { createDefaultDeskSettings } from '@studio/common/lib/desk-settings';
 import { __ } from '@wordpress/i18n';
+import { box, buttons, formatListBullets, plus } from '@wordpress/icons';
+import { Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import motionStyles from '@/components/floating-surface-motion/style.module.css';
 import { useDeskSettings } from '@/data/queries/use-desk-config';
-import { useSessions } from '@/data/queries/use-sessions';
+import { useSessions, useUpdateSessionMetadata } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { useFullscreen } from '@/hooks/use-fullscreen';
 import { ChatsButton } from '@/ui-desks/chrome/chats-button';
@@ -13,7 +15,7 @@ import {
 	getDeskToolbarButtonSide,
 	normalizeDeskToolbarSettings,
 } from '@/ui-desks/chrome/toolbar-layout';
-import { Button, List, ListItem } from '@/ui-desks/components';
+import { Button } from '@/ui-desks/components';
 import { useChats } from '../context';
 import { SessionSurface } from '../session-surface';
 import { useChatPanelResize } from '../use-chat-panel-resize';
@@ -26,12 +28,115 @@ interface ChatsProps {
 	siteId?: string;
 }
 
+const COMPACT_STORAGE_KEY = 'ui-desks-chat-list-compact';
+
+function readStoredCompactPreference() {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+
+	return window.localStorage.getItem( COMPACT_STORAGE_KEY ) === '1';
+}
+
+function persistCompactPreference( compact: boolean ) {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	window.localStorage.setItem( COMPACT_STORAGE_KEY, compact ? '1' : '0' );
+}
+
 function getSessionTitle( session: AiSessionSummary ) {
 	return session.firstPrompt?.trim() || __( 'New chat' );
 }
 
 function getSessionSubtitle( session: AiSessionSummary ) {
 	return session.assistantReplyPreview ?? __( 'Ask Studio anything to get started.' );
+}
+
+function formatSessionTimeSince( value: string ) {
+	const timestamp = Date.parse( value );
+	if ( Number.isNaN( timestamp ) ) {
+		return '';
+	}
+
+	const seconds = Math.max( 0, Math.floor( ( Date.now() - timestamp ) / 1000 ) );
+	if ( seconds < 60 ) {
+		return __( 'now' );
+	}
+
+	const minutes = Math.floor( seconds / 60 );
+	if ( minutes < 60 ) {
+		return `${ minutes }m`;
+	}
+
+	const hours = Math.floor( minutes / 60 );
+	if ( hours < 24 ) {
+		return `${ hours }h`;
+	}
+
+	const days = Math.floor( hours / 24 );
+	if ( days < 7 ) {
+		return `${ days }d`;
+	}
+
+	const weeks = Math.floor( days / 7 );
+	if ( weeks < 4 ) {
+		return `${ weeks }w`;
+	}
+
+	const months = Math.floor( days / 30 );
+	if ( months < 12 ) {
+		return `${ months }mo`;
+	}
+
+	return `${ Math.floor( days / 365 ) }y`;
+}
+
+function ChatSessionRow( {
+	session,
+	active,
+	metadataPending,
+	onSelect,
+	onArchiveChange,
+}: {
+	session: AiSessionSummary;
+	active: boolean;
+	metadataPending: boolean;
+	onSelect: ( sessionId: string ) => void;
+	onArchiveChange: ( session: AiSessionSummary, archived: boolean ) => void;
+} ) {
+	const archived = !! session.archived;
+
+	return (
+		<div className={ styles.sessionItem } data-active={ active ? 'true' : 'false' }>
+			<button
+				type="button"
+				className={ styles.sessionSelectButton }
+				onClick={ () => onSelect( session.id ) }
+			>
+				<span className={ styles.sessionItemRow }>
+					<span className={ styles.sessionItemTitle }>{ getSessionTitle( session ) }</span>
+					<span className={ styles.sessionItemMeta }>
+						<span className={ styles.sessionItemTime }>
+							{ formatSessionTimeSince( session.updatedAt || session.createdAt ) }
+						</span>
+					</span>
+				</span>
+				<span className={ styles.sessionItemPreview }>{ getSessionSubtitle( session ) }</span>
+			</button>
+			<button
+				type="button"
+				className={ styles.sessionItemArchive }
+				aria-label={ archived ? __( 'Unarchive conversation' ) : __( 'Archive conversation' ) }
+				title={ archived ? __( 'Unarchive' ) : __( 'Archive' ) }
+				disabled={ metadataPending }
+				onClick={ () => onArchiveChange( session, ! archived ) }
+			>
+				<Icon icon={ box } size={ 16 } />
+			</button>
+		</div>
+	);
 }
 
 export function ChatsTrigger() {
@@ -60,6 +165,7 @@ export function Chats( { siteId }: ChatsProps ) {
 	const { data: sessions, isFetching: isFetchingSessions } = useSessions();
 	const { data: sites } = useSites();
 	const isFullscreen = useFullscreen();
+	const updateSessionMetadata = useUpdateSessionMetadata();
 	const fallbackDeskSettings = useMemo( () => createDefaultDeskSettings(), [] );
 	const deskSettings = useMemo(
 		() => normalizeDeskToolbarSettings( savedDeskSettings ?? fallbackDeskSettings ),
@@ -68,17 +174,24 @@ export function Chats( { siteId }: ChatsProps ) {
 	const side = getDeskToolbarButtonSide( deskSettings.toolbarLayout, 'chat' );
 	const { width, isResizing, listCollapsed, collapseList, expandList, startResize } =
 		useChatPanelResize( side );
+	const [ compact, setCompact ] = useState( readStoredCompactPreference );
+	const [ archivedOpen, setArchivedOpen ] = useState( false );
 	const site = siteId ? sites?.find( ( candidate ) => candidate.id === siteId ) : undefined;
-	const filteredSessions = siteId
+	const scopedSessions = siteId
 		? site?.path
-			? ( sessions ?? [] ).filter(
-					( session ) => session.ownerSitePath === site.path && ! session.archived
-			  )
+			? ( sessions ?? [] ).filter( ( session ) => session.ownerSitePath === site.path )
 			: []
-		: ( sessions ?? [] ).filter( ( session ) => ! session.ownerSitePath && ! session.archived );
-	const chatSessions = [ ...filteredSessions ].sort(
+		: ( sessions ?? [] ).filter( ( session ) => ! session.ownerSitePath );
+	const chatSessions = [ ...scopedSessions ].sort(
 		( a, b ) => Date.parse( b.updatedAt ) - Date.parse( a.updatedAt )
 	);
+	const starredSessions = chatSessions.filter(
+		( session ) => session.starred && ! session.archived
+	);
+	const regularSessions = chatSessions.filter(
+		( session ) => ! session.starred && ! session.archived
+	);
+	const archivedSessions = chatSessions.filter( ( session ) => session.archived );
 	const selectedSession =
 		chatSessions.find( ( session ) => session.id === selectedSessionId ) ??
 		( sessions ?? [] ).find( ( session ) => session.id === selectedSessionId );
@@ -89,6 +202,20 @@ export function Chats( { siteId }: ChatsProps ) {
 			clearSelection();
 		}
 	}, [ clearSelection, isFetchingSessions, selectedSession, selectedSessionId, sessions ] );
+
+	useEffect( () => {
+		persistCompactPreference( compact );
+	}, [ compact ] );
+
+	const updateSessionArchived = ( session: AiSessionSummary, archived: boolean ) => {
+		void updateSessionMetadata.mutateAsync( {
+			sessionId: session.id,
+			patch: {
+				archived,
+				starred: session.starred,
+			},
+		} );
+	};
 
 	return (
 		<Dialog.Root open={ open } onOpenChange={ setOpen } modal={ false } disablePointerDismissal>
@@ -117,25 +244,95 @@ export function Chats( { siteId }: ChatsProps ) {
 					aria-label={ __( 'Conversations' ) }
 				>
 					{ ! isListCollapsed ? (
-						<div className={ styles.listPane }>
+						<div
+							className={ styles.listPane }
+							data-compact={ compact ? 'true' : 'false' }
+							data-archived-open={ archivedOpen ? 'true' : 'false' }
+						>
 							<header className={ styles.header }>
 								<h2>{ __( 'Conversations' ) }</h2>
+								<div className={ styles.headerActions }>
+									<Button
+										variant="quiet"
+										size="small"
+										className={ styles.headerAction }
+										data-active={ compact ? 'true' : 'false' }
+										aria-pressed={ compact }
+										icon={ compact ? buttons : formatListBullets }
+										label={ compact ? __( 'Expand list' ) : __( 'Compact list' ) }
+										onClick={ () => setCompact( ( current ) => ! current ) }
+									/>
+									<Button
+										variant="quiet"
+										size="small"
+										className={ styles.headerAction }
+										icon={ plus }
+										label={ __( 'New chat' ) }
+										disabled={ isCreatingChat }
+										aria-busy={ isCreatingChat }
+										onClick={ () => void startNewChat() }
+									/>
+								</div>
 							</header>
-							<List className={ styles.list }>
-								{ chatSessions.length > 0 ? (
-									chatSessions.map( ( session ) => (
-										<ListItem
+							<div className={ styles.list }>
+								{ starredSessions.length > 0 ? (
+									<section className={ styles.sessionSection } data-kind="starred">
+										<div className={ styles.sessionSectionLabel }>{ __( 'Starred' ) }</div>
+										{ starredSessions.map( ( session ) => (
+											<ChatSessionRow
+												key={ session.id }
+												session={ session }
+												active={ session.id === selectedSessionId }
+												metadataPending={ updateSessionMetadata.isPending }
+												onSelect={ selectSession }
+												onArchiveChange={ updateSessionArchived }
+											/>
+										) ) }
+									</section>
+								) : null }
+								<section className={ styles.sessionSection } data-kind="regular">
+									{ regularSessions.map( ( session ) => (
+										<ChatSessionRow
 											key={ session.id }
+											session={ session }
 											active={ session.id === selectedSessionId }
-											label={ getSessionTitle( session ) }
-											description={ getSessionSubtitle( session ) }
-											onClick={ () => selectSession( session.id ) }
+											metadataPending={ updateSessionMetadata.isPending }
+											onSelect={ selectSession }
+											onArchiveChange={ updateSessionArchived }
 										/>
-									) )
-								) : (
-									<div className={ styles.emptyList }>{ __( 'No conversations yet.' ) }</div>
-								) }
-							</List>
+									) ) }
+									{ starredSessions.length === 0 && regularSessions.length === 0 ? (
+										<div className={ styles.emptyList }>{ __( 'No conversations yet.' ) }</div>
+									) : null }
+								</section>
+							</div>
+							{ archivedSessions.length > 0 ? (
+								<div className={ styles.archived } data-open={ archivedOpen ? 'true' : 'false' }>
+									<button
+										type="button"
+										className={ styles.archivedToggle }
+										aria-expanded={ archivedOpen }
+										onClick={ () => setArchivedOpen( ( current ) => ! current ) }
+									>
+										<span>{ __( 'Archived' ) }</span>
+										<span className={ styles.archivedCount }>{ archivedSessions.length }</span>
+									</button>
+									{ archivedOpen ? (
+										<div className={ styles.archivedList }>
+											{ archivedSessions.map( ( session ) => (
+												<ChatSessionRow
+													key={ session.id }
+													session={ session }
+													active={ session.id === selectedSessionId }
+													metadataPending={ updateSessionMetadata.isPending }
+													onSelect={ selectSession }
+													onArchiveChange={ updateSessionArchived }
+												/>
+											) ) }
+										</div>
+									) : null }
+								</div>
+							) : null }
 							<footer className={ styles.footer }>
 								<Button
 									className={ styles.newChatButton }

--- a/apps/ui/src/ui-desks/chats/panel/style.module.css
+++ b/apps/ui/src/ui-desks/chats/panel/style.module.css
@@ -99,6 +99,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	gap: 12px;
 	padding: 16px 24px 12px;
 	color: var(--ui-desks-text, #14171a);
 }
@@ -111,17 +112,280 @@
 	letter-spacing: 0;
 }
 
+.headerActions {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	flex: 0 0 auto;
+}
+
+.headerAction {
+	color: var(--ui-desks-muted, #6b7280);
+}
+
+.headerAction[data-active='true'] {
+	color: var(--ui-desks-text, #14171a);
+	background: var(--ui-desks-control-hover, rgba(15, 23, 42, 0.07));
+}
+
 .list {
 	flex: 1;
 	min-height: 0;
 	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	padding: 8px 12px;
+	scrollbar-gutter: stable;
 }
 
 .emptyList {
-	padding: 12px 0;
+	padding: 20px 12px;
 	color: var(--ui-desks-muted, #6b7280);
 	font-size: 13px;
 	line-height: 18px;
+}
+
+.sessionSection {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.sessionSection + .sessionSection {
+	margin-top: 12px;
+}
+
+.sessionSectionLabel {
+	padding: 6px 12px 4px;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 11px;
+	line-height: 14px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+}
+
+.sessionItem {
+	position: relative;
+	min-width: 0;
+	color: var(--ui-desks-text, #14171a);
+}
+
+.sessionSelectButton {
+	--session-item-background: transparent;
+	--wp-ui-button-background-color: var(--session-item-background);
+	--wp-ui-button-background-color-active: var(--session-item-background);
+	--wp-ui-button-border-color: transparent;
+	--wp-ui-button-border-color-active: transparent;
+
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 10px 12px;
+	border: 0;
+	border-radius: var(--ui-desks-radius-button, 12px);
+	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	background: var(--session-item-background);
+	color: inherit;
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+	-webkit-app-region: no-drag;
+}
+
+.sessionSelectButton:hover,
+.sessionSelectButton:focus-visible {
+	--session-item-background: rgba(15, 23, 42, 0.04);
+	outline: none;
+}
+
+.sessionSelectButton:focus:not(:focus-visible) {
+	outline: none;
+	background-color: var(--session-item-background);
+	border-color: transparent;
+}
+
+.sessionItem[data-active='true'] .sessionSelectButton {
+	--session-item-background: var(--ui-desks-control-hover, rgba(15, 23, 42, 0.07));
+}
+
+.sessionItemRow {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.sessionItemTitle,
+.sessionItemPreview {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.sessionItemTitle {
+	flex: 1;
+	font-size: 13px;
+	line-height: 18px;
+	font-weight: 500;
+}
+
+.sessionItemPreview {
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 12px;
+	line-height: 16px;
+}
+
+.sessionItemMeta {
+	flex: 0 0 auto;
+	display: inline-flex;
+	justify-content: flex-end;
+	min-width: 22px;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 11px;
+	line-height: 16px;
+	font-feature-settings: 'tnum' 1;
+}
+
+.sessionItemTime {
+	transition: opacity 120ms ease;
+}
+
+.sessionItem:hover .sessionItemTime,
+.sessionItem:focus-within .sessionItemTime {
+	opacity: 0;
+}
+
+.sessionItemArchive {
+	position: absolute;
+	top: 7px;
+	right: 8px;
+	z-index: 1;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	padding: 0;
+	border: 0;
+	border-radius: 6px;
+	background: transparent;
+	color: var(--ui-desks-muted, #6b7280);
+	cursor: pointer;
+	opacity: 0;
+	pointer-events: none;
+	transition:
+		opacity 120ms ease,
+		background 120ms ease,
+		color 120ms ease;
+}
+
+.sessionItemArchive svg {
+	fill: currentColor;
+}
+
+.sessionItem:hover .sessionItemArchive,
+.sessionItem:focus-within .sessionItemArchive {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.sessionItemArchive:hover,
+.sessionItemArchive:focus-visible {
+	background: rgba(15, 23, 42, 0.08);
+	color: var(--ui-desks-text, #14171a);
+	outline: none;
+}
+
+.sessionItemArchive:disabled {
+	cursor: default;
+	color: var(--ui-desks-muted, #6b7280);
+	opacity: 0.45;
+}
+
+.listPane[data-compact='true'] .sessionItemPreview {
+	display: none;
+}
+
+.listPane[data-compact='true'] .sessionSelectButton {
+	padding-top: 6px;
+	padding-bottom: 6px;
+	border-radius: 7px;
+}
+
+.listPane[data-compact='true'] .sessionItemTitle {
+	font-size: 12px;
+	line-height: 16px;
+}
+
+.listPane[data-compact='true'] .sessionItemArchive {
+	top: 3px;
+}
+
+.archived {
+	display: flex;
+	flex: 0 0 auto;
+	min-height: 0;
+	flex-direction: column;
+	border-top: 1px solid var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+	background: rgba(15, 23, 42, 0.02);
+	transition: flex 240ms cubic-bezier(0.32, 0.72, 0.24, 1);
+}
+
+.archived[data-open='true'] {
+	flex: 1 1 0;
+}
+
+.archivedToggle {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	padding: 12px 24px;
+	border: 0;
+	background: transparent;
+	color: var(--ui-desks-muted, #6b7280);
+	font: inherit;
+	font-size: 12px;
+	line-height: 16px;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	cursor: pointer;
+	-webkit-app-region: no-drag;
+}
+
+.archivedToggle:hover,
+.archivedToggle:focus-visible {
+	color: var(--ui-desks-text, #14171a);
+	outline: none;
+}
+
+.archivedCount {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 18px;
+	height: 16px;
+	padding: 0 6px;
+	border-radius: 999px;
+	background: rgba(15, 23, 42, 0.08);
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 10px;
+	line-height: 16px;
+	font-weight: 700;
+	font-feature-settings: 'tnum' 1;
+}
+
+.archivedList {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	overflow-y: auto;
+	padding: 4px 12px 12px;
 }
 
 .footer {


### PR DESCRIPTION
### Summary
- Brought the archive/unarchive control into better alignment with the timestamp slot in the chat list rows.
- Shifted the hover button slightly right so its padded icon visually replaces the time label more closely.

### Testing
- `npx eslint --fix` on the touched chat panel files
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-desks/chats`