### PR TITLE
Fix install_taxonomy_scripts path resolution in bundled CLI

### DIFF
--- a/apps/cli/ai/skills.ts
+++ b/apps/cli/ai/skills.ts
@@ -22,12 +22,29 @@ function parseSkillFile( filePath: string ): Skill | null {
 
 let cachedSkills: Skill[] | null = null;
 
+// Resolves the skills directory. In source this is `apps/cli/ai/skills`
+// (next to this file); after bundling everything collapses into the CLI
+// out dir and the `viteStaticCopy` step places skills at `<outDir>/skills`
+// (e.g. `dist/cli/skills`), which is again next to this (bundled) file.
+// Resolving relative to `import.meta.dirname` therefore works in both
+// cases — callers that need a skill asset MUST go through this helper
+// rather than hand-rolling their own relative path.
+export function getSkillsRoot(): string {
+	return path.resolve( import.meta.dirname, 'skills' );
+}
+
+// Returns the absolute path to a file/dir inside a specific skill, e.g.
+// `getSkillPath( 'taxonomist', 'scripts' )`.
+export function getSkillPath( skillName: string, ...segments: string[] ): string {
+	return path.join( getSkillsRoot(), skillName, ...segments );
+}
+
 // Discovers `apps/cli/ai/skills/<name>/SKILL.md` files at startup; cached
 // for the process lifetime since skills never change at runtime.
 export function loadSkills(): Skill[] {
 	if ( cachedSkills ) return cachedSkills;
 
-	const skillsRoot = path.resolve( import.meta.dirname, 'skills' );
+	const skillsRoot = getSkillsRoot();
 
 	if ( ! fs.existsSync( skillsRoot ) ) {
 		// Loud warning so a broken bundle path doesn't silently disable Skill.

--- a/apps/cli/ai/tools/install-taxonomy-scripts.ts
+++ b/apps/cli/ai/tools/install-taxonomy-scripts.ts
@@ -1,6 +1,7 @@
 import { cp } from 'fs/promises';
 import path from 'path';
 import { Type } from 'typebox';
+import { getSkillPath } from 'cli/ai/skills';
 import { defineTool } from './define-tool';
 import { resolveSite, textResult } from './utils';
 
@@ -16,7 +17,7 @@ export const installTaxonomyScriptsTool = defineTool(
 	async ( args ) => {
 		try {
 			const site = await resolveSite( args.nameOrPath );
-			const srcDir = path.join( import.meta.dirname, '..', 'skills', 'taxonomist', 'scripts' );
+			const srcDir = getSkillPath( 'taxonomist', 'scripts' );
 			const destDir = path.join( site.path, TAXONOMIST_SCRIPTS_DIR );
 
 			await cp( srcDir, destDir, { recursive: true } );


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude diagnosed the bundled path-resolution bug, implemented the fix, and verified it against a fresh `cli:build` (confirming skills land at `dist/cli/skills/taxonomist/scripts` and not the previously-resolved `dist/skills/...`). All AI-authored changes were reviewed before committing.

## Proposed Changes

The `install_taxonomy_scripts` agent tool copies the Taxonomist PHP scripts into a site before they're run via `wp_cli eval-file`. It resolved its source directory with a parent-relative path that was only correct in the source tree. Once the CLI is bundled, every chunk collapses into `dist/cli`, so that `..` segment pointed at a directory that doesn't exist — meaning the tool silently failed to install the scripts in any packaged build.

This change resolves skill assets the same way the Skill loader already does, through a shared helper anchored next to the (bundled or source) module. The result: Taxonomist scripts install correctly in both source and bundled CLI, and there's now a single source of truth for locating skill files so the two depth-different call sites can't drift apart again. This aligns with the recent build fix that copies skills to `<outDir>/skills` next to the chunks.

## Testing Instructions

1. `npm run cli:build`
2. Confirm `apps/cli/dist/cli/skills/taxonomist/scripts/` exists (apply-changes.php, backup.php, export-posts.php, restore.php) and `apps/cli/dist/skills/` does **not**.
3. From a bundled CLI agent session, run the `install_taxonomy_scripts` tool against a site and confirm the scripts appear under `tmp/taxonomist/` in the site directory.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
