### PR TITLE
Guard against wpcom-dependent Jetpack modules on local sites

### DIFF
--- a/apps/cli/ai/plugin-recommendations.ts
+++ b/apps/cli/ai/plugin-recommendations.ts
@@ -101,7 +101,7 @@ Specific Jetpack rules above (e.g. Forms) take precedence; this rule only applie
 wp_cli eval 'foreach (\\WP_Block_Type_Registry::get_instance()->get_all_registered() as $n => $b) if (strpos($n, "jetpack/") === 0 && (!isset($b->supports["inserter"]) || $b->supports["inserter"] !== false)) echo $n . PHP_EOL;'
 \`\`\`
    If the block you expect isn't listed, the relevant Jetpack module is probably inactive. Run \`wp_cli jetpack module list\` to see the matrix and \`wp_cli jetpack module activate <slug>\` to turn it on, then re-list.
-   **Important — wpcom-dependent modules**: Some modules require a WordPress.com connection and **will fail with an error** in Studio's local environment. Do NOT attempt to activate: \`subscriptions\`, \`blaze\`, \`stats\`, \`sync\`, or any module that requires a live wpcom site. For newsletter signups, use the Jetpack Forms \`contact-form\` module (already covered above) — do not activate \`subscriptions\`.
+   **Important — wpcom-dependent modules**: Some modules (e.g. \`subscriptions\`, \`blaze\`, \`stats\`) require a WordPress.com connection and will fail with an error if the site is not connected. Before activating these, check: \`wp_cli jetpack connection status\`. If the site is not connected to wpcom, fall back to an equivalent that works locally — for newsletter signups, use Jetpack Forms (\`contact-form\` module, already covered above).
 3. Use the block in the page markup and validate with \`validate_blocks\`.
 
 \`core/html\` with raw HTML stays a last resort for the cases the block content guidelines call out (inline SVG, marquee/cursor, a single bottom-of-page \`<script>\`).`,

--- a/apps/cli/ai/plugin-recommendations.ts
+++ b/apps/cli/ai/plugin-recommendations.ts
@@ -101,6 +101,7 @@ Specific Jetpack rules above (e.g. Forms) take precedence; this rule only applie
 wp_cli eval 'foreach (\\WP_Block_Type_Registry::get_instance()->get_all_registered() as $n => $b) if (strpos($n, "jetpack/") === 0 && (!isset($b->supports["inserter"]) || $b->supports["inserter"] !== false)) echo $n . PHP_EOL;'
 \`\`\`
    If the block you expect isn't listed, the relevant Jetpack module is probably inactive. Run \`wp_cli jetpack module list\` to see the matrix and \`wp_cli jetpack module activate <slug>\` to turn it on, then re-list.
+   **Important — wpcom-dependent modules**: Some modules require a WordPress.com connection and **will fail with an error** in Studio's local environment. Do NOT attempt to activate: \`subscriptions\`, \`blaze\`, \`stats\`, \`sync\`, or any module that requires a live wpcom site. For newsletter signups, use the Jetpack Forms \`contact-form\` module (already covered above) — do not activate \`subscriptions\`.
 3. Use the block in the page markup and validate with \`validate_blocks\`.
 
 \`core/html\` with raw HTML stays a last resort for the cases the block content guidelines call out (inline SVG, marquee/cursor, a single bottom-of-page \`<script>\`).`,

--- a/apps/cli/ai/plugin-recommendations.ts
+++ b/apps/cli/ai/plugin-recommendations.ts
@@ -101,7 +101,7 @@ Specific Jetpack rules above (e.g. Forms) take precedence; this rule only applie
 wp_cli eval 'foreach (\\WP_Block_Type_Registry::get_instance()->get_all_registered() as $n => $b) if (strpos($n, "jetpack/") === 0 && (!isset($b->supports["inserter"]) || $b->supports["inserter"] !== false)) echo $n . PHP_EOL;'
 \`\`\`
    If the block you expect isn't listed, the relevant Jetpack module is probably inactive. Run \`wp_cli jetpack module list\` to see the matrix and \`wp_cli jetpack module activate <slug>\` to turn it on, then re-list.
-   **Important — wpcom-dependent modules**: Some modules (e.g. \`subscriptions\`, \`blaze\`, \`stats\`) require a WordPress.com connection and will fail with an error if the site is not connected. Before activating these, check: \`wp_cli jetpack connection status\`. If the site is not connected to wpcom, fall back to an equivalent that works locally — for newsletter signups, use Jetpack Forms (\`contact-form\` module, already covered above).
+   **Important — wpcom-dependent modules**: Some modules (e.g. \`subscriptions\`, \`blaze\`, \`stats\`) require a WordPress.com connection and will fail with an error if the site is not connected. Before activating these, check: \`wp_cli jetpack connection status\`. If the site is not connected, skip that module.
 3. Use the block in the page markup and validate with \`validate_blocks\`.
 
 \`core/html\` with raw HTML stays a last resort for the cases the block content guidelines call out (inline SVG, marquee/cursor, a single bottom-of-page \`<script>\`).`,


### PR DESCRIPTION
## What

Adds explicit guidance in the AI agent's Jetpack plugin recommendations to check for a WordPress.com connection before trying to activate modules that require one (e.g. `subscriptions`, `blaze`, `stats`).

If the site is not connected to wpcom, the agent falls back to Jetpack Forms (`contact-form` module) for newsletter signups instead of hitting:

```
Error: Newsletter could not be activated. Exit code: 1
```

## Why

The `subscriptions` Jetpack module has `Requires Connection: Yes` in its module header. Jetpack's activation code explicitly blocks it when there's no wpcom connection — even `JETPACK_DEV_DEBUG` doesn't help because it only sets offline mode, which still enforces the connection check for modules that require it.

Studio Code is local-first, so local sites won't have a Jetpack connection by default. The agent was blindly trying to activate `subscriptions` (e.g. when adding a newsletter signup), triggering the error every time.

## Testing Instructions

Build a new local site with a newsletter signup (e.g. "a site for a coffee shop"). The agent should now:
1. Check connection status with `wp jetpack connection status`
2. If not connected, use Jetpack Forms (`contact-form`) instead of trying to activate `subscriptions`

## Related

Reported by youknowriad in #studio-code.

<!-- Proof of Concept: no -->

## Pre-merge Checklist

- [x] Changes work as described
- [ ] Tests updated/added
- [ ] No new tech debt introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)