### PR TITLE
Segregate AiOutputAdapter to remove JSON-mode no-op stubs and unsafe casts

### DIFF
--- a/apps/cli/ai/output-adapter.ts
+++ b/apps/cli/ai/output-adapter.ts
@@ -4,7 +4,15 @@ import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import type { AiProviderId } from 'cli/ai/providers';
 import type { AskUserQuestion, SiteInfo } from 'cli/ai/types';
 
-export interface AiOutputAdapter {
+/**
+ * Fire-and-forget surface the agent loop pushes information into: lifecycle,
+ * display chrome, agent-turn notifications, and turn completion. Every method
+ * returns `void`, so a silent implementation is a *legitimate* contract — the
+ * JSON path simply has no wire form for terminal chrome. That's why the no-op
+ * defaults live on {@link HeadlessReporterBase} (inherited once) instead of
+ * being hand-stubbed per adapter.
+ */
+export interface AgentReporter {
 	currentProvider: AiProviderId;
 	currentModel: AiModelId;
 	activeSite: SiteInfo | null;
@@ -30,18 +38,72 @@ export interface AiOutputAdapter {
 	endAgentTurn(): void;
 	addUserMessage( text: string ): void;
 	handleEvent( event: AgentSessionEvent ): void;
-
-	waitForInput(): Promise< string >;
-	askUser( questions: AskUserQuestion[] ): Promise< Record< string, string > >;
-	openActiveSiteInBrowser(): Promise< boolean >;
+	emitTurnCompleted(
+		status: TurnCompletedStatus,
+		sessionId: string,
+		usage?: { numTurns: number; costUsd?: number }
+	): void;
 }
 
-export class JsonAdapter implements AiOutputAdapter {
+/**
+ * Request/response surface: it *promises a value back*, so — unlike the
+ * fire-and-forget {@link AgentReporter} — a no-op or `throw` here would break
+ * the caller's contract (an LSP violation). Every implementation MUST honor it
+ * with a real answer; the JSON adapter does so via the desktop IPC round-trip
+ * (or the documented pause-and-halt fallback), never by throwing.
+ */
+export interface UserInteractor {
+	askUser( questions: AskUserQuestion[] ): Promise< Record< string, string > >;
+}
+
+/**
+ * The polymorphic surface `runCommand` depends on. Interactive-only capabilities
+ * (`waitForInput`, `openActiveSiteInBrowser`, replay, …) deliberately live only
+ * on the concrete {@link AiChatUI}, reached after the `instanceof AiChatUI`
+ * guard — so they cannot be invoked on a headless adapter that can't honor them.
+ */
+export type AiOutputAdapter = AgentReporter & UserInteractor;
+
+/**
+ * A complete, do-nothing {@link AgentReporter}. Subclasses override only the
+ * methods that actually carry agent information to the consumer (and any
+ * lifecycle they need); everything else stays a legitimately-silent no-op.
+ */
+export abstract class HeadlessReporterBase implements AgentReporter {
 	currentProvider: AiProviderId = 'wpcom';
 	currentModel: AiModelId = DEFAULT_MODEL;
 	activeSite: SiteInfo | null = null;
 	onSiteSelected: ( ( site: SiteInfo ) => void ) | null = null;
 	onInterrupt: ( () => void ) | null = null;
+
+	start(): void {}
+	stop(): void {}
+	showWelcome(): void {}
+	showOnboarding(): void {}
+	showCapabilities(): void {}
+	showSuccess( _message: string ): void {}
+	setBusy( _active: boolean ): void {}
+	setStatusMessage( _message: string | null ): void {}
+	setDaemonStatus( _state: { running: boolean; pid?: number } ): void {}
+	addUserMessage( _text: string ): void {}
+	endAgentTurn(): void {}
+
+	// Information-bearing methods: a concrete reporter MUST decide how to surface
+	// these, so they stay abstract rather than silently defaulting to no-op.
+	abstract showProgress( message: string ): void;
+	abstract showInfo( message: string ): void;
+	abstract showError( message: string ): void;
+	abstract setLoaderMessage( message: string, update?: boolean ): void;
+	abstract beginAgentTurn( sessionId?: string ): void;
+	abstract handleEvent( event: AgentSessionEvent ): void;
+	abstract emitTurnCompleted(
+		status: TurnCompletedStatus,
+		sessionId: string,
+		usage?: { numTurns: number; costUsd?: number }
+	): void;
+}
+
+export class JsonAdapter extends HeadlessReporterBase implements AiOutputAdapter {
 	onBeforeExit: ( () => Promise< void > ) | null = null;
 	permissionResponse: Record< string, string > | null = null;
 
@@ -74,28 +136,8 @@ export class JsonAdapter implements AiOutputAdapter {
 		}
 	}
 
-	showWelcome(): void {
-		// No-op in JSON mode
-	}
-
-	showOnboarding(): void {
-		// No-op in JSON mode
-	}
-
-	showCapabilities(): void {
-		// No-op in JSON mode
-	}
-
-	showSuccess( _message: string ): void {
-		// No-op in JSON mode
-	}
-
 	showProgress( message: string ): void {
 		emitEvent( { type: 'progress', timestamp: new Date().toISOString(), message } );
-	}
-
-	setBusy( _active: boolean ): void {
-		// No-op in JSON mode
 	}
 
 	showInfo( message: string ): void {
@@ -106,14 +148,6 @@ export class JsonAdapter implements AiOutputAdapter {
 		emitEvent( { type: 'error', timestamp: new Date().toISOString(), message } );
 	}
 
-	setStatusMessage(): void {
-		// No-op in JSON mode
-	}
-
-	setDaemonStatus(): void {
-		// No-op in JSON mode
-	}
-
 	setLoaderMessage( message: string, _update?: boolean ): void {
 		this.showProgress( message );
 	}
@@ -121,14 +155,6 @@ export class JsonAdapter implements AiOutputAdapter {
 	beginAgentTurn( sessionId?: string ): void {
 		this.activeSessionId = sessionId ?? '';
 		emitEvent( { type: 'turn.started', timestamp: new Date().toISOString() } );
-	}
-
-	endAgentTurn(): void {
-		// turn.completed is emitted separately with status and usage
-	}
-
-	addUserMessage( _text: string ): void {
-		// No-op in JSON mode — the service already knows the message it sent
 	}
 
 	handleEvent( event: AgentSessionEvent ): void {
@@ -150,10 +176,6 @@ export class JsonAdapter implements AiOutputAdapter {
 			status,
 			usage,
 		} );
-	}
-
-	waitForInput(): Promise< string > {
-		throw new Error( 'waitForInput is not available in JSON mode' );
 	}
 
 	async askUser( questions: AskUserQuestion[] ): Promise< Record< string, string > > {
@@ -199,9 +221,5 @@ export class JsonAdapter implements AiOutputAdapter {
 		await this.onBeforeExit?.();
 		process.exitCode = 0;
 		return new Promise< Record< string, string > >( () => {} );
-	}
-
-	openActiveSiteInBrowser(): Promise< boolean > {
-		throw new Error( 'openActiveSiteInBrowser is not available in JSON mode' );
 	}
 }

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1431,6 +1431,13 @@ export class AiChatUI implements AiOutputAdapter {
 	}
 
 	/**
+	 * Turn completion is surfaced inline as the turn unfolds (the loader,
+	 * usage, and tool output are already on screen), so there is nothing to
+	 * emit for the terminal — only the JSON wire needs a discrete event.
+	 */
+	emitTurnCompleted(): void {}
+
+	/**
 	 * Returns true when the current/last turn surfaced the AI usage cap
 	 * message to the user. Lets callers suppress redundant downstream
 	 * errors (e.g. the SDK's "process exited with code 1" that follows

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -555,11 +555,11 @@ export async function runCommand( options: {
 				options.initialFiles
 			);
 			const jsonStatus = result.status === 'interrupted' ? 'error' : result.status;
-			( ui as JsonAdapter ).emitTurnCompleted( jsonStatus, result.sessionId );
+			ui.emitTurnCompleted( jsonStatus, result.sessionId );
 		} catch ( error ) {
 			process.exitCode = 1;
 			handleAgentTurnError( error );
-			( ui as JsonAdapter ).emitTurnCompleted( 'error', session?.getSessionId() ?? '' );
+			ui.emitTurnCompleted( 'error', session?.getSessionId() ?? '' );
 		} finally {
 			setLocalSiteSelectedCallback( null );
 			ui.stop();


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Diagnosis, design exploration, and implementation were done with Claude Code. A multi-agent design panel generated and adversarially critiqued five candidate architectures (role interfaces, event bus, presenter/interactor split, event-sourcing reducer, tagged union); the chosen approach is the smallest one that removes every flagged defect without over-abstracting a 2-implementation system. All findings were verified against the real call graph (the panel caught that the chrome methods are invoked on the un-narrowed value, and that two other consumers already bind the concrete TUI) before any code changed.

## Proposed Changes

`JsonAdapter` was littered with ~10 `// No-op in JSON mode` method bodies, two methods that `throw` ("not available in JSON mode"), and the agent loop reached a JSON-only method through an unsafe `( ui as JsonAdapter )` cast. These are three SOLID smells in one place: a fat interface forcing irrelevant methods onto a client (ISP), a subtype breaking its supertype's contract (LSP), and the consumer secretly depending on concrete types (OCP/leaky polymorphism).

The fix splits the surface along the seam the data already has — **fire-and-forget vs. request/response**:

- **`AgentReporter`** — the `void` display/lifecycle/turn surface. A silent implementation is a *legitimate* contract here, so the no-op chrome defaults now live once on a `HeadlessReporterBase` that `JsonAdapter` inherits, instead of being hand-stubbed per method. `JsonAdapter` overrides only the handful of methods that actually emit a wire event.
- **`UserInteractor`** — the async `askUser` that *promises a value back*, which every implementation must honor for real (never no-op/throw).
- The two interactive-only, previously-throwing methods (`waitForInput`, `openActiveSiteInBrowser`) now exist solely on the concrete `AiChatUI`, reached only after the existing `instanceof AiChatUI` guard — so they can no longer be invoked on, or throw from, a headless adapter.
- `emitTurnCompleted` becomes a first-class `AgentReporter` member, deleting both `as JsonAdapter` casts.

No user-visible behavior change — this is an internal refactor of the CLI agent's output abstraction. The JSON wire protocol, the desktop IPC round-trip, and the standalone pause-and-halt flow are all byte-for-byte unchanged.

## Testing Instructions

- `npm run typecheck` — passes clean.
- `npm test -- apps/cli/ai apps/cli/commands/ai` — 129 tests pass (incl. the JsonAdapter IPC interrupt/lifecycle suite).
- `npm run cli:build` — bundles successfully.
- Smoke: `studio code "<prompt>" --json` still emits the same `turn.started` / `message` / `turn.completed` event stream; the interactive REPL (`studio code`) is unaffected.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested this change with relevant unit tests?
- [ ] Have you added or updated relevant documentation?

🤖 Generated with [Claude Code](https://claude.com/claude-code)