### PR TITLE
Add a site details dropdown to site desks

### DIFF
--- a/apps/ui/src/ui-desks/chrome/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/index.tsx
@@ -1,10 +1,12 @@
 import { createDefaultDeskSettings } from '@studio/common/lib/desk-settings';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDeskSettings, useUpdateDeskSettings } from '@/data/queries/use-desk-config';
+import { useSites } from '@/data/queries/use-sites';
 import { ChatsTrigger } from '../chats';
 import { DeskCreateMenu } from './create-menu';
 import { DeskHeader } from './header';
 import { DeskSettingsButton } from './settings-button';
+import { SiteDetailsDropdown } from './site-details-dropdown';
 import { DeskSiteMapButton } from './site-map-button';
 import { DeskSiteMapTitle } from './site-map-title';
 import {
@@ -36,6 +38,8 @@ export function DeskChrome( {
 	onToggleSettings,
 }: DeskChromeProps ) {
 	const { data: savedSettings } = useDeskSettings();
+	const { data: sites } = useSites();
+	const activeSite = sites?.find( ( candidate ) => candidate.id === siteId );
 	const fallbackSettings = useMemo( () => createDefaultDeskSettings(), [] );
 	const settings = useMemo(
 		() => normalizeDeskToolbarSettings( savedSettings ?? fallbackSettings ),
@@ -106,11 +110,16 @@ export function DeskChrome( {
 				clearDragState={ clearDragState }
 				onReorder={ reorderButton }
 				leading={
-					<DeskMenu
-						siteId={ siteId }
-						disabled={ editingToolbar }
-						showSiteName={ settings.showSiteName }
-					/>
+					<>
+						<DeskMenu
+							siteId={ siteId }
+							disabled={ editingToolbar }
+							showSiteName={ settings.showSiteName }
+						/>
+						{ activeSite ? (
+							<SiteDetailsDropdown site={ activeSite } disabled={ editingToolbar } />
+						) : null }
+					</>
 				}
 			/>
 		</DeskHeader>

--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx
@@ -1,0 +1,164 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConnector } from '@/data/core';
+import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
+import { usePublishPreviewSite } from '@/data/queries/use-preview-site';
+import {
+	useIsSiteStarting,
+	useIsSiteStopping,
+	useStartSite,
+	useStopSite,
+} from '@/data/queries/use-sites';
+import { useSnapshots } from '@/data/queries/use-snapshots';
+import { usePullSiteFromLive, usePushSiteToLive } from '@/data/queries/use-sync-site';
+import { SiteDetailsDropdown } from './index';
+import type { SiteDetails } from '@/data/core';
+
+vi.mock( '@tanstack/react-query', () => ( {
+	useIsMutating: () => 0,
+} ) );
+
+vi.mock( '@/data/core', () => ( {
+	useConnector: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-connected-wpcom-sites', () => ( {
+	useConnectedWpcomSites: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-preview-site', () => ( {
+	usePublishPreviewSite: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-sites', () => ( {
+	useIsSiteStarting: vi.fn(),
+	useIsSiteStopping: vi.fn(),
+	useStartSite: vi.fn(),
+	useStopSite: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-snapshots', () => ( {
+	useSnapshots: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-sync-site', () => ( {
+	PULL_FROM_LIVE_MUTATION_KEY: [ 'pullSiteFromLive' ],
+	PUSH_TO_LIVE_MUTATION_KEY: [ 'pushSiteToLive' ],
+	usePullSiteFromLive: vi.fn(),
+	usePushSiteToLive: vi.fn(),
+} ) );
+
+const useConnectorMock = vi.mocked( useConnector );
+const useConnectedWpcomSitesMock = vi.mocked( useConnectedWpcomSites );
+const usePublishPreviewSiteMock = vi.mocked( usePublishPreviewSite );
+const useIsSiteStartingMock = vi.mocked( useIsSiteStarting );
+const useIsSiteStoppingMock = vi.mocked( useIsSiteStopping );
+const useStartSiteMock = vi.mocked( useStartSite );
+const useStopSiteMock = vi.mocked( useStopSite );
+const useSnapshotsMock = vi.mocked( useSnapshots );
+const usePullSiteFromLiveMock = vi.mocked( usePullSiteFromLive );
+const usePushSiteToLiveMock = vi.mocked( usePushSiteToLive );
+
+describe( 'SiteDetailsDropdown', () => {
+	const openExternalUrl = vi.fn();
+	const publishPreviewMutate = vi.fn();
+	const pullMutate = vi.fn();
+	const pushMutate = vi.fn();
+	const startMutate = vi.fn();
+	const stopMutate = vi.fn();
+
+	beforeEach( () => {
+		openExternalUrl.mockReset();
+		publishPreviewMutate.mockReset();
+		pullMutate.mockReset();
+		pushMutate.mockReset();
+		startMutate.mockReset();
+		stopMutate.mockReset();
+
+		useConnectorMock.mockReturnValue( {
+			getPublishCheckoutUrl: () => 'https://wordpress.com/setup/studio',
+			openExternalUrl,
+		} as never );
+		useSnapshotsMock.mockReturnValue( {
+			data: [
+				{
+					url: 'preview.example.wordpress.com',
+					atomicSiteId: 123,
+					localSiteId: 'site-1',
+					date: Date.now(),
+				},
+			],
+		} as never );
+		useConnectedWpcomSitesMock.mockReturnValue( {
+			data: [
+				{
+					id: 456,
+					localSiteId: 'site-1',
+					name: 'Live Site',
+					url: 'live.example.com',
+					isStaging: false,
+					isPressable: false,
+					syncSupport: 'syncable',
+					lastPullTimestamp: null,
+					lastPushTimestamp: null,
+				},
+			],
+		} as never );
+		usePublishPreviewSiteMock.mockReturnValue( {
+			isPending: false,
+			mutate: publishPreviewMutate,
+		} as never );
+		usePushSiteToLiveMock.mockReturnValue( { mutate: pushMutate } as never );
+		usePullSiteFromLiveMock.mockReturnValue( { mutate: pullMutate } as never );
+		useStartSiteMock.mockReturnValue( { mutate: startMutate } as never );
+		useStopSiteMock.mockReturnValue( { mutate: stopMutate } as never );
+		useIsSiteStartingMock.mockReturnValue( false );
+		useIsSiteStoppingMock.mockReturnValue( false );
+	} );
+
+	it( 'renders site details and wires the primary row actions', async () => {
+		const site = createSite();
+		render( <SiteDetailsDropdown site={ site } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Site details for Local Studio Site' } ) );
+
+		expect( await screen.findByText( 'Local' ) ).toBeVisible();
+		expect( screen.getByText( 'Preview' ) ).toBeVisible();
+		expect( screen.getByText( 'Live' ) ).toBeVisible();
+		expect( screen.getAllByText( 'Running on localhost' )[ 0 ] ).toBeVisible();
+		expect( screen.getByText( 'Connected' ) ).toBeVisible();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Stop site' } ) );
+		expect( stopMutate ).toHaveBeenCalledWith( 'site-1' );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Push to Preview' } ) );
+		expect( publishPreviewMutate ).toHaveBeenCalledWith( {
+			siteId: 'site-1',
+			existingHostname: 'preview.example.wordpress.com',
+		} );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Push to Live' } ) );
+		expect( pushMutate ).toHaveBeenCalledWith( { siteId: 'site-1', remoteSiteId: 456 } );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Pull from Live' } ) );
+		expect( pullMutate ).toHaveBeenCalledWith( { siteId: 'site-1', remoteSiteId: 456 } );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Open local site' } ) );
+		await waitFor( () =>
+			expect( openExternalUrl ).toHaveBeenCalledWith( 'http://localhost:8881' )
+		);
+	} );
+} );
+
+function createSite( overrides: Partial< SiteDetails > = {} ): SiteDetails {
+	return {
+		id: 'site-1',
+		name: 'Local Studio Site',
+		path: '/tmp/local-studio-site',
+		port: 8881,
+		running: true,
+		phpVersion: '8.4',
+		...overrides,
+	};
+}

--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.tsx
@@ -1,0 +1,436 @@
+import { useIsMutating } from '@tanstack/react-query';
+import { __, sprintf } from '@wordpress/i18n';
+import { download, external, formatListBullets, upload } from '@wordpress/icons';
+import { clsx } from 'clsx';
+import { useMemo, useState } from 'react';
+import {
+	deriveSiteStatus,
+	ensureProtocol,
+	getSnapshotHostname,
+	pickLatestSnapshot,
+	pickLiveSite,
+} from '@/components/site-dropdown/utils';
+import { SiteIcon } from '@/components/site-icon';
+import { useConnector } from '@/data/core';
+import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
+import { usePublishPreviewSite } from '@/data/queries/use-preview-site';
+import {
+	useIsSiteStarting,
+	useIsSiteStopping,
+	useStartSite,
+	useStopSite,
+} from '@/data/queries/use-sites';
+import { useSnapshots } from '@/data/queries/use-snapshots';
+import {
+	PULL_FROM_LIVE_MUTATION_KEY,
+	PUSH_TO_LIVE_MUTATION_KEY,
+	usePullSiteFromLive,
+	usePushSiteToLive,
+} from '@/data/queries/use-sync-site';
+import { formatRelativeTime } from '@/lib/format-relative-time';
+import { getSiteDisplayUrl, getSiteUrl } from '@/lib/get-site-url';
+import { Button, Menu } from '@/ui-desks/components';
+import styles from './style.module.css';
+import type { SiteDetails } from '@/data/core';
+import type { ReactNode } from 'react';
+
+interface SiteDetailsDropdownProps {
+	site: SiteDetails;
+	disabled?: boolean;
+}
+
+function useIsSiteSyncing( siteId: string ): { push: boolean; pull: boolean } {
+	const push =
+		useIsMutating( {
+			mutationKey: PUSH_TO_LIVE_MUTATION_KEY,
+			predicate: ( mutation ) =>
+				( mutation.state.variables as { siteId: string } | undefined )?.siteId === siteId,
+		} ) > 0;
+	const pull =
+		useIsMutating( {
+			mutationKey: PULL_FROM_LIVE_MUTATION_KEY,
+			predicate: ( mutation ) =>
+				( mutation.state.variables as { siteId: string } | undefined )?.siteId === siteId,
+		} ) > 0;
+	return { push, pull };
+}
+
+export function SiteDetailsDropdown( { site, disabled = false }: SiteDetailsDropdownProps ) {
+	const connector = useConnector();
+	const [ open, setOpen ] = useState( false );
+	const { data: snapshots } = useSnapshots();
+	const { data: connectedSites } = useConnectedWpcomSites( site.id );
+	const previewSnapshot = useMemo(
+		() => pickLatestSnapshot( snapshots, site.id ),
+		[ snapshots, site.id ]
+	);
+	const liveSite = useMemo( () => pickLiveSite( connectedSites ), [ connectedSites ] );
+	const startSite = useStartSite();
+	const stopSite = useStopSite();
+	const publishPreviewSite = usePublishPreviewSite();
+	const pushSiteToLive = usePushSiteToLive();
+	const pullSiteFromLive = usePullSiteFromLive();
+	const isStarting = useIsSiteStarting( site.id );
+	const isStopping = useIsSiteStopping( site.id );
+	const { push: isPushPending, pull: isPullPending } = useIsSiteSyncing( site.id );
+	const { status } = deriveSiteStatus( site, isStarting, isStopping );
+	const checkoutUrl = connector.getPublishCheckoutUrl( site );
+	const isPreviewPending = publishPreviewSite.isPending;
+	const isSyncing = isPreviewPending || isPushPending || isPullPending;
+	const previewActionLabel = isPreviewPending
+		? __( 'Pushing to Preview' )
+		: __( 'Push to Preview' );
+	const pushActionLabel = isPushPending ? __( 'Pushing to Live' ) : __( 'Push to Live' );
+	const pullActionLabel = isPullPending ? __( 'Pulling from Live' ) : __( 'Pull from Live' );
+
+	const openExternal = ( url: string ) => {
+		setOpen( false );
+		void connector.openExternalUrl( url );
+	};
+
+	const handleToggleServer = () => {
+		if ( status === 'transitioning' ) {
+			return;
+		}
+		if ( site.running ) {
+			stopSite.mutate( site.id );
+		} else {
+			startSite.mutate( site.id );
+		}
+	};
+
+	const handlePreviewClick = () => {
+		if ( isSyncing ) {
+			return;
+		}
+		publishPreviewSite.mutate( {
+			siteId: site.id,
+			existingHostname: previewSnapshot ? getSnapshotHostname( previewSnapshot ) : undefined,
+		} );
+	};
+
+	const handlePushClick = () => {
+		if ( ! liveSite || isSyncing ) {
+			return;
+		}
+		pushSiteToLive.mutate( { siteId: site.id, remoteSiteId: liveSite.id } );
+	};
+
+	const handlePullClick = () => {
+		if ( ! liveSite || isSyncing ) {
+			return;
+		}
+		pullSiteFromLive.mutate( { siteId: site.id, remoteSiteId: liveSite.id } );
+	};
+
+	return (
+		<Menu.Root modal={ false } open={ open } onOpenChange={ setOpen }>
+			<Menu.Trigger
+				render={
+					<Button
+						className={ styles.detailsTrigger }
+						disabled={ disabled }
+						icon={ formatListBullets }
+						label={ sprintf(
+							/* translators: %s: current site name. */
+							__( 'Site details for %s' ),
+							site.name
+						) }
+						data-status={ status }
+					/>
+				}
+			/>
+			<Menu.Popup side="bottom" align="start" sideOffset={ 8 } className={ styles.popup }>
+				<header className={ styles.header }>
+					<div className={ styles.headerIdentity }>
+						<SiteBadge site={ site } size="panel" />
+						<div className={ styles.headerText }>
+							<div className={ styles.headerTitle } title={ site.name }>
+								{ site.name }
+							</div>
+							<StatusLine tone={ status }>{ getHeaderStatusText( status, site ) }</StatusLine>
+						</div>
+					</div>
+					<Button
+						className={ styles.serverButton }
+						variant="filled"
+						size="small"
+						label={ site.running ? __( 'Stop site' ) : __( 'Start site' ) }
+						disabled={ status === 'transitioning' }
+						aria-busy={ status === 'transitioning' ? 'true' : undefined }
+						onClick={ handleToggleServer }
+					>
+						<span
+							className={ site.running ? styles.stopGlyph : styles.startGlyph }
+							aria-hidden="true"
+						/>
+						{ getServerButtonLabel( site.running, isStarting, isStopping ) }
+					</Button>
+				</header>
+
+				<div className={ styles.divider } />
+
+				<div className={ styles.rows }>
+					<DetailsRow
+						label={ __( 'Local' ) }
+						status={ status }
+						statusText={ getLocalStatusText( status, site ) }
+						actions={
+							<OpenButton
+								label={ __( 'Open local site' ) }
+								disabled={ ! site.running }
+								onClick={ () => openExternal( getSiteUrl( site ) ) }
+							/>
+						}
+					/>
+					<DetailsRow
+						label={ __( 'Preview' ) }
+						status={ previewSnapshot ? 'running' : 'stopped' }
+						statusText={
+							previewSnapshot
+								? sprintf(
+										/* translators: %s: relative time since the preview site was last synced. */
+										__( 'Synced %s' ),
+										formatRelativeTimestamp( previewSnapshot.date )
+								  )
+								: __( 'Not yet created' )
+						}
+						actions={
+							<>
+								<Button
+									className={ styles.syncButton }
+									variant="quiet"
+									size="small"
+									icon={ upload }
+									label={ previewActionLabel }
+									disabled={ isSyncing }
+									aria-busy={ isPreviewPending ? 'true' : undefined }
+									onClick={ handlePreviewClick }
+								>
+									{ isPreviewPending ? __( 'Pushing...' ) : __( 'Push to Preview' ) }
+								</Button>
+								<OpenButton
+									label={ __( 'Open preview site' ) }
+									disabled={ ! previewSnapshot }
+									onClick={ () => {
+										if ( previewSnapshot ) {
+											openExternal( ensureProtocol( previewSnapshot.url ) );
+										}
+									} }
+								/>
+							</>
+						}
+					/>
+					<DetailsRow
+						label={ __( 'Live' ) }
+						status={ liveSite ? 'running' : 'stopped' }
+						statusText={
+							liveSite ? (
+								<>
+									<span>{ __( 'Connected' ) }</span>
+									<span className={ styles.statusSeparator } aria-hidden="true" />
+									<span>{ __( 'WordPress.com' ) }</span>
+								</>
+							) : (
+								__( 'Not connected' )
+							)
+						}
+						actions={
+							liveSite ? (
+								<>
+									<Button
+										className={ styles.syncButton }
+										variant="quiet"
+										size="small"
+										icon={ upload }
+										label={ pushActionLabel }
+										disabled={ isSyncing }
+										aria-busy={ isPushPending ? 'true' : undefined }
+										onClick={ handlePushClick }
+									>
+										{ isPushPending ? __( 'Pushing...' ) : __( 'Push to Live' ) }
+									</Button>
+									<Button
+										className={ styles.syncButton }
+										variant="quiet"
+										size="small"
+										icon={ download }
+										label={ pullActionLabel }
+										disabled={ isSyncing }
+										aria-busy={ isPullPending ? 'true' : undefined }
+										onClick={ handlePullClick }
+									>
+										{ isPullPending ? __( 'Pulling...' ) : __( 'Pull' ) }
+									</Button>
+									<OpenButton
+										label={ __( 'Open live site' ) }
+										disabled={ isSyncing }
+										onClick={ () => openExternal( ensureProtocol( liveSite.url ) ) }
+									/>
+								</>
+							) : (
+								<Button
+									className={ styles.syncButton }
+									variant="filled"
+									size="small"
+									label={ __( 'Connect live site' ) }
+									disabled={ ! checkoutUrl }
+									onClick={ () => {
+										if ( checkoutUrl ) {
+											openExternal( checkoutUrl );
+										}
+									} }
+								>
+									{ __( 'Connect' ) }
+								</Button>
+							)
+						}
+					/>
+				</div>
+			</Menu.Popup>
+		</Menu.Root>
+	);
+}
+
+function DetailsRow( {
+	label,
+	status,
+	statusText,
+	actions,
+}: {
+	label: string;
+	status: SiteStatusTone;
+	statusText: ReactNode;
+	actions: ReactNode;
+} ) {
+	return (
+		<div className={ styles.row }>
+			<div className={ styles.rowText }>
+				<div className={ styles.rowLabel }>{ label }</div>
+				<StatusLine tone={ status }>{ statusText }</StatusLine>
+			</div>
+			<div className={ styles.rowActions }>{ actions }</div>
+		</div>
+	);
+}
+
+function OpenButton( {
+	label,
+	disabled,
+	onClick,
+}: {
+	label: string;
+	disabled?: boolean;
+	onClick: () => void;
+} ) {
+	return (
+		<Button
+			className={ styles.openButton }
+			variant="filled"
+			size="small"
+			icon={ external }
+			label={ label }
+			disabled={ disabled }
+			onClick={ onClick }
+		>
+			{ __( 'Open' ) }
+		</Button>
+	);
+}
+
+type SiteStatusTone = 'running' | 'transitioning' | 'stopped';
+
+function StatusLine( { tone, children }: { tone: SiteStatusTone; children: ReactNode } ) {
+	return (
+		<div className={ styles.statusLine }>
+			<span
+				className={ clsx( styles.statusDot, styles[ `statusDot_${ tone }` ] ) }
+				aria-hidden="true"
+			/>
+			<span className={ styles.statusText }>{ children }</span>
+		</div>
+	);
+}
+
+function SiteBadge( {
+	site,
+	size,
+	status,
+}: {
+	site: SiteDetails;
+	size: 'panel';
+	status?: SiteStatusTone;
+} ) {
+	const hasSiteIcon = Boolean( site.siteIcon );
+	const content = hasSiteIcon ? (
+		<SiteIcon
+			className={ styles.siteBadgeImage }
+			seed={ getSiteIconSeed( site ) }
+			imageSrc={ site.siteIcon }
+		/>
+	) : (
+		<span className={ styles.siteInitials }>{ getSiteInitials( site.name ) }</span>
+	);
+
+	return (
+		<span
+			className={ clsx( styles.siteBadge, styles[ `siteBadge_${ size }` ] ) }
+			aria-hidden="true"
+		>
+			{ content }
+			{ status ? (
+				<span className={ clsx( styles.badgeStatus, styles[ `badgeStatus_${ status }` ] ) } />
+			) : null }
+		</span>
+	);
+}
+
+function getSiteIconSeed( site: SiteDetails ) {
+	return `${ site.id }:${ site.name }:${ site.path }`;
+}
+
+function getSiteInitials( name: string ) {
+	const words = name.trim().split( /\s+/ ).filter( Boolean );
+	const initials =
+		words.length >= 2
+			? `${ words[ 0 ].charAt( 0 ) }${ words[ 1 ].charAt( 0 ) }`
+			: words[ 0 ]?.slice( 0, 2 );
+	return ( initials || 'S' ).toUpperCase();
+}
+
+function getHeaderStatusText( status: SiteStatusTone, site: SiteDetails ) {
+	if ( status === 'transitioning' ) {
+		return site.running ? __( 'Stopping site' ) : __( 'Starting site' );
+	}
+	return site.running ? __( 'Running on localhost' ) : __( 'Stopped' );
+}
+
+function getLocalStatusText( status: SiteStatusTone, site: SiteDetails ) {
+	if ( status === 'transitioning' ) {
+		return site.running ? __( 'Stopping...' ) : __( 'Starting...' );
+	}
+	if ( site.running ) {
+		return site.customDomain
+			? sprintf(
+					/* translators: %s: the local custom domain for the site. */
+					__( 'Running at %s' ),
+					getSiteDisplayUrl( site )
+			  )
+			: __( 'Running on localhost' );
+	}
+	return __( 'Stopped' );
+}
+
+function getServerButtonLabel( isRunning: boolean, isStarting: boolean, isStopping: boolean ) {
+	if ( isStarting ) {
+		return __( 'Starting...' );
+	}
+	if ( isStopping ) {
+		return __( 'Stopping...' );
+	}
+	return isRunning ? __( 'Stop' ) : __( 'Start' );
+}
+
+function formatRelativeTimestamp( timestamp: number ) {
+	return formatRelativeTime( new Date( timestamp ).toISOString() );
+}

--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/style.module.css
@@ -1,0 +1,251 @@
+.detailsTrigger {
+	position: relative;
+}
+
+.detailsTrigger::after {
+	content: '';
+	position: absolute;
+	right: 7px;
+	bottom: 7px;
+	width: 7px;
+	height: 7px;
+	border: 2px solid var(--ui-desks-material, #fff);
+	border-radius: 999px;
+	background: rgba(15, 23, 42, 0.32);
+}
+
+.detailsTrigger[data-status='running']::after {
+	background: #57c565;
+}
+
+.detailsTrigger[data-status='transitioning']::after {
+	background: #d69e2e;
+}
+
+.popup {
+	box-sizing: border-box;
+	width: min(418px, calc(100vw - 32px));
+	padding: 12px;
+	gap: 0;
+	border-radius: var(--ui-desks-radius-surface, 18px);
+	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+	min-width: 0;
+	padding: 4px 4px 10px;
+}
+
+.headerIdentity {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-width: 0;
+}
+
+.headerText {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.headerTitle {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--ui-desks-text, #14171a);
+	font-size: 13px;
+	line-height: 18px;
+	font-weight: 600;
+}
+
+.serverButton {
+	flex: 0 0 auto;
+	gap: 6px;
+}
+
+.stopGlyph {
+	width: 7px;
+	height: 7px;
+	border-radius: 2px;
+	background: currentColor;
+}
+
+.startGlyph {
+	width: 0;
+	height: 0;
+	margin-left: 2px;
+	border-top: 5px solid transparent;
+	border-bottom: 5px solid transparent;
+	border-left: 8px solid currentColor;
+}
+
+.divider {
+	height: 1px;
+	margin: 0 0 6px;
+	background: var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+}
+
+.rows {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.row {
+	display: grid;
+	grid-template-columns: minmax(120px, 1fr) auto;
+	align-items: center;
+	gap: 12px;
+	min-height: 54px;
+	padding: 4px 4px;
+}
+
+.rowText {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.rowLabel {
+	color: var(--ui-desks-text, #14171a);
+	font-size: 14px;
+	line-height: 20px;
+	font-weight: 600;
+}
+
+.rowActions {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 4px;
+	min-width: 0;
+}
+
+.syncButton,
+.openButton {
+	white-space: nowrap;
+}
+
+.openButton {
+	min-width: 68px;
+}
+
+.statusLine {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+	min-width: 0;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 12px;
+	line-height: 16px;
+}
+
+.statusDot {
+	width: 5px;
+	height: 5px;
+	border-radius: 999px;
+	background: rgba(15, 23, 42, 0.32);
+	flex: 0 0 auto;
+}
+
+.statusDot_running {
+	background: #57c565;
+}
+
+.statusDot_transitioning {
+	background: #d69e2e;
+}
+
+.statusDot_stopped {
+	background: rgba(15, 23, 42, 0.28);
+}
+
+.statusText {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.statusSeparator {
+	width: 3px;
+	height: 3px;
+	border-radius: 999px;
+	background: currentColor;
+	opacity: 0.65;
+}
+
+.siteBadge {
+	position: relative;
+	display: inline-grid;
+	place-items: center;
+	flex: 0 0 auto;
+	border-radius: 999px;
+	background: #111318;
+	color: #fff;
+	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+	overflow: visible;
+}
+
+.siteBadge_panel {
+	width: 24px;
+	height: 24px;
+}
+
+.siteInitials {
+	font-size: 10px;
+	line-height: 1;
+	font-weight: 700;
+	letter-spacing: 0;
+}
+
+.siteBadgeImage {
+	width: 100%;
+	height: 100%;
+	border-radius: inherit;
+}
+
+.badgeStatus {
+	position: absolute;
+	right: -1px;
+	bottom: -1px;
+	width: 9px;
+	height: 9px;
+	border: 2px solid var(--ui-desks-material, #fff);
+	border-radius: 999px;
+	background: rgba(15, 23, 42, 0.32);
+}
+
+.badgeStatus_running {
+	background: #57c565;
+}
+
+.badgeStatus_transitioning {
+	background: #d69e2e;
+}
+
+.badgeStatus_stopped {
+	background: rgba(15, 23, 42, 0.32);
+}
+
+@media (max-width: 460px) {
+	.row {
+		grid-template-columns: 1fr;
+		gap: 8px;
+		padding-block: 8px;
+	}
+
+	.rowActions {
+		justify-content: flex-start;
+		flex-wrap: wrap;
+	}
+}


### PR DESCRIPTION
## Summary
- Add a dedicated site details dropdown button to site desks that shows the local, preview, and live site actions in a layout close to the reference screenshot.
- Keep the existing left site menu behavior intact so the site list remains available there.
- Add coverage for the new dropdown interactions, including server start/stop, preview publish, live sync actions, and opening the local site.

## Testing
- `npx eslint --fix` on the changed UI files
- `npm test -- apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx`
- `npm run typecheck`
- `npm -w @studio/ui run build`