### PR TITLE
Stop re-verifying deleted sites in sync reconciliation

### DIFF
--- a/apps/studio/src/stores/sync/wpcom-sites.ts
+++ b/apps/studio/src/stores/sync/wpcom-sites.ts
@@ -140,13 +140,20 @@ export const wpcomSitesApi = createApi( {
 
 						// Connected sites that weren't on page 1 need explicit verification
 						// before we'd mark them deleted — otherwise pagination would flag
-						// any connected site past the first page as gone.
+						// any connected site past the first page as gone. Sites already in
+						// the terminal `deleted` state are skipped: re-verifying them just
+						// spams 403s from wp.com when the user has lost access.
 						const fetchedIds = new Set(
 							parsedResponse.sites
 								.map( ( s ) => sitesEndpointSiteSchema.safeParse( s ).data?.ID )
 								.filter( ( id ): id is number => typeof id === 'number' )
 						);
-						const missingConnectedIds = connectedIds.filter( ( id ) => ! fetchedIds.has( id ) );
+						const verifiableConnectedIds = allConnectedSites
+							.filter( ( s ) => s.syncSupport !== 'deleted' )
+							.map( ( { id } ) => id );
+						const missingConnectedIds = verifiableConnectedIds.filter(
+							( id ) => ! fetchedIds.has( id )
+						);
 
 						const verifiedDeletedIds = new Set< number >();
 						const supplementalSites: SyncSite[] = [];

--- a/apps/studio/src/stores/sync/wpcom-sites.ts
+++ b/apps/studio/src/stores/sync/wpcom-sites.ts
@@ -140,9 +140,7 @@ export const wpcomSitesApi = createApi( {
 
 						// Connected sites that weren't on page 1 need explicit verification
 						// before we'd mark them deleted — otherwise pagination would flag
-						// any connected site past the first page as gone. Sites already in
-						// the terminal `deleted` state are skipped: re-verifying them just
-						// spams 403s from wp.com when the user has lost access.
+						// any connected site past the first page as gone.
 						const fetchedIds = new Set(
 							parsedResponse.sites
 								.map( ( s ) => sitesEndpointSiteSchema.safeParse( s ).data?.ID )


### PR DESCRIPTION
### Related issues

None — bug found while investigating console noise locally.

### Proposed Changes

- In `wpcomSitesApi.getWpComSites` reconciliation (`apps/studio/src/stores/sync/wpcom-sites.ts`), exclude connected sites whose `syncSupport === 'deleted'` from the per-site verification loop.
- These sites are in a terminal state (already verified gone via a prior 404). On every refresh they were re-fetched via `GET /rest/v1.1/sites/{id}`, which now returns `403 Forbidden` for most users (wp.com switches from 404 → 403 once the row is ACL'd off). The code already falls through correctly for non-404 errors, so the only effect was console-error spam and wasted API calls.
- Recovery path still works: if a previously-deleted site reappears in page 1 of `/me/sites`, `reconcileConnectedSites` updates its `syncSupport` from the fresh data as before.

### Testing Instructions

1. Sign in to Studio with a wp.com account that has at least one connected site marked `"syncSupport": "deleted"` in `~/.studio/shared.json` (e.g., a connection to a site that was later deleted on wp.com).
2. Open the renderer DevTools console.
3. Open the Sync sites modal so `getWpComSites` runs.
4. Confirm there are **no** `GET https://public-api.wordpress.com/rest/v1.1/sites/{id}... 403 (Forbidden)` errors for the deleted sites in the console.
5. Confirm that active connected sites still appear, sync UI still works, and deleted entries continue to show their deleted state.

### Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

---

Note: no new tests were added. `wpcomSitesApi.queryFn` isn't currently unit-tested and adding fresh mocking scaffolding for this two-line filter would be disproportionate. All existing sync tests (`reconcile-connected-sites`, `get-sync-support`, `modules/sync/tests`) pass.