### PR TITLE
Hide the stopped status square in the sidebar until the site row is hovered

### DIFF
--- a/apps/ui/src/components/sidebar-button/style.module.css
+++ b/apps/ui/src/components/sidebar-button/style.module.css
@@ -8,4 +8,9 @@
 	min-width: 0;
 	background-color: transparent;
 	border-color: transparent;
+
+	/* The primitive clips the background to the padding box, which insets any
+	   row highlight by the 1px (transparent) border and shrinks its corner
+	   radius, making button rows render differently from plain-div rows. */
+	background-clip: border-box;
 }

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -169,7 +169,21 @@
 	background: transparent;
 	color: inherit;
 	cursor: var(--wpds-cursor-control);
-	transition: background-color 100ms ease;
+	transition: background-color 100ms ease, opacity 100ms ease;
+}
+
+/* A stopped site carries no signal worth surfacing, so its gray status square
+   stays hidden until the row is hovered, focused, has an open menu, or is the
+   active site; running/transitioning dots remain always visible. */
+.siteStatus[data-state='stopped'] {
+	opacity: 0;
+}
+
+.siteActive .siteStatus[data-state='stopped'],
+.siteHeader:hover .siteStatus[data-state='stopped'],
+.siteHeader:focus-within .siteStatus[data-state='stopped'],
+.siteHeader:has(.siteAction[data-popup-open]) .siteStatus[data-state='stopped'] {
+	opacity: 1;
 }
 
 .siteStatus:not([aria-disabled='true']):is(:hover, :focus-visible) {


### PR DESCRIPTION
## Related issues

<!-- No linked issue — small UI refinement requested during development. -->

## How AI was used in this PR

The change was implemented with Claude Code (Fable 5) from a one-line prompt describing the desired behavior; the result was reviewed manually.

## Proposed Changes

In the agentic UI sidebar, every site row permanently showed its status square — including the gray "stopped" square, which carries no useful signal and added visual noise to a list where most sites are typically stopped.

- A stopped site's status square is now hidden by default and fades in when the row is hovered, focused via keyboard, or has its actions menu open — the same reveal behavior the row's other action buttons already use.
- The active site's row keeps the square visible, consistent with that row always showing its action buttons, so the click-to-start affordance stays discoverable.
- Running and starting/stopping indicators are unchanged and remain always visible, since those carry actual signal.

## Testing Instructions

1. Launch Studio with the agentic UI enabled and have a few sites in the sidebar, at least one running and one stopped.
2. Verify stopped sites show no gray status square at rest, while the running site keeps its green dot.
3. Hover a stopped site's row: the gray square fades in alongside the menu and new-chat buttons, and clicking it starts the site.
4. Tab through the sidebar with the keyboard: focusing a stopped row's controls also reveals the square.
5. Verify the currently selected (active) site still shows its status square without hovering.
6. Check both light and dark appearance — behavior should be identical.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)