### PR TITLE
Fix dark mode in Studio Code conversation dialogs

### DIFF
--- a/apps/studio/src/components/studio-code-session/composer/family-switch-confirm-dialog.tsx
+++ b/apps/studio/src/components/studio-code-session/composer/family-switch-confirm-dialog.tsx
@@ -2,6 +2,7 @@ import { getAiModelLabel } from '@studio/common/ai/models';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Dialog } from '@wordpress/ui';
 import buttonDefense from '../wp-ui-button-defense.module.css';
+import dialogDefense from '../wp-ui-dialog-defense.module.css';
 import type { AiModelId } from '@studio/common/ai/models';
 
 /**
@@ -36,7 +37,7 @@ export function FamilySwitchConfirmDialog( {
 				}
 			} }
 		>
-			<Dialog.Popup size="small">
+			<Dialog.Popup size="small" className={ dialogDefense.popup }>
 				<Dialog.Header>
 					<Dialog.Title>{ __( 'Start a new conversation?' ) }</Dialog.Title>
 				</Dialog.Header>

--- a/apps/studio/src/components/studio-code-session/site-created-dialog.tsx
+++ b/apps/studio/src/components/studio-code-session/site-created-dialog.tsx
@@ -1,6 +1,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Dialog } from '@wordpress/ui';
 import buttonDefense from './wp-ui-button-defense.module.css';
+import dialogDefense from './wp-ui-dialog-defense.module.css';
 import type { PendingSiteCreation } from './use-site-creation-switch';
 
 /**
@@ -30,7 +31,7 @@ export function SiteCreatedDialog( {
 				}
 			} }
 		>
-			<Dialog.Popup size="small">
+			<Dialog.Popup size="small" className={ dialogDefense.popup }>
 				<Dialog.Header>
 					<Dialog.Title>{ __( 'Site created' ) }</Dialog.Title>
 				</Dialog.Header>

--- a/apps/studio/src/components/studio-code-session/wp-ui-dialog-defense.module.css
+++ b/apps/studio/src/components/studio-code-session/wp-ui-dialog-defense.module.css
@@ -1,0 +1,21 @@
+/*
+ * @wordpress/ui's Dialog reads its colors from `--wpds-color-*` tokens, but
+ * apps/studio has no app-wide color ThemeProvider (only the density-scoped one
+ * in Studio Code), so those tokens keep their light-only fallbacks from
+ * `@wordpress/theme`. The popup also portals out to <body>, beyond any Studio
+ * frame styling. The result: a white popup with dark, near-invisible text in
+ * dark mode (STU-1835).
+ *
+ * Remap the few color tokens the Dialog chrome consumes onto Studio's
+ * dark-aware `--color-frame-*` tokens so the popup follows the active scheme.
+ * Set on the popup itself (where the tokens are read); the header, content,
+ * footer, title and neutral buttons inherit them. The doubled class (0,2,0)
+ * out-specifies `@wordpress/ui`'s own `.popup`. Apply to every Dialog.Popup we
+ * render in this app.
+ */
+.popup.popup {
+	--wpds-color-bg-surface-neutral-strong: var(--color-frame-bg);
+	--wpds-color-fg-content-neutral: var(--color-frame-text);
+	--wpds-color-stroke-surface-neutral: var(--color-frame-border);
+	--wpds-color-fg-interactive-neutral: var(--color-frame-text);
+}


### PR DESCRIPTION
## Related Issues

- Fixes [STU-1835](https://linear.app/a8c/issue/STU-1835/fix-dark-mode-in-start-new-conversation-modal)

## How AI was used in this PR

Claude Code located the affected dialogs, traced the token cascade, and implemented the fix.

## Proposed Changes

In dark mode the Studio Code dialogs — "Start a new conversation?" (shown when switching to a different model family) and "Site created" — appeared as a white box with dark, barely-readable text while the rest of Studio Code followed the dark scheme. They now match dark mode: dark surface, light text, and a correct border.

These dialogs come from `@wordpress/ui`, which colors itself from `--wpds-color-*` design tokens. `apps/studio` has no app-wide color `ThemeProvider`, so those tokens keep their light-only fallbacks, and the dialog popup portals out to `<body>` beyond Studio's frame styling — so it stayed light regardless of scheme. The fix remaps the few color tokens the dialog chrome reads onto Studio's existing dark-aware `--color-frame-*` tokens, mirroring the existing `wp-ui-button-defense` pattern.

## Testing Instructions

1. Run `npm start`
2. Set Studio App  Dark mode in Settings -> General
3. Open Studio, go to the **Studio Code** tab.
4. Send a message
5. Change the model from Claude to GPT, or vice versa. 
6. Confirm the dialog uses a dark background with readable text
7. Repeat in Light appearance to confirm no regression.


| Before | After |
|--------|--------|
|  <img width="1212" height="932" alt="Screenshot 2026-06-16 at 13 35 51" src="https://github.com/user-attachments/assets/805a3e6a-c068-45bd-9cd4-d93cf0731a18" /> | <img width="1212" height="932" alt="Screenshot 2026-06-16 at 13 32 25" src="https://github.com/user-attachments/assets/5c0f1315-84ee-4c14-bc79-b9beee97fa46" /> |




## Pre-merge Checklist

- [x] Linted modified files
- [x] Type checks pass (`apps/studio`)
- [x] Existing `studio-code-session` tests pass
- [ ] Visually verified in both light and dark
