### PR TITLE
Fix typo in a test case name

### DIFF
--- a/apps/studio/src/components/tests/content-tab-import-export.test.tsx
+++ b/apps/studio/src/components/tests/content-tab-import-export.test.tsx
@@ -68,7 +68,7 @@ describe( 'ContentTabImportExport Import', () => {
 		expect( screen.getByText( /Drop file/i ) ).toBeInTheDocument();
 	} );
 
-	test( 'should display inital text on drop leave', async () => {
+	test( 'should display initial text on drop leave', async () => {
 		renderWithProvider( <ContentTabImportExport selectedSite={ selectedSite } /> );
 		await waitFor( () => {
 			expect( screen.getByTestId( 'import-export-supported' ) ).toBeVisible();


### PR DESCRIPTION
Single typo fix: `inital` -> `initial` in a Vitest test name.
No behavior change.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*