### PR TITLE
Rename Assistant tab to Studio Code

### DIFF
--- a/apps/studio/src/components/tests/site-content-tabs.test.tsx
+++ b/apps/studio/src/components/tests/site-content-tabs.test.tsx
@@ -105,7 +105,7 @@ describe( 'SiteContentTabs', () => {
 		expect( screen.queryByRole( 'tab', { name: 'Sync', selected: false } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Previews', selected: false } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Settings', selected: false } ) ).toBeVisible();
-		expect( screen.queryByRole( 'tab', { name: 'Assistant', selected: false } ) ).toBeVisible();
+		expect( screen.queryByRole( 'tab', { name: 'Studio Code', selected: false } ) ).toBeVisible();
 		expect(
 			screen.queryByRole( 'tab', { name: 'Backup', selected: false } )
 		).not.toBeInTheDocument();

--- a/apps/studio/src/hooks/use-content-tabs.tsx
+++ b/apps/studio/src/hooks/use-content-tabs.tsx
@@ -44,7 +44,7 @@ function useTabs() {
 		tabs.push( {
 			order: 6,
 			name: 'assistant',
-			title: __( 'Assistant' ),
+			title: __( 'Studio Code' ),
 			className: 'components-tab-panel__tabs--assistant ltr:pl-8 rtl:pr-8 ltr:ml-auto rtl:mr-auto',
 		} );
 


### PR DESCRIPTION
## Related issues

- Related to p1780926766083729/1780924859.254889-slack-C06DRMD6VPZ

## How AI was used in this PR

Used AI to apply the label rename and update the affected unit test.

## Proposed Changes

- Renames the site content tab previously labeled **Assistant** to **Studio Code**, giving the AI feature a clearer, product-aligned name. Users now see "Studio Code" in the tab bar where they previously saw "Assistant".

## Testing Instructions

- Open a site in Studio.
- Confirm the tab in the content area reads **Studio Code** instead of **Assistant**.
- Confirm the tab still opens the same panel and works as before.

| Before | After |
|--------|--------|
| <img width="1222" height="838" alt="Screenshot 2026-06-08 at 14 49 21" src="https://github.com/user-attachments/assets/bf2a3209-a7e4-4ec3-b823-6edea50e6dfd" /> | <img width="1222" height="838" alt="Screenshot 2026-06-08 at 14 50 41" src="https://github.com/user-attachments/assets/00dddbad-fab2-4f54-9d43-c17d91867ce9" /> |

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?