### PR TITLE
apps/ui: Require WordPress.com login for Studio Desk chat and hide stale empty-state suggestions

### DIFF
--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -448,6 +448,10 @@ export async function continueAiSession(
 	prompt: string,
 	options: { displayMessage?: string } = {}
 ): Promise< { runId: string } > {
+	if ( ! ( await oauthClient.isAuthenticated() ) ) {
+		throw new Error( __( 'WordPress.com login required. Log in to use Studio Desk chat.' ) );
+	}
+
 	await reconcileSessionEnvironmentBeforeRun( sessionId );
 	return startAgentRun( {
 		sessionId,

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -201,6 +201,10 @@ export function createIpcConnector(): Connector {
 			await ipcApi.clearAuthenticationToken();
 		},
 
+		onAuthStateChanged( listener ) {
+			return ipcListener.subscribe( 'auth-updated', () => listener() );
+		},
+
 		// Sites
 		async getSites(): Promise< SiteDetails[] > {
 			return ( await ipcApi.getSiteDetails() ) as SiteDetails[];

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -105,6 +105,7 @@ export interface Connector {
 	getAuthUser(): Promise< AuthUser | null >;
 	authenticate(): Promise< void >;
 	logout(): Promise< void >;
+	onAuthStateChanged?( listener: () => void ): () => void;
 
 	// Sites
 	getSites(): Promise< SiteDetails[] >;

--- a/apps/ui/src/data/queries/use-auth-user.ts
+++ b/apps/ui/src/data/queries/use-auth-user.ts
@@ -1,10 +1,19 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { useConnector } from '@/data/core';
 
 export const AUTH_USER_QUERY_KEY = [ 'auth-user' ] as const;
 
 export function useAuthUser() {
 	const connector = useConnector();
+	const queryClient = useQueryClient();
+
+	useEffect( () => {
+		return connector.onAuthStateChanged?.( () => {
+			void queryClient.invalidateQueries( { queryKey: AUTH_USER_QUERY_KEY } );
+		} );
+	}, [ connector, queryClient ] );
+
 	return useQuery( {
 		queryKey: AUTH_USER_QUERY_KEY,
 		queryFn: () => connector.getAuthUser(),

--- a/apps/ui/src/ui-desks/chats/composer/index.test.tsx
+++ b/apps/ui/src/ui-desks/chats/composer/index.test.tsx
@@ -7,6 +7,7 @@ import type { ReactNode } from 'react';
 const composerMocks = vi.hoisted( () => ( {
 	onSend: vi.fn(),
 	onInterrupt: vi.fn(),
+	onLogin: vi.fn(),
 	setQueryData: vi.fn(),
 	invalidateQueries: vi.fn(),
 	setSessionModel: vi.fn(),
@@ -114,6 +115,7 @@ describe( 'desks chat Composer', () => {
 	beforeEach( () => {
 		composerMocks.onSend.mockReset().mockResolvedValue( undefined );
 		composerMocks.onInterrupt.mockReset().mockResolvedValue( undefined );
+		composerMocks.onLogin.mockReset();
 		composerMocks.setQueryData.mockReset();
 		composerMocks.invalidateQueries.mockReset();
 		composerMocks.setSessionModel.mockReset().mockResolvedValue( undefined );
@@ -139,13 +141,35 @@ describe( 'desks chat Composer', () => {
 
 		expect( screen.getByRole( 'button', { name: 'Queue' } ) ).toBeEnabled();
 	} );
+
+	it( 'shows a login requirement and blocks the composer when unauthenticated', () => {
+		renderComposer( { busy: false, authRequired: true } );
+
+		expect(
+			screen.getByText( 'Log in with WordPress.com to use Studio Desk chat.' )
+		).toBeVisible();
+		expect( screen.getByPlaceholderText( 'Log in to use Studio Desk chat.' ) ).toBeDisabled();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Log in with WordPress.com' } ) );
+
+		expect( composerMocks.onLogin ).toHaveBeenCalledTimes( 1 );
+		expect( composerMocks.onSend ).not.toHaveBeenCalled();
+	} );
 } );
 
-function renderComposer( { busy }: { busy: boolean } ) {
+function renderComposer( {
+	busy,
+	authRequired = false,
+}: {
+	busy: boolean;
+	authRequired?: boolean;
+} ) {
 	return render(
 		<Composer
 			busy={ busy }
 			error={ null }
+			authRequired={ authRequired }
+			onLogin={ composerMocks.onLogin }
 			model="claude-sonnet-4-6"
 			onSend={ composerMocks.onSend }
 			onInterrupt={ composerMocks.onInterrupt }

--- a/apps/ui/src/ui-desks/chats/composer/index.tsx
+++ b/apps/ui/src/ui-desks/chats/composer/index.tsx
@@ -50,6 +50,10 @@ interface ComposerProps {
 	busy: boolean;
 	isInterrupting?: boolean;
 	error: string | null;
+	authRequired?: boolean;
+	authLoading?: boolean;
+	authPending?: boolean;
+	onLogin?: () => void;
 	model: AiModelId;
 	onSend: ( prompt: string, options?: { displayMessage?: string } ) => Promise< void >;
 	onInterrupt: () => Promise< void >;
@@ -71,6 +75,10 @@ export function Composer( {
 	busy,
 	isInterrupting = false,
 	error,
+	authRequired = false,
+	authLoading = false,
+	authPending = false,
+	onLogin,
 	model,
 	onSend,
 	onInterrupt,
@@ -122,6 +130,10 @@ export function Composer( {
 	}, [ draftPrompt ] );
 
 	const send = useCallback( async () => {
+		if ( authRequired || authLoading ) {
+			return;
+		}
+
 		const trimmed = value.trim();
 		if ( ! trimmed ) {
 			return;
@@ -142,7 +154,7 @@ export function Composer( {
 			setValue( trimmed );
 			setContextWidgets( widgetsToSend );
 		}
-	}, [ contextWidgets, onSend, value ] );
+	}, [ authLoading, authRequired, contextWidgets, onSend, value ] );
 
 	useEffect( () => {
 		if (
@@ -202,6 +214,9 @@ export function Composer( {
 
 	const handleModelChange = useCallback(
 		( picked: AiModelId ) => {
+			if ( authRequired || authLoading ) {
+				return;
+			}
 			if ( picked === model ) {
 				return;
 			}
@@ -218,7 +233,7 @@ export function Composer( {
 			}
 			applySameFamilyModel( picked );
 		},
-		[ applySameFamilyModel, entries, model, onSwitchSession ]
+		[ applySameFamilyModel, authLoading, authRequired, entries, model, onSwitchSession ]
 	);
 
 	const cancelFamilyChange = useCallback( () => {
@@ -246,7 +261,8 @@ export function Composer( {
 		}
 	}, [ connector, onSwitchSession, ownerSiteId, pendingFamilyChange, queryClient ] );
 
-	const canSend = value.trim().length > 0;
+	const authBlocked = authRequired || authLoading;
+	const canSend = ! authBlocked && value.trim().length > 0;
 	const showSendButton = ! busy || canSend;
 	const sendAriaLabel = busy ? __( 'Queue' ) : __( 'Send' );
 	const visibleContextWidgets = contextWidgets.slice( 0, MAX_VISIBLE_CHAT_WIDGETS );
@@ -258,6 +274,26 @@ export function Composer( {
 				className={ styles.root }
 				data-active={ canSend || contextWidgets.length > 0 ? 'true' : 'false' }
 			>
+				{ authRequired ? (
+					<div className={ styles.authNotice }>
+						<span>{ __( 'Log in with WordPress.com to use Studio Desk chat.' ) }</span>
+						<Button
+							label={
+								authPending
+									? __( 'Opening WordPress.com login' )
+									: __( 'Log in with WordPress.com' )
+							}
+							size="small"
+							variant="filled"
+							tone="primary"
+							disabled={ authPending }
+							aria-busy={ authPending }
+							onClick={ onLogin }
+						>
+							{ authPending ? __( 'Opening login...' ) : __( 'Log in' ) }
+						</Button>
+					</div>
+				) : null }
 				{ contextWidgets.length > 0 && (
 					<div className={ styles.attachments } aria-label={ __( 'Attached canvas widgets' ) }>
 						{ visibleContextWidgets.map( ( widget ) => (
@@ -297,9 +333,16 @@ export function Composer( {
 					<textarea
 						ref={ textareaRef }
 						className={ styles.input }
-						placeholder={ __( 'Ask Studio Desk…' ) }
+						placeholder={
+							authLoading
+								? __( 'Checking WordPress.com login...' )
+								: authRequired
+								? __( 'Log in to use Studio Desk chat.' )
+								: __( 'Ask Studio Desk…' )
+						}
 						value={ previewPrompt ?? value }
 						data-preview={ previewPrompt ? 'true' : 'false' }
+						disabled={ authBlocked }
 						onChange={ ( event ) => setValue( event.target.value ) }
 						onKeyDown={ ( event ) => {
 							if ( event.key === 'Escape' && busy ) {
@@ -328,6 +371,7 @@ export function Composer( {
 												tooltipLabel={ false }
 												aria-label={ __( 'Commands' ) }
 												title={ __( 'Commands' ) }
+												disabled={ authBlocked }
 											>
 												<Icon icon={ code } size={ 20 } />
 											</Button>
@@ -359,7 +403,7 @@ export function Composer( {
 										sessionId={ sessionId }
 										effectiveEnvironment={ effectiveEnvironment }
 										liveSite={ liveSite }
-										disabled={ busy }
+										disabled={ busy || authBlocked }
 									/>
 								) : null }
 								<Menu.Root modal={ false }>
@@ -373,6 +417,7 @@ export function Composer( {
 												tooltipLabel={ false }
 												aria-label={ __( 'Select model' ) }
 												title={ __( 'Select model' ) }
+												disabled={ authBlocked }
 											>
 												<span>{ getAiModelLabel( model ) }</span>
 												<Icon icon={ chevronDownSmall } size={ 14 } />

--- a/apps/ui/src/ui-desks/chats/composer/style.module.css
+++ b/apps/ui/src/ui-desks/chats/composer/style.module.css
@@ -37,6 +37,24 @@
 	padding: 0 6px;
 }
 
+.authNotice {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	padding: 10px 12px;
+	border: 1px solid var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+	border-radius: 12px;
+	background: rgba(255, 255, 255, 0.72);
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 12px;
+	line-height: 16px;
+}
+
+.authNotice span {
+	min-width: 0;
+}
+
 .attachment {
 	position: relative;
 	flex: 0 0 auto;
@@ -80,6 +98,10 @@
 
 .input::placeholder {
 	color: var(--ui-desks-muted, #6b7280);
+}
+
+.input:disabled {
+	cursor: not-allowed;
 }
 
 .input[data-preview='true'] {

--- a/apps/ui/src/ui-desks/chats/context.tsx
+++ b/apps/ui/src/ui-desks/chats/context.tsx
@@ -32,6 +32,7 @@ export interface ChatsContextValue {
 	autoFocusSessionId?: string;
 	isCreatingChat: boolean;
 	pendingPrompt?: PendingChatPrompt;
+	authRequiredPrompt?: ChatPromptRequest;
 	composerWidgetAttachmentRequest?: ComposerWidgetAttachmentRequest;
 	composerWidgetDragPreview?: ComposerWidgetDragPreview;
 	isComposerWidgetDragTarget: boolean;
@@ -60,6 +61,7 @@ const defaultChatsContext: ChatsContextValue = {
 	autoFocusSessionId: undefined,
 	isCreatingChat: false,
 	pendingPrompt: undefined,
+	authRequiredPrompt: undefined,
 	composerWidgetAttachmentRequest: undefined,
 	composerWidgetDragPreview: undefined,
 	isComposerWidgetDragTarget: false,

--- a/apps/ui/src/ui-desks/chats/panel/index.tsx
+++ b/apps/ui/src/ui-desks/chats/panel/index.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useEffect, useState } from 'react';
 import motionStyles from '@/components/floating-surface-motion/style.module.css';
+import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
 import { useSessions, useUpdateSessionMetadata } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { useFullscreen } from '@/hooks/use-fullscreen';
@@ -14,6 +15,7 @@ import { useChats } from '../context';
 import { SessionSurface } from '../session-surface';
 import { WidgetContextThumbnailList } from '../widget-context';
 import styles from './style.module.css';
+import type { ChatPromptRequest } from '../context';
 import type { ChatPanelResizeState, ChatPanelSide } from '../use-chat-panel-resize';
 import type { AiSessionSummary } from '@/data/core';
 import type { CSSProperties } from 'react';
@@ -135,6 +137,73 @@ function ChatSessionRow( {
 	);
 }
 
+function EmptyChatState( {
+	authRequiredPrompt,
+	onContinuePrompt,
+}: {
+	authRequiredPrompt?: ChatPromptRequest;
+	onContinuePrompt: ( request: ChatPromptRequest ) => Promise< string >;
+} ) {
+	const { data: authUser, isLoading: isLoadingAuthUser } = useAuthUser();
+	const login = useLogin();
+
+	if ( ! isLoadingAuthUser && ! authUser ) {
+		return (
+			<div className={ styles.emptyChat }>
+				<div className={ styles.emptyChatContent }>
+					<div className={ styles.emptyChatTitle }>{ __( 'Log in to use Studio Desk chat' ) }</div>
+					<p>{ __( 'Studio Desk chat requires a WordPress.com account.' ) }</p>
+					{ authRequiredPrompt ? (
+						<div className={ styles.emptyChatDraft }>
+							<span>{ __( 'Draft prompt' ) }</span>
+							<p>{ authRequiredPrompt.displayMessage ?? authRequiredPrompt.prompt }</p>
+						</div>
+					) : null }
+					<Button
+						label={
+							login.isPending
+								? __( 'Opening WordPress.com login' )
+								: __( 'Log in with WordPress.com' )
+						}
+						disabled={ login.isPending }
+						aria-busy={ login.isPending }
+						onClick={ () => login.mutate() }
+						tone="primary"
+						variant="filled"
+					>
+						{ login.isPending ? __( 'Opening login...' ) : __( 'Log in with WordPress.com' ) }
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	if ( authUser && authRequiredPrompt ) {
+		return (
+			<div className={ styles.emptyChat }>
+				<div className={ styles.emptyChatContent }>
+					<div className={ styles.emptyChatTitle }>{ __( 'Ready to continue' ) }</div>
+					<p>{ __( 'Your draft prompt is ready to send in a new chat.' ) }</p>
+					<div className={ styles.emptyChatDraft }>
+						<span>{ __( 'Draft prompt' ) }</span>
+						<p>{ authRequiredPrompt.displayMessage ?? authRequiredPrompt.prompt }</p>
+					</div>
+					<Button
+						label={ __( 'Continue with draft' ) }
+						onClick={ () => void onContinuePrompt( authRequiredPrompt ) }
+						tone="primary"
+						variant="filled"
+					>
+						{ __( 'Continue with draft' ) }
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	return <div className={ styles.emptyChat }>{ __( 'Ask Studio anything to get started.' ) }</div>;
+}
+
 export function ChatsTrigger() {
 	const { open, setOpen } = useChats();
 
@@ -150,11 +219,13 @@ export function Chats( { siteId, side, panel }: ChatsProps ) {
 		autoFocusSessionId,
 		isCreatingChat,
 		pendingPrompt,
+		authRequiredPrompt,
 		composerWidgetDragPreview,
 		selectSession,
 		switchSession,
 		clearSelection,
 		startNewChat,
+		startChatWithPrompt,
 		consumePendingPrompt,
 	} = useChats();
 	const { data: sessions, isFetching: isFetchingSessions } = useSessions();
@@ -356,9 +427,10 @@ export function Chats( { siteId, side, panel }: ChatsProps ) {
 									onInitialPromptConsumed={ consumePendingPrompt }
 								/>
 							) : (
-								<div className={ styles.emptyChat }>
-									{ __( 'Ask Studio anything to get started.' ) }
-								</div>
+								<EmptyChatState
+									authRequiredPrompt={ authRequiredPrompt }
+									onContinuePrompt={ startChatWithPrompt }
+								/>
 							) }
 						</div>
 					) : null }

--- a/apps/ui/src/ui-desks/chats/panel/style.module.css
+++ b/apps/ui/src/ui-desks/chats/panel/style.module.css
@@ -407,6 +407,7 @@
 }
 
 .emptyChat {
+	width: 100%;
 	height: 100%;
 	display: flex;
 	align-items: flex-start;
@@ -414,6 +415,57 @@
 	padding-top: 48px;
 	color: var(--ui-desks-muted, #6b7280);
 	font-size: 13px;
+}
+
+.emptyChatContent {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 12px;
+	width: min(320px, calc(100% - 32px));
+	text-align: center;
+}
+
+.emptyChatContent p {
+	margin: 0;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 13px;
+	line-height: 18px;
+}
+
+.emptyChatTitle {
+	color: var(--ui-desks-text, #14171a);
+	font-size: 14px;
+	line-height: 20px;
+	font-weight: 600;
+}
+
+.emptyChatDraft {
+	width: 100%;
+	box-sizing: border-box;
+	padding: 10px 12px;
+	border: 1px solid var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+	border-radius: 12px;
+	background: rgba(255, 255, 255, 0.64);
+	text-align: left;
+}
+
+.emptyChatDraft span {
+	display: block;
+	margin-bottom: 4px;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 11px;
+	line-height: 14px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.emptyChatDraft p {
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	color: var(--ui-desks-text, #14171a);
 }
 
 .resizeHandle {

--- a/apps/ui/src/ui-desks/chats/provider.test.tsx
+++ b/apps/ui/src/ui-desks/chats/provider.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConnectorProvider } from '@/data/core';
 import { useChats } from './context';
 import { ChatsProvider } from './provider';
-import type { Connector } from '@/data/core';
+import type { AuthUser, Connector } from '@/data/core';
 import type { AiSessionPlacementUpdatedEvent } from '@/data/core/types';
 
 const routerMock = vi.hoisted( () => ( {
@@ -90,9 +90,53 @@ describe( 'ChatsProvider session placement changes', () => {
 			existing: true,
 		} );
 	} );
+
+	it( 'does not create a chat when the user is logged out', async () => {
+		routerMock.search = { chats: true };
+		const { connector } = renderProvider( { authUser: null } );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Start new chat' } ) );
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'expanded' ) ).toHaveTextContent( 'expanded' )
+		);
+		expect( connector.createSession ).not.toHaveBeenCalled();
+		expect( screen.getByTestId( 'selected-session' ) ).toHaveTextContent( 'none' );
+	} );
+
+	it( 'keeps a prompt for the login-required state instead of creating a chat', async () => {
+		routerMock.search = { chats: true };
+		const { connector } = renderProvider( { authUser: null } );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Start prompt chat' } ) );
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'auth-required-prompt' ) ).toHaveTextContent( 'Draft prompt' )
+		);
+		expect( connector.createSession ).not.toHaveBeenCalled();
+		expect( screen.getByTestId( 'selected-session' ) ).toHaveTextContent( 'none' );
+	} );
+
+	it( 'creates and selects a chat when the user is logged in', async () => {
+		routerMock.search = { chats: true };
+		const { connector } = renderProvider();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Start new chat' } ) );
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'selected-session' ) ).toHaveTextContent( 'created-session' )
+		);
+		expect( connector.createSession ).toHaveBeenCalledTimes( 1 );
+	} );
 } );
 
-function renderProvider( siteId?: string ) {
+function renderProvider( {
+	siteId,
+	authUser = createAuthUser(),
+}: {
+	siteId?: string;
+	authUser?: AuthUser | null;
+} = {} ) {
 	let placementListener: ( ( event: AiSessionPlacementUpdatedEvent ) => void ) | undefined;
 	const queryClient = new QueryClient( {
 		defaultOptions: {
@@ -102,24 +146,30 @@ function renderProvider( siteId?: string ) {
 		},
 	} );
 	const connector = {
+		getAuthUser: vi.fn().mockResolvedValue( authUser ),
+		onAuthStateChanged: vi.fn( () => vi.fn() ),
 		onSessionPlacementUpdated: vi.fn( ( listener ) => {
 			placementListener = listener;
 			return vi.fn();
 		} ),
-		createSession: vi.fn(),
+		createSession: vi.fn().mockResolvedValue( {
+			id: 'created-session',
+		} ),
 	} as unknown as Connector;
 
 	render(
 		<QueryClientProvider client={ queryClient }>
 			<ConnectorProvider connector={ connector }>
 				<ChatsProvider siteId={ siteId }>
-					<SelectedSessionStatus />
+					<ChatStateStatus />
+					<StartChatButtons />
 				</ChatsProvider>
 			</ConnectorProvider>
 		</QueryClientProvider>
 	);
 
 	return {
+		connector,
 		emitPlacement: ( event: AiSessionPlacementUpdatedEvent ) => {
 			if ( ! placementListener ) {
 				throw new Error( 'No placement listener registered.' );
@@ -131,9 +181,37 @@ function renderProvider( siteId?: string ) {
 	};
 }
 
-function SelectedSessionStatus() {
-	const { selectedSessionId } = useChats();
-	return <div data-testid="selected-session">{ selectedSessionId ?? 'none' }</div>;
+function ChatStateStatus() {
+	const { selectedSessionId, expanded, authRequiredPrompt } = useChats();
+	return (
+		<>
+			<div data-testid="selected-session">{ selectedSessionId ?? 'none' }</div>
+			<div data-testid="expanded">{ expanded ? 'expanded' : 'collapsed' }</div>
+			<div data-testid="auth-required-prompt">{ authRequiredPrompt?.displayMessage ?? 'none' }</div>
+		</>
+	);
+}
+
+function StartChatButtons() {
+	const { startNewChat, startChatWithPrompt } = useChats();
+	return (
+		<>
+			<button type="button" onClick={ () => void startNewChat() }>
+				Start new chat
+			</button>
+			<button
+				type="button"
+				onClick={ () =>
+					void startChatWithPrompt( {
+						prompt: 'Full prompt',
+						displayMessage: 'Draft prompt',
+					} )
+				}
+			>
+				Start prompt chat
+			</button>
+		</>
+	);
 }
 
 function createPlacementEvent(): AiSessionPlacementUpdatedEvent {
@@ -145,5 +223,13 @@ function createPlacementEvent(): AiSessionPlacementUpdatedEvent {
 			siteName: 'Created Site',
 			sitePath: '/sites/created-site',
 		},
+	};
+}
+
+function createAuthUser(): AuthUser {
+	return {
+		id: 1,
+		email: 'user@example.com',
+		displayName: 'Studio User',
 	};
 }

--- a/apps/ui/src/ui-desks/chats/provider.tsx
+++ b/apps/ui/src/ui-desks/chats/provider.tsx
@@ -2,6 +2,7 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useConnector } from '@/data/core';
+import { useAuthUser } from '@/data/queries/use-auth-user';
 import { useCreateSession } from '@/data/queries/use-sessions';
 import {
 	Button,
@@ -64,11 +65,15 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 	const { open, setOpen, createChatRequestId, routeSessionId, navigate } = useChatsSearch();
 	const connector = useConnector();
 	const createSession = useCreateSession();
+	const { data: authUser, refetch: refetchAuthUser } = useAuthUser();
 	const lastCreateChatRequestId = useRef( createChatRequestId );
 	const [ selectedSessionId, setSelectedSessionId ] = useState< string | undefined >( undefined );
 	const [ expanded, setExpanded ] = useState( false );
 	const [ autoFocusSessionId, setAutoFocusSessionId ] = useState< string | undefined >( undefined );
 	const [ pendingPrompt, setPendingPrompt ] = useState< PendingChatPrompt | undefined >(
+		undefined
+	);
+	const [ authRequiredPrompt, setAuthRequiredPrompt ] = useState< ChatPromptRequest | undefined >(
 		undefined
 	);
 	const [ composerWidgetAttachmentRequest, setComposerWidgetAttachmentRequest ] = useState<
@@ -101,6 +106,7 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 			setSelectedSessionId( sessionId );
 			setExpanded( true );
 			setAutoFocusSessionId( undefined );
+			setAuthRequiredPrompt( undefined );
 			setRouteSession( sessionId );
 		},
 		[ setRouteSession ]
@@ -111,6 +117,7 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 			setSelectedSessionId( sessionId );
 			setExpanded( true );
 			setAutoFocusSessionId( sessionId );
+			setAuthRequiredPrompt( undefined );
 			setRouteSession( sessionId );
 		},
 		[ setRouteSession ]
@@ -120,6 +127,7 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 		setSelectedSessionId( undefined );
 		setExpanded( false );
 		setAutoFocusSessionId( undefined );
+		setAuthRequiredPrompt( undefined );
 		setRouteSession( undefined );
 	}, [ setRouteSession ] );
 
@@ -128,6 +136,7 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 		setExpanded( false );
 		setAutoFocusSessionId( undefined );
 		setPendingPlacementSwitch( undefined );
+		setAuthRequiredPrompt( undefined );
 		void navigate( {
 			to: '.',
 			search: ( previous: ChatsSearch ) => ( {
@@ -138,17 +147,63 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 		} );
 	}, [ navigate ] );
 
+	const showAuthRequired = useCallback(
+		( prompt?: ChatPromptRequest ) => {
+			setSelectedSessionId( undefined );
+			setExpanded( true );
+			setAutoFocusSessionId( undefined );
+			setAuthRequiredPrompt( prompt );
+			void navigate( {
+				to: '.',
+				search: ( previous: ChatsSearch ) => ( {
+					...previous,
+					chats: true,
+					session: undefined,
+				} ),
+			} );
+		},
+		[ navigate ]
+	);
+
+	const ensureAuthenticatedForChat = useCallback( async () => {
+		if ( authUser ) {
+			return true;
+		}
+
+		const result = await refetchAuthUser();
+		return !! result.data;
+	}, [ authUser, refetchAuthUser ] );
+
 	const startNewChat = useCallback( async () => {
+		if ( ! ( await ensureAuthenticatedForChat() ) ) {
+			showAuthRequired();
+			return;
+		}
+
+		setAuthRequiredPrompt( undefined );
 		const session = await createSession.mutateAsync( siteId );
 		setSelectedSessionId( session.id );
 		setExpanded( true );
 		setAutoFocusSessionId( session.id );
 		setRouteSession( session.id );
 		setOpen( true );
-	}, [ createSession, setOpen, setRouteSession, siteId ] );
+	}, [
+		createSession,
+		ensureAuthenticatedForChat,
+		setOpen,
+		setRouteSession,
+		showAuthRequired,
+		siteId,
+	] );
 
 	const startChatWithPrompt = useCallback(
 		async ( request: ChatPromptRequest ) => {
+			if ( ! ( await ensureAuthenticatedForChat() ) ) {
+				showAuthRequired( request );
+				return '';
+			}
+
+			setAuthRequiredPrompt( undefined );
 			const session = await createSession.mutateAsync( siteId );
 			setSelectedSessionId( session.id );
 			setExpanded( true );
@@ -163,7 +218,14 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 			setOpen( true );
 			return session.id;
 		},
-		[ createSession, setOpen, setRouteSession, siteId ]
+		[
+			createSession,
+			ensureAuthenticatedForChat,
+			setOpen,
+			setRouteSession,
+			showAuthRequired,
+			siteId,
+		]
 	);
 
 	const consumePendingPrompt = useCallback( ( promptId: string ) => {
@@ -268,6 +330,7 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 				autoFocusSessionId,
 				isCreatingChat: createSession.isPending,
 				pendingPrompt,
+				authRequiredPrompt,
 				composerWidgetAttachmentRequest,
 				composerWidgetDragPreview,
 				isComposerWidgetDragTarget,

--- a/apps/ui/src/ui-desks/chats/session-surface/empty-state.test.ts
+++ b/apps/ui/src/ui-desks/chats/session-surface/empty-state.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { hasVisibleUserPrompt, shouldShowEmptyConversation } from './empty-state';
+import type { SessionEntry } from '@mariozechner/pi-coding-agent';
+
+describe( 'desks chat empty state', () => {
+	it( 'detects user-visible prompt entries', () => {
+		expect(
+			hasVisibleUserPrompt( [
+				{
+					type: 'custom',
+					customType: 'studio.user_prompt',
+					timestamp: '2026-05-21T10:00:00.000Z',
+					data: { source: 'prompt', text: 'Create a home page' },
+				} as SessionEntry,
+			] )
+		).toBe( true );
+	} );
+
+	it( 'ignores ask-user answers because they are not rendered as user prompts', () => {
+		expect(
+			hasVisibleUserPrompt( [
+				{
+					type: 'custom',
+					customType: 'studio.user_prompt',
+					timestamp: '2026-05-21T10:00:00.000Z',
+					data: { source: 'ask_user', text: 'Yes, continue' },
+				} as SessionEntry,
+			] )
+		).toBe( false );
+	} );
+
+	it( 'hides suggestions once a prompt is submitted before entries update', () => {
+		expect(
+			shouldShowEmptyConversation( {
+				hasVisibleUserPrompt: false,
+				hasSubmittedPrompt: true,
+				hasPendingInitialPrompt: false,
+				hasActiveRun: false,
+				queuedPromptCount: 0,
+			} )
+		).toBe( false );
+	} );
+
+	it( 'hides suggestions for pending initial prompts and queued prompts', () => {
+		expect(
+			shouldShowEmptyConversation( {
+				hasVisibleUserPrompt: false,
+				hasSubmittedPrompt: false,
+				hasPendingInitialPrompt: true,
+				hasActiveRun: false,
+				queuedPromptCount: 0,
+			} )
+		).toBe( false );
+
+		expect(
+			shouldShowEmptyConversation( {
+				hasVisibleUserPrompt: false,
+				hasSubmittedPrompt: false,
+				hasPendingInitialPrompt: false,
+				hasActiveRun: false,
+				queuedPromptCount: 1,
+			} )
+		).toBe( false );
+	} );
+} );

--- a/apps/ui/src/ui-desks/chats/session-surface/empty-state.ts
+++ b/apps/ui/src/ui-desks/chats/session-surface/empty-state.ts
@@ -1,0 +1,39 @@
+import {
+	isStudioCustomEntryOfType,
+	type StudioCustomEntry,
+} from '@studio/common/ai/sessions/entry-types';
+import type { SessionEntry } from '@mariozechner/pi-coding-agent';
+
+interface EmptyConversationState {
+	hasVisibleUserPrompt: boolean;
+	hasSubmittedPrompt: boolean;
+	hasPendingInitialPrompt: boolean;
+	hasActiveRun: boolean;
+	queuedPromptCount: number;
+}
+
+export function hasVisibleUserPrompt( entries: SessionEntry[] | undefined ): boolean {
+	return ( entries ?? [] ).some( ( entry ) => {
+		if ( ! isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ) {
+			return false;
+		}
+		const data = ( entry as StudioCustomEntry< 'studio.user_prompt' > ).data;
+		return data?.source === 'prompt' && typeof data.text === 'string' && data.text.trim() !== '';
+	} );
+}
+
+export function shouldShowEmptyConversation( {
+	hasVisibleUserPrompt,
+	hasSubmittedPrompt,
+	hasPendingInitialPrompt,
+	hasActiveRun,
+	queuedPromptCount,
+}: EmptyConversationState ): boolean {
+	return (
+		! hasVisibleUserPrompt &&
+		! hasSubmittedPrompt &&
+		! hasPendingInitialPrompt &&
+		! hasActiveRun &&
+		queuedPromptCount === 0
+	);
+}

--- a/apps/ui/src/ui-desks/chats/session-surface/index.tsx
+++ b/apps/ui/src/ui-desks/chats/session-surface/index.tsx
@@ -1,9 +1,9 @@
 import { resolveSessionModel } from '@studio/common/ai/models';
-import { isStudioCustomEntryOfType } from '@studio/common/ai/sessions/entry-types';
 import { __ } from '@wordpress/i18n';
 import { box, chevronLeft, chevronRight, previous, starEmpty, starFilled } from '@wordpress/icons';
 import { clsx } from 'clsx';
 import {
+	useCallback,
 	useEffect,
 	useLayoutEffect,
 	useMemo,
@@ -13,6 +13,7 @@ import {
 	type Ref,
 } from 'react';
 import { useAgentRun } from '@/data/queries/use-agent-run';
+import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import {
 	useSession,
@@ -27,8 +28,10 @@ import { Composer, ComposerSkeleton } from '../composer';
 import { pickLiveSite } from '../composer/environment-pill';
 import { Conversation } from '../conversation';
 import { QueuedPrompts } from '../queued-prompts';
+import { hasVisibleUserPrompt, shouldShowEmptyConversation } from './empty-state';
 import styles from './style.module.css';
 import type { PendingChatPrompt } from '../context';
+import type { SendMessageOptions } from '@/data/queries/use-agent-run';
 
 interface SessionSurfaceProps {
 	siteId?: string;
@@ -110,10 +113,12 @@ function formatChatDate( value: string ) {
 }
 
 function EmptyConversation( {
+	authRequired,
 	onPreviewPrompt,
 	onClearPreview,
 	onSelectPrompt,
 }: {
+	authRequired: boolean;
 	onPreviewPrompt: ( prompt: string ) => void;
 	onClearPreview: () => void;
 	onSelectPrompt: ( prompt: string ) => void;
@@ -121,30 +126,34 @@ function EmptyConversation( {
 	return (
 		<div className={ styles.emptyConversation }>
 			<div className={ styles.emptyConversationPrompt }>
-				{ __( 'Ask Studio Desk anything to get started.' ) }
+				{ authRequired
+					? __( 'Log in with WordPress.com to start a Studio Desk chat.' )
+					: __( 'Ask Studio Desk anything to get started.' ) }
 			</div>
-			<div className={ styles.emptyConversationExamples }>
-				{ EXAMPLE_PROMPTS.map( ( example ) => (
-					<Button
-						key={ example.short }
-						variant="quiet"
-						size="small"
-						className={ styles.emptyConversationExample }
-						label={ example.short }
-						title={ example.full }
-						onMouseEnter={ () => onPreviewPrompt( example.full ) }
-						onMouseLeave={ onClearPreview }
-						onFocus={ () => onPreviewPrompt( example.full ) }
-						onBlur={ onClearPreview }
-						onClick={ () => {
-							onSelectPrompt( example.full );
-							onClearPreview();
-						} }
-					>
-						{ example.short }
-					</Button>
-				) ) }
-			</div>
+			{ authRequired ? null : (
+				<div className={ styles.emptyConversationExamples }>
+					{ EXAMPLE_PROMPTS.map( ( example ) => (
+						<Button
+							key={ example.short }
+							variant="quiet"
+							size="small"
+							className={ styles.emptyConversationExample }
+							label={ example.short }
+							title={ example.full }
+							onMouseEnter={ () => onPreviewPrompt( example.full ) }
+							onMouseLeave={ onClearPreview }
+							onFocus={ () => onPreviewPrompt( example.full ) }
+							onBlur={ onClearPreview }
+							onClick={ () => {
+								onSelectPrompt( example.full );
+								onClearPreview();
+							} }
+						>
+							{ example.short }
+						</Button>
+					) ) }
+				</div>
+			) }
 		</div>
 	);
 }
@@ -176,6 +185,8 @@ function SessionSurfaceContent( {
 	onInitialPromptConsumed,
 }: SessionSurfaceProps ) {
 	const { data, isLoading, error } = useSession( sessionId );
+	const { data: authUser, isLoading: isLoadingAuthUser } = useAuthUser();
+	const login = useLogin();
 	const { data: sites } = useSites();
 	const ownerSitePath = data?.summary.ownerSitePath;
 	const ownerSite = ownerSitePath
@@ -210,11 +221,10 @@ function SessionSurfaceContent( {
 		[ pendingQuestions ]
 	);
 	const composerBusy = hasActiveRun || pendingQuestions.length > 0;
-	const isEmpty = useMemo(
-		() =>
-			! ( data?.entries ?? [] ).some( ( entry ) =>
-				isStudioCustomEntryOfType( entry, 'studio.user_prompt' )
-			),
+	const authLoading = isLoadingAuthUser && ! authUser;
+	const authRequired = ! isLoadingAuthUser && ! authUser;
+	const hasRenderedUserPrompt = useMemo(
+		() => hasVisibleUserPrompt( data?.entries ),
 		[ data?.entries ]
 	);
 	const scrollRef = useRef< HTMLDivElement >( null );
@@ -223,7 +233,28 @@ function SessionSurfaceContent( {
 	const [ exampleDraft, setExampleDraft ] = useState< { id: number; prompt: string } | null >(
 		null
 	);
+	const [ hasSubmittedPrompt, setHasSubmittedPrompt ] = useState( false );
+	const hasPendingInitialPrompt = initialPrompt?.sessionId === sessionId;
+	const showEmptyConversation = shouldShowEmptyConversation( {
+		hasVisibleUserPrompt: hasRenderedUserPrompt,
+		hasSubmittedPrompt,
+		hasPendingInitialPrompt,
+		hasActiveRun,
+		queuedPromptCount: queuedPrompts.length,
+	} );
 	useSessionCommands( sessionId );
+
+	useEffect( () => {
+		setHasSubmittedPrompt( false );
+	}, [ sessionId ] );
+
+	const sendMessageAndHideSuggestions = useCallback(
+		async ( prompt: string, options?: SendMessageOptions ) => {
+			setHasSubmittedPrompt( true );
+			await sendMessage( prompt, options );
+		},
+		[ sendMessage ]
+	);
 
 	const toggleStar = () => {
 		void updateSessionMetadata.mutateAsync( {
@@ -243,19 +274,29 @@ function SessionSurfaceContent( {
 		if ( ! data || ! initialPrompt || initialPrompt.sessionId !== sessionId ) {
 			return;
 		}
+		if ( ! authUser ) {
+			return;
+		}
 		if ( sentInitialPromptIdsRef.current.has( initialPrompt.id ) ) {
 			return;
 		}
 
 		sentInitialPromptIdsRef.current.add( initialPrompt.id );
-		void sendMessage( initialPrompt.prompt, {
+		void sendMessageAndHideSuggestions( initialPrompt.prompt, {
 			displayMessage: initialPrompt.displayMessage,
 		} )
 			.then( () => onInitialPromptConsumed?.( initialPrompt.id ) )
 			.catch( () => {
 				sentInitialPromptIdsRef.current.delete( initialPrompt.id );
 			} );
-	}, [ data, initialPrompt, onInitialPromptConsumed, sendMessage, sessionId ] );
+	}, [
+		authUser,
+		data,
+		initialPrompt,
+		onInitialPromptConsumed,
+		sendMessageAndHideSuggestions,
+		sessionId,
+	] );
 
 	useLayoutEffect( () => {
 		const node = scrollRef.current;
@@ -354,8 +395,12 @@ function SessionSurfaceContent( {
 						busy={ composerBusy }
 						isInterrupting={ isInterrupting }
 						error={ runError }
+						authRequired={ authRequired }
+						authLoading={ authLoading }
+						authPending={ login.isPending }
+						onLogin={ () => login.mutate() }
 						model={ currentModel }
-						onSend={ sendMessage }
+						onSend={ sendMessageAndHideSuggestions }
 						onInterrupt={ interrupt }
 						sessionId={ sessionId }
 						effectiveEnvironment={ effectiveEnvironment }
@@ -370,8 +415,9 @@ function SessionSurfaceContent( {
 				</div>
 			}
 		>
-			{ isEmpty ? (
+			{ showEmptyConversation ? (
 				<EmptyConversation
+					authRequired={ authRequired }
 					onPreviewPrompt={ setPreviewPrompt }
 					onClearPreview={ () => setPreviewPrompt( null ) }
 					onSelectPrompt={ ( prompt ) => {


### PR DESCRIPTION
## Summary
- Gate Studio Desk chat creation and prompt submission on WordPress.com auth so logged-out users see a clear login flow instead of a disappearing session
- Refresh auth state when the OAuth deeplink completes, and surface a login-required message in the chat UI
- Hide empty-state prompt suggestions as soon as a prompt is submitted, queued, or rendered so they do not linger after the conversation has started
- Add focused coverage for auth-gated chat flows and empty-state visibility rules

## Testing
- `npx eslint --fix` on the modified files
- `npm test -- apps/ui/src/ui-desks/chats/provider.test.tsx apps/ui/src/ui-desks/chats/composer/index.test.tsx apps/ui/src/ui-desks/chats/session-surface/empty-state.test.ts`
- `npm run typecheck`