### PR TITLE
Refocus PR template on intent and user impact

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Help reviewers understand what to look for and verify that you've reviewed the c
 
 
 
-## Description
+## Proposed Changes
 
 <!--
 Explain the intent of this PR:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,16 @@ Help reviewers understand what to look for and verify that you've reviewed the c
 
 
 
-## Proposed Changes
+## Description
+
+<!--
+Explain the intent of this PR:
+- What problem does it solve, or what need does it address?
+- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
+- Note any user-visible behavior changes or trade-offs.
+
+Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
+-->
 
 -
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ WordPress Studio - Electron desktop app for managing local WordPress sites. Buil
 
 **Branches**: Create from `trunk` using dash-separated lowercase names. Include a verb for clarity. Examples: `new-dark-mode`, `improve-agent-instructions`, `fix-login-bug`, `add-logout-button`. For Linear issues: `stu-123-update-sync-feature`.
 **Commits**: Single-line messages. Clear and descriptive. Focus on "what" and "why", not "how"
-**PRs**: Create PR against `trunk` branch. Use the template from `.github/PULL_REQUEST_TEMPLATE.md` (include Related issues, How AI was used in this PR, Description, Testing Instructions, Pre-merge Checklist). In **Description**, focus on the intent of the change and the user impact (the "why" and how the user experiences it) — do not list modified files or describe implementation mechanics; the diff already shows that. MUST pass all CI checks before merge.
+**PRs**: Create PR against `trunk` branch. Use the template from `.github/PULL_REQUEST_TEMPLATE.md` (include Related issues, How AI was used in this PR, Proposed Changes, Testing Instructions, Pre-merge Checklist). In **Proposed Changes**, focus on the intent of the change and the user impact (the "why" and how the user experiences it) — do not list modified files or describe implementation mechanics; the diff already shows that. MUST pass all CI checks before merge.
 **IMPORTANT**: Prefer merging `trunk` into your branch over rebasing. Avoid force pushes to trunk/main branches. Avoid force pushes to already-pushed branches - add new commits instead.
 
 ## Large & Exploratory Contributions (Vibe-Coded Features)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ WordPress Studio - Electron desktop app for managing local WordPress sites. Buil
 
 **Branches**: Create from `trunk` using dash-separated lowercase names. Include a verb for clarity. Examples: `new-dark-mode`, `improve-agent-instructions`, `fix-login-bug`, `add-logout-button`. For Linear issues: `stu-123-update-sync-feature`.
 **Commits**: Single-line messages. Clear and descriptive. Focus on "what" and "why", not "how"
-**PRs**: Create PR against `trunk` branch. Use the template from `.github/PULL_REQUEST_TEMPLATE.md` (include Related issues, Proposed Changes, Testing Instructions, Pre-merge Checklist). MUST pass all CI checks before merge.
+**PRs**: Create PR against `trunk` branch. Use the template from `.github/PULL_REQUEST_TEMPLATE.md` (include Related issues, How AI was used in this PR, Description, Testing Instructions, Pre-merge Checklist). In **Description**, focus on the intent of the change and the user impact (the "why" and how the user experiences it) — do not list modified files or describe implementation mechanics; the diff already shows that. MUST pass all CI checks before merge.
 **IMPORTANT**: Prefer merging `trunk` into your branch over rebasing. Avoid force pushes to trunk/main branches. Avoid force pushes to already-pushed branches - add new commits instead.
 
 ## Large & Exploratory Contributions (Vibe-Coded Features)


### PR DESCRIPTION
## Related issues

N/A

## How AI was used in this PR

Claude Code (Opus 4.7) drafted the PR template guidance comment and the AGENTS.md update.

## Proposed Changes

- Add a guidance comment under **Proposed Changes** in `.github/PULL_REQUEST_TEMPLATE.md` so authors describe the intent of the PR and the user impact (the "why" and how the user experiences it) instead of listing modified files or implementation mechanics.
- Update `AGENTS.md` so the Git & PR Conventions section lists the current template sections (including **How AI was used in this PR**) and reinforces the intent-focused description rule for AI contributors.

## Testing Instructions

- Open a new PR against this repo and confirm GitHub renders the **Proposed Changes** section with the new guidance comment.
- Re-read `AGENTS.md` "Git & PR Conventions" and confirm it now references the updated template sections and the intent-focused rule.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)
