### PR TITLE
Fetch every page of syncable sites and mark already-connected ones

### DIFF
--- a/apps/studio/src/modules/sync/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/sync/lib/ipc-handlers.ts
@@ -524,7 +524,11 @@ export async function fetchSyncableWpcomSites( _event: IpcMainInvokeEvent ): Pro
 	if ( ! token?.accessToken ) {
 		throw new Error( 'Authentication required to fetch WordPress.com sites.' );
 	}
-	return fetchSyncableSites( token.accessToken );
+	// Pass the already-connected remote IDs so the transform can mark those
+	// sites 'already-connected' instead of offering them as syncable again.
+	const connectedSites = await getAllConnectedWpcomSitesForCurrentUser();
+	const connectedSiteIds = connectedSites.map( ( site ) => site.id );
+	return fetchSyncableSites( token.accessToken, { connectedSiteIds } );
 }
 
 export async function getConnectedWpcomSites(

--- a/tools/common/lib/sync/sync-api.ts
+++ b/tools/common/lib/sync/sync-api.ts
@@ -30,24 +30,48 @@ const SITE_FIELDS = [
 	'environment_type',
 ].join( ',' );
 
-export async function fetchSyncableSites( token: string ): Promise< SyncSite[] > {
+export async function fetchSyncableSites(
+	token: string,
+	options?: { connectedSiteIds?: number[] }
+): Promise< SyncSite[] > {
 	const wpcom = wpcomFactory( token, wpcomXhrRequest );
 
-	const rawResponse = await wpcom.req.get(
-		{
-			apiNamespace: 'rest/v1.2',
-			path: '/me/sites',
-		},
-		{
-			fields: SITE_FIELDS,
-			filter: 'atomic,wpcom',
-			options: 'created_at,wpcom_staging_blog_ids',
-			site_activity: 'active',
-		}
-	);
+	// Mirrors the desktop renderer's site-picker query (wpcomSitesApi), but
+	// drains every page so callers get the full account in one call — the
+	// unpaginated v1.2 endpoint silently returned only a subset of sites.
+	const PER_PAGE = 100;
+	const MAX_PAGES = 20;
+	const allSites: unknown[] = [];
 
-	const parsed = sitesEndpointResponseSchema.parse( rawResponse );
-	return transformSitesResponse( parsed.sites );
+	for ( let page = 1; page <= MAX_PAGES; page++ ) {
+		const rawResponse = await wpcom.req.get(
+			{
+				apiNamespace: 'rest/v1.3',
+				path: '/me/sites',
+			},
+			{
+				fields: SITE_FIELDS,
+				filter: 'atomic,wpcom',
+				options: 'created_at,wpcom_staging_blog_ids,software_version',
+				site_activity: 'active',
+				include_a8c_owned: false,
+				page,
+				per_page: PER_PAGE,
+			}
+		);
+
+		const parsed = sitesEndpointResponseSchema.parse( rawResponse );
+		allSites.push( ...parsed.sites );
+		// The endpoint may clamp the requested page size, so judge "last page"
+		// by the server-reported per_page when it's present.
+		if ( parsed.sites.length < ( parsed.per_page ?? PER_PAGE ) ) {
+			break;
+		}
+	}
+
+	return transformSitesResponse( allSites, {
+		connectedSiteIds: options?.connectedSiteIds,
+	} );
 }
 
 export async function initiateBackup(


### PR DESCRIPTION
## Related issues

- Part of the site-creation onboarding redesign — see the umbrella PR (linked below once open) for the full plan.

## How AI was used in this PR

Split out of the `workbench/site-creation` exploration branch with Claude Code; designed and tested by Shaun on the original branch.

## Proposed Changes

- Users with many WordPress.com sites were only seeing a subset in the site picker: the unpaginated v1.2 `/me/sites` request silently truncated results. The fetch now drains every page via the v1.3 endpoint, so the full account is always available.
- Sites that are already connected to a local site are now marked as such, so pickers can show an "already connected" state instead of offering them again.

## Testing Instructions

- With a WordPress.com account that has more than 100 sites, open the sync "Connect site" modal — every site should be listed.
- Connect a site, then reopen the picker — the connected site should appear as already connected.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
