### PR TITLE
Stop native PHP server worker processes

### DIFF
--- a/apps/cli/lib/types/wordpress-server-ipc.ts
+++ b/apps/cli/lib/types/wordpress-server-ipc.ts
@@ -103,6 +103,13 @@ const childMessageActivity = z.object( {
 	topic: z.literal( 'activity' ),
 } );
 
+const childMessageServerProcessStarted = z.object( {
+	topic: z.literal( 'server-process-started' ),
+	data: z.object( {
+		pid: z.number(),
+	} ),
+} );
+
 const childMessageResult = z.object( {
 	originalMessageId: z.string(),
 	topic: z.literal( 'result' ),
@@ -164,6 +171,7 @@ const childMessageSiteStopped = z.object( {
 const childMessageRaw = z.discriminatedUnion( 'topic', [
 	childMessageReady,
 	childMessageActivity,
+	childMessageServerProcessStarted,
 	childMessageResult,
 	childMessageError,
 	childMessageConsole,

--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -604,10 +604,11 @@ async function doStartServer(
 		} );
 		spawnedChild = serverChild;
 		if ( serverChild.pid !== undefined ) {
-			process.send?.( {
+			const message: ChildMessageRaw = {
 				topic: 'server-process-started',
 				data: { pid: serverChild.pid },
-			} );
+			};
+			process.send?.( message );
 		}
 
 		await new Promise< void >( ( resolve, reject ) => {

--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -166,7 +166,7 @@ function spawnPhpProcess(
 
 type RunPhpCommandOptions = SpawnPhpProcessOptions;
 
-function killPhpServerProcess( child: ChildProcess, signal: NodeJS.Signals ): void {
+function killProcessGroup( child: ChildProcess, signal: NodeJS.Signals ): void {
 	if ( process.platform !== 'win32' && child.pid ) {
 		try {
 			process.kill( -child.pid, signal );
@@ -490,10 +490,10 @@ async function restartPhpServer(): Promise< void > {
 
 	// Remove the crash listener so the imminent SIGTERM is not reported as an unexpected crash.
 	oldChild.removeAllListeners( 'exit' );
-	killPhpServerProcess( oldChild, 'SIGTERM' );
+	killProcessGroup( oldChild, 'SIGTERM' );
 	await new Promise< void >( ( resolve ) => {
 		const timeout = setTimeout( () => {
-			killPhpServerProcess( oldChild, 'SIGKILL' );
+			killProcessGroup( oldChild, 'SIGKILL' );
 		}, STOP_SERVER_TIMEOUT );
 		oldChild.once( 'close', () => {
 			clearTimeout( timeout );
@@ -603,6 +603,12 @@ async function doStartServer(
 			enableXdebug: config.enableXdebug,
 		} );
 		spawnedChild = serverChild;
+		if ( serverChild.pid !== undefined ) {
+			process.send?.( {
+				topic: 'server-process-started',
+				data: { pid: serverChild.pid },
+			} );
+		}
 
 		await new Promise< void >( ( resolve, reject ) => {
 			serverChild.once( 'spawn', () => {
@@ -634,7 +640,7 @@ async function doStartServer(
 		return spawnedChild;
 	} catch ( error ) {
 		if ( spawnedChild ) {
-			killPhpServerProcess( spawnedChild, 'SIGKILL' );
+			killProcessGroup( spawnedChild, 'SIGKILL' );
 		}
 		await stopSymlinkWatcher();
 
@@ -676,7 +682,7 @@ async function stopServer(): Promise< StopServerResult > {
 	await new Promise< void >( ( resolve ) => {
 		const forceKillTimeout = setTimeout( () => {
 			errorToConsole( 'PHP child did not exit in time; sending SIGKILL' );
-			killPhpServerProcess( child, 'SIGKILL' );
+			killProcessGroup( child, 'SIGKILL' );
 		}, STOP_SERVER_TIMEOUT );
 
 		child.once( 'close', () => {
@@ -684,7 +690,7 @@ async function stopServer(): Promise< StopServerResult > {
 			resolve();
 		} );
 
-		killPhpServerProcess( child, 'SIGTERM' );
+		killProcessGroup( child, 'SIGTERM' );
 	} );
 
 	logToConsole( 'Server stopped gracefully' );
@@ -919,7 +925,7 @@ function killPhpProcess(): void {
 		try {
 			// Detach the unexpected-exit listener so the imminent SIGKILL is not logged as a crash.
 			phpProcess.removeAllListeners( 'exit' );
-			killPhpServerProcess( phpProcess, 'SIGKILL' );
+			killProcessGroup( phpProcess, 'SIGKILL' );
 		} catch {
 			// Best effort — nothing useful to do if this fails.
 		}

--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -112,6 +112,7 @@ function errorToConsole( ...args: Parameters< typeof console.error > ) {
 }
 
 type SpawnPhpProcessOptions = {
+	detached?: boolean;
 	disallowRiskyFunctions?: boolean;
 	env?: NodeJS.ProcessEnv;
 	mode?: 'pipe' | 'capture-stdout';
@@ -130,6 +131,7 @@ function spawnPhpProcess(
 		signal,
 		env,
 		mode = 'pipe',
+		detached = false,
 		enableXdebug = false,
 		onlyPathsThatPhpCanAccess = [],
 		disallowRiskyFunctions = false,
@@ -147,6 +149,7 @@ function spawnPhpProcess(
 		env: env ? { ...process.env, ...env } : process.env,
 		stdio: [ 'ignore', 'pipe', 'pipe' ],
 		signal,
+		detached,
 	} );
 
 	if ( mode === 'pipe' ) {
@@ -162,6 +165,19 @@ function spawnPhpProcess(
 }
 
 type RunPhpCommandOptions = SpawnPhpProcessOptions;
+
+function killPhpServerProcess( child: ChildProcess, signal: NodeJS.Signals ): void {
+	if ( process.platform !== 'win32' && child.pid ) {
+		try {
+			process.kill( -child.pid, signal );
+			return;
+		} catch {
+			// Fall back to the parent process if the process group is already gone.
+		}
+	}
+
+	child.kill( signal );
+}
 
 async function runPhpCommand(
 	args: string[],
@@ -472,14 +488,12 @@ async function restartPhpServer(): Promise< void > {
 	const oldChild = phpProcess;
 	phpProcess = null;
 
-	// Detach so the imminent SIGTERM is not reported as an unexpected crash.
+	// Remove the crash listener so the imminent SIGTERM is not reported as an unexpected crash.
 	oldChild.removeAllListeners( 'exit' );
-	oldChild.kill( 'SIGTERM' );
+	killPhpServerProcess( oldChild, 'SIGTERM' );
 	await new Promise< void >( ( resolve ) => {
 		const timeout = setTimeout( () => {
-			if ( ! oldChild.killed ) {
-				oldChild.kill( 'SIGKILL' );
-			}
+			killPhpServerProcess( oldChild, 'SIGKILL' );
 		}, STOP_SERVER_TIMEOUT );
 		oldChild.once( 'close', () => {
 			clearTimeout( timeout );
@@ -584,6 +598,7 @@ async function doStartServer(
 				PHP_CLI_SERVER_WORKERS: '4',
 			},
 			onlyPathsThatPhpCanAccess: Array.from( openBasedirAllowlist ),
+			detached: process.platform !== 'win32',
 			disallowRiskyFunctions: true,
 			enableXdebug: config.enableXdebug,
 		} );
@@ -618,8 +633,8 @@ async function doStartServer(
 
 		return spawnedChild;
 	} catch ( error ) {
-		if ( spawnedChild && ! spawnedChild.killed ) {
-			spawnedChild.kill( 'SIGKILL' );
+		if ( spawnedChild ) {
+			killPhpServerProcess( spawnedChild, 'SIGKILL' );
 		}
 		await stopSymlinkWatcher();
 
@@ -661,17 +676,15 @@ async function stopServer(): Promise< StopServerResult > {
 	await new Promise< void >( ( resolve ) => {
 		const forceKillTimeout = setTimeout( () => {
 			errorToConsole( 'PHP child did not exit in time; sending SIGKILL' );
-			if ( ! child.killed ) {
-				child.kill( 'SIGKILL' );
-			}
+			killPhpServerProcess( child, 'SIGKILL' );
 		}, STOP_SERVER_TIMEOUT );
 
-		child.once( 'exit', () => {
+		child.once( 'close', () => {
 			clearTimeout( forceKillTimeout );
 			resolve();
 		} );
 
-		child.kill( 'SIGTERM' );
+		killPhpServerProcess( child, 'SIGTERM' );
 	} );
 
 	logToConsole( 'Server stopped gracefully' );
@@ -902,11 +915,11 @@ async function ipcMessageHandler( packet: unknown ) {
 }
 
 function killPhpProcess(): void {
-	if ( phpProcess && ! phpProcess.killed ) {
+	if ( phpProcess ) {
 		try {
 			// Detach the unexpected-exit listener so the imminent SIGKILL is not logged as a crash.
 			phpProcess.removeAllListeners( 'exit' );
-			phpProcess.kill( 'SIGKILL' );
+			killPhpServerProcess( phpProcess, 'SIGKILL' );
 		} catch {
 			// Best effort — nothing useful to do if this fails.
 		}

--- a/apps/cli/process-manager-daemon.ts
+++ b/apps/cli/process-manager-daemon.ts
@@ -45,7 +45,8 @@ type ManagedProcessBase = {
 	stderrBuffer: string[];
 	stderrBufferBytes: number;
 	settled: boolean;
-	subprocessGroupPid?: number;
+	// Track child pids of the child process so that they aren't orphaned when the parent exits.
+	grandchildrenPids?: number[];
 };
 type ManagedProcessRunning = ManagedProcessBase & {
 	pid: number;
@@ -264,11 +265,16 @@ export class ProcessManagerDaemon {
 				},
 			} );
 
-			if ( event.success && event.data.type === 'process-message' ) {
-				const raw = event.data.payload.raw;
-				if ( raw.topic === 'server-process-started' ) {
-					managedProcess.subprocessGroupPid = raw.data.pid;
-				}
+			if (
+				event.success &&
+				event.data.type === 'process-message' &&
+				event.data.payload.raw.topic === 'server-process-started'
+			) {
+				managedProcess.grandchildrenPids ??= [];
+				managedProcess.grandchildrenPids.push( event.data.payload.raw.data.pid );
+			}
+
+			if ( event.success ) {
 				void this.broadcastEvent( event.data );
 			}
 		} );
@@ -493,11 +499,13 @@ export class ProcessManagerDaemon {
 			}
 		}
 
-		if ( managedProcess.subprocessGroupPid ) {
-			try {
-				process.kill( -managedProcess.subprocessGroupPid, signal );
-			} catch {
-				// Do nothing
+		if ( managedProcess.grandchildrenPids ) {
+			for ( const pid of managedProcess.grandchildrenPids ) {
+				try {
+					process.kill( -pid, signal );
+				} catch {
+					// Do nothing
+				}
 			}
 		}
 	}

--- a/apps/cli/process-manager-daemon.ts
+++ b/apps/cli/process-manager-daemon.ts
@@ -45,6 +45,7 @@ type ManagedProcessBase = {
 	stderrBuffer: string[];
 	stderrBufferBytes: number;
 	settled: boolean;
+	subprocessGroupPid?: number;
 };
 type ManagedProcessRunning = ManagedProcessBase & {
 	pid: number;
@@ -263,7 +264,11 @@ export class ProcessManagerDaemon {
 				},
 			} );
 
-			if ( event.success ) {
+			if ( event.success && event.data.type === 'process-message' ) {
+				const raw = event.data.payload.raw;
+				if ( raw.topic === 'server-process-started' ) {
+					managedProcess.subprocessGroupPid = raw.data.pid;
+				}
 				void this.broadcastEvent( event.data );
 			}
 		} );
@@ -475,14 +480,22 @@ export class ProcessManagerDaemon {
 		}
 
 		// Children are spawned with `detached: true` on non-Windows, so each lives in its own
-		// process group. Signalling the negative PID delivers to every member of that group,
-		// including grandchildren (e.g. the PHP server spawned by the wrapper).
+		// process group. Native PHP can spawn the PHP server in its own group too, so signal both
+		// when the wrapper reports that pid.
 		try {
 			process.kill( -pid, signal );
 		} catch {
 			// Group send can fail if the leader has already exited but children remain.
 			try {
 				managedProcess.child.kill( signal );
+			} catch {
+				// Do nothing
+			}
+		}
+
+		if ( managedProcess.subprocessGroupPid ) {
+			try {
+				process.kill( -managedProcess.subprocessGroupPid, signal );
 			} catch {
 				// Do nothing
 			}

--- a/apps/cli/tests/daemon.test.ts
+++ b/apps/cli/tests/daemon.test.ts
@@ -237,4 +237,53 @@ describe( 'ProcessManagerDaemon', () => {
 			payload: {},
 		} );
 	} );
+
+	it.skipIf( process.platform === 'win32' )(
+		'signals a reported subprocess process group when killing the wrapper',
+		async () => {
+			const child = new MockChildProcess();
+			spawnMock.mockReturnValue( child );
+			const { ProcessManagerDaemon } = await import( '../process-manager-daemon' );
+
+			const daemon = new ProcessManagerDaemon();
+			const daemonInternal = daemon as unknown as {
+				handleRequest: ( request: unknown ) => Promise< {
+					type: string;
+					payload: { process?: { pmId: number; name: string; status: string; pid?: number } };
+				} >;
+				managedProcesses: Map< number, unknown >;
+				signalProcessGroup: ( managedProcess: unknown, signal: NodeJS.Signals ) => Promise< void >;
+			};
+
+			const response = await daemonInternal.handleRequest( {
+				type: 'start-process',
+				requestId: '1',
+				processName: testProcessName,
+				scriptPath: '/tmp/test-child.js',
+				env: {},
+				args: [],
+			} );
+
+			const processDesc = response.payload.process;
+			if ( ! processDesc ) {
+				throw new Error( 'Expected start-process response to include a process' );
+			}
+
+			child.emit( 'message', { topic: 'server-process-started', data: { pid: 9876 } } );
+
+			const managedProcess = daemonInternal.managedProcesses.get( processDesc.pmId );
+			if ( ! managedProcess ) {
+				throw new Error( 'Expected process manager to store the managed process' );
+			}
+
+			const killSpy = vi.spyOn( process, 'kill' ).mockImplementation( () => true );
+			try {
+				await daemonInternal.signalProcessGroup( managedProcess, 'SIGKILL' );
+				expect( killSpy ).toHaveBeenCalledWith( -4321, 'SIGKILL' );
+				expect( killSpy ).toHaveBeenCalledWith( -9876, 'SIGKILL' );
+			} finally {
+				killSpy.mockRestore();
+			}
+		}
+	);
 } );


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes RSM-3785

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

AI helped inspect the restart failure logs, identify the native PHP worker cleanup path, and draft the process-group fix. I reviewed the code and verified it with the checks below.

## Proposed Changes

- Spawn the long-running native PHP built-in server in its own Unix process group.
- Send `SIGTERM`/`SIGKILL` to that process group during stop, restart, startup failure cleanup, and wrapper shutdown so PHP worker children do not keep the port bound.
- Keep Windows behavior unchanged and keep short-lived PHP commands, WP-CLI commands, and Blueprint execution on the existing spawn path.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a native PHP site in Studio.
- While the site is running, change its WordPress version.
- Confirm Studio stops the site, updates WordPress, and restarts it on the same port.
- Confirm logs no longer show `Address already in use`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
