### PR TITLE
Release 1.10.2 npm

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "wp-studio",
 	"author": "Automattic Inc.",
-	"version": "1.10.1",
+	"version": "1.10.2",
 	"productName": "Studio CLI",
 	"description": "WordPress Studio CLI",
 	"license": "GPL-2.0-or-later",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -3,7 +3,7 @@
 	"author": "Automattic Inc.",
 	"private": true,
 	"productName": "Studio",
-	"version": "1.10.1",
+	"version": "1.10.2",
 	"description": "Local WordPress development environment using Playgrounds",
 	"homepage": "https://developer.wordpress.com/studio/",
 	"license": "GPL-2.0-or-later",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
 		},
 		"apps/cli": {
 			"name": "wp-studio",
-			"version": "1.10.1",
+			"version": "1.10.2",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -634,7 +634,7 @@
 		},
 		"apps/studio": {
 			"name": "studio-app",
-			"version": "1.10.1",
+			"version": "1.10.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@formatjs/intl-locale": "^3.4.5",


### PR DESCRIPTION
## Related issue

## How AI was used in this PR

Used to create the PR

## Proposed Changes

- Bump version from 1.10.1 to 1.10.2 for both CLI (`wp-studio`) and App (`studio-app`).

## Testing Instructions

- Run `npm run cli:build` and verify `node apps/cli/dist/cli/main.mjs --version` reports `1.10.2`.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?