### PR TITLE
Upload nightly full installers and wire up fastlane tests

### DIFF
--- a/.buildkite/commands/run-fastlane-tests.sh
+++ b/.buildkite/commands/run-fastlane-tests.sh
@@ -6,7 +6,7 @@ if .buildkite/commands/should-skip-job.sh --job-type fastlane; then
   exit 0
 fi
 
-echo '--- :ruby: Run Fastlane Helper Tests'
+echo '--- :fastlane: Run fastlane Helper Tests'
 # Tests use stdlib minitest and don't require bundler — see fastlane/test/*.
 for test_file in fastlane/test/*_test.rb; do
   ruby "$test_file"

--- a/.buildkite/commands/run-fastlane-tests.sh
+++ b/.buildkite/commands/run-fastlane-tests.sh
@@ -7,7 +7,6 @@ if .buildkite/commands/should-skip-job.sh --job-type fastlane; then
 fi
 
 echo '--- :fastlane: Run fastlane Helper Tests'
-# Tests use stdlib minitest and don't require bundler — see fastlane/test/*.
 for test_file in fastlane/test/*_test.rb; do
   ruby "$test_file"
 done

--- a/.buildkite/commands/run-fastlane-tests.sh
+++ b/.buildkite/commands/run-fastlane-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if .buildkite/commands/should-skip-job.sh --job-type fastlane; then
+  exit 0
+fi
+
+echo '--- :ruby: Run Fastlane Helper Tests'
+# Tests use stdlib minitest and don't require bundler — see fastlane/test/*.
+for test_file in fastlane/test/*_test.rb; do
+  ruby "$test_file"
+done

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -79,14 +79,17 @@ TEST_PATTERNS=(
 )
 
 # Fastlane / Ruby setup files - changes here affect the standalone fastlane
-# helper tests. Anything that the test runner reads (Fastfile, lib/, test/) or
-# that defines the Ruby environment belongs here.
+# helper tests. Anything that the test runner reads (Fastfile, lib/, test/),
+# that defines the Ruby environment, or that implements this CI job's runner /
+# skip logic belongs here.
 FASTLANE_PATTERNS=(
   "fastlane/**"
   "Gemfile"
   "Gemfile.lock"
   ".ruby-version"
   ".bundle/**"
+  ".buildkite/commands/run-fastlane-tests.sh"
+  ".buildkite/commands/should-skip-job.sh"
 )
 
 show_skip_message() {

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -14,6 +14,8 @@ set -eu
 #              Since metrics measure app performance, test file changes don't affect them.
 #   - build: Skip if changes are limited to documentation and config files.
 #            Does NOT skip on localization changes since builds should include translation updates.
+#   - fastlane: Inverse of the others — only runs when fastlane/ or Ruby setup files change.
+#               Used for the standalone tests in fastlane/test/. App-only PRs skip it.
 #
 # Exit codes:
 #   0 - Job should be skipped
@@ -76,6 +78,17 @@ TEST_PATTERNS=(
   "metrics/**"
 )
 
+# Fastlane / Ruby setup files - changes here affect the standalone fastlane
+# helper tests. Anything that the test runner reads (Fastfile, lib/, test/) or
+# that defines the Ruby environment belongs here.
+FASTLANE_PATTERNS=(
+  "fastlane/**"
+  "Gemfile"
+  "Gemfile.lock"
+  ".ruby-version"
+  ".bundle/**"
+)
+
 show_skip_message() {
   local job_type=$1
   local job_label="${BUILDKITE_LABEL:-$job_type}"
@@ -107,7 +120,7 @@ done
 
 if [[ -z "$job_type" ]]; then
   echo "Error: --job-type is required"
-  echo "Usage: should-skip-job.sh --job-type <validation|metrics|build>"
+  echo "Usage: should-skip-job.sh --job-type <validation|metrics|build|fastlane>"
   exit 1
 fi
 
@@ -147,9 +160,18 @@ case "$job_type" in
     fi
     ;;
 
+  "fastlane")
+    # Run only if at least one changed file is fastlane/ or Ruby-setup-related.
+    # Other job types treat fastlane changes as non-code; this one is the inverse.
+    if ! pr_changed_files --any-match "${FASTLANE_PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    ;;
+
   *)
     echo "Unknown job type: $job_type"
-    echo "Valid types: validation, metrics, build"
+    echo "Valid types: validation, metrics, build, fastlane"
     exit 1
     ;;
 esac

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,6 +38,16 @@ steps:
       - github_commit_status:
           context: Lint
 
+  - label: ":ruby: Fastlane Helper Tests"
+    agents:
+      queue: mac
+    key: fastlane_tests
+    command: bash .buildkite/commands/run-fastlane-tests.sh
+    plugins: [$CI_TOOLKIT_PLUGIN]
+    notify:
+      - github_commit_status:
+          context: Fastlane Helper Tests
+
   - label: Unit Tests on {{matrix}}
     key: unit_tests
     command: bash .buildkite/commands/run-unit-tests.sh "{{matrix}}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
       - github_commit_status:
           context: Lint
 
-  - label: ":ruby: Fastlane Helper Tests"
+  - label: ":fastlane: fastlane Helper Tests"
     agents:
       queue: mac
     key: fastlane_tests
@@ -46,7 +46,7 @@ steps:
     plugins: [$CI_TOOLKIT_PLUGIN]
     notify:
       - github_commit_status:
-          context: Fastlane Helper Tests
+          context: fastlane Helper Tests
 
   - label: Unit Tests on {{matrix}}
     key: unit_tests

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,6 +7,7 @@ fastlane_require 'json'
 fastlane_require 'net/http'
 fastlane_require 'uri'
 
+require_relative 'lib/studio_apps_cdn_upload'
 require_relative 'lib/studio_release_git'
 require_relative 'lib/studio_release_version'
 
@@ -712,12 +713,14 @@ def distribute_builds(
     }
   }
 
-  builds_to_upload = release_tag.nil? ? update_builds : { **update_builds, **full_install_builds }
+  builds_to_upload = { **update_builds, **full_install_builds }
 
-  UI.message("Uploading #{builds_to_upload.count} builds (#{release_tag.nil? ? 'dev: updates only' : 'release: all builds'})")
+  UI.message("Uploading #{builds_to_upload.count} builds (#{build_type})")
 
   # Upload to Apps CDN
   builds_to_upload.each_value do |build|
+    visibility = StudioAppsCdnUpload.visibility_for(build_type: build_type, install_type: build[:install_type])
+
     result = upload_file_to_apps_cdn(
       site_id: WPCOM_STUDIO_SITE_ID,
       product: 'WordPress.com Studio',
@@ -726,7 +729,7 @@ def distribute_builds(
       arch: build[:arch],
       build_type: build_type,
       install_type: build[:install_type],
-      visibility: 'external',
+      visibility: visibility,
       version: version,
       build_number: build_number,
       release_notes: release_notes,

--- a/fastlane/lib/studio_apps_cdn_upload.rb
+++ b/fastlane/lib/studio_apps_cdn_upload.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module StudioAppsCdnUpload
+  # Returns the Apps CDN visibility (`'internal'` or `'external'`) for a build.
+  #
+  # Nightly full installers are restricted to logged-in Automatticians via the
+  # Apps CDN visibility filter, so the `/nightly` link only resolves for
+  # internal users. Update binaries stay external — the in-app auto-updater is
+  # unauthenticated and would otherwise stop seeing nightly updates. Beta and
+  # Production stay external across the board.
+  def self.visibility_for(build_type:, install_type:)
+    return 'internal' if build_type == 'Nightly' && install_type == 'Full Install'
+
+    'external'
+  end
+end

--- a/fastlane/test/studio_apps_cdn_upload_test.rb
+++ b/fastlane/test/studio_apps_cdn_upload_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Sanity checks for fastlane/lib/studio_apps_cdn_upload.rb.
+#
+# Run with: `ruby fastlane/test/studio_apps_cdn_upload_test.rb`
+# (No bundle / fastlane required — minitest ships with stdlib Ruby.)
+
+require 'minitest/autorun'
+require_relative '../lib/studio_apps_cdn_upload'
+
+class StudioAppsCdnUploadTest < Minitest::Test
+  def test_nightly_full_install_is_internal
+    assert_equal 'internal', StudioAppsCdnUpload.visibility_for(build_type: 'Nightly', install_type: 'Full Install')
+  end
+
+  def test_nightly_update_is_external
+    assert_equal 'external', StudioAppsCdnUpload.visibility_for(build_type: 'Nightly', install_type: 'Update')
+  end
+
+  def test_beta_full_install_is_external
+    assert_equal 'external', StudioAppsCdnUpload.visibility_for(build_type: 'Beta', install_type: 'Full Install')
+  end
+
+  def test_beta_update_is_external
+    assert_equal 'external', StudioAppsCdnUpload.visibility_for(build_type: 'Beta', install_type: 'Update')
+  end
+
+  def test_production_full_install_is_external
+    assert_equal 'external', StudioAppsCdnUpload.visibility_for(build_type: 'Production', install_type: 'Full Install')
+  end
+
+  def test_production_update_is_external
+    assert_equal 'external', StudioAppsCdnUpload.visibility_for(build_type: 'Production', install_type: 'Update')
+  end
+end


### PR DESCRIPTION
## Related issues

- [AINFRA-2434](https://linear.app/a8c/issue/AINFRA-2434/nightly-cdn-links-for-wordpress-studio-trunk-builds)
- Companion change required on the backend to enabled to resolving `/nightly`. Until that lands, the new uploads are silently created but the URL still 404s — this PR is safe to merge before or after.

## How AI was used in this PR

Claude (Opus 4.7) wrote the changes after a back-and-forth on visibility semantics and CI gating.
Reviewed and iterated on by the author.

## Proposed Changes

- `trunk` now uploads full installers (DMG/EXE/APPX) to the Apps CDN.
- Nightly full installers get `visibility: 'internal'` (Automatticians only); update binaries stay `external` so the unauthenticated Electron/Squirrel auto-updater keeps working — see [PR #3623](https://github.com/Automattic/studio/pull/3623).
- New `fastlane Helper Tests` CI step.

## Testing Instructions

- Locally: `ruby fastlane/test/*_test.rb` — all 35 cases pass.
- `trunk` verification (**after merge**): inspect the next `trunk` Buildkite "Distribute Dev Builds" step — the `🔗 Build available for …` annotation should now list DMG/EXE/APPX entries alongside the existing Update entries, and the Mac/Silicon DMGs should appear on appscdn.wordpress.com as Nightly + Internal posts.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (N/A — fastlane + CI only.)