### PR TITLE
Honor the dependency cooldown in the apps/studio bundle install

### DIFF
--- a/apps/studio/.npmrc
+++ b/apps/studio/.npmrc
@@ -1,0 +1,5 @@
+; The packaging step (`install:bundle`) runs `npm install --no-workspaces` with this directory as
+; the project root, so it does NOT inherit the repo-root .npmrc. Mirror the dependency cooldown here
+; so bundled dependencies also ignore just-published (day-0) releases, which protects the build from
+; same-day upstream regressions (e.g. a transient bad peer-dependency range in a fresh release).
+min-release-age=2


### PR DESCRIPTION
## Related issues

- N/A — fixes a CI breakage caused by a same-day upstream dependency regression.

## How AI was used in this PR

Diagnosed with Claude Code from a failing Buildkite E2E log, confirmed the root cause against the npm registry, and validated the fix with a `--no-workspaces` dry-run install before committing. I reviewed the change.

## Proposed Changes

The `apps/studio` packaging step (`install:bundle`) started failing for every branch with an npm `ERESOLVE` error: the project uses React 19, but `@wordpress/compose@8.1.0` — published today — regressed its React peer back to `^18`. Because the dependency range is `^8.0.0`, the bundle install resolved to the just-published `8.1.0` and hard-failed.

The repo already has a 2-day dependency cooldown (`min-release-age=2` in the root `.npmrc`) intended to absorb exactly this kind of day-0 regression. But `install:bundle` runs `npm install --no-workspaces` with `apps/studio` as the project root, so it does **not** inherit the repo-root `.npmrc` — the cooldown never applied there, and the bad release slipped through.

This adds `apps/studio/.npmrc` with the same `min-release-age=2`, so the bundle install honors the cooldown too. With it in place, the install ignores `<2-day-old` releases and resolves the good `@wordpress/compose@8.0.0` (React 19 peer). User/dev impact: unblocks packaging and E2E across all branches, and hardens the build against future same-day upstream regressions — not just this one.

## Testing Instructions

- From `apps/studio`, a fresh bundle resolve now selects the good version and succeeds:
  `cd apps/studio && npm install --no-package-lock --no-workspaces --install-links --dry-run` → resolves `@wordpress/compose 8.0.0`, exits 0 (no fatal `ERESOLVE`).
- Without this file the same command resolves `8.1.0` and fails with the React peer `ERESOLVE`.
- CI: the E2E job's `install:bundle` step should now pass.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (No application code changes — config only; validated via dry-run install.)
