### PR TITLE
apps/ui: Add a site shortcuts widget to the default desk

### DIFF
--- a/apps/ui/src/ui-desks/desk/default-desk.test.ts
+++ b/apps/ui/src/ui-desks/desk/default-desk.test.ts
@@ -1,11 +1,11 @@
 import { assertDeskConfig } from '@studio/common/lib/desk-config';
 import { describe, expect, it } from 'vitest';
-import { BOOKMARK_WIDGET_TYPE } from '@/ui-desks/widgets/bookmark/types';
 import { DRAWING_WIDGET_TYPE } from '@/ui-desks/widgets/drawing/types';
 import { EMBED_WIDGET_TYPE } from '@/ui-desks/widgets/embed/types';
 import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
 import { SITE_CARD_WIDGET_TYPE } from '@/ui-desks/widgets/site-card/types';
 import { SITE_PREVIEW_WIDGET_TYPE } from '@/ui-desks/widgets/site-preview/types';
+import { SITE_SHORTCUTS_WIDGET_TYPE } from '@/ui-desks/widgets/site-shortcuts/types';
 import { THEME_WIDGET_TYPE } from '@/ui-desks/widgets/theme/types';
 import { createDefaultSiteDeskConfig, defaultUserDesk } from './default-desk';
 
@@ -55,13 +55,13 @@ describe( 'default desk configs', () => {
 	} );
 
 	it( 'creates a valid first-run site desk', () => {
-		const desk = createDefaultSiteDeskConfig( 'https://example.test' );
+		const desk = createDefaultSiteDeskConfig();
 
 		expect( () => assertDeskConfig( desk ) ).not.toThrow();
 		expect( Number.isNaN( Date.parse( desk.updatedAt ) ) ).toBe( false );
 		expect( desk.viewport ).toEqual( {
-			x: 440.72744922694875,
-			y: 53.85707696744839,
+			x: 419.18831968677756,
+			y: 98.5921921662651,
 			z: 0.6035527097673408,
 		} );
 		expect( desk.widgets.map( ( widget ) => widget.id ) ).toEqual( [
@@ -70,7 +70,7 @@ describe( 'default desk configs', () => {
 			'home-preview',
 			'site-notes',
 			'2f456fe8-0351-49ec-b816-3629382036a3',
-			'5efaab75-bd70-4332-bdf1-e1183e78331f',
+			'site-shortcuts',
 			'e60190a0-d2df-4c16-b283-eb19ed8e4839',
 		] );
 		expect( desk.widgets.map( ( widget ) => widget.type ) ).toEqual( [
@@ -79,14 +79,14 @@ describe( 'default desk configs', () => {
 			SITE_PREVIEW_WIDGET_TYPE,
 			NOTE_WIDGET_TYPE,
 			NOTE_WIDGET_TYPE,
-			BOOKMARK_WIDGET_TYPE,
+			SITE_SHORTCUTS_WIDGET_TYPE,
 			NOTE_WIDGET_TYPE,
 		] );
 		expect( desk.widgets.some( ( widget ) => widget.type === DRAWING_WIDGET_TYPE ) ).toBe( false );
 	} );
 
-	it( 'uses Lola desk content with a dynamic bookmark URL', () => {
-		const desk = createDefaultSiteDeskConfig( 'https://example.test' );
+	it( 'uses the My Bright Website desk content as the default site desk', () => {
+		const desk = createDefaultSiteDeskConfig();
 
 		expect( desk.widgets.find( ( widget ) => widget.id === 'site-notes' ) ).toMatchObject( {
 			type: NOTE_WIDGET_TYPE,
@@ -108,25 +108,15 @@ describe( 'default desk configs', () => {
 				path: '/',
 			},
 		} );
-		expect(
-			desk.widgets.find( ( widget ) => widget.id === '5efaab75-bd70-4332-bdf1-e1183e78331f' )
-		).toMatchObject( {
-			type: BOOKMARK_WIDGET_TYPE,
-			widgetProps: {
-				url: 'https://example.test/',
+		expect( desk.widgets.find( ( widget ) => widget.id === 'site-shortcuts' ) ).toMatchObject( {
+			type: SITE_SHORTCUTS_WIDGET_TYPE,
+			x: 181.3992831377875,
+			y: 688.0537779757126,
+			shapeProps: {
+				w: 363.3217408954813,
+				h: 538.6254582619412,
 			},
-		} );
-	} );
-
-	it( 'keeps an existing trailing slash on the dynamic bookmark URL', () => {
-		const desk = createDefaultSiteDeskConfig( 'https://example.test/' );
-
-		expect(
-			desk.widgets.find( ( widget ) => widget.id === '5efaab75-bd70-4332-bdf1-e1183e78331f' )
-		).toMatchObject( {
-			widgetProps: {
-				url: 'https://example.test/',
-			},
+			widgetProps: {},
 		} );
 	} );
 } );

--- a/apps/ui/src/ui-desks/desk/default-desk.ts
+++ b/apps/ui/src/ui-desks/desk/default-desk.ts
@@ -1,10 +1,10 @@
 import { DESK_CONFIG_VERSION, type DeskConfig } from '@/ui-desks/desk/types';
-import { BOOKMARK_WIDGET_TYPE } from '@/ui-desks/widgets/bookmark/types';
 import { DRAWING_WIDGET_TYPE } from '@/ui-desks/widgets/drawing/types';
 import { EMBED_WIDGET_TYPE } from '@/ui-desks/widgets/embed/types';
 import { NOTE_WIDGET_TYPE } from '@/ui-desks/widgets/note/types';
 import { SITE_CARD_WIDGET_TYPE } from '@/ui-desks/widgets/site-card/types';
 import { SITE_PREVIEW_WIDGET_TYPE } from '@/ui-desks/widgets/site-preview/types';
+import { SITE_SHORTCUTS_WIDGET_TYPE } from '@/ui-desks/widgets/site-shortcuts/types';
 import { THEME_WIDGET_TYPE } from '@/ui-desks/widgets/theme/types';
 
 const STUDIO_TOUR_VIDEO_URL = 'https://www.youtube.com/watch?v=2MV17Qzj_T0';
@@ -114,13 +114,13 @@ export const defaultUserDesk: DeskConfig = {
 	],
 };
 
-export function createDefaultSiteDeskConfig( siteUrl = '' ): DeskConfig {
+export function createDefaultSiteDeskConfig(): DeskConfig {
 	return {
 		version: DESK_CONFIG_VERSION,
 		updatedAt: new Date().toISOString(),
 		viewport: {
-			x: 440.72744922694875,
-			y: 53.85707696744839,
+			x: 419.18831968677756,
+			y: 98.5921921662651,
 			z: 0.6035527097673408,
 		},
 		widgets: [
@@ -129,7 +129,7 @@ export function createDefaultSiteDeskConfig( siteUrl = '' ): DeskConfig {
 				type: SITE_CARD_WIDGET_TYPE,
 				x: 184.83596516477996,
 				y: 101.06117767440315,
-				zIndex: 'a00xF',
+				zIndex: 'a04MU',
 				shapeProps: {
 					w: 360,
 					h: 200,
@@ -143,7 +143,7 @@ export function createDefaultSiteDeskConfig( siteUrl = '' ): DeskConfig {
 				type: THEME_WIDGET_TYPE,
 				x: 631.6308732298062,
 				y: 785.2649837045076,
-				zIndex: 'a1BoL',
+				zIndex: 'a17Zw',
 				shapeProps: {
 					w: 760,
 					h: 440,
@@ -157,7 +157,7 @@ export function createDefaultSiteDeskConfig( siteUrl = '' ): DeskConfig {
 				type: SITE_PREVIEW_WIDGET_TYPE,
 				x: 634.5565745594427,
 				y: 98.47227110772417,
-				zIndex: 'a21Yp',
+				zIndex: 'a27H4',
 				shapeProps: {
 					w: 754.6531489796062,
 					h: 603.3094530012401,
@@ -171,7 +171,7 @@ export function createDefaultSiteDeskConfig( siteUrl = '' ): DeskConfig {
 				type: NOTE_WIDGET_TYPE,
 				x: 1278.0300192133188,
 				y: 659.9530248690811,
-				zIndex: 'a32wj',
+				zIndex: 'a34je',
 				shapeProps: {
 					w: 164.11440409609554,
 					h: 80,
@@ -187,7 +187,7 @@ export function createDefaultSiteDeskConfig( siteUrl = '' ): DeskConfig {
 				type: NOTE_WIDGET_TYPE,
 				x: 1269.3487977572597,
 				y: 1177.163284949601,
-				zIndex: 'a49JE',
+				zIndex: 'a4A6S',
 				shapeProps: {
 					w: 160.64603845116085,
 					h: 80,
@@ -199,27 +199,25 @@ export function createDefaultSiteDeskConfig( siteUrl = '' ): DeskConfig {
 				},
 			},
 			{
-				id: '5efaab75-bd70-4332-bdf1-e1183e78331f',
-				type: BOOKMARK_WIDGET_TYPE,
-				x: 246.437937197667,
-				y: 333.81664542698036,
-				zIndex: 'a516A',
+				id: 'site-shortcuts',
+				type: SITE_SHORTCUTS_WIDGET_TYPE,
+				x: 181.3992831377875,
+				y: 688.0537779757126,
+				zIndex: 'a5CE6',
 				shapeProps: {
-					w: 300,
-					h: 101,
+					w: 363.3217408954813,
+					h: 538.6254582619412,
 				},
-				widgetProps: {
-					url: normalizeDefaultSiteDeskUrl( siteUrl ),
-				},
+				widgetProps: {},
 			},
 			{
 				id: 'e60190a0-d2df-4c16-b283-eb19ed8e4839',
 				type: NOTE_WIDGET_TYPE,
-				x: 237.7295705934331,
-				y: 470.6123135830188,
-				zIndex: 'a61Ch',
+				x: 183.78101380809494,
+				y: 336.58687589714395,
+				zIndex: 'a62yJ',
 				shapeProps: {
-					w: 304.9708960372699,
+					w: 360,
 					h: 316,
 				},
 				widgetProps: {
@@ -230,13 +228,4 @@ export function createDefaultSiteDeskConfig( siteUrl = '' ): DeskConfig {
 			},
 		],
 	};
-}
-
-function normalizeDefaultSiteDeskUrl( url: string ) {
-	const trimmedUrl = url.trim();
-	if ( ! trimmedUrl ) {
-		return '';
-	}
-
-	return trimmedUrl.endsWith( '/' ) ? trimmedUrl : `${ trimmedUrl }/`;
 }

--- a/apps/ui/src/ui-desks/desk/provider/index.tsx
+++ b/apps/ui/src/ui-desks/desk/provider/index.tsx
@@ -159,17 +159,14 @@ export function DeskProvider( {
 	statusMessage,
 }: DeskProviderProps ) {
 	const hasExternalDeskConfig = Boolean( deskConfig );
-	const { data: sites, isLoading: isLoadingSites } = useSites();
+	const { data: sites } = useSites();
 	const site = sites?.find( ( candidate ) => candidate.id === siteId );
-	const defaultSiteUrl = site ? site.url ?? getSiteUrl( site ) : undefined;
 	const {
 		desk: persistedDesk,
 		isLoading: isLoadingPersistedDesk,
 		saveDeskConfig,
 	} = useDeskPersistence( siteId, {
 		enabled: ! hasExternalDeskConfig,
-		defaultSiteUrl,
-		isDefaultSiteUrlLoading: Boolean( siteId && isLoadingSites ),
 	} );
 	const desk = deskConfig ?? persistedDesk;
 	const isLoading = externalIsLoading ?? isLoadingPersistedDesk;

--- a/apps/ui/src/ui-desks/desk/provider/persistence.ts
+++ b/apps/ui/src/ui-desks/desk/provider/persistence.ts
@@ -5,40 +5,31 @@ import type { DeskConfig } from '../types';
 
 interface DeskPersistenceOptions {
 	enabled?: boolean;
-	defaultSiteUrl?: string;
-	isDefaultSiteUrlLoading?: boolean;
 }
 
 export function useDeskPersistence( siteId?: string, options: DeskPersistenceOptions = {} ) {
 	const enabled = options.enabled ?? true;
 	const { data: savedDesk, isLoading } = useDeskConfig( siteId, enabled );
 	const { mutate: saveDeskConfig } = useSaveDeskConfig( siteId );
-	const defaultDesk = useMemo(
-		() => createDefaultDeskConfig( siteId, options.defaultSiteUrl ),
-		[ options.defaultSiteUrl, siteId ]
-	);
+	const defaultDesk = useMemo( () => createDefaultDeskConfig( siteId ), [ siteId ] );
 	const desk = ( savedDesk as DeskConfig | undefined ) ?? defaultDesk;
-	const canSaveDefaultDesk = ! siteId || Boolean( options.defaultSiteUrl );
-	const isWaitingForDefaultSiteUrl = Boolean(
-		siteId && ! savedDesk && ! canSaveDefaultDesk && options.isDefaultSiteUrlLoading
-	);
 
 	useEffect( () => {
-		if ( enabled && ! isLoading && ! savedDesk && canSaveDefaultDesk ) {
+		if ( enabled && ! isLoading && ! savedDesk ) {
 			saveDeskConfig( defaultDesk );
 		}
-	}, [ canSaveDefaultDesk, defaultDesk, enabled, isLoading, savedDesk, saveDeskConfig ] );
+	}, [ defaultDesk, enabled, isLoading, savedDesk, saveDeskConfig ] );
 
 	return {
 		desk,
-		isLoading: isLoading || isWaitingForDefaultSiteUrl,
+		isLoading,
 		saveDeskConfig,
 	};
 }
 
-function createDefaultDeskConfig( siteId?: string, defaultSiteUrl?: string ): DeskConfig {
+function createDefaultDeskConfig( siteId?: string ): DeskConfig {
 	if ( siteId ) {
-		return createDefaultSiteDeskConfig( defaultSiteUrl );
+		return createDefaultSiteDeskConfig();
 	}
 
 	return defaultUserDesk;

--- a/apps/ui/src/ui-desks/widgets/registry.ts
+++ b/apps/ui/src/ui-desks/widgets/registry.ts
@@ -13,6 +13,7 @@ import { postCollectionWidgetDefinition } from '@/ui-desks/widgets/post-collecti
 import { scratchpadWidgetDefinition } from '@/ui-desks/widgets/scratchpad/definition';
 import { siteCardWidgetDefinition } from '@/ui-desks/widgets/site-card/definition';
 import { sitePreviewWidgetDefinition } from '@/ui-desks/widgets/site-preview/definition';
+import { siteShortcutsWidgetDefinition } from '@/ui-desks/widgets/site-shortcuts/definition';
 import { themeWidgetDefinition } from '@/ui-desks/widgets/theme/definition';
 import { themePatternWidgetDefinition } from '@/ui-desks/widgets/theme-pattern/definition';
 import { themePatternBrowserWidgetDefinition } from '@/ui-desks/widgets/theme-pattern-browser/definition';
@@ -37,6 +38,7 @@ export const widgetDefinitions = {
 	[ postCollectionWidgetDefinition.type ]: postCollectionWidgetDefinition,
 	[ siteCardWidgetDefinition.type ]: siteCardWidgetDefinition,
 	[ sitePreviewWidgetDefinition.type ]: sitePreviewWidgetDefinition,
+	[ siteShortcutsWidgetDefinition.type ]: siteShortcutsWidgetDefinition,
 	[ themeStylesWidgetDefinition.type ]: themeStylesWidgetDefinition,
 	[ themeWidgetDefinition.type ]: themeWidgetDefinition,
 	[ themePatternBrowserWidgetDefinition.type ]: themePatternBrowserWidgetDefinition,

--- a/apps/ui/src/ui-desks/widgets/site-shortcuts/component/index.test.tsx
+++ b/apps/ui/src/ui-desks/widgets/site-shortcuts/component/index.test.tsx
@@ -1,0 +1,139 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConnector } from '@/data/core';
+import {
+	useIsSiteStarting,
+	useIsSiteStopping,
+	useSites,
+	useStartSite,
+} from '@/data/queries/use-sites';
+import { useUserPreferences } from '@/data/queries/use-user-preferences';
+import { useDesk } from '@/ui-desks/desk/provider';
+import { SiteShortcutsWidgetComponent } from './index';
+
+vi.mock( '@/data/core', () => ( {
+	useConnector: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-sites', () => ( {
+	useSites: vi.fn(),
+	useStartSite: vi.fn(),
+	useIsSiteStarting: vi.fn(),
+	useIsSiteStopping: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-user-preferences', () => ( {
+	useUserPreferences: vi.fn(),
+} ) );
+
+vi.mock( '@/ui-desks/desk/provider', () => ( {
+	useDesk: vi.fn(),
+} ) );
+
+const useConnectorMock = vi.mocked( useConnector );
+const useSitesMock = vi.mocked( useSites );
+const useStartSiteMock = vi.mocked( useStartSite );
+const useIsSiteStartingMock = vi.mocked( useIsSiteStarting );
+const useIsSiteStoppingMock = vi.mocked( useIsSiteStopping );
+const useUserPreferencesMock = vi.mocked( useUserPreferences );
+const useDeskMock = vi.mocked( useDesk );
+
+describe( 'SiteShortcutsWidgetComponent', () => {
+	const openSiteUrl = vi.fn();
+	const startSite = vi.fn();
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		openSiteUrl.mockResolvedValue( undefined );
+		startSite.mockResolvedValue( undefined );
+		useConnectorMock.mockReturnValue( {
+			openSiteUrl,
+			openSiteFolder: vi.fn(),
+			openSiteInEditor: vi.fn(),
+			openSiteInTerminal: vi.fn(),
+		} as never );
+		useDeskMock.mockReturnValue( { siteId: 'site-1' } as never );
+		useStartSiteMock.mockReturnValue( {
+			isPending: false,
+			mutateAsync: startSite,
+		} as never );
+		useIsSiteStartingMock.mockReturnValue( false );
+		useIsSiteStoppingMock.mockReturnValue( false );
+		useUserPreferencesMock.mockReturnValue( {
+			data: {
+				editor: 'zed',
+				terminal: 'terminal',
+				colorScheme: 'system',
+				locale: undefined,
+			},
+		} as never );
+		useSitesMock.mockReturnValue( {
+			data: [ createSite( { running: true } ) ],
+		} as never );
+	} );
+
+	it( 'opens WordPress admin links for the current desk site', async () => {
+		renderSiteShortcuts();
+
+		expect( screen.queryByText( 'Demo Site' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'localhost:8881' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Running' ) ).not.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'WP Admin' } ) );
+
+		await waitFor( () => {
+			expect( openSiteUrl ).toHaveBeenCalledWith( 'site-1', '/wp-admin/' );
+		} );
+		expect( startSite ).not.toHaveBeenCalled();
+		expect( screen.getByRole( 'button', { name: 'Zed' } ) ).toBeEnabled();
+	} );
+
+	it( 'starts stopped sites before opening WordPress shortcuts', async () => {
+		useSitesMock.mockReturnValue( {
+			data: [ createSite( { running: false } ) ],
+		} as never );
+		renderSiteShortcuts();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'phpMyAdmin' } ) );
+
+		await waitFor( () => {
+			expect( startSite ).toHaveBeenCalledWith( 'site-1' );
+			expect( openSiteUrl ).toHaveBeenCalledWith(
+				'site-1',
+				'/phpmyadmin/index.php?route=/database/structure&db=wordpress'
+			);
+		} );
+	} );
+} );
+
+function renderSiteShortcuts() {
+	render(
+		<SiteShortcutsWidgetComponent
+			id="shortcuts-1"
+			widgetProps={ {} }
+			isEditing={ false }
+			isHovered={ false }
+			isSelected={ false }
+			onWidgetPropsChange={ vi.fn() }
+			onEditComplete={ vi.fn() }
+		/>
+	);
+}
+
+function createSite( overrides: { running: boolean } ) {
+	return {
+		id: 'site-1',
+		name: 'Demo Site',
+		path: '/Users/example/Studio/demo',
+		port: 8881,
+		running: overrides.running,
+		phpVersion: '8.4',
+		themeDetails: {
+			name: 'Twenty Twenty-Six',
+			path: 'twentytwentysix',
+			slug: 'twentytwentysix',
+			isBlockTheme: true,
+		},
+	};
+}

--- a/apps/ui/src/ui-desks/widgets/site-shortcuts/component/index.tsx
+++ b/apps/ui/src/ui-desks/widgets/site-shortcuts/component/index.tsx
@@ -1,0 +1,341 @@
+import { supportedEditorConfig } from '@studio/common/lib/user-settings/editor';
+import { terminalConfig } from '@studio/common/lib/user-settings/terminal';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	archive,
+	code,
+	desktop,
+	external,
+	grid,
+	Icon,
+	layout,
+	navigation,
+	page,
+	pencil,
+	preformatted,
+	styles as stylesIcon,
+	symbolFilled,
+	widget as widgetIcon,
+} from '@wordpress/icons';
+import { useState } from 'react';
+import { useConnector } from '@/data/core';
+import {
+	useIsSiteStarting,
+	useIsSiteStopping,
+	useSites,
+	useStartSite,
+} from '@/data/queries/use-sites';
+import { useUserPreferences } from '@/data/queries/use-user-preferences';
+import { Button } from '@/ui-desks/components';
+import { useDesk } from '@/ui-desks/desk/provider';
+import { SITE_SHORTCUTS_WIDGET_TYPE, type SiteShortcutsWidgetProps } from '../types';
+import styles from './style.module.css';
+import type {
+	DeskWidgetComponentProps,
+	DeskWidgetThumbnailComponentProps,
+} from '@/ui-desks/widgets/types';
+import type { ComponentProps, PointerEvent } from 'react';
+
+type SiteShortcutsWidgetComponentProps = DeskWidgetComponentProps< SiteShortcutsWidgetProps >;
+type ShortcutIcon = ComponentProps< typeof Icon >[ 'icon' ];
+
+interface SiteShortcutAction {
+	id: string;
+	label: string;
+	icon: ShortcutIcon;
+	emphasis?: 'primary';
+	disabled?: boolean;
+	run: () => Promise< void >;
+}
+
+interface SiteShortcutGroup {
+	id: string;
+	title: string;
+	actions: SiteShortcutAction[];
+}
+
+export function SiteShortcutsWidgetComponent( {
+	id,
+	widgetProps,
+}: SiteShortcutsWidgetComponentProps ) {
+	const connector = useConnector();
+	const desk = useDesk();
+	const { data: sites } = useSites();
+	const { data: userPreferences } = useUserPreferences();
+	const startSite = useStartSite();
+	const effectiveSiteId = widgetProps.siteId ?? desk.siteId;
+	const site = sites?.find( ( candidate ) => candidate.id === effectiveSiteId );
+	const isStarting = useIsSiteStarting( effectiveSiteId );
+	const isStopping = useIsSiteStopping( effectiveSiteId );
+	const [ busyActionId, setBusyActionId ] = useState< string | null >( null );
+	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
+	const hasSite = Boolean( effectiveSiteId && site );
+	const isRuntimeBusy = isStarting || isStopping || startSite.isPending;
+	const isActionBusy = Boolean( busyActionId );
+	const runtimeActionDisabled = ! hasSite || isRuntimeBusy || isActionBusy;
+	const localActionDisabled = ! hasSite || isActionBusy;
+	const editorLabel = userPreferences?.editor
+		? supportedEditorConfig[ userPreferences.editor ].label
+		: __( 'Editor' );
+	const terminalLabel = userPreferences?.terminal
+		? terminalConfig[ userPreferences.terminal ].name
+		: __( 'Terminal' );
+
+	const getRequiredSiteId = () => {
+		if ( ! effectiveSiteId ) {
+			throw new Error( 'No site selected.' );
+		}
+		return effectiveSiteId;
+	};
+
+	const openSitePath = async (
+		path = '',
+		options?: Parameters< typeof connector.openSiteUrl >[ 2 ]
+	) => {
+		const siteId = getRequiredSiteId();
+		if ( ! site?.running ) {
+			await startSite.mutateAsync( siteId );
+		}
+		if ( options ) {
+			await connector.openSiteUrl( siteId, path, options );
+			return;
+		}
+		await connector.openSiteUrl( siteId, path );
+	};
+
+	const openLocalTool = async ( tool: 'folder' | 'editor' | 'terminal' ) => {
+		const siteId = getRequiredSiteId();
+		if ( tool === 'folder' ) {
+			await connector.openSiteFolder( siteId );
+			return;
+		}
+		if ( tool === 'editor' ) {
+			await connector.openSiteInEditor( siteId );
+			return;
+		}
+		await connector.openSiteInTerminal( siteId );
+	};
+
+	const groups: SiteShortcutGroup[] = [
+		{
+			id: 'wordpress',
+			title: __( 'WordPress' ),
+			actions: [
+				{
+					id: 'open-site',
+					label: __( 'Open site' ),
+					icon: external,
+					emphasis: 'primary',
+					disabled: runtimeActionDisabled,
+					run: () => openSitePath( '', { autoLogin: false } ),
+				},
+				{
+					id: 'wp-admin',
+					label: __( 'WP Admin' ),
+					icon: desktop,
+					emphasis: 'primary',
+					disabled: runtimeActionDisabled,
+					run: () => openSitePath( '/wp-admin/' ),
+				},
+				{
+					id: 'phpmyadmin',
+					label: __( 'phpMyAdmin' ),
+					icon: grid,
+					disabled: runtimeActionDisabled,
+					run: () => openSitePath( '/phpmyadmin/index.php?route=/database/structure&db=wordpress' ),
+				},
+			],
+		},
+		{
+			id: 'customize',
+			title: __( 'Customize' ),
+			actions: getCustomizeActions( Boolean( site?.themeDetails?.isBlockTheme === false ) ).map(
+				( action ) => ( {
+					...action,
+					disabled: runtimeActionDisabled,
+					run: () => openSitePath( action.path ),
+				} )
+			),
+		},
+		{
+			id: 'local',
+			title: __( 'Local' ),
+			actions: [
+				{
+					id: 'files',
+					label: __( 'Files' ),
+					icon: archive,
+					disabled: localActionDisabled,
+					run: () => openLocalTool( 'folder' ),
+				},
+				{
+					id: 'editor',
+					label: editorLabel,
+					icon: code,
+					disabled: localActionDisabled || ! userPreferences?.editor,
+					run: () => openLocalTool( 'editor' ),
+				},
+				{
+					id: 'terminal',
+					label: terminalLabel,
+					icon: preformatted,
+					disabled: localActionDisabled,
+					run: () => openLocalTool( 'terminal' ),
+				},
+			],
+		},
+	];
+
+	const runShortcut = async ( action: SiteShortcutAction ) => {
+		if ( action.disabled || busyActionId ) {
+			return;
+		}
+
+		setBusyActionId( action.id );
+		setErrorMessage( null );
+		try {
+			await action.run();
+		} catch ( error ) {
+			console.error( 'Failed to run site shortcut:', error );
+			setErrorMessage(
+				sprintf(
+					/* translators: %s: shortcut label, such as "WP Admin". */
+					__( 'Could not open %s.' ),
+					action.label
+				)
+			);
+		} finally {
+			setBusyActionId( null );
+		}
+	};
+
+	return (
+		<section
+			className={ styles.card }
+			data-studio-desk-widget={ SITE_SHORTCUTS_WIDGET_TYPE }
+			data-studio-desk-widget-id={ id }
+		>
+			<header className={ styles.header }>
+				<h2 className={ styles.title }>{ __( 'Site shortcuts' ) }</h2>
+			</header>
+
+			{ hasSite ? (
+				<div className={ styles.groups }>
+					{ groups.map( ( group ) => (
+						<div className={ styles.group } key={ group.id }>
+							<h3 className={ styles.groupTitle }>{ group.title }</h3>
+							<div className={ styles.actions }>
+								{ group.actions.map( ( action ) => (
+									<Button
+										key={ action.id }
+										className={ styles.action }
+										icon={ action.icon }
+										label={ action.label }
+										variant="filled"
+										tone={ action.emphasis === 'primary' ? 'inverse' : 'neutral' }
+										size="large"
+										disabled={ action.disabled }
+										aria-busy={ busyActionId === action.id ? 'true' : undefined }
+										onPointerDown={ stopCanvasPointer }
+										onClick={ () => void runShortcut( action ) }
+									>
+										<span>{ action.label }</span>
+									</Button>
+								) ) }
+							</div>
+						</div>
+					) ) }
+				</div>
+			) : (
+				<div className={ styles.empty }>{ __( 'Choose a site to use shortcuts.' ) }</div>
+			) }
+
+			{ errorMessage ? <div className={ styles.error }>{ errorMessage }</div> : null }
+		</section>
+	);
+}
+
+export function SiteShortcutsWidgetThumbnailComponent( {
+	id,
+}: DeskWidgetThumbnailComponentProps< SiteShortcutsWidgetProps > ) {
+	return (
+		<div
+			className={ styles.thumbnail }
+			data-studio-desk-widget={ SITE_SHORTCUTS_WIDGET_TYPE }
+			data-studio-desk-widget-id={ id }
+		>
+			<span className={ styles.thumbnailIcon } aria-hidden="true">
+				<Icon icon={ external } size={ 16 } />
+			</span>
+			<span>{ __( 'Site shortcuts' ) }</span>
+		</div>
+	);
+}
+
+function getCustomizeActions( isClassicTheme: boolean ) {
+	if ( isClassicTheme ) {
+		return [
+			{
+				id: 'customizer',
+				label: __( 'Customizer' ),
+				icon: pencil,
+				path: '/wp-admin/customize.php',
+			},
+			{
+				id: 'menus',
+				label: __( 'Menus' ),
+				icon: navigation,
+				path: '/wp-admin/nav-menus.php',
+			},
+			{
+				id: 'widgets',
+				label: __( 'Widgets' ),
+				icon: widgetIcon,
+				path: '/wp-admin/widgets.php',
+			},
+		];
+	}
+
+	return [
+		{
+			id: 'site-editor',
+			label: __( 'Site Editor' ),
+			icon: desktop,
+			path: '/wp-admin/site-editor.php',
+		},
+		{
+			id: 'styles',
+			label: __( 'Styles' ),
+			icon: stylesIcon,
+			path: '/wp-admin/site-editor.php?path=%2Fwp_global_styles',
+		},
+		{
+			id: 'patterns',
+			label: __( 'Patterns' ),
+			icon: symbolFilled,
+			path: '/wp-admin/site-editor.php?path=%2Fpatterns',
+		},
+		{
+			id: 'navigation',
+			label: __( 'Navigation' ),
+			icon: navigation,
+			path: '/wp-admin/site-editor.php?path=%2Fnavigation',
+		},
+		{
+			id: 'templates',
+			label: __( 'Templates' ),
+			icon: layout,
+			path: '/wp-admin/site-editor.php?path=%2Fwp_template',
+		},
+		{
+			id: 'pages',
+			label: __( 'Pages' ),
+			icon: page,
+			path: '/wp-admin/site-editor.php?path=%2Fpage',
+		},
+	];
+}
+
+function stopCanvasPointer( event: PointerEvent< HTMLButtonElement > ) {
+	event.stopPropagation();
+}

--- a/apps/ui/src/ui-desks/widgets/site-shortcuts/component/style.module.css
+++ b/apps/ui/src/ui-desks/widgets/site-shortcuts/component/style.module.css
@@ -1,0 +1,133 @@
+.card {
+	box-sizing: border-box;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 22px;
+	padding: 24px;
+	background: #fff;
+	border-radius: 18px;
+	corner-shape: superellipse(1.42);
+	-webkit-corner-shape: superellipse(1.42);
+	box-shadow:
+		0 1px 2px rgba(15, 23, 42, 0.04),
+		0 18px 44px rgba(15, 23, 42, 0.09);
+	color: var(--ui-desks-text, #14171a);
+	font-family: inherit;
+	cursor: grab;
+	overflow: hidden;
+}
+
+.header {
+	min-width: 0;
+}
+
+.title,
+.groupTitle {
+	margin: 0;
+	letter-spacing: 0;
+}
+
+.title {
+	color: #14171a;
+	font-size: 20px;
+	font-weight: 700;
+	line-height: 1.2;
+	overflow-wrap: anywhere;
+}
+
+.groups {
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 26px;
+	padding-right: 2px;
+	overflow: auto;
+}
+
+.group {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	min-width: 0;
+}
+
+.groupTitle {
+	color: #5f6673;
+	font-size: 11px;
+	font-weight: 700;
+	line-height: 1.25;
+	text-transform: uppercase;
+}
+
+.actions {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 8px;
+}
+
+.action {
+	width: 100%;
+}
+
+.empty {
+	flex: 1;
+	display: grid;
+	place-items: center;
+	min-height: 160px;
+	padding: 24px;
+	border: 1px dashed rgba(15, 23, 42, 0.16);
+	border-radius: 12px;
+	color: #5f6673;
+	font-size: 13px;
+	line-height: 1.4;
+	text-align: center;
+}
+
+.error {
+	margin-top: auto;
+	padding: 8px 10px;
+	border-radius: 8px;
+	background: #fff0f0;
+	color: #8a2424;
+	font-size: 12px;
+	line-height: 16px;
+}
+
+.thumbnail {
+	box-sizing: border-box;
+	width: 100%;
+	height: 100%;
+	display: grid;
+	grid-template-columns: 26px minmax(0, 1fr);
+	align-items: center;
+	gap: 8px;
+	padding: 8px;
+	background: #fff;
+	border: 1px solid rgba(15, 23, 42, 0.08);
+	border-radius: 10px;
+	color: #14171a;
+	font-size: 10px;
+	font-weight: 600;
+	line-height: 1.2;
+	overflow: hidden;
+}
+
+.thumbnail > span:last-child {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.thumbnailIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
+	border-radius: 7px;
+	background: #14171a;
+	color: #fff;
+}

--- a/apps/ui/src/ui-desks/widgets/site-shortcuts/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/site-shortcuts/definition.ts
@@ -1,0 +1,41 @@
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+import {
+	SiteShortcutsWidgetComponent,
+	SiteShortcutsWidgetThumbnailComponent,
+} from '@/ui-desks/widgets/site-shortcuts/component';
+import {
+	isSiteShortcutsWidgetProps,
+	SITE_SHORTCUTS_WIDGET_TYPE,
+	type SiteShortcutsWidget,
+} from './types';
+import type { WidgetDefinition } from '@/ui-desks/widgets/types';
+
+export const siteShortcutsWidgetDefinition = {
+	type: SITE_SHORTCUTS_WIDGET_TYPE,
+	name: () => __( 'Site shortcuts' ),
+	Component: SiteShortcutsWidgetComponent,
+	thumbnail: SiteShortcutsWidgetThumbnailComponent,
+	shouldStartEditingOnCreate: false,
+	isWidgetProps: isSiteShortcutsWidgetProps,
+	getIndicator: () => ( {
+		cornerRadius: 18,
+		stroke: '#3858e9',
+	} ),
+	labels: {
+		add: () => __( 'New site shortcuts' ),
+	},
+	icon: external,
+	getInitialWidget: () => ( {
+		shapeProps: {
+			w: 400,
+			h: 500,
+		},
+		widgetProps: {},
+	} ),
+	getSummary: () => __( 'Site shortcuts' ),
+	resizeConstraints: {
+		minWidth: 340,
+		minHeight: 360,
+	},
+} satisfies WidgetDefinition< SiteShortcutsWidget >;

--- a/apps/ui/src/ui-desks/widgets/site-shortcuts/types.ts
+++ b/apps/ui/src/ui-desks/widgets/site-shortcuts/types.ts
@@ -1,0 +1,23 @@
+import type { RectangleWidgetShapeProps } from '@/ui-desks/widget-actions/geometry';
+import type { DeskWidgetBase } from '@studio/common/types/desk';
+
+export const SITE_SHORTCUTS_WIDGET_TYPE = 'site-shortcuts';
+
+export type SiteShortcutsWidgetProps = {
+	siteId?: string;
+};
+
+export type SiteShortcutsWidget = DeskWidgetBase<
+	typeof SITE_SHORTCUTS_WIDGET_TYPE,
+	RectangleWidgetShapeProps,
+	SiteShortcutsWidgetProps
+>;
+
+export function isSiteShortcutsWidgetProps( value: unknown ): value is SiteShortcutsWidgetProps {
+	return (
+		Boolean( value ) &&
+		typeof value === 'object' &&
+		( ( value as Partial< SiteShortcutsWidgetProps > ).siteId === undefined ||
+			typeof ( value as Partial< SiteShortcutsWidgetProps > ).siteId === 'string' )
+	);
+}

--- a/apps/ui/src/ui-desks/widgets/types.ts
+++ b/apps/ui/src/ui-desks/widgets/types.ts
@@ -14,6 +14,7 @@ import type { PostCollectionWidget } from '@/ui-desks/widgets/post-collection/ty
 import type { ScratchpadWidget } from '@/ui-desks/widgets/scratchpad/types';
 import type { SiteCardWidget } from '@/ui-desks/widgets/site-card/types';
 import type { SitePreviewWidget } from '@/ui-desks/widgets/site-preview/types';
+import type { SiteShortcutsWidget } from '@/ui-desks/widgets/site-shortcuts/types';
 import type { ThemeWidget } from '@/ui-desks/widgets/theme/types';
 import type { ThemePatternWidget } from '@/ui-desks/widgets/theme-pattern/types';
 import type { ThemePatternBrowserWidget } from '@/ui-desks/widgets/theme-pattern-browser/types';
@@ -349,6 +350,7 @@ export type DeskWidget =
 	| PostCollectionWidget
 	| SiteCardWidget
 	| SitePreviewWidget
+	| SiteShortcutsWidget
 	| ThemeWidget
 	| ThemePatternBrowserWidget
 	| ThemeTemplateBrowserWidget
@@ -371,6 +373,7 @@ export type DeskWidgetDefinition =
 	| WidgetDefinition< PostCollectionWidget >
 	| WidgetDefinition< SiteCardWidget >
 	| WidgetDefinition< SitePreviewWidget >
+	| WidgetDefinition< SiteShortcutsWidget >
 	| WidgetDefinition< ThemeWidget >
 	| WidgetDefinition< ThemePatternBrowserWidget >
 	| WidgetDefinition< ThemeTemplateBrowserWidget >


### PR DESCRIPTION
## Summary
- Add a new `site-shortcuts` widget to the desk widget registry
- Persist site shortcut layout state through the desk provider
- Update the default desk to include the new widget and cover it with tests
- Add component and styling tests for the widget UI

## Testing
- Added/updated unit tests for the default desk, persistence, and site shortcuts widget
- Not run (not requested)