### PR TITLE
Add onboarding UI primitives: dot grid, illustrations, footer, busy overlay

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -17,6 +17,7 @@
 		"@tanstack/react-query": "^5.75.5",
 		"@tanstack/react-query-persist-client": "^5.96.2",
 		"@tanstack/react-router": "^1.120.14",
+		"@wordpress/a11y": "^4.47.0",
 		"@wordpress/api-fetch": "^7.47.0",
 		"@wordpress/components": "^34.0.0",
 		"@wordpress/core-data": "^7.47.0",

--- a/apps/ui/src/components/busy-overlay/index.tsx
+++ b/apps/ui/src/components/busy-overlay/index.tsx
@@ -1,0 +1,15 @@
+import styles from './style.module.css';
+
+/**
+ * Transparent full-window shield that blocks pointer interaction while a
+ * long-running action (site creation, connect-and-pull) finishes. Pair it
+ * with disabled/loading states on the triggering button — it deliberately
+ * covers everything, including the onboarding close button, so a stray
+ * click can't interrupt the work mid-flight.
+ */
+export function BusyOverlay( { active }: { active: boolean } ) {
+	if ( ! active ) {
+		return null;
+	}
+	return <div aria-hidden="true" className={ styles.overlay } />;
+}

--- a/apps/ui/src/components/busy-overlay/style.module.css
+++ b/apps/ui/src/components/busy-overlay/style.module.css
@@ -1,0 +1,7 @@
+.overlay {
+	position: fixed;
+	inset: 0;
+	/* Above the onboarding close button (7) and footer actions (6). */
+	z-index: 8;
+	cursor: progress;
+}

