### PR TITLE
Update `php.ini` to mirror Playground

### DIFF
--- a/apps/cli/lib/native-php.ts
+++ b/apps/cli/lib/native-php.ts
@@ -138,7 +138,11 @@ export function getNativePhpIniContents( phpVersion: NativePhpSupportedVersion )
 		path.join( getPhpBinaryDir( phpVersion ), CA_BUNDLE_FILENAME )
 	);
 	const directives: string[] = [
-		'memory_limit=512M',
+		'memory_limit=256M',
+		'post_max_size=2G',
+		'upload_max_filesize=2G',
+		'display_errors=1',
+		'display_startup_errors=1',
 		`opcache.cache_id="studio-php${ phpVersion }"`,
 		`openssl.cafile="${ caBundlePath }"`,
 		`curl.cainfo="${ caBundlePath }"`,

--- a/apps/cli/lib/native-php.ts
+++ b/apps/cli/lib/native-php.ts
@@ -138,7 +138,7 @@ export function getNativePhpIniContents( phpVersion: NativePhpSupportedVersion )
 		path.join( getPhpBinaryDir( phpVersion ), CA_BUNDLE_FILENAME )
 	);
 	const directives: string[] = [
-		'memory_limit=256M',
+		'memory_limit=512M',
 		'post_max_size=2G',
 		'upload_max_filesize=2G',
 		'display_errors=1',


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- N/A

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

I used Claude to advise on how some of the config parameters interact and which parameters are relevant to include.

## Proposed Changes

This PR updates the `php.ini` file that's written to the native PHP binary directories to include the following new directives:

```ini
post_max_size=2G
upload_max_filesize=2G
display_errors=1
display_startup_errors=1
```

These are sensible directives, and they mirror what Playground does.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start a site with the "Native PHP runtime" beta feature activated
2. Upload a large asset (preferably over 1GB)
3. Ensure that it works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
