### PR TITLE
Add visual-polish skill + inspect_design tool to fix unpolished generated designs

### DIFF
--- a/apps/cli/ai/skills/block-content/SKILL.md
+++ b/apps/cli/ai/skills/block-content/SKILL.md
@@ -16,6 +16,7 @@ Use this skill before writing or editing page content, post content, templates, 
 - For forms or features core blocks do not cleanly provide, load the `plugin-recommendations` skill and use editable plugin blocks.
 - No decorative HTML comments such as `<!-- Hero Section -->` or `<!-- Features -->`. Only WordPress block delimiter comments are allowed.
 - No custom class names on inner DOM elements. Put custom classes only on the outermost block wrapper via the block `className` attribute.
+- Style buttons via `.wp-element-button` — the inner element WordPress applies the button's padding, background, and border to (shared by the button block and buttons from other blocks). A custom class on a button block sits on the `.wp-block-button` wrapper, so descend to `.your-class .wp-element-button`; never style the wrapper directly, or its padding stacks on top of the default and the button doubles in size.
 - No inline `style` attributes or block `style` attributes for styling. Use `className` plus the theme's `style.css`.
 - Use `core/spacer` for empty spacing elements, not empty `core/group` blocks.
 - No emojis anywhere in generated content.
@@ -90,4 +91,3 @@ Do not use `--post_content-file=<host path>`. `wp_cli` runs inside the PHP-WASM 
 
 - Run `validate_html_blocks` after every write or edit that creates or changes block content. If it reports invalid `core/html` blocks, rewrite only those blocks as editable core or plugin blocks, then call `validate_html_blocks` again before editor validation.
 - Run `validate_and_fix_blocks` after `validate_html_blocks` passes. Call it with `filePath` whenever the content lives in a file; safe editor serialization fixes are applied directly to that file. If it says an auto-fix was applied, do not manually replace markup or call validation again unless you intentionally change block markup afterward. Use the diff only to inspect structural changes for CSS impact. Classes added or removed by the validator can affect layout and styling.
-- After fixing invalid blocks, take desktop and mobile screenshots and check that layout, spacing, and full-width sections still render as intended.

--- a/apps/cli/ai/skills/visual-design/SKILL.md
+++ b/apps/cli/ai/skills/visual-design/SKILL.md
@@ -50,5 +50,3 @@ Interpret the user's brief creatively and make choices that feel specific to the
 ## Match Complexity To The Vision
 
 Maximalist designs need enough layered detail, motion, and visual systems to feel intentional. Minimalist or refined designs need restraint, exact spacing, strong typography, and careful hierarchy. Do not confuse minimal with unfinished.
-
-Before writing files or block markup, state a compact internal direction in your own words, then implement in small increments and verify visually.

