### PR TITLE
Fix About dialog showing empty in build artifact

### DIFF
--- a/apps/studio/electron.vite.config.ts
+++ b/apps/studio/electron.vite.config.ts
@@ -93,10 +93,12 @@ export default defineConfig( {
 					{
 						src: normalizePath( resolve( __dirname, 'src/about-menu/about-menu.html' ) ),
 						dest: '.',
+						rename: { stripBase: true },
 					},
 					{
 						src: normalizePath( resolve( __dirname, 'src/about-menu/studio-app-icon.png' ) ),
 						dest: '.',
+						rename: { stripBase: true },
 					},
 				],
 			} ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4595,7 +4595,7 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "dist/cli.js"
+				"pi-ai": "./dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"
@@ -9394,185 +9394,6 @@
 				"node": ">= 12.13.0"
 			}
 		},
-		"node_modules/@mariozechner/clipboard": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.3.tgz",
-			"integrity": "sha512-e7jASirzfm+ROiOGFh843+cFZTy3DfzP+jldCvh8RnEk0C3QihDTn7dd7Yh7KAJydwIJ18FJSZ2swHvCJhk18g==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">= 10"
-			},
-			"optionalDependencies": {
-				"@mariozechner/clipboard-darwin-arm64": "0.3.3",
-				"@mariozechner/clipboard-darwin-universal": "0.3.3",
-				"@mariozechner/clipboard-darwin-x64": "0.3.3",
-				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.3",
-				"@mariozechner/clipboard-linux-arm64-musl": "0.3.3",
-				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.3",
-				"@mariozechner/clipboard-linux-x64-gnu": "0.3.3",
-				"@mariozechner/clipboard-linux-x64-musl": "0.3.3",
-				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.3",
-				"@mariozechner/clipboard-win32-x64-msvc": "0.3.3"
-			}
-		},
-		"node_modules/@mariozechner/clipboard-darwin-arm64": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.3.tgz",
-			"integrity": "sha512-+zhuZGXqVrdkbIRdnwiZNbTJ7V3elq/A+C5d5laJoyhJgWs41eO5NUMkBkj6f23F2L4PRXEhdn5/ktlPx+bG3Q==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/clipboard-darwin-universal": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.3.tgz",
-			"integrity": "sha512-x9aRfTyndVqpEQ44LNNCK/EXZd9y8rWkLQgNhmWpby9PXrjPhNxfjUc2Db4mt4nJjU/4zzO8F5v/XyzlUGSdhQ==",
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/clipboard-darwin-x64": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.3.tgz",
-			"integrity": "sha512-6ut/NawB0KiYPCwrirgNp6Br62LntL978q7G6d/Rs2pmPvQb53bP96eUMYl+Y3a7Qk13bGZ4w9rVPFxRE9m9ag==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.3.tgz",
-			"integrity": "sha512-gf3dH4kBddU1AOyHVB53mjLUFfJAKlTmxTMw51jdeg7eE7IjfEBXVvM4bifMtBxbWkT0eA0FUZ1C0KQ6Z5l6pw==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.3.tgz",
-			"integrity": "sha512-o1paj2+zmAQ/LaPS85XJCxhNowNQpxYM2cGY6pWvB5Kqmz6hZjl6CzDg5tbf1hZkn/Em6jpOaE2UtMxKdELBDA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.3.tgz",
-			"integrity": "sha512-dkEhE4ekePJwMbBq9HP1//CFMNmDzA/iV9AXqBfvL5CWmmDIRXqh4A3YZt3tWO/HdMerX+xNCEiR7WiOsIG+UA==",
-			"cpu": [
-				"riscv64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.3.tgz",
-			"integrity": "sha512-lT2yANtTLlEtFBIH3uGoRa/CQas/eBoLNi3qr9axQFoRgF4RGPSJ66yHOSnMECBneTIb1Iqv3UxokTfX27CdoQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.3.tgz",
-			"integrity": "sha512-saq/MCB0QHK/7ZZLjAZ0QkbY944dyjOsur8gneGCfMitt+GOiE1CU4OUipHC4b6x8UDY9bRLsR4aBaxu22OFPA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.3.tgz",
-			"integrity": "sha512-cGuvSj0/2X2w983yEcKw+i+r1EBej6ZZIN+fXG3eY2G/HaIQpbXpLvMxKyZ9LKtbZx+Z6q/gELEoSBMLML6BaQ==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.3.tgz",
-			"integrity": "sha512-5hvaEq/bgYovTIGx43O/S7loIHYV3ue90WcV1dz0wdMXroVKZKeU/yfwM0PALQA1OcrEHiGXGySFReXr72lGtA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
 		"node_modules/@mistralai/mistralai": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
@@ -14362,12 +14183,6 @@
 			"engines": {
 				"node": ">= 18"
 			}
-		},
-		"node_modules/@silvia-odwyer/photon-node": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
-			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-			"license": "Apache-2.0"
 		},
 		"node_modules/@simple-git/args-pathspec": {
 			"version": "1.0.3",
@@ -24027,6 +23842,7 @@
 			"version": "13.0.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
 			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"minimatch": "^10.2.2",
@@ -24078,6 +23894,7 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
 			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -24087,6 +23904,7 @@
 			"version": "5.0.6",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
 			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -24099,6 +23917,7 @@
 			"version": "11.5.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
 			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -24108,6 +23927,7 @@
 			"version": "10.2.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
 			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"brace-expansion": "^5.0.5"
@@ -24123,6 +23943,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
 			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -24132,6 +23953,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
 			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"lru-cache": "^11.0.0",
@@ -24550,15 +24372,6 @@
 			"version": "1.2.2",
 			"license": "MIT"
 		},
-		"node_modules/highlight.js": {
-			"version": "10.7.3",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/hoist-non-react-statics": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -24579,6 +24392,7 @@
 		},
 		"node_modules/hosted-git-info": {
 			"version": "2.8.9",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/hotkeys-js": {
@@ -25879,6 +25693,7 @@
 			"version": "1.21.7",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
 			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+			"devOptional": true,
 			"license": "MIT",
 			"bin": {
 				"jiti": "bin/jiti.js"
@@ -34448,6 +34263,7 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
 			"integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=22.19.0"


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Diagnosed and fixed with Claude Code.

## Proposed Changes

The About Studio dialog was loading empty when running the packaged build artifact, while working fine in `npm start` (dev mode). Vite 8 (rolldown) changed how `viteStaticCopy` resolves absolute `src` paths — they're now matched relative to the project root, so the directory structure (`src/about-menu/`) was being preserved in the output. This placed `about-menu.html` at `out/renderer/src/about-menu/about-menu.html` instead of `out/renderer/about-menu.html` where the main process expects it.

Adding `rename: { stripBase: true }` to both `viteStaticCopy` targets strips the subdirectory prefix so files land at the renderer root as before.

Also includes the `package-lock.json` update from the `@mariozechner` → `@earendil-works` package rename (#3707) that was merged to trunk but the lock file wasn't pushed.

## Testing Instructions

- Build a production artifact: `npm run make`
- Launch the app, open **Studio > About WordPress Studio**
- Dialog should show version, platform info, and all labels correctly (not blank)

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?