### PR TITLE
Default wpcom provider for Studio Code in Studio UI

### DIFF
--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -315,6 +315,12 @@ export async function runCommand( options: {
 	const config = await readCliConfig();
 	let showCapabilitiesOnConnect = ! config.aiProvider;
 
+	// Since Studio Code inside Studio UI is free right now - we decided to default to WordPress.com provider so far.
+	if ( isJsonMode && showCapabilitiesOnConnect ) {
+		await switchProvider( 'wpcom', false );
+		showCapabilitiesOnConnect = false;
+	}
+
 	if ( showCapabilitiesOnConnect ) {
 		ui.showOnboarding();
 

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -315,7 +315,7 @@ export async function runCommand( options: {
 	const config = await readCliConfig();
 	let showCapabilitiesOnConnect = ! config.aiProvider;
 
-	// Since Studio Code inside Studio UI is free right now - we decided to default to WordPress.com provider so far.
+	// Studio Code Desktop defaults to WordPress.com provider.
 	if ( isJsonMode && showCapabilitiesOnConnect ) {
 		await switchProvider( 'wpcom', false );
 		showCapabilitiesOnConnect = false;

--- a/apps/cli/commands/ai/tests/index.test.ts
+++ b/apps/cli/commands/ai/tests/index.test.ts
@@ -7,11 +7,6 @@ import { createStudioSession } from 'cli/ai/sessions/pi-session';
 import { readCliConfig } from 'cli/lib/cli-config/core';
 import { runCommand } from '../index';
 
-// `runCommand` pulls in the whole AI chat stack (TUI, agent runtime, slash
-// commands, sessions). We stub the heavy collaborators and drive a single
-// JSON-mode turn the way Studio Desktop does (an `initialMessage` with a mocked
-// agent runtime), so the provider-selection logic runs to completion without an
-// interactive UI.
 vi.mock( '@studio/common/lib/shared-config', () => ( {
 	readAuthToken: vi.fn(),
 } ) );
@@ -59,8 +54,6 @@ vi.mock( 'cli/ai/daemon-status-poll', () => ( {
 	startDaemonStatusPolling: vi.fn( () => vi.fn() ),
 } ) );
 vi.mock( 'cli/commands/auth/login', () => ( { runCommand: vi.fn() } ) );
-// AiChatUI is referenced only via `instanceof`; a bare class avoids loading the
-// real TUI implementation.
 vi.mock( 'cli/ai/ui', () => ( { AiChatUI: class AiChatUI {} } ) );
 vi.mock( 'cli/logger', () => ( {
 	Logger: class {},

--- a/apps/cli/commands/ai/tests/index.test.ts
+++ b/apps/cli/commands/ai/tests/index.test.ts
@@ -1,0 +1,110 @@
+import { readAuthToken } from '@studio/common/lib/shared-config';
+import { vi, type Mock } from 'vitest';
+import { resolveInitialAiProvider, saveSelectedAiProvider } from 'cli/ai/auth';
+import { JsonAdapter } from 'cli/ai/output-adapter';
+import { runStudioAgentTurn } from 'cli/ai/runtimes/pi';
+import { createStudioSession } from 'cli/ai/sessions/pi-session';
+import { readCliConfig } from 'cli/lib/cli-config/core';
+import { runCommand } from '../index';
+
+// `runCommand` pulls in the whole AI chat stack (TUI, agent runtime, slash
+// commands, sessions). We stub the heavy collaborators and drive a single
+// JSON-mode turn the way Studio Desktop does (an `initialMessage` with a mocked
+// agent runtime), so the provider-selection logic runs to completion without an
+// interactive UI.
+vi.mock( '@studio/common/lib/shared-config', () => ( {
+	readAuthToken: vi.fn(),
+} ) );
+vi.mock( 'cli/ai/auth', () => ( {
+	resolveInitialAiProvider: vi.fn(),
+	saveSelectedAiProvider: vi.fn(),
+	getAvailableAiProviders: vi.fn( () => [ 'wpcom' ] ),
+	isAiProviderReady: vi.fn(),
+	prepareAiProvider: vi.fn(),
+	resolveAiEnvironment: vi.fn(),
+	resolveUnavailableAiProvider: vi.fn(),
+} ) );
+vi.mock( 'cli/ai/providers', () => ( {
+	AI_PROVIDERS: { wpcom: 'WordPress.com', 'anthropic-api-key': 'Anthropic · API key' },
+	getAiProviderDefinition: () => ( {
+		supportsModel: () => true,
+		defaultModel: 'claude-default',
+	} ),
+} ) );
+vi.mock( 'cli/lib/cli-config/core', () => ( {
+	readCliConfig: vi.fn(),
+} ) );
+vi.mock( 'cli/lib/cli-config/sites', () => ( {
+	findSiteByFolder: vi.fn(),
+} ) );
+vi.mock( 'cli/ai/sessions/context', () => ( {
+	resolveResumeSessionContext: () => ( { provider: undefined, model: undefined } ),
+} ) );
+vi.mock( 'cli/ai/sessions/pi-session', () => ( {
+	createStudioSession: vi.fn(),
+	openStudioSession: vi.fn(),
+	listStudioSessionFiles: vi.fn(),
+} ) );
+vi.mock( 'cli/ai/sessions/replay', () => ( { replaySessionHistory: vi.fn() } ) );
+vi.mock( 'cli/ai/sessions/paths', () => ( { getAiSessionsRootDirectory: vi.fn() } ) );
+vi.mock( 'cli/ai/runtimes/pi', () => ( {
+	// A completed turn so the JSON single-turn path returns instead of looping.
+	runStudioAgentTurn: vi.fn( () => ( { result: Promise.resolve(), interrupt: vi.fn() } ) ),
+} ) );
+vi.mock( 'cli/ai/slash-commands', () => ( { getActiveSlashCommands: vi.fn( () => [] ) } ) );
+vi.mock( 'cli/ai/browser-utils', () => ( { closeSharedBrowser: vi.fn() } ) );
+vi.mock( 'cli/ai/chat-artifacts', () => ( { setChatArtifactCallback: vi.fn() } ) );
+vi.mock( 'cli/ai/site-selection', () => ( { setLocalSiteSelectedCallback: vi.fn() } ) );
+vi.mock( 'cli/ai/daemon-status-poll', () => ( {
+	startDaemonStatusPolling: vi.fn( () => vi.fn() ),
+} ) );
+vi.mock( 'cli/commands/auth/login', () => ( { runCommand: vi.fn() } ) );
+// AiChatUI is referenced only via `instanceof`; a bare class avoids loading the
+// real TUI implementation.
+vi.mock( 'cli/ai/ui', () => ( { AiChatUI: class AiChatUI {} } ) );
+vi.mock( 'cli/logger', () => ( {
+	Logger: class {},
+	LoggerError: class LoggerError extends Error {},
+	setProgressCallback: vi.fn(),
+} ) );
+
+describe( 'AI runCommand — Desktop (JSON mode) provider default', () => {
+	let stdoutSpy: ReturnType< typeof vi.spyOn >;
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		( createStudioSession as Mock ).mockResolvedValue( {
+			appendCustomEntry: vi.fn( () => 'entry-id' ),
+			getSessionId: () => 'session-id',
+			getEntries: () => [],
+		} );
+		( readAuthToken as Mock ).mockResolvedValue( null );
+		// Silence the NDJSON the adapter writes to stdout.
+		stdoutSpy = vi.spyOn( process.stdout, 'write' ).mockImplementation( () => true );
+	} );
+
+	afterEach( () => {
+		stdoutSpy.mockRestore();
+	} );
+
+	it( 'defaults to the wpcom provider on first run when none is configured', async () => {
+		( readCliConfig as Mock ).mockResolvedValue( { aiProvider: undefined } );
+		( resolveInitialAiProvider as Mock ).mockResolvedValue( 'wpcom' );
+
+		await runCommand( { adapter: new JsonAdapter(), initialMessage: 'hello' } );
+
+		expect( runStudioAgentTurn ).toHaveBeenCalled();
+		expect( saveSelectedAiProvider ).toHaveBeenCalledTimes( 1 );
+		expect( saveSelectedAiProvider ).toHaveBeenCalledWith( 'wpcom' );
+	} );
+
+	it( 'does not override an already-configured provider', async () => {
+		( readCliConfig as Mock ).mockResolvedValue( { aiProvider: 'anthropic-api-key' } );
+		( resolveInitialAiProvider as Mock ).mockResolvedValue( 'anthropic-api-key' );
+
+		await runCommand( { adapter: new JsonAdapter(), initialMessage: 'hello' } );
+
+		expect( runStudioAgentTurn ).toHaveBeenCalled();
+		expect( saveSelectedAiProvider ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Fixes STU-1777

## How AI was used in this PR
I figured out and wrote the code manually. AI just double checked the approach. Since AI was generating overengineered solutions.

## Proposed Changes
In Studio UI we decided to default to wpcom provider, since it's free right now and there is no sense for users to use own keys.


## Testing Instructions
1. `npm run cli:build`
2. `node apps/cli/dist/cli/main.mjs code`
3. Select wpcom
4. Assert that no regresion, it work well as before
5. `npm start`
6. Open Studio Code tab
7. Open `~/.studio/cli.json`
8. Remove `aiProvider`
9. Say `hi` to Assistant
11. Assert that you imiidiatelly see the response from AI. And assert that `aiProvider` has value `wpcom` in `~/.studio/cli.json`

