### PR TITLE
Adjust login screen for Studio Code UI to align with otehr screens

### DIFF
--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -15,7 +15,6 @@ import {
 	useMemo,
 	useRef,
 	useState,
-	type PropsWithChildren,
 	type ReactNode,
 	type Ref,
 	type UIEvent,
@@ -105,7 +104,11 @@ function SessionHeader( { onNewConversation }: { onNewConversation: () => void }
 	);
 }
 
-function StudioCodeDescription( { children }: PropsWithChildren ) {
+function NoAuth() {
+	const isOffline = useOffline();
+	const { authenticate } = useAuth();
+	const offlineMessage = __( "You're currently offline." );
+
 	return (
 		<div className="p-8 flex justify-between max-w-3xl gap-4 overflow-hidden">
 			<div className="flex flex-col">
@@ -127,67 +130,55 @@ function StudioCodeDescription( { children }: PropsWithChildren ) {
 						</div>
 					) ) }
 				</div>
-				{ children }
+				<div className="mt-8">
+					<Tooltip disabled={ ! isOffline } icon={ offlineIcon } text={ offlineMessage }>
+						<Button
+							aria-description={ isOffline ? offlineMessage : '' }
+							aria-disabled={ isOffline }
+							variant="primary"
+							onClick={ () => {
+								if ( isOffline ) {
+									return;
+								}
+								authenticate();
+							} }
+						>
+							{ __( 'Log in to WordPress.com' ) }
+							<ArrowIcon />
+						</Button>
+					</Tooltip>
+				</div>
+				<div className="mt-3 w-[40ch] text-frame-text-secondary a8c-body">
+					<Tooltip
+						disabled={ ! isOffline }
+						icon={ offlineIcon }
+						text={ offlineMessage }
+						placement="bottom-start"
+					>
+						<span>
+							{ __( 'A WordPress.com account is required to use Studio Code.' ) }{ ' ' }
+							<Button
+								aria-description={ isOffline ? offlineMessage : '' }
+								aria-disabled={ isOffline }
+								className="!p-0 text-frame-theme hover:opacity-80 h-auto inline-flex items-center"
+								onClick={ () => {
+									if ( isOffline ) {
+										return;
+									}
+									getIpcApi().authenticate( true );
+								} }
+							>
+								{ __( 'Create a free account' ) }
+								<ArrowIcon />
+							</Button>
+						</span>
+					</Tooltip>
+				</div>
 			</div>
 			<IllustrationGrid>
 				<StudioCodeTabImage />
 			</IllustrationGrid>
 		</div>
-	);
-}
-
-function NoAuth() {
-	const isOffline = useOffline();
-	const { authenticate } = useAuth();
-	const offlineMessage = __( "You're currently offline." );
-
-	return (
-		<StudioCodeDescription>
-			<div className="mt-8">
-				<Tooltip disabled={ ! isOffline } icon={ offlineIcon } text={ offlineMessage }>
-					<Button
-						aria-description={ isOffline ? offlineMessage : '' }
-						aria-disabled={ isOffline }
-						variant="primary"
-						onClick={ () => {
-							if ( isOffline ) {
-								return;
-							}
-							authenticate();
-						} }
-					>
-						{ __( 'Log in to WordPress.com' ) }
-						<ArrowIcon />
-					</Button>
-				</Tooltip>
-			</div>
-			<div className="mt-3 w-[40ch] text-frame-text-secondary a8c-body">
-				<Tooltip
-					disabled={ ! isOffline }
-					icon={ offlineIcon }
-					text={ offlineMessage }
-					placement="bottom-start"
-				>
-					<span>
-						{ __( 'A WordPress.com account is required to use Studio Code.' ) }{ ' ' }
-						<Button
-							aria-description={ isOffline ? offlineMessage : '' }
-							aria-disabled={ isOffline }
-							className="!p-0 text-frame-theme hover:opacity-80 h-auto inline-flex items-center"
-							onClick={ () => {
-								if ( isOffline ) {
-									return;
-								}
-								getIpcApi().authenticate( true );
-							} }
-						>
-							{ __( 'Create a free account' ) }
-							<ArrowIcon />
-						</Button>
-					</span>
-				</Tooltip>
-			</div>
-		</StudioCodeDescription>
 	);
 }
 

--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -5,9 +5,8 @@ import {
 } from '@studio/common/ai/sessions/entry-types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Spinner } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { chevronDown } from '@wordpress/icons';
