### PR TITLE
Redesign the onboarding shell and create-site form

### DIFF
--- a/apps/ui/src/components/create-site-form/index.tsx
+++ b/apps/ui/src/components/create-site-form/index.tsx
@@ -5,10 +5,12 @@ import { RecommendedPHPVersion } from '@studio/common/types/php-versions';
 import { BaseControl, CheckboxControl } from '@wordpress/components';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
-import { chevronDown, chevronRight } from '@wordpress/icons';
+import { chevronLeft, chevronDown, chevronRight } from '@wordpress/icons';
 import { Button, Icon } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { BusyOverlay } from '@/components/busy-overlay';
 import { LearnHowLink, LearnMoreLink } from '@/components/learn-more';
+import { OnboardingFooter } from '@/components/onboarding-footer';
 import {
 	adminEmailField,
 	adminPasswordField,
@@ -21,6 +23,7 @@ import {
 } from '@/components/site-fields';
 import { usePathValidator } from '@/data/queries/use-create-site-helpers';
 import { useSites } from '@/data/queries/use-sites';
+import { useWordPressVersions } from '@/data/queries/use-wordpress-versions';
 import styles from './style.module.css';
 import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
 import type {
@@ -302,6 +305,36 @@ export function CreateSiteForm( {
 		} );
 	}, [ initialValues ] );
 
+	const { data: wpVersions } = useWordPressVersions();
+
+	// Land keyboard focus in the Site name field on mount — it's the first
+	// thing every flow asks for. The onboarding layout's heading-focus
+	// fallback yields when a page claims focus itself.
+	const formRef = useRef< HTMLFormElement >( null );
+	useEffect( () => {
+		const input = formRef.current?.querySelector< HTMLInputElement >(
+			'input[type="text"], input:not([type])'
+		);
+		input?.focus();
+	}, [] );
+
+	// Drop a wpVersion that isn't in the installable-versions list (e.g. a
+	// blueprint preferring a release below the minimum supported version) —
+	// mirrors the desktop renderer, which silently ignores unsupported
+	// preferred versions. Keyed on the current value as well as the list:
+	// initial values seed asynchronously, so with a warm versions cache the
+	// list alone would never change again and a late seed would slip through.
+	useEffect( () => {
+		if ( ! wpVersions?.length ) {
+			return;
+		}
+		setData( ( prev ) =>
+			wpVersions.some( ( version ) => version.value === prev.wpVersion )
+				? prev
+				: { ...prev, wpVersion: DEFAULT_WORDPRESS_VERSION }
+		);
+	}, [ wpVersions, data.wpVersion ] );
+
 	const fields = useMemo< Field< FormData >[] >(
 		() => [
 			siteNameField< FormData >(),
@@ -321,7 +354,7 @@ export function CreateSiteForm( {
 				},
 			},
 			phpVersionField< FormData >(),
-			wpVersionField< FormData >( DEFAULT_WORDPRESS_VERSION ),
+			wpVersionField< FormData >( DEFAULT_WORDPRESS_VERSION, wpVersions ),
 			adminUsernameField< FormData >(),
 			adminPasswordField< FormData >(),
 			adminEmailField< FormData >(),
@@ -335,7 +368,7 @@ export function CreateSiteForm( {
 				Edit: EnableHttpsControl,
 			},
 		],
-		[ existingDomainNames ]
+		[ existingDomainNames, wpVersions ]
 	);
 
 	const basicForm = useMemo< Form >(
@@ -425,70 +458,100 @@ export function CreateSiteForm( {
 
 	const advancedErrorCount = countAdvancedErrors( validity, advancedForm );
 
-	return (
-		<form className={ styles.form } onSubmit={ handleSubmit }>
-			<DataForm< FormData >
-				data={ data }
-				fields={ fields }
-				form={ basicForm }
-				onChange={ handleChange }
-				validity={ validity }
-			/>
-
+	// The buttons stay inside the <form> element so the submit button keeps
+	// its implicit form association while floating in the footer.
+	const actionButtons = (
+		<>
 			<Button
 				type="button"
-				variant="unstyled"
+				variant="minimal"
 				tone="neutral"
-				className={ styles.advancedToggle }
-				onClick={ () => setIsAdvancedOpen( ( value ) => ! value ) }
-				aria-expanded={ isAdvancedOpen }
+				onClick={ onCancel }
+				disabled={ isSubmitting }
 			>
-				<Icon icon={ isAdvancedOpen ? chevronDown : chevronRight } />
-				<span>{ __( 'Advanced settings' ) }</span>
-				{ ! isAdvancedOpen && advancedErrorCount > 0 && (
-					<span className={ styles.advancedErrorCount }>
-						{ advancedErrorCount === 1
-							? __( '1 error found' )
-							: /* translators: %d: number of errors */
-							  `${ advancedErrorCount } ${ __( 'errors found' ) }` }
-					</span>
-				) }
+				<Icon icon={ chevronLeft } size={ 16 } />
+				<span>{ __( 'Back' ) }</span>
 			</Button>
+			<Button
+				type="submit"
+				variant="solid"
+				tone="brand"
+				disabled={ ! canSubmit }
+				loading={ isSubmitting }
+				loadingAnnouncement={ __( 'Creating site' ) }
+				data-testid="create-site-submit"
+			>
+				{ submitLabel ?? __( 'Create site' ) }
+			</Button>
+		</>
+	);
 
-			{ isAdvancedOpen && (
+	return (
+		<form ref={ formRef } className={ styles.form } onSubmit={ handleSubmit }>
+			{ /* While creating, shield the rest of the window and freeze the
+			     fields (inert) — the submit button's spinner is the progress
+			     indication. */ }
+			<BusyOverlay active={ !! isSubmitting } />
+			{ /* The frosted panel wraps only the fields: its backdrop-filter
+			     turns it into a containing block for fixed descendants, so the
+			     fixed OnboardingFooter must stay outside (but inside the form
+			     for the submit button's implicit association). */ }
+			<div className={ styles.panel } inert={ isSubmitting || undefined }>
 				<DataForm< FormData >
 					data={ data }
 					fields={ fields }
-					form={ advancedForm }
+					form={ basicForm }
 					onChange={ handleChange }
 					validity={ validity }
 				/>
-			) }
 
-			{ submitError && <div className={ styles.submitError }>{ submitError }</div> }
-
-			<div className={ styles.actions }>
 				<Button
 					type="button"
-					variant="minimal"
+					variant="unstyled"
 					tone="neutral"
-					onClick={ onCancel }
-					disabled={ isSubmitting }
+					className={ styles.advancedToggle }
+					onClick={ () => setIsAdvancedOpen( ( value ) => ! value ) }
+					aria-expanded={ isAdvancedOpen }
 				>
-					{ __( 'Cancel' ) }
+					<Icon icon={ isAdvancedOpen ? chevronDown : chevronRight } />
+					<span>{ __( 'Advanced settings' ) }</span>
+					{ ! isAdvancedOpen && advancedErrorCount > 0 && (
+						<span className={ styles.advancedErrorCount }>
+							{ advancedErrorCount === 1
+								? __( '1 error found' )
+								: /* translators: %d: number of errors */
+								  `${ advancedErrorCount } ${ __( 'errors found' ) }` }
+						</span>
+					) }
 				</Button>
-				<Button
-					type="submit"
-					variant="solid"
-					tone="brand"
-					disabled={ ! canSubmit }
-					loading={ isSubmitting }
-					loadingAnnouncement={ __( 'Creating site' ) }
-					data-testid="create-site-submit"
+
+				<div
+					className={
+						isAdvancedOpen
+							? `${ styles.advancedCollapse } ${ styles.advancedCollapseOpen }`
+							: styles.advancedCollapse
+					}
+					inert={ ! isAdvancedOpen || undefined }
 				>
-					{ submitLabel ?? __( 'Create site' ) }
-				</Button>
+					<div className={ styles.advancedCollapseInner }>
+						<DataForm< FormData >
+							data={ data }
+							fields={ fields }
+							form={ advancedForm }
+							onChange={ handleChange }
+							validity={ validity }
+						/>
+					</div>
+				</div>
+
+				{ submitError && (
+					<div role="alert" className={ styles.submitError }>
+						{ submitError }
+					</div>
+				) }
 			</div>
+
+			<OnboardingFooter>{ actionButtons }</OnboardingFooter>
 		</form>
 	);
 }

--- a/apps/ui/src/components/create-site-form/style.module.css
+++ b/apps/ui/src/components/create-site-form/style.module.css
@@ -1,13 +1,25 @@
 .form {
-	display: flex;
-	flex-direction: column;
-	gap: 24px;
 	text-align: left;
 }
 
-/* The path trigger is a <button>, but we style it to sit within the
-   DataForm grid the same way the text/email inputs do — 40px tall, 1px
-   neutral border, 2px radius, matching the InputBase chrome so the field
+/* Frosted panel around the fields so the fixed dot grid reads as a
+   backdrop instead of bleeding through the (transparent-filled) inputs —
+   same treatment as the onboarding home cards. Kept off the <form> itself:
+   backdrop-filter creates a containing block, which would capture the
+   fixed footer. */
+.panel {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	padding: 32px;
+	border: 1px solid var(--wpds-color-stroke-surface-neutral, #ddd);
+	border-radius: 12px;
+	background: color-mix(in srgb, var(--wpds-color-bg-surface-neutral-strong, #fff) 50%, transparent);
+	backdrop-filter: blur(12px);
+}
+
+/* The path trigger is a <button>, but it mirrors the @wordpress/ui
+   InputLayout chrome (height, border, radius, type, tokens) so the field
    reads as "one more input" alongside its siblings. The actual value is
    chosen via the OS folder picker opened by clicking the button. */
 .pathTrigger {
@@ -16,36 +28,38 @@
 	justify-content: space-between;
 	gap: 8px;
 	width: 100%;
-	min-height: 40px;
-	padding: 0 4px 0 12px;
-	border: 1px solid #8a8a8a;
+	height: 40px;
+	padding: 0 4px 0 var(--wpds-dimension-padding-md, 12px);
+	background-color: var(--wpds-color-bg-interactive-neutral-weak);
+	border: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-interactive-neutral);
+	/* Fixed 2px, not the radius-sm token (this app bumps it to 4px): the
+	   sibling DataForm fields are @wordpress/components controls with a
+	   hardcoded 2px radius, and the path field must match them. */
 	border-radius: 2px;
-	background: #fff;
-	color: #1e1e1e;
-	font: inherit;
-	font-size: 16px;
+	color: var(--wpds-color-fg-interactive-neutral);
+	font-family: var(--wpds-typography-font-family-body);
+	font-size: var(--wpds-typography-font-size-md, 13px);
+	line-height: 1;
 	text-align: left;
 	cursor: pointer;
-	transition: border-color 0.15s, box-shadow 0.15s;
+	transition: border-color 0.15s;
 }
 
 .pathTrigger:hover {
-	border-color: #1e1e1e;
+	border-color: var(--wpds-color-stroke-interactive-neutral-active);
 }
 
 .pathTrigger:focus-visible {
-	border-color: #1e1e1e;
-	box-shadow: 0 0 0 0.5px #1e1e1e;
-	outline: none;
+	outline: 2px solid var(--wpds-color-stroke-focus-brand, #3858e9);
+	outline-offset: -1px;
 }
 
 .pathTriggerError {
-	border-color: #d63638;
+	border-color: var(--wpds-color-stroke-interactive-error, #d63638);
 }
 
 .pathTriggerError:focus-visible {
-	border-color: #d63638;
-	box-shadow: 0 0 0 0.5px #d63638;
+	outline-color: var(--wpds-color-stroke-interactive-error, #d63638);
 }
 
 .pathValue {
@@ -57,19 +71,19 @@
 }
 
 .pathValuePlaceholder {
-	color: #757575;
+	color: var(--wpds-color-fg-interactive-neutral-disabled);
 }
 
 .pathTriggerAction {
 	flex: 0 0 auto;
 	padding: 6px 12px;
-	font-size: 13px;
+	font-size: var(--wpds-typography-font-size-md, 13px);
 	font-weight: 500;
-	color: #1e1e1e;
+	color: var(--wpds-color-fg-interactive-neutral);
 }
 
 .pathErrorHelp {
-	color: #d63638;
+	color: var(--wpds-color-fg-content-error, #d63638);
 }
 
 .advancedToggle {
@@ -79,23 +93,53 @@
 	align-self: flex-start;
 }
 
+/* Animated expand/collapse for the Advanced settings — the 0fr -> 1fr grid
+   row transition slides the content open without measuring heights. The
+   content stays mounted (inert while closed) so closing animates too. */
+.advancedCollapse {
+	display: grid;
+	grid-template-rows: 0fr;
+	opacity: 0;
+	/* Cancels the panel's 24px flex gap while collapsed — the zero-height
+	   row would otherwise leave a phantom gap under the toggle. */
+	margin-top: -24px;
+	transition: grid-template-rows 0.25s ease, opacity 0.2s ease, margin-top 0.25s ease;
+}
+
+.advancedCollapseOpen {
+	grid-template-rows: 1fr;
+	opacity: 1;
+	margin-top: 0;
+}
+
+.advancedCollapseInner {
+	overflow: hidden;
+	min-height: 0;
+	/* The clip needed for the collapse animation would also shave outset
+	   focus rings off fields at the container edges; the negative margin +
+	   equal padding widens the clip box without moving the content. */
+	padding: 4px;
+	margin: -4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.advancedCollapse {
+		transition: none;
+	}
+}
+
 .advancedErrorCount {
 	margin-left: 8px;
 	font-size: 12px;
 	font-weight: 500;
-	color: #d63638;
+	color: var(--wpds-color-fg-content-error, #d63638);
 }
 
 .submitError {
 	padding: 10px 12px;
 	border-radius: 4px;
-	background: #fce8e8;
-	color: #7a1a1a;
+	background: color-mix(in srgb, var(--wpds-color-fg-content-error, #d63638) 12%, transparent);
+	color: var(--wpds-color-fg-content-error, #7a1a1a);
 	font-size: 13px;
 }
 
-.actions {
-	display: flex;
-	justify-content: flex-end;
-	gap: 8px;
-}

--- a/apps/ui/src/components/onboarding-layout/index.tsx
+++ b/apps/ui/src/components/onboarding-layout/index.tsx
@@ -15,18 +15,32 @@ interface OnboardingLayoutProps {
 	/**
 	 * Content width variant. Defaults to a narrow column (`'default'`) sized
 	 * for forms and short cards; `'wide'` is used by pages that host grids of
-	 * content (e.g. the blueprint selector).
+	 * content (e.g. the blueprint selector); `'full'` is for thumbnail-heavy
+	 * pages (the Connect a site picker) that scale with the window.
 	 */
-	width?: 'default' | 'wide';
+	width?: 'default' | 'wide' | 'full';
+	/**
+	 * Decorative layer rendered behind the content (e.g. the dot-grid
+	 * backdrop). The caller positions it; it paints under the content and
+	 * close button by DOM order.
+	 */
+	background?: ReactNode;
 }
 
 export function OnboardingLayout( {
 	children,
 	onClose,
 	width = 'default',
+	background,
 }: OnboardingLayoutProps ) {
 	return (
-		<Stack align="center" justify="center" className={ styles.root }>
+		<Stack align="flex-start" justify="center" className={ styles.root }>
+			{ background }
+			<div aria-hidden="true">
+				<div className={ `${ styles.dragEdge } ${ styles.dragEdgeTop }` } />
+				<div className={ `${ styles.dragEdge } ${ styles.dragEdgeLeft }` } />
+				<div className={ `${ styles.dragEdge } ${ styles.dragEdgeBottom }` } />
+			</div>
 			{ onClose && (
 				<IconButton
 					className={ styles.close }
@@ -38,7 +52,11 @@ export function OnboardingLayout( {
 					onClick={ onClose }
 				/>
 			) }
-			<div className={ `${ styles.content } ${ width === 'wide' ? styles.contentWide : '' }` }>
+			<div
+				className={ `${ styles.content } ${ width === 'wide' ? styles.contentWide : '' } ${
+					width === 'full' ? styles.contentFull : ''
+				}` }
+			>
 				{ children }
 			</div>
 		</Stack>

--- a/apps/ui/src/components/onboarding-layout/style.module.css
+++ b/apps/ui/src/components/onboarding-layout/style.module.css
@@ -1,24 +1,78 @@
 .root {
 	height: 100vh;
 	position: relative;
+	overflow-y: auto;
+	/* New stacking context so the backdrop layer's negative z-index nests
+	   here (behind the content, above the root's background) instead of
+	   escaping below an ancestor's paint. */
+	isolation: isolate;
 }
 
 .content {
 	max-width: 640px;
 	width: 100%;
 	padding: var(--wpds-dimension-padding-3xl);
+	/* Auto block margins center the content vertically when it's shorter
+	   than the viewport but — unlike `justify: center` on the flex parent —
+	   keep the top reachable by scrolling when it's taller (e.g. the full
+	   blueprint gallery). */
+	margin-block: auto;
 }
 
 /* `wide` variant — used by content-heavy onboarding pages like the blueprint
    selector. Sized to fit a 3-column card grid (see `blueprint-selector`). */
 .contentWide {
-	max-width: 820px;
+	max-width: 960px;
+}
+
+/* `full` variant — thumbnail grids that benefit from the extra room on
+   large windows, still capped so rows don't sprawl indefinitely. */
+.contentFull {
+	max-width: 1360px;
+}
+
+/* The onboarding flow fills the window with no title bar; invisible strips
+   along the top, left, and bottom edges act as the window drag region. A
+   full-background region would also work, but it would swallow the mouse
+   events the interactive dot grid depends on. The right edge is left free
+   for the scroll bar, and interactive elements overlapping a strip (the
+   close button) stay clickable via the global no-drag rule. */
+.dragEdge {
+	position: fixed;
+	pointer-events: none;
+	-webkit-app-region: drag;
+}
+
+.dragEdgeTop {
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 36px;
+}
+
+.dragEdgeLeft {
+	top: 36px;
+	left: 0;
+	bottom: 0;
+	width: 16px;
+}
+
+.dragEdgeBottom {
+	left: 16px;
+	right: 0;
+	bottom: 0;
+	height: 16px;
 }
 
 .close {
-	position: absolute;
+	/* Fixed so it stays in the corner while the page scrolls; above the
+	   footer scrim/actions (z-index 5/6). */
+	position: fixed;
 	top: 16px;
 	right: 16px;
+	z-index: 7;
+	/* Own snapshot group so route view transitions leave it stationary. */
+	view-transition-name: onboarding-close;
 }
 
 .close svg {

--- a/apps/ui/src/components/site-fields/index.ts
+++ b/apps/ui/src/components/site-fields/index.ts
@@ -13,6 +13,7 @@ import {
 import { validateAdminEmail, validateAdminUsername } from '@studio/common/lib/passwords';
 import { SupportedPHPVersions } from '@studio/common/types/php-versions';
 import { __ } from '@wordpress/i18n';
+import type { WordPressVersion } from '@studio/common/lib/wordpress-versions';
 import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
 import type { Field } from '@wordpress/dataviews';
 
@@ -39,15 +40,37 @@ export function phpVersionField< T extends { phpVersion: SupportedPHPVersion } >
 	};
 }
 
+/**
+ * Builder for the WordPress version field. With a fetched `versions` list it
+ * renders a select ordered like the desktop renderer's version picker —
+ * auto-updating "latest" first, then nightly/beta, then stable releases.
+ * Without one (offline, fetch failed, still loading) it stays a free-text
+ * input so site creation is never blocked on the wordpress.org API.
+ */
 export function wpVersionField< T extends { wpVersion: string } >(
-	placeholder: string
+	placeholder: string,
+	versions?: WordPressVersion[]
 ): Field< T > {
-	return {
+	const field: Field< T > = {
 		id: 'wpVersion',
 		type: 'text',
 		label: __( 'WordPress version' ),
 		placeholder,
 	};
+	if ( versions?.length ) {
+		const beta = versions.filter( ( version ) => version.isBeta || version.isDevelopment );
+		const stable = versions.filter(
+			( version ) => version.value !== 'latest' && ! version.isBeta && ! version.isDevelopment
+		);
+		field.elements = [
+			...versions
+				.filter( ( version ) => version.value === 'latest' )
+				.map( ( version ) => ( { value: version.value, label: __( 'latest' ) } ) ),
+			...beta.map( ( version ) => ( { value: version.value, label: version.label } ) ),
+			...stable.map( ( version ) => ( { value: version.value, label: version.label } ) ),
+		];
+	}
+	return field;
 }
 
 export function adminUsernameField< T extends { adminUsername: string } >(): Field< T > {

--- a/apps/ui/src/ui-classic/router/layout-onboarding/index.tsx
+++ b/apps/ui/src/ui-classic/router/layout-onboarding/index.tsx
@@ -1,9 +1,12 @@
-import { createRoute, Outlet, useMatches, useNavigate } from '@tanstack/react-router';
+import { createRoute, Outlet, useLocation, useMatches, useNavigate } from '@tanstack/react-router';
+import { useEffect, useRef } from 'react';
+import { DotGrid } from '@/components/dot-grid';
 import { OnboardingLayout } from '@/components/onboarding-layout';
 import { useSites } from '@/data/queries/use-sites';
 import { rootRoute } from '../layout-root';
+import styles from './style.module.css';
 
-function OnboardingShell() {
+export function OnboardingShell() {
 	const navigate = useNavigate();
 	const { data: sites } = useSites();
 	const hasSites = ( sites?.length ?? 0 ) > 0;
@@ -14,18 +17,69 @@ function OnboardingShell() {
 	// "configure" step reuses the shared site form and should match the
 	// narrow "/onboarding/create" width.
 	const matches = useMatches();
+	const isFull = matches.some( ( match ) => match.pathname === '/onboarding/connect' );
 	const isWide = matches.some( ( match ) => {
 		if ( match.pathname === '/onboarding' ) return true;
 		if ( match.pathname !== '/onboarding/blueprint' ) return false;
 		const step = ( match.search as { step?: string } ).step;
 		return step !== 'configure';
 	} );
+	// The dot grid backs every step of the flow; it stays mounted across
+	// navigations so its intro sweep plays once per visit, not per step.
+	const dotGrid = (
+		<div aria-hidden="true" className={ styles.dotGridLayer }>
+			<DotGrid spacing={ 32 } crossSize={ 5 } opacity={ 0.2 } />
+		</div>
+	);
+	// Moving between onboarding pages/steps unmounts the control that was
+	// focused (a card, a Back button), dropping keyboard focus to <body>.
+	// Hand it to the incoming page's heading instead so keyboard and
+	// screen-reader context follows the navigation.
+	const contentRef = useRef< HTMLDivElement >( null );
+	const { href } = useLocation();
+	const lastHref = useRef( href );
+	useEffect( () => {
+		if ( lastHref.current === href ) {
+			return;
+		}
+		lastHref.current = href;
+		const focusHeading = () => {
+			const content = contentRef.current;
+			if ( ! content ) {
+				return false;
+			}
+			// A page that claims focus itself (e.g. the create form focusing
+			// its Site name field) wins over the default heading focus.
+			const active = document.activeElement;
+			if ( active && active !== document.body && content.contains( active ) ) {
+				return true;
+			}
+			const heading = content.querySelector( 'h1' );
+			if ( ! heading ) {
+				return false;
+			}
+			heading.setAttribute( 'tabindex', '-1' );
+			heading.focus();
+			return true;
+		};
+		// The blueprint/import configure steps render empty for one frame
+		// while adopting a pending hand-off; retry once after paint.
+		if ( ! focusHeading() ) {
+			const raf = requestAnimationFrame( () => void focusHeading() );
+			return () => cancelAnimationFrame( raf );
+		}
+	}, [ href ] );
+
 	return (
 		<OnboardingLayout
 			onClose={ hasSites ? () => void navigate( { to: '/' } ) : undefined }
-			width={ isWide ? 'wide' : 'default' }
+			width={ isFull ? 'full' : isWide ? 'wide' : 'default' }
+			background={ dotGrid }
 		>
-			<Outlet />
+			{ /* display: contents — focus-management hook point only, no layout. */ }
+			<div ref={ contentRef } className={ styles.outlet }>
+				<Outlet />
+			</div>
 		</OnboardingLayout>
 	);
 }

--- a/apps/ui/src/ui-classic/router/layout-onboarding/style.module.css
+++ b/apps/ui/src/ui-classic/router/layout-onboarding/style.module.css
@@ -1,5 +1,23 @@
 .page {
 	width: 100%;
+	text-align: center;
+	/* Breathing room so content scrolls clear of the fixed footer bar. */
+	padding-bottom: 72px;
+}
+
+/* Tall, scrolling pages (the blueprint gallery) sit flush against the
+   viewport top once they overflow; give the heading room to breathe. */
+.pageSpacious {
+	padding-top: 64px;
+}
+
+/* Forms read better as a narrow left-aligned column centered in the
+   viewport — matches the desktop renderer's Add Site form layout. Sized so
+   the fields keep their usual width inside the form's frosted panel
+   padding. */
+.page form {
+	max-width: 480px;
+	margin-inline: auto;
 	text-align: left;
 }
 
@@ -14,50 +32,33 @@
 	margin: 0 0 32px;
 }
 
-.cards {
-	display: flex;
-	gap: 16px;
+/* Layout-neutral wrapper so the shell can find and focus the active page's
+   heading after navigation. */
+.outlet {
+	display: contents;
 }
 
-.card {
-	position: relative;
-	display: block;
-	text-align: left;
-	padding: 24px;
-	width: 240px;
-	border: 1px solid var(--wpds-color-stroke-surface-neutral, #ddd);
-	border-radius: 8px;
-	cursor: pointer;
-	color: inherit;
-	text-decoration: none;
-	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+/* The heading takes programmatic focus after step changes; suppress the
+   default ring for pointer/programmatic focus while `:focus-visible` keeps
+   the browser's keyboard indicator. */
+.outlet h1:focus:not(:focus-visible) {
+	outline: none;
 }
 
-.card:hover {
-	border-color: var(--wpds-color-stroke-interactive-neutral, #bbb);
-}
-
-.cardDisabled {
-	opacity: 0.55;
-	cursor: not-allowed;
-}
-
-.cardTitle {
-	font-weight: 600;
-	margin-bottom: 8px;
-}
-
-.cardBody {
-	color: var(--wpds-color-fg-content-neutral-weak, #666);
-	font-size: 0.875rem;
-}
-
-.cardBadge {
-	position: absolute;
-	top: 12px;
-	right: 12px;
-	font-size: 11px;
-	text-transform: uppercase;
-	letter-spacing: 0.04em;
-	color: var(--wpds-color-fg-content-neutral-weak, #555);
+/* Decorative dot-grid backdrop behind every onboarding step. Fixed so it
+   stays put while tall pages (the gallery, the connect picker) scroll.
+   Deliberately NOT view-transition-named: named groups always composite
+   above the root snapshot during route transitions, which would flash the
+   grid over the page for the duration of every navigation — a backdrop
+   must stay inside the root snapshot. */
+.dotGridLayer {
+	position: fixed;
+	inset: 0;
+	overflow: hidden;
+	pointer-events: none;
+	/* Positioned elements paint above all non-positioned content, so
+	   without this the grid draws over plain elements (inputs, headings).
+	   Negative z-index puts it behind everything inside the isolated
+	   layout root (see onboarding-layout's `isolation: isolate`). */
+	z-index: -1;
 }

--- a/apps/ui/src/ui-classic/router/route-onboarding-create/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-onboarding-create/index.tsx
@@ -1,5 +1,6 @@
 import { createRoute, useNavigate } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import { CreateSiteForm } from '@/components/create-site-form';
 import {
@@ -11,7 +12,7 @@ import { onboardingLayoutRoute } from '../layout-onboarding';
 import styles from '../layout-onboarding/style.module.css';
 import type { CreateSiteFormValues } from '@/components/create-site-form';
 
-function CreateSitePage() {
+export function CreateSitePage() {
 	const navigate = useNavigate();
 	const { data: sites } = useSites();
 	const { data: existingDomainNames } = useExistingCustomDomains();
@@ -33,6 +34,13 @@ function CreateSitePage() {
 				adminPassword: values.adminPassword || undefined,
 				adminEmail: values.adminEmail || undefined,
 			} );
+			speak(
+				sprintf(
+					// translators: %s is the site name.
+					__( '%s site added.' ),
+					values.name
+				)
+			);
 			await navigate( { to: '/sites/$siteId/new', params: { siteId: site.id } } );
 		} catch ( error ) {
 			setSubmitError(
@@ -51,7 +59,7 @@ function CreateSitePage() {
 				initialValues={ proposedName ? { name: proposedName } : undefined }
 				existingDomainNames={ existingDomainNames ?? [] }
 				onSubmit={ handleSubmit }
-				onCancel={ () => void navigate( { to: '/onboarding' } ) }
+				onCancel={ () => void navigate( { to: '/onboarding/blueprint' } ) }
 				isSubmitting={ createSite.isPending }
 				submitError={ submitError }
 			/>

--- a/apps/ui/src/ui-classic/router/router.tsx
+++ b/apps/ui/src/ui-classic/router/router.tsx
@@ -35,6 +35,9 @@ export function createAppRouter( context: RouterContext ) {
 		routeTree,
 		context,
 		defaultPreload: 'intent',
+		// Animate route (and step) changes with the View Transitions API —
+		// the fade-and-rise keyframes live in index.css.
+		defaultViewTransition: true,
 		history: createPackagedRouterHistory(),
 	} );
 }


### PR DESCRIPTION
## Related issues

- Part of the site-creation onboarding redesign — see the umbrella PR (linked below once open) for the full plan.
- **Draft note:** based on `site-creation-foundation` (the merged wave-1 PRs) so the diff shows only this flow's changes. Once wave 1 merges, this will be retargeted to `trunk` and marked ready.

## How AI was used in this PR

Split out of the `workbench/site-creation` exploration branch with Claude Code; designed and tested by Shaun on the original branch.

## Proposed Changes

- The onboarding shell gets the new visual identity: the interactive dot-grid backdrop, window dragging from the edges, view-transition animations between steps, and focus management when sub-pages swap in.
- The create-site form is redesigned to match: Back instead of Cancel, a proper WordPress version selector replacing the free-text field, collapsible advanced settings with inline error counts, and a busy state that shields the form while the site is created.

## Testing Instructions

- Start with no sites (or use the Add Site menu) to enter onboarding, open "Create a new site", and exercise the form: version selector, advanced settings validation, and submit. Verify in both light and dark mode.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
