### PR TITLE
Studio Code: pause autoscroll while reading earlier messages

### DIFF
--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -2,9 +2,19 @@ import { resolveSessionModel } from '@studio/common/ai/models';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
 import { privateApis } from '@wordpress/theme';
-import { Button as UiButton } from '@wordpress/ui';
-import { useLayoutEffect, useMemo, useRef, type ReactNode, type Ref } from 'react';
+import { Button as UiButton, Icon } from '@wordpress/ui';
+import {
+	useCallback,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+	type ReactNode,
+	type Ref,
+	type UIEvent,
+} from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import { useAuth } from 'src/hooks/use-auth';
@@ -16,6 +26,7 @@ import { Conversation } from './conversation';
 import { unlock } from './lock-unlock';
 import { queryClient } from './query-client';
 import { QueuedPrompts } from './queued-prompts';
+import { isScrolledToBottom } from './scroll-utils';
 import styles from './style.module.css';
 import { AgentRunProvider, useAgentRun } from './use-agent-run';
 import { useSession } from './use-session';
@@ -29,18 +40,32 @@ interface SessionFrameProps {
 	header?: ReactNode;
 	composer?: ReactNode;
 	scrollRef?: Ref< HTMLDivElement >;
+	onScroll?: ( event: UIEvent< HTMLDivElement > ) => void;
+	scrollToBottomButton?: ReactNode;
 	children?: ReactNode;
 }
 
