### PR TITLE
Use `Intl.Locale` over `@formatjs/intl-locale`

### DIFF
--- a/apps/cli/lib/site-language.ts
+++ b/apps/cli/lib/site-language.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import { Locale } from '@formatjs/intl-locale';
 import { match } from '@formatjs/intl-localematcher';
 import { DEFAULT_LOCALE } from '@studio/common/lib/locale';
 import { getWpFilesPath } from 'cli/lib/dependency-management/paths';
@@ -82,7 +81,7 @@ export async function getPreferredSiteLanguage( wpVersion = 'latest' ): Promise<
 		// Filter out invalid locales
 		.filter( ( item ) => {
 			try {
-				new Locale( item );
+				new Intl.Locale( item );
 				return true;
 			} catch ( exception ) {
 				return false;

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -29,6 +29,7 @@
 		"@earendil-works/pi-ai": "0.78.0",
 		"@earendil-works/pi-coding-agent": "0.78.0",
 		"@earendil-works/pi-tui": "0.78.0",
+		"@formatjs/intl-localematcher": "^0.8.10",
 		"@inquirer/prompts": "^8.5.2",
 		"@modelcontextprotocol/sdk": "^1.27.1",
 		"@php-wasm/node": "3.1.36",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -25,11 +25,11 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.91.1",
-		"@inquirer/prompts": "^8.5.2",
 		"@earendil-works/pi-agent-core": "0.78.0",
 		"@earendil-works/pi-ai": "0.78.0",
 		"@earendil-works/pi-coding-agent": "0.78.0",
 		"@earendil-works/pi-tui": "0.78.0",
+		"@inquirer/prompts": "^8.5.2",
 		"@modelcontextprotocol/sdk": "^1.27.1",
 		"@php-wasm/node": "3.1.36",
 		"@php-wasm/universal": "3.1.36",

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -2,6 +2,7 @@ import { cpSync, existsSync, mkdirSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import semver from 'semver';
 import { defineConfig } from 'vite';
+import { analyzer } from 'vite-bundle-analyzer';
 import packageJson from './package.json';
 
 const nodeBuiltinExternals: RegExp[] = [
@@ -34,6 +35,7 @@ const skillsSourcePath = resolve( __dirname, 'ai/skills' );
 
 export const baseConfig = defineConfig( {
 	plugins: [
+		analyzer(),
 		{
 			name: 'write-dist-extras',
 			apply: 'build',

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -2,7 +2,6 @@ import { cpSync, existsSync, mkdirSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import semver from 'semver';
 import { defineConfig } from 'vite';
-import { analyzer } from 'vite-bundle-analyzer';
 import packageJson from './package.json';
 
 const nodeBuiltinExternals: RegExp[] = [
@@ -35,7 +34,6 @@ const skillsSourcePath = resolve( __dirname, 'ai/skills' );
 
 export const baseConfig = defineConfig( {
 	plugins: [
-		analyzer(),
 		{
 			name: 'write-dist-extras',
 			apply: 'build',

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -29,8 +29,7 @@
 		"typecheck": "tsc -p tsconfig.json --noEmit"
 	},
 	"dependencies": {
-		"@formatjs/intl-locale": "^3.4.5",
-		"@formatjs/intl-localematcher": "^0.5.4",
+		"@formatjs/intl-localematcher": "^0.8.10",
 		"@sentry/electron": "^7.13.0",
 		"@studio/common": "file:../../tools/common",
 		"@vscode/sudo-prompt": "^9.3.1",
@@ -63,6 +62,7 @@
 		"@automattic/generate-password": "^0.2.0",
 		"@automattic/interpolate-components": "^1.2.1",
 		"@base-ui/react": "^1.3.0",
+		"@earendil-works/pi-coding-agent": "0.78.0",
 		"@electron-forge/cli": "^7.11.2",
 		"@electron-forge/maker-deb": "^7.11.2",
 		"@electron-forge/maker-dmg": "^7.11.2",
@@ -70,7 +70,6 @@
 		"@electron-forge/maker-zip": "^7.11.2",
 		"@electron-forge/plugin-auto-unpack-natives": "^7.11.2",
 		"@inquirer/prompts": "^8.5.2",
-		"@earendil-works/pi-coding-agent": "0.78.0",
 		"@reduxjs/toolkit": "^2.12.0",
 		"@rive-app/react-canvas": "^4.18.0",
 		"@sentry/react": "^10.56.0",

--- a/apps/studio/src/lib/locale-node.ts
+++ b/apps/studio/src/lib/locale-node.ts
@@ -12,7 +12,10 @@ export function getSupportedLocale() {
 	// `app.getLocale` returns the current application locale, acquired using
 	// Chromium's `l10n_util` library. This value is utilized to determine
 	// the best fit for supported locales.
-	return match( [ app.getLocale() ], supportedLocales, DEFAULT_LOCALE ) as SupportedLocale;
+	const matched = match( [ app.getLocale() ], supportedLocales, DEFAULT_LOCALE );
+	// `match` canonicalizes BCP-47 casing (e.g. `zh-cn` -> `zh-CN`), but our
+	// supported-locale keys are lowercase
+	return matched.toLowerCase() as SupportedLocale;
 }
 
 export async function getUserLocaleWithFallback() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
 				"@earendil-works/pi-ai": "0.78.0",
 				"@earendil-works/pi-coding-agent": "0.78.0",
 				"@earendil-works/pi-tui": "0.78.0",
+				"@formatjs/intl-localematcher": "^0.8.10",
 				"@inquirer/prompts": "^8.5.2",
 				"@modelcontextprotocol/sdk": "^1.27.1",
 				"@php-wasm/node": "3.1.36",

--- a/package-lock.json
+++ b/package-lock.json
@@ -539,8 +539,7 @@
 			"version": "1.10.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@formatjs/intl-locale": "^3.4.5",
-				"@formatjs/intl-localematcher": "^0.5.4",
+				"@formatjs/intl-localematcher": "^0.8.10",
 				"@sentry/electron": "^7.13.0",
 				"@studio/common": "file:../../tools/common",
 				"@vscode/sudo-prompt": "^9.3.1",
@@ -8232,43 +8231,19 @@
 			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
 			"license": "MIT"
 		},
-		"node_modules/@formatjs/ecma402-abstract": {
-			"version": "1.18.2",
-			"license": "MIT",
-			"dependencies": {
-				"@formatjs/intl-localematcher": "0.5.4",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@formatjs/intl-enumerator": {
-			"version": "1.4.5",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@formatjs/intl-getcanonicallocales": {
-			"version": "2.3.0",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@formatjs/intl-locale": {
-			"version": "3.4.5",
-			"license": "MIT",
-			"dependencies": {
-				"@formatjs/ecma402-abstract": "1.18.2",
-				"@formatjs/intl-enumerator": "1.4.5",
-				"@formatjs/intl-getcanonicallocales": "2.3.0",
-				"tslib": "^2.4.0"
-			}
+		"node_modules/@formatjs/fast-memoize": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz",
+			"integrity": "sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==",
+			"license": "MIT"
 		},
 		"node_modules/@formatjs/intl-localematcher": {
-			"version": "0.5.4",
+			"version": "0.8.10",
+			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.10.tgz",
+			"integrity": "sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==",
 			"license": "MIT",
 			"dependencies": {
-				"tslib": "^2.4.0"
+				"@formatjs/fast-memoize": "3.1.6"
 			}
 		},
 		"node_modules/@gar/promisify": {

--- a/package.json
+++ b/package.json
@@ -89,9 +89,9 @@
 		"patch-package": "^8.0.1",
 		"prettier": "npm:wp-prettier@3.0.3",
 		"tsx": "^4.22.1",
-		"undici": "^8.3.0",
 		"typescript": "~6.0.3",
 		"typescript-eslint": "^8.59.4",
+		"undici": "^8.3.0",
 		"vite": "^8.0.16",
 		"vitest": "^4.0.18",
 		"web-streams-polyfill": "^4.2.0"


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- N/A

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

To verify that the `Intl.Locale` constructor throws in the same way that the `Locale` constructor from `@formatjs/intl-locale` does.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

- Uninstall the `@formatjs/intl-locale` npm module and replace our (very simple) use of the `Locale` constructor with the standard library `Intl.Locale` constructor ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale)). `@formatjs/intl-locale` is indeed a polyfill for `Intl.Locale` ([ref](https://formatjs.github.io/docs/polyfills/intl-locale/)).
- Before this change, the `@formatjs` namespace took up 323kB in the CLI JS bundle. After this change, only `@formatjs/intl-localematcher` remains, which takes up 46kB.
- I also took the opportunity to explicitly list `@formatjs/intl-localematcher` as a dependency in `apps/cli` (and to update that dependency).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

CI should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
