### PR TITLE
Improve session empty state background animation

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/empty-background/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/empty-background/index.tsx
@@ -5,19 +5,93 @@ import logoSrc from './wordpress-logo.webp';
 const SIZE = 320;
 const PAD = 130;
 const CANVAS_SIZE = SIZE + PAD * 2;
-const RES = 5;
-const DOT_SIZE = 5;
-const REPEL_RADIUS = 120;
-const REPEL_MAX = 28;
-const PULL_RADIUS = 120;
-const PULL_MAX = 6;
+const RES = 6;
+const RECT_SIZE = 4;
+const MAX_DPR = 2;
+const MOTION_RADIUS = 240;
+const MOTION_RADIUS_SQUARED = MOTION_RADIUS * MOTION_RADIUS;
+const MOTION_PUSH = 74;
+const MOTION_DRIFT = 34;
+const MOTION_SWIRL = 30;
+const ORBIT_OFFSET = 12;
+const ORBIT_FORCE = 0.18;
+const ORBIT_SPEED = 0.0016;
+const POINTER_EASE = 0.05;
+const SPRING = 0.028;
+const DAMPING = 0.88;
 const BLUE: [ number, number, number ] = [ 56, 88, 233 ];
 const LIGHT_BLUE: [ number, number, number ] = [ 220, 230, 255 ];
 const WAVE_INTERVAL = 9000;
 const WAVE_DURATION = 2300;
 const WAVE_BAND = 0.38;
+const WAVE_PAUSE = WAVE_INTERVAL - WAVE_DURATION;
+const RIPPLE_DURATION = 1900;
+const RIPPLE_BAND = 22;
+const RIPPLE_PUSH = 46;
+const MAX_RIPPLES = 4;
+const COLOR_STEPS = 18;
+const VELOCITY_EPSILON_SQUARED = 0.001;
+const DISPLACEMENT_EPSILON_SQUARED = 0.04;
+const REFERENCE_FRAME_MS = 1000 / 120;
+const MIN_FRAME_FACTOR = 0.5;
+const MAX_FRAME_FACTOR = 4;
 
-type Particle = { x: number; y: number; hx: number; hy: number; cx: number; cy: number };
+const COLOR_STYLES = Array.from( { length: COLOR_STEPS + 1 }, ( _, step ) => {
+	const intensity = step / COLOR_STEPS;
+	const r = Math.round( BLUE[ 0 ] + ( LIGHT_BLUE[ 0 ] - BLUE[ 0 ] ) * intensity );
+	const g = Math.round( BLUE[ 1 ] + ( LIGHT_BLUE[ 1 ] - BLUE[ 1 ] ) * intensity );
+	const b = Math.round( BLUE[ 2 ] + ( LIGHT_BLUE[ 2 ] - BLUE[ 2 ] ) * intensity );
+
+	return `rgb(${ r }, ${ g }, ${ b })`;
+} );
+
+const BASE_COLOR = COLOR_STYLES[ 0 ];
+
+function getColorStyle( intensity: number ) {
+	const step = Math.min( COLOR_STEPS, Math.max( 0, Math.round( intensity * COLOR_STEPS ) ) );
+
+	return COLOR_STYLES[ step ];
+}
+
+function getFrameFactor( timestamp: number, previousTimestamp: number | null ) {
+	if ( previousTimestamp === null ) {
+		return 1;
+	}
+
+	const frameFactor = ( timestamp - previousTimestamp ) / REFERENCE_FRAME_MS;
+
+	return Math.min( MAX_FRAME_FACTOR, Math.max( MIN_FRAME_FACTOR, frameFactor ) );
+}
+
+function scaleEasingForFrameFactor( value: number, frameFactor: number ) {
+	return 1 - Math.pow( 1 - value, frameFactor );
+}
+
+type Particle = {
+	x: number;
+	y: number;
+	vx: number;
+	vy: number;
+	hx: number;
+	hy: number;
+	cx: number;
+	cy: number;
+	waveCoord: number;
+	shimmer: number;
+	orbitPhaseOffset: number;
+};
+
+type Ripple = { x: number; y: number; start: number };
+
+type ActiveRipple = {
+	x: number;
+	y: number;
+	radius: number;
+	band: number;
+	fade: number;
+	minRadiusSquared: number;
+	maxRadiusSquared: number;
+};
 
 export function EmptyBackground() {
 	const canvasRef = useRef< HTMLCanvasElement >( null );
@@ -28,25 +102,377 @@ export function EmptyBackground() {
 			return;
 		}
 
-		const dpr = window.devicePixelRatio || 1;
-		canvas.width = CANVAS_SIZE * dpr;
-		canvas.height = CANVAS_SIZE * dpr;
-		canvas.style.setProperty( '--empty-background-canvas-size', `${ CANVAS_SIZE }px` );
-		const ctx = canvas.getContext( '2d' );
+		const canvasElement = canvas;
+		const dpr = Math.min( window.devicePixelRatio || 1, MAX_DPR );
+		canvasElement.width = Math.round( CANVAS_SIZE * dpr );
+		canvasElement.height = Math.round( CANVAS_SIZE * dpr );
+		canvasElement.style.setProperty( '--empty-background-canvas-size', `${ CANVAS_SIZE }px` );
+
+		const ctx = canvasElement.getContext( '2d', { alpha: true } );
 		if ( ! ctx ) {
 			return;
 		}
-		ctx.scale( dpr, dpr );
-		ctx.imageSmoothingEnabled = false;
+
+		const context = ctx;
+		context.scale( dpr, dpr );
+		context.imageSmoothingEnabled = false;
 
 		const particles: Particle[] = [];
+		const ripples: Ripple[] = [];
+		const reducedMotionQuery =
+			typeof window.matchMedia === 'function'
+				? window.matchMedia( '(prefers-reduced-motion: reduce)' )
+				: null;
+		const animationStart = performance.now();
+		const bounds = {
+			left: 0,
+			top: 0,
+			scale: 1,
+		};
+
 		let mouseX = -9999;
 		let mouseY = -9999;
+		let targetMouseX = -9999;
+		let targetMouseY = -9999;
 		let hover = false;
-		let raf = 0;
+		let raf: number | null = null;
+		let waveTimeout: number | null = null;
 		let cancelled = false;
+		let imageReady = false;
+		let pageVisible = ! document.hidden;
+		let isIntersecting = true;
+		let reducedMotion = reducedMotionQuery?.matches ?? false;
+		let logoRadius = 1;
+		let currentWaveStart = 0;
+		let currentWaveActive = false;
+		let waveCos = 1;
+		let waveSin = 0;
+		let previousFrameTimestamp: number | null = null;
+
+		function canAnimate() {
+			return (
+				imageReady &&
+				particles.length > 0 &&
+				! cancelled &&
+				! reducedMotion &&
+				pageVisible &&
+				isIntersecting
+			);
+		}
+
+		function updateBounds() {
+			const rect = canvasElement.getBoundingClientRect();
+			bounds.left = rect.left;
+			bounds.top = rect.top;
+			bounds.scale = rect.width > 0 ? CANVAS_SIZE / rect.width : 1;
+		}
+
+		function clearScheduledWave() {
+			if ( waveTimeout === null ) {
+				return;
+			}
+
+			window.clearTimeout( waveTimeout );
+			waveTimeout = null;
+		}
+
+		function cancelLoop() {
+			if ( raf !== null ) {
+				cancelAnimationFrame( raf );
+				raf = null;
+			}
+			previousFrameTimestamp = null;
+		}
+
+		function resetParticles() {
+			for ( let i = 0; i < particles.length; i++ ) {
+				const pt = particles[ i ];
+				pt.x = pt.hx;
+				pt.y = pt.hy;
+				pt.vx = 0;
+				pt.vy = 0;
+			}
+		}
+
+		function drawStatic() {
+			context.clearRect( 0, 0, CANVAS_SIZE, CANVAS_SIZE );
+			context.fillStyle = BASE_COLOR;
+
+			for ( let i = 0; i < particles.length; i++ ) {
+				const pt = particles[ i ];
+				context.fillRect( pt.hx - RECT_SIZE / 2, pt.hy - RECT_SIZE / 2, RECT_SIZE, RECT_SIZE );
+			}
+		}
+
+		function scheduleNextWave( delay = WAVE_PAUSE ) {
+			if ( ! canAnimate() || waveTimeout !== null ) {
+				return;
+			}
+
+			waveTimeout = window.setTimeout( () => {
+				waveTimeout = null;
+				beginWave();
+			}, delay );
+		}
+
+		function ensureLoop() {
+			if ( ! canAnimate() || raf !== null ) {
+				return;
+			}
+
+			raf = requestAnimationFrame( tick );
+		}
+
+		function beginWave() {
+			if ( ! canAnimate() ) {
+				return;
+			}
+
+			clearScheduledWave();
+			currentWaveStart = performance.now();
+			currentWaveActive = true;
+
+			const ang = Math.random() * Math.PI * 2;
+			waveCos = Math.cos( ang );
+			waveSin = Math.sin( ang );
+
+			for ( let i = 0; i < particles.length; i++ ) {
+				const pt = particles[ i ];
+				const proj = ( pt.cx * waveCos + pt.cy * waveSin ) / logoRadius;
+				pt.waveCoord = ( proj + 1 ) / 2;
+				pt.shimmer = 0.45 + Math.random() * 0.55;
+			}
+
+			ensureLoop();
+		}
+
+		function pauseAnimation() {
+			cancelLoop();
+			clearScheduledWave();
+			currentWaveActive = false;
+			resetParticles();
+			drawStatic();
+		}
+
+		function syncAnimationState() {
+			if ( ! imageReady ) {
+				return;
+			}
+
+			if ( ! canAnimate() ) {
+				pauseAnimation();
+				return;
+			}
+
+			if ( raf !== null || currentWaveActive || hover || ripples.length > 0 ) {
+				ensureLoop();
+				return;
+			}
+
+			drawStatic();
+			scheduleNextWave( 0 );
+		}
+
+		function tick( timestamp: number ) {
+			raf = null;
+			if ( ! canAnimate() ) {
+				pauseAnimation();
+				return;
+			}
+
+			const frameFactor = getFrameFactor( timestamp, previousFrameTimestamp );
+			previousFrameTimestamp = timestamp;
+			const pointerEase = scaleEasingForFrameFactor( POINTER_EASE, frameFactor );
+			const spring = SPRING * frameFactor;
+			const damping = Math.pow( DAMPING, frameFactor );
+			context.clearRect( 0, 0, CANVAS_SIZE, CANVAS_SIZE );
+
+			const activeRipples: ActiveRipple[] = [];
+			for ( let i = ripples.length - 1; i >= 0; i-- ) {
+				const t = ( timestamp - ripples[ i ].start ) / RIPPLE_DURATION;
+				if ( t > 1 ) {
+					ripples.splice( i, 1 );
+					continue;
+				}
+
+				const eased = 1 - Math.pow( 1 - t, 3 );
+				const radius = eased * logoRadius * 2.35;
+				const band = RIPPLE_BAND + t * 12;
+				const minRadius = Math.max( 0, radius - band );
+				const maxRadius = radius + band;
+				activeRipples.push( {
+					x: ripples[ i ].x,
+					y: ripples[ i ].y,
+					radius,
+					band,
+					fade: 1 - t,
+					minRadiusSquared: minRadius * minRadius,
+					maxRadiusSquared: maxRadius * maxRadius,
+				} );
+			}
+
+			let waveT = -99;
+			if ( currentWaveActive ) {
+				const waveElapsed = timestamp - currentWaveStart;
+				if ( waveElapsed <= WAVE_DURATION ) {
+					waveT = ( waveElapsed / WAVE_DURATION ) * ( 1 + WAVE_BAND * 2 ) - WAVE_BAND;
+				} else {
+					currentWaveActive = false;
+					scheduleNextWave();
+				}
+			}
+
+			let motionX = 0;
+			let motionY = 0;
+			if ( hover ) {
+				const nextMouseX = mouseX + ( targetMouseX - mouseX ) * pointerEase;
+				const nextMouseY = mouseY + ( targetMouseY - mouseY ) * pointerEase;
+				motionX = nextMouseX - mouseX;
+				motionY = nextMouseY - mouseY;
+				mouseX = nextMouseX;
+				mouseY = nextMouseY;
+			}
+
+			const motionDistance = Math.hypot( motionX, motionY );
+			const motionEnergy = Math.min( 1, motionDistance / frameFactor / 9 );
+			const motionDirX = motionDistance > 0.0001 ? motionX / motionDistance : 0;
+			const motionDirY = motionDistance > 0.0001 ? motionY / motionDistance : 0;
+			const elapsed = timestamp - animationStart;
+			const orbitAngle = elapsed * ORBIT_SPEED;
+			const orbitCos = hover ? Math.cos( orbitAngle ) : 1;
+			const orbitSin = hover ? Math.sin( orbitAngle ) : 0;
+			const orbitPulsePhase = elapsed * 0.002;
+			let hasPointerInfluence = false;
+			let maxVelocitySquared = 0;
+			let maxDisplacementSquared = 0;
+
+			for ( let i = 0; i < particles.length; i++ ) {
+				const pt = particles[ i ];
+				let targetX = pt.hx;
+				let targetY = pt.hy;
+				let wakeInfluence = 0;
+				let orbitForceX = 0;
+				let orbitForceY = 0;
+				let rippleIntensity = 0;
+
+				if ( hover ) {
+					const dx = pt.hx - mouseX;
+					const dy = pt.hy - mouseY;
+					const distanceSquared = dx * dx + dy * dy;
+
+					if ( distanceSquared < MOTION_RADIUS_SQUARED ) {
+						const d = Math.sqrt( distanceSquared ) || 0.0001;
+						const unitX = dx / d;
+						const unitY = dy / d;
+						const proximity = 1 - d / MOTION_RADIUS;
+						const motionInfluence = proximity * proximity * ( 3 - 2 * proximity );
+
+						if ( motionInfluence > 0 ) {
+							hasPointerInfluence = true;
+							wakeInfluence = motionInfluence * motionEnergy;
+
+							targetX += unitX * MOTION_PUSH * motionInfluence;
+							targetY += unitY * MOTION_PUSH * motionInfluence;
+
+							const orbitOffset = ORBIT_OFFSET * motionInfluence;
+							const rotatedX = unitX * orbitCos - unitY * orbitSin;
+							const rotatedY = unitY * orbitCos + unitX * orbitSin;
+							targetX += ( rotatedX - unitX ) * orbitOffset;
+							targetY += ( rotatedY - unitY ) * orbitOffset;
+
+							if ( wakeInfluence > 0 && motionDistance > 0.0001 ) {
+								const side = Math.sign( dx * motionDirY - dy * motionDirX ) || 1;
+								const swirl = MOTION_SWIRL * wakeInfluence * side;
+								targetX += motionDirX * MOTION_DRIFT * wakeInfluence - motionDirY * swirl;
+								targetY += motionDirY * MOTION_DRIFT * wakeInfluence + motionDirX * swirl;
+							}
+
+							const orbitPulse = 0.7 + 0.3 * Math.sin( orbitPulsePhase + pt.orbitPhaseOffset );
+							const orbitForce = ORBIT_FORCE * motionInfluence * orbitPulse;
+							orbitForceX = -unitY * orbitForce;
+							orbitForceY = unitX * orbitForce;
+						}
+					}
+				}
+
+				for ( let rippleIndex = 0; rippleIndex < activeRipples.length; rippleIndex++ ) {
+					const ripple = activeRipples[ rippleIndex ];
+					const rdx = pt.hx - ripple.x;
+					const rdy = pt.hy - ripple.y;
+					const rippleDistanceSquared = rdx * rdx + rdy * rdy;
+					if (
+						rippleDistanceSquared < ripple.minRadiusSquared ||
+						rippleDistanceSquared > ripple.maxRadiusSquared
+					) {
+						continue;
+					}
+
+					const rd = Math.sqrt( rippleDistanceSquared ) || 0.0001;
+					const bandDistance = Math.abs( rd - ripple.radius );
+
+					if ( bandDistance < ripple.band ) {
+						const intensity = ( 1 - bandDistance / ripple.band ) * ripple.fade;
+						rippleIntensity = Math.max( rippleIntensity, intensity );
+						targetX += ( rdx / rd ) * intensity * RIPPLE_PUSH;
+						targetY += ( rdy / rd ) * intensity * RIPPLE_PUSH;
+					}
+				}
+
+				pt.vx += ( targetX - pt.x ) * spring;
+				pt.vy += ( targetY - pt.y ) * spring;
+				pt.vx += orbitForceX * frameFactor;
+				pt.vy += orbitForceY * frameFactor;
+				pt.vx *= damping;
+				pt.vy *= damping;
+				pt.x += pt.vx * frameFactor;
+				pt.y += pt.vy * frameFactor;
+
+				let intensity = 0;
+				if ( currentWaveActive ) {
+					const dw = Math.abs( pt.waveCoord - waveT );
+					if ( dw < WAVE_BAND ) {
+						intensity = ( 1 - dw / WAVE_BAND ) * pt.shimmer;
+					}
+				}
+				intensity = Math.max( intensity, rippleIntensity, wakeInfluence * 0.65 );
+
+				const size = RECT_SIZE + rippleIntensity * 1.6 + wakeInfluence * 0.8;
+				context.fillStyle = getColorStyle( intensity );
+				context.fillRect( pt.x - size / 2, pt.y - size / 2, size, size );
+
+				const velocitySquared = pt.vx * pt.vx + pt.vy * pt.vy;
+				if ( velocitySquared > maxVelocitySquared ) {
+					maxVelocitySquared = velocitySquared;
+				}
+
+				const displacementX = pt.x - pt.hx;
+				const displacementY = pt.y - pt.hy;
+				const displacementSquared = displacementX * displacementX + displacementY * displacementY;
+				if ( displacementSquared > maxDisplacementSquared ) {
+					maxDisplacementSquared = displacementSquared;
+				}
+			}
+
+			const shouldContinue =
+				currentWaveActive ||
+				activeRipples.length > 0 ||
+				hasPointerInfluence ||
+				maxVelocitySquared > VELOCITY_EPSILON_SQUARED ||
+				maxDisplacementSquared > DISPLACEMENT_EPSILON_SQUARED;
+
+			if ( shouldContinue ) {
+				ensureLoop();
+				return;
+			}
+
+			resetParticles();
+			previousFrameTimestamp = null;
+			drawStatic();
+			scheduleNextWave();
+		}
 
 		const img = new Image();
+		img.decoding = 'async';
 		img.onload = () => {
 			if ( cancelled ) {
 				return;
@@ -81,20 +507,32 @@ export function EmptyBackground() {
 						particles.push( {
 							x: offsetX + x,
 							y: offsetY + y,
+							vx: 0,
+							vy: 0,
 							hx: offsetX + x,
 							hy: offsetY + y,
 							cx: 0,
 							cy: 0,
+							waveCoord: 0,
+							shimmer: 1,
+							orbitPhaseOffset: 0,
 						} );
 					}
 				}
 			}
 
-			let minX = Infinity,
-				minY = Infinity,
-				maxX = -Infinity,
-				maxY = -Infinity;
-			for ( const pt of particles ) {
+			imageReady = true;
+			if ( particles.length === 0 ) {
+				drawStatic();
+				return;
+			}
+
+			let minX = Infinity;
+			let minY = Infinity;
+			let maxX = -Infinity;
+			let maxY = -Infinity;
+			for ( let i = 0; i < particles.length; i++ ) {
+				const pt = particles[ i ];
 				if ( pt.hx < minX ) {
 					minX = pt.hx;
 				}
@@ -108,100 +546,109 @@ export function EmptyBackground() {
 					maxY = pt.hy;
 				}
 			}
+
 			const logoMidX = ( minX + maxX ) / 2;
 			const logoMidY = ( minY + maxY ) / 2;
-			let logoRadius = 1;
-			for ( const pt of particles ) {
+			for ( let i = 0; i < particles.length; i++ ) {
+				const pt = particles[ i ];
 				pt.cx = pt.hx - logoMidX;
 				pt.cy = pt.hy - logoMidY;
+				pt.orbitPhaseOffset = pt.cx * 0.03 + pt.cy * 0.02;
 				const r = Math.hypot( pt.cx, pt.cy );
 				if ( r > logoRadius ) {
 					logoRadius = r;
 				}
 			}
 
-			const start = performance.now();
-			let lastCycle = -1;
-			let waveCos = 1;
-			let waveSin = 0;
-
-			const tick = () => {
-				ctx.clearRect( 0, 0, CANVAS_SIZE, CANVAS_SIZE );
-				const now = performance.now() - start;
-				const cycleIdx = Math.floor( now / WAVE_INTERVAL );
-				if ( cycleIdx !== lastCycle ) {
-					lastCycle = cycleIdx;
-					const ang = Math.random() * Math.PI * 2;
-					waveCos = Math.cos( ang );
-					waveSin = Math.sin( ang );
-				}
-				const cycleMs = now % WAVE_INTERVAL;
-				const waveT =
-					cycleMs <= WAVE_DURATION
-						? ( cycleMs / WAVE_DURATION ) * ( 1 + WAVE_BAND * 2 ) - WAVE_BAND
-						: -99;
-
-				for ( const pt of particles ) {
-					const dx = pt.x - mouseX;
-					const dy = pt.y - mouseY;
-					const d = Math.hypot( dx, dy ) || 0.0001;
-					const hdx = pt.hx - pt.x;
-					const hdy = pt.hy - pt.y;
-					const dh = Math.hypot( hdx, hdy ) || 0.0001;
-
-					const push = hover
-						? Math.max( 0, Math.min( REPEL_MAX, REPEL_MAX - ( d * REPEL_MAX ) / REPEL_RADIUS ) )
-						: 0;
-					const pull = ( dh * PULL_MAX ) / PULL_RADIUS;
-
-					pt.x += ( dx / d ) * push + ( hdx / dh ) * pull;
-					pt.y += ( dy / d ) * push + ( hdy / dh ) * pull;
-
-					const proj = ( pt.cx * waveCos + pt.cy * waveSin ) / logoRadius;
-					const waveCoord = ( proj + 1 ) / 2;
-					let intensity = 0;
-					const dw = Math.abs( waveCoord - waveT );
-					if ( dw < WAVE_BAND ) {
-						intensity = ( 1 - dw / WAVE_BAND ) * ( 0.45 + Math.random() * 0.55 );
-					}
-					const r = BLUE[ 0 ] + ( LIGHT_BLUE[ 0 ] - BLUE[ 0 ] ) * intensity;
-					const g = BLUE[ 1 ] + ( LIGHT_BLUE[ 1 ] - BLUE[ 1 ] ) * intensity;
-					const b = BLUE[ 2 ] + ( LIGHT_BLUE[ 2 ] - BLUE[ 2 ] ) * intensity;
-					ctx.fillStyle = `rgb(${ r }, ${ g }, ${ b })`;
-					ctx.beginPath();
-					ctx.arc( pt.x, pt.y, DOT_SIZE / 2, 0, Math.PI * 2 );
-					ctx.fill();
-				}
-				raf = requestAnimationFrame( tick );
-			};
-			tick();
+			drawStatic();
+			beginWave();
 		};
 		img.src = logoSrc;
 
-		const onMove = ( event: MouseEvent ) => {
-			const rect = canvas.getBoundingClientRect();
-			const scale = rect.width > 0 ? CANVAS_SIZE / rect.width : 1;
-			mouseX = ( event.clientX - rect.left ) * scale;
-			mouseY = ( event.clientY - rect.top ) * scale;
+		const setPointerFromEvent = ( event: MouseEvent ) => {
+			targetMouseX = ( event.clientX - bounds.left ) * bounds.scale;
+			targetMouseY = ( event.clientY - bounds.top ) * bounds.scale;
+			if ( mouseX < -1000 || mouseY < -1000 ) {
+				mouseX = targetMouseX;
+				mouseY = targetMouseY;
+			}
 		};
-		const onEnter = () => {
+		const onMove = ( event: MouseEvent ) => {
+			setPointerFromEvent( event );
+			ensureLoop();
+		};
+		const onEnter = ( event: MouseEvent ) => {
 			hover = true;
+			updateBounds();
+			setPointerFromEvent( event );
+			ensureLoop();
 		};
 		const onLeave = () => {
 			hover = false;
 			mouseX = -9999;
 			mouseY = -9999;
+			targetMouseX = -9999;
+			targetMouseY = -9999;
+			ensureLoop();
 		};
-		canvas.addEventListener( 'mousemove', onMove );
-		canvas.addEventListener( 'mouseenter', onEnter );
-		canvas.addEventListener( 'mouseleave', onLeave );
+		const onClick = ( event: MouseEvent ) => {
+			if ( ! canAnimate() ) {
+				return;
+			}
+
+			updateBounds();
+			ripples.push( {
+				x: ( event.clientX - bounds.left ) * bounds.scale,
+				y: ( event.clientY - bounds.top ) * bounds.scale,
+				start: performance.now(),
+			} );
+			if ( ripples.length > MAX_RIPPLES ) {
+				ripples.splice( 0, ripples.length - MAX_RIPPLES );
+			}
+			ensureLoop();
+		};
+		const onVisibilityChange = () => {
+			pageVisible = ! document.hidden;
+			syncAnimationState();
+		};
+		const onReducedMotionChange = ( event: MediaQueryListEvent ) => {
+			reducedMotion = event.matches;
+			syncAnimationState();
+		};
+
+		updateBounds();
+		canvasElement.addEventListener( 'mousemove', onMove, { passive: true } );
+		canvasElement.addEventListener( 'mouseenter', onEnter, { passive: true } );
+		canvasElement.addEventListener( 'mouseleave', onLeave, { passive: true } );
+		canvasElement.addEventListener( 'click', onClick );
+		document.addEventListener( 'visibilitychange', onVisibilityChange );
+		reducedMotionQuery?.addEventListener( 'change', onReducedMotionChange );
+
+		const resizeObserver =
+			typeof ResizeObserver !== 'undefined' ? new ResizeObserver( () => updateBounds() ) : null;
+		resizeObserver?.observe( canvasElement );
+
+		const intersectionObserver =
+			typeof IntersectionObserver !== 'undefined'
+				? new IntersectionObserver( ( entries ) => {
+						isIntersecting = entries.some( ( entry ) => entry.isIntersecting );
+						syncAnimationState();
+				  } )
+				: null;
+		intersectionObserver?.observe( canvasElement );
 
 		return () => {
 			cancelled = true;
-			cancelAnimationFrame( raf );
-			canvas.removeEventListener( 'mousemove', onMove );
-			canvas.removeEventListener( 'mouseenter', onEnter );
-			canvas.removeEventListener( 'mouseleave', onLeave );
+			cancelLoop();
+			clearScheduledWave();
+			canvasElement.removeEventListener( 'mousemove', onMove );
+			canvasElement.removeEventListener( 'mouseenter', onEnter );
+			canvasElement.removeEventListener( 'mouseleave', onLeave );
+			canvasElement.removeEventListener( 'click', onClick );
+			document.removeEventListener( 'visibilitychange', onVisibilityChange );
+			reducedMotionQuery?.removeEventListener( 'change', onReducedMotionChange );
+			resizeObserver?.disconnect();
+			intersectionObserver?.disconnect();
 		};
 	}, [] );
 

--- a/apps/ui/src/ui-classic/components/session-view/empty-background/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/empty-background/style.module.css
@@ -5,11 +5,15 @@
 	align-items: center;
 	justify-content: center;
 	pointer-events: none;
+	contain: layout paint;
 }
 
 .canvas {
 	display: block;
 	width: min(100%, var(--empty-background-canvas-size, 580px));
 	height: auto;
+	aspect-ratio: 1;
+	cursor: pointer;
 	pointer-events: auto;
+	touch-action: none;
 }


### PR DESCRIPTION
## Related issues

- Related to #3646 (this ports the empty state improvements from that PR so they can land separately)

## How AI was used in this PR

Claude Code was used to extract the empty-state changes from #3646 and verify them (lint, typecheck, tests).

## Proposed Changes

Ports the redesigned session empty state background from #3646:

- The WordPress logo particle animation is now physics-based: particles respond to pointer movement with push, drift, and swirl forces, and spring back smoothly instead of snapping.
- Clicking the logo triggers a ripple effect.
- The animation is significantly cheaper when idle: it fully pauses between shimmer waves, when the page is hidden, when the canvas is off-screen, and respects `prefers-reduced-motion` (static rendering).
- Frame-rate independent motion (consistent feel on high-refresh displays) and capped device pixel ratio to limit canvas memory.

## Testing Instructions

- Enable the Agentic UI via Studio → Beta Features.
- Start a new chat so the empty session view shows the WordPress logo particle background.
- Move the pointer over the logo: particles should swirl and drift around the cursor, then settle back.
- Click the logo: a ripple should propagate outward.
- Leave it idle: a shimmer wave should pass every few seconds; otherwise the animation should be static (no continuous repaint in DevTools performance panel).
- With "Reduce motion" enabled in System Settings, the logo should render statically.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)