### PR TITLE
Refine agentic-UI sidebar: site-row clarity, alignment, and snappier motion

### DIFF
--- a/apps/ui/src/components/sidebar-header/style.module.css
+++ b/apps/ui/src/components/sidebar-header/style.module.css
@@ -18,15 +18,12 @@
 }
 
 /* In macOS fullscreen the traffic lights are hidden, so reclaim the
-   padding that was reserved for them and align the title with the
-   site list entries below — the site list outer padding is `2xl`, each
-   row carries `xs` of padding-inline, and the site label sits inside a
-   button with another `sm`, so its text starts at `2xl + xs + sm`
-   (= `xl + 2*sm`) from the sidebar edge. */
+   padding that was reserved for them and align the title with the site
+   list entries below. The site list outer padding is `2xl` and its rows
+   now start flush with that edge (no row/button inline-start padding), so
+   the site label text starts at `2xl` from the sidebar edge. */
 .fullscreen {
-	padding-left: calc(
-		var(--wpds-dimension-padding-xl) + 2 * var(--wpds-dimension-padding-sm)
-	);
+	padding-left: var(--wpds-dimension-padding-2xl);
 }
 
 .title {
@@ -43,7 +40,9 @@
 .actions {
 	display: flex;
 	align-items: center;
-	gap: var(--wpds-dimension-padding-xs);
+	/* Match the site-row action buttons (`.siteActions` in site-list), which
+	   sit flush with no gap. */
+	gap: 0;
 	opacity: 0.65;
 }
 

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -620,24 +620,26 @@ function SiteSection( {
 					</div>
 				) : null }
 			</header>
-			{ group.sessions.length > 0 ? (
+			{ group.sessions.length > 0 || group.site ? (
 				<div
 					className={ clsx( styles.sessionListFrame, isOpen && styles.sessionListFrameOpen ) }
 					aria-hidden={ ! isOpen }
 				>
-					<ul className={ styles.sessionList }>
-						{ group.sessions.map( ( session ) => (
-							<SessionItem key={ session.id } session={ session } isVisible={ isOpen } />
-						) ) }
-					</ul>
-				</div>
-			) : group.site && isOpen ? (
-				<div className={ styles.emptyChatState }>
-					<span className={ styles.emptyChatText }>{ __( 'No active chats' ) }</span>
-					<span className={ styles.emptyChatSeparator } aria-hidden="true">
-						•
-					</span>
-					<NewSessionTextButton site={ group.site } />
+					{ group.sessions.length > 0 ? (
+						<ul className={ styles.sessionList }>
+							{ group.sessions.map( ( session ) => (
+								<SessionItem key={ session.id } session={ session } isVisible={ isOpen } />
+							) ) }
+						</ul>
+					) : group.site ? (
+						<div className={ styles.emptyChatState }>
+							<span className={ styles.emptyChatText }>{ __( 'No active chats' ) }</span>
+							<span className={ styles.emptyChatSeparator } aria-hidden="true">
+								•
+							</span>
+							<NewSessionTextButton site={ group.site } />
+						</div>
+					) : null }
 				</div>
 			) : null }
 		</section>

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -8,7 +8,7 @@
 	   sidebar chrome. The right side is smaller: rows carry `sm` of their
 	   own right padding, and `xl + sm` keeps the row icons (site status,
 	   actions) visually aligned with the header's drawer icon. */
-	padding: var(--wpds-dimension-padding-3xl) var(--wpds-dimension-padding-xl)
+	padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-xl)
 		var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-2xl);
 	display: flex;
 	flex-direction: column;
@@ -41,19 +41,13 @@
 	min-width: 0;
 	box-sizing: border-box;
 	height: var(--site-list-row-height);
+	/* No inline-start padding: the row's leading content (site icon / title)
+	   sits flush with the sidebar content edge (`.root`'s 2xl inline padding),
+	   lining the title up with the macOS window traffic lights. The button
+	   inside (`.siteToggle`) also drops its inline-start padding to match. */
 	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm)
-		var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-xs);
+		var(--wpds-dimension-padding-xs) 0;
 	border-radius: 6px;
-	transition: background-color 100ms ease;
-}
-
-.siteHeader:hover,
-.siteHeader:focus-within {
-	background-color: var(--site-list-row-background-hover);
-}
-
-.siteActive .siteHeader {
-	background-color: var(--site-list-row-background-active);
 }
 
 .siteText {
@@ -68,6 +62,10 @@
 	max-width: 100%;
 	height: auto;
 	gap: 0;
+	/* Drop the Button primitive's inline-start padding so the icon/title start
+	   at the row's leading edge (see `.siteHeader`). Unlayered, so it beats the
+	   primitive's layered padding. */
+	padding-inline-start: 0;
 }
 
 .siteIconSlot {
@@ -80,13 +78,16 @@
 	transform: translateX(-4px) scale(0.75);
 	transform-origin: left center;
 	overflow: hidden;
-	transition: inline-size 150ms ease, margin-inline-end 150ms ease, opacity 150ms ease,
-		transform 150ms ease;
+	transition: inline-size 120ms ease, margin-inline-end 120ms ease, opacity 120ms ease,
+		transform 120ms ease;
 }
 
 .siteActive .siteIconSlot {
 	inline-size: 16px;
-	margin-inline-end: var(--wpds-dimension-padding-xs);
+	/* Gap between the site icon and its title. Kept in sync with the chat-row
+	   indent below (`.sessionLink` padding-inline-start), which carries the same
+	   +4px so chat labels stay aligned under the site title. */
+	margin-inline-end: calc(var(--wpds-dimension-padding-xs) + 4px);
 	opacity: 1;
 	transform: translateX(0) scale(1);
 }
