### PR TITLE
apps/ui: Seed new site desks with a useful default layout

### DIFF
--- a/apps/ui/src/ui-desks/desk/default-desk.test.ts
+++ b/apps/ui/src/ui-desks/desk/default-desk.test.ts
@@ -1,0 +1,63 @@
+import { assertDeskConfig } from '@studio/common/lib/desk-config';
+import { describe, expect, it } from 'vitest';
+import { DRAWING_WIDGET_TYPE } from '@/ui-desks/widgets/drawing/types';
+import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
+import { POST_COLLECTION_WIDGET_TYPE } from '@/ui-desks/widgets/post-collection/types';
+import { SITE_CARD_WIDGET_TYPE } from '@/ui-desks/widgets/site-card/types';
+import { SITE_PREVIEW_WIDGET_TYPE } from '@/ui-desks/widgets/site-preview/types';
+import { THEME_WIDGET_TYPE } from '@/ui-desks/widgets/theme/types';
+import { createDefaultSiteDeskConfig } from './default-desk';
+
+describe( 'default desk configs', () => {
+	it( 'creates a valid first-run site desk', () => {
+		const desk = createDefaultSiteDeskConfig();
+
+		expect( () => assertDeskConfig( desk ) ).not.toThrow();
+		expect( Number.isNaN( Date.parse( desk.updatedAt ) ) ).toBe( false );
+		expect( desk.widgets.map( ( widget ) => widget.id ) ).toEqual( [
+			'site-card',
+			'home-preview',
+			'site-notes',
+			'recent-posts',
+			'active-theme',
+		] );
+		expect( desk.widgets.map( ( widget ) => widget.type ) ).toEqual( [
+			SITE_CARD_WIDGET_TYPE,
+			SITE_PREVIEW_WIDGET_TYPE,
+			NOTE_WIDGET_TYPE,
+			POST_COLLECTION_WIDGET_TYPE,
+			THEME_WIDGET_TYPE,
+		] );
+		expect( desk.widgets.some( ( widget ) => widget.type === DRAWING_WIDGET_TYPE ) ).toBe( false );
+	} );
+
+	it( 'seeds the site desk with editable notes and site-aware widgets', () => {
+		const desk = createDefaultSiteDeskConfig();
+
+		expect( desk.widgets.find( ( widget ) => widget.id === 'site-notes' ) ).toMatchObject( {
+			type: NOTE_WIDGET_TYPE,
+			widgetProps: {
+				text: 'Ideas / TODO',
+				tone: 'yellow',
+			},
+		} );
+		expect( desk.widgets.find( ( widget ) => widget.id === 'home-preview' ) ).toMatchObject( {
+			type: SITE_PREVIEW_WIDGET_TYPE,
+			widgetProps: {
+				path: '/',
+			},
+		} );
+		expect( desk.widgets.find( ( widget ) => widget.id === 'recent-posts' ) ).toMatchObject( {
+			type: POST_COLLECTION_WIDGET_TYPE,
+			widgetProps: {
+				query: {
+					postType: 'post',
+					perPage: 5,
+					status: 'publish',
+					orderby: 'date',
+					order: 'desc',
+				},
+			},
+		} );
+	} );
+} );

--- a/apps/ui/src/ui-desks/desk/default-desk.test.ts
+++ b/apps/ui/src/ui-desks/desk/default-desk.test.ts
@@ -1,8 +1,8 @@
 import { assertDeskConfig } from '@studio/common/lib/desk-config';
 import { describe, expect, it } from 'vitest';
+import { BOOKMARK_WIDGET_TYPE } from '@/ui-desks/widgets/bookmark/types';
 import { DRAWING_WIDGET_TYPE } from '@/ui-desks/widgets/drawing/types';
 import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
