### PR TITLE
Agentic UI: Fix sidebar resize lag and the jump when expanding

### DIFF
--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -30,7 +30,11 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 		<SidebarCollapsedContext.Provider value={ collapsed }>
 			<div className={ styles.root }>
 				<aside
-					className={ clsx( styles.sidebar, collapsed && styles.sidebarCollapsed ) }
+					className={ clsx(
+						styles.sidebar,
+						collapsed && styles.sidebarCollapsed,
+						sidebarResize.isResizing && styles.sidebarResizing
+					) }
 					style={ sidebarStyle }
 				>
 					<SidebarHeader onToggleSidebar={ () => setCollapsed( true ) } />

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -6,7 +6,11 @@
 
 .sidebar {
 	width: var(--sidebar-width, 320px);
-	min-width: 240px;
+	/* The 240px floor is owned by useResizablePanel, which clamps
+	   --sidebar-width on every path. A CSS min-width here would be redundant
+	   while open and, because it can't transition in lockstep with width, would
+	   snap the panel to 240px at the start of the open animation. */
+	min-width: 0;
 	max-width: 25vw;
 	flex-shrink: 0;
 	background-color: var(--wpds-color-bg-surface-neutral-weak);
@@ -19,6 +23,14 @@
 	   inner wrapper. */
 	overflow-y: auto;
 	transition: width 150ms ease;
+}
+
+/* While dragging the handle the width updates every frame; the collapse
+   transition above would animate toward each step and lag behind the cursor.
+   Drop it for the duration of the drag (mirrors `.rootPreviewResizing` in
+   preview-split-frame). */
+.sidebarResizing {
+	transition: none;
 }
 
 /* Stay pinned at the bottom as the sidebar scrolls; `margin-top: auto`
@@ -34,7 +46,6 @@
 
 .sidebarCollapsed {
 	width: 0;
-	min-width: 0;
 }
 
 .main {


### PR DESCRIPTION
## Related issues

- N/A — small follow-up surfaced while working on sidebar/preview resizing.

## How AI was used in this PR

Authored with Claude Code: it diagnosed both transition issues (the collapse `transition: width` bleeding into the handle drag, and the redundant CSS `min-width` snapping the expand animation) and made the fixes. The diff was reviewed and the resize floor confirmed to still be enforced by `useResizablePanel`.

## Proposed Changes

Two small fixes to how the agentic-UI sidebar animates:

- **Resizing the sidebar felt laggy.** The width transition that powers the collapse/expand animation was also animating every frame of a handle drag, so the panel trailed the cursor. It's now suppressed while dragging, so the sidebar tracks the pointer 1:1.
- **Expanding the sidebar jumped.** Opening from collapsed snapped instantly to ~240px before animating the rest of the way, because a CSS `min-width` floor took effect the moment the panel un-collapsed while width was still animating from 0. Width now animates cleanly from 0; the minimum width is still enforced — the resize hook owns that floor on every path — so the panel still can't be sized below it.

Transition behavior only; no visual/color changes.

## Testing Instructions

1. Open the agentic UI with the sidebar visible.
2. Drag the sidebar resize handle — it should follow the cursor with no lag or rubber-banding.
3. Collapse the sidebar (drawer toggle), then expand it — the open animation should grow smoothly from 0 with no initial jump to ~240px. Closing should remain smooth.
4. Confirm you still can't drag or keyboard-resize the sidebar below its 240px minimum.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
