### PR TITLE
Fix "Failed to bump stat" errors on first CLI run

### DIFF
--- a/apps/cli/lib/cli-config/core.ts
+++ b/apps/cli/lib/cli-config/core.ts
@@ -97,15 +97,19 @@ export async function readCliConfig(): Promise< CliConfig > {
 	}
 }
 
+async function ensureConfigDirectory(): Promise< void > {
+	const configDir = getConfigDirectory();
+	if ( ! fs.existsSync( configDir ) ) {
+		fs.mkdirSync( configDir, { recursive: true } );
+		await hideDirectoryOnWindows( configDir );
+	}
+}
+
 export async function saveCliConfig( config: CliConfig ): Promise< void > {
 	try {
 		config.version = CLI_CONFIG_VERSION;
 
-		const configDir = getConfigDirectory();
-		if ( ! fs.existsSync( configDir ) ) {
-			fs.mkdirSync( configDir, { recursive: true } );
-			await hideDirectoryOnWindows( configDir );
-		}
+		await ensureConfigDirectory();
 
 		const configPath = getCliConfigPath();
 		const fileContent = JSON.stringify( config, null, 2 ) + '\n';
@@ -122,6 +126,10 @@ export async function saveCliConfig( config: CliConfig ): Promise< void > {
 const LOCKFILE_PATH = path.join( getConfigDirectory(), CLI_CONFIG_LOCKFILE_NAME );
 
 export async function lockCliConfig(): Promise< void > {
+	// The lockfile lives inside the config directory. On a first run that directory may not exist
+	// yet (e.g. telemetry bumps fire before `setupServerFiles()` creates it), and `lockfile.lock`
+	// would reject with ENOENT instead of waiting. Ensure the directory exists before locking.
+	await ensureConfigDirectory();
 	await lockFileAsync( LOCKFILE_PATH, { wait: LOCKFILE_WAIT_TIME, stale: LOCKFILE_STALE_TIME } );
 }
 


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude Code traced the first-run `Failed to bump stat:` console errors back to a lock-before-create race, wrote a standalone reproduction confirming `lockfile.lock` rejects with `ENOENT` when the parent directory is missing, and authored the fix. All output was reviewed by the author.

## Proposed Changes

On the very first launch of any `studio` CLI command (e.g. `studio code`), users see several `Failed to bump stat: …` errors printed to the console. They vanish on the second run, but the noise looks like something is broken.

The cause: the telemetry middleware runs before the middleware that creates the `~/.studio` config directory. The unique-stat bumps lock `~/.studio/cli.json.lock` before saving, and `lockfile.lock` rejects immediately with `ENOENT` when that directory doesn't exist yet (the `wait` option only retries on `EEXIST`, not a missing parent). The rejection surfaces as the error.

This change ensures the config directory exists before acquiring the lock, so first-run bumps persist correctly and no errors are printed. It also makes telemetry slightly more accurate: previously the "last bumped" timestamp failed to save on first run, causing aggregated unique stats (first launch, weekly/monthly unique) to be double-counted on the second run. The existing directory-creation logic is extracted into a shared helper and reused.

## Testing Instructions

1. Remove the config dir to simulate a fresh install: `mv ~/.studio ~/.studio.bak` (back it up).
2. Build the CLI: `npm run cli:build`.
3. Run a command twice: `node apps/cli/dist/cli/main.mjs code` (or any command).
4. **Before this change:** the first run prints several `Failed to bump stat: …` lines; the second run is clean.
5. **After this change:** both runs are clean — no `Failed to bump stat` output.
6. Restore your config: `rm -rf ~/.studio && mv ~/.studio.bak ~/.studio`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?