### PR TITLE
apps/ui: Improve the design of the settings dialog.

### DIFF
--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -4,44 +4,44 @@
 
 	/* Overlay stacking — portals mount into `document.body` and must beat
 	   app-chrome stacking contexts (sidebar header z-index: 1, floating
-	   toggle z-index: 10). The menu popup uses the same 100 via its
-	   component stylesheet; dialogs sit at the same tier. Tooltips live
-	   higher so help text on controls inside a menu/dialog still surfaces
-	   above the containing popup. */
-	--wp-ui-dialog-z-index: 100;
-	--wp-ui-tooltip-z-index: 200;
+	   toggle z-index: 10). Menus stay below modal surfaces; tooltips live
+	   above dialogs so help text on controls inside a modal still surfaces
+	   above the containing overlay. */
+	--ui-desks-z-popover: 100;
+	--ui-desks-z-dialog: 700;
+	--ui-desks-z-tooltip: 800;
+	--wp-ui-dialog-z-index: var( --ui-desks-z-dialog );
+	--wp-ui-tooltip-z-index: var( --ui-desks-z-tooltip );
 
-	--ui-desks-bg: rgb(232, 234, 235);
+	--ui-desks-bg: rgb( 232, 234, 235 );
 	--ui-desks-material: #fff;
-	--ui-desks-glass: rgba(255, 255, 255, 0.85);
-	--ui-desks-glass-border: rgba(255, 255, 255, 0.7);
+	--ui-desks-glass: rgba( 255, 255, 255, 0.85 );
+	--ui-desks-glass-border: rgba( 255, 255, 255, 0.7 );
 	--ui-desks-text: #14171a;
 	--ui-desks-muted: #6b7280;
-	--ui-desks-divider: rgba(15, 23, 42, 0.06);
-	--ui-desks-control-hover: rgba(15, 23, 42, 0.07);
+	--ui-desks-divider: rgba( 15, 23, 42, 0.06 );
+	--ui-desks-control-hover: rgba( 15, 23, 42, 0.07 );
 	--ui-desks-focus: #3858e9;
 	--ui-desks-radius-control: 16px;
 	--ui-desks-radius-surface: 18px;
 	--ui-desks-radius-panel: 22px;
 	--ui-desks-radius-button: 12px;
