### PR TITLE
Spawn PHP with multiple workers on Unix

### DIFF
--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -578,6 +578,10 @@ async function doStartServer(
 				STUDIO_PHPMYADMIN_PATH: getPhpMyAdminPath(),
 				STUDIO_NATIVE_PHPMYADMIN_WP_ENV_PATH: phpMyAdminWpEnvPath,
 				STUDIO_PHPMYADMIN_SESSION_PATH: getPhpMyAdminSessionPath( config ),
+				// Lets `php -S` serve concurrent requests so a single slow request
+				// doesn't block the whole site. Unix-only — Windows silently ignores it
+				// because the built-in server has no fork() there.
+				PHP_CLI_SERVER_WORKERS: '4',
 			},
 			onlyPathsThatPhpCanAccess: Array.from( openBasedirAllowlist ),
 			disallowRiskyFunctions: true,


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

N/A

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

I reasoned with Claude about how to do this, despite being such a minimal change, and ultimately asked Claude to make the edit, too.

## Proposed Changes

Pass the environment variable `PHP_CLI_SERVER_WORKERS=4` to all native PHP processes. On Unix, this allows the PHP server to accept concurrent requests. Unfortunately, this is not true on Windows. 

Per my research, concurrent PHP requests should not be an issue for SQLite, as it has built-in concurrency handling when running natively on "regular" file systems. It's a different story from Playground, which has to work around WASM limitations to achieve the behavior that SQLite has on native platforms.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This should be tested by using Studio sites extensively. Having verified that this is fine at the conceptual level, I'm fine with CI passing and us running beta testing after landing this.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
