### PR TITLE
Host the site preview at the dashboard layout so it persists across routes

### DIFF
--- a/apps/ui/src/components/preview-split-frame/index.tsx
+++ b/apps/ui/src/components/preview-split-frame/index.tsx
@@ -1,0 +1,94 @@
+import { __ } from '@wordpress/i18n';
+import { clsx } from 'clsx';
+import { useEffect, useState, type CSSProperties, type ReactNode } from 'react';
+import { ResizeHandle, ResizeOverlay } from '@/components/resize-handle';
+import { useResizablePanel } from '@/hooks/use-resizable-panel';
+import { PREVIEW_PANEL_CONFIG, PREVIEW_PANEL_STORAGE_KEY } from '@/lib/resizable-panels';
+import styles from './style.module.css';
+
+// Keep in sync with the flex-basis transition duration in style.module.css.
+const PREVIEW_TOGGLE_DURATION = 150;
+
+interface PreviewSplitFrameProps {
+	// The preview panel content. Kept mounted (hidden behind the content
+	// column) while `previewOpen` is false so the webview stays warm and the
+	// panel can slide in and out.
+	preview?: ReactNode;
+	previewOpen?: boolean;
+	children?: ReactNode;
+}
+
+// Splits the frame between the main content column and the site preview. The
+// preview slot is pinned to the right edge at its resizable width; the
+// content column sits on top of it and shrinks to reveal it, so toggling
+// animates by transitioning only the content column's flex-basis while the
+// preview keeps a constant width (no mid-animation webview reflow).
+export function PreviewSplitFrame( {
+	preview,
+	previewOpen = false,
+	children,
+}: PreviewSplitFrameProps ) {
+	const previewMounted = preview != null;
+	const showPreview = previewMounted && previewOpen;
+	const previewResize = useResizablePanel( {
+		config: PREVIEW_PANEL_CONFIG,
+		edge: 'left',
+		storageKey: PREVIEW_PANEL_STORAGE_KEY,
+	} );
+	// Animate only open/close toggles of an already-mounted preview — never
+	// the initial layout, so a route loading with the preview visible doesn't
+	// replay the slide-in. The render-phase update makes the transition class
+	// land in the same commit as the flex-basis change; an effect-based
+	// update would race it.
+	const [ animating, setAnimating ] = useState( false );
+	const [ previousPreview, setPreviousPreview ] = useState( {
+		mounted: previewMounted,
+		open: showPreview,
+	} );
+	if ( previousPreview.mounted !== previewMounted || previousPreview.open !== showPreview ) {
+		setPreviousPreview( { mounted: previewMounted, open: showPreview } );
+		if ( previousPreview.mounted && previewMounted ) {
+			setAnimating( true );
+		}
+	}
+	useEffect( () => {
+		if ( ! animating ) {
+			return;
+		}
+		const timeoutId = window.setTimeout( () => setAnimating( false ), PREVIEW_TOGGLE_DURATION );
+		return () => window.clearTimeout( timeoutId );
+	}, [ animating, showPreview ] );
+
+	const rootStyle = { '--site-preview-width': `${ previewResize.width }px` } as CSSProperties;
+
+	return (
+		<div
+			className={ clsx(
+				styles.root,
+				showPreview && styles.rootPreviewOpen,
+				animating && styles.rootPreviewAnimating
+			) }
+			style={ rootStyle }
+		>
+			<div className={ styles.contentColumn }>{ children }</div>
+			{ previewMounted ? (
+				<div className={ clsx( styles.previewSlot, showPreview && styles.previewSlotOpen ) }>
+					{ preview }
+				</div>
+			) : null }
+			{ showPreview && ! animating ? (
+				<ResizeHandle
+					className={ styles.previewResizeHandle }
+					label={ __( 'Resize site preview' ) }
+					minWidth={ previewResize.minWidth }
+					maxWidth={ previewResize.maxWidth }
+					width={ previewResize.width }
+					isResizing={ previewResize.isResizing }
+					onResizeStart={ previewResize.handleResizeStart }
+					onKeyDown={ previewResize.handleKeyDown }
+				/>
+			) : null }
+			{ previewResize.isResizing ? <ResizeOverlay /> : null }
+		</div>
+	);
+}

