### PR TITLE
apps/ui: Add delete site action to the Desks site details dropdown

### DIFF
--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx
@@ -1,10 +1,11 @@
 import '@testing-library/jest-dom/vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import { usePublishPreviewSite } from '@/data/queries/use-preview-site';
 import {
+	useDeleteSite,
 	useIsSiteStarting,
 	useIsSiteStopping,
 	useStartSite,
@@ -40,6 +41,7 @@ vi.mock( '@/data/queries/use-preview-site', () => ( {
 } ) );
 
 vi.mock( '@/data/queries/use-sites', () => ( {
+	useDeleteSite: vi.fn(),
 	useIsSiteStarting: vi.fn(),
 	useIsSiteStopping: vi.fn(),
 	useStartSite: vi.fn(),
@@ -60,6 +62,7 @@ vi.mock( '@/data/queries/use-sync-site', () => ( {
 const useConnectorMock = vi.mocked( useConnector );
 const useConnectedWpcomSitesMock = vi.mocked( useConnectedWpcomSites );
 const usePublishPreviewSiteMock = vi.mocked( usePublishPreviewSite );
+const useDeleteSiteMock = vi.mocked( useDeleteSite );
 const useIsSiteStartingMock = vi.mocked( useIsSiteStarting );
 const useIsSiteStoppingMock = vi.mocked( useIsSiteStopping );
 const useStartSiteMock = vi.mocked( useStartSite );
@@ -73,6 +76,7 @@ describe( 'SiteDetailsDropdown', () => {
 	const publishPreviewMutate = vi.fn();
 	const pullMutate = vi.fn();
 	const pushMutate = vi.fn();
+	const deleteMutate = vi.fn();
 	const startMutate = vi.fn();
 	const stopMutate = vi.fn();
 
@@ -81,6 +85,7 @@ describe( 'SiteDetailsDropdown', () => {
 		publishPreviewMutate.mockReset();
 		pullMutate.mockReset();
 		pushMutate.mockReset();
+		deleteMutate.mockReset();
 		startMutate.mockReset();
 		stopMutate.mockReset();
 		routerMock.navigate.mockReset();
@@ -120,6 +125,10 @@ describe( 'SiteDetailsDropdown', () => {
 		} as never );
 		usePushSiteToLiveMock.mockReturnValue( { mutate: pushMutate } as never );
 		usePullSiteFromLiveMock.mockReturnValue( { mutate: pullMutate } as never );
+		useDeleteSiteMock.mockReturnValue( {
+			isPending: false,
+			mutate: deleteMutate,
+		} as never );
 		useStartSiteMock.mockReturnValue( { mutate: startMutate } as never );
 		useStopSiteMock.mockReturnValue( { mutate: stopMutate } as never );
 		useIsSiteStartingMock.mockReturnValue( false );
@@ -164,6 +173,40 @@ describe( 'SiteDetailsDropdown', () => {
 			to: '/sites/$siteId/settings',
 			params: { siteId: 'site-1' },
 		} );
+	} );
+
+	it( 'confirms before deleting the site from the dropdown', async () => {
+		const site = createSite();
+		render( <SiteDetailsDropdown site={ site } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Site details for Local Studio Site' } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Delete site' } ) );
+
+		const dialog = await screen.findByRole( 'dialog', { name: 'Delete Local Studio Site' } );
+		expect(
+			within( dialog ).getByText(
+				"The site's database will be lost, including all posts, pages, comments, and media."
+			)
+		).toBeVisible();
+		expect(
+			within( dialog ).getByRole( 'checkbox', {
+				name: 'Delete site files from my computer',
+			} )
+		).toBeChecked();
+
+		fireEvent.click( within( dialog ).getByRole( 'button', { name: 'Delete site' } ) );
+
+		expect( deleteMutate ).toHaveBeenCalledWith(
+			{ id: 'site-1', deleteFiles: true },
+			expect.objectContaining( {
+				onSuccess: expect.any( Function ),
+				onError: expect.any( Function ),
+			} )
+		);
+
+		const options = deleteMutate.mock.calls[ 0 ][ 1 ];
+		options.onSuccess();
+		expect( routerMock.navigate ).toHaveBeenCalledWith( { to: '/' } );
 	} );
 } );
 

--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.tsx
@@ -1,7 +1,7 @@
 import { useIsMutating } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
-import { cog, download, external, formatListBullets, upload } from '@wordpress/icons';
+import { cog, download, external, formatListBullets, trash, upload } from '@wordpress/icons';
 import { clsx } from 'clsx';
 import { useMemo, useState } from 'react';
 import {
@@ -16,6 +16,7 @@ import { useConnector } from '@/data/core';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import { usePublishPreviewSite } from '@/data/queries/use-preview-site';
 import {
+	useDeleteSite,
 	useIsSiteStarting,
 	useIsSiteStopping,
 	useStartSite,
@@ -30,7 +31,16 @@ import {
 } from '@/data/queries/use-sync-site';
 import { formatRelativeTime } from '@/lib/format-relative-time';
 import { getSiteDisplayUrl, getSiteUrl } from '@/lib/get-site-url';
-import { Button, Menu } from '@/ui-desks/components';
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogError,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Menu,
+} from '@/ui-desks/components';
 import styles from './style.module.css';
 import type { SiteDetails } from '@/data/core';
 import type { ReactNode } from 'react';
@@ -60,6 +70,9 @@ export function SiteDetailsDropdown( { site, disabled = false }: SiteDetailsDrop
 	const connector = useConnector();
 	const navigate = useNavigate();
 	const [ open, setOpen ] = useState( false );
+	const [ deleteDialogOpen, setDeleteDialogOpen ] = useState( false );
+	const [ deleteFiles, setDeleteFiles ] = useState( true );
+	const [ deleteError, setDeleteError ] = useState< string | null >( null );
 	const { data: snapshots } = useSnapshots();
 	const { data: connectedSites } = useConnectedWpcomSites( site.id );
 	const previewSnapshot = useMemo(
@@ -72,6 +85,7 @@ export function SiteDetailsDropdown( { site, disabled = false }: SiteDetailsDrop
 	const publishPreviewSite = usePublishPreviewSite();
 	const pushSiteToLive = usePushSiteToLive();
 	const pullSiteFromLive = usePullSiteFromLive();
+	const deleteSite = useDeleteSite();
 	const isStarting = useIsSiteStarting( site.id );
 	const isStopping = useIsSiteStopping( site.id );
 	const { push: isPushPending, pull: isPullPending } = useIsSiteSyncing( site.id );
@@ -130,182 +144,290 @@ export function SiteDetailsDropdown( { site, disabled = false }: SiteDetailsDrop
 		pullSiteFromLive.mutate( { siteId: site.id, remoteSiteId: liveSite.id } );
 	};
 
+	const handleDeleteClick = () => {
+		setOpen( false );
+		setDeleteFiles( true );
+		setDeleteError( null );
+		setDeleteDialogOpen( true );
+	};
+
+	const closeDeleteDialog = () => {
+		if ( deleteSite.isPending ) {
+			return;
+		}
+		setDeleteDialogOpen( false );
+		setDeleteError( null );
+	};
+
+	const handleConfirmDelete = () => {
+		setDeleteError( null );
+		deleteSite.mutate(
+			{ id: site.id, deleteFiles },
+			{
+				onSuccess: () => {
+					setDeleteDialogOpen( false );
+					void navigate( { to: '/' } );
+				},
+				onError: ( error: Error ) => {
+					setDeleteError( error.message || __( 'Unable to delete the site. Please try again.' ) );
+				},
+			}
+		);
+	};
+
 	return (
-		<Menu.Root modal={ false } open={ open } onOpenChange={ setOpen }>
-			<Menu.Trigger
-				render={
-					<Button
-						className={ styles.detailsTrigger }
-						disabled={ disabled }
-						icon={ formatListBullets }
-						label={ sprintf(
-							/* translators: %s: current site name. */
-							__( 'Site details for %s' ),
-							site.name
-						) }
-						data-status={ status }
-					/>
-				}
-			/>
-			<Menu.Popup side="bottom" align="start" sideOffset={ 8 } className={ styles.popup }>
-				<header className={ styles.header }>
-					<div className={ styles.headerIdentity }>
-						<SiteBadge site={ site } size="panel" />
-						<div className={ styles.headerText }>
-							<div className={ styles.headerTitle } title={ site.name }>
-								{ site.name }
-							</div>
-							<StatusLine tone={ status }>{ getHeaderStatusText( status, site ) }</StatusLine>
-						</div>
-					</div>
-					<div className={ styles.headerActions }>
+		<>
+			<Menu.Root modal={ false } open={ open } onOpenChange={ setOpen }>
+				<Menu.Trigger
+					render={
 						<Button
-							className={ styles.settingsButton }
-							variant="filled"
-							size="small"
-							icon={ cog }
-							label={ __( 'Open site settings' ) }
-							onClick={ handleSiteSettingsClick }
+							className={ styles.detailsTrigger }
+							disabled={ disabled }
+							icon={ formatListBullets }
+							label={ sprintf(
+								/* translators: %s: current site name. */
+								__( 'Site details for %s' ),
+								site.name
+							) }
+							data-status={ status }
 						/>
-						<Button
-							className={ styles.serverButton }
-							variant="filled"
-							size="small"
-							label={ site.running ? __( 'Stop site' ) : __( 'Start site' ) }
-							disabled={ status === 'transitioning' }
-							aria-busy={ status === 'transitioning' ? 'true' : undefined }
-							onClick={ handleToggleServer }
-						>
-							<span
-								className={ site.running ? styles.stopGlyph : styles.startGlyph }
-								aria-hidden="true"
+					}
+				/>
+				<Menu.Popup side="bottom" align="start" sideOffset={ 8 } className={ styles.popup }>
+					<header className={ styles.header }>
+						<div className={ styles.headerIdentity }>
+							<SiteBadge site={ site } size="panel" />
+							<div className={ styles.headerText }>
+								<div className={ styles.headerTitle } title={ site.name }>
+									{ site.name }
+								</div>
+								<StatusLine tone={ status }>{ getHeaderStatusText( status, site ) }</StatusLine>
+							</div>
+						</div>
+						<div className={ styles.headerActions }>
+							<Button
+								className={ styles.settingsButton }
+								variant="filled"
+								size="small"
+								icon={ cog }
+								label={ __( 'Open site settings' ) }
+								onClick={ handleSiteSettingsClick }
 							/>
-							{ getServerButtonLabel( site.running, isStarting, isStopping ) }
-						</Button>
-					</div>
-				</header>
-
-				<div className={ styles.divider } />
-
-				<div className={ styles.rows }>
-					<DetailsRow
-						label={ __( 'Local' ) }
-						status={ status }
-						statusText={ getLocalStatusText( status, site ) }
-						actions={
-							<OpenButton
-								label={ __( 'Open local site' ) }
-								disabled={ ! site.running }
-								onClick={ () => openExternal( getSiteUrl( site ) ) }
-							/>
-						}
-					/>
-					<DetailsRow
-						label={ __( 'Preview' ) }
-						status={ previewSnapshot ? 'running' : 'stopped' }
-						statusText={
-							previewSnapshot
-								? sprintf(
-										/* translators: %s: relative time since the preview site was last synced. */
-										__( 'Synced %s' ),
-										formatRelativeTimestamp( previewSnapshot.date )
-								  )
-								: __( 'Not yet created' )
-						}
-						actions={
-							<>
-								<Button
-									className={ styles.syncButton }
-									variant="quiet"
-									size="small"
-									icon={ upload }
-									label={ previewActionLabel }
-									disabled={ isSyncing }
-									aria-busy={ isPreviewPending ? 'true' : undefined }
-									onClick={ handlePreviewClick }
-								>
-									{ isPreviewPending ? __( 'Pushing...' ) : __( 'Push to Preview' ) }
-								</Button>
-								<OpenButton
-									label={ __( 'Open preview site' ) }
-									disabled={ ! previewSnapshot }
-									onClick={ () => {
-										if ( previewSnapshot ) {
-											openExternal( ensureProtocol( previewSnapshot.url ) );
-										}
-									} }
+							<Button
+								className={ styles.serverButton }
+								variant="filled"
+								size="small"
+								label={ site.running ? __( 'Stop site' ) : __( 'Start site' ) }
+								disabled={ status === 'transitioning' }
+								aria-busy={ status === 'transitioning' ? 'true' : undefined }
+								onClick={ handleToggleServer }
+							>
+								<span
+									className={ site.running ? styles.stopGlyph : styles.startGlyph }
+									aria-hidden="true"
 								/>
-							</>
-						}
-					/>
-					<DetailsRow
-						label={ __( 'Live' ) }
-						status={ liveSite ? 'running' : 'stopped' }
-						statusText={
-							liveSite ? (
-								<>
-									<span>{ __( 'Connected' ) }</span>
-									<span className={ styles.statusSeparator } aria-hidden="true" />
-									<span>{ __( 'WordPress.com' ) }</span>
-								</>
-							) : (
-								__( 'Not connected' )
-							)
-						}
-						actions={
-							liveSite ? (
+								{ getServerButtonLabel( site.running, isStarting, isStopping ) }
+							</Button>
+						</div>
+					</header>
+
+					<div className={ styles.divider } />
+
+					<div className={ styles.rows }>
+						<DetailsRow
+							label={ __( 'Local' ) }
+							status={ status }
+							statusText={ getLocalStatusText( status, site ) }
+							actions={
+								<OpenButton
+									label={ __( 'Open local site' ) }
+									disabled={ ! site.running }
+									onClick={ () => openExternal( getSiteUrl( site ) ) }
+								/>
+							}
+						/>
+						<DetailsRow
+							label={ __( 'Preview' ) }
+							status={ previewSnapshot ? 'running' : 'stopped' }
+							statusText={
+								previewSnapshot
+									? sprintf(
+											/* translators: %s: relative time since the preview site was last synced. */
+											__( 'Synced %s' ),
+											formatRelativeTimestamp( previewSnapshot.date )
+									  )
+									: __( 'Not yet created' )
+							}
+							actions={
 								<>
 									<Button
 										className={ styles.syncButton }
 										variant="quiet"
 										size="small"
 										icon={ upload }
-										label={ pushActionLabel }
+										label={ previewActionLabel }
 										disabled={ isSyncing }
-										aria-busy={ isPushPending ? 'true' : undefined }
-										onClick={ handlePushClick }
+										aria-busy={ isPreviewPending ? 'true' : undefined }
+										onClick={ handlePreviewClick }
 									>
-										{ isPushPending ? __( 'Pushing...' ) : __( 'Push to Live' ) }
-									</Button>
-									<Button
-										className={ styles.syncButton }
-										variant="quiet"
-										size="small"
-										icon={ download }
-										label={ pullActionLabel }
-										disabled={ isSyncing }
-										aria-busy={ isPullPending ? 'true' : undefined }
-										onClick={ handlePullClick }
-									>
-										{ isPullPending ? __( 'Pulling...' ) : __( 'Pull' ) }
+										{ isPreviewPending ? __( 'Pushing...' ) : __( 'Push to Preview' ) }
 									</Button>
 									<OpenButton
-										label={ __( 'Open live site' ) }
-										disabled={ isSyncing }
-										onClick={ () => openExternal( ensureProtocol( liveSite.url ) ) }
+										label={ __( 'Open preview site' ) }
+										disabled={ ! previewSnapshot }
+										onClick={ () => {
+											if ( previewSnapshot ) {
+												openExternal( ensureProtocol( previewSnapshot.url ) );
+											}
+										} }
 									/>
 								</>
-							) : (
-								<Button
-									className={ styles.syncButton }
-									variant="filled"
-									size="small"
-									label={ __( 'Connect live site' ) }
-									disabled={ ! checkoutUrl }
-									onClick={ () => {
-										if ( checkoutUrl ) {
-											openExternal( checkoutUrl );
-										}
-									} }
-								>
-									{ __( 'Connect' ) }
-								</Button>
-							)
-						}
-					/>
-				</div>
-			</Menu.Popup>
-		</Menu.Root>
+							}
+						/>
+						<DetailsRow
+							label={ __( 'Live' ) }
+							status={ liveSite ? 'running' : 'stopped' }
+							statusText={
+								liveSite ? (
+									<>
+										<span>{ __( 'Connected' ) }</span>
+										<span className={ styles.statusSeparator } aria-hidden="true" />
+										<span>{ __( 'WordPress.com' ) }</span>
+									</>
+								) : (
+									__( 'Not connected' )
+								)
+							}
+							actions={
+								liveSite ? (
+									<>
+										<Button
+											className={ styles.syncButton }
+											variant="quiet"
+											size="small"
+											icon={ upload }
+											label={ pushActionLabel }
+											disabled={ isSyncing }
+											aria-busy={ isPushPending ? 'true' : undefined }
+											onClick={ handlePushClick }
+										>
+											{ isPushPending ? __( 'Pushing...' ) : __( 'Push to Live' ) }
+										</Button>
+										<Button
+											className={ styles.syncButton }
+											variant="quiet"
+											size="small"
+											icon={ download }
+											label={ pullActionLabel }
+											disabled={ isSyncing }
+											aria-busy={ isPullPending ? 'true' : undefined }
+											onClick={ handlePullClick }
+										>
+											{ isPullPending ? __( 'Pulling...' ) : __( 'Pull' ) }
+										</Button>
+										<OpenButton
+											label={ __( 'Open live site' ) }
+											disabled={ isSyncing }
+											onClick={ () => openExternal( ensureProtocol( liveSite.url ) ) }
+										/>
+									</>
+								) : (
+									<Button
+										className={ styles.syncButton }
+										variant="filled"
+										size="small"
+										label={ __( 'Connect live site' ) }
+										disabled={ ! checkoutUrl }
+										onClick={ () => {
+											if ( checkoutUrl ) {
+												openExternal( checkoutUrl );
+											}
+										} }
+									>
+										{ __( 'Connect' ) }
+									</Button>
+								)
+							}
+						/>
+					</div>
+
+					<div className={ styles.divider } />
+					<div className={ styles.footerActions }>
+						<Button
+							className={ styles.deleteButton }
+							variant="quiet"
+							size="medium"
+							icon={ trash }
+							label={ __( 'Delete site' ) }
+							disabled={ isSyncing || deleteSite.isPending }
+							onClick={ handleDeleteClick }
+						>
+							{ __( 'Delete site' ) }
+						</Button>
+					</div>
+				</Menu.Popup>
+			</Menu.Root>
+			<Dialog
+				ariaLabel={ sprintf(
+					/* translators: %s: site name. */
+					__( 'Delete %s' ),
+					site.name
+				) }
+				gap="compact"
+				onClose={ closeDeleteDialog }
+				open={ deleteDialogOpen }
+				size="small"
+			>
+				<DialogHeader>
+					<DialogTitle>
+						{ sprintf(
+							/* translators: %s: site name. */
+							__( 'Delete %s' ),
+							site.name
+						) }
+					</DialogTitle>
+				</DialogHeader>
+				<DialogContent className={ styles.deleteDialogContent }>
+					<p className={ styles.deleteDialogText }>
+						{ __(
+							"The site's database will be lost, including all posts, pages, comments, and media."
+						) }
+					</p>
+					<label className={ styles.deleteDialogCheckbox }>
+						<input
+							type="checkbox"
+							checked={ deleteFiles }
+							disabled={ deleteSite.isPending }
+							onChange={ ( event ) => setDeleteFiles( event.target.checked ) }
+						/>
+						<span>{ __( 'Delete site files from my computer' ) }</span>
+					</label>
+					{ deleteError ? <DialogError>{ deleteError }</DialogError> : null }
+				</DialogContent>
+				<DialogFooter>
+					<Button
+						variant="quiet"
+						size="medium"
+						label={ __( 'Cancel' ) }
+						disabled={ deleteSite.isPending }
+						onClick={ closeDeleteDialog }
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						className={ styles.confirmDeleteButton }
+						variant="filled"
+						size="medium"
+						label={ __( 'Delete site' ) }
+						disabled={ deleteSite.isPending }
+						aria-busy={ deleteSite.isPending ? 'true' : undefined }
+						onClick={ handleConfirmDelete }
+					>
+						{ deleteSite.isPending ? __( 'Deleting...' ) : __( 'Delete site' ) }
+					</Button>
+				</DialogFooter>
+			</Dialog>
+		</>
 	);
 }
 

--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/style.module.css
@@ -104,6 +104,56 @@
 	gap: 2px;
 }
 
+.footerActions {
+	display: flex;
+	padding: 6px 4px 0;
+}
+
+.deleteButton {
+	width: 100%;
+	justify-content: flex-start;
+	color: #b32d2e;
+}
+
+.deleteButton:hover:not(:disabled) {
+	background: rgba(179, 45, 46, 0.08);
+}
+
+.deleteDialogContent {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.deleteDialogText {
+	margin: 0;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 13px;
+	line-height: 18px;
+}
+
+.deleteDialogCheckbox {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: var(--ui-desks-text, #14171a);
+	font-size: 13px;
+	line-height: 18px;
+}
+
+.deleteDialogCheckbox input {
+	flex: 0 0 auto;
+}
+
+.confirmDeleteButton {
+	--button-background: #b32d2e;
+	--button-foreground: #fff;
+}
+
+.confirmDeleteButton:hover:not(:disabled) {
+	--button-background: #8a2424;
+}
+
 .row {
 	display: grid;
 	grid-template-columns: minmax(120px, 1fr) auto;


### PR DESCRIPTION
## Summary
- Adds a destructive `Delete site` action to the Desks site details dropdown
- Opens a confirmation dialog with the existing delete-files checkbox before removing the site
- Navigates back to the app root after a successful delete
- Adds styling for the destructive action and confirmation dialog

## Testing
- Added dropdown coverage for opening the delete dialog, confirming deletion, and post-delete navigation
- UI behavior was validated locally with the existing site details dropdown test suite
- Lint/format and typecheck passed