+import { check, chevronDown, Icon as WpIcon } from '@wordpress/icons';
 import { privateApis } from '@wordpress/theme';
 import { Button as UiButton, Icon } from '@wordpress/ui';
 import {
@@ -16,12 +15,16 @@ import {
 	useMemo,
 	useRef,
 	useState,
+	type PropsWithChildren,
 	type ReactNode,
 	type Ref,
 	type UIEvent,
 } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
+import { IllustrationGrid } from 'src/components/illustration-grid';
+import offlineIcon from 'src/components/offline-icon';
+import { Tooltip } from 'src/components/tooltip';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
@@ -33,6 +36,7 @@ import { queryClient } from './query-client';
 import { QueuedPrompts } from './queued-prompts';
 import { isScrolledToBottom } from './scroll-utils';
 import { SiteCreatedDialog } from './site-created-dialog';
+import { StudioCodeTabImage } from './studio-code-tab-image';
 import styles from './style.module.css';
 import { AgentRunProvider, useAgentRun } from './use-agent-run';
 import { useExamplePrompts } from './use-example-prompts';
@@ -101,28 +105,89 @@ function SessionHeader( { onNewConversation }: { onNewConversation: () => void }
 	);
 }
 
-function UnauthenticatedNotice( { onAuthenticate }: { onAuthenticate: () => void } ) {
+function StudioCodeDescription( { children }: PropsWithChildren ) {
 	return (
-		<div className="px-4 pb-4">
-			<div className="p-3 rounded border border-frame-border bg-frame/45">
-				<div className="mb-3 a8c-label-semibold">{ __( 'Hold up!' ) }</div>
-				<div className="mb-1">
-					{ __( 'You need to log in to your WordPress.com account to use Studio Code.' ) }
-				</div>
-				<div className="mb-3">
-					{ createInterpolateElement(
-						__( "If you don't have an account yet, <a>create one for free</a>." ),
-						{
-							a: <Button variant="link" onClick={ () => getIpcApi().authenticate( true ) } />,
-						}
+		<div className="p-8 flex justify-between max-w-3xl gap-4 overflow-hidden">
+			<div className="flex flex-col">
+				<div className="a8c-subtitle mb-1">{ __( 'Build with Studio Code' ) }</div>
+				<div className="w-[40ch] text-frame-text-secondary a8c-body">
+					{ __(
+						'Your AI coding agent for WordPress. Describe what you want and Studio Code builds, edits, and debugs your site.'
 					) }
 				</div>
-				<Button variant="primary" onClick={ onAuthenticate }>
-					{ __( 'Log in to WordPress.com' ) }
-					<ArrowIcon />
-				</Button>
+				<div className="mt-6">
+					{ [
+						__( 'Create and edit themes, plugins, and content.' ),
+						__( 'Debug issues and run WordPress commands.' ),
+						__( 'Powered by your WordPress.com account.' ),
+					].map( ( text ) => (
+						<div key={ text } className="text-frame-text-secondary a8c-body flex items-center">
+							<WpIcon className="fill-frame-theme ltr:mr-2 rtl:ml-2 shrink-0" icon={ check } />
+							{ text }
+						</div>
+					) ) }
+				</div>
+				{ children }
 			</div>
+			<IllustrationGrid>
+				<StudioCodeTabImage />
+			</IllustrationGrid>
 		</div>
+	);
+}
+
+function NoAuth() {
+	const isOffline = useOffline();
+	const { authenticate } = useAuth();
+	const offlineMessage = __( "You're currently offline." );
+
+	return (
+		<StudioCodeDescription>
+			<div className="mt-8">
+				<Tooltip disabled={ ! isOffline } icon={ offlineIcon } text={ offlineMessage }>
+					<Button
+						aria-description={ isOffline ? offlineMessage : '' }
+						aria-disabled={ isOffline }
+						variant="primary"
+						onClick={ () => {
+							if ( isOffline ) {
+								return;
+							}
+							authenticate();
+						} }
+					>
+						{ __( 'Log in to WordPress.com' ) }
+						<ArrowIcon />
+					</Button>
+				</Tooltip>
+			</div>
+			<div className="mt-3 w-[40ch] text-frame-text-secondary a8c-body">
+				<Tooltip
+					disabled={ ! isOffline }
+					icon={ offlineIcon }
+					text={ offlineMessage }
+					placement="bottom-start"
+				>
+					<span>
+						{ __( 'A WordPress.com account is required to use Studio Code.' ) }{ ' ' }
+						<Button
+							aria-description={ isOffline ? offlineMessage : '' }
+							aria-disabled={ isOffline }
+							className="!p-0 text-frame-theme hover:opacity-80 h-auto inline-flex items-center"
+							onClick={ () => {
+								if ( isOffline ) {
+									return;
+								}
+								getIpcApi().authenticate( true );
+							} }
+						>
+							{ __( 'Create a free account' ) }
+							<ArrowIcon />
+						</Button>
+					</span>
+				</Tooltip>
+			</div>
+		</StudioCodeDescription>
 	);
 }
 
@@ -377,11 +442,10 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 }
 
 function SessionGate( { selectedSite }: { selectedSite: SiteDetails } ) {
-	const { isAuthenticated, authenticate } = useAuth();
-	const isOffline = useOffline();
+	const { isAuthenticated } = useAuth();
 
-	if ( ! isAuthenticated && ! isOffline ) {
-		return <UnauthenticatedNotice onAuthenticate={ authenticate } />;
+	if ( ! isAuthenticated ) {
+		return <NoAuth />;
 	}
 
 	return <SessionContent selectedSite={ selectedSite } />;

--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -121,8 +121,8 @@ function NoAuth() {
 				<div className="mt-6">
 					{ [
 						__( 'Create and edit themes, plugins, and content.' ),
-						__( 'Debug issues and run WordPress commands.' ),
-						__( 'Powered by your WordPress.com account.' ),
+						__( 'Debug issues and run WP-CLI commands.' ),
+						__( 'Build with built-in feedback loops and agent skills.' ),
 					].map( ( text ) => (
 						<div key={ text } className="text-frame-text-secondary a8c-body flex items-center">
 							<WpIcon className="fill-frame-theme ltr:mr-2 rtl:ml-2 shrink-0" icon={ check } />

--- a/apps/studio/src/components/studio-code-session/studio-code-tab-image.tsx
+++ b/apps/studio/src/components/studio-code-session/studio-code-tab-image.tsx
@@ -1,0 +1,69 @@
+export const StudioCodeTabImage = () => (
+	<svg
+		width="220"
+		height="200"
+		viewBox="0 0 220 200"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<style>
+			{ `
+				.scti-card { fill: var(--color-frame-surface); }
+				.scti-dot { fill: var(--color-frame-text); fill-opacity: 0.3; }
+				.scti-bubble-in { fill: var(--color-frame-text); fill-opacity: 0.08; }
+				.scti-line { fill: var(--color-frame-text); fill-opacity: 0.25; }
+				.scti-line-light { fill: white; fill-opacity: 0.7; }
+			` }
+		</style>
+
+		<g filter="url(#scti-shadow)">
+			<rect x="24" y="34" width="172" height="132" rx="10" className="scti-card" />
+		</g>
+
+		<circle cx="42" cy="52" r="2.5" className="scti-dot" />
+		<circle cx="50" cy="52" r="2.5" className="scti-dot" />
+		<circle cx="58" cy="52" r="2.5" className="scti-dot" />
+
+		<rect x="40" y="72" width="92" height="24" rx="12" className="scti-bubble-in" />
+		<rect x="52" y="81" width="68" height="4" rx="2" className="scti-line" />
+
+		<rect x="40" y="104" width="64" height="18" rx="9" className="scti-bubble-in" />
+		<rect x="52" y="111" width="40" height="4" rx="2" className="scti-line" />
+
+		<rect x="92" y="132" width="88" height="24" rx="12" fill="#3858E9" />
+		<rect x="104" y="141" width="64" height="4" rx="2" className="scti-line-light" />
+
+		<path
+			d="M178 24C178 29 174 34 166 36C174 38 178 43 178 48C178 43 182 38 190 36C182 34 178 29 178 24Z"
+			fill="#3858E9"
+		/>
+
+		<circle cx="36" cy="120" r="4" fill="#01C404" />
+		<circle cx="194" cy="150" r="3.5" className="scti-dot" />
+
+		<defs>
+			<filter
+				id="scti-shadow"
+				x="14"
+				y="28"
+				width="192"
+				height="152"
+				filterUnits="userSpaceOnUse"
+				colorInterpolationFilters="sRGB"
+			>
+				<feFlood floodOpacity="0" result="BackgroundImageFix" />
+				<feColorMatrix
+					in="SourceAlpha"
+					type="matrix"
+					values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+					result="hardAlpha"
+				/>
+				<feOffset dy="3" />
+				<feGaussianBlur stdDeviation="5" />
+				<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.08 0" />
+				<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+				<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
+			</filter>
+		</defs>
+	</svg>
+);


### PR DESCRIPTION
Fixes STU-1800

## How AI was used in this PR

AI wrote code, I reviewed, iterated a few times and tested.

## Proposed Changes
Let's align login screen with Sync and Preview tabs.

<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="1149" height="760" alt="Screenshot 2026-06-08 at 19 27 27" src="https://github.com/user-attachments/assets/64382ec0-46e7-4bc8-963e-7ca9daa40267" />
<td><img width="1144" height="754" alt="Screenshot 2026-06-08 at 19 27 08" src="https://github.com/user-attachments/assets/f65902be-b2a3-4077-bc24-ffdbea2ba2a9" />
</tr>
</table>

## Testing Instructions
1. Run studio
2. Open Studio Code tab
3. Assert that you see the new scren and buttons work correctly on it