### PR TITLE
Add site-creation plumbing: name collision lookup, version data, deeplink handoffs

### DIFF
--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -1,10 +1,12 @@
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
+import { fetchWordPressVersions } from '@studio/common/lib/wordpress-versions';
 import { __ } from '@wordpress/i18n';
 import type {
 	ActiveAgentRun,
 	AiSessionSummary,
 	AiSessionPlacementUpdatedEvent,
 	AuthUser,
+	AvailableSitePath,
 	ColorScheme,
 	Connector,
 	DeskConfig,
@@ -192,8 +194,8 @@ export function createIpcConnector(): Connector {
 			};
 		},
 
-		async authenticate(): Promise< void > {
-			await ipcApi.authenticate( false );
+		async authenticate( signup = false ): Promise< void > {
+			await ipcApi.authenticate( signup );
 		},
 
 		async logout(): Promise< void > {
@@ -221,6 +223,7 @@ export function createIpcConnector(): Connector {
 				adminPassword,
 				adminEmail,
 				blueprint,
+				skipStart,
 			} = params;
 			return ( await ipcApi.createSite( path, {
 				siteName: name,
@@ -232,6 +235,7 @@ export function createIpcConnector(): Connector {
 				adminPassword,
 				adminEmail,
 				blueprint,
+				noStart: skipStart,
 			} ) ) as SiteDetails;
 		},
 
@@ -256,6 +260,16 @@ export function createIpcConnector(): Connector {
 
 		async generateProposedSiteName( usedSites ): Promise< string > {
 			return ( await ipcApi.generateSiteNameFromList( usedSites ) ) as string;
+		},
+
+		async findAvailableSitePath( baseName ): Promise< AvailableSitePath > {
+			// The main process resolves the numbered-name collision search in a
+			// single call (checking both existing site names and non-empty site
+			// folders) — same helper `copySite` uses above.
+			const sites = ( await ipcApi.getSiteDetails() ) as SiteDetails[];
+			const name = ( await ipcApi.generateNumberedNameFromList( baseName, sites ) ) as string;
+			const { path } = ( await ipcApi.generateProposedSitePath( name ) ) as { path: string };
+			return { name, path };
 		},
 
 		async generateProposedSitePath( siteName ): Promise< ProposedSitePath > {
@@ -336,6 +350,13 @@ export function createIpcConnector(): Connector {
 			return list;
 		},
 
+		async getWordPressVersions() {
+			// Fetches straight from the wordpress.org version-check API (the
+			// renderer CSP allows api.wordpress.org) using the same shared
+			// helper the desktop renderer's version selector relies on.
+			return fetchWordPressVersions();
+		},
+
 		async getFilePath( file ) {
 			// `webUtils.getPathForFile` is a synchronous preload-only API; the
 			// connector wraps it in a Promise to keep the surface uniform and
@@ -354,6 +375,21 @@ export function createIpcConnector(): Connector {
 
 		async cleanupBlueprintTempDir( tempDir ) {
 			await ipcApi.cleanupBlueprintTempDir( tempDir );
+		},
+
+		async readBlueprintFile( filePath ): Promise< Record< string, unknown > > {
+			return ( await ipcApi.readBlueprintFile( filePath ) ) as Record< string, unknown >;
+		},
+
+		onAddSiteRequested( listener ) {
+			return ipcListener.subscribe( 'add-site', () => listener() );
+		},
+
+		onAddSiteWithBlueprint( listener ) {
+			return ipcListener.subscribe(
+				'add-site-with-blueprint',
+				( _event: unknown, payload: { blueprintPath: string } ) => listener( payload )
+			);
 		},
 
 		async importSiteFromBackup( siteId, backup ): Promise< SiteDetails > {

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -4,6 +4,7 @@ export type {
 	AiModelId,
 	AiSessionSummary,
 	AuthUser,
+	AvailableSitePath,
 	ColorScheme,
 	Connector,
 	CreateSiteParams,

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -4,6 +4,7 @@ import type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessio
 import type { SupportedLocale } from '@studio/common/lib/locale';
 import type { SupportedEditor } from '@studio/common/lib/user-settings/editor';
 import type { SupportedTerminal } from '@studio/common/lib/user-settings/terminal';
+import type { WordPressVersion } from '@studio/common/lib/wordpress-versions';
 import type { DeskConfig, DeskSettings } from '@studio/common/types/desk';
 import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
 import type { Snapshot } from '@studio/common/types/snapshot';
@@ -98,7 +99,9 @@ export interface Connector {
 	requiresAuth: boolean;
 	isAuthenticated(): Promise< boolean >;
 	getAuthUser(): Promise< AuthUser | null >;
-	authenticate(): Promise< void >;
+	// Starts the WordPress.com OAuth flow in the browser. Pass `signup` to
+	// land on account creation instead of login.
+	authenticate( signup?: boolean ): Promise< void >;
 	logout(): Promise< void >;
 	onAuthStateChanged?( listener: () => void ): () => void;
 
@@ -139,6 +142,11 @@ export interface Connector {
 	// and domain lookups).
 	generateProposedSitePath( siteName: string ): Promise< ProposedSitePath >;
 	generateProposedSiteName( usedSites: SiteDetails[] ): Promise< string >;
+	// Resolves a base name to one that doesn't collide with an existing site
+	// name or a non-empty site folder ("My Site", "My Site 2", …), returning
+	// it with its proposed directory. The collision search runs in the main
+	// process so callers pay a constant number of IPC round-trips.
+	findAvailableSitePath( baseName: string ): Promise< AvailableSitePath >;
 	selectSiteFolder( defaultPath: string ): Promise< SelectedSiteFolder | null >;
 	comparePaths( path1: string, path2: string ): Promise< boolean >;
 	getAllCustomDomains(): Promise< string[] >;
@@ -147,6 +155,11 @@ export interface Connector {
 	// flow. Sourced from the public wpcom/v2/studio-app/blueprints endpoint —
 	// no auth required, localized by the user's current UI locale.
 	getFeaturedBlueprints( locale?: string ): Promise< FeaturedBlueprint[] >;
+
+	// Installable WordPress versions from the wordpress.org version-check
+	// API: a "latest" auto-updating option first, then nightly/beta and
+	// stable releases down to Playground's minimum supported version.
+	getWordPressVersions(): Promise< WordPressVersion[] >;
 
 	// Resolves the absolute filesystem path of a File handle picked or dropped
 	// in the renderer. Returns an empty string when the underlying file lacks
@@ -161,6 +174,19 @@ export interface Connector {
 	// temp directory automatically when it uses the extracted blueprint.
 	extractBlueprintBundle( zipFilePath: string ): Promise< ExtractedBlueprintBundle >;
 	cleanupBlueprintTempDir( tempDir: string ): Promise< void >;
+
+	// Reads a Blueprint JSON file from disk. Used by the `wp-studio://add-site`
+	// deep link, which downloads and validates the blueprint in the main
+	// process and hands the renderer a temp file path to read it back from.
+	readBlueprintFile( filePath: string ): Promise< Record< string, unknown > >;
+
+	// Fires when the user asks to add a site from outside the renderer —
+	// currently the File ▸ Add Site… menu item (⌘N).
+	onAddSiteRequested( listener: () => void ): () => void;
+	// Fires when a `wp-studio://add-site?blueprint_url=…` (or `blueprint=…`)
+	// deep link arrives. The payload points at a blueprint JSON file the main
+	// process already downloaded and validated; read it via `readBlueprintFile`.
+	onAddSiteWithBlueprint( listener: ( payload: { blueprintPath: string } ) => void ): () => void;
 
 	// Imports a backup archive into an already-created site. Extracts the
 	// archive, installs the SQLite integration if missing, then imports the
@@ -340,6 +366,10 @@ export interface CreateSiteParams {
 	adminUsername?: string;
 	adminPassword?: string;
 	adminEmail?: string;
+	// Skips starting the site server after creation. Used by flows that
+	// immediately overwrite the fresh install (pulling a connected
+	// WordPress.com site), where the sync handler restarts the server itself.
+	skipStart?: boolean;
 	// Optional blueprint payload. When present, `blueprint` is the parsed
 	// blueprint JSON; `slug` is set for featured blueprints (used for stats);
 	// `filePath` points at the extracted `blueprint.json` inside a ZIP bundle
@@ -363,6 +393,11 @@ export interface ProposedSitePath {
 	isEmpty: boolean;
 	isWordPress: boolean;
 	isNameTooLong?: boolean;
+}
+
+export interface AvailableSitePath {
+	name: string;
+	path: string;
 }
 
 export interface SelectedSiteFolder {

--- a/apps/ui/src/data/queries/use-create-site-helpers.ts
+++ b/apps/ui/src/data/queries/use-create-site-helpers.ts
@@ -2,7 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { useConnector } from '@/data/core';
-import type { ProposedSitePath, SelectedSiteFolder, SiteDetails } from '@/data/core';
+import type {
+	AvailableSitePath,
+	ProposedSitePath,
+	SelectedSiteFolder,
+	SiteDetails,
+} from '@/data/core';
 
 const CUSTOM_DOMAINS_QUERY_KEY = [ 'customDomains' ] as const;
 const PROPOSED_SITE_NAME_QUERY_KEY = [ 'proposedSiteName' ] as const;
@@ -32,6 +37,23 @@ export function useProposedSiteName( sites: SiteDetails[] | undefined ) {
 		enabled: !! sites,
 		staleTime: Infinity,
 	} );
+}
+
+/**
+ * Finds a site name that doesn't collide with an existing site or a
+ * non-empty site folder by appending an incrementing suffix ("My Site",
+ * "My Site 2", ...), and returns it together with its proposed directory.
+ * Used when a flow seeds the name from an external source — a connected
+ * WordPress.com site, a blueprint, a backup filename — rather than user
+ * input. The search runs in the main process in one round-trip.
+ */
+export function useFindAvailableSiteName() {
+	const connector = useConnector();
+	return useCallback(
+		( baseName: string ): Promise< AvailableSitePath > =>
+			connector.findAvailableSitePath( baseName ),
+		[ connector ]
+	);
 }
 
 /**

--- a/apps/ui/src/data/queries/use-wordpress-versions.ts
+++ b/apps/ui/src/data/queries/use-wordpress-versions.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+
+const WORDPRESS_VERSIONS_QUERY_KEY = [ 'wordpress-versions' ] as const;
+
+/**
+ * Installable WordPress versions for the create-site and site-settings
+ * forms. The list changes only when WordPress ships a release, so keep it
+ * fresh for an hour; failures fall back to the form's static default
+ * rather than blocking site creation.
+ */
+export function useWordPressVersions() {
+	const connector = useConnector();
+	return useQuery( {
+		queryKey: WORDPRESS_VERSIONS_QUERY_KEY,
+		queryFn: () => connector.getWordPressVersions(),
+		staleTime: 60 * 60 * 1000,
+		retry: 1,
+	} );
+}

--- a/apps/ui/src/hooks/use-add-site-listener.test.tsx
+++ b/apps/ui/src/hooks/use-add-site-listener.test.tsx
@@ -1,0 +1,111 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectorProvider } from '@/data/core';
+import { clearPendingBlueprint, peekPendingBlueprint } from '@/lib/pending-blueprint';
+import { useAddSiteListener } from './use-add-site-listener';
+import type { Connector } from '@/data/core';
+
+const routerMock = vi.hoisted( () => ( {
+	navigate: vi.fn(),
+} ) );
+
+vi.mock( '@tanstack/react-router', () => ( {
+	useNavigate: () => routerMock.navigate,
+} ) );
+
+function HookHost() {
+	useAddSiteListener();
+	return null;
+}
+
+function renderListener( connectorOverrides: Partial< Connector > = {} ) {
+	const addSiteListeners: Array< () => void > = [];
+	const blueprintListeners: Array< ( payload: { blueprintPath: string } ) => void > = [];
+
+	const connector = {
+		onAddSiteRequested( listener: () => void ) {
+			addSiteListeners.push( listener );
+			return () => {};
+		},
+		onAddSiteWithBlueprint( listener: ( payload: { blueprintPath: string } ) => void ) {
+			blueprintListeners.push( listener );
+			return () => {};
+		},
+		readBlueprintFile: vi.fn().mockResolvedValue( {
+			meta: { title: 'My Blueprint', description: 'A test blueprint' },
+			steps: [],
+		} ),
+		...connectorOverrides,
+	} as unknown as Connector;
+
+	render(
+		<ConnectorProvider connector={ connector }>
+			<HookHost />
+		</ConnectorProvider>
+	);
+
+	return {
+		connector,
+		emitAddSite: () => addSiteListeners.forEach( ( listener ) => listener() ),
+		emitAddSiteWithBlueprint: ( payload: { blueprintPath: string } ) =>
+			blueprintListeners.forEach( ( listener ) => listener( payload ) ),
+	};
+}
+
+describe( 'useAddSiteListener', () => {
+	beforeEach( () => {
+		routerMock.navigate.mockReset();
+		clearPendingBlueprint();
+	} );
+
+	it( 'navigates to onboarding when the add-site menu event fires', () => {
+		const { emitAddSite } = renderListener();
+
+		emitAddSite();
+
+		expect( routerMock.navigate ).toHaveBeenCalledWith( { to: '/onboarding' } );
+	} );
+
+	it( 'stores the deep-linked blueprint and lands on the configure step', async () => {
+		const { connector, emitAddSiteWithBlueprint } = renderListener();
+
+		emitAddSiteWithBlueprint( { blueprintPath: '/tmp/blueprint-123.json' } );
+
+		await waitFor( () =>
+			expect( routerMock.navigate ).toHaveBeenCalledWith( {
+				to: '/onboarding/blueprint',
+				search: { step: 'configure' },
+			} )
+		);
+		expect( connector.readBlueprintFile ).toHaveBeenCalledWith( '/tmp/blueprint-123.json' );
+		expect( peekPendingBlueprint() ).toMatchObject( {
+			title: 'My Blueprint',
+			excerpt: 'A test blueprint',
+		} );
+	} );
+
+	it( 'falls back to a generic title when the blueprint has no meta', async () => {
+		const { emitAddSiteWithBlueprint } = renderListener( {
+			readBlueprintFile: vi.fn().mockResolvedValue( { steps: [] } ),
+		} );
+
+		emitAddSiteWithBlueprint( { blueprintPath: '/tmp/blueprint-456.json' } );
+
+		await waitFor( () => expect( routerMock.navigate ).toHaveBeenCalled() );
+		expect( peekPendingBlueprint() ).toMatchObject( { title: 'Blueprint' } );
+	} );
+
+	it( 'does not navigate when the blueprint file cannot be read', async () => {
+		const consoleError = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+		const { connector, emitAddSiteWithBlueprint } = renderListener( {
+			readBlueprintFile: vi.fn().mockRejectedValue( new Error( 'missing file' ) ),
+		} );
+
+		emitAddSiteWithBlueprint( { blueprintPath: '/tmp/gone.json' } );
+
+		await waitFor( () => expect( connector.readBlueprintFile ).toHaveBeenCalled() );
+		expect( routerMock.navigate ).not.toHaveBeenCalled();
+		expect( peekPendingBlueprint() ).toBeNull();
+		consoleError.mockRestore();
+	} );
+} );

--- a/apps/ui/src/hooks/use-add-site-listener.ts
+++ b/apps/ui/src/hooks/use-add-site-listener.ts
@@ -1,0 +1,54 @@
+import { generateDefaultBlueprintDescription } from '@studio/common/lib/blueprint-settings';
+import { useNavigate } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import { useConnector } from '@/data/core';
+import { setPendingBlueprint } from '@/lib/pending-blueprint';
+import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
+
+/**
+ * Bridges renderer-external "add a site" requests into the router. Two
+ * sources, both originating in the main process:
+ *
+ * - The File ▸ Add Site… menu item (⌘N) fires a plain `add-site` event —
+ *   navigate to the onboarding flow picker.
+ * - A `wp-studio://add-site?blueprint_url=…` deep link fires
+ *   `add-site-with-blueprint` with the path of a blueprint JSON the main
+ *   process already downloaded and validated. Load it, stash it in the
+ *   pending-blueprint slot, and land directly on the configure step.
+ *
+ * Must be mounted inside the RouterProvider (it navigates); the classic
+ * router's root layout is the canonical spot.
+ */
+export function useAddSiteListener(): void {
+	const connector = useConnector();
+	const navigate = useNavigate();
+
+	useEffect( () => {
+		return connector.onAddSiteRequested( () => {
+			void navigate( { to: '/onboarding' } );
+		} );
+	}, [ connector, navigate ] );
+
+	useEffect( () => {
+		return connector.onAddSiteWithBlueprint( async ( { blueprintPath } ) => {
+			try {
+				const blueprintJson = await connector.readBlueprintFile( blueprintPath );
+				const blueprint = blueprintJson as BlueprintV1Declaration;
+				const meta = ( blueprintJson as { meta?: { title?: string; description?: string } } ).meta;
+
+				setPendingBlueprint( {
+					title: meta?.title || __( 'Blueprint' ),
+					excerpt: meta?.description || generateDefaultBlueprintDescription( blueprint ),
+					blueprint,
+				} );
+				void navigate( {
+					to: '/onboarding/blueprint',
+					search: { step: 'configure' },
+				} );
+			} catch ( error ) {
+				console.error( 'Failed to load blueprint from deep link:', error );
+			}
+		} );
+	}, [ connector, navigate ] );
+}

--- a/apps/ui/src/hooks/use-seeded-site-name.ts
+++ b/apps/ui/src/hooks/use-seeded-site-name.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { useFindAvailableSiteName } from '@/data/queries/use-create-site-helpers';
+
+/**
+ * Resolves a seeded site name (from a blueprint, a backup filename, a
+ * connected site, …) to a variant that doesn't collide with an existing
+ * site ("Name", "Name 2", …). Returns `null` while resolving — callers
+ * hold the form's initial values until then since they're applied only
+ * once. Falls back to the raw name if the collision check fails, so the
+ * form still seeds; the create form's path validation surfaces any real
+ * conflict before submit.
+ */
+export function useSeededSiteName( baseName: string | null ): string | null {
+	const findAvailableSiteName = useFindAvailableSiteName();
+	const [ seededName, setSeededName ] = useState< string | null >( null );
+
+	useEffect( () => {
+		if ( ! baseName ) {
+			setSeededName( null );
+			return;
+		}
+		let cancelled = false;
+		findAvailableSiteName( baseName )
+			.then( ( { name } ) => {
+				if ( ! cancelled ) {
+					setSeededName( name );
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setSeededName( baseName );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ baseName, findAvailableSiteName ] );
+
+	return seededName;
+}

--- a/apps/ui/src/lib/backup-files.ts
+++ b/apps/ui/src/lib/backup-files.ts
@@ -1,0 +1,22 @@
+import { ACCEPTED_IMPORT_FILE_TYPES } from '@studio/common/constants';
+
+export function isValidBackupFile( file: File ): boolean {
+	const lower = file.name.toLowerCase();
+	return ACCEPTED_IMPORT_FILE_TYPES.some( ( ext ) => lower.endsWith( ext ) );
+}
+
+/**
+ * Derives a friendly default site name from a backup filename. Strips the
+ * archive extension and common "site-backup-2024-01-01" date suffixes so the
+ * form can seed the site name without the user having to retype it.
+ */
+export function nameFromFilename( filename: string ): string {
+	const basename = filename.replace( /^.*[\\/]/, '' );
+	const lower = basename.toLowerCase();
+	const ext = ACCEPTED_IMPORT_FILE_TYPES.find( ( candidate ) => lower.endsWith( candidate ) );
+	return ( ext ? basename.slice( 0, -ext.length ) : basename )
+		.replace( /[-_](backup|export|wordpress|jetpack)(s)?$/i, '' )
+		.replace( /[-_]\d{4}[-_]\d{2}[-_]\d{2}.*$/, '' )
+		.replace( /[-_]+/g, ' ' )
+		.trim();
+}

--- a/apps/ui/src/lib/pending-backup.ts
+++ b/apps/ui/src/lib/pending-backup.ts
@@ -1,0 +1,21 @@
+import { createPendingSlot } from './pending-slot';
+
+/**
+ * One-slot handoff for a backup archive picked outside the import route's
+ * own UI — currently the drop-target card on the onboarding home screen.
+ * The picker stores the file here and navigates to the configure step; the
+ * route adopts it into component state on arrival and clears the slot.
+ */
+
+export interface PendingBackup {
+	file: File;
+	// Resolved via `connector.getFilePath` at pick-time so the import route
+	// doesn't have to await the preload bridge again.
+	path: string;
+}
+
+export const pendingBackupSlot = createPendingSlot< PendingBackup >();
+
+export const setPendingBackup = pendingBackupSlot.set;
+export const peekPendingBackup = pendingBackupSlot.peek;
+export const clearPendingBackup = pendingBackupSlot.clear;

--- a/apps/ui/src/lib/pending-blueprint.ts
+++ b/apps/ui/src/lib/pending-blueprint.ts
@@ -1,0 +1,14 @@
+import { createPendingSlot } from './pending-slot';
+import type { PickedBlueprint } from '@/components/blueprint-selector';
+
+/**
+ * One-slot handoff for a blueprint that arrives from outside the blueprint
+ * route's own UI — currently the `wp-studio://add-site` deep link. The
+ * listener stores the blueprint here and navigates to the configure step;
+ * the route adopts it into component state on arrival and clears the slot.
+ */
+export const pendingBlueprintSlot = createPendingSlot< PickedBlueprint >();
+
+export const setPendingBlueprint = pendingBlueprintSlot.set;
+export const peekPendingBlueprint = pendingBlueprintSlot.peek;
+export const clearPendingBlueprint = pendingBlueprintSlot.clear;

--- a/apps/ui/src/lib/pending-slot.ts
+++ b/apps/ui/src/lib/pending-slot.ts
@@ -1,0 +1,49 @@
+/**
+ * A one-slot handoff between a producer outside a route's own UI (a deep
+ * link, the onboarding home screen) and the route that consumes the value.
+ * The producer `set`s the value and navigates; the route adopts it on
+ * arrival and `clear`s the slot.
+ *
+ * `subscribe` notifies on every set/clear so routes can read the slot via
+ * `useSyncExternalStore` and react to a new value arriving while already
+ * mounted (e.g. a second deep link mid-configure). Adoption and clearing
+ * stay split (rather than an atomic take) so React StrictMode's
+ * double-invoked effects can't consume the value on the first pass and
+ * bounce the user back on the second.
+ */
+export interface PendingSlot< T > {
+	set( value: T ): void;
+	peek(): T | null;
+	clear(): void;
+	subscribe( listener: () => void ): () => void;
+}
+
+export function createPendingSlot< T >(): PendingSlot< T > {
+	let value: T | null = null;
+	const listeners = new Set< () => void >();
+	const notify = () => {
+		for ( const listener of [ ...listeners ] ) {
+			listener();
+		}
+	};
+	return {
+		set( next: T ) {
+			value = next;
+			notify();
+		},
+		peek: () => value,
+		clear() {
+			if ( value === null ) {
+				return;
+			}
+			value = null;
+			notify();
+		},
+		subscribe( listener: () => void ) {
+			listeners.add( listener );
+			return () => {
+				listeners.delete( listener );
+			};
+		},
+	};
+}


### PR DESCRIPTION
## Related issues

- Part of the site-creation onboarding redesign — see the umbrella PR (linked below once open) for the full plan.

## How AI was used in this PR

Split out of the `workbench/site-creation` exploration branch with Claude Code; designed and tested by Shaun on the original branch. Includes a unit test for the add-site listener.

## Proposed Changes

Data-layer groundwork for the redesigned onboarding flows (no UI changes yet):

- Seeded site names ("My Site", "My Site 2", …) are now resolved in the main process in a single round-trip, instead of the renderer probing paths one by one.
- A WordPress versions query so the create form can offer a version selector instead of a free-text field.
- A `wp-studio://add-site` deeplink/menu listener plus one-slot handoffs (`pending-blueprint`, `pending-backup`) that let an external trigger hand a blueprint or backup to the onboarding routes without racing React StrictMode's double effects.
- Backup-file validation helpers shared by the import entry points.

## Testing Instructions

- Nothing user-visible yet. `npm run typecheck` and `npx vitest run apps/ui/src/hooks/use-add-site-listener.test.tsx` pass.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
