### PR TITLE
Fix CLI build breakage from the Vite 8 / plugin upgrade (Rolldown require + skills copy)

### DIFF
--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -75,6 +75,14 @@ export const baseConfig = defineConfig( {
 				format: 'es',
 				entryFileNames: '[name].mjs',
 				chunkFileNames: '[name]-[hash].mjs',
+				// Some bundled CommonJS dependencies (e.g. `lockfile`, `debug`) call
+				// `require( ... )` for Node built-ins at module init. Rolldown (the
+				// default bundler in Vite 8) emits a shim that throws when those calls
+				// run in an ESM output (`.mjs`), since ESM has no implicit `require`.
+				// Provide a real `require` per chunk via `createRequire` so the shim
+				// uses it instead of throwing.
+				banner:
+					'import { createRequire as __studioCreateRequire } from "node:module"; const require = __studioCreateRequire(import.meta.url);',
 			},
 			external: ( id ) => {
 				// Bundle the `@wp-playground/blueprints/blueprint-schema-validator` module since we've defined

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -29,6 +29,9 @@ if ( ! minimumNodeVersion ) {
 const bundledWpFilesPath = resolve( __dirname, '..', '..', 'wp-files' );
 const phpSourceCodePath = resolve( __dirname, 'php' );
 const bundledReprintPhar = resolve( __dirname, 'lib/pull/reprint.phar' );
+// The Skill tool loads skills from `<chunk dir>/skills` at runtime (see
+// `ai/skills.ts`), so they must sit directly next to the built chunks.
+const skillsSourcePath = resolve( __dirname, 'ai/skills' );
 
 export const baseConfig = defineConfig( {
 	plugins: [
@@ -50,6 +53,9 @@ export const baseConfig = defineConfig( {
 				}
 				if ( existsSync( bundledReprintPhar ) ) {
 					copyFileSync( bundledReprintPhar, resolve( outDir, 'reprint.phar' ) );
+				}
+				if ( existsSync( skillsSourcePath ) ) {
+					cpSync( skillsSourcePath, resolve( outDir, 'skills' ), { recursive: true } );
 				}
 			},
 		},
@@ -80,9 +86,16 @@ export const baseConfig = defineConfig( {
 				// default bundler in Vite 8) emits a shim that throws when those calls
 				// run in an ESM output (`.mjs`), since ESM has no implicit `require`.
 				// Provide a real `require` per chunk via `createRequire` so the shim
-				// uses it instead of throwing.
-				banner:
-					'import { createRequire as __studioCreateRequire } from "node:module"; const require = __studioCreateRequire(import.meta.url);',
+				// uses it instead of throwing. `main.mjs` additionally gets a shebang so
+				// the npm-published bundle can be executed directly as a CLI (harmless in
+				// other builds — Node ignores it when the file is run via `node main.mjs`).
+				banner: ( chunk ) => {
+					const requireShim =
+						'import { createRequire as __studioCreateRequire } from "node:module"; const require = __studioCreateRequire(import.meta.url);';
+					return chunk.fileName === 'main.mjs'
+						? `#!/usr/bin/env node\n${ requireShim }`
+						: requireShim;
+				},
 			},
 			external: ( id ) => {
 				// Bundle the `@wp-playground/blueprints/blueprint-schema-validator` module since we've defined

--- a/apps/cli/vite.config.dev.ts
+++ b/apps/cli/vite.config.dev.ts
@@ -1,21 +1,10 @@
 import { resolve } from 'path';
 import { defineConfig, mergeConfig } from 'vite';
-import { viteStaticCopy } from 'vite-plugin-static-copy';
 import { baseConfig } from './vite.config.base';
 
 export default mergeConfig(
 	baseConfig,
 	defineConfig( {
-		plugins: [
-			viteStaticCopy( {
-				targets: [
-					{
-						src: 'ai/skills',
-						dest: '.',
-					},
-				],
-			} ),
-		],
 		build: {
 			lib: {
 				entry: {

--- a/apps/cli/vite.config.npm.ts
+++ b/apps/cli/vite.config.npm.ts
@@ -1,28 +1,11 @@
 import { defineConfig, mergeConfig } from 'vite';
-import { viteStaticCopy } from 'vite-plugin-static-copy';
 import { baseConfig } from './vite.config.base';
 
 export default mergeConfig(
 	baseConfig,
 	defineConfig( {
-		plugins: [
-			viteStaticCopy( {
-				targets: [
-					{
-						src: 'ai/skills',
-						dest: '.',
-					},
-				],
-			} ),
-		],
 		build: {
 			sourcemap: false,
-			rollupOptions: {
-				output: {
-					// Add shebang to main.mjs so it can be executed directly as a CLI.
-					banner: ( chunk ) => ( chunk.fileName === 'main.mjs' ? '#!/usr/bin/env node' : '' ),
-				},
-			},
 		},
 		define: {
 			__ENABLE_CLI_TELEMETRY__: true,


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Diagnosis and fixes were authored with Claude Code. It traced two runtime failures of `studio code` back to the Vite group bump (#3674): the Rollup→Rolldown `require` change and the vite-plugin-static-copy 3→4 path change. Each fix was verified by rebuilding (dev + npm configs) and running the CLI end-to-end, plus typecheck/lint.

## Proposed Changes

The Vite 7→8 group upgrade (#3674) broke the CLI build in two ways. Both surfaced as `studio code` failing at startup.

**1. `require(...)` for Node built-ins threw in the ESM bundle.**
Vite 8 switched the default bundler from Rollup to **Rolldown**. When Rolldown inlines a CommonJS dependency that calls `require( ... )` at module init (e.g. `lockfile` → `require("fs")`, `debug`/`supports-color` → `require("tty")`), it emits a shim that throws in `.mjs` output, which has no implicit `require`. Rollup + esbuild previously injected a working `require` automatically, so the same bundled code worked before the upgrade. Fixed by giving each ESM chunk a real `require` via a `createRequire` banner (the Rolldown-documented remedy) — covering the whole class at once, including transitive CJS deps that can't be externalized by name.

**2. Skills stopped being bundled.**
The same group bump updated `vite-plugin-static-copy` from 3.x to 4.x, which changed how `src: 'ai/skills', dest: '.'` resolves — skills landed at `dist/cli/ai/skills` instead of `dist/cli/skills`. The Skill loader looks next to the chunks, so `studio code` logged `skills directory not found` and ran with no skills. Fixed by copying skills in the base config's existing `write-dist-extras` step (the same way `php`/`wp-files`/`reprint.phar` are handled), so they land at `<outDir>/skills` deterministically for every build, independent of plugin version.

Also consolidated the `main.mjs` shebang and the `createRequire` shim into a single base-config banner, so the npm build's banner no longer overrides (and drops) the require shim. The duplicated `viteStaticCopy` skills blocks in the dev/npm configs were removed.

User impact: the CLI builds and runs again (skills available). No behavior change in the shipped desktop app — these are build-time bundling fixes.

## Testing Instructions

1. `npm run cli:build`
2. `node apps/cli/dist/cli/main.mjs code --help` (use Node 24)
3. Expect exit code 0, no `skills directory not found` warning, and no `require` error during module load.
4. Confirm skills are bundled: `find apps/cli/dist/cli/skills -name SKILL.md | wc -l` → 9.

Note: running the CLI standalone requires Node 24 (the `await using` syntax in the bundle needs a recent V8); unrelated to these fixes. The packaged desktop app runs under Electron 41's V8, which is unaffected.

## Notes for reviewers

- Pre-existing, out of scope: the `install-taxonomy-scripts` tool resolves `import.meta.dirname/../skills/...`. The `..` is correct in source (`ai/tools` → `ai/skills`) but resolves to `dist/skills` once bundled (parent of the chunk dir), which never matches. Not touched here; flagged for a separate fix.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?