### PR TITLE
Fix screenshot eval assertion to match the tool's JPEG output

### DIFF
--- a/eval/promptfoo.config.yaml
+++ b/eval/promptfoo.config.yaml
@@ -138,29 +138,53 @@ tests:
               return { pass: false, score: 0, reason: `expected two screenshot media payloads, got ${JSON.stringify(payloads).slice(0, 500)}` };
             }
 
+            // take_screenshot emits JPEG; key the expected width by viewport so
+            // the check survives a future format change rather than the extension.
             const expectedWidths = new Map([
-              ['screenshot-desktop.png', 1040],
-              ['screenshot-mobile.png', 390],
+              ['desktop', 1040],
+              ['mobile', 390],
             ]);
+            // Read pixel dimensions from a PNG or JPEG buffer; null if neither.
+            const readImageSize = (buf) => {
+              if (buf.length > 24 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) {
+                return { format: 'png', width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+              }
+              if (buf.length > 4 && buf[0] === 0xff && buf[1] === 0xd8) {
+                let offset = 2;
+                while (offset + 9 < buf.length) {
+                  if (buf[offset] !== 0xff) { offset++; continue; }
+                  const marker = buf[offset + 1];
+                  // Markers without a length payload: skip past them.
+                  if (marker === 0xd8 || marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7) || marker === 0x01) {
+                    offset += 2;
+                    continue;
+                  }
+                  // Start-of-frame markers carry the dimensions (excluding DHT/JPG/DAC).
+                  if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+                    return { format: 'jpeg', height: buf.readUInt16BE(offset + 5), width: buf.readUInt16BE(offset + 7) };
+                  }
+                  offset += 2 + buf.readUInt16BE(offset + 2);
+                }
+              }
+              return null;
+            };
             const seen = [];
             for (const payload of payloads) {
               const source = payload.widgetProps?.source;
-              const expectedWidth = expectedWidths.get(source?.name);
+              const viewport = (source?.name || '').replace(/^screenshot-/, '').replace(/\.(png|jpe?g)$/i, '');
+              const expectedWidth = expectedWidths.get(viewport);
               if (!expectedWidth) {
                 return { pass: false, score: 0, reason: `unexpected screenshot payload source: ${JSON.stringify(source)}` };
               }
               if (typeof source.path !== 'string' || !existsSync(source.path)) {
                 return { pass: false, score: 0, reason: `screenshot file is missing: ${JSON.stringify(source)}` };
               }
-              const png = readFileSync(source.path);
-              const isPng = png.length > 24 && png[0] === 0x89 && png[1] === 0x50 && png[2] === 0x4e && png[3] === 0x47;
-              const width = isPng ? png.readUInt32BE(16) : 0;
-              const height = isPng ? png.readUInt32BE(20) : 0;
-              if (!isPng || width !== expectedWidth || height < 600) {
+              const size = readImageSize(readFileSync(source.path));
+              if (!size || size.width !== expectedWidth || size.height < 600) {
                 return {
                   pass: false,
                   score: 0,
-                  reason: `${source.name} did not look like the expected PNG screenshot: png=${isPng}, width=${width}, height=${height}`,
+                  reason: `${source.name} did not look like the expected screenshot: ${JSON.stringify(size)}`,
                 };
               }
               seen.push(source.name);


### PR DESCRIPTION
## Related issues

None.

## How AI was used in this PR

The code change and this PR description were drafted with Claude Code; the diagnosis was confirmed by running the eval suite locally.

## Proposed Changes

The `screenshot-all-timing` agent eval has been failing because its assertion still expected PNG screenshots, while `take_screenshot` now produces JPEG (`screenshot-desktop.jpg` / `screenshot-mobile.jpg`, `image/jpeg`). The agent behavior was correct all along — one fast `viewport: "all"` capture of desktop and mobile — but the check rejected the payload on the file name/format and parsed dimensions as PNG.

This updates the assertion to validate the real invariant rather than the encoding:
- Keys the expected width by viewport (`desktop` → 1040, `mobile` → 390) instead of the file extension, so it no longer breaks if the format changes again.
- Reads pixel dimensions from either a PNG or a JPEG buffer.

The eval suite is green again, so the daily eval reports an accurate signal instead of a standing false failure.

## Testing Instructions

1. From `eval/`, run the screenshot case:
   `npx promptfoo@0.121.4 eval -c promptfoo.config.yaml --no-cache --filter-pattern "screenshot verification"`
2. Confirm it passes (it captures one `viewport: "all"` screenshot and validates the desktop/mobile JPEG dimensions).

## Pre-merge Checklist

- [x] Have you checked for similar PRs that may already address this?
- [x] Verified locally (the case passes).
- [ ] Reviewed by a teammate.