--- a/apps/ui/src/components/dot-grid/index.tsx
+++ b/apps/ui/src/components/dot-grid/index.tsx
@@ -1,0 +1,473 @@
+import { useEffect, useRef } from 'react';
+import styles from './style.module.css';
+
+/**
+ * Animated dot-grid backdrop, ported from the desktop renderer's
+ * `DotGrid`. Renders a grid of crosses joined by dashed lines on a canvas;
+ * dots spring away from the cursor, mouse-down focuses the repulsion radius,
+ * and mouse-up emits a ripple. Honors `prefers-reduced-motion` by drawing a
+ * static grid instead. The draw color comes from the canvas' computed CSS
+ * `color`, so it tracks light/dark token changes for free.
+ */
+
+interface DotGridProps {
+	opacity?: number;
+	repulsion?: number;
+	rippleStrength?: number;
+	spacing?: number;
+	crossSize?: number;
+	crossThickness?: number;
+	className?: string;
+	/**
+	 * Set false while the grid is hidden (e.g. faded out behind a sub-page)
+	 * to pause the physics/render loop instead of burning CPU on invisible
+	 * frames. The simulation state survives, so re-activating doesn't replay
+	 * the intro sweep.
+	 */
+	active?: boolean;
+}
+
+const SPRING_K = 0.07;
+const DAMPING = 0.8;
+const SLEEP_EPS = 0.08;
+
+const RADIUS_BASE = 150;
+const RADIUS_EXPANDED = 30;
+const RADIUS_EXPAND_SPEED = 0.28;
+const RADIUS_CONTRACT_SPEED = 0.1;
+
+const RIPPLE_SPEED = 9;
+const RIPPLE_HALF_WIDTH = 32;
+
+const INTRO_SPEED = 18;
+const INTRO_FADE_WIDTH = 80;
+
+const TARGET_MS = 1000 / 60;
+
+interface Ripple {
+	x: number;
+	y: number;
+	radius: number;
+	maxRadius: number;
+}
+
+export function DotGrid( {
+	opacity = 0.25,
+	repulsion = 0.25,
+	rippleStrength = 1,
+	spacing = 24,
+	crossSize = 4,
+	crossThickness = 0.75,
+	className,
+	active = true,
+}: DotGridProps ) {
+	const canvasRef = useRef< HTMLCanvasElement >( null );
+	// Bridges the `active` prop into the long-lived effect below without
+	// tearing the simulation down (the effect's deps stay layout-only).
+	const setActiveRef = useRef< ( value: boolean ) => void >( () => {} );
+
+	useEffect( () => {
+		const canvas = canvasRef.current;
+		if ( ! canvas ) return;
+
+		let ctx: CanvasRenderingContext2D | null = null;
+		let isActive = true;
+		let color = '';
+		let mouseX = -9999;
+		let mouseY = -9999;
+		let rafId: number | null = null;
+		let lastTimestamp = 0;
+
+		let currentRadius = RADIUS_BASE;
+		let targetRadius = RADIUS_BASE;
+		let ripples: Ripple[] = [];
+
+		let introRadius = 0;
+		let introComplete = false;
+
+		let cols = 0;
+		let rows = 0;
+		let ox: Float32Array;
+		let oy: Float32Array;
+		let vx: Float32Array;
+		let vy: Float32Array;
+
+		function readColor() {
+			if ( ! canvas ) return;
+			color = getComputedStyle( canvas ).color;
+		}
+
+		function initDots() {
+			if ( ! canvas ) return;
+			cols = Math.ceil( canvas.offsetWidth / spacing ) + 1;
+			rows = Math.ceil( canvas.offsetHeight / spacing ) + 1;
+			const n = cols * rows;
+			ox = new Float32Array( n );
+			oy = new Float32Array( n );
+			vx = new Float32Array( n );
+			vy = new Float32Array( n );
+		}
+
+		function tick( timestamp: number ): boolean {
+			if ( ! ctx || ! canvas ) return false;
+			const rawDt = lastTimestamp === 0 ? TARGET_MS : timestamp - lastTimestamp;
+			lastTimestamp = timestamp;
+			const dt = Math.min( rawDt / TARGET_MS, 3 );
+
+			const cssW = canvas.offsetWidth;
+			const cssH = canvas.offsetHeight;
+			ctx.clearRect( 0, 0, cssW, cssH );
+			ctx.fillStyle = color;
+
+			const expandFactor = 1 - Math.pow( 1 - RADIUS_EXPAND_SPEED, dt );
+			const contractFactor = 1 - Math.pow( 1 - RADIUS_CONTRACT_SPEED, dt );
+			const lerpFactor = currentRadius < targetRadius ? expandFactor : contractFactor;
+			currentRadius += ( targetRadius - currentRadius ) * lerpFactor;
+			const radiusAnimating = Math.abs( currentRadius - targetRadius ) > 0.3;
+
+			if ( ! introComplete ) {
+				introRadius += INTRO_SPEED * dt;
+				const diag = Math.sqrt( cssW * cssW + cssH * cssH );
+				if ( introRadius > diag + INTRO_FADE_WIDTH ) {
+					introComplete = true;
+					ctx.globalAlpha = 1;
+				}
+			}
+
+			const dampFactor = Math.pow( DAMPING, dt );
+			const cursorActive = isActive && mouseX > -9998;
+			let anyActive = false;
+
+			for ( let r = 0; r < rows; r++ ) {
+				for ( let c = 0; c < cols; c++ ) {
+					const i = r * cols + c;
+					const rx = c * spacing;
+					const ry = r * spacing;
+
+					let dvx = vx[ i ];
+					let dvy = vy[ i ];
+					let dox = ox[ i ];
+					let doy = oy[ i ];
+
+					// Hover repulsion
+					if ( cursorActive ) {
+						const cx2 = rx + dox;
+						const cy2 = ry + doy;
+						const ddx = cx2 - mouseX;
+						const ddy = cy2 - mouseY;
+						const dist = Math.sqrt( ddx * ddx + ddy * ddy );
+						if ( dist < currentRadius && dist > 0.5 ) {
+							const force = ( repulsion * ( 1 - dist / currentRadius ) ) / dist;
+							dvx += force * ddx * dt;
+							dvy += force * ddy * dt;
+						}
+					}
+
+					// Ripple wavefronts
+					for ( const ripple of ripples ) {
+						const cx2 = rx + dox;
+						const cy2 = ry + doy;
+						const ddx = cx2 - ripple.x;
+						const ddy = cy2 - ripple.y;
+						const dist = Math.sqrt( ddx * ddx + ddy * ddy );
+						if ( dist > 0.5 ) {
+							const delta = dist - ripple.radius;
+							const falloff = Math.exp( -0.5 * ( delta / RIPPLE_HALF_WIDTH ) ** 2 );
+							const force = ( rippleStrength * falloff ) / dist;
+							dvx += force * ddx * dt;
+							dvy += force * ddy * dt;
+						}
+					}
+
+					// Spring toward rest
+					dvx += SPRING_K * -dox * dt;
+					dvy += SPRING_K * -doy * dt;
+
+					// Damping
+					dvx *= dampFactor;
+					dvy *= dampFactor;
+
+					// Integrate
+					dox += dvx * dt;
+					doy += dvy * dt;
+
+					ox[ i ] = dox;
+					oy[ i ] = doy;
+					vx[ i ] = dvx;
+					vy[ i ] = dvy;
+
+					if (
+						Math.abs( dvx ) > SLEEP_EPS ||
+						Math.abs( dvy ) > SLEEP_EPS ||
+						Math.abs( dox ) > SLEEP_EPS ||
+						Math.abs( doy ) > SLEEP_EPS
+					) {
+						anyActive = true;
+					}
+				}
+			}
+
+			// Draw dotted connecting lines
+			ctx.strokeStyle = color;
+			ctx.lineWidth = crossThickness;
+			ctx.setLineDash( [ 1, 4 ] );
+			for ( let r = 0; r < rows; r++ ) {
+				for ( let c = 0; c < cols; c++ ) {
+					const i = r * cols + c;
+					const x = c * spacing + ox[ i ];
+					const y = r * spacing + oy[ i ];
+
+					if ( ! introComplete ) {
+						const distFromCorner = Math.sqrt( ( c * spacing ) ** 2 + ( r * spacing ) ** 2 );
+						ctx.globalAlpha = Math.max(
+							0,
+							Math.min( 1, ( introRadius - distFromCorner ) / INTRO_FADE_WIDTH )
+						);
+					}
+
+					// Horizontal line to right neighbor
+					if ( c < cols - 1 ) {
+						const ni = r * cols + ( c + 1 );
+						const nx = ( c + 1 ) * spacing + ox[ ni ];
+						const ny = r * spacing + oy[ ni ];
+						ctx.beginPath();
+						ctx.moveTo( x + crossSize, y );
+						ctx.lineTo( nx - crossSize, ny );
+						ctx.stroke();
+					}
+					// Vertical line to bottom neighbor
+					if ( r < rows - 1 ) {
+						const ni = ( r + 1 ) * cols + c;
+						const nx = c * spacing + ox[ ni ];
+						const ny = ( r + 1 ) * spacing + oy[ ni ];
+						ctx.beginPath();
+						ctx.moveTo( x, y + crossSize );
+						ctx.lineTo( nx, ny - crossSize );
+						ctx.stroke();
+					}
+				}
+			}
+			ctx.setLineDash( [] );
+
+			// Draw crosses on top
+			ctx.fillStyle = color;
+			for ( let r = 0; r < rows; r++ ) {
+				for ( let c = 0; c < cols; c++ ) {
+					const i = r * cols + c;
+					const x = c * spacing + ox[ i ];
+					const y = r * spacing + oy[ i ];
+
+					if ( ! introComplete ) {
+						const distFromCorner = Math.sqrt( ( c * spacing ) ** 2 + ( r * spacing ) ** 2 );
+						ctx.globalAlpha = Math.max(
+							0,
+							Math.min( 1, ( introRadius - distFromCorner ) / INTRO_FADE_WIDTH )
+						);
+					}
+
+					ctx.fillRect( x - crossSize, y - crossThickness / 2, crossSize * 2, crossThickness );
+					ctx.fillRect( x - crossThickness / 2, y - crossSize, crossThickness, crossSize * 2 );
+				}
+			}
+
+			if ( ! introComplete ) ctx.globalAlpha = 1;
+
+			for ( const ripple of ripples ) ripple.radius += RIPPLE_SPEED * dt;
+			ripples = ripples.filter( ( rip ) => rip.radius < rip.maxRadius );
+
+			return anyActive || cursorActive || radiusAnimating || ripples.length > 0 || ! introComplete;
+		}
+
+		function loop( timestamp: number ) {
+			if ( tick( timestamp ) ) {
+				rafId = requestAnimationFrame( loop );
+			} else {
+				rafId = null;
+				lastTimestamp = 0;
+			}
+		}
+
+		function ensureLoop() {
+			if ( rafId === null ) {
+				lastTimestamp = 0;
+				rafId = requestAnimationFrame( loop );
+			}
+		}
+
+		function drawStatic() {
+			if ( ! ctx || ! canvas ) return;
+			const cssW = canvas.offsetWidth;
+			const cssH = canvas.offsetHeight;
+			ctx.clearRect( 0, 0, cssW, cssH );
+
+			ctx.strokeStyle = color;
+			ctx.lineWidth = crossThickness;
+			ctx.setLineDash( [ 1, 4 ] );
+			for ( let r = 0; r < rows; r++ ) {
+				for ( let c = 0; c < cols; c++ ) {
+					const x = c * spacing;
+					const y = r * spacing;
+					if ( c < cols - 1 ) {
+						ctx.beginPath();
+						ctx.moveTo( x + crossSize, y );
+						ctx.lineTo( ( c + 1 ) * spacing - crossSize, y );
+						ctx.stroke();
+					}
+					if ( r < rows - 1 ) {
+						ctx.beginPath();
+						ctx.moveTo( x, y + crossSize );
+						ctx.lineTo( x, ( r + 1 ) * spacing - crossSize );
+						ctx.stroke();
+					}
+				}
+			}
+			ctx.setLineDash( [] );
+
+			ctx.fillStyle = color;
+			for ( let r = 0; r < rows; r++ ) {
+				for ( let c = 0; c < cols; c++ ) {
+					const x = c * spacing;
+					const y = r * spacing;
+					ctx.fillRect( x - crossSize, y - crossThickness / 2, crossSize * 2, crossThickness );
+					ctx.fillRect( x - crossThickness / 2, y - crossSize, crossThickness, crossSize * 2 );
+				}
+			}
+		}
+
+		function setupCanvas() {
+			if ( ! canvas ) return;
+			const dpr = window.devicePixelRatio || 1;
+			canvas.width = Math.round( canvas.offsetWidth * dpr );
+			canvas.height = Math.round( canvas.offsetHeight * dpr );
+			ctx = canvas.getContext( '2d' )!;
+			ctx.scale( dpr, dpr );
+			readColor();
+			initDots();
+		}
+
+		function resize() {
+			setupCanvas();
+			ensureLoop();
+		}
+
+		function resizeStatic() {
+			setupCanvas();
+			drawStatic();
+		}
+
+		const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+
+		if ( prefersReducedMotion ) {
+			resizeStatic();
+
+			const resizeObserver = new ResizeObserver( resizeStatic );
+			resizeObserver.observe( canvas );
+
+			const mediaQuery = window.matchMedia( '(prefers-color-scheme: dark)' );
+			const onColorChange = () => {
+				readColor();
+				drawStatic();
+			};
+			mediaQuery.addEventListener( 'change', onColorChange );
+
+			return () => {
+				resizeObserver.disconnect();
+				mediaQuery.removeEventListener( 'change', onColorChange );
+			};
+		}
+
+		function onMouseMove( e: MouseEvent ) {
+			if ( ! canvas || ! isActive ) return;
+			const rect = canvas.getBoundingClientRect();
+			const x = e.clientX - rect.left;
+			const y = e.clientY - rect.top;
+			const inside = x >= 0 && x <= rect.width && y >= 0 && y <= rect.height;
+			mouseX = inside ? x : -9999;
+			mouseY = inside ? y : -9999;
+			ensureLoop();
+		}
+
+		function onMouseDown( e: MouseEvent ) {
+			if ( ! canvas || ! isActive ) return;
+			const rect = canvas.getBoundingClientRect();
+			const x = e.clientX - rect.left;
+			const y = e.clientY - rect.top;
+			if ( x >= 0 && x <= rect.width && y >= 0 && y <= rect.height ) {
+				targetRadius = RADIUS_EXPANDED;
+				ensureLoop();
+			}
+		}
+
+		function onMouseUp( e: MouseEvent ) {
+			if ( ! canvas || ! isActive ) return;
+			targetRadius = RADIUS_BASE;
+			if ( mouseX > -9998 ) {
+				const rect = canvas.getBoundingClientRect();
+				const x = e.clientX - rect.left;
+				const y = e.clientY - rect.top;
+				const diag = Math.sqrt( rect.width ** 2 + rect.height ** 2 );
+				ripples.push( {
+					x,
+					y,
+					radius: currentRadius * 0.85,
+					maxRadius: diag + RIPPLE_HALF_WIDTH * 4,
+				} );
+			}
+			ensureLoop();
+		}
+
+		setActiveRef.current = ( value: boolean ) => {
+			if ( isActive === value ) return;
+			isActive = value;
+			if ( ! value ) {
+				// Forget the cursor and any pressed state so the springs settle
+				// to rest in a few frames and the loop goes to sleep.
+				mouseX = -9999;
+				mouseY = -9999;
+				targetRadius = RADIUS_BASE;
+			}
+			ensureLoop();
+		};
+
+		resize();
+
+		document.addEventListener( 'mousemove', onMouseMove );
+		document.addEventListener( 'mousedown', onMouseDown );
+		document.addEventListener( 'mouseup', onMouseUp );
+
+		const resizeObserver = new ResizeObserver( resize );
+		resizeObserver.observe( canvas );
+
+		const mediaQuery = window.matchMedia( '(prefers-color-scheme: dark)' );
+		// Wake the loop for at least one frame so a sleeping grid repaints in
+		// the new color (the reduced-motion branch does the drawStatic
+		// equivalent above).
+		const onColorChange = () => {
+			readColor();
+			ensureLoop();
+		};
+		mediaQuery.addEventListener( 'change', onColorChange );
+
+		return () => {
+			if ( rafId !== null ) cancelAnimationFrame( rafId );
+			setActiveRef.current = () => {};
+			document.removeEventListener( 'mousemove', onMouseMove );
+			document.removeEventListener( 'mousedown', onMouseDown );
+			document.removeEventListener( 'mouseup', onMouseUp );
+			resizeObserver.disconnect();
+			mediaQuery.removeEventListener( 'change', onColorChange );
+		};
+	}, [ spacing, repulsion, rippleStrength, crossSize, crossThickness ] );
+
+	useEffect( () => {
+		setActiveRef.current( active );
+	}, [ active ] );
+
+	return (
+		<canvas
+			ref={ canvasRef }
+			className={ className ? `${ styles.canvas } ${ className }` : styles.canvas }
+			style={ { opacity } }
+		/>
+	);
+}

