### PR TITLE
Studio Code: Advertise image input support in Pi runtime

### DIFF
--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -304,7 +304,7 @@ function buildModel(
 		id: modelId,
 		name: modelId,
 		baseUrl,
-		input: [ 'text' as const ],
+		input: [ 'text' as const, 'image' as const ],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		...( creds.extraHeaders ? { headers: creds.extraHeaders } : {} ),
 	};

--- a/apps/cli/ai/tests/pi-runtime.test.ts
+++ b/apps/cli/ai/tests/pi-runtime.test.ts
@@ -242,6 +242,20 @@ describe( 'pi runtime', () => {
 		expect( final.type ).toBe( 'agent_end' );
 	} );
 
+	it( 'advertises image input support so screenshot tool results can be analyzed', async () => {
+		await runRuntime( {
+			prompt: 'hello',
+			env: {
+				OPENAI_API_KEY: 'sk-test',
+				OPENAI_BASE_URL: 'https://proxy.example.com/v1',
+			},
+			model: 'gpt-5.5',
+			session: newSession(),
+		} );
+
+		expect( mocks.createdSessions[ 0 ].options.model?.input ).toEqual( [ 'text', 'image' ] );
+	} );
+
 	it( 'registers guarded file-writing tools without adding a separate chunk tool', async () => {
 		await runRuntime( {
 			prompt: 'hello',
@@ -399,6 +413,7 @@ describe( 'pi runtime', () => {
 		const options = mocks.createdSessions[ 0 ].options;
 		expect( options.model?.provider ).toBe( 'studio-wpcom-anthropic' );
 		expect( options.model?.api ).toBe( 'anthropic-messages' );
+		expect( options.model?.input ).toEqual( [ 'text', 'image' ] );
 		const auth = await options.modelRegistry!.getApiKeyAndHeaders( options.model! );
 		expect( auth ).toMatchObject( {
 			ok: true,


### PR DESCRIPTION
## Summary
- Update the Pi model metadata to advertise `image` input alongside `text` so screenshot tool results can be passed back for visual analysis.
- Add regression coverage for both the OpenAI and WPCOM Anthropic runtime paths to ensure the advertised model capabilities stay intact.

## Testing
- `npx eslint --fix` on the modified files
- `npm test -- apps/cli/ai/tests/tools.test.ts apps/cli/ai/tests/pi-runtime.test.ts`
- `npm run typecheck`