### PR TITLE
Studio Code: Shrink screenshot payloads sent to vision models

### DIFF
--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -36,6 +36,7 @@ import { createSkillTool } from 'cli/ai/tools/skill';
 import { takeScreenshotTool } from 'cli/ai/tools/take-screenshot';
 import { createWpcomRequestTool } from 'cli/ai/tools/wpcom-request';
 import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
+import { stripStaleImagesFromContext } from './strip-stale-images';
 import {
 	type StudioToolPayloadGuardState,
 	updateStudioToolPayloadGuardState,
@@ -367,10 +368,14 @@ function createWpcomAnthropicProviderConfig(
 				defaultHeaders: options?.headers,
 			} );
 			const clientForPi = client as unknown as AnthropicOptions[ 'client' ];
-			return streamAnthropic( m as Model< 'anthropic-messages' >, ctx, {
-				...( options as AnthropicOptions | undefined ),
-				client: clientForPi,
-			} );
+			return streamAnthropic(
+				m as Model< 'anthropic-messages' >,
+				stripStaleImagesFromContext( ctx ),
+				{
+					...( options as AnthropicOptions | undefined ),
+					client: clientForPi,
+				}
+			);
 		},
 		models: [
 			{

--- a/apps/cli/ai/runtimes/pi/strip-stale-images.ts
+++ b/apps/cli/ai/runtimes/pi/strip-stale-images.ts
@@ -1,0 +1,79 @@
+import type { Context, Message } from '@mariozechner/pi-ai';
+
+/**
+ * Placeholder text inserted where an image block used to live. Kept short so
+ * it doesn't itself bloat the context.
+ */
+export const STALE_IMAGE_PLACEHOLDER_TEXT = '[image removed from older turn to save context]';
+
+function messageContainsImage( message: Message ): boolean {
+	if ( message.role !== 'user' && message.role !== 'toolResult' ) {
+		return false;
+	}
+	const content = message.content;
+	if ( typeof content === 'string' ) {
+		return false;
+	}
+	return content.some( ( block ) => block.type === 'image' );
+}
+
+function findLastImageMessageIndex( messages: Message[] ): number {
+	for ( let i = messages.length - 1; i >= 0; i-- ) {
+		if ( messageContainsImage( messages[ i ] ) ) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+function stripImagesFromMessage( message: Message ): Message {
+	if ( message.role !== 'user' && message.role !== 'toolResult' ) {
+		return message;
+	}
+	const content = message.content;
+	if ( typeof content === 'string' ) {
+		return message;
+	}
+	const stripped = content.map( ( block ) =>
+		block.type === 'image' ? { type: 'text' as const, text: STALE_IMAGE_PLACEHOLDER_TEXT } : block
+	);
+	return { ...message, content: stripped } as Message;
+}
+
+/**
+ * Return a new {@link Context} where every message except the most recent
+ * image-bearing one has its `image` content blocks replaced with a short
+ * placeholder. Compaction in pi-coding-agent keeps a window of recent turns
+ * verbatim, so without this pass every accumulated screenshot stays in
+ * history and bloats the request body until the wpcom AI proxy rejects it
+ * with HTTP 400 (no body).
+ *
+ * The most recent image-bearing message is left untouched so the model can
+ * still "see" what it just captured. Earlier images are assumed to have
+ * already been analyzed and don't need to be re-sent.
+ */
+export function stripStaleImagesFromContext( ctx: Context ): Context {
+	const messages = ctx.messages;
+	const lastImageIdx = findLastImageMessageIndex( messages );
+	if ( lastImageIdx <= 0 ) {
+		return ctx;
+	}
+
+	let mutated = false;
+	const transformed = messages.map( ( message, index ) => {
+		if ( index >= lastImageIdx ) {
+			return message;
+		}
+		if ( ! messageContainsImage( message ) ) {
+			return message;
+		}
+		mutated = true;
+		return stripImagesFromMessage( message );
+	} );
+
+	if ( ! mutated ) {
+		return ctx;
+	}
+
+	return { ...ctx, messages: transformed };
+}

--- a/apps/cli/ai/tests/screenshot-helpers.test.ts
+++ b/apps/cli/ai/tests/screenshot-helpers.test.ts
@@ -2,12 +2,12 @@ import { readFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { saveScreenshotPngToTempFile } from '../tools/screenshot-helpers';
+import { saveScreenshotToTempFile } from '../tools/screenshot-helpers';
 
 describe( 'screenshot helpers', () => {
 	it( 'saves screenshots to a temporary local file', async () => {
 		const buffer = Buffer.from( 'not-really-a-png' );
-		const result = await saveScreenshotPngToTempFile( buffer, { viewportType: 'desktop' } );
+		const result = await saveScreenshotToTempFile( buffer, { viewportType: 'desktop' } );
 
 		try {
 			expect( result.path.startsWith( os.tmpdir() ) ).toBe( true );

--- a/apps/cli/ai/tests/strip-stale-images.test.ts
+++ b/apps/cli/ai/tests/strip-stale-images.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+	STALE_IMAGE_PLACEHOLDER_TEXT,
+	stripStaleImagesFromContext,
+} from '../runtimes/pi/strip-stale-images';
+import type { Context, ImageContent, TextContent } from '@mariozechner/pi-ai';
+
+function imageBlock( label = 'pixels' ): ImageContent {
+	return { type: 'image', data: Buffer.from( label ).toString( 'base64' ), mimeType: 'image/jpeg' };
+}
+
+function textBlock( text: string ): TextContent {
+	return { type: 'text', text };
+}
+
+function context( messages: Context[ 'messages' ] ): Context {
+	return { messages };
+}
+
+describe( 'stripStaleImagesFromContext', () => {
+	it( 'leaves the context untouched when at most one message carries images', () => {
+		const onlyScreenshot = context( [
+			{
+				role: 'toolResult',
+				toolCallId: 'tool-1',
+				toolName: 'take_screenshot',
+				content: [ textBlock( 'Screenshot captured' ), imageBlock( 'desktop' ) ],
+				isError: false,
+				timestamp: 1,
+			},
+		] );
+		expect( stripStaleImagesFromContext( onlyScreenshot ) ).toBe( onlyScreenshot );
+
+		const noImages = context( [
+			{ role: 'user', content: [ textBlock( 'hello' ) ], timestamp: 1 },
+		] );
+		expect( stripStaleImagesFromContext( noImages ) ).toBe( noImages );
+	} );
+
+	it( 'replaces image blocks in older messages with a placeholder and keeps the latest images', () => {
+		const ctx = context( [
+			{
+				role: 'toolResult',
+				toolCallId: 'tool-1',
+				toolName: 'take_screenshot',
+				content: [ textBlock( 'First' ), imageBlock( 'old' ) ],
+				isError: false,
+				timestamp: 1,
+			},
+			{
+				role: 'toolResult',
+				toolCallId: 'tool-2',
+				toolName: 'take_screenshot',
+				content: [ textBlock( 'Second' ), imageBlock( 'new' ) ],
+				isError: false,
+				timestamp: 2,
+			},
+		] );
+
+		const result = stripStaleImagesFromContext( ctx );
+		expect( ( result.messages[ 0 ] as { content: unknown[] } ).content ).toEqual( [
+			textBlock( 'First' ),
+			textBlock( STALE_IMAGE_PLACEHOLDER_TEXT ),
+		] );
+		expect( result.messages[ 1 ] ).toBe( ctx.messages[ 1 ] );
+	} );
+} );

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -289,7 +289,7 @@ describe( 'Studio AI MCP tools', () => {
 	} );
 
 	it( 'keeps take_screenshot output compact while returning a media payload', async () => {
-		const screenshotBuffer = Buffer.from( 'fake-png' );
+		const screenshotBuffer = Buffer.from( 'fake-jpeg' );
 		const page = {
 			emulateMedia: vi.fn(),
 			goto: vi.fn(),
@@ -316,7 +316,7 @@ describe( 'Studio AI MCP tools', () => {
 		expect( result.content[ 1 ] ).toEqual( {
 			type: 'image',
 			data: screenshotBuffer.toString( 'base64' ),
-			mimeType: 'image/png',
+			mimeType: 'image/jpeg',
 		} );
 
 		const payload = JSON.parse( text!.split( 'mediaWidgetPayload=' )[ 1 ] ) as {
@@ -326,8 +326,8 @@ describe( 'Studio AI MCP tools', () => {
 	} );
 
 	it( 'can capture desktop and mobile screenshots in one take_screenshot call', async () => {
-		const desktopBuffer = Buffer.from( 'desktop-png' );
-		const mobileBuffer = Buffer.from( 'mobile-png' );
+		const desktopBuffer = Buffer.from( 'desktop-jpeg' );
+		const mobileBuffer = Buffer.from( 'mobile-jpeg' );
 		const createPage = ( buffer: Buffer ) => ( {
 			emulateMedia: vi.fn(),
 			goto: vi.fn(),
@@ -357,12 +357,12 @@ describe( 'Studio AI MCP tools', () => {
 			{
 				type: 'image',
 				data: desktopBuffer.toString( 'base64' ),
-				mimeType: 'image/png',
+				mimeType: 'image/jpeg',
 			},
 			{
 				type: 'image',
 				data: mobileBuffer.toString( 'base64' ),
-				mimeType: 'image/png',
+				mimeType: 'image/jpeg',
 			},
 		] );
 
@@ -371,8 +371,8 @@ describe( 'Studio AI MCP tools', () => {
 		} >;
 		try {
 			expect( payloads.map( ( payload ) => payload.widgetProps.source.name ) ).toEqual( [
-				'screenshot-desktop.png',
-				'screenshot-mobile.png',
+				'screenshot-desktop.jpg',
+				'screenshot-mobile.jpg',
 			] );
 		} finally {
 			await Promise.all(

--- a/apps/cli/ai/tools/screenshot-helpers.ts
+++ b/apps/cli/ai/tools/screenshot-helpers.ts
@@ -35,6 +35,15 @@ export const SHARE_VIEWPORTS = {
  */
 export const SHARE_DEVICE_SCALE_FACTOR = 2;
 
+/**
+ * Quality used when re-encoding a screenshot as JPEG for vision-model input.
+ * Full-page PNG captures can run to multiple megabytes; the wpcom AI proxy
+ * rejects oversized request bodies with an empty 400 before they ever reach
+ * the model. JPEG at this quality compresses long page captures by roughly
+ * 5–10× with no perceptible loss of layout fidelity for the agent.
+ */
+const MODEL_JPEG_QUALITY = 80;
+
 const IMAGE_SETTLE_TIMEOUT_MS = 3000;
 const PAGE_SETTLE_TIMEOUT_MS = 2500;
 
@@ -44,17 +53,25 @@ async function waitForPageToSettle( page: Page ): Promise< void > {
 		.catch( () => {} );
 }
 
+export type ScreenshotFormat = 'png' | 'jpeg';
+
 /**
- * Capture a PNG screenshot of `url` at the given viewport and return it as a
- * Buffer. Shared by both `take_screenshot` and `share_screenshot`; callers
- * decide whether to expose the image as base64, a temp local file, or an
- * external media event.
+ * Capture a screenshot of `url` at the given viewport. Shared by both
+ * `take_screenshot` and `share_screenshot`; callers decide whether to expose
+ * the image as base64, a temp local file, or an external media event. Use
+ * `jpeg` for vision-model input — full-page PNGs balloon to multi-MB and
+ * trip the wpcom AI proxy's request-size limit.
  */
-export async function captureScreenshotPngBuffer(
+export async function captureScreenshotBuffer(
 	url: string,
 	viewport: { width: number; height: number },
-	options: { fullPage: boolean; deviceScaleFactor?: number }
+	options: {
+		fullPage: boolean;
+		deviceScaleFactor?: number;
+		format?: ScreenshotFormat;
+	}
 ): Promise< Buffer > {
+	const format = options.format ?? 'png';
 	const browser = await getSharedBrowser();
 	const page = await browser.newPage( {
 		viewport,
@@ -129,7 +146,14 @@ export async function captureScreenshotPngBuffer(
 			`,
 		} );
 
-		const buffer = await page.screenshot( { fullPage: options.fullPage, type: 'png' } );
+		const buffer =
+			format === 'jpeg'
+				? await page.screenshot( {
+						fullPage: options.fullPage,
+						type: 'jpeg',
+						quality: MODEL_JPEG_QUALITY,
+				  } )
+				: await page.screenshot( { fullPage: options.fullPage, type: 'png' } );
 		return Buffer.from( buffer );
 	} finally {
 		await page.close();
@@ -137,25 +161,34 @@ export async function captureScreenshotPngBuffer(
 }
 
 /**
- * Capture a PNG screenshot of `url` at the given viewport and return it as
- * a base64 string. Used by `share_screenshot`, where the remote-session
- * media event carries image bytes directly.
+ * Capture a PNG screenshot and return it as a base64 string. Used by
+ * `share_screenshot`, where retina-quality PNG survives Telegram's
+ * compression pipeline noticeably better than JPEG (see
+ * {@link SHARE_DEVICE_SCALE_FACTOR}).
  */
 export async function captureScreenshotPng(
 	url: string,
 	viewport: { width: number; height: number },
 	options: { fullPage: boolean; deviceScaleFactor?: number }
 ): Promise< string > {
-	const buffer = await captureScreenshotPngBuffer( url, viewport, options );
+	const buffer = await captureScreenshotBuffer( url, viewport, { ...options, format: 'png' } );
 	return buffer.toString( 'base64' );
 }
 
-export async function saveScreenshotPngToTempFile(
+export async function saveScreenshotToTempFile(
 	buffer: Buffer,
-	options: { viewportType: string }
-): Promise< { path: string; fileUrl: string; name: string; mimeType: 'image/png' } > {
+	options: { viewportType: string; format?: ScreenshotFormat }
+): Promise< {
+	path: string;
+	fileUrl: string;
+	name: string;
+	mimeType: 'image/png' | 'image/jpeg';
+} > {
+	const format = options.format ?? 'png';
+	const extension = format === 'jpeg' ? 'jpg' : 'png';
+	const mimeType = format === 'jpeg' ? 'image/jpeg' : 'image/png';
 	const directory = await mkdtemp( path.join( os.tmpdir(), 'studio-screenshot-' ) );
-	const name = `screenshot-${ options.viewportType }.png`;
+	const name = `screenshot-${ options.viewportType }.${ extension }`;
 	const filePath = path.join( directory, name );
 
 	await writeFile( filePath, buffer );
@@ -164,6 +197,6 @@ export async function saveScreenshotPngToTempFile(
 		path: filePath,
 		fileUrl: pathToFileURL( filePath ).href,
 		name,
-		mimeType: 'image/png',
+		mimeType,
 	};
 }

--- a/apps/cli/ai/tools/take-screenshot.ts
+++ b/apps/cli/ai/tools/take-screenshot.ts
@@ -1,11 +1,7 @@
 import { Type } from 'typebox';
 import { emitProgress } from 'cli/logger';
 import { defineTool } from './define-tool';
-import {
-	captureScreenshotPngBuffer,
-	saveScreenshotPngToTempFile,
-	VIEWPORTS,
-} from './screenshot-helpers';
+import { captureScreenshotBuffer, saveScreenshotToTempFile, VIEWPORTS } from './screenshot-helpers';
 
 const screenshotViewportSchema = Type.Enum( [ 'desktop', 'mobile', 'all' ], {
 	description:
@@ -28,7 +24,7 @@ function getViewportLabel( viewportTypes: ScreenshotViewportType[] ): string {
 export const takeScreenshotTool = defineTool(
 	'take_screenshot',
 	'Takes a full-page screenshot of a URL. Returns the screenshot as an image that you can analyze visually. ' +
-		'Also saves the screenshot as a temporary local PNG and returns a ready-to-use media widget payload. ' +
+		'Also saves the screenshot as a temporary local image and returns a ready-to-use media widget payload. ' +
 		'Supports desktop and mobile viewports; pass `viewport: "all"` when you need both for design verification. ' +
 		'Use this to verify the site looks correct after building it. ' +
 		'Use `share_screenshot` instead only in remote sessions where you need to deliver the rendered page outside the Studio UI.',
@@ -43,13 +39,18 @@ export const takeScreenshotTool = defineTool(
 			emitProgress( `Taking ${ viewportLabel } screenshot of ${ args.url }…` );
 			const captures = await Promise.all(
 				viewportTypes.map( async ( viewportType ) => {
-					const buffer = await captureScreenshotPngBuffer( args.url, VIEWPORTS[ viewportType ], {
+					const buffer = await captureScreenshotBuffer( args.url, VIEWPORTS[ viewportType ], {
 						fullPage: true,
+						format: 'jpeg',
 					} );
-					const screenshotFile = await saveScreenshotPngToTempFile( buffer, { viewportType } );
+					const screenshotFile = await saveScreenshotToTempFile( buffer, {
+						viewportType,
+						format: 'jpeg',
+					} );
 					return {
 						viewportType,
 						buffer,
+						mimeType: screenshotFile.mimeType,
 						mediaWidgetPayload: {
 							type: 'media',
 							widgetProps: {
@@ -92,7 +93,7 @@ export const takeScreenshotTool = defineTool(
 					...captures.map( ( capture ) => ( {
 						type: 'image' as const,
 						data: capture.buffer.toString( 'base64' ),
-						mimeType: 'image/png',
+						mimeType: capture.mimeType,
 					} ) ),
 				],
 			};


### PR DESCRIPTION
## Related issues

<!-- No tracked issue — surfaced from a failing \`studio code\` session. -->

## How AI was used in this PR

Built collaboratively with Claude in `studio code`. The agent diagnosed the failure (traced the JSONL session log, identified the proxy 400 fingerprint), drafted the JPEG capture refactor and the `stripStaleImagesFromContext` helper, and wrote the tests. The PR author reviewed and pushed back on an earlier "translate the error string" change which was dropped as guesswork — keeping only the two fixes that address the actual cause.

## Proposed Changes

A `studio code` session building a site (~50 turns, two full-page screenshots from `take_screenshot` with `viewport: "all"`) failed with `400 status code (no body)` from the wpcom AI proxy. The proxy was rejecting the request body at the edge — empty body, no JSON error from Anthropic — because the tool result carried ~2.6 MB of base64 PNG image data. After compaction, the screenshot stayed in the kept-recent window, so retries reproduced the same 400.

Two changes:

1. **`take_screenshot` captures JPEG q80 instead of PNG.** Full-page captures shrink by roughly 5–10× with no perceptible loss for layout review. The temp file saved alongside the chat artifact follows the same format. `share_screenshot` keeps PNG (retina 2× for Telegram per the existing `SHARE_DEVICE_SCALE_FACTOR` comment).
2. **`stripStaleImagesFromContext` runs on every wpcom Anthropic request.** Replaces image blocks in older user/tool-result messages with a short text placeholder, keeping images only in the most recent image-bearing message. pi-coding-agent's compaction otherwise preserves every accumulated screenshot in the keep-recent window.

Deprecated PNG helpers in `screenshot-helpers.ts` (`captureScreenshotPngBuffer`, `saveScreenshotPngToTempFile`) were removed once nothing was calling them outside of `share_screenshot` (which uses the surviving `captureScreenshotPng`).

## Testing Instructions

- `npm run typecheck` — clean
- `npx eslint --fix apps/cli/ai/...` — clean
- `npm test -- apps/cli/ai/tests/strip-stale-images.test.ts apps/cli/ai/tests/tools.test.ts apps/cli/ai/tests/screenshot-helpers.test.ts apps/cli/ai/tests/pi-runtime.test.ts` — 59 passing
- Manual: run `studio code` against a site with a long landing page, ask it to take a `viewport: "all"` screenshot, confirm the agent receives the image and the next turn doesn't 400. The `Source: { mimeType: 'image/jpeg' }` in the media widget payload is the easy tell.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you added or updated unit/E2E tests for the changes (when applicable)?
- [x] Have you tested the changes locally or in CI?

🤖 Generated with [Claude Code](https://claude.com/claude-code)