### PR TITLE
Update beta token copy to 'Generous token limits'

### DIFF
--- a/apps/studio/src/modules/user-settings/components/prompt-info.tsx
+++ b/apps/studio/src/modules/user-settings/components/prompt-info.tsx
@@ -11,7 +11,7 @@ export function PromptInfo() {
 					<div className="flex w-full flex-row justify-between gap-8 ">
 						<div className="flex flex-row items-center text-right">
 							<span className="text-frame-text-secondary">
-								{ __( 'Unlimited tokens while Studio Code is in beta.' ) }
+								{ __( 'Generous token limits while Studio Code is in beta.' ) }
 							</span>
 						</div>
 					</div>

--- a/apps/studio/src/modules/user-settings/components/tests/user-settings.test.tsx
+++ b/apps/studio/src/modules/user-settings/components/tests/user-settings.test.tsx
@@ -143,7 +143,7 @@ describe( 'UserSettings', () => {
 				expect( screen.getByText( 'Preview sites' ) ).toBeInTheDocument();
 				expect( screen.getByText( 'Studio Code' ) ).toBeInTheDocument();
 				expect(
-					screen.getByText( 'Unlimited tokens while Studio Code is in beta.' )
+					screen.getByText( 'Generous token limits while Studio Code is in beta.' )
 				).toBeInTheDocument();
 				expect( screen.queryByText( /monthly prompts used/ ) ).not.toBeInTheDocument();
 			} );


### PR DESCRIPTION
## Related issues

- Related to STU-1820

## How AI was used in this PR

Used AI to locate the copy string and update it across the component and its test.

## Proposed Changes
We added Studio Code limits last week. We plan to display a proper progress bar for those limits. Until then I suggest just updating the text in the settings modal.

## Testing Instructions

1. Open Settings → Account.
2. Under the Studio Code section, confirm the text reads "Generous token limits while Studio Code is in beta."

| Before | After |
|--------|--------|
|  <img width="1212" height="932" alt="Screenshot 2026-06-15 at 10 20 11" src="https://github.com/user-attachments/assets/4ce2afda-fe31-475d-aa47-118eee6eb7f0" /> | <img width="1212" height="932" alt="Screenshot 2026-06-15 at 10 19 45" src="https://github.com/user-attachments/assets/0acf9eca-5615-459c-beae-70c9f16c63e8" /> |


## Pre-merge Checklist

- [x] Updated unit test to match new copy
- [x] `user-settings.test.tsx` passes