### PR TITLE
fix(cli): restore the session's recorded model when resuming by id

### DIFF
--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -4,7 +4,7 @@ import {
 	type StudioChatFileAttachment,
 } from '@studio/common/ai/chat-files';
 import { type StudioChatImage } from '@studio/common/ai/chat-images';
-import { DEFAULT_MODEL, type AiModelId } from '@studio/common/ai/models';
+import { DEFAULT_MODEL, resolveSessionModel, type AiModelId } from '@studio/common/ai/models';
 import { getAgentEndTurnResult } from '@studio/common/ai/session-events';
 import { buildSkillInvocationPrompt } from '@studio/common/ai/slash-commands';
 import { readAuthToken } from '@studio/common/lib/shared-config';
@@ -146,6 +146,8 @@ export async function runCommand( options: {
 					if ( sm.getSessionId() === options.resumeSessionId ) {
 						session = sm;
 						match = file;
+						currentModel = resolveSessionModel( sm.getEntries() );
+						ui.currentModel = currentModel;
 						break;
 					}
 				} catch {

--- a/apps/cli/commands/ai/tests/index.test.ts
+++ b/apps/cli/commands/ai/tests/index.test.ts
@@ -3,7 +3,7 @@ import { vi, type Mock } from 'vitest';
 import { resolveInitialAiProvider, saveSelectedAiProvider } from 'cli/ai/auth';
 import { JsonAdapter } from 'cli/ai/output-adapter';
 import { runStudioAgentTurn } from 'cli/ai/runtimes/pi';
-import { createStudioSession } from 'cli/ai/sessions/pi-session';
+import { createStudioSession, listStudioSessionFiles, openStudioSession } from 'cli/ai/sessions/pi-session';
 import { readCliConfig } from 'cli/lib/cli-config/core';
 import { runCommand } from '../index';
 
@@ -99,5 +99,47 @@ describe( 'AI runCommand — Desktop (JSON mode) provider default', () => {
 
 		expect( runStudioAgentTurn ).toHaveBeenCalled();
 		expect( saveSelectedAiProvider ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'AI runCommand — resume by id restores session model', () => {
+	let stdoutSpy: ReturnType< typeof vi.spyOn >;
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		( readAuthToken as Mock ).mockResolvedValue( null );
+		( readCliConfig as Mock ).mockResolvedValue( { aiProvider: 'wpcom' } );
+		( resolveInitialAiProvider as Mock ).mockResolvedValue( 'wpcom' );
+		stdoutSpy = vi.spyOn( process.stdout, 'write' ).mockImplementation( () => true );
+	} );
+
+	afterEach( () => {
+		stdoutSpy.mockRestore();
+	} );
+
+	it( 'uses the model recorded in the session rather than DEFAULT_MODEL', async () => {
+		// Build a minimal session whose entries record a model_change to a
+		// non-default model — the same shape that `resolveSessionModel` reads.
+		const sessionEntries = [
+			{ type: 'model_change', id: 'e1', parentId: null, timestamp: '2024-01-01T00:00:00Z', modelId: 'claude-opus-4-8' },
+		];
+		const mockSm = {
+			appendCustomEntry: vi.fn( () => 'entry-id' ),
+			getSessionId: () => 'resume-id-123',
+			getEntries: () => sessionEntries,
+		};
+
+		( listStudioSessionFiles as Mock ).mockResolvedValue( [ '/sessions/session-1.jsonl' ] );
+		( openStudioSession as Mock ).mockResolvedValue( mockSm );
+
+		await runCommand( {
+			adapter: new JsonAdapter(),
+			initialMessage: 'hello',
+			resumeSessionId: 'resume-id-123',
+		} );
+
+		expect( runStudioAgentTurn ).toHaveBeenCalledTimes( 1 );
+		const callArgs = ( runStudioAgentTurn as Mock ).mock.calls[ 0 ][ 0 ] as { model: string };
+		expect( callArgs.model ).toBe( 'claude-opus-4-8' );
 	} );
 } );

--- a/apps/cli/commands/ai/tests/index.test.ts
+++ b/apps/cli/commands/ai/tests/index.test.ts
@@ -3,7 +3,11 @@ import { vi, type Mock } from 'vitest';
 import { resolveInitialAiProvider, saveSelectedAiProvider } from 'cli/ai/auth';
 import { JsonAdapter } from 'cli/ai/output-adapter';
 import { runStudioAgentTurn } from 'cli/ai/runtimes/pi';
-import { createStudioSession, listStudioSessionFiles, openStudioSession } from 'cli/ai/sessions/pi-session';
+import {
+	createStudioSession,
+	listStudioSessionFiles,
+	openStudioSession,
+} from 'cli/ai/sessions/pi-session';
 import { readCliConfig } from 'cli/lib/cli-config/core';
 import { runCommand } from '../index';
 
@@ -121,7 +125,13 @@ describe( 'AI runCommand — resume by id restores session model', () => {
 		// Build a minimal session whose entries record a model_change to a
 		// non-default model — the same shape that `resolveSessionModel` reads.
 		const sessionEntries = [
-			{ type: 'model_change', id: 'e1', parentId: null, timestamp: '2024-01-01T00:00:00Z', modelId: 'claude-opus-4-8' },
+			{
+				type: 'model_change',
+				id: 'e1',
+				parentId: null,
+				timestamp: '2024-01-01T00:00:00Z',
+				modelId: 'claude-opus-4-8',
+			},
 		];
 		const mockSm = {
 			appendCustomEntry: vi.fn( () => 'entry-id' ),


### PR DESCRIPTION
Resuming a session with \`--resume-session\` was silently dropping the model: the session file records every model change, but the resume-by-id path never read it, so every resumed turn ran the default model no matter what you were using before. The interactive resume path already restores it via \`resolveResumeSessionContext\` — this brings the by-id path in line.

One line of behavior: after finding the session, resolve the recorded model and use it for the turn. \`resolveSessionModel\` already falls back to the default for sessions with no recorded model or a model we no longer offer, so nothing changes for those.

Found this while wiring multi-turn benchmarks in studio-eval: we resume sessions headlessly with \`--json --resume-session\`, and model comparisons were quietly all running the default model on the follow-up turns. Verified end to end there too: a resumed turn on \`claude-sonnet-4-6\` now stays on sonnet (the session JSONL shows no model flip back to the default).

## Testing
- New test in \`apps/cli/commands/ai/tests/index.test.ts\`: resuming by id a session whose JSONL records a \`model_change\` to a non-default model asserts \`runStudioAgentTurn\` receives that model.
- \`npx vitest run apps/cli/commands/ai/tests/index.test.ts\` — 3 passed.
- \`npm run typecheck\` in \`apps/cli\` — clean.