### PR TITLE
Exclude unnecessary items from ASAR archive

### DIFF
--- a/apps/studio/forge.config.ts
+++ b/apps/studio/forge.config.ts
@@ -35,45 +35,34 @@ const config: ForgeConfig = {
 				return {};
 			},
 		},
+		// Patterns are matched against paths inside the asar root, which is
+		// apps/studio/ (electron-forge packages from this package). Anchor each
+		// pattern at the asar root with a leading slash.
 		ignore: [
-			// Exclude major development directories
-			/^\/\..*/, // All dotfiles and dot directories
-			/^\/apps\/studio\/src/,
-			/^\/apps\/studio\/e2e/,
-			/^\/apps\/cli/,
-			/^\/tools\/common/,
-			/^\/vendor/,
-			/^\/fastlane/,
-			/^\/docs/,
-			/^\/scripts/,
-			/^\/tools/,
+			// Dev/test sources and fixtures — runtime uses /dist instead.
+			/^\/\..*/, // dotfiles and dot directories
+			/^\/src/,
+			/^\/e2e/,
+			/^\/__mocks__/,
 			/^\/patches/,
-			/^\/tools\/metrics/,
-			/^\/test-results/,
-			/^\/webpack-loaders/,
-			/^\/apps\/studio\/installers/,
+			/^\/entitlements/,
+			/^\/installers/,
+			// Build-time helpers
+			/^\/windowsSign\.ts$/,
 			// Config files
-			/^\/webpack\./,
 			/^\/tsconfig\./,
 			/^\/vitest\./,
-			/^\/playwright\./,
 			/^\/postcss\./,
 			/^\/tailwind\./,
 			/^\/forge\./,
 			/^\/electron\./,
-			/^\/apps\/studio\/.*\\.config\\./,
-			/^\/apps\/studio\/tailwind\\.config\\.js$/,
-			/^\/apps\/studio\/postcss\\.config\\.js$/,
-			/^\/apps\/studio\/index\.html$/,
-			/^\/Gemfile/,
+			/^\/index\.html$/,
 			/^\/.*\.md$/,
 			/^\/.*\.txt$/,
 			/^\/.*\.log$/,
-			// External resources (shouldn't be in asar)
+			// Resources copied separately via extraResource
 			/^\/assets/,
 			/^\/bin/,
-			/^\/apps\/cli\/dist\/cli/,
-			/^\/dist\/playground-cli/,
 		],
 	},
 	rebuildConfig: {},


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-1746

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Claude did the implementation based on my spec.

## Proposed Changes

While experimenting with https://github.com/Automattic/studio/pull/3545, I got curious about what exactly makes the Studio installer so large. I noticed that the `Contents/Resources/app.asar` archive contained some directories that aren't needed:

- `__mocks__`
- `e2e` 
- `installers`
- `src`

This PR removes them from the output by changing the `ignore` config in `forge.config.ts`. Several entries in that array aren't relevant after the monorepo migration, either, so Claude cleaned up a bunch of additional ones.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

CI should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
