### PR TITLE
Studio Code: follow the conversation to a newly created site

### DIFF
--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -32,11 +32,13 @@ import { unlock } from './lock-unlock';
 import { queryClient } from './query-client';
 import { QueuedPrompts } from './queued-prompts';
 import { isScrolledToBottom } from './scroll-utils';
+import { SiteCreatedDialog } from './site-created-dialog';
 import styles from './style.module.css';
 import { AgentRunProvider, useAgentRun } from './use-agent-run';
 import { useExamplePrompts } from './use-example-prompts';
 import { useSession } from './use-session';
 import { useSingleSession } from './use-single-session';
+import { useSiteCreationSwitch } from './use-site-creation-switch';
 import buttonDefense from './wp-ui-button-defense.module.css';
 import type { SessionEntry } from '@mariozechner/pi-coding-agent';
 import '@wordpress/theme/design-tokens.css';
@@ -178,6 +180,15 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 	const { sessionId, setSessionId, newSession } = useSingleSession( selectedSite.id );
 	const { data, isLoading } = useSession( sessionId );
 	const {
+		pending: pendingSiteCreation,
+		openNewSite,
+		stayHere,
+	} = useSiteCreationSwitch( {
+		sessionId,
+		currentSiteId: selectedSite.id,
+		onStartNewChat: () => void newSession(),
+	} );
+	const {
 		isRunning,
 		hasActiveRun,
 		isInterrupting,
@@ -288,65 +299,72 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 	}
 
 	return (
-		<SessionFrame
-			scrollRef={ scrollRef }
-			onScroll={ handleScroll }
-			header={ <SessionHeader onNewConversation={ () => void newSession() } /> }
-			scrollToBottomButton={
-				! stickToBottom && (
-					<div className={ styles.scrollToBottom }>
-						<UiButton
-							variant="outline"
-							tone="neutral"
-							size="small"
-							className={ buttonDefense.button }
-							aria-label={ __( 'Scroll to bottom' ) }
-							onClick={ handleScrollToBottomClick }
-						>
-							<Icon icon={ chevronDown } size={ 18 } />
-						</UiButton>
+		<>
+			<SessionFrame
+				scrollRef={ scrollRef }
+				onScroll={ handleScroll }
+				header={ <SessionHeader onNewConversation={ () => void newSession() } /> }
+				scrollToBottomButton={
+					! stickToBottom && (
+						<div className={ styles.scrollToBottom }>
+							<UiButton
+								variant="outline"
+								tone="neutral"
+								size="small"
+								className={ buttonDefense.button }
+								aria-label={ __( 'Scroll to bottom' ) }
+								onClick={ handleScrollToBottomClick }
+							>
+								<Icon icon={ chevronDown } size={ 18 } />
+							</UiButton>
+						</div>
+					)
+				}
+				composer={
+					<div className={ styles.classicColumn }>
+						<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
+						<Composer
+							busy={ composerBusy }
+							isInterrupting={ isInterrupting }
+							error={ runError }
+							model={ currentModel }
+							onSend={ sendMessage }
+							onInterrupt={ interrupt }
+							sessionId={ sessionId }
+							entries={ data.entries }
+							ownerSiteId={ selectedSite.id }
+							onSwitchSession={ setSessionId }
+							draftPrompt={ promptDraft }
+							previewPrompt={ previewPrompt }
+						/>
 					</div>
-				)
-			}
-			composer={
-				<div className={ styles.classicColumn }>
-					<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
-					<Composer
-						busy={ composerBusy }
-						isInterrupting={ isInterrupting }
-						error={ runError }
-						model={ currentModel }
-						onSend={ sendMessage }
-						onInterrupt={ interrupt }
-						sessionId={ sessionId }
-						entries={ data.entries }
-						ownerSiteId={ selectedSite.id }
-						onSwitchSession={ setSessionId }
-						draftPrompt={ promptDraft }
-						previewPrompt={ previewPrompt }
-					/>
+				}
+			>
+				<div className={ cx( styles.classicColumn, styles.classicConversationSpacing ) }>
+					{ showEmptyConversation ? (
+						<EmptyConversation
+							onPreviewPrompt={ setPreviewPrompt }
+							onClearPreview={ clearPreview }
+							onSelectPrompt={ selectPrompt }
+						/>
+					) : (
+						<Conversation
+							data={ data }
+							isRunning={ isRunning }
+							startedAt={ startedAt }
+							pendingQuestions={ pendingQuestionTexts }
+							pendingAnswers={ pendingAnswers }
+							onAnswerQuestion={ answerQuestion }
+						/>
+					) }
 				</div>
-			}
-		>
-			<div className={ cx( styles.classicColumn, styles.classicConversationSpacing ) }>
-				{ showEmptyConversation ? (
-					<EmptyConversation
-						onPreviewPrompt={ setPreviewPrompt }
-						onClearPreview={ clearPreview }
-						onSelectPrompt={ selectPrompt }
-					/>
-				) : (
-					<Conversation
-						data={ data }
-						isRunning={ isRunning }
-						startedAt={ startedAt }
-						pendingQuestions={ pendingQuestionTexts }
-						pendingAnswers={ pendingAnswers }
-						onAnswerQuestion={ answerQuestion }
-					/>
-				) }
-			</div>
-		</SessionFrame>
+			</SessionFrame>
+			<SiteCreatedDialog
+				pending={ pendingSiteCreation }
+				onOpenNewSite={ openNewSite }
+				onStayHere={ stayHere }
+			/>
+		</>
 	);
 }
 

