### PR TITLE
Rename deprecated build.rollupOptions to build.rolldownOptions in Vite configs

### DIFF
--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -76,7 +76,7 @@ export const baseConfig = defineConfig( {
 		},
 		outDir: 'dist/cli',
 		target: 'node22',
-		rollupOptions: {
+		rolldownOptions: {
 			output: {
 				format: 'es',
 				entryFileNames: '[name].mjs',

--- a/apps/studio/electron.vite.config.ts
+++ b/apps/studio/electron.vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig( {
 			externalizeDeps: {
 				exclude: [ '@studio/common' ],
 			},
-			rollupOptions: {
+			rolldownOptions: {
 				input: {
 					index: resolve( __dirname, 'src/index.ts' ),
 				},
@@ -52,7 +52,7 @@ export default defineConfig( {
 	preload: {
 		build: {
 			externalizeDeps: { exclude: [ '@sentry/electron' ] },
-			rollupOptions: {
+			rolldownOptions: {
 				input: {
 					preload: resolve( __dirname, 'src/preload.ts' ),
 				},
@@ -135,7 +135,7 @@ export default defineConfig( {
 		},
 		build: {
 			sourcemap: true,
-			rollupOptions: {
+			rolldownOptions: {
 				input: resolve( __dirname, 'index.html' ),
 				output: {
 					// Extract CSS into separate files (like Webpack's MiniCssExtractPlugin)

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -48,7 +48,7 @@ export default defineConfig( {
 	},
 	build: {
 		outDir: 'dist',
-		rollupOptions: {
+		rolldownOptions: {
 			input: resolve( __dirname, 'index.html' ),
 		},
 	},


### PR DESCRIPTION
## Related issues

- None — small maintenance change noticed while reading the configs.

## How AI was used in this PR

Claude Code identified why editors flag `rollupOptions` as deprecated (Vite 8 is Rolldown-based and keeps `rollupOptions` only as a deprecated alias of `rolldownOptions`), applied the rename, and verified the builds. Changes were reviewed by the author.

## Proposed Changes

- Since the Vite 8 upgrade, `build.rollupOptions` is a deprecated alias of `build.rolldownOptions`, so editors render it struck-through in our configs. This renames the option to the canonical name in the three configs that still used it (`apps/ui`, `apps/studio` electron-vite config, `apps/cli`).
- No behavior change — the alias is functionally identical and electron-vite normalizes it to `rolldownOptions` internally anyway. This just removes the deprecation noise and keeps us off an alias that will eventually be dropped.

## Testing Instructions

- `npm run typecheck` passes.
- `npm run cli:build` succeeds and the output keeps the `.mjs` entry names and `createRequire` banner from the renamed options.
- `npx electron-vite build --config ./electron.vite.config.ts --outDir=dist` (from `apps/studio`) succeeds for main/preload/renderer, with the `vendor` and `sentry` manual chunks still produced.
- `npx vite build` (from `apps/ui`) succeeds.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)