### PR TITLE
Studio Code: Add promptfoo coverage for optimized screenshot verification

### DIFF
--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -59,7 +59,7 @@ IMPORTANT: Before doing ANY work, you MUST first check the site's plan by callin
   - \`query\`: Optional query parameters object
   - \`body\`: Optional request body for POST/PUT
   - \`apiNamespace\`: Defaults to \`"wp/v2"\`. Set to \`""\` (empty string) for WP.com REST API v1.1, or \`"wpcom/v2"\` for WP.com v2 endpoints.
-- **take_screenshot**: Take a full-page screenshot of a URL (supports desktop and mobile viewports)
+- **take_screenshot**: Take a full-page screenshot of a URL (supports desktop, mobile, or \`viewport: "all"\` for both)
 - **site_create**: Create a new local WordPress site (use this to create a local site before pulling remote content into it)
 - **site_pull**: Pull the remote WordPress.com site to a local site. Create a local site first with site_create, then pull into it. Specify sync options (all, sqls, uploads, plugins, themes, contents).
 
@@ -104,7 +104,7 @@ Use \`per_page\` and \`page\` for pagination. Use \`status\` to filter by publis
 1. **Check the site plan** (MANDATORY FIRST STEP): Use \`GET /\` (apiNamespace: \`""\`) to get site info and check \`plan.product_slug\`. Stop and inform the user if they request features unavailable on their plan.
 2. **Understand the site**: Use \`GET /posts\` to list content, \`GET /themes?status=active\` to see the active theme.
 3. **Make changes**: Use POST requests to create/update content, manage templates, switch themes.
-4. **Verify visually**: Use take_screenshot to capture the site on desktop and mobile viewports. Check spacing, alignment, colors, contrast, and layout. Fix any issues.
+4. **Verify visually**: Use take_screenshot with \`viewport: "all"\` to capture the site on desktop and mobile viewports in one call. Check spacing, alignment, colors, contrast, and layout. Fix any issues.
 
 ## General rules
 
@@ -163,7 +163,7 @@ Then continue with:
 3. **Write theme/plugin files**: For a brand new theme, call \`scaffold_theme\` first — it drops an unopinionated block-theme baseline (style.css with only the theme header, theme.json with appearanceTools only, functions.php with frontend + editor style enqueue, default templates and parts, empty assets/fonts and patterns dirs) and activates it by default. Then use Write and Edit to fill the scaffold (one part/template/file per turn). For plugins or for editing an existing theme, use Write and Edit directly under the site's wp-content/themes/ or wp-content/plugins/ directory.
 4. **Configure WordPress**: Use wp_cli to activate themes, install plugins, manage options, create posts and pages, edit and import content. The site must be running. Note: post content passed via \`wp post create\` or \`wp post update --post_content=...\` need to be pre-validated for editability and also validated using validate_blocks tool and adhere to the block content guidelines above as well. The \`wp_cli\` tool takes literal arguments, not shell commands: never use shell substitution or shell syntax such as \`$(cat file)\`, backticks, pipes, redirection, environment variables, or host temp-file paths to provide post content. Pass the literal content directly in \`--post_content=...\`, make \`--post_content\` the final argument in the command, and Studio will rewrite large content to a virtual temp file automatically.
 5. **Check the misuse of HTML blocks**: Verify if HTML blocks were used as sections or not. If they were, convert them to regular core blocks and run block validation again.
-6. **Check the result**: Use take_screenshot to capture the site's landing page on desktop and mobile and verify the design visually on both viewports, check for wrong spacing, alignment, colors, contrast, borders, hover styles and other visual issues. Fix any issues found. Pay particular attention to the navigation menu and the CTA buttons. The design needs to match your original expectations. **Width check**: any section that was meant to be full-width (heroes, banners, edge-to-edge galleries, full-bleed footers) must visibly span the entire viewport in the desktop screenshot. If a "full-width" section only spans the content column (~700px at 1280px viewport), the block markup is missing \`align: "full"\` on the outer group or has a mismatched inner \`layout\` type — see the block-theme layout cascade rules above. Fix in markup, not custom CSS.
+6. **Check the result**: Use take_screenshot with \`viewport: "all"\` to capture the site's landing page on desktop and mobile in one call and verify the design visually on both viewports, check for wrong spacing, alignment, colors, contrast, borders, hover styles and other visual issues. Fix any issues found. Pay particular attention to the navigation menu and the CTA buttons. The design needs to match your original expectations. **Width check**: any section that was meant to be full-width (heroes, banners, edge-to-edge galleries, full-bleed footers) must visibly span the entire viewport in the desktop screenshot. If a "full-width" section only spans the content column (~700px at 1280px viewport), the block markup is missing \`align: "full"\` on the outer group or has a mismatched inner \`layout\` type — see the block-theme layout cascade rules above. Fix in markup, not custom CSS.
 
 ## Working cadence
 
@@ -193,7 +193,7 @@ Generated file payloads over 14KB are rejected by \`Write\` and \`Edit\`; genera
 - wp_cli: Run WP-CLI commands on a running site
 - scaffold_theme: Scaffold a minimal block theme (style.css, theme.json, functions.php with frontend + editor enqueue, default templates and parts, empty assets/fonts and patterns dirs) into a site and activate it. Use as the first step when starting a new custom theme; the agent fills design-specific content afterwards. Block themes only.
 - validate_blocks: Validate block content for correctness on a running site (runs each block through its save() function in a real browser). Requires a site name or path. Call after every file write/edit that contains block content.
-- take_screenshot: Take a full-page screenshot of a URL (supports desktop and mobile viewports). Use this to visually check the site after building it.
+- take_screenshot: Take a full-page screenshot of a URL (supports desktop, mobile, or \`viewport: "all"\` for both). Use this to visually check the site after building it.
 - need_for_speed: Measure frontend performance metrics (TTFB, FCP, LCP, CLS, page weight, DOM size, JS/CSS/image/font asset breakdown) for a running site. Use this to identify performance bottlenecks and guide optimization.
 - rank_me_up: Run an on-page SEO audit (title/meta tags, headings, image alt text, OpenGraph/Twitter cards, JSON-LD structured data, robots.txt and sitemap.xml availability) for a running site. Use this to identify on-page SEO issues and guide fixes.
 - site_connected_remote_sites: List the WordPress.com sites already attached to a local site. Call this before site_push to decide how to ask the user which remote site to target.

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -236,6 +236,64 @@ describe( 'Studio AI MCP tools', () => {
 		await rm( path.dirname( payload.widgetProps.source.path ), { recursive: true, force: true } );
 	} );
 
+	it( 'can capture desktop and mobile screenshots in one take_screenshot call', async () => {
+		const desktopBuffer = Buffer.from( 'desktop-png' );
+		const mobileBuffer = Buffer.from( 'mobile-png' );
+		const createPage = ( buffer: Buffer ) => ( {
+			emulateMedia: vi.fn(),
+			goto: vi.fn(),
+			waitForLoadState: vi.fn().mockResolvedValue( undefined ),
+			evaluate: vi.fn(),
+			addStyleTag: vi.fn(),
+			screenshot: vi.fn().mockResolvedValue( buffer ),
+			close: vi.fn(),
+		} );
+		const desktopPage = createPage( desktopBuffer );
+		const mobilePage = createPage( mobileBuffer );
+		const browser = {
+			newPage: vi.fn().mockResolvedValueOnce( desktopPage ).mockResolvedValueOnce( mobilePage ),
+		};
+		vi.mocked( getSharedBrowser ).mockResolvedValue( browser as never );
+
+		const result = await getTool( 'take_screenshot' ).rawHandler( {
+			url: 'http://localhost:8903/story-time',
+			viewport: 'all',
+		} as never );
+		const text = getTextContent( result );
+
+		expect( text ).toContain( 'Screenshots captured (desktop, mobile).' );
+		expect( text ).toContain( 'mediaWidgetPayloads=' );
+		expect( browser.newPage ).toHaveBeenCalledTimes( 2 );
+		expect( result.content.slice( 1 ) ).toEqual( [
+			{
+				type: 'image',
+				data: desktopBuffer.toString( 'base64' ),
+				mimeType: 'image/png',
+			},
+			{
+				type: 'image',
+				data: mobileBuffer.toString( 'base64' ),
+				mimeType: 'image/png',
+			},
+		] );
+
+		const payloads = JSON.parse( text!.split( 'mediaWidgetPayloads=' )[ 1 ] ) as Array< {
+			widgetProps: { source: { path: string; name: string } };
+		} >;
+		try {
+			expect( payloads.map( ( payload ) => payload.widgetProps.source.name ) ).toEqual( [
+				'screenshot-desktop.png',
+				'screenshot-mobile.png',
+			] );
+		} finally {
+			await Promise.all(
+				payloads.map( ( payload ) =>
+					rm( path.dirname( payload.widgetProps.source.path ), { recursive: true, force: true } )
+				)
+			);
+		}
+	} );
+
 	it( 'emits explicit Studio widget artifacts from studio_present', async () => {
 		const tool = resolveStudioToolDefinitions( {
 			emitChatArtifacts: true,

--- a/apps/cli/ai/tools/screenshot-helpers.ts
+++ b/apps/cli/ai/tools/screenshot-helpers.ts
@@ -4,6 +4,9 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { getSharedBrowser } from 'cli/ai/browser-utils';
 
+type Browser = Awaited< ReturnType< typeof getSharedBrowser > >;
+type Page = Awaited< ReturnType< Browser[ 'newPage' ] > >;
+
 /**
  * Tall portrait viewport used by `take_screenshot` for full-page captures
  * where the agent wants to inspect the whole scrolled page at once.
@@ -32,6 +35,15 @@ export const SHARE_VIEWPORTS = {
  */
 export const SHARE_DEVICE_SCALE_FACTOR = 2;
 
+const IMAGE_SETTLE_TIMEOUT_MS = 3000;
+const PAGE_SETTLE_TIMEOUT_MS = 2500;
+
+async function waitForPageToSettle( page: Page ): Promise< void > {
+	await page
+		.waitForLoadState( 'networkidle', { timeout: PAGE_SETTLE_TIMEOUT_MS } )
+		.catch( () => {} );
+}
+
 /**
  * Capture a PNG screenshot of `url` at the given viewport and return it as a
  * Buffer. Shared by both `take_screenshot` and `share_screenshot`; callers
@@ -52,48 +64,60 @@ export async function captureScreenshotPngBuffer(
 	try {
 		await page.emulateMedia( { reducedMotion: 'reduce' } );
 		await page.goto( url, { waitUntil: 'domcontentloaded', timeout: 30000 } );
-		await page.waitForLoadState( 'networkidle', { timeout: 10000 } ).catch( () => {} );
+		await waitForPageToSettle( page );
 
 		// For full-page captures, scroll through the entire document so
 		// lazy-loaded images can begin loading. For viewport captures we keep
 		// the page where it is and only wait on images that intersect the
 		// first viewport, so above-the-fold shots stay quick on long pages.
-		await page.evaluate( async ( fullPage ) => {
-			const delay = ( ms: number ) =>
-				new Promise< void >( ( resolve ) => setTimeout( resolve, ms ) );
+		await page.evaluate(
+			async ( { fullPage, imageSettleTimeoutMs } ) => {
+				const delay = ( ms: number ) =>
+					new Promise< void >( ( resolve ) => setTimeout( resolve, ms ) );
+				const waitForPaint = () =>
+					new Promise< void >( ( resolve ) => {
+						requestAnimationFrame( () => requestAnimationFrame( () => resolve() ) );
+					} );
 
-			if ( fullPage ) {
-				const scrollHeight = document.body.scrollHeight;
-				const viewportHeight = window.innerHeight;
-				for ( let y = 0; y < scrollHeight; y += viewportHeight ) {
-					window.scrollTo( 0, y );
-					await delay( 100 );
-				}
-				window.scrollTo( 0, 0 );
-			}
+				await Promise.race( [ document.fonts?.ready ?? Promise.resolve(), delay( 1000 ) ] );
 
-			const pendingImages = Array.from( document.images ).filter( ( img ) => {
-				if ( img.complete ) {
-					return false;
-				}
 				if ( fullPage ) {
-					return true;
+					const scrollHeight = Math.max(
+						document.body.scrollHeight,
+						document.documentElement.scrollHeight
+					);
+					const viewportHeight = window.innerHeight;
+					for ( let y = 0; y < scrollHeight; y += viewportHeight ) {
+						window.scrollTo( 0, y );
+						await waitForPaint();
+					}
+					window.scrollTo( 0, 0 );
 				}
-				const rect = img.getBoundingClientRect();
-				return rect.bottom > 0 && rect.top < window.innerHeight;
-			} );
-			const timeout = new Promise< void >( ( resolve ) => setTimeout( resolve, 5000 ) );
-			const allImages = Promise.all(
-				pendingImages.map(
-					( img ) =>
-						new Promise< void >( ( resolve ) => {
-							img.addEventListener( 'load', () => resolve(), { once: true } );
-							img.addEventListener( 'error', () => resolve(), { once: true } );
-						} )
-				)
-			);
-			await Promise.race( [ allImages, timeout ] );
-		}, options.fullPage );
+
+				const pendingImages = Array.from( document.images ).filter( ( img ) => {
+					if ( img.complete ) {
+						return false;
+					}
+					if ( fullPage ) {
+						return true;
+					}
+					const rect = img.getBoundingClientRect();
+					return rect.bottom > 0 && rect.top < window.innerHeight;
+				} );
+				const timeout = delay( imageSettleTimeoutMs );
+				const allImages = Promise.all(
+					pendingImages.map(
+						( img ) =>
+							new Promise< void >( ( resolve ) => {
+								img.addEventListener( 'load', () => resolve(), { once: true } );
+								img.addEventListener( 'error', () => resolve(), { once: true } );
+							} )
+					)
+				);
+				await Promise.race( [ allImages, timeout ] );
+			},
+			{ fullPage: options.fullPage, imageSettleTimeoutMs: IMAGE_SETTLE_TIMEOUT_MS }
+		);
 
 		// Hide the WordPress admin bar and scrollbars for cleaner shots.
 		await page.addStyleTag( {

--- a/apps/cli/ai/tools/take-screenshot.ts
+++ b/apps/cli/ai/tools/take-screenshot.ts
@@ -7,59 +7,93 @@ import {
 	VIEWPORTS,
 } from './screenshot-helpers';
 
+const screenshotViewportSchema = Type.Enum( [ 'desktop', 'mobile', 'all' ], {
+	description:
+		'Viewport size: "desktop" (1040x1248), "mobile" (390x844), or "all" to capture both in one tool call. Defaults to desktop.',
+} );
+type ScreenshotViewportArgument = 'desktop' | 'mobile' | 'all';
+type ScreenshotViewportType = keyof typeof VIEWPORTS;
+
+function resolveViewportTypes( viewport?: ScreenshotViewportArgument ): ScreenshotViewportType[] {
+	if ( viewport === 'all' ) {
+		return [ 'desktop', 'mobile' ];
+	}
+	return [ viewport ?? 'desktop' ];
+}
+
+function getViewportLabel( viewportTypes: ScreenshotViewportType[] ): string {
+	return viewportTypes.length === 1 ? viewportTypes[ 0 ] : viewportTypes.join( ' and ' );
+}
+
 export const takeScreenshotTool = defineTool(
 	'take_screenshot',
 	'Takes a full-page screenshot of a URL. Returns the screenshot as an image that you can analyze visually. ' +
 		'Also saves the screenshot as a temporary local PNG and returns a ready-to-use media widget payload. ' +
-		'Supports desktop and mobile viewports. Use this to verify the site looks correct after building it. ' +
+		'Supports desktop and mobile viewports; pass `viewport: "all"` when you need both for design verification. ' +
+		'Use this to verify the site looks correct after building it. ' +
 		'Use `share_screenshot` instead only in remote sessions where you need to deliver the rendered page outside the Studio UI.',
 	{
 		url: Type.String( { description: 'The URL to screenshot' } ),
-		viewport: Type.Optional(
-			Type.Enum( [ 'desktop', 'mobile' ], {
-				description:
-					'Viewport size: "desktop" (1040x1248) or "mobile" (390x844). Defaults to desktop.',
-			} )
-		),
+		viewport: Type.Optional( screenshotViewportSchema ),
 	},
 	async ( args ) => {
 		try {
-			const viewportType = args.viewport ?? 'desktop';
-			emitProgress( `Taking ${ viewportType } screenshot of ${ args.url }…` );
-			const buffer = await captureScreenshotPngBuffer( args.url, VIEWPORTS[ viewportType ], {
-				fullPage: true,
-			} );
-			const screenshotFile = await saveScreenshotPngToTempFile( buffer, { viewportType } );
-			const mediaWidgetPayload = {
-				type: 'media',
-				widgetProps: {
-					url: screenshotFile.fileUrl,
-					mediaKind: 'image',
-					alt: `Screenshot of ${ args.url } (${ viewportType })`,
-					mediaId: null,
-					source: {
-						type: 'local',
-						path: screenshotFile.path,
-						name: screenshotFile.name,
-						mimeType: screenshotFile.mimeType,
-					},
-				},
-			};
-			emitProgress( `Screenshot captured (${ viewportType })` );
+			const viewportTypes = resolveViewportTypes( args.viewport );
+			const viewportLabel = getViewportLabel( viewportTypes );
+			emitProgress( `Taking ${ viewportLabel } screenshot of ${ args.url }…` );
+			const captures = await Promise.all(
+				viewportTypes.map( async ( viewportType ) => {
+					const buffer = await captureScreenshotPngBuffer( args.url, VIEWPORTS[ viewportType ], {
+						fullPage: true,
+					} );
+					const screenshotFile = await saveScreenshotPngToTempFile( buffer, { viewportType } );
+					return {
+						viewportType,
+						buffer,
+						mediaWidgetPayload: {
+							type: 'media',
+							widgetProps: {
+								url: screenshotFile.fileUrl,
+								mediaKind: 'image',
+								alt: `Screenshot of ${ args.url } (${ viewportType })`,
+								mediaId: null,
+								source: {
+									type: 'local',
+									path: screenshotFile.path,
+									name: screenshotFile.name,
+									mimeType: screenshotFile.mimeType,
+								},
+							},
+						},
+					};
+				} )
+			);
+			const textLines =
+				captures.length === 1
+					? [
+							`Screenshot captured (${ captures[ 0 ].viewportType }).`,
+							`mediaWidgetPayload=${ JSON.stringify( captures[ 0 ].mediaWidgetPayload ) }`,
+					  ]
+					: [
+							`Screenshots captured (${ captures
+								.map( ( capture ) => capture.viewportType )
+								.join( ', ' ) }).`,
+							`mediaWidgetPayloads=${ JSON.stringify(
+								captures.map( ( capture ) => capture.mediaWidgetPayload )
+							) }`,
+					  ];
+			emitProgress( `Screenshot captured (${ viewportLabel })` );
 			return {
 				content: [
 					{
 						type: 'text' as const,
-						text: [
-							`Screenshot captured (${ viewportType }).`,
-							`mediaWidgetPayload=${ JSON.stringify( mediaWidgetPayload ) }`,
-						].join( '\n' ),
+						text: textLines.join( '\n' ),
 					},
-					{
+					...captures.map( ( capture ) => ( {
 						type: 'image' as const,
-						data: buffer.toString( 'base64' ),
+						data: capture.buffer.toString( 'base64' ),
 						mimeType: 'image/png',
-					},
+					} ) ),
 				],
 			};
 		} catch ( error ) {

--- a/eval/README.md
+++ b/eval/README.md
@@ -16,11 +16,12 @@ npm run eval:view
 
 - **identity** — Agent identifies itself correctly (verified by an LLM judge).
 - **site-creation** — Agent calls `site_create` and it succeeds.
+- **screenshot-all-timing** — Agent creates a minimal site and visually verifies the homepage on desktop and mobile. Asserts the agent uses one `take_screenshot` call with `viewport: "all"`, returns valid desktop/mobile PNG payloads, and keeps the screenshot tool under 15s.
 - **single-page-build-turn-cadence** — Agent builds a simple one-page site. Asserts (a) every individual turn stays under 60s (wall-clock between successive assistant messages) and (b) no `wp_cli` call uses `--post_content-file=` (which silently fails inside PHP-WASM).
 - **jetpack-catchall-slideshow** — Agent reaches for Jetpack on a slideshow request. Asserts the generated page content uses a `jetpack/*` block (i.e. the catch-all rule fired instead of the agent falling back to raw HTML).
 
 ## Adding tests
 
-Tests live in `promptfoo.config.yaml`. The runner returns raw JSON (`toolCalls`, `toolResults`, `textSegments`, `questions`, `turnDurationsMs`) — write assertions in the YAML, not in the runner.
+Tests live in `promptfoo.config.yaml`. The runner returns raw JSON (`toolCalls`, `toolResults`, `toolEvents`, `textSegments`, `questions`, `turnDurationsMs`) — write assertions in the YAML, not in the runner.
 
 The grader (`grader-provider.mjs`) handles `llm-rubric` assertions via the WP.com AI proxy. No extra API key needed if you're logged into Studio.

--- a/eval/promptfoo.config.yaml
+++ b/eval/promptfoo.config.yaml
@@ -78,6 +78,117 @@ tests:
             return { pass: ok, score: ok ? 1 : 0, reason: ok ? 'site_create succeeded' : `site_create result: ${JSON.stringify(result)}` };
           });
 
+  # Regression: trunk handles desktop/mobile visual verification as separate
+  # screenshot calls. The optimized tool exposes `viewport: "all"` so the agent
+  # can satisfy the same user request with one timed call and two PNG payloads.
+  - description: screenshot verification captures desktop and mobile in one fast call
+    vars:
+      caseId: screenshot-all-timing
+      timeoutMs: 240000
+      askUserPolicy: allow_all
+      prompt: |
+        First check if a site named "Eval Screenshot Timing" exists using
+        site_list. If it does, delete it with site_delete so we start from
+        a clean slate. Do NOT touch any other site.
+
+        Then create a new site named "Eval Screenshot Timing". Do not
+        customize the theme. Verify the homepage visually with screenshots
+        for both desktop and mobile, then briefly report whether the
+        screenshots were captured.
+    assert:
+      - type: javascript
+        value: |
+          return import('node:fs').then(({ readFileSync, existsSync }) => {
+            const marker = output.split(/\r?\n/).map(l => l.trim()).find(l => l.startsWith('EVAL_RUNNER_RESULT_FILE='));
+            if (!marker) return { pass: false, score: 0, reason: `no result-file marker on stdout; got: ${output.slice(0, 200)}` };
+            const d = JSON.parse(readFileSync(marker.slice('EVAL_RUNNER_RESULT_FILE='.length), 'utf8'));
+            const screenshotCalls = (d.toolCalls || []).filter(t => t.name === 'take_screenshot');
+            if (screenshotCalls.length !== 1) {
+              return {
+                pass: false,
+                score: 0,
+                reason: `expected one take_screenshot call for desktop+mobile verification, got ${screenshotCalls.length}: ${JSON.stringify(screenshotCalls.map(t => t.input))}`,
+              };
+            }
+            const call = screenshotCalls[0];
+            if (call.input?.viewport !== 'all') {
+              return {
+                pass: false,
+                score: 0,
+                reason: `expected take_screenshot to use viewport="all"; got ${JSON.stringify(call.input)}`,
+              };
+            }
+
+            const result = (d.toolResults || []).find(r => r.toolUseId === call.id);
+            if (!result || result.isError) {
+              return { pass: false, score: 0, reason: `take_screenshot failed: ${JSON.stringify(result)}` };
+            }
+            const rawPayloads = (result.text || '').split('mediaWidgetPayloads=')[1];
+            if (!rawPayloads) {
+              return { pass: false, score: 0, reason: `screenshot result did not include mediaWidgetPayloads: ${(result.text || '').slice(0, 500)}` };
+            }
+
+            let payloads;
+            try {
+              payloads = JSON.parse(rawPayloads);
+            } catch (error) {
+              return { pass: false, score: 0, reason: `could not parse mediaWidgetPayloads JSON: ${error instanceof Error ? error.message : String(error)}` };
+            }
+            if (!Array.isArray(payloads) || payloads.length !== 2) {
+              return { pass: false, score: 0, reason: `expected two screenshot media payloads, got ${JSON.stringify(payloads).slice(0, 500)}` };
+            }
+
+            const expectedWidths = new Map([
+              ['screenshot-desktop.png', 1040],
+              ['screenshot-mobile.png', 390],
+            ]);
+            const seen = [];
+            for (const payload of payloads) {
+              const source = payload.widgetProps?.source;
+              const expectedWidth = expectedWidths.get(source?.name);
+              if (!expectedWidth) {
+                return { pass: false, score: 0, reason: `unexpected screenshot payload source: ${JSON.stringify(source)}` };
+              }
+              if (typeof source.path !== 'string' || !existsSync(source.path)) {
+                return { pass: false, score: 0, reason: `screenshot file is missing: ${JSON.stringify(source)}` };
+              }
+              const png = readFileSync(source.path);
+              const isPng = png.length > 24 && png[0] === 0x89 && png[1] === 0x50 && png[2] === 0x4e && png[3] === 0x47;
+              const width = isPng ? png.readUInt32BE(16) : 0;
+              const height = isPng ? png.readUInt32BE(20) : 0;
+              if (!isPng || width !== expectedWidth || height < 600) {
+                return {
+                  pass: false,
+                  score: 0,
+                  reason: `${source.name} did not look like the expected PNG screenshot: png=${isPng}, width=${width}, height=${height}`,
+                };
+              }
+              seen.push(source.name);
+            }
+            return { pass: true, score: 1, reason: `captured valid screenshots: ${seen.join(', ')}` };
+          });
+      - type: javascript
+        value: |
+          return import('node:fs').then(({ readFileSync }) => {
+            const marker = output.split(/\r?\n/).map(l => l.trim()).find(l => l.startsWith('EVAL_RUNNER_RESULT_FILE='));
+            if (!marker) return { pass: false, score: 0, reason: `no result-file marker on stdout; got: ${output.slice(0, 200)}` };
+            const d = JSON.parse(readFileSync(marker.slice('EVAL_RUNNER_RESULT_FILE='.length), 'utf8'));
+            const events = (d.toolEvents || []).filter(t => t.toolName === 'take_screenshot');
+            if (events.length !== 1 || typeof events[0].durationMs !== 'number') {
+              return { pass: false, score: 0, reason: `expected one timed take_screenshot event, got ${JSON.stringify(events)}` };
+            }
+            const limitMs = 15000;
+            const duration = events[0].durationMs;
+            const pass = duration < limitMs;
+            return {
+              pass,
+              score: pass ? 1 : 0,
+              reason: pass
+                ? `take_screenshot completed in ${duration}ms`
+                : `take_screenshot took ${duration}ms, expected < ${limitMs}ms`,
+            };
+          });
+
   # Every individual turn (wall-clock between successive assistant messages)
   # should stay under 60s. Slow turns stall the UI.
   - description: single-page site build keeps every turn under 60s


### PR DESCRIPTION
## Summary
- Added a regression eval that asks the agent to verify a fresh site visually on desktop and mobile, then asserts the optimized screenshot path is used.
- The eval checks for one `take_screenshot` call with `viewport: "all"`, validates the two PNG payloads, and enforces a timing ceiling using `toolEvents`.
- Documented the new eval in `eval/README.md`.

## Testing
- YAML parse check for `eval/promptfoo.config.yaml` passed.
- Focused Vitest suite for the screenshot helpers and agent tools passed.
- Workspace typecheck passed.
- Lint/format ran on the modified source files.