### PR TITLE
Studio Code: Force a fresh TUI render after slash-command restarts

### DIFF
--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -205,6 +205,26 @@ describe( 'AiChatUI.clearTranscript', () => {
 	} );
 } );
 
+describe( 'AiChatUI.start', () => {
+	it( 'forces a fresh render after restarting the TUI', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			start: () => void;
+			[ key: string ]: unknown;
+		};
+		const tui = {
+			start: vi.fn(),
+			requestRender: vi.fn(),
+		};
+
+		ui.tui = tui;
+
+		ui.start();
+
+		expect( tui.start ).toHaveBeenCalledTimes( 1 );
+		expect( tui.requestRender ).toHaveBeenCalledWith( true );
+	} );
+} );
+
 describe( 'AiChatUI interrupt handling', () => {
 	it( 'centralizes ESC interruption cleanup and only calls the interrupt callback once', () => {
 		const ui = Object.create( AiChatUI.prototype ) as {

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1116,6 +1116,10 @@ export class AiChatUI implements AiOutputAdapter {
 
 	start(): void {
 		this.tui.start();
+		// Logger progress and daemon-status updates can request renders while
+		// the TUI is stopped for an external prompt. pi-tui leaves that request
+		// pending, so force a fresh render when resuming.
+		this.tui.requestRender( true );
 	}
 
 	showWelcome(): void {


### PR DESCRIPTION
## Summary
- Force `AiChatUI.start()` to request a fresh render after restarting the TUI, so stale pending renders do not leave `studio code` feeling frozen after `/login`, `/logout`, or `/provider`.
- Add a regression test covering the restart behavior.

## Testing
- Added unit coverage for the TUI restart path in `apps/cli/ai/tests/ui.test.ts`.
- Not run (not requested).