### PR TITLE
Fix Dark theme for Studio Code

### DIFF
--- a/apps/studio/src/components/studio-code-session/composer/style.module.css
+++ b/apps/studio/src/components/studio-code-session/composer/style.module.css
@@ -6,16 +6,16 @@
 .shell {
 	display: flex;
 	flex-direction: column;
-	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border: 1px solid var(--color-frame-border);
 	border-radius: 16px;
-	background-color: var(--wpds-color-bg-surface-neutral-strong);
+	background-color: var(--color-frame-bg);
 	padding: var(--wpds-dimension-padding-lg);
 	box-shadow: 0 1px 2px rgb(0 0 0 / 4%), 0 4px 12px rgb(0 0 0 / 6%);
 	transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
 .shell:focus-within {
-	border-color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	border-color: var(--color-frame-theme);
 	box-shadow: 0 1px 2px rgb(0 0 0 / 6%), 0 6px 16px rgb(0 0 0 / 8%);
 }
 
@@ -24,7 +24,7 @@
 }
 
 .shellDragging {
-	border-color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	border-color: var(--color-frame-theme);
 	border-style: dashed;
 }
 
@@ -36,8 +36,8 @@
 	align-items: center;
 	justify-content: center;
 	border-radius: 16px;
-	background-color: var(--wpds-color-bg-surface-neutral-strong);
-	color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	background-color: var(--color-frame-bg);
+	color: var(--color-frame-theme);
 	font-size: var(--wpds-typography-font-size-sm);
 	pointer-events: none;
 }
@@ -63,11 +63,11 @@
 	max-width: 220px;
 	height: 28px;
 	padding: 0 4px 0 6px;
-	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border: 1px solid var(--color-frame-border);
 	border-radius: var(--wpds-border-radius-sm, 4px);
