### PR TITLE
site-spec: expand into creative direction (layout, hero, typography)

### DIFF
--- a/apps/cli/ai/skills/site-spec/SKILL.md
+++ b/apps/cli/ai/skills/site-spec/SKILL.md
@@ -1,39 +1,64 @@
 ---
 name: site-spec
-description: Gather the site name and layout preference before building a WordPress site. Run this before creating any new site.
+description: Gather the site name, then auto-expand into a creative direction (pages, layout, hero, typography) before building a WordPress site. Run this before creating any new site.
 user-invokable: true
 ---
 
 # Site Spec Discovery
 
-Before creating a new WordPress site, gather the user's basic preferences through a short interactive discovery phase. This produces a **Site Spec** that guides all subsequent design and development decisions.
-
-## How to Run
-
-Gather preferences through 2 rounds. Keep it concise.
+Before creating a new WordPress site, gather the user's name and expand it into a full creative direction. This produces a **Site Spec** that guides all subsequent design and development decisions.
 
 **AskUserQuestion constraints**: Each call supports 1-4 questions, each with 2-4 options. An "Other" free-form option is automatically provided by the system — do NOT add one yourself. Keep option labels short (1-5 words). Only use AskUserQuestion for questions that have meaningful predefined options. For open-ended questions (like asking for a name), just ask in your text output — the user will type their answer in the prompt.
 
-### Round 1 — Name
+## Round 1 — Name
 
-Ask the user for their business/site name in your text output. **Stop here and wait for their reply** — do NOT call any tools or continue to the next round. The user needs a chance to type their answer in the prompt.
+Ask the user for their business/site name in your text output — unless it was already stated clearly in their message (e.g. *"create a site called Pan de Casa"*), in which case use it directly and skip to Round 2.
 
-### Round 2 — Layout
+**Critical**: if you ask the name question, your response must end immediately after that question. No tool calls. No Round 2. No extra text. The user will type their answer and send it — only after receiving their reply do you move to Round 2.
 
-After the user provides the name, use AskUserQuestion for:
-- One-page site or multi-page site? (e.g., single scrollable page with sections vs. separate pages for each area)
+## Round 2 — Expand into a Creative Direction
 
-## After Gathering Answers
+Once you have the name, **do not ask questions about layout or pages**. Instead, infer everything from the name and context, commit to a concrete creative direction, and brief the user before building.
 
-Call `site_create` with the provided name and use the layout preference to guide all subsequent design decisions.
+### Step A — Read the brief
+
+| Signal | Action |
+|--------|--------|
+| Site type is clear ("Bar Boogie", "Morning Light Bakery") | Auto-expand — go to Step B |
+| Site type is ambiguous ("a site for my business") | Ask **one** specific question to resolve it, then go to Step B |
+| User said "minimal", "one page", or "just a placeholder" | Skip expansion — use a simple one-page layout, go to Step C |
+
+### Step B — Decide the four pillars
+
+Commit to all of these without asking:
+
+**Layout** — Pick the shape that fits the site type:
+- `vertical-stack` — standard header/content/footer (default)
+- `landing-page` — single scrollable page, anchor-linked sections (portfolios, product launches, one-pager requests)
+- `magazine-grid` — homepage is a post archive (blogs, publications)
+- `canvas` — full-bleed imagery, floating chrome (photography, art portfolios)
+
+**Pages & sections** — Decide which pages to create and what sections go on each. A bar needs Home + Menu + Events + Contact; a SaaS needs Home (features/pricing/CTA) + About + Contact. Match the type — don't default to a minimal skeleton.
+
+**Hero composition** — One short paragraph of cinematic prose: composition strategy (full-bleed / asymmetric / centered / split), image placement, typographic weight, overall mood. This is the spatial anchor that guides downstream block choices. Example: *"A full-bleed photo of latte art fills the right two-thirds of the screen. Display-serif type sits left, large and slightly oversized. A single rust-colored CTA rests low with generous breathing room. The composition feels still, like a held breath."*
+
+**Typography** — A font pairing that fits the name and type. Examples: coffee shop → Fraunces + Spectral; law firm → Cormorant Garamond + Source Sans; esports → Rajdhani + JetBrains Mono. When the signal is weak, default to a clean humanist pair.
+
+### Step C — Brief the user in ≤4 lines
+
+Tell the user what you decided before building. Example:
+
+> *"Building a 5-page site for Boogie Bar: Home, Menu, Events, Gallery, and Contact. Dark & moody aesthetic, jazz-inspired typography, amber/black palette. Includes a reservations form and newsletter signup."*
+
+**Do not ask for approval.** Proceed immediately to `site_create`.
 
 ## After site_create returns
 
