### PR TITLE
Fix localization e2e by selecting Empty site card via data-testid instead of accessible name

### DIFF
--- a/apps/studio/e2e/localization.test.ts
+++ b/apps/studio/e2e/localization.test.ts
@@ -129,10 +129,8 @@ test.describe( 'Localization', () => {
 		await expect( addSiteModal.createSiteButton ).toBeVisible();
 		await addSiteModal.createSiteButton.click();
 
-		// Select "Empty site" and continue to the create form.
-		// "Empty site" is untranslated so the English text works in all locales.
 		// Use force:true because the app-drag-region overlay intercepts pointer events.
-		const emptySiteBtn = session.mainWindow.getByRole( 'button', { name: /Empty site/ } );
+		const emptySiteBtn = session.mainWindow.getByTestId( 'empty-site-card' );
 		await expect( emptySiteBtn ).toBeVisible( { timeout: 5000 } );
 		await emptySiteBtn.click( { force: true } );
 		await addSiteModal.continueButton.click();

--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -61,6 +61,7 @@ function EmptySiteCard( { isSelected, onClick }: { isSelected: boolean; onClick:
 	return (
 		<button
 			onClick={ onClick }
+			data-testid="empty-site-card"
 			className={ cx(
 				'flex flex-col h-full rounded-lg border overflow-hidden text-left transition-colors',
 				isSelected


### PR DESCRIPTION
## How AI was used in this PR

AI helped


## Proposed Changes

During releasing beta1 I encountered the next error - https://buildkite.com/automattic/studio/builds/16564#019e4a95-04fd-4d3b-9cb5-9bb33b3cfd49

```

Call log:
--
  | - Expect "toBeVisible" with timeout 5000ms
  | - waiting for getByRole('button', { name: /Empty site/ })
  |  
  |  
  | 134 \| 		// Use force:true because the app-drag-region overlay intercepts pointer events.
  | 135 \| 		const emptySiteBtn = session.mainWindow.getByRole( 'button', { name: /Empty site/ } );
  | > 136 \| 		await expect( emptySiteBtn ).toBeVisible( { timeout: 5000 } );
  | \| 		                             ^
  | 137 \| 		await emptySiteBtn.click( { force: true } );
  | 138 \| 		await addSiteModal.continueButton.click();
  | 139 \|
  | at /opt/ci/builds/builder/automattic/studio/apps/studio/e2e/localization.test.ts:136:32

```

With this PR we are starting using test-id instead of raw english phrase, which is now broken due to "Empty site" becaume translated.

@katinthehatsite I see that it was added by you, so asking your review as you are in context and maybe I am missing something.

## Testing Instructions
CI is green
You can verify that CI was red before [here](https://github.com/Automattic/studio/pull/3564/), but with this fix it's now green there.