### PR TITLE
Fix type error in default PHP migration by narrowing version to native-supported set

### DIFF
--- a/apps/cli/migrations/06-install-bundled-default-php.ts
+++ b/apps/cli/migrations/06-install-bundled-default-php.ts
@@ -1,7 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
-import { getConfiguredPhpBinaryVersion } from '@studio/common/lib/php-binary-metadata';
+import {
+	getConfiguredPhpBinaryVersion,
+	resolveNativePhpVersion,
+} from '@studio/common/lib/php-binary-metadata';
 import { getPhpBinaryPath } from 'cli/lib/dependency-management/paths';
 import type { Migration } from '@studio/common/lib/migration';
 
@@ -14,7 +17,8 @@ function getBundledPhpBinaryRoot(): string {
 }
 
 function getDefaultPhpPatchVersion(): string {
-	return getConfiguredPhpBinaryVersion( DEFAULT_PHP_VERSION ) ?? DEFAULT_PHP_VERSION;
+	const nativeVersion = resolveNativePhpVersion( DEFAULT_PHP_VERSION );
+	return getConfiguredPhpBinaryVersion( nativeVersion ) ?? nativeVersion;
 }
 
 function getBundledDefaultPhpDir(): string {

--- a/apps/cli/migrations/tests/06-install-bundled-default-php.test.ts
+++ b/apps/cli/migrations/tests/06-install-bundled-default-php.test.ts
@@ -2,7 +2,10 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
-import { getConfiguredPhpBinaryVersion } from '@studio/common/lib/php-binary-metadata';
+import {
+	getConfiguredPhpBinaryVersion,
+	resolveNativePhpVersion,
+} from '@studio/common/lib/php-binary-metadata';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installBundledDefaultPhp } from 'cli/migrations/06-install-bundled-default-php';
 
@@ -14,7 +17,7 @@ function getBinaryName(): string {
 }
 
 function getDefaultPhpPatchVersion(): string {
-	return getConfiguredPhpBinaryVersion( DEFAULT_PHP_VERSION )!;
+	return getConfiguredPhpBinaryVersion( resolveNativePhpVersion( DEFAULT_PHP_VERSION ) )!;
 }
 
 function getBundledDefaultPhpDir(): string {


### PR DESCRIPTION
## How AI was used in this PR

AI helped to fix it

## Proposed Changes
<img width="1389" height="336" alt="Screenshot 2026-05-20 at 16 42 14" src="https://github.com/user-attachments/assets/dc74b4e7-9139-419e-9c83-0b1559aaab69" />
- Narrow DEFAULT_PHP_VERSION via resolveNativePhpVersion() before passing it to getConfiguredPhpBinaryVersion() in apps/cli/migrations/06-install-bundled-default-php.ts and its test, 
- No runtime behavior change — the default value ("8.4") is already a native-supported version; this only satisfies the type checker. 


## Testing Instructions
Code review

