### PR TITLE
Studio Code: Guard oversized AI write and bash tool payloads

### DIFF
--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -36,7 +36,11 @@ import { createSkillTool } from 'cli/ai/tools/skill';
 import { takeScreenshotTool } from 'cli/ai/tools/take-screenshot';
 import { createWpcomRequestTool } from 'cli/ai/tools/wpcom-request';
 import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
-import { withStudioToolPayloadGuard } from './tool-safety';
+import {
+	type StudioToolPayloadGuardState,
+	updateStudioToolPayloadGuardState,
+	withStudioToolPayloadGuard,
+} from './tool-safety';
 import type { AskUserHandler, SiteInfo } from 'cli/ai/types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -204,10 +208,14 @@ async function runAgentSessionTurn(
 
 	let session: AgentSession | undefined;
 	let unsubscribe: ( () => void ) | undefined;
+	const payloadGuardState: StudioToolPayloadGuardState = {};
 	try {
-		session = await createStudioAgentSession( config, family, resolved.creds );
+		session = await createStudioAgentSession( config, family, resolved.creds, payloadGuardState );
 		setActiveSession( session );
-		unsubscribe = session.subscribe( config.onEvent );
+		unsubscribe = session.subscribe( ( event ) => {
+			updateStudioToolPayloadGuardState( event, payloadGuardState );
+			config.onEvent( event );
+		} );
 
 		if ( controller.signal.aborted ) {
 			await session.abort();
@@ -230,7 +238,8 @@ async function runAgentSessionTurn(
 async function createStudioAgentSession(
 	config: ResolvedStudioAgentTurnConfig,
 	family: AiModelFamily,
-	creds: ResolvedCredentials
+	creds: ResolvedCredentials,
+	payloadGuardState: StudioToolPayloadGuardState
 ): Promise< AgentSession > {
 	const model = buildModel( config.model, family, creds );
 	const isRemoteSite = Boolean( config.activeSite?.remote && config.activeSite?.wpcomSiteId );
@@ -250,7 +259,7 @@ async function createStudioAgentSession(
 			: { chatArtifactsEnabled, remoteSession }
 	);
 
-	const tools = buildAgentTools( config, chatArtifactsEnabled, remoteSession );
+	const tools = buildAgentTools( config, chatArtifactsEnabled, remoteSession, payloadGuardState );
 	const toolDefinitions = tools.map( toToolDefinition );
 	const { authStorage, modelRegistry } = createModelRegistry( model, family, creds );
 	const settingsManager = createSettingsManager( config.env );
@@ -404,7 +413,8 @@ function toToolDefinition( tool: AgentToolAny ): ToolDefinition {
 function buildAgentTools(
 	config: ResolvedStudioAgentTurnConfig,
 	chatArtifactsEnabled: boolean,
-	remoteSession: boolean
+	remoteSession: boolean,
+	payloadGuardState: StudioToolPayloadGuardState
 ): AgentToolAny[] {
 	const isRemoteSite = Boolean(
 		config.activeSite?.remote && config.activeSite?.wpcomSiteId && config.wpcomAccessToken
@@ -436,9 +446,18 @@ function buildAgentTools(
 
 	const piTools: AgentToolAny[] = [
 		renameTool( createReadTool( STUDIO_SITES_ROOT ), 'Read' ),
-		withStudioToolPayloadGuard( renameTool( createWriteTool( STUDIO_SITES_ROOT ), 'Write' ) ),
-		withStudioToolPayloadGuard( renameTool( createEditTool( STUDIO_SITES_ROOT ), 'Edit' ) ),
-		withStudioToolPayloadGuard( renameTool( createBashTool( STUDIO_SITES_ROOT ), 'Bash' ) ),
+		withStudioToolPayloadGuard(
+			renameTool( createWriteTool( STUDIO_SITES_ROOT ), 'Write' ),
+			payloadGuardState
+		),
+		withStudioToolPayloadGuard(
+			renameTool( createEditTool( STUDIO_SITES_ROOT ), 'Edit' ),
+			payloadGuardState
+		),
+		withStudioToolPayloadGuard(
+			renameTool( createBashTool( STUDIO_SITES_ROOT ), 'Bash' ),
+			payloadGuardState
+		),
 		renameTool( createGrepTool( STUDIO_SITES_ROOT ), 'Grep' ),
 		renameTool( createFindTool( STUDIO_SITES_ROOT ), 'Glob' ),
 		renameTool( createLsTool( STUDIO_SITES_ROOT ), 'Ls' ),

--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -36,6 +36,7 @@ import { createSkillTool } from 'cli/ai/tools/skill';
 import { takeScreenshotTool } from 'cli/ai/tools/take-screenshot';
 import { createWpcomRequestTool } from 'cli/ai/tools/wpcom-request';
 import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
+import { withStudioToolPayloadGuard } from './tool-safety';
 import type { AskUserHandler, SiteInfo } from 'cli/ai/types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -435,9 +436,9 @@ function buildAgentTools(
 
 	const piTools: AgentToolAny[] = [
 		renameTool( createReadTool( STUDIO_SITES_ROOT ), 'Read' ),
-		renameTool( createWriteTool( STUDIO_SITES_ROOT ), 'Write' ),
-		renameTool( createEditTool( STUDIO_SITES_ROOT ), 'Edit' ),
-		renameTool( createBashTool( STUDIO_SITES_ROOT ), 'Bash' ),
+		withStudioToolPayloadGuard( renameTool( createWriteTool( STUDIO_SITES_ROOT ), 'Write' ) ),
+		withStudioToolPayloadGuard( renameTool( createEditTool( STUDIO_SITES_ROOT ), 'Edit' ) ),
+		withStudioToolPayloadGuard( renameTool( createBashTool( STUDIO_SITES_ROOT ), 'Bash' ) ),
 		renameTool( createGrepTool( STUDIO_SITES_ROOT ), 'Grep' ),
 		renameTool( createFindTool( STUDIO_SITES_ROOT ), 'Glob' ),
 		renameTool( createLsTool( STUDIO_SITES_ROOT ), 'Ls' ),

--- a/apps/cli/ai/runtimes/pi/tool-safety.ts
+++ b/apps/cli/ai/runtimes/pi/tool-safety.ts
@@ -1,0 +1,101 @@
+import { type AgentTool } from '@mariozechner/pi-agent-core';
+
+// Keep individual model-generated tool payloads below the range where long
+// strings have been observed to arrive incomplete.
+export const STUDIO_FILE_TOOL_MAX_BYTES = 14 * 1024;
+export const STUDIO_BASH_COMMAND_MAX_BYTES = 8 * 1024;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AgentToolAny = AgentTool< any >;
+
+function getByteLength( value: string ): number {
+	return Buffer.byteLength( value, 'utf8' );
+}
+
+function formatBytes( bytes: number ): string {
+	return `${ bytes } bytes`;
+}
+
+function getStringParam( params: unknown, key: string ): string | undefined {
+	if ( ! params || typeof params !== 'object' ) {
+		return undefined;
+	}
+	const value = ( params as Record< string, unknown > )[ key ];
+	return typeof value === 'string' ? value : undefined;
+}
+
+function createPayloadLimitMessage(
+	toolName: string,
+	fieldName: string,
+	actualBytes: number,
+	maxBytes: number
+): string {
+	const nextStep =
+		toolName === 'Bash'
+			? 'Split the work into smaller Write/Edit calls. Do not retry with Bash heredocs or Python scripts; they carry the same large payload risk.'
+			: 'Write a small skeleton and fill it with smaller Edit calls. Do not retry with Bash heredocs or Python scripts; they carry the same large payload risk.';
+
+	return `${ toolName } ${ fieldName } is ${ formatBytes(
+		actualBytes
+	) }, exceeding Studio's ${ formatBytes( maxBytes ) } single-call safety limit. ${ nextStep }`;
+}
+
+function getPayloadLimitViolation( toolName: string, params: unknown ): string | undefined {
+	if ( toolName === 'Write' ) {
+		const content = getStringParam( params, 'content' );
+		const bytes = content ? getByteLength( content ) : 0;
+		if ( bytes > STUDIO_FILE_TOOL_MAX_BYTES ) {
+			return createPayloadLimitMessage( toolName, 'content', bytes, STUDIO_FILE_TOOL_MAX_BYTES );
+		}
+	}
+
+	if ( toolName === 'Edit' ) {
+		for ( const fieldName of [ 'old_string', 'new_string' ] ) {
+			const value = getStringParam( params, fieldName );
+			const bytes = value ? getByteLength( value ) : 0;
+			if ( bytes > STUDIO_FILE_TOOL_MAX_BYTES ) {
+				return createPayloadLimitMessage( toolName, fieldName, bytes, STUDIO_FILE_TOOL_MAX_BYTES );
+			}
+		}
+	}
+
+	if ( toolName === 'Bash' ) {
+		const command = getStringParam( params, 'command' );
+		const bytes = command ? getByteLength( command ) : 0;
+		if ( bytes > STUDIO_BASH_COMMAND_MAX_BYTES ) {
+			return createPayloadLimitMessage( toolName, 'command', bytes, STUDIO_BASH_COMMAND_MAX_BYTES );
+		}
+	}
+
+	return undefined;
+}
+
+function getPayloadLimitDescription( toolName: string, description: string ): string {
+	if ( toolName === 'Write' || toolName === 'Edit' ) {
+		return `${ description }\n\nStudio safety: keep generated file payloads at or below ${ formatBytes(
+			STUDIO_FILE_TOOL_MAX_BYTES
+		) } per call. For larger files, write a small skeleton and fill it with smaller Edit calls. Do not use Bash heredocs or Python scripts as a workaround.`;
+	}
+
+	if ( toolName === 'Bash' ) {
+		return `${ description }\n\nStudio safety: commands longer than ${ formatBytes(
+			STUDIO_BASH_COMMAND_MAX_BYTES
+		) } are rejected. Do not use Bash heredocs or Python scripts to write large generated files; use smaller Write/Edit calls instead.`;
+	}
+
+	return description;
+}
+
+export function withStudioToolPayloadGuard( tool: AgentToolAny ): AgentToolAny {
+	return {
+		...tool,
+		description: getPayloadLimitDescription( tool.name, tool.description ),
+		execute: async ( toolCallId, params, signal, onUpdate ) => {
+			const violation = getPayloadLimitViolation( tool.name, params );
+			if ( violation ) {
+				throw new Error( violation );
+			}
+			return tool.execute( toolCallId, params, signal, onUpdate );
+		},
+	};
+}

--- a/apps/cli/ai/runtimes/pi/tool-safety.ts
+++ b/apps/cli/ai/runtimes/pi/tool-safety.ts
@@ -1,4 +1,5 @@
 import { type AgentTool } from '@mariozechner/pi-agent-core';
+import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 
 // Keep individual model-generated tool payloads below the range where long
 // strings have been observed to arrive incomplete.
@@ -7,6 +8,12 @@ export const STUDIO_BASH_COMMAND_MAX_BYTES = 8 * 1024;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AgentToolAny = AgentTool< any >;
+
+const SIDE_EFFECTING_TOOL_NAMES = new Set( [ 'Write', 'Edit', 'Bash' ] );
+
+export interface StudioToolPayloadGuardState {
+	incompleteSideEffectingToolCallReason?: string;
+}
 
 function getByteLength( value: string ): number {
 	return Buffer.byteLength( value, 'utf8' );
@@ -70,6 +77,42 @@ function getPayloadLimitViolation( toolName: string, params: unknown ): string |
 	return undefined;
 }
 
+function getToolCallNames( content: unknown ): string[] {
+	if ( ! Array.isArray( content ) ) {
+		return [];
+	}
+	return content.flatMap( ( block ) => {
+		if ( ! block || typeof block !== 'object' ) {
+			return [];
+		}
+		const item = block as Record< string, unknown >;
+		return item.type === 'toolCall' && typeof item.name === 'string' ? [ item.name ] : [];
+	} );
+}
+
+export function updateStudioToolPayloadGuardState(
+	event: AgentSessionEvent,
+	state: StudioToolPayloadGuardState
+): void {
+	if ( event.type !== 'message_end' || event.message.role !== 'assistant' ) {
+		return;
+	}
+
+	const toolCallNames = getToolCallNames( event.message.content );
+	const sideEffectingToolCallNames = toolCallNames.filter( ( name ) =>
+		SIDE_EFFECTING_TOOL_NAMES.has( name )
+	);
+
+	if ( event.message.stopReason === 'length' && sideEffectingToolCallNames.length > 0 ) {
+		state.incompleteSideEffectingToolCallReason = `Refusing to run ${ sideEffectingToolCallNames.join(
+			', '
+		) } because the assistant response hit the model output limit while generating tool arguments. The arguments may be partial even if they parse as JSON. Retry with a small skeleton and smaller Edit calls; do not use Bash heredocs or Python scripts.`;
+		return;
+	}
+
+	state.incompleteSideEffectingToolCallReason = undefined;
+}
+
 function getPayloadLimitDescription( toolName: string, description: string ): string {
 	if ( toolName === 'Write' || toolName === 'Edit' ) {
 		return `${ description }\n\nStudio safety: keep generated file payloads at or below ${ formatBytes(
@@ -86,11 +129,21 @@ function getPayloadLimitDescription( toolName: string, description: string ): st
 	return description;
 }
 
-export function withStudioToolPayloadGuard( tool: AgentToolAny ): AgentToolAny {
+export function withStudioToolPayloadGuard(
+	tool: AgentToolAny,
+	state?: StudioToolPayloadGuardState
+): AgentToolAny {
 	return {
 		...tool,
 		description: getPayloadLimitDescription( tool.name, tool.description ),
 		execute: async ( toolCallId, params, signal, onUpdate ) => {
+			if (
+				state?.incompleteSideEffectingToolCallReason &&
+				SIDE_EFFECTING_TOOL_NAMES.has( tool.name )
+			) {
+				throw new Error( state.incompleteSideEffectingToolCallReason );
+			}
+
 			const violation = getPayloadLimitViolation( tool.name, params );
 			if ( violation ) {
 				throw new Error( violation );

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -169,6 +169,8 @@ Then continue with:
 
 One \`Write\` or \`Edit\` per turn (read-only \`site_info\`, \`site_list\`, \`wp_cli\` queries may be combined). Short prose between tools — no long design-plan essays. The CLI only renders complete assistant messages, so a turn that batches files or emits >~200 lines spins silently for minutes and can hit gateway timeouts. Cadence is also a quality lever: the screenshot-fix loop only works after small visible increments.
 
+Generated file payloads over 14KB are rejected by \`Write\` and \`Edit\`; generated \`Bash\` commands over 8KB are rejected. For larger files, write a small skeleton and fill anchors with smaller \`Edit\` calls. Never use Bash heredocs, \`cat > file <<EOF\`, or Python scripts as a workaround for large generated files — they carry the same payload-truncation risk and are intentionally blocked when too large.
+
 **After \`site_create\`** (or "redesign"/"rebuild"/"start over" triggers), the next turn MUST be small: \`site_info\`, a single \`scaffold_theme\` call, or a single ≤50-line \`Write\`. Never *fill* a whole theme in one turn — \`scaffold_theme\` only ships a baseline; design content (custom templates, parts, CSS) still goes one Write/Edit per turn.
 
 **Long files (>~200 lines): skeleton first, then fill across Edits.**

--- a/apps/cli/ai/tests/pi-runtime.test.ts
+++ b/apps/cli/ai/tests/pi-runtime.test.ts
@@ -88,6 +88,33 @@ const DEFAULT_MOCK_EVENTS: AgentSessionEvent[] = [
 	{ type: 'agent_end', messages: [] },
 ];
 
+type MessageEndEvent = Extract< AgentSessionEvent, { type: 'message_end' } >;
+
+const assistantMessage = (
+	content: unknown[],
+	stopReason: 'stop' | 'length' = 'stop'
+): MessageEndEvent =>
+	( {
+		type: 'message_end',
+		message: {
+			role: 'assistant',
+			content,
+			api: 'openai-completions',
+			provider: 'openai',
+			model: 'gpt-5.5',
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason,
+			timestamp: 0,
+		},
+	} ) as MessageEndEvent;
+
 class FakeSession {
 	private listener?: ( event: AgentSessionEvent ) => void;
 	public state: { model: { id: string; provider: string }; messages: unknown[] };
@@ -269,6 +296,47 @@ describe( 'pi runtime', () => {
 			} )
 		).rejects.toThrow( /Do not retry with Bash heredocs or Python scripts/ );
 		expect( write.description ).toContain( 'small skeleton' );
+	} );
+
+	it( 'rejects side-effecting tool calls from length-truncated assistant messages', async () => {
+		mocks.nextEvents = [
+			assistantMessage(
+				[
+					{
+						type: 'toolCall',
+						id: 'tool-call-1',
+						name: 'Write',
+						arguments: {
+							path: '/tmp/studio/site/tmp/large.txt',
+							content: 'partial content under the size limit',
+						},
+						partialJson: '{"path":"/tmp/studio/site/tmp/large.txt","content":"partial',
+						index: 0,
+					},
+				],
+				'length'
+			),
+			{ type: 'agent_end', messages: [] },
+		] as AgentSessionEvent[];
+
+		await runRuntime( {
+			prompt: 'hello',
+			env: {
+				OPENAI_API_KEY: 'sk-test',
+				OPENAI_BASE_URL: 'https://proxy.example.com/v1',
+			},
+			model: 'gpt-5.5',
+			session: newSession(),
+		} );
+
+		const write = getCreatedTool( 'Write' );
+
+		await expect(
+			write.execute( 'write-call', {
+				path: '/tmp/studio/site/tmp/large.txt',
+				content: 'partial content under the size limit',
+			} )
+		).rejects.toThrow( /hit the model output limit/ );
 	} );
 
 	it( 'leaves retry policy to pi settings defaults', async () => {

--- a/apps/cli/ai/tests/pi-runtime.test.ts
+++ b/apps/cli/ai/tests/pi-runtime.test.ts
@@ -128,6 +128,23 @@ class FakeSession {
 
 const newSession = () => SessionManager.inMemory( '/tmp/eval' );
 
+type RuntimeTool = {
+	name: string;
+	description: string;
+	execute: (
+		toolCallId: string,
+		params: Record< string, unknown >
+	) => Promise< { content: Array< { type: string; text: string } > } >;
+};
+
+function getCreatedTool( name: string ): RuntimeTool {
+	const tools = ( mocks.createdSessions[ 0 ].options.customTools ??
+		[] ) as unknown as RuntimeTool[];
+	const tool = tools.find( ( item ) => item.name === name );
+	expect( tool ).toBeTruthy();
+	return tool!;
+}
+
 const findAssistantText = ( events: AgentSessionEvent[] ): string | undefined => {
 	for ( const e of events ) {
 		if ( e.type === 'message_end' && e.message.role === 'assistant' ) {
@@ -196,6 +213,62 @@ describe( 'pi runtime', () => {
 		expect( findAssistantText( events ) ).toBe( 'mocked openai response' );
 		const final = events[ events.length - 1 ];
 		expect( final.type ).toBe( 'agent_end' );
+	} );
+
+	it( 'registers guarded file-writing tools without adding a separate chunk tool', async () => {
+		await runRuntime( {
+			prompt: 'hello',
+			env: {
+				OPENAI_API_KEY: 'sk-test',
+				OPENAI_BASE_URL: 'https://proxy.example.com/v1',
+			},
+			model: 'gpt-5.5',
+			session: newSession(),
+		} );
+
+		const tools = ( mocks.createdSessions[ 0 ].options.customTools ??
+			[] ) as unknown as RuntimeTool[];
+		const toolNames = tools.map( ( tool ) => tool.name );
+		expect( toolNames ).not.toContain( 'WriteChunk' );
+		expect( getCreatedTool( 'Write' ).description ).toContain( 'small skeleton' );
+		expect( getCreatedTool( 'Edit' ).description ).toContain( 'small skeleton' );
+		expect( getCreatedTool( 'Bash' ).description ).toContain( '8192 bytes' );
+	} );
+
+	it( 'rejects oversized direct Write, Edit, and Bash payloads with actionable errors', async () => {
+		await runRuntime( {
+			prompt: 'hello',
+			env: {
+				OPENAI_API_KEY: 'sk-test',
+				OPENAI_BASE_URL: 'https://proxy.example.com/v1',
+			},
+			model: 'gpt-5.5',
+			session: newSession(),
+		} );
+
+		const write = getCreatedTool( 'Write' );
+		const edit = getCreatedTool( 'Edit' );
+		const bash = getCreatedTool( 'Bash' );
+
+		await expect(
+			write.execute( 'write-call', {
+				path: '/tmp/studio/site/tmp/large.txt',
+				content: 'x'.repeat( 14 * 1024 + 1 ),
+			} )
+		).rejects.toThrow( /single-call safety limit/ );
+		await expect(
+			edit.execute( 'edit-call', {
+				path: '/tmp/studio/site/tmp/large.txt',
+				old_string: '<!-- anchor -->',
+				new_string: 'x'.repeat( 14 * 1024 + 1 ),
+			} )
+		).rejects.toThrow( /single-call safety limit/ );
+		await expect(
+			bash.execute( 'bash-call', {
+				command: 'x'.repeat( 8 * 1024 + 1 ),
+			} )
+		).rejects.toThrow( /Do not retry with Bash heredocs or Python scripts/ );
+		expect( write.description ).toContain( 'small skeleton' );
 	} );
 
 	it( 'leaves retry policy to pi settings defaults', async () => {


### PR DESCRIPTION
## Summary
- Add explicit payload guards around `Write`, `Edit`, and `Bash` so oversized generated arguments fail fast with actionable errors instead of silently truncating.
- Set file-writing payloads to 14KB and Bash command payloads to 8KB.
- Update the AI prompt to steer large file generation back to skeleton-plus-edit workflows.
- Add runtime coverage for the new guard behavior and remove the separate chunked write path.

## Testing
- `npx eslint --fix apps/cli/ai/runtimes/pi/index.ts apps/cli/ai/runtimes/pi/tool-safety.ts apps/cli/ai/system-prompt.ts apps/cli/ai/tests/pi-runtime.test.ts`
- `npm test -- apps/cli/ai/tests/pi-runtime.test.ts`
- `npm run typecheck`