### PR TITLE
Studio Code: example prompt suggestions for empty conversations

### DIFF
--- a/apps/studio/src/components/site-content-tabs.tsx
+++ b/apps/studio/src/components/site-content-tabs.tsx
@@ -11,6 +11,7 @@ import { SiteIsBeingCreated } from 'src/components/site-is-being-created';
 import { MIN_WIDTH_CLASS_TO_MEASURE } from 'src/constants';
 import { TabName } from 'src/hooks/use-content-tabs';
 import { useEffectiveTab } from 'src/hooks/use-effective-tab';
+import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { cx } from 'src/lib/cx';
@@ -20,6 +21,7 @@ export function SiteContentTabs() {
 	const { selectedSite, siteCreationMessages } = useSiteDetails();
 	const { importState } = useImportExport();
 	const { effectiveTab, selectedTab, setSelectedTab, tabs } = useEffectiveTab();
+	const { enableStudioCodeUi } = useFeatureFlags();
 	const { __ } = useI18n();
 
 	// Remount: Avoid focus loss on user tab changes (no remount),
@@ -98,7 +100,7 @@ export function SiteContentTabs() {
 					<div
 						className={ cx(
 							'h-full overflow-y-auto',
-							effectiveTab === 'assistant' && 'bg-frame-surface'
+							effectiveTab === 'assistant' && ! enableStudioCodeUi && 'bg-frame-surface'
 						) }
 						style={ {
 							scrollbarWidth: 'thin',

--- a/apps/studio/src/components/studio-code-session/composer/index.tsx
+++ b/apps/studio/src/components/studio-code-session/composer/index.tsx
@@ -6,7 +6,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { arrowUp, chevronDownSmall } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import * as Menu from '../menu';
 import { SESSIONS_QUERY_KEY } from '../use-session';
@@ -52,6 +52,14 @@ interface ComposerProps {
 	// dropdown still works for unowned sessions.
 	ownerSiteId?: string;
 	onSwitchSession?: ( sessionId: string ) => void;
+	// Populates (but does not send) the textarea, e.g. when the user clicks an
+	// example prompt on an empty conversation. The `id` lets us re-apply the
+	// same prompt text more than once.
+	draftPrompt?: { id: number; prompt: string } | null;
+	// Temporarily previews a prompt in the textarea (muted) without committing
+	// it to the draft, e.g. while hovering an example prompt. Clearing it
+	// restores whatever the user had typed.
+	previewPrompt?: string | null;
 }
 
 const isMacPlatform =
@@ -68,9 +76,30 @@ export function Composer( {
 	entries,
 	ownerSiteId,
 	onSwitchSession,
+	draftPrompt,
+	previewPrompt,
 }: ComposerProps ) {
 	const [ value, setValue ] = useState( '' );
+	const textareaRef = useRef< HTMLTextAreaElement | null >( null );
+	const appliedDraftPromptIdRef = useRef< number | null >( null );
 	const queryClient = useQueryClient();
+
+	useEffect( () => {
+		if ( ! draftPrompt || appliedDraftPromptIdRef.current === draftPrompt.id ) {
+			return;
+		}
+		appliedDraftPromptIdRef.current = draftPrompt.id;
+		setValue( draftPrompt.prompt );
+		queueMicrotask( () => {
+			const node = textareaRef.current;
+			if ( ! node ) {
+				return;
+			}
+			node.focus();
+			const length = node.value.length;
+			node.setSelectionRange( length, length );
+		} );
+	}, [ draftPrompt ] );
 
 	// Cross-family swap state. We hold the picked model here while the
 	// confirmation dialog is open; nothing is persisted until the user
@@ -202,9 +231,11 @@ export function Composer( {
 			<div className={ styles.root }>
 				<div className={ styles.shell }>
 					<textarea
+						ref={ textareaRef }
 						className={ styles.input }
 						placeholder={ placeholder }
-						value={ value }
+						value={ previewPrompt ?? value }
+						data-preview={ previewPrompt ? 'true' : 'false' }
 						onChange={ ( event ) => setValue( event.target.value ) }
 						onKeyDown={ ( event ) => {
 							if ( event.key === 'Escape' && busy ) {

--- a/apps/studio/src/components/studio-code-session/composer/style.module.css
+++ b/apps/studio/src/components/studio-code-session/composer/style.module.css
@@ -38,6 +38,10 @@
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
+.input[data-preview='true'] {
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
 .toolbar {
 	display: flex;
 	align-items: flex-end;

--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -31,6 +31,7 @@ import { queryClient } from './query-client';
 import { QueuedPrompts } from './queued-prompts';
 import styles from './style.module.css';
 import { AgentRunProvider, useAgentRun } from './use-agent-run';
+import { useExamplePrompts } from './use-example-prompts';
 import { useSession } from './use-session';
 import { useSingleSession } from './use-single-session';
 import buttonDefense from './wp-ui-button-defense.module.css';
@@ -106,45 +107,6 @@ function UnauthenticatedNotice( { onAuthenticate }: { onAuthenticate: () => void
 	);
 }
 
-const EXAMPLE_PROMPTS: { short: string; full: string }[] = [
-	{
-		short: __( 'Build a plugin' ),
-		full: __(
-			'Help me build a small WordPress plugin from scratch. Ask me what problem it should solve, scaffold the plugin folder and main file, then walk me through the hooks and code we need to wire it up.'
-		),
-	},
-	{
-		short: __( 'Create a block' ),
-		full: __(
-			'Help me create a custom Gutenberg block. Scaffold the block files, set up the edit and save components, and explain how to register it so I can see it in the editor.'
-		),
-	},
-	{
-		short: __( 'Fix an error' ),
-		full: __(
-			'Something on my site is broken. Help me track down the error — check the logs, look at the relevant code, explain what is going wrong, and propose a fix.'
-		),
-	},
-	{
-		short: __( 'Custom post type' ),
-		full: __(
-			'Add a custom post type to my site. Ask me what it is for, then register it with sensible labels and settings and show me where the code lives.'
-		),
-	},
-	{
-		short: __( 'Tweak my theme' ),
-		full: __(
-			'Take a look at my active theme and suggest a few small improvements I could make to the design or layout, then help me implement one of them.'
-		),
-	},
-	{
-		short: __( 'Explain my site' ),
-		full: __(
-			'Give me an overview of how this site is put together — the active theme, the installed plugins, and anything notable in the code — so I understand what I am working with.'
-		),
-	},
-];
-
 function hasVisibleUserPrompt( entries: SessionEntry[] ): boolean {
 	return entries.some( ( entry ) => {
 		if ( ! isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ) {
@@ -164,15 +126,17 @@ function EmptyConversation( {
 	onClearPreview: () => void;
 	onSelectPrompt: ( prompt: string ) => void;
 } ) {
+	const examplePrompts = useExamplePrompts();
+
 	return (
 		<div className={ styles.emptyConversation }>
 			<div className={ styles.emptyConversationPrompt }>
 				{ __( 'Ask Studio Code anything to get started.' ) }
 			</div>
 			<div className={ styles.emptyConversationExamples }>
-				{ EXAMPLE_PROMPTS.map( ( example ) => (
+				{ examplePrompts.map( ( example ) => (
 					<button
-						key={ example.short }
+						key={ example.id }
 						type="button"
 						className={ styles.emptyConversationExample }
 						title={ example.full }

--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -1,10 +1,22 @@
 import { resolveSessionModel } from '@studio/common/ai/models';
+import {
+	isStudioCustomEntryOfType,
+	type StudioCustomEntry,
+} from '@studio/common/ai/sessions/entry-types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { privateApis } from '@wordpress/theme';
 import { Button as UiButton } from '@wordpress/ui';
-import { useLayoutEffect, useMemo, useRef, type ReactNode, type Ref } from 'react';
+import {
+	useCallback,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+	type ReactNode,
+	type Ref,
+} from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import { useAuth } from 'src/hooks/use-auth';
@@ -21,6 +33,7 @@ import { AgentRunProvider, useAgentRun } from './use-agent-run';
 import { useSession } from './use-session';
 import { useSingleSession } from './use-single-session';
 import buttonDefense from './wp-ui-button-defense.module.css';
+import type { SessionEntry } from '@mariozechner/pi-coding-agent';
 import '@wordpress/theme/design-tokens.css';
 
 const { ThemeProvider } = unlock( privateApis );
@@ -92,6 +105,93 @@ function UnauthenticatedNotice( { onAuthenticate }: { onAuthenticate: () => void
 	);
 }
 
+const EXAMPLE_PROMPTS: { short: string; full: string }[] = [
+	{
+		short: __( 'Build a plugin' ),
+		full: __(
+			'Help me build a small WordPress plugin from scratch. Ask me what problem it should solve, scaffold the plugin folder and main file, then walk me through the hooks and code we need to wire it up.'
+		),
+	},
+	{
+		short: __( 'Create a block' ),
+		full: __(
+			'Help me create a custom Gutenberg block. Scaffold the block files, set up the edit and save components, and explain how to register it so I can see it in the editor.'
+		),
+	},
+	{
+		short: __( 'Fix an error' ),
+		full: __(
+			'Something on my site is broken. Help me track down the error — check the logs, look at the relevant code, explain what is going wrong, and propose a fix.'
+		),
+	},
+	{
+		short: __( 'Custom post type' ),
+		full: __(
+			'Add a custom post type to my site. Ask me what it is for, then register it with sensible labels and settings and show me where the code lives.'
+		),
+	},
+	{
+		short: __( 'Tweak my theme' ),
+		full: __(
+			'Take a look at my active theme and suggest a few small improvements I could make to the design or layout, then help me implement one of them.'
+		),
+	},
+	{
+		short: __( 'Explain my site' ),
+		full: __(
+			'Give me an overview of how this site is put together — the active theme, the installed plugins, and anything notable in the code — so I understand what I am working with.'
+		),
+	},
+];
+
+function hasVisibleUserPrompt( entries: SessionEntry[] ): boolean {
+	return entries.some( ( entry ) => {
+		if ( ! isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ) {
+			return false;
+		}
+		const data = ( entry as StudioCustomEntry< 'studio.user_prompt' > ).data;
+		return data?.source === 'prompt';
+	} );
+}
+
+function EmptyConversation( {
+	onPreviewPrompt,
+	onClearPreview,
+	onSelectPrompt,
+}: {
+	onPreviewPrompt: ( prompt: string ) => void;
+	onClearPreview: () => void;
+	onSelectPrompt: ( prompt: string ) => void;
+} ) {
+	return (
+		<div className={ styles.emptyConversation }>
+			<div className={ styles.emptyConversationPrompt }>
+				{ __( 'Ask Studio Code anything to get started.' ) }
+			</div>
+			<div className={ styles.emptyConversationExamples }>
+				{ EXAMPLE_PROMPTS.map( ( example ) => (
+					<button
+						key={ example.short }
+						type="button"
+						className={ styles.emptyConversationExample }
+						title={ example.full }
+						onMouseEnter={ () => onPreviewPrompt( example.full ) }
+						onMouseLeave={ onClearPreview }
+						onFocus={ () => onPreviewPrompt( example.full ) }
+						onBlur={ onClearPreview }
+						onClick={ () => {
+							onSelectPrompt( example.full );
+							onClearPreview();
+						} }
+					>
+						{ example.short }
+					</button>
+				) ) }
+			</div>
+		</div>
+	);
+}
+
 function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 	const { sessionId, setSessionId, newSession } = useSingleSession( selectedSite.id );
 	const { data, isLoading } = useSession( sessionId );
@@ -120,6 +220,18 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 	);
 	const composerBusy = hasActiveRun || pendingQuestions.length > 0;
 	const scrollRef = useRef< HTMLDivElement >( null );
+
+	const [ promptDraft, setPromptDraft ] = useState< { id: number; prompt: string } | null >( null );
+	const [ previewPrompt, setPreviewPrompt ] = useState< string | null >( null );
+	const draftIdRef = useRef( 0 );
+	const selectPrompt = useCallback( ( prompt: string ) => {
+		draftIdRef.current += 1;
+		setPromptDraft( { id: draftIdRef.current, prompt } );
+	}, [] );
+	const clearPreview = useCallback( () => setPreviewPrompt( null ), [] );
+
+	const showEmptyConversation =
+		! hasActiveRun && queuedPrompts.length === 0 && ! hasVisibleUserPrompt( data?.entries ?? [] );
 
 	useLayoutEffect( () => {
 		const node = scrollRef.current;
@@ -173,19 +285,29 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 						entries={ data.entries }
 						ownerSiteId={ selectedSite.id }
 						onSwitchSession={ setSessionId }
+						draftPrompt={ promptDraft }
+						previewPrompt={ previewPrompt }
 					/>
 				</div>
 			}
 		>
 			<div className={ cx( styles.classicColumn, styles.classicConversationSpacing ) }>
-				<Conversation
-					data={ data }
-					isRunning={ isRunning }
-					startedAt={ startedAt }
-					pendingQuestions={ pendingQuestionTexts }
-					pendingAnswers={ pendingAnswers }
-					onAnswerQuestion={ answerQuestion }
-				/>
+				{ showEmptyConversation ? (
+					<EmptyConversation
+						onPreviewPrompt={ setPreviewPrompt }
+						onClearPreview={ clearPreview }
+						onSelectPrompt={ selectPrompt }
+					/>
+				) : (
+					<Conversation
+						data={ data }
+						isRunning={ isRunning }
+						startedAt={ startedAt }
+						pendingQuestions={ pendingQuestionTexts }
+						pendingAnswers={ pendingAnswers }
+						onAnswerQuestion={ answerQuestion }
+					/>
+				) }
 			</div>
 		</SessionFrame>
 	);

--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -4,6 +4,7 @@ import {
 	type StudioCustomEntry,
 } from '@studio/common/ai/sessions/entry-types';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { privateApis } from '@wordpress/theme';
@@ -254,7 +255,11 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 						<ComposerSkeleton />
 					</div>
 				}
-			/>
+			>
+				<div className={ styles.loading } role="status" aria-live="polite">
+					<Spinner className={ styles.loadingSpinner } />
+				</div>
+			</SessionFrame>
 		);
 	}
 

--- a/apps/studio/src/components/studio-code-session/style.module.css
+++ b/apps/studio/src/components/studio-code-session/style.module.css
@@ -74,3 +74,48 @@
 .classicComposerOuter {
 	padding: 0 calc(var(--wpds-dimension-padding-2xl) * 2) var(--wpds-dimension-padding-xl);
 }
+
+.emptyConversation {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-lg);
+	margin-top: 40px;
+	padding: 0 var(--wpds-dimension-padding-sm);
+}
+
+.emptyConversationPrompt {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-sm);
+	text-align: center;
+}
+
+.emptyConversationExamples {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: var(--wpds-dimension-padding-md);
+	max-width: 420px;
+}
+
+/* Doubled class (0,2,0) so the background survives Tailwind preflight's
+   unlayered `[type='button'] { background-color: transparent }` reset — see
+   wp-ui-button-defense.module.css for the full rationale. */
+.emptyConversationExample.emptyConversationExample {
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	background: var(--wpds-color-bg-surface-neutral-weak);
+	color: var(--wpds-color-fg-content-neutral);
+	font: inherit;
+	font-size: var(--wpds-typography-font-size-md);
+	line-height: 20px;
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-lg);
+	border-radius: var(--wpds-border-radius-lg);
+	cursor: pointer;
+	transition: background 140ms ease, border-color 140ms ease;
+}
+
+.emptyConversationExample:hover,
+.emptyConversationExample:focus-visible {
+	background: var(--wpds-color-bg-surface-brand);
+	border-color: var(--wpds-color-fg-interactive-brand);
+}

--- a/apps/studio/src/components/studio-code-session/style.module.css
+++ b/apps/studio/src/components/studio-code-session/style.module.css
@@ -18,6 +18,19 @@
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
+.loading {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	min-height: 0;
+}
+
+.loadingSpinner {
+	width: 36px;
+	height: 36px;
+}
+
 .header {
 	display: flex;
 	align-items: center;

--- a/apps/studio/src/components/studio-code-session/use-example-prompts.ts
+++ b/apps/studio/src/components/studio-code-session/use-example-prompts.ts
@@ -1,0 +1,67 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { useMemo } from 'react';
+
+export interface ExamplePrompt {
+	id: string;
+	short: string;
+	full: string;
+}
+
+/**
+ * Example prompts shown on an empty Studio Code conversation.
+ *
+ * Defined as a hook (rather than a module-level constant) so the `__()` calls
+ * are re-evaluated through `useI18n` whenever the user switches languages —
+ * a top-level constant would be translated only once, at module load.
+ */
+export function useExamplePrompts(): ExamplePrompt[] {
+	const { __ } = useI18n();
+
+	return useMemo(
+		() => [
+			{
+				id: 'build-a-plugin',
+				short: __( 'Build a plugin' ),
+				full: __(
+					'Help me build a small WordPress plugin from scratch. Ask me what problem it should solve, scaffold the plugin folder and main file, then walk me through the hooks and code we need to wire it up.'
+				),
+			},
+			{
+				id: 'create-a-block',
+				short: __( 'Create a block' ),
+				full: __(
+					'Help me create a custom Gutenberg block. Scaffold the block files, set up the edit and save components, and explain how to register it so I can see it in the editor.'
+				),
+			},
+			{
+				id: 'fix-an-error',
+				short: __( 'Fix an error' ),
+				full: __(
+					'Something on my site is broken. Help me track down the error — check the logs, look at the relevant code, explain what is going wrong, and propose a fix.'
+				),
+			},
+			{
+				id: 'custom-post-type',
+				short: __( 'Custom post type' ),
+				full: __(
+					'Add a custom post type to my site. Ask me what it is for, then register it with sensible labels and settings and show me where the code lives.'
+				),
+			},
+			{
+				id: 'tweak-my-theme',
+				short: __( 'Tweak my theme' ),
+				full: __(
+					'Take a look at my active theme and suggest a few small improvements I could make to the design or layout, then help me implement one of them.'
+				),
+			},
+			{
+				id: 'explain-my-site',
+				short: __( 'Explain my site' ),
+				full: __(
+					'Give me an overview of how this site is put together — the active theme, the installed plugins, and anything notable in the code — so I understand what I am working with.'
+				),
+			},
+		],
+		[ __ ]
+	);
+}


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Built with Claude Code: implemented the empty-state suggestions, the composer hover-preview/draft wiring, the loading state, and the styling. The author reviewed the diff and iterated on the visual design.

## Proposed Changes

When the Studio Code UI is enabled, the assistant tab now uses the agentic session UI but showed nothing for a brand-new conversation or while the session was loading. This adds a friendlier empty state and a loading state:

- On an empty conversation, a short set of example-prompt chips is shown (build a plugin, create a block, fix an error, etc.), mirroring the suggestions in the desks UI.
- Hovering (or focusing) a chip previews its full prompt in the composer in muted text without committing it; moving away restores whatever the user had typed.
- Clicking a chip populates the composer with the full prompt so the user can edit before sending. The suggestions disappear once the conversation has a real prompt or a run is active.
- While the session is loading, a centered spinner is shown in the conversation area instead of a blank tab.
- The assistant tab's grey surface background is dropped when the Studio Code UI is on, so the conversation matches the white background of the other site tabs.

## Testing Instructions

1. Enable the Studio Code UI (`ENABLE_STUDIO_CODE_UI` / `enableStudioCodeUi` feature flag).
2. Open a site and go to the Assistant tab. While the session loads, confirm a centered spinner appears (no blank tab).
3. With no prior conversation, confirm the example-prompt chips appear, are outlined and clearly visible against the white background.
4. Hover a chip: the composer shows the full prompt in muted text. Move away: it clears (and any text you typed is preserved).
5. Click a chip: the composer is populated with the full prompt and focused, cursor at the end. Edit/send as normal.
6. Once you send a prompt (or a run is active), the suggestions no longer show.
7. With the flag off, the legacy assistant tab (including its grey background) is unchanged.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?