--- a/apps/cli/ai/skills/visual-polish/SKILL.md
+++ b/apps/cli/ai/skills/visual-polish/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: visual-polish
+description: Verify and polish a built or redesigned site by diagnosing rendered-DOM issues against intent and fixing them in a planned, batched screenshot-and-fix loop.
+user-invokable: true
+---
+
+# Visual Polish
+
+Use this skill to verify a built or redesigned site and fix the design issues that make generated sites feel unpolished. The generated block markup, the editor serialization fixes from `validate_and_fix_blocks`, and WordPress's own injected layout classes mean the rendered page often differs from what you intended. This skill closes that gap.
+
+The core method is **diagnose from evidence, not from memory**. Do not guess why something looks wrong from the screenshot alone — the rendered DOM usually differs from the markup you wrote. Read the real DOM with `inspect_design`, find the actual cause, then fix it.
+
+## Method: diagnose the whole page first, then fix in one batch
+
+The most important rule: **do not fix issues one at a time as you find them.** Fixing reactively makes you miss related issues, introduce regressions, and burn expensive screenshot passes. Split the work into strict phases.
+
+### Phase 1 — Diagnose (read-only — make NO edits in this phase)
+
+1. Enumerate every section and component of the page (from the page markup you wrote, or by inspecting the top-level containers).
+2. Take one `take_screenshot` with `viewport: "all"` (desktop + mobile).
+3. Go **section by section**. For each, call `inspect_design` on the relevant selectors and compare the rendered DOM and computed styles against your intent and the theme's `style.css` (read it). The screenshot is the symptom; `inspect_design` is the cause — never diagnose from the screenshot alone, because subtle issues like doubled button padding barely show in pixels. Inspect even sections that look roughly right, and always inspect:
+   - every section wrapper — for width and centering,
+   - every button — BOTH `.wp-block-button` and `.wp-block-button__link`, with `includeHover: true`.
+4. List the **complete** set of issues before fixing anything — a concise checklist, one short line per issue: the section, the root cause from the DOM, and the exact fix (file, selector, change). A list, not prose.
+
+Do not make a single edit until you have diagnosed every section and listed every issue. **A complete diagnosis is the gate into Phase 2.**
+
+### Phase 2 — Fix the whole batch
+
+Work through the plan with targeted `Edit` calls (one `Write`/`Edit` per turn, per the system prompt cadence — never batch files into one turn). Do **not** screenshot between edits. If an edit changes block markup (not just CSS), re-run `validate_and_fix_blocks` on that file and re-check its diff, since the serializer can change classes again.
+
+### Phase 3 — Verify and loop
+
+After the whole batch, take one `viewport: "all"` screenshot. Check each plan item off and look for regressions the fixes introduced. Each pass is expensive, so cap the cycle at **5 passes**. If issues remain and you are within that budget, return to Phase 1 for what's left — re-diagnose the remaining issues with `inspect_design`, don't fix blind.
+
+## Recurring issues and what to inspect
+
+The issues below are common examples, **not an exhaustive list**. Treat them as a starting checklist, not the full scope of what to look for — fix every visual problem the screenshot reveals, including ones not listed here, and apply the same method (inspect the rendered DOM, find the real cause, then fix). For each, the cause lives in the DOM — inspect, don't guess.
+
+### Section width or centering is off
+
+Symptom: a section meant to be full-width renders in the narrow content column; a section is wider/narrower than intended; or a section's content sits off-center instead of centered.
+
+Inspect the section wrapper. Check `boundingBox` (`x` and `width`) against `viewportWidth`, and read the `ancestors` chain plus the `margin-left`/`margin-right` computed values. WordPress constrains children of constrained-layout containers via `.is-layout-constrained > *:not(.alignfull):not(.alignwide)` (~700px), which custom CSS like `width: 100%` cannot override — and a constrained layout is also what centers inner content (via auto inline margins). For a full-width section with centered content, the outer group needs `{"align":"full","layout":{"type":"constrained"}}`. When width or centering is wrong, the cause is the `align`/`layout` on the block markup (or custom margins/widths fighting the layout) — fix it in the markup, not by forcing width or margins in CSS.
+
+### Button styling is doubled or on the wrong element
+
+Symptom: a button looks too big (doubled padding), its background/border/radius is wrong, or it has two conflicting hover effects.
+
+The button block is **two nested elements**: the `.wp-block-button` wrapper and, inside it, the `.wp-block-button__link` — the actual `<a>`/`<button>`, also carrying `.wp-element-button`. WordPress core applies the button's padding, background, border, and radius to the inner `.wp-block-button__link` / `.wp-element-button`, NOT the wrapper. Your CSS must target that same inner element so it **overrides** the default instead of stacking a second padded box on the wrapper.
+
+The common trap: a custom `className` on a button block lands on the **wrapper** (`.wp-block-button.your-class`), not the link. So `.your-class { padding … }` styles the wrapper, on top of WP's default padding on the inner link — doubled box. Descend to the inner element instead: `.your-class .wp-element-button`.
+
+For **global** button styling (consistent buttons site-wide), target `.wp-element-button` in `style.css`. WordPress puts that class on the inner styled element of every button — the button block and buttons from other blocks (search, file, etc.) — so one rule covers them all and overrides cleanly.
+
+Inspect BOTH selectors with `includeHover: true` and compare their computed styles:
+
+- If padding/background/border is set on BOTH the wrapper and the link, the button renders with **doubled padding and looks too big** — remove that styling from the wrapper (or its custom class) and put it on `.wp-element-button` / `.wp-block-button__link`.
+- There must be exactly ONE hover rule, on the inner element (`.wp-element-button:hover` or `.wp-block-button__link:hover`), never the `.wp-block-button` wrapper. If both have hover styles you get **two conflicting hover effects** — delete the wrapper hover. Use the `hover` block in the inspect output to confirm only the inner element changes.
+
+### Spacing between blocks differs from intent
+
+Symptom: gaps between paragraphs, headings, or sections are larger or smaller than the CSS suggests.
+
+Vertical rhythm is owned by WordPress layout CSS, not your margins: `:where(.is-layout-flow) > * + *` applies `margin-block-start: var(--wp--style--block-gap)`. Inspect the container and the adjacent blocks — read `customProperties["--wp--style--block-gap"]` and the `margin-top`/`margin-bottom` computed values. If block-gap is fighting your margins, set spacing through `theme.json` `spacing.blockGap` or the block's own spacing, or override knowing that exact selector.
+
+### Backgrounds inside grids/columns are wrong
+
+Symptom: a column or grid cell background doesn't appear, doesn't fill the cell, or sits on the wrong element.
+
+Inspect `.wp-block-column` (or the grid cell) and any inner `core/group` you put the background on. Check which node's `background-color`/`background-image` is set and whether its `boundingBox` actually fills the cell. A background on an inner group only covers its content height; to fill the cell, the color belongs on the column/cell node. Columns are flex items — confirm `align-items`/stretch behavior matches intent.
+
+## Notes
+
+- Fix in markup or `style.css` per the `block-content` skill rules — no inline styles, no custom stylesheets, no custom classes on inner DOM elements.
+- The site must be running for `take_screenshot` and `inspect_design`.

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -97,7 +97,7 @@ ${ getStudioWidgetPromptManifest() }`
 IMPORTANT: You MUST use your Studio tools to manage WordPress sites. Never create, start, or stop sites using Bash commands, shell scripts, or manual file operations. Never run \`wp\` commands via Bash — always use the wp_cli tool instead. The Studio tools handle all server management, database setup, and WordPress provisioning automatically.
 IMPORTANT: For any generated content for the site, these three principles are mandatory:
 
-- Gorgeous design: Load the \`visual-design\` skill for site creation, redesign, layout, style, CSS, typography, color, motion, or polish work.
+- Gorgeous design: Load the \`visual-design\` skill for site creation, redesign, layout, style, CSS, typography, color, or motion work. To verify and polish the rendered result, load the \`visual-polish\` skill.
 - Editable block content: Load the \`block-content\` skill before writing page, post, template, template-part, or other block markup.
 - Valid blocks: Use validate_html_blocks first to catch invalid core/html usage, then use validate_and_fix_blocks to validate in the live editor. When called with filePath, validate_and_fix_blocks applies safe editor-serialization fixes directly to that file and returns a CSS-review diff.
 
@@ -120,7 +120,7 @@ Then continue with:
 3. **Write theme/plugin files**: For a brand new theme, call \`scaffold_theme\` first — it drops an unopinionated block-theme baseline (style.css with only the theme header, theme.json with appearanceTools only, functions.php with frontend + editor style enqueue, default templates and parts, empty assets/fonts and patterns dirs) and activates it by default. Then use Write and Edit to fill the scaffold (one part/template/file per turn). For plugins or for editing an existing theme, use Write and Edit directly under the site's wp-content/themes/ or wp-content/plugins/ directory.
 4. **Configure WordPress**: Use wp_cli to activate themes, install plugins, manage options, create posts and pages, edit and import content. The site must be running. Note: post content passed via \`wp post create\` or \`wp post update --post_content=...\` need to be pre-validated for editability, follow the \`block-content\` skill, checked with validate_html_blocks, and validated/fixed with validate_and_fix_blocks. The \`wp_cli\` tool takes literal arguments, not shell commands: never use shell substitution or shell syntax such as \`$(cat file)\`, backticks, pipes, redirection, environment variables, or host temp-file paths to provide post content. Pass the literal content directly in \`--post_content=...\`, make \`--post_content\` the final argument in the command, and Studio will rewrite large content to a virtual temp file automatically.
 5. **Check and fix block validity**: Run validate_html_blocks on block content first. If it reports invalid core/html blocks, rewrite only those blocks as editable core or plugin blocks and call validate_html_blocks again. Then call validate_and_fix_blocks with filePath whenever the content lives in a file. If validate_and_fix_blocks says an auto-fix was applied, the file already contains the fixed block content; do not manually replace markup or call validation again unless you intentionally change block markup afterward. Use the diff only to inspect class/nesting changes and update CSS selectors if needed. For inline content, use any returned fixed block content exactly as the replacement content.
-6. **Check the result**: Use take_screenshot with \`viewport: "all"\` to capture the site's landing page on desktop and mobile in one call and verify the design visually on both viewports, check for wrong spacing, alignment, colors, contrast, borders, hover styles and other visual issues. Fix any issues found. Pay particular attention to the navigation menu and the CTA buttons. The design needs to match your original expectations. **Width check**: any section that was meant to be full-width (heroes, banners, edge-to-edge galleries, full-bleed footers) must visibly span the entire viewport in the desktop screenshot. If a "full-width" section only spans the content column (~700px at 1280px viewport), the block markup is missing \`align: "full"\` on the outer group or has a mismatched inner \`layout\` type. Fix in markup, not custom CSS.
+6. **Check and polish the result**: Load the \`visual-polish\` skill and run it to polish the design. The design must match your original expectations.
 
 ## Working cadence
 
@@ -149,6 +149,7 @@ For long CSS or page-content files (>~200 lines), load the \`block-content\` ski
 - validate_html_blocks: Check core/html blocks for misuse. Call before live editor validation; rewrite reported invalid HTML blocks as editable core or plugin blocks and call this again until it passes.
 - validate_and_fix_blocks: Validate block content in the running site's real block editor. With filePath, applies safe editor fixes directly to the file and returns a CSS-review diff. With inline content, returns exact fixed block content plus the diff. Requires a site name or path. Call after every file write/edit that contains block content.
 - take_screenshot: Take a full-page screenshot of a URL (supports desktop, mobile, or \`viewport: "all"\` for both). Use this to visually check the site after building it.
+- inspect_design: Inspect the rendered DOM and computed styles of a page by CSS selector to root-cause visual issues. Pair with take_screenshot when verifying or polishing a design.
 - need_for_speed: Measure frontend performance metrics (TTFB, FCP, LCP, CLS, page weight, DOM size, JS/CSS/image/font asset breakdown) for a running site. Use this to identify performance bottlenecks and guide optimization.
 - rank_me_up: Run an on-page SEO audit (title/meta tags, headings, image alt text, OpenGraph/Twitter cards, JSON-LD structured data, robots.txt and sitemap.xml availability) for a running site. Use this to identify on-page SEO issues and guide fixes.
 - site_connected_remote_sites: List the WordPress.com sites already attached to a local site. Call this before site_push to decide how to ask the user which remote site to target.
@@ -214,8 +215,10 @@ const REMOTE_DESIGN_GUIDELINES = `## Design capabilities by plan
 
 const LOCAL_SKILL_ROUTING = `## Skill routing
 
-For any site creation, redesign, landing page, homepage, layout, style, CSS, typography, color, motion, or visual polish work, load the \`visual-design\` skill before writing design files or block markup.
+For any site creation, redesign, landing page, homepage, layout, style, CSS, typography, color, or motion work, load the \`visual-design\` skill before writing design files or block markup.
 
 For any page/post content, template or template-part content, block markup, block-theme layout, full-width section, or \`core/html\` use, load the \`block-content\` skill before writing markup or validating block content.
+
+For verifying and polishing a built or redesigned site — checking the rendered result against intent and diagnosing layout/width, spacing, button, background, or hover issues — load the \`visual-polish\` skill and use \`inspect_design\` to root-cause from the rendered DOM before fixing.
 
 For forms, ecommerce, events, LMS, galleries/slideshows, embeds, SEO/performance plugin choices, or any feature that core WordPress blocks do not cleanly provide, load the \`plugin-recommendations\` skill before installing plugins or writing plugin-provided block markup.`;

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -386,6 +386,83 @@ describe( 'Studio AI MCP tools', () => {
 		}
 	} );
 
