### PR TITLE
Rename Copy site to Duplicate site

### DIFF
--- a/apps/studio/src/components/content-tab-settings.tsx
+++ b/apps/studio/src/components/content-tab-settings.tsx
@@ -122,7 +122,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 						{ ( { onClose }: { onClose: () => void } ) => (
 							<MenuGroup>
 								<SettingsMenuItem onClick={ () => void copySite( selectedSite.id ) }>
-									{ __( 'Copy site' ) }
+									{ __( 'Duplicate site' ) }
 								</SettingsMenuItem>
 								<SettingsMenuItem
 									onClick={ () => {

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -2124,7 +2124,7 @@ export function showSiteContextMenu(
 
 	menu.append(
 		new MenuItem( {
-			label: __( 'Copy site…' ),
+			label: __( 'Duplicate site…' ),
 			enabled: ! isLoading && ! isAnySiteAdding,
 			click: () => {
 				sendIpcEventToRendererWithWindow(

--- a/apps/studio/src/tests/show-site-context-menu.test.ts
+++ b/apps/studio/src/tests/show-site-context-menu.test.ts
@@ -176,7 +176,7 @@ describe( 'showSiteContextMenu', () => {
 			const editorItem = menuItems.find( ( item ) => item.label === 'Open in Visual Studio Code' );
 			const terminalItem = menuItems.find( ( item ) => item.label === 'Open in Terminal' );
 			const editItem = menuItems.find( ( item ) => item.label === 'Edit site…' );
-			const copyItem = menuItems.find( ( item ) => item.label === 'Copy site…' );
+			const copyItem = menuItems.find( ( item ) => item.label === 'Duplicate site…' );
 			const deleteItem = menuItems.find( ( item ) => item.label === 'Delete site…' );
 
 			expect( stopItem?.enabled ).toBe( true );

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -275,7 +275,7 @@ function SiteActionsMenu( { site }: { site: SiteDetails } ) {
 						{ __( 'Site settings' ) }
 					</Menu.Item>
 					<Menu.Item disabled={ copySite.isPending } onClick={ () => copySite.mutate( site.id ) }>
-						{ copySite.isPending ? __( 'Copying…' ) : __( 'Copy site' ) }
+						{ copySite.isPending ? __( 'Duplicating…' ) : __( 'Duplicate site' ) }
 					</Menu.Item>
 					<Menu.Separator />
 					<Menu.Item disabled={ isExporting } onClick={ () => exportFullSite.mutate( site.id ) }>


### PR DESCRIPTION
## How AI was used in this PR
Didn't use

## Proposed Changes
NIT Every time I see "Copy site" - I feel confused. Maybe it's personal, but I used to see word "Duplicate" in such cases. And when I see "Copy", I expect to paste it somewhere.
I propose to rename to "Duplicate site".
macOS example:<br/>
<img width="1005" height="446" alt="Screenshot 2026-06-10 at 14 19 08" src="https://github.com/user-attachments/assets/cf3411a3-d748-4201-9ae7-f885b4f23cab" />


## Testing Instructions
Visual review should suffice