### PR TITLE
apps/ui: Add a desks-native connect site modal

### DIFF
--- a/apps/ui/src/data/queries/use-wpcom-sites.ts
+++ b/apps/ui/src/data/queries/use-wpcom-sites.ts
@@ -22,7 +22,7 @@ export function useSyncableWpcomSites( options: { enabled?: boolean } = {} ) {
 // Mirrors `useConnectedWpcomSites` but returns connections for every local
 // site — used to filter out WordPress.com sites that are already attached to
 // another Studio site when picking a publish target.
-export function useAllConnectedWpcomSites() {
+export function useAllConnectedWpcomSites( options: { enabled?: boolean } = {} ) {
 	const connector = useConnector();
 	return useQuery( {
 		queryKey: ALL_CONNECTED_WPCOM_SITES_QUERY_KEY,
@@ -30,12 +30,13 @@ export function useAllConnectedWpcomSites() {
 		// as "no filter" so we get every connection on record. See the
 		// `getConnectedWpcomSites` main-process handler.
 		queryFn: () => connector.getConnectedWpcomSites( '' ),
+		enabled: options.enabled ?? true,
 	} );
 }
 
 export function usePickableWpcomSites( options: { enabled?: boolean } = {} ) {
 	const syncable = useSyncableWpcomSites( options );
-	const connected = useAllConnectedWpcomSites();
+	const connected = useAllConnectedWpcomSites( options );
 
 	const data = useMemo< SyncSite[] | undefined >( () => {
 		if ( ! syncable.data ) {
@@ -50,6 +51,11 @@ export function usePickableWpcomSites( options: { enabled?: boolean } = {} ) {
 	return {
 		data,
 		isLoading: syncable.isLoading || connected.isLoading,
+		isFetching: syncable.isFetching || connected.isFetching,
 		error: syncable.error ?? connected.error,
+		refetch: () => {
+			void syncable.refetch();
+			void connected.refetch();
+		},
 	};
 }

--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
+import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import { usePublishPreviewSite } from '@/data/queries/use-preview-site';
 import {
@@ -13,6 +14,7 @@ import {
 } from '@/data/queries/use-sites';
 import { useSnapshots } from '@/data/queries/use-snapshots';
 import { usePullSiteFromLive, usePushSiteToLive } from '@/data/queries/use-sync-site';
+import { usePickableWpcomSites } from '@/data/queries/use-wpcom-sites';
 import { SiteDetailsDropdown } from './index';
 import type { SiteDetails } from '@/data/core';
 
@@ -30,6 +32,11 @@ vi.mock( '@tanstack/react-query', () => ( {
 
 vi.mock( '@/data/core', () => ( {
 	useConnector: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-auth-user', () => ( {
+	useAuthUser: vi.fn(),
+	useLogin: vi.fn(),
 } ) );
 
 vi.mock( '@/data/queries/use-connected-wpcom-sites', () => ( {
@@ -59,7 +66,13 @@ vi.mock( '@/data/queries/use-sync-site', () => ( {
 	usePushSiteToLive: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-wpcom-sites', () => ( {
+	usePickableWpcomSites: vi.fn(),
+} ) );
+
 const useConnectorMock = vi.mocked( useConnector );
+const useAuthUserMock = vi.mocked( useAuthUser );
+const useLoginMock = vi.mocked( useLogin );
 const useConnectedWpcomSitesMock = vi.mocked( useConnectedWpcomSites );
 const usePublishPreviewSiteMock = vi.mocked( usePublishPreviewSite );
 const useDeleteSiteMock = vi.mocked( useDeleteSite );
@@ -70,9 +83,12 @@ const useStopSiteMock = vi.mocked( useStopSite );
 const useSnapshotsMock = vi.mocked( useSnapshots );
 const usePullSiteFromLiveMock = vi.mocked( usePullSiteFromLive );
 const usePushSiteToLiveMock = vi.mocked( usePushSiteToLive );
+const usePickableWpcomSitesMock = vi.mocked( usePickableWpcomSites );
 
 describe( 'SiteDetailsDropdown', () => {
 	const openExternalUrl = vi.fn();
+	const connectWpcomSite = vi.fn();
+	const refetchConnectedSites = vi.fn();
 	const publishPreviewMutate = vi.fn();
 	const pullMutate = vi.fn();
 	const pushMutate = vi.fn();
@@ -82,6 +98,10 @@ describe( 'SiteDetailsDropdown', () => {
 
 	beforeEach( () => {
 		openExternalUrl.mockReset();
+		connectWpcomSite.mockReset();
+		connectWpcomSite.mockResolvedValue( undefined );
+		refetchConnectedSites.mockReset();
+		refetchConnectedSites.mockResolvedValue( {} );
 		publishPreviewMutate.mockReset();
 		pullMutate.mockReset();
 		pushMutate.mockReset();
@@ -92,7 +112,16 @@ describe( 'SiteDetailsDropdown', () => {
 
 		useConnectorMock.mockReturnValue( {
 			getPublishCheckoutUrl: () => 'https://wordpress.com/setup/studio',
+			connectWpcomSite,
 			openExternalUrl,
+		} as never );
+		useAuthUserMock.mockReturnValue( {
+			data: { id: 1, email: 'person@example.com', displayName: 'Person' },
+			isLoading: false,
+		} as never );
+		useLoginMock.mockReturnValue( {
+			isPending: false,
+			mutate: vi.fn(),
 		} as never );
 		useSnapshotsMock.mockReturnValue( {
 			data: [
@@ -118,6 +147,26 @@ describe( 'SiteDetailsDropdown', () => {
 					lastPushTimestamp: null,
 				},
 			],
+			refetch: refetchConnectedSites,
+		} as never );
+		usePickableWpcomSitesMock.mockReturnValue( {
+			data: [
+				{
+					id: 789,
+					localSiteId: '',
+					name: 'Remote Site',
+					url: 'https://remote.example.com',
+					isStaging: false,
+					isPressable: false,
+					syncSupport: 'syncable',
+					lastPullTimestamp: null,
+					lastPushTimestamp: null,
+				},
+			],
+			isLoading: false,
+			isFetching: false,
+			error: null,
+			refetch: vi.fn(),
 		} as never );
 		usePublishPreviewSiteMock.mockReturnValue( {
 			isPending: false,
@@ -207,6 +256,62 @@ describe( 'SiteDetailsDropdown', () => {
 		const options = deleteMutate.mock.calls[ 0 ][ 1 ];
 		options.onSuccess();
 		expect( routerMock.navigate ).toHaveBeenCalledWith( { to: '/' } );
+	} );
+
+	it( 'opens a desks modal to connect an existing WordPress.com site', async () => {
+		useConnectedWpcomSitesMock.mockReturnValue( {
+			data: [],
+			refetch: refetchConnectedSites,
+		} as never );
+		const site = createSite();
+		render( <SiteDetailsDropdown site={ site } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Site details for Local Studio Site' } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Connect live site' } ) );
+
+		const dialog = await screen.findByRole( 'dialog', { name: 'Connect a live site' } );
+		expect( within( dialog ).getByText( 'Remote Site' ) ).toBeVisible();
+		expect( openExternalUrl ).not.toHaveBeenCalledWith( 'https://wordpress.com/setup/studio' );
+
+		fireEvent.click( within( dialog ).getByText( 'Remote Site' ) );
+		fireEvent.click( within( dialog ).getByRole( 'button', { name: 'Connect selected site' } ) );
+
+		await waitFor( () =>
+			expect( connectWpcomSite ).toHaveBeenCalledWith( 'site-1', {
+				id: 789,
+				localSiteId: 'site-1',
+				name: 'Remote Site',
+				url: 'https://remote.example.com',
+				isStaging: false,
+				isPressable: false,
+				syncSupport: 'already-connected',
+				lastPullTimestamp: null,
+				lastPushTimestamp: null,
+			} )
+		);
+		expect( refetchConnectedSites ).toHaveBeenCalled();
+	} );
+
+	it( 'keeps creating a new WordPress.com site available from the connect modal', async () => {
+		useConnectedWpcomSitesMock.mockReturnValue( {
+			data: [],
+			refetch: refetchConnectedSites,
+		} as never );
+		const site = createSite();
+		render( <SiteDetailsDropdown site={ site } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Site details for Local Studio Site' } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Connect live site' } ) );
+
+		const dialog = await screen.findByRole( 'dialog', { name: 'Connect a live site' } );
+		fireEvent.click(
+			within( dialog ).getByRole( 'button', { name: 'Create a new WordPress.com site' } )
+		);
+
+		await waitFor( () =>
+			expect( openExternalUrl ).toHaveBeenCalledWith( 'https://wordpress.com/setup/studio' )
+		);
+		expect( connectWpcomSite ).not.toHaveBeenCalled();
 	} );
 } );
 

--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/index.tsx
@@ -1,18 +1,20 @@
 import { useIsMutating } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
-import { cog, download, external, formatListBullets, trash, upload } from '@wordpress/icons';
+import { cog, download, external, formatListBullets, plus, trash, upload } from '@wordpress/icons';
 import { clsx } from 'clsx';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
 	deriveSiteStatus,
 	ensureProtocol,
 	getSnapshotHostname,
 	pickLatestSnapshot,
 	pickLiveSite,
+	stripProtocol,
 } from '@/components/site-dropdown/utils';
 import { SiteIcon } from '@/components/site-icon';
 import { useConnector } from '@/data/core';
+import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import { usePublishPreviewSite } from '@/data/queries/use-preview-site';
 import {
@@ -29,20 +31,25 @@ import {
 	usePullSiteFromLive,
 	usePushSiteToLive,
 } from '@/data/queries/use-sync-site';
+import { usePickableWpcomSites } from '@/data/queries/use-wpcom-sites';
 import { formatRelativeTime } from '@/lib/format-relative-time';
 import { getSiteDisplayUrl, getSiteUrl } from '@/lib/get-site-url';
 import {
 	Button,
 	Dialog,
+	DialogCloseButton,
 	DialogContent,
 	DialogError,
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
+	List,
+	ListItem,
+	LoadingPlaceholder,
 	Menu,
 } from '@/ui-desks/components';
 import styles from './style.module.css';
-import type { SiteDetails } from '@/data/core';
+import type { SiteDetails, SyncSite } from '@/data/core';
 import type { ReactNode } from 'react';
 
 interface SiteDetailsDropdownProps {
@@ -71,10 +78,13 @@ export function SiteDetailsDropdown( { site, disabled = false }: SiteDetailsDrop
 	const navigate = useNavigate();
 	const [ open, setOpen ] = useState( false );
 	const [ deleteDialogOpen, setDeleteDialogOpen ] = useState( false );
+	const [ connectDialogOpen, setConnectDialogOpen ] = useState( false );
 	const [ deleteFiles, setDeleteFiles ] = useState( true );
 	const [ deleteError, setDeleteError ] = useState< string | null >( null );
 	const { data: snapshots } = useSnapshots();
-	const { data: connectedSites } = useConnectedWpcomSites( site.id );
+	const { data: connectedSites, refetch: refetchConnectedSites } = useConnectedWpcomSites(
+		site.id
+	);
 	const previewSnapshot = useMemo(
 		() => pickLatestSnapshot( snapshots, site.id ),
 		[ snapshots, site.id ]
@@ -149,6 +159,15 @@ export function SiteDetailsDropdown( { site, disabled = false }: SiteDetailsDrop
 		setDeleteFiles( true );
 		setDeleteError( null );
 		setDeleteDialogOpen( true );
+	};
+
+	const handleConnectClick = () => {
+		setOpen( false );
+		setConnectDialogOpen( true );
+	};
+
+	const closeConnectDialog = () => {
+		setConnectDialogOpen( false );
 	};
 
 	const closeDeleteDialog = () => {
@@ -337,12 +356,7 @@ export function SiteDetailsDropdown( { site, disabled = false }: SiteDetailsDrop
 										variant="filled"
 										size="small"
 										label={ __( 'Connect live site' ) }
-										disabled={ ! checkoutUrl }
-										onClick={ () => {
-											if ( checkoutUrl ) {
-												openExternal( checkoutUrl );
-											}
-										} }
+										onClick={ handleConnectClick }
 									>
 										{ __( 'Connect' ) }
 									</Button>
@@ -427,8 +441,275 @@ export function SiteDetailsDropdown( { site, disabled = false }: SiteDetailsDrop
 					</Button>
 				</DialogFooter>
 			</Dialog>
+			{ connectDialogOpen ? (
+				<ConnectLiveSiteDialog
+					site={ site }
+					canCreateNew={ Boolean( checkoutUrl ) }
+					onClose={ closeConnectDialog }
+					onConnected={ async () => {
+						await refetchConnectedSites();
+					} }
+					onCreateNew={ () => {
+						if ( checkoutUrl ) {
+							closeConnectDialog();
+							openExternal( checkoutUrl );
+						}
+					} }
+				/>
+			) : null }
 		</>
 	);
+}
+
+function ConnectLiveSiteDialog( {
+	site,
+	canCreateNew,
+	onClose,
+	onConnected,
+	onCreateNew,
+}: {
+	site: SiteDetails;
+	canCreateNew: boolean;
+	onClose: () => void;
+	onConnected: () => Promise< unknown >;
+	onCreateNew: () => void;
+} ) {
+	const connector = useConnector();
+	const { data: user, isLoading: isLoadingUser } = useAuthUser();
+	const login = useLogin();
+	const pickableSites = usePickableWpcomSites( { enabled: Boolean( user ) } );
+	const [ selectedSiteId, setSelectedSiteId ] = useState< number | null >( null );
+	const [ searchQuery, setSearchQuery ] = useState( '' );
+	const [ error, setError ] = useState< string | null >( null );
+	const [ isConnecting, setIsConnecting ] = useState( false );
+	const sites = useMemo( () => pickableSites.data ?? [], [ pickableSites.data ] );
+	const filteredSites = useMemo( () => {
+		const query = searchQuery.trim().toLowerCase();
+		if ( ! query ) {
+			return sites;
+		}
+		return sites.filter( ( candidate ) =>
+			[ candidate.name, candidate.url ].some( ( value ) => value.toLowerCase().includes( query ) )
+		);
+	}, [ sites, searchQuery ] );
+	const selectedSite = sites.find( ( candidate ) => candidate.id === selectedSiteId ) ?? null;
+	const isLoadingSites = Boolean( user ) && pickableSites.isLoading;
+	const isBusy = isConnecting || login.isPending;
+
+	useEffect( () => {
+		if ( selectedSiteId && ! sites.some( ( candidate ) => candidate.id === selectedSiteId ) ) {
+			setSelectedSiteId( null );
+		}
+	}, [ selectedSiteId, sites ] );
+
+	useEffect( () => {
+		if ( ! selectedSiteId && sites.length === 1 ) {
+			setSelectedSiteId( sites[ 0 ].id );
+		}
+	}, [ selectedSiteId, sites ] );
+
+	const handleClose = () => {
+		if ( isBusy ) {
+			return;
+		}
+		onClose();
+	};
+
+	const handleConnect = async () => {
+		if ( ! selectedSite || isConnecting ) {
+			return;
+		}
+		setError( null );
+		setIsConnecting( true );
+		try {
+			await connector.connectWpcomSite( site.id, {
+				...selectedSite,
+				localSiteId: site.id,
+				syncSupport: 'already-connected',
+			} );
+			await onConnected();
+			setIsConnecting( false );
+			onClose();
+		} catch ( connectError ) {
+			console.error( 'Failed to connect WordPress.com site:', connectError );
+			setError( __( 'Unable to connect this site. Please try again.' ) );
+			setIsConnecting( false );
+		}
+	};
+
+	return (
+		<Dialog
+			ariaLabel={ __( 'Connect a live site' ) }
+			className={ styles.connectDialog }
+			onClose={ handleClose }
+			open
+			size="default"
+		>
+			<DialogHeader>
+				<DialogTitle>{ __( 'Connect a live site' ) }</DialogTitle>
+				<DialogCloseButton onClose={ handleClose } />
+			</DialogHeader>
+			<DialogContent className={ styles.connectDialogContent }>
+				{ isLoadingUser ? (
+					<div className={ styles.connectLoading }>
+						<LoadingPlaceholder text={ __( 'Checking WordPress.com account' ) } />
+					</div>
+				) : user ? (
+					<>
+						<div className={ styles.connectSearchRow }>
+							<input
+								className={ styles.connectSearchInput }
+								type="search"
+								value={ searchQuery }
+								placeholder={ __( 'Search sites' ) }
+								aria-label={ __( 'Search WordPress.com sites' ) }
+								onChange={ ( event ) => setSearchQuery( event.target.value ) }
+							/>
+							<Button
+								variant="quiet"
+								size="small"
+								label={ __( 'Refresh site list' ) }
+								disabled={ pickableSites.isFetching || isConnecting }
+								onClick={ pickableSites.refetch }
+							>
+								{ pickableSites.isFetching ? __( 'Refreshing...' ) : __( 'Refresh' ) }
+							</Button>
+						</div>
+						<div className={ styles.connectSitesPanel }>
+							<ConnectSitesContent
+								error={ pickableSites.error }
+								filteredSites={ filteredSites }
+								isLoading={ isLoadingSites }
+								searchQuery={ searchQuery }
+								selectedSiteId={ selectedSiteId }
+								onSelectSite={ setSelectedSiteId }
+							/>
+						</div>
+					</>
+				) : (
+					<div className={ styles.connectAuthPrompt }>
+						<p>{ __( 'Log in with WordPress.com to choose from your sites.' ) }</p>
+						<Button
+							variant="filled"
+							tone="primary"
+							size="medium"
+							label={ __( 'Log in with WordPress.com' ) }
+							disabled={ login.isPending }
+							onClick={ () => {
+								setError( null );
+								login.mutate( undefined, {
+									onError: () => {
+										setError( __( 'Unable to start WordPress.com login. Please try again.' ) );
+									},
+								} );
+							} }
+						>
+							{ login.isPending ? __( 'Logging in...' ) : __( 'Log in with WordPress.com' ) }
+						</Button>
+					</div>
+				) }
+				{ error ? <DialogError>{ error }</DialogError> : null }
+			</DialogContent>
+			<DialogFooter className={ styles.connectFooter }>
+				<Button
+					className={ styles.createLiveSiteButton }
+					variant="quiet"
+					size="medium"
+					icon={ plus }
+					label={ __( 'Create a new WordPress.com site' ) }
+					disabled={ isBusy || ! canCreateNew }
+					onClick={ onCreateNew }
+				>
+					{ __( 'Create a new WordPress.com site' ) }
+				</Button>
+				<div className={ styles.connectFooterActions }>
+					<Button
+						variant="quiet"
+						size="medium"
+						label={ __( 'Cancel' ) }
+						disabled={ isBusy }
+						onClick={ handleClose }
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="filled"
+						tone="primary"
+						size="medium"
+						label={ __( 'Connect selected site' ) }
+						disabled={ ! user || ! selectedSite || isBusy }
+						aria-busy={ isConnecting ? 'true' : undefined }
+						onClick={ handleConnect }
+					>
+						{ isConnecting ? __( 'Connecting...' ) : __( 'Connect' ) }
+					</Button>
+				</div>
+			</DialogFooter>
+		</Dialog>
+	);
+}
+
+function ConnectSitesContent( {
+	error,
+	filteredSites,
+	isLoading,
+	onSelectSite,
+	searchQuery,
+	selectedSiteId,
+}: {
+	error: unknown;
+	filteredSites: SyncSite[];
+	isLoading: boolean;
+	onSelectSite: ( siteId: number ) => void;
+	searchQuery: string;
+	selectedSiteId: number | null;
+} ) {
+	if ( isLoading ) {
+		return (
+			<div className={ styles.connectLoading }>
+				<LoadingPlaceholder text={ __( 'Loading your sites' ) } />
+				<LoadingPlaceholder />
+			</div>
+		);
+	}
+
+	if ( error ) {
+		return (
+			<div className={ styles.connectEmptyState }>
+				{ __( 'Unable to load WordPress.com sites.' ) }
+			</div>
+		);
+	}
+
+	if ( filteredSites.length === 0 ) {
+		return (
+			<div className={ styles.connectEmptyState }>
+				{ searchQuery
+					? __( 'No sites match your search.' )
+					: __( 'No WordPress.com sites are available to connect.' ) }
+			</div>
+		);
+	}
+
+	return (
+		<List className={ styles.connectSitesList }>
+			{ filteredSites.map( ( candidate ) => (
+				<ListItem
+					key={ candidate.id }
+					active={ candidate.id === selectedSiteId }
+					description={ getConnectSiteDescription( candidate ) }
+					label={ candidate.name || stripProtocol( candidate.url ) }
+					onClick={ () => onSelectSite( candidate.id ) }
+				/>
+			) ) }
+		</List>
+	);
+}
+
+function getConnectSiteDescription( site: SyncSite ) {
+	const provider = site.isPressable ? __( 'Pressable' ) : __( 'WordPress.com' );
+	const environment = site.isStaging ? __( 'Staging' ) : __( 'Production' );
+	return `${ stripProtocol( site.url ) } - ${ provider } - ${ environment }`;
 }
 
 function DetailsRow( {

--- a/apps/ui/src/ui-desks/chrome/site-details-dropdown/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/site-details-dropdown/style.module.css
@@ -154,6 +154,108 @@
 	--button-background: #8a2424;
 }
 
+.connectDialog {
+	width: min(640px, calc(100vw - 48px));
+}
+
+.connectDialogContent {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	min-height: 268px;
+}
+
+.connectSearchRow {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.connectSearchInput {
+	width: 100%;
+	min-width: 0;
+	height: 36px;
+	box-sizing: border-box;
+	padding: 0 12px;
+	border: 1px solid rgba(15, 23, 42, 0.1);
+	border-radius: var(--ui-desks-radius-button, 12px);
+	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	background: rgba(255, 255, 255, 0.56);
+	color: var(--ui-desks-text, #14171a);
+	font: inherit;
+	font-size: 13px;
+	line-height: 18px;
+	outline: none;
+}
+
+.connectSearchInput::placeholder {
+	color: var(--ui-desks-muted, #6b7280);
+}
+
+.connectSearchInput:focus {
+	border-color: var(--ui-desks-focus, #3858e9);
+	box-shadow: 0 0 0 1px var(--ui-desks-focus, #3858e9);
+}
+
+.connectSitesPanel {
+	min-height: 0;
+	max-height: 320px;
+	overflow-y: auto;
+	border: 1px solid rgba(15, 23, 42, 0.08);
+	border-radius: var(--ui-desks-radius-surface, 18px);
+	corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	-webkit-corner-shape: var(--ui-desks-corner-shape, superellipse(1.42));
+	background: rgba(255, 255, 255, 0.34);
+}
+
+.connectSitesList {
+	padding: 6px;
+}
+
+.connectLoading {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+	padding: 16px;
+}
+
+.connectEmptyState,
+.connectAuthPrompt {
+	display: flex;
+	min-height: 180px;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	padding: 24px;
+	color: var(--ui-desks-muted, #6b7280);
+	font-size: 13px;
+	line-height: 18px;
+	text-align: center;
+}
+
+.connectAuthPrompt p {
+	max-width: 34ch;
+	margin: 0;
+}
+
+.connectFooter {
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.connectFooterActions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+}
+
+.createLiveSiteButton {
+	max-width: 280px;
+	justify-content: flex-start;
+}
+
 .row {
 	display: grid;
 	grid-template-columns: minmax(120px, 1fr) auto;


### PR DESCRIPTION
## Summary
- Replaced the desks-ui site-details connect action with a centered desks dialog instead of opening WordPress.com directly.
- Built the modal with desks components and local styling: auth-aware loading states, searchable pickable sites, refresh, connect, and create-new actions.
- Extended the shared WP.com site query helper so the desks modal can opt in cleanly and refresh its data.
- Added coverage for connecting an existing site and creating a new WordPress.com site from the modal.

## Testing
- `npm test -- apps/ui/src/ui-desks/chrome/site-details-dropdown/index.test.tsx`
- `npm run typecheck`
- `npx eslint --fix` on the modified TS/TSX files passed; the CSS file is ignored by the repo ESLint config and emitted a non-blocking warning.