### PR TITLE
Redesign the blueprint gallery and seed site names from blueprints

### DIFF
--- a/apps/ui/src/components/blueprint-selector/index.tsx
+++ b/apps/ui/src/components/blueprint-selector/index.tsx
@@ -1,11 +1,17 @@
+import { EMPTY_SITE_PLAYGROUND_URL } from '@studio/common/constants';
+import {
+	curateBlueprintsForDisplay,
+	FEATURED_BLUEPRINT_SLUGS,
+} from '@studio/common/lib/blueprint-curation';
 import { generateDefaultBlueprintDescription } from '@studio/common/lib/blueprint-settings';
 import { validateBlueprintData } from '@studio/common/lib/blueprint-validation';
+import { Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { external } from '@wordpress/icons';
-import { Button, Icon } from '@wordpress/ui';
-import { useCallback, useState } from 'react';
-import { FileDropzone } from '@/components/file-dropzone';
+import { seen } from '@wordpress/icons';
+import { Button, Icon, Tooltip } from '@wordpress/ui';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useConnector } from '@/data/core';
+import { useGridArrowNavigation } from '@/hooks/use-grid-arrow-navigation';
 import styles from './style.module.css';
 import type { FeaturedBlueprint } from '@/data/core';
 import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
@@ -23,20 +29,158 @@ export interface PickedBlueprint {
 }
 
 interface BlueprintSelectorProps {
-	featured: FeaturedBlueprint[] | undefined;
-	isFeaturedLoading: boolean;
+	blueprints: FeaturedBlueprint[] | undefined;
+	isLoading: boolean;
 	onPick: ( blueprint: PickedBlueprint ) => void;
+	// Picking the "Empty site" card — callers route this to the plain
+	// create-site flow rather than running an empty blueprint.
+	onPickEmpty: () => void;
 }
 
 const FILE_ACCEPT = 'application/json,.json,application/zip,.zip';
 
