### PR TITLE
Use next minor version for trunk dev builds (x.(y+1).0-devN)

### DIFF
--- a/scripts/prepare-dev-build-version.mjs
+++ b/scripts/prepare-dev-build-version.mjs
@@ -24,8 +24,9 @@ if ( ! parsedVersion ) {
 	throw new Error( `Invalid version in latestTag: ${ latestTag }` );
 }
 
-// Create dev version using just the core version numbers (major.minor.patch)
-const devVersion = `${ parsedVersion.major }.${ parsedVersion.minor }.${ parsedVersion.patch }-dev${ commitCount }`;
+// Create dev version targeting the next minor release (major.minor+1.0-devN),
+// so trunk builds sort above any stable or beta of the last release.
+const devVersion = `${ parsedVersion.major }.${ parsedVersion.minor + 1 }.0-dev${ commitCount }`;
 
 packageJson.version = devVersion;
 


### PR DESCRIPTION
## Related issues

- STU-1759

## How AI was used in this PR

Claude made the one-line change to `scripts/prepare-dev-build-version.mjs`.

## Proposed Changes

- Trunk dev builds were previously versioned as `x.y.z-devN` (e.g. `1.9.0-dev5`), which sorts *below* any `1.10.0-betaN` or the last stable release by semver.
- Now dev builds are versioned as `x.(y+1).0-devN` (e.g. `1.10.0-dev5`), which is unambiguously newer than any `1.9.x` stable or `1.9.x-beta`, and also newer than `1.10.0-betaN` (semver pre-release sorts before the release).

## Testing Instructions

- Run `GITHUB_SHA=abc123 node ./scripts/prepare-dev-build-version.mjs` (with a real tag in the repo) and verify `apps/studio/package.json` shows the bumped minor version with a `-devN` suffix.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?