@@ -298,9 +299,13 @@
 	align-items: center;
 	justify-content: center;
 	gap: var(--wpds-dimension-padding-xs);
-	min-height: 28px;
-	margin: var(--wpds-dimension-padding-xs) 0 var(--wpds-dimension-padding-sm);
-	padding: 0 var(--wpds-dimension-padding-sm);
+	/* Collapsible grid child of `.sessionListFrame`, mirroring `.sessionList` so
+	   the empty placeholder expands/collapses with the same animation. The frame
+	   supplies the open-state vertical spacing (its animated margins), and the
+	   vertical padding here gives the single line a comfortable resting height. */
+	min-height: 0;
+	overflow: hidden;
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font-size: var(--wpds-typography-font-size-xs);
 	line-height: 1.2;
@@ -347,8 +352,8 @@
 	margin-bottom: 0;
 	opacity: 0;
 	pointer-events: none;
-	transition: grid-template-rows 160ms ease, margin-top 160ms ease, margin-bottom 160ms ease,
-		opacity 120ms ease;
+	transition: grid-template-rows 120ms ease, margin-top 120ms ease, margin-bottom 120ms ease,
+		opacity 80ms ease;
 }
 
 .sessionListFrameOpen {
@@ -387,13 +392,21 @@
 	width: 100%;
 	box-sizing: border-box;
 	height: var(--site-list-row-height);
+	/* Chat labels align under the active site's title text. The site row now
+	   starts flush with the sidebar edge, and its title begins one icon width
+	   (16px) plus the icon→title gap past that edge — so this indent mirrors
+	   `.siteActive .siteIconSlot`'s inline-size + margin-inline-end. */
 	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm)
-		var(--wpds-dimension-padding-xs) calc(var(--wpds-dimension-padding-sm) + 24px);
+		var(--wpds-dimension-padding-xs) calc(16px + var(--wpds-dimension-padding-xs) + 4px);
 	border-radius: 6px;
 	background-color: var(--session-link-background);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font-size: var(--wpds-typography-font-size-sm);
 	font-weight: var(--wpds-typography-font-weight-regular);
+	/* The Button primitive transitions `all` over 150ms, which makes the hover
+	   text-color/background feel sluggish; override with a quick,
+	   property-scoped transition so the row reacts promptly to the pointer. */
+	transition: color 80ms ease, background-color 80ms ease;
 }
 
 .sessionLinkRunning {


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Authored with Claude Code from a series of design-feedback notes on the agentic-UI (`apps/ui`) sidebar. Each change was made and explained interactively; all edits were reviewed by the author, and the diff was kept scoped to the three sidebar files (an unrelated `package-lock.json` churn was reverted). Typecheck and lint were run on the touched files.

## Proposed Changes

A pass of polish on the `apps/ui` sidebar site list, addressing several pieces of design feedback:

- **Selecting a chat no longer "highlights" its parent site.** The site header is an expand/collapse toggle, not a navigable row, so it no longer carries an active background when one of its chats is selected, nor a hover background — removing the misleading impression that the row itself is selectable. The active site is still distinguished by its revealed icon and bolder title.
- **Site titles align with the macOS window traffic lights.** Per-row and per-button inline-start padding was removed so a site's leading content sits flush with the sidebar content edge. Chat rows and the fullscreen header title were shifted by the same amount so everything stays aligned.
- **Cleaner spacing.** A bit more room between the site icon and its title (with chat labels re-aligned to match), the header action buttons now share the same flush spacing as the site-row action buttons, and the gap above the site list was reduced so it sits closer to the header.
- **Snappier motion.** The chat-list expand/collapse and the active-site icon reveal were sped up, and the chat row's hover text-color transition — previously inheriting the Button primitive's sluggish `all 150ms` — now uses a quick, property-scoped transition so rows react promptly to the pointer.
- **Consistent empty-state animation.** A site with no chats previously popped its "No active chats" placeholder in and out; it now expands/collapses with the exact same animation as a populated chat list.

## Testing Instructions

1. Run the app and open the agentic UI (`apps/ui`) sidebar with at least one site that has chats and one site with none.
2. Select a chat: confirm the parent site row is **not** highlighted, and hovering a site header shows no row background (the chevron/actions still reveal on hover).
3. Confirm site titles line up with the window traffic lights' left edge; confirm chat labels tuck neatly under the site title.
4. Expand/collapse a site with chats and a site with no chats — both should animate identically and feel snappy. Hover chat rows and confirm the text color reacts promptly.
5. Verify in **both light and dark** color schemes, and in macOS fullscreen (title should still align with the site list).

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?