### PR TITLE
Proof of concept: Studio 2.0 combined UI

### DIFF
--- a/apps/studio/src/main-window.ts
+++ b/apps/studio/src/main-window.ts
@@ -9,6 +9,7 @@ import fs from 'fs';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { portFinder } from '@studio/common/lib/port-finder';
+import { normalizeStudioUiMode } from '@studio/common/lib/studio-ui-mode';
 import {
 	DEFAULT_HEIGHT,
 	DEFAULT_WIDTH,
@@ -27,7 +28,7 @@ import {
 	loadWindowBounds,
 	saveWindowBounds,
 } from 'src/storage/user-data';
-import type { StudioUiMode } from '@studio/common/types/desk';
+import type { StoredStudioUiMode, StudioUiMode } from '@studio/common/types/desk';
 import type { UserData, WindowBounds } from 'src/storage/storage-types';
 
 let mainWindow: BrowserWindow | null;
@@ -40,8 +41,7 @@ interface RendererLocation {
 }
 
 export function getPreferredStudioUiMode( userData: Pick< UserData, 'desks' > ): StudioUiMode {
-	const preferredMode = userData.desks?.defaultUiMode;
-	return preferredMode === 'desks' || preferredMode === 'agentic' ? preferredMode : 'default';
+	return normalizeStudioUiMode( userData.desks?.defaultUiMode );
 }
 
 function getRendererFilePath( mode: StudioUiMode ) {
@@ -120,13 +120,14 @@ async function loadRendererLocation( window: BrowserWindow, location: RendererLo
 
 export async function loadMainWindowRenderer(
 	window: BrowserWindow,
-	mode?: StudioUiMode
+	mode?: StoredStudioUiMode
 ): Promise< void > {
 	const userData = await loadUserData();
+	const normalizedMode = normalizeStudioUiMode( mode );
 	const location = getRendererLocation( {
 		desks: {
 			...userData.desks,
-			...( mode ? { defaultUiMode: mode } : {} ),
+			...( mode ? { defaultUiMode: normalizedMode } : {} ),
 		},
 	} );
 	await loadRendererLocation( window, location );

--- a/apps/studio/src/modules/desks/lib/ipc-handlers.test.ts
+++ b/apps/studio/src/modules/desks/lib/ipc-handlers.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment node
+ */
+import { BrowserWindow, type IpcMainInvokeEvent } from 'electron';
+import { vi } from 'vitest';
+import { loadMainWindowRenderer } from 'src/main-window';
+import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
+import { getStudioUiMode, setStudioUiMode } from './ipc-handlers';
+import type { UserData } from 'src/storage/storage-types';
+
+vi.mock( 'electron', () => ( {
+	BrowserWindow: {
+		fromWebContents: vi.fn(),
+	},
+	dialog: {
+		showOpenDialog: vi.fn(),
+		showSaveDialog: vi.fn(),
+	},
+} ) );
+
+vi.mock( 'src/main-window', () => ( {
+	loadMainWindowRenderer: vi.fn().mockResolvedValue( undefined ),
+} ) );
+
+vi.mock( 'src/storage/user-data', () => ( {
+	loadUserData: vi.fn(),
+	lockAppdata: vi.fn().mockResolvedValue( undefined ),
+	saveUserData: vi.fn().mockResolvedValue( undefined ),
+	unlockAppdata: vi.fn().mockResolvedValue( undefined ),
+} ) );
+
+const mockEvent = {
+	sender: {},
+	frameId: 1,
+} as IpcMainInvokeEvent;
+
+const mockUserData: UserData = {
+	version: 1,
+	siteMetadata: {},
+};
+
+describe( 'desk Studio UI mode IPC handlers', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.useRealTimers();
+		vi.mocked( loadUserData ).mockResolvedValue( mockUserData );
+		vi.mocked( BrowserWindow.fromWebContents ).mockReturnValue( {
+			isDestroyed: vi.fn().mockReturnValue( false ),
+		} as unknown as BrowserWindow );
+	} );
+
+	it.each( [
+		[ 'default', 'default' ],
+		[ 'studio2', 'studio2' ],
+		[ 'agentic', 'studio2' ],
+		[ 'desks', 'studio2' ],
+	] )( 'returns %s stored mode as %s', async ( storedMode, expectedMode ) => {
+		vi.mocked( loadUserData ).mockResolvedValue( {
+			...mockUserData,
+			desks: {
+				defaultUiMode: storedMode as never,
+			},
+		} );
+
+		await expect( getStudioUiMode( mockEvent ) ).resolves.toBe( expectedMode );
+	} );
+
+	it( 'normalizes legacy mode before persisting and reloading', async () => {
+		vi.useFakeTimers();
+		vi.mocked( loadUserData ).mockResolvedValue( {
+			...mockUserData,
+			desks: {
+				defaultUiMode: 'default',
+			},
+		} );
+		const parentWindow = {
+			isDestroyed: vi.fn().mockReturnValue( false ),
+		} as unknown as BrowserWindow;
+		vi.mocked( BrowserWindow.fromWebContents ).mockReturnValue( parentWindow );
+
+		await setStudioUiMode( mockEvent, 'agentic' );
+		await vi.runAllTimersAsync();
+
+		expect( saveUserData ).toHaveBeenCalledWith( {
+			...mockUserData,
+			desks: {
+				defaultUiMode: 'studio2',
+			},
+		} );
+		expect( loadMainWindowRenderer ).toHaveBeenCalledWith( parentWindow, 'studio2' );
+	} );
+
+	it( 'rejects invalid mode before locking or saving', async () => {
+		await expect( setStudioUiMode( mockEvent, 'invalid' as never ) ).rejects.toThrow(
+			'Invalid Studio UI mode.'
+		);
+
+		expect( lockAppdata ).not.toHaveBeenCalled();
+		expect( saveUserData ).not.toHaveBeenCalled();
+		expect( unlockAppdata ).not.toHaveBeenCalled();
+	} );
+} );

--- a/apps/studio/src/modules/desks/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/desks/lib/ipc-handlers.ts
@@ -3,7 +3,16 @@ import fsPromises from 'fs/promises';
 import nodePath from 'path';
 import { assertDeskConfig } from '@studio/common/lib/desk-config';
 import { normalizeDeskSettings } from '@studio/common/lib/desk-settings';
-import { type DeskConfig, type DeskSettings, type StudioUiMode } from '@studio/common/types/desk';
+import {
+	assertSupportedStudioUiMode,
+	normalizeStudioUiMode,
+} from '@studio/common/lib/studio-ui-mode';
+import {
+	type DeskConfig,
+	type DeskSettings,
+	type StoredStudioUiMode,
+	type StudioUiMode,
+} from '@studio/common/types/desk';
 import { __ } from '@wordpress/i18n';
 import { loadMainWindowRenderer } from 'src/main-window';
 import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
@@ -15,12 +24,6 @@ function isRecord( value: unknown ): value is Record< string, unknown > {
 function assertSiteId( siteId: unknown ): asserts siteId is string {
 	if ( typeof siteId !== 'string' || ! siteId ) {
 		throw new Error( 'Invalid site desk config: expected site id.' );
-	}
-}
-
-function assertStudioUiMode( mode: unknown ): asserts mode is StudioUiMode {
-	if ( mode !== 'default' && mode !== 'desks' && mode !== 'agentic' ) {
-		throw new Error( 'Invalid Studio UI mode.' );
 	}
 }
 
@@ -52,15 +55,15 @@ export async function getDeskSettings( _event: IpcMainInvokeEvent ): Promise< De
 
 export async function getStudioUiMode( _event: IpcMainInvokeEvent ): Promise< StudioUiMode > {
 	const userData = await loadUserData();
-	const mode = userData.desks?.defaultUiMode;
-	return mode === 'desks' || mode === 'agentic' ? mode : 'default';
+	return normalizeStudioUiMode( userData.desks?.defaultUiMode );
 }
 
 export async function setStudioUiMode(
 	event: IpcMainInvokeEvent,
-	mode: StudioUiMode
+	mode: StoredStudioUiMode
 ): Promise< void > {
-	assertStudioUiMode( mode );
+	assertSupportedStudioUiMode( mode );
+	const normalizedMode = normalizeStudioUiMode( mode );
 	await lockAppdata();
 	try {
 		const userData = await loadUserData();
@@ -68,7 +71,7 @@ export async function setStudioUiMode(
 			...userData,
 			desks: {
 				...userData.desks,
-				defaultUiMode: mode,
+				defaultUiMode: normalizedMode,
 			},
 		} );
 	} finally {
@@ -78,7 +81,7 @@ export async function setStudioUiMode(
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	if ( parentWindow && ! parentWindow.isDestroyed() ) {
 		setTimeout( () => {
-			void loadMainWindowRenderer( parentWindow, mode );
+			void loadMainWindowRenderer( parentWindow, normalizedMode );
 		}, 0 );
 	}
 }

--- a/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
@@ -130,12 +130,8 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 		}
 	};
 
-	const switchToDesksUi = () => {
-		void getIpcApi().setStudioUiMode( 'desks' );
-	};
-
-	const switchToAgenticUi = () => {
-		void getIpcApi().setStudioUiMode( 'agentic' );
+	const switchToStudio2Ui = () => {
+		void getIpcApi().setStudioUiMode( 'studio2' );
 	};
 
 	return (
@@ -161,14 +157,9 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 			) }
 			{ enableDesksUiSwitch && (
 				<SettingsFormField label={ __( 'Studio UI' ) }>
-					<div className="flex flex-wrap gap-3">
-						<Button variant="secondary" onClick={ switchToDesksUi }>
-							{ __( 'Switch to Desks UI' ) }
-						</Button>
-						<Button variant="secondary" onClick={ switchToAgenticUi }>
-							{ __( 'Switch to Agentic UI' ) }
-						</Button>
-					</div>
+					<Button variant="secondary" onClick={ switchToStudio2Ui }>
+						{ __( 'Switch to Studio 2.0' ) }
+					</Button>
 				</SettingsFormField>
 			) }
 			<div className="mt-auto pt-2 flex justify-end gap-3">

--- a/apps/ui/src/app/use-ui-mode.test.ts
+++ b/apps/ui/src/app/use-ui-mode.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { resolveLaunchUiMode } from './use-ui-mode';
+
+describe( 'resolveLaunchUiMode', () => {
+	it( 'maps Studio 2 launch modes to the classic shell', () => {
+		expect( resolveLaunchUiMode( 'studio2' ) ).toBe( 'classic' );
+		expect( resolveLaunchUiMode( 'agentic' ) ).toBe( 'classic' );
+		expect( resolveLaunchUiMode( 'desks' ) ).toBe( 'classic' );
+	} );
+
+	it( 'ignores missing and unknown launch modes', () => {
+		expect( resolveLaunchUiMode( null ) ).toBeUndefined();
+		expect( resolveLaunchUiMode( 'default' ) ).toBeUndefined();
+		expect( resolveLaunchUiMode( 'bogus' ) ).toBeUndefined();
+	} );
+} );

--- a/apps/ui/src/app/use-ui-mode.ts
+++ b/apps/ui/src/app/use-ui-mode.ts
@@ -3,7 +3,14 @@ import { useCallback, useState } from 'react';
 export type UiMode = 'classic' | 'desks';
 
 const STUDIO_UI_MODE_PARAM = 'studio-ui-mode';
-const DEFAULT_UI_MODE: UiMode = 'desks';
+const DEFAULT_UI_MODE: UiMode = 'classic';
+
+export function resolveLaunchUiMode( mode: string | null ): UiMode | undefined {
+	if ( mode === 'studio2' || mode === 'agentic' || mode === 'desks' ) {
+		return 'classic';
+	}
+	return undefined;
+}
 
 function readLaunchUiMode(): UiMode | undefined {
 	if ( typeof window === 'undefined' ) {
@@ -12,12 +19,7 @@ function readLaunchUiMode(): UiMode | undefined {
 
 	try {
 		const mode = new URLSearchParams( window.location.search ).get( STUDIO_UI_MODE_PARAM );
-		if ( mode === 'desks' ) {
-			return 'desks';
-		}
-		if ( mode === 'agentic' ) {
-			return 'classic';
-		}
+		return resolveLaunchUiMode( mode );
 	} catch {
 		return undefined;
 	}

--- a/apps/ui/src/components/settings-view/index.test.tsx
+++ b/apps/ui/src/components/settings-view/index.test.tsx
@@ -1,0 +1,115 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConnector } from '@/data/core';
+import { useInstalledApps } from '@/data/queries/use-installed-apps';
+import { useSaveUserPreferences, useUserPreferences } from '@/data/queries/use-user-preferences';
+import { useFullscreen } from '@/hooks/use-fullscreen';
+import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
+import { SettingsView } from './index';
+import type { ReactNode } from 'react';
+
+const mocks = vi.hoisted( () => ( {
+	setStudioUiMode: vi.fn(),
+	mutate: vi.fn(),
+} ) );
+
+vi.mock( '@wordpress/dataviews', () => ( {
+	DataForm: () => <div data-testid="data-form" />,
+} ) );
+
+vi.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+vi.mock( '@wordpress/ui', () => ( {
+	Button: ( {
+		children,
+		disabled,
+		loading,
+		onClick,
+		type = 'button',
+	}: {
+		children?: ReactNode;
+		disabled?: boolean;
+		loading?: boolean;
+		onClick?: () => void;
+		type?: 'button' | 'submit';
+	} ) => (
+		<button type={ type } disabled={ disabled || loading } onClick={ onClick }>
+			{ children }
+		</button>
+	),
+} ) );
+
+vi.mock( '@/components/tabs', () => ( {
+	Root: ( { children }: { children?: ReactNode } ) => <div>{ children }</div>,
+	List: ( { children }: { children?: ReactNode } ) => <div>{ children }</div>,
+	Tab: ( { children }: { children?: ReactNode } ) => <button type="button">{ children }</button>,
+	Panel: ( { children }: { children?: ReactNode } ) => <div>{ children }</div>,
+} ) );
+
+vi.mock( '@/data/core', () => ( {
+	useConnector: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-installed-apps', () => ( {
+	useInstalledApps: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-user-preferences', () => ( {
+	useSaveUserPreferences: vi.fn(),
+	useUserPreferences: vi.fn(),
+} ) );
+
+vi.mock( '@/hooks/use-fullscreen', () => ( {
+	useFullscreen: vi.fn(),
+} ) );
+
+vi.mock( '@/hooks/use-sidebar-collapsed', () => ( {
+	useSidebarCollapsed: vi.fn(),
+} ) );
+
+const useConnectorMock = vi.mocked( useConnector );
+const useInstalledAppsMock = vi.mocked( useInstalledApps );
+const useUserPreferencesMock = vi.mocked( useUserPreferences );
+const useSaveUserPreferencesMock = vi.mocked( useSaveUserPreferences );
+const useFullscreenMock = vi.mocked( useFullscreen );
+const useSidebarCollapsedMock = vi.mocked( useSidebarCollapsed );
+
+describe( 'SettingsView', () => {
+	beforeEach( () => {
+		mocks.setStudioUiMode.mockReset().mockResolvedValue( undefined );
+		mocks.mutate.mockReset();
+
+		useConnectorMock.mockReturnValue( {
+			setStudioUiMode: mocks.setStudioUiMode,
+		} as unknown as ReturnType< typeof useConnector > );
+		useInstalledAppsMock.mockReturnValue( { data: undefined } as ReturnType<
+			typeof useInstalledApps
+		> );
+		useUserPreferencesMock.mockReturnValue( {
+			data: {
+				editor: null,
+				terminal: null,
+				colorScheme: 'system',
+				locale: 'en',
+			},
+			isLoading: false,
+		} as ReturnType< typeof useUserPreferences > );
+		useSaveUserPreferencesMock.mockReturnValue( {
+			isPending: false,
+			mutate: mocks.mutate,
+		} as unknown as ReturnType< typeof useSaveUserPreferences > );
+		useFullscreenMock.mockReturnValue( false );
+		useSidebarCollapsedMock.mockReturnValue( false );
+	} );
+
+	it( 'switches back to the default Studio UI from preferences', () => {
+		render( <SettingsView activeTab="preferences" onTabChange={ vi.fn() } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Switch to Default Studio UI' } ) );
+
+		expect( mocks.setStudioUiMode ).toHaveBeenCalledWith( 'default' );
+	} );
+} );

--- a/apps/ui/src/components/settings-view/index.tsx
+++ b/apps/ui/src/components/settings-view/index.tsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import * as Tabs from '@/components/tabs';
+import { useConnector } from '@/data/core';
 import { persister } from '@/data/core/query-client';
 import { useInstalledApps } from '@/data/queries/use-installed-apps';
 import { useSaveUserPreferences, useUserPreferences } from '@/data/queries/use-user-preferences';
@@ -125,6 +126,7 @@ export function SettingsView( {
 	activeTab: TabId;
 	onTabChange: ( tab: TabId ) => void;
 } ) {
+	const connector = useConnector();
 	const { data: saved, isLoading } = useUserPreferences();
 	const { data: installedApps } = useInstalledApps();
 	const savePreferences = useSaveUserPreferences();
@@ -185,6 +187,10 @@ export function SettingsView( {
 	const handleChange = useCallback( ( update: Record< string, unknown > ) => {
 		setData( ( prev ) => ( prev ? { ...prev, ...( update as Partial< FormData > ) } : prev ) );
 	}, [] );
+
+	const switchToDefaultStudioUi = useCallback( () => {
+		void connector.setStudioUiMode( 'default' );
+	}, [ connector ] );
 
 	if ( isLoading || ! data || ! saved ) {
 		return <div className={ styles.state }>{ __( 'Loading…' ) }</div>;
@@ -248,6 +254,12 @@ export function SettingsView( {
 									form={ preferencesForm }
 									onChange={ handleChange }
 								/>
+								<div className={ styles.studioUiControl }>
+									<label className={ styles.studioUiLabel }>{ __( 'Studio UI' ) }</label>
+									<Button type="button" variant="outline" onClick={ switchToDefaultStudioUi }>
+										{ __( 'Switch to Default Studio UI' ) }
+									</Button>
+								</div>
 							</Tabs.Panel>
 
 							<div className={ styles.actions }>

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -75,6 +75,20 @@
 	gap: var(--wpds-dimension-padding-xl);
 }
 
+.studioUiControl {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--wpds-dimension-padding-sm);
+	margin-top: var(--wpds-dimension-padding-xl);
+}
+
+.studioUiLabel {
+	font-size: var(--wpds-typography-font-size-sm);
+	font-weight: 500;
+	color: var(--wpds-color-fg-content-neutral);
+}
+
 .actions {
 	display: flex;
 	justify-content: flex-end;

--- a/apps/ui/src/components/sidebar-nav/index.test.tsx
+++ b/apps/ui/src/components/sidebar-nav/index.test.tsx
@@ -1,0 +1,59 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, within } from '@testing-library/react';
+import { cloneElement, isValidElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { SidebarNav } from './index';
+import type { ReactNode } from 'react';
+
+vi.mock( '@tanstack/react-router', () => ( {
+	Link: ( { children, to }: { children?: ReactNode; to: string } ) => (
+		<a href={ to }>{ children }</a>
+	),
+} ) );
+
+vi.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+vi.mock( '@wordpress/icons', () => ( {
+	category: {},
+	cog: {},
+	comment: {},
+	layout: {},
+} ) );
+
+vi.mock( '@wordpress/ui', () => ( {
+	Button: ( { children, render }: { children?: ReactNode; render?: ReactNode } ) => {
+		if ( render ) {
+			return <>{ render }</>;
+		}
+
+		return <button type="button">{ children }</button>;
+	},
+	Icon: () => null,
+} ) );
+
+vi.mock( '@/components/sidebar-button', () => ( {
+	SidebarButton: ( { children, render }: { children?: ReactNode; render?: ReactNode } ) => {
+		if ( isValidElement( render ) ) {
+			return cloneElement( render, undefined, children );
+		}
+
+		return <button type="button">{ children }</button>;
+	},
+} ) );
+
+describe( 'SidebarNav', () => {
+	it( 'renders Chat, Desk, Settings as links and keeps Skills visible as a label', () => {
+		render( <SidebarNav /> );
+
+		const nav = screen.getByRole( 'navigation' );
+		const links = within( nav ).getAllByRole( 'link' );
+
+		expect( links.map( ( link ) => link.textContent ) ).toEqual( [ 'Chat', 'Desk', 'Settings' ] );
+		expect( screen.getByRole( 'link', { name: 'Desk' } ) ).toHaveAttribute( 'href', '/desk' );
+
+		expect( screen.getByText( 'Skills' ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'Skills' } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/apps/ui/src/components/sidebar-nav/index.tsx
+++ b/apps/ui/src/components/sidebar-nav/index.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { category, cog, comment } from '@wordpress/icons';
+import { category, cog, comment, layout } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { SidebarButton } from '@/components/sidebar-button';
@@ -17,6 +17,7 @@ type NavItem = {
 function getItems(): NavItem[] {
 	return [
 		{ key: 'chat', label: __( 'Chat' ), icon: comment, to: '/dashboard' },
+		{ key: 'desk', label: __( 'Desk' ), icon: layout, to: '/desk' },
 		{ key: 'settings', label: __( 'Settings' ), icon: cog, to: '/settings' },
 		{ key: 'skills', label: __( 'Skills' ), icon: category },
 	];

--- a/apps/ui/src/ui-classic/router/route-desk/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-desk/index.tsx
@@ -1,0 +1,24 @@
+import { createRoute } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { Desk } from '@/ui-desks/desk';
+import { dashboardLayoutRoute } from '../layout-dashboard';
+import styles from './style.module.css';
+
+function DeskPage() {
+	return (
+		<section
+			className={ styles.root }
+			data-ui-mode="desks"
+			aria-label={ __( 'Desk' ) }
+			data-testid="studio-2-desk-view"
+		>
+			<Desk embedded />
+		</section>
+	);
+}
+
+export const deskRoute = createRoute( {
+	getParentRoute: () => dashboardLayoutRoute,
+	path: '/desk',
+	component: DeskPage,
+} );

--- a/apps/ui/src/ui-classic/router/route-desk/style.module.css
+++ b/apps/ui/src/ui-classic/router/route-desk/style.module.css
@@ -1,0 +1,6 @@
+.root {
+	height: 100%;
+	min-height: 0;
+	overflow: hidden;
+	position: relative;
+}

--- a/apps/ui/src/ui-classic/router/route-site-desk/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-site-desk/index.tsx
@@ -1,0 +1,29 @@
+import { createRoute } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { WordPressDataProvider } from '@/data/wordpress/provider';
+import { Desk } from '@/ui-desks/desk';
+import { dashboardLayoutRoute } from '../layout-dashboard';
+import styles from '../route-desk/style.module.css';
+
+function SiteDeskPage() {
+	const { siteId } = siteDeskRoute.useParams();
+
+	return (
+		<section
+			className={ styles.root }
+			data-ui-mode="desks"
+			aria-label={ __( 'Desk' ) }
+			data-testid="studio-2-site-desk-view"
+		>
+			<WordPressDataProvider key={ siteId } siteId={ siteId }>
+				<Desk siteId={ siteId } embedded />
+			</WordPressDataProvider>
+		</section>
+	);
+}
+
+export const siteDeskRoute = createRoute( {
+	getParentRoute: () => dashboardLayoutRoute,
+	path: '/sites/$siteId',
+	component: SiteDeskPage,
+} );

--- a/apps/ui/src/ui-classic/router/router.test.ts
+++ b/apps/ui/src/ui-classic/router/router.test.ts
@@ -1,0 +1,23 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it, vi } from 'vitest';
+import { createAppRouter } from './router';
+import type { ReactNode } from 'react';
+
+vi.mock( '@/ui-desks/desk', () => ( {
+	Desk: () => null,
+} ) );
+
+vi.mock( '@/data/wordpress/provider', () => ( {
+	WordPressDataProvider: ( { children }: { children: ReactNode } ) => children,
+} ) );
+
+describe( 'createAppRouter', () => {
+	it( 'registers embedded site Desk routes in the Agentic shell', () => {
+		const router = createAppRouter( {
+			connector: {} as never,
+			queryClient: new QueryClient(),
+		} );
+
+		expect( router.routesByPath[ '/sites/$siteId' ] ).toBeDefined();
+	} );
+} );

--- a/apps/ui/src/ui-classic/router/router.tsx
+++ b/apps/ui/src/ui-classic/router/router.tsx
@@ -4,6 +4,7 @@ import { dashboardLayoutRoute } from './layout-dashboard';
 import { onboardingLayoutRoute } from './layout-onboarding';
 import { rootRoute } from './layout-root';
 import { dashboardRoute } from './route-dashboard';
+import { deskRoute } from './route-desk';
 import { indexRoute } from './route-index';
 import { newSessionRoute } from './route-new-session';
 import { onboardingBlueprintRoute } from './route-onboarding-blueprint';
@@ -12,6 +13,7 @@ import { onboardingHomeRoute } from './route-onboarding-home';
 import { onboardingImportRoute } from './route-onboarding-import';
 import { sessionDetailRoute } from './route-session-detail';
 import { settingsRoute } from './route-settings';
+import { siteDeskRoute } from './route-site-desk';
 import { siteSettingsRoute } from './route-site-settings';
 import type { RouterContext } from './layout-root';
 
@@ -21,7 +23,9 @@ const routeTree = rootRoute.addChildren( [
 		dashboardRoute,
 		newSessionRoute,
 		sessionDetailRoute,
+		siteDeskRoute,
 		siteSettingsRoute,
+		deskRoute,
 		settingsRoute,
 	] ),
 	onboardingLayoutRoute.addChildren( [

--- a/apps/ui/src/ui-desks/chats/panel/index.tsx
+++ b/apps/ui/src/ui-desks/chats/panel/index.tsx
@@ -24,6 +24,8 @@ interface ChatsProps {
 	siteId?: string;
 	side: ChatPanelSide;
 	panel: ChatPanelResizeState;
+	embedded?: boolean;
+	container?: HTMLElement | null;
 }
 
 const COMPACT_STORAGE_KEY = 'ui-desks-chat-list-compact';
@@ -210,7 +212,7 @@ export function ChatsTrigger() {
 	return <ChatsButton open={ open } onToggle={ () => setOpen( ! open ) } />;
 }
 
-export function Chats( { siteId, side, panel }: ChatsProps ) {
+export function Chats( { siteId, side, panel, embedded = false, container }: ChatsProps ) {
 	const {
 		open,
 		setOpen,
@@ -255,6 +257,13 @@ export function Chats( { siteId, side, panel }: ChatsProps ) {
 		chatSessions.find( ( session ) => session.id === selectedSessionId ) ??
 		( sessions ?? [] ).find( ( session ) => session.id === selectedSessionId );
 	const isListCollapsed = expanded && listCollapsed;
+	const embeddedBounds = embedded ? container?.getBoundingClientRect() : undefined;
+	const widgetDragPreviewX = composerWidgetDragPreview
+		? composerWidgetDragPreview.x - ( embeddedBounds?.left ?? 0 )
+		: 0;
+	const widgetDragPreviewY = composerWidgetDragPreview
+		? composerWidgetDragPreview.y - ( embeddedBounds?.top ?? 0 )
+		: 0;
 
 	useEffect( () => {
 		if ( selectedSessionId && sessions && ! isFetchingSessions && ! selectedSession ) {
@@ -278,7 +287,7 @@ export function Chats( { siteId, side, panel }: ChatsProps ) {
 
 	return (
 		<Dialog.Root open={ open } onOpenChange={ setOpen } modal={ false } disablePointerDismissal>
-			<Dialog.Portal>
+			<Dialog.Portal container={ embedded ? container : undefined }>
 				<Dialog.Popup
 					initialFocus={ false }
 					finalFocus={ false }
@@ -292,6 +301,7 @@ export function Chats( { siteId, side, panel }: ChatsProps ) {
 					data-expanded={ expanded ? 'true' : 'false' }
 					data-list-collapsed={ isListCollapsed ? 'true' : 'false' }
 					data-resizing={ isResizing ? 'true' : 'false' }
+					data-ui-desks-embedded={ embedded ? 'true' : undefined }
 					data-ui-desks-chat-dropzone={ expanded && selectedSessionId ? 'true' : undefined }
 					style={
 						expanded
@@ -448,8 +458,8 @@ export function Chats( { siteId, side, panel }: ChatsProps ) {
 						className={ styles.widgetDragPreview }
 						style={
 							{
-								'--desk-widget-drag-preview-x': `${ composerWidgetDragPreview.x }px`,
-								'--desk-widget-drag-preview-y': `${ composerWidgetDragPreview.y }px`,
+								'--desk-widget-drag-preview-x': `${ widgetDragPreviewX }px`,
+								'--desk-widget-drag-preview-y': `${ widgetDragPreviewY }px`,
 							} as CSSProperties
 						}
 						aria-hidden="true"

--- a/apps/ui/src/ui-desks/chats/panel/style.module.css
+++ b/apps/ui/src/ui-desks/chats/panel/style.module.css
@@ -46,6 +46,14 @@
 	width: min(var(--desk-chats-panel-width), calc(100vw - 2 * var(--desk-chats-panel-gap)));
 }
 
+.panel[data-ui-desks-embedded='true'] {
+	width: min(var(--desk-chats-list-pane-width), calc(100% - 2 * var(--desk-chats-panel-gap)));
+}
+
+.panelExpanded[data-ui-desks-embedded='true'] {
+	width: min(var(--desk-chats-panel-width), calc(100% - 2 * var(--desk-chats-panel-gap)));
+}
+
 .panel[data-resizing='true'] {
 	transition: none;
 }

--- a/apps/ui/src/ui-desks/chrome/header/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/header/index.tsx
@@ -6,15 +6,28 @@ import type { ReactNode } from 'react';
 
 interface DeskHeaderProps {
 	children: ReactNode;
+	embedded?: boolean;
 	centerChildren?: ReactNode;
 	rightChildren?: ReactNode;
 }
 
-export function DeskHeader( { children, centerChildren, rightChildren }: DeskHeaderProps ) {
+export function DeskHeader( {
+	children,
+	embedded = false,
+	centerChildren,
+	rightChildren,
+}: DeskHeaderProps ) {
 	const isFullscreen = useFullscreen();
 
 	return (
-		<div className={ clsx( styles.root, isFullscreen && styles.fullscreen ) }>
+		<div
+			className={ clsx(
+				styles.root,
+				isFullscreen && styles.fullscreen,
+				embedded && styles.embedded
+			) }
+			data-ui-desks-embedded={ embedded ? 'true' : undefined }
+		>
 			<span className={ styles.title }>{ __( 'Studio' ) }</span>
 			<div className={ styles.actions }>{ children }</div>
 			{ centerChildren && <div className={ styles.centerActions }>{ centerChildren }</div> }

--- a/apps/ui/src/ui-desks/chrome/header/style.module.css
+++ b/apps/ui/src/ui-desks/chrome/header/style.module.css
@@ -73,3 +73,27 @@
 .fullscreen .centerActions {
 	top: var(--desk-chrome-edge-offset);
 }
+
+.embedded {
+	--desk-chrome-edge-offset: var(--wpds-dimension-padding-xl);
+	--desk-embedded-top-offset: var(--desk-chrome-edge-offset);
+}
+
+.embedded .title {
+	display: none;
+}
+
+.embedded .actions {
+	top: var(--desk-embedded-top-offset);
+	left: var(--desk-chrome-edge-offset);
+}
+
+.embedded .rightActions {
+	top: var(--desk-embedded-top-offset);
+	right: var(--desk-chrome-edge-offset);
+}
+
+.embedded .centerActions {
+	top: var(--desk-embedded-top-offset);
+	max-width: min(360px, calc(100% - 320px));
+}

--- a/apps/ui/src/ui-desks/chrome/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/index.tsx
@@ -20,6 +20,7 @@ import { DeskMenu } from './user-menu';
 
 interface DeskChromeProps {
 	siteId?: string;
+	embedded?: boolean;
 	siteMapOpen?: boolean;
 	siteMapPageCount?: number;
 	settingsOpen: boolean;
@@ -30,6 +31,7 @@ interface DeskChromeProps {
 
 export function DeskChrome( {
 	siteId,
+	embedded = false,
 	siteMapOpen = false,
 	siteMapPageCount,
 	settingsOpen,
@@ -86,6 +88,7 @@ export function DeskChrome( {
 
 	return (
 		<DeskHeader
+			embedded={ embedded }
 			centerChildren={ siteMapOpen ? <DeskSiteMapTitle pageCount={ siteMapPageCount } /> : null }
 			rightChildren={
 				<ToolbarRow
@@ -113,6 +116,7 @@ export function DeskChrome( {
 					<>
 						<DeskMenu
 							siteId={ siteId }
+							embedded={ embedded }
 							disabled={ editingToolbar }
 							showSiteName={ settings.showSiteName }
 						/>

--- a/apps/ui/src/ui-desks/chrome/user-menu/index.test.ts
+++ b/apps/ui/src/ui-desks/chrome/user-menu/index.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getDeskMenuRouteTargets } from './index';
+
+describe( 'getDeskMenuRouteTargets', () => {
+	it( 'keeps standalone Desk navigation on the standalone routes', () => {
+		expect( getDeskMenuRouteTargets( false ) ).toEqual( {
+			userDesk: '/',
+			siteDesk: '/sites/$siteId',
+		} );
+	} );
+
+	it( 'returns to the embedded user Desk route in Studio 2.0', () => {
+		expect( getDeskMenuRouteTargets( true ) ).toEqual( {
+			userDesk: '/desk',
+			siteDesk: '/sites/$siteId',
+		} );
+	} );
+} );

--- a/apps/ui/src/ui-desks/chrome/user-menu/index.tsx
+++ b/apps/ui/src/ui-desks/chrome/user-menu/index.tsx
@@ -17,15 +17,33 @@ const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
 
 interface DeskMenuProps {
 	siteId?: string;
+	embedded?: boolean;
 	disabled?: boolean;
 	showSiteName?: boolean;
+}
+
+interface DeskMenuRouteTargets {
+	userDesk: '/' | '/desk';
+	siteDesk: '/sites/$siteId';
+}
+
+export function getDeskMenuRouteTargets( embedded = false ): DeskMenuRouteTargets {
+	return {
+		userDesk: embedded ? '/desk' : '/',
+		siteDesk: '/sites/$siteId',
+	};
 }
 
 function getSiteIconSeed( site: SiteDetails ) {
 	return `${ site.id }:${ site.name }:${ site.path }`;
 }
 
-export function DeskMenu( { siteId, disabled = false, showSiteName = true }: DeskMenuProps ) {
+export function DeskMenu( {
+	siteId,
+	embedded = false,
+	disabled = false,
+	showSiteName = true,
+}: DeskMenuProps ) {
 	const navigate = useNavigate();
 	const connector = useConnector();
 	const { data: user } = useAuthUser();
@@ -43,13 +61,14 @@ export function DeskMenu( { siteId, disabled = false, showSiteName = true }: Des
 	const switcherSites = activeSite
 		? [ activeSite, ...( sites ?? [] ).filter( ( candidate ) => candidate.id !== activeSite.id ) ]
 		: sites ?? [];
+	const routes = getDeskMenuRouteTargets( embedded );
 
 	const openLink = ( url: string ) => {
 		void connector.openExternalUrl( url );
 	};
 
 	const openUserDashboard = () => {
-		void navigate( { to: '/' } );
+		void navigate( { to: routes.userDesk } );
 	};
 
 	const switchToDefaultUi = () => {
@@ -60,7 +79,7 @@ export function DeskMenu( { siteId, disabled = false, showSiteName = true }: Des
 		if ( nextSiteId === siteId ) {
 			return;
 		}
-		void navigate( { to: '/sites/$siteId', params: { siteId: nextSiteId } } );
+		void navigate( { to: routes.siteDesk, params: { siteId: nextSiteId } } );
 	};
 
 	const trigger = siteId ? (

--- a/apps/ui/src/ui-desks/desk/canvas/index.tsx
+++ b/apps/ui/src/ui-desks/desk/canvas/index.tsx
@@ -87,7 +87,14 @@ export function DeskCanvas() {
 
 			event.preventDefault();
 			event.stopPropagation();
-			setContextMenu( resolveDeskContextMenuState( editor, event.clientX, event.clientY ) );
+			const embeddedRoot = event.currentTarget.closest(
+				'[data-ui-desks-embedded="true"]'
+			) as HTMLElement | null;
+			setContextMenu(
+				resolveDeskContextMenuState( editor, event.clientX, event.clientY, {
+					boundaryRect: embeddedRoot?.getBoundingClientRect(),
+				} )
+			);
 		},
 		[ editor, isReadOnly ]
 	);

--- a/apps/ui/src/ui-desks/desk/canvas/style.module.css
+++ b/apps/ui/src/ui-desks/desk/canvas/style.module.css
@@ -11,6 +11,13 @@
 	min-height: 100vh;
 }
 
+:global([data-ui-desks-embedded='true']) .canvas,
+:global([data-ui-desks-embedded='true']) .loading {
+	width: 100%;
+	height: 100%;
+	min-height: 0;
+}
+
 .statusMessage {
 	position: absolute;
 	inset: 0;

--- a/apps/ui/src/ui-desks/desk/context-menu/index.tsx
+++ b/apps/ui/src/ui-desks/desk/context-menu/index.tsx
@@ -793,7 +793,8 @@ function ContextMenuSeparator() {
 }
 
 function getMenuPosition( state: DeskContextMenuState, menuMode: MenuMode ) {
-	if ( typeof window === 'undefined' ) {
+	const boundary = state.boundary;
+	if ( typeof window === 'undefined' && ! boundary ) {
 		return {
 			left: state.x,
 			top: state.y,
@@ -804,14 +805,13 @@ function getMenuPosition( state: DeskContextMenuState, menuMode: MenuMode ) {
 		menuMode === 'pick-post' || menuMode === 'pick-page' || menuMode === 'pick-site-card'
 			? PICKER_WIDTH
 			: MENU_WIDTH;
+	const maxWidth = boundary?.width ?? window.innerWidth;
+	const maxHeight = boundary?.height ?? window.innerHeight;
 	return {
-		left: Math.max(
-			VIEWPORT_MARGIN,
-			Math.min( state.x, window.innerWidth - width - VIEWPORT_MARGIN )
-		),
+		left: Math.max( VIEWPORT_MARGIN, Math.min( state.x, maxWidth - width - VIEWPORT_MARGIN ) ),
 		top: Math.max(
 			VIEWPORT_MARGIN,
-			Math.min( state.y, window.innerHeight - MENU_MAX_HEIGHT - VIEWPORT_MARGIN )
+			Math.min( state.y, maxHeight - MENU_MAX_HEIGHT - VIEWPORT_MARGIN )
 		),
 	};
 }

--- a/apps/ui/src/ui-desks/desk/context-menu/state/index.test.ts
+++ b/apps/ui/src/ui-desks/desk/context-menu/state/index.test.ts
@@ -64,6 +64,34 @@ describe( 'resolveDeskContextMenuState', () => {
 		expect( state.shapeIds ).toEqual( [ 'shape:b' ] );
 		expect( editor.setSelectedShapes ).toHaveBeenCalledWith( [ 'shape:b' ] );
 	} );
+
+	it( 'keeps page coordinates viewport-based while positioning menus inside an embedded boundary', () => {
+		const editor = createEditorMock( {
+			shapes: [],
+			hitShapeId: null,
+		} );
+
+		const state = resolveDeskContextMenuState( editor, 312, 144, {
+			boundaryRect: {
+				left: 240,
+				top: 40,
+				width: 800,
+				height: 600,
+			},
+		} );
+
+		expect( state ).toMatchObject( {
+			kind: 'empty',
+			pagePoint: { x: 312, y: 144 },
+			x: 72,
+			y: 104,
+			boundary: {
+				width: 800,
+				height: 600,
+			},
+		} );
+		expect( editor.screenToPage ).toHaveBeenCalledWith( { x: 312, y: 144 } );
+	} );
 } );
 
 function createShape( id: string, stackId?: string ) {

--- a/apps/ui/src/ui-desks/desk/context-menu/state/index.ts
+++ b/apps/ui/src/ui-desks/desk/context-menu/state/index.ts
@@ -7,6 +7,10 @@ export interface DeskContextMenuState {
 	kind: DeskContextMenuKind;
 	x: number;
 	y: number;
+	boundary?: {
+		width: number;
+		height: number;
+	};
 	pagePoint: {
 		x: number;
 		y: number;
@@ -26,9 +30,24 @@ export type ContextMenuResolverEditor = Pick<
 export function resolveDeskContextMenuState(
 	editor: ContextMenuResolverEditor,
 	x: number,
-	y: number
+	y: number,
+	options: {
+		boundaryRect?: Pick< DOMRect, 'left' | 'top' | 'width' | 'height' >;
+	} = {}
 ): DeskContextMenuState {
 	const pagePoint = editor.screenToPage( { x, y } );
+	const boundary = options.boundaryRect
+		? {
+				width: options.boundaryRect.width,
+				height: options.boundaryRect.height,
+		  }
+		: undefined;
+	const menuPoint = options.boundaryRect
+		? {
+				x: x - options.boundaryRect.left,
+				y: y - options.boundaryRect.top,
+		  }
+		: { x, y };
 	const shape = editor.getShapeAtPoint( pagePoint, {
 		hitInside: true,
 		renderingOnly: true,
@@ -36,7 +55,7 @@ export function resolveDeskContextMenuState(
 
 	if ( ! shape ) {
 		editor.setSelectedShapes( [] );
-		return { kind: 'empty', shapeIds: [], pagePoint, x, y };
+		return { kind: 'empty', shapeIds: [], pagePoint, x: menuPoint.x, y: menuPoint.y, boundary };
 	}
 
 	const stackId = getStackId( shape );
@@ -46,14 +65,35 @@ export function resolveDeskContextMenuState(
 			.filter( ( member ) => getStackId( member ) === stackId )
 			.map( ( member ) => member.id );
 		editor.setSelectedShapes( memberIds );
-		return { kind: 'multi', shapeIds: memberIds, pagePoint, x, y };
+		return {
+			kind: 'multi',
+			shapeIds: memberIds,
+			pagePoint,
+			x: menuPoint.x,
+			y: menuPoint.y,
+			boundary,
+		};
 	}
 
 	const currentSelection = editor.getSelectedShapeIds();
 	if ( currentSelection.includes( shape.id ) && currentSelection.length > 1 ) {
-		return { kind: 'multi', shapeIds: currentSelection, pagePoint, x, y };
+		return {
+			kind: 'multi',
+			shapeIds: currentSelection,
+			pagePoint,
+			x: menuPoint.x,
+			y: menuPoint.y,
+			boundary,
+		};
 	}
 
 	editor.setSelectedShapes( [ shape.id ] );
-	return { kind: 'single', shapeIds: [ shape.id ], pagePoint, x, y };
+	return {
+		kind: 'single',
+		shapeIds: [ shape.id ],
+		pagePoint,
+		x: menuPoint.x,
+		y: menuPoint.y,
+		boundary,
+	};
 }

--- a/apps/ui/src/ui-desks/desk/context-menu/style.module.css
+++ b/apps/ui/src/ui-desks/desk/context-menu/style.module.css
@@ -13,8 +13,8 @@
 	flex-direction: column;
 	gap: 2px;
 	width: 240px;
-	max-width: calc(100vw - 16px);
-	max-height: min(420px, calc(100vh - 16px));
+	max-width: calc(100% - 16px);
+	max-height: min(420px, calc(100% - 16px));
 	overflow-y: auto;
 	padding: 6px;
 	background: var(--ui-desks-material, #fff);

--- a/apps/ui/src/ui-desks/desk/index.tsx
+++ b/apps/ui/src/ui-desks/desk/index.tsx
@@ -22,21 +22,22 @@ import type { CSSProperties, ReactNode } from 'react';
 
 interface DeskProps {
 	siteId?: string;
+	embedded?: boolean;
 }
 
-export function Desk( { siteId }: DeskProps ) {
+export function Desk( { siteId, embedded = false }: DeskProps ) {
 	if ( siteId ) {
-		return <SiteDesk siteId={ siteId } />;
+		return <SiteDesk siteId={ siteId } embedded={ embedded } />;
 	}
 
-	return <UserDesk />;
+	return <UserDesk embedded={ embedded } />;
 }
 
-function UserDesk() {
+function UserDesk( { embedded = false }: Pick< DeskProps, 'embedded' > ) {
 	return (
 		<ChatsProvider>
 			<DeskProvider key="user">
-				<DeskShell>
+				<DeskShell embedded={ embedded }>
 					<DeskCanvas />
 				</DeskShell>
 			</DeskProvider>
@@ -44,7 +45,10 @@ function UserDesk() {
 	);
 }
 
-function SiteDesk( { siteId }: Required< DeskProps > ) {
+function SiteDesk( {
+	siteId,
+	embedded = false,
+}: Required< Pick< DeskProps, 'siteId' > > & Pick< DeskProps, 'embedded' > ) {
 	const [ siteMapOpen, setSiteMapOpen ] = useState( false );
 	const siteMap = useSiteMapDeskConfig( siteId, siteMapOpen );
 	const providerKey = siteMapOpen ? `${ siteId }:site-map:${ siteMap.signature }` : siteId;
@@ -63,6 +67,7 @@ function SiteDesk( { siteId }: Required< DeskProps > ) {
 			>
 				<DeskShell
 					siteId={ siteId }
+					embedded={ embedded }
 					siteMapOpen={ siteMapOpen }
 					siteMapIsLoading={ siteMapOpen && siteMap.isLoading }
 					siteMapPageCount={ siteMapOpen && ! siteMap.isLoading ? siteMap.pageCount : undefined }
@@ -77,6 +82,7 @@ function SiteDesk( { siteId }: Required< DeskProps > ) {
 
 function DeskShell( {
 	siteId,
+	embedded = false,
 	siteMapOpen,
 	siteMapIsLoading,
 	siteMapPageCount,
@@ -89,6 +95,7 @@ function DeskShell( {
 	onToggleSiteMap?: () => void;
 	children: ReactNode;
 } ) {
+	const [ rootElement, setRootElement ] = useState< HTMLElement | null >( null );
 	const updateDeskSettings = useUpdateDeskSettings();
 	const { data: savedSettings } = useDeskSettings();
 	const fallbackSettings = useMemo( () => createDefaultDeskSettings(), [] );
@@ -110,74 +117,81 @@ function DeskShell( {
 	} as CSSProperties;
 	const [ settingsOpen, setSettingsOpen ] = useState( false );
 	const [ editingToolbar, setEditingToolbar ] = useState( false );
+	const ShellElement = embedded ? 'div' : 'main';
 
 	return (
-		<>
-			<Chats siteId={ siteId } side={ chatSide } panel={ chatPanel } />
-			<main
-				className={ styles.root }
-				aria-label={ getDeskLabel( siteId ) }
-				data-site-id={ siteId }
-				data-toolbar-editing={ editingToolbar ? 'true' : 'false' }
-				style={ rootStyle }
-			>
-				<DeskChrome
-					siteId={ siteId }
-					siteMapOpen={ siteMapOpen }
-					siteMapPageCount={ siteMapPageCount }
-					settingsOpen={ settingsOpen }
-					editingToolbar={ editingToolbar }
-					onToggleSiteMap={ onToggleSiteMap }
-					onToggleSettings={ () => setSettingsOpen( ( open ) => ! open ) }
-				/>
-				{ children }
-				{ siteMapIsLoading && <SiteMapLoadingWidget /> }
-				<DeskWidgetToolbar />
-				<DeskSettingsModal
-					open={ settingsOpen }
-					onOpenChange={ setSettingsOpen }
-					onEditToolbar={ () => setEditingToolbar( true ) }
-				/>
-				{ editingToolbar && (
-					<>
-						<button
+		<ShellElement
+			ref={ setRootElement }
+			className={ styles.root }
+			aria-label={ getDeskLabel( siteId ) }
+			data-ui-desks-root
+			data-ui-desks-embedded={ embedded ? 'true' : undefined }
+			data-site-id={ siteId }
+			data-toolbar-editing={ editingToolbar ? 'true' : 'false' }
+			style={ rootStyle }
+		>
+			<Chats
+				siteId={ siteId }
+				side={ chatSide }
+				panel={ chatPanel }
+				embedded={ embedded }
+				container={ rootElement }
+			/>
+			<DeskChrome
+				siteId={ siteId }
+				embedded={ embedded }
+				siteMapOpen={ siteMapOpen }
+				siteMapPageCount={ siteMapPageCount }
+				settingsOpen={ settingsOpen }
+				editingToolbar={ editingToolbar }
+				onToggleSiteMap={ onToggleSiteMap }
+				onToggleSettings={ () => setSettingsOpen( ( open ) => ! open ) }
+			/>
+			{ children }
+			{ siteMapIsLoading && <SiteMapLoadingWidget /> }
+			<DeskWidgetToolbar />
+			<DeskSettingsModal
+				open={ settingsOpen }
+				onOpenChange={ setSettingsOpen }
+				onEditToolbar={ () => setEditingToolbar( true ) }
+			/>
+			{ editingToolbar && (
+				<>
+					<button
+						type="button"
+						className={ styles.toolbarEditBackdrop }
+						aria-label={ __( 'Exit toolbar editing' ) }
+						onClick={ () => setEditingToolbar( false ) }
+					/>
+					<div className={ styles.toolbarEditActions }>
+						<Button
 							type="button"
-							className={ styles.toolbarEditBackdrop }
-							aria-label={ __( 'Exit toolbar editing' ) }
+							label={ __( 'Done' ) }
+							variant="chrome"
+							size="large"
 							onClick={ () => setEditingToolbar( false ) }
-						/>
-						<div className={ styles.toolbarEditActions }>
-							<Button
-								type="button"
-								label={ __( 'Done' ) }
-								variant="chrome"
-								size="large"
-								onClick={ () => setEditingToolbar( false ) }
-							>
-								{ __( 'Done' ) }
-							</Button>
-							<Button
-								type="button"
-								label={ __( 'Reset' ) }
-								variant="chrome"
-								size="large"
-								onClick={ () =>
-									updateDeskSettings( { toolbarLayout: DEFAULT_DESK_TOOLBAR_LAYOUT } )
-								}
-							>
-								{ __( 'Reset' ) }
-							</Button>
-						</div>
-					</>
-				) }
-			</main>
-		</>
+						>
+							{ __( 'Done' ) }
+						</Button>
+						<Button
+							type="button"
+							label={ __( 'Reset' ) }
+							variant="chrome"
+							size="large"
+							onClick={ () => updateDeskSettings( { toolbarLayout: DEFAULT_DESK_TOOLBAR_LAYOUT } ) }
+						>
+							{ __( 'Reset' ) }
+						</Button>
+					</div>
+				</>
+			) }
+		</ShellElement>
 	);
 }
 
 function SiteMapLoadingWidget() {
 	return (
-		<div className={ styles.siteMapLoadingWidget } aria-live="polite">
+		<div className={ styles.siteMapLoadingWidget } aria-live="polite" data-ui-desks-loading>
 			<LoadingPlaceholder text={ __( 'Loading site map' ) } />
 		</div>
 	);

--- a/apps/ui/src/ui-desks/desk/style.module.css
+++ b/apps/ui/src/ui-desks/desk/style.module.css
@@ -3,6 +3,15 @@
 	background: var(--ui-desks-bg, rgb(232, 234, 235));
 }
 
+.root[data-ui-desks-embedded='true'] {
+	position: relative;
+	height: 100%;
+	min-height: 0;
+	overflow: hidden;
+	isolation: isolate;
+	transform: translateZ(0);
+}
+
 .root[data-toolbar-editing='true'] [data-ui-desks-canvas] {
 	filter: blur(8px) brightness(0.96);
 	transition: filter 220ms ease;
@@ -60,4 +69,16 @@
 	inset: 12px;
 	border: 3px solid #14171a;
 	border-radius: 8px;
+}
+
+.root[data-ui-desks-embedded='true'] .toolbarEditBackdrop {
+	position: fixed;
+}
+
+.root[data-ui-desks-embedded='true'] .toolbarEditActions {
+	top: var(--wpds-dimension-padding-xl);
+}
+
+.root[data-ui-desks-embedded='true'] .siteMapLoadingWidget {
+	position: fixed;
 }

--- a/docs/superpowers/specs/2026-05-26-studio-2-ui-design.md
+++ b/docs/superpowers/specs/2026-05-26-studio-2-ui-design.md
@@ -40,6 +40,8 @@ The app should expose two user-facing UI modes:
 - Default Studio UI
 - Studio 2.0
 
+Both settings surfaces need an escape path. The existing default Studio Settings modal should offer **Studio 2.0**. The Studio 2.0 settings route should offer a way to return to **Default Studio UI**. This prevents logged-out users from getting trapped in Studio 2.0.
+
 The persisted Studio 2.0 mode should use a stable internal key, recommended: `studio2`.
 
 Legacy stored values should be treated as compatibility aliases:
@@ -77,6 +79,7 @@ Primary files expected to change:
 - `apps/studio/src/modules/desks/lib/ipc-handlers.ts`: normalize mode reads and writes, including legacy values.
 - `apps/studio/src/modules/user-settings/components/preferences-tab.tsx`: show Studio 2.0 as the single next-generation option instead of separate Desks and Agentic buttons.
 - `apps/ui/src/app/use-ui-mode.ts`: map `studio2`, `agentic`, and `desks` launch params to the Agentic shell mode.
+- `apps/ui/src/components/settings-view/index.tsx`: add a Studio UI setting that can switch Studio 2.0 back to Default Studio UI.
 - `apps/ui/src/components/sidebar-nav/index.tsx`: add the Desk sidebar item.
 - `apps/ui/src/ui-classic/router/router.tsx`: register the new Desk route.
 - `apps/ui/src/ui-classic/router/route-desk/index.tsx`: render the embedded global Desk.
@@ -136,6 +139,7 @@ Manual verification:
 - Launch with `ENABLE_DESKS_UI_SWITCH=true`
 - Confirm Settings shows Studio 2.0, not separate Agentic UI and Desks UI choices
 - Switch to Studio 2.0
+- From Studio 2.0 Settings, switch back to Default Studio UI while logged out
 - Click Desk in the sidebar
 - Confirm the full Desk toolbar and Desk chat panel remain available
 - Restart the app and confirm Studio 2.0 is restored

--- a/docs/superpowers/specs/2026-05-26-studio-2-ui-design.md
+++ b/docs/superpowers/specs/2026-05-26-studio-2-ui-design.md
@@ -1,0 +1,158 @@
+# Studio 2.0 UI Design Spec
+
+## Goal
+
+Create a new branch that turns the current Agentic UI into **Studio 2.0** by adding the global Desks experience as a sidebar destination. Studio 2.0 replaces the separate user-facing Agentic UI and Desks UI mode options.
+
+## Product Direction
+
+Studio 2.0 is not a third independent shell. It is the current Agentic UI, renamed, with Desk added as a first-class view.
+
+The default Studio UI remains available as the stable/current experience. Studio 2.0 becomes the single experimental next-generation experience. Users should no longer see separate **Agentic UI** and **Desks UI** choices in Settings or switcher menus.
+
+## User Experience
+
+When Studio 2.0 is active, the existing Agentic sidebar remains the primary navigation surface. The sidebar should include:
+
+- Chat
+- Desk
+- Settings
+- Skills
+
+Clicking **Desk** opens the global user desk by default. It does not infer a site-specific desk from the current session or selected site.
+
+The Desk view replaces only the right-side content area of the Agentic shell. The Agentic sidebar remains visible and usable. The embedded Desk keeps the full Desks experience:
+
+- Desk toolbar
+- Desk create menu
+- Desk settings
+- Desk canvas
+- Desk widget toolbar
+- Desk chat panel
+- User desk persistence
+
+The standalone Desks UI can remain in code as reusable internals, but it should no longer be exposed as a top-level user-facing mode.
+
+## Mode Model
+
+The app should expose two user-facing UI modes:
+
+- Default Studio UI
+- Studio 2.0
+
+The persisted Studio 2.0 mode should use a stable internal key, recommended: `studio2`.
+
+Legacy stored values should be treated as compatibility aliases:
+
+- `agentic` resolves to `studio2`
+- `desks` resolves to `studio2`
+- `studio2` resolves to `studio2`
+- `default` resolves to `default`
+- invalid or missing values resolve to `default`
+
+New writes should persist only normalized values. If a user selects Studio 2.0, config should store `desks.defaultUiMode: "studio2"`, not `agentic` or `desks`.
+
+Renderer launch URLs should use `studio-ui-mode=studio2` for Studio 2.0. Legacy query values `agentic` and `desks` should still launch the Studio 2.0 shell for compatibility.
+
+## Architecture
+
+Studio 2.0 should reuse the current Agentic shell by rendering `ClassicUiApp`. The existing `ClassicUiApp` router already owns the Agentic sidebar layout and right-side content area, so the Desk integration should be route-based inside that router.
+
+Add a new route under the existing dashboard layout:
+
+- Path: `/desk`
+- Parent: `dashboardLayoutRoute`
+- Component: a small wrapper that renders the global Desks `<Desk />` without a `siteId`
+
+This route should inherit `SidebarLayout`, so the Desk surface appears in the Agentic right-side panel while the sidebar remains visible.
+
+The route should import the reusable Desks `Desk` component from `apps/ui/src/ui-desks/desk`. It should not mount `DesksUiApp`, because that would create a second top-level router and app shell inside the Agentic shell.
+
+## Component Boundaries
+
+Primary files expected to change:
+
+- `tools/common/types/desk.ts`: add the normalized `studio2` mode while preserving legacy type handling where needed.
+- `apps/studio/src/main-window.ts`: normalize stored UI mode and load the Studio 2.0 renderer path/query.
+- `apps/studio/src/modules/desks/lib/ipc-handlers.ts`: normalize mode reads and writes, including legacy values.
+- `apps/studio/src/modules/user-settings/components/preferences-tab.tsx`: show Studio 2.0 as the single next-generation option instead of separate Desks and Agentic buttons.
+- `apps/ui/src/app/use-ui-mode.ts`: map `studio2`, `agentic`, and `desks` launch params to the Agentic shell mode.
+- `apps/ui/src/components/sidebar-nav/index.tsx`: add the Desk sidebar item.
+- `apps/ui/src/ui-classic/router/router.tsx`: register the new Desk route.
+- `apps/ui/src/ui-classic/router/route-desk/index.tsx`: render the embedded global Desk.
+
+Tests should live near the affected code, following the repo's current patterns.
+
+## Data Flow
+
+Settings calls `setStudioUiMode( "studio2" )`. The main process validates and normalizes the value, persists it under `userData.desks.defaultUiMode`, and reloads the renderer.
+
+At app launch, the main process reads `userData.desks.defaultUiMode`, normalizes it, and selects the renderer:
+
+- `default`: existing default renderer
+- `studio2`, `agentic`, or `desks`: Desks renderer bundle with `studio-ui-mode=studio2`
+
+Inside the Desks renderer bundle, `useUiMode()` treats `studio2`, `agentic`, and `desks` as the Agentic shell. The `/desk` route is then responsible for embedding the global Desk within that shell.
+
+## Error Handling
+
+Invalid mode values should never break startup. They should fall back to `default`.
+
+Legacy values should not be destructive. Reading `agentic` or `desks` should launch Studio 2.0 even before the next settings write normalizes the stored value.
+
+The embedded Desk route should use the existing global Desk behavior. If Desk data is still loading, existing Desks loading and placeholder states should render unchanged.
+
+## Accessibility And Interaction
+
+The Desk sidebar item should behave like the existing Chat and Settings items:
+
+- Uses the existing `SidebarButton` pattern
+- Has an icon and localized label
+- Supports active route styling
+- Works with keyboard navigation through the existing link/button semantics
+
+The embedded Desk should keep its existing accessible labels, toolbar controls, and modal behavior. The integration should not add a second app-level sidebar inside the Desk content.
+
+## Testing Plan
+
+Add or update unit tests for mode normalization:
+
+- `default` stays `default`
+- `studio2` stays `studio2`
+- stored `agentic` resolves to `studio2`
+- stored `desks` resolves to `studio2`
+- invalid values fall back to `default`
+- `setStudioUiMode( "studio2" )` persists `studio2`
+
+Add UI/router coverage for the Agentic shell:
+
+- Sidebar includes Chat, Desk, Settings, and Skills
+- Clicking Desk navigates to `/desk`
+- `/desk` renders the global Desk surface
+- The sidebar remains visible while Desk is shown
+
+Manual verification:
+
+- Launch with `ENABLE_DESKS_UI_SWITCH=true`
+- Confirm Settings shows Studio 2.0, not separate Agentic UI and Desks UI choices
+- Switch to Studio 2.0
+- Click Desk in the sidebar
+- Confirm the full Desk toolbar and Desk chat panel remain available
+- Restart the app and confirm Studio 2.0 is restored
+- Force stored config values `agentic` and `desks`, then confirm both open Studio 2.0
+
+## Out Of Scope
+
+This branch should not:
+
+- Merge all Desks routes into the Agentic router
+- Add site-specific Desk routing from the sidebar item
+- Remove the standalone Desks code paths if they are still needed as reusable internals
+- Redesign Desk chrome or Agentic chrome beyond the new sidebar item and mode labels
+- Change Desk widget behavior, site map behavior, or Desk chat behavior
+
+## Open Risks
+
+The main risk is duplicated chat surfaces: Agentic already has chat-oriented navigation, and the embedded Desk keeps its own Desk chat panel. This is intentional for this branch because the requirement is to keep the full Desks experience. If it proves noisy in practice, it should be evaluated in a follow-up branch rather than folded into this initial integration.
+
+The second risk is route/search interaction. The Desks chat provider uses route search params for chat state. The new `/desk` route should preserve those search params through the existing packaged router history. Tests should cover navigation enough to catch obvious regressions.

--- a/tools/common/lib/studio-ui-mode.ts
+++ b/tools/common/lib/studio-ui-mode.ts
@@ -1,0 +1,23 @@
+import type { StoredStudioUiMode, StudioUiMode } from '../types/desk';
+
+export const STUDIO_UI_MODE_DEFAULT: StudioUiMode = 'default';
+export const STUDIO_UI_MODE_STUDIO2: StudioUiMode = 'studio2';
+
+const SUPPORTED_STUDIO_UI_MODES = new Set< StoredStudioUiMode >( [
+	'default',
+	'studio2',
+	'agentic',
+	'desks',
+] );
+
+export function normalizeStudioUiMode( mode: unknown ): StudioUiMode {
+	return mode === 'studio2' || mode === 'agentic' || mode === 'desks'
+		? STUDIO_UI_MODE_STUDIO2
+		: STUDIO_UI_MODE_DEFAULT;
+}
+
+export function assertSupportedStudioUiMode( mode: unknown ): asserts mode is StoredStudioUiMode {
+	if ( ! SUPPORTED_STUDIO_UI_MODES.has( mode as StoredStudioUiMode ) ) {
+		throw new Error( 'Invalid Studio UI mode.' );
+	}
+}

--- a/tools/common/lib/tests/studio-ui-mode.test.ts
+++ b/tools/common/lib/tests/studio-ui-mode.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+	assertSupportedStudioUiMode,
+	normalizeStudioUiMode,
+	STUDIO_UI_MODE_DEFAULT,
+	STUDIO_UI_MODE_STUDIO2,
+} from '../studio-ui-mode';
+
+describe( 'normalizeStudioUiMode', () => {
+	it.each( [
+		[ 'default', STUDIO_UI_MODE_DEFAULT ],
+		[ 'studio2', STUDIO_UI_MODE_STUDIO2 ],
+		[ 'agentic', STUDIO_UI_MODE_STUDIO2 ],
+		[ 'desks', STUDIO_UI_MODE_STUDIO2 ],
+		[ 'bogus', STUDIO_UI_MODE_DEFAULT ],
+		[ undefined, STUDIO_UI_MODE_DEFAULT ],
+		[ null, STUDIO_UI_MODE_DEFAULT ],
+	] )( 'normalizes %s to %s', ( input, expected ) => {
+		expect( normalizeStudioUiMode( input ) ).toBe( expected );
+	} );
+} );
+
+describe( 'assertSupportedStudioUiMode', () => {
+	it.each( [ 'default', 'studio2', 'agentic', 'desks' ] )( 'accepts %s', ( input ) => {
+		expect( () => assertSupportedStudioUiMode( input ) ).not.toThrow();
+	} );
+
+	it( 'rejects unknown modes', () => {
+		expect( () => assertSupportedStudioUiMode( 'bogus' ) ).toThrow( 'Invalid Studio UI mode.' );
+	} );
+} );

--- a/tools/common/types/desk.ts
+++ b/tools/common/types/desk.ts
@@ -1,7 +1,9 @@
 export const DESK_CONFIG_VERSION = 1;
 export const DESK_SETTINGS_VERSION = 1;
 
-export type StudioUiMode = 'default' | 'desks' | 'agentic';
+export type StudioUiMode = 'default' | 'studio2';
+export type LegacyStudioUiMode = 'desks' | 'agentic';
+export type StoredStudioUiMode = StudioUiMode | LegacyStudioUiMode;
 
 export interface DeskToolbarLayout {
 	left: string[];
@@ -77,7 +79,7 @@ export interface DeskConfig< TWidget extends DeskWidgetBase = DeskWidgetBase > {
 }
 
 export interface DesksConfig {
-	defaultUiMode?: StudioUiMode;
+	defaultUiMode?: StoredStudioUiMode;
 	settings?: DeskSettings;
 	user?: DeskConfig;
 	sites?: Record< string, DeskConfig >;


### PR DESCRIPTION

<img width="1106" height="779" alt="image" src="https://github.com/user-attachments/assets/30e61648-db99-431e-a1a4-d40dc15c9fb6" />

<img width="1106" height="779" alt="image" src="https://github.com/user-attachments/assets/0fa10549-29f3-4ae5-a68f-1057d347d342" />

This intentionally combines the two new UI experiments: Agentic UI and Desks. The result is useful as a prototype, but it does not fully resolve many side effects.

The awkward part is that Agentic UI and Desks each currently have their own ideas about conversations and site selection. We may want to reduce Desks into a more focused visual layer, perhaps renamed **Canvas**, and let the Agentic UI own conversations, session history, and app navigation. Another direction to explore is whether each site in the sidebar should have its own Desk/Canvas.

## Testing Instructions

- Set `ENABLE_DESKS_UI_SWITCH=true`.
- Open default Studio Settings and verify it shows **Switch to Studio 2.0**, not separate Agentic UI and Desks UI choices.
- Switch to Studio 2.0 and verify the Agentic shell opens.
- Confirm the sidebar includes **Desk**.
- Open **Desk** and verify the global Desk is embedded in the right pane while the Agentic sidebar remains visible.
- From the Desk menu, switch between sites and verify the app stays in the Studio 2.0 shell.
- From Studio 2.0 Settings, switch back to Default Studio UI while logged out.
