### PR TITLE
Revert "Increase npm dependency cooldown to two days"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       interval: "weekly"
 
     cooldown:
-      default-days: 2
+      default-days: 1
 
     allow:
       # Automattic packages

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=2
+min-release-age=1


### PR DESCRIPTION
Temporarily reverts Automattic/studio#3671 because it broke our builds