### PR TITLE
Remove jetpack/subscriptions newsletter signup recommendation

### DIFF
--- a/apps/cli/ai/block-content-policy.ts
+++ b/apps/cli/ai/block-content-policy.ts
@@ -7,7 +7,7 @@ const PLUGIN_RECOMMENDATION_HTML_BLOCK_POLICIES = [
 	{
 		htmlPatterns: [ /<(form|input|select|textarea|fieldset)\b/i ],
 		htmlPolicyMessage:
-			'core/html contains form markup. Load the plugin-recommendations skill and use editable plugin blocks such as Jetpack Forms or jetpack/subscriptions. This keeps forms editable in the block editor and handles submission without custom backend code.',
+			'core/html contains form markup. Load the plugin-recommendations skill and use editable plugin blocks such as Jetpack Forms. This keeps forms editable in the block editor and handles submission without custom backend code.',
 	},
 ];
 

--- a/apps/cli/ai/skills/block-content/SKILL.md
+++ b/apps/cli/ai/skills/block-content/SKILL.md
@@ -13,7 +13,7 @@ Use this skill before writing or editing page content, post content, templates, 
 - Use editable WordPress blocks for content and layout. Prefer `core/group`, `core/columns`, `core/heading`, `core/paragraph`, `core/list`, `core/image`, `core/buttons`, and theme CSS.
 - Only use `core/html` blocks for inline SVGs, interaction markup with no block equivalent such as marquee or custom cursor markup, or a single bottom-of-page `<script>` block.
 - Never use `core/html` to wrap text content, headings, layout sections, lists, or forms.
-- For forms, newsletter signup, or features core blocks do not cleanly provide, load the `plugin-recommendations` skill and use editable plugin blocks.
+- For forms or features core blocks do not cleanly provide, load the `plugin-recommendations` skill and use editable plugin blocks.
 - No decorative HTML comments such as `<!-- Hero Section -->` or `<!-- Features -->`. Only WordPress block delimiter comments are allowed.
 - No custom class names on inner DOM elements. Put custom classes only on the outermost block wrapper via the block `className` attribute.
 - No inline `style` attributes or block `style` attributes for styling. Use `className` plus the theme's `style.css`.

--- a/apps/cli/ai/skills/plugin-recommendations/SKILL.md
+++ b/apps/cli/ai/skills/plugin-recommendations/SKILL.md
@@ -6,7 +6,7 @@ user-invokable: true
 
 # Plugin Recommendations
 
-Use this skill when the user asks for a feature that core WordPress blocks do not cleanly provide, such as forms, newsletter signup, slideshows, related content, business hours, ecommerce, events, LMS/course features, or third-party embeds.
+Use this skill when the user asks for a feature that core WordPress blocks do not cleanly provide, such as forms, slideshows, related content, business hours, ecommerce, events, LMS/course features, or third-party embeds.
 
 ## Decision Rules
 
@@ -39,8 +39,6 @@ wp_cli eval 'foreach (\WP_Block_Type_Registry::get_instance()->get_all_registere
 ## Jetpack Forms
 
 When the user asks for a contact form, feedback form, survey, or any other interactive form that collects submissions, use Jetpack Forms - not raw HTML `<form>` elements.
-
-Newsletter signups are different. See the "Newsletter Signup" section below. `jetpack/contact-form` only stores submissions as Feedback entries; it does not subscribe anyone to a newsletter. Using contact-form for an email-signup form will silently fail to record subscribers.
 
 Install the plugin and activate the `contact-form` Jetpack module first if not already active. Both steps are required, otherwise the form blocks render as empty `<div>` elements on the frontend:
 
