### PR TITLE
Add --omit=peer to install:bundle to prevent Windows path-too-long failures

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -21,7 +21,7 @@
 		"make:macos-arm64": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && tsx ../../scripts/build-desks-renderer.ts && SKIP_DMG=true FILE_ARCHITECTURE=arm64 electron-forge make . --arch=arm64 --platform=darwin",
 		"make:linux-x64": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && tsx ../../scripts/build-desks-renderer.ts && electron-forge make . --arch=x64 --platform=linux",
 		"make:linux-arm64": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && tsx ../../scripts/build-desks-renderer.ts && electron-forge make . --arch=arm64 --platform=linux",
-		"install:bundle": "npm install --no-package-lock --no-progress --install-links --no-workspaces && patch-package && node ../../scripts/remove-fs-ext-other-platform-binaries.mjs",
+		"install:bundle": "npm install --no-package-lock --no-progress --install-links --no-workspaces --omit=peer && patch-package && node ../../scripts/remove-fs-ext-other-platform-binaries.mjs",
 		"lint": "eslint src e2e",
 		"package": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && tsx ../../scripts/build-desks-renderer.ts && electron-forge package .",
 		"publish": "electron-forge publish .",


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code made the one-line change and ran typecheck to confirm nothing broke.

## Proposed Changes

The `install:bundle` script installs production dependencies into the packaged app before galactus prunes devDependencies. Without `--omit=peer`, npm auto-installs peer dependencies (e.g. `react-native`, `@react-native/*`) that galactus does not prune because they are not marked as `devDependencies`. On Windows these produce deeply nested paths that exceed the MAX_PATH limit and cause the Squirrel maker to fail.

Adding `--omit=peer` prevents npm from installing peer-only packages during the bundle step. There is no overlap between auto-installed peer deps and runtime `dependencies` in `apps/studio/package.json`, so this is safe.

## Testing Instructions

- Run `npm run make:windows-x64` (or trigger a Windows CI build) and confirm the Squirrel maker no longer hits path-too-long errors.
- `npm run typecheck` in `apps/studio` continues to pass.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?