### PR TITLE
Pin Electron to 41.4.0 to fix macOS Keychain prompt regression

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -93,7 +93,7 @@
 		"@wp-playground/blueprints": "3.1.34",
 		"cli-table3": "^0.6.5",
 		"date-fns": "^3.3.1",
-		"electron": "^42.1.0",
+		"electron": "41.4.0",
 		"electron-devtools-installer": "^4.0.0",
 		"electron-vite": "^5.0.0",
 		"patch-package": "^8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"@types/fs-extra": "^11.0.4",
 				"@vitest/ui": "^4.1.5",
 				"@yao-pkg/pkg": "^6.13.1",
+				"electron": "41.4.0",
 				"electron-playwright-helpers": "^2.1.0",
 				"eslint": "^9.39.4",
 				"eslint-config-prettier": "^9.1.2",
@@ -638,53 +639,6 @@
 				"appdmg": "^0.6.6"
 			}
 		},
-		"apps/studio/node_modules/@electron/get": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-			"integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"env-paths": "^2.2.0",
-				"fs-extra": "^8.1.0",
-				"got": "^11.8.5",
-				"progress": "^2.0.3",
-				"semver": "^6.2.0",
-				"sumchecker": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"optionalDependencies": {
-				"global-agent": "^3.0.0"
-			}
-		},
-		"apps/studio/node_modules/@electron/get/node_modules/fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6 <7 || >=8"
-			}
-		},
-		"apps/studio/node_modules/@electron/get/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"apps/studio/node_modules/@inquirer/ansi": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
@@ -1174,16 +1128,6 @@
 				"react": "^16.14.0 || 17.x || 18.x || 19.x"
 			}
 		},
-		"apps/studio/node_modules/@types/node": {
-			"version": "24.12.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-			"integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~7.16.0"
-			}
-		},
 		"apps/studio/node_modules/chardet": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
@@ -1199,25 +1143,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">= 12"
-			}
-		},
-		"apps/studio/node_modules/electron": {
-			"version": "41.4.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-41.4.0.tgz",
-			"integrity": "sha512-1afmxJGyrZ4bve+PDCs8YtNjjVu4cPwUtSjx36o6gyJWI0NvhebMKtIzzKNOScRyXntH2hX0i350Xgm3BKiEYQ==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"dependencies": {
-				"@electron/get": "^2.0.0",
-				"@types/node": "^24.9.0",
-				"extract-zip": "^2.0.1"
-			},
-			"bin": {
-				"electron": "cli.js"
-			},
-			"engines": {
-				"node": ">= 12.20.55"
 			}
 		},
 		"apps/studio/node_modules/iconv-lite": {
@@ -1244,16 +1169,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
-			}
-		},
-		"apps/studio/node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-			"dev": true,
-			"license": "MIT",
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
 			}
 		},
 		"apps/studio/node_modules/mute-stream": {
@@ -1301,23 +1216,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"apps/studio/node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"apps/studio/node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.0.0"
 			}
 		},
 		"apps/ui": {
@@ -20309,6 +20207,25 @@
 			"version": "1.1.1",
 			"license": "MIT"
 		},
+		"node_modules/electron": {
+			"version": "41.4.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-41.4.0.tgz",
+			"integrity": "sha512-1afmxJGyrZ4bve+PDCs8YtNjjVu4cPwUtSjx36o6gyJWI0NvhebMKtIzzKNOScRyXntH2hX0i350Xgm3BKiEYQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron/get": "^2.0.0",
+				"@types/node": "^24.9.0",
+				"extract-zip": "^2.0.1"
+			},
+			"bin": {
+				"electron": "cli.js"
+			},
+			"engines": {
+				"node": ">= 12.20.55"
+			}
+		},
 		"node_modules/electron-devtools-installer": {
 			"version": "4.0.0",
 			"dev": true,
@@ -20658,6 +20575,90 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/electron/node_modules/@electron/get": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+			"integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
+			}
+		},
+		"node_modules/electron/node_modules/@types/node": {
+			"version": "24.12.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+			"integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.16.0"
+			}
+		},
+		"node_modules/electron/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/electron/node_modules/jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+			"dev": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/electron/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/electron/node_modules/undici-types": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/electron/node_modules/universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4.0.0"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -610,7 +610,7 @@
 				"@wp-playground/blueprints": "3.1.34",
 				"cli-table3": "^0.6.5",
 				"date-fns": "^3.3.1",
-				"electron": "^42.1.0",
+				"electron": "41.4.0",
 				"electron-devtools-installer": "^4.0.0",
 				"electron-vite": "^5.0.0",
 				"patch-package": "^8.0.1",
@@ -636,6 +636,53 @@
 				"@rollup/rollup-linux-x64-gnu": "^4.50.2",
 				"@rollup/rollup-win32-x64-msvc": "^4.50.2",
 				"appdmg": "^0.6.6"
+			}
+		},
+		"apps/studio/node_modules/@electron/get": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+			"integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
+			}
+		},
+		"apps/studio/node_modules/@electron/get/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"apps/studio/node_modules/@electron/get/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"apps/studio/node_modules/@inquirer/ansi": {
@@ -1127,6 +1174,16 @@
 				"react": "^16.14.0 || 17.x || 18.x || 19.x"
 			}
 		},
+		"apps/studio/node_modules/@types/node": {
+			"version": "24.12.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+			"integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.16.0"
+			}
+		},
 		"apps/studio/node_modules/chardet": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
@@ -1142,6 +1199,25 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">= 12"
+			}
+		},
+		"apps/studio/node_modules/electron": {
+			"version": "41.4.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-41.4.0.tgz",
+			"integrity": "sha512-1afmxJGyrZ4bve+PDCs8YtNjjVu4cPwUtSjx36o6gyJWI0NvhebMKtIzzKNOScRyXntH2hX0i350Xgm3BKiEYQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron/get": "^2.0.0",
+				"@types/node": "^24.9.0",
+				"extract-zip": "^2.0.1"
+			},
+			"bin": {
+				"electron": "cli.js"
+			},
+			"engines": {
+				"node": ">= 12.20.55"
 			}
 		},
 		"apps/studio/node_modules/iconv-lite": {
@@ -1168,6 +1244,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
+			}
+		},
+		"apps/studio/node_modules/jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+			"dev": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"apps/studio/node_modules/mute-stream": {
@@ -1215,6 +1301,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"apps/studio/node_modules/undici-types": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"apps/studio/node_modules/universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
 			}
 		},
 		"apps/ui": {
@@ -20206,25 +20309,6 @@
 			"version": "1.1.1",
 			"license": "MIT"
 		},
-		"node_modules/electron": {
-			"version": "42.1.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-42.1.0.tgz",
-			"integrity": "sha512-0szNwC/0dWtkvNce5j3ThiuL0TxBNrZN/BZhdOiGwbLreiD/+u3MGpkct4hA5Ycagb8MXjpEr5/oosi+FwuKRQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@electron/get": "^5.0.0",
-				"@types/node": "^24.9.0",
-				"extract-zip": "^2.0.1"
-			},
-			"bin": {
-				"electron": "cli.js",
-				"install-electron": "install.js"
-			},
-			"engines": {
-				"node": ">= 22.12.0"
-			}
-		},
 		"node_modules/electron-devtools-installer": {
 			"version": "4.0.0",
 			"dev": true,
@@ -20577,57 +20661,6 @@
 			"engines": {
 				"node": ">= 4.0.0"
 			}
-		},
-		"node_modules/electron/node_modules/@electron/get": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
-			"integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"env-paths": "^3.0.0",
-				"graceful-fs": "^4.2.11",
-				"progress": "^2.0.3",
-				"semver": "^7.6.3",
-				"sumchecker": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=22.12.0"
-			},
-			"optionalDependencies": {
-				"undici": "^7.24.4"
-			}
-		},
-		"node_modules/electron/node_modules/@types/node": {
-			"version": "24.12.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-			"integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~7.16.0"
-			}
-		},
-		"node_modules/electron/node_modules/env-paths": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-			"integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/electron/node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/electron2appx": {
 			"version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
 				"@types/fs-extra": "^11.0.4",
 				"@vitest/ui": "^4.1.5",
 				"@yao-pkg/pkg": "^6.13.1",
-				"electron": "41.4.0",
 				"electron-playwright-helpers": "^2.1.0",
 				"eslint": "^9.39.4",
 				"eslint-config-prettier": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
 		"eval:view": "npx promptfoo@0.121.4 view"
 	},
 	"devDependencies": {
-		"electron": "41.4.0",
 		"@automattic/wp-babel-makepot": "^1.2.0",
 		"@eslint/js": "^9.39.4",
 		"@playwright/test": "^1.59.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"eval:view": "npx promptfoo@0.121.4 view"
 	},
 	"devDependencies": {
+		"electron": "41.4.0",
 		"@automattic/wp-babel-makepot": "^1.2.0",
 		"@eslint/js": "^9.39.4",
 		"@playwright/test": "^1.59.1",


### PR DESCRIPTION
## Related issues

- Related to https://github.com/electron/electron/pull/50419

## How AI was used in this PR

Used Claude Code to research the regression, identify the offending commit, and apply the fix.

## Proposed Changes

- Pins `electron` from `^42.1.0` to exact `41.4.0` in `apps/studio/package.json`
- Updates `package-lock.json` accordingly

## Testing Instructions

1. Build and launch Studio on macOS
2. Confirm the macOS Keychain prompt **no longer appears** on startup
3. Verify normal site operations (create/start/stop sites) still work

## Context

Electron 42 introduced a regression ([electron/electron#50419](https://github.com/electron/electron/pull/50419)) where ESM named imports from `'electron'` touch the OS keychain on `app.ready` even when `safeStorage` is never called by app code. This causes a macOS Keychain permission dialog ("Electron wants to use your confidential information stored in 'Studio Safe Storage'") to appear on every launch.

The fix is merged into Electron's `main` branch (targeting Electron 43). Since no 42.x backport exists, we pin to 41.4.0 until Electron 43 ships.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?