### PR TITLE
apps/ui: Add desks site settings route

### DIFF
--- a/apps/ui/src/ui-desks/app.tsx
+++ b/apps/ui/src/ui-desks/app.tsx
@@ -9,10 +9,12 @@ import {
 } from './onboarding';
 import { desksRootRoute } from './router/root';
 import { siteDeskRoute } from './site-desk';
+import { desksSiteSettingsRoute } from './site-settings';
 import { userDeskRoute } from './user-desk';
 
 const routeTree = desksRootRoute.addChildren( [
 	userDeskRoute,
+	desksSiteSettingsRoute,
 	siteDeskRoute,
 	desksOnboardingHomeRoute,
 	desksOnboardingCreateRoute,

--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx
@@ -15,6 +15,14 @@ import { usePullSiteFromLive, usePushSiteToLive } from '@/data/queries/use-sync-
 import { SiteDetailsDropdown } from './index';
 import type { SiteDetails } from '@/data/core';
 
+const routerMock = vi.hoisted( () => ( {
+	navigate: vi.fn(),
+} ) );
+
+vi.mock( '@tanstack/react-router', () => ( {
+	useNavigate: () => routerMock.navigate,
+} ) );
+
 vi.mock( '@tanstack/react-query', () => ( {
 	useIsMutating: () => 0,
 } ) );
@@ -75,6 +83,7 @@ describe( 'SiteDetailsDropdown', () => {
 		pushMutate.mockReset();
 		startMutate.mockReset();
 		stopMutate.mockReset();
+		routerMock.navigate.mockReset();
 
 		useConnectorMock.mockReturnValue( {
 			getPublishCheckoutUrl: () => 'https://wordpress.com/setup/studio',
@@ -148,6 +157,13 @@ describe( 'SiteDetailsDropdown', () => {
 		await waitFor( () =>
 			expect( openExternalUrl ).toHaveBeenCalledWith( 'http://localhost:8881' )
 		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Site details for Local Studio Site' } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Open site settings' } ) );
+		expect( routerMock.navigate ).toHaveBeenCalledWith( {
+			to: '/sites/$siteId/settings',
+			params: { siteId: 'site-1' },
+		} );
 	} );
 } );
 

--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.tsx
@@ -1,6 +1,7 @@
 import { useIsMutating } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
-import { download, external, formatListBullets, upload } from '@wordpress/icons';
+import { cog, download, external, formatListBullets, upload } from '@wordpress/icons';
 import { clsx } from 'clsx';
 import { useMemo, useState } from 'react';
 import {
@@ -57,6 +58,7 @@ function useIsSiteSyncing( siteId: string ): { push: boolean; pull: boolean } {
 
 export function SiteDetailsDropdown( { site, disabled = false }: SiteDetailsDropdownProps ) {
 	const connector = useConnector();
+	const navigate = useNavigate();
 	const [ open, setOpen ] = useState( false );
 	const { data: snapshots } = useSnapshots();
 	const { data: connectedSites } = useConnectedWpcomSites( site.id );
@@ -86,6 +88,11 @@ export function SiteDetailsDropdown( { site, disabled = false }: SiteDetailsDrop
 	const openExternal = ( url: string ) => {
 		setOpen( false );
 		void connector.openExternalUrl( url );
+	};
+
+	const handleSiteSettingsClick = () => {
+		setOpen( false );
+		void navigate( { to: '/sites/$siteId/settings', params: { siteId: site.id } } );
 	};
 
 	const handleToggleServer = () => {
@@ -151,21 +158,31 @@ export function SiteDetailsDropdown( { site, disabled = false }: SiteDetailsDrop
 							<StatusLine tone={ status }>{ getHeaderStatusText( status, site ) }</StatusLine>
 						</div>
 					</div>
-					<Button
-						className={ styles.serverButton }
-						variant="filled"
-						size="small"
-						label={ site.running ? __( 'Stop site' ) : __( 'Start site' ) }
-						disabled={ status === 'transitioning' }
-						aria-busy={ status === 'transitioning' ? 'true' : undefined }
-						onClick={ handleToggleServer }
-					>
-						<span
-							className={ site.running ? styles.stopGlyph : styles.startGlyph }
-							aria-hidden="true"
+					<div className={ styles.headerActions }>
+						<Button
+							className={ styles.settingsButton }
+							variant="filled"
+							size="small"
+							icon={ cog }
+							label={ __( 'Open site settings' ) }
+							onClick={ handleSiteSettingsClick }
 						/>
-						{ getServerButtonLabel( site.running, isStarting, isStopping ) }
-					</Button>
+						<Button
+							className={ styles.serverButton }
+							variant="filled"
+							size="small"
+							label={ site.running ? __( 'Stop site' ) : __( 'Start site' ) }
+							disabled={ status === 'transitioning' }
+							aria-busy={ status === 'transitioning' ? 'true' : undefined }
+							onClick={ handleToggleServer }
+						>
+							<span
+								className={ site.running ? styles.stopGlyph : styles.startGlyph }
+								aria-hidden="true"
+							/>
+							{ getServerButtonLabel( site.running, isStarting, isStopping ) }
+						</Button>
+					</div>
 				</header>
 
 				<div className={ styles.divider } />

--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/style.module.css
@@ -64,6 +64,13 @@
 	font-weight: 600;
 }
 
+.headerActions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex: 0 0 auto;
+}
+
 .serverButton {
 	flex: 0 0 auto;
 	gap: 6px;
@@ -128,7 +135,8 @@
 }
 
 .syncButton,
-.openButton {
+.openButton,
+.settingsButton {
 	white-space: nowrap;
 }
 

--- a/apps/ui/src/ui-desks/site-settings/index.test.ts
+++ b/apps/ui/src/ui-desks/site-settings/index.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isDesksSiteSettingsTab, validateDesksSiteSettingsSearch } from './index';
+
+describe( 'desks site settings route search', () => {
+	it( 'accepts known site settings tabs', () => {
+		expect( isDesksSiteSettingsTab( 'general' ) ).toBe( true );
+		expect( isDesksSiteSettingsTab( 'debugging' ) ).toBe( true );
+	} );
+
+	it( 'drops unknown tab values from search params', () => {
+		expect( validateDesksSiteSettingsSearch( { tab: 'missing' } ) ).toEqual( {} );
+		expect( validateDesksSiteSettingsSearch( { tab: 1 } ) ).toEqual( {} );
+	} );
+
+	it( 'keeps valid tab values in search params', () => {
+		expect( validateDesksSiteSettingsSearch( { tab: 'debugging' } ) ).toEqual( {
+			tab: 'debugging',
+		} );
+	} );
+} );

--- a/apps/ui/src/ui-desks/site-settings/index.tsx
+++ b/apps/ui/src/ui-desks/site-settings/index.tsx
@@ -1,0 +1,423 @@
+import { DEFAULT_WORDPRESS_VERSION } from '@studio/common/constants';
+import { generateCustomDomainFromSiteName } from '@studio/common/lib/domains';
+import { decodePassword, encodePassword } from '@studio/common/lib/passwords';
+import { RecommendedPHPVersion } from '@studio/common/types/php-versions';
+import { createRoute, useNavigate } from '@tanstack/react-router';
+import { DataForm, useFormValidity } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { arrowLeft } from '@wordpress/icons';
+import { clsx } from 'clsx';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { LearnHowLink } from '@/components/learn-more';
+import {
+	adminEmailField,
+	adminPasswordField,
+	adminUsernameField,
+	customDomainField,
+	customDomainToggleField,
+	enableDebugDisplayField,
+	enableDebugLogField,
+	enableXdebugField,
+	phpVersionField,
+	siteNameField,
+	wpVersionField,
+} from '@/components/site-fields';
+import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
+import { useSites, useUpdateSite, useXdebugEnabledSite } from '@/data/queries/use-sites';
+import { DeskHeader } from '@/ui-desks/chrome/header';
+import { DeskMenu } from '@/ui-desks/chrome/user-menu';
+import { Button, Surface } from '@/ui-desks/components';
+import { desksRootRoute } from '../router/root';
+import styles from './style.module.css';
+import type { SiteDetails } from '@/data/core';
+import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
+import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
+import type { FormEvent } from 'react';
+
+type TabId = 'general' | 'debugging';
+
+interface SiteSettingsSearch {
+	tab?: TabId;
+}
+
+interface FormData {
+	name: string;
+	phpVersion: SupportedPHPVersion;
+	wpVersion: string;
+	useCustomDomain: boolean;
+	customDomain: string;
+	enableHttps: boolean;
+	adminUsername: string;
+	adminPassword: string;
+	adminEmail: string;
+	enableXdebug: boolean;
+	enableDebugLog: boolean;
+	enableDebugDisplay: boolean;
+}
+
+function getEffectiveWpVersion( site: SiteDetails | undefined ): string {
+	return site?.isWpAutoUpdating !== false ? '' : DEFAULT_WORDPRESS_VERSION;
+}
+
+function initialFormData( site: SiteDetails ): FormData {
+	return {
+		name: site.name,
+		phpVersion: ( site.phpVersion as SupportedPHPVersion ) ?? RecommendedPHPVersion,
+		wpVersion: getEffectiveWpVersion( site ),
+		useCustomDomain: Boolean( site.customDomain ),
+		customDomain: site.customDomain ?? '',
+		enableHttps: site.enableHttps ?? false,
+		adminUsername: site.adminUsername ?? 'admin',
+		adminPassword: decodePassword( site.adminPassword ?? '' ) || 'password',
+		adminEmail: site.adminEmail || 'admin@localhost.com',
+		enableXdebug: site.enableXdebug ?? false,
+		enableDebugLog: site.enableDebugLog ?? false,
+		enableDebugDisplay: site.enableDebugDisplay ?? false,
+	};
+}
+
+function EnableHttpsControl( { data: item, field, onChange }: DataFormControlProps< FormData > ) {
+	return (
+		<div className={ styles.checkboxControl }>
+			<label className={ styles.checkboxLabel }>
+				<input
+					type="checkbox"
+					checked={ item.enableHttps }
+					onChange={ ( event ) => onChange( { enableHttps: event.target.checked } ) }
+				/>
+				<span>{ field.label }</span>
+			</label>
+			<p className={ styles.fieldHelp }>
+				{ __(
+					'You need to manually add the Studio root certificate authority to your keychain and trust it to enable HTTPS.'
+				) }{ ' ' }
+				<LearnHowLink docsLinksKey="docsSslInStudio" />
+			</p>
+		</div>
+	);
+}
+
+function DesksSiteSettingsPage() {
+	const { siteId } = desksSiteSettingsRoute.useParams();
+	const { tab } = desksSiteSettingsRoute.useSearch();
+	const navigate = useNavigate();
+	const activeTab: TabId = tab ?? 'general';
+
+	return (
+		<DesksSiteSettingsView
+			siteId={ siteId }
+			activeTab={ activeTab }
+			onBack={ () => void navigate( { to: '/sites/$siteId', params: { siteId } } ) }
+			onTabChange={ ( next ) =>
+				void navigate( {
+					to: '/sites/$siteId/settings',
+					params: { siteId },
+					search: { tab: next },
+					replace: true,
+				} )
+			}
+		/>
+	);
+}
+
+function DesksSiteSettingsView( {
+	siteId,
+	activeTab,
+	onBack,
+	onTabChange,
+}: {
+	siteId: string;
+	activeTab: TabId;
+	onBack: () => void;
+	onTabChange: ( tab: TabId ) => void;
+} ) {
+	const { data: sites, isLoading: sitesLoading } = useSites();
+	const site = sites?.find( ( candidate ) => candidate.id === siteId );
+
+	return (
+		<div className={ styles.root }>
+			<DeskHeader
+				rightChildren={
+					<Button
+						type="button"
+						icon={ arrowLeft }
+						label={ __( 'Back to site desk' ) }
+						variant="chrome"
+						size="medium"
+						onClick={ onBack }
+					>
+						{ __( 'Site desk' ) }
+					</Button>
+				}
+			>
+				<DeskMenu siteId={ siteId } />
+			</DeskHeader>
+			<main className={ styles.main } aria-label={ __( 'Site settings' ) }>
+				{ sitesLoading ? (
+					<div className={ styles.state }>{ __( 'Loading...' ) }</div>
+				) : site ? (
+					<SiteSettingsBody site={ site } activeTab={ activeTab } onTabChange={ onTabChange } />
+				) : (
+					<div className={ styles.state }>
+						<h1>{ __( 'Site not found' ) }</h1>
+						<p>{ siteId }</p>
+					</div>
+				) }
+			</main>
+		</div>
+	);
+}
+
+function SiteSettingsTabs( {
+	activeTab,
+	onTabChange,
+}: {
+	activeTab: TabId;
+	onTabChange: ( tab: TabId ) => void;
+} ) {
+	return (
+		<div className={ styles.tabs } role="tablist" aria-label={ __( 'Site settings sections' ) }>
+			{ ( [ 'general', 'debugging' ] as const ).map( ( tabId ) => (
+				<button
+					key={ tabId }
+					type="button"
+					role="tab"
+					id={ `desks-site-settings-tab-${ tabId }` }
+					aria-controls={ `desks-site-settings-panel-${ tabId }` }
+					aria-selected={ activeTab === tabId }
+					className={ clsx( styles.tab, activeTab === tabId && styles.activeTab ) }
+					onClick={ () => onTabChange( tabId ) }
+				>
+					{ tabId === 'general' ? __( 'General' ) : __( 'Debugging' ) }
+				</button>
+			) ) }
+		</div>
+	);
+}
+
+function SiteSettingsBody( {
+	site,
+	activeTab,
+	onTabChange,
+}: {
+	site: SiteDetails;
+	activeTab: TabId;
+	onTabChange: ( tab: TabId ) => void;
+} ) {
+	const { data: allDomains } = useExistingCustomDomains();
+	const existingDomainNames = useMemo(
+		() => ( allDomains ?? [] ).filter( ( domain ) => domain !== site.customDomain ),
+		[ allDomains, site.customDomain ]
+	);
+	const { data: xdebugEnabledSite } = useXdebugEnabledSite();
+	const xdebugConflictSiteName =
+		xdebugEnabledSite && xdebugEnabledSite.id !== site.id ? xdebugEnabledSite.name : undefined;
+
+	const updateSite = useUpdateSite();
+	const [ submitError, setSubmitError ] = useState< string | null >( null );
+	const [ data, setData ] = useState< FormData >( () => initialFormData( site ) );
+
+	useEffect( () => {
+		setData( initialFormData( site ) );
+		setSubmitError( null );
+	}, [ site ] );
+
+	const fields = useMemo< Field< FormData >[] >(
+		() => [
+			siteNameField< FormData >(),
+			phpVersionField< FormData >(),
+			wpVersionField< FormData >( DEFAULT_WORDPRESS_VERSION ),
+			adminUsernameField< FormData >(),
+			adminPasswordField< FormData >(),
+			adminEmailField< FormData >(),
+			customDomainToggleField< FormData >(),
+			customDomainField< FormData >( existingDomainNames ),
+			{
+				id: 'enableHttps',
+				type: 'boolean',
+				label: __( 'Enable HTTPS' ),
+				isVisible: ( item: FormData ) => item.useCustomDomain,
+				Edit: EnableHttpsControl,
+			},
+			enableXdebugField< FormData >( { conflictingSiteName: xdebugConflictSiteName } ),
+			enableDebugLogField< FormData >(),
+			enableDebugDisplayField< FormData >(),
+		],
+		[ existingDomainNames, xdebugConflictSiteName ]
+	);
+
+	const generalForm = useMemo< Form >(
+		() => ( {
+			layout: { type: 'regular', labelPosition: 'top' },
+			fields: [
+				'name',
+				{
+					id: 'versions',
+					layout: { type: 'row' },
+					children: [ 'phpVersion', 'wpVersion' ],
+				},
+				{
+					id: 'adminCredentials',
+					layout: { type: 'row' },
+					children: [ 'adminUsername', 'adminPassword' ],
+				},
+				'adminEmail',
+				'useCustomDomain',
+				'customDomain',
+				'enableHttps',
+			],
+		} ),
+		[]
+	);
+	const debuggingForm = useMemo< Form >(
+		() => ( {
+			layout: { type: 'regular', labelPosition: 'top' },
+			fields: [ 'enableXdebug', 'enableDebugLog', 'enableDebugDisplay' ],
+		} ),
+		[]
+	);
+	const fullForm = useMemo< Form >(
+		() => ( {
+			layout: { type: 'regular', labelPosition: 'top' },
+			fields: [ ...generalForm.fields!, ...debuggingForm.fields! ],
+		} ),
+		[ generalForm, debuggingForm ]
+	);
+
+	const { validity, isValid } = useFormValidity( data, fields, fullForm );
+
+	const handleChange = useCallback( ( update: Record< string, unknown > ) => {
+		setData( ( prev ) => {
+			const next: FormData = { ...prev, ...( update as Partial< FormData > ) };
+			if ( ! prev.useCustomDomain && next.useCustomDomain && ! next.customDomain ) {
+				next.customDomain = generateCustomDomainFromSiteName( next.name );
+			}
+			return next;
+		} );
+	}, [] );
+
+	const initial = useMemo( () => initialFormData( site ), [ site ] );
+	const isUnchanged = useMemo(
+		() =>
+			( Object.keys( initial ) as Array< keyof FormData > ).every(
+				( key ) => initial[ key ] === data[ key ]
+			),
+		[ data, initial ]
+	);
+
+	const xdebugBlocked = data.enableXdebug && !! xdebugConflictSiteName && ! site.enableXdebug;
+	const canSubmit = isValid && ! isUnchanged && ! updateSite.isPending && ! xdebugBlocked;
+
+	const handleSubmit = ( event: FormEvent ) => {
+		event.preventDefault();
+		if ( ! canSubmit ) return;
+		setSubmitError( null );
+		const usedCustomDomain = data.useCustomDomain
+			? data.customDomain || generateCustomDomainFromSiteName( data.name )
+			: undefined;
+		const wpPinned = data.wpVersion.trim();
+		const updated: SiteDetails = {
+			...site,
+			name: data.name,
+			phpVersion: data.phpVersion,
+			isWpAutoUpdating: ! wpPinned,
+			customDomain: usedCustomDomain,
+			enableHttps: !! usedCustomDomain && data.enableHttps,
+			adminUsername: data.adminUsername,
+			adminPassword: encodePassword( data.adminPassword ),
+			adminEmail: data.adminEmail,
+			enableXdebug: data.enableXdebug,
+			enableDebugLog: data.enableDebugLog,
+			enableDebugDisplay: data.enableDebugDisplay,
+		};
+		updateSite.mutate(
+			{ site: updated, wpVersion: wpPinned || undefined },
+			{
+				onError: ( error ) => {
+					setSubmitError( ( error as Error ).message ?? __( 'Unable to save changes.' ) );
+				},
+			}
+		);
+	};
+
+	return (
+		<Surface className={ styles.panel }>
+			<div className={ styles.panelHeader }>
+				<div className={ styles.titleBlock }>
+					<p className={ styles.eyebrow }>{ site.name }</p>
+					<h1 id="desks-site-settings-title">{ __( 'Site settings' ) }</h1>
+				</div>
+				<SiteSettingsTabs activeTab={ activeTab } onTabChange={ onTabChange } />
+			</div>
+			<form onSubmit={ handleSubmit } className={ styles.form }>
+				<div
+					role="tabpanel"
+					id="desks-site-settings-panel-general"
+					aria-labelledby="desks-site-settings-tab-general"
+					hidden={ activeTab !== 'general' }
+				>
+					<DataForm< FormData >
+						data={ data }
+						fields={ fields }
+						form={ generalForm }
+						onChange={ handleChange }
+						validity={ validity }
+					/>
+				</div>
+				<div
+					role="tabpanel"
+					id="desks-site-settings-panel-debugging"
+					aria-labelledby="desks-site-settings-tab-debugging"
+					hidden={ activeTab !== 'debugging' }
+				>
+					<DataForm< FormData >
+						data={ data }
+						fields={ fields }
+						form={ debuggingForm }
+						onChange={ handleChange }
+						validity={ validity }
+					/>
+				</div>
+
+				{ submitError && <div className={ styles.submitError }>{ submitError }</div> }
+
+				<div className={ styles.actions }>
+					<Button
+						type="submit"
+						label={ __( 'Save settings' ) }
+						variant="filled"
+						tone="primary"
+						size="medium"
+						disabled={ ! canSubmit }
+						aria-busy={ updateSite.isPending }
+					>
+						{ updateSite.isPending ? __( 'Saving...' ) : __( 'Save settings' ) }
+					</Button>
+				</div>
+			</form>
+		</Surface>
+	);
+}
+
+export function isDesksSiteSettingsTab( value: string ): value is TabId {
+	return value === 'general' || value === 'debugging';
+}
+
+export function validateDesksSiteSettingsSearch(
+	search: Record< string, unknown >
+): SiteSettingsSearch {
+	const value = search.tab;
+	if ( typeof value === 'string' && isDesksSiteSettingsTab( value ) ) {
+		return { tab: value };
+	}
+	return {};
+}
+
+export const desksSiteSettingsRoute = createRoute( {
+	getParentRoute: () => desksRootRoute,
+	path: '/sites/$siteId/settings',
+	validateSearch: validateDesksSiteSettingsSearch,
+	component: DesksSiteSettingsPage,
+} );
+
+export type DesksSiteSettingsTabId = TabId;

--- a/apps/ui/src/ui-desks/site-settings/style.module.css
+++ b/apps/ui/src/ui-desks/site-settings/style.module.css
@@ -1,0 +1,243 @@
+.root {
+	min-height: 100vh;
+	background: var(--ui-desks-bg, rgb(232, 234, 235));
+	color: var(--ui-desks-text, #14171a);
+}
+
+.main {
+	box-sizing: border-box;
+	width: 100%;
+	min-height: 100vh;
+	padding: 120px 24px 48px;
+	display: flex;
+	justify-content: center;
+	align-items: flex-start;
+}
+
+.state {
+	box-sizing: border-box;
+	width: min(720px, 100%);
+	padding: 32px;
+	color: var(--ui-desks-muted, #6b7280);
+	background: var(--ui-desks-material, #fff);
+	border-radius: var(--ui-desks-radius-panel, 22px);
+	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	box-shadow: var(--ui-desks-shadow-control, 0 8px 24px rgba(15, 23, 42, 0.06));
+}
+
+.state h1 {
+	margin-bottom: 8px;
+	font-weight: 600;
+	color: var(--ui-desks-text, #14171a);
+}
+
+.state p {
+	margin: 0;
+}
+
+.panel {
+	box-sizing: border-box;
+	width: min(760px, 100%);
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	padding: 0;
+	overflow: hidden;
+	border-radius: var(--ui-desks-radius-panel, 22px);
+}
+
+.panelHeader {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	padding: 32px 32px 0;
+	border-bottom: 1px solid var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+}
+
+.titleBlock {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.titleBlock h1 {
+	font-size: 24px;
+	line-height: 32px;
+	font-weight: 600;
+	color: var(--ui-desks-text, #14171a);
+}
+
+.eyebrow {
+	margin: 0;
+	max-width: 100%;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 13px;
+	line-height: 18px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.tabs {
+	display: flex;
+	align-items: flex-end;
+	gap: 24px;
+}
+
+.tab {
+	position: relative;
+	margin: 0 0 -1px;
+	padding: 0 0 14px;
+	border: 0;
+	background: transparent;
+	color: var(--ui-desks-muted, #6b7280);
+	font: inherit;
+	font-size: 13px;
+	line-height: 18px;
+	cursor: pointer;
+}
+
+.tab::after {
+	content: '';
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	height: 1px;
+	background: transparent;
+}
+
+.tab:hover,
+.tab:focus-visible,
+.activeTab {
+	color: var(--ui-desks-text, #14171a);
+}
+
+.tab:focus-visible {
+	outline: 2px solid var(--ui-desks-focus, #3858e9);
+	outline-offset: 3px;
+	border-radius: 4px;
+}
+
+.activeTab {
+	font-weight: 600;
+}
+
+.activeTab::after {
+	background: var(--ui-desks-text, #14171a);
+}
+
+.form {
+	padding: 32px;
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}
+
+.form [role='tabpanel'][hidden] {
+	display: none;
+}
+
+.form :global(.dataviews-form) {
+	gap: 20px;
+}
+
+.form :global(.dataviews-form__field-control),
+.form :global(.components-base-control) {
+	margin-bottom: 0;
+}
+
+.form :global(.components-base-control__label),
+.form :global(.components-input-control__label),
+.form :global(.components-toggle-control__label) {
+	color: var(--ui-desks-text, #14171a);
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 18px;
+}
+
+.form :global(.components-input-control__container),
+.form :global(.components-select-control__input),
+.form :global(.components-text-control__input) {
+	border-radius: var(--ui-desks-radius-button, 12px);
+}
+
+.form :global(.components-input-control__input),
+.form :global(.components-select-control__input),
+.form :global(.components-text-control__input) {
+	min-height: 38px;
+	color: var(--ui-desks-text, #14171a);
+}
+
+.form :global(.components-base-control__help),
+.form :global(.components-toggle-control__help) {
+	margin-top: 6px;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 12px;
+	line-height: 17px;
+}
+
+.form :global(.components-toggle-control .components-form-toggle.is-checked .components-form-toggle__track) {
+	background: var(--ui-desks-focus, #3858e9);
+}
+
+.checkboxControl {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.checkboxLabel {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	width: fit-content;
+	color: var(--ui-desks-text, #14171a);
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 18px;
+	cursor: pointer;
+}
+
+.checkboxLabel input[type='checkbox'] {
+	flex: 0 0 auto;
+	width: 16px;
+	height: 16px;
+	margin: 0;
+	accent-color: var(--ui-desks-focus, #3858e9);
+	cursor: pointer;
+}
+
+.fieldHelp {
+	margin: 0;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 12px;
+	line-height: 17px;
+}
+
+.submitError {
+	padding: 10px 12px;
+	border-radius: var(--ui-desks-radius-button, 12px);
+	background: #fce8e8;
+	color: #7a1a1a;
+	font-size: 13px;
+	line-height: 18px;
+}
+
+.actions {
+	display: flex;
+	justify-content: flex-end;
+}
+
+@media (max-width: 640px) {
+	.main {
+		padding: 104px 12px 24px;
+	}
+
+	.panelHeader,
+	.form {
+		padding-right: 20px;
+		padding-left: 20px;
+	}
+}


### PR DESCRIPTION
## Related issues

- Related to desks UI site management

## How AI was used in this PR

Codex implemented the route, adapted the classic site settings behavior to desks UI components, moved the entry point into the site details dropdown, and ran local validation.

## Proposed Changes

- Add a desks UI route at /sites//settings with General and Debugging tabs for site settings.
- Reuse the existing site update/query behavior while adapting the surface, buttons, and tab styling to desks UI components.
- Add an icon-only site settings button to the site details dropdown header, immediately before the Start/Stop action.
- Cover route search validation and dropdown navigation with tests.

## Testing Instructions

- Open a site in desks UI.
- Open the site details dropdown.
- Click the cog button next to Start/Stop.
- Confirm the site settings screen opens and the General/Debugging tabs update the tab search param.
- Edit a setting and confirm Save enables only when the form is valid and changed.

Validation run locally:

- npx eslint --fix apps/ui/src/ui-desks/site-settings/index.tsx apps/ui/src/ui-desks/site-settings/index.test.ts apps/ui/src/ui-desks/app.tsx apps/ui/src/ui-desks/chrome/site-details-dropdown/index.tsx apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx apps/ui/src/ui-desks/chrome/site-details-dropdown/style.module.css
- npm run typecheck
- npm test -- apps/ui/src/ui-desks/site-settings/index.test.ts apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?