--- a/apps/ui/src/components/preview-split-frame/style.module.css
+++ b/apps/ui/src/components/preview-split-frame/style.module.css
@@ -1,0 +1,62 @@
+.root {
+	display: flex;
+	flex-direction: row;
+	height: 100%;
+	min-height: 0;
+	position: relative;
+	overflow: hidden;
+}
+
+/* Opaque and above the preview slot so it fully covers the (still mounted)
+   preview while the panel is toggled off. Scrolls itself so routes taller
+   than the viewport (e.g. settings) keep working under the fixed-height
+   frame. */
+.contentColumn {
+	display: flex;
+	flex-direction: column;
+	flex: 0 0 100%;
+	min-width: 0;
+	min-height: 0;
+	position: relative;
+	z-index: 1;
+	overflow: auto;
+	background-color: var(--wpds-color-bg-surface-neutral);
+}
+
+.rootPreviewOpen .contentColumn {
+	flex-basis: calc(100% - var(--site-preview-width, 520px));
+}
+
+/* Applied only around open/close toggles (see PREVIEW_TOGGLE_DURATION) so
+   the initial layout and drag-resizing stay instant. */
+.rootPreviewAnimating .contentColumn {
+	transition: flex-basis 150ms ease;
+}
+
+.previewSlot {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: var(--site-preview-width, 520px);
+	/* Once the close animation finishes, drop the slot out of the focus and
+	   accessibility tree — the webview behind the content column stays
+	   mounted but must not be reachable. The delay keeps it visible while it
+	   slides closed; opening flips visibility immediately. */
+	visibility: hidden;
+	transition: visibility 0s linear 150ms;
+}
+
+.previewSlotOpen {
+	visibility: visible;
+	transition-delay: 0s;
+}
+
+/* Centers the 8px hit area on the content/preview boundary. */
+.previewResizeHandle {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	right: calc(var(--site-preview-width, 520px) - 4px);
+	justify-content: center;
+}

--- a/apps/ui/src/hooks/use-session-ui.tsx
+++ b/apps/ui/src/hooks/use-session-ui.tsx
@@ -5,12 +5,16 @@ import {
 	useEffect,
 	useMemo,
 	useReducer,
+	useRef,
 	type Dispatch,
+	type MutableRefObject,
 	type ReactNode,
 } from 'react';
 import { useConnector } from '@/data/core';
+import type { Annotation } from '@/components/site-preview/types';
 
-// Session-scoped UI store. Holds the slices of UI state that the chat agent
+// Dashboard-scoped UI store (mounted once in the dashboard layout, shared by
+// every route under it). Holds the slices of UI state that the chat agent
 // can influence (preview panel today; future: composer, conversation pane,
 // modals, etc.) so that components can read/update them while a separate
 // bridge — `useSessionCommands` — translates agent events into actions.
@@ -70,9 +74,29 @@ function reducer( state: SessionUIState, action: SessionUIAction ): SessionUISta
 // `useSessionCommands`) don't re-run on every state change.
 const SessionUIStateContext = createContext< SessionUIState | null >( null );
 const SessionUIDispatchContext = createContext< Dispatch< SessionUIAction > | null >( null );
