### PR TITLE
Remove Opus 4.7 model from Studio Code agent

### DIFF
--- a/tools/common/ai/models.ts
+++ b/tools/common/ai/models.ts
@@ -20,7 +20,6 @@ export interface AiModel {
 // reasoning turns.
 export const AI_MODELS = [
 	{ id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', family: 'anthropic' },
-	{ id: 'claude-opus-4-7', label: 'Opus 4.7', family: 'anthropic' },
 	{ id: 'claude-opus-4-8', label: 'Opus 4.8', family: 'anthropic' },
 	{ id: 'gpt-5.5', label: 'GPT 5.5', family: 'openai' },
 ] as const satisfies readonly AiModel[];


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Authored with Claude Code. It removed the model registry entry and verified the change with eslint and the TypeScript type checker. The author reviewed the change.

## Proposed Changes

Removes the **Opus 4.7** option from the Studio Code agent model picker, leaving Sonnet 4.6 and Opus 4.8 as the available Anthropic models. Since the registry is centralized, this single change propagates to the model picker, provider availability, and session model validation (sessions pinned to Opus 4.7 auto-fall back to the default model).

The default model (Sonnet 4.6) is unaffected.

## Testing Instructions

- Open the Studio Code agent chat composer and confirm **Opus 4.7** no longer appears in the model picker.
- Confirm Sonnet 4.6 and Opus 4.8 are still selectable and turns run.
- `npm run typecheck` passes.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?