### PR TITLE
Fix ineffective dynamic imports in scratchpad widget

### DIFF
--- a/apps/ui/src/ui-desks/widgets/scratchpad/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/definition.ts
@@ -1,16 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
 import {
-	buildWidgetContextDisplayMessage,
-	buildWidgetContextPrompt,
-} from '@/ui-desks/chats/widget-context';
-import {
-	completeConnectorPreview,
-	createConnectorPreview,
-	toPlainPoint,
-	updateConnectorEnd,
-} from '@/ui-desks/connectors/editor-commands';
-import {
 	RECTANGLE_WIDGET_SHAPE_TYPE,
 	type RectangleWidgetShape,
 } from '@/ui-desks/shapes/rectangle-widget/types';
@@ -110,6 +100,9 @@ function getScratchpadMediaDropActions(
 			label: BUILD_SOMETHING_LIKE_THIS_PROMPT,
 			onClick: () =>
 				context.runAction( async () => {
+					const { buildWidgetContextDisplayMessage, buildWidgetContextPrompt } = await import(
+						'@/ui-desks/chats/widget-context'
+					);
 					updateScratchpadReference( context.editor, intent, { agentStatus: 'pending' } );
 					try {
 						const sessionId = await context.startChatWithPrompt( {
@@ -134,7 +127,7 @@ function getScratchpadMediaDropActions(
 		{
 			label: __( 'Use this image' ),
 			onClick: () =>
-				context.runAction( () => createConnectorBetweenWidgets( context.editor, intent ) ),
+				context.runAction( async () => createConnectorBetweenWidgets( context.editor, intent ) ),
 		},
 	];
 }
@@ -176,7 +169,12 @@ function updateScratchpadReference(
 	} );
 }
 
-function createConnectorBetweenWidgets( editor: Editor, intent: WidgetCustomDropActionIntent ) {
+async function createConnectorBetweenWidgets(
+	editor: Editor,
+	intent: WidgetCustomDropActionIntent
+) {
+	const { completeConnectorPreview, createConnectorPreview, toPlainPoint, updateConnectorEnd } =
+		await import( '@/ui-desks/connectors/editor-commands' );
 	const sourceBounds = editor.getShapePageBounds( intent.sourceShapeId );
 	const targetBounds = editor.getShapePageBounds( intent.targetShapeId );
 	if ( ! sourceBounds || ! targetBounds ) {

--- a/apps/ui/src/ui-desks/widgets/scratchpad/definition.ts
+++ b/apps/ui/src/ui-desks/widgets/scratchpad/definition.ts
@@ -1,6 +1,16 @@
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
 import {
+	buildWidgetContextDisplayMessage,
+	buildWidgetContextPrompt,
+} from '@/ui-desks/chats/widget-context';
+import {
+	completeConnectorPreview,
+	createConnectorPreview,
+	toPlainPoint,
+	updateConnectorEnd,
+} from '@/ui-desks/connectors/editor-commands';
+import {
 	RECTANGLE_WIDGET_SHAPE_TYPE,
 	type RectangleWidgetShape,
 } from '@/ui-desks/shapes/rectangle-widget/types';
@@ -100,9 +110,6 @@ function getScratchpadMediaDropActions(
 			label: BUILD_SOMETHING_LIKE_THIS_PROMPT,
 			onClick: () =>
 				context.runAction( async () => {
-					const { buildWidgetContextDisplayMessage, buildWidgetContextPrompt } = await import(
-						'@/ui-desks/chats/widget-context'
-					);
 					updateScratchpadReference( context.editor, intent, { agentStatus: 'pending' } );
 					try {
 						const sessionId = await context.startChatWithPrompt( {
@@ -127,7 +134,7 @@ function getScratchpadMediaDropActions(
 		{
 			label: __( 'Use this image' ),
 			onClick: () =>
-				context.runAction( async () => createConnectorBetweenWidgets( context.editor, intent ) ),
+				context.runAction( () => createConnectorBetweenWidgets( context.editor, intent ) ),
 		},
 	];
 }
@@ -169,12 +176,7 @@ function updateScratchpadReference(
 	} );
 }
 
-async function createConnectorBetweenWidgets(
-	editor: Editor,
-	intent: WidgetCustomDropActionIntent
-) {
-	const { completeConnectorPreview, createConnectorPreview, toPlainPoint, updateConnectorEnd } =
-		await import( '@/ui-desks/connectors/editor-commands' );
+function createConnectorBetweenWidgets( editor: Editor, intent: WidgetCustomDropActionIntent ) {
 	const sourceBounds = editor.getShapePageBounds( intent.sourceShapeId );
 	const targetBounds = editor.getShapePageBounds( intent.targetShapeId );
 	if ( ! sourceBounds || ! targetBounds ) {

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -51,7 +51,7 @@ export default defineConfig( {
 		rollupOptions: {
 			input: resolve( __dirname, 'index.html' ),
 			onwarn( warning, defaultHandler ) {
-				// These dynamic imports break a circular dependency
+				// These dynamic imports break a circular dependency in ui-desks
 				// (definition.ts → widget-context/editor-commands → registry → definition.ts)
 				// and cannot be used for code-splitting because the modules are also
 				// statically imported elsewhere. Suppress the noise.

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -50,6 +50,16 @@ export default defineConfig( {
 		outDir: 'dist',
 		rollupOptions: {
 			input: resolve( __dirname, 'index.html' ),
+			onwarn( warning, defaultHandler ) {
+				// These dynamic imports break a circular dependency
+				// (definition.ts → widget-context/editor-commands → registry → definition.ts)
+				// and cannot be used for code-splitting because the modules are also
+				// statically imported elsewhere. Suppress the noise.
+				if ( warning.code === 'INEFFECTIVE_DYNAMIC_IMPORT' ) {
+					return;
+				}
+				defaultHandler( warning );
+			},
 		},
 	},
 } );


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code identified the issue and made the fix.

## Proposed Changes

During `npm run make`, the build emitted two `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings for `@/ui-desks/chats/widget-context` and `@/ui-desks/connectors/editor-commands` in the scratchpad widget definition. These modules are dynamically imported to break a circular dependency (`definition.ts` → `widget-context`/`editor-commands` → `registry` → `definition.ts`), but because they are also statically imported by other modules in the same chunk, the bundler cannot move them into a separate chunk and emits the warning.

The dynamic imports are load-bearing (removing them causes a runtime crash), so the fix is to suppress the warning via an `onwarn` handler in `apps/ui/vite.config.ts` rather than converting them to static imports.

## Testing Instructions

- Run `npm run make` and confirm the two `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings are gone from the build output.
- Verify the scratchpad drag-to-chat and drag-to-connect interactions still work.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?