### PR TITLE
Pin @wordpress/compose to 8.0.0 (8.1.0 dropped React 19 peer)

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -88,7 +88,7 @@
 		"@types/yauzl": "^2.10.3",
 		"@vitejs/plugin-react": "^5.1.4",
 		"@wordpress/components": "^34.0.0",
-		"@wordpress/compose": "^8.0.0",
+		"@wordpress/compose": "8.0.0",
 		"@wordpress/dataviews": "^15.0.0",
 		"@wordpress/element": "^7.0.0",
 		"@wordpress/icons": "13.2.0",
@@ -129,6 +129,7 @@
 	"overrides": {
 		"fs-ext": {
 			"nan": "2.25.0"
-		}
+		},
+		"@wordpress/compose": "8.0.0"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -605,7 +605,7 @@
 				"@types/yauzl": "^2.10.3",
 				"@vitejs/plugin-react": "^5.1.4",
 				"@wordpress/components": "^34.0.0",
-				"@wordpress/compose": "^8.0.0",
+				"@wordpress/compose": "8.0.0",
 				"@wordpress/dataviews": "^15.0.0",
 				"@wordpress/element": "^7.0.0",
 				"@wordpress/icons": "13.2.0",


### PR DESCRIPTION
## Related issues

<!-- No tracked issue — surfaced directly by failing CI on trunk-based branches. -->

- Related to the upstream `@wordpress/compose@8.1.0` release (see below)

## How AI was used in this PR

Claude Code diagnosed failing **E2E Tests** and **Performance Metrics** CI jobs from the Buildkite logs, traced the `ERESOLVE` to a newly-published upstream dependency, confirmed the resolution fix with a dry-run of the failing install command, and prepared the version pin. The change was reviewed before opening.

## Proposed Changes

**What's up:** Our E2E and Performance Metrics jobs started failing during the *app packaging* step (before any test runs) with an `npm ERESOLVE` error — React 19 vs a React-18 peer from `@wordpress/compose`.

**Root cause:** `@wordpress/compose@8.1.0` was published to npm on 2026-06-04 and **narrowed its React peer dependency back down to `^18.0.0`** (8.0.0 declared `^19.2.4`). `apps/studio` depends on `@wordpress/compose@^8.0.0` (a floating range) alongside React 19. The packaging step (`app:install:bundle`) installs with `--no-package-lock`, so it re-resolves from scratch and now grabs the React-18-only 8.1.0, which can't coexist with React 19. The `.npmrc` `min-release-age` guard that should have excluded a same-day release is silently ignored by the CI's npm version (it logs `Unknown project config "min-release-age"`), so nothing held the new version back.

This is **not branch-specific** — trunk hits the identical failure on its next packaging run. It first surfaced on a feature branch only because that branch happened to run CI shortly after 8.1.0 published.

**Fix:** Pin `@wordpress/compose` to an exact `8.0.0` (the last release compatible with React 19), both as the direct dependency and as an override so the no-workspaces bundle install can't pull 8.1.0 transitively. This mirrors the project's existing convention of exact-pinning supply-chain-fragile packages (e.g. `@wp-playground/*`). No user-visible behavior change; this only stabilizes the dependency resolution.

## Testing Instructions

1. Check out this branch.
2. Run the command the packaging step uses:
   ```
   cd apps/studio && npm install --no-package-lock --no-workspaces --install-links --ignore-scripts --dry-run
   ```
3. Confirm it resolves `@wordpress/compose 8.0.0` and completes **without** an `npm error code ERESOLVE` (a few benign `npm warn ERESOLVE overriding peer dependency` lines are expected).
4. The **E2E Tests** and **Performance Metrics** CI jobs should pass.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
