### PR TITLE
Pin @wordpress/icons to 13.1.0 to fix npm run make

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -88,7 +88,7 @@
 		"@wordpress/compose": "^7.36.0",
 		"@wordpress/dataviews": "^14.2.0",
 		"@wordpress/element": "^6.39.0",
-		"@wordpress/icons": "^13.0.0",
+		"@wordpress/icons": "13.1.0",
 		"@wordpress/react-i18n": "^4.45.0",
 		"@wp-playground/blueprints": "3.1.34",
 		"cli-table3": "^0.6.5",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -24,7 +24,7 @@
 		"@wordpress/dataviews": "^14.2.0",
 		"@wordpress/html-entities": "^4.45.0",
 		"@wordpress/i18n": "^6.18.0",
-		"@wordpress/icons": "^13.0.0",
+		"@wordpress/icons": "13.1.0",
 		"@wordpress/private-apis": "^1.10.0",
 		"@wordpress/react-i18n": "^4.45.0",
 		"@wordpress/rich-text": "7.45.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1234,7 +1234,7 @@
 				"@wordpress/dataviews": "^14.2.0",
 				"@wordpress/html-entities": "^4.45.0",
 				"@wordpress/i18n": "^6.18.0",
-				"@wordpress/icons": "^13.0.0",
+				"@wordpress/icons": "13.1.0",
 				"@wordpress/private-apis": "^1.10.0",
 				"@wordpress/react-i18n": "^4.45.0",
 				"@wordpress/rich-text": "7.45.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -605,7 +605,7 @@
 				"@wordpress/compose": "^7.36.0",
 				"@wordpress/dataviews": "^14.2.0",
 				"@wordpress/element": "^6.39.0",
-				"@wordpress/icons": "^13.0.0",
+				"@wordpress/icons": "13.1.0",
 				"@wordpress/react-i18n": "^4.45.0",
 				"@wp-playground/blueprints": "3.1.34",
 				"cli-table3": "^0.6.5",


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code identified the dependency conflict and applied the fix.

## Proposed Changes

I propose to pin `@wordpress/icons` to `13.1.0` (exact version, no `^`) in `apps/studio/package.json`.

`@wordpress/icons@13.2.0` was recently published and bumped its peer dependency to `react@^19.2.4`. Studio is on React 18, so `npm run make` (which runs `install:bundle` in a clean temp directory) fails with an `ERESOLVE` error when npm resolves `^13.0.0` to `13.2.0`.

We have another PR that bumps React to 19, but it still requires a bunch of work.

## Testing Instructions

- Delete `node_modules`, run `npm install`, then `npm run make` - should complete without the `ERESOLVE` peer dependency error.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?