### PR TITLE
fix: show friendly error instead of Zod validation dump when backup status response is unexpected

### DIFF
--- a/apps/studio/src/stores/sync/sync-operations-slice.ts
+++ b/apps/studio/src/stores/sync/sync-operations-slice.ts
@@ -879,13 +879,14 @@ const pollPullBackupThunk = createTypedAsyncThunk(
 				apiNamespace: 'wpcom/v2',
 				backup_id: backupId,
 			} );
-			const response = syncBackupResponseSchema.parse( rawResponse );
+			const parseResult = syncBackupResponseSchema.safeParse( rawResponse );
+			if ( ! parseResult.success ) {
+				console.error( 'Unexpected backup status response:', rawResponse );
+				throw new Error( __( 'Unexpected response from server while checking backup status' ) );
+			}
+			const response = parseResult.data;
 
 			signal.throwIfAborted();
-
-			if ( ! response.status ) {
-				throw new Error( 'Unexpected backup response: missing status' );
-			}
 
 			const hasBackupCompleted = response.status === 'finished';
 			const downloadUrl = hasBackupCompleted ? response.download_url : null;

--- a/tools/common/lib/sync/sync-api.ts
+++ b/tools/common/lib/sync/sync-api.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { Readable } from 'stream';
 import { z } from 'zod';
+import { __ } from '@wordpress/i18n';
 import wpcomFactory from '@studio/common/lib/wpcom-factory';
 import wpcomXhrRequest from '@studio/common/lib/wpcom-xhr-request-factory';
 import {
@@ -93,7 +94,12 @@ export async function pollBackupStatus(
 		backup_id: backupId,
 	} );
 
-	const response = syncBackupResponseSchema.parse( rawResponse );
+	const parseResult = syncBackupResponseSchema.safeParse( rawResponse );
+	if ( ! parseResult.success ) {
+		console.error( 'Unexpected backup status response:', rawResponse );
+		throw new Error( __( 'Unexpected response from server while checking backup status' ) );
+	}
+	const response = parseResult.data;
 	return {
 		status: response.status,
 		downloadUrl: response.download_url ?? null,

--- a/tools/common/lib/sync/sync-api.ts
+++ b/tools/common/lib/sync/sync-api.ts
@@ -1,7 +1,5 @@
 import fs from 'fs';
 import { Readable } from 'stream';
-import { z } from 'zod';
-import { __ } from '@wordpress/i18n';
 import wpcomFactory from '@studio/common/lib/wpcom-factory';
 import wpcomXhrRequest from '@studio/common/lib/wpcom-xhr-request-factory';
 import {
@@ -11,6 +9,8 @@ import {
 	importResponseSchema,
 } from '@studio/common/types/sync';
 import { backupLsItemSchema, backupLsResponseBodySchema } from '@studio/common/types/sync-tree';
+import { __ } from '@wordpress/i18n';
+import { z } from 'zod';
 import { transformSitesResponse } from './transform-sites';
 import type { SyncSite, ImportResponse, SyncOption } from '@studio/common/types/sync';
 import type { BackupLsItem } from '@studio/common/types/sync-tree';

--- a/tools/common/lib/sync/sync-api.ts
+++ b/tools/common/lib/sync/sync-api.ts
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import { Readable } from 'stream';
+import { __ } from '@wordpress/i18n';
+import { z } from 'zod';
 import wpcomFactory from '@studio/common/lib/wpcom-factory';
 import wpcomXhrRequest from '@studio/common/lib/wpcom-xhr-request-factory';
 import {
@@ -9,8 +11,6 @@ import {
 	importResponseSchema,
 } from '@studio/common/types/sync';
 import { backupLsItemSchema, backupLsResponseBodySchema } from '@studio/common/types/sync-tree';
-import { __ } from '@wordpress/i18n';
-import { z } from 'zod';
 import { transformSitesResponse } from './transform-sites';
 import type { SyncSite, ImportResponse, SyncOption } from '@studio/common/types/sync';
 import type { BackupLsItem } from '@studio/common/types/sync-tree';


### PR DESCRIPTION
## Related issues

- Related to STU-1785

## How AI was used in this PR

Claude Code was used to identify the root cause and implement the fix, with the developer guiding the approach and verifying the fix worked against a real server.

## Proposed Changes

When the sync backup status endpoint (GET) returns an unexpected response shape — such as a `WP_Error` — Studio was displaying a raw Zod validation error dump in the "Error pulling from \<site\>" dialog, e.g.:

```
[ { "code": "invalid_value", "values": [ "in-progress", "finished", "failed" ], "path": [ "status" ], ... } ]
```

This happened because `syncBackupResponseSchema.parse()` throws a `ZodError` on unexpected input, and `ZodError.message` is the raw JSON of all validation issues - which ended up verbatim in the user-facing dialog.

The fix replaces `.parse()` with `.safeParse()` in both the Desktop pull poller and the CLI pull poller. On validation failure, a friendly translated error message is thrown instead, and the unexpected raw response is logged to the console for debugging. Normal `failed` status responses from the server are unaffected and continue through the existing pull failure UI path.

## Testing Instructions

- Trigger a pull from a site whose backup status endpoint returns an unexpected response shape (e.g., a `WP_Error`), or sandbox the API and hardcode error response there
- Previously: dialog showed raw Zod JSON
- Now: dialog shows "Unexpected response from server while checking backup status"
- A valid `{ status: 'failed', percent: 0, error: '...' }` response should show the normal red "Error pulling changes" inline in the UI without a dialog

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?