### PR TITLE
Fix "No API key found" in studio code when wpcom token contains $ or !

### DIFF
--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -372,13 +372,25 @@ function createModelRegistry(
 	return { authStorage, modelRegistry };
 }
 
+// pi (>= 0.78) parses `registerProvider` config values (apiKey, headers) as
+// templates: a `$NAME` / `${NAME}` sequence is read as an environment-variable
+// reference and a leading `!` is read as a shell command. wpcom OAuth tokens are
+// random strings that can contain `$` followed by a name-like sequence, so pi
+// resolves that fragment to an undefined env var and treats the provider as
+// unauthenticated ("No API key found for studio-wpcom-anthropic."). Escape the
+// token so pi treats it as a literal: `$` -> `$$`, and a leading `!` -> `$!`.
+function escapePiConfigValue( value: string ): string {
+	const dollarEscaped = value.replace( /\$/g, () => '$$' );
+	return dollarEscaped.startsWith( '!' ) ? `$${ dollarEscaped }` : dollarEscaped;
+}
+
 function createWpcomAnthropicProviderConfig(
 	model: Model< 'anthropic-messages' >,
 	creds: ResolvedCredentials
 ): ProviderConfigInput {
 	return {
 		baseUrl: creds.baseURL,
-		apiKey: creds.apiKey,
+		apiKey: escapePiConfigValue( creds.apiKey ),
 		api: 'anthropic-messages',
 		headers: creds.extraHeaders,
 		streamSimple: ( m, ctx, options?: SimpleStreamOptions ) => {

--- a/apps/cli/ai/tests/pi-runtime.test.ts
+++ b/apps/cli/ai/tests/pi-runtime.test.ts
@@ -433,6 +433,30 @@ describe( 'pi runtime', () => {
 		} );
 	} );
 
+	// pi parses registerProvider config values as templates, so a wpcom token
+	// containing `$name` would be read as an undefined env-var reference and the
+	// provider would look unauthenticated ("No API key found"). The token must be
+	// escaped so pi resolves it back to the literal value.
+	it( 'keeps the wpcom token configured when it contains template metacharacters', async () => {
+		const tokenWithDollar = 'abc$t5CmlMyb$VRe7t1xyz';
+
+		await runRuntime( {
+			prompt: 'hello',
+			env: {
+				ANTHROPIC_AUTH_TOKEN: tokenWithDollar,
+				ANTHROPIC_BASE_URL: 'https://proxy.example.com',
+				ANTHROPIC_CUSTOM_HEADERS: 'X-WPCOM-AI-Feature: studio-assistant-anthropic',
+			},
+			model: 'claude-sonnet-4-6',
+			session: newSession(),
+		} );
+
+		const options = mocks.createdSessions[ 0 ].options;
+		expect( options.modelRegistry!.hasConfiguredAuth( options.model! ) ).toBe( true );
+		const auth = await options.modelRegistry!.getApiKeyAndHeaders( options.model! );
+		expect( auth ).toMatchObject( { ok: true, apiKey: tokenWithDollar } );
+	} );
+
 	// Silent header-drop would surface as an opaque 401 from the wpcom proxy.
 	it( 'warns and continues when STUDIO_OPENAI_DEFAULT_HEADERS is malformed', async () => {
 		const warnSpy = vi.spyOn( console, 'warn' ).mockImplementation( () => {} );


### PR DESCRIPTION
## Related issues

- Related to https://github.com/Automattic/studio/pull/3707

## How AI was used in this PR

Used an AI coding assistant to trace the failure from the surfaced error string back through the `pi` model registry, then to draft the escaping helper, the regression test, and this description, which was slightly modified.

## Proposed Changes

Fixes parsing the WP.com token with "special" characters `$` or `!`.

Some users hit `No API key found for studio-wpcom-anthropic.` the moment they run `studio code`, even while fully logged in to WordPress.com. The failure is intermittent and account-specific: it only strikes when the user's WordPress.com OAuth token happens to contain a `$` (or a leading `!`).

Studio hands that token to the `pi` agent runtime as a provider API key. Since the `pi` 0.78 upgrade, provider config values are parsed as templates — a `$name` fragment is treated as an environment-variable reference and a leading `!` as a shell command. So a token like `abc$xyz...` was read as a reference to a non-existent env var `$xyz`, leaving the provider looking unauthenticated and blocking the agent before any request was made.

This escapes the token before registering the provider so `pi` treats it as a literal value. Affected users can now start `studio code` and chat normally; users whose tokens never contained those characters are unaffected. The real upstream request still receives the original token unchanged.

## Testing Instructions

1. `npm run cli:build`
2. `node apps/cli/dist/cli/main.mjs code`
3. Run `/logout`, or move the whole `~/.studio` folder.
4. Run `/login`
5. Paste your token in the terminal. Make sure the token contains the characters `$` or `!`
6. Confirm you can interact with Studio Code.
7. Confirm that the new test case added to `apps/cli/ai/tests/pi-runtime.test.ts` fails on trunk and passes on this branch.

| Before | After |
|--------|--------|
|  <img width="860" height="423" alt="Screenshot 2026-06-09 at 13 56 36" src="https://github.com/user-attachments/assets/933ef752-cc73-4f04-800f-fae3bc653aff" /> | <img width="864" height="613" alt="Screenshot 2026-06-09 at 14 08 40" src="https://github.com/user-attachments/assets/4aef830e-7349-47d3-915c-5811edf86ac7" /> |

Note: the bug surfaces only for tokens containing `$`/`!`. To reproduce the original failure deterministically, register the wpcom Anthropic provider with such a token (covered by the added test).

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