-	background-color: var(--wpds-color-bg-surface-neutral);
+	background-color: var(--color-frame-surface);
 	font-size: var(--wpds-typography-font-size-xs);
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 }
 
 .attachmentThumb {
@@ -82,7 +82,7 @@
 	display: inline-flex;
 	flex-shrink: 0;
 	align-items: center;
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 .attachmentName {
@@ -96,7 +96,7 @@
 .attachmentSize {
 	flex-shrink: 0;
 	white-space: nowrap;
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 .attachmentRemove {
@@ -110,14 +110,14 @@
 	border: 0;
 	border-radius: var(--wpds-border-radius-sm, 4px);
 	background-color: transparent;
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 	cursor: pointer;
 }
 
 .attachmentRemove:hover,
 .attachmentRemove:focus-visible {
-	background-color: var(--wpds-color-bg-surface-neutral-strong);
-	color: var(--wpds-color-fg-content-neutral);
+	background-color: var(--color-frame-bg);
+	color: var(--color-frame-text);
 }
 
 .inputWrapper {
@@ -146,7 +146,7 @@
 	padding: var(--wpds-dimension-padding-xs) 0;
 	border: 0;
 	background: transparent;
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 	font-size: var(--wpds-typography-font-size-md);
 	line-height: 1.5;
 	width: 100%;
@@ -157,11 +157,11 @@
 }
 
 .input::placeholder {
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 .input[data-preview='true'] {
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 .toolbar {
@@ -186,10 +186,10 @@
 	width: 22px;
 	height: 22px;
 	padding: 0;
-	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border: 1px solid var(--color-frame-border);
 	border-radius: var(--wpds-border-radius-sm, 4px);
 	background-color: transparent;
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 	cursor: pointer;
 	font: inherit;
 }
@@ -201,12 +201,12 @@
 
 .iconButton:hover:not(:disabled),
 .iconButton:focus-visible:not(:disabled) {
-	background-color: var(--wpds-color-bg-surface-neutral);
+	background-color: var(--color-frame-surface);
 }
 
 .iconButton:disabled {
 	cursor: not-allowed;
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 .pill {
@@ -218,7 +218,7 @@
 	border: 0;
 	border-radius: var(--wpds-border-radius-sm, 4px);
 	background-color: transparent;
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 	font: inherit;
 	font-size: var(--wpds-typography-font-size-sm);
 	cursor: pointer;
@@ -226,7 +226,7 @@
 
 .pill:hover:not(:disabled),
 .pill:focus-visible:not(:disabled) {
-	background-color: var(--wpds-color-bg-surface-neutral);
+	background-color: var(--color-frame-surface);
 }
 
 .pill:disabled {
@@ -242,12 +242,12 @@
 .commandName {
 	font-family: var(--wpds-typography-font-family-mono, ui-monospace, monospace);
 	font-size: var(--wpds-typography-font-size-sm);
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 }
 
 .commandDescription {
 	font-size: var(--wpds-typography-font-size-xs);
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 .sendButton,
@@ -269,7 +269,7 @@
    which has equal specificity to a single class and would otherwise win by
    load order, leaving the button invisible. */
 .toolbar .sendButton {
-	background-color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	background-color: var(--color-frame-theme);
 	color: #fff;
 }
 
@@ -284,8 +284,8 @@
 }
 
 .toolbar .stopButton {
-	background-color: var(--wpds-color-fg-content-neutral);
-	color: var(--wpds-color-bg-surface-neutral-strong);
+	background-color: var(--color-frame-text);
+	color: var(--color-frame-bg);
 }
 
 .stopButton:hover,
@@ -324,7 +324,7 @@
 	padding: 0 var(--wpds-dimension-padding-xs);
 	min-height: 16px;
 	font-size: var(--wpds-typography-font-size-xs);
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 .metaHint {
@@ -338,6 +338,6 @@
 }
 
 .error {
-	color: var(--wpds-color-fg-content-error, #dc2626);
+	color: var(--color-frame-error);
 	font-size: var(--wpds-typography-font-size-xs);
 }

--- a/apps/studio/src/components/studio-code-session/conversation/style.module.css
+++ b/apps/studio/src/components/studio-code-session/conversation/style.module.css
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: var(--wpds-dimension-padding-lg);
+	color: var(--color-frame-text);
 }
 
 /* User bubbles act as turn anchors; give them generous breathing room above
@@ -19,14 +20,14 @@
 .userText {
 	align-self: flex-end;
 	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
-	background-color: color-mix(in srgb, var(--wpds-color-fg-interactive-brand, #2563eb) 10%, transparent);
+	background-color: color-mix(in srgb, var(--color-frame-theme) 16%, transparent);
 	/* Bottom-right tight so the bubble reads as originating from the user
 	   on the right; other corners round generously. */
 	border-radius: 18px 18px var(--wpds-border-radius-md, 8px) 18px;
 	max-width: 80%;
 	font-size: var(--wpds-typography-font-size-md);
 	line-height: 1.55;
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 	white-space: pre-wrap;
 	word-wrap: break-word;
 }
@@ -49,11 +50,11 @@
 	gap: 4px;
 	max-width: 200px;
 	padding: 2px 8px;
-	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border: 1px solid var(--color-frame-border);
 	border-radius: var(--wpds-border-radius-sm, 4px);
-	background-color: var(--wpds-color-bg-surface-neutral);
+	background-color: var(--color-frame-surface);
 	font-size: var(--wpds-typography-font-size-xs);
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 .userAttachmentName {
@@ -70,7 +71,7 @@
 	max-width: 160px;
 	max-height: 160px;
 	border-radius: var(--wpds-border-radius-md, 8px);
-	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border: 1px solid var(--color-frame-border);
 	object-fit: cover;
 }
 
@@ -86,7 +87,7 @@
 	gap: var(--wpds-dimension-padding-sm);
 	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
 	font-size: var(--wpds-typography-font-size-sm);
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 	padding: 2px 0;
 	min-width: 0;
 }
@@ -101,8 +102,8 @@
 .toolOutput {
 	margin: 0;
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
-	border-left: 2px solid var(--wpds-color-stroke-surface-neutral);
-	color: var(--wpds-color-fg-content-neutral);
+	border-left: 2px solid var(--color-frame-border);
+	color: var(--color-frame-text);
 	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
 	font-size: var(--wpds-typography-font-size-xs);
 	line-height: 1.5;
@@ -117,8 +118,8 @@
 }
 
 .toolOutputError {
-	border-left-color: var(--wpds-color-fg-content-error, #dc2626);
-	color: var(--wpds-color-fg-content-error, #dc2626);
+	border-left-color: var(--color-frame-error);
+	color: var(--color-frame-error);
 }
 
 .toolOutputToggle {
@@ -126,7 +127,7 @@
 	background: none;
 	border: none;
 	padding: 0;
-	color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	color: var(--color-frame-theme);
 	font: inherit;
 	font-size: var(--wpds-typography-font-size-xs);
 	cursor: pointer;
@@ -138,13 +139,13 @@
 }
 
 .toolLabel {
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 	font-weight: 600;
 	flex-shrink: 0;
 }
 
 .toolDetail {
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -160,7 +161,7 @@
 
 .questionText {
 	margin: 0;
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 }
 
 .questionOptions {
@@ -176,7 +177,7 @@
 	background: none;
 	border: none;
 	padding: 0;
-	color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	color: var(--color-frame-theme);
 	font: inherit;
 	cursor: pointer;
 }
@@ -187,7 +188,7 @@
 }
 
 .questionOption:disabled {
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 	opacity: 0.6;
 	cursor: default;
 }
@@ -197,7 +198,7 @@
 .questionOptionPicked,
 .questionOptionPicked:disabled {
 	font-weight: 600;
-	color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	color: var(--color-frame-theme);
 	opacity: 1;
 }
 
@@ -206,8 +207,8 @@
 	margin: var(--wpds-dimension-padding-sm) 0;
 	padding: 2px 10px;
 	border-radius: 9999px;
-	background-color: var(--wpds-color-bg-surface-neutral-weak);
-	color: var(--wpds-color-fg-content-neutral-weak);
+	background-color: var(--color-frame-surface);
+	color: var(--color-frame-text-secondary);
 	font-size: var(--wpds-typography-font-size-xs);
 	text-align: center;
 }

--- a/apps/studio/src/components/studio-code-session/markdown/style.module.css
+++ b/apps/studio/src/components/studio-code-session/markdown/style.module.css
@@ -1,5 +1,5 @@
 .root {
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 	font-size: var(--wpds-typography-font-size-md);
 	line-height: 1.65;
 	/* Subtle opentype improvements — lining numerals in tables, contextual
@@ -31,7 +31,7 @@
 	font-weight: 500;
 	line-height: 1.25;
 	letter-spacing: -0.01em;
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 }
 
 .h1 {
@@ -51,7 +51,7 @@
 	font-weight: 500;
 	letter-spacing: 0.06em;
 	text-transform: uppercase;
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 /* Tighten coupling when a heading immediately follows another heading. */
@@ -80,7 +80,7 @@
 }
 
 .li::marker {
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 .li > .p {
@@ -97,7 +97,7 @@
 }
 
 .a {
-	color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	color: var(--color-frame-theme);
 	font-weight: 500;
 	text-decoration: underline;
 	text-decoration-thickness: 1px;
@@ -120,8 +120,8 @@
 .blockquote {
 	margin: 0 0 1em;
 	padding: 0.25em 0 0.25em 1em;
-	border-left: 2px solid var(--wpds-color-stroke-surface-neutral);
-	color: var(--wpds-color-fg-content-neutral-weak);
+	border-left: 2px solid var(--color-frame-border);
+	color: var(--color-frame-text-secondary);
 }
 
 .blockquote > *:last-child {
@@ -131,16 +131,16 @@
 .hr {
 	margin: 2em 0;
 	border: 0;
-	border-top: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-top: 1px solid var(--color-frame-border);
 }
 
 .codeInline {
 	padding: 0.1em 0.35em;
 	border-radius: 4px;
-	background-color: var(--wpds-color-bg-surface-neutral-weak);
+	background-color: var(--color-frame-surface);
 	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
 	font-size: 0.875em;
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 	/* Discourage code from breaking awkwardly across lines. */
 	white-space: nowrap;
 }
@@ -149,7 +149,7 @@
 	margin: 0.75em 0 1.25em;
 	padding: 0.875em 1em;
 	border-radius: var(--wpds-border-radius-md, 8px);
-	background-color: var(--wpds-color-bg-surface-neutral-weak);
+	background-color: var(--color-frame-surface);
 	font-family: var(--wpds-typography-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
 	font-size: 0.85em;
 	line-height: 1.55;
@@ -168,7 +168,7 @@
 .tableWrap {
 	margin: 0 0 1em;
 	overflow-x: auto;
-	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border: 1px solid var(--color-frame-border);
 	border-radius: var(--wpds-border-radius-md, 8px);
 }
 
@@ -181,7 +181,7 @@
 .th,
 .td {
 	padding: 0.5em 0.75em;
-	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-bottom: 1px solid var(--color-frame-border);
 	text-align: left;
 	vertical-align: top;
 }
@@ -193,6 +193,6 @@
 
 .th {
 	font-weight: 500;
-	color: var(--wpds-color-fg-content-neutral);
-	background-color: var(--wpds-color-bg-surface-neutral-weak);
+	color: var(--color-frame-text);
+	background-color: var(--color-frame-surface);
 }

--- a/apps/studio/src/components/studio-code-session/menu/style.module.css
+++ b/apps/studio/src/components/studio-code-session/menu/style.module.css
@@ -13,11 +13,11 @@
 .popup {
 	min-width: 160px;
 	padding: var(--wpds-dimension-padding-xs);
-	background: var(--wpds-color-bg-surface-neutral-strong);
-	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+	background: var(--color-frame-bg);
+	border: var(--wpds-border-width-xs) solid var(--color-frame-border);
 	border-radius: var(--wpds-border-radius-lg);
 	box-shadow: var(--wpds-elevation-md);
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 	display: flex;
 	flex-direction: column;
 	gap: var(--wpds-dimension-padding-xs);
@@ -29,7 +29,7 @@
 	gap: var(--wpds-dimension-gap-sm);
 	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
 	border-radius: var(--wpds-border-radius-sm);
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 	font-size: var(--wpds-typography-font-size-sm);
 	line-height: var(--wpds-typography-line-height-sm);
 	cursor: var(--wpds-cursor-control);
@@ -39,11 +39,11 @@
 
 .item[data-highlighted],
 .item:hover {
-	background: var(--wpds-color-bg-surface-neutral);
+	background: var(--color-frame-surface);
 }
 
 .item[data-disabled] {
-	color: var(--wpds-color-fg-interactive-neutral-disabled);
+	color: var(--color-frame-text-secondary);
 	cursor: not-allowed;
 }
 
@@ -58,7 +58,7 @@
 	width: 18px;
 	height: 18px;
 	flex-shrink: 0;
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 }
 
 .indicatorMark {
@@ -81,6 +81,6 @@
 .separator {
 	height: 1px;
 	margin: var(--wpds-dimension-padding-xs) 0;
-	background: var(--wpds-color-stroke-surface-neutral);
+	background: var(--color-frame-border);
 	border: 0;
 }

--- a/apps/studio/src/components/studio-code-session/queued-prompts/style.module.css
+++ b/apps/studio/src/components/studio-code-session/queued-prompts/style.module.css
@@ -15,13 +15,13 @@
 	/* Match the user bubble shape but lighter so staged follow-ups read as
 	   "drafted, not sent". Mirrors `.userText` (right-aligned, bottom-right
 	   tight corner). */
-	background-color: color-mix(in srgb, var(--wpds-color-fg-interactive-brand, #2563eb) 4%, transparent);
-	border: 1px dashed color-mix(in srgb, var(--wpds-color-fg-interactive-brand, #2563eb) 30%, transparent);
+	background-color: color-mix(in srgb, var(--color-frame-theme) 8%, transparent);
+	border: 1px dashed color-mix(in srgb, var(--color-frame-theme) 35%, transparent);
 	border-radius: 18px 18px var(--wpds-border-radius-md, 8px) 18px;
 	max-width: 80%;
 	font-size: var(--wpds-typography-font-size-md);
 	line-height: 1.55;
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 .text {
@@ -41,7 +41,7 @@
 	border-radius: 50%;
 	padding: 0;
 	background: transparent;
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 	font: inherit;
 	font-size: 16px;
 	line-height: 1;
@@ -56,6 +56,6 @@
 
 .remove:hover,
 .remove:focus-visible {
-	background-color: color-mix(in srgb, var(--wpds-color-fg-interactive-brand, #2563eb) 12%, transparent);
-	color: var(--wpds-color-fg-content-neutral);
+	background-color: color-mix(in srgb, var(--color-frame-theme) 14%, transparent);
+	color: var(--color-frame-text);
 }

--- a/apps/studio/src/components/studio-code-session/style.module.css
+++ b/apps/studio/src/components/studio-code-session/style.module.css
@@ -3,6 +3,7 @@
 	flex-direction: row;
 	height: 100%;
 	min-height: 0;
+	color: var(--color-frame-text);
 }
 
 .chatColumn {
@@ -15,7 +16,7 @@
 
 .state {
 	padding: var(--wpds-dimension-padding-xl);
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 }
 
 .loading {
@@ -38,7 +39,7 @@
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-2xl);
 	min-height: 46px;
 	font-size: var(--wpds-typography-font-size-sm);
-	color: var(--wpds-color-fg-content-neutral);
+	color: var(--color-frame-text);
 	-webkit-app-region: drag;
 }
 
@@ -51,6 +52,15 @@
 	align-items: center;
 	gap: var(--wpds-dimension-padding-xs);
 	-webkit-app-region: no-drag;
+}
+
+.headerActions :global(button) {
+	color: var(--color-frame-text-secondary) !important;
+}
+
+.headerActions :global(button:hover),
+.headerActions :global(button:focus-visible) {
+	color: var(--color-frame-text) !important;
 }
 
 .scroll {
@@ -129,7 +139,7 @@
 }
 
 .emptyConversationPrompt {
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 	font-size: var(--wpds-typography-font-size-sm);
 	text-align: center;
 }
@@ -146,9 +156,9 @@
    unlayered `[type='button'] { background-color: transparent }` reset — see
    wp-ui-button-defense.module.css for the full rationale. */
 .emptyConversationExample.emptyConversationExample {
-	border: 1px solid var(--wpds-color-stroke-surface-neutral);
-	background: var(--wpds-color-bg-surface-neutral-weak);
-	color: var(--wpds-color-fg-content-neutral);
+	border: 1px solid var(--color-frame-border);
+	background: var(--color-frame-surface);
+	color: var(--color-frame-text);
 	font: inherit;
 	font-size: var(--wpds-typography-font-size-md);
 	line-height: 20px;
@@ -160,6 +170,6 @@
 
 .emptyConversationExample:hover,
 .emptyConversationExample:focus-visible {
-	background: var(--wpds-color-bg-surface-brand);
-	border-color: var(--wpds-color-fg-interactive-brand);
+	background: color-mix(in srgb, var(--color-frame-theme) 12%, transparent);
+	border-color: var(--color-frame-theme);
 }

--- a/apps/studio/src/components/studio-code-session/thinking-indicator/style.module.css
+++ b/apps/studio/src/components/studio-code-session/thinking-indicator/style.module.css
@@ -2,7 +2,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 2px;
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 	font-size: var(--wpds-typography-font-size-sm);
 	/* Reserves space so mounting / unmounting the inner content doesn't
 	   shift the surrounding layout. Holds ~one head line + one progress line. */
@@ -19,7 +19,7 @@
 	width: 8px;
 	height: 8px;
 	border-radius: 50%;
-	background-color: var(--wpds-color-fg-interactive-brand, #2563eb);
+	background-color: var(--color-frame-theme);
 	animation: pulse 1.2s ease-in-out infinite;
 	flex-shrink: 0;
 }
@@ -29,14 +29,14 @@
 }
 
 .elapsed {
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 	opacity: 0.7;
 	font-variant-numeric: tabular-nums;
 }
 
 .progress {
 	padding-left: calc(8px + var(--wpds-dimension-padding-md));
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--color-frame-text-secondary);
 	opacity: 0.8;
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
## Related issues

- Fixes STU-1809

## How AI was used in this PR
AI adjusted `color` and `background` properties. I tested by applying changes file by file, everything looks good.

## Proposed Changes
Dark theme for Studio Code is broken. With this PR we are fixing it to align with Studio styles.
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="1378" height="913" alt="Screenshot 2026-06-09 at 16 30 08" src="https://github.com/user-attachments/assets/5d396679-4de5-4ce1-9ddd-b1e1429fd220" />
<td><img width="1381" height="915" alt="Screenshot 2026-06-09 at 16 30 49" src="https://github.com/user-attachments/assets/dd60377e-e84e-4b14-b851-c47619c949a0" />
</tr>
</table>

## Testing Instructions
1. npm start
2. Open Studio Code tab
3. Assert that for Light theme no regressions
4. Set Dark theme
5. Assert that everything looks good