### PR TITLE
Overwrite db.php before importing database

### DIFF
--- a/apps/cli/commands/tests/import.e2e.test.ts
+++ b/apps/cli/commands/tests/import.e2e.test.ts
@@ -17,6 +17,7 @@
  */
 import fs from 'fs';
 import path from 'path';
+import * as tar from 'tar';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
 	cleanupCliEnv,
@@ -183,6 +184,47 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: studio import', () => {
 			// Importing into a running site stops it first, then restores the
 			// running state after the import completes.
 			expect( await isSiteRunningPerCliList( env, sitePath ) ).toBe( true );
+			assertImportedSiteOnDisk( sitePath );
+			expect( await getBlogname( env, sitePath ) ).toBe( FIXTURE_BLOGNAME );
+		}
+	);
+
+	// Regression test for https://github.com/Automattic/studio/issues/3518
+	// where db.php overwrites SQLite drop-in during restore causing database import error
+	// "Could not determine the version of the SQLite integration plugin".
+	it(
+		'imports a backup containing db.php drop-in',
+		{ tags: [ 'e2e' ], timeout: 300_000 },
+		async () => {
+			if ( ! env ) {
+				throw new Error( 'CLI e2e env was not initialised' );
+			}
+
+			const workDir = path.join( env.root, 'db-php' );
+			const cwd = path.join( workDir, 'contents' );
+			fs.mkdirSync( cwd, { recursive: true } );
+			await tar.x( { file: path.join( FIXTURES_DIR, 'jetpack-backup.tar.gz' ), cwd } );
+
+			fs.writeFileSync(
+				path.join( cwd, 'wp-content', 'db.php' ),
+				'<?php\n/**\n * Plugin Name: Query Monitor Database Class (Drop-in)\n */\nclass QM_DB extends wpdb {}\n'
+			);
+
+			const file = path.join( workDir, 'jetpack-backup-db-php-replaced.tar.gz' );
+			await tar.c( { file, cwd, gzip: true }, fs.readdirSync( cwd ) );
+			const sitePath = await createStoppedSite(
+				env,
+				'Foreign DB Import E2E Site',
+				'import-db-php'
+			);
+
+			const result = await runCli( [ 'import', file, '--path', sitePath ], env );
+			expect( result.code, result.stderr ).toBe( 0 );
+
+			const db = fs.readFileSync( path.join( sitePath, 'wp-content', 'db.php' ), 'utf8' );
+			expect( db ).toContain( 'SQLITE_DB_DROPIN_VERSION' );
+			expect( db ).not.toContain( 'QM_DB' );
+
 			assertImportedSiteOnDisk( sitePath );
 			expect( await getBlogname( env, sitePath ) ).toBe( FIXTURE_BLOGNAME );
 		}

--- a/apps/cli/lib/import-export/import/importers/importer.ts
+++ b/apps/cli/lib/import-export/import/importers/importer.ts
@@ -17,6 +17,7 @@ import semver from 'semver';
 import trash from 'trash';
 import { SiteData } from 'cli/lib/cli-config/core';
 import { runWpCliCommand } from 'cli/lib/run-wp-cli-command';
+import { installSqliteIntegration } from 'cli/lib/sqlite-integration';
 import { ImportExportEventEmitter } from '../../events';
 import { BackupContents, MetaFileData } from '../types';
 import { updateSiteUrl } from '../update-site-url';
@@ -76,6 +77,9 @@ abstract class BaseImporter extends ImportExportEventEmitter implements Importer
 		const sortedSqlFiles = sqlFiles.sort( ( a, b ) => a.localeCompare( b ) );
 		let processedFiles = 0;
 		const totalFiles = sortedSqlFiles.length;
+
+		// db.php may be non-SQLite drop-in from backup
+		await installSqliteIntegration( site.path );
 
 		for ( const sqlFile of sortedSqlFiles ) {
 			const sqlTempFile = `${ generateBackupFilename( 'sql' ) }.sql`;


### PR DESCRIPTION
Ensure SQLite integration is in place since importing database reads file to determine version.

## Related issues

- Fixes Automattic/studio#3518

## How AI was used in this PR

This was my own work. I asked AI to investigate the problem from the issue and it made some random changes that didn't make any difference.

## Proposed Changes

The database import reads `SQLITE_DB_DROPIN_VERSION` but which doesn't exist, because db.php got overwritten by the import as I have Query Monitor plugin installed on my WordPress.com site. Therefore, recreate db.php before importing the database (at the expense of Query Monitor no longer having its drop-in db.php active).

## Testing Instructions

I only have one paid site (my personal site) on WordPress.com, so I tested by

1. Having Query Monitor installed on a site.
2. Pulling it into a new site created in Studio.
3. Error from Automattic/studio#3518 does not occur.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
