### PR TITLE
[PoC] Studio Web: run the Agentic UI in a browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ cli/vendor/
 
 # Build output
 dist
+dist-web
 
 # Playwright traces
 test-results

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -156,6 +156,22 @@ async function main() {
 	);
 	studioArgv.command( 'ai', false, studioCodeCommandBuilder );
 
+	studioArgv.command( {
+		command: 'web-server',
+		describe: __( 'Start the Studio Web backend (HTTP/SSE) for the browser UI' ),
+		builder: ( webYargs: StudioArgv ) => {
+			return webYargs.option( 'port', {
+				type: 'number',
+				description: __( 'Port to listen on' ),
+				default: 8088,
+			} );
+		},
+		handler: async ( argv ) => {
+			process.env.STUDIO_WEB_SERVER_PORT = String( ( argv as { port?: number } ).port ?? 8088 );
+			await import( 'cli/web-server/index.js' );
+		},
+	} );
+
 	registerExportCommand( studioArgv );
 	registerImportCommand( studioArgv );
 	registerMcpCommand( studioArgv );

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -59,6 +59,7 @@ export const baseConfig = defineConfig( {
 		lib: {
 			entry: {
 				main: resolve( __dirname, 'index.ts' ),
+				'web-server': resolve( __dirname, 'web-server/index.ts' ),
 				'process-manager-daemon': resolve( __dirname, 'process-manager-daemon.ts' ),
 				'proxy-daemon': resolve( __dirname, 'proxy-daemon.ts' ),
 				'playground-server-child': resolve( __dirname, 'playground-server-child.ts' ),

--- a/apps/cli/web-server/agent-runs.ts
+++ b/apps/cli/web-server/agent-runs.ts
@@ -1,0 +1,167 @@
+import { fork, type ChildProcess } from 'node:child_process';
+import crypto from 'node:crypto';
+import type { ActiveAgentRun, AgentEvent, AgentRunEvent } from '@studio/common/ai/agent-events';
+import type { JsonEvent } from '@studio/common/ai/json-events';
+
+/**
+ * Headless analog of the desktop `run-manager` (apps/studio/src/modules/
+ * ai-agent/run-manager.ts). It forks the exact same CLI subcommand the desktop
+ * forks — `code sessions resume <id> <prompt> --json` — relays the child's
+ * `JsonEvent`s as `AgentRunEvent`s, and synthesizes the same lifecycle events
+ * (`run.started`, `run.exited`, ...). The only difference is the sink: instead
+ * of `webContents.send`, events go to a broadcaster (SSE) injected via
+ * `setBroadcast`.
+ */
+
+interface AgentRun {
+	runId: string;
+	sessionId: string;
+	child: ChildProcess;
+	interrupted: boolean;
+	interruptAttempts: number;
+	startedAt: number;
+}
+
+const runsBySessionId = new Map< string, AgentRun >();
+const runsById = new Map< string, AgentRun >();
+
+type Broadcast = ( event: AgentRunEvent ) => void;
+let broadcast: Broadcast = () => {};
+
+export function setBroadcast( fn: Broadcast ): void {
+	broadcast = fn;
+}
+
+function nowIso(): string {
+	return new Date().toISOString();
+}
+
+function send( run: AgentRun, event: AgentEvent ): void {
+	broadcast( { runId: run.runId, sessionId: run.sessionId, event } );
+}
+
+export interface StartAgentRunOptions {
+	sessionId: string;
+	prompt: string;
+	displayMessage?: string;
+}
+
+export function startAgentRun( options: StartAgentRunOptions ): { runId: string } {
+	const { sessionId, prompt, displayMessage } = options;
+
+	if ( runsBySessionId.has( sessionId ) ) {
+		throw new Error( `A run is already in progress for session ${ sessionId }` );
+	}
+
+	const runId = crypto.randomUUID();
+	const startedAt = Date.now();
+	const args = [ 'code', 'sessions', 'resume', sessionId, prompt, '--json', '--avoid-telemetry' ];
+	if ( displayMessage ) {
+		args.push( '--display-message', displayMessage );
+	}
+
+	// Re-invoke this same CLI bundle. The child emits JSON transport events over
+	// the Node IPC channel (process.send), which we read via `message`.
+	const child = fork( process.argv[ 1 ], args, {
+		stdio: [ 'ignore', 'inherit', 'inherit', 'ipc' ],
+		execArgv: [ '--experimental-wasm-jspi' ],
+		env: { ...process.env },
+	} );
+
+	const run: AgentRun = {
+		runId,
+		sessionId,
+		child,
+		interrupted: false,
+		interruptAttempts: 0,
+		startedAt,
+	};
+
+	runsBySessionId.set( sessionId, run );
+	runsById.set( runId, run );
+
+	child.on( 'spawn', () => {
+		send( run, { type: 'run.started', timestamp: nowIso() } );
+	} );
+
+	child.on( 'message', ( message ) => {
+		// The CLI's Logger also writes to this channel with a different shape;
+		// forward only messages that look like the JSON transport envelope.
+		if ( message && typeof message === 'object' && 'type' in message ) {
+			send( run, message as JsonEvent );
+		}
+	} );
+
+	child.on( 'error', ( error ) => {
+		send( run, {
+			type: 'error',
+			timestamp: nowIso(),
+			message: error.message || 'CLI subprocess failed to start',
+		} );
+	} );
+
+	child.on( 'exit', ( code ) => {
+		runsBySessionId.delete( sessionId );
+		runsById.delete( runId );
+		if ( run.interrupted ) {
+			send( run, { type: 'run.interrupted', timestamp: nowIso() } );
+		}
+		send( run, {
+			type: 'run.exited',
+			timestamp: nowIso(),
+			status: code === 0 ? 'success' : 'error',
+			code,
+		} );
+	} );
+
+	return { runId };
+}
+
+export function listActiveAgentRuns(): ActiveAgentRun[] {
+	return Array.from( runsBySessionId.values() ).map( ( run ) => ( {
+		runId: run.runId,
+		sessionId: run.sessionId,
+		startedAt: run.startedAt,
+		phase: run.interrupted ? 'interrupting' : 'running',
+	} ) );
+}
+
+const INTERRUPT_FORCE_KILL_TIMEOUT_MS = 2000;
+
+export function interruptAgentRun( runId: string ): void {
+	const run = runsById.get( runId );
+	if ( ! run ) {
+		return;
+	}
+	run.interrupted = true;
+	run.interruptAttempts += 1;
+	if ( runsBySessionId.get( run.sessionId ) === run ) {
+		runsBySessionId.delete( run.sessionId );
+	}
+
+	if ( run.interruptAttempts > 1 ) {
+		run.child.kill( 'SIGKILL' );
+		return;
+	}
+
+	if ( run.child.connected ) {
+		run.child.send( { type: 'interrupt' } );
+		send( run, { type: 'run.interrupting', timestamp: nowIso() } );
+		setTimeout( () => {
+			if ( runsById.get( runId ) === run && ! run.child.killed ) {
+				run.child.kill( 'SIGKILL' );
+			}
+		}, INTERRUPT_FORCE_KILL_TIMEOUT_MS ).unref();
+		return;
+	}
+
+	run.child.kill( 'SIGKILL' );
+}
+
+export function answerAgentRun( runId: string, answers: Record< string, string > ): void {
+	const run = runsById.get( runId );
+	if ( ! run || ! run.child.connected ) {
+		return;
+	}
+	run.child.send( { type: 'answer', answers } );
+}

--- a/apps/cli/web-server/index.ts
+++ b/apps/cli/web-server/index.ts
@@ -1,6 +1,7 @@
 import { isAiModelId } from '@studio/common/ai/models';
 import {
 	appendModelChangeEntry,
+	appendStudioEntry,
 	createAiSession,
 	deleteAiSession,
 	listAiSessions,
@@ -17,6 +18,7 @@ import {
 	setBroadcast,
 	startAgentRun,
 } from './agent-runs';
+import { ensureWorkspace } from './workspaces';
 import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { SitesEndpointSite } from '@studio/common/types/sync';
 import type { Request, Response } from 'express';
@@ -176,9 +178,19 @@ app.get( '/sessions', async ( _req: Request, res: Response ) => {
 } );
 
 app.post( '/sessions', async ( _req: Request, res: Response ) => {
-	// `siteId` is accepted but ignored for the PoC: sessions start unbound and
-	// the agent creates/binds a site during the run.
-	res.json( await createAiSession( root ) );
+	// Studio Web runs the agent on a per-session, git-backed workspace — the
+	// cloud analog of Studio App's local site. Create the session, provision its
+	// workspace, and bind it via a `studio.site_selected` entry so the forked
+	// agent (`code sessions resume`) resolves the workspace as its active site.
+	// (`siteId` for seeding from an existing WP.com site is a later increment.)
+	const session = await createAiSession( root );
+	const workspace = ensureWorkspace( session.id );
+	await appendStudioEntry( root, session.id, 'studio.site_selected', {
+		siteName: workspace.name,
+		sitePath: workspace.path,
+		remote: false,
+	} );
+	res.json( await loadAiSession( root, session.id ) );
 } );
 
 app.get( '/sessions/:id', async ( req: Request, res: Response ) => {

--- a/apps/cli/web-server/index.ts
+++ b/apps/cli/web-server/index.ts
@@ -1,0 +1,262 @@
+import { isAiModelId } from '@studio/common/ai/models';
+import {
+	appendModelChangeEntry,
+	createAiSession,
+	deleteAiSession,
+	listAiSessions,
+	loadAiSession,
+} from '@studio/common/ai/sessions/store';
+import { readAuthToken } from '@studio/common/lib/shared-config';
+import { getSyncSupport } from '@studio/common/lib/sync/sync-support';
+import express from 'express';
+import { getAiSessionsRootDirectory } from 'cli/ai/sessions/paths';
+import {
+	answerAgentRun,
+	interruptAgentRun,
+	listActiveAgentRuns,
+	setBroadcast,
+	startAgentRun,
+} from './agent-runs';
+import type { AgentRunEvent } from '@studio/common/ai/agent-events';
+import type { SitesEndpointSite } from '@studio/common/types/sync';
+import type { Request, Response } from 'express';
+
+const DEFAULT_PORT = 8088;
+
+function getPort(): number {
+	return parseInt( process.env.STUDIO_WEB_SERVER_PORT ?? String( DEFAULT_PORT ), 10 );
+}
+
+// Express 5 types route params as `string | string[]`; named params are always
+// plain strings at runtime, so narrow them here.
+function param( req: Request, name: string ): string {
+	const value = req.params[ name ];
+	return Array.isArray( value ) ? value[ 0 ] ?? '' : value ?? '';
+}
+
+const root = getAiSessionsRootDirectory();
+const app = express();
+
+// Permissive CORS for the localhost PoC: the SPA dev server (5300) and this
+// backend live on different ports. EventSource (GET /events) needs no
+// preflight, but the JSON POST/PATCH/DELETE routes do.
+app.use( ( req: Request, res: Response, next ) => {
+	res.setHeader( 'Access-Control-Allow-Origin', req.headers.origin ?? '*' );
+	res.setHeader( 'Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS' );
+	res.setHeader( 'Access-Control-Allow-Headers', 'Content-Type' );
+	if ( req.method === 'OPTIONS' ) {
+		res.sendStatus( 204 );
+		return;
+	}
+	next();
+} );
+
+app.use( express.json() );
+
+// --- Server-Sent Events: one stream carries every run's AgentRunEvents -------
+
+const sseClients = new Set< Response >();
+
+app.get( '/events', ( req: Request, res: Response ) => {
+	res.setHeader( 'Content-Type', 'text/event-stream' );
+	res.setHeader( 'Cache-Control', 'no-cache' );
+	res.setHeader( 'Connection', 'keep-alive' );
+	res.flushHeaders?.();
+	res.write( ': connected\n\n' );
+	sseClients.add( res );
+	req.on( 'close', () => {
+		sseClients.delete( res );
+	} );
+} );
+
+// Broadcast every agent event to all connected SSE clients, in the same
+// envelope the web connector expects (channel + payload).
+setBroadcast( ( event: AgentRunEvent ) => {
+	const data = JSON.stringify( { channel: 'agent', payload: event } );
+	for ( const client of sseClients ) {
+		client.write( `data: ${ data }\n\n` );
+	}
+} );
+
+// --- Health ------------------------------------------------------------------
+
+app.get( '/health', ( _req: Request, res: Response ) => {
+	res.json( { status: 'ok' } );
+} );
+
+// --- Sites -------------------------------------------------------------------
+
+// Studio Web is a hosted product: the browser has no local Studio. The site
+// list is the user's WordPress.com sites, fetched live from the dotcom API
+// using the stored auth token — not local Studio config. We list only sites the
+// user can actually work on in Studio (Studio's own "syncable" criterion:
+// administered, supported host/plan, not deleted), so the 1000s of P2s a user
+// can merely read don't flood the list.
+const WPCOM_SITE_FIELDS = [
+	'ID',
+	'name',
+	'URL',
+	'icon',
+	'is_deleted',
+	'capabilities',
+	'is_wpcom_atomic',
+	'plan',
+	'jetpack',
+	'hosting_provider_guess',
+	'environment_type',
+	'options',
+].join( ',' );
+
+app.get( '/sites', async ( _req: Request, res: Response ) => {
+	const token = await readAuthToken();
+	if ( ! token ) {
+		// Not signed in to WordPress.com — no sites to show.
+		res.json( [] );
+		return;
+	}
+
+	const url = new URL( 'https://public-api.wordpress.com/rest/v1.1/me/sites' );
+	url.searchParams.set( 'fields', WPCOM_SITE_FIELDS );
+	// `wpcom_staging_blog_ids` lets us point the browser at a site's staging
+	// environment instead of production (see below).
+	url.searchParams.set( 'options', 'wpcom_staging_blog_ids' );
+	const response = await fetch( url, {
+		headers: { Authorization: `Bearer ${ token.accessToken }` },
+	} );
+	if ( ! response.ok ) {
+		res.status( response.status ).json( {
+			error: `WordPress.com sites fetch failed (${ response.status })`,
+		} );
+		return;
+	}
+
+	const body = ( await response.json() ) as { sites?: SitesEndpointSite[] };
+	const allSites = body.sites ?? [];
+
+	// Look up any site's URL by blog id, and collect every staging blog id so
+	// staging environments aren't listed as their own cards (they're surfaced
+	// through their production parent below).
+	const urlByBlogId = new Map< number, string >();
+	const stagingBlogIds = new Set< number >();
+	for ( const site of allSites ) {
+		urlByBlogId.set( site.ID, site.URL );
+		for ( const stagingId of site.options?.wpcom_staging_blog_ids ?? [] ) {
+			stagingBlogIds.add( stagingId );
+		}
+	}
+
+	const sites = allSites
+		// `getSyncSupport` with no connected ids returns 'syncable' for sites the
+		// user administers on a supported host/plan — i.e. usable in Studio.
+		.filter( ( site ) => getSyncSupport( site, [] ) === 'syncable' )
+		.filter( ( site ) => ! stagingBlogIds.has( site.ID ) )
+		.map( ( site ) => {
+			// Studio Web edits sites on their staging environment, never
+			// production. When a site has a staging blog, surface its URL.
+			const stagingId = site.options?.wpcom_staging_blog_ids?.[ 0 ];
+			const siteUrl = ( stagingId && urlByBlogId.get( stagingId ) ) || site.URL;
+			return {
+				id: String( site.ID ),
+				name: site.name || site.URL || String( site.ID ),
+				path: '',
+				port: 0,
+				running: true,
+				url: siteUrl,
+				phpVersion: '',
+				siteIcon: site.icon?.img ?? null,
+			};
+		} );
+	res.json( sites );
+} );
+
+// --- AI sessions -------------------------------------------------------------
+
+app.get( '/sessions', async ( _req: Request, res: Response ) => {
+	res.json( await listAiSessions( root ) );
+} );
+
+app.post( '/sessions', async ( _req: Request, res: Response ) => {
+	// `siteId` is accepted but ignored for the PoC: sessions start unbound and
+	// the agent creates/binds a site during the run.
+	res.json( await createAiSession( root ) );
+} );
+
+app.get( '/sessions/:id', async ( req: Request, res: Response ) => {
+	res.json( await loadAiSession( root, param( req, 'id' ) ) );
+} );
+
+app.delete( '/sessions/:id', async ( req: Request, res: Response ) => {
+	await deleteAiSession( root, param( req, 'id' ) );
+	res.sendStatus( 204 );
+} );
+
+app.patch( '/sessions/:id', async ( req: Request, res: Response ) => {
+	// Star/archive aren't persisted in the PoC (no shared store helper); echo
+	// the requested state on top of the current summary so the UI stays in sync.
+	const { summary } = await loadAiSession( root, param( req, 'id' ) );
+	const patch = req.body as { starred?: boolean; archived?: boolean };
+	res.json( { ...summary, ...patch } );
+} );
+
+app.post( '/sessions/:id/model', async ( req: Request, res: Response ) => {
+	const { model } = req.body as { model?: string };
+	if ( ! model || ! isAiModelId( model ) ) {
+		res.status( 400 ).json( { error: `Unknown AI model: ${ model }` } );
+		return;
+	}
+	await appendModelChangeEntry( root, param( req, 'id' ), '', model );
+	res.sendStatus( 204 );
+} );
+
+app.post( '/sessions/:id/messages', ( req: Request, res: Response ) => {
+	const { prompt, displayMessage } = req.body as { prompt?: string; displayMessage?: string };
+	if ( ! prompt ) {
+		res.status( 400 ).json( { error: 'prompt is required' } );
+		return;
+	}
+	const { runId } = startAgentRun( { sessionId: param( req, 'id' ), prompt, displayMessage } );
+	res.json( { runId } );
+} );
+
+// --- Runs --------------------------------------------------------------------
+
+app.get( '/runs/active', ( _req: Request, res: Response ) => {
+	res.json( listActiveAgentRuns() );
+} );
+
+app.post( '/runs/:runId/interrupt', ( req: Request, res: Response ) => {
+	interruptAgentRun( param( req, 'runId' ) );
+	res.sendStatus( 204 );
+} );
+
+app.post( '/runs/:runId/answer', ( req: Request, res: Response ) => {
+	const { answers } = req.body as { answers?: Record< string, string > };
+	answerAgentRun( param( req, 'runId' ), answers ?? {} );
+	res.sendStatus( 204 );
+} );
+
+// --- Error handling ----------------------------------------------------------
+
+app.use( ( err: unknown, _req: Request, res: Response, _next: ( e?: unknown ) => void ) => {
+	const message = err instanceof Error ? err.message : String( err );
+	res.status( 500 ).json( { error: message } );
+} );
+
+const port = getPort();
+const server = app.listen( port, () => {
+	console.log( `\nWordPress Studio Web Server` );
+	console.log( `==========================` );
+	console.log( `Listening:  http://localhost:${ port }` );
+	console.log( `Health:     http://localhost:${ port }/health` );
+	console.log( `Events:     http://localhost:${ port }/events (SSE)` );
+	console.log( '' );
+	console.log( `Point the web UI at this with VITE_STUDIO_API_URL=http://localhost:${ port }` );
+	console.log( '' );
+} );
+
+process.on( 'SIGINT', () => {
+	server.close( () => process.exit( 0 ) );
+} );
+process.on( 'SIGTERM', () => {
+	server.close( () => process.exit( 0 ) );
+} );

--- a/apps/cli/web-server/workspaces.ts
+++ b/apps/cli/web-server/workspaces.ts
@@ -1,0 +1,66 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
+
+/**
+ * Per-session workspace for Studio Web — the cloud analog of Studio App's local
+ * site layer. Each session gets its own git-backed working directory that the
+ * agent operates on as its active site. (PoC: the workspace lives under
+ * STUDIO_SITES_ROOT so the agent's file tools — scoped to that root — can reach
+ * it without relocating HOME, which would move session storage too.)
+ *
+ * "git-backed" is deliberate: it's the project container Studio Web will use
+ * instead of Telex's artefact.xml/S3 — `git status` is the change set and a
+ * later `git push` is the publish/deploy step (WordPress.com GitHub Deployments).
+ */
+
+const WORKSPACE_PREFIX = 'studio-web';
+
+export interface Workspace {
+	name: string;
+	slug: string;
+	path: string;
+}
+
+function git( cwd: string, args: string[] ): void {
+	execFileSync( 'git', args, {
+		cwd,
+		stdio: 'ignore',
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: 'Studio Web',
+			GIT_AUTHOR_EMAIL: 'studio-web@local',
+			GIT_COMMITTER_NAME: 'Studio Web',
+			GIT_COMMITTER_EMAIL: 'studio-web@local',
+		},
+	} );
+}
+
+/**
+ * Ensure a git-backed workspace exists for `sessionId` and return it. Idempotent:
+ * an existing workspace is returned untouched so re-runs of a session reuse it.
+ */
+export function ensureWorkspace( sessionId: string ): Workspace {
+	const slug = `${ WORKSPACE_PREFIX }-${ sessionId.slice( 0, 8 ) }`;
+	const workspacePath = path.join( STUDIO_SITES_ROOT, slug );
+	const name = `Studio Web (${ sessionId.slice( 0, 8 ) })`;
+
+	if ( ! fs.existsSync( workspacePath ) ) {
+		fs.mkdirSync( workspacePath, { recursive: true } );
+	}
+	if ( ! fs.existsSync( path.join( workspacePath, '.git' ) ) ) {
+		fs.writeFileSync(
+			path.join( workspacePath, '.gitignore' ),
+			// Track deployable code only, like a WordPress.com GitHub Deployments repo.
+			[ '/wp-content/uploads/', '/wp-content/database/', '**/*.sqlite', '.DS_Store', '' ].join(
+				'\n'
+			)
+		);
+		git( workspacePath, [ 'init', '-b', 'main' ] );
+		git( workspacePath, [ 'add', '-A' ] );
+		git( workspacePath, [ 'commit', '--allow-empty', '-m', 'studio-web: workspace baseline' ] );
+	}
+
+	return { name, slug, path: workspacePath };
+}

--- a/apps/ui/index.web.html
+++ b/apps/ui/index.web.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Studio Web</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/src/main.web.tsx"></script>
+	</body>
+</html>

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -5,10 +5,13 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
+		"dev:web": "STUDIO_TARGET=web vite",
 		"build": "vite build",
+		"build:web": "STUDIO_TARGET=web vite build",
 		"lint": "eslint src",
 		"typecheck": "tsc -p tsconfig.json --noEmit",
-		"preview": "vite preview"
+		"preview": "vite preview",
+		"preview:web": "STUDIO_TARGET=web vite preview"
 	},
 	"dependencies": {
 		"@base-ui/react": "^1.3.0",

--- a/apps/ui/src/app/use-ui-mode.ts
+++ b/apps/ui/src/app/use-ui-mode.ts
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 export type UiMode = 'classic' | 'desks';
 
 const STUDIO_UI_MODE_PARAM = 'studio-ui-mode';
+const STUDIO_UI_MODE_STORAGE_KEY = 'studio-ui-mode';
 const DEFAULT_UI_MODE: UiMode = 'desks';
 
 function readLaunchUiMode(): UiMode | undefined {
@@ -23,8 +24,28 @@ function readLaunchUiMode(): UiMode | undefined {
 	}
 }
 
+// Persisted so a real-path web build keeps its mode across reloads/deep links
+// (the desktop renderer stays on a single hash route, so this just mirrors the
+// in-memory default there).
+function readStoredUiMode(): UiMode | undefined {
+	try {
+		const stored = window.localStorage?.getItem( STUDIO_UI_MODE_STORAGE_KEY );
+		return stored === 'desks' || stored === 'classic' ? stored : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function storeUiMode( mode: UiMode ) {
+	try {
+		window.localStorage?.setItem( STUDIO_UI_MODE_STORAGE_KEY, mode );
+	} catch {
+		// Ignore storage failures (private mode, etc.).
+	}
+}
+
 function readInitialUiMode(): UiMode {
-	return readLaunchUiMode() ?? DEFAULT_UI_MODE;
+	return readLaunchUiMode() ?? readStoredUiMode() ?? DEFAULT_UI_MODE;
 }
 
 function resetRoute() {
@@ -54,6 +75,7 @@ export function useUiMode() {
 			}
 
 			setModeState( nextMode );
+			storeUiMode( nextMode );
 			resetRoute();
 		},
 		[ mode ]

--- a/apps/ui/src/data/core/connectors/web/index.ts
+++ b/apps/ui/src/data/core/connectors/web/index.ts
@@ -1,0 +1,423 @@
+import { createDefaultDeskSettings } from '@studio/common/lib/desk-settings';
+import { DEFAULT_MESSAGE_SEND_SHORTCUT } from '@studio/common/lib/user-settings/message-send-shortcut';
+import type {
+	ActiveAgentRun,
+	AiSessionPlacementUpdatedEvent,
+	AiSessionSummary,
+	AuthUser,
+	Connector,
+	DeskConfig,
+	DeskSettings,
+	FeatureFlags,
+	FeaturedBlueprint,
+	InstalledApps,
+	LoadedAiSession,
+	SiteDetails,
+	Snapshot,
+	StudioUiMode,
+	SyncSite,
+	UserPreferences,
+} from '../../types';
+import type { AgentRunEvent } from '@studio/common/ai/agent-events';
+
+export interface WebConnectorOptions {
+	// Base URL of the `studio web-server` backend, e.g. http://localhost:8088.
+	apiBaseUrl: string;
+}
+
+/**
+ * Thrown by connector methods that have no meaning in a browser (native file
+ * dialogs, opening an editor/terminal, etc.). Callers in the UI already wrap
+ * these affordances in try/catch, so throwing keeps the surface honest without
+ * breaking the app.
+ */
+export class WebUnsupportedError extends Error {
+	constructor( operation: string ) {
+		super( `"${ operation }" is not available in Studio Web.` );
+		this.name = 'WebUnsupportedError';
+	}
+}
+
+// Envelope used by the backend's `/events` SSE stream so a single connection
+// can carry both agent-run events and session-placement updates.
+type ServerEvent =
+	| { channel: 'agent'; payload: AgentRunEvent }
+	| { channel: 'placement'; payload: AiSessionPlacementUpdatedEvent };
+
+/**
+ * Connector that talks to the headless `studio web-server` over HTTP + SSE.
+ * It is the web analog of the Electron IPC connector: the same React app, the
+ * same `AgentRunEvent` stream, a different transport.
+ *
+ * Only the surface the PoC exercises is implemented for real (AI sessions and
+ * runs, the site list, featured blueprints, external links). Desktop-only
+ * capabilities either return benign defaults (so mount-time queries don't
+ * throw) or throw `WebUnsupportedError` for user-triggered actions.
+ */
+export function createWebConnector( { apiBaseUrl }: WebConnectorOptions ): Connector {
+	const base = apiBaseUrl.replace( /\/$/, '' );
+
+	const agentListeners = new Set< ( event: AgentRunEvent ) => void >();
+	const placementListeners = new Set< ( event: AiSessionPlacementUpdatedEvent ) => void >();
+	let eventSource: EventSource | undefined;
+
+	async function api< T >( path: string, init?: RequestInit ): Promise< T > {
+		const response = await fetch( `${ base }${ path }`, {
+			...init,
+			headers: {
+				'Content-Type': 'application/json',
+				...init?.headers,
+			},
+		} );
+		if ( ! response.ok ) {
+			const text = await response.text().catch( () => '' );
+			throw new Error(
+				`${ init?.method ?? 'GET' } ${ path } failed (${ response.status }): ${ text }`
+			);
+		}
+		if ( response.status === 204 ) {
+			return undefined as T;
+		}
+		return ( await response.json() ) as T;
+	}
+
+	function findSiteUrl( sites: SiteDetails[], siteId: string ): string {
+		const site = sites.find( ( candidate ) => candidate.id === siteId );
+		if ( ! site?.url ) {
+			throw new Error( `Site ${ siteId } has no URL` );
+		}
+		return site.url;
+	}
+
+	return {
+		async init() {
+			// One SSE connection carries both agent and placement events; the
+			// browser's EventSource reconnects automatically.
+			eventSource = new EventSource( `${ base }/events` );
+			eventSource.onmessage = ( message ) => {
+				let parsed: ServerEvent;
+				try {
+					parsed = JSON.parse( message.data ) as ServerEvent;
+				} catch {
+					return;
+				}
+				if ( parsed.channel === 'agent' ) {
+					agentListeners.forEach( ( listener ) => listener( parsed.payload ) );
+				} else if ( parsed.channel === 'placement' ) {
+					placementListeners.forEach( ( listener ) => listener( parsed.payload ) );
+				}
+			};
+		},
+
+		// Auth — the PoC runs unauthenticated, like the desktop app.
+		requiresAuth: false,
+		async isAuthenticated() {
+			return true;
+		},
+		async getAuthUser(): Promise< AuthUser | null > {
+			return null;
+		},
+		async authenticate() {
+			// No-op: the PoC has no login gate.
+		},
+		async logout() {
+			// No-op.
+		},
+		onAuthStateChanged() {
+			return () => {};
+		},
+
+		// Sites
+		async getSites(): Promise< SiteDetails[] > {
+			return api< SiteDetails[] >( '/sites' );
+		},
+		async createSite() {
+			throw new WebUnsupportedError( 'createSite' );
+		},
+		async deleteSite() {
+			throw new WebUnsupportedError( 'deleteSite' );
+		},
+		async copySite(): Promise< SiteDetails > {
+			throw new WebUnsupportedError( 'copySite' );
+		},
+		async startSite() {
+			throw new WebUnsupportedError( 'startSite' );
+		},
+		async stopSite() {
+			throw new WebUnsupportedError( 'stopSite' );
+		},
+		async updateSite() {
+			throw new WebUnsupportedError( 'updateSite' );
+		},
+		async refreshSiteIcon() {
+			// No-op: icons come back with getSites().
+		},
+		async getXdebugEnabledSite(): Promise< SiteDetails | null > {
+			return null;
+		},
+		async exportFullSite(): Promise< string | null > {
+			throw new WebUnsupportedError( 'exportFullSite' );
+		},
+		async exportDatabase(): Promise< string | null > {
+			throw new WebUnsupportedError( 'exportDatabase' );
+		},
+		async generateProposedSiteName(): Promise< string > {
+			throw new WebUnsupportedError( 'generateProposedSiteName' );
+		},
+		async generateProposedSitePath() {
+			throw new WebUnsupportedError( 'generateProposedSitePath' );
+		},
+		async selectSiteFolder() {
+			throw new WebUnsupportedError( 'selectSiteFolder' );
+		},
+		async comparePaths() {
+			throw new WebUnsupportedError( 'comparePaths' );
+		},
+		async getAllCustomDomains(): Promise< string[] > {
+			return [];
+		},
+
+		// Featured blueprints — public endpoint, identical to the IPC connector.
+		async getFeaturedBlueprints( locale ) {
+			const url = new URL( 'https://public-api.wordpress.com/wpcom/v2/studio-app/blueprints' );
+			if ( locale ) {
+				url.searchParams.set( 'locale', locale );
+			}
+			const response = await fetch( url.toString() );
+			if ( ! response.ok ) {
+				throw new Error( `Failed to fetch blueprints: ${ response.status }` );
+			}
+			const body = ( await response.json() ) as {
+				blueprints?: Array< {
+					slug?: string;
+					title?: string;
+					excerpt?: string;
+					image?: string;
+					playground_url?: string;
+					blueprint?: unknown;
+				} >;
+			};
+			const list: FeaturedBlueprint[] = [];
+			for ( const item of body.blueprints ?? [] ) {
+				if (
+					typeof item.slug !== 'string' ||
+					typeof item.title !== 'string' ||
+					typeof item.excerpt !== 'string' ||
+					typeof item.image !== 'string' ||
+					typeof item.playground_url !== 'string' ||
+					! item.blueprint ||
+					typeof item.blueprint !== 'object'
+				) {
+					continue;
+				}
+				list.push( {
+					slug: item.slug,
+					title: item.title,
+					excerpt: item.excerpt,
+					image: item.image,
+					playgroundUrl: item.playground_url,
+					blueprint: item.blueprint as FeaturedBlueprint[ 'blueprint' ],
+				} );
+			}
+			return list;
+		},
+
+		async getFilePath() {
+			// Browsers can't resolve a real filesystem path for a File.
+			return '';
+		},
+		async readLocalMediaFile() {
+			throw new WebUnsupportedError( 'readLocalMediaFile' );
+		},
+		async extractBlueprintBundle() {
+			throw new WebUnsupportedError( 'extractBlueprintBundle' );
+		},
+		async cleanupBlueprintTempDir() {
+			// No-op.
+		},
+		async importSiteFromBackup(): Promise< SiteDetails > {
+			throw new WebUnsupportedError( 'importSiteFromBackup' );
+		},
+
+		// Preview snapshots / sync — out of PoC scope.
+		async getSnapshots(): Promise< Snapshot[] > {
+			return [];
+		},
+		async publishPreviewSite(): Promise< { url: string } > {
+			throw new WebUnsupportedError( 'publishPreviewSite' );
+		},
+		async getConnectedWpcomSites(): Promise< SyncSite[] > {
+			return [];
+		},
+		async fetchSyncableWpcomSites(): Promise< SyncSite[] > {
+			return [];
+		},
+		async connectWpcomSite() {
+			throw new WebUnsupportedError( 'connectWpcomSite' );
+		},
+		async disconnectWpcomSite() {
+			throw new WebUnsupportedError( 'disconnectWpcomSite' );
+		},
+		onSyncConnectSite() {
+			return () => {};
+		},
+		async pushSiteToLive() {
+			throw new WebUnsupportedError( 'pushSiteToLive' );
+		},
+		async pullSiteFromLive() {
+			throw new WebUnsupportedError( 'pullSiteFromLive' );
+		},
+		getPublishCheckoutUrl() {
+			return undefined;
+		},
+
+		// AI sessions — the headline. HTTP routes on the web-server, backed by
+		// the shared session store and the same CLI agent the desktop forks.
+		async getSessions(): Promise< AiSessionSummary[] > {
+			return api< AiSessionSummary[] >( '/sessions' );
+		},
+		async getSession( sessionId ): Promise< LoadedAiSession > {
+			return api< LoadedAiSession >( `/sessions/${ encodeURIComponent( sessionId ) }` );
+		},
+		async deleteSession( sessionId ) {
+			await api( `/sessions/${ encodeURIComponent( sessionId ) }`, { method: 'DELETE' } );
+		},
+		async updateSessionMetadata( sessionId, patch ): Promise< AiSessionSummary > {
+			return api< AiSessionSummary >( `/sessions/${ encodeURIComponent( sessionId ) }`, {
+				method: 'PATCH',
+				body: JSON.stringify( patch ),
+			} );
+		},
+		async createSession( siteId ): Promise< AiSessionSummary > {
+			return api< AiSessionSummary >( '/sessions', {
+				method: 'POST',
+				body: JSON.stringify( { siteId } ),
+			} );
+		},
+		async continueSession( sessionId, prompt, options ): Promise< { runId: string } > {
+			return api< { runId: string } >( `/sessions/${ encodeURIComponent( sessionId ) }/messages`, {
+				method: 'POST',
+				body: JSON.stringify( { prompt, displayMessage: options?.displayMessage } ),
+			} );
+		},
+		async getActiveAgentRuns(): Promise< ActiveAgentRun[] > {
+			return api< ActiveAgentRun[] >( '/runs/active' );
+		},
+		async setSessionModel( sessionId, model ) {
+			await api( `/sessions/${ encodeURIComponent( sessionId ) }/model`, {
+				method: 'POST',
+				body: JSON.stringify( { model } ),
+			} );
+		},
+		async interruptAgentRun( runId ) {
+			await api( `/runs/${ encodeURIComponent( runId ) }/interrupt`, { method: 'POST' } );
+		},
+		async answerAgentQuestion( runId, answers ) {
+			await api( `/runs/${ encodeURIComponent( runId ) }/answer`, {
+				method: 'POST',
+				body: JSON.stringify( { answers } ),
+			} );
+		},
+		async setSessionEnvironment( _sessionId, environment ) {
+			// The PoC's agent always acts on the backend's local runtime.
+			return { environment };
+		},
+		onAgentEvent( listener ) {
+			agentListeners.add( listener );
+			return () => agentListeners.delete( listener );
+		},
+		onSessionPlacementUpdated( listener ) {
+			placementListeners.add( listener );
+			return () => placementListeners.delete( listener );
+		},
+
+		// User preferences — sensible browser defaults.
+		async getUserPreferences(): Promise< UserPreferences > {
+			return {
+				editor: null,
+				terminal: null,
+				colorScheme: 'system',
+				messageSendShortcut: DEFAULT_MESSAGE_SEND_SHORTCUT,
+				wpAdminOpenTarget: 'default-browser',
+				locale: undefined,
+			};
+		},
+		async setUserPreferences() {
+			// No-op for the PoC.
+		},
+		async getInstalledApps(): Promise< InstalledApps > {
+			return {} as InstalledApps;
+		},
+
+		// Desks / feature flags — defaults so both UI modes mount cleanly.
+		async getFeatureFlags(): Promise< FeatureFlags > {
+			return { enableDesksUiSwitch: false };
+		},
+		async getStudioUiMode(): Promise< StudioUiMode > {
+			return 'agentic';
+		},
+		async setStudioUiMode() {
+			// No-op: UI mode is chosen client-side on the web.
+		},
+		async getDeskSettings(): Promise< DeskSettings > {
+			return createDefaultDeskSettings();
+		},
+		async saveDeskSettings() {
+			// No-op for the PoC.
+		},
+		async exportDeskConfig(): Promise< string | null > {
+			return null;
+		},
+		async importDeskConfig(): Promise< DeskConfig | null > {
+			return null;
+		},
+		async getUserDeskConfig(): Promise< DeskConfig | undefined > {
+			return undefined;
+		},
+		async saveUserDeskConfig() {
+			// No-op for the PoC.
+		},
+		async getSiteDeskConfig(): Promise< DeskConfig | undefined > {
+			return undefined;
+		},
+		async saveSiteDeskConfig() {
+			// No-op for the PoC.
+		},
+
+		async fetchSiteRest() {
+			throw new WebUnsupportedError( 'fetchSiteRest' );
+		},
+
+		// Filesystem / native integrations — not available in a browser.
+		async openSiteFolder() {
+			throw new WebUnsupportedError( 'openSiteFolder' );
+		},
+		async openSiteInEditor() {
+			throw new WebUnsupportedError( 'openSiteInEditor' );
+		},
+		async openSiteInTerminal() {
+			throw new WebUnsupportedError( 'openSiteInTerminal' );
+		},
+
+		// External links work natively in the browser.
+		async openExternalUrl( url ) {
+			window.open( url, '_blank', 'noopener,noreferrer' );
+		},
+		async openSiteUrl( siteId, relativeUrl = '' ) {
+			const sites = await api< SiteDetails[] >( '/sites' );
+			const target = new URL( relativeUrl || '/', findSiteUrl( sites, siteId ) ).toString();
+			window.open( target, '_blank', 'noopener,noreferrer' );
+		},
+
+		// Window chrome — no traffic lights in a browser tab.
+		async isFullscreen() {
+			return false;
+		},
+		onFullscreenChange() {
+			return () => {};
+		},
+		onSiteEvent() {
+			return () => {};
+		},
+	};
+}

--- a/apps/ui/src/lib/get-site-url.ts
+++ b/apps/ui/src/lib/get-site-url.ts
@@ -8,6 +8,12 @@ export function getSiteUrl( site: SiteDetails ): string {
 		const protocol = site.enableHttps ? 'https' : 'http';
 		return `${ protocol }://${ site.customDomain }`;
 	}
+	// Hosted sites (e.g. Studio Web) carry an absolute remote URL and no local
+	// port. Prefer it; on desktop running sites this is the same localhost URL
+	// the fallback would build, so behavior there is unchanged.
+	if ( site.url ) {
+		return site.url;
+	}
 	return `http://localhost:${ site.port }`;
 }
 

--- a/apps/ui/src/main.web.tsx
+++ b/apps/ui/src/main.web.tsx
@@ -1,0 +1,55 @@
+import { getLocaleData, isSupportedLocale } from '@studio/common/lib/locale';
+import { defaultI18n } from '@wordpress/i18n';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from '@/app';
+import { persistPromise } from '@/data/core';
+import { createWebConnector } from '@/data/core/connectors/web';
+import type { Connector } from '@/data/core';
+
+// Web entry point. Identical to `main.tsx` except it wires the HTTP/SSE web
+// connector instead of the Electron IPC connector, so the same React app runs
+// in a plain browser tab against the `studio web-server` backend.
+
+async function loadTranslations( connector: Connector ) {
+	const { locale } = await connector.getUserPreferences();
+	if ( ! locale || ! isSupportedLocale( locale ) ) {
+		return;
+	}
+	const translations = getLocaleData( locale )?.messages;
+	if ( translations ) {
+		defaultI18n.setLocaleData( translations );
+	}
+}
+
+// Studio Web defaults to the classic (agentic) UI — it uses real-path routing
+// that survives reloads/deep links, and it's the surface PR #3646 redesigns.
+// Seed the persisted mode only when the user hasn't already chosen one.
+function seedDefaultUiMode() {
+	try {
+		const hasParam = new URLSearchParams( window.location.search ).has( 'studio-ui-mode' );
+		if ( ! hasParam && ! window.localStorage.getItem( 'studio-ui-mode' ) ) {
+			window.localStorage.setItem( 'studio-ui-mode', 'classic' );
+		}
+	} catch {
+		// Ignore storage failures.
+	}
+}
+
+async function bootstrap() {
+	seedDefaultUiMode();
+
+	const connector = createWebConnector( {
+		apiBaseUrl: import.meta.env.VITE_STUDIO_API_URL ?? 'http://localhost:8088',
+	} );
+
+	await Promise.all( [ connector.init?.(), loadTranslations( connector ), persistPromise ] );
+
+	createRoot( document.getElementById( 'root' )! ).render(
+		<StrictMode>
+			<App connector={ connector } />
+		</StrictMode>
+	);
+}
+
+void bootstrap();

--- a/apps/ui/src/vite-env.d.ts
+++ b/apps/ui/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+	// Base URL of the `studio web-server` backend the web connector talks to.
+	readonly VITE_STUDIO_API_URL?: string;
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -18,8 +18,48 @@ const directDeps = Object.entries( pkg.dependencies ?? {} )
 	.filter( ( [ , version ] ) => ! version.startsWith( 'file:' ) )
 	.map( ( [ name ] ) => name );
 
+// Web target (`STUDIO_TARGET=web`) builds a standalone browser app wired to the
+// HTTP/SSE web connector. It uses a separate entry/output/port so the default
+// Electron-renderer build (`dist/`, port 5200) stays byte-for-byte unchanged.
+const isWeb = process.env.STUDIO_TARGET === 'web';
+
+// In dev, Vite serves the root `index.html` (which loads the Electron entry,
+// `main.tsx`) for every SPA navigation, regardless of `build.rollupOptions.input`.
+// Serve `index.web.html` instead for any document navigation (`/`, `/sites`,
+// `/sessions/:id`, …) so the web entry + web connector load and client-side
+// routing/refresh works. Module and asset requests pass through untouched.
+const webDevEntryPlugin = {
+	name: 'studio-web-dev-entry',
+	apply: 'serve' as const,
+	configureServer( server: {
+		middlewares: {
+			use: (
+				fn: (
+					req: { url?: string; headers?: Record< string, unknown > },
+					res: unknown,
+					next: () => void
+				) => void
+			) => void;
+		};
+	} ) {
+		server.middlewares.use( ( req, _res, next ) => {
+			const accept = String( req.headers?.accept ?? '' );
+			const [ pathname ] = ( req.url ?? '' ).split( '?' );
+			const isInternal =
+				pathname.startsWith( '/@' ) ||
+				pathname.startsWith( '/src/' ) ||
+				pathname.startsWith( '/node_modules/' ) ||
+				pathname.includes( '.' );
+			if ( accept.includes( 'text/html' ) && ! isInternal ) {
+				req.url = '/index.web.html';
+			}
+			next();
+		} );
+	},
+};
+
 export default defineConfig( {
-	plugins: [ react(), dsTokenFallbacks() ],
+	plugins: [ react(), dsTokenFallbacks(), ...( isWeb ? [ webDevEntryPlugin ] : [] ) ],
 	css: {
 		postcss: {
 			plugins: [ dsTokenFallbacksPostcss ],
@@ -44,12 +84,12 @@ export default defineConfig( {
 		include: directDeps,
 	},
 	server: {
-		port: 5200,
+		port: isWeb ? 5300 : 5200,
 	},
 	build: {
-		outDir: 'dist',
+		outDir: isWeb ? 'dist-web' : 'dist',
 		rollupOptions: {
-			input: resolve( __dirname, 'index.html' ),
+			input: resolve( __dirname, isWeb ? 'index.web.html' : 'index.html' ),
 		},
 	},
 } );


### PR DESCRIPTION
## Related issues

- Related to #3646 — this PR is **stacked on top of it** (base branch `interface-improvements`). No companion issue yet; opening as a directional proof of concept.

> Note: to satisfy the pre-push "up to date with trunk" check, the branch also includes a routine merge of `trunk`. The actual change is a single commit; reviewers can focus on that.

## How AI was used in this PR

This PR was built by an AI agent (Claude Code) — including this description — and then reviewed by me. The agent added the web entry, the web connector, and the CLI `web-server`, and verified the end-to-end flow in a real browser. Please review with that context in mind.

## Proposed Changes

A proof of concept that runs Studio's new **Agentic UI (`apps/ui`) in a plain web browser**, as a foundation for "Studio Web."

`apps/ui` already talks to the backend only through its `Connector` interface, so this adds a web build target, a non-Electron connector, and a small headless backend — **without changing the UI itself**:

- You can open the Agentic UI in a browser tab and chat with the Studio Code agent. The agent runs exactly as it does on desktop — the same CLI engine and the same streamed `AgentRunEvent`s — only the transport differs (HTTP + SSE instead of Electron IPC). No A2A in this path.
- The site list is the user's **WordPress.com sites, fetched live from the dotcom API**, limited to sites they can actually work on in Studio (the existing "syncable" criterion). For atomic sites that have a staging environment, the browser targets **staging**, not production.
- Everything runs on **localhost** for now.

This is directional, not production-ready: it shows that one portable Agentic UI can serve both desktop and web by swapping the connector. It deliberately skips the hosted/multi-tenant concerns — per-user isolation/sandboxing, WordPress.com login/OAuth, durable sessions, and deployment — which are the natural follow-ups.

## Testing Instructions

Requires being logged in to WordPress.com via the Studio CLI/app (the site list and agent use that token).

1. `npm run cli:build`
2. Backend: `node apps/cli/dist/cli/main.mjs web-server` → serves `http://localhost:8088`
3. Frontend: `cd apps/ui && npm run dev:web` → serves `http://localhost:5300`
4. Open `http://localhost:5300` — the Agentic UI loads and lists your WordPress.com sites.
5. Pick a site → **New chat** → send a prompt; the agent's reply streams in. Interrupt and answer-a-question work too.

Quick backend checks without the UI:

```
curl -s localhost:8088/health
curl -s localhost:8088/sites | python3 -m json.tool
```

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? — `tsc` (apps/cli + apps/ui) and ESLint are clean. One known cosmetic console warning remains on web (a `desk-config` query returns `undefined`); it's inherent to the connector contract and non-fatal.
