### PR TITLE
Fix stopping sites while Studio quits

### DIFF
--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -429,8 +429,45 @@ async function appBoot() {
 	 */
 	let shouldStopSitesOnQuit = true;
 	let isQuittingConfirmed = false;
+	let isStoppingSitesBeforeQuit = false;
+	let hasCleanedUpBeforeQuit = false;
+
+	function cleanupBeforeQuit() {
+		if ( hasCleanedUpBeforeQuit ) {
+			return;
+		}
+
+		hasCleanedUpBeforeQuit = true;
+		markAppQuitting();
+		globalShortcut.unregisterAll();
+		stopCliEventsSubscriber();
+		stopRemoteSessionStatusPolling?.();
+		stopRemoteSessionStatusPolling = undefined;
+	}
+
+	function stopSitesAndExit() {
+		if ( isStoppingSitesBeforeQuit ) {
+			return;
+		}
+
+		isStoppingSitesBeforeQuit = true;
+		cleanupBeforeQuit();
+
+		void ( async () => {
+			try {
+				await stopAllServers( true, STOP_ALL_SERVERS_ON_QUIT_TIMEOUT_MS );
+			} finally {
+				app.exit();
+			}
+		} )();
+	}
 
 	app.on( 'before-quit', ( event ) => {
+		if ( isStoppingSitesBeforeQuit ) {
+			event.preventDefault();
+			return;
+		}
+
 		if ( isQuittingConfirmed ) {
 			return;
 		}
@@ -480,14 +517,18 @@ async function appBoot() {
 
 				if ( userData.stopSitesOnQuit !== undefined ) {
 					shouldStopSitesOnQuit = userData.stopSitesOnQuit;
+					if ( shouldStopSitesOnQuit ) {
+						stopSitesAndExit();
+						return;
+					}
+
 					isQuittingConfirmed = true;
 					app.quit();
 					return;
 				}
 
 				if ( process.env.E2E ) {
-					isQuittingConfirmed = true;
-					app.quit();
+					stopSitesAndExit();
 					return;
 				}
 
@@ -523,6 +564,11 @@ async function appBoot() {
 				}
 
 				shouldStopSitesOnQuit = stopSites;
+				if ( shouldStopSitesOnQuit ) {
+					stopSitesAndExit();
+					return;
+				}
+
 				isQuittingConfirmed = true;
 				app.quit();
 			} )();
@@ -532,20 +578,16 @@ async function appBoot() {
 	} );
 
 	app.on( 'will-quit', ( event ) => {
-		markAppQuitting();
-		globalShortcut.unregisterAll();
-		stopCliEventsSubscriber();
-		stopRemoteSessionStatusPolling?.();
+		if ( isStoppingSitesBeforeQuit ) {
+			event.preventDefault();
+			return;
+		}
+
+		cleanupBeforeQuit();
 
 		if ( shouldStopSitesOnQuit ) {
 			event.preventDefault();
-			stopAllServers( true, STOP_ALL_SERVERS_ON_QUIT_TIMEOUT_MS )
-				.then( () => {
-					app.exit();
-				} )
-				.catch( () => {
-					app.exit();
-				} );
+			stopSitesAndExit();
 		}
 	} );
 

--- a/apps/studio/src/tests/index.test.ts
+++ b/apps/studio/src/tests/index.test.ts
@@ -170,6 +170,29 @@ function mockElectron() {
 	return { mockedEvents };
 }
 
+function mockRunningSites() {
+	const stopAllServers = vi.fn().mockResolvedValue( undefined );
+
+	vi.doMock( 'src/site-server', () => ( {
+		getRunningSiteCount: vi.fn().mockReturnValue( 1 ),
+		stopAllServers,
+		SiteServer: {
+			fetchAll: vi.fn().mockResolvedValue( undefined ),
+		},
+	} ) );
+
+	return stopAllServers;
+}
+
+function restoreE2E( value: string | undefined ) {
+	if ( value === undefined ) {
+		delete process.env.E2E;
+		return;
+	}
+
+	process.env.E2E = value;
+}
+
 // Silence `console.log`, `console.warn`, and `console.error` output
 beforeAll( () => {
 	vi.spyOn( console, 'log' ).mockImplementation( () => {} );
@@ -298,5 +321,109 @@ describe( 'App initialization', () => {
 		Object.defineProperty( process, 'platform', { value: originalProcessPlatform } );
 
 		await mockedEvents[ 'will-quit' ]( { preventDefault: vi.fn() } );
+	} );
+
+	it( 'should stop running sites before exiting when confirmed while quitting', async () => {
+		const stopAllServers = mockRunningSites();
+		const { mockedEvents } = mockElectron();
+		const originalE2E = process.env.E2E;
+		delete process.env.E2E;
+		vi.resetModules();
+
+		try {
+			const { app, dialog, globalShortcut } = await import( 'electron' );
+			vi.mocked( dialog.showMessageBox ).mockResolvedValue( {
+				response: 0,
+				checkboxChecked: false,
+			} );
+
+			await import( '../index' );
+
+			const preventDefault = vi.fn();
+			await mockedEvents[ 'before-quit' ]( { preventDefault } );
+
+			expect( preventDefault ).toHaveBeenCalled();
+			await vi.waitFor( () => {
+				expect( dialog.showMessageBox ).toHaveBeenCalled();
+			} );
+			await vi.waitFor( () => {
+				expect( stopAllServers ).toHaveBeenCalledWith( true, 6000 );
+				expect( app.exit ).toHaveBeenCalled();
+			} );
+			expect( app.quit ).not.toHaveBeenCalled();
+			expect( globalShortcut.unregisterAll ).toHaveBeenCalled();
+		} finally {
+			restoreE2E( originalE2E );
+			vi.doUnmock( 'src/site-server' );
+			vi.resetModules();
+		}
+	} );
+
+	it( 'should leave running sites as the default quit dialog action', async () => {
+		const stopAllServers = mockRunningSites();
+		const { mockedEvents } = mockElectron();
+		const originalE2E = process.env.E2E;
+		delete process.env.E2E;
+		vi.resetModules();
+
+		try {
+			const { app, dialog, globalShortcut } = await import( 'electron' );
+			vi.mocked( dialog.showMessageBox ).mockResolvedValue( {
+				response: 1,
+				checkboxChecked: false,
+			} );
+
+			await import( '../index' );
+
+			await mockedEvents[ 'before-quit' ]( { preventDefault: vi.fn() } );
+
+			await vi.waitFor( () => {
+				expect( dialog.showMessageBox ).toHaveBeenCalledWith(
+					expect.objectContaining( { defaultId: 1 } )
+				);
+			} );
+			await vi.waitFor( () => {
+				expect( app.quit ).toHaveBeenCalled();
+			} );
+			expect( stopAllServers ).not.toHaveBeenCalled();
+			expect( app.exit ).not.toHaveBeenCalled();
+			expect( globalShortcut.unregisterAll ).not.toHaveBeenCalled();
+		} finally {
+			restoreE2E( originalE2E );
+			vi.doUnmock( 'src/site-server' );
+			vi.resetModules();
+		}
+	} );
+
+	it( 'should keep Studio open without cleanup when running-sites quit is cancelled', async () => {
+		const stopAllServers = mockRunningSites();
+		const { mockedEvents } = mockElectron();
+		const originalE2E = process.env.E2E;
+		delete process.env.E2E;
+		vi.resetModules();
+
+		try {
+			const { app, dialog, globalShortcut } = await import( 'electron' );
+			vi.mocked( dialog.showMessageBox ).mockResolvedValue( {
+				response: 2,
+				checkboxChecked: false,
+			} );
+
+			await import( '../index' );
+
+			await mockedEvents[ 'before-quit' ]( { preventDefault: vi.fn() } );
+			await vi.waitFor( () => {
+				expect( dialog.showMessageBox ).toHaveBeenCalled();
+			} );
+
+			expect( stopAllServers ).not.toHaveBeenCalled();
+			expect( app.quit ).not.toHaveBeenCalled();
+			expect( app.exit ).not.toHaveBeenCalled();
+			expect( globalShortcut.unregisterAll ).not.toHaveBeenCalled();
+		} finally {
+			restoreE2E( originalE2E );
+			vi.doUnmock( 'src/site-server' );
+			vi.resetModules();
+		}
 	} );
 } );


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-1778

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Used Codex to trace the quit flow, review recent related PRs (#2314, #3350, #3608, #2426, #2683), implement the fix, and add regression tests. I reviewed the final diff and ran the verification commands below.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

- Makes the **Stop sites** quit-dialog action reliably stop running sites before Studio exits.
- Keeps the existing safer quit behavior intact: **Leave running** remains the default, and **Cancel** keeps Studio open without entering shutdown cleanup.
- Preserves the ghost-window protection from the recent quit-flow fix by only marking Studio as quitting once the user has committed to quitting.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start one or more sites, quit Studio, choose **Stop sites**, and verify Studio exits after the sites stop.
- Start one or more sites, quit Studio, press Enter or choose **Leave running**, and verify Studio exits while the sites keep running.
- Start one or more sites, quit Studio, choose **Cancel**, and verify Studio stays open.
- With sites still starting, quit Studio and choose **Stop sites**; verify Studio quits without reopening ghost windows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
