### PR TITLE
Make the site preview toolbar a window drag region

### DIFF
--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -23,6 +23,14 @@
 	flex-shrink: 0;
 	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
 	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
+	-webkit-app-region: drag;
+}
+
+/* The toolbar doubles as a window drag region; the controls and the
+   tooltip-bearing title opt back out so they keep receiving mouse events. */
+.header button,
+.browserTitle {
+	-webkit-app-region: no-drag;
 }
 
 .browserControls {


### PR DESCRIPTION
## Related issues

- Related to #3646

## How AI was used in this PR

Claude Code identified the remaining toolbar delta between #3646 and trunk, and wrote the CSS change following the existing drag-region pattern in the session view header.

## Proposed Changes

- The site preview toolbar now acts as a window drag region, so you can grab it to move the Studio window — matching how the chat header behaves and how browser toolbars typically work. 
- The toolbar controls (back/forward/refresh, annotate, submit, open in browser) and the page title opt out of the drag region, so clicking them and hovering the title for its URL tooltip keep working as before.

## Testing Instructions

- Enable the Agentic UI via the Studio → Beta Features menu and open a chat with the site preview panel visible.
- Press and drag on an empty area of the preview toolbar (e.g. beside the page title): the window should move.
- Verify the back/forward/refresh buttons, the annotate and submit buttons, and the open-in-browser button still respond to clicks.
- Hover the page title and confirm the URL tooltip still appears.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)