### PR TITLE
Port the split-panel site preview from the agentic UI redesign

### DIFF
--- a/apps/studio/src/ipc-utils.ts
+++ b/apps/studio/src/ipc-utils.ts
@@ -52,6 +52,7 @@ export interface IpcEvents {
 		},
 	];
 	'test-render-failure': [ void ];
+	'toggle-site-preview': [ void ];
 	'theme-details-loading': [ { id: string } ];
 	'theme-details-loaded': [ { id: string; details: StartedSiteDetails[ 'themeDetails' ] } ];
 	'thumbnail-loading': [ { id: string } ];

--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -309,6 +309,14 @@ async function getAppMenu(
 			submenu: [
 				{ label: __( 'Show Tab Bar' ), role: 'toggleTabBar' },
 				{ label: __( 'Show All Tabs' ), role: 'showAllTabs' },
+				{
+					label: __( 'Toggle Site Preview' ),
+					accelerator: 'CommandOrControl+Shift+B',
+					enabled: ! needsOnboarding,
+					click: () => {
+						void sendIpcEventToRenderer( 'toggle-site-preview' );
+					},
+				},
 				...( process.env.NODE_ENV === 'development' ? devTools : [] ),
 				{
 					label: __( 'Actual Size' ),

--- a/apps/ui/src/components/resize-handle/style.module.css
+++ b/apps/ui/src/components/resize-handle/style.module.css
@@ -1,18 +1,19 @@
 .resizeHandle {
-	width: 15px;
+	width: 8px;
 	z-index: 20;
 	display: flex;
-	align-items: center;
+	align-items: stretch;
+	justify-content: center;
 	box-sizing: border-box;
 	cursor: col-resize;
 	outline: none;
 	-webkit-app-region: no-drag;
 }
 
+/* Thin full-height line that lights up the panel border on hover/drag. */
 .resizeHandleIndicator {
-	width: 3px;
-	height: 48px;
-	border-radius: 999px;
+	width: 2px;
+	align-self: stretch;
 	background-color: var(--wpds-color-stroke-interactive-brand, #2563eb);
 	opacity: 0;
 	transition: opacity 120ms ease;

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -44,10 +44,16 @@
 	position: relative;
 }
 
+/* The negative margin cancels the handle's width so it adds no space to the
+   flex row — the main content butts straight against the sidebar's border and
+   the hit area overlays main's left edge. position/z-index lift it above main
+   (a later flex sibling) so the full-height indicator sits on the border. */
 .resizeHandle {
+	position: relative;
+	z-index: 20;
 	flex-shrink: 0;
+	margin-right: -8px;
 	justify-content: flex-start;
-	padding-left: 4px;
 }
 
 .floatingToggle {

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -2,15 +2,11 @@ import { __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight, external, pencil } from '@wordpress/icons';
 import { ariaKeyShortcut, displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { Button, IconButton, Tooltip } from '@wordpress/ui';
-import { clsx } from 'clsx';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ResizeHandle, ResizeOverlay } from '@/components/resize-handle';
 import { useConnector } from '@/data/core';
 import { useIsSiteStarting, useStartSite } from '@/data/queries/use-sites';
-import { useResizablePanel } from '@/hooks/use-resizable-panel';
 import { getSiteUrl } from '@/lib/get-site-url';
 import { playIcon, refreshIcon } from '@/lib/icons';
-import { PREVIEW_PANEL_CONFIG, PREVIEW_PANEL_STORAGE_KEY } from '@/lib/resizable-panels';
 import {
 	INSPECTOR_BRIDGE_PREFIX,
 	INSPECTOR_COMMAND_EVENT,
@@ -19,7 +15,7 @@ import {
 import styles from './style.module.css';
 import type { Annotation } from './types';
 import type { SiteDetails } from '@/data/core';
-import type { CSSProperties, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 export type { Annotation } from './types';
 
@@ -38,6 +34,9 @@ interface SitePreviewProps {
 	// back/forward) so the parent can keep its `path` in sync without
 	// forcing a reload.
 	onPathChange?: ( path: string ) => void;
+	// True while the panel is toggled off but kept mounted (so the webview
+	// stays warm). Disables the global browser shortcuts in that state.
+	collapsed?: boolean;
 }
 
 interface InspectorEvent {
@@ -208,6 +207,7 @@ export function SitePreview( {
 	reloadNonce,
 	onAnnotationsDone,
 	onPathChange,
+	collapsed = false,
 }: SitePreviewProps ) {
 	const connector = useConnector();
 	const startSite = useStartSite();
@@ -228,14 +228,6 @@ export function SitePreview( {
 		? Math.max( browserState.progress, 0.12 )
 		: browserState.progress;
 	const showLoadingProgress = canPreview && progress > 0;
-	const previewResize = useResizablePanel( {
-		config: PREVIEW_PANEL_CONFIG,
-		edge: 'left',
-		storageKey: PREVIEW_PANEL_STORAGE_KEY,
-	} );
-	const previewStyle = {
-		'--site-preview-width': `${ previewResize.width }px`,
-	} as CSSProperties;
 
 	const handlePreviewNavigation = useCallback(
 		( url: string ) => {
@@ -280,7 +272,7 @@ export function SitePreview( {
 	// document. Shortcuts pressed inside the guest page are forwarded by the
 	// inspector script through the console bridge instead.
 	useEffect( () => {
-		if ( ! canPreview ) {
+		if ( ! canPreview || collapsed ) {
 			return;
 		}
 		const handleKeyDown = ( event: globalThis.KeyboardEvent ) => {
@@ -303,31 +295,11 @@ export function SitePreview( {
 
 		document.addEventListener( 'keydown', handleKeyDown, { capture: true } );
 		return () => document.removeEventListener( 'keydown', handleKeyDown, { capture: true } );
-	}, [ canPreview, sendBrowserCommand ] );
+	}, [ canPreview, collapsed, sendBrowserCommand ] );
 
 	return (
-		<aside
-			ref={ rootRef }
-			className={ styles.root }
-			style={ previewStyle }
-			aria-label={ __( 'Site preview' ) }
-		>
-			<ResizeHandle
-				className={ styles.resizeHandle }
-				label={ __( 'Resize site preview' ) }
-				minWidth={ previewResize.minWidth }
-				maxWidth={ previewResize.maxWidth }
-				width={ previewResize.width }
-				isResizing={ previewResize.isResizing }
-				onResizeStart={ previewResize.handleResizeStart }
-				onKeyDown={ previewResize.handleKeyDown }
-			/>
+		<aside ref={ rootRef } className={ styles.root } aria-label={ __( 'Site preview' ) }>
 			<div className={ styles.header }>
-				<div className={ styles.trafficLights } aria-hidden="true">
-					<span className={ clsx( styles.trafficLight, styles.trafficLightActive ) } />
-					<span className={ styles.trafficLight } />
-					<span className={ styles.trafficLight } />
-				</div>
 				{ canPreview ? (
 					<>
 						<div className={ styles.browserControls } aria-label={ __( 'Browser navigation' ) }>
@@ -467,7 +439,6 @@ export function SitePreview( {
 					</div>
 				) }
 			</div>
-			{ previewResize.isResizing ? <ResizeOverlay /> : null }
 		</aside>
 	);
 }

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -1,28 +1,16 @@
+/* Fills the preview slot of the session frame's split layout; the slot owns
+   the panel's width, this panel just provides the border separator. */
 .root {
 	display: flex;
 	flex-direction: column;
 	position: relative;
-	width: var(--site-preview-width, 520px);
-	min-width: 360px;
-	max-width: 50vw;
-	flex-shrink: 0;
+	width: 100%;
+	height: 100%;
+	min-width: 0;
 	min-height: 0;
-	margin: calc(var(--wpds-dimension-padding-md) * 2) calc(var(--wpds-dimension-padding-md) * 2)
-		calc(var(--wpds-dimension-padding-md) * 2) 0;
 	background-color: var(--wpds-color-bg-surface-neutral);
-	border: 1px solid var(--wpds-color-stroke-surface-neutral);
-	border-radius: var(--wpds-border-radius-lg, 12px);
-	overflow: visible;
-	box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
-}
-
-.resizeHandle {
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	left: -15px;
-	justify-content: flex-end;
-	padding-right: 4px;
+	border-left: 1px solid var(--wpds-color-stroke-surface-neutral);
+	overflow: hidden;
 }
 
 .header {
@@ -35,8 +23,6 @@
 	flex-shrink: 0;
 	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
 	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
-	border-top-left-radius: inherit;
-	border-top-right-radius: inherit;
 }
 
 .browserControls {
@@ -100,28 +86,11 @@
 	transition: transform 160ms ease-out;
 }
 
-.trafficLights {
-	display: flex;
-	align-items: center;
-	gap: 5px;
-}
-
 .separator {
 	width: 1px;
 	height: 14px;
 	background-color: var(--wpds-color-stroke-surface-neutral);
 	opacity: 0.6;
-}
-
-.trafficLight {
-	width: 7px;
-	height: 7px;
-	border-radius: 50%;
-	background-color: var(--wpds-color-stroke-surface-neutral);
-}
-
-.trafficLightActive {
-	background-color: var(--wpds-color-fg-interactive-brand, #2563eb);
 }
 
 .headerSpacer {
@@ -135,8 +104,6 @@
 	position: relative;
 	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
 	overflow: hidden;
-	border-bottom-right-radius: inherit;
-	border-bottom-left-radius: inherit;
 }
 
 .spinnerOverlay {

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -714,5 +714,11 @@ export function createIpcConnector(): Connector {
 			const ipcListener = ( window as any ).ipcListener;
 			return ipcListener.subscribe( 'site-event', () => listener() );
 		},
+
+		onToggleSitePreview( listener ) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const ipcListener = ( window as any ).ipcListener;
+			return ipcListener.subscribe( 'toggle-site-preview', () => listener() );
+		},
 	};
 }

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -311,6 +311,10 @@ export interface Connector {
 	// Fires whenever a site is created, updated, started, stopped, or deleted.
 	// Consumers typically invalidate cached site data in response.
 	onSiteEvent( listener: () => void ): () => void;
+
+	// Fires when the user activates "View > Toggle Site Preview" (⌘⇧B) in the
+	// application menu.
+	onToggleSitePreview( listener: () => void ): () => void;
 }
 
 export type ColorScheme = 'system' | 'light' | 'dark';

--- a/apps/ui/src/hooks/use-session-ui.tsx
+++ b/apps/ui/src/hooks/use-session-ui.tsx
@@ -2,11 +2,13 @@ import {
 	createContext,
 	useCallback,
 	useContext,
+	useEffect,
 	useMemo,
 	useReducer,
 	type Dispatch,
 	type ReactNode,
 } from 'react';
+import { useConnector } from '@/data/core';
 
 // Session-scoped UI store. Holds the slices of UI state that the chat agent
 // can influence (preview panel today; future: composer, conversation pane,
@@ -36,7 +38,7 @@ export type SessionUIAction =
 	| { type: 'preview/update-path'; path: string };
 
 const INITIAL_STATE: SessionUIState = {
-	preview: { open: false, path: '/', reloadNonce: 0 },
+	preview: { open: true, path: '/', reloadNonce: 0 },
 };
 
 function reducer( state: SessionUIState, action: SessionUIAction ): SessionUIState {
@@ -71,6 +73,12 @@ const SessionUIDispatchContext = createContext< Dispatch< SessionUIAction > | nu
 
 export function SessionUIProvider( { children }: { children: ReactNode } ) {
 	const [ state, dispatch ] = useReducer( reducer, INITIAL_STATE );
+	const connector = useConnector();
+	useEffect( () => {
+		return connector.onToggleSitePreview( () => {
+			dispatch( { type: 'preview/toggle' } );
+		} );
+	}, [ connector ] );
 	return (
 		<SessionUIDispatchContext.Provider value={ dispatch }>
 			<SessionUIStateContext.Provider value={ state }>{ children }</SessionUIStateContext.Provider>

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -3,7 +3,18 @@ import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
-import { useCallback, useLayoutEffect, useMemo, useRef, type ReactNode, type Ref } from 'react';
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+	type CSSProperties,
+	type ReactNode,
+	type Ref,
+} from 'react';
+import { ResizeHandle, ResizeOverlay } from '@/components/resize-handle';
 import { SiteDropdown } from '@/components/site-dropdown';
 import { SiteIcon } from '@/components/site-icon';
 import { SitePreview } from '@/components/site-preview';
@@ -13,10 +24,12 @@ import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites
 import { useSession, useSessionEffectiveEnvironment } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { useFullscreen } from '@/hooks/use-fullscreen';
+import { useResizablePanel } from '@/hooks/use-resizable-panel';
 import { useSessionCommands } from '@/hooks/use-session-commands';
 import { SessionUIProvider, useSessionPreviewUI } from '@/hooks/use-session-ui';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
 import { drawerIcon } from '@/lib/icons';
+import { PREVIEW_PANEL_CONFIG, PREVIEW_PANEL_STORAGE_KEY } from '@/lib/resizable-panels';
 import { formatAnnotationsAsPrompt, formatAnnotationsSubmittedMessage } from './annotations';
 import { Composer, ComposerSkeleton } from './composer';
 import { pickLiveSite } from './composer/environment-pill';
@@ -25,6 +38,9 @@ import { EmptyBackground } from './empty-background';
 import { QueuedPrompts } from './queued-prompts';
 import styles from './style.module.css';
 import type { AiSessionSummary } from '@/data/core';
+
+// Keep in sync with the flex-basis transition duration in style.module.css.
+const PREVIEW_TOGGLE_DURATION = 150;
 
 interface SessionHeaderProps {
 	summary: AiSessionSummary;
@@ -97,14 +113,70 @@ function SessionHeader( {
 interface SessionFrameProps {
 	header?: ReactNode;
 	composer?: ReactNode;
+	// The preview panel content. Kept mounted (hidden behind the chat column)
+	// while `previewOpen` is false so the webview stays warm and the panel can
+	// slide in and out.
 	preview?: ReactNode;
+	previewOpen?: boolean;
 	scrollRef?: Ref< HTMLDivElement >;
 	children?: ReactNode;
 }
 
-function SessionFrame( { header, composer, preview, scrollRef, children }: SessionFrameProps ) {
+// Splits the session screen between the chat column and the site preview. The
+// preview slot is pinned to the right edge at its resizable width; the chat
+// column sits on top of it and shrinks to reveal it, so toggling animates by
+// transitioning only the chat column's flex-basis while the preview keeps a
+// constant width (no mid-animation webview reflow).
+function SessionFrame( {
+	header,
+	composer,
+	preview,
+	previewOpen = false,
+	scrollRef,
+	children,
+}: SessionFrameProps ) {
+	const previewMounted = preview != null;
+	const showPreview = previewMounted && previewOpen;
+	const previewResize = useResizablePanel( {
+		config: PREVIEW_PANEL_CONFIG,
+		edge: 'left',
+		storageKey: PREVIEW_PANEL_STORAGE_KEY,
+	} );
+	// Animate only open/close toggles of an already-mounted preview — never
+	// the initial layout, so a session loading with the preview visible
+	// doesn't replay the slide-in. The render-phase update makes the
+	// transition class land in the same commit as the flex-basis change; an
+	// effect-based update would race it.
+	const [ animating, setAnimating ] = useState( false );
+	const [ previousPreview, setPreviousPreview ] = useState( {
+		mounted: previewMounted,
+		open: showPreview,
+	} );
+	if ( previousPreview.mounted !== previewMounted || previousPreview.open !== showPreview ) {
+		setPreviousPreview( { mounted: previewMounted, open: showPreview } );
+		if ( previousPreview.mounted && previewMounted ) {
+			setAnimating( true );
+		}
+	}
+	useEffect( () => {
+		if ( ! animating ) {
+			return;
+		}
+		const timeoutId = window.setTimeout( () => setAnimating( false ), PREVIEW_TOGGLE_DURATION );
+		return () => window.clearTimeout( timeoutId );
+	}, [ animating, showPreview ] );
+
+	const rootStyle = { '--site-preview-width': `${ previewResize.width }px` } as CSSProperties;
+
 	return (
-		<div className={ styles.root }>
+		<div
+			className={ clsx(
+				styles.root,
+				showPreview && styles.rootPreviewOpen,
+				animating && styles.rootPreviewAnimating
+			) }
+			style={ rootStyle }
+		>
 			<div className={ styles.chatColumn }>
 				{ header }
 				<div ref={ scrollRef } className={ clsx( styles.scroll, styles.classicScroll ) }>
@@ -114,7 +186,24 @@ function SessionFrame( { header, composer, preview, scrollRef, children }: Sessi
 					{ composer }
 				</div>
 			</div>
-			{ preview }
+			{ preview != null ? (
+				<div className={ clsx( styles.previewSlot, showPreview && styles.previewSlotOpen ) }>
+					{ preview }
+				</div>
+			) : null }
+			{ showPreview && ! animating ? (
+				<ResizeHandle
+					className={ styles.previewResizeHandle }
+					label={ __( 'Resize site preview' ) }
+					minWidth={ previewResize.minWidth }
+					maxWidth={ previewResize.maxWidth }
+					width={ previewResize.width }
+					isResizing={ previewResize.isResizing }
+					onResizeStart={ previewResize.handleResizeStart }
+					onKeyDown={ previewResize.handleKeyDown }
+				/>
+			) : null }
+			{ previewResize.isResizing ? <ResizeOverlay /> : null }
 		</div>
 	);
 }
@@ -259,14 +348,16 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 					/>
 				</div>
 			}
+			previewOpen={ showPreview }
 			preview={
-				showPreview && ownerSite ? (
+				canTogglePreview && ownerSite ? (
 					<SitePreview
 						site={ ownerSite }
 						path={ preview.path }
 						reloadNonce={ preview.reloadNonce }
 						onAnnotationsDone={ handleAnnotationsDone }
 						onPathChange={ preview.updatePath }
+						collapsed={ ! showPreview }
 					/>
 				) : null
 			}

--- a/apps/ui/src/ui-classic/components/session-view/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/style.module.css
@@ -3,14 +3,59 @@
 	flex-direction: row;
 	height: 100%;
 	min-height: 0;
+	position: relative;
+	overflow: hidden;
 }
 
+/* Opaque and above the preview slot so it fully covers the (still mounted)
+   preview while the panel is toggled off. */
 .chatColumn {
 	display: flex;
 	flex-direction: column;
-	flex: 1;
+	flex: 0 0 100%;
 	min-width: 0;
 	min-height: 0;
+	position: relative;
+	z-index: 1;
+	background-color: var(--wpds-color-bg-surface-neutral);
+}
+
+.rootPreviewOpen .chatColumn {
+	flex-basis: calc(100% - var(--site-preview-width, 520px));
+}
+
+/* Applied only around open/close toggles (see PREVIEW_TOGGLE_DURATION) so
+   the initial layout and drag-resizing stay instant. */
+.rootPreviewAnimating .chatColumn {
+	transition: flex-basis 150ms ease;
+}
+
+.previewSlot {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: var(--site-preview-width, 520px);
+	/* Once the close animation finishes, drop the slot out of the focus and
+	   accessibility tree — the webview behind the chat column stays mounted
+	   but must not be reachable. The delay keeps it visible while it slides
+	   closed; opening flips visibility immediately. */
+	visibility: hidden;
+	transition: visibility 0s linear 150ms;
+}
+
+.previewSlotOpen {
+	visibility: visible;
+	transition-delay: 0s;
+}
+
+/* Centers the 8px hit area on the chat/preview boundary. */
+.previewResizeHandle {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	right: calc(var(--site-preview-width, 520px) - 4px);
+	justify-content: center;
 }
 
 .state {


### PR DESCRIPTION
## Related issues

- Related to #3646

## How AI was used in this PR

Built with Claude Code. It studied the design and behavior of the preview panel work in #3646 and reimplemented it against current trunk (the split/animation logic was rewritten in a simpler form rather than copied). Code reviewed and visually verified by the author.

## Proposed Changes

Ports the site preview panel behavior from the agentic UI redesign (#3646) to trunk:

- The session site preview is now a true split panel — full height, flush against the window edge with a border separator — instead of a floating card. Opening and closing slides the panel in and out, and the webview keeps a constant width during the animation so the page never reflows mid-slide. The preview also stays mounted while toggled off, so reopening it is instant and keeps the page state.
- The preview is now open by default when a session has a local site.
- Resize handles (site preview and left sidebar) are redesigned as a thin full-height indicator that lights up the panel border on hover/drag, and no longer take up layout space.
- New OS-level **View → Toggle Site Preview** menu item with the ⌘⇧B shortcut. The renderer consumes the event through the `StudioConnector` abstraction (no direct `ipcListener` usage).
- The fake browser traffic lights are removed from the preview toolbar — they belonged to the floating "browser window" aesthetic.

## Testing Instructions

- Launch with the agentic UI enabled: `ENABLE_AGENTIC_UI=true npm start`.
- Open a chat session attached to a local site: the preview should be open by default as a split panel (no margins/shadow), with the site behind a 1px border.
- Toggle the preview via the header button and via **View → Toggle Site Preview** (⌘⇧B): the panel should slide in/out smoothly, and the page state (e.g. scroll position, wp-admin login) should survive a close/reopen.
- Hover the boundary between chat and preview, and the boundary between sidebar and content: a thin full-height blue indicator should appear; dragging resizes, double-checking the width persists across restarts.
- Keyboard resize: focus a handle and use arrow keys / Home / End.
- Verify in both light and dark mode, and that ⌘R / ⌘[ / ⌘] only drive the preview while it is open.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)