### PR TITLE
Revert Fable 5 model from Studio Code agent

### DIFF
--- a/tools/common/ai/models.ts
+++ b/tools/common/ai/models.ts
@@ -20,14 +20,14 @@ export interface AiModel {
 // reasoning turns.
 export const AI_MODELS = [
 	{ id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', family: 'anthropic' },
+	{ id: 'claude-opus-4-7', label: 'Opus 4.7', family: 'anthropic' },
 	{ id: 'claude-opus-4-8', label: 'Opus 4.8', family: 'anthropic' },
-	{ id: 'claude-fable-5', label: 'Fable 5', family: 'anthropic' },
 	{ id: 'gpt-5.5', label: 'GPT 5.5', family: 'openai' },
 ] as const satisfies readonly AiModel[];
 
 export type AiModelId = ( typeof AI_MODELS )[ number ][ 'id' ];
 
-export const DEFAULT_MODEL: AiModelId = 'claude-fable-5';
+export const DEFAULT_MODEL: AiModelId = 'claude-sonnet-4-6';
 
 // Module-scoped lookup so `getAiModelFamily` / `getAiModelLabel` are O(1)
 // and don't re-scan the array per call. Keyed by id; values are the same


### PR DESCRIPTION
## Related issues

- Related to #3747

## How AI was used in this PR

Authored with Claude Code. It located the affected commits in #3747, reverted the model registry entry, restored the previous default model and the Opus 4.7 entry, and verified the change with eslint and the TypeScript type checker. The author reviewed the change.

## Proposed Changes

Reverts the changes from #3747. Fable 5 is no longer available, so removing it prevents users from selecting a model that will fail at request time. This restores the model picker to its prior state:

- Removes the **Fable 5** option from the Studio Code agent model picker.
- Restores the default model to **Sonnet 4.6** (it had been switched to Fable 5).
- Restores the **Opus 4.7** option that #3747 had removed.

## Testing Instructions

- Open the Studio Code agent chat composer and confirm **Fable 5** no longer appears in the model picker, and **Opus 4.7** is present again.
- Confirm new sessions default to **Sonnet 4.6**.
- `npm run typecheck` passes.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?