### PR TITLE
fix: Studio Code Stop button stranding CLI subprocess via IPC interrupt

### DIFF
--- a/apps/studio/src/components/tests/content-tab-assistant.test.tsx
+++ b/apps/studio/src/components/tests/content-tab-assistant.test.tsx
@@ -13,6 +13,7 @@ import {
 	MIMIC_CONVERSATION_DELAY,
 } from 'src/components/content-tab-assistant';
 import { LOCAL_STORAGE_CHAT_MESSAGES_KEY, CLEAR_HISTORY_REMINDER_TIME } from 'src/constants';
+import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useGetWpVersion } from 'src/hooks/use-get-wp-version';
 import { useOffline } from 'src/hooks/use-offline';
 import { ThemeDetailsProvider } from 'src/hooks/use-theme-details';
@@ -28,6 +29,13 @@ store.replaceReducer( testReducer );
 vi.mock( 'src/hooks/use-offline' );
 vi.mock( 'src/lib/get-ipc-api' );
 vi.mock( 'src/hooks/use-get-wp-version' );
+vi.mock( 'src/hooks/use-feature-flags' );
+
+// Lightweight marker so the gating tests can detect which branch rendered
+// without pulling in the full Studio Code chat tree.
+vi.mock( 'src/components/studio-code-chat', () => ( {
+	StudioCodeChat: () => <div data-testid="studio-code-chat-marker" />,
+} ) );
 
 vi.mock( 'src/lib/app-globals', () => ( {
 	getAppGlobals: () => ( {
@@ -168,6 +176,10 @@ describe( 'ContentTabAssistant', () => {
 		store.dispatch( chatActions.setMessages( { instanceId: runningSite.id, messages: [] } ) );
 
 		vi.mocked( useOffline ).mockReturnValue( false );
+		// Default to the legacy assistant; gating tests opt into Studio Code UI.
+		vi.mocked( useFeatureFlags, { partial: true } ).mockReturnValue( {
+			enableStudioCodeUi: false,
+		} );
 		vi.mocked( useGetWelcomeMessages, { partial: true } ).mockReturnValue( {
 			data: {
 				messages: [ 'Welcome to our service!', 'How can I help you today?' ],
@@ -496,5 +508,25 @@ describe( 'ContentTabAssistant', () => {
 		// Changing to the second site should restore the input
 		rerender( buildContextTree( { selectedSite: anotherSite } ) );
 		expect( getInput() ).toHaveValue( 'Another message' );
+	} );
+
+	describe( 'feature-flag gating', () => {
+		it( 'renders Studio Code chat when enableStudioCodeUi is true', () => {
+			vi.mocked( useFeatureFlags, { partial: true } ).mockReturnValue( {
+				enableStudioCodeUi: true,
+			} );
+
+			renderWithContext();
+
+			expect( screen.getByTestId( 'studio-code-chat-marker' ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( 'ai-input-textarea' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'renders the legacy WPCOM assistant when enableStudioCodeUi is false', () => {
+			renderWithContext();
+
+			expect( screen.queryByTestId( 'studio-code-chat-marker' ) ).not.toBeInTheDocument();
+			expect( getInput() ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/apps/studio/src/components/tests/studio-code-chat.test.tsx
+++ b/apps/studio/src/components/tests/studio-code-chat.test.tsx
@@ -1,0 +1,240 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StudioCodeChat } from 'src/components/studio-code-chat';
+import { useAuth } from 'src/hooks/use-auth';
+import { useOffline } from 'src/hooks/use-offline';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import type { IpcRendererEvent } from 'electron';
+import type { StudioCodeEvent } from 'src/modules/studio-code/studio-code-event-types';
+
+vi.mock( 'src/hooks/use-auth' );
+vi.mock( 'src/hooks/use-offline' );
+vi.mock( 'src/lib/get-ipc-api' );
+
+// Keep the message renderer trivial so the test asserts conversation flow
+// (driven by the real reducer + event parser) rather than markdown output.
+vi.mock( 'src/components/studio-code-message', () => ( {
+	StudioCodeMessage: ( {
+		message,
+	}: {
+		message: { role: string; content: string; toolCalls: { name: string; status: string }[] };
+	} ) => (
+		<div data-testid={ `message-${ message.role }` }>
+			<span>{ message.content }</span>
+			{ message.toolCalls.map( ( tc, i ) => (
+				<span key={ i } data-testid="tool-call">
+					{ tc.name }:{ tc.status }
+				</span>
+			) ) }
+		</div>
+	),
+} ) );
+
+// Minimal AIInput so we can drive input + send/clear deterministically.
+vi.mock( 'src/components/ai-input', () => ( {
+	AIInput: ( {
+		input,
+		setInput,
+		handleSend,
+		clearConversation,
+		disabled,
+	}: {
+		input: string;
+		setInput: ( v: string ) => void;
+		handleSend: () => void;
+		clearConversation: () => void;
+		disabled: boolean;
+	} ) => (
+		<div>
+			<textarea
+				data-testid="ai-input"
+				value={ input }
+				disabled={ disabled }
+				onChange={ ( e ) => setInput( e.target.value ) }
+			/>
+			<button data-testid="send" onClick={ handleSend }>
+				send
+			</button>
+			<button data-testid="clear" onClick={ clearConversation }>
+				clear
+			</button>
+		</div>
+	),
+} ) );
+
+const mockStudioCodeSendMessage = vi.fn();
+const mockStudioCodeRespondToPermission = vi.fn();
+const mockAuthenticate = vi.fn();
+
+const selectedSite = {
+	id: 'site-1',
+	name: 'One',
+	path: '/sites/one',
+} as unknown as SiteDetails;
+
+// Capture the renderer-side listener registered via useIpcListener.
+let capturedListener:
+	| ( ( event: IpcRendererEvent, data: { siteId: string; event: StudioCodeEvent } ) => void )
+	| null = null;
+
+function emit( event: StudioCodeEvent, siteId = selectedSite.id ) {
+	act( () => {
+		capturedListener?.( {} as IpcRendererEvent, { siteId, event } );
+	} );
+}
+
+beforeEach( () => {
+	vi.clearAllMocks();
+	localStorage.clear();
+	capturedListener = null;
+	window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+	window.ipcListener = {
+		subscribe: vi.fn( ( channel: string, listener: unknown ) => {
+			if ( channel === 'studio-code-event' ) {
+				capturedListener = listener as typeof capturedListener;
+			}
+			return () => undefined;
+		} ),
+	} as never;
+
+	vi.mocked( useOffline ).mockReturnValue( false );
+	vi.mocked( useAuth, { partial: true } ).mockReturnValue( {
+		isAuthenticated: true,
+		authenticate: mockAuthenticate,
+	} );
+	vi.mocked( getIpcApi ).mockReturnValue( {
+		studioCodeSendMessage: mockStudioCodeSendMessage,
+		studioCodeRespondToPermission: mockStudioCodeRespondToPermission,
+		authenticate: mockAuthenticate,
+	} as never );
+} );
+
+afterEach( () => {
+	localStorage.clear();
+} );
+
+describe( 'StudioCodeChat', () => {
+	it( 'sends a typed message through the IPC bridge and renders it', () => {
+		render( <StudioCodeChat selectedSite={ selectedSite } /> );
+
+		fireEvent.change( screen.getByTestId( 'ai-input' ), {
+			target: { value: 'build me a plugin' },
+		} );
+		fireEvent.click( screen.getByTestId( 'send' ) );
+
+		expect( mockStudioCodeSendMessage ).toHaveBeenCalledWith(
+			'site-1',
+			'/sites/one',
+			'One',
+			'build me a plugin'
+		);
+		expect( screen.getByTestId( 'message-user' ) ).toHaveTextContent( 'build me a plugin' );
+	} );
+
+	it( 'does not send empty input', () => {
+		render( <StudioCodeChat selectedSite={ selectedSite } /> );
+		fireEvent.click( screen.getByTestId( 'send' ) );
+		expect( mockStudioCodeSendMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders streamed assistant text and tool calls from CLI events', () => {
+		render( <StudioCodeChat selectedSite={ selectedSite } /> );
+
+		emit( { type: 'turn.started', timestamp: 't' } );
+		emit( {
+			type: 'message',
+			timestamp: 't',
+			message: {
+				type: 'message_end',
+				message: {
+					role: 'assistant',
+					content: [
+						{ type: 'text', text: 'Working on it' },
+						{ type: 'toolCall', id: 'c1', name: 'Read', arguments: {} },
+					],
+				},
+			},
+		} as never );
+
+		const assistant = screen.getByTestId( 'message-assistant' );
+		expect( assistant ).toHaveTextContent( 'Working on it' );
+		expect( screen.getByTestId( 'tool-call' ) ).toHaveTextContent( 'Read:running' );
+
+		emit( {
+			type: 'message',
+			timestamp: 't',
+			message: {
+				type: 'turn_end',
+				toolResults: [
+					{
+						role: 'toolResult',
+						toolCallId: 'c1',
+						content: [ { type: 'text', text: 'ok' } ],
+						isError: false,
+					},
+				],
+			},
+		} as never );
+		expect( screen.getByTestId( 'tool-call' ) ).toHaveTextContent( 'Read:completed' );
+	} );
+
+	it( 'shows a permission prompt and answers it over IPC', () => {
+		render( <StudioCodeChat selectedSite={ selectedSite } /> );
+
+		// Establish lastUserMessage so the resume carries it.
+		fireEvent.change( screen.getByTestId( 'ai-input' ), { target: { value: 'do a thing' } } );
+		fireEvent.click( screen.getByTestId( 'send' ) );
+
+		emit( {
+			type: 'question.asked',
+			timestamp: 't',
+			questions: [
+				{
+					question: 'Allow file write?',
+					options: [
+						{ label: 'Allow', description: '' },
+						{ label: 'Deny', description: '' },
+					],
+				},
+			],
+		} );
+
+		expect( screen.getByText( 'Permission Required' ) ).toBeInTheDocument();
+		fireEvent.click( screen.getByRole( 'button', { name: 'Allow' } ) );
+
+		expect( mockStudioCodeRespondToPermission ).toHaveBeenCalledWith(
+			'site-1',
+			'/sites/one',
+			'One',
+			'do a thing',
+			{ 'Allow file write?': 'Allow' }
+		);
+		// Dialog dismissed after answering.
+		expect( screen.queryByText( 'Permission Required' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'clears the conversation', () => {
+		render( <StudioCodeChat selectedSite={ selectedSite } /> );
+		fireEvent.change( screen.getByTestId( 'ai-input' ), { target: { value: 'hi' } } );
+		fireEvent.click( screen.getByTestId( 'send' ) );
+		expect( screen.getByTestId( 'message-user' ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByTestId( 'clear' ) );
+		expect( screen.queryByTestId( 'message-user' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the login gate and disables input when unauthenticated', () => {
+		vi.mocked( useAuth, { partial: true } ).mockReturnValue( {
+			isAuthenticated: false,
+			authenticate: mockAuthenticate,
+		} );
+
+		render( <StudioCodeChat selectedSite={ selectedSite } /> );
+
+		expect(
+			screen.getByText( 'You need to log in to your WordPress.com account to use Studio Code.' )
+		).toBeInTheDocument();
+		expect( screen.getByTestId( 'ai-input' ) ).toBeDisabled();
+	} );
+} );

--- a/apps/studio/src/lib/tests/feature-flags.test.ts
+++ b/apps/studio/src/lib/tests/feature-flags.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	buildFeatureFlags,
+	getFeatureFlagFromEnv,
+	setFeatureFlagInEnv,
+} from 'src/lib/feature-flags';
+
+const ENV_VAR = 'ENABLE_STUDIO_CODE_UI';
+
+describe( 'feature-flags', () => {
+	beforeEach( () => {
+		delete process.env[ ENV_VAR ];
+	} );
+
+	afterEach( () => {
+		delete process.env[ ENV_VAR ];
+	} );
+
+	describe( 'getFeatureFlagFromEnv', () => {
+		it( 'returns the default (false) when the env var is unset', () => {
+			expect( getFeatureFlagFromEnv( 'enableStudioCodeUi' ) ).toBe( false );
+		} );
+
+		it( 'returns true only for the exact string "true"', () => {
+			process.env[ ENV_VAR ] = 'true';
+			expect( getFeatureFlagFromEnv( 'enableStudioCodeUi' ) ).toBe( true );
+
+			process.env[ ENV_VAR ] = 'false';
+			expect( getFeatureFlagFromEnv( 'enableStudioCodeUi' ) ).toBe( false );
+
+			process.env[ ENV_VAR ] = '1';
+			expect( getFeatureFlagFromEnv( 'enableStudioCodeUi' ) ).toBe( false );
+		} );
+
+		it( 'returns false for an unknown flag', () => {
+			expect( getFeatureFlagFromEnv( 'nope' as never ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'setFeatureFlagInEnv', () => {
+		it( 'writes the env var so getFeatureFlagFromEnv reflects it', () => {
+			setFeatureFlagInEnv( 'enableStudioCodeUi', true );
+			expect( process.env[ ENV_VAR ] ).toBe( 'true' );
+			expect( getFeatureFlagFromEnv( 'enableStudioCodeUi' ) ).toBe( true );
+
+			setFeatureFlagInEnv( 'enableStudioCodeUi', false );
+			expect( process.env[ ENV_VAR ] ).toBe( 'false' );
+			expect( getFeatureFlagFromEnv( 'enableStudioCodeUi' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'buildFeatureFlags', () => {
+		it( 'includes enableStudioCodeUi resolved from the environment', () => {
+			expect( buildFeatureFlags().enableStudioCodeUi ).toBe( false );
+
+			setFeatureFlagInEnv( 'enableStudioCodeUi', true );
+			expect( buildFeatureFlags().enableStudioCodeUi ).toBe( true );
+		} );
+	} );
+} );

--- a/apps/studio/src/modules/studio-code/ipc-handlers.ts
+++ b/apps/studio/src/modules/studio-code/ipc-handlers.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { readSharedConfig } from '@studio/common/lib/shared-config';
-import { abortTurn, spawnTurn } from './studio-code-process';
+import { abortTurn, answerTurn, spawnTurn } from './studio-code-process';
 
 export async function studioCodeSendMessage(
 	_event: IpcMainInvokeEvent,
@@ -18,12 +18,14 @@ export async function studioCodeSendMessage(
 export async function studioCodeRespondToPermission(
 	_event: IpcMainInvokeEvent,
 	siteId: string,
-	sitePath: string,
-	siteName: string,
-	message: string,
+	_sitePath: string,
+	_siteName: string,
+	_message: string,
 	permissionResponse: Record< string, string >
 ): Promise< void > {
-	spawnTurn( siteId, sitePath, siteName, message, { permissionResponse } );
+	// The CLI child for this turn is still alive, awaiting the answer over IPC.
+	// Deliver it so the same turn resumes instead of respawning the process.
+	answerTurn( siteId, permissionResponse );
 }
 
 export function studioCodeAbort( _event: IpcMainInvokeEvent, siteId: string ): void {

--- a/apps/studio/src/modules/studio-code/studio-code-process.ts
+++ b/apps/studio/src/modules/studio-code/studio-code-process.ts
@@ -1,6 +1,5 @@
 import { app } from 'electron';
-import { ChildProcess, spawn } from 'node:child_process';
-import readline from 'node:readline';
+import { ChildProcess, fork } from 'node:child_process';
 import * as Sentry from '@sentry/electron/main';
 import { sendIpcEventToRenderer } from 'src/ipc-utils';
 import { getBundledNodeBinaryPath, getCliPath } from 'src/storage/paths';
@@ -8,35 +7,66 @@ import type { StudioCodeEvent } from './studio-code-event-types';
 
 interface SiteSession {
 	activeTurn: ChildProcess | null;
-	activeTurnRl: readline.Interface | null;
 	appQuitHandler: ( () => void ) | null;
 	lastSessionId: string | null;
+	interruptAttempts: number;
 }
 
 // Module-level registry keyed by siteId
 const sessions = new Map< string, SiteSession >();
 
+// Grace period before escalating a graceful interrupt to SIGKILL. The first
+// abort asks the CLI to interrupt over IPC (so the session recorder flushes);
+// if it doesn't land quickly, we force-kill so the chat can't stay stuck busy.
+const INTERRUPT_FORCE_KILL_TIMEOUT_MS = 2000;
+
 function getOrCreateSession( siteId: string ): SiteSession {
 	let session = sessions.get( siteId );
 	if ( ! session ) {
-		session = { activeTurn: null, activeTurnRl: null, appQuitHandler: null, lastSessionId: null };
+		session = { activeTurn: null, appQuitHandler: null, lastSessionId: null, interruptAttempts: 0 };
 		sessions.set( siteId, session );
 	}
 	return session;
 }
 
-function cleanupTurn( session: SiteSession ): void {
+function forceKill( session: SiteSession ): void {
 	if ( session.appQuitHandler ) {
 		app.off( 'will-quit', session.appQuitHandler );
 		session.appQuitHandler = null;
 	}
-	session.activeTurnRl?.close();
-	session.activeTurnRl = null;
 	if ( session.activeTurn ) {
 		session.activeTurn.removeAllListeners();
-		session.activeTurn.kill();
+		session.activeTurn.kill( 'SIGKILL' );
 		session.activeTurn = null;
 	}
+}
+
+// Graceful interrupt: tell the CLI child to interrupt via the Agent SDK and
+// exit cleanly. SIGTERM is swallowed by module-level handlers (e.g.
+// wordpress-server-manager) that aren't wired to the SDK, so we use the Node
+// IPC `interrupt` message — mirroring `ai-agent/run-manager.ts`. A second
+// abort, or a disconnected child, escalates straight to SIGKILL.
+function interruptTurn( session: SiteSession ): void {
+	const child = session.activeTurn;
+	if ( ! child ) {
+		return;
+	}
+
+	session.interruptAttempts += 1;
+
+	if ( session.interruptAttempts > 1 || ! child.connected ) {
+		forceKill( session );
+		return;
+	}
+
+	child.send( { type: 'interrupt' } );
+
+	// Safety net: force-kill if the graceful path doesn't land in time.
+	setTimeout( () => {
+		if ( session.activeTurn === child && ! child.killed ) {
+			forceKill( session );
+		}
+	}, INTERRUPT_FORCE_KILL_TIMEOUT_MS ).unref();
 }
 
 export function spawnTurn(
@@ -46,67 +76,50 @@ export function spawnTurn(
 	message: string,
 	options?: {
 		resumeSessionId?: string;
-		permissionResponse?: Record< string, string >;
 	}
 ): void {
 	const session = getOrCreateSession( siteId );
 
 	// Kill any active turn for this site
-	cleanupTurn( session );
+	forceKill( session );
+	session.interruptAttempts = 0;
 
 	const nodePath = getBundledNodeBinaryPath();
 	const cliPath = getCliPath();
 
-	const args = [
-		'--experimental-wasm-jspi',
-		cliPath,
-		'code',
-		message,
-		'--json',
-		'--path',
-		sitePath,
-		'--site-name',
-		siteName,
-	];
+	const args = [ 'code', message, '--json', '--path', sitePath, '--site-name', siteName ];
 
 	const sessionId = options?.resumeSessionId ?? session.lastSessionId;
 	if ( sessionId ) {
 		args.push( '--resume-session', sessionId );
 	}
 
-	if ( options?.permissionResponse ) {
-		args.push( '--permission-response', JSON.stringify( options.permissionResponse ) );
-	}
-
-	const child = spawn( nodePath, args, {
-		stdio: [ 'pipe', 'pipe', 'pipe' ],
+	const child = fork( cliPath, args, {
+		// Agent events arrive over the Node IPC channel (via `process.send` in
+		// the child); `emitEvent` prefers it when available. stdio is otherwise
+		// ignored — we no longer parse NDJSON from stdout.
+		stdio: [ 'ignore', 'ignore', 'ignore', 'ipc' ],
+		execPath: nodePath,
+		execArgv: [ '--experimental-wasm-jspi' ],
 		env: { ...process.env },
 	} );
 
 	session.activeTurn = child;
 
-	const rl = readline.createInterface( { input: child.stdout! } );
-	session.activeTurnRl = rl;
-
-	rl.on( 'line', ( line ) => {
-		try {
-			const event: StudioCodeEvent = JSON.parse( line );
-
-			if ( event.type === 'turn.completed' && event.sessionId ) {
-				session.lastSessionId = event.sessionId;
-			}
-
-			void sendIpcEventToRenderer( 'studio-code-event', { siteId, event } );
-		} catch {
-			console.error( `[StudioCode - ${ siteId }] Non-JSON stdout line:`, line );
+	child.on( 'message', ( message ) => {
+		// The CLI's `Logger` also writes to this IPC channel with a different
+		// shape (`{ action, status, message }`). Forward only the CLI JSON
+		// transport envelope.
+		if ( ! message || typeof message !== 'object' || ! ( 'type' in message ) ) {
+			return;
 		}
-	} );
+		const event = message as StudioCodeEvent;
 
-	child.stderr?.on( 'data', ( data: Buffer ) => {
-		const text = data.toString().trimEnd();
-		if ( text ) {
-			console.error( `[StudioCode - ${ siteId }] stderr:`, text );
+		if ( event.type === 'turn.completed' && event.sessionId ) {
+			session.lastSessionId = event.sessionId;
 		}
+
+		void sendIpcEventToRenderer( 'studio-code-event', { siteId, event } );
 	} );
 
 	child.on( 'error', ( error ) => {
@@ -114,36 +127,44 @@ export function spawnTurn(
 		Sentry.captureException( error );
 	} );
 
-	child.on( 'close', ( exitCode, signal ) => {
+	child.on( 'exit', ( exitCode, signal ) => {
 		console.info(
 			`[StudioCode - ${ siteId }] Process exited with code ${ exitCode }, signal ${ signal }`
 		);
-		rl.close();
 		if ( session.appQuitHandler ) {
 			app.off( 'will-quit', session.appQuitHandler );
 			session.appQuitHandler = null;
 		}
 		if ( session.activeTurn === child ) {
 			session.activeTurn = null;
-			session.activeTurnRl = null;
 		}
 	} );
 
-	const appQuitHandler = () => cleanupTurn( session );
+	const appQuitHandler = () => forceKill( session );
 	session.appQuitHandler = appQuitHandler;
 	app.on( 'will-quit', appQuitHandler );
+}
+
+// Deliver a permission/question answer to the live CLI child. The CLI's
+// `JsonAdapter.askUser` is awaiting this IPC message and resumes the same turn.
+export function answerTurn( siteId: string, answers: Record< string, string > ): void {
+	const session = sessions.get( siteId );
+	const child = session?.activeTurn;
+	if ( child?.connected ) {
+		child.send( { type: 'answer', answers } );
+	}
 }
 
 export function abortTurn( siteId: string ): void {
 	const session = sessions.get( siteId );
 	if ( session ) {
-		cleanupTurn( session );
+		interruptTurn( session );
 	}
 }
 
 export function stopAllProcesses(): void {
 	for ( const [ , session ] of sessions ) {
-		cleanupTurn( session );
+		forceKill( session );
 	}
 	sessions.clear();
 }

--- a/apps/studio/src/modules/studio-code/tests/ipc-handlers.test.ts
+++ b/apps/studio/src/modules/studio-code/tests/ipc-handlers.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment node
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { readSharedConfig } from '@studio/common/lib/shared-config';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	studioCodeAbort,
+	studioCodeCheckProvider,
+	studioCodeRespondToPermission,
+	studioCodeSendMessage,
+} from '../ipc-handlers';
+import { abortTurn, answerTurn, spawnTurn } from '../studio-code-process';
+import type { IpcMainInvokeEvent } from 'electron';
+
+vi.mock( '../studio-code-process', () => ( {
+	spawnTurn: vi.fn(),
+	answerTurn: vi.fn(),
+	abortTurn: vi.fn(),
+} ) );
+
+vi.mock( '@studio/common/lib/shared-config', () => ( {
+	readSharedConfig: vi.fn(),
+} ) );
+
+vi.mock( 'node:fs', () => ( {
+	existsSync: vi.fn(),
+} ) );
+
+const mockEvent = {} as IpcMainInvokeEvent;
+
+beforeEach( () => {
+	vi.clearAllMocks();
+} );
+
+describe( 'studioCodeSendMessage', () => {
+	it( 'delegates to spawnTurn', async () => {
+		await studioCodeSendMessage( mockEvent, 'site-1', '/sites/one', 'One', 'hello' );
+		expect( spawnTurn ).toHaveBeenCalledWith( 'site-1', '/sites/one', 'One', 'hello' );
+	} );
+} );
+
+describe( 'studioCodeRespondToPermission', () => {
+	it( 'delivers the answer to the live child via answerTurn (no respawn)', async () => {
+		await studioCodeRespondToPermission( mockEvent, 'site-1', '/sites/one', 'One', 'Continue', {
+			'Allow read?': 'Allow',
+		} );
+		expect( answerTurn ).toHaveBeenCalledWith( 'site-1', { 'Allow read?': 'Allow' } );
+		expect( spawnTurn ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'studioCodeAbort', () => {
+	it( 'delegates to abortTurn', () => {
+		studioCodeAbort( mockEvent, 'site-1' );
+		expect( abortTurn ).toHaveBeenCalledWith( 'site-1' );
+	} );
+} );
+
+describe( 'studioCodeCheckProvider', () => {
+	it( 'reports no providers when nothing is configured', async () => {
+		vi.mocked( readSharedConfig ).mockResolvedValue( {} as never );
+		vi.mocked( fs.existsSync ).mockReturnValue( false );
+		delete process.env.ANTHROPIC_API_KEY;
+
+		const result = await studioCodeCheckProvider( mockEvent );
+		expect( result ).toEqual( { available: false, providers: [] } );
+	} );
+
+	it( 'detects wpcom, anthropic-api-key, and anthropic-claude providers', async () => {
+		vi.mocked( readSharedConfig ).mockResolvedValue( { authToken: { accessToken: 'x' } } as never );
+		process.env.ANTHROPIC_API_KEY = 'sk-test';
+		const claudeConfigPath = path.join( os.homedir(), '.claude', '.credentials.json' );
+		vi.mocked( fs.existsSync ).mockImplementation( ( p ) => p === claudeConfigPath );
+
+		const result = await studioCodeCheckProvider( mockEvent );
+		expect( result.available ).toBe( true );
+		expect( result.providers ).toEqual(
+			expect.arrayContaining( [ 'wpcom', 'anthropic-api-key', 'anthropic-claude' ] )
+		);
+
+		delete process.env.ANTHROPIC_API_KEY;
+	} );
+} );

--- a/apps/studio/src/modules/studio-code/tests/studio-code-process.test.ts
+++ b/apps/studio/src/modules/studio-code/tests/studio-code-process.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+/**
+ * @vitest-environment node
+ */
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock electron and dependencies before importing the module
+const mockAppOn = vi.fn();
+const mockAppOff = vi.fn();
 vi.mock( 'electron', () => ( {
-	app: { on: vi.fn(), off: vi.fn() },
+	app: { on: mockAppOn, off: mockAppOff },
 } ) );
 vi.mock( '@sentry/electron/main', () => ( {
 	captureException: vi.fn(),
@@ -11,25 +16,209 @@ vi.mock( 'src/storage/paths', () => ( {
 	getCliPath: () => '/mock/cli/path',
 	getBundledNodeBinaryPath: () => '/mock/node/path',
 } ) );
+
+const mockSendIpcEventToRenderer = vi.fn();
 vi.mock( 'src/ipc-utils', () => ( {
-	sendIpcEventToRenderer: vi.fn(),
+	sendIpcEventToRenderer: ( ...args: unknown[] ) => mockSendIpcEventToRenderer( ...args ),
 } ) );
 
-describe( 'StudioCodeProcess module', () => {
-	it( 'should export expected functions', async () => {
-		const mod = await import( '../studio-code-process' );
-		expect( mod.spawnTurn ).toBeDefined();
-		expect( mod.abortTurn ).toBeDefined();
-		expect( mod.stopAllProcesses ).toBeDefined();
+const mockFork = vi.fn();
+vi.mock( 'node:child_process', () => ( {
+	fork: ( ...args: unknown[] ) => mockFork( ...args ),
+} ) );
+
+// A fake ChildProcess: an EventEmitter with the IPC surface the module uses.
+class FakeChild extends EventEmitter {
+	connected = true;
+	killed = false;
+	send = vi.fn();
+	kill = vi.fn( ( _signal?: string ) => {
+		this.killed = true;
+		return true;
+	} );
+}
+
+function newChild(): FakeChild {
+	const child = new FakeChild();
+	mockFork.mockReturnValueOnce( child );
+	return child;
+}
+
+async function loadModule() {
+	vi.resetModules();
+	return import( '../studio-code-process' );
+}
+
+beforeEach( () => {
+	vi.clearAllMocks();
+	vi.useFakeTimers();
+} );
+
+afterEach( () => {
+	vi.useRealTimers();
+} );
+
+describe( 'spawnTurn', () => {
+	it( 'forks the CLI with the ipc channel, wasm flag, and base args', async () => {
+		const child = newChild();
+		const { spawnTurn } = await loadModule();
+
+		spawnTurn( 'site-1', '/sites/one', 'One', 'hello' );
+
+		expect( child ).toBeDefined();
+		expect( mockFork ).toHaveBeenCalledTimes( 1 );
+		const [ cliPath, args, opts ] = mockFork.mock.calls[ 0 ];
+		expect( cliPath ).toBe( '/mock/cli/path' );
+		expect( args ).toEqual( [
+			'code',
+			'hello',
+			'--json',
+			'--path',
+			'/sites/one',
+			'--site-name',
+			'One',
+		] );
+		expect( opts ).toMatchObject( {
+			stdio: [ 'ignore', 'ignore', 'ignore', 'ipc' ],
+			execPath: '/mock/node/path',
+			execArgv: [ '--experimental-wasm-jspi' ],
+		} );
 	} );
 
-	it( 'abortTurn does not throw for unknown siteId', async () => {
-		const mod = await import( '../studio-code-process' );
-		expect( () => mod.abortTurn( 'nonexistent-site' ) ).not.toThrow();
+	it( 'forwards CLI envelope messages to the renderer and captures sessionId for resume', async () => {
+		const child = newChild();
+		const { spawnTurn } = await loadModule();
+
+		spawnTurn( 'site-1', '/sites/one', 'One', 'hello' );
+
+		// Non-envelope (Logger) messages are ignored.
+		child.emit( 'message', { action: 'foo', status: 'inprogress' } );
+		child.emit( 'message', null );
+		expect( mockSendIpcEventToRenderer ).not.toHaveBeenCalled();
+
+		const event = { type: 'turn.started', timestamp: 't' };
+		child.emit( 'message', event );
+		expect( mockSendIpcEventToRenderer ).toHaveBeenCalledWith( 'studio-code-event', {
+			siteId: 'site-1',
+			event,
+		} );
+
+		// turn.completed with a sessionId is captured for the next turn's resume.
+		child.emit( 'message', {
+			type: 'turn.completed',
+			timestamp: 't',
+			sessionId: 'sess-123',
+			status: 'success',
+		} );
+
+		const child2 = newChild();
+		spawnTurn( 'site-1', '/sites/one', 'One', 'again' );
+		const args2 = mockFork.mock.calls[ 1 ][ 1 ] as string[];
+		expect( args2 ).toContain( '--resume-session' );
+		expect( args2 ).toContain( 'sess-123' );
+		expect( child2 ).toBeDefined();
 	} );
 
-	it( 'stopAllProcesses does not throw when no processes exist', async () => {
-		const mod = await import( '../studio-code-process' );
-		expect( () => mod.stopAllProcesses() ).not.toThrow();
+	it( 'passes an explicit resumeSessionId through', async () => {
+		newChild();
+		const { spawnTurn } = await loadModule();
+		spawnTurn( 'site-1', '/sites/one', 'One', 'hi', { resumeSessionId: 'explicit-id' } );
+		const args = mockFork.mock.calls[ 0 ][ 1 ] as string[];
+		expect( args.slice( -2 ) ).toEqual( [ '--resume-session', 'explicit-id' ] );
+	} );
+} );
+
+describe( 'abortTurn', () => {
+	it( 'sends a graceful interrupt over IPC, never SIGTERM', async () => {
+		const child = newChild();
+		const { spawnTurn, abortTurn } = await loadModule();
+		spawnTurn( 'site-1', '/sites/one', 'One', 'hello' );
+
+		abortTurn( 'site-1' );
+
+		expect( child.send ).toHaveBeenCalledWith( { type: 'interrupt' } );
+		expect( child.kill ).not.toHaveBeenCalled();
+	} );
+
+	it( 'force-kills with SIGKILL after the grace period if still alive', async () => {
+		const child = newChild();
+		const { spawnTurn, abortTurn } = await loadModule();
+		spawnTurn( 'site-1', '/sites/one', 'One', 'hello' );
+
+		abortTurn( 'site-1' );
+		vi.advanceTimersByTime( 2000 );
+
+		expect( child.kill ).toHaveBeenCalledWith( 'SIGKILL' );
+	} );
+
+	it( 'escalates straight to SIGKILL on a second abort', async () => {
+		const child = newChild();
+		const { spawnTurn, abortTurn } = await loadModule();
+		spawnTurn( 'site-1', '/sites/one', 'One', 'hello' );
+
+		abortTurn( 'site-1' );
+		abortTurn( 'site-1' );
+
+		expect( child.kill ).toHaveBeenCalledWith( 'SIGKILL' );
+	} );
+
+	it( 'force-kills immediately when the child is disconnected', async () => {
+		const child = newChild();
+		const { spawnTurn, abortTurn } = await loadModule();
+		spawnTurn( 'site-1', '/sites/one', 'One', 'hello' );
+		child.connected = false;
+
+		abortTurn( 'site-1' );
+
+		expect( child.send ).not.toHaveBeenCalled();
+		expect( child.kill ).toHaveBeenCalledWith( 'SIGKILL' );
+	} );
+
+	it( 'does not throw for an unknown siteId', async () => {
+		const { abortTurn } = await loadModule();
+		expect( () => abortTurn( 'nonexistent-site' ) ).not.toThrow();
+	} );
+} );
+
+describe( 'answerTurn', () => {
+	it( 'delivers the answer to the live child over IPC', async () => {
+		const child = newChild();
+		const { spawnTurn, answerTurn } = await loadModule();
+		spawnTurn( 'site-1', '/sites/one', 'One', 'hello' );
+
+		answerTurn( 'site-1', { 'Allow read?': 'Allow' } );
+
+		expect( child.send ).toHaveBeenCalledWith( {
+			type: 'answer',
+			answers: { 'Allow read?': 'Allow' },
+		} );
+	} );
+
+	it( 'is a no-op when the child is disconnected or missing', async () => {
+		const child = newChild();
+		const { spawnTurn, answerTurn } = await loadModule();
+		spawnTurn( 'site-1', '/sites/one', 'One', 'hello' );
+		child.connected = false;
+
+		expect( () => answerTurn( 'site-1', { q: 'a' } ) ).not.toThrow();
+		expect( () => answerTurn( 'unknown', { q: 'a' } ) ).not.toThrow();
+		expect( child.send ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'stopAllProcesses', () => {
+	it( 'does not throw when no processes exist', async () => {
+		const { stopAllProcesses } = await loadModule();
+		expect( () => stopAllProcesses() ).not.toThrow();
+	} );
+
+	it( 'force-kills every active turn', async () => {
+		const child = newChild();
+		const { spawnTurn, stopAllProcesses } = await loadModule();
+		spawnTurn( 'site-1', '/sites/one', 'One', 'hello' );
+
+		stopAllProcesses();
+
+		expect( child.kill ).toHaveBeenCalledWith( 'SIGKILL' );
 	} );
 } );


### PR DESCRIPTION
Migrate studio-code to fork+IPC (interrupt/answer) with SIGKILL fallback, mirroring the ai-agent run-manager pattern; add main + renderer tests.

## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes #

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->



## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

-

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
