### PR TITLE
Agentic UI: Edit Chat Titles, and Add New Description Metadata

### DIFF
--- a/apps/cli/commands/ai/sessions/helpers.ts
+++ b/apps/cli/commands/ai/sessions/helpers.ts
@@ -2,9 +2,40 @@ import { truncateToWidth, visibleWidth } from '@earendil-works/pi-tui';
 import { select } from '@inquirer/prompts';
 import { listAiSessions } from '@studio/common/ai/sessions/store';
 import chalk from '@studio/common/lib/chalk';
+import { readSharedSessions } from '@studio/common/lib/shared-config';
 import { __ } from '@wordpress/i18n';
 import { getAiSessionsRootDirectory } from 'cli/ai/sessions/paths';
 import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
+
+/**
+ * Session files persist only the event log; user/generated titles and
+ * descriptions live in shared.json (written by the desktop app). Hydrate
+ * them the same way the desktop's `hydrateAiSessionSummary` does so
+ * `session.title` is populated for display.
+ */
+export async function hydrateSessionMetadata(
+	sessions: AiSessionSummary[]
+): Promise< AiSessionSummary[] > {
+	let metadataById: Awaited< ReturnType< typeof readSharedSessions > >;
+	try {
+		metadataById = await readSharedSessions();
+	} catch {
+		// Display degrades to first prompts when shared.json is unreadable.
+		return sessions;
+	}
+	return sessions.map( ( session ) => {
+		const metadata = metadataById[ session.id ];
+		if ( ! metadata ) {
+			return session;
+		}
+		return {
+			...session,
+			title: metadata.userTitle ?? metadata.generatedTitle ?? session.firstPrompt,
+			description:
+				metadata.userDescription ?? metadata.generatedDescription ?? session.assistantReplyPreview,
+		};
+	} );
+}
 
 function formatSessionTimestamp( timestamp: string ): string {
 	const parsed = Date.parse( timestamp );
@@ -202,7 +233,9 @@ export async function chooseSessionForAction(
 	actionLabel: string,
 	noSessionsMessage: string
 ): Promise< AiSessionSummary | undefined > {
-	const sessions = await listAiSessions( getAiSessionsRootDirectory() );
+	const sessions = await hydrateSessionMetadata(
+		await listAiSessions( getAiSessionsRootDirectory() )
+	);
 	if ( sessions.length === 0 ) {
 		console.log( noSessionsMessage );
 		return undefined;

--- a/apps/cli/commands/ai/sessions/helpers.ts
+++ b/apps/cli/commands/ai/sessions/helpers.ts
@@ -73,7 +73,7 @@ function formatSessionCompactLine(
 	layout: { idWidth: number; relativeWidth: number }
 ): string {
 	const relative = getRelativeTime( session.updatedAt );
-	const prompt = toSingleLine( session.firstPrompt ?? __( '(No prompt yet)' ) );
+	const prompt = toSingleLine( session.title ?? session.firstPrompt ?? __( '(No prompt yet)' ) );
 	const separator = chalk.dim( ' • ' );
 	const idText = padEndVisible( session.id, layout.idWidth );
 	const relativeText = padEndVisible( relative, layout.relativeWidth );
@@ -90,7 +90,8 @@ function formatSessionCompactLine(
 		terminalWidth - visibleWidth( prefixPlain ) - statusPlainWidth - gapWidth - suffixWidth - 1
 	);
 	const abstract = truncateWithEllipsis( prompt, maxPromptLength );
-	const promptStyled = session.firstPrompt ? chalk.white( abstract ) : chalk.dim( abstract );
+	const promptStyled =
+		session.title || session.firstPrompt ? chalk.white( abstract ) : chalk.dim( abstract );
 
 	const statusGlyph =
 		session.endReason === 'error'

--- a/apps/cli/commands/ai/sessions/list.ts
+++ b/apps/cli/commands/ai/sessions/list.ts
@@ -1,7 +1,7 @@
 import { listAiSessions } from '@studio/common/ai/sessions/store';
 import { __ } from '@wordpress/i18n';
 import { getAiSessionsRootDirectory } from 'cli/ai/sessions/paths';
-import { displaySessionsCompact } from 'cli/commands/ai/sessions/helpers';
+import { displaySessionsCompact, hydrateSessionMetadata } from 'cli/commands/ai/sessions/helpers';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -10,7 +10,9 @@ const logger = new Logger< string >();
 type SessionOutputFormat = 'compact' | 'json';
 
 export async function runCommand( format: SessionOutputFormat ): Promise< void > {
-	const sessions = await listAiSessions( getAiSessionsRootDirectory() );
+	const sessions = await hydrateSessionMetadata(
+		await listAiSessions( getAiSessionsRootDirectory() )
+	);
 
 	if ( format === 'json' ) {
 		console.log( JSON.stringify( sessions, null, 2 ) );

--- a/apps/cli/commands/ai/sessions/tests/helpers.test.ts
+++ b/apps/cli/commands/ai/sessions/tests/helpers.test.ts
@@ -1,0 +1,61 @@
+import { readSharedSessions } from '@studio/common/lib/shared-config';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { hydrateSessionMetadata } from '../helpers';
+import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
+
+vi.mock( '@studio/common/lib/shared-config', () => ( {
+	readSharedSessions: vi.fn(),
+} ) );
+
+const readSharedSessionsMock = vi.mocked( readSharedSessions );
+
+function createSession( id: string ): AiSessionSummary {
+	return {
+		id,
+		filePath: `/tmp/${ id }.jsonl`,
+		createdAt: '2026-05-01T00:00:00.000Z',
+		updatedAt: '2026-05-01T00:00:00.000Z',
+		activeEnvironment: 'local',
+		eventCount: 4,
+		firstPrompt: 'Build a landing page',
+		assistantReplyPreview: 'Added a hero section.',
+	};
+}
+
+describe( 'hydrateSessionMetadata', () => {
+	beforeEach( () => {
+		readSharedSessionsMock.mockReset();
+	} );
+
+	it( 'hydrates titles and descriptions from shared config, preferring user overrides', async () => {
+		readSharedSessionsMock.mockResolvedValue( {
+			'session-1': {
+				userTitle: 'My custom title',
+				generatedTitle: 'Generated title',
+				generatedDescription: 'Generated description',
+			},
+		} );
+
+		const [ session ] = await hydrateSessionMetadata( [ createSession( 'session-1' ) ] );
+
+		expect( session.title ).toBe( 'My custom title' );
+		expect( session.description ).toBe( 'Generated description' );
+	} );
+
+	it( 'leaves sessions without shared metadata untouched', async () => {
+		readSharedSessionsMock.mockResolvedValue( {} );
+
+		const [ session ] = await hydrateSessionMetadata( [ createSession( 'session-1' ) ] );
+
+		expect( session.title ).toBeUndefined();
+		expect( session.firstPrompt ).toBe( 'Build a landing page' );
+	} );
+
+	it( 'returns sessions unchanged when shared config is unreadable', async () => {
+		readSharedSessionsMock.mockRejectedValue( new Error( 'corrupt' ) );
+
+		const sessions = [ createSession( 'session-1' ) ];
+
+		await expect( hydrateSessionMetadata( sessions ) ).resolves.toEqual( sessions );
+	} );
+} );

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -251,10 +251,22 @@ function hydrateAiSessionSummary(
 	summary: AiSessionSummary,
 	metadata?: SharedSessionMetadata
 ): AiSessionSummary {
+	const title = metadata?.userTitle ?? metadata?.generatedTitle ?? summary.firstPrompt;
+	const description =
+		metadata?.userDescription ?? metadata?.generatedDescription ?? summary.assistantReplyPreview;
 	return {
 		...summary,
 		starred: metadata?.starred,
 		archived: metadata?.archived,
+		userTitle: metadata?.userTitle,
+		generatedTitle: metadata?.generatedTitle,
+		userDescription: metadata?.userDescription,
+		generatedDescription: metadata?.generatedDescription,
+		titleGeneratedAt: metadata?.titleGeneratedAt,
+		descriptionGeneratedAt: metadata?.descriptionGeneratedAt,
+		descriptionGeneratedEventCount: metadata?.descriptionGeneratedEventCount,
+		title,
+		description,
 	};
 }
 

--- a/apps/studio/src/modules/ai-agent/run-manager.ts
+++ b/apps/studio/src/modules/ai-agent/run-manager.ts
@@ -13,6 +13,7 @@ import {
 	StatsMetric,
 } from 'src/lib/bump-stats';
 import { getBundledNodeBinaryPath, getCliPath } from 'src/storage/paths';
+import { generateAiSessionMetadata } from './session-metadata';
 import type { ActiveAgentRun, AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { StudioChatArtifactData } from '@studio/common/ai/chat-artifacts';
 import type { StudioChatFileAttachment } from '@studio/common/ai/chat-files';
@@ -259,6 +260,11 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 		}
 
 		void run.eventQueue.finally( async () => {
+			if ( code === 0 && ! run.interrupted ) {
+				await generateAiSessionMetadata( sessionId ).catch( ( error ) => {
+					console.warn( 'Failed to generate AI session metadata', error );
+				} );
+			}
 			if ( run.interrupted ) {
 				sendEvent( run, { type: 'run.interrupted', timestamp: nowIso() } );
 			}

--- a/apps/studio/src/modules/ai-agent/session-metadata.ts
+++ b/apps/studio/src/modules/ai-agent/session-metadata.ts
@@ -1,0 +1,153 @@
+import { isStudioCustomEntryOfType } from '@studio/common/ai/sessions/entry-types';
+import { loadAiSession } from '@studio/common/ai/sessions/store';
+import {
+	readSharedSession,
+	updateSharedSession,
+	type SharedSessionMetadata,
+} from '@studio/common/lib/shared-config';
+import { getAiSessionsRootDirectory } from 'src/lib/ai-sessions';
+import type { SessionEntry } from '@earendil-works/pi-coding-agent';
+import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
+
+const TITLE_MAX_LENGTH = 80;
+const DESCRIPTION_MAX_LENGTH = 220;
+const SUMMARY_MIN_USER_PROMPTS = 3;
+const SUMMARY_REGENERATE_EVENT_DELTA = 8;
+
+function stripTrailingSentencePunctuation( value: string ): string {
+	return value.replace( /[.!?]+$/, '' ).trim();
+}
+
+function cleanText( value: string | undefined ): string {
+	return ( value ?? '' )
+		.replace( /```[\s\S]*?```/g, ' ' )
+		.replace( /`([^`]+)`/g, '$1' )
+		.replace( /\[([^\]]+)\]\([^)]+\)/g, '$1' )
+		.replace( /https?:\/\/\S+/g, ' ' )
+		.replace( /\s+/g, ' ' )
+		.trim();
+}
+
+function truncateAtWordBoundary( value: string, maxLength: number ): string {
+	if ( value.length <= maxLength ) {
+		return value;
+	}
+	const truncated = value.slice( 0, maxLength + 1 );
+	const lastSpace = truncated.lastIndexOf( ' ' );
+	const candidate = lastSpace > maxLength * 0.6 ? truncated.slice( 0, lastSpace ) : truncated;
+	return `${ candidate.trim().replace( /[.,;:!?-]+$/, '' ) }...`;
+}
+
+function stripPromptPrefix( value: string ): string {
+	return value
+		.replace( /^(please|can you|could you|would you|help me|i need you to|i want to)\s+/i, '' )
+		.replace( /^(build|create|make|add|fix|update|change|review|explain)\s+me\s+/i, '$1 ' )
+		.trim();
+}
+
+function getUserPrompts( entries: SessionEntry[] ): string[] {
+	const prompts: string[] = [];
+	for ( const entry of entries ) {
+		if ( ! isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ) {
+			continue;
+		}
+		if ( entry.data?.source !== 'prompt' ) {
+			continue;
+		}
+		const text = cleanText( entry.data.text );
+		if ( text ) {
+			prompts.push( text );
+		}
+	}
+	return prompts;
+}
+
+function buildGeneratedTitle( summary: AiSessionSummary ): string | undefined {
+	const firstPrompt = stripPromptPrefix( cleanText( summary.firstPrompt ) );
+	if ( ! firstPrompt ) {
+		return undefined;
+	}
+
+	const firstLine = firstPrompt.split( /(?<=[.!?])\s+|\n/ )[ 0 ] ?? firstPrompt;
+	return stripTrailingSentencePunctuation( truncateAtWordBoundary( firstLine, TITLE_MAX_LENGTH ) );
+}
+
+function buildGeneratedDescription(
+	summary: AiSessionSummary,
+	userPrompts: string[]
+): string | undefined {
+	const title = cleanText( summary.title ) || buildGeneratedTitle( summary );
+	const assistantPreview = cleanText( summary.assistantReplyPreview );
+
+	if ( title && assistantPreview ) {
+		return truncateAtWordBoundary(
+			`Working on ${ title.charAt( 0 ).toLowerCase() }${ title.slice(
+				1
+			) }. Latest: ${ assistantPreview }`,
+			DESCRIPTION_MAX_LENGTH
+		);
+	}
+
+	const promptSummary = userPrompts.slice( 0, 3 ).join( '; ' );
+	return promptSummary
+		? truncateAtWordBoundary( promptSummary, DESCRIPTION_MAX_LENGTH )
+		: undefined;
+}
+
+function shouldGenerateDescription(
+	summary: AiSessionSummary,
+	metadata: SharedSessionMetadata,
+	userPromptCount: number
+): boolean {
+	if ( metadata.userDescription ) {
+		return false;
+	}
+	if ( userPromptCount < SUMMARY_MIN_USER_PROMPTS ) {
+		return false;
+	}
+	if ( metadata.descriptionGeneratedEventCount === undefined ) {
+		return true;
+	}
+	return (
+		summary.eventCount - metadata.descriptionGeneratedEventCount >= SUMMARY_REGENERATE_EVENT_DELTA
+	);
+}
+
+export async function generateAiSessionMetadata( sessionId: string ): Promise< void > {
+	const { summary, entries } = await loadAiSession( getAiSessionsRootDirectory(), sessionId );
+	const metadata = ( await readSharedSession( summary.id ) ) ?? {};
+	const now = new Date().toISOString();
+	const patch: Partial< SharedSessionMetadata > = {};
+	const userPrompts = getUserPrompts( entries );
+
+	if ( ! metadata.userTitle && ! metadata.generatedTitle ) {
+		const generatedTitle = buildGeneratedTitle( summary );
+		if ( generatedTitle ) {
+			patch.generatedTitle = generatedTitle;
+			patch.titleGeneratedAt = now;
+		}
+	}
+
+	if ( shouldGenerateDescription( summary, metadata, userPrompts.length ) ) {
+		const generatedDescription = buildGeneratedDescription(
+			{
+				...summary,
+				title:
+					metadata.userTitle ??
+					metadata.generatedTitle ??
+					patch.generatedTitle ??
+					summary.firstPrompt,
+			},
+			userPrompts
+		);
+		if ( generatedDescription ) {
+			patch.generatedDescription = generatedDescription;
+			patch.descriptionGeneratedAt = now;
+			patch.descriptionGeneratedEventCount = summary.eventCount;
+		}
+	}
+
+	if ( Object.keys( patch ).length > 0 ) {
+		await updateSharedSession( summary.id, patch );
+	}
+}

--- a/apps/studio/src/modules/ai-agent/session-metadata.ts
+++ b/apps/studio/src/modules/ai-agent/session-metadata.ts
@@ -5,6 +5,7 @@ import {
 	updateSharedSession,
 	type SharedSessionMetadata,
 } from '@studio/common/lib/shared-config';
+import { __, sprintf } from '@wordpress/i18n';
 import { getAiSessionsRootDirectory } from 'src/lib/ai-sessions';
 import type { SessionEntry } from '@earendil-works/pi-coding-agent';
 import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
@@ -32,9 +33,12 @@ function truncateAtWordBoundary( value: string, maxLength: number ): string {
 	if ( value.length <= maxLength ) {
 		return value;
 	}
-	const truncated = value.slice( 0, maxLength + 1 );
+	// Reserve room for the ellipsis so the result never exceeds maxLength.
+	const budget = maxLength - 3;
+	const truncated = value.slice( 0, budget + 1 );
 	const lastSpace = truncated.lastIndexOf( ' ' );
-	const candidate = lastSpace > maxLength * 0.6 ? truncated.slice( 0, lastSpace ) : truncated;
+	const candidate =
+		lastSpace > budget * 0.6 ? truncated.slice( 0, lastSpace ) : truncated.slice( 0, budget );
 	return `${ candidate.trim().replace( /[.,;:!?-]+$/, '' ) }...`;
 }
 
@@ -69,7 +73,9 @@ function buildGeneratedTitle( summary: AiSessionSummary ): string | undefined {
 	}
 
 	const firstLine = firstPrompt.split( /(?<=[.!?])\s+|\n/ )[ 0 ] ?? firstPrompt;
-	return stripTrailingSentencePunctuation( truncateAtWordBoundary( firstLine, TITLE_MAX_LENGTH ) );
+	// Strip sentence punctuation before truncating; the other way around
+	// would eat the ellipsis the truncation just appended.
+	return truncateAtWordBoundary( stripTrailingSentencePunctuation( firstLine ), TITLE_MAX_LENGTH );
 }
 
 function buildGeneratedDescription(
@@ -81,9 +87,12 @@ function buildGeneratedDescription(
 
 	if ( title && assistantPreview ) {
 		return truncateAtWordBoundary(
-			`Working on ${ title.charAt( 0 ).toLowerCase() }${ title.slice(
-				1
-			) }. Latest: ${ assistantPreview }`,
+			sprintf(
+				/* translators: 1: chat title, 2: preview of the assistant's latest reply */
+				__( 'Working on %1$s. Latest: %2$s' ),
+				title,
+				assistantPreview
+			),
 			DESCRIPTION_MAX_LENGTH
 		);
 	}

--- a/apps/studio/src/modules/ai-agent/tests/session-metadata.test.ts
+++ b/apps/studio/src/modules/ai-agent/tests/session-metadata.test.ts
@@ -1,0 +1,125 @@
+import { loadAiSession } from '@studio/common/ai/sessions/store';
+import { readSharedSession, updateSharedSession } from '@studio/common/lib/shared-config';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { generateAiSessionMetadata } from '../session-metadata';
+import type { LoadedAiSession } from '@studio/common/ai/sessions/types';
+
+vi.mock( 'src/lib/ai-sessions', () => ( {
+	getAiSessionsRootDirectory: () => '/tmp/studio-sessions',
+} ) );
+
+vi.mock( '@studio/common/ai/sessions/store', () => ( {
+	loadAiSession: vi.fn(),
+} ) );
+
+vi.mock( '@studio/common/lib/shared-config', () => ( {
+	readSharedSession: vi.fn(),
+	updateSharedSession: vi.fn(),
+} ) );
+
+const loadAiSessionMock = vi.mocked( loadAiSession );
+const readSharedSessionMock = vi.mocked( readSharedSession );
+const updateSharedSessionMock = vi.mocked( updateSharedSession );
+
+describe( 'generateAiSessionMetadata', () => {
+	beforeEach( () => {
+		loadAiSessionMock.mockReset();
+		readSharedSessionMock.mockReset().mockResolvedValue( undefined );
+		updateSharedSessionMock.mockReset().mockResolvedValue( undefined );
+	} );
+
+	it( 'generates a title from the first prompt after a successful turn', async () => {
+		loadAiSessionMock.mockResolvedValue(
+			createLoadedSession( {
+				firstPrompt: 'Can you build a landing page for a coffee shop?',
+				eventCount: 4,
+				prompts: [ 'Can you build a landing page for a coffee shop?' ],
+			} )
+		);
+
+		await generateAiSessionMetadata( 'session-1' );
+
+		expect( updateSharedSessionMock ).toHaveBeenCalledWith(
+			'session-1',
+			expect.objectContaining( {
+				generatedTitle: 'build a landing page for a coffee shop',
+				titleGeneratedAt: expect.any( String ),
+			} )
+		);
+	} );
+
+	it( 'does not overwrite user-authored chat details', async () => {
+		readSharedSessionMock.mockResolvedValue( {
+			userTitle: 'My title',
+			userDescription: 'My description',
+		} );
+		loadAiSessionMock.mockResolvedValue(
+			createLoadedSession( {
+				firstPrompt: 'Update the homepage',
+				assistantReplyPreview: 'Changed the hero and footer.',
+				eventCount: 12,
+				prompts: [ 'Update the homepage', 'Tweak the hero', 'Adjust the footer' ],
+			} )
+		);
+
+		await generateAiSessionMetadata( 'session-1' );
+
+		expect( updateSharedSessionMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'generates and later refreshes a description after enough chat activity', async () => {
+		readSharedSessionMock.mockResolvedValue( { descriptionGeneratedEventCount: 1 } );
+		loadAiSessionMock.mockResolvedValue(
+			createLoadedSession( {
+				firstPrompt: 'Fix checkout',
+				assistantReplyPreview: 'Updated the checkout flow and added validation.',
+				eventCount: 12,
+				prompts: [ 'Fix checkout', 'Add validation', 'Polish errors' ],
+			} )
+		);
+
+		await generateAiSessionMetadata( 'session-1' );
+
+		expect( updateSharedSessionMock ).toHaveBeenCalledWith(
+			'session-1',
+			expect.objectContaining( {
+				generatedDescription: expect.stringContaining( 'Latest: Updated the checkout flow' ),
+				descriptionGeneratedAt: expect.any( String ),
+				descriptionGeneratedEventCount: 12,
+			} )
+		);
+	} );
+} );
+
+function createLoadedSession( {
+	firstPrompt,
+	assistantReplyPreview,
+	eventCount,
+	prompts,
+}: {
+	firstPrompt: string;
+	assistantReplyPreview?: string;
+	eventCount: number;
+	prompts: string[];
+} ): LoadedAiSession {
+	return {
+		summary: {
+			id: 'session-1',
+			filePath: '/tmp/session.jsonl',
+			createdAt: '2026-05-01T00:00:00.000Z',
+			updatedAt: '2026-05-01T00:00:00.000Z',
+			firstPrompt,
+			assistantReplyPreview,
+			activeEnvironment: 'local' as const,
+			eventCount,
+		},
+		entries: prompts.map( ( prompt, index ) => ( {
+			type: 'custom' as const,
+			id: `entry-${ index }`,
+			parentId: null,
+			timestamp: '2026-05-01T00:00:00.000Z',
+			customType: 'studio.user_prompt' as const,
+			data: { text: prompt, source: 'prompt' as const },
+		} ) ),
+	};
+}

--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -8,6 +8,7 @@ import {
 	useSessions,
 	useUnarchiveSession,
 	useUpdateSessionMetadata,
+	useUpdateSessionTitleDescription,
 } from '@/data/queries/use-sessions';
 import {
 	useCopySite,
@@ -69,6 +70,7 @@ vi.mock( '@/data/queries/use-sessions', () => ( {
 	useSessions: vi.fn(),
 	useUnarchiveSession: vi.fn(),
 	useUpdateSessionMetadata: vi.fn(),
+	useUpdateSessionTitleDescription: vi.fn(),
 } ) );
 
 vi.mock( '@/data/queries/use-sites', () => ( {
@@ -89,6 +91,7 @@ const useSessionsMock = vi.mocked( useSessions );
 const useArchiveSessionMock = vi.mocked( useArchiveSession );
 const useUnarchiveSessionMock = vi.mocked( useUnarchiveSession );
 const useUpdateSessionMetadataMock = vi.mocked( useUpdateSessionMetadata );
+const useUpdateSessionTitleDescriptionMock = vi.mocked( useUpdateSessionTitleDescription );
 const useSitesMock = vi.mocked( useSites );
 const useStartSiteMock = vi.mocked( useStartSite );
 const useStopSiteMock = vi.mocked( useStopSite );
@@ -100,6 +103,7 @@ const useExportFullSiteMock = vi.mocked( useExportFullSite );
 const useDeleteSiteMock = vi.mocked( useDeleteSite );
 
 describe( 'SiteList', () => {
+	const updateTitleDescriptionMutateAsync = vi.fn();
 	const startSiteMutate = vi.fn();
 	const stopSiteMutate = vi.fn();
 
@@ -107,6 +111,7 @@ describe( 'SiteList', () => {
 		navigateMock.mockReset();
 		routerParams = { siteId: 'site-1' };
 		routerPathname = '/sites/site-1';
+		updateTitleDescriptionMutateAsync.mockReset().mockResolvedValue( undefined );
 		startSiteMutate.mockReset();
 		stopSiteMutate.mockReset();
 		useIsSessionRunningMock.mockReset().mockReturnValue( false );
@@ -114,6 +119,10 @@ describe( 'SiteList', () => {
 		useUpdateSessionMetadataMock.mockReturnValue( { mutate: vi.fn(), isPending: false } as never );
 		useArchiveSessionMock.mockReturnValue( { mutate: vi.fn(), isPending: false } as never );
 		useUnarchiveSessionMock.mockReturnValue( { mutate: vi.fn(), isPending: false } as never );
+		useUpdateSessionTitleDescriptionMock.mockReturnValue( {
+			mutateAsync: updateTitleDescriptionMutateAsync,
+			isPending: false,
+		} as never );
 		useStartSiteMock.mockReturnValue( { mutate: startSiteMutate, isPending: false } as never );
 		useStopSiteMock.mockReturnValue( { mutate: stopSiteMutate, isPending: false } as never );
 		useIsSiteStartingMock.mockReturnValue( false );
@@ -137,6 +146,8 @@ describe( 'SiteList', () => {
 			data: [
 				{
 					id: 'session-1',
+					title: 'Generated title',
+					generatedTitle: 'Generated title',
 					firstPrompt: 'Build a landing page',
 					ownerSitePath: '/Users/example/Studio/example-site',
 					updatedAt: '2026-05-01T12:00:00.000Z',
@@ -148,6 +159,34 @@ describe( 'SiteList', () => {
 
 	afterEach( () => {
 		vi.useRealTimers();
+	} );
+
+	it( 'edits a chat title in place from the sidebar', async () => {
+		render( <SiteList /> );
+
+		fireEvent.doubleClick( screen.getByText( 'Generated title' ) );
+		const input = screen.getByRole( 'textbox', { name: 'Chat title' } );
+		expect( input ).toHaveValue( 'Generated title' );
+
+		fireEvent.change( input, { target: { value: 'Better sidebar title' } } );
+		fireEvent.submit( input.closest( 'form' )! );
+
+		expect( updateTitleDescriptionMutateAsync ).toHaveBeenCalledWith( {
+			sessionId: 'session-1',
+			title: 'Better sidebar title',
+		} );
+	} );
+
+	it( 'does not save an unchanged generated sidebar title as a user override', async () => {
+		render( <SiteList /> );
+
+		fireEvent.doubleClick( screen.getByText( 'Generated title' ) );
+		fireEvent.submit( screen.getByRole( 'textbox', { name: 'Chat title' } ).closest( 'form' )! );
+
+		expect( updateTitleDescriptionMutateAsync ).toHaveBeenCalledWith( {
+			sessionId: 'session-1',
+			title: undefined,
+		} );
 	} );
 
 	it( 'shows an empty chat state for open sites without active chats', () => {
@@ -165,6 +204,8 @@ describe( 'SiteList', () => {
 			data: [
 				{
 					id: 'unassigned-session',
+					title: 'Loose chat',
+					generatedTitle: 'Loose chat',
 					firstPrompt: 'Review this idea',
 					updatedAt: '2026-05-02T12:00:00.000Z',
 				},
@@ -182,6 +223,8 @@ describe( 'SiteList', () => {
 			data: [
 				{
 					id: 'archived-unassigned-session',
+					title: 'Archived loose chat',
+					generatedTitle: 'Archived loose chat',
 					firstPrompt: 'Archive me',
 					updatedAt: '2026-05-02T12:00:00.000Z',
 					archived: true,
@@ -313,7 +356,7 @@ describe( 'SiteList', () => {
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Show chats' } ) );
 
-		expect( screen.getByText( 'Build a landing page' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Generated title' ) ).toBeInTheDocument();
 		expect( useIsSessionRunningMock ).toHaveBeenCalledWith( 'session-1' );
 		expect( useSessionHasPendingQuestionMock ).toHaveBeenCalledWith( 'session-1' );
 	} );

--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -177,6 +177,17 @@ describe( 'SiteList', () => {
 		} );
 	} );
 
+	it( 'starts renaming from the chat actions menu', async () => {
+		render( <SiteList /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Chat actions' } ) );
+		fireEvent.click( await screen.findByRole( 'menuitem', { name: 'Rename conversation' } ) );
+
+		expect( screen.getByRole( 'textbox', { name: 'Chat title' } ) ).toHaveValue(
+			'Generated title'
+		);
+	} );
+
 	it( 'does not save an unchanged generated sidebar title as a user override', async () => {
 		render( <SiteList /> );
 

--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -183,10 +183,10 @@ describe( 'SiteList', () => {
 		fireEvent.doubleClick( screen.getByText( 'Generated title' ) );
 		fireEvent.submit( screen.getByRole( 'textbox', { name: 'Chat title' } ).closest( 'form' )! );
 
-		expect( updateTitleDescriptionMutateAsync ).toHaveBeenCalledWith( {
-			sessionId: 'session-1',
-			title: undefined,
-		} );
+		// Nothing changed, so no shared.json write happens and the editor closes.
+		expect( updateTitleDescriptionMutateAsync ).not.toHaveBeenCalled();
+		expect( screen.queryByRole( 'textbox', { name: 'Chat title' } ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Generated title' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows an empty chat state for open sites without active chats', () => {

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -212,11 +212,18 @@ function SessionItem( { session, isVisible }: { session: AiSessionSummary; isVis
 		if ( updateTitleDescription.isPending || isSavingTitleRef.current ) {
 			return;
 		}
+		// Nothing changed (e.g. double-click then blur): skip the shared.json
+		// write and invalidations a no-op mutation would trigger.
+		const nextTitle = getUserTitleOverride();
+		if ( nextTitle === session.userTitle ) {
+			setIsEditing( false );
+			return;
+		}
 		isSavingTitleRef.current = true;
 		try {
 			await updateTitleDescription.mutateAsync( {
 				sessionId: session.id,
-				title: getUserTitleOverride(),
+				title: nextTitle,
 			} );
 			setIsEditing( false );
 		} catch {

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/icons';
 import { Button, Dialog, Icon, IconButton, Tooltip } from '@wordpress/ui';
 import { clsx } from 'clsx';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as Menu from '@/components/menu';
 import { SidebarButton } from '@/components/sidebar-button';
 import { deriveSiteStatus } from '@/components/site-dropdown/utils';
@@ -23,6 +23,7 @@ import {
 	useSessions,
 	useUnarchiveSession,
 	useUpdateSessionMetadata,
+	useUpdateSessionTitleDescription,
 } from '@/data/queries/use-sessions';
 import {
 	useCopySite,
@@ -161,9 +162,112 @@ function SessionActionsMenu( { session }: { session: AiSessionSummary } ) {
 }
 
 function SessionItem( { session, isVisible }: { session: AiSessionSummary; isVisible: boolean } ) {
-	const label = session.firstPrompt?.trim();
+	const label = session.title?.trim() || session.firstPrompt?.trim();
 	const isRunning = useIsSessionRunning( session.id );
 	const hasPendingQuestion = useSessionHasPendingQuestion( session.id );
+	const updateTitleDescription = useUpdateSessionTitleDescription();
+	const params = useParams( { strict: false } ) as { sessionId?: string };
+	const isActive = params.sessionId === session.id;
+	const generatedTitle = session.generatedTitle ?? session.firstPrompt ?? '';
+	const [ isEditing, setIsEditing ] = useState( false );
+	const [ draftTitle, setDraftTitle ] = useState( session.userTitle ?? generatedTitle );
+	const inputRef = useRef< HTMLInputElement | null >( null );
+	const isSavingTitleRef = useRef( false );
+
+	useEffect( () => {
+		if ( ! isEditing ) {
+			setDraftTitle( session.userTitle ?? generatedTitle );
+		}
+	}, [ generatedTitle, isEditing, session.userTitle ] );
+
+	useEffect( () => {
+		if ( isEditing ) {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		}
+	}, [ isEditing ] );
+
+	const normalizeTitle = ( value: string ): string | undefined => {
+		const normalized = value.trim();
+		return normalized || undefined;
+	};
+
+	const getUserTitleOverride = (): string | undefined => {
+		const normalized = normalizeTitle( draftTitle );
+		if ( ! normalized ) {
+			return undefined;
+		}
+		return normalized === normalizeTitle( generatedTitle ) ? undefined : normalized;
+	};
+
+	const startEditing = () => {
+		if ( isRunning ) {
+			return;
+		}
+		setDraftTitle( session.userTitle ?? generatedTitle );
+		setIsEditing( true );
+	};
+
+	const saveTitle = async () => {
+		if ( updateTitleDescription.isPending || isSavingTitleRef.current ) {
+			return;
+		}
+		isSavingTitleRef.current = true;
+		try {
+			await updateTitleDescription.mutateAsync( {
+				sessionId: session.id,
+				title: getUserTitleOverride(),
+			} );
+			setIsEditing( false );
+		} catch {
+			inputRef.current?.focus();
+		} finally {
+			isSavingTitleRef.current = false;
+		}
+	};
+
+	const cancelEditing = () => {
+		setDraftTitle( session.userTitle ?? generatedTitle );
+		setIsEditing( false );
+	};
+
+	if ( isEditing ) {
+		return (
+			<li className={ styles.sessionItem }>
+				<form
+					className={ clsx(
+						styles.sessionLink,
+						styles.sessionEditForm,
+						isActive && styles.sessionLinkActive
+					) }
+					onSubmit={ ( event ) => {
+						event.preventDefault();
+						void saveTitle();
+					} }
+				>
+					<input
+						ref={ inputRef }
+						className={ styles.sessionTitleInput }
+						value={ draftTitle }
+						aria-label={ __( 'Chat title' ) }
+						placeholder={ __( 'Untitled chat' ) }
+						disabled={ updateTitleDescription.isPending }
+						onChange={ ( event ) => setDraftTitle( event.target.value ) }
+						onBlur={ () => void saveTitle() }
+						onKeyDown={ ( event ) => {
+							if ( event.key === 'Escape' ) {
+								event.preventDefault();
+								cancelEditing();
+							}
+						} }
+					/>
+					{ updateTitleDescription.isPending ? (
+						<Spinner className={ styles.sessionSpinner } label={ __( 'Saving…' ) } />
+					) : null }
+				</form>
+			</li>
+		);
+	}
 
 	return (
 		<li className={ styles.sessionItem }>
@@ -203,7 +307,16 @@ function SessionItem( { session, isVisible }: { session: AiSessionSummary; isVis
 					<Spinner className={ styles.sessionInlineSpinner } label={ __( 'Working…' ) } />
 				) : null }
 				<span className={ clsx( styles.sessionLabel, ! label && styles.sessionLabelUntitled ) }>
-					{ label || __( 'Untitled chat' ) }
+					<span
+						className={ styles.sessionEditableTitle }
+						onDoubleClick={ ( event ) => {
+							event.preventDefault();
+							event.stopPropagation();
+							startEditing();
+						} }
+					>
+						{ label || __( 'Untitled chat' ) }
+					</span>
 				</span>
 				<span className={ styles.sessionTime }>{ formatRelativeTime( session.updatedAt ) }</span>
 			</SidebarButton>

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -5,6 +5,7 @@ import {
 	chevronDown,
 	chevronRight,
 	moreHorizontal,
+	pencil,
 	plus,
 	starEmpty,
 	starFilled,
@@ -108,7 +109,13 @@ function groupSessionsByOwner(
 	return groups;
 }
 
-function SessionActionsMenu( { session }: { session: AiSessionSummary } ) {
+function SessionActionsMenu( {
+	session,
+	onRename,
+}: {
+	session: AiSessionSummary;
+	onRename: () => void;
+} ) {
 	const updateSessionMetadata = useUpdateSessionMetadata();
 	const archiveSession = useArchiveSession();
 	const unarchiveSession = useUnarchiveSession();
@@ -140,6 +147,10 @@ function SessionActionsMenu( { session }: { session: AiSessionSummary } ) {
 				}
 			/>
 			<Menu.Popup side="bottom" align="end">
+				<Menu.Item disabled={ isPending } onClick={ onRename }>
+					<Icon icon={ pencil } size={ 16 } />
+					{ __( 'Rename conversation' ) }
+				</Menu.Item>
 				<Menu.Item
 					disabled={ isPending }
 					onClick={ () => updateMetadata( { starred: ! starred, archived } ) }
@@ -329,7 +340,7 @@ function SessionItem( { session, isVisible }: { session: AiSessionSummary; isVis
 			</SidebarButton>
 			{ ! isRunning ? (
 				<div className={ styles.sessionActions }>
-					<SessionActionsMenu session={ session } />
+					<SessionActionsMenu session={ session } onRename={ startEditing } />
 				</div>
 			) : null }
 		</li>

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -370,6 +370,14 @@
 	position: relative;
 }
 
+.sessionEditForm {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-xs);
+	border: 0;
+	outline: 0;
+}
+
 .sessionLabel {
 	flex: 1;
 	min-width: 0;
@@ -380,6 +388,37 @@
 
 .sessionLabelUntitled {
 	font-style: italic;
+}
+
+.sessionEditableTitle {
+	display: block;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-weight: var(--wpds-typography-font-weight-regular);
+}
+
+.sessionLinkActive .sessionEditableTitle {
+	font-weight: var(--wpds-typography-font-weight-medium, 500);
+}
+
+.sessionTitleInput {
+	flex: 1;
+	min-width: 0;
+	height: calc(var(--site-list-row-height) - var(--wpds-dimension-padding-sm));
+	box-sizing: border-box;
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: 4px;
+	padding: 0 var(--wpds-dimension-padding-xs);
+	background: var(--wpds-color-bg-surface-neutral);
+	color: var(--wpds-color-fg-content-neutral);
+	font: inherit;
+}
+
+.sessionTitleInput:focus {
+	outline: 2px solid var(--ui-desks-focus, #3858e9);
+	outline-offset: 0;
 }
 
 .sessionTime {

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -8,6 +8,7 @@ import {
 	useSessions,
 	useUnarchiveSession,
 	useUpdateSessionMetadata,
+	useUpdateSessionTitleDescription,
 } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { SessionUIProvider } from '@/hooks/use-session-ui';
@@ -48,6 +49,7 @@ vi.mock( '@/data/queries/use-sessions', () => ( {
 	useSessions: vi.fn(),
 	useUnarchiveSession: vi.fn(),
 	useUpdateSessionMetadata: vi.fn(),
+	useUpdateSessionTitleDescription: vi.fn(),
 } ) );
 
 vi.mock( '@/data/queries/use-sites', () => ( {
@@ -64,11 +66,13 @@ const useSessionsMock = vi.mocked( useSessions );
 const useArchiveSessionMock = vi.mocked( useArchiveSession );
 const useUnarchiveSessionMock = vi.mocked( useUnarchiveSession );
 const useUpdateSessionMetadataMock = vi.mocked( useUpdateSessionMetadata );
+const useUpdateSessionTitleDescriptionMock = vi.mocked( useUpdateSessionTitleDescription );
 
 describe( 'SiteOverviewView', () => {
 	const archiveMutate = vi.fn();
 	const unarchiveMutate = vi.fn();
 	const updateMetadataMutate = vi.fn();
+	const updateTitleDescriptionMutateAsync = vi.fn();
 	const createSession = vi.fn();
 	const continueSession = vi.fn();
 	const setSessionModel = vi.fn();
@@ -93,6 +97,7 @@ describe( 'SiteOverviewView', () => {
 		archiveMutate.mockReset();
 		unarchiveMutate.mockReset();
 		updateMetadataMutate.mockReset();
+		updateTitleDescriptionMutateAsync.mockReset().mockResolvedValue( undefined );
 		createSession.mockReset().mockResolvedValue( { id: 'new-session' } );
 		continueSession.mockReset().mockResolvedValue( { runId: 'run-1' } );
 		setSessionModel.mockReset().mockResolvedValue( undefined );
@@ -111,6 +116,10 @@ describe( 'SiteOverviewView', () => {
 		} as never );
 		useUpdateSessionMetadataMock.mockReturnValue( {
 			mutate: updateMetadataMutate,
+			isPending: false,
+		} as never );
+		useUpdateSessionTitleDescriptionMock.mockReturnValue( {
+			mutateAsync: updateTitleDescriptionMutateAsync,
 			isPending: false,
 		} as never );
 		useSitesMock.mockReturnValue( {
@@ -136,6 +145,7 @@ describe( 'SiteOverviewView', () => {
 				{
 					id: 'archived-session',
 					firstPrompt: 'Archived chat',
+					description: 'Archived detail should stay hidden',
 					ownerSitePath: '/Users/example/Studio/example-site',
 					updatedAt: '2026-05-02T12:00:00.000Z',
 					archived: true,
@@ -209,6 +219,7 @@ describe( 'SiteOverviewView', () => {
 			'href',
 			'/sessions/archived-session'
 		);
+		expect( screen.queryByText( 'Archived detail should stay hidden' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'keeps the site details content focused on chats', () => {
@@ -251,6 +262,54 @@ describe( 'SiteOverviewView', () => {
 				starred: true,
 				archived: false,
 			},
+		} );
+	} );
+
+	it( 'edits chat title and description from the site details view', async () => {
+		renderOverview();
+
+		fireEvent.click( screen.getAllByRole( 'button', { name: 'Edit' } )[ 0 ] );
+		fireEvent.change( screen.getByLabelText( 'Title' ), {
+			target: { value: 'Better title' },
+		} );
+		fireEvent.change( screen.getByLabelText( 'Description' ), {
+			target: { value: 'Short useful description' },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		expect( updateTitleDescriptionMutateAsync ).toHaveBeenCalledWith( {
+			sessionId: 'active-session',
+			title: 'Better title',
+			description: 'Short useful description',
+		} );
+	} );
+
+	it( 'keeps unchanged generated chat details as generated metadata', async () => {
+		useSessionsMock.mockReturnValue( {
+			data: [
+				{
+					id: 'generated-session',
+					firstPrompt: 'Original prompt',
+					generatedTitle: 'Generated title',
+					generatedDescription: 'Generated description',
+					ownerSitePath: '/Users/example/Studio/example-site',
+					updatedAt: '2026-05-01T12:00:00.000Z',
+				},
+			],
+			isLoading: false,
+		} as never );
+
+		renderOverview();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Edit' } ) );
+		expect( screen.getByLabelText( 'Title' ) ).toHaveValue( 'Generated title' );
+		expect( screen.getByLabelText( 'Description' ) ).toHaveValue( 'Generated description' );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		expect( updateTitleDescriptionMutateAsync ).toHaveBeenCalledWith( {
+			sessionId: 'generated-session',
+			title: undefined,
+			description: undefined,
 		} );
 	} );
 

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -12,7 +12,7 @@ import {
 	undo,
 } from '@wordpress/icons';
 import { Button, Dialog, Field, Icon, IconButton, Input, Textarea } from '@wordpress/ui';
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import { PreviewSplitContent } from '@/components/preview-split-frame';
 import { useConnector } from '@/data/core';
 import {
@@ -449,11 +449,16 @@ function EditChatDetailsDialog( {
 		session.userDescription ?? generatedDescription
 	);
 
+	// Reset only when the dialog opens. The generated fallbacks can change
+	// while it's open (e.g. a background run finishes and regenerates the
+	// description), and that must not clobber in-progress edits.
+	const wasOpenRef = useRef( false );
 	useEffect( () => {
-		if ( open ) {
+		if ( open && ! wasOpenRef.current ) {
 			setTitle( session.userTitle ?? generatedTitle );
 			setDescription( session.userDescription ?? generatedDescription );
 		}
+		wasOpenRef.current = open;
 	}, [ generatedDescription, generatedTitle, open, session.userDescription, session.userTitle ] );
 
 	const normalizeField = ( value: string ): string | undefined => {
@@ -471,11 +476,17 @@ function EditChatDetailsDialog( {
 
 	const handleSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
-		await updateTitleDescription.mutateAsync( {
-			sessionId: session.id,
-			title: getUserOverride( title, generatedTitle ),
-			description: getUserOverride( description, generatedDescription ),
-		} );
+		try {
+			await updateTitleDescription.mutateAsync( {
+				sessionId: session.id,
+				title: getUserOverride( title, generatedTitle ),
+				description: getUserOverride( description, generatedDescription ),
+			} );
+		} catch {
+			// Keep the dialog open so the edits aren't lost; the error message
+			// below the fields explains what happened.
+			return;
+		}
 		onOpenChange( false );
 	};
 
@@ -514,6 +525,11 @@ function EditChatDetailsDialog( {
 									rows={ 3 }
 								/>
 							</Field.Root>
+							{ updateTitleDescription.isError ? (
+								<p className={ styles.dialogError } role="alert">
+									{ __( 'Saving chat details failed. Please try again.' ) }
+								</p>
+							) : null }
 						</div>
 					</Dialog.Content>
 					<Dialog.Footer>

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -2,9 +2,17 @@ import { DEFAULT_MODEL } from '@studio/common/ai/models';
 import { useQueryClient } from '@tanstack/react-query';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { box, chevronDown, chevronRight, starEmpty, starFilled, undo } from '@wordpress/icons';
-import { Button, Icon, IconButton } from '@wordpress/ui';
-import { useCallback, useMemo, useState } from 'react';
+import {
+	box,
+	chevronDown,
+	chevronRight,
+	pencil,
+	starEmpty,
+	starFilled,
+	undo,
+} from '@wordpress/icons';
+import { Button, Dialog, Field, Icon, IconButton, Input, Textarea } from '@wordpress/ui';
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 import { PreviewSplitContent } from '@/components/preview-split-frame';
 import { useConnector } from '@/data/core';
 import {
@@ -13,6 +21,7 @@ import {
 	useSessions,
 	useUnarchiveSession,
 	useUpdateSessionMetadata,
+	useUpdateSessionTitleDescription,
 } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { SessionUIProvider } from '@/hooks/use-session-ui';
@@ -325,8 +334,10 @@ function ActiveChatRow( {
 	onArchive: ( session: AiSessionSummary ) => void;
 	onToggleStar: ( session: AiSessionSummary ) => void;
 } ) {
-	const label = session.firstPrompt?.trim() || __( 'Untitled chat' );
+	const label = session.title?.trim() || session.firstPrompt?.trim() || __( 'Untitled chat' );
+	const description = session.description?.trim() || session.assistantReplyPreview?.trim();
 	const starred = !! session.starred;
+	const [ editOpen, setEditOpen ] = useState( false );
 
 	return (
 		<li className={ styles.chatRow }>
@@ -336,6 +347,7 @@ function ActiveChatRow( {
 				className={ styles.chatLink }
 			>
 				<span className={ styles.chatTitle }>{ label }</span>
+				{ description ? <span className={ styles.chatMeta }>{ description }</span> : null }
 			</Link>
 			<div className={ styles.chatEndSlot }>
 				<span className={ styles.chatTime }>{ formatRelativeTime( session.updatedAt ) }</span>
@@ -355,6 +367,15 @@ function ActiveChatRow( {
 						variant="minimal"
 						tone="neutral"
 						size="small"
+						icon={ pencil }
+						label={ __( 'Edit' ) }
+						className={ styles.chatIconAction }
+						onClick={ () => setEditOpen( true ) }
+					/>
+					<IconButton
+						variant="minimal"
+						tone="neutral"
+						size="small"
 						icon={ box }
 						label={ archiveLabel }
 						className={ styles.chatIconAction }
@@ -363,6 +384,9 @@ function ActiveChatRow( {
 					/>
 				</div>
 			</div>
+			{ editOpen ? (
+				<EditChatDetailsDialog session={ session } open={ editOpen } onOpenChange={ setEditOpen } />
+			) : null }
 		</li>
 	);
 }
@@ -378,7 +402,7 @@ function ArchivedChatRow( {
 	actionDisabled: boolean;
 	onUnarchive: ( session: AiSessionSummary ) => void;
 } ) {
-	const label = session.firstPrompt?.trim() || __( 'Untitled chat' );
+	const label = session.title?.trim() || session.firstPrompt?.trim() || __( 'Untitled chat' );
 
 	return (
 		<li className={ styles.archivedChatRow }>
@@ -405,5 +429,113 @@ function ArchivedChatRow( {
 				/>
 			</div>
 		</li>
+	);
+}
+
+function EditChatDetailsDialog( {
+	session,
+	open,
+	onOpenChange,
+}: {
+	session: AiSessionSummary;
+	open: boolean;
+	onOpenChange: ( open: boolean ) => void;
+} ) {
+	const updateTitleDescription = useUpdateSessionTitleDescription();
+	const generatedTitle = session.generatedTitle ?? session.firstPrompt ?? '';
+	const generatedDescription = session.generatedDescription ?? session.assistantReplyPreview ?? '';
+	const [ title, setTitle ] = useState( session.userTitle ?? generatedTitle );
+	const [ description, setDescription ] = useState(
+		session.userDescription ?? generatedDescription
+	);
+
+	useEffect( () => {
+		if ( open ) {
+			setTitle( session.userTitle ?? generatedTitle );
+			setDescription( session.userDescription ?? generatedDescription );
+		}
+	}, [ generatedDescription, generatedTitle, open, session.userDescription, session.userTitle ] );
+
+	const normalizeField = ( value: string ): string | undefined => {
+		const trimmed = value.trim();
+		return trimmed || undefined;
+	};
+
+	const getUserOverride = ( value: string, generatedFallback: string ): string | undefined => {
+		const normalized = normalizeField( value );
+		if ( ! normalized ) {
+			return undefined;
+		}
+		return normalized === normalizeField( generatedFallback ) ? undefined : normalized;
+	};
+
+	const handleSubmit = async ( event: FormEvent ) => {
+		event.preventDefault();
+		await updateTitleDescription.mutateAsync( {
+			sessionId: session.id,
+			title: getUserOverride( title, generatedTitle ),
+			description: getUserOverride( description, generatedDescription ),
+		} );
+		onOpenChange( false );
+	};
+
+	return (
+		<Dialog.Root
+			open={ open }
+			onOpenChange={ ( next ) => {
+				if ( ! updateTitleDescription.isPending ) {
+					onOpenChange( next );
+				}
+			} }
+		>
+			<Dialog.Popup size="small">
+				<form onSubmit={ handleSubmit }>
+					<Dialog.Header>
+						<Dialog.Title>{ __( 'Edit chat details' ) }</Dialog.Title>
+					</Dialog.Header>
+					<Dialog.Content>
+						<div className={ styles.dialogFields }>
+							<Field.Root className={ styles.dialogField } render={ <div /> }>
+								<Field.Label variant="plain">{ __( 'Title' ) }</Field.Label>
+								<Input
+									value={ title }
+									onValueChange={ setTitle }
+									placeholder={ generatedTitle || __( 'Untitled chat' ) }
+									disabled={ updateTitleDescription.isPending }
+								/>
+							</Field.Root>
+							<Field.Root className={ styles.dialogField } render={ <div /> }>
+								<Field.Label variant="plain">{ __( 'Description' ) }</Field.Label>
+								<Textarea
+									value={ description }
+									onValueChange={ setDescription }
+									placeholder={ generatedDescription || __( 'Add a short description' ) }
+									disabled={ updateTitleDescription.isPending }
+									rows={ 3 }
+								/>
+							</Field.Root>
+						</div>
+					</Dialog.Content>
+					<Dialog.Footer>
+						<Dialog.Action
+							variant="minimal"
+							tone="neutral"
+							disabled={ updateTitleDescription.isPending }
+						>
+							{ __( 'Cancel' ) }
+						</Dialog.Action>
+						<Button
+							type="submit"
+							variant="solid"
+							tone="brand"
+							loading={ updateTitleDescription.isPending }
+							loadingAnnouncement={ __( 'Saving chat details' ) }
+						>
+							{ __( 'Save' ) }
+						</Button>
+					</Dialog.Footer>
+				</form>
+			</Dialog.Popup>
+		</Dialog.Root>
 	);
 }

--- a/apps/ui/src/components/site-overview-view/style.module.css
+++ b/apps/ui/src/components/site-overview-view/style.module.css
@@ -496,3 +496,10 @@
 	font-size: var(--wpds-typography-font-size-sm);
 	line-height: var(--wpds-typography-line-height-sm);
 }
+
+.dialogError {
+	margin: 0;
+	color: var(--wpds-color-fg-content-error, #b32d2e);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+}

--- a/apps/ui/src/components/site-overview-view/style.module.css
+++ b/apps/ui/src/components/site-overview-view/style.module.css
@@ -295,6 +295,16 @@
 	padding-inline-end: var(--active-chat-actions-width);
 }
 
+.chatMeta {
+	display: -webkit-box;
+	overflow: hidden;
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-md);
+	line-height: 18px;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+}
+
 .emptyChats {
 	margin: 0;
 	padding-inline: var(--chat-text-offset);
@@ -471,4 +481,18 @@
 .archivedChatRow:focus-within .archivedChatAction {
 	opacity: 1;
 	pointer-events: auto;
+}
+
+.dialogFields {
+	display: grid;
+	gap: var(--wpds-dimension-padding-md);
+	padding-block-end: calc(var(--wpds-border-width-focus, 2px) + 1px);
+}
+
+.dialogField {
+	display: grid;
+	gap: var(--wpds-dimension-padding-xs);
+	color: var(--wpds-color-fg-content-neutral);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
 }

--- a/apps/ui/src/data/queries/use-sessions.ts
+++ b/apps/ui/src/data/queries/use-sessions.ts
@@ -52,9 +52,14 @@ function mergeSessionMetadata(
 	summary: AiSessionSummary,
 	patch: Partial< AiSessionMetadata >
 ): AiSessionSummary {
-	return {
+	const next = {
 		...summary,
 		...patch,
+	};
+	return {
+		...next,
+		title: next.userTitle ?? next.generatedTitle ?? next.firstPrompt,
+		description: next.userDescription ?? next.generatedDescription ?? next.assistantReplyPreview,
 	};
 }
 
@@ -132,6 +137,39 @@ export function useUpdateSessionMetadata() {
 			void queryClient.invalidateQueries( { queryKey: [ ...SESSIONS_QUERY_KEY, sessionId ] } );
 		},
 	} );
+}
+
+export function useUpdateSessionTitleDescription() {
+	const updateSessionMetadata = useUpdateSessionMetadata();
+	type Variables = {
+		sessionId: string;
+		title?: string;
+		description?: string;
+	};
+	const buildPatch = ( variables: Variables ): Partial< AiSessionMetadata > => {
+		const patch: Partial< AiSessionMetadata > = {};
+		if ( Object.prototype.hasOwnProperty.call( variables, 'title' ) ) {
+			patch.userTitle = variables.title;
+		}
+		if ( Object.prototype.hasOwnProperty.call( variables, 'description' ) ) {
+			patch.userDescription = variables.description;
+		}
+		return patch;
+	};
+
+	return {
+		...updateSessionMetadata,
+		mutate: ( variables: Variables ) =>
+			updateSessionMetadata.mutate( {
+				sessionId: variables.sessionId,
+				patch: buildPatch( variables ),
+			} ),
+		mutateAsync: ( variables: Variables ) =>
+			updateSessionMetadata.mutateAsync( {
+				sessionId: variables.sessionId,
+				patch: buildPatch( variables ),
+			} ),
+	};
 }
 
 function useSessionArchivedMutation( archived: boolean ) {

--- a/apps/ui/src/ui-desks/chats/panel/index.tsx
+++ b/apps/ui/src/ui-desks/chats/panel/index.tsx
@@ -45,11 +45,15 @@ function persistCompactPreference( compact: boolean ) {
 }
 
 function getSessionTitle( session: AiSessionSummary ) {
-	return session.firstPrompt?.trim() || __( 'New chat' );
+	return session.title?.trim() || session.firstPrompt?.trim() || __( 'New chat' );
 }
 
 function getSessionSubtitle( session: AiSessionSummary ) {
-	return session.assistantReplyPreview ?? __( 'Ask Studio anything to get started.' );
+	return (
+		session.description ??
+		session.assistantReplyPreview ??
+		__( 'Ask Studio anything to get started.' )
+	);
 }
 
 function formatSessionTimeSince( value: string ) {

--- a/tools/common/ai/sessions/types.ts
+++ b/tools/common/ai/sessions/types.ts
@@ -5,6 +5,13 @@ export type TurnStatus = 'success' | 'error' | 'max_turns' | 'interrupted';
 export interface AiSessionMetadata {
 	starred?: boolean;
 	archived?: boolean;
+	userTitle?: string;
+	generatedTitle?: string;
+	userDescription?: string;
+	generatedDescription?: string;
+	titleGeneratedAt?: string;
+	descriptionGeneratedAt?: string;
+	descriptionGeneratedEventCount?: number;
 }
 
 export interface AiSessionSummary extends AiSessionMetadata {
@@ -12,6 +19,8 @@ export interface AiSessionSummary extends AiSessionMetadata {
 	filePath: string;
 	createdAt: string;
 	updatedAt: string;
+	title?: string;
+	description?: string;
 	firstPrompt?: string;
 	assistantReplyPreview?: string;
 	// Desktop-only placement, hydrated by the app from app.json. CLI session

--- a/tools/common/lib/shared-config.ts
+++ b/tools/common/lib/shared-config.ts
@@ -29,6 +29,13 @@ export const sharedSessionMetadataSchema = z
 	.object( {
 		starred: z.boolean().optional(),
 		archived: z.boolean().optional(),
+		userTitle: z.string().optional(),
+		generatedTitle: z.string().optional(),
+		userDescription: z.string().optional(),
+		generatedDescription: z.string().optional(),
+		titleGeneratedAt: z.string().optional(),
+		descriptionGeneratedAt: z.string().optional(),
+		descriptionGeneratedEventCount: z.number().optional(),
 	} )
 	.loose();
 
@@ -125,6 +132,24 @@ function pruneSharedSessionMetadata( metadata: SharedSessionMetadata ): void {
 	}
 	if ( ! metadata.archived ) {
 		delete metadata.archived;
+	}
+	for ( const key of [
+		'userTitle',
+		'generatedTitle',
+		'userDescription',
+		'generatedDescription',
+		'titleGeneratedAt',
+		'descriptionGeneratedAt',
+	] as const ) {
+		if ( typeof metadata[ key ] === 'string' ) {
+			metadata[ key ] = metadata[ key ].trim();
+		}
+		if ( ! metadata[ key ] ) {
+			delete metadata[ key ];
+		}
+	}
+	if ( metadata.descriptionGeneratedEventCount === undefined ) {
+		delete metadata.descriptionGeneratedEventCount;
 	}
 }
 

--- a/tools/common/lib/tests/shared-config.test.ts
+++ b/tools/common/lib/tests/shared-config.test.ts
@@ -204,17 +204,18 @@ describe( 'Shared Config', () => {
 					JSON.stringify( {
 						version: 1,
 						sessions: {
-							abc123: { starred: true },
+							abc123: { starred: true, userTitle: 'Launch plan' },
 						},
 					} )
 				)
 			);
 
 			await expect( readSharedSessions() ).resolves.toEqual( {
-				abc123: { starred: true },
+				abc123: { starred: true, userTitle: 'Launch plan' },
 			} );
 			await expect( readSharedSession( 'abc123' ) ).resolves.toEqual( {
 				starred: true,
+				userTitle: 'Launch plan',
 			} );
 			await expect( readSharedSession( 'missing' ) ).resolves.toBeUndefined();
 		} );
@@ -223,17 +224,17 @@ describe( 'Shared Config', () => {
 			vi.mocked( readFile ).mockResolvedValue( Buffer.from( JSON.stringify( { version: 1 } ) ) );
 
 			await expect(
-				updateSharedSession( 'abc123', { starred: true, archived: true } )
+				updateSharedSession( 'abc123', { starred: true, userDescription: '  Brief  ' } )
 			).resolves.toEqual( {
 				starred: true,
-				archived: true,
+				userDescription: 'Brief',
 			} );
 
 			const written = vi.mocked( writeFile ).mock.calls[ 0 ][ 1 ] as string;
 			expect( JSON.parse( written ) ).toEqual( {
 				version: 1,
 				sessions: {
-					abc123: { starred: true, archived: true },
+					abc123: { starred: true, userDescription: 'Brief' },
 				},
 			} );
 		} );
@@ -244,7 +245,7 @@ describe( 'Shared Config', () => {
 					JSON.stringify( {
 						version: 1,
 						sessions: {
-							abc123: { starred: true, archived: true },
+							abc123: { starred: true, archived: true, userTitle: '  ' },
 						},
 					} )
 				)


### PR DESCRIPTION
This PR aims to help users scan and identify their chat sessions in the new Agentic UI. This PR adds:
- Users can double-click on a chat in their sidebar to edit it's title.
- The Site Detail view now lists chat titles along with a new description field for active chats. There's also a new action to edit, which opens a modal with fields for the title and description.

This sets the stage for generating better titles and description automatically with AI. For example, we could use the users initial message to generate a more apt title for the chat. Then, after a few messages, we could generate a short description of the conversation.

<img width="270" height="349" alt="image" src="https://github.com/user-attachments/assets/e85d21c8-6673-47e2-a2b9-8a3e4d88b2b8" />
<img width="341" height="376" alt="image" src="https://github.com/user-attachments/assets/422fb102-2c43-40d5-9bf5-f2ddde624183" />
<img width="722" height="678" alt="image" src="https://github.com/user-attachments/assets/e4ed7e10-4f20-4743-852a-3323e7f002bc" />
