### PR TITLE
[codex] Move Desks UI switch to beta features

### DIFF
--- a/apps/studio/src/components/tests/content-tab-settings.test.tsx
+++ b/apps/studio/src/components/tests/content-tab-settings.test.tsx
@@ -38,7 +38,7 @@ const snapshotTestActions = {
 let testStore = createTestStore( {
 	preloadedState: {
 		betaFeatures: {
-			features: { remoteSession: false, nativePhpRuntime: false },
+			features: { remoteSession: false, nativePhpRuntime: false, enableDesksUiSwitch: false },
 			loading: false,
 		},
 	},
@@ -49,7 +49,7 @@ function createCustomTestStore( nativePhpRuntime = false ) {
 	const store = createTestStore( {
 		preloadedState: {
 			betaFeatures: {
-				features: { remoteSession: false, nativePhpRuntime },
+				features: { remoteSession: false, nativePhpRuntime, enableDesksUiSwitch: false },
 				loading: false,
 			},
 		},

--- a/apps/studio/src/components/tests/remote-session-indicator.test.tsx
+++ b/apps/studio/src/components/tests/remote-session-indicator.test.tsx
@@ -32,7 +32,10 @@ function setupHooks( {
 	isRunning: boolean;
 	isLoading?: boolean;
 } ) {
-	vi.mocked( useBetaFeatures ).mockReturnValue( { remoteSession } );
+	vi.mocked( useBetaFeatures ).mockReturnValue( {
+		remoteSession,
+		enableDesksUiSwitch: false,
+	} );
 	vi.mocked( useAuth, { partial: true } ).mockReturnValue( { isAuthenticated } );
 	vi.mocked( useRemoteSessionStatus ).mockReturnValue( {
 		status: isRunning ? { running: true } : undefined,

--- a/apps/studio/src/ipc-types.d.ts
+++ b/apps/studio/src/ipc-types.d.ts
@@ -100,12 +100,12 @@ type IpcApi = {
 interface FeatureFlags {
 	enableBlueprints: boolean;
 	enableStudioCodeUi: boolean;
-	enableDesksUiSwitch: boolean;
 }
 
 interface BetaFeatures {
 	remoteSession: boolean;
 	nativePhpRuntime?: boolean;
+	enableDesksUiSwitch: boolean;
 }
 
 interface AppGlobals extends FeatureFlags {

--- a/apps/studio/src/lib/beta-features.ts
+++ b/apps/studio/src/lib/beta-features.ts
@@ -37,10 +37,10 @@ export function getBetaFeaturesDefinition(): Record< keyof BetaFeatures, BetaFea
 			description: __( 'Run Studio sites with native PHP instead of Playground.' ),
 		},
 		enableDesksUiSwitch: {
-			label: __( 'Desks UI switch' ),
+			label: __( 'Enable Studio UI Switcher' ),
 			key: 'enableDesksUiSwitch',
 			default: BETA_FEATURE_DEFAULTS.enableDesksUiSwitch,
-			description: __( 'Show the option to switch Studio into the Desks UI.' ),
+			description: __( 'Show the option to switch Studio UI modes.' ),
 		},
 	};
 }

--- a/apps/studio/src/lib/beta-features.ts
+++ b/apps/studio/src/lib/beta-features.ts
@@ -15,6 +15,7 @@ export interface BetaFeatureDefinition {
 const BETA_FEATURE_DEFAULTS: Record< keyof BetaFeatures, boolean > = {
 	remoteSession: false,
 	nativePhpRuntime: false,
+	enableDesksUiSwitch: false,
 };
 
 /**
@@ -34,6 +35,12 @@ export function getBetaFeaturesDefinition(): Record< keyof BetaFeatures, BetaFea
 			label: __( 'Native PHP runtime' ),
 			default: BETA_FEATURE_DEFAULTS.nativePhpRuntime,
 			description: __( 'Run Studio sites with native PHP instead of Playground.' ),
+		},
+		enableDesksUiSwitch: {
+			label: __( 'Desks UI switch' ),
+			key: 'enableDesksUiSwitch',
+			default: BETA_FEATURE_DEFAULTS.enableDesksUiSwitch,
+			description: __( 'Show the option to switch Studio into the Desks UI.' ),
 		},
 	};
 }

--- a/apps/studio/src/lib/feature-flags.ts
+++ b/apps/studio/src/lib/feature-flags.ts
@@ -18,12 +18,6 @@ export const FEATURE_FLAGS: Record< keyof FeatureFlags, FeatureFlagDefinition > 
 		flag: 'enableStudioCodeUi',
 		default: false,
 	},
-	enableDesksUiSwitch: {
-		label: 'Enable Studio UI Switcher',
-		env: 'ENABLE_DESKS_UI_SWITCH',
-		flag: 'enableDesksUiSwitch',
-		default: false,
-	},
 } as const;
 
 export function getFeatureFlagFromEnv( flag: keyof FeatureFlags ): boolean {

--- a/apps/studio/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/apps/studio/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -73,7 +73,7 @@ const renderWithProvider = ( children: React.ReactElement, nativePhpRuntime = fa
 	const store = createTestStore( {
 		preloadedState: {
 			betaFeatures: {
-				features: { remoteSession: false, nativePhpRuntime },
+				features: { remoteSession: false, nativePhpRuntime, enableDesksUiSwitch: false },
 				loading: false,
 			},
 		},

--- a/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
@@ -3,7 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Button from 'src/components/button';
 import { FormPathInputComponent } from 'src/components/form-path-input';
-import { useFeatureFlags } from 'src/hooks/use-feature-flags';
+import { useBetaFeatures } from 'src/hooks/use-beta-features';
 import { isWindowsStore } from 'src/lib/app-globals';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { ColorSchemePicker } from 'src/modules/user-settings/components/color-scheme-picker';
@@ -33,7 +33,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 	const { __ } = useI18n();
 	const savedLocale = useI18nLocale();
 	const dispatch = useAppDispatch();
-	const { enableDesksUiSwitch } = useFeatureFlags();
+	const { enableDesksUiSwitch } = useBetaFeatures();
 
 	const { data: colorScheme } = useGetColorSchemeQuery();
 	const { data: editor } = useGetUserEditorQuery();

--- a/apps/studio/src/stores/beta-features-slice.ts
+++ b/apps/studio/src/stores/beta-features-slice.ts
@@ -8,7 +8,7 @@ type BetaFeaturesState = {
 };
 
 const initialState: BetaFeaturesState = {
-	features: { remoteSession: false, nativePhpRuntime: false },
+	features: { remoteSession: false, nativePhpRuntime: false, enableDesksUiSwitch: false },
 	loading: false,
 };
 


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Codex made the targeted flag refactor, reviewed the diff, and ran the verification commands listed below.

## Proposed Changes

- Move `enableDesksUiSwitch` out of env-backed dev feature flags.
- Add `enableDesksUiSwitch` to persisted beta features and expose it in the Beta Features menu.
- Read the Desks UI switch setting from beta-feature state in Preferences.
- Update beta-feature test state fixtures for the new key.

## Testing Instructions

- `npx eslint --fix apps/studio/src/components/tests/content-tab-settings.test.tsx apps/studio/src/components/tests/remote-session-indicator.test.tsx apps/studio/src/ipc-types.d.ts apps/studio/src/lib/beta-features.ts apps/studio/src/lib/feature-flags.ts apps/studio/src/modules/site-settings/tests/edit-site-details.test.tsx apps/studio/src/modules/user-settings/components/preferences-tab.tsx apps/studio/src/stores/beta-features-slice.ts`
- `npm run typecheck`
- `npm test -- apps/studio/src/components/tests/content-tab-settings.test.tsx apps/studio/src/modules/site-settings/tests/edit-site-details.test.tsx apps/studio/src/components/tests/remote-session-indicator.test.tsx`

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
