### PR TITLE
Remove accidental node-abi direct dependency from package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
 				"apps/*",
 				"tools/*"
 			],
-			"dependencies": {
-				"node-abi": "^3.92.0"
-			},
 			"devDependencies": {
 				"@automattic/wp-babel-makepot": "^1.2.0",
 				"@eslint/js": "^9.39.2",
@@ -26420,6 +26417,7 @@
 			"version": "3.92.0",
 			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
 			"integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"


### PR DESCRIPTION
## Related issues

- Follow-up to the Electron 42 upgrade

## How AI was used in this PR

Claude Code identified and fixed the issue.

## Proposed Changes

- Removes the spurious `node-abi: ^3.92.0` entry from the root package's `dependencies` in `package-lock.json`

This was accidentally introduced during the Electron 42 merge when `npm install --package-lock-only node-abi@3.92.0` was run to pin the version — that command added it as a direct root dependency in the lockfile even though it's only a transitive dep. `node-abi@3.92.0` is still resolved correctly as a transitive dependency.

## Testing Instructions

- `npm ci` should work as before
- `node-abi` should still resolve to `3.92.0`

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?