--- a/apps/ui/src/components/dot-grid/style.module.css
+++ b/apps/ui/src/components/dot-grid/style.module.css
@@ -1,0 +1,8 @@
+.canvas {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	pointer-events: none;
+	color: var(--wpds-color-fg-content-neutral-weak, #666);
+}

--- a/apps/ui/src/components/onboarding-footer/index.tsx
+++ b/apps/ui/src/components/onboarding-footer/index.tsx
@@ -1,0 +1,19 @@
+import styles from './style.module.css';
+import type { ReactNode } from 'react';
+
+/**
+ * Fixed action bar docked to the bottom of the onboarding flow, with a
+ * progressive-blur scrim so content scrolls away underneath it — the
+ * apps/ui counterpart of the desktop renderer's Add Site stepper.
+ * `CreateSiteForm` renders one around its actions; selector-style routes
+ * render their own. The first child (Back) is pinned bottom-left and the
+ * remaining actions sit bottom-right.
+ */
+export function OnboardingFooter( { children }: { children: ReactNode } ) {
+	return (
+		<>
+			<div aria-hidden="true" className={ styles.scrim } />
+			<div className={ styles.actions }>{ children }</div>
+		</>
+	);
+}

--- a/apps/ui/src/components/onboarding-footer/style.module.css
+++ b/apps/ui/src/components/onboarding-footer/style.module.css
@@ -1,0 +1,45 @@
+/* Progressive blur scrim: the backdrop blur fades out toward the top via
+   the mask, and the background gradient keeps the action bar legible over
+   content scrolling underneath — mirrors the desktop renderer's stepper. */
+.scrim {
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	height: 88px;
+	pointer-events: none;
+	z-index: 5;
+	/* Own snapshot group so the router's view transition doesn't fade/rise
+	   the fixed bar along with the page content. */
+	view-transition-name: onboarding-footer-scrim;
+	background: linear-gradient(
+		to top,
+		var(--wpds-color-bg-surface-neutral, #fff) 10%,
+		color-mix(in srgb, var(--wpds-color-bg-surface-neutral, #fff) 80%, transparent) 55%,
+		transparent
+	);
+	backdrop-filter: blur(10px);
+	-webkit-mask-image: linear-gradient(to top, black 45%, transparent);
+	mask-image: linear-gradient(to top, black 45%, transparent);
+}
+
+.actions {
+	position: fixed;
+	bottom: 20px;
+	left: 20px;
+	right: 20px;
+	z-index: 6;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 12px;
+	/* Own snapshot group — see .scrim. The persistent Back button reads as
+	   stationary chrome across steps instead of animating with the page. */
+	view-transition-name: onboarding-footer-actions;
+}
+
+/* The first action is always Back/Cancel — pin it bottom-left and keep the
+   primary action(s) bottom-right. */
+.actions > :first-child {
+	margin-right: auto;
+}

--- a/apps/ui/src/components/onboarding-illustrations/index.tsx
+++ b/apps/ui/src/components/onboarding-illustrations/index.tsx
@@ -1,0 +1,153 @@
+/**
+ * Illustrations for the onboarding flow-picker cards, ported from the
+ * desktop renderer's Add Site options screen. Strokes and fills use design
+ * tokens so they adapt to light/dark mode without overrides.
+ *
+ * Rest animations are kept very subtle — a single dashed accent spins slowly
+ * on each illustration. On hover (triggered by `illustrationHostClass` on the
+ * parent card), a secondary element picks up the brand color and a second
+ * motion kicks in.
+ */
+
+import styles from './style.module.css';
+
+const STROKE = 'var(--wpds-color-fg-content-neutral, #1e1e1e)';
+
+/** Apply to the hoverable card that contains an illustration. */
+export const illustrationHostClass = styles.host;
+
+export function BuildNewSiteIllustration() {
+	return (
+		<svg
+			width="198"
+			height="110"
+			viewBox="0 0 198 110"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			data-keep-size
+		>
+			<circle
+				cx="99"
+				cy="55.5"
+				r="36"
+				stroke={ STROKE }
+				strokeWidth="4"
+				strokeLinecap="round"
+				className={ styles.themeStroke }
+			/>
+			<circle
+				cx="99"
+				cy="55.5"
+				r="28.75"
+				stroke={ STROKE }
+				strokeWidth="0.5"
+				strokeLinecap="round"
+				strokeDasharray="6 6"
+				className={ styles.hoverSpinReverse }
+			/>
+			<circle
+				cx="99"
+				cy="55.5"
+				r="5.5"
+				stroke={ STROKE }
+				strokeLinecap="round"
+				strokeDasharray="1 5"
+				className={ styles.spin }
+			/>
+		</svg>
+	);
+}
+
+export function ConnectSiteIllustration() {
+	return (
+		<svg
+			width="198"
+			height="110"
+			viewBox="0 0 198 110"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			data-keep-size
+		>
+			<circle
+				cx="99"
+				cy="45"
+				r="5.5"
+				stroke={ STROKE }
+				strokeLinecap="round"
+				strokeDasharray="1 5"
+				className={ styles.spin }
+			/>
+			<path
+				className={ styles.arrowNudge }
+				d="M100.75 58C100.75 57.0335 99.9665 56.25 99 56.25C98.0335 56.25 97.25 57.0335 97.25 58H99H100.75ZM97.7626 92.2374C98.446 92.9209 99.554 92.9209 100.237 92.2374L111.374 81.1005C112.058 80.4171 112.058 79.309 111.374 78.6256C110.691 77.9422 109.583 77.9422 108.899 78.6256L99 88.5251L89.1005 78.6256C88.4171 77.9422 87.309 77.9422 86.6256 78.6256C85.9422 79.309 85.9422 80.4171 86.6256 81.1005L97.7626 92.2374ZM99 58H97.25L97.25 91L99 91L100.75 91L100.75 58H99Z"
+				fill={ STROKE }
+			/>
+			<path
+				className={ styles.themeFill }
+				d="M131 24C135.418 24 139 27.5817 139 32V59C139 63.4183 135.418 67 131 67H103V63H131L131.206 62.9951C133.319 62.8879 135 61.14 135 59V32C135 29.86 133.319 28.1121 131.206 28.0049L131 28H67C64.7909 28 63 29.7909 63 32V59L63.0049 59.2061C63.1121 61.3194 64.86 63 67 63H95V67H67C62.5817 67 59 63.4183 59 59V32C59 27.5817 62.5817 24 67 24H131Z"
+				fill={ STROKE }
+			/>
+		</svg>
+	);
+}
+
+export function DropBackupIllustration() {
+	return (
+		<svg
+			width="198"
+			height="110"
+			viewBox="0 0 198 110"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			data-keep-size
+		>
+			{ /* Mask that hides the portion of the back folder that sits under the
+			     front square, so the back can drift behind without appearing
+			     on top of the front outline. */ }
+			<defs>
+				<mask
+					id="dropbackup-outside-front"
+					maskUnits="userSpaceOnUse"
+					maskContentUnits="userSpaceOnUse"
+					x="0"
+					y="0"
+					width="198"
+					height="110"
+				>
+					<rect x="0" y="0" width="198" height="110" fill="white" />
+					<rect x="89.5" y="44.25" width="50" height="50" rx="10" fill="black" />
+				</mask>
+			</defs>
+			<g mask="url(#dropbackup-outside-front)">
+				<path
+					className={ styles.cardShift }
+					d="M98 15C103.523 15 108 19.4772 108 25V39.9561H104V25C104 21.6863 101.314 19 98 19H68C64.6863 19 62 21.6863 62 25V55C62 58.3137 64.6863 61 68 61H84.8633V65H68L67.4854 64.9873C62.3721 64.7281 58.2719 60.6279 58.0127 55.5146L58 55V25C58 19.4772 62.4772 15 68 15H98ZM108 48.9561V55C108 60.3502 103.798 64.7195 98.5146 64.9873L98 65H93.8633V61H98C101.314 61 104 58.3137 104 55V48.9561H108Z"
+					fill={ STROKE }
+					fillOpacity="0.6"
+				/>
+			</g>
+			<rect
+				x="89.5"
+				y="44.25"
+				width="50"
+				height="50"
+				rx="10"
+				stroke={ STROKE }
+				strokeWidth="4"
+				className={ styles.themeStroke }
+			/>
+			<circle
+				cx="115"
+				cy="69.5"
+				r="5.5"
+				stroke={ STROKE }
+				strokeLinecap="round"
+				strokeDasharray="1 5"
+				className={ styles.spin }
+			/>
+		</svg>
+	);
+}

--- a/apps/ui/src/components/onboarding-illustrations/style.module.css
+++ b/apps/ui/src/components/onboarding-illustrations/style.module.css
@@ -1,0 +1,89 @@
+/* Animation and hover treatment for the onboarding illustrations. The
+   `host` class goes on the hoverable card that contains an illustration —
+   hover effects on individual SVG parts key off it, mirroring the Tailwind
+   `group`/`group-hover` pairing the desktop renderer uses. */
+
+.host {
+	/* Hover scope only — no visual styles of its own. */
+}
+
+/* Rotate SVG children around their own centroid rather than the
+   document origin. */
+.spin,
+.hoverSpinReverse {
+	transform-box: fill-box;
+	transform-origin: center;
+}
+
+.spin {
+	animation: spin 20s linear infinite;
+}
+
+.host:hover .hoverSpinReverse {
+	animation: spin 24s linear infinite reverse;
+}
+
+.themeStroke {
+	transition: stroke 0.15s ease;
+}
+
+.host:hover .themeStroke {
+	stroke: var(--wpds-color-stroke-interactive-brand, #3858e9);
+}
+
+.themeFill {
+	transition: fill 0.15s ease;
+}
+
+.host:hover .themeFill {
+	fill: var(--wpds-color-fg-interactive-brand, #3858e9);
+}
+
+.host:hover .arrowNudge {
+	animation: arrow-nudge 1.2s ease-in-out infinite;
+}
+
+.host:hover .cardShift {
+	animation: card-shift 3s ease-in-out infinite;
+}
+
+@keyframes spin {
+	from {
+		transform: rotate(0deg);
+	}
+
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+@keyframes arrow-nudge {
+	0%,
+	100% {
+		transform: translateY(0);
+	}
+
+	50% {
+		transform: translateY(2px);
+	}
+}
+
+@keyframes card-shift {
+	0%,
+	100% {
+		transform: translate(0, 0);
+	}
+
+	50% {
+		transform: translate(-3px, -3px);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.spin,
+	.host:hover .hoverSpinReverse,
+	.host:hover .arrowNudge,
+	.host:hover .cardShift {
+		animation: none;
+	}
+}

--- a/apps/ui/src/hooks/use-grid-arrow-navigation.ts
+++ b/apps/ui/src/hooks/use-grid-arrow-navigation.ts
@@ -1,0 +1,73 @@
+import { useCallback } from 'react';
+
+const NAV_KEYS = [ 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End' ];
+
+/**
+ * Arrow-key navigation between the items of a card grid (or row). Attach the
+ * returned handler to the container's `onKeyDown` and mark each navigable
+ * control with `data-arrow-nav-item`.
+ *
+ * Left/Right move linearly (direction-aware for RTL); Up/Down move by visual
+ * row using the container's resolved CSS-grid column count (flex rows resolve
+ * to one "column", which degrades to linear movement); Home/End jump to the
+ * ends. Tab order is left untouched — arrows are an enhancement on top of it,
+ * so overlay controls inside a card wrapper (preview buttons, CTAs) keep
+ * their regular tab stops.
+ */
+export function useGridArrowNavigation() {
+	return useCallback( ( event: React.KeyboardEvent< HTMLElement > ) => {
+		if ( ! NAV_KEYS.includes( event.key ) ) {
+			return;
+		}
+		const target = event.target as HTMLElement;
+		const origin = target.closest< HTMLElement >( '[data-arrow-nav-item]' );
+		if ( ! origin ) {
+			return;
+		}
+		const container = event.currentTarget;
+		const items = Array.from(
+			container.querySelectorAll< HTMLElement >( '[data-arrow-nav-item]' )
+		);
+		const index = items.indexOf( origin );
+		if ( index === -1 ) {
+			return;
+		}
+
+		const style = getComputedStyle( container );
+		const columns =
+			style.display === 'grid' && style.gridTemplateColumns !== 'none'
+				? style.gridTemplateColumns.split( ' ' ).length
+				: 1;
+		const isRtl = style.direction === 'rtl';
+		const forward = isRtl ? 'ArrowLeft' : 'ArrowRight';
+		const backward = isRtl ? 'ArrowRight' : 'ArrowLeft';
+
+		let next = -1;
+		switch ( event.key ) {
+			case forward:
+				next = index + 1;
+				break;
+			case backward:
+				next = index - 1;
+				break;
+			case 'ArrowDown':
+				next = index + columns;
+				break;
+			case 'ArrowUp':
+				next = index - columns;
+				break;
+			case 'Home':
+				next = 0;
+				break;
+			case 'End':
+				next = items.length - 1;
+				break;
+		}
+
+		if ( next < 0 || next >= items.length || next === index ) {
+			return;
+		}
+		event.preventDefault();
+		items[ next ].focus();
+	}, [] );
+}

--- a/apps/ui/src/hooks/use-mouse-navigation.ts
+++ b/apps/ui/src/hooks/use-mouse-navigation.ts
@@ -1,0 +1,25 @@
+import { useRouter } from '@tanstack/react-router';
+import { useEffect } from 'react';
+
+/**
+ * Wires the mouse's back/forward side buttons (buttons 3 and 4) to router
+ * history. Electron doesn't translate these into navigation on its own the
+ * way browsers do, so without this they're dead clicks.
+ */
+export function useMouseNavigation(): void {
+	const router = useRouter();
+
+	useEffect( () => {
+		const handleMouseUp = ( event: MouseEvent ) => {
+			if ( event.button === 3 ) {
+				event.preventDefault();
+				router.history.back();
+			} else if ( event.button === 4 ) {
+				event.preventDefault();
+				router.history.forward();
+			}
+		};
+		window.addEventListener( 'mouseup', handleMouseUp );
+		return () => window.removeEventListener( 'mouseup', handleMouseUp );
+	}, [ router ] );
+}

--- a/apps/ui/src/hooks/use-offline.ts
+++ b/apps/ui/src/hooks/use-offline.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks the browser's online/offline state. Mirrors the desktop renderer's
+ * hook of the same name — used to disable network-dependent flows like
+ * connecting a WordPress.com site.
+ */
+export function useOffline(): boolean {
+	const [ isOffline, setIsOffline ] = useState( ! navigator.onLine );
+
+	useEffect( () => {
+		const handleOnline = () => setIsOffline( false );
+		const handleOffline = () => setIsOffline( true );
+		window.addEventListener( 'online', handleOnline );
+		window.addEventListener( 'offline', handleOffline );
+		return () => {
+			window.removeEventListener( 'online', handleOnline );
+			window.removeEventListener( 'offline', handleOffline );
+		};
+	}, [] );
+
+	return isOffline;
+}

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -112,19 +112,33 @@ textarea,
 
 /* Show the focus ring only on keyboard focus, overriding @wordpress/ui's
    :focus-based outline. Unlayered CSS wins over WP UI's cascade layers.
-   `a` covers Button primitives rendered as links via its `render` prop.
-   Also revert the background/border shift @wordpress/ui's Button applies on
-   `:focus` — when a Dialog auto-focuses a button on open, the "active" look
-   would otherwise show without any user intent. Leave `color` alone:
-   loading buttons rely on `color: transparent` to hide their label while
-   the spinner runs, and overriding that here would make the label visible
-   again. */
+   `a` covers Button primitives rendered as links via its `render` prop. */
 button:focus:not( :focus-visible ),
 a:focus:not( :focus-visible ),
 [role='button']:focus:not( :focus-visible ) {
 	outline: none;
-	background-color: var( --wp-ui-button-background-color );
-	border-color: var( --wp-ui-button-border-color );
+}
+
+/* Revert the background/border shift @wordpress/ui's Button applies on
+   `:focus` — when a Dialog auto-focuses a button on open, the "active" look
+   would otherwise show without any user intent. Leave `color` alone:
+   loading buttons rely on `color: transparent` to hide their label while
+   the spinner runs, and overriding that here would make the label visible
+   again.
+
+   Declared inside WP UI's own `wp-ui-overrides` layer (its highest), NOT
+   unlayered: it must beat the layered focus shift but lose to unlayered
+   component styles. Custom buttons (the onboarding cards) don't define
+   the --wp-ui-button-* props, and an unlayered declaration here would
+   evaluate the undefined var() and reset their backgrounds to transparent
+   on click. */
+@layer wp-ui-overrides {
+	button:focus:not( :focus-visible ),
+	a:focus:not( :focus-visible ),
+	[role='button']:focus:not( :focus-visible ) {
+		background-color: var( --wp-ui-button-background-color );
+		border-color: var( --wp-ui-button-border-color );
+	}
 }
 
 /* Compact density: shrink icons to match the tighter spacing tokens.
@@ -135,6 +149,45 @@ a:focus:not( :focus-visible ),
 [data-wpds-density='compact'] [data-ui-mode='classic'] svg {
 	width: 16px;
 	height: 16px;
+}
+
+/* Escape hatch for non-icon SVGs (illustrations, thumbnails) that size
+   themselves through their width/height attributes — `auto` defers back to
+   the attribute values the compact-density rule above would override. */
+[data-wpds-density='compact'] [data-ui-mode='classic'] svg[data-keep-size] {
+	width: auto;
+	height: auto;
+}
+
+/* Step transitions for the classic router (`defaultViewTransition` in
+   createAppRouter) — the outgoing view fades while the incoming one fades
+   in with a slight rise, echoing the desktop renderer's Navigator slide. */
+@keyframes view-transition-exit {
+	to {
+		opacity: 0;
+	}
+}
+
+@keyframes view-transition-enter {
+	from {
+		opacity: 0;
+		transform: translateY(10px);
+	}
+}
+
+::view-transition-old(root) {
+	animation: 120ms ease-out both view-transition-exit;
+}
+
+::view-transition-new(root) {
+	animation: 220ms ease-out both view-transition-enter;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	::view-transition-old(root),
+	::view-transition-new(root) {
+		animation: none;
+	}
 }
 
 /* Desks uses each shape's indicator as the visible selection outline.
@@ -158,6 +211,33 @@ a:focus:not( :focus-visible ),
 .components-combobox-control__suggestions-container,
 .components-form-token-field__suggestions-list {
 	background-color: var( --wp-components-color-background, #fff );
+}
+
+/* Input prefix icons (e.g. the email field's envelope) render with the SVG
+   default black fill; inherit the input's foreground so they track dark
+   mode. */
+.components-input-control-prefix-wrapper svg {
+	fill: currentColor;
+}
+
+/* The combobox suggestions popup defines no focus outline of its own, so
+   keyboard focus falls back to the UA default ring, which follows the OS
+   accent color (orange, green, …). Suppress it entirely: the combobox
+   input keeps its own focus ring, and a second ring around the popup reads
+   as a double focus indicator. The active option's highlight carries the
+   selection state inside the list. */
+.components-combobox-control__suggestions-container:focus-visible,
+.components-form-token-field__suggestions-list:focus-visible,
+.components-popover [role='listbox']:focus-visible {
+	outline: none;
+}
+
+/* CheckboxControl hardcodes a white box; defer to the themed input
+   background so unchecked boxes don't glow in dark mode. Specificity beats
+   the emotion-generated class that ships the hardcoded white; scoped to
+   :not(:checked) so the checked state keeps its accent fill. */
+input.components-checkbox-control__input[type='checkbox']:not(:checked) {
+	background: var( --wp-components-color-background, #fff );
 }
 
 /* Honor the user's reduced-motion preference across the entire app. Class-

--- a/apps/ui/src/lib/docs-links.ts
+++ b/apps/ui/src/lib/docs-links.ts
@@ -15,6 +15,10 @@ const DOCS_LINKS = {
 	docsSslInStudio: {
 		en: 'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/',
 	},
+	docsSyncSupportedSites: {
+		en: 'https://developer.wordpress.com/docs/developer-tools/studio/sync/#supported-sites',
+		es: 'https://developer.wordpress.com/es/docs/herramientas-para-desarrolladores/studio/sync/#sitios-compatibles',
+	},
 } as const satisfies Record< string, TranslatedLink >;
 
 export type DocsLinkKey = keyof typeof DOCS_LINKS;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,6 +1079,7 @@
 				"@tanstack/react-query": "^5.75.5",
 				"@tanstack/react-query-persist-client": "^5.96.2",
 				"@tanstack/react-router": "^1.120.14",
+				"@wordpress/a11y": "^4.47.0",
 				"@wordpress/api-fetch": "^7.47.0",
 				"@wordpress/components": "^34.0.0",
 				"@wordpress/core-data": "^7.47.0",
@@ -4712,6 +4713,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4727,6 +4731,9 @@
 			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -4744,6 +4751,9 @@
 			"cpu": [
 				"riscv64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4760,6 +4770,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4775,6 +4788,9 @@
 			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,


### PR DESCRIPTION
## Related issues

- Part of the site-creation onboarding redesign — see the umbrella PR (linked below once open) for the full plan.

## How AI was used in this PR

Split out of the `workbench/site-creation` exploration branch with Claude Code; designed and tested by Shaun on the original branch.

## Proposed Changes

Self-contained building blocks for the redesigned site-creation onboarding (nothing renders them yet — the flow PRs that follow wire them up):

- An interactive dot-grid canvas backdrop and a set of onboarding illustrations that give the new flows their visual identity.
- A shared onboarding footer and a busy overlay that shields the window during long-running actions like site creation.
- Keyboard/a11y groundwork: arrow-key grid navigation, keyboard-only focus rings, and an `@wordpress/a11y` dependency for screen-reader announcements.
- Small hooks for offline detection and mouse back/forward navigation buttons.

## Testing Instructions

- Nothing is user-visible yet; this lands dormant code. Verify the app builds and existing UI is unaffected (focus rings on buttons should only show for keyboard focus, in both light and dark mode).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