-function SessionFrame( { header, composer, scrollRef, children }: SessionFrameProps ) {
+function SessionFrame( {
+	header,
+	composer,
+	scrollRef,
+	onScroll,
+	scrollToBottomButton,
+	children,
+}: SessionFrameProps ) {
 	return (
 		<div className={ styles.root }>
 			<div className={ styles.chatColumn }>
 				{ header }
-				<div ref={ scrollRef } className={ cx( styles.scroll, styles.classicScroll ) }>
+				<div
+					ref={ scrollRef }
+					className={ cx( styles.scroll, styles.classicScroll ) }
+					onScroll={ onScroll }
+				>
 					{ children }
 				</div>
 				<div className={ cx( styles.composerOuter, styles.classicComposerOuter ) }>
+					{ scrollToBottomButton }
 					{ composer }
 				</div>
 			</div>
@@ -120,18 +145,52 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 	);
 	const composerBusy = hasActiveRun || pendingQuestions.length > 0;
 	const scrollRef = useRef< HTMLDivElement >( null );
+	// Whether new content should keep the view pinned to the bottom. Disabled
+	// when the user scrolls up to read history, re-enabled when they return.
+	const [ stickToBottom, setStickToBottom ] = useState( true );
+	// Set while the effect drives `scrollTop` programmatically so the resulting
+	// scroll event doesn't get mistaken for the user scrolling up.
+	const isProgrammaticScroll = useRef( false );
 
-	useLayoutEffect( () => {
+	const scrollToBottom = useCallback( () => {
 		const node = scrollRef.current;
 		if ( ! node ) {
 			return;
 		}
+		isProgrammaticScroll.current = true;
+		node.scrollTop = node.scrollHeight;
+	}, [] );
+
+	const handleScroll = useCallback( ( event: UIEvent< HTMLDivElement > ) => {
+		if ( isProgrammaticScroll.current ) {
+			return;
+		}
+		setStickToBottom( isScrolledToBottom( event.currentTarget ) );
+	}, [] );
+
+	const handleScrollToBottomClick = useCallback( () => {
+		scrollToBottom();
+		setStickToBottom( true );
+	}, [ scrollToBottom ] );
+
+	// A fresh session starts pinned to the bottom.
+	useLayoutEffect( () => {
+		setStickToBottom( true );
+	}, [ sessionId ] );
+
+	useLayoutEffect( () => {
+		const node = scrollRef.current;
+		if ( ! node || ! stickToBottom ) {
+			return;
+		}
+		isProgrammaticScroll.current = true;
 		node.scrollTop = node.scrollHeight;
 		const id = requestAnimationFrame( () => {
 			node.scrollTop = node.scrollHeight;
+			isProgrammaticScroll.current = false;
 		} );
 		return () => cancelAnimationFrame( id );
-	}, [ sessionId, data, isRunning, queuedPrompts.length ] );
+	}, [ sessionId, data, isRunning, queuedPrompts.length, stickToBottom ] );
 
 	if ( ! sessionId || isLoading ) {
 		return (
@@ -158,7 +217,24 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 	return (
 		<SessionFrame
 			scrollRef={ scrollRef }
+			onScroll={ handleScroll }
 			header={ <SessionHeader onNewConversation={ () => void newSession() } /> }
+			scrollToBottomButton={
+				! stickToBottom && (
+					<div className={ styles.scrollToBottom }>
+						<UiButton
+							variant="outline"
+							tone="neutral"
+							size="small"
+							className={ buttonDefense.button }
+							aria-label={ __( 'Scroll to bottom' ) }
+							onClick={ handleScrollToBottomClick }
+						>
+							<Icon icon={ chevronDown } size={ 18 } />
+						</UiButton>
+					</div>
+				)
+			}
 			composer={
 				<div className={ styles.classicColumn }>
 					<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />

--- a/apps/studio/src/components/studio-code-session/scroll-utils.test.ts
+++ b/apps/studio/src/components/studio-code-session/scroll-utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { isScrolledToBottom } from './scroll-utils';
+
+describe( 'isScrolledToBottom', () => {
+	it( 'returns true when exactly at the bottom', () => {
+		expect( isScrolledToBottom( { scrollHeight: 1000, scrollTop: 800, clientHeight: 200 } ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'returns true when within the threshold of the bottom', () => {
+		// 20px remaining, default threshold is 32px.
+		expect( isScrolledToBottom( { scrollHeight: 1000, scrollTop: 780, clientHeight: 200 } ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'returns false when scrolled up beyond the threshold', () => {
+		// 200px remaining, well beyond the 32px threshold.
+		expect( isScrolledToBottom( { scrollHeight: 1000, scrollTop: 600, clientHeight: 200 } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'treats the threshold boundary as not-at-bottom (strict less-than)', () => {
+		// Exactly 32px remaining equals the threshold, so it is not "< threshold".
+		expect(
+			isScrolledToBottom( { scrollHeight: 1000, scrollTop: 768, clientHeight: 200 }, 32 )
+		).toBe( false );
+		// One pixel inside the boundary is at-bottom.
+		expect(
+			isScrolledToBottom( { scrollHeight: 1000, scrollTop: 769, clientHeight: 200 }, 32 )
+		).toBe( true );
+	} );
+
+	it( 'honors a custom threshold', () => {
+		expect(
+			isScrolledToBottom( { scrollHeight: 1000, scrollTop: 700, clientHeight: 200 }, 150 )
+		).toBe( true );
+		expect(
+			isScrolledToBottom( { scrollHeight: 1000, scrollTop: 700, clientHeight: 200 }, 50 )
+		).toBe( false );
+	} );
+} );

--- a/apps/studio/src/components/studio-code-session/scroll-utils.ts
+++ b/apps/studio/src/components/studio-code-session/scroll-utils.ts
@@ -1,0 +1,16 @@
+interface ScrollMetrics {
+	scrollHeight: number;
+	scrollTop: number;
+	clientHeight: number;
+}
+
+/**
+ * Returns true when a scroll container is at (or within `threshold` pixels of)
+ * its bottom. Pure helper so the stick-to-bottom logic stays unit-testable.
+ */
+export function isScrolledToBottom(
+	{ scrollHeight, scrollTop, clientHeight }: ScrollMetrics,
+	threshold = 32
+): boolean {
+	return scrollHeight - scrollTop - clientHeight < threshold;
+}

--- a/apps/studio/src/components/studio-code-session/style.module.css
+++ b/apps/studio/src/components/studio-code-session/style.module.css
@@ -81,7 +81,7 @@
 	display: flex;
 	justify-content: flex-end;
 	padding-bottom: var(--wpds-dimension-padding-sm);
-	padding-right: calc( var(--wpds-dimension-padding-xl) + var(--wpds-dimension-padding-sm));
+	padding-inline-end: calc( var(--wpds-dimension-padding-xl) + var(--wpds-dimension-padding-sm));
 	pointer-events: none;
 	z-index: 1;
 }

--- a/apps/studio/src/components/studio-code-session/style.module.css
+++ b/apps/studio/src/components/studio-code-session/style.module.css
@@ -71,15 +71,17 @@
 
 /* Floating "scroll to bottom" affordance. Anchored to the top edge of the
    composer area and lifted above it so it sits just over the conversation
-   without overlapping the composer. */
+   without overlapping the composer. Aligned to the right edge, next to the
+   conversation scrollbar. */
 .scrollToBottom {
 	position: absolute;
 	bottom: 100%;
 	left: 0;
 	right: 0;
 	display: flex;
-	justify-content: center;
+	justify-content: flex-end;
 	padding-bottom: var(--wpds-dimension-padding-sm);
+	padding-right: calc( var(--wpds-dimension-padding-xl) + var(--wpds-dimension-padding-sm));
 	pointer-events: none;
 	z-index: 1;
 }

--- a/apps/studio/src/components/studio-code-session/style.module.css
+++ b/apps/studio/src/components/studio-code-session/style.module.css
@@ -90,6 +90,13 @@
 	pointer-events: auto;
 	border-radius: 50%;
 	box-shadow: var(--wpds-elevation-shadow-md, 0 2px 8px rgba(0, 0, 0, 0.15));
+	/* Square dimensions + zeroed WP-UI padding vars so the chevron sits in a
+	   perfect circle instead of a pill. */
+	width: 32px;
+	height: 32px;
+	min-width: 32px;
+	--wp-ui-button-padding-inline: 0px;
+	--wp-ui-button-padding-block: 0px;
 }
 
 .classicScroll {

--- a/apps/studio/src/components/studio-code-session/style.module.css
+++ b/apps/studio/src/components/studio-code-session/style.module.css
@@ -53,6 +53,28 @@
 
 .composerOuter {
 	flex: 0 0 auto;
+	position: relative;
+}
+
+/* Floating "scroll to bottom" affordance. Anchored to the top edge of the
+   composer area and lifted above it so it sits just over the conversation
+   without overlapping the composer. */
+.scrollToBottom {
+	position: absolute;
+	bottom: 100%;
+	left: 0;
+	right: 0;
+	display: flex;
+	justify-content: center;
+	padding-bottom: var(--wpds-dimension-padding-sm);
+	pointer-events: none;
+	z-index: 1;
+}
+
+.scrollToBottom > * {
+	pointer-events: auto;
+	border-radius: 50%;
+	box-shadow: var(--wpds-elevation-shadow-md, 0 2px 8px rgba(0, 0, 0, 0.15));
 }
 
 .classicScroll {


### PR DESCRIPTION
## Related issues

- Related to https://github.com/Automattic/studio/pull/3651#issuecomment-4592262341

## How AI was used in this PR

AI-assisted implementation and unit tests.

## Proposed Changes

The Studio Code session used to force-scroll to the bottom on every update, yanking you back down whenever the agent streamed output — so you couldn't read earlier messages during a run. It now follows new output only while you're already at the bottom. Scrolling up pauses the auto-follow; scrolling back to the bottom, or clicking a floating "scroll to bottom" button that appears while paused, resumes it. A fresh session starts pinned to the bottom.

## Testing Instructions

- Enable Studio Code UI and  access Studio Assistant tab send a few messages and observe the current auto-scroll
- While at the bottom: view keeps following new output (unchanged).
- Scroll up mid-run: the view stays put. A "scroll to bottom" button appears.
- Click the button (or scroll back down): view returns to the bottom and resumes following.
- Switch sessions: starts pinned to the bottom.


<img width="1219" height="792" alt="Screenshot 2026-06-02 at 13 28 19" src="https://github.com/user-attachments/assets/9d93539d-728a-4073-b4a6-4985af40b082" />




## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?