### PR TITLE
Agentic UI: Chat, Tools, Questions

### DIFF
--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -446,7 +446,7 @@ describe( 'AiChatUI.handleEvent', () => {
 		expect( joined ).toContain( 'WordPress.com API GET /posts' );
 		expect( joined ).toContain( 'GET /posts: Returned 2 posts' );
 		expect( joined ).toContain( 'Full API response hidden' );
-		expect( joined ).toContain( 'Run terminal command' );
+		expect( joined ).toContain( 'Run npm test' );
 		expect( joined ).toContain( 'Command completed: 2 tests passed' );
 		expect( joined ).toContain( 'Command output hidden' );
 		expect( joined ).toContain( 'Read theme/style.css' );

--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -446,7 +446,7 @@ describe( 'AiChatUI.handleEvent', () => {
 		expect( joined ).toContain( 'WordPress.com API GET /posts' );
 		expect( joined ).toContain( 'GET /posts: Returned 2 posts' );
 		expect( joined ).toContain( 'Full API response hidden' );
-		expect( joined ).toContain( 'Run npm test' );
+		expect( joined ).toContain( 'Run terminal command' );
 		expect( joined ).toContain( 'Command completed: 2 tests passed' );
 		expect( joined ).toContain( 'Command output hidden' );
 		expect( joined ).toContain( 'Read theme/style.css' );

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -255,6 +255,7 @@ function hydrateAiSessionSummary(
 		...summary,
 		starred: metadata?.starred,
 		archived: metadata?.archived,
+		lastReadEventCount: metadata?.lastReadEventCount,
 	};
 }
 

--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -140,6 +140,7 @@ describe( 'SiteList', () => {
 					firstPrompt: 'Build a landing page',
 					ownerSitePath: '/Users/example/Studio/example-site',
 					updatedAt: '2026-05-01T12:00:00.000Z',
+					eventCount: 4,
 				},
 			],
 			isLoading: false,
@@ -335,7 +336,29 @@ describe( 'SiteList', () => {
 
 		render( <SiteList /> );
 
-		expect( screen.getByRole( 'status', { name: 'Studio needs an answer.' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'status', { name: 'Studio needs an answer' } ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'status', { name: 'Working…' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows an unread indicator for inactive chats with new messages', () => {
+		useSessionsMock.mockReturnValue( {
+			data: [
+				{
+					id: 'session-1',
+					title: 'Generated title',
+					generatedTitle: 'Generated title',
+					firstPrompt: 'Build a landing page',
+					ownerSitePath: '/Users/example/Studio/example-site',
+					updatedAt: '2026-05-01T12:00:00.000Z',
+					eventCount: 8,
+					lastReadEventCount: 5,
+				},
+			],
+			isLoading: false,
+		} as never );
+
+		render( <SiteList /> );
+
+		expect( screen.getByRole( 'status', { name: 'Unread messages' } ) ).toBeInTheDocument();
 	} );
 } );

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -16,7 +16,7 @@ import * as Menu from '@/components/menu';
 import { SidebarButton } from '@/components/sidebar-button';
 import { deriveSiteStatus } from '@/components/site-dropdown/utils';
 import { SiteIcon } from '@/components/site-icon';
-import { Spinner } from '@/components/spinner';
+import { StatusDot, type StatusDotStatus } from '@/components/status-dot';
 import { useIsSessionRunning, useSessionHasPendingQuestion } from '@/data/queries/use-agent-run';
 import {
 	useArchiveSession,
@@ -160,10 +160,37 @@ function SessionActionsMenu( { session }: { session: AiSessionSummary } ) {
 	);
 }
 
+function SessionStatusIndicator( { label, status }: { label: string; status: StatusDotStatus } ) {
+	return (
+		<Tooltip.Provider delay={ 0 }>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					render={
+						<StatusDot
+							status={ status }
+							className={ styles.sessionStatusIndicator }
+							role="status"
+							aria-label={ label }
+						/>
+					}
+				/>
+				<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>{ label }</Tooltip.Popup>
+			</Tooltip.Root>
+		</Tooltip.Provider>
+	);
+}
+
 function SessionItem( { session, isVisible }: { session: AiSessionSummary; isVisible: boolean } ) {
 	const label = session.firstPrompt?.trim();
 	const isRunning = useIsSessionRunning( session.id );
 	const hasPendingQuestion = useSessionHasPendingQuestion( session.id );
+	const params = useParams( { strict: false } ) as { sessionId?: string };
+	const isActive = params.sessionId === session.id;
+	const hasUnreadMessages =
+		! isActive &&
+		typeof session.lastReadEventCount === 'number' &&
+		typeof session.eventCount === 'number' &&
+		session.eventCount > session.lastReadEventCount;
 
 	return (
 		<li className={ styles.sessionItem }>
@@ -181,26 +208,14 @@ function SessionItem( { session, isVisible }: { session: AiSessionSummary; isVis
 				}
 			>
 				{ hasPendingQuestion ? (
-					<Tooltip.Provider delay={ 0 }>
-						<Tooltip.Root>
-							<Tooltip.Trigger
-								render={
-									<span
-										className={ styles.sessionQuestionIndicator }
-										role="status"
-										aria-label={ __( 'Studio needs an answer.' ) }
-									>
-										?
-									</span>
-								}
-							/>
-							<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
-								{ __( 'Studio needs an answer.' ) }
-							</Tooltip.Popup>
-						</Tooltip.Root>
-					</Tooltip.Provider>
+					<SessionStatusIndicator
+						label={ __( 'Studio needs an answer' ) }
+						status="waiting-response"
+					/>
 				) : isRunning ? (
-					<Spinner className={ styles.sessionInlineSpinner } label={ __( 'Working…' ) } />
+					<SessionStatusIndicator label={ __( 'Working…' ) } status="loading" />
+				) : hasUnreadMessages ? (
+					<SessionStatusIndicator label={ __( 'Unread messages' ) } status="finished-response" />
 				) : null }
 				<span className={ clsx( styles.sessionLabel, ! label && styles.sessionLabelUntitled ) }>
 					{ label || __( 'Untitled chat' ) }

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -396,11 +396,11 @@
 }
 
 .sessionStatusIndicator {
-	--status-dot-size: 12px;
+	--status-dot-size: 8px;
 
 	position: absolute;
 	inset-block-start: 50%;
-	inset-inline-start: calc(var(--wpds-dimension-padding-sm) + 6px);
+	inset-inline-start: calc(var(--wpds-dimension-padding-sm) + 8px);
 	transform: translateY(-50%);
 }
 

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -395,28 +395,12 @@
 	align-self: center;
 }
 
-.sessionInlineSpinner {
+.sessionStatusIndicator {
+	--status-dot-size: 12px;
+
 	position: absolute;
 	inset-block-start: 50%;
 	inset-inline-start: calc(var(--wpds-dimension-padding-sm) + 6px);
-	margin-block-start: -6px;
-}
-
-.sessionQuestionIndicator {
-	position: absolute;
-	inset-block-start: 50%;
-	inset-inline-start: calc(var(--wpds-dimension-padding-sm) + 4px);
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	inline-size: 16px;
-	block-size: 16px;
-	border-radius: 50%;
-	background-color: #facc15;
-	color: #422006;
-	font-size: 11px;
-	font-weight: 700;
-	line-height: 1;
 	transform: translateY(-50%);
 }
 

--- a/apps/ui/src/components/status-dot/index.tsx
+++ b/apps/ui/src/components/status-dot/index.tsx
@@ -1,0 +1,20 @@
+import { clsx } from 'clsx';
+import { forwardRef, type ComponentPropsWithoutRef } from 'react';
+import styles from './style.module.css';
+
+export type StatusDotStatus = 'loading' | 'waiting-response' | 'finished-response';
+
+interface StatusDotProps extends ComponentPropsWithoutRef< 'span' > {
+	status: StatusDotStatus;
+}
+
+export const StatusDot = forwardRef< HTMLSpanElement, StatusDotProps >( function StatusDot(
+	{ status, className, ...props },
+	ref
+) {
+	return (
+		<span ref={ ref } className={ clsx( styles.root, className ) } { ...props }>
+			<span className={ clsx( styles.visual, styles[ status ] ) } aria-hidden="true" />
+		</span>
+	);
+} );

--- a/apps/ui/src/components/status-dot/style.module.css
+++ b/apps/ui/src/components/status-dot/style.module.css
@@ -1,0 +1,44 @@
+.root {
+	--status-dot-size: 8px;
+	--status-dot-blue: var(--wpds-color-fg-interactive-brand, #3858e9);
+	--status-dot-orange: #d97706;
+
+	display: inline-grid;
+	place-items: center;
+	inline-size: var(--status-dot-size);
+	block-size: var(--status-dot-size);
+	flex-shrink: 0;
+}
+
+.visual {
+	display: block;
+	inline-size: 100%;
+	block-size: 100%;
+	background-color: var(--status-dot-blue);
+	border-radius: 999px;
+}
+
+.loading {
+	animation: pulse 1.2s ease-in-out infinite;
+}
+
+.waiting-response {
+	background-color: var(--status-dot-orange);
+	border-radius: 2px;
+}
+
+.finished-response {
+	background-color: var(--status-dot-blue);
+}
+
+@keyframes pulse {
+	0%,
+	100% {
+		opacity: 0.35;
+		transform: scale(0.85);
+	}
+	50% {
+		opacity: 1;
+		transform: scale(1);
+	}
+}

--- a/apps/ui/src/data/queries/use-agent-run.tsx
+++ b/apps/ui/src/data/queries/use-agent-run.tsx
@@ -19,6 +19,7 @@ import type {
 	LoadedAiSession,
 	SessionEntry,
 	StudioChatImage,
+	StudioCustomEntry,
 } from '@/data/core';
 
 function nowIso(): string {
@@ -609,6 +610,24 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 			if ( ! state.runId ) {
 				return;
 			}
+			updateCache( sessionId, ( entries ) =>
+				entries.map( ( entry ) => {
+					if ( entry.type !== 'custom' || entry.customType !== 'studio.agent_question' ) {
+						return entry;
+					}
+					const questionEntry = entry as StudioCustomEntry< 'studio.agent_question' >;
+					if ( questionEntry.data?.question !== question ) {
+						return entry;
+					}
+					return {
+						...questionEntry,
+						data: {
+							...questionEntry.data,
+							selectedLabel: answer,
+						},
+					} as SessionEntry;
+				} )
+			);
 			const nextAnswers = { ...state.pendingAnswers, [ question ]: answer };
 			const complete = state.pendingQuestions.every(
 				( q ) => typeof nextAnswers[ q.question ] === 'string'
@@ -620,7 +639,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 				dispatchSession( sessionId, { type: 'question_answered', question, answer } );
 			}
 		},
-		[ connector, dispatchSession, stateStore ]
+		[ connector, dispatchSession, stateStore, updateCache ]
 	);
 
 	const value = useMemo< AgentRunStore >(

--- a/apps/ui/src/data/queries/use-sessions.ts
+++ b/apps/ui/src/data/queries/use-sessions.ts
@@ -1,6 +1,6 @@
 import { deriveEffectiveEnvironment } from '@studio/common/ai/sessions/effective-site';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useConnector } from '@/data/core';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import type { AiSessionMetadata, AiSessionSummary, LoadedAiSession } from '@/data/core';
@@ -136,19 +136,30 @@ export function useUpdateSessionMetadata() {
 
 export function useMarkSessionRead() {
 	const updateSessionMetadata = useUpdateSessionMetadata();
+	// Stable wrappers (TanStack's `mutate`/`mutateAsync` keep their identity)
+	// so consumers can list them in effect deps without re-running per render.
+	const { mutate, mutateAsync } = updateSessionMetadata;
+	const markRead = useCallback(
+		( variables: { sessionId: string; eventCount: number } ) =>
+			mutate( {
+				sessionId: variables.sessionId,
+				patch: { lastReadEventCount: variables.eventCount },
+			} ),
+		[ mutate ]
+	);
+	const markReadAsync = useCallback(
+		( variables: { sessionId: string; eventCount: number } ) =>
+			mutateAsync( {
+				sessionId: variables.sessionId,
+				patch: { lastReadEventCount: variables.eventCount },
+			} ),
+		[ mutateAsync ]
+	);
 
 	return {
 		...updateSessionMetadata,
-		mutate: ( variables: { sessionId: string; eventCount: number } ) =>
-			updateSessionMetadata.mutate( {
-				sessionId: variables.sessionId,
-				patch: { lastReadEventCount: variables.eventCount },
-			} ),
-		mutateAsync: ( variables: { sessionId: string; eventCount: number } ) =>
-			updateSessionMetadata.mutateAsync( {
-				sessionId: variables.sessionId,
-				patch: { lastReadEventCount: variables.eventCount },
-			} ),
+		mutate: markRead,
+		mutateAsync: markReadAsync,
 	};
 }
 

--- a/apps/ui/src/data/queries/use-sessions.ts
+++ b/apps/ui/src/data/queries/use-sessions.ts
@@ -134,6 +134,24 @@ export function useUpdateSessionMetadata() {
 	} );
 }
 
+export function useMarkSessionRead() {
+	const updateSessionMetadata = useUpdateSessionMetadata();
+
+	return {
+		...updateSessionMetadata,
+		mutate: ( variables: { sessionId: string; eventCount: number } ) =>
+			updateSessionMetadata.mutate( {
+				sessionId: variables.sessionId,
+				patch: { lastReadEventCount: variables.eventCount },
+			} ),
+		mutateAsync: ( variables: { sessionId: string; eventCount: number } ) =>
+			updateSessionMetadata.mutateAsync( {
+				sessionId: variables.sessionId,
+				patch: { lastReadEventCount: variables.eventCount },
+			} ),
+	};
+}
+
 function useSessionArchivedMutation( archived: boolean ) {
 	const updateSessionMetadata = useUpdateSessionMetadata();
 

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
@@ -87,12 +87,14 @@ describe( 'Conversation tool rows', () => {
 
 		expect( screen.queryByText( /first output line/ ) ).not.toBeInTheDocument();
 
-		const toolRow = screen.getByRole( 'button', { name: /Run command npm test/ } );
+		const toolRow = screen.getByRole( 'button', { name: 'Run terminal command' } );
 		expect( toolRow ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect( screen.queryByText( 'npm test' ) ).not.toBeInTheDocument();
 
 		fireEvent.click( toolRow );
 
 		expect( toolRow ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect( screen.getByText( 'npm test' ) ).toBeInTheDocument();
 		expect( screen.getByText( /first output line/ ) ).toBeInTheDocument();
 
 		fireEvent.click( toolRow );
@@ -126,7 +128,7 @@ describe( 'Conversation tool rows', () => {
 
 		expect( screen.queryByRole( 'button', { name: 'Show more' } ) ).not.toBeInTheDocument();
 
-		fireEvent.click( screen.getByRole( 'button', { name: /Run command npm test/ } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Run terminal command' } ) );
 
 		expect( screen.getByText( /output line 13/ ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: 'Show more' } ) ).not.toBeInTheDocument();

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
@@ -65,6 +65,47 @@ describe( 'entriesToRenderItems', () => {
 			},
 		] );
 	} );
+
+	it( 'resolves picked answers positionally for a multi-question batch', () => {
+		// Mirrors how the CLI persists a batch: all questions first, then the
+		// answers in question order. Both questions share option labels, so
+		// label matching alone would attribute the wrong answer.
+		const items = entriesToRenderItems( [
+			agentQuestionEntry( 'q1', 'Install Jetpack?', [ 'Yes', 'No' ] ),
+			agentQuestionEntry( 'q2', 'Activate dark mode?', [ 'Yes', 'No' ] ),
+			askUserAnswerEntry( 'a1', 'No' ),
+			askUserAnswerEntry( 'a2', 'Yes' ),
+		] );
+
+		expect( items ).toMatchObject( [
+			{ kind: 'agent-question', question: 'Install Jetpack?', pickedLabel: 'No' },
+			{ kind: 'agent-question', question: 'Activate dark mode?', pickedLabel: 'Yes' },
+		] );
+	} );
+
+	it( 'highlights no answer when a batch has fewer answers than questions', () => {
+		const items = entriesToRenderItems( [
+			agentQuestionEntry( 'q1', 'Install Jetpack?', [ 'Yes', 'No' ] ),
+			agentQuestionEntry( 'q2', 'Activate dark mode?', [ 'Yes', 'No' ] ),
+			askUserAnswerEntry( 'a1', 'Yes' ),
+		] );
+
+		expect( items ).toMatchObject( [
+			{ kind: 'agent-question', question: 'Install Jetpack?', pickedLabel: undefined },
+			{ kind: 'agent-question', question: 'Activate dark mode?', pickedLabel: undefined },
+		] );
+	} );
+
+	it( 'resolves a single historical question from its persisted answer', () => {
+		const items = entriesToRenderItems( [
+			agentQuestionEntry( 'q1', 'Install Jetpack?', [ 'Yes', 'No' ] ),
+			askUserAnswerEntry( 'a1', 'Yes' ),
+		] );
+
+		expect( items ).toMatchObject( [
+			{ kind: 'agent-question', question: 'Install Jetpack?', pickedLabel: 'Yes' },
+		] );
+	} );
 } );
 
 describe( 'Conversation tool rows', () => {
@@ -361,4 +402,32 @@ function toolResultEntry( text: string ): SessionEntry {
 			content: [ { type: 'text', text } ],
 		},
 	} as unknown as SessionEntry;
+}
+
+function agentQuestionEntry( id: string, question: string, labels: string[] ): SessionEntry {
+	return {
+		type: 'custom',
+		id,
+		parentId: null,
+		timestamp: '2026-06-05T12:00:01.000Z',
+		customType: 'studio.agent_question',
+		data: {
+			question,
+			options: labels.map( ( label ) => ( { label, description: '' } ) ),
+		},
+	} as SessionEntry;
+}
+
+function askUserAnswerEntry( id: string, text: string ): SessionEntry {
+	return {
+		type: 'custom',
+		id,
+		parentId: null,
+		timestamp: '2026-06-05T12:00:02.000Z',
+		customType: 'studio.user_prompt',
+		data: {
+			text,
+			source: 'ask_user',
+		},
+	} as SessionEntry;
 }

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from 'vitest';
-import { entriesToRenderItems } from './index';
-import type { SessionEntry } from '@/data/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { Conversation, entriesToRenderItems } from './index';
+import type { LoadedAiSession, SessionEntry } from '@/data/core';
+
+vi.mock( '@/components/markdown', () => ( {
+	Markdown: ( { children }: { children: string } ) => children,
+} ) );
+
+vi.mock( '../thinking-indicator', () => ( {
+	ThinkingIndicator: () => null,
+} ) );
 
 describe( 'entriesToRenderItems', () => {
 	it( 'attaches image previews to the matching user prompt', () => {
@@ -56,3 +66,297 @@ describe( 'entriesToRenderItems', () => {
 		] );
 	} );
 } );
+
+describe( 'Conversation tool rows', () => {
+	it( 'keeps tool results hidden until the label row is clicked', async () => {
+		const data = loadedSession( [
+			assistantToolCallEntry( 'Bash', { command: 'npm test' } ),
+			toolResultEntry( 'first output line\nsecond output line' ),
+		] );
+
+		render(
+			createElement( Conversation, {
+				data,
+				isRunning: false,
+				startedAt: null,
+				pendingQuestions: new Set< string >(),
+				pendingAnswers: {},
+				onAnswerQuestion: vi.fn(),
+			} )
+		);
+
+		expect( screen.queryByText( /first output line/ ) ).not.toBeInTheDocument();
+
+		const toolRow = screen.getByRole( 'button', { name: /Run command npm test/ } );
+		expect( toolRow ).toHaveAttribute( 'aria-expanded', 'false' );
+
+		fireEvent.click( toolRow );
+
+		expect( toolRow ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect( screen.getByText( /first output line/ ) ).toBeInTheDocument();
+
+		fireEvent.click( toolRow );
+
+		expect( toolRow ).toHaveAttribute( 'aria-expanded', 'false' );
+		await waitFor( () =>
+			expect( screen.queryByText( /first output line/ ) ).not.toBeInTheDocument()
+		);
+	} );
+
+	it( 'shows long tool results in the opened details without an extra toggle', () => {
+		const longOutput = Array.from(
+			{ length: 13 },
+			( _, index ) => `output line ${ index + 1 }`
+		).join( '\n' );
+		const data = loadedSession( [
+			assistantToolCallEntry( 'Bash', { command: 'npm test' } ),
+			toolResultEntry( longOutput ),
+		] );
+
+		render(
+			createElement( Conversation, {
+				data,
+				isRunning: false,
+				startedAt: null,
+				pendingQuestions: new Set< string >(),
+				pendingAnswers: {},
+				onAnswerQuestion: vi.fn(),
+			} )
+		);
+
+		expect( screen.queryByRole( 'button', { name: 'Show more' } ) ).not.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: /Run command npm test/ } ) );
+
+		expect( screen.getByText( /output line 13/ ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Show more' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Show less' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'summarizes WP-CLI commands while preserving the raw command in details', () => {
+		const command =
+			'post list --post_type=post --post_status=publish --fields=ID,post_title,post_date --format=table';
+		const data = loadedSession( [
+			assistantToolCallEntry( 'wp_cli', { nameOrPath: "Shaun's Blog", command } ),
+			toolResultEntry( 'ID\tpost_title\tpost_date\n1\tHello world\t2026-06-05' ),
+		] );
+
+		render(
+			createElement( Conversation, {
+				data,
+				isRunning: false,
+				startedAt: null,
+				pendingQuestions: new Set< string >(),
+				pendingAnswers: {},
+				onAnswerQuestion: vi.fn(),
+			} )
+		);
+
+		const toolRow = screen.getByRole( 'button', {
+			name: 'List published posts',
+		} );
+		expect( toolRow ).toBeInTheDocument();
+		expect( screen.queryByText( /--fields=ID/ ) ).not.toBeInTheDocument();
+
+		fireEvent.click( toolRow );
+
+		expect( screen.queryByText( 'Command' ) ).not.toBeInTheDocument();
+		expect(
+			screen.getByText( ( content ) => content.includes( `wp ${ command }` ) )
+		).toBeInTheDocument();
+		expect( screen.queryByText( /Site: Shaun's Blog/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps screenshot row details focused on the action', () => {
+		const data = loadedSession( [
+			assistantToolCallEntry( 'take_screenshot', {
+				url: 'http://localhost:8882',
+				viewport: 'all',
+			} ),
+			toolResultEntry( 'Screenshot captured' ),
+		] );
+
+		render(
+			createElement( Conversation, {
+				data,
+				isRunning: false,
+				startedAt: null,
+				pendingQuestions: new Set< string >(),
+				pendingAnswers: {},
+				onAnswerQuestion: vi.fn(),
+			} )
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Capture screenshot' } ) ).toBeInTheDocument();
+		expect( screen.queryByText( /localhost:8882/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /all/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps annotation browser row details focused on the action', () => {
+		const data = loadedSession( [
+			assistantToolCallEntry( 'open_annotation_browser', {
+				url: 'http://localhost:8882',
+			} ),
+			toolResultEntry( 'Annotation browser ready' ),
+		] );
+
+		render(
+			createElement( Conversation, {
+				data,
+				isRunning: false,
+				startedAt: null,
+				pendingQuestions: new Set< string >(),
+				pendingAnswers: {},
+				onAnswerQuestion: vi.fn(),
+			} )
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Open annotation browser' } ) ).toBeInTheDocument();
+		expect( screen.queryByText( /localhost:8882/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the Ask User tool row while showing the question UI', () => {
+		const data = loadedSession( [
+			assistantToolCallEntry( 'AskUserQuestion', {
+				question: "What kind of vibe do you want for your blog's design?",
+			} ),
+			{
+				type: 'custom',
+				id: 'question',
+				parentId: null,
+				timestamp: '2026-06-05T12:00:01.000Z',
+				customType: 'studio.agent_question',
+				data: {
+					question: "What kind of vibe do you want for your blog's design?",
+					options: [
+						{ label: 'Minimal & Clean', description: '' },
+						{ label: 'Warm & Cozy', description: '' },
+					],
+				},
+			} as SessionEntry,
+		] );
+
+		render(
+			createElement( Conversation, {
+				data,
+				isRunning: false,
+				startedAt: null,
+				pendingQuestions: new Set< string >(),
+				pendingAnswers: {},
+				onAnswerQuestion: vi.fn(),
+			} )
+		);
+
+		expect( screen.queryByText( 'Ask user' ) ).not.toBeInTheDocument();
+		expect(
+			screen.getByText( "What kind of vibe do you want for your blog's design?" )
+		).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Minimal & Clean' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows Ask User option descriptions and a selected historical answer', () => {
+		const question = "What kind of vibe do you want for your blog's design?";
+		const onAnswerQuestion = vi.fn();
+		const data = loadedSession( [
+			{
+				type: 'custom',
+				id: 'question',
+				parentId: null,
+				timestamp: '2026-06-05T12:00:01.000Z',
+				customType: 'studio.agent_question',
+				data: {
+					question,
+					selectedLabel: 'Bold & Editorial',
+					options: [
+						{
+							label: 'Minimal & Clean',
+							description: 'Quiet typography, generous spacing, and simple structure.',
+						},
+						{
+							label: 'Bold & Editorial',
+							description: 'Large headlines, sharp contrast, and magazine-style pacing.',
+						},
+					],
+				},
+			} as SessionEntry,
+		] );
+
+		render(
+			createElement( Conversation, {
+				data,
+				isRunning: false,
+				startedAt: null,
+				pendingQuestions: new Set< string >(),
+				pendingAnswers: {},
+				onAnswerQuestion,
+			} )
+		);
+
+		expect( screen.getAllByRole( 'listitem' ) ).toHaveLength( 2 );
+		expect(
+			screen.getByText( 'Quiet typography, generous spacing, and simple structure.' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Large headlines, sharp contrast, and magazine-style pacing.' )
+		).toBeInTheDocument();
+
+		const pickedOption = screen.getByRole( 'button', { name: 'Bold & Editorial' } );
+		expect( pickedOption ).toHaveAttribute( 'aria-pressed', 'true' );
+		expect( pickedOption ).toBeDisabled();
+
+		fireEvent.click( pickedOption );
+
+		expect( onAnswerQuestion ).not.toHaveBeenCalled();
+	} );
+} );
+
+function loadedSession( entries: SessionEntry[] ): LoadedAiSession {
+	return {
+		summary: {
+			id: 'session-1',
+			filePath: '/tmp/session-1.json',
+			createdAt: '2026-06-05T12:00:00.000Z',
+			updatedAt: '2026-06-05T12:00:00.000Z',
+			activeEnvironment: 'local',
+			eventCount: entries.length,
+		},
+		entries,
+	};
+}
+
+function assistantToolCallEntry(
+	name: string,
+	args: Record< string, unknown > = {}
+): SessionEntry {
+	return {
+		type: 'message',
+		id: `assistant-${ name }`,
+		parentId: null,
+		timestamp: '2026-06-05T12:00:00.000Z',
+		message: {
+			role: 'assistant',
+			content: [
+				{
+					type: 'toolCall',
+					id: 'tool-call-1',
+					name,
+					arguments: args,
+				},
+			],
+		},
+	} as unknown as SessionEntry;
+}
+
+function toolResultEntry( text: string ): SessionEntry {
+	return {
+		type: 'message',
+		id: 'tool-result',
+		parentId: null,
+		timestamp: '2026-06-05T12:00:01.000Z',
+		message: {
+			role: 'toolResult',
+			toolCallId: 'tool-call-1',
+			content: [ { type: 'text', text } ],
+		},
+	} as unknown as SessionEntry;
+}

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -8,9 +8,50 @@ import {
 	getToolDisplayName,
 	type NormalizedToolResult,
 } from '@studio/common/ai/tools';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	blockDefault,
+	brush,
+	capturePhoto,
+	category,
+	chartBar,
+	check,
+	cloud,
+	cloudDownload,
+	cloudUpload,
+	code,
+	create,
+	download,
+	file,
+	globe,
+	help,
+	Icon,
+	info,
+	link,
+	list,
+	media,
+	navigation,
+	offline,
+	pencil,
+	pending,
+	people,
+	plugins,
+	plusCircle,
+	post,
+	search,
+	seen,
+	settings,
+	share,
+	styles as stylesIcon,
+	tag,
+	tool,
+	trash,
+	trendingUp,
+	update,
+	upload,
+} from '@wordpress/icons';
 import { clsx } from 'clsx';
-import { useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState, type ReactElement } from 'react';
 import { Markdown } from '@/components/markdown';
 import { ThinkingIndicator } from '../thinking-indicator';
 import styles from './style.module.css';
@@ -37,6 +78,7 @@ type RenderItem =
 			key: string;
 			question: string;
 			options: Array< { label: string; description: string } >;
+			pickedLabel?: string;
 	  }
 	| { kind: 'interrupted-marker'; key: string };
 
@@ -71,7 +113,7 @@ interface PiToolResultLike {
 	isError?: boolean;
 }
 
-const HIDDEN_TOOL_ROWS = new Set( [ 'studio_present' ] );
+const HIDDEN_TOOL_ROWS = new Set( [ 'studio_present', 'AskUserQuestion' ] );
 
 interface UserImageAttachment extends StudioChatImageAttachment {
 	src?: string;
@@ -142,6 +184,34 @@ function buildUserImageAttachments(
 		} );
 	}
 	return attachments;
+}
+
+function findAskUserAnswerAfter(
+	entries: SessionEntry[],
+	entryIndex: number,
+	options: Array< { label: string } >
+): string | undefined {
+	const optionLabels = new Set( options.map( ( option ) => option.label ) );
+	for ( let index = entryIndex + 1; index < entries.length; index += 1 ) {
+		const entry = entries[ index ];
+		if (
+			isStudioCustomEntryOfType( entry, 'studio.agent_question' ) ||
+			isStudioCustomEntryOfType( entry, 'studio.turn_closed' )
+		) {
+			return undefined;
+		}
+		if ( ! isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ) {
+			continue;
+		}
+		const data = ( entry as StudioCustomEntry< 'studio.user_prompt' > ).data;
+		if ( data?.source === 'ask_user' && optionLabels.has( data.text ) ) {
+			return data.text;
+		}
+		if ( data?.source === 'prompt' ) {
+			return undefined;
+		}
+	}
+	return undefined;
 }
 
 export function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {
@@ -220,6 +290,8 @@ export function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {
 				key: `${ entryIndex }:question`,
 				question: data.question,
 				options: data.options,
+				pickedLabel:
+					data.selectedLabel ?? findAskUserAnswerAfter( entries, entryIndex, data.options ),
 			} );
 			return;
 		}
@@ -288,7 +360,515 @@ function AssistantText( { text }: { text: string } ) {
 	return <Markdown>{ text }</Markdown>;
 }
 
-const TOOL_RESULT_PREVIEW_MAX_LINES = 12;
+const TOOL_DETAIL_MAX_LENGTH = 96;
+const TOOL_DETAILS_ANIMATION_MS = 140;
+
+interface ClassicToolDisplay {
+	label: string;
+	detail: string;
+	inputText: string;
+}
+
+function getInputString( input: Record< string, unknown > | undefined, key: string ): string {
+	const value = input?.[ key ];
+	return typeof value === 'string' ? value.trim() : '';
+}
+
+function truncateToolDetail( value: string, maxLength = TOOL_DETAIL_MAX_LENGTH ): string {
+	if ( value.length <= maxLength ) {
+		return value;
+	}
+	return value.slice( 0, maxLength - 1 ).trimEnd() + '…';
+}
+
+function shortPath( value: string ): string {
+	return value.split( '/' ).filter( Boolean ).slice( -2 ).join( '/' ) || value;
+}
+
+function splitCommandArgs( command: string ): string[] {
+	return (
+		command
+			.match( /(?:[^\s"']+|"[^"]*"|'[^']*')+/g )
+			?.map( ( arg ) => arg.replace( /^(['"])(.*)\1$/, '$2' ) )
+			.filter( Boolean ) ?? []
+	);
+}
+
+function getWpCliOptionValue( args: string[], option: string ): string | undefined {
+	const inlinePrefix = `${ option }=`;
+	for ( let index = 0; index < args.length; index += 1 ) {
+		const arg = args[ index ];
+		if ( arg.startsWith( inlinePrefix ) ) {
+			return arg.slice( inlinePrefix.length );
+		}
+		if ( arg === option ) {
+			return args[ index + 1 ];
+		}
+	}
+	return undefined;
+}
+
+function getPostTypeName( postType: string | undefined, plural: boolean ): string {
+	switch ( postType ) {
+		case 'page':
+			return plural ? __( 'pages' ) : __( 'page' );
+		case 'attachment':
+			return plural ? __( 'media items' ) : __( 'media item' );
+		case 'product':
+			return plural ? __( 'products' ) : __( 'product' );
+		case 'post':
+		case undefined:
+		case '':
+			return plural ? __( 'posts' ) : __( 'post' );
+		default:
+			return postType.replace( /[-_]+/g, ' ' );
+	}
+}
+
+function getWpCliPostLabel( args: string[] ): string {
+	const action = args[ 1 ];
+	const postType = getWpCliOptionValue( args, '--post_type' );
+	const postStatus = getWpCliOptionValue( args, '--post_status' );
+	const singularPostType = getPostTypeName( postType, false );
+	const pluralPostType = getPostTypeName( postType, true );
+
+	switch ( action ) {
+		case 'list':
+			if ( postStatus === 'publish' ) {
+				return sprintf(
+					/* translators: %s: plural post type, such as posts or pages. */
+					__( 'List published %s' ),
+					pluralPostType
+				);
+			}
+			return sprintf(
+				/* translators: %s: plural post type, such as posts or pages. */
+				__( 'List %s' ),
+				pluralPostType
+			);
+		case 'get':
+			return sprintf(
+				/* translators: %s: post type, such as post or page. */
+				__( 'Read %s' ),
+				singularPostType
+			);
+		case 'create':
+			return sprintf(
+				/* translators: %s: post type, such as post or page. */
+				__( 'Create %s' ),
+				singularPostType
+			);
+		case 'update':
+			return sprintf(
+				/* translators: %s: post type, such as post or page. */
+				__( 'Update %s' ),
+				singularPostType
+			);
+		case 'delete':
+			return sprintf(
+				/* translators: %s: post type, such as post or page. */
+				__( 'Delete %s' ),
+				singularPostType
+			);
+		default:
+			return __( 'Manage content' );
+	}
+}
+
+function getWpCliCommandLabel( command: string ): string {
+	const args = splitCommandArgs( command );
+	const [ entity, action, target ] = args;
+
+	switch ( entity ) {
+		case 'theme':
+			switch ( action ) {
+				case 'list':
+					return __( 'List themes' );
+				case 'activate':
+					return target ? sprintf( __( 'Activate theme %s' ), target ) : __( 'Activate theme' );
+				case 'install':
+					return target ? sprintf( __( 'Install theme %s' ), target ) : __( 'Install theme' );
+				case 'delete':
+					return target ? sprintf( __( 'Delete theme %s' ), target ) : __( 'Delete theme' );
+				default:
+					return __( 'Manage themes' );
+			}
+		case 'plugin':
+			switch ( action ) {
+				case 'list':
+					return __( 'List plugins' );
+				case 'activate':
+					return target ? sprintf( __( 'Activate plugin %s' ), target ) : __( 'Activate plugin' );
+				case 'deactivate':
+					return target
+						? sprintf( __( 'Deactivate plugin %s' ), target )
+						: __( 'Deactivate plugin' );
+				case 'install':
+					return target ? sprintf( __( 'Install plugin %s' ), target ) : __( 'Install plugin' );
+				case 'delete':
+					return target ? sprintf( __( 'Delete plugin %s' ), target ) : __( 'Delete plugin' );
+				case 'update':
+					return target ? sprintf( __( 'Update plugin %s' ), target ) : __( 'Update plugin' );
+				default:
+					return __( 'Manage plugins' );
+			}
+		case 'post':
+			return getWpCliPostLabel( args );
+		case 'option':
+			if ( action === 'get' ) {
+				return target === 'blogname' ? __( 'Read site title' ) : __( 'Read site option' );
+			}
+			if ( action === 'update' ) {
+				return target === 'blogname' ? __( 'Update site title' ) : __( 'Update site option' );
+			}
+			return __( 'Manage site options' );
+		case 'user':
+			switch ( action ) {
+				case 'list':
+					return __( 'List users' );
+				case 'create':
+					return __( 'Create user' );
+				case 'update':
+					return __( 'Update user' );
+				case 'delete':
+					return __( 'Delete user' );
+				default:
+					return __( 'Manage users' );
+			}
+		case 'media':
+			return action === 'import' ? __( 'Import media' ) : __( 'Manage media' );
+		case 'menu':
+			return action === 'list' ? __( 'List menus' ) : __( 'Manage menus' );
+		case 'term':
+			return action === 'list' ? __( 'List terms' ) : __( 'Manage terms' );
+		case 'cache':
+			return action === 'flush' ? __( 'Flush cache' ) : __( 'Manage cache' );
+		case 'rewrite':
+			return action === 'flush' ? __( 'Flush permalinks' ) : __( 'Manage permalinks' );
+		case 'eval':
+		case 'eval-file':
+			return __( 'Run WordPress code' );
+		default:
+			return __( 'Run WordPress command' );
+	}
+}
+
+function getAskUserDetail( input: Record< string, unknown > | undefined ): string {
+	const questions = input?.questions;
+	if ( ! Array.isArray( questions ) || questions.length === 0 ) {
+		return '';
+	}
+	const firstQuestion = questions[ 0 ];
+	if (
+		firstQuestion &&
+		typeof firstQuestion === 'object' &&
+		'question' in firstQuestion &&
+		typeof firstQuestion.question === 'string'
+	) {
+		return truncateToolDetail( firstQuestion.question );
+	}
+	return '';
+}
+
+function stringifyToolInput( input: Record< string, unknown > ): string {
+	try {
+		return JSON.stringify( input, null, 2 );
+	} catch {
+		return String( input );
+	}
+}
+
+function getClassicToolInputText(
+	name: string,
+	input: Record< string, unknown > | undefined
+): string {
+	if ( ! input || Object.keys( input ).length === 0 ) {
+		return '';
+	}
+
+	if ( name === 'wp_cli' ) {
+		const command = getInputString( input, 'command' );
+		if ( ! command ) {
+			return '';
+		}
+		return `wp ${ command }`;
+	}
+
+	if ( name === 'Bash' ) {
+		const command = getInputString( input, 'command' );
+		return command;
+	}
+
+	return stringifyToolInput( input );
+}
+
+function getClassicToolDisplay(
+	name: string,
+	input: Record< string, unknown > | undefined
+): ClassicToolDisplay {
+	const url = getInputString( input, 'url' );
+	const host = getInputString( input, 'host' );
+	const command = getInputString( input, 'command' );
+	const filePath = getInputString( input, 'filePath' );
+	const genericDetail = getToolDetail( name, input );
+
+	const display: ClassicToolDisplay = {
+		label: getToolDisplayName( name ),
+		detail: genericDetail,
+		inputText: getClassicToolInputText( name, input ),
+	};
+
+	switch ( name ) {
+		case 'site_create':
+			display.label = __( 'Create site' );
+			display.detail = getInputString( input, 'name' );
+			break;
+		case 'site_list':
+			display.label = __( 'List sites' );
+			display.detail = '';
+			break;
+		case 'site_info':
+			display.label = __( 'Inspect site' );
+			display.detail = '';
+			break;
+		case 'site_start':
+			display.label = __( 'Start site' );
+			display.detail = '';
+			break;
+		case 'site_stop':
+			display.label = __( 'Stop site' );
+			display.detail = '';
+			break;
+		case 'site_delete':
+			display.label = __( 'Delete site' );
+			display.detail = '';
+			break;
+		case 'site_push':
+			display.label = __( 'Push site' );
+			display.detail = '';
+			break;
+		case 'site_pull':
+			display.label = __( 'Pull site' );
+			display.detail = '';
+			break;
+		case 'site_import':
+			display.label = __( 'Import site' );
+			display.detail = '';
+			break;
+		case 'site_export':
+			display.label = __( 'Export site' );
+			display.detail = '';
+			break;
+		case 'site_connected_remote_sites':
+			display.label = __( 'List connected remote sites' );
+			display.detail = '';
+			break;
+		case 'preview_create':
+			display.label = __( 'Create preview' );
+			display.detail = '';
+			break;
+		case 'preview_list':
+			display.label = __( 'List previews' );
+			display.detail = '';
+			break;
+		case 'preview_update':
+			display.label = __( 'Update preview' );
+			display.detail = host;
+			break;
+		case 'preview_delete':
+			display.label = __( 'Delete preview' );
+			display.detail = host;
+			break;
+		case 'wp_cli':
+			display.label = command ? getWpCliCommandLabel( command ) : __( 'Run WordPress command' );
+			display.detail = '';
+			break;
+		case 'open_annotation_browser':
+			display.label = __( 'Open annotation browser' );
+			display.detail = '';
+			break;
+		case 'wait_for_annotations':
+			display.label = __( 'Wait for annotations' );
+			display.detail = '';
+			break;
+		case 'AskUserQuestion':
+			display.label = __( 'Ask user' );
+			display.detail = getAskUserDetail( input );
+			break;
+		case 'take_screenshot':
+			display.label = __( 'Capture screenshot' );
+			display.detail = '';
+			break;
+		case 'share_screenshot':
+			display.label = __( 'Share screenshot' );
+			display.detail = url;
+			break;
+		case 'validate_html_blocks':
+			display.label = __( 'Check block HTML' );
+			display.detail = filePath ? shortPath( filePath ) : __( 'inline content' );
+			break;
+		case 'validate_and_fix_blocks':
+			display.label = __( 'Fix block HTML' );
+			display.detail = filePath ? shortPath( filePath ) : __( 'inline content' );
+			break;
+		case 'scaffold_theme':
+			display.label = __( 'Create theme' );
+			display.detail = getInputString( input, 'name' );
+			break;
+		case 'install_taxonomy_scripts':
+			display.label = __( 'Install taxonomy tools' );
+			display.detail = '';
+			break;
+		case 'need_for_speed':
+			display.label = __( 'Audit performance' );
+			display.detail = '';
+			break;
+		case 'rank_me_up':
+			display.label = __( 'Audit SEO' );
+			display.detail = '';
+			break;
+		case 'wpcom_request':
+			display.label = __( 'Contact WordPress.com' );
+			display.detail = genericDetail;
+			break;
+		case 'Read':
+		case 'Write':
+		case 'Edit':
+			display.detail = genericDetail ? shortPath( genericDetail ) : '';
+			break;
+		case 'Bash':
+			display.label = __( 'Run command' );
+			display.detail = command ? truncateToolDetail( command ) : '';
+			break;
+	}
+
+	display.detail = truncateToolDetail( display.detail );
+	return display;
+}
+
+function getWpCliToolIcon( command: string ): ReactElement {
+	const [ entity ] = splitCommandArgs( command );
+
+	switch ( entity ) {
+		case 'theme':
+			return stylesIcon;
+		case 'plugin':
+			return plugins;
+		case 'post':
+			return post;
+		case 'option':
+			return settings;
+		case 'user':
+			return people;
+		case 'media':
+			return media;
+		case 'menu':
+			return navigation;
+		case 'term':
+			return tag;
+		case 'cache':
+			return update;
+		case 'rewrite':
+			return link;
+		case 'eval':
+		case 'eval-file':
+			return code;
+		default:
+			return code;
+	}
+}
+
+function getToolIcon(
+	name: string,
+	input: Record< string, unknown > | undefined
+): ReactElement | null {
+	switch ( name ) {
+		case 'site_create':
+			return plusCircle;
+		case 'site_list':
+			return list;
+		case 'site_info':
+			return info;
+		case 'site_start':
+			return globe;
+		case 'site_stop':
+			return offline;
+		case 'site_delete':
+			return trash;
+		case 'site_push':
+			return cloudUpload;
+		case 'site_pull':
+			return cloudDownload;
+		case 'site_import':
+			return upload;
+		case 'site_export':
+			return download;
+		case 'site_connected_remote_sites':
+			return link;
+		case 'preview_create':
+			return seen;
+		case 'preview_list':
+			return list;
+		case 'preview_update':
+			return update;
+		case 'preview_delete':
+			return trash;
+		case 'wp_cli': {
+			const command = getInputString( input, 'command' );
+			return command ? getWpCliToolIcon( command ) : code;
+		}
+		case 'open_annotation_browser':
+			return pencil;
+		case 'wait_for_annotations':
+			return pending;
+		case 'AskUserQuestion':
+			return help;
+		case 'take_screenshot':
+		case 'share_screenshot':
+			return name === 'take_screenshot' ? capturePhoto : share;
+		case 'validate_html_blocks':
+			return check;
+		case 'validate_and_fix_blocks':
+			return tool;
+		case 'scaffold_theme':
+			return brush;
+		case 'install_taxonomy_scripts':
+			return category;
+		case 'need_for_speed':
+			return chartBar;
+		case 'rank_me_up':
+			return trendingUp;
+		case 'wpcom_request':
+			return cloud;
+		case 'Read':
+			return file;
+		case 'Write':
+			return create;
+		case 'Edit':
+			return pencil;
+		case 'Bash':
+			return code;
+		case 'Grep':
+		case 'Glob':
+			return search;
+		case 'Ls':
+			return list;
+		case 'Skill':
+			return blockDefault;
+		case 'Task':
+			return tool;
+		case 'TodoWrite':
+			return check;
+		default:
+			return null;
+	}
+}
+
+function ToolIcon( { icon }: { icon: ReactElement | null } ) {
+	return (
+		<Icon icon={ icon ?? tool } size={ 18 } className={ styles.toolIcon } aria-hidden="true" />
+	);
+}
 
 function ToolUseRow( {
 	name,
@@ -299,38 +879,84 @@ function ToolUseRow( {
 	input?: Record< string, unknown >;
 	result?: NormalizedToolResult;
 } ) {
-	const label = getToolDisplayName( name );
-	const detail = getToolDetail( name, input );
-	const [ expanded, setExpanded ] = useState( false );
+	const display = getClassicToolDisplay( name, input );
+	const icon = getToolIcon( name, input );
+	const [ detailsState, setDetailsState ] = useState< 'closed' | 'opening' | 'open' | 'closing' >(
+		'closed'
+	);
+	const detailsId = useId();
 	const resultText = result?.text?.trim() ?? '';
 	const hasOutput = resultText.length > 0;
-	const isLong = resultText.split( '\n' ).length > TOOL_RESULT_PREVIEW_MAX_LINES;
+	const hasInput = display.inputText.length > 0;
+	const hasExpandableDetails = hasOutput || hasInput;
+	const isDetailsRendered = detailsState !== 'closed';
+	const isDetailsExpanded = detailsState === 'opening' || detailsState === 'open';
+
+	useEffect( () => {
+		if ( detailsState !== 'opening' ) {
+			return;
+		}
+		const frame = requestAnimationFrame( () => setDetailsState( 'open' ) );
+		return () => cancelAnimationFrame( frame );
+	}, [ detailsState ] );
+
+	useEffect( () => {
+		if ( detailsState !== 'closing' ) {
+			return;
+		}
+		const timeout = window.setTimeout(
+			() => setDetailsState( 'closed' ),
+			TOOL_DETAILS_ANIMATION_MS
+		);
+		return () => window.clearTimeout( timeout );
+	}, [ detailsState ] );
+
+	const rowContent = (
+		<>
+			<ToolIcon icon={ icon } />
+			<span className={ styles.toolLabel }>{ display.label }</span>
+			{ display.detail ? <span className={ styles.toolDetail }>{ display.detail }</span> : null }
+		</>
+	);
 
 	return (
 		<div className={ styles.toolBlock }>
-			<div className={ styles.toolRow }>
-				<span className={ styles.toolLabel }>{ label }</span>
-				{ detail ? <span className={ styles.toolDetail }>{ detail }</span> : null }
-			</div>
-			{ hasOutput ? (
-				<div className={ styles.toolOutputWrap }>
-					<pre
-						className={ clsx(
-							styles.toolOutput,
-							result?.isError && styles.toolOutputError,
-							! expanded && isLong && styles.toolOutputCollapsed
-						) }
-					>
-						{ resultText }
-					</pre>
-					{ isLong ? (
-						<button
-							type="button"
-							className={ styles.toolOutputToggle }
-							onClick={ () => setExpanded( ( prev ) => ! prev ) }
-						>
-							{ expanded ? __( 'Show less' ) : __( 'Show more' ) }
-						</button>
+			{ hasExpandableDetails ? (
+				<button
+					type="button"
+					className={ clsx( styles.toolRow, styles.toolRowButton ) }
+					aria-expanded={ isDetailsExpanded }
+					aria-controls={ detailsId }
+					onClick={ () =>
+						setDetailsState( ( state ) =>
+							state === 'open' || state === 'opening' ? 'closing' : 'opening'
+						)
+					}
+					title={ isDetailsExpanded ? __( 'Hide tool details' ) : __( 'Show tool details' ) }
+				>
+					{ rowContent }
+				</button>
+			) : (
+				<div className={ styles.toolRow }>{ rowContent }</div>
+			) }
+			{ hasExpandableDetails && isDetailsRendered ? (
+				<div
+					id={ detailsId }
+					className={ styles.toolOutputWrap }
+					data-state={ detailsState === 'open' ? 'open' : 'closed' }
+					aria-hidden={ ! isDetailsExpanded }
+					onTransitionEnd={ ( event ) => {
+						if ( event.target !== event.currentTarget || detailsState !== 'closing' ) {
+							return;
+						}
+						setDetailsState( 'closed' );
+					} }
+				>
+					{ hasInput ? <pre className={ styles.toolInput }>{ display.inputText }</pre> : null }
+					{ hasOutput ? (
+						<pre className={ clsx( styles.toolOutput, result?.isError && styles.toolOutputError ) }>
+							{ resultText }
+						</pre>
 					) : null }
 				</div>
 			) : null }
@@ -351,6 +977,8 @@ function AgentQuestion( {
 	pickedLabel: string | undefined;
 	onAnswer: ( label: string ) => void;
 } ) {
+	const optionsId = useId();
+
 	return (
 		<div className={ styles.question }>
 			<p className={ styles.questionText }>{ question }</p>
@@ -358,16 +986,40 @@ function AgentQuestion( {
 				<ul className={ styles.questionOptions }>
 					{ options.map( ( option, index ) => {
 						const picked = option.label === pickedLabel;
+						const descriptionId = option.description
+							? `${ optionsId }-option-${ index }-description`
+							: undefined;
 						return (
-							<li key={ index }>
+							<li key={ index } className={ styles.questionOptionItem }>
 								<button
 									type="button"
 									className={ clsx( styles.questionOption, picked && styles.questionOptionPicked ) }
 									disabled={ ! isInteractive }
 									onClick={ () => onAnswer( option.label ) }
-									title={ option.description }
+									aria-label={ option.label }
+									aria-describedby={ descriptionId }
+									aria-pressed={ picked }
 								>
-									{ option.label }
+									<span className={ styles.questionOptionNumber } aria-hidden="true">
+										{ picked ? (
+											<Icon
+												icon={ check }
+												size={ 14 }
+												className={ styles.questionOptionCheck }
+												aria-hidden="true"
+											/>
+										) : (
+											index + 1
+										) }
+									</span>
+									<span className={ styles.questionOptionCopy }>
+										<span className={ styles.questionOptionLabel }>{ option.label }</span>
+										{ option.description ? (
+											<span id={ descriptionId } className={ styles.questionOptionDescription }>
+												{ option.description }
+											</span>
+										) : null }
+									</span>
 								</button>
 							</li>
 						);
@@ -426,7 +1078,7 @@ export function Conversation( {
 								question={ item.question }
 								options={ item.options }
 								isInteractive={ pendingQuestions.has( item.question ) }
-								pickedLabel={ pendingAnswers[ item.question ] }
+								pickedLabel={ pendingAnswers[ item.question ] ?? item.pickedLabel }
 								onAnswer={ ( label ) => onAnswerQuestion( item.question, label ) }
 							/>
 						);

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -192,26 +192,52 @@ function findAskUserAnswerAfter(
 	options: Array< { label: string } >
 ): string | undefined {
 	const optionLabels = new Set( options.map( ( option ) => option.label ) );
-	for ( let index = entryIndex + 1; index < entries.length; index += 1 ) {
+	// A question batch persists as N contiguous `studio.agent_question`
+	// entries followed by the answers in the same order (see
+	// `askUserAndPersistAnswers` in apps/cli/commands/ai), so this question's
+	// answer sits at the same offset in the answer block as the question
+	// holds within its batch.
+	let batchPosition = 0;
+	for ( let index = entryIndex - 1; index >= 0; index -= 1 ) {
+		if ( ! isStudioCustomEntryOfType( entries[ index ], 'studio.agent_question' ) ) {
+			break;
+		}
+		batchPosition += 1;
+	}
+	let batchSize = batchPosition + 1;
+	let index = entryIndex + 1;
+	while (
+		index < entries.length &&
+		isStudioCustomEntryOfType( entries[ index ], 'studio.agent_question' )
+	) {
+		batchSize += 1;
+		index += 1;
+	}
+	const answers: string[] = [];
+	for ( ; index < entries.length && answers.length < batchSize; index += 1 ) {
 		const entry = entries[ index ];
 		if (
 			isStudioCustomEntryOfType( entry, 'studio.agent_question' ) ||
 			isStudioCustomEntryOfType( entry, 'studio.turn_closed' )
 		) {
-			return undefined;
+			break;
 		}
 		if ( ! isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ) {
 			continue;
 		}
 		const data = ( entry as StudioCustomEntry< 'studio.user_prompt' > ).data;
-		if ( data?.source === 'ask_user' && optionLabels.has( data.text ) ) {
-			return data.text;
+		if ( data?.source !== 'ask_user' ) {
+			break;
 		}
-		if ( data?.source === 'prompt' ) {
-			return undefined;
-		}
+		answers.push( data.text );
 	}
-	return undefined;
+	// Blank answers are skipped at persist time; a count mismatch makes the
+	// positional mapping unreliable, so highlight nothing rather than guess.
+	if ( answers.length !== batchSize ) {
+		return undefined;
+	}
+	const answer = answers[ batchPosition ];
+	return optionLabels.has( answer ) ? answer : undefined;
 }
 
 export function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -737,8 +737,8 @@ function getClassicToolDisplay(
 			display.detail = genericDetail ? shortPath( genericDetail ) : '';
 			break;
 		case 'Bash':
-			display.label = __( 'Run command' );
-			display.detail = command ? truncateToolDetail( command ) : '';
+			display.label = __( 'Run terminal command' );
+			display.detail = '';
 			break;
 	}
 

--- a/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
@@ -84,81 +84,177 @@
 }
 
 .toolRow {
+	--tool-trigger-color: color-mix(
+		in srgb,
+		var(--wpds-color-fg-content-neutral-weak) 60%,
+		transparent
+	);
+	--tool-icon-color: var(--tool-trigger-color);
+
+	position: relative;
 	display: flex;
 	align-items: baseline;
-	gap: var(--wpds-dimension-padding-sm);
-	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-	font-size: var(--wpds-typography-font-size-sm);
-	color: var(--wpds-color-fg-content-neutral-weak);
+	gap: var(--wpds-dimension-padding-xs);
+	font-size: var(--wpds-typography-font-size-md);
+	line-height: 1.55;
+	color: var(--tool-trigger-color);
 	padding: 2px 0;
 	min-width: 0;
 }
 
+.toolRowButton {
+	--wp-ui-button-background-color: transparent;
+	--wp-ui-button-border-color: transparent;
+
+	appearance: none;
+	align-self: flex-start;
+	max-width: calc(100% + 16px);
+	margin: -4px -8px;
+	padding: 4px 8px;
+	border: 0;
+	border-radius: var(--wpds-border-radius-sm, 4px);
+	background: transparent;
+	font-family: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+
+.toolRowButton:hover,
+.toolRowButton:focus-visible {
+	--tool-trigger-color: var(--wpds-color-fg-interactive-neutral-active);
+	--tool-icon-color: var(--tool-trigger-color);
+
+	background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
+}
+
+.toolRowButton:focus:not(:focus-visible) {
+	outline: none;
+	background-color: transparent;
+}
+
+.toolRowButton:hover:focus:not(:focus-visible) {
+	--tool-trigger-color: var(--wpds-color-fg-interactive-neutral-active);
+	--tool-icon-color: var(--tool-trigger-color);
+
+	background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
+}
+
+.toolRowButton:hover .toolLabel,
+.toolRowButton:hover .toolDetail,
+.toolRowButton:focus-visible .toolLabel,
+.toolRowButton:focus-visible .toolDetail {
+	color: var(--wpds-color-fg-interactive-neutral-active);
+}
+
+.toolRowButton:focus-visible {
+	outline: 2px solid var(--wpds-color-stroke-interactive-focus, #2563eb);
+	outline-offset: 2px;
+}
+
 .toolOutputWrap {
-	margin-left: var(--wpds-dimension-padding-md);
+	margin: 0 0 0 -8px;
+	padding: 0 var(--wpds-dimension-padding-lg);
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
+	gap: var(--wpds-dimension-padding-xs);
+	max-height: 0;
+	overflow: hidden;
+	box-sizing: border-box;
+	border-radius: var(--wpds-border-radius-sm, 4px);
+	background-color: var(--wpds-color-bg-surface-neutral-weak);
+	opacity: 0;
+	transform: translateY(-2px);
+	transition:
+		max-height 140ms ease,
+		opacity 110ms ease,
+		transform 140ms ease,
+		margin-top 140ms ease,
+		padding-top 140ms ease,
+		padding-bottom 140ms ease;
+}
+
+.toolOutputWrap[data-state='open'] {
+	margin-top: 8px;
+	padding-top: var(--wpds-dimension-padding-lg);
+	padding-bottom: var(--wpds-dimension-padding-lg);
+	max-height: min(320px, 45vh);
+	overflow: auto;
+	opacity: 1;
+	transform: translateY(0);
+}
+
+.toolInput {
+	margin: 0;
+	padding: 0;
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: 1.5;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+	overflow: visible;
 }
 
 .toolOutput {
 	margin: 0;
-	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
-	border-left: 2px solid var(--wpds-color-stroke-surface-neutral);
+	padding: 0;
 	color: var(--wpds-color-fg-content-neutral);
 	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
 	font-size: var(--wpds-typography-font-size-xs);
 	line-height: 1.5;
 	white-space: pre-wrap;
 	word-wrap: break-word;
-	overflow: hidden;
-}
-
-.toolOutputCollapsed {
-	max-height: calc(1.5em * 12);
-	mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+	overflow: visible;
 }
 
 .toolOutputError {
-	border-left-color: var(--wpds-color-fg-content-error, #dc2626);
 	color: var(--wpds-color-fg-content-error, #dc2626);
 }
 
-.toolOutputToggle {
-	align-self: flex-start;
-	background: none;
-	border: none;
-	padding: 0;
-	color: var(--wpds-color-fg-interactive-brand, #2563eb);
-	font: inherit;
-	font-size: var(--wpds-typography-font-size-xs);
-	cursor: pointer;
-}
-
-.toolOutputToggle:hover,
-.toolOutputToggle:focus-visible {
-	text-decoration: underline;
-}
-
 .toolLabel {
-	color: var(--wpds-color-fg-content-neutral);
-	font-weight: 600;
+	color: var(--tool-trigger-color);
+	font-weight: 400;
 	flex-shrink: 0;
 }
 
 .toolDetail {
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--tool-trigger-color);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	min-width: 0;
-	flex: 1;
+	flex: 0 1 auto;
+}
+
+.toolRow .toolIcon {
+	flex: 0 0 auto;
+	width: 18px;
+	height: 18px;
+	color: var(--tool-icon-color);
+	stroke: var(--tool-icon-color);
+	transition:
+		color 120ms ease,
+		fill 120ms ease,
+		stroke 120ms ease;
+	transform: translateY(3px);
+}
+
+.toolRow .toolIcon,
+.toolRow .toolIcon :where(path:not([fill='none']), rect:not([fill='none']), circle:not([fill='none']), polygon:not([fill='none'])) {
+	fill: var(--tool-icon-color);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.toolOutputWrap,
+	.toolIcon {
+		transition: none;
+	}
 }
 
 .question {
 	display: flex;
 	flex-direction: column;
-	gap: var(--wpds-dimension-padding-sm);
+	gap: var(--wpds-dimension-padding-lg);
 }
 
 .questionText {
@@ -171,26 +267,113 @@
 	margin: 0;
 	padding: 0;
 	display: flex;
-	flex-wrap: wrap;
-	gap: var(--wpds-dimension-padding-md);
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-lg);
+	border-radius: var(--wpds-border-radius-lg);
+}
+
+.questionOptionItem {
+	margin: 0;
+	padding: 0;
 }
 
 .questionOption {
-	background: none;
+	--wp-ui-button-background-color: transparent;
+	--wp-ui-button-border-color: transparent;
+
+	display: flex;
+	align-items: flex-start;
+	gap: var(--wpds-dimension-padding-md);
+	width: 100%;
+	background: transparent;
 	border: none;
 	padding: 0;
-	color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	border-radius: var(--wpds-border-radius-sm, 4px);
+	color: var(--wpds-color-fg-content-neutral);
 	font: inherit;
+	text-align: left;
 	cursor: pointer;
 }
 
 .questionOption:hover:not(:disabled),
 .questionOption:focus-visible:not(:disabled) {
-	text-decoration: underline;
+	outline: none;
+}
+
+.questionOption:focus:not(:focus-visible) {
+	outline: none;
+	background-color: transparent;
+}
+
+.questionOption:hover:focus:not(:focus-visible) {
+	background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
+}
+
+.questionOption:focus-visible:not(:disabled) {
+	box-shadow: 0 0 0 2px var(--wpds-color-stroke-interactive-focus, #2563eb);
+}
+
+.questionOption:hover:not(:disabled) .questionOptionLabel,
+.questionOption:focus-visible:not(:disabled) .questionOptionLabel {
+	color: var(--wpds-color-fg-interactive-brand, #2563eb);
+}
+
+.questionOption:hover:not(:disabled) .questionOptionNumber,
+.questionOption:focus-visible:not(:disabled) .questionOptionNumber {
+	border-color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	color: var(--wpds-color-fg-interactive-brand, #2563eb);
+}
+
+.questionOptionNumber {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	min-width: 1.5em;
+	height: 1.5em;
+	margin-top: 3px;
+	padding: 0 0.35em;
+	border: 1px dashed var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-sm, 4px);
+	background-color: var(--wpds-color-bg-surface-neutral);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: 1;
+	transition:
+		border-color 120ms ease,
+		color 120ms ease;
+}
+
+.questionOptionCheck {
+	width: 14px;
+	height: 14px;
+	color: currentColor;
+	fill: currentColor;
+}
+
+.questionOptionCheck :where(path:not([fill='none'])) {
+	fill: currentColor;
+}
+
+.questionOptionCopy {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	min-width: 0;
+}
+
+.questionOptionLabel {
+	color: var(--wpds-color-fg-content-neutral);
+	transition: color 120ms ease;
+}
+
+.questionOptionDescription {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: 1.4;
 }
 
 .questionOption:disabled {
-	color: var(--wpds-color-fg-content-neutral-weak);
 	opacity: 0.6;
 	cursor: default;
 }
@@ -199,9 +382,20 @@
    can still see their choice once the batch is finalized. */
 .questionOptionPicked,
 .questionOptionPicked:disabled {
-	font-weight: 600;
-	color: var(--wpds-color-fg-interactive-brand, #2563eb);
 	opacity: 1;
+}
+
+.questionOptionPicked .questionOptionNumber,
+.questionOptionPicked:disabled .questionOptionNumber {
+	border-color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	background-color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	color: var(--wpds-color-bg-surface-neutral-strong);
+}
+
+.questionOptionPicked .questionOptionLabel,
+.questionOptionPicked:disabled .questionOptionLabel {
+	color: var(--wpds-color-fg-content-neutral);
+	font-weight: 500;
 }
 
 .interruptedMarker {

--- a/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
@@ -95,11 +95,15 @@
 	display: flex;
 	align-items: baseline;
 	gap: var(--wpds-dimension-padding-xs);
+	box-sizing: border-box;
+	max-width: 100%;
 	font-size: var(--wpds-typography-font-size-md);
 	line-height: 1.55;
 	color: var(--tool-trigger-color);
 	padding: 2px 0;
 	min-width: 0;
+	overflow: hidden;
+	white-space: nowrap;
 }
 
 .toolRowButton {
@@ -108,7 +112,7 @@
 
 	appearance: none;
 	align-self: flex-start;
-	max-width: calc(100% + 16px);
+	max-width: 100%;
 	margin: -4px -8px;
 	padding: 4px 8px;
 	border: 0;
@@ -214,7 +218,11 @@
 .toolLabel {
 	color: var(--tool-trigger-color);
 	font-weight: 400;
-	flex-shrink: 0;
+	min-width: 0;
+	flex: 0 1 auto;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .toolDetail {
@@ -223,7 +231,7 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	min-width: 0;
-	flex: 0 1 auto;
+	flex: 1 1 auto;
 }
 
 .toolRow .toolIcon {

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -70,7 +70,7 @@ function SessionViewContent( {
 } ) {
 	const navigate = useNavigate();
 	const { data, isLoading, error } = useSession( sessionId );
-	const markSessionRead = useMarkSessionRead();
+	const { mutate: markSessionRead } = useMarkSessionRead();
 	const lastReadMarkRef = useRef< string | null >( null );
 	const { data: sites } = useSites();
 	const ownerSitePath = data?.summary.ownerSitePath;
@@ -125,7 +125,11 @@ function SessionViewContent( {
 	useSessionPreviewAnnotations( handleAnnotationsDone, canTogglePreview && !! ownerSite );
 
 	useEffect( () => {
-		if ( ! data ) {
+		// Wait for the subprocess to exit before marking read: the mutation's
+		// invalidation refetches the session, and during a run the on-disk
+		// event count keeps growing, so each refetch would re-trigger the
+		// mutation in a loop while racing the optimistic transcript writes.
+		if ( ! data || hasActiveRun ) {
 			return;
 		}
 		const eventCount = data.summary.eventCount;
@@ -133,9 +137,9 @@ function SessionViewContent( {
 		const markKey = `${ sessionId }:${ eventCount }`;
 		if ( eventCount > lastReadEventCount && lastReadMarkRef.current !== markKey ) {
 			lastReadMarkRef.current = markKey;
-			markSessionRead.mutate( { sessionId, eventCount } );
+			markSessionRead( { sessionId, eventCount } );
 		}
-	}, [ data, markSessionRead, sessionId ] );
+	}, [ data, hasActiveRun, markSessionRead, sessionId ] );
 
 	useLayoutEffect( () => {
 		const node = scrollRef.current;

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -2,12 +2,16 @@ import { resolveSessionModel } from '@studio/common/ai/models';
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { clsx } from 'clsx';
-import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { PreviewSplitContent } from '@/components/preview-split-frame';
 import { type Annotation } from '@/components/site-preview/types';
 import { useAgentRun } from '@/data/queries/use-agent-run';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
-import { useSession, useSessionEffectiveEnvironment } from '@/data/queries/use-sessions';
+import {
+	useMarkSessionRead,
+	useSession,
+	useSessionEffectiveEnvironment,
+} from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { useSessionCommands } from '@/hooks/use-session-commands';
 import { SessionUIProvider, useSessionPreviewAnnotations } from '@/hooks/use-session-ui';
@@ -66,6 +70,8 @@ function SessionViewContent( {
 } ) {
 	const navigate = useNavigate();
 	const { data, isLoading, error } = useSession( sessionId );
+	const markSessionRead = useMarkSessionRead();
+	const lastReadMarkRef = useRef< string | null >( null );
 	const { data: sites } = useSites();
 	const ownerSitePath = data?.summary.ownerSitePath;
 	const ownerSite = ownerSitePath
@@ -117,6 +123,19 @@ function SessionViewContent( {
 		[ sendMessage ]
 	);
 	useSessionPreviewAnnotations( handleAnnotationsDone, canTogglePreview && !! ownerSite );
+
+	useEffect( () => {
+		if ( ! data ) {
+			return;
+		}
+		const eventCount = data.summary.eventCount;
+		const lastReadEventCount = data.summary.lastReadEventCount ?? -1;
+		const markKey = `${ sessionId }:${ eventCount }`;
+		if ( eventCount > lastReadEventCount && lastReadMarkRef.current !== markKey ) {
+			lastReadMarkRef.current = markKey;
+			markSessionRead.mutate( { sessionId, eventCount } );
+		}
+	}, [ data, markSessionRead, sessionId ] );
 
 	useLayoutEffect( () => {
 		const node = scrollRef.current;

--- a/apps/ui/src/ui-classic/components/session-view/thinking-indicator/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/thinking-indicator/index.tsx
@@ -1,5 +1,6 @@
 import { randomThinkingMessage } from '@studio/common/ai/thinking-messages';
 import { useEffect, useState } from 'react';
+import { StatusDot } from '@/components/status-dot';
 import styles from './style.module.css';
 
 export function ThinkingIndicator( {
@@ -37,7 +38,7 @@ export function ThinkingIndicator( {
 			{ active ? (
 				<>
 					<div className={ styles.head }>
-						<span className={ styles.dot } aria-hidden="true" />
+						<StatusDot status="loading" className={ styles.dot } aria-hidden="true" />
 						<span className={ styles.label }>{ message }</span>
 						{ elapsedSeconds > 0 ? (
 							<span className={ styles.elapsed }>{ `${ elapsedSeconds }s` }</span>

--- a/apps/ui/src/ui-classic/components/session-view/thinking-indicator/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/thinking-indicator/style.module.css
@@ -1,4 +1,6 @@
 .root {
+	--thinking-dot-size: 8px;
+
 	display: flex;
 	flex-direction: column;
 	gap: 2px;
@@ -16,11 +18,8 @@
 }
 
 .dot {
-	width: 8px;
-	height: 8px;
-	border-radius: 50%;
-	background-color: var(--wpds-color-fg-interactive-brand, #2563eb);
-	animation: pulse 1.2s ease-in-out infinite;
+	--status-dot-size: var(--thinking-dot-size);
+
 	flex-shrink: 0;
 }
 
@@ -35,22 +34,10 @@
 }
 
 .progress {
-	padding-left: calc(8px + var(--wpds-dimension-padding-md));
+	padding-left: calc(var(--thinking-dot-size) + var(--wpds-dimension-padding-md));
 	color: var(--wpds-color-fg-content-neutral-weak);
 	opacity: 0.8;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-}
-
-@keyframes pulse {
-	0%,
-	100% {
-		opacity: 0.35;
-		transform: scale(0.85);
-	}
-	50% {
-		opacity: 1;
-		transform: scale(1);
-	}
 }

--- a/apps/ui/src/ui-desks/chats/conversation/style.module.css
+++ b/apps/ui/src/ui-desks/chats/conversation/style.module.css
@@ -82,17 +82,25 @@
 	display: flex;
 	align-items: baseline;
 	gap: 8px;
+	box-sizing: border-box;
+	max-width: 100%;
 	min-width: 0;
+	overflow: hidden;
 	padding: 2px 0;
 	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
 	font-size: 12px;
 	color: var(--ui-desks-muted, #6b7280);
+	white-space: nowrap;
 }
 
 .toolLabel {
 	color: var(--ui-desks-text, #14171a);
 	font-weight: 600;
-	flex-shrink: 0;
+	min-width: 0;
+	flex: 0 1 auto;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .toolDetail {

--- a/tools/common/ai/sessions/entry-types.ts
+++ b/tools/common/ai/sessions/entry-types.ts
@@ -30,6 +30,7 @@ export interface StudioToolProgressData {
 export interface StudioAgentQuestionData {
 	question: string;
 	options: Array< { label: string; description: string } >;
+	selectedLabel?: string;
 }
 
 export type StudioTurnStatus = 'success' | 'error' | 'max_turns' | 'interrupted';

--- a/tools/common/ai/sessions/types.ts
+++ b/tools/common/ai/sessions/types.ts
@@ -5,6 +5,7 @@ export type TurnStatus = 'success' | 'error' | 'max_turns' | 'interrupted';
 export interface AiSessionMetadata {
 	starred?: boolean;
 	archived?: boolean;
+	lastReadEventCount?: number;
 }
 
 export interface AiSessionSummary extends AiSessionMetadata {

--- a/tools/common/ai/tests/tools.test.ts
+++ b/tools/common/ai/tests/tools.test.ts
@@ -2,12 +2,20 @@ import { describe, expect, it } from 'vitest';
 import { getToolDetail, getToolDisplayName } from '../tools';
 
 describe( 'tool display helpers', () => {
-	it( 'keeps terminal command triggers short', () => {
-		expect( getToolDisplayName( 'Bash' ) ).toBe( 'Run terminal command' );
-		expect(
-			getToolDetail( 'Bash', {
-				command: "cat > /tmp/now-playing-draft.txt << 'ENDOFPOST'",
-			} )
-		).toBe( '' );
+	// Surfaces without an expandable input panel (CLI, Studio Code tab) rely
+	// on the shared detail to show what command ran; ui-classic hides it
+	// locally in favor of its own input panel.
+	it( 'shows the Bash command as the shared detail', () => {
+		expect( getToolDisplayName( 'Bash' ) ).toBe( 'Run' );
+		expect( getToolDetail( 'Bash', { command: 'wp plugin activate jetpack' } ) ).toBe(
+			'wp plugin activate jetpack'
+		);
+	} );
+
+	it( 'truncates long Bash commands', () => {
+		const command = `cat > /tmp/now-playing-draft.txt << 'ENDOFPOST' with much more text after it`;
+		const detail = getToolDetail( 'Bash', { command } );
+		expect( detail.length ).toBeLessThanOrEqual( 60 );
+		expect( detail.endsWith( '…' ) ).toBe( true );
 	} );
 } );

--- a/tools/common/ai/tests/tools.test.ts
+++ b/tools/common/ai/tests/tools.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { getToolDetail, getToolDisplayName } from '../tools';
+
+describe( 'tool display helpers', () => {
+	it( 'keeps terminal command triggers short', () => {
+		expect( getToolDisplayName( 'Bash' ) ).toBe( 'Run terminal command' );
+		expect(
+			getToolDetail( 'Bash', {
+				command: "cat > /tmp/now-playing-draft.txt << 'ENDOFPOST'",
+			} )
+		).toBe( '' );
+	} );
+} );

--- a/tools/common/ai/tools.ts
+++ b/tools/common/ai/tools.ts
@@ -35,7 +35,7 @@ export function getToolDisplayName( name: string ): string {
 		Read: __( 'Read' ),
 		Write: __( 'Write' ),
 		Edit: __( 'Edit' ),
-		Bash: __( 'Run' ),
+		Bash: __( 'Run terminal command' ),
 		Glob: __( 'Search' ),
 		Grep: __( 'Search' ),
 		Ls: __( 'List' ),
@@ -45,8 +45,6 @@ export function getToolDisplayName( name: string ): string {
 	};
 	return displayNames[ name ] ?? name;
 }
-
-const BASH_DETAIL_MAX_LENGTH = 60;
 
 /**
  * Short detail string extracted from a tool's input, suitable for display
@@ -103,12 +101,7 @@ export function getToolDetail( name: string, input?: Record< string, unknown > )
 			return '';
 		}
 		case 'Bash':
-			if ( typeof input.command !== 'string' ) {
-				return '';
-			}
-			return input.command.length > BASH_DETAIL_MAX_LENGTH
-				? input.command.slice( 0, BASH_DETAIL_MAX_LENGTH - 3 ) + '…'
-				: input.command;
+			return '';
 		case 'Skill':
 			if ( typeof input.name === 'string' ) {
 				return input.name;

--- a/tools/common/ai/tools.ts
+++ b/tools/common/ai/tools.ts
@@ -35,7 +35,7 @@ export function getToolDisplayName( name: string ): string {
 		Read: __( 'Read' ),
 		Write: __( 'Write' ),
 		Edit: __( 'Edit' ),
-		Bash: __( 'Run terminal command' ),
+		Bash: __( 'Run' ),
 		Glob: __( 'Search' ),
 		Grep: __( 'Search' ),
 		Ls: __( 'List' ),
@@ -45,6 +45,8 @@ export function getToolDisplayName( name: string ): string {
 	};
 	return displayNames[ name ] ?? name;
 }
+
+const BASH_DETAIL_MAX_LENGTH = 60;
 
 /**
  * Short detail string extracted from a tool's input, suitable for display
@@ -101,7 +103,12 @@ export function getToolDetail( name: string, input?: Record< string, unknown > )
 			return '';
 		}
 		case 'Bash':
-			return '';
+			if ( typeof input.command !== 'string' ) {
+				return '';
+			}
+			return input.command.length > BASH_DETAIL_MAX_LENGTH
+				? input.command.slice( 0, BASH_DETAIL_MAX_LENGTH - 3 ) + '…'
+				: input.command;
 		case 'Skill':
 			if ( typeof input.name === 'string' ) {
 				return input.name;

--- a/tools/common/lib/shared-config.ts
+++ b/tools/common/lib/shared-config.ts
@@ -29,6 +29,7 @@ export const sharedSessionMetadataSchema = z
 	.object( {
 		starred: z.boolean().optional(),
 		archived: z.boolean().optional(),
+		lastReadEventCount: z.number().optional(),
 	} )
 	.loose();
 
@@ -125,6 +126,9 @@ function pruneSharedSessionMetadata( metadata: SharedSessionMetadata ): void {
 	}
 	if ( ! metadata.archived ) {
 		delete metadata.archived;
+	}
+	if ( metadata.lastReadEventCount === undefined ) {
+		delete metadata.lastReadEventCount;
 	}
 }
 

--- a/tools/common/lib/tests/shared-config.test.ts
+++ b/tools/common/lib/tests/shared-config.test.ts
@@ -223,17 +223,22 @@ describe( 'Shared Config', () => {
 			vi.mocked( readFile ).mockResolvedValue( Buffer.from( JSON.stringify( { version: 1 } ) ) );
 
 			await expect(
-				updateSharedSession( 'abc123', { starred: true, archived: true } )
+				updateSharedSession( 'abc123', {
+					starred: true,
+					archived: true,
+					lastReadEventCount: 7,
+				} )
 			).resolves.toEqual( {
 				starred: true,
 				archived: true,
+				lastReadEventCount: 7,
 			} );
 
 			const written = vi.mocked( writeFile ).mock.calls[ 0 ][ 1 ] as string;
 			expect( JSON.parse( written ) ).toEqual( {
 				version: 1,
 				sessions: {
-					abc123: { starred: true, archived: true },
+					abc123: { starred: true, archived: true, lastReadEventCount: 7 },
 				},
 			} );
 		} );


### PR DESCRIPTION
This PR builds on #3646, adding:
- More human Tool calls descriptions in the conversation, with icons.
- Clicking a tool call opens more details with a scrollable container for longer details.
- Ask User tool calls show the possible options with descriptions as an ordered list.
- Status indicators in the sidebar help you know when the agent is working (pulsing dot), awaiting your response (orange square), or finished (static dot).

<img width="1194" height="794" alt="image" src="https://github.com/user-attachments/assets/dee114f4-ae17-4887-90b6-62cb5a255204" />
<img width="1126" height="813" alt="image" src="https://github.com/user-attachments/assets/0b898d1b-cea3-4fcc-b6d1-feb4349c02bb" />