### PR TITLE
Align chat titles to teh left in agentic mode

### DIFF
--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -192,6 +192,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	text-align: start;
 }
 
 .sessionTime {


### PR DESCRIPTION
## How AI was used in this PR

AI implemented. I tested.



## Proposed Changes
Align chat titles to the left.
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="305" height="224" alt="Screenshot 2026-06-10 at 14 44 56" src="https://github.com/user-attachments/assets/2f0b0f16-880f-412b-9c81-760583b052f5" />
<td><img width="307" height="214" alt="Screenshot 2026-06-10 at 14 46 39" src="https://github.com/user-attachments/assets/d2847b8e-286e-4e4d-b4dd-96f3f0a02606" />
</tr>
</table>

## Testing Instructions
Visual review