### PR TITLE
Move sync environment and mshots helpers to tools/common

### DIFF
--- a/apps/studio/src/modules/sync/components/environment-badge.tsx
+++ b/apps/studio/src/modules/sync/components/environment-badge.tsx
@@ -1,7 +1,7 @@
+import { getEnvironmentLabel, EnvironmentType } from '@studio/common/lib/sync/environment-utils';
 import { __ } from '@wordpress/i18n';
 import { Badge } from 'src/components/badge';
 import { cx } from 'src/lib/cx';
-import { getEnvironmentLabel, EnvironmentType } from 'src/modules/sync/lib/environment-utils';
 
 interface EnvironmentBadgeProps {
 	type: EnvironmentType;

--- a/apps/studio/src/modules/sync/components/site-name-box.tsx
+++ b/apps/studio/src/modules/sync/components/site-name-box.tsx
@@ -1,5 +1,5 @@
 import { EnvironmentBadge, StudioBadge } from 'src/modules/sync/components/environment-badge';
-import type { EnvironmentType } from 'src/modules/sync/lib/environment-utils';
+import type { EnvironmentType } from '@studio/common/lib/sync/environment-utils';
 
 type SiteNameBoxProps = {
 	siteName: string;

--- a/apps/studio/src/modules/sync/components/sync-connected-sites.tsx
+++ b/apps/studio/src/modules/sync/components/sync-connected-sites.tsx
@@ -1,3 +1,4 @@
+import { getSiteEnvironment } from '@studio/common/lib/sync/environment-utils';
 import { Icon } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -34,7 +35,6 @@ import {
 	convertTreeToPullOptions,
 	convertTreeToPushOptions,
 } from 'src/modules/sync/lib/convert-tree-to-sync-options';
-import { getSiteEnvironment } from 'src/modules/sync/lib/environment-utils';
 import { useAppDispatch, useI18nLocale, useRootSelector } from 'src/stores';
 import {
 	syncOperationsSelectors,

--- a/apps/studio/src/modules/sync/components/sync-dialog.tsx
+++ b/apps/studio/src/modules/sync/components/sync-dialog.tsx
@@ -1,5 +1,6 @@
 import { PRESSABLE_PHP_VERSION } from '@studio/common/constants';
 import { SYNC_PUSH_SIZE_LIMIT_GB } from '@studio/common/lib/sync/constants';
+import { getSiteEnvironment } from '@studio/common/lib/sync/environment-utils';
 import {
 	Icon,
 	SelectControl,
@@ -29,7 +30,6 @@ import { SiteNameBox } from 'src/modules/sync/components/site-name-box';
 import { useSelectedItemsPushSize } from 'src/modules/sync/hooks/use-selected-items-push-size';
 import { useSyncDialogTexts } from 'src/modules/sync/hooks/use-sync-dialog-texts';
 import { useTopLevelSyncTree } from 'src/modules/sync/hooks/use-top-level-sync-tree';
-import { getSiteEnvironment } from 'src/modules/sync/lib/environment-utils';
 import { useI18nLocale } from 'src/stores';
 import {
 	useHostingPhpVersion,

--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector-classic.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector-classic.tsx
@@ -1,3 +1,4 @@
+import { getSiteEnvironment } from '@studio/common/lib/sync/environment-utils';
 import { Icon, SearchControl as SearchControlWp, Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -17,7 +18,6 @@ import { getLocalizedLink } from 'src/lib/get-localized-link';
 import { CreateButton } from 'src/modules/sync/components/create-button';
 import { EnvironmentBadge } from 'src/modules/sync/components/environment-badge';
 import { NoWpcomSitesModal } from 'src/modules/sync/components/no-wpcom-sites-modal';
-import { getSiteEnvironment } from 'src/modules/sync/lib/environment-utils';
 import { useI18nLocale, useRootSelector } from 'src/stores';
 import {
 	connectedSitesSelectors,

--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -1,3 +1,5 @@
+import { getSiteEnvironment } from '@studio/common/lib/sync/environment-utils';
+import { getMshotUrl } from '@studio/common/lib/sync/mshots';
 import { Icon, SearchControl as SearchControlWp, Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -15,7 +17,6 @@ import { getLocalizedLink } from 'src/lib/get-localized-link';
 import { CreateButton } from 'src/modules/sync/components/create-button';
 import { EnvironmentBadge } from 'src/modules/sync/components/environment-badge';
 import { NoWpcomSitesModal } from 'src/modules/sync/components/no-wpcom-sites-modal';
-import { getSiteEnvironment } from 'src/modules/sync/lib/environment-utils';
 import { useI18nLocale, useRootSelector } from 'src/stores';
 import {
 	connectedSitesSelectors,
@@ -416,10 +417,6 @@ function ListSites( {
 			<div className="pointer-events-none sticky bottom-0 h-10 -mt-10 z-10 bg-gradient-to-t from-frame to-transparent" />
 		</div>
 	);
-}
-
-function getMshotUrl( siteUrl: string ): string {
-	return `https://s0.wp.com/mshots/v1/${ encodeURIComponent( siteUrl ) }?w=600&h=400`;
 }
 
 function SiteThumbnail( {

--- a/apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -1,6 +1,6 @@
+import { EnvironmentType } from '@studio/common/lib/sync/environment-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
-import { EnvironmentType } from 'src/modules/sync/lib/environment-utils';
 
 type TextByEnvironment = {
 	[ key in EnvironmentType ]: {

--- a/tools/common/lib/sync/environment-utils.ts
+++ b/tools/common/lib/sync/environment-utils.ts
@@ -1,6 +1,6 @@
-import { SyncSite } from '@studio/common/types/sync';
 import { __ } from '@wordpress/i18n';
 import { z } from 'zod';
+import type { SyncSite } from '@studio/common/types/sync';
 
 const EnvironmentSchema = z.enum( [ 'production', 'staging', 'development' ] );
 export type EnvironmentType = z.infer< typeof EnvironmentSchema >;

--- a/tools/common/lib/sync/mshots.ts
+++ b/tools/common/lib/sync/mshots.ts
@@ -1,0 +1,4 @@
+// WordPress.com screenshot service used for remote-site thumbnails.
+export function getMshotUrl( siteUrl: string ): string {
+	return `https://s0.wp.com/mshots/v1/${ encodeURIComponent( siteUrl ) }?w=600&h=400`;
+}


### PR DESCRIPTION
## Related issues

- Part of the site-creation onboarding redesign — see the umbrella PR (linked below once open) for the full plan.

## How AI was used in this PR

This PR was split out of the `workbench/site-creation` exploration branch with Claude Code. The change itself is a mechanical move; Shaun designed and tested the work on the original branch.

## Proposed Changes

- Moves the sync environment helpers (`getSiteEnvironment`, `getEnvironmentLabel`) and the mshots screenshot-URL helper into `tools/common` so they can be shared beyond the desktop renderer (the upcoming Connect onboarding flow in `apps/ui` needs both).
- No behavior change — pure relocation plus import updates.

## Testing Instructions

- Open the sync sites modal and the sync dialog: environment badges (Production/Staging/Development) and site thumbnails should look exactly as before.
- `npm run typecheck` passes.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