+// Ref (not state) so registering/unregistering the handler never re-renders
+// the tree; the dashboard-level preview reads it lazily on submit.
+const SessionUIPreviewAnnotationsContext = createContext< MutableRefObject<
+	( ( annotations: Annotation[] ) => void ) | undefined
+> | null >( null );
 
 export function SessionUIProvider( { children }: { children: ReactNode } ) {
+	// Views mount their own provider so they stay usable standalone (e.g. in
+	// tests), but when one is already mounted above — the dashboard layout —
+	// the nested provider reuses it instead of forking the state.
+	const parentState = useContext( SessionUIStateContext );
+	const parentDispatch = useContext( SessionUIDispatchContext );
+	if ( parentState && parentDispatch ) {
+		return <>{ children }</>;
+	}
+	return <SessionUIProviderRoot>{ children }</SessionUIProviderRoot>;
+}
+
+function SessionUIProviderRoot( { children }: { children: ReactNode } ) {
 	const [ state, dispatch ] = useReducer( reducer, INITIAL_STATE );
+	const previewAnnotationsRef = useRef< ( ( annotations: Annotation[] ) => void ) | undefined >(
+		undefined
+	);
 	const connector = useConnector();
 	useEffect( () => {
 		return connector.onToggleSitePreview( () => {
@@ -81,7 +105,11 @@ export function SessionUIProvider( { children }: { children: ReactNode } ) {
 	}, [ connector ] );
 	return (
 		<SessionUIDispatchContext.Provider value={ dispatch }>
-			<SessionUIStateContext.Provider value={ state }>{ children }</SessionUIStateContext.Provider>
+			<SessionUIPreviewAnnotationsContext.Provider value={ previewAnnotationsRef }>
+				<SessionUIStateContext.Provider value={ state }>
+					{ children }
+				</SessionUIStateContext.Provider>
+			</SessionUIPreviewAnnotationsContext.Provider>
 		</SessionUIDispatchContext.Provider>
 	);
 }
@@ -141,4 +169,38 @@ export function useSessionPreviewUI(): SessionPreviewUI {
 			updatePath,
 		]
 	);
+}
+
+// Registers the on-screen session's annotations handler (its "send to chat")
+// with the shared store, so the dashboard-level preview can submit
+// annotations to whichever session is currently displayed.
+export function useSessionPreviewAnnotations(
+	onAnnotationsDone: ( annotations: Annotation[] ) => void,
+	enabled: boolean
+): void {
+	const ref = useContext( SessionUIPreviewAnnotationsContext );
+	if ( ! ref ) {
+		throw new Error( 'useSessionPreviewAnnotations must be used within a SessionUIProvider' );
+	}
+	useEffect( () => {
+		if ( ! enabled ) {
+			return;
+		}
+		ref.current = onAnnotationsDone;
+		return () => {
+			if ( ref.current === onAnnotationsDone ) {
+				ref.current = undefined;
+			}
+		};
+	}, [ enabled, onAnnotationsDone, ref ] );
+}
+
+export function useSessionPreviewAnnotationsHandler(): ( annotations: Annotation[] ) => void {
+	const ref = useContext( SessionUIPreviewAnnotationsContext );
+	if ( ! ref ) {
+		throw new Error(
+			'useSessionPreviewAnnotationsHandler must be used within a SessionUIProvider'
+		);
+	}
+	return useCallback( ( annotations: Annotation[] ) => ref.current?.( annotations ), [ ref ] );
 }

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -3,33 +3,23 @@ import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
-import {
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-	useState,
-	type CSSProperties,
-	type ReactNode,
-	type Ref,
-} from 'react';
-import { ResizeHandle, ResizeOverlay } from '@/components/resize-handle';
+import { useCallback, useLayoutEffect, useMemo, useRef, type ReactNode, type Ref } from 'react';
 import { SiteDropdown } from '@/components/site-dropdown';
 import { SiteIcon } from '@/components/site-icon';
-import { SitePreview } from '@/components/site-preview';
 import { type Annotation } from '@/components/site-preview/types';
 import { useAgentRun } from '@/data/queries/use-agent-run';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import { useSession, useSessionEffectiveEnvironment } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { useFullscreen } from '@/hooks/use-fullscreen';
-import { useResizablePanel } from '@/hooks/use-resizable-panel';
 import { useSessionCommands } from '@/hooks/use-session-commands';
-import { SessionUIProvider, useSessionPreviewUI } from '@/hooks/use-session-ui';
+import {
+	SessionUIProvider,
+	useSessionPreviewAnnotations,
+	useSessionPreviewUI,
+} from '@/hooks/use-session-ui';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
 import { drawerIcon } from '@/lib/icons';
-import { PREVIEW_PANEL_CONFIG, PREVIEW_PANEL_STORAGE_KEY } from '@/lib/resizable-panels';
 import { formatAnnotationsAsPrompt, formatAnnotationsSubmittedMessage } from './annotations';
 import { Composer, ComposerSkeleton } from './composer';
 import { pickLiveSite } from './composer/environment-pill';
@@ -38,9 +28,6 @@ import { EmptyBackground } from './empty-background';
 import { QueuedPrompts } from './queued-prompts';
 import styles from './style.module.css';
 import type { AiSessionSummary } from '@/data/core';
-
-// Keep in sync with the flex-basis transition duration in style.module.css.
-const PREVIEW_TOGGLE_DURATION = 150;
 
 interface SessionHeaderProps {
 	summary: AiSessionSummary;
@@ -113,97 +100,23 @@ function SessionHeader( {
 interface SessionFrameProps {
 	header?: ReactNode;
 	composer?: ReactNode;
-	// The preview panel content. Kept mounted (hidden behind the chat column)
-	// while `previewOpen` is false so the webview stays warm and the panel can
-	// slide in and out.
-	preview?: ReactNode;
-	previewOpen?: boolean;
 	scrollRef?: Ref< HTMLDivElement >;
 	children?: ReactNode;
 }
 
-// Splits the session screen between the chat column and the site preview. The
-// preview slot is pinned to the right edge at its resizable width; the chat
-// column sits on top of it and shrinks to reveal it, so toggling animates by
-// transitioning only the chat column's flex-basis while the preview keeps a
-// constant width (no mid-animation webview reflow).
-function SessionFrame( {
-	header,
-	composer,
-	preview,
-	previewOpen = false,
-	scrollRef,
-	children,
-}: SessionFrameProps ) {
-	const previewMounted = preview != null;
-	const showPreview = previewMounted && previewOpen;
-	const previewResize = useResizablePanel( {
-		config: PREVIEW_PANEL_CONFIG,
-		edge: 'left',
-		storageKey: PREVIEW_PANEL_STORAGE_KEY,
-	} );
-	// Animate only open/close toggles of an already-mounted preview — never
-	// the initial layout, so a session loading with the preview visible
-	// doesn't replay the slide-in. The render-phase update makes the
-	// transition class land in the same commit as the flex-basis change; an
-	// effect-based update would race it.
-	const [ animating, setAnimating ] = useState( false );
-	const [ previousPreview, setPreviousPreview ] = useState( {
-		mounted: previewMounted,
-		open: showPreview,
-	} );
-	if ( previousPreview.mounted !== previewMounted || previousPreview.open !== showPreview ) {
-		setPreviousPreview( { mounted: previewMounted, open: showPreview } );
-		if ( previousPreview.mounted && previewMounted ) {
-			setAnimating( true );
-		}
-	}
-	useEffect( () => {
-		if ( ! animating ) {
-			return;
-		}
-		const timeoutId = window.setTimeout( () => setAnimating( false ), PREVIEW_TOGGLE_DURATION );
-		return () => window.clearTimeout( timeoutId );
-	}, [ animating, showPreview ] );
-
-	const rootStyle = { '--site-preview-width': `${ previewResize.width }px` } as CSSProperties;
-
+// Lays out the chat column: header on top, scrollable conversation in the
+// middle, composer pinned at the bottom. The site preview panel lives in the
+// dashboard layout's PreviewSplitFrame, which keeps it mounted across routes.
+function SessionFrame( { header, composer, scrollRef, children }: SessionFrameProps ) {
 	return (
-		<div
-			className={ clsx(
-				styles.root,
-				showPreview && styles.rootPreviewOpen,
-				animating && styles.rootPreviewAnimating
-			) }
-			style={ rootStyle }
-		>
-			<div className={ styles.chatColumn }>
-				{ header }
-				<div ref={ scrollRef } className={ clsx( styles.scroll, styles.classicScroll ) }>
-					{ children }
-				</div>
-				<div className={ clsx( styles.composerOuter, styles.classicComposerOuter ) }>
-					{ composer }
-				</div>
+		<div className={ styles.root }>
+			{ header }
+			<div ref={ scrollRef } className={ clsx( styles.scroll, styles.classicScroll ) }>
+				{ children }
 			</div>
-			{ preview != null ? (
-				<div className={ clsx( styles.previewSlot, showPreview && styles.previewSlotOpen ) }>
-					{ preview }
-				</div>
-			) : null }
-			{ showPreview && ! animating ? (
-				<ResizeHandle
-					className={ styles.previewResizeHandle }
-					label={ __( 'Resize site preview' ) }
-					minWidth={ previewResize.minWidth }
-					maxWidth={ previewResize.maxWidth }
-					width={ previewResize.width }
-					isResizing={ previewResize.isResizing }
-					onResizeStart={ previewResize.handleResizeStart }
-					onKeyDown={ previewResize.handleKeyDown }
-				/>
-			) : null }
-			{ previewResize.isResizing ? <ResizeOverlay /> : null }
+			<div className={ clsx( styles.composerOuter, styles.classicComposerOuter ) }>
+				{ composer }
+			</div>
 		</div>
 	);
 }
@@ -272,6 +185,9 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 		},
 		[ sendMessage ]
 	);
+	// The preview panel itself is hosted by the dashboard layout; route its
+	// annotation submissions to this session while it is on screen.
+	useSessionPreviewAnnotations( handleAnnotationsDone, canTogglePreview );
 
 	useLayoutEffect( () => {
 		const node = scrollRef.current;
@@ -347,19 +263,6 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 						}
 					/>
 				</div>
-			}
-			previewOpen={ showPreview }
-			preview={
-				canTogglePreview && ownerSite ? (
-					<SitePreview
-						site={ ownerSite }
-						path={ preview.path }
-						reloadNonce={ preview.reloadNonce }
-						onAnnotationsDone={ handleAnnotationsDone }
-						onPathChange={ preview.updatePath }
-						collapsed={ ! showPreview }
-					/>
-				) : null
 			}
 		>
 			{ isEmpty ? <EmptyBackground /> : null }

--- a/apps/ui/src/ui-classic/components/session-view/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/style.module.css
@@ -1,61 +1,10 @@
+/* The chat column. The site preview panel lives in the dashboard layout's
+   PreviewSplitFrame, which hosts this view in its content column. */
 .root {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 	height: 100%;
 	min-height: 0;
-	position: relative;
-	overflow: hidden;
-}
-
-/* Opaque and above the preview slot so it fully covers the (still mounted)
-   preview while the panel is toggled off. */
-.chatColumn {
-	display: flex;
-	flex-direction: column;
-	flex: 0 0 100%;
-	min-width: 0;
-	min-height: 0;
-	position: relative;
-	z-index: 1;
-	background-color: var(--wpds-color-bg-surface-neutral);
-}
-
-.rootPreviewOpen .chatColumn {
-	flex-basis: calc(100% - var(--site-preview-width, 520px));
-}
-
-/* Applied only around open/close toggles (see PREVIEW_TOGGLE_DURATION) so
-   the initial layout and drag-resizing stay instant. */
-.rootPreviewAnimating .chatColumn {
-	transition: flex-basis 150ms ease;
-}
-
-.previewSlot {
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	width: var(--site-preview-width, 520px);
-	/* Once the close animation finishes, drop the slot out of the focus and
-	   accessibility tree — the webview behind the chat column stays mounted
-	   but must not be reachable. The delay keeps it visible while it slides
-	   closed; opening flips visibility immediately. */
-	visibility: hidden;
-	transition: visibility 0s linear 150ms;
-}
-
-.previewSlotOpen {
-	visibility: visible;
-	transition-delay: 0s;
-}
-
-/* Centers the 8px hit area on the chat/preview boundary. */
-.previewResizeHandle {
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	right: calc(var(--site-preview-width, 520px) - 4px);
-	justify-content: center;
 }
 
 .state {

--- a/apps/ui/src/ui-classic/router/layout-dashboard/index.tsx
+++ b/apps/ui/src/ui-classic/router/layout-dashboard/index.tsx
@@ -1,13 +1,98 @@
-import { createRoute, Outlet } from '@tanstack/react-router';
+import { createRoute, Outlet, useRouterState } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { PreviewSplitFrame } from '@/components/preview-split-frame';
 import { SidebarLayout } from '@/components/sidebar-layout';
+import { SitePreview } from '@/components/site-preview';
+import { useSession, useSessionEffectiveEnvironment } from '@/data/queries/use-sessions';
+import { useSites } from '@/data/queries/use-sites';
+import {
+	SessionUIProvider,
+	useSessionPreviewAnnotationsHandler,
+	useSessionPreviewUI,
+} from '@/hooks/use-session-ui';
 import { rootRoute } from '../layout-root';
+
+// Only session detail routes host the preview; on every other route
+// (settings, site settings…) the last previewed site stays mounted but
+// hidden.
+function getRouteSessionId( pathname: string ): string | undefined {
+	const match = /^\/sessions\/([^/]+)\/?$/.exec( pathname );
+	return match ? decodeURIComponent( match[ 1 ] ) : undefined;
+}
+
+function DashboardLayout() {
+	return (
+		<SessionUIProvider>
+			<DashboardLayoutContent />
+		</SessionUIProvider>
+	);
+}
+
+// Hosts the site preview at the dashboard level so the webview stays mounted
+// (and warm) while navigating between sessions, sites, and other routes. The
+// previewed site follows the current session; routes without one keep the
+// last previewed site loaded behind a closed panel.
+function DashboardLayoutContent() {
+	const sessionId = useRouterState( {
+		select: ( state ) => getRouteSessionId( state.location.pathname ),
+	} );
+	const { data: sites } = useSites();
+	const { data: sessionData } = useSession( sessionId );
+	const preview = useSessionPreviewUI();
+	const onAnnotationsDone = useSessionPreviewAnnotationsHandler();
+	const sessionOwnerSitePath = sessionData?.summary.ownerSitePath;
+	const sessionSite = sessionOwnerSitePath
+		? sites?.find( ( site ) => site.path === sessionOwnerSitePath )
+		: undefined;
+	const effectiveEnvironment = useSessionEffectiveEnvironment(
+		sessionData?.summary,
+		sessionSite?.id
+	);
+	const routeSite = effectiveEnvironment === 'local' ? sessionSite : undefined;
+	// While the session is still loading (`sessionData` undefined) the route
+	// counts as preview-capable, so switching between sessions doesn't close
+	// and reopen the panel around the fetch.
+	const supportsPreview = sessionId !== undefined && ( sessionData === undefined || !! routeSite );
+	// Remember the last previewed site by id (looked up fresh each render so
+	// `running` and friends don't go stale) to keep its webview warm across
+	// routes and to bridge the gap while the next route's site resolves.
+	const [ lastPreviewSiteId, setLastPreviewSiteId ] = useState< string | undefined >();
+	useEffect( () => {
+		if ( routeSite ) {
+			setLastPreviewSiteId( routeSite.id );
+		}
+	}, [ routeSite ] );
+	const lastPreviewSite = lastPreviewSiteId
+		? sites?.find( ( site ) => site.id === lastPreviewSiteId )
+		: undefined;
+	const previewSite = routeSite ?? lastPreviewSite;
+	const showPreview = preview.open && supportsPreview && !! previewSite;
+
+	return (
+		<SidebarLayout>
+			<PreviewSplitFrame
+				previewOpen={ showPreview }
+				preview={
+					previewSite ? (
+						<SitePreview
+							site={ previewSite }
+							path={ preview.path }
+							reloadNonce={ preview.reloadNonce }
+							onAnnotationsDone={ onAnnotationsDone }
+							onPathChange={ preview.updatePath }
+							collapsed={ ! showPreview }
+						/>
+					) : undefined
+				}
+			>
+				<Outlet />
+			</PreviewSplitFrame>
+		</SidebarLayout>
+	);
+}
 
 export const dashboardLayoutRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	id: 'dashboard-layout',
-	component: () => (
-		<SidebarLayout>
-			<Outlet />
-		</SidebarLayout>
-	),
+	component: DashboardLayout,
 } );


### PR DESCRIPTION
## Related issues

- Related to #3646 (ports the cross-route preview persistence from the agentic UI redesign)

## How AI was used in this PR

Implemented with Claude Code in a pair session: it ported and adapted the preview-persistence architecture from #3646 onto the split-preview implementation that landed in #3817, with human review of the approach, scope trims, and manual testing of the result.

## Proposed Changes

Today the site preview is owned by the session view, so any navigation — switching sessions, opening Settings — unmounts the webview and the next visit pays a full reload (white flash, lost scroll position, cold page). This PR moves preview ownership up to the dashboard layout, as in the agentic UI redesign:

- Navigating between sessions of the same site keeps the preview exactly where it was — no reload, no flicker.
- Navigating to routes without a preview (Settings, site settings) slides the panel closed but keeps the last previewed site's webview warm, so coming back is instant.
- The panel's open/closed state and current path are now remembered across navigation instead of resetting per session. Closing the preview in one session keeps it closed in the next (intentional behavior change).
- Annotations submitted from the preview are routed to whichever session is currently on screen.

The split/animation/resize mechanics from #3817 are unchanged — they moved into a reusable `PreviewSplitFrame` component so the layout and the session view share them.

## Testing Instructions

1. Open a session for a running local site, browse the preview to an inner page (e.g. `/wp-admin/`).
2. Switch to another session of the same site → the preview must not reload and keeps the page.
3. Switch to a session of a different local site → the panel stays open; the webview swaps to the new site.
4. Go to Settings → the panel slides closed. Return to the session → it reopens instantly with the same page (no reload).
5. Close the preview with the header toggle, switch sessions → it stays closed; the app-menu toggle works from any route.
6. Annotate + Submit in session A → message lands in A. Switch to session B and submit annotations → lands in B.
7. A live-environment session shows no preview and no toggle.
8. Drag and keyboard-resize the panel (arrows, Home/End on the focused handle); width persists across restarts.
9. Long Settings page still scrolls; verify both light and dark mode.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)