+	it( 'inspect_design returns rendered DOM facts for the requested selectors', async () => {
+		const report = [
+			{
+				selector: '.wp-block-button__link',
+				matchCount: 1,
+				matches: [
+					{
+						tag: 'a',
+						classes: [ 'wp-block-button__link', 'wp-element-button' ],
+						boundingBox: { x: 0, y: 0, width: 120, height: 44 },
+						computedStyle: { 'background-color': 'rgb(0, 0, 0)' },
+						ancestors: [ 'div.wp-block-button' ],
+					},
+				],
+			},
+		];
+		const page = {
+			emulateMedia: vi.fn(),
+			goto: vi.fn(),
+			waitForLoadState: vi.fn().mockResolvedValue( undefined ),
+			evaluate: vi.fn().mockResolvedValueOnce( undefined ).mockResolvedValueOnce( report ),
+			hover: vi.fn(),
+			mouse: { move: vi.fn() },
+			close: vi.fn(),
+		};
+		const browser = { newPage: vi.fn().mockResolvedValue( page ) };
+		vi.mocked( getSharedBrowser ).mockResolvedValue( browser as never );
+
+		const result = await getTool( 'inspect_design' ).rawHandler( {
+			url: 'http://localhost:8903/',
+			selectors: [ '.wp-block-button__link' ],
+		} as never );
+
+		const parsed = JSON.parse( getTextContent( result )! );
+		expect( parsed.viewport ).toBe( 'desktop' );
+		expect( parsed.viewportWidth ).toBe( 1040 );
+		expect( parsed.selectors[ 0 ].matchCount ).toBe( 1 );
+		expect( parsed.selectors[ 0 ].matches[ 0 ].computedStyle[ 'background-color' ] ).toBe(
+			'rgb(0, 0, 0)'
+		);
+		expect( parsed.hover ).toBeUndefined();
+		expect( page.hover ).not.toHaveBeenCalled();
+		expect( page.close ).toHaveBeenCalled();
+	} );
+
+	it( 'inspect_design captures hover styles when includeHover is set', async () => {
+		const report = [ { selector: '.wp-block-button__link', matchCount: 1, matches: [] } ];
+		const page = {
+			emulateMedia: vi.fn(),
+			goto: vi.fn(),
+			waitForLoadState: vi.fn().mockResolvedValue( undefined ),
+			evaluate: vi
+				.fn()
+				.mockResolvedValueOnce( undefined )
+				.mockResolvedValueOnce( report )
+				.mockResolvedValueOnce( { 'background-color': 'rgb(255, 0, 0)' } ),
+			hover: vi.fn().mockResolvedValue( undefined ),
+			mouse: { move: vi.fn().mockResolvedValue( undefined ) },
+			close: vi.fn(),
+		};
+		const browser = { newPage: vi.fn().mockResolvedValue( page ) };
+		vi.mocked( getSharedBrowser ).mockResolvedValue( browser as never );
+
+		const result = await getTool( 'inspect_design' ).rawHandler( {
+			url: 'http://localhost:8903/',
+			selectors: [ '.wp-block-button__link' ],
+			viewport: 'mobile',
+			includeHover: true,
+		} as never );
+
+		const parsed = JSON.parse( getTextContent( result )! );
+		expect( parsed.viewport ).toBe( 'mobile' );
+		expect( parsed.viewportWidth ).toBe( 390 );
+		expect( page.hover ).toHaveBeenCalledWith( '.wp-block-button__link', expect.anything() );
+		expect( parsed.hover[ 0 ].computedStyle[ 'background-color' ] ).toBe( 'rgb(255, 0, 0)' );
+	} );
+
 	it( 'emits explicit Studio widget artifacts from studio_present', async () => {
 		const tool = resolveStudioToolDefinitions( {
 			emitChatArtifacts: true,

--- a/apps/cli/ai/tools/index.ts
+++ b/apps/cli/ai/tools/index.ts
@@ -5,6 +5,7 @@ import { deletePreviewTool } from './delete-preview';
 import { deleteSiteTool } from './delete-site';
 import { exportSiteTool } from './export-site';
 import { importSiteTool } from './import-site';
+import { inspectDesignTool } from './inspect-design';
 import { installTaxonomyScriptsTool } from './install-taxonomy-scripts';
 import { listConnectedRemoteSitesTool } from './list-connected-remote-sites';
 import { listPreviewsTool } from './list-previews';
@@ -46,6 +47,7 @@ export const studioToolDefinitions: AnyStudioAgentTool[] = [
 	validateHtmlBlocksTool,
 	validateAndFixBlocksTool,
 	takeScreenshotTool,
+	inspectDesignTool,
 	shareScreenshotTool,
 	installTaxonomyScriptsTool,
 	auditPerformanceTool,

--- a/apps/cli/ai/tools/inspect-design.ts
+++ b/apps/cli/ai/tools/inspect-design.ts
@@ -1,0 +1,281 @@
+import { Type } from 'typebox';
+import { getSharedBrowser } from 'cli/ai/browser-utils';
+import { emitProgress } from 'cli/logger';
+import { defineTool } from './define-tool';
+import { textResult } from './utils';
+
+/**
+ * Viewports mirror `take_screenshot` so the DOM the agent inspects matches the
+ * pixels it sees. Layout-dependent issues (constrained width, column stacking)
+ * differ between desktop and mobile, so the agent picks the one it is
+ * diagnosing.
+ */
+const INSPECT_VIEWPORTS = {
+	desktop: { width: 1040, height: 1248 },
+	mobile: { width: 390, height: 844 },
+} as const;
+
+type InspectViewport = keyof typeof INSPECT_VIEWPORTS;
+
+/**
+ * Curated, design-relevant computed-style properties. The full computed style
+ * is hundreds of properties; this set covers the layout, box, background,
+ * typography, flex/grid, and interaction concerns the polish loop reasons
+ * about, while keeping the tool output small. WordPress layout custom
+ * properties (block gap) are read separately via getPropertyValue.
+ */
+const COMPUTED_PROPERTIES = [
+	'display',
+	'position',
+	'width',
+	'height',
+	'max-width',
+	'min-height',
+	'box-sizing',
+	'margin-top',
+	'margin-right',
+	'margin-bottom',
+	'margin-left',
+	'padding-top',
+	'padding-right',
+	'padding-bottom',
+	'padding-left',
+	'background-color',
+	'background-image',
+	'color',
+	'border-top-width',
+	'border-style',
+	'border-color',
+	'border-radius',
+	'box-shadow',
+	'opacity',
+	'font-family',
+	'font-size',
+	'font-weight',
+	'line-height',
+	'letter-spacing',
+	'text-align',
+	'text-decoration-line',
+	'flex-direction',
+	'flex-wrap',
+	'justify-content',
+	'align-items',
+	'gap',
+	'column-gap',
+	'row-gap',
+	'grid-template-columns',
+	'transform',
+	'transition',
+	'cursor',
+] as const;
+
+/**
+ * WordPress layout selectors resolve block spacing through this custom
+ * property. Reading it on a section explains gaps that "don't match" the CSS
+ * the agent wrote, since `:where(.is-layout-flow) > * + *` owns the spacing.
+ */
+const CUSTOM_PROPERTIES = [ '--wp--style--block-gap' ] as const;
+
+const MAX_MATCHES_PER_SELECTOR = 5;
+const HTML_PREVIEW_LENGTH = 400;
+const ANCESTOR_DEPTH = 6;
+
+export const inspectDesignTool = defineTool(
+	'inspect_design',
+	'Inspects the RENDERED DOM of a live page to diagnose visual issues at their root cause. ' +
+		"Given CSS selectors, returns each matched element's tag and class list, bounding box (so you can see actual rendered width/height vs intent), " +
+		'curated computed styles (box model, background, typography, flex/grid, borders), the WordPress block-gap custom property, ' +
+		'and the ancestor chain of layout classes (is-layout-constrained, alignfull, wp-block-group) that controls width and spacing. ' +
+		'Pass `includeHover: true` to also capture computed styles while hovering the first match — use this for button/link hover states. ' +
+		'Pair this with take_screenshot: the screenshot shows the symptom, inspect_design shows the cause. ' +
+		'Use it before editing CSS so you target the element that actually carries the style (e.g. .wp-block-button__link, not the .wp-block-button wrapper) instead of guessing.',
+	{
+		url: Type.String( { description: 'The URL of the running site page to inspect' } ),
+		selectors: Type.Array( Type.String(), {
+			minItems: 1,
+			description:
+				'CSS selectors to inspect, e.g. [".hero", ".wp-block-button", ".wp-block-button__link", ".wp-block-column"]. Each is queried against the rendered page.',
+		} ),
+		viewport: Type.Optional(
+			Type.Enum( [ 'desktop', 'mobile' ], {
+				description:
+					'Viewport to render at: "desktop" (1040px wide) or "mobile" (390px wide). Defaults to desktop. Use "mobile" to diagnose responsive issues.',
+			} )
+		),
+		includeHover: Type.Optional(
+			Type.Boolean( {
+				description:
+					'When true, also captures the computed styles of the first match of each selector while it is hovered. Use for button/link hover diagnosis.',
+			} )
+		),
+	},
+	async ( args ) => {
+		const viewport: InspectViewport = ( args.viewport as InspectViewport ) ?? 'desktop';
+		emitProgress(
+			`Inspecting ${ args.selectors.length } selector(s) on ${ args.url } (${ viewport })…`
+		);
+
+		const browser = await getSharedBrowser();
+		const page = await browser.newPage( {
+			viewport: INSPECT_VIEWPORTS[ viewport ],
+			ignoreHTTPSErrors: true,
+		} );
+
+		try {
+			await page.emulateMedia( { reducedMotion: 'reduce' } );
+			await page.goto( args.url, { waitUntil: 'domcontentloaded', timeout: 30000 } );
+			await page.waitForLoadState( 'networkidle', { timeout: 2500 } ).catch( () => {} );
+			await page.evaluate(
+				() => new Promise< void >( ( resolve ) => requestAnimationFrame( () => resolve() ) )
+			);
+
+			const report = await page.evaluate(
+				( {
+					selectors,
+					properties,
+					customProperties,
+					maxMatches,
+					htmlPreviewLength,
+					ancestorDepth,
+				} ) => {
+					const describeNode = ( el: Element ) => {
+						const classList = Array.from( el.classList );
+						const style = getComputedStyle( el );
+						const computed: Record< string, string > = {};
+						for ( const prop of properties ) {
+							computed[ prop ] = style.getPropertyValue( prop ).trim();
+						}
+						const custom: Record< string, string > = {};
+						for ( const prop of customProperties ) {
+							const value = style.getPropertyValue( prop ).trim();
+							if ( value ) {
+								custom[ prop ] = value;
+							}
+						}
+						const rect = el.getBoundingClientRect();
+						const html = el.outerHTML;
+						return {
+							tag: el.tagName.toLowerCase(),
+							id: el.id || undefined,
+							classes: classList,
+							boundingBox: {
+								x: Math.round( rect.x ),
+								y: Math.round( rect.y ),
+								width: Math.round( rect.width ),
+								height: Math.round( rect.height ),
+							},
+							computedStyle: computed,
+							customProperties: Object.keys( custom ).length ? custom : undefined,
+							outerHTMLPreview:
+								html.length > htmlPreviewLength ? html.slice( 0, htmlPreviewLength ) + '…' : html,
+						};
+					};
+
+					const ancestorChain = ( el: Element ): string[] => {
+						const chain: string[] = [];
+						let current = el.parentElement;
+						let depth = 0;
+						while ( current && current.tagName !== 'HTML' && depth < ancestorDepth ) {
+							const classes = Array.from( current.classList );
+							chain.push(
+								`${ current.tagName.toLowerCase() }${
+									classes.length ? '.' + classes.join( '.' ) : ''
+								}`
+							);
+							current = current.parentElement;
+							depth++;
+						}
+						return chain;
+					};
+
+					return selectors.map( ( selector ) => {
+						let elements: Element[];
+						try {
+							elements = Array.from( document.querySelectorAll( selector ) );
+						} catch ( error ) {
+							return {
+								selector,
+								error: `Invalid selector: ${
+									error instanceof Error ? error.message : String( error )
+								}`,
+							};
+						}
+						return {
+							selector,
+							matchCount: elements.length,
+							matches: elements.slice( 0, maxMatches ).map( ( el, index ) => ( {
+								...describeNode( el ),
+								ancestors: index === 0 ? ancestorChain( el ) : undefined,
+							} ) ),
+						};
+					} );
+				},
+				{
+					selectors: args.selectors,
+					properties: COMPUTED_PROPERTIES as readonly string[] as string[],
+					customProperties: CUSTOM_PROPERTIES as readonly string[] as string[],
+					maxMatches: MAX_MATCHES_PER_SELECTOR,
+					htmlPreviewLength: HTML_PREVIEW_LENGTH,
+					ancestorDepth: ANCESTOR_DEPTH,
+				}
+			);
+
+			let hover:
+				| Array< { selector: string; computedStyle?: Record< string, string >; error?: string } >
+				| undefined;
+			if ( args.includeHover ) {
+				hover = [];
+				for ( const selector of args.selectors ) {
+					try {
+						await page.hover( selector, { timeout: 2000 } );
+						const computedStyle = await page.evaluate(
+							( { sel, properties } ) => {
+								const el = document.querySelector( sel );
+								if ( ! el ) {
+									return undefined;
+								}
+								const style = getComputedStyle( el );
+								const computed: Record< string, string > = {};
+								for ( const prop of properties ) {
+									computed[ prop ] = style.getPropertyValue( prop ).trim();
+								}
+								return computed;
+							},
+							{ sel: selector, properties: COMPUTED_PROPERTIES as readonly string[] as string[] }
+						);
+						hover.push( { selector, computedStyle } );
+						await page.mouse.move( 0, 0 );
+					} catch ( error ) {
+						hover.push( {
+							selector,
+							error: `Could not hover: ${
+								error instanceof Error ? error.message : String( error )
+							}`,
+						} );
+					}
+				}
+			}
+
+			emitProgress( `Inspected ${ args.selectors.length } selector(s) on ${ args.url }` );
+			return textResult(
+				JSON.stringify(
+					{
+						url: args.url,
+						viewport,
+						viewportWidth: INSPECT_VIEWPORTS[ viewport ].width,
+						selectors: report,
+						...( hover ? { hover } : {} ),
+					},
+					null,
+					2
+				)
+			);
+		} catch ( error ) {
+			throw new Error(
+				`Design inspection failed: ${ error instanceof Error ? error.message : String( error ) }`
+			);
+		} finally {
+			await page.close();
+		}
+	}
+);


### PR DESCRIPTION
## Related issues

<!-- none yet -->

- Related to #

## How AI was used in this PR

Built with Claude Code (agent prompt + skill engineering). The new `inspect_design` tool, the `visual-polish` skill, and the prompt/skill wiring were authored and iterated with AI; the design of the detection loop and the button/layout root-cause guidance came out of real test sessions on generated sites. Code, tests, and skill copy were human-reviewed.

## Proposed Changes

Sites built by the Studio Code agent frequently come out looking "unpolished" — sections not centered, full-width sections rendering in the narrow content column, buttons with doubled padding and conflicting hover styles, off spacing and column backgrounds. The root cause is that the **rendered DOM differs from the markup the agent intended**: WordPress injects its own layout classes, `validate_and_fix_blocks` re-serializes block markup, and the button block is two nested elements. The existing screenshot-and-fix step let the agent diagnose from pixels alone and guess at causes — so it kept "fixing" the wrong thing.

This gives the agent the ability to see *why* a page looks wrong, and a disciplined workflow for fixing it:

- **`inspect_design` tool** — inspects the rendered DOM for given CSS selectors and returns bounding boxes, curated computed styles, the WordPress block-gap custom property, the ancestor layout-class chain, and optional `:hover` styles. The screenshot is the symptom; this is the cause.
- **`visual-polish` skill** — a diagnose-the-whole-page-first, fix-as-a-batch, verify workflow (capped iterations). It pairs the screenshot with `inspect_design` and carries a checklist of the recurring issues (section width/centering, doubled/mis-targeted button styling, block-gap spacing, column/grid backgrounds, hover), each mapped to exactly what to inspect.
- **Authoring fix** — a `block-content` rule to style buttons via `.wp-element-button` (the inner element WordPress styles) so a custom class on the `.wp-block-button` wrapper doesn't stack padding and double the button's size.
- Wiring: workflow step 6 and skill routing now hand polish work to `visual-polish`; `visual-design` is scoped to creating the design direction. Removed now-redundant verification snippets that duplicated the new skill.

Opening as a **draft / Proof of Concept**: the detection loop still needs more real-site validation (recent tests show the agent sometimes skips the diagnosis gate), so this is intended as a directional starting point for review rather than a finished change.

## Testing Instructions

1. `npm run cli:build`
2. Have the Studio Code agent build or redesign a site, then let it run the polish pass (it loads `visual-polish` at step 6).
3. Verify it calls `inspect_design` to diagnose before editing, and that buttons, full-width/centered sections, spacing, and hover render as intended.
4. Unit tests: `npm test -- apps/cli/ai/tests/tools.test.ts apps/cli/ai/tests/system-prompt.test.ts` (includes new `inspect_design` coverage).

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?