### PR TITLE
Share the curated blueprint list via tools/common

### DIFF
--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -17,7 +17,7 @@ export const AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
 export const NIGHTLY_UPDATE_TTL_MS = 24 * 60 * 60 * 1000;
 export const MACOS_TRAFFIC_LIGHT_POSITION = { x: 20, y: 20 };
 export const WINDOWS_TITLEBAR_HEIGHT = 44;
-export const EMPTY_SITE_PLAYGROUND_URL = 'https://playground.wordpress.net/';
+export { EMPTY_SITE_PLAYGROUND_URL } from '@studio/common/constants';
 export const ABOUT_WINDOW_WIDTH = 300;
 export const ABOUT_WINDOW_HEIGHT = 350;
 export const BUG_REPORT_URL =

--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -1,4 +1,8 @@
 import {
+	curateBlueprintsForDisplay,
+	FEATURED_BLUEPRINT_SLUGS,
+} from '@studio/common/lib/blueprint-curation';
+import {
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
@@ -171,46 +175,6 @@ function BlueprintCard( {
 	);
 }
 
-const BLUEPRINT_DISPLAY_NAMES: Record< string, string > = {
-	'Quick Start': 'WordPress.com',
-	Development: 'WordPress Dev',
-	Commerce: 'WooCommerce',
-};
-
-function getBlueprintExcerptOverrides( __: ( text: string ) => string ): Record< string, string > {
-	return {
-		'Quick Start': __(
-			'A WordPress.com-like environment with Business plan plugins and themes pre-installed.'
-		),
-		Commerce: __(
-			'Create your next online store with WooCommerce and its companion plugins pre-installed.'
-		),
-		Development: __( 'A streamlined environment for building and testing themes or plugins.' ),
-	};
-}
-
-const BLUEPRINT_ORDER: Record< string, number > = {
-	'Quick Start': 1,
-	Commerce: 2,
-	Development: 3,
-};
-
-const FEATURED_BLUEPRINT_SLUGS = new Set( [ 'woo-shop', 'development', 'quick-start' ] );
-
-function renameBlueprintsForDisplay(
-	blueprints: Blueprint[],
-	__: ( text: string ) => string
-): Blueprint[] {
-	const excerptOverrides = getBlueprintExcerptOverrides( __ );
-	return [ ...blueprints ]
-		.sort( ( a, b ) => ( BLUEPRINT_ORDER[ a.title ] ?? 99 ) - ( BLUEPRINT_ORDER[ b.title ] ?? 99 ) )
-		.map( ( item ) => ( {
-			...item,
-			excerpt: excerptOverrides[ item.title ] || item.excerpt,
-			title: BLUEPRINT_DISPLAY_NAMES[ item.title ] || item.title,
-		} ) );
-}
-
 export function NewSiteOptions( {
 	blueprints,
 	isLoadingBlueprints,
@@ -286,7 +250,7 @@ export function NewSiteOptions( {
 						{ __( 'Could not load templates.' ) }
 					</div>
 				) : (
-					renameBlueprintsForDisplay( featuredBlueprints, __ ).map( ( item ) => (
+					curateBlueprintsForDisplay( featuredBlueprints, __ ).map( ( item ) => (
 						<BlueprintCard
 							key={ item.slug }
 							blueprint={ item }

--- a/tools/common/constants.ts
+++ b/tools/common/constants.ts
@@ -36,6 +36,7 @@ export const CERT_UNTRUSTED_ROOT = 'CERT_TRUST_IS_UNTRUSTED_ROOT'; // Windows AP
 export const DEFAULT_CUSTOM_DOMAIN_SUFFIX = '.wp.local';
 
 // WordPress constants
+export const EMPTY_SITE_PLAYGROUND_URL = 'https://playground.wordpress.net/';
 export const MINIMUM_WORDPRESS_VERSION = '6.2.1' as const; // https://wordpress.github.io/wordpress-playground/blueprints/examples/#load-an-older-wordpress-version
 export const DEFAULT_WORDPRESS_VERSION = 'latest' as const;
 export const DEFAULT_PHP_VERSION: typeof RecommendedPHPVersion = RecommendedPHPVersion;

--- a/tools/common/lib/blueprint-curation.ts
+++ b/tools/common/lib/blueprint-curation.ts
@@ -1,0 +1,56 @@
+/**
+ * Display curation for the public blueprints gallery, shared by the desktop
+ * renderer's Add Site flow and the apps/ui onboarding flow so the two can't
+ * drift. The wpcom blueprints endpoint returns raw titles/excerpts; these
+ * helpers rename the featured trio for display, override their excerpts,
+ * and pin their order.
+ */
+
+type TranslateFn = ( text: string ) => string;
+
+export const FEATURED_BLUEPRINT_SLUGS: ReadonlySet< string > = new Set( [
+	'woo-shop',
+	'development',
+	'quick-start',
+] );
+
+const BLUEPRINT_DISPLAY_NAMES: Record< string, string > = {
+	'Quick Start': 'WordPress.com',
+	Development: 'WordPress Dev',
+	Commerce: 'WooCommerce',
+};
+
+const BLUEPRINT_ORDER: Record< string, number > = {
+	'Quick Start': 1,
+	Commerce: 2,
+	Development: 3,
+};
+
+// Takes the translate function as a parameter (rather than importing the
+// global `__`) so callers using a scoped i18n instance — like the desktop
+// renderer's I18nProvider — still get translated strings.
+function getBlueprintExcerptOverrides( __: TranslateFn ): Record< string, string > {
+	return {
+		'Quick Start': __(
+			'A WordPress.com-like environment with Business plan plugins and themes pre-installed.'
+		),
+		Commerce: __(
+			'Create your next online store with WooCommerce and its companion plugins pre-installed.'
+		),
+		Development: __( 'A streamlined environment for building and testing themes or plugins.' ),
+	};
+}
+
+export function curateBlueprintsForDisplay< T extends { title: string; excerpt: string } >(
+	blueprints: T[],
+	__: TranslateFn
+): T[] {
+	const excerptOverrides = getBlueprintExcerptOverrides( __ );
+	return [ ...blueprints ]
+		.sort( ( a, b ) => ( BLUEPRINT_ORDER[ a.title ] ?? 99 ) - ( BLUEPRINT_ORDER[ b.title ] ?? 99 ) )
+		.map( ( item ) => ( {
+			...item,
+			excerpt: excerptOverrides[ item.title ] || item.excerpt,
+			title: BLUEPRINT_DISPLAY_NAMES[ item.title ] || item.title,
+		} ) );
+}


### PR DESCRIPTION
## Related issues

- Part of the site-creation onboarding redesign — see the umbrella PR (linked below once open) for the full plan.

## How AI was used in this PR

Split out of the `workbench/site-creation` exploration branch with Claude Code; designed and tested by Shaun on the original branch.

## Proposed Changes

- The desktop Add Site flow renames, reorders, and re-describes the featured blueprints (WordPress.com / WooCommerce / WordPress Dev) inline. That curation now lives in `tools/common` so the new onboarding gallery in `apps/ui` can present the same blueprints the same way.
- `EMPTY_SITE_PLAYGROUND_URL` moves to shared constants for the same reason.
- No behavior change in the desktop flow.

## Testing Instructions

- Open Add Site in the desktop app: the featured blueprint cards should show the same names, order, and descriptions as before.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
