### PR TITLE
Always use default UI mode in production builds

### DIFF
--- a/apps/studio/src/modules/desks/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/desks/lib/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, dialog, type IpcMainInvokeEvent } from 'electron';
+import { app, BrowserWindow, dialog, type IpcMainInvokeEvent } from 'electron';
 import fsPromises from 'fs/promises';
 import nodePath from 'path';
 import { assertDeskConfig } from '@studio/common/lib/desk-config';
@@ -51,6 +51,9 @@ export async function getDeskSettings( _event: IpcMainInvokeEvent ): Promise< De
 }
 
 export async function getStudioUiMode( _event: IpcMainInvokeEvent ): Promise< StudioUiMode > {
+	if ( app.isPackaged ) {
+		return 'default';
+	}
 	const userData = await loadUserData();
 	const mode = userData.desks?.defaultUiMode;
 	return mode === 'desks' || mode === 'agentic' ? mode : 'default';

--- a/apps/studio/src/modules/desks/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/desks/lib/ipc-handlers.ts
@@ -51,7 +51,7 @@ export async function getDeskSettings( _event: IpcMainInvokeEvent ): Promise< De
 }
 
 export async function getStudioUiMode( _event: IpcMainInvokeEvent ): Promise< StudioUiMode > {
-	if ( app.isPackaged ) {
+	if ( process.env.NODE_ENV === 'production' && app.isPackaged ) {
 		return 'default';
 	}
 	const userData = await loadUserData();


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude identified the fix location and implemented the change.

## Proposed Changes

When a user enables the desk or agentic UI in dev mode, the preference is persisted in `app.json`. Opening a production build would then load that stored mode and render the non-default UI, even though desk/agentic UI is a dev-only feature.

This fix makes `getStudioUiMode` return `'default'` unconditionally when `app.isPackaged` is true, so production builds are never affected by a dev-mode UI preference.

## Testing Instructions

1. Run the app in dev mode
2. Enable the new UI via the feature flag and switch to desk UI
3. Close dev mode
4. Open a production build — it should show the standard (default) UI

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?