-The turn immediately after `site_create` is the biggest source of perceived hangs. Acknowledge the site in ≤2 lines of prose, then make your next tool call a small one — `site_info`, or a single ≤50-line first `Write`. Do NOT scaffold the theme, chain multiple Writes, or write a long design-plan essay in this turn. Grow the build across many small turns (see the "Working cadence" section of the system prompt).
+The turn immediately after `site_create` is the biggest source of perceived hangs. Acknowledge the site in ≤2 lines of prose, then make your next tool call a small one — `site_info`, or a single ≤50-line first `Write`. Do NOT scaffold the theme, chain multiple Writes, or write a long design-plan essay in this turn. Grow the build across many small turns.
 
 ## When to Skip Discovery
 
-Do NOT ask questions if:
-- The user already provided the name and layout preference in the initial prompt. Proceed directly with site creation.
+Do NOT run this skill if:
+- The user already provided the name AND a detailed layout/content spec. Proceed directly with site creation.
 - The user says "just build something" or "surprise me". Pick a bold creative direction yourself and proceed.
-- The user explicitly asks to skip the setup or says they don't want questions.
+- The user explicitly asks to skip setup.

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -107,7 +107,7 @@ For any request that involves a WordPress site, you MUST first determine which s
 
 - **Active site + ambiguous "create" / "build" / "make" / "design a site"**: Ask whether to update the active site or create a separate new site before calling site_create. Use AskUserQuestion when available with options like "Use current site" and "Create new site".
 - **Active site + explicit "new" / "separate" / "another" site**: Run the \`site-spec\` skill to gather the site name and layout preference FIRST, then call site_create.
-- **No active site + "create" / "build" / "make" a site**: Run the \`site-spec\` skill to gather the site name and layout preference FIRST, then call site_create.
+- **No active site + "create" / "build" / "make" a site**: Run the \`site-spec\` skill FIRST — it gathers the site name and expands the brief into a creative direction (pages, layout, hero, typography), then call site_create.
 - **"Redesign" / "update" / "change this site"**: Reuse the active site.
 - **User names a specific existing site**: Call site_list to find it.
 - **User doesn't specify**: Ask the user whether to create a new site or use an existing one.


### PR DESCRIPTION
## What

Enhances the `site-spec` skill to auto-expand a vague brief into a creative direction — inferring layout, pages/sections, hero composition, and typography from the site name — then briefs the user in ≤4 lines before building.

Addresses @youknowriad's feedback on #3610: *"we should not remove site spec, we should enhance it"*.

## Why

When a user says *"make a site for my bar"*, the current skill asks one binary question (one-page or multi-page?) and then the agent guesses everything else. The result is usually a minimal skeleton.

Telex's better output quality comes from two specific things it does before writing any file:
1. **Hero composition** — a short paragraph of cinematic prose describing the spatial layout (full-bleed / asymmetric / centered, image placement, typographic weight). This becomes the spatial anchor for all downstream block choices.
2. **Typography inference** — a font pairing derived from the site type (coffee shop → Fraunces + Spectral; law firm → Cormorant Garamond + Source Sans).

Both happen without asking the user anything extra.

## Changes

- `apps/cli/ai/skills/site-spec/SKILL.md` — replaces the one-page/multi-page question with auto-expansion: layout mode, pages/sections, hero composition, typography. Also includes the Round 1 stop-instruction fix from #3615.
- `apps/cli/ai/system-prompt.ts` — one-line update to the site-creation routing description.

**2 files, +42/−17 lines.**

## Relationship to other PRs

- Supersedes the separate `creative-direction` skill in #3629 (draft/PoC) — same goal, one skill instead of two.
- Includes the Round 1 bug fix from #3615.

## Testing

```bash
npm run cli:build
```

1. *"ayudame a crear un sitio para una hamburguesería"* — agent should ask the name, stop, wait for reply, then auto-expand (layout + hero + typography) and brief you before building. No layout question.
2. *"create a site called Bean & Brew"* — agent should skip Round 1 (name already given), auto-expand directly, brief you, then build.