-import { POST_COLLECTION_WIDGET_TYPE } from '@/ui-desks/widgets/post-collection/types';
 import { SITE_CARD_WIDGET_TYPE } from '@/ui-desks/widgets/site-card/types';
 import { SITE_PREVIEW_WIDGET_TYPE } from '@/ui-desks/widgets/site-preview/types';
 import { THEME_WIDGET_TYPE } from '@/ui-desks/widgets/theme/types';
@@ -10,53 +10,77 @@ import { createDefaultSiteDeskConfig } from './default-desk';
 
 describe( 'default desk configs', () => {
 	it( 'creates a valid first-run site desk', () => {
-		const desk = createDefaultSiteDeskConfig();
+		const desk = createDefaultSiteDeskConfig( 'https://example.test' );
 
 		expect( () => assertDeskConfig( desk ) ).not.toThrow();
 		expect( Number.isNaN( Date.parse( desk.updatedAt ) ) ).toBe( false );
+		expect( desk.viewport ).toEqual( {
+			x: 440.72744922694875,
+			y: 53.85707696744839,
+			z: 0.6035527097673408,
+		} );
 		expect( desk.widgets.map( ( widget ) => widget.id ) ).toEqual( [
 			'site-card',
+			'active-theme',
 			'home-preview',
 			'site-notes',
-			'recent-posts',
-			'active-theme',
+			'2f456fe8-0351-49ec-b816-3629382036a3',
+			'5efaab75-bd70-4332-bdf1-e1183e78331f',
+			'e60190a0-d2df-4c16-b283-eb19ed8e4839',
 		] );
 		expect( desk.widgets.map( ( widget ) => widget.type ) ).toEqual( [
 			SITE_CARD_WIDGET_TYPE,
+			THEME_WIDGET_TYPE,
 			SITE_PREVIEW_WIDGET_TYPE,
 			NOTE_WIDGET_TYPE,
-			POST_COLLECTION_WIDGET_TYPE,
-			THEME_WIDGET_TYPE,
+			NOTE_WIDGET_TYPE,
+			BOOKMARK_WIDGET_TYPE,
+			NOTE_WIDGET_TYPE,
 		] );
 		expect( desk.widgets.some( ( widget ) => widget.type === DRAWING_WIDGET_TYPE ) ).toBe( false );
 	} );
 
-	it( 'seeds the site desk with editable notes and site-aware widgets', () => {
-		const desk = createDefaultSiteDeskConfig();
+	it( 'uses Lola desk content with a dynamic bookmark URL', () => {
+		const desk = createDefaultSiteDeskConfig( 'https://example.test' );
 
 		expect( desk.widgets.find( ( widget ) => widget.id === 'site-notes' ) ).toMatchObject( {
 			type: NOTE_WIDGET_TYPE,
 			widgetProps: {
-				text: 'Ideas / TODO',
-				tone: 'yellow',
+				text: 'Site Preview',
+				tone: 'neon-blue',
+				textSize: 2,
 			},
 		} );
 		expect( desk.widgets.find( ( widget ) => widget.id === 'home-preview' ) ).toMatchObject( {
 			type: SITE_PREVIEW_WIDGET_TYPE,
+			x: 634.5565745594427,
+			y: 98.47227110772417,
+			shapeProps: {
+				w: 754.6531489796062,
+				h: 603.3094530012401,
+			},
 			widgetProps: {
 				path: '/',
 			},
 		} );
-		expect( desk.widgets.find( ( widget ) => widget.id === 'recent-posts' ) ).toMatchObject( {
-			type: POST_COLLECTION_WIDGET_TYPE,
+		expect(
+			desk.widgets.find( ( widget ) => widget.id === '5efaab75-bd70-4332-bdf1-e1183e78331f' )
+		).toMatchObject( {
+			type: BOOKMARK_WIDGET_TYPE,
 			widgetProps: {
-				query: {
-					postType: 'post',
-					perPage: 5,
-					status: 'publish',
-					orderby: 'date',
-					order: 'desc',
-				},
+				url: 'https://example.test/',
+			},
+		} );
+	} );
+
+	it( 'keeps an existing trailing slash on the dynamic bookmark URL', () => {
+		const desk = createDefaultSiteDeskConfig( 'https://example.test/' );
+
+		expect(
+			desk.widgets.find( ( widget ) => widget.id === '5efaab75-bd70-4332-bdf1-e1183e78331f' )
+		).toMatchObject( {
+			widgetProps: {
+				url: 'https://example.test/',
 			},
 		} );
 	} );

--- a/apps/ui/src/ui-desks/desk/default-desk.ts
+++ b/apps/ui/src/ui-desks/desk/default-desk.ts
@@ -1,11 +1,11 @@
 import { DESK_CONFIG_VERSION, type DeskConfig } from '@/ui-desks/desk/types';
+import { BOOKMARK_WIDGET_TYPE } from '@/ui-desks/widgets/bookmark/types';
 import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
-import { POST_COLLECTION_WIDGET_TYPE } from '@/ui-desks/widgets/post-collection/types';
 import { getScratchpadShapePropsForScope } from '@/ui-desks/widgets/scratchpad/sizing';
 import { SCRATCHPAD_WIDGET_TYPE } from '@/ui-desks/widgets/scratchpad/types';
 import { SITE_CARD_WIDGET_TYPE } from '@/ui-desks/widgets/site-card/types';
 import { SITE_PREVIEW_WIDGET_TYPE } from '@/ui-desks/widgets/site-preview/types';
-import { THEME_CARD_SHAPE_PROPS, THEME_WIDGET_TYPE } from '@/ui-desks/widgets/theme/types';
+import { THEME_WIDGET_TYPE } from '@/ui-desks/widgets/theme/types';
 
 const EXAMPLE_SCRATCHPAD_HTML = `<!doctype html>
 <html>
@@ -93,17 +93,22 @@ export const defaultUserDesk: DeskConfig = {
 	],
 };
 
-export function createDefaultSiteDeskConfig(): DeskConfig {
+export function createDefaultSiteDeskConfig( siteUrl = '' ): DeskConfig {
 	return {
 		version: DESK_CONFIG_VERSION,
 		updatedAt: new Date().toISOString(),
+		viewport: {
+			x: 440.72744922694875,
+			y: 53.85707696744839,
+			z: 0.6035527097673408,
+		},
 		widgets: [
 			{
 				id: 'site-card',
 				type: SITE_CARD_WIDGET_TYPE,
-				x: 96,
-				y: 96,
-				zIndex: 'a1',
+				x: 184.83596516477996,
+				y: 101.06117767440315,
+				zIndex: 'a00xF',
 				shapeProps: {
 					w: 360,
 					h: 200,
@@ -113,14 +118,28 @@ export function createDefaultSiteDeskConfig(): DeskConfig {
 				},
 			},
 			{
+				id: 'active-theme',
+				type: THEME_WIDGET_TYPE,
+				x: 631.6308732298062,
+				y: 785.2649837045076,
+				zIndex: 'a1BoL',
+				shapeProps: {
+					w: 760,
+					h: 440,
+				},
+				widgetProps: {
+					viewMode: 'stack',
+				},
+			},
+			{
 				id: 'home-preview',
 				type: SITE_PREVIEW_WIDGET_TYPE,
-				x: 496,
-				y: 96,
-				zIndex: 'a2',
+				x: 634.5565745594427,
+				y: 98.47227110772417,
+				zIndex: 'a21Yp',
 				shapeProps: {
-					w: 640,
-					h: 460,
+					w: 754.6531489796062,
+					h: 603.3094530012401,
 				},
 				widgetProps: {
 					path: '/',
@@ -129,51 +148,74 @@ export function createDefaultSiteDeskConfig(): DeskConfig {
 			{
 				id: 'site-notes',
 				type: NOTE_WIDGET_TYPE,
-				x: 96,
-				y: 328,
-				zIndex: 'a3',
+				x: 1278.0300192133188,
+				y: 659.9530248690811,
+				zIndex: 'a32wj',
 				shapeProps: {
-					w: 240,
-					h: 180,
+					w: 164.11440409609554,
+					h: 80,
 				},
 				widgetProps: {
-					text: 'Ideas / TODO',
+					text: 'Site Preview',
+					tone: 'neon-blue',
+					textSize: 2,
+				},
+			},
+			{
+				id: '2f456fe8-0351-49ec-b816-3629382036a3',
+				type: NOTE_WIDGET_TYPE,
+				x: 1269.3487977572597,
+				y: 1177.163284949601,
+				zIndex: 'a49JE',
+				shapeProps: {
+					w: 160.64603845116085,
+					h: 80,
+				},
+				widgetProps: {
+					text: 'Theme',
+					tone: 'violet',
+					textSize: 2,
+				},
+			},
+			{
+				id: '5efaab75-bd70-4332-bdf1-e1183e78331f',
+				type: BOOKMARK_WIDGET_TYPE,
+				x: 246.437937197667,
+				y: 333.81664542698036,
+				zIndex: 'a516A',
+				shapeProps: {
+					w: 300,
+					h: 101,
+				},
+				widgetProps: {
+					url: normalizeDefaultSiteDeskUrl( siteUrl ),
+				},
+			},
+			{
+				id: 'e60190a0-d2df-4c16-b283-eb19ed8e4839',
+				type: NOTE_WIDGET_TYPE,
+				x: 237.7295705934331,
+				y: 470.6123135830188,
+				zIndex: 'a61Ch',
+				shapeProps: {
+					w: 304.9708960372699,
+					h: 316,
+				},
+				widgetProps: {
+					text: "<strong>Welcome to your Site's desk, y</strong><strong>ou can do a lot from here<br><br></strong> - Add post collections<br> - Paste links, media<br> - Iterate on your site with AI<br> - Preview and deploy<br><br> and a lot more...",
 					tone: 'yellow',
-				},
-			},
-			{
-				id: 'recent-posts',
-				type: POST_COLLECTION_WIDGET_TYPE,
-				x: 96,
-				y: 560,
-				zIndex: 'a4',
-				shapeProps: {
-					w: 1,
-					h: 1,
-				},
-				widgetProps: {
-					query: {
-						postType: 'post',
-						perPage: 5,
-						status: 'publish',
-						orderby: 'date',
-						order: 'desc',
-					},
-				},
-			},
-			{
-				id: 'active-theme',
-				type: THEME_WIDGET_TYPE,
-				x: 496,
-				y: 600,
-				zIndex: 'a5',
-				shapeProps: {
-					...THEME_CARD_SHAPE_PROPS,
-				},
-				widgetProps: {
-					viewMode: 'stack',
+					textSize: 1,
 				},
 			},
 		],
 	};
+}
+
+function normalizeDefaultSiteDeskUrl( url: string ) {
+	const trimmedUrl = url.trim();
+	if ( ! trimmedUrl ) {
+		return '';
+	}
+
+	return trimmedUrl.endsWith( '/' ) ? trimmedUrl : `${ trimmedUrl }/`;
 }

--- a/apps/ui/src/ui-desks/desk/default-desk.ts
+++ b/apps/ui/src/ui-desks/desk/default-desk.ts
@@ -1,6 +1,11 @@
 import { DESK_CONFIG_VERSION, type DeskConfig } from '@/ui-desks/desk/types';
+import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
+import { POST_COLLECTION_WIDGET_TYPE } from '@/ui-desks/widgets/post-collection/types';
 import { getScratchpadShapePropsForScope } from '@/ui-desks/widgets/scratchpad/sizing';
 import { SCRATCHPAD_WIDGET_TYPE } from '@/ui-desks/widgets/scratchpad/types';
+import { SITE_CARD_WIDGET_TYPE } from '@/ui-desks/widgets/site-card/types';
+import { SITE_PREVIEW_WIDGET_TYPE } from '@/ui-desks/widgets/site-preview/types';
+import { THEME_CARD_SHAPE_PROPS, THEME_WIDGET_TYPE } from '@/ui-desks/widgets/theme/types';
 
 const EXAMPLE_SCRATCHPAD_HTML = `<!doctype html>
 <html>
@@ -87,3 +92,88 @@ export const defaultUserDesk: DeskConfig = {
 		},
 	],
 };
+
+export function createDefaultSiteDeskConfig(): DeskConfig {
+	return {
+		version: DESK_CONFIG_VERSION,
+		updatedAt: new Date().toISOString(),
+		widgets: [
+			{
+				id: 'site-card',
+				type: SITE_CARD_WIDGET_TYPE,
+				x: 96,
+				y: 96,
+				zIndex: 'a1',
+				shapeProps: {
+					w: 360,
+					h: 200,
+				},
+				widgetProps: {
+					previewVisible: false,
+				},
+			},
+			{
+				id: 'home-preview',
+				type: SITE_PREVIEW_WIDGET_TYPE,
+				x: 496,
+				y: 96,
+				zIndex: 'a2',
+				shapeProps: {
+					w: 640,
+					h: 460,
+				},
+				widgetProps: {
+					path: '/',
+				},
+			},
+			{
+				id: 'site-notes',
+				type: NOTE_WIDGET_TYPE,
+				x: 96,
+				y: 328,
+				zIndex: 'a3',
+				shapeProps: {
+					w: 240,
+					h: 180,
+				},
+				widgetProps: {
+					text: 'Ideas / TODO',
+					tone: 'yellow',
+				},
+			},
+			{
+				id: 'recent-posts',
+				type: POST_COLLECTION_WIDGET_TYPE,
+				x: 96,
+				y: 560,
+				zIndex: 'a4',
+				shapeProps: {
+					w: 1,
+					h: 1,
+				},
+				widgetProps: {
+					query: {
+						postType: 'post',
+						perPage: 5,
+						status: 'publish',
+						orderby: 'date',
+						order: 'desc',
+					},
+				},
+			},
+			{
+				id: 'active-theme',
+				type: THEME_WIDGET_TYPE,
+				x: 496,
+				y: 600,
+				zIndex: 'a5',
+				shapeProps: {
+					...THEME_CARD_SHAPE_PROPS,
+				},
+				widgetProps: {
+					viewMode: 'stack',
+				},
+			},
+		],
+	};
+}

--- a/apps/ui/src/ui-desks/desk/provider/index.tsx
+++ b/apps/ui/src/ui-desks/desk/provider/index.tsx
@@ -159,19 +159,22 @@ export function DeskProvider( {
 	statusMessage,
 }: DeskProviderProps ) {
 	const hasExternalDeskConfig = Boolean( deskConfig );
+	const { data: sites, isLoading: isLoadingSites } = useSites();
+	const site = sites?.find( ( candidate ) => candidate.id === siteId );
+	const defaultSiteUrl = site ? site.url ?? getSiteUrl( site ) : undefined;
 	const {
 		desk: persistedDesk,
 		isLoading: isLoadingPersistedDesk,
 		saveDeskConfig,
 	} = useDeskPersistence( siteId, {
 		enabled: ! hasExternalDeskConfig,
+		defaultSiteUrl,
+		isDefaultSiteUrlLoading: Boolean( siteId && isLoadingSites ),
 	} );
 	const desk = deskConfig ?? persistedDesk;
 	const isLoading = externalIsLoading ?? isLoadingPersistedDesk;
 	const connector = useConnector();
 	const registry = useRegistry();
-	const { data: sites } = useSites();
-	const site = sites?.find( ( candidate ) => candidate.id === siteId );
 	const isRunningSite = Boolean( siteId && site?.running );
 	const [ editor, setEditor ] = useState< Editor | null >( null );
 	const [ isHydrated, setIsHydrated ] = useState( false );

--- a/apps/ui/src/ui-desks/desk/provider/persistence.ts
+++ b/apps/ui/src/ui-desks/desk/provider/persistence.ts
@@ -5,31 +5,40 @@ import type { DeskConfig } from '../types';
 
 interface DeskPersistenceOptions {
 	enabled?: boolean;
+	defaultSiteUrl?: string;
+	isDefaultSiteUrlLoading?: boolean;
 }
 
 export function useDeskPersistence( siteId?: string, options: DeskPersistenceOptions = {} ) {
 	const enabled = options.enabled ?? true;
 	const { data: savedDesk, isLoading } = useDeskConfig( siteId, enabled );
 	const { mutate: saveDeskConfig } = useSaveDeskConfig( siteId );
-	const defaultDesk = useMemo( () => createDefaultDeskConfig( siteId ), [ siteId ] );
+	const defaultDesk = useMemo(
+		() => createDefaultDeskConfig( siteId, options.defaultSiteUrl ),
+		[ options.defaultSiteUrl, siteId ]
+	);
 	const desk = ( savedDesk as DeskConfig | undefined ) ?? defaultDesk;
+	const canSaveDefaultDesk = ! siteId || Boolean( options.defaultSiteUrl );
+	const isWaitingForDefaultSiteUrl = Boolean(
+		siteId && ! savedDesk && ! canSaveDefaultDesk && options.isDefaultSiteUrlLoading
+	);
 
 	useEffect( () => {
-		if ( enabled && ! isLoading && ! savedDesk ) {
+		if ( enabled && ! isLoading && ! savedDesk && canSaveDefaultDesk ) {
 			saveDeskConfig( defaultDesk );
 		}
-	}, [ defaultDesk, enabled, isLoading, savedDesk, saveDeskConfig ] );
+	}, [ canSaveDefaultDesk, defaultDesk, enabled, isLoading, savedDesk, saveDeskConfig ] );
 
 	return {
 		desk,
-		isLoading,
+		isLoading: isLoading || isWaitingForDefaultSiteUrl,
 		saveDeskConfig,
 	};
 }
 
-function createDefaultDeskConfig( siteId?: string ): DeskConfig {
+function createDefaultDeskConfig( siteId?: string, defaultSiteUrl?: string ): DeskConfig {
 	if ( siteId ) {
-		return createDefaultSiteDeskConfig();
+		return createDefaultSiteDeskConfig( defaultSiteUrl );
 	}
 
 	return defaultUserDesk;

--- a/apps/ui/src/ui-desks/desk/provider/persistence.ts
+++ b/apps/ui/src/ui-desks/desk/provider/persistence.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { useDeskConfig, useSaveDeskConfig } from '@/data/queries/use-desk-config';
-import { defaultUserDesk } from '../default-desk';
-import { DESK_CONFIG_VERSION, type DeskConfig } from '../types';
+import { createDefaultSiteDeskConfig, defaultUserDesk } from '../default-desk';
+import type { DeskConfig } from '../types';
 
 interface DeskPersistenceOptions {
 	enabled?: boolean;
@@ -29,11 +29,7 @@ export function useDeskPersistence( siteId?: string, options: DeskPersistenceOpt
 
 function createDefaultDeskConfig( siteId?: string ): DeskConfig {
 	if ( siteId ) {
-		return {
-			version: DESK_CONFIG_VERSION,
-			updatedAt: new Date().toISOString(),
-			widgets: [],
-		};
+		return createDefaultSiteDeskConfig();
 	}
 
 	return defaultUserDesk;


### PR DESCRIPTION
## Summary
- Add a dedicated first-run site desk layout with a site card, home preview, sticky note, recent posts collection, and active theme card.
- Switch site desk persistence to use that default layout instead of an empty canvas on first access.
- Add unit coverage for the generated site desk config and its key widgets.

## Testing
- `npx eslint --fix` on the modified desk files
- `npm test -- apps/ui/src/ui-desks/desk/default-desk.test.ts`
- `npm run typecheck`