### PR TITLE
Move annotation controls from the previewed page into the preview toolbar

### DIFF
--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -65,27 +65,6 @@ describe( 'SitePreview', () => {
 		expect( screen.getByRole( 'button', { name: 'Start site' } ) ).toBeVisible();
 	} );
 
-	it( 'keeps annotation controls disabled until the inspector reports ready', () => {
-		useConnectorMock.mockReturnValue( {
-			startSite: vi.fn().mockResolvedValue( undefined ),
-		} as never );
-
-		renderPreview(
-			<SitePreview site={ createSite( { running: true } ) } path="/" reloadNonce={ 0 } />
-		);
-
-		// The iframe fallback has no inspector, so the annotate toggle renders
-		// but never becomes interactive, and Submit (which needs a pending
-		// annotation count) is not shown at all.
-		expect( screen.getByRole( 'button', { name: 'Annotate' } ) ).toHaveAttribute(
-			'aria-disabled',
-			'true'
-		);
-		expect(
-			screen.queryByRole( 'button', { name: 'Submit annotations' } )
-		).not.toBeInTheDocument();
-	} );
-
 	it( 'shows a refresh button that reloads the active preview surface', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),

--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -60,8 +60,30 @@ describe( 'SitePreview', () => {
 		renderPreview( <SitePreview site={ createSite() } path="/wp-admin/" reloadNonce={ 0 } /> );
 
 		expect( screen.queryByRole( 'button', { name: 'Refresh' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Annotate' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'http://localhost:8881/wp-admin/' ) ).not.toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Start site' } ) ).toBeVisible();
+	} );
+
+	it( 'keeps annotation controls disabled until the inspector reports ready', () => {
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+		} as never );
+
+		renderPreview(
+			<SitePreview site={ createSite( { running: true } ) } path="/" reloadNonce={ 0 } />
+		);
+
+		// The iframe fallback has no inspector, so the annotate toggle renders
+		// but never becomes interactive, and Submit (which needs a pending
+		// annotation count) is not shown at all.
+		expect( screen.getByRole( 'button', { name: 'Annotate' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+		expect(
+			screen.queryByRole( 'button', { name: 'Submit annotations' } )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'shows a refresh button that reloads the active preview surface', () => {

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -370,7 +370,7 @@ export function SitePreview( {
 							<Button
 								variant="minimal"
 								tone="neutral"
-								size="compact"
+								size="small"
 								disabled={ ! canAnnotate }
 								aria-pressed={ inspectorState.isPicking }
 								aria-label={ inspectorState.isPicking ? __( 'Stop annotating' ) : __( 'Annotate' ) }
@@ -382,7 +382,7 @@ export function SitePreview( {
 								<Button
 									variant="solid"
 									tone="brand"
-									size="compact"
+									size="small"
 									disabled={ ! canAnnotate }
 									aria-label={ __( 'Submit annotations' ) }
 									onClick={ () => sendInspectorCommand( 'submit' ) }

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { chevronLeft, chevronRight, external } from '@wordpress/icons';
 import { ariaKeyShortcut, displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { Button, IconButton, Tooltip } from '@wordpress/ui';
@@ -383,12 +383,21 @@ export function SitePreview( {
 									variant="solid"
 									tone="brand"
 									size="small"
+									className={ styles.annotationSubmit }
 									disabled={ ! canAnnotate }
-									aria-label={ __( 'Submit annotations' ) }
+									aria-label={ sprintf(
+										/* translators: %d: number of pending annotations. */
+										_n(
+											'Submit %d annotation',
+											'Submit %d annotations',
+											inspectorState.annotationCount
+										),
+										inspectorState.annotationCount
+									) }
 									onClick={ () => sendInspectorCommand( 'submit' ) }
 								>
 									{ __( 'Submit' ) }
-									<span className={ styles.annotationCount }>
+									<span className={ styles.annotationCount } aria-hidden="true">
 										{ inspectorState.annotationCount }
 									</span>
 								</Button>

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { chevronLeft, chevronRight, external } from '@wordpress/icons';
+import { chevronLeft, chevronRight, external, pencil } from '@wordpress/icons';
 import { ariaKeyShortcut, displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { Button, IconButton, Tooltip } from '@wordpress/ui';
 import { clsx } from 'clsx';
@@ -367,17 +367,16 @@ export function SitePreview( {
 							</ToolbarTooltip>
 						</div>
 						<div className={ styles.annotationControls }>
-							<Button
+							<IconButton
 								variant="minimal"
 								tone="neutral"
 								size="small"
+								icon={ pencil }
+								label={ inspectorState.isPicking ? __( 'Stop annotating' ) : __( 'Annotate' ) }
 								disabled={ ! canAnnotate }
 								aria-pressed={ inspectorState.isPicking }
-								aria-label={ inspectorState.isPicking ? __( 'Stop annotating' ) : __( 'Annotate' ) }
 								onClick={ () => sendInspectorCommand( 'toggle-picking' ) }
-							>
-								{ inspectorState.isPicking ? __( 'Picking...' ) : __( 'Annotate' ) }
-							</Button>
+							/>
 							{ inspectorState.annotationCount > 0 ? (
 								<Button
 									variant="solid"

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -11,7 +11,11 @@ import { useResizablePanel } from '@/hooks/use-resizable-panel';
 import { getSiteUrl } from '@/lib/get-site-url';
 import { playIcon, refreshIcon } from '@/lib/icons';
 import { PREVIEW_PANEL_CONFIG, PREVIEW_PANEL_STORAGE_KEY } from '@/lib/resizable-panels';
-import { INSPECTOR_BRIDGE_PREFIX, INSPECTOR_PAGE_SCRIPT } from './inspector-script';
+import {
+	INSPECTOR_BRIDGE_PREFIX,
+	INSPECTOR_COMMAND_EVENT,
+	INSPECTOR_PAGE_SCRIPT,
+} from './inspector-script';
 import styles from './style.module.css';
 import type { Annotation } from './types';
 import type { SiteDetails } from '@/data/core';
@@ -27,7 +31,7 @@ interface SitePreviewProps {
 	path: string;
 	// Bumped by the parent to force a webview reload.
 	reloadNonce: number;
-	// Called when the user clicks "Submit" in the inspector toolbar. Receives
+	// Called when the user clicks "Submit" in the annotation controls. Receives
 	// the full annotation payload assembled inside the webview's guest page.
 	onAnnotationsDone?: ( annotations: Annotation[] ) => void;
 	// Called when the user navigates within the preview (link clicks,
@@ -37,9 +41,22 @@ interface SitePreviewProps {
 }
 
 interface InspectorEvent {
-	type: 'browser-command' | 'done';
+	type: 'browser-command' | 'done' | 'state';
 	annotations?: Annotation[];
+	isPicking?: boolean;
+	annotationCount?: number;
 	command?: BrowserShortcutCommandType;
+}
+
+interface InspectorState {
+	ready: boolean;
+	isPicking: boolean;
+	annotationCount: number;
+}
+
+interface InspectorCommand {
+	id: number;
+	type: 'toggle-picking' | 'submit';
 }
 
 interface BrowserNavigationState {
@@ -93,6 +110,12 @@ const EMPTY_BROWSER_STATE: BrowserNavigationState = {
 	loading: false,
 	progress: 0,
 	title: null,
+};
+
+const EMPTY_INSPECTOR_STATE: InspectorState = {
+	ready: false,
+	isPicking: false,
+	annotationCount: 0,
 };
 
 function safeWebviewBoolean( webview: WebviewTag | null, method: 'canGoBack' | 'canGoForward' ) {
@@ -195,8 +218,11 @@ export function SitePreview( {
 	const [ browserState, setBrowserState ] =
 		useState< BrowserNavigationState >( EMPTY_BROWSER_STATE );
 	const [ browserCommand, setBrowserCommand ] = useState< BrowserCommand | null >( null );
+	const [ inspectorState, setInspectorState ] = useState< InspectorState >( EMPTY_INSPECTOR_STATE );
+	const [ inspectorCommand, setInspectorCommand ] = useState< InspectorCommand | null >( null );
 	const rootRef = useRef< HTMLElement | null >( null );
 	const commandIdRef = useRef( 0 );
+	const canAnnotate = canPreview && inspectorState.ready;
 	const pageTitle = getToolbarPageTitle( browserState.title, site.name );
 	const progress = browserState.loading
 		? Math.max( browserState.progress, 0.12 )
@@ -224,9 +250,16 @@ export function SitePreview( {
 	const handleBrowserStateChange = useCallback( ( state: BrowserNavigationState ) => {
 		setBrowserState( ( current ) => ( areBrowserStatesEqual( current, state ) ? current : state ) );
 	}, [] );
+	const handleInspectorState = useCallback( ( state: InspectorState ) => {
+		setInspectorState( state );
+	}, [] );
 	const sendBrowserCommand = useCallback( ( type: BrowserCommand[ 'type' ] ) => {
 		commandIdRef.current += 1;
 		setBrowserCommand( { id: commandIdRef.current, type } );
+	}, [] );
+	const sendInspectorCommand = useCallback( ( type: InspectorCommand[ 'type' ] ) => {
+		commandIdRef.current += 1;
+		setInspectorCommand( { id: commandIdRef.current, type } );
 	}, [] );
 
 	const browserShortcuts = useMemo(
@@ -240,6 +273,7 @@ export function SitePreview( {
 
 	useEffect( () => {
 		setBrowserState( EMPTY_BROWSER_STATE );
+		setInspectorState( EMPTY_INSPECTOR_STATE );
 	}, [ site.id ] );
 
 	// Browser shortcuts (⌘R / ⌘[ / ⌘]) pressed while focus is in the host
@@ -332,6 +366,34 @@ export function SitePreview( {
 								<span className={ styles.browserTitle }>{ pageTitle }</span>
 							</ToolbarTooltip>
 						</div>
+						<div className={ styles.annotationControls }>
+							<Button
+								variant="minimal"
+								tone="neutral"
+								size="compact"
+								disabled={ ! canAnnotate }
+								aria-pressed={ inspectorState.isPicking }
+								aria-label={ inspectorState.isPicking ? __( 'Stop annotating' ) : __( 'Annotate' ) }
+								onClick={ () => sendInspectorCommand( 'toggle-picking' ) }
+							>
+								{ inspectorState.isPicking ? __( 'Picking...' ) : __( 'Annotate' ) }
+							</Button>
+							{ inspectorState.annotationCount > 0 ? (
+								<Button
+									variant="solid"
+									tone="brand"
+									size="compact"
+									disabled={ ! canAnnotate }
+									aria-label={ __( 'Submit annotations' ) }
+									onClick={ () => sendInspectorCommand( 'submit' ) }
+								>
+									{ __( 'Submit' ) }
+									<span className={ styles.annotationCount }>
+										{ inspectorState.annotationCount }
+									</span>
+								</Button>
+							) : null }
+						</div>
 					</>
 				) : (
 					<span className={ styles.headerSpacer } aria-hidden="true" />
@@ -360,6 +422,8 @@ export function SitePreview( {
 							url={ previewUrl }
 							reloadNonce={ reloadNonce }
 							onAnnotationsDone={ onAnnotationsDone }
+							onInspectorState={ handleInspectorState }
+							inspectorCommand={ inspectorCommand }
 							browserCommand={ browserCommand }
 							onBrowserStateChange={ handleBrowserStateChange }
 							onBrowserCommand={ sendBrowserCommand }
@@ -445,6 +509,8 @@ interface WebviewSurfaceProps {
 	url: string;
 	reloadNonce: number;
 	onAnnotationsDone?: ( annotations: Annotation[] ) => void;
+	onInspectorState?: ( state: InspectorState ) => void;
+	inspectorCommand?: InspectorCommand | null;
 	browserCommand?: BrowserCommand | null;
 	onBrowserStateChange?: ( state: BrowserNavigationState ) => void;
 	onBrowserCommand?: ( type: BrowserShortcutCommandType ) => void;
@@ -463,6 +529,8 @@ function WebviewSurface( {
 	url,
 	reloadNonce,
 	onAnnotationsDone,
+	onInspectorState,
+	inspectorCommand,
 	browserCommand,
 	onBrowserStateChange,
 	onBrowserCommand,
@@ -471,6 +539,7 @@ function WebviewSurface( {
 	const ref = useRef< HTMLElement | null >( null );
 	const [ ready, setReady ] = useState( false );
 	const onAnnotationsDoneRef = useRef( onAnnotationsDone );
+	const onInspectorStateRef = useRef( onInspectorState );
 	const onBrowserStateChangeRef = useRef( onBrowserStateChange );
 	const onBrowserCommandRef = useRef( onBrowserCommand );
 	const onNavigateRef = useRef( onNavigate );
@@ -483,6 +552,9 @@ function WebviewSurface( {
 	useEffect( () => {
 		onAnnotationsDoneRef.current = onAnnotationsDone;
 	}, [ onAnnotationsDone ] );
+	useEffect( () => {
+		onInspectorStateRef.current = onInspectorState;
+	}, [ onInspectorState ] );
 	useEffect( () => {
 		onBrowserStateChangeRef.current = onBrowserStateChange;
 	}, [ onBrowserStateChange ] );
@@ -583,10 +655,22 @@ function WebviewSurface( {
 			domReadyRef.current = true;
 			setReady( true );
 			publishDocumentTitle();
-			webview.executeJavaScript( INSPECTOR_PAGE_SCRIPT, false ).catch( () => {
-				// Transient injection failures (e.g. frame swapped mid-eval)
-				// are recoverable on the next dom-ready.
-			} );
+			webview
+				.executeJavaScript( INSPECTOR_PAGE_SCRIPT, false )
+				.then( () => {
+					// The injected script reports the real picking/count state
+					// through the console bridge; this just flips `ready` so the
+					// host controls enable without waiting for that round-trip.
+					onInspectorStateRef.current?.( {
+						ready: true,
+						isPicking: false,
+						annotationCount: 0,
+					} );
+				} )
+				.catch( () => {
+					// Transient injection failures (e.g. frame swapped mid-eval)
+					// are recoverable on the next dom-ready.
+				} );
 		};
 
 		const handleConsoleMessage = ( event: Event ) => {
@@ -604,6 +688,14 @@ function WebviewSurface( {
 				if ( isBrowserShortcutCommand( parsed.command ) ) {
 					onBrowserCommandRef.current?.( parsed.command );
 				}
+				return;
+			}
+			if ( parsed.type === 'state' ) {
+				onInspectorStateRef.current?.( {
+					ready: true,
+					isPicking: Boolean( parsed.isPicking ),
+					annotationCount: typeof parsed.annotationCount === 'number' ? parsed.annotationCount : 0,
+				} );
 				return;
 			}
 			if ( parsed.type !== 'done' || ! parsed.annotations ) return;
@@ -627,6 +719,7 @@ function WebviewSurface( {
 		};
 		const handleStartLoading = () => {
 			didReadTitleAfterLoad = false;
+			onInspectorStateRef.current?.( EMPTY_INSPECTOR_STATE );
 			publishBrowserState( { title: null } );
 			startProgress();
 		};
@@ -678,6 +771,21 @@ function WebviewSurface( {
 		lastReloadNonceRef.current = reloadNonce;
 		webview.loadURL( url ).catch( () => undefined );
 	}, [ url, reloadNonce, ready, initialNav.url, initialNav.reloadNonce ] );
+
+	useEffect( () => {
+		if ( ! ready || ! inspectorCommand ) return;
+		const webview = ref.current as WebviewTag | null;
+		if ( ! webview ) return;
+		const detail = JSON.stringify( { type: inspectorCommand.type } );
+		webview
+			.executeJavaScript(
+				`window.dispatchEvent(new CustomEvent(${ JSON.stringify(
+					INSPECTOR_COMMAND_EVENT
+				) }, { detail: ${ detail } }));`,
+				false
+			)
+			.catch( () => undefined );
+	}, [ inspectorCommand, ready ] );
 
 	useEffect( () => {
 		if ( ! ready || ! browserCommand ) return;

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -1,4 +1,4 @@
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight, external } from '@wordpress/icons';
 import { ariaKeyShortcut, displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { Button, IconButton, Tooltip } from '@wordpress/ui';
@@ -383,23 +383,11 @@ export function SitePreview( {
 									variant="solid"
 									tone="brand"
 									size="small"
-									className={ styles.annotationSubmit }
 									disabled={ ! canAnnotate }
-									aria-label={ sprintf(
-										/* translators: %d: number of pending annotations. */
-										_n(
-											'Submit %d annotation',
-											'Submit %d annotations',
-											inspectorState.annotationCount
-										),
-										inspectorState.annotationCount
-									) }
+									aria-label={ __( 'Submit annotations' ) }
 									onClick={ () => sendInspectorCommand( 'submit' ) }
 								>
 									{ __( 'Submit' ) }
-									<span className={ styles.annotationCount } aria-hidden="true">
-										{ inspectorState.annotationCount }
-									</span>
 								</Button>
 							) : null }
 						</div>

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -8,10 +8,16 @@
  * `console-message` event:
  *   guest -> host: `__studio-inspector__:{ "type": "done", ... }`
  *
- * The same bridge also forwards browser keyboard shortcuts (reload,
- * back, forward) pressed while focus is inside the guest page, so the
- * host toolbar can handle them:
+ * The same bridge also reports picking/annotation-count state changes and
+ * forwards browser keyboard shortcuts (reload, back, forward) pressed while
+ * focus is inside the guest page, so the host toolbar can handle them:
+ *   guest -> host: `__studio-inspector__:{ "type": "state", ... }`
  *   guest -> host: `__studio-inspector__:{ "type": "browser-command", ... }`
+ *
+ * The annotation controls live in the host toolbar (not in the page), and
+ * drive the inspector by dispatching `INSPECTOR_COMMAND_EVENT` custom events
+ * on the guest `window` via `webview.executeJavaScript()`:
+ *   host -> guest: `{ "type": "toggle-picking" | "submit" | "report-state" }`
  *
  * Layout strategy: markers and the picking highlight use `position: absolute`
  * anchored at *document* coordinates (viewport rect + scroll offset). They
@@ -20,17 +26,26 @@
  */
 
 export const INSPECTOR_BRIDGE_PREFIX = '__studio-inspector__:';
+export const INSPECTOR_COMMAND_EVENT = '__studio-inspector-command';
 
 export const INSPECTOR_PAGE_SCRIPT =
 	String.raw`
 ( () => {
 	if ( window.__studioInspectorMounted ) {
+		window.dispatchEvent(
+			new CustomEvent( '` +
+	INSPECTOR_COMMAND_EVENT +
+	String.raw`', { detail: { type: 'report-state' } } )
+		);
 		return;
 	}
 	window.__studioInspectorMounted = true;
 
 	const BRIDGE_PREFIX = '` +
 	INSPECTOR_BRIDGE_PREFIX +
+	String.raw`';
+	const COMMAND_EVENT = '` +
+	INSPECTOR_COMMAND_EVENT +
 	String.raw`';
 	const HOST_ID = '__studio-inspector-host';
 
@@ -193,35 +208,6 @@ export const INSPECTOR_PAGE_SCRIPT =
 		.popup .cancel:hover { background: rgba(255,255,255,0.08); }
 		.popup .save { background: #fff; color: #1a1a1a; }
 		.popup .save[disabled] { opacity: 0.4; cursor: default; }
-		.toolbar {
-			position: fixed; bottom: 1.25rem; right: 1.25rem;
-			display: flex; align-items: center; gap: 6px;
-			background: #1a1a1a; color: #fff; border-radius: 22px;
-			padding: 6px;
-			box-shadow: 0 2px 8px rgba(0,0,0,0.2), 0 4px 16px rgba(0,0,0,0.1);
-			pointer-events: auto;
-		}
-		.toolbar button {
-			height: 32px; padding: 0 12px;
-			background: transparent; color: #fff;
-			border: none; border-radius: 16px;
-			font: 600 12px/1 inherit; cursor: pointer;
-			white-space: nowrap;
-		}
-		.toolbar button:hover { background: rgba(255,255,255,0.1); }
-		.toolbar button.active { background: #2563eb; color: #fff; }
-		.toolbar button.active:hover { background: #2563eb; }
-		.toolbar button.primary { background: #fff; color: #1a1a1a; }
-		.toolbar button.primary:hover { background: #f0f0f0; }
-		.toolbar button.primary[disabled] {
-			opacity: 0.5; cursor: default; background: #fff;
-		}
-		.toolbar .count {
-			min-width: 22px; height: 22px; padding: 0 6px;
-			display: inline-flex; align-items: center; justify-content: center;
-			background: rgba(255,255,255,0.15); color: #fff;
-			border-radius: 11px; font: 600 11px/1 inherit;
-		}
 	` +
 	'`' +
 	String.raw`;
@@ -240,10 +226,17 @@ export const INSPECTOR_PAGE_SCRIPT =
 	const markerNodes = new Map(); /* id -> marker element */
 	let highlightNode = null;
 	let popupNode = null;
-	let toolbarNode = null;
 
 	function persistAnnotations() {
 		window.__studioInspectorState = annotations;
+	}
+
+	function sendState() {
+		send( {
+			type: 'state',
+			isPicking,
+			annotationCount: annotations.length,
+		} );
 	}
 
 	function syncMarkers() {
@@ -305,64 +298,50 @@ export const INSPECTOR_PAGE_SCRIPT =
 		}
 	}
 
-	function showToolbar() {
-		if ( toolbarNode ) {
-			toolbarNode.remove();
-			toolbarNode = null;
-		}
-		toolbarNode = document.createElement( 'div' );
-		toolbarNode.className = 'toolbar';
-
-		const pickBtn = document.createElement( 'button' );
-		pickBtn.textContent = isPicking ? 'Picking… click an element' : 'Annotate';
-		if ( isPicking ) pickBtn.className = 'active';
-		pickBtn.addEventListener( 'click', () => {
-			isPicking = ! isPicking;
-			if ( ! isPicking ) hoveredEl = null;
-			activePopup = null;
-			persistAnnotations();
-			render();
-		} );
-		toolbarNode.appendChild( pickBtn );
-
-		if ( annotations.length > 0 ) {
-			const count = document.createElement( 'span' );
-			count.className = 'count';
-			count.textContent = String( annotations.length );
-			count.title = annotations.length + ' annotation(s) pending';
-			toolbarNode.appendChild( count );
-		}
-
-		const submitBtn = document.createElement( 'button' );
-		submitBtn.className = 'primary';
-		submitBtn.textContent = 'Submit';
-		submitBtn.disabled = annotations.length === 0;
-		submitBtn.title =
-			annotations.length === 0
-				? 'Add at least one annotation first'
-				: 'Submit annotations to the agent';
-		submitBtn.addEventListener( 'click', () => {
-			if ( annotations.length === 0 ) return;
-			const sent = annotations.slice();
-			send( { type: 'done', annotations: sent } );
-			annotations = [];
-			activePopup = null;
-			isPicking = false;
-			hoveredEl = null;
-			persistAnnotations();
-			render();
-		} );
-		toolbarNode.appendChild( submitBtn );
-
-		root.appendChild( toolbarNode );
-	}
-
 	function render() {
 		syncMarkers();
 		showHighlight( hoveredEl );
 		showPopup();
-		showToolbar();
+		sendState();
 	}
+
+	function togglePicking() {
+		isPicking = ! isPicking;
+		if ( ! isPicking ) hoveredEl = null;
+		activePopup = null;
+		persistAnnotations();
+		render();
+	}
+
+	function submitAnnotations() {
+		if ( annotations.length === 0 ) {
+			sendState();
+			return;
+		}
+		const sent = annotations.slice();
+		send( { type: 'done', annotations: sent } );
+		annotations = [];
+		activePopup = null;
+		isPicking = false;
+		hoveredEl = null;
+		persistAnnotations();
+		render();
+	}
+
+	window.addEventListener( COMMAND_EVENT, ( event ) => {
+		const command = event.detail || {};
+		if ( command.type === 'toggle-picking' ) {
+			togglePicking();
+			return;
+		}
+		if ( command.type === 'submit' ) {
+			submitAnnotations();
+			return;
+		}
+		if ( command.type === 'report-state' ) {
+			sendState();
+		}
+	} );
 
 	function buildPopup( state ) {
 		const popup = document.createElement( 'div' );

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -76,18 +76,30 @@
 	flex-shrink: 0;
 }
 
+.annotationSubmit {
+	position: relative;
+}
+
+/* Floating count badge on the button's top-right corner. The ring
+   (box-shadow) separates it from both the button and the header behind. */
 .annotationCount {
-	min-width: 16px;
-	height: 16px;
-	margin-left: 6px;
-	padding: 0 4px;
+	position: absolute;
+	top: -5px;
+	right: -5px;
+	min-width: 14px;
+	height: 14px;
+	padding: 0 3px;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	background-color: rgb(255 255 255 / 20%);
-	border-radius: 8px;
-	font-size: var(--wpds-typography-font-size-xs);
+	color: var(--wpds-color-fg-content-neutral);
+	background-color: var(--wpds-color-bg-surface-neutral);
+	border-radius: 999px;
+	box-shadow: 0 0 0 1px var(--wpds-color-stroke-surface-neutral);
+	font-size: 10px;
+	font-weight: 600;
 	line-height: 1;
+	pointer-events: none;
 }
 
 /* 2px bar overlapping the header's bottom border, like a browser's page-load

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -76,32 +76,6 @@
 	flex-shrink: 0;
 }
 
-.annotationSubmit {
-	position: relative;
-}
-
-/* Floating count badge on the button's top-right corner. The ring
-   (box-shadow) separates it from both the button and the header behind. */
-.annotationCount {
-	position: absolute;
-	top: -5px;
-	right: -5px;
-	min-width: 14px;
-	height: 14px;
-	padding: 0 3px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	color: var(--wpds-color-fg-content-neutral);
-	background-color: var(--wpds-color-bg-surface-neutral);
-	border-radius: 999px;
-	box-shadow: 0 0 0 1px var(--wpds-color-stroke-surface-neutral);
-	font-size: 10px;
-	font-weight: 600;
-	line-height: 1;
-	pointer-events: none;
-}
-
 /* 2px bar overlapping the header's bottom border, like a browser's page-load
    indicator. The inner span is scaled by inline style as progress advances. */
 .loadingProgress {

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -69,6 +69,27 @@
 	line-height: 16px;
 }
 
+.annotationControls {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-xs);
+	flex-shrink: 0;
+}
+
+.annotationCount {
+	min-width: 16px;
+	height: 16px;
+	margin-left: 6px;
+	padding: 0 4px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background-color: rgb(255 255 255 / 20%);
+	border-radius: 8px;
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: 1;
+}
+
 /* 2px bar overlapping the header's bottom border, like a browser's page-load
    indicator. The inner span is scaled by inline style as progress advances. */
 .loadingProgress {


### PR DESCRIPTION
## Related issues

- Related to #3646 (follow-up to #3756)

## How AI was used in this PR

The change was extracted and adapted from #3646 by Claude Code under human direction, continuing the incremental porting of that PR's preview improvements to trunk (after #3756). The control design was iterated interactively (icon button toggle, small sizes, no count badge). Lint, typecheck, and the `apps/ui` test suite were run as verification.

## Proposed Changes

The Annotate and Submit controls for the site-preview annotation feature currently live in a floating toolbar that the inspector script injects *inside* the previewed page. That overlay covers page content, doesn't match Studio's design language, and visually belongs to the site rather than to Studio.

This PR moves those controls into the preview panel's toolbar, next to the browser navigation controls added in #3756:

- A **pencil icon button** toggles annotation picking (pressed state while picking; tooltip flips between "Annotate" and "Stop annotating").
- A **Submit** button appears only while there are pending annotations and sends them to the chat, as before.
- The in-page annotation experience is unchanged: element highlighting, numbered markers, comment popups, and Escape behavior all stay as they are — only the controls moved out of the page.
- The host toolbar and the in-page inspector stay in sync across navigations, so pending annotations made on a page are still submittable after the inspector re-initializes.

## Testing Instructions

1. Build and run the app, enable the Agentic UI via the Beta Features menu.
2. Open a chat for a running site and show the site preview — the pencil button appears in the preview toolbar; no toolbar overlay appears inside the page anymore.
3. Click the pencil, pick an element, add a comment, and save: a Submit button appears in the toolbar.
4. Add a second annotation, then click Submit: the annotations arrive in the chat composer as before, and the Submit button disappears.
5. Navigate to another page and back while annotations are pending: the Submit button reflects the pending state after each load.
6. Verify Escape still cancels picking / closes the comment popup, and check the toolbar in both light and dark appearance.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)