-	--ui-desks-corner-shape: superellipse(1.42);
-	--ui-desks-z-popover: 100;
-	--ui-desks-shadow-control:
-		0 1px 2px rgba(15, 23, 42, 0.04), 0 8px 24px rgba(15, 23, 42, 0.06);
-	--ui-desks-shadow-control-raised:
-		0 1px 2px rgba(15, 23, 42, 0.04), 0 18px 44px rgba(15, 23, 42, 0.1);
-	--ui-desks-shadow-surface-raised:
-		0 1px 2px rgba(15, 23, 42, 0.04), 0 18px 44px rgba(15, 23, 42, 0.1);
+	--ui-desks-corner-shape: superellipse( 1.42 );
+	--ui-desks-shadow-control: 0 1px 2px rgba( 15, 23, 42, 0.04 ), 0 8px 24px rgba( 15, 23, 42, 0.06 );
+	--ui-desks-shadow-control-raised: 0 1px 2px rgba( 15, 23, 42, 0.04 ),
+		0 18px 44px rgba( 15, 23, 42, 0.1 );
+	--ui-desks-shadow-surface-raised: 0 1px 2px rgba( 15, 23, 42, 0.04 ),
+		0 18px 44px rgba( 15, 23, 42, 0.1 );
 }
 
 body {
 	margin: 0;
 	padding: 0;
-	font-family: var(--wpds-typography-font-family-body);
-	font-size: var(--wpds-typography-font-size-md);
-	line-height: var(--wpds-typography-line-height-md);
-	background-color: var(--wpds-color-bg-surface-neutral);
-	color: var(--wpds-color-fg-content-neutral);
+	font-family: var( --wpds-typography-font-family-body );
+	font-size: var( --wpds-typography-font-size-md );
+	line-height: var( --wpds-typography-line-height-md );
+	background-color: var( --wpds-color-bg-surface-neutral );
+	color: var( --wpds-color-fg-content-neutral );
 	color-scheme: light dark;
 	scrollbar-width: thin;
 	scrollbar-color: gray transparent;
@@ -59,40 +59,40 @@ h3,
 h4,
 h5,
 h6 {
-	font-family: var(--wpds-typography-font-family-heading);
-	font-weight: var(--wpds-typography-font-weight-regular);
-	color: var(--wpds-color-fg-content-neutral);
+	font-family: var( --wpds-typography-font-family-heading );
+	font-weight: var( --wpds-typography-font-weight-regular );
+	color: var( --wpds-color-fg-content-neutral );
 	margin: 0;
 }
 
 h1 {
-	font-size: var(--wpds-typography-font-size-2xl);
-	line-height: var(--wpds-typography-line-height-2xl);
+	font-size: var( --wpds-typography-font-size-2xl );
+	line-height: var( --wpds-typography-line-height-2xl );
 }
 
 h2 {
-	font-size: var(--wpds-typography-font-size-xl);
-	line-height: var(--wpds-typography-line-height-xl);
+	font-size: var( --wpds-typography-font-size-xl );
+	line-height: var( --wpds-typography-line-height-xl );
 }
 
 h3 {
-	font-size: var(--wpds-typography-font-size-lg);
-	line-height: var(--wpds-typography-line-height-lg);
+	font-size: var( --wpds-typography-font-size-lg );
+	line-height: var( --wpds-typography-line-height-lg );
 }
 
 h4 {
-	font-size: var(--wpds-typography-font-size-md);
-	line-height: var(--wpds-typography-line-height-md);
+	font-size: var( --wpds-typography-font-size-md );
+	line-height: var( --wpds-typography-line-height-md );
 }
 
 h5 {
-	font-size: var(--wpds-typography-font-size-sm);
-	line-height: var(--wpds-typography-line-height-sm);
+	font-size: var( --wpds-typography-font-size-sm );
+	line-height: var( --wpds-typography-line-height-sm );
 }
 
 h6 {
-	font-size: var(--wpds-typography-font-size-xs);
-	line-height: var(--wpds-typography-line-height-xs);
+	font-size: var( --wpds-typography-font-size-xs );
+	line-height: var( --wpds-typography-line-height-xs );
 }
 
 /* Interactive elements inside drag-region ancestors (title bars, section
@@ -104,7 +104,7 @@ button,
 a,
 input,
 textarea,
-[role="button"],
+[role='button'],
 [data-base-ui-portal],
 [data-base-ui-portal] * {
 	-webkit-app-region: no-drag;
@@ -119,12 +119,12 @@ textarea,
    loading buttons rely on `color: transparent` to hide their label while
    the spinner runs, and overriding that here would make the label visible
    again. */
-button:focus:not(:focus-visible),
-a:focus:not(:focus-visible),
-[role="button"]:focus:not(:focus-visible) {
+button:focus:not( :focus-visible ),
+a:focus:not( :focus-visible ),
+[role='button']:focus:not( :focus-visible ) {
 	outline: none;
-	background-color: var(--wp-ui-button-background-color);
-	border-color: var(--wp-ui-button-border-color);
+	background-color: var( --wp-ui-button-background-color );
+	border-color: var( --wp-ui-button-border-color );
 }
 
 /* Compact density: shrink icons to match the tighter spacing tokens.
@@ -157,7 +157,7 @@ a:focus:not(:focus-visible),
    itself uses so the control reads as one solid field. */
 .components-combobox-control__suggestions-container,
 .components-form-token-field__suggestions-list {
-	background-color: var(--wp-components-color-background, #fff);
+	background-color: var( --wp-components-color-background, #fff );
 }
 
 /* Honor the user's reduced-motion preference across the entire app. Class-
@@ -165,7 +165,7 @@ a:focus:not(:focus-visible),
    needed to clamp them. Components that genuinely need to keep motion can
    re-enable it with a more specific `!important` rule inside the same
    media query. */
-@media (prefers-reduced-motion: reduce) {
+@media ( prefers-reduced-motion: reduce ) {
 	*,
 	*::before,
 	*::after {

--- a/apps/ui/src/ui-desks/chrome/settings-modal/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/settings-modal/index.tsx
@@ -158,7 +158,7 @@ export function DeskSettingsModal( { open, onOpenChange, onEditToolbar }: DeskSe
 					{ status?.tone === 'success' && <DialogTip>{ status.message }</DialogTip> }
 				</div>
 			</DialogContent>
-			<DialogFooter>
+			<DialogFooter className={ styles.settingsFooter }>
 				<Button
 					type="button"
 					label={ __( 'Edit toolbar' ) }

--- a/apps/ui/src/ui-desks/chrome/settings-modal/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/settings-modal/style.module.css
@@ -24,7 +24,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 10px;
-	margin-top: 10px;
+	margin-top: 20px;
 	padding-top: 14px;
 	border-top: 1px solid var( --ui-desks-divider, rgba( 15, 23, 42, 0.06 ) );
 }
@@ -40,4 +40,10 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
+}
+
+.settingsFooter {
+	margin-top: 10px;
+	padding-top: 14px;
+	border-top: 1px solid var( --ui-desks-divider, rgba( 15, 23, 42, 0.06 ) );
 }

--- a/apps/ui/src/ui-desks/chrome/settings-modal/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/settings-modal/style.module.css
@@ -4,10 +4,10 @@
 	align-items: center;
 	justify-content: flex-start;
 	gap: 10px;
-	color: var(--ui-desks-text, #14171a);
-	font-size: var(--wpds-typography-font-size-sm);
-	font-weight: var(--wpds-typography-font-weight-medium, 500);
-	line-height: var(--wpds-typography-line-height-sm);
+	color: var( --ui-desks-text, #14171a );
+	font-size: var( --wpds-typography-font-size-sm );
+	font-weight: var( --wpds-typography-font-weight-medium, 500 );
+	line-height: var( --wpds-typography-line-height-sm );
 	cursor: pointer;
 }
 
@@ -16,7 +16,7 @@
 	width: 16px;
 	height: 16px;
 	margin: 0;
-	accent-color: var(--wp-admin-theme-color, #3858e9);
+	accent-color: var( --wp-admin-theme-color, #3858e9 );
 	cursor: pointer;
 }
 
@@ -24,15 +24,16 @@
 	display: flex;
 	flex-direction: column;
 	gap: 10px;
+	margin-top: 10px;
 	padding-top: 14px;
-	border-top: 1px solid var(--ui-desks-divider, rgba(15, 23, 42, 0.06));
+	border-top: 1px solid var( --ui-desks-divider, rgba( 15, 23, 42, 0.06 ) );
 }
 
 .settingsSectionTitle {
-	color: var(--ui-desks-text, #14171a);
-	font-size: var(--wpds-typography-font-size-sm);
-	font-weight: var(--wpds-typography-font-weight-semibold, 600);
-	line-height: var(--wpds-typography-line-height-sm);
+	color: var( --ui-desks-text, #14171a );
+	font-size: var( --wpds-typography-font-size-sm );
+	font-weight: var( --wpds-typography-font-weight-semibold, 600 );
+	line-height: var( --wpds-typography-line-height-sm );
 }
 
 .settingsActions {

--- a/apps/ui/src/ui-desks/components/dialog/style.module.css
+++ b/apps/ui/src/ui-desks/components/dialog/style.module.css
@@ -1,45 +1,45 @@
 .backdrop {
 	position: fixed;
 	inset: 0;
-	z-index: 700;
+	z-index: var( --ui-desks-z-dialog, 700 );
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: rgba(15, 23, 42, 0.18);
-	-webkit-backdrop-filter: blur(8px);
-	backdrop-filter: blur(8px);
+	background: rgba( 15, 23, 42, 0.18 );
+	-webkit-backdrop-filter: blur( 8px );
+	backdrop-filter: blur( 8px );
 	pointer-events: auto;
 	animation: fadeIn 200ms ease;
 }
 
 .dialog {
-	width: min(560px, calc(100vw - 48px));
-	max-height: min(80vh, calc(100vh - 48px));
+	width: min( 560px, calc( 100vw - 48px ) );
+	max-height: min( 80vh, calc( 100vh - 48px ) );
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
 	box-sizing: border-box;
 	padding: 20px;
-	border: 1px solid rgba(255, 255, 255, 0.7);
-	border-radius: var(--ui-desks-radius-panel, 22px);
-	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
-	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
-	background: rgba(255, 255, 255, 0.62);
+	border: 1px solid rgba( 255, 255, 255, 0.7 );
+	border-radius: var( --ui-desks-radius-panel, 22px );
+	corner-shape: var( --ui-desks-corner-shape, superellipse( 1.42 ) );
+	-webkit-corner-shape: var( --ui-desks-corner-shape, superellipse( 1.42 ) );
+	background: rgba( 255, 255, 255, 0.62 );
 	box-shadow:
-		0 1px 2px rgba(15, 23, 42, 0.04),
-		0 18px 44px rgba(15, 23, 42, 0.1);
-	color: var(--ui-desks-text, #14171a);
-	-webkit-backdrop-filter: saturate(180%) blur(28px);
-	backdrop-filter: saturate(180%) blur(28px);
-	animation: rise 280ms cubic-bezier(0.32, 0.72, 0.24, 1);
+		0 1px 2px rgba( 15, 23, 42, 0.04 ),
+		0 18px 44px rgba( 15, 23, 42, 0.1 );
+	color: var( --ui-desks-text, #14171a );
+	-webkit-backdrop-filter: saturate( 180% ) blur( 28px );
+	backdrop-filter: saturate( 180% ) blur( 28px );
+	animation: rise 280ms cubic-bezier( 0.32, 0.72, 0.24, 1 );
 }
 
 .narrow {
-	width: min(520px, calc(100vw - 48px));
+	width: min( 520px, calc( 100vw - 48px ) );
 }
 
 .small {
-	width: min(440px, calc(100vw - 48px));
+	width: min( 440px, calc( 100vw - 48px ) );
 }
 
 .compact {
@@ -60,9 +60,9 @@
 
 .title {
 	margin: 0;
-	font-size: var(--wpds-typography-font-size-md);
-	font-weight: var(--wpds-typography-font-weight-semibold, 600);
-	line-height: var(--wpds-typography-line-height-md);
+	font-size: var( --wpds-typography-font-size-md );
+	font-weight: var( --wpds-typography-font-weight-semibold, 600 );
+	line-height: var( --wpds-typography-line-height-md );
 }
 
 .closeButton {
@@ -98,7 +98,7 @@
 	padding: 8px 4px;
 	border: 0;
 	background: transparent;
-	color: var(--ui-desks-text, #14171a);
+	color: var( --ui-desks-text, #14171a );
 	font: inherit;
 	font-size: 15px;
 	line-height: 1.45;
@@ -109,7 +109,7 @@
 }
 
 .input::placeholder {
-	color: var(--ui-desks-muted, #6b7280);
+	color: var( --ui-desks-muted, #6b7280 );
 }
 
 .error {
@@ -120,7 +120,7 @@
 
 .tip {
 	margin: 0;
-	color: var(--ui-desks-muted, #6b7280);
+	color: var( --ui-desks-muted, #6b7280 );
 	font-size: 12px;
 	line-height: 1.4;
 }
@@ -138,11 +138,11 @@
 @keyframes rise {
 	from {
 		opacity: 0;
-		transform: translateY(8px) scale(0.98);
+		transform: translateY( 8px ) scale( 0.98 );
 	}
 
 	to {
 		opacity: 1;
-		transform: translateY(0) scale(1);
+		transform: translateY( 0 ) scale( 1 );
 	}
 }


### PR DESCRIPTION
## Summary

This PR refines the visual structure of the Desks settings dialog.

The dialog now gives the settings sections more deliberate separation: the "Desk data" section has more space above its divider, and the "Edit toolbar" action row is separated from the content with a matching divider. This makes the dialog read as three clear areas: basic settings, desk data actions, and toolbar customization.

It also updates the shared overlay layer tokens so tooltips from controls inside Desks dialogs appear above the dialog overlay instead of being hidden behind it.

## Testing

- `npx prettier --check apps/ui/src/index.css apps/ui/src/ui-desks/components/dialog/style.module.css apps/ui/src/ui-desks/chrome/settings-modal/index.tsx apps/ui/src/ui-desks/chrome/settings-modal/style.module.css`
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-desks/desk/default-desk.test.ts apps/ui/src/ui-desks/desk/provider/resolvers.test.ts`

Note: `npx eslint --fix` was run on the changed files. The TSX file passed; the CSS files are ignored by the current ESLint config and reported warnings only.
