### PR TITLE
Studio Code: Lower agent thinking level from high to medium

### DIFF
--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -291,7 +291,7 @@ async function createStudioAgentSession(
 		authStorage,
 		modelRegistry,
 		model,
-		thinkingLevel: 'high',
+		thinkingLevel: 'medium',
 		sessionManager: config.session,
 		settingsManager,
 		resourceLoader,


### PR DESCRIPTION
## Related issues

None.

## How AI was used in this PR

Authored end-to-end by Claude (via `studio code`) — change is a one-line config edit guided by an A/B evaluation. The same agent ran the 10-site eval used to motivate the change.

## Proposed Changes

- [`apps/cli/ai/runtimes/pi/index.ts`](https://github.com/Automattic/studio/blob/trunk/apps/cli/ai/runtimes/pi/index.ts): switch the Studio Code agent's `thinkingLevel` from `'high'` to `'medium'`.

## Motivation

Ran an A/B across **5 site-build prompts × 2 thinking levels** (10 total builds) on the WordPress.com provider, `claude-sonnet-4-6`. Same prompts, same model, only `thinkingLevel` varies.

| | Medium (n=5) | High (n=5) | Δ |
|---|---:|---:|---:|
| Avg wallclock per build | 450 s (7m 30s) | 577 s (9m 37s) | **+28% slower at high** |
| Avg internal turns | 53.8 | 61.6 | +14% |
| Avg seconds per turn | 8.37 | 9.36 | **+12% slower per turn at high** |
| Worst single-turn latency | 32.0 s | 74.1 s | 2× worse tail at high |

High thinking is consistently slower per turn (the irreducible cost of deeper reasoning), drives ~14% more turns, and has a noticeably worse worst-case turn latency (74 s vs 32 s in the slowest sessions). In side-by-side review of the resulting sites, the medium builds were not visibly worse in design quality.

The 10 evaluation sites can be inspected locally — see Testing Instructions below.

## Testing Instructions

1. Pull this branch and `npm install` if needed.
2. Build the CLI: `npm run cli:build`.
3. Run `node apps/cli/dist/cli/main.mjs code` and ask the agent to build a one-page WordPress site (e.g. "Build me a one-page site for a bakery called 'Foo'…").
4. Confirm the build completes successfully and the resulting site looks reasonable. Expect ~7–8 min wallclock for a typical one-page site (vs ~9–10 min before).

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?