@@ -83,30 +81,11 @@ Each field block is a container with two inner blocks: `jetpack/label` (accepts 
 
 The container `jetpack/contact-form` supports `subject` (email subject line) and `to` (recipient address or comma-separated list).
 
-## Newsletter Signup
-
-When the user asks for a newsletter signup, email signup, "subscribe to our newsletter", mailing list opt-in, or anything that should add the visitor as a subscriber, use the `jetpack/subscriptions` block - not `jetpack/contact-form`. `jetpack/subscriptions` creates real subscribers in Jetpack/WordPress.com; `jetpack/contact-form` only writes Feedback entries and never subscribes anyone.
-
-Activate the `subscriptions` module in addition to the Jetpack plugin. Without this, the block renders empty on the frontend:
-
-```text
-wp_cli plugin install jetpack --activate
-wp_cli jetpack module activate subscriptions
-```
-
-The block is self-closing. It renders its own email field and submit button. Do not wrap it in `jetpack/contact-form` and do not add `jetpack/field-*` children.
-
-```html
-<!-- wp:jetpack/subscriptions {"buttonOnNewLine":false,"submitButtonText":"Subscribe","successMessage":"Thanks for subscribing!"} /-->
-```
-
-Useful attributes: `submitButtonText` (string), `successMessage` (string shown after a successful subscription), `buttonOnNewLine` (boolean to place the button below the input), `showSubscribersTotal` (boolean), `includeSocialFollowers` (boolean). All are optional; the defaults render a usable form.
-
 ## Jetpack For Non-Core Needs
 
 When the user wants a feature that no core block cleanly provides - slideshows, related-posts grids, business hours, Mailchimp signups, and similar features - prefer a Jetpack block over a raw-HTML `core/html` block.
 
-Specific Jetpack rules above, such as forms and newsletter signup, take precedence. This rule only applies when none of them cover the request.
+The specific Jetpack Forms rule above takes precedence. This rule only applies when it does not cover the request.
 
 When it applies:
 

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -218,4 +218,4 @@ For any site creation, redesign, landing page, homepage, layout, style, CSS, typ
 
 For any page/post content, template or template-part content, block markup, block-theme layout, full-width section, or \`core/html\` use, load the \`block-content\` skill before writing markup or validating block content.
 
-For forms, newsletter signup, ecommerce, events, LMS, galleries/slideshows, embeds, SEO/performance plugin choices, or any feature that core WordPress blocks do not cleanly provide, load the \`plugin-recommendations\` skill before installing plugins or writing plugin-provided block markup.`;
+For forms, ecommerce, events, LMS, galleries/slideshows, embeds, SEO/performance plugin choices, or any feature that core WordPress blocks do not cleanly provide, load the \`plugin-recommendations\` skill before installing plugins or writing plugin-provided block markup.`;

--- a/apps/cli/ai/tests/system-prompt.test.ts
+++ b/apps/cli/ai/tests/system-prompt.test.ts
@@ -53,8 +53,8 @@ describe( 'buildSystemPrompt', () => {
 
 		expect( prompt ).toContain( 'plugin-recommendations' );
 		expect( prompt ).toContain( 'any feature that core WordPress blocks do not cleanly provide' );
-		expect( prompt ).not.toContain( '## Newsletter signup' );
-		expect( prompt ).not.toContain( 'wp_cli jetpack module activate subscriptions' );
+		expect( prompt ).not.toContain( '## Jetpack Forms' );
+		expect( prompt ).not.toContain( 'wp_cli jetpack module activate contact-form' );
 	} );
 
 	it( 'routes block markup recipes to the block content skill', () => {


### PR DESCRIPTION
## Related issues

- Related to: agent-generated newsletter signup blocks rendering empty on Studio sites

## How AI was used in this PR

Claude Code edited the agent's `plugin-recommendations` skill and the related routing references to drop the `jetpack/subscriptions` block recommendation. I reviewed the diff and confirmed the remaining Jetpack Forms section is unchanged.

## Proposed Changes

- Remove the `## Newsletter Signup` section from [apps/cli/ai/skills/plugin-recommendations/SKILL.md](apps/cli/ai/skills/plugin-recommendations/SKILL.md), along with the cross-reference paragraph in the `## Jetpack Forms` section and the "newsletter signup" mention in the skill intro/precedence note.
- Drop `jetpack/subscriptions` from the `core/html` form-markup policy message in [apps/cli/ai/block-content-policy.ts](apps/cli/ai/block-content-policy.ts).
- Drop "newsletter signup" from the routing pointers in [apps/cli/ai/system-prompt.ts](apps/cli/ai/system-prompt.ts) and [apps/cli/ai/skills/block-content/SKILL.md](apps/cli/ai/skills/block-content/SKILL.md).
- Update the stale newsletter/subscriptions guard in [apps/cli/ai/tests/system-prompt.test.ts](apps/cli/ai/tests/system-prompt.test.ts) to an equivalent guard against the still-present Jetpack Forms section content (the test verifies on-demand skill content isn't eagerly loaded into the system prompt).

## Why

`jetpack/subscriptions` requires a Jetpack / WordPress.com connection to actually create subscribers. Local Studio sites don't have that connection by default, so when the agent generated newsletter signup markup, the block rendered as an empty form on the frontend. Removing the recommendation prevents that failure mode until we have a story for the connection step. Jetpack Forms (contact form) does not have the same requirement and stays in the skill.

## Testing Instructions

- `npm test -- apps/cli/ai/tests/block-content-policy.test.ts apps/cli/ai/tests/system-prompt.test.ts` — 11/11 pass.
- Ask the agent for a "newsletter signup" or "email subscribe form" on a local site and confirm it no longer reaches for `jetpack/subscriptions`. The Jetpack Forms / contact-form path should still work for contact forms.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?