--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -179,6 +179,7 @@ function EmptyConversation( {
 function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 	const { sessionId, setSessionId, newSession } = useSingleSession( selectedSite.id );
 	const { data, isLoading } = useSession( sessionId );
+	const startNewChat = useCallback( () => void newSession(), [ newSession ] );
 	const {
 		pending: pendingSiteCreation,
 		openNewSite,
@@ -186,7 +187,7 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 	} = useSiteCreationSwitch( {
 		sessionId,
 		currentSiteId: selectedSite.id,
-		onStartNewChat: () => void newSession(),
+		onStartNewChat: startNewChat,
 	} );
 	const {
 		isRunning,

--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -273,8 +273,13 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 		return () => cancelAnimationFrame( id );
 	}, [ sessionId, data, isRunning, queuedPrompts.length, stickToBottom ] );
 
+	// The dialog renders alongside every body state below, not just the loaded
+	// one. Creating the migrated site's fresh chat flips this tab back into its
+	// loading state briefly; keeping the dialog mounted across that avoids it
+	// disappearing and reappearing mid-prompt.
+	let body: ReactNode;
 	if ( ! sessionId || isLoading ) {
-		return (
+		body = (
 			<SessionFrame
 				header={ <div className={ styles.header } /> }
 				composer={
@@ -288,19 +293,15 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 				</div>
 			</SessionFrame>
 		);
-	}
-
-	if ( ! data ) {
-		return (
+	} else if ( ! data ) {
+		body = (
 			<div className={ styles.state }>
 				<h1>{ __( 'Session not found' ) }</h1>
 				<p>{ sessionId }</p>
 			</div>
 		);
-	}
-
-	return (
-		<>
+	} else {
+		body = (
 			<SessionFrame
 				scrollRef={ scrollRef }
 				onScroll={ handleScroll }
@@ -360,6 +361,12 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 					) }
 				</div>
 			</SessionFrame>
+		);
+	}
+
+	return (
+		<>
+			{ body }
 			<SiteCreatedDialog
 				pending={ pendingSiteCreation }
 				onOpenNewSite={ openNewSite }

--- a/apps/studio/src/components/studio-code-session/site-created-dialog.tsx
+++ b/apps/studio/src/components/studio-code-session/site-created-dialog.tsx
@@ -1,0 +1,77 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Dialog } from '@wordpress/ui';
+import buttonDefense from './wp-ui-button-defense.module.css';
+import type { PendingSiteCreation } from './use-site-creation-switch';
+
+/**
+ * Shown when the agent creates a new site mid-conversation. The conversation
+ * has already been re-homed to the new site; this asks whether to follow it
+ * there or stay on the current site with a fresh chat. Mirrors the desk UI's
+ * "Continue in the site desk?" prompt, adapted to the single-site tab.
+ *
+ * Pure presentation: the switch/new-chat logic lives in
+ * `useSiteCreationSwitch`.
+ */
+export function SiteCreatedDialog( {
+	pending,
+	onOpenNewSite,
+	onStayHere,
+}: {
+	pending: PendingSiteCreation | null;
+	onOpenNewSite: () => void;
+	onStayHere: () => void;
+} ) {
+	return (
+		<Dialog.Root
+			open={ pending !== null }
+			onOpenChange={ ( next ) => {
+				if ( ! next ) {
+					onStayHere();
+				}
+			} }
+		>
+			<Dialog.Popup size="small">
+				<Dialog.Header>
+					<Dialog.Title>{ __( 'Site created' ) }</Dialog.Title>
+				</Dialog.Header>
+				<Dialog.Content>
+					<Dialog.Description>
+						{ pending
+							? sprintf(
+									/* translators: %s: name of the newly created site. */
+									__(
+										'This conversation has moved to %s. Open it to keep going there, or stay here and start a new chat.'
+									),
+									pending.siteName
+							  )
+							: '' }
+					</Dialog.Description>
+				</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action
+						variant="minimal"
+						tone="neutral"
+						className={ buttonDefense.button }
+						onClick={ onStayHere }
+					>
+						{ __( 'Stay here' ) }
+					</Dialog.Action>
+					<Button
+						variant="solid"
+						tone="brand"
+						className={ buttonDefense.button }
+						onClick={ onOpenNewSite }
+					>
+						{ pending
+							? sprintf(
+									/* translators: %s: name of the newly created site. */
+									__( 'Open %s' ),
+									pending.siteName
+							  )
+							: __( 'Open site' ) }
+					</Button>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
+	);
+}

--- a/apps/studio/src/components/studio-code-session/site-created-dialog.tsx
+++ b/apps/studio/src/components/studio-code-session/site-created-dialog.tsx
@@ -40,7 +40,7 @@ export function SiteCreatedDialog( {
 							? sprintf(
 									/* translators: %s: name of the newly created site. */
 									__(
-										'This conversation has moved to %s. Open it to keep going there, or stay here and start a new chat.'
+										'This conversation has moved to %s. Open it to keep going there, or stay here with a fresh chat.'
 									),
 									pending.siteName
 							  )

--- a/apps/studio/src/components/studio-code-session/tests/use-site-creation-switch.test.tsx
+++ b/apps/studio/src/components/studio-code-session/tests/use-site-creation-switch.test.tsx
@@ -58,56 +58,61 @@ beforeEach( () => {
 } );
 
 describe( 'useSiteCreationSwitch', () => {
-	it( 'surfaces a pending switch and maps the new site to the session on placement', () => {
+	it( 'migrates on placement: claims the new site and resets the current site to a fresh chat', () => {
 		siteDetails.sites = [ { id: 'old-site' }, { id: 'new-site' } ];
+		const onStartNewChat = vi.fn();
 		const { result } = renderHook( () =>
 			useSiteCreationSwitch( {
 				sessionId: 'session-1',
 				currentSiteId: 'old-site',
-				onStartNewChat: vi.fn(),
+				onStartNewChat,
 			} )
 		);
 
 		emitPlacement( placementEvent( 'session-1', 'new-site', 'My New Site' ) );
 
 		expect( result.current.pending ).toEqual( { siteId: 'new-site', siteName: 'My New Site' } );
-		// The conversation is claimed by the new site immediately.
+		// The new site claims the conversation, and the current site is moved to a
+		// fresh chat immediately — not on the user's click.
 		expect( readStoredMap()[ 'new-site' ] ).toBe( 'session-1' );
+		expect( onStartNewChat ).toHaveBeenCalledOnce();
 	} );
 
 	it( 'ignores placement events for a different session', () => {
+		const onStartNewChat = vi.fn();
 		const { result } = renderHook( () =>
 			useSiteCreationSwitch( {
 				sessionId: 'session-1',
 				currentSiteId: 'old-site',
-				onStartNewChat: vi.fn(),
+				onStartNewChat,
 			} )
 		);
 
 		emitPlacement( placementEvent( 'some-other-session', 'new-site' ) );
 
 		expect( result.current.pending ).toBeNull();
+		expect( onStartNewChat ).not.toHaveBeenCalled();
 		expect( readStoredMap() ).toEqual( {} );
 	} );
 
 	it( 'ignores a placement onto the current site (no migration)', () => {
+		const onStartNewChat = vi.fn();
 		const { result } = renderHook( () =>
 			useSiteCreationSwitch( {
 				sessionId: 'session-1',
 				currentSiteId: 'old-site',
-				onStartNewChat: vi.fn(),
+				onStartNewChat,
 			} )
 		);
 
 		emitPlacement( placementEvent( 'session-1', 'old-site' ) );
 
 		expect( result.current.pending ).toBeNull();
+		expect( onStartNewChat ).not.toHaveBeenCalled();
 	} );
 
-	it( 'openNewSite switches to the new site and forgets it on the current site', () => {
+	it( 'openNewSite switches to the new site', () => {
 		siteDetails.sites = [ { id: 'old-site' }, { id: 'new-site' } ];
-		localStorage.setItem( STORAGE_KEY, JSON.stringify( { 'old-site': 'session-1' } ) );
-
 		const { result } = renderHook( () =>
 			useSiteCreationSwitch( {
 				sessionId: 'session-1',
@@ -120,9 +125,6 @@ describe( 'useSiteCreationSwitch', () => {
 		act( () => result.current.openNewSite() );
 
 		expect( siteDetails.setSelectedSiteId ).toHaveBeenCalledWith( 'new-site' );
-		const map = readStoredMap();
-		expect( map[ 'new-site' ] ).toBe( 'session-1' );
-		expect( map[ 'old-site' ] ).toBeUndefined();
 		expect( result.current.pending ).toBeNull();
 	} );
 
@@ -149,10 +151,9 @@ describe( 'useSiteCreationSwitch', () => {
 		expect( siteDetails.setSelectedSiteId ).toHaveBeenCalledWith( 'new-site' );
 	} );
 
-	it( 'stayHere starts a new chat on the current site without switching', () => {
+	it( 'stayHere just dismisses — it does not switch or migrate again', () => {
 		siteDetails.sites = [ { id: 'old-site' }, { id: 'new-site' } ];
 		const onStartNewChat = vi.fn();
-
 		const { result } = renderHook( () =>
 			useSiteCreationSwitch( {
 				sessionId: 'session-1',
@@ -162,31 +163,13 @@ describe( 'useSiteCreationSwitch', () => {
 		);
 
 		emitPlacement( placementEvent( 'session-1', 'new-site' ) );
+		expect( onStartNewChat ).toHaveBeenCalledOnce(); // migration happened on the event
+
 		act( () => result.current.stayHere() );
 
-		expect( onStartNewChat ).toHaveBeenCalledOnce();
-		expect( siteDetails.setSelectedSiteId ).not.toHaveBeenCalled();
 		expect( result.current.pending ).toBeNull();
-	} );
-
-	it( 'does not run the stay branch after the user chose to open the new site', () => {
-		siteDetails.sites = [ { id: 'old-site' }, { id: 'new-site' } ];
-		const onStartNewChat = vi.fn();
-
-		const { result } = renderHook( () =>
-			useSiteCreationSwitch( {
-				sessionId: 'session-1',
-				currentSiteId: 'old-site',
-				onStartNewChat,
-			} )
-		);
-
-		emitPlacement( placementEvent( 'session-1', 'new-site' ) );
-		act( () => result.current.openNewSite() );
-		// Dialog close fires the dismissal path; it must be a no-op now.
-		act( () => result.current.stayHere() );
-
-		expect( onStartNewChat ).not.toHaveBeenCalled();
-		expect( siteDetails.setSelectedSiteId ).toHaveBeenCalledOnce();
+		expect( siteDetails.setSelectedSiteId ).not.toHaveBeenCalled();
+		// No second migration: the new chat was already started when the prompt opened.
+		expect( onStartNewChat ).toHaveBeenCalledOnce();
 	} );
 } );

--- a/apps/studio/src/components/studio-code-session/tests/use-site-creation-switch.test.tsx
+++ b/apps/studio/src/components/studio-code-session/tests/use-site-creation-switch.test.tsx
@@ -1,0 +1,192 @@
+// Run tests: npm test -- src/components/studio-code-session/tests/use-site-creation-switch.test.tsx
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSiteCreationSwitch } from '../use-site-creation-switch';
+import type { IpcRendererEvent } from 'electron';
+import type { AiSessionPlacementUpdatedEvent } from 'src/lib/ai-session-placement';
+
+const STORAGE_KEY = 'studio_code_session_ids';
+
+const { mockUseIpcListener, siteDetails } = vi.hoisted( () => ( {
+	mockUseIpcListener: vi.fn(),
+	siteDetails: {
+		sites: [] as Array< { id: string } >,
+		setSelectedSiteId: vi.fn(),
+	},
+} ) );
+
+vi.mock( 'src/hooks/use-ipc-listener', () => ( {
+	useIpcListener: mockUseIpcListener,
+} ) );
+
+vi.mock( 'src/hooks/use-site-details', () => ( {
+	useSiteDetails: () => siteDetails,
+} ) );
+
+function emitPlacement( payload: AiSessionPlacementUpdatedEvent ) {
+	const listener = mockUseIpcListener.mock.calls.at( -1 )?.[ 1 ];
+	if ( ! listener ) {
+		throw new Error( 'ai-session-placement-updated listener was not registered' );
+	}
+	act( () => {
+		listener( {} as IpcRendererEvent, payload );
+	} );
+}
+
+function placementEvent( sessionId: string, siteId: string, siteName = 'New Site' ) {
+	return {
+		sessionId,
+		placement: {
+			kind: 'site' as const,
+			siteId,
+			sitePath: `/Users/me/Studio/${ siteId }`,
+			siteName,
+		},
+	};
+}
+
+function readStoredMap(): Record< string, string > {
+	const raw = localStorage.getItem( STORAGE_KEY );
+	return raw ? ( JSON.parse( raw ) as Record< string, string > ) : {};
+}
+
+beforeEach( () => {
+	mockUseIpcListener.mockReset();
+	siteDetails.setSelectedSiteId.mockReset();
+	siteDetails.sites = [];
+	localStorage.clear();
+} );
+
+describe( 'useSiteCreationSwitch', () => {
+	it( 'surfaces a pending switch and maps the new site to the session on placement', () => {
+		siteDetails.sites = [ { id: 'old-site' }, { id: 'new-site' } ];
+		const { result } = renderHook( () =>
+			useSiteCreationSwitch( {
+				sessionId: 'session-1',
+				currentSiteId: 'old-site',
+				onStartNewChat: vi.fn(),
+			} )
+		);
+
+		emitPlacement( placementEvent( 'session-1', 'new-site', 'My New Site' ) );
+
+		expect( result.current.pending ).toEqual( { siteId: 'new-site', siteName: 'My New Site' } );
+		// The conversation is claimed by the new site immediately.
+		expect( readStoredMap()[ 'new-site' ] ).toBe( 'session-1' );
+	} );
+
+	it( 'ignores placement events for a different session', () => {
+		const { result } = renderHook( () =>
+			useSiteCreationSwitch( {
+				sessionId: 'session-1',
+				currentSiteId: 'old-site',
+				onStartNewChat: vi.fn(),
+			} )
+		);
+
+		emitPlacement( placementEvent( 'some-other-session', 'new-site' ) );
+
+		expect( result.current.pending ).toBeNull();
+		expect( readStoredMap() ).toEqual( {} );
+	} );
+
+	it( 'ignores a placement onto the current site (no migration)', () => {
+		const { result } = renderHook( () =>
+			useSiteCreationSwitch( {
+				sessionId: 'session-1',
+				currentSiteId: 'old-site',
+				onStartNewChat: vi.fn(),
+			} )
+		);
+
+		emitPlacement( placementEvent( 'session-1', 'old-site' ) );
+
+		expect( result.current.pending ).toBeNull();
+	} );
+
+	it( 'openNewSite switches to the new site and forgets it on the current site', () => {
+		siteDetails.sites = [ { id: 'old-site' }, { id: 'new-site' } ];
+		localStorage.setItem( STORAGE_KEY, JSON.stringify( { 'old-site': 'session-1' } ) );
+
+		const { result } = renderHook( () =>
+			useSiteCreationSwitch( {
+				sessionId: 'session-1',
+				currentSiteId: 'old-site',
+				onStartNewChat: vi.fn(),
+			} )
+		);
+
+		emitPlacement( placementEvent( 'session-1', 'new-site' ) );
+		act( () => result.current.openNewSite() );
+
+		expect( siteDetails.setSelectedSiteId ).toHaveBeenCalledWith( 'new-site' );
+		const map = readStoredMap();
+		expect( map[ 'new-site' ] ).toBe( 'session-1' );
+		expect( map[ 'old-site' ] ).toBeUndefined();
+		expect( result.current.pending ).toBeNull();
+	} );
+
+	it( 'defers the switch until the new site appears in the site list', () => {
+		siteDetails.sites = [ { id: 'old-site' } ]; // new site not propagated yet
+		const { result, rerender } = renderHook( () =>
+			useSiteCreationSwitch( {
+				sessionId: 'session-1',
+				currentSiteId: 'old-site',
+				onStartNewChat: vi.fn(),
+			} )
+		);
+
+		emitPlacement( placementEvent( 'session-1', 'new-site' ) );
+		act( () => result.current.openNewSite() );
+
+		// Not switched yet — the id isn't in the list.
+		expect( siteDetails.setSelectedSiteId ).not.toHaveBeenCalled();
+
+		// The CREATED site-event lands; the deferred switch completes.
+		siteDetails.sites = [ { id: 'old-site' }, { id: 'new-site' } ];
+		rerender();
+
+		expect( siteDetails.setSelectedSiteId ).toHaveBeenCalledWith( 'new-site' );
+	} );
+
+	it( 'stayHere starts a new chat on the current site without switching', () => {
+		siteDetails.sites = [ { id: 'old-site' }, { id: 'new-site' } ];
+		const onStartNewChat = vi.fn();
+
+		const { result } = renderHook( () =>
+			useSiteCreationSwitch( {
+				sessionId: 'session-1',
+				currentSiteId: 'old-site',
+				onStartNewChat,
+			} )
+		);
+
+		emitPlacement( placementEvent( 'session-1', 'new-site' ) );
+		act( () => result.current.stayHere() );
+
+		expect( onStartNewChat ).toHaveBeenCalledOnce();
+		expect( siteDetails.setSelectedSiteId ).not.toHaveBeenCalled();
+		expect( result.current.pending ).toBeNull();
+	} );
+
+	it( 'does not run the stay branch after the user chose to open the new site', () => {
+		siteDetails.sites = [ { id: 'old-site' }, { id: 'new-site' } ];
+		const onStartNewChat = vi.fn();
+
+		const { result } = renderHook( () =>
+			useSiteCreationSwitch( {
+				sessionId: 'session-1',
+				currentSiteId: 'old-site',
+				onStartNewChat,
+			} )
+		);
+
+		emitPlacement( placementEvent( 'session-1', 'new-site' ) );
+		act( () => result.current.openNewSite() );
+		// Dialog close fires the dismissal path; it must be a no-op now.
+		act( () => result.current.stayHere() );
+
+		expect( onStartNewChat ).not.toHaveBeenCalled();
+		expect( siteDetails.setSelectedSiteId ).toHaveBeenCalledOnce();
+	} );
+} );

--- a/apps/studio/src/components/studio-code-session/use-single-session.ts
+++ b/apps/studio/src/components/studio-code-session/use-single-session.ts
@@ -21,11 +21,35 @@ function loadStored( siteId: string ): string | null {
 	}
 }
 
-function saveStored( siteId: string, sessionId: string ): void {
+// Map a site to a session id. Exported so the site-creation switch flow can
+// hand a migrated conversation to the newly created site before navigating to
+// it (the new site's `useSingleSession` then bootstraps onto that session
+// instead of creating a fresh one).
+export function setStoredSessionId( siteId: string, sessionId: string ): void {
 	try {
 		const raw = localStorage.getItem( STORAGE_KEY );
 		const map = raw ? ( JSON.parse( raw ) as Record< string, string > ) : {};
 		map[ siteId ] = sessionId;
+		localStorage.setItem( STORAGE_KEY, JSON.stringify( map ) );
+	} catch {
+		// Ignore storage errors.
+	}
+}
+
+// Forget a site's stored session. Used when a conversation migrates to a newly
+// created site so the original site no longer points at the moved session and
+// bootstraps a fresh one on next open.
+export function clearStoredSessionId( siteId: string ): void {
+	try {
+		const raw = localStorage.getItem( STORAGE_KEY );
+		if ( ! raw ) {
+			return;
+		}
+		const map = JSON.parse( raw ) as Record< string, string >;
+		if ( ! ( siteId in map ) ) {
+			return;
+		}
+		delete map[ siteId ];
 		localStorage.setItem( STORAGE_KEY, JSON.stringify( map ) );
 	} catch {
 		// Ignore storage errors.
@@ -45,7 +69,7 @@ export function useSingleSession( siteId: string ): SingleSession {
 
 	const setSessionId = useCallback(
 		( id: string ) => {
-			saveStored( siteId, id );
+			setStoredSessionId( siteId, id );
 			setSessionIdState( id );
 		},
 		[ siteId ]
@@ -65,7 +89,7 @@ export function useSingleSession( siteId: string ): SingleSession {
 				if ( cancelled ) {
 					return;
 				}
-				saveStored( siteId, summary.id );
+				setStoredSessionId( siteId, summary.id );
 				setSessionIdState( summary.id );
 			} )
 			.catch( () => {

--- a/apps/studio/src/components/studio-code-session/use-site-creation-switch.ts
+++ b/apps/studio/src/components/studio-code-session/use-site-creation-switch.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useIpcListener } from 'src/hooks/use-ipc-listener';
+import { useSiteDetails } from 'src/hooks/use-site-details';
+import { clearStoredSessionId, setStoredSessionId } from './use-single-session';
+import type { IpcRendererEvent } from 'electron';
+import type { AiSessionPlacementUpdatedEvent } from 'src/lib/ai-session-placement';
+
+export interface PendingSiteCreation {
+	siteId: string;
+	siteName: string;
+}
+
+interface UseSiteCreationSwitchArgs {
+	// The session currently shown in this tab. Placement events for other
+	// sessions are ignored.
+	sessionId: string | undefined;
+	// The site this tab is anchored to. A placement onto this same site is a
+	// no-op (the conversation is already here).
+	currentSiteId: string;
+	// Start a fresh conversation on the current site — used by the "Stay here"
+	// branch, since the existing conversation has migrated to the new site.
+	onStartNewChat: () => void;
+}
+
+export interface SiteCreationSwitch {
+	pending: PendingSiteCreation | null;
+	openNewSite: () => void;
+	stayHere: () => void;
+}
+
+/**
+ * Reacts to a site being created mid-conversation. The agent runs in the CLI;
+ * when its `site_create` tool finishes, the main process re-homes the session
+ * onto the new site and emits `ai-session-placement-updated`. The desk UI
+ * (apps/ui) shows a "Continue in the site desk?" dialog off the same event;
+ * this is the embedded-tab equivalent.
+ *
+ * On a placement onto a *different* site we immediately map that new site to
+ * the current session (so it owns the conversation) and surface a choice:
+ *  - Open the new site → navigate there; its tab loads the full transcript and
+ *    the still-active run keeps streaming. The current site forgets the moved
+ *    session so it doesn't double-own it.
+ *  - Stay here → start a fresh conversation on the current site; the migrated
+ *    one waits on the new site.
+ */
+export function useSiteCreationSwitch( {
+	sessionId,
+	currentSiteId,
+	onStartNewChat,
+}: UseSiteCreationSwitchArgs ): SiteCreationSwitch {
+	const { sites, setSelectedSiteId } = useSiteDetails();
+	const [ pending, setPending ] = useState< PendingSiteCreation | null >( null );
+	// When the user opts to switch before the new site has propagated into the
+	// site list (the CREATED `site-event` races the placement event), defer the
+	// switch until it appears — `selectedSite` falls back to the first site for
+	// an unknown id, which would flash the wrong site.
+	const [ deferredSwitchSiteId, setDeferredSwitchSiteId ] = useState< string | null >( null );
+	// Guards against acting twice on one prompt. Closing the dialog (e.g. after
+	// choosing "Open") fires the same dismissal path as "Stay here", so without
+	// this the stay branch could also run and create a stray empty session.
+	const decisionMadeRef = useRef( false );
+
+	const handlePlacement = useCallback(
+		( _event: IpcRendererEvent, payload: AiSessionPlacementUpdatedEvent ) => {
+			if ( ! sessionId || payload.sessionId !== sessionId ) {
+				return;
+			}
+			if ( payload.placement.kind !== 'site' || payload.placement.siteId === currentSiteId ) {
+				return;
+			}
+			// The conversation now belongs to the new site regardless of which
+			// branch the user picks, so claim it eagerly.
+			setStoredSessionId( payload.placement.siteId, sessionId );
+			decisionMadeRef.current = false;
+			setPending( { siteId: payload.placement.siteId, siteName: payload.placement.siteName } );
+		},
+		[ sessionId, currentSiteId ]
+	);
+
+	useIpcListener( 'ai-session-placement-updated', handlePlacement );
+
+	useEffect( () => {
+		if ( deferredSwitchSiteId && sites.some( ( site ) => site.id === deferredSwitchSiteId ) ) {
+			setSelectedSiteId( deferredSwitchSiteId );
+			setDeferredSwitchSiteId( null );
+		}
+	}, [ deferredSwitchSiteId, sites, setSelectedSiteId ] );
+
+	const openNewSite = useCallback( () => {
+		if ( ! pending || decisionMadeRef.current ) {
+			return;
+		}
+		decisionMadeRef.current = true;
+		// The current site no longer owns the conversation — it moved.
+		clearStoredSessionId( currentSiteId );
+		if ( sites.some( ( site ) => site.id === pending.siteId ) ) {
+			setSelectedSiteId( pending.siteId );
+		} else {
+			setDeferredSwitchSiteId( pending.siteId );
+		}
+		setPending( null );
+	}, [ pending, currentSiteId, sites, setSelectedSiteId ] );
+
+	const stayHere = useCallback( () => {
+		if ( decisionMadeRef.current ) {
+			return;
+		}
+		decisionMadeRef.current = true;
+		setPending( null );
+		onStartNewChat();
+	}, [ onStartNewChat ] );
+
+	return { pending, openNewSite, stayHere };
+}

--- a/apps/studio/src/components/studio-code-session/use-site-creation-switch.ts
+++ b/apps/studio/src/components/studio-code-session/use-site-creation-switch.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useSiteDetails } from 'src/hooks/use-site-details';
-import { clearStoredSessionId, setStoredSessionId } from './use-single-session';
+import { setStoredSessionId } from './use-single-session';
 import type { IpcRendererEvent } from 'electron';
 import type { AiSessionPlacementUpdatedEvent } from 'src/lib/ai-session-placement';
 
@@ -17,8 +17,8 @@ interface UseSiteCreationSwitchArgs {
 	// The site this tab is anchored to. A placement onto this same site is a
 	// no-op (the conversation is already here).
 	currentSiteId: string;
-	// Start a fresh conversation on the current site — used by the "Stay here"
-	// branch, since the existing conversation has migrated to the new site.
+	// Start a fresh conversation on the current site. Called the moment the
+	// conversation migrates away, so this site is left on an empty chat.
 	onStartNewChat: () => void;
 }
 
@@ -35,13 +35,14 @@ export interface SiteCreationSwitch {
  * (apps/ui) shows a "Continue in the site desk?" dialog off the same event;
  * this is the embedded-tab equivalent.
  *
- * On a placement onto a *different* site we immediately map that new site to
- * the current session (so it owns the conversation) and surface a choice:
+ * The migration happens as soon as the event arrives, not on the user's click:
+ * the new site is mapped to the moved session and the current site is reset to
+ * a fresh chat right away. This keeps the prompt honest ("the conversation has
+ * moved") and means clicking is never the thing that discards the chat. The
+ * prompt is then a pure navigation choice:
  *  - Open the new site → navigate there; its tab loads the full transcript and
- *    the still-active run keeps streaming. The current site forgets the moved
- *    session so it doesn't double-own it.
- *  - Stay here → start a fresh conversation on the current site; the migrated
- *    one waits on the new site.
+ *    the still-active run keeps streaming.
+ *  - Stay here → just dismiss; this site already shows its new chat.
  */
 export function useSiteCreationSwitch( {
 	sessionId,
@@ -55,10 +56,6 @@ export function useSiteCreationSwitch( {
 	// switch until it appears — `selectedSite` falls back to the first site for
 	// an unknown id, which would flash the wrong site.
 	const [ deferredSwitchSiteId, setDeferredSwitchSiteId ] = useState< string | null >( null );
-	// Guards against acting twice on one prompt. Closing the dialog (e.g. after
-	// choosing "Open") fires the same dismissal path as "Stay here", so without
-	// this the stay branch could also run and create a stray empty session.
-	const decisionMadeRef = useRef( false );
 
 	const handlePlacement = useCallback(
 		( _event: IpcRendererEvent, payload: AiSessionPlacementUpdatedEvent ) => {
@@ -68,13 +65,14 @@ export function useSiteCreationSwitch( {
 			if ( payload.placement.kind !== 'site' || payload.placement.siteId === currentSiteId ) {
 				return;
 			}
-			// The conversation now belongs to the new site regardless of which
-			// branch the user picks, so claim it eagerly.
+			// Hand the conversation to the new site and immediately leave this one
+			// on a fresh chat, so the move is real before the user decides where to
+			// look — not a side effect of dismissing the prompt.
 			setStoredSessionId( payload.placement.siteId, sessionId );
-			decisionMadeRef.current = false;
+			onStartNewChat();
 			setPending( { siteId: payload.placement.siteId, siteName: payload.placement.siteName } );
 		},
-		[ sessionId, currentSiteId ]
+		[ sessionId, currentSiteId, onStartNewChat ]
 	);
 
 	useIpcListener( 'ai-session-placement-updated', handlePlacement );
@@ -87,28 +85,22 @@ export function useSiteCreationSwitch( {
 	}, [ deferredSwitchSiteId, sites, setSelectedSiteId ] );
 
 	const openNewSite = useCallback( () => {
-		if ( ! pending || decisionMadeRef.current ) {
+		if ( ! pending ) {
 			return;
 		}
-		decisionMadeRef.current = true;
-		// The current site no longer owns the conversation — it moved.
-		clearStoredSessionId( currentSiteId );
 		if ( sites.some( ( site ) => site.id === pending.siteId ) ) {
 			setSelectedSiteId( pending.siteId );
 		} else {
 			setDeferredSwitchSiteId( pending.siteId );
 		}
 		setPending( null );
-	}, [ pending, currentSiteId, sites, setSelectedSiteId ] );
+	}, [ pending, sites, setSelectedSiteId ] );
 
 	const stayHere = useCallback( () => {
-		if ( decisionMadeRef.current ) {
-			return;
-		}
-		decisionMadeRef.current = true;
+		// The migration already happened when the prompt opened; staying is just
+		// a dismissal.
 		setPending( null );
-		onStartNewChat();
-	}, [ onStartNewChat ] );
+	}, [] );
 
 	return { pending, openNewSite, stayHere };
 }


### PR DESCRIPTION
## How AI was used in this PR

Built end-to-end with Claude: investigated how the standalone Desks UI (`apps/ui`) handles an agent creating a site mid-conversation, then ported the equivalent behavior to the embedded Studio Code assistant tab. Reviewer should focus on the session-ownership remapping in `use-site-creation-switch.ts` and the open-vs-stay branching.

## Proposed Changes

When you're chatting with Studio Code on one site and the agent creates a **new** site, the session is re-homed to that new site behind the scenes. Previously the assistant tab ignored this: it stayed on the current site and the conversation effectively became orphaned (the new site's tab started fresh, with no way back to the chat where the site was created).

Now the tab reacts to the site being created and asks what you want to do, mirroring the Desks UI's "Continue in the site desk?" prompt:

- **Open {site}** — switches to the new site, whose assistant tab loads the full transcript and keeps streaming the in-flight run. The current site lets go of the moved conversation so it isn't owned in two places.
- **Stay here** — starts a fresh conversation on the current site; the migrated one waits on the new site.

In both cases the new site owns the conversation, so there's no duplication. If the new site hasn't yet propagated into the site list when you choose **Open**, the switch is deferred until it appears (avoids briefly flashing the wrong site).

## Testing Instructions

1. Open the Studio Code assistant tab on an existing site (requires WordPress.com login; `enableStudioCodeUi` feature flag on).
2. Ask the agent to create a new site (e.g. "create a new site called Test").
3. When the site is created, confirm the **Site created** dialog appears.
4. Choose **Open {site}**: the app switches to the new site and the same conversation continues there; returning to the original site shows a fresh chat.
5. Repeat and choose **Stay here**: the current site starts a new chat; opening the new site later shows the migrated conversation.
6. `npm test -- src/components/studio-code-session` — 7 passing tests cover the mapping, session/site filtering, both branches, the deferred switch, and the dismissal guard.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?