### PR TITLE
Extract plugin recommendations skill

### DIFF
--- a/apps/cli/ai/block-content-policy.ts
+++ b/apps/cli/ai/block-content-policy.ts
@@ -1,4 +1,4 @@
-import { PLUGIN_RECOMMENDATIONS } from './plugin-recommendations';
+import { HTML_BLOCK_POLICY_RECOMMENDATIONS } from './plugin-recommendations';
 
 const BLOCK_COMMENT_PATTERN = /<!--\s*\/?wp:[^>]*-->/g;
 const SINGLE_SCRIPT_PATTERN = /^<script(?:\s[^>]*)?>[\s\S]*<\/script>\s*$/i;
@@ -20,11 +20,9 @@ export function getHtmlBlockPolicyIssues( content: string ): string[] {
 	}
 
 	// Check plugin-specific patterns first so we return a targeted message.
-	for ( const recommendation of PLUGIN_RECOMMENDATIONS ) {
-		if ( recommendation.htmlPatterns && recommendation.htmlPolicyMessage ) {
-			if ( recommendation.htmlPatterns.some( ( pattern ) => pattern.test( html ) ) ) {
-				return [ recommendation.htmlPolicyMessage ];
-			}
+	for ( const recommendation of HTML_BLOCK_POLICY_RECOMMENDATIONS ) {
+		if ( recommendation.htmlPatterns.some( ( pattern ) => pattern.test( html ) ) ) {
+			return [ recommendation.htmlPolicyMessage ];
 		}
 	}
 

--- a/apps/cli/ai/plugin-recommendations.ts
+++ b/apps/cli/ai/plugin-recommendations.ts
@@ -1,136 +1,17 @@
-export interface PluginRecommendation {
-	/** Human-readable plugin name. */
-	name: string;
-	/** WP-CLI installable slug (e.g. "jetpack"). */
-	pluginSlug: string;
-	/** Block names made available after activation. Omit when blocks are discovered at runtime rather than enumerated. */
-	blocks?: string[];
+export interface HtmlBlockPolicyRecommendation {
 	/**
-	 * Instruction injected into the system prompt.
-	 * Explain when to use this plugin and how to use its blocks.
+	 * Raw HTML patterns that should be represented by editable blocks instead of
+	 * core/html.
 	 */
-	guidance: string;
-	/**
-	 * If set, HTML block content matching any of these patterns is flagged
-	 * by getHtmlBlockPolicyIssues() with htmlPolicyMessage instead of the
-	 * generic "use core blocks" message.
-	 */
-	htmlPatterns?: RegExp[];
+	htmlPatterns: RegExp[];
 	/** Error message emitted when htmlPatterns match. */
-	htmlPolicyMessage?: string;
+	htmlPolicyMessage: string;
 }
 
-export const PLUGIN_RECOMMENDATIONS: PluginRecommendation[] = [
+export const HTML_BLOCK_POLICY_RECOMMENDATIONS: HtmlBlockPolicyRecommendation[] = [
 	{
-		name: 'Jetpack Forms',
-		pluginSlug: 'jetpack',
-		blocks: [
-			'jetpack/contact-form',
-			'jetpack/field-name',
-			'jetpack/field-text',
-			'jetpack/field-email',
-			'jetpack/field-url',
-			'jetpack/field-telephone',
-			'jetpack/field-textarea',
-			'jetpack/field-checkbox',
-			'jetpack/field-checkbox-multiple',
-			'jetpack/field-radio',
-			'jetpack/field-select',
-			'jetpack/label',
-			'jetpack/input',
-			'jetpack/subscriptions',
-			'core/button',
-		],
-		guidance: `## Forms
-
-When the user asks for a contact form, feedback form, survey, or any other interactive form that collects submissions, you MUST use Jetpack Forms — not raw HTML <form> elements.
-
-**Newsletter signups are different — see the "Newsletter signup" section below.** \`jetpack/contact-form\` only stores submissions as Feedback entries; it does NOT subscribe anyone to a newsletter. Using contact-form for an email-signup form will silently fail to record subscribers.
-
-Install the plugin AND activate the \`contact-form\` Jetpack module first if not already active — both steps are required, otherwise the form blocks render as empty \`<div>\` elements on the frontend:
-\`\`\`
-wp_cli plugin install jetpack --activate
-wp_cli jetpack module activate contact-form
-\`\`\`
-
-Then build the form with blocks. Each field is a container block that holds a \`jetpack/label\` and a \`jetpack/input\` child. The submit button is a standard \`core/button\` (written as \`wp:button\` in block markup) placed directly inside the form container.
-
-\`\`\`html
-<!-- wp:jetpack/contact-form {"jetpackCRM":false,"variationName":"default","lock":{"remove":true,"move":true},"layout":{"type":"flex","flexWrap":"nowrap","orientation":"vertical","justifyContent":"left","verticalAlignment":"top"}} -->
-<div class="wp-block-jetpack-contact-form"><!-- wp:jetpack/field-name {"required":true,"fieldVariant":"name"} -->
-<div><!-- wp:jetpack/label {"label":"Name"} /-->
-
-<!-- wp:jetpack/input /--></div>
-<!-- /wp:jetpack/field-name -->
-
-<!-- wp:jetpack/field-email {"required":true} -->
-<div><!-- wp:jetpack/label {"label":"Email"} /-->
-
-<!-- wp:jetpack/input /--></div>
-<!-- /wp:jetpack/field-email -->
-
-<!-- wp:jetpack/field-textarea -->
-<div><!-- wp:jetpack/label {"label":"Message"} /-->
-
-<!-- wp:jetpack/input {"type":"textarea"} /--></div>
-<!-- /wp:jetpack/field-textarea -->
-
-<!-- wp:button {"tagName":"button","type":"submit","lock":{"move":false,"remove":true}} -->
-<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Contact us</button></div>
-<!-- /wp:button --></div>
-<!-- /wp:jetpack/contact-form -->
-\`\`\`
-
-Available field block types: jetpack/field-name, jetpack/field-text, jetpack/field-email, jetpack/field-url, jetpack/field-telephone, jetpack/field-textarea, jetpack/field-checkbox, jetpack/field-checkbox-multiple, jetpack/field-radio, jetpack/field-select.
-
-Each field block is a container with two inner blocks: \`jetpack/label\` (accepts a "label" string attribute) and \`jetpack/input\` (accepts a "type" attribute — defaults to text; use "textarea" for jetpack/field-textarea). Top-level field attributes: "required" (boolean), "fieldVariant" (string, e.g. "name" for jetpack/field-name).
-The container jetpack/contact-form supports: "subject" (email subject line), "to" (recipient address or comma-separated list).
-
-## Newsletter signup
-
-When the user asks for a newsletter signup, email signup, "subscribe to our newsletter", mailing list opt-in, or anything that should add the visitor as a subscriber, use the \`jetpack/subscriptions\` block — NOT \`jetpack/contact-form\`. \`jetpack/subscriptions\` creates real subscribers in Jetpack/WordPress.com; \`jetpack/contact-form\` only writes Feedback entries and never subscribes anyone.
-
-Activate the \`subscriptions\` module (in addition to the Jetpack plugin being installed) — without this, the block renders empty on the frontend:
-\`\`\`
-wp_cli plugin install jetpack --activate
-wp_cli jetpack module activate subscriptions
-\`\`\`
-
-The block is self-closing — it renders its own email field and submit button. Do not wrap it in \`jetpack/contact-form\` and do not add \`jetpack/field-*\` children.
-
-\`\`\`html
-<!-- wp:jetpack/subscriptions {"buttonOnNewLine":false,"submitButtonText":"Subscribe","successMessage":"Thanks for subscribing!"} /-->
-\`\`\`
-
-Useful attributes: \`submitButtonText\` (string), \`successMessage\` (string shown after a successful subscription), \`buttonOnNewLine\` (boolean — place the button below the input), \`showSubscribersTotal\` (boolean), \`includeSocialFollowers\` (boolean). All optional; the defaults render a usable form.`,
 		htmlPatterns: [ /<(form|input|select|textarea|fieldset)\b/i ],
 		htmlPolicyMessage:
-			'core/html contains a <form> element. Use Jetpack Forms blocks instead: install the "jetpack" plugin and build the form with jetpack/contact-form and jetpack/field-* blocks (or jetpack/subscriptions for newsletter signups). This keeps forms editable in the block editor and handles submission without custom backend code.',
-	},
-	{
-		name: 'Jetpack (general)',
-		pluginSlug: 'jetpack',
-		guidance: `## Default to Jetpack for non-core needs
-
-When the user wants a feature that no core block cleanly provides — slideshows, related-posts grids, business hours, mailchimp signups, etc. — prefer a Jetpack block over a raw-HTML \`core/html\` block.
-
-Specific Jetpack rules above (e.g. Forms) take precedence; this rule only applies when none of them cover the request. When it does apply:
-
-1. Make sure Jetpack is active: \`wp_cli plugin install jetpack --activate\`.
-2. Discover the candidate block by listing what Jetpack has registered:
-\`\`\`
-wp_cli eval 'foreach (\\WP_Block_Type_Registry::get_instance()->get_all_registered() as $n => $b) if (strpos($n, "jetpack/") === 0 && (!isset($b->supports["inserter"]) || $b->supports["inserter"] !== false)) echo $n . PHP_EOL;'
-\`\`\`
-   If the block you expect isn't listed, the relevant Jetpack module is probably inactive. Run \`wp_cli jetpack module list\` to see the matrix and \`wp_cli jetpack module activate <slug>\` to turn it on, then re-list.
-3. Use the block in the page markup and validate with \`validate_blocks\`.
-
-\`core/html\` with raw HTML stays a last resort for the cases the block content guidelines call out (inline SVG, marquee/cursor, a single bottom-of-page \`<script>\`).`,
+			'core/html contains form markup. Load the plugin-recommendations skill and use editable plugin blocks such as Jetpack Forms or jetpack/subscriptions. This keeps forms editable in the block editor and handles submission without custom backend code.',
 	},
 ];
-
-/**
- * Returns the system-prompt section generated from all plugin recommendations.
- */
-export function buildPluginRecommendationsSection(): string {
-	return PLUGIN_RECOMMENDATIONS.map( ( r ) => r.guidance ).join( '\n\n' );
-}

--- a/apps/cli/ai/skills/plugin-recommendations/SKILL.md
+++ b/apps/cli/ai/skills/plugin-recommendations/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: plugin-recommendations
+description: Choose WordPress plugins and plugin-provided blocks for features that core WordPress blocks do not cover, while keeping generated content editable and avoiding raw HTML fallbacks.
+user-invokable: true
+---
+
+# Plugin Recommendations
+
+Use this skill when the user asks for a feature that core WordPress blocks do not cleanly provide, such as forms, newsletter signup, slideshows, related content, business hours, ecommerce, events, LMS/course features, or third-party embeds.
+
+## Decision Rules
+
+- Prefer core WordPress blocks when they satisfy the request.
+- Prefer installed and active plugins before installing new ones.
+- Prefer plugin-provided blocks over raw `core/html` for user-editable features.
+- Install a plugin only when the feature needs backend behavior, registered blocks, or maintained integrations.
+- Do not stack overlapping plugins for the same concern unless the user explicitly asks.
+- Keep `core/html` as a last resort for the block content guidelines' allowed cases: inline SVG, interaction markup with no block equivalent, or a single bottom-of-page script block.
+
+## Discovery Workflow
+
+1. List active plugins:
+
+```text
+wp_cli plugin list --status=active --format=json
+```
+
+2. If considering a plugin, check whether it is already installed or active.
+3. Discover registered blocks:
+
+```text
+wp_cli eval 'foreach (\WP_Block_Type_Registry::get_instance()->get_all_registered() as $n => $b) echo $n . PHP_EOL;'
+```
+
+4. If you expect a plugin block but it is missing, check whether the plugin uses modules or feature flags, then activate the relevant module.
+5. Use the registered block in editable block markup.
+6. Validate generated block markup with `validate_blocks`.
+
+## Jetpack Forms
+
+When the user asks for a contact form, feedback form, survey, or any other interactive form that collects submissions, use Jetpack Forms - not raw HTML `<form>` elements.
+
+Newsletter signups are different. See the "Newsletter Signup" section below. `jetpack/contact-form` only stores submissions as Feedback entries; it does not subscribe anyone to a newsletter. Using contact-form for an email-signup form will silently fail to record subscribers.
+
+Install the plugin and activate the `contact-form` Jetpack module first if not already active. Both steps are required, otherwise the form blocks render as empty `<div>` elements on the frontend:
+
+```text
+wp_cli plugin install jetpack --activate
+wp_cli jetpack module activate contact-form
+```
+
+Then build the form with blocks. Each field is a container block that holds a `jetpack/label` and a `jetpack/input` child. The submit button is a standard `core/button` (written as `wp:button` in block markup) placed directly inside the form container.
+
+```html
+<!-- wp:jetpack/contact-form {"jetpackCRM":false,"variationName":"default","lock":{"remove":true,"move":true},"layout":{"type":"flex","flexWrap":"nowrap","orientation":"vertical","justifyContent":"left","verticalAlignment":"top"}} -->
+<div class="wp-block-jetpack-contact-form"><!-- wp:jetpack/field-name {"required":true,"fieldVariant":"name"} -->
+<div><!-- wp:jetpack/label {"label":"Name"} /-->
+
+<!-- wp:jetpack/input /--></div>
+<!-- /wp:jetpack/field-name -->
+
+<!-- wp:jetpack/field-email {"required":true} -->
+<div><!-- wp:jetpack/label {"label":"Email"} /-->
+
+<!-- wp:jetpack/input /--></div>
+<!-- /wp:jetpack/field-email -->
+
+<!-- wp:jetpack/field-textarea -->
+<div><!-- wp:jetpack/label {"label":"Message"} /-->
+
+<!-- wp:jetpack/input {"type":"textarea"} /--></div>
+<!-- /wp:jetpack/field-textarea -->
+
+<!-- wp:button {"tagName":"button","type":"submit","lock":{"move":false,"remove":true}} -->
+<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Contact us</button></div>
+<!-- /wp:button --></div>
+<!-- /wp:jetpack/contact-form -->
+```
+
+Available field block types: `jetpack/field-name`, `jetpack/field-text`, `jetpack/field-email`, `jetpack/field-url`, `jetpack/field-telephone`, `jetpack/field-textarea`, `jetpack/field-checkbox`, `jetpack/field-checkbox-multiple`, `jetpack/field-radio`, `jetpack/field-select`.
+
+Each field block is a container with two inner blocks: `jetpack/label` (accepts a `label` string attribute) and `jetpack/input` (accepts a `type` attribute, defaults to text; use `textarea` for `jetpack/field-textarea`). Top-level field attributes include `required` (boolean) and `fieldVariant` (string, for example `name` for `jetpack/field-name`).
+
+The container `jetpack/contact-form` supports `subject` (email subject line) and `to` (recipient address or comma-separated list).
+
+## Newsletter Signup
+
+When the user asks for a newsletter signup, email signup, "subscribe to our newsletter", mailing list opt-in, or anything that should add the visitor as a subscriber, use the `jetpack/subscriptions` block - not `jetpack/contact-form`. `jetpack/subscriptions` creates real subscribers in Jetpack/WordPress.com; `jetpack/contact-form` only writes Feedback entries and never subscribes anyone.
+
+Activate the `subscriptions` module in addition to the Jetpack plugin. Without this, the block renders empty on the frontend:
+
+```text
+wp_cli plugin install jetpack --activate
+wp_cli jetpack module activate subscriptions
+```
+
+The block is self-closing. It renders its own email field and submit button. Do not wrap it in `jetpack/contact-form` and do not add `jetpack/field-*` children.
+
+```html
+<!-- wp:jetpack/subscriptions {"buttonOnNewLine":false,"submitButtonText":"Subscribe","successMessage":"Thanks for subscribing!"} /-->
+```
+
+Useful attributes: `submitButtonText` (string), `successMessage` (string shown after a successful subscription), `buttonOnNewLine` (boolean to place the button below the input), `showSubscribersTotal` (boolean), `includeSocialFollowers` (boolean). All are optional; the defaults render a usable form.
+
+## Jetpack For Non-Core Needs
+
+When the user wants a feature that no core block cleanly provides - slideshows, related-posts grids, business hours, Mailchimp signups, and similar features - prefer a Jetpack block over a raw-HTML `core/html` block.
+
+Specific Jetpack rules above, such as forms and newsletter signup, take precedence. This rule only applies when none of them cover the request.
+
+When it applies:
+
+1. Make sure Jetpack is active:
+
+```text
+wp_cli plugin install jetpack --activate
+```
+
+2. Discover candidate Jetpack blocks by listing what Jetpack has registered:
+
+```text
+wp_cli eval 'foreach (\WP_Block_Type_Registry::get_instance()->get_all_registered() as $n => $b) if (strpos($n, "jetpack/") === 0 && (!isset($b->supports["inserter"]) || $b->supports["inserter"] !== false)) echo $n . PHP_EOL;'
+```
+
+If the block you expect is not listed, the relevant Jetpack module is probably inactive. Run:
+
+```text
+wp_cli jetpack module list
+```
+
+Then activate the needed module:
+
+```text
+wp_cli jetpack module activate <slug>
+```
+
+3. Use the registered block in page markup and validate with `validate_blocks`.

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -2,7 +2,6 @@ import {
 	getStudioPresentationRulesPrompt,
 	getStudioWidgetPromptManifest,
 } from '@studio/common/ai/studio-widgets';
-import { buildPluginRecommendationsSection } from './plugin-recommendations';
 
 interface RemoteSiteContext {
 	name: string;
@@ -257,7 +256,6 @@ const REMOTE_DESIGN_GUIDELINES = `## Design capabilities by plan
 - Custom CSS, global styles, plugin management, and advanced customization become available.
 - Check the specific plan to determine exact capabilities.`;
 
-// Evaluated lazily so unit tests that stub PLUGIN_RECOMMENDATIONS still work.
 function buildLocalContentGuidelines(): string {
 	return `## Block content guidelines
 
@@ -282,11 +280,11 @@ To break out of the content width, use these three patterns:
 - **Full-bleed section, full-bleed inner** (image grids, edge-to-edge galleries): outer AND inner \`core/group {"align":"full","layout":{"type":"default"}}\`. Children render at full viewport width.
 - **Standard constrained content**: omit \`align\` entirely and write blocks normally.
 
-The single most common failure is "I made a hero full-width but its inner content is narrow" — that's a missing \`align: "full"\` on the outer group or a mismatched inner \`layout\` type. Fix in markup, not in CSS.
-
-${ buildPluginRecommendationsSection() }`;
+The single most common failure is "I made a hero full-width but its inner content is narrow" — that's a missing \`align: "full"\` on the outer group or a mismatched inner \`layout\` type. Fix in markup, not in CSS.`;
 }
 
 const LOCAL_SKILL_ROUTING = `## Skill routing
 
-For any site creation, redesign, landing page, homepage, layout, style, CSS, typography, color, motion, or visual polish work, load the \`visual-design\` skill before writing design files or block markup.`;
+For any site creation, redesign, landing page, homepage, layout, style, CSS, typography, color, motion, or visual polish work, load the \`visual-design\` skill before writing design files or block markup.
+
+For forms, newsletter signup, ecommerce, events, LMS, galleries/slideshows, embeds, SEO/performance plugin choices, or any feature that core WordPress blocks do not cleanly provide, load the \`plugin-recommendations\` skill before installing plugins or writing plugin-provided block markup.`;

--- a/apps/cli/ai/tests/system-prompt.test.ts
+++ b/apps/cli/ai/tests/system-prompt.test.ts
@@ -35,14 +35,13 @@ describe( 'buildSystemPrompt', () => {
 		expect( prompt ).toContain( '- pdf:' );
 	} );
 
-	it( 'steers newsletter signups to jetpack/subscriptions, not jetpack/contact-form', () => {
+	it( 'routes plugin-specific feature work to the plugin recommendations skill', () => {
 		const prompt = buildSystemPrompt( { chatArtifactsEnabled: true } );
 
-		expect( prompt ).toContain( '## Newsletter signup' );
-		expect( prompt ).toContain( 'jetpack/subscriptions' );
-		expect( prompt ).toContain( 'wp_cli jetpack module activate subscriptions' );
-		// The contact-form section should warn against using it for newsletters.
-		expect( prompt ).toMatch( /contact-form[^]*only stores submissions as Feedback/ );
+		expect( prompt ).toContain( 'plugin-recommendations' );
+		expect( prompt ).toContain( 'any feature that core WordPress blocks do not cleanly provide' );
+		expect( prompt ).not.toContain( '## Newsletter signup' );
+		expect( prompt ).not.toContain( 'wp_cli jetpack module activate subscriptions' );
 	} );
 
 	it( 'omits Studio presentation rules when chat artifacts are disabled', () => {


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Codex helped extract the existing inline plugin recommendation guidance into a dedicated skill, preserving the current recommendations while reducing the core system prompt size.

## Proposed Changes

- Add a `plugin-recommendations` skill for general plugin selection guidance, including the existing Jetpack Forms, newsletter signup, Jetpack, and slideshow recommendations.
- Route plugin-specific feature work from the core prompt to the new skill instead of embedding the full recommendation catalog inline.
- Keep the deterministic raw HTML form policy in code so generated form markup still gets flagged and redirected to editable plugin blocks.
- Update the system prompt test to verify skill routing instead of inline plugin guidance.

## Testing Instructions

- `npx eslint --fix apps/cli/ai/system-prompt.ts apps/cli/ai/plugin-recommendations.ts apps/cli/ai/block-content-policy.ts apps/cli/ai/tests/system-prompt.test.ts`
- `npm run typecheck`
- `npm test -- apps/cli/ai/tests/system-prompt.test.ts apps/cli/ai/tests/block-content-policy.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
