### PR TITLE
Fix dark mode support in the agentic UI site preview panel

### DIFF
--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -33,7 +33,7 @@
 	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-lg);
 	min-height: 32px;
 	flex-shrink: 0;
-	background-color: #fff;
+	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
 	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
 	border-top-left-radius: inherit;
 	border-top-right-radius: inherit;
@@ -133,7 +133,7 @@
 	min-height: 0;
 	display: flex;
 	position: relative;
-	background-color: #fff;
+	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
 	overflow: hidden;
 	border-bottom-right-radius: inherit;
 	border-bottom-left-radius: inherit;
@@ -146,7 +146,11 @@
 	align-items: center;
 	justify-content: center;
 	pointer-events: none;
-	background-color: rgba(255, 255, 255, 0.6);
+	background-color: color-mix(
+		in srgb,
+		var(--wpds-color-bg-surface-neutral-strong, #fff) 60%,
+		transparent
+	);
 }
 
 .spinner {
@@ -169,7 +173,7 @@
 	width: 100%;
 	height: 100%;
 	border: 0;
-	background-color: #fff;
+	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
 }
 
 .empty {


### PR DESCRIPTION
## Related issues

<!-- None — spotted during dark-mode usage of the agentic UI. -->

## How AI was used in this PR

This PR was authored with Claude Code: it located the hardcoded colors, picked the replacement tokens by matching sibling components (e.g. the session composer), and verified the token values both schemes resolve to by running `@wordpress/theme`'s ramp generator with the same seeds the app's ThemeProvider uses. Changes were reviewed by hand.

## Proposed Changes

- In dark mode, the site preview panel next to an agentic session stayed mostly white: the browser-style header, the panel body, the iframe backdrop, and the loading spinner overlay all used hardcoded white backgrounds, clashing with the rest of the dark UI.
- These surfaces now use the theme's `--wpds-color-bg-surface-neutral-strong` token (with the previous white as fallback), so the panel follows the system color scheme like its siblings. Light mode is pixel-identical (`#fff`); dark mode resolves to `#242424`, keeping the same elevated-above-background hierarchy the panel has in light mode.
- The spinner overlay derives its translucency from the same token via `color-mix`, matching the pattern already used elsewhere in `apps/ui`.

## Testing Instructions

1. Launch Studio with the agentic UI enabled and open a session with the site preview panel visible.
2. Switch macOS to dark appearance (System Settings → Appearance → Dark): the preview header, body, and loading states should render with dark surfaces instead of white.
3. Switch back to light appearance and confirm the panel looks unchanged from trunk.
4. Trigger a page load in the preview to check the spinner overlay tint in both schemes.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)