### PR TITLE
Move the Desks UI switch into beta features

### DIFF
--- a/apps/studio/src/ipc-types.d.ts
+++ b/apps/studio/src/ipc-types.d.ts
@@ -97,11 +97,11 @@ type IpcApi = {
 interface FeatureFlags {
 	enableBlueprints: boolean;
 	enableStudioCodeUi: boolean;
-	enableDesksUiSwitch: boolean;
 }
 
 interface BetaFeatures {
 	nativePhpRuntime?: boolean;
+	desksUi?: boolean;
 }
 
 interface AppGlobals extends FeatureFlags {

--- a/apps/studio/src/lib/beta-features.ts
+++ b/apps/studio/src/lib/beta-features.ts
@@ -14,6 +14,7 @@ export interface BetaFeatureDefinition {
  */
 const BETA_FEATURE_DEFAULTS: Record< keyof BetaFeatures, boolean > = {
 	nativePhpRuntime: false,
+	desksUi: false,
 };
 
 /**
@@ -27,6 +28,12 @@ export function getBetaFeaturesDefinition(): Record< keyof BetaFeatures, BetaFea
 			label: __( 'Native PHP runtime' ),
 			default: BETA_FEATURE_DEFAULTS.nativePhpRuntime,
 			description: __( 'Run Studio sites with native PHP instead of Playground.' ),
+		},
+		desksUi: {
+			key: 'desksUi',
+			label: __( 'Desks UI' ),
+			default: BETA_FEATURE_DEFAULTS.desksUi,
+			description: __( 'Try the new Desks UI for Studio.' ),
 		},
 	};
 }

--- a/apps/studio/src/lib/feature-flags.ts
+++ b/apps/studio/src/lib/feature-flags.ts
@@ -18,12 +18,6 @@ export const FEATURE_FLAGS: Record< keyof FeatureFlags, FeatureFlagDefinition > 
 		flag: 'enableStudioCodeUi',
 		default: false,
 	},
-	enableDesksUiSwitch: {
-		label: 'Enable Desks UI Switch',
-		env: 'ENABLE_DESKS_UI_SWITCH',
-		flag: 'enableDesksUiSwitch',
-		default: false,
-	},
 } as const;
 
 export function getFeatureFlagFromEnv( flag: keyof FeatureFlags ): boolean {

--- a/apps/studio/src/lib/tests/beta-features.test.ts
+++ b/apps/studio/src/lib/tests/beta-features.test.ts
@@ -1,0 +1,68 @@
+import { SITE_RUNTIME_NATIVE_PHP } from '@studio/common/lib/site-runtime';
+import { vi } from 'vitest';
+import { EMPTY_USER_DATA } from 'src/storage/storage-types';
+import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
+import { getBetaFeatures, getBetaFeaturesDefinition, updateBetaFeature } from '../beta-features';
+
+vi.mock( 'src/storage/user-data', () => ( {
+	loadUserData: vi.fn(),
+	saveUserData: vi.fn(),
+	lockAppdata: vi.fn(),
+	unlockAppdata: vi.fn(),
+} ) );
+
+const originalStudioRuntime = process.env.STUDIO_RUNTIME;
+let mockUserData = structuredClone( EMPTY_USER_DATA );
+
+beforeEach( () => {
+	vi.clearAllMocks();
+	mockUserData = structuredClone( EMPTY_USER_DATA );
+	vi.mocked( lockAppdata ).mockResolvedValue( undefined );
+	vi.mocked( unlockAppdata ).mockResolvedValue( undefined );
+	vi.mocked( loadUserData ).mockImplementation( async () => structuredClone( mockUserData ) );
+	vi.mocked( saveUserData ).mockImplementation( async ( userData ) => {
+		mockUserData = structuredClone( userData );
+	} );
+} );
+
+afterEach( () => {
+	if ( originalStudioRuntime === undefined ) {
+		delete process.env.STUDIO_RUNTIME;
+		return;
+	}
+	process.env.STUDIO_RUNTIME = originalStudioRuntime;
+} );
+
+describe( 'beta features', () => {
+	it( 'defines the Desks UI beta feature', () => {
+		expect( getBetaFeaturesDefinition().desksUi ).toMatchObject( {
+			key: 'desksUi',
+			label: 'Desks UI',
+			default: false,
+			description: 'Try the new Desks UI for Studio.',
+		} );
+	} );
+
+	it( 'returns defaults for beta features not persisted yet', async () => {
+		mockUserData.betaFeatures = { nativePhpRuntime: true };
+
+		await expect( getBetaFeatures() ).resolves.toEqual( {
+			nativePhpRuntime: true,
+			desksUi: false,
+		} );
+		expect( process.env.STUDIO_RUNTIME ).toBe( SITE_RUNTIME_NATIVE_PHP );
+	} );
+
+	it( 'persists Desks UI changes without overwriting existing beta features', async () => {
+		mockUserData.betaFeatures = { nativePhpRuntime: true };
+
+		await updateBetaFeature( 'desksUi', true );
+
+		expect( lockAppdata ).toHaveBeenCalled();
+		expect( unlockAppdata ).toHaveBeenCalled();
+		expect( mockUserData.betaFeatures ).toEqual( {
+			nativePhpRuntime: true,
+			desksUi: true,
+		} );
+	} );
+} );

--- a/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
@@ -3,7 +3,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Button from 'src/components/button';
 import { FormPathInputComponent } from 'src/components/form-path-input';
-import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { isWindowsStore } from 'src/lib/app-globals';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { ColorSchemePicker } from 'src/modules/user-settings/components/color-scheme-picker';
@@ -13,7 +12,7 @@ import { StudioCliToggle } from 'src/modules/user-settings/components/studio-cli
 import { TerminalPicker } from 'src/modules/user-settings/components/terminal-picker';
 import { SupportedEditor } from 'src/modules/user-settings/lib/editor';
 import { SupportedTerminal } from 'src/modules/user-settings/lib/terminal';
-import { useAppDispatch, useI18nLocale } from 'src/stores';
+import { useAppDispatch, useI18nLocale, useRootSelector } from 'src/stores';
 import { saveUserLocale } from 'src/stores/i18n-slice';
 import {
 	useGetColorSchemeQuery,
@@ -33,7 +32,9 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 	const { __ } = useI18n();
 	const savedLocale = useI18nLocale();
 	const dispatch = useAppDispatch();
-	const { enableDesksUiSwitch } = useFeatureFlags();
+	const desksUiEnabled = useRootSelector( ( state ) =>
+		Boolean( state.betaFeatures.features.desksUi )
+	);
 
 	const { data: colorScheme } = useGetColorSchemeQuery();
 	const { data: editor } = useGetUserEditorQuery();
@@ -155,7 +156,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 			{ ! isWindowsStore() && (
 				<StudioCliToggle value={ isCliInstalledSelection } onChange={ setDirtyIsCliInstalled } />
 			) }
-			{ enableDesksUiSwitch && (
+			{ desksUiEnabled && (
 				<SettingsFormField label={ __( 'Studio UI' ) }>
 					<div>
 						<Button variant="secondary" onClick={ switchToDesksUi }>


### PR DESCRIPTION
**Summary**
- Move the Desks UI switch out of the dev-only feature flags and into persisted beta features.
- Add a `desksUi` beta feature definition with a user-facing label and description.
- Update Preferences to show the Desks UI switch when that beta feature is enabled.
- Add coverage for beta feature defaults and persistence.

**Testing**
- `npx eslint --fix` on the modified files.
- `npm run typecheck`.
- `npm test` for the new beta feature test and the user settings UI test suite.