### PR TITLE
apps/ui: Use a clearer logged-out avatar in the desks user menu

### DIFF
--- a/apps/ui/src/ui-desks/chrome/user-menu/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/user-menu/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
-import { chevronDownSmall } from '@wordpress/icons';
+import { chevronDownSmall, commentAuthorAvatar } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { Gravatar } from '@/components/gravatar';
 import { SiteIcon } from '@/components/site-icon';
@@ -91,7 +91,9 @@ export function DeskMenu( { siteId, disabled = false, showSiteName = true }: Des
 			{ user ? (
 				<Gravatar className={ styles.avatar } email={ user.email } isDark={ themeIsDark } />
 			) : (
-				<span className={ styles.loginAvatar } aria-hidden="true" />
+				<span className={ styles.loginAvatar } aria-hidden="true">
+					<Icon icon={ commentAuthorAvatar } size={ 18 } />
+				</span>
 			) }
 		</Button>
 	);

--- a/apps/ui/src/ui-desks/chrome/user-menu/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/user-menu/index.tsx
@@ -91,9 +91,12 @@ export function DeskMenu( { siteId, disabled = false, showSiteName = true }: Des
 			{ user ? (
 				<Gravatar className={ styles.avatar } email={ user.email } isDark={ themeIsDark } />
 			) : (
-				<span className={ styles.loginAvatar } aria-hidden="true">
-					<Icon icon={ commentAuthorAvatar } size={ 18 } />
-				</span>
+				<Icon
+					icon={ commentAuthorAvatar }
+					size={ 24 }
+					className={ styles.loginAvatar }
+					aria-hidden="true"
+				/>
 			) }
 		</Button>
 	);

--- a/apps/ui/src/ui-desks/chrome/user-menu/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/user-menu/style.module.css
@@ -39,8 +39,19 @@
 }
 
 .loginAvatar {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	border-radius: 50%;
-	background: rgba(15, 23, 42, 0.06);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	background: var(--wpds-color-bg-surface-neutral);
+	box-shadow:
+		inset 0 0 0 1px rgba(15, 23, 42, 0.08),
+		0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.loginAvatar svg {
+	fill: currentColor;
 }
 
 .popup {

--- a/apps/ui/src/ui-desks/chrome/user-menu/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/user-menu/style.module.css
@@ -39,15 +39,7 @@
 }
 
 .loginAvatar {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	border-radius: 50%;
 	color: var(--wpds-color-fg-content-neutral-weak);
-	background: var(--wpds-color-bg-surface-neutral);
-	box-shadow:
-		inset 0 0 0 1px rgba(15, 23, 42, 0.08),
-		0 1px 2px rgba(15, 23, 42, 0.04);
 }
 
 .loginAvatar svg {


### PR DESCRIPTION
## Summary
- Replace the empty logged-out avatar placeholder in the desks chrome user menu with the WordPress account glyph
- Remove the outer circular avatar treatment so the fallback reads as a simple icon
- Keep the logged-in gravatar behavior unchanged

## Testing
- Lint and formatting passed for the touched UI file
- Typecheck passed across the workspaces
- Focused desks chrome tests passed