-export function BlueprintSelector( {
-	featured,
-	isFeaturedLoading,
+/**
+ * Preview (eye) button overlaid on a card's image. Rendered as a sibling of
+ * the card's pick button (inside `cardMediaOverlay`) rather than nested in
+ * it, so the markup stays valid — nested interactive elements aren't.
+ */
+function PreviewOverlay( { url, title }: { url: string; title: string } ) {
+	const connector = useConnector();
+	const label = __( 'Preview in your browser' );
+	return (
+		<div className={ styles.cardMediaOverlay }>
+			<Tooltip.Provider delay={ 200 }>
+				<Tooltip.Root>
+					<Tooltip.Trigger
+						render={
+							<button
+								type="button"
+								className={ styles.previewButton }
+								onClick={ () => void connector.openExternalUrl( url ) }
+								aria-label={ sprintf(
+									// translators: %s is the blueprint title.
+									__( 'Preview %s in Playground' ),
+									title
+								) }
+							>
+								<Icon icon={ seen } size={ 16 } />
+							</button>
+						}
+					/>
+					<Tooltip.Popup positioner={ <Tooltip.Positioner side="bottom" /> }>
+						{ label }
+					</Tooltip.Popup>
+				</Tooltip.Root>
+			</Tooltip.Provider>
+		</div>
+	);
+}
+
+function EmptySiteCard( { onPick }: { onPick: () => void } ) {
+	return (
+		<li className={ styles.cardWrapper }>
+			<button type="button" className={ styles.card } onClick={ onPick } data-arrow-nav-item>
+				<span className={ styles.emptyMedia }>
+					<span className={ styles.emptyMediaGrid } />
+					{ /* Centered document glyph */ }
+					<svg
+						width="44"
+						height="56"
+						viewBox="0 0 44 56"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+						aria-hidden="true"
+						data-keep-size
+					>
+						<path
+							d="M 4 4 L 28 4 L 40 16 L 40 52 L 4 52 Z"
+							stroke="currentColor"
+							strokeWidth="1.5"
+							strokeLinejoin="round"
+							fill="none"
+						/>
+						<path
+							d="M 28 4 L 28 16 L 40 16"
+							stroke="currentColor"
+							strokeWidth="1.5"
+							strokeLinejoin="round"
+							fill="none"
+						/>
+					</svg>
+				</span>
+				<span className={ styles.cardBody }>
+					<h3 className={ styles.cardTitle }>{ __( 'Empty site' ) }</h3>
+					<p className={ styles.cardExcerpt }>
+						{ __( 'A clean WordPress install. Build whatever you want from scratch.' ) }
+					</p>
+				</span>
+			</button>
+			<PreviewOverlay url={ EMPTY_SITE_PLAYGROUND_URL } title={ __( 'Empty site' ) } />
+		</li>
+	);
+}
+
+function BlueprintCard( {
+	blueprint,
 	onPick,
+}: {
+	blueprint: FeaturedBlueprint;
+	onPick: ( blueprint: FeaturedBlueprint ) => void;
+} ) {
+	return (
+		<li className={ styles.cardWrapper }>
+			<button
+				type="button"
+				className={ styles.card }
+				onClick={ () => onPick( blueprint ) }
+				data-arrow-nav-item
+			>
+				{ blueprint.image ? (
+					<img className={ styles.cardImage } src={ blueprint.image } alt="" loading="lazy" />
+				) : (
+					<span className={ styles.cardImageFallback }>{ blueprint.title }</span>
+				) }
+				<span className={ styles.cardBody }>
+					<h3 className={ styles.cardTitle }>{ blueprint.title }</h3>
+					<p className={ styles.cardExcerpt } title={ blueprint.excerpt }>
+						{ blueprint.excerpt }
+					</p>
+				</span>
+			</button>
+			{ blueprint.playgroundUrl && (
+				<PreviewOverlay url={ blueprint.playgroundUrl } title={ blueprint.title } />
+			) }
+		</li>
+	);
+}
+
+export function BlueprintSelector( {
+	blueprints,
+	isLoading,
+	onPick,
+	onPickEmpty,
 }: BlueprintSelectorProps ) {
 	const connector = useConnector();
+	const uploadInputRef = useRef< HTMLInputElement | null >( null );
+	const handleGridKeyDown = useGridArrowNavigation();
 	const [ uploadError, setUploadError ] = useState< string | null >( null );
+
+	// The endpoint returns blueprints oldest-first; newest-first reads better
+	// in the Explore grid (matches the desktop renderer).
+	const allBlueprints = useMemo( () => ( blueprints ?? [] ).slice().reverse(), [ blueprints ] );
+
+	const featuredBlueprints = useMemo(
+		() =>
+			curateBlueprintsForDisplay(
+				allBlueprints.filter( ( blueprint ) => FEATURED_BLUEPRINT_SLUGS.has( blueprint.slug ) ),
+				__
+			),
+		[ allBlueprints ]
+	);
+	const exploreBlueprints = useMemo(
+		() => allBlueprints.filter( ( blueprint ) => ! FEATURED_BLUEPRINT_SLUGS.has( blueprint.slug ) ),
+		[ allBlueprints ]
+	);
 
 	const handleFeaturedClick = useCallback(
 		( item: FeaturedBlueprint ) => {
@@ -49,18 +193,6 @@ export function BlueprintSelector( {
 			} );
 		},
 		[ onPick ]
-	);
-
-	const handlePreviewClick = useCallback(
-		( event: React.MouseEvent< HTMLButtonElement >, item: FeaturedBlueprint ) => {
-			// Stop the click from bubbling to the card's pick handler — the
-			// user explicitly asked to preview, not to select.
-			event.stopPropagation();
-			if ( item.playgroundUrl ) {
-				void connector.openExternalUrl( item.playgroundUrl );
-			}
-		},
-		[ connector ]
 	);
 
 	/**
@@ -170,64 +302,94 @@ export function BlueprintSelector( {
 		[ acceptParsedBlueprint, connector ]
 	);
 
+	// Callers advertise "drop in your own", so the whole selector accepts
+	// blueprint drops; any validation error renders next to the Upload
+	// button above the explore grid.
+	const handleRootDrop = useCallback(
+		( event: React.DragEvent< HTMLDivElement > ) => {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+			event.preventDefault();
+			const file = event.dataTransfer.files[ 0 ];
+			if ( ! file ) {
+				return;
+			}
+			void handleFile( file );
+		},
+		[ handleFile ]
+	);
+
 	return (
-		<div className={ styles.root }>
+		<div
+			className={ styles.root }
+			onDragOver={ ( event ) => event.preventDefault() }
+			onDrop={ handleRootDrop }
+		>
 			<section className={ styles.section }>
-				<h2 className={ styles.sectionTitle }>{ __( 'Upload your own' ) }</h2>
-				<FileDropzone
-					accept={ FILE_ACCEPT }
-					prompt={ __( 'Drop a Blueprint JSON or ZIP bundle here, or' ) }
-					onFile={ ( file ) => void handleFile( file ) }
-					error={ uploadError }
-				/>
+				<ul
+					className={ `${ styles.grid } ${ styles.gridFeatured }` }
+					onKeyDown={ handleGridKeyDown }
+				>
+					<EmptySiteCard onPick={ onPickEmpty } />
+					{ isLoading && (
+						<li className={ styles.gridStatus }>
+							<Spinner />
+						</li>
+					) }
+					{ ! isLoading && allBlueprints.length === 0 && (
+						<li className={ styles.gridStatus }>{ __( 'Could not load templates.' ) }</li>
+					) }
+					{ featuredBlueprints.map( ( item ) => (
+						<BlueprintCard key={ item.slug } blueprint={ item } onPick={ handleFeaturedClick } />
+					) ) }
+				</ul>
 			</section>
 
-			<section className={ styles.section }>
-				<h2 className={ styles.sectionTitle }>{ __( 'Featured blueprints' ) }</h2>
-				{ isFeaturedLoading && (
-					<p className={ styles.featuredHint }>{ __( 'Loading featured blueprints…' ) }</p>
-				) }
-				{ ! isFeaturedLoading && ( ! featured || featured.length === 0 ) && (
-					<p className={ styles.featuredHint }>
-						{ __( 'No featured blueprints available right now.' ) }
+			<section className={ `${ styles.section } ${ styles.exploreSection }` }>
+				<header className={ styles.exploreHeader }>
+					<h2 className={ styles.sectionTitle }>{ __( 'More blueprints' ) }</h2>
+					<p className={ styles.exploreSubtitle }>
+						{ __( 'Get started quickly with a one of our blueprints, or' ) }{ ' ' }
+						<Button
+							type="button"
+							variant="minimal"
+							tone="brand"
+							className={ styles.uploadLink }
+							onClick={ () => uploadInputRef.current?.click() }
+						>
+							{ __( 'upload a blueprint' ) }
+						</Button>
+						{ '.' }
+					</p>
+				</header>
+				{ uploadError && (
+					<p role="alert" className={ styles.uploadError }>
+						{ uploadError }
 					</p>
 				) }
-				{ featured && featured.length > 0 && (
-					<ul className={ styles.grid }>
-						{ featured.map( ( item ) => (
-							<li key={ item.slug } className={ styles.cardWrapper }>
-								<button
-									type="button"
-									className={ styles.card }
-									onClick={ () => handleFeaturedClick( item ) }
-								>
-									{ item.image && (
-										<img className={ styles.cardImage } src={ item.image } alt="" loading="lazy" />
-									) }
-									<div className={ styles.cardBody }>
-										<h3 className={ styles.cardTitle }>{ item.title }</h3>
-										<p className={ styles.cardExcerpt }>{ item.excerpt }</p>
-									</div>
-								</button>
-								{ item.playgroundUrl && (
-									<Button
-										type="button"
-										variant="minimal"
-										tone="neutral"
-										size="small"
-										className={ styles.previewButton }
-										onClick={ ( event ) => handlePreviewClick( event, item ) }
-										aria-label={ sprintf(
-											// translators: %s is the blueprint title.
-											__( 'Preview %s in Playground' ),
-											item.title
-										) }
-									>
-										<Icon icon={ external } />
-										<span>{ __( 'Preview' ) }</span>
-									</Button>
-								) }
-							</li>
+				<input
+					ref={ uploadInputRef }
+					type="file"
+					accept={ FILE_ACCEPT }
+					className={ styles.hiddenInput }
+					onChange={ ( event ) => {
+						const file = event.target.files?.[ 0 ];
+						if ( file ) {
+							void handleFile( file );
+						}
+						// Reset so re-picking the same file after an error re-fires
+						// `change`.
+						event.target.value = '';
+					} }
+				/>
+				{ exploreBlueprints.length > 0 && (
+					<ul
+						className={ `${ styles.grid } ${ styles.gridCompact }` }
+						onKeyDown={ handleGridKeyDown }
+					>
+						{ exploreBlueprints.map( ( item ) => (
+							<BlueprintCard key={ item.slug } blueprint={ item } onPick={ handleFeaturedClick } />
 						) ) }
 					</ul>
 				) }

--- a/apps/ui/src/components/blueprint-selector/style.module.css
+++ b/apps/ui/src/components/blueprint-selector/style.module.css
@@ -16,12 +16,6 @@
 	margin: 0;
 }
 
-.featuredHint {
-	margin: 0;
-	color: var(--wpds-color-fg-content-neutral-weak, #666);
-	font-size: 0.875rem;
-}
-
 .grid {
 	list-style: none;
 	margin: 0;
@@ -39,6 +33,98 @@
 	}
 }
 
+/* The featured row (Empty site + the curated trio) fits four across on the
+   wide layout and folds to a 2x2 grid when the window narrows. */
+.gridFeatured {
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+@media (max-width: 880px) {
+	.gridFeatured {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+/* Extra room between the featured row and the explore section so the
+   curated cards stand apart from the long tail. */
+.exploreSection {
+	margin-top: 40px;
+}
+
+/* Centered intro for the blueprints long tail: heading, one-line blurb,
+   then the search + upload controls. */
+.exploreHeader {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	text-align: center;
+	margin-bottom: 24px;
+}
+
+.exploreSubtitle {
+	margin: 0;
+	color: var(--wpds-color-fg-content-neutral-weak, #666);
+	font-size: 0.875rem;
+}
+
+/* Inline "upload a blueprint" link inside the subtitle — strip the button
+   box so it flows with the sentence. */
+.uploadLink {
+	padding: 0;
+	height: auto;
+	min-height: 0;
+	font-size: inherit;
+}
+
+/* Matches the FileDropzone error pill the upload section used to render. */
+.uploadError {
+	padding: 8px 12px;
+	border-radius: 4px;
+	background: #fce8e8;
+	color: #7a1a1a;
+	font-size: 13px;
+	margin: 0;
+}
+
+.hiddenInput {
+	display: none;
+}
+
+/* Denser columns + tighter type than the featured row, so the open-by-
+   default explore grid reads as secondary to the curated cards. */
+.gridCompact {
+	grid-template-columns: repeat(5, minmax(0, 1fr));
+	gap: 12px;
+}
+
+@media (max-width: 880px) {
+	.gridCompact {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+}
+
+.gridCompact .cardBody {
+	padding: 10px 12px 12px;
+	gap: 4px;
+}
+
+.gridCompact .cardTitle {
+	font-size: 0.8125rem;
+}
+
+.gridCompact .cardExcerpt {
+	font-size: 0.75rem;
+	-webkit-line-clamp: 2;
+}
+
+.gridStatus {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--wpds-color-fg-content-neutral-weak, #666);
+	font-size: 0.875rem;
+}
+
 .cardWrapper {
 	position: relative;
 }
@@ -47,6 +133,7 @@
 	display: flex;
 	flex-direction: column;
 	width: 100%;
+	height: 100%;
 	padding: 0;
 	border: 1px solid var(--wpds-color-stroke-surface-neutral, #ddd);
 	border-radius: 8px;
@@ -55,20 +142,71 @@
 	overflow: hidden;
 	text-align: left;
 	color: inherit;
+	transition: border-color 0.15s ease;
 }
 
 .card:hover {
-	border-color: var(--wpds-color-stroke-interactive-neutral, #bbb);
+	border-color: var(--wpds-color-stroke-interactive-brand, #3858e9);
+}
+
+/* Keyboard focus mirrors the hover affordance, plus an offset ring. */
+.card:focus-visible {
+	outline: 2px solid var(--wpds-color-stroke-interactive-brand, #3858e9);
+	outline-offset: 2px;
+	border-color: var(--wpds-color-stroke-interactive-brand, #3858e9);
+}
+
+/* Anchors the Live Preview pill to the card's media area. Sits outside the
+   pick button (siblings, not nested) so the markup stays valid; the wrapper
+   itself ignores pointer events so card clicks pass through. */
+.cardMediaOverlay {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	aspect-ratio: 16 / 9;
+	pointer-events: none;
 }
 
 .previewButton {
 	position: absolute;
-	top: 8px;
+	bottom: 8px;
 	right: 8px;
+	pointer-events: auto;
+	display: inline-flex;
+	align-items: center;
 	gap: 4px;
-	background: rgba(255, 255, 255, 0.92);
-	backdrop-filter: blur(6px);
+	padding: 4px 8px;
+	border: 1px solid rgba(255, 255, 255, 0.9);
 	border-radius: 4px;
+	background: rgba(255, 255, 255, 0.92);
+	color: #1e1e1e;
+	font-size: 11px;
+	line-height: 1;
+	white-space: nowrap;
+	cursor: pointer;
+	backdrop-filter: blur(6px);
+	/* Hairline dark ring outside the light border so the pill separates
+	   from both light and dark imagery — a contrast edge, not elevation. */
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+	/* Revealed on card hover (the button sits inside the hovered wrapper,
+	   so pointing at its corner shows it too) or on keyboard focus. */
+	opacity: 0;
+	transition: opacity 0.15s ease;
+}
+
+.cardWrapper:hover .previewButton,
+.previewButton:focus-visible {
+	opacity: 1;
+}
+
+.previewButton:focus-visible {
+	outline: 2px solid var(--wpds-color-stroke-interactive-brand, #3858e9);
+	outline-offset: 2px;
+}
+
+.previewButton:hover {
+	background: #fff;
 }
 
 .cardImage {
@@ -76,6 +214,40 @@
 	aspect-ratio: 16 / 9;
 	object-fit: cover;
 	background: #f0f0f0;
+}
+
+.cardImageFallback {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	background: var(--wpds-color-bg-surface-neutral, #f0f0f0);
+	color: var(--wpds-color-fg-content-neutral-weak, #666);
+	font-size: 0.8125rem;
+}
+
+/* Thumbnail for the Empty Site card — a fixed dark slate with a faint grid
+   and a document glyph, identical in both color schemes by design. */
+.emptyMedia {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	background: #1f1f1f;
+	color: #fff;
+	overflow: hidden;
+}
+
+.emptyMediaGrid {
+	position: absolute;
+	inset: 0;
+	background-image:
+		linear-gradient(rgba(255, 255, 255, 0.06) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(255, 255, 255, 0.06) 1px, transparent 1px);
+	background-size: 32px 32px;
 }
 
 .cardBody {
@@ -88,6 +260,9 @@
 .cardTitle {
 	font-size: 0.95rem;
 	font-weight: 600;
+	/* The global h3 rule pins line-height to the fixed 28px lg token, which
+	   reads double-spaced at this reduced font size once a title wraps. */
+	line-height: 1.3;
 	margin: 0;
 }
 

--- a/apps/ui/src/ui-classic/router/layout-root/index.tsx
+++ b/apps/ui/src/ui-classic/router/layout-root/index.tsx
@@ -1,4 +1,6 @@
 import { createRootRouteWithContext, Outlet } from '@tanstack/react-router';
+import { useAddSiteListener } from '@/hooks/use-add-site-listener';
+import { useMouseNavigation } from '@/hooks/use-mouse-navigation';
 import type { Connector } from '@/data/core';
 import type { QueryClient } from '@tanstack/react-query';
 
@@ -7,6 +9,12 @@ export interface RouterContext {
 	connector: Connector;
 }
 
+function RootLayout() {
+	useAddSiteListener();
+	useMouseNavigation();
+	return <Outlet />;
+}
+
 export const rootRoute = createRootRouteWithContext< RouterContext >()( {
-	component: () => <Outlet />,
+	component: RootLayout,
 } );

--- a/apps/ui/src/ui-classic/router/route-onboarding-blueprint/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-onboarding-blueprint/index.tsx
@@ -2,20 +2,23 @@ import {
 	extractFormValuesFromBlueprint,
 	updateBlueprintWithFormValues,
 } from '@studio/common/lib/blueprint-settings';
-import { createRoute, useNavigate } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
-import { arrowLeft } from '@wordpress/icons';
+import { createRoute, useNavigate, useSearch } from '@tanstack/react-router';
+import { speak } from '@wordpress/a11y';
+import { __, sprintf } from '@wordpress/i18n';
+import { chevronLeft } from '@wordpress/icons';
 import { Button, Icon } from '@wordpress/ui';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import { flushSync } from 'react-dom';
 import { BlueprintSelector, type PickedBlueprint } from '@/components/blueprint-selector';
 import { CreateSiteForm } from '@/components/create-site-form';
+import { OnboardingFooter } from '@/components/onboarding-footer';
 import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
 import { useFeaturedBlueprints } from '@/data/queries/use-featured-blueprints';
 import { useCreateSite } from '@/data/queries/use-sites';
+import { useSeededSiteName } from '@/hooks/use-seeded-site-name';
+import { pendingBlueprintSlot } from '@/lib/pending-blueprint';
 import { onboardingLayoutRoute } from '../layout-onboarding';
 import styles from '../layout-onboarding/style.module.css';
-import localStyles from './style.module.css';
 import type { CreateSiteFormValues } from '@/components/create-site-form';
 
 type Step = 'select' | 'configure';
@@ -24,8 +27,10 @@ interface BlueprintSearch {
 	step?: Step;
 }
 
-function OnboardingBlueprintPage() {
-	const { step } = onboardingBlueprintRoute.useSearch();
+export function OnboardingBlueprintPage() {
+	// Loose useSearch (rather than the route instance's) so the component
+	// works when mounted under the desks router's copy of this path too.
+	const { step } = useSearch( { strict: false } ) as BlueprintSearch;
 	const navigate = useNavigate();
 	const activeStep: Step = step === 'configure' ? 'configure' : 'select';
 
@@ -34,21 +39,44 @@ function OnboardingBlueprintPage() {
 	const createSite = useCreateSite();
 
 	// Picked blueprint lives in component state — survives navigation between
-	// steps but not a hard refresh. If the user lands on `step=configure` with
-	// no picked blueprint (refresh, direct URL), the effect below bounces them
-	// back to the selector.
+	// steps but not a hard refresh. The pending-blueprint slot (populated by
+	// the `wp-studio://add-site` deep link before it navigates here) hands a
+	// blueprint over from outside the route.
 	const [ picked, setPicked ] = useState< PickedBlueprint | null >( null );
 	const [ submitError, setSubmitError ] = useState( '' );
+	const pending = useSyncExternalStore( pendingBlueprintSlot.subscribe, pendingBlueprintSlot.peek );
 
+	// Adopt a pending hand-off whenever one arrives on the configure step —
+	// including while another blueprint is already being configured, so a
+	// fresh deep link always wins and the slot never holds a stale value.
 	useEffect( () => {
-		if ( activeStep === 'configure' && ! picked ) {
-			void navigate( {
-				to: '/onboarding/blueprint',
-				search: { step: 'select' },
-				replace: true,
-			} );
+		if ( activeStep !== 'configure' || ! pending ) {
+			return;
 		}
-	}, [ activeStep, picked, navigate ] );
+		setPicked( pending );
+		setSubmitError( '' );
+		pendingBlueprintSlot.clear();
+	}, [ activeStep, pending ] );
+
+	// Landing on `step=configure` with nothing picked and nothing pending
+	// (hard refresh, direct URL, history navigation) bounces to the selector.
+	useEffect( () => {
+		if ( activeStep !== 'configure' || picked || pending ) {
+			return;
+		}
+		void navigate( {
+			to: '/onboarding/blueprint',
+			search: { step: 'select' },
+			replace: true,
+		} );
+	}, [ activeStep, picked, pending, navigate ] );
+
+	// The blueprint's suggested site name can collide with an existing site
+	// folder; resolve an available variant ("Name", "Name 2", ...) before
+	// seeding the form, like the desktop renderer does.
+	const seededName = useSeededSiteName(
+		picked ? extractFormValuesFromBlueprint( picked.blueprint ).siteName || picked.title : null
+	);
 
 	const handlePick = useCallback(
 		( blueprint: PickedBlueprint ) => {
@@ -109,6 +137,13 @@ function OnboardingBlueprintPage() {
 					filePath: picked.filePath,
 				},
 			} );
+			speak(
+				sprintf(
+					// translators: %s is the site name.
+					__( '%s site added.' ),
+					values.name
+				)
+			);
 			await navigate( { to: '/sites/$siteId/new', params: { siteId: site.id } } );
 		} catch ( error ) {
 			setSubmitError(
@@ -121,18 +156,28 @@ function OnboardingBlueprintPage() {
 
 	if ( activeStep === 'select' ) {
 		return (
-			<div className={ styles.page }>
-				<h1 className={ styles.title }>{ __( 'Start from a Blueprint' ) }</h1>
+			<div className={ `${ styles.page } ${ styles.pageSpacious }` }>
+				<h1 className={ styles.title }>{ __( 'Build a new site' ) }</h1>
 				<p className={ styles.subtitle }>
-					{ __(
-						'Pick a featured Blueprint or drop in your own to provision plugins, content, and settings.'
-					) }
+					{ __( 'Choose a starting point for your new WordPress site.' ) }
 				</p>
 				<BlueprintSelector
-					featured={ featured.data }
-					isFeaturedLoading={ featured.isLoading }
+					blueprints={ featured.data }
+					isLoading={ featured.isLoading }
 					onPick={ handlePick }
+					onPickEmpty={ () => void navigate( { to: '/onboarding/create' } ) }
 				/>
+				<OnboardingFooter>
+					<Button
+						type="button"
+						variant="minimal"
+						tone="neutral"
+						onClick={ () => void navigate( { to: '/onboarding' } ) }
+					>
+						<Icon icon={ chevronLeft } size={ 16 } />
+						<span>{ __( 'Back' ) }</span>
+					</Button>
+				</OnboardingFooter>
 			</div>
 		);
 	}
@@ -141,33 +186,30 @@ function OnboardingBlueprintPage() {
 	// above; render nothing in the intermediate frame to avoid a flash.
 	if ( ! picked ) return null;
 
-	const initialValues = mapBlueprintSettingsToFormValues(
-		extractFormValuesFromBlueprint( picked.blueprint ),
-		picked.title
-	);
+	// Hold the form until the collision-checked name resolves — initial
+	// values are applied once, so seeding early with a colliding name would
+	// lock it in.
+	const initialValues = seededName
+		? {
+				...mapBlueprintSettingsToFormValues(
+					extractFormValuesFromBlueprint( picked.blueprint ),
+					picked.title
+				),
+				name: seededName,
+		  }
+		: undefined;
 
 	return (
 		<div className={ styles.page }>
-			<Button
-				type="button"
-				variant="minimal"
-				tone="neutral"
-				className={ localStyles.backLink }
-				onClick={ handleBackToSelect }
-			>
-				<Icon icon={ arrowLeft } />
-				<span>{ __( 'Back to Blueprints' ) }</span>
-			</Button>
 			<h1 className={ styles.title }>{ picked.title }</h1>
 			{ picked.excerpt && <p className={ styles.subtitle }>{ picked.excerpt }</p> }
 			<CreateSiteForm
 				initialValues={ initialValues }
 				existingDomainNames={ existingDomainNames ?? [] }
 				onSubmit={ handleSubmit }
-				onCancel={ () => void navigate( { to: '/onboarding' } ) }
+				onCancel={ handleBackToSelect }
 				isSubmitting={ createSite.isPending }
 				submitError={ submitError }
-				submitLabel={ __( 'Create site from Blueprint' ) }
 			/>
 		</div>
 	);
@@ -193,15 +235,19 @@ function mapBlueprintSettingsToFormValues(
 	};
 }
 
+// Exported so the desks router can register the same page under its own
+// route tree with identical search semantics.
+export function validateBlueprintSearch( search: Record< string, unknown > ): BlueprintSearch {
+	const value = search.step;
+	if ( value === 'configure' || value === 'select' ) {
+		return { step: value };
+	}
+	return {};
+}
+
 export const onboardingBlueprintRoute = createRoute( {
 	getParentRoute: () => onboardingLayoutRoute,
 	path: '/onboarding/blueprint',
-	validateSearch: ( search: Record< string, unknown > ): BlueprintSearch => {
-		const value = search.step;
-		if ( value === 'configure' || value === 'select' ) {
-			return { step: value };
-		}
-		return {};
-	},
+	validateSearch: validateBlueprintSearch,
 	component: OnboardingBlueprintPage,
 } );

--- a/apps/ui/src/ui-classic/router/route-onboarding-blueprint/style.module.css
+++ b/apps/ui/src/ui-classic/router/route-onboarding-blueprint/style.module.css
@@ -1,8 +1,0 @@
-.backLink {
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
-	align-self: flex-start;
-	margin-bottom: 16px;
-	padding: 4px 8px 4px 4px;
-}

--- a/apps/ui/src/ui-desks/onboarding/index.tsx
+++ b/apps/ui/src/ui-desks/onboarding/index.tsx
@@ -223,9 +223,10 @@ export function DeskOnboardingBlueprint() {
 						) }
 					</p>
 					<BlueprintSelector
-						featured={ featured.data }
-						isFeaturedLoading={ featured.isLoading }
+						blueprints={ featured.data }
+						isLoading={ featured.isLoading }
 						onPick={ handlePick }
+						onPickEmpty={ () => void navigate( { to: '/onboarding/create' } ) }
 					/>
 				</div>
 			</OnboardingLayout>


### PR DESCRIPTION
## Related issues

- Part of the site-creation onboarding redesign — see the umbrella PR (linked below once open) for the full plan.
- **Draft note:** based on `site-creation-foundation`; will be retargeted to `trunk` and marked ready once wave 1 merges.

## How AI was used in this PR

Split out of the `workbench/site-creation` exploration branch with Claude Code; designed and tested by Shaun on the original branch.

## Proposed Changes

- The blueprint step becomes a gallery: featured blueprints with hover previews, an "Empty site" card that routes to the plain create flow, a "More blueprints" section, and upload folded in as a link rather than a separate dropzone section.
- Arrow keys navigate the gallery grid, and picking a blueprint seeds a collision-free site name into the configure form.
- The `wp-studio://add-site` deeplink and the Add Site menu item now land in this flow with the blueprint pre-picked.

## Testing Instructions

- Onboarding → "Start from a blueprint": browse, search, preview, and pick blueprints; try uploading a blueprint JSON/ZIP; confirm arrow-key navigation works. Verify light and dark mode.
- Open a `wp-studio://add-site?blueprintPath=…` deeplink and confirm it lands on the configure step with the blueprint applied.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
