### PR TITLE
Bust browser cache on push by versioning all assets (STU-1845)

### DIFF
--- a/apps/cli/commands/export.ts
+++ b/apps/cli/commands/export.ts
@@ -126,7 +126,8 @@ export async function runCommand(
 	mode: 'full' | 'content' | 'db' = 'full',
 	splitDbDumpByTable = false,
 	includeOnlyPaths?: string[],
-	applyDeployIgnore = false
+	applyDeployIgnore = false,
+	bumpAssetVersions = false
 ): Promise< void > {
 	try {
 		logger.reportStart( LoggerAction.START_DAEMON, __( 'Starting process daemon…' ) );
@@ -164,6 +165,7 @@ export async function runCommand(
 			splitDatabaseDumpByTable: splitDbDumpByTable,
 			specificSelectionPaths: includeOnlyPaths,
 			ignoreFilter,
+			bumpAssetVersions,
 		} );
 
 		if ( ! exporter ) {
@@ -243,6 +245,14 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					default: false,
 					description: __( 'Apply .deployignore patterns when exporting' ),
 					hidden: true,
+				} )
+				.option( 'bump-asset-versions', {
+					type: 'boolean',
+					default: false,
+					description: __(
+						'Bump theme stylesheet versions so pushed asset changes bust the browser cache'
+					),
+					hidden: true,
 				} );
 		},
 		handler: async ( argv ) => {
@@ -276,7 +286,8 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					argv.mode,
 					argv.splitDbDumpByTable,
 					argv.includeOnly,
-					argv.applyDeployIgnore
+					argv.applyDeployIgnore,
+					argv.bumpAssetVersions
 				);
 			} catch ( error ) {
 				if ( error instanceof LoggerError ) {

--- a/apps/cli/commands/push.ts
+++ b/apps/cli/commands/push.ts
@@ -121,6 +121,7 @@ export async function runCommand(
 			splitDatabaseDumpByTable: true,
 			specificSelectionPaths,
 			ignoreFilter: deployIgnore,
+			bumpAssetVersions: true,
 		} );
 
 		if ( ! exporter ) {

--- a/apps/cli/commands/push.ts
+++ b/apps/cli/commands/push.ts
@@ -268,6 +268,13 @@ export async function runCommand(
 		logger.reportSuccess(
 			sprintf( __( 'Successfully pushed to %1$s (%2$s)' ), remoteSite.name, remoteSite.url )
 		);
+		if ( includes.wpContent ) {
+			logger.reportSuccess(
+				__(
+					'Asset cache versions were refreshed, so your changes appear without a hard refresh. Visitors re-download CSS/JS once after this push.'
+				)
+			);
+		}
 	} finally {
 		fs.rmSync( tempDir, { recursive: true, force: true } );
 	}

--- a/apps/cli/lib/import-export/export/exporters/default-exporter.ts
+++ b/apps/cli/lib/import-export/export/exporters/default-exporter.ts
@@ -36,10 +36,29 @@ const prefixedLegacyMuPluginNames = LEGACY_MU_PLUGIN_FILENAMES.map(
 	( name ) => `wp-content/mu-plugins/${ name }`
 );
 
+// Matches a theme root stylesheet, e.g. `wp-content/themes/my-theme/style.css`.
+// Archive names use forward slashes, but normalize defensively for safety.
+export function isThemeStylesheet( archiveName: string ): boolean {
+	const normalized = archiveName.split( path.sep ).join( '/' );
+	return /^wp-content\/themes\/[^/]+\/style\.css$/.test( normalized );
+}
+
+// Appends a cache-busting suffix to the theme stylesheet's `Version:` header so the
+// theme version (and thus the `?ver=` of every asset enqueued with it) changes on
+// each push. Returns the content unchanged when no `Version:` header is present.
+export function bumpStylesheetVersion( content: string, suffix: string ): string {
+	return content.replace(
+		/^([ \t]*\*?[ \t]*Version:[ \t]*)(.+?)[ \t]*$/m,
+		( _match, prefix, version ) => `${ prefix }${ version }-${ suffix }`
+	);
+}
+
 export class DefaultExporter extends ImportExportEventEmitter implements Exporter {
 	private archiveBuilder!: Archiver;
 	private backup: BackupContents;
 	private readonly options: ExportOptions;
+	// Per-export cache-busting suffix; empty unless `bumpAssetVersions` is set.
+	private readonly assetVersionSuffix: string;
 
 	isExactPathExcluded( pathToCheck: string ) {
 		const PATHS_TO_EXCLUDE = [
@@ -83,6 +102,7 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 	constructor( options: ExportOptions ) {
 		super();
 		this.options = options;
+		this.assetVersionSuffix = options.bumpAssetVersions ? `studio-${ Date.now() }` : '';
 		this.backup = {
 			backupFile: options.backupFile,
 			sqlFiles: [],
@@ -233,7 +253,7 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 					) {
 						continue;
 					}
-					this.archiveBuilder.file( fullPath, { name: archivePath } );
+					this.addContentFile( fullPath, archivePath );
 				}
 			}
 		}
@@ -271,10 +291,24 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 			) {
 				continue;
 			}
-			this.archiveBuilder.file( fs.realpathSync( fullEntryPathOnDisk ), {
-				name: entryPathRelativeToArchiveRoot,
-			} );
+			this.addContentFile( fs.realpathSync( fullEntryPathOnDisk ), entryPathRelativeToArchiveRoot );
 		}
+	}
+
+	// Adds a wp-content file to the archive. When cache-busting is enabled and the
+	// file is a theme stylesheet, its `Version:` header is bumped in the archived
+	// copy (the source file on disk is never modified) so WordPress re-enqueues the
+	// theme's assets with a fresh `?ver=`, forcing browsers to drop stale CSS/JS.
+	private addContentFile( diskPath: string, archiveName: string ): void {
+		if ( this.assetVersionSuffix && isThemeStylesheet( archiveName ) ) {
+			const original = fs.readFileSync( diskPath, 'utf-8' );
+			const bumped = bumpStylesheetVersion( original, this.assetVersionSuffix );
+			if ( bumped !== original ) {
+				this.archiveBuilder.append( bumped, { name: archiveName } );
+				return;
+			}
+		}
+		this.archiveBuilder.file( diskPath, { name: archiveName } );
 	}
 
 	private async addDatabase(): Promise< void > {

--- a/apps/cli/lib/import-export/export/exporters/default-exporter.ts
+++ b/apps/cli/lib/import-export/export/exporters/default-exporter.ts
@@ -36,29 +36,53 @@ const prefixedLegacyMuPluginNames = LEGACY_MU_PLUGIN_FILENAMES.map(
 	( name ) => `wp-content/mu-plugins/${ name }`
 );
 
-// Matches a theme root stylesheet, e.g. `wp-content/themes/my-theme/style.css`.
-// Archive names use forward slashes, but normalize defensively for safety.
-export function isThemeStylesheet( archiveName: string ): boolean {
-	const normalized = archiveName.split( path.sep ).join( '/' );
-	return /^wp-content\/themes\/[^/]+\/style\.css$/.test( normalized );
+// Archive path of the per-push cache-busting mu-plugin.
+export const CACHE_BUST_MU_PLUGIN_PATH = 'wp-content/mu-plugins/studio-asset-cache-bust.php';
+
+// Builds a small mu-plugin that stamps a per-push version onto every locally enqueued
+// style/script. Because it filters `style_loader_src`/`script_loader_src` at runtime, it
+// busts the browser cache for ALL assets a site enqueues — theme, plugin, auto-injected,
+// or hand-written `wp_enqueue_*` calls with hard-coded versions — without parsing or
+// rewriting any source files. The token changes once per push, so assets are re-fetched
+// after a deploy and cached normally between deploys.
+export function buildCacheBustMuPlugin( token: string ): string {
+	const safeToken = token.replace( /[^a-zA-Z0-9._-]/g, '' );
+	return `<?php
+/**
+ * Studio: bust browser caches for pushed asset changes.
+ *
+ * Generated automatically on each push so that styles/scripts changed locally are
+ * re-fetched by browsers instead of served stale. Safe to delete; it is regenerated
+ * on the next push.
+ */
+defined( 'ABSPATH' ) || exit;
+
+if ( ! defined( 'STUDIO_ASSET_CACHE_BUST_VERSION' ) ) {
+	define( 'STUDIO_ASSET_CACHE_BUST_VERSION', '${ safeToken }' );
 }
 
-// Appends a cache-busting suffix to the theme stylesheet's `Version:` header so the
-// theme version (and thus the `?ver=` of every asset enqueued with it) changes on
-// each push. Returns the content unchanged when no `Version:` header is present.
-export function bumpStylesheetVersion( content: string, suffix: string ): string {
-	return content.replace(
-		/^([ \t]*\*?[ \t]*Version:[ \t]*)(.+?)[ \t]*$/m,
-		( _match, prefix, version ) => `${ prefix }${ version }-${ suffix }`
-	);
+function studio_asset_cache_bust_src( $src ) {
+	if ( ! is_string( $src ) || '' === $src ) {
+		return $src;
+	}
+	// Only version assets served from this site; leave external URLs untouched.
+	if ( false === strpos( $src, '/wp-content/' ) && false === strpos( $src, '/wp-includes/' ) ) {
+		return $src;
+	}
+	return add_query_arg( 'ver', STUDIO_ASSET_CACHE_BUST_VERSION, $src );
+}
+
+add_filter( 'style_loader_src', 'studio_asset_cache_bust_src', 9999 );
+add_filter( 'script_loader_src', 'studio_asset_cache_bust_src', 9999 );
+`;
 }
 
 export class DefaultExporter extends ImportExportEventEmitter implements Exporter {
 	private archiveBuilder!: Archiver;
 	private backup: BackupContents;
 	private readonly options: ExportOptions;
-	// Per-export cache-busting suffix; empty unless `bumpAssetVersions` is set.
-	private readonly assetVersionSuffix: string;
+	// Per-push cache-busting token; empty unless `bumpAssetVersions` is set.
+	private readonly cacheBustToken: string;
 
 	isExactPathExcluded( pathToCheck: string ) {
 		const PATHS_TO_EXCLUDE = [
@@ -102,7 +126,7 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 	constructor( options: ExportOptions ) {
 		super();
 		this.options = options;
-		this.assetVersionSuffix = options.bumpAssetVersions ? `studio-${ Date.now() }` : '';
+		this.cacheBustToken = options.bumpAssetVersions ? `studio-${ Date.now() }` : '';
 		this.backup = {
 			backupFile: options.backupFile,
 			sqlFiles: [],
@@ -155,6 +179,7 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 		try {
 			this.addWpConfig();
 			await this.addWpContent();
+			this.addCacheBustMuPlugin();
 			await this.addDatabase();
 			const studioJsonPath = await this.createStudioJsonFile();
 			this.archiveBuilder.file( studioJsonPath, { name: 'meta.json' } );
@@ -253,7 +278,7 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 					) {
 						continue;
 					}
-					this.addContentFile( fullPath, archivePath );
+					this.archiveBuilder.file( fullPath, { name: archivePath } );
 				}
 			}
 		}
@@ -291,24 +316,23 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 			) {
 				continue;
 			}
-			this.addContentFile( fs.realpathSync( fullEntryPathOnDisk ), entryPathRelativeToArchiveRoot );
+			this.archiveBuilder.file( fs.realpathSync( fullEntryPathOnDisk ), {
+				name: entryPathRelativeToArchiveRoot,
+			} );
 		}
 	}
 
-	// Adds a wp-content file to the archive. When cache-busting is enabled and the
-	// file is a theme stylesheet, its `Version:` header is bumped in the archived
-	// copy (the source file on disk is never modified) so WordPress re-enqueues the
-	// theme's assets with a fresh `?ver=`, forcing browsers to drop stale CSS/JS.
-	private addContentFile( diskPath: string, archiveName: string ): void {
-		if ( this.assetVersionSuffix && isThemeStylesheet( archiveName ) ) {
-			const original = fs.readFileSync( diskPath, 'utf-8' );
-			const bumped = bumpStylesheetVersion( original, this.assetVersionSuffix );
-			if ( bumped !== original ) {
-				this.archiveBuilder.append( bumped, { name: archiveName } );
-				return;
-			}
+	// On a push (cache-busting enabled), inject a mu-plugin that stamps a per-push
+	// version onto every locally enqueued asset so browsers re-fetch changed CSS/JS
+	// instead of serving stale copies. Added directly to the archive; never written
+	// to the local site. Skipped for database-only pushes.
+	private addCacheBustMuPlugin(): void {
+		if ( ! this.cacheBustToken || ! this.options.includes.wpContent ) {
+			return;
 		}
-		this.archiveBuilder.file( diskPath, { name: archiveName } );
+		this.archiveBuilder.append( buildCacheBustMuPlugin( this.cacheBustToken ), {
+			name: CACHE_BUST_MU_PLUGIN_PATH,
+		} );
 	}
 
 	private async addDatabase(): Promise< void > {

--- a/apps/cli/lib/import-export/export/exporters/tests/default-exporter.test.ts
+++ b/apps/cli/lib/import-export/export/exporters/tests/default-exporter.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { bumpStylesheetVersion, isThemeStylesheet } from '../default-exporter';
+
+describe( 'isThemeStylesheet', () => {
+	it( 'matches a theme root stylesheet', () => {
+		expect( isThemeStylesheet( 'wp-content/themes/my-theme/style.css' ) ).toBe( true );
+	} );
+
+	it( 'does not match nested or non-stylesheet files', () => {
+		expect( isThemeStylesheet( 'wp-content/themes/my-theme/assets/style.css' ) ).toBe( false );
+		expect( isThemeStylesheet( 'wp-content/themes/my-theme/functions.php' ) ).toBe( false );
+		expect( isThemeStylesheet( 'wp-content/plugins/my-plugin/style.css' ) ).toBe( false );
+	} );
+} );
+
+describe( 'bumpStylesheetVersion', () => {
+	const suffix = 'studio-1718560000000';
+
+	it( 'appends the cache-busting suffix to the Version header', () => {
+		const stylesheet = [ '/*', 'Theme Name: My Theme', 'Version: 1.4.2', '*/' ].join( '\n' );
+		const result = bumpStylesheetVersion( stylesheet, suffix );
+		expect( result ).toContain( `Version: 1.4.2-${ suffix }` );
+	} );
+
+	it( 'preserves indentation and only touches the version line', () => {
+		const stylesheet = [ '/*', ' * Theme Name: My Theme', ' * Version: 2.0', ' */' ].join( '\n' );
+		const result = bumpStylesheetVersion( stylesheet, suffix );
+		expect( result ).toContain( ` * Version: 2.0-${ suffix }` );
+		expect( result ).toContain( ' * Theme Name: My Theme' );
+	} );
+
+	it( 'returns the content unchanged when no Version header is present', () => {
+		const stylesheet = [ '/*', 'Theme Name: My Theme', '*/' ].join( '\n' );
+		expect( bumpStylesheetVersion( stylesheet, suffix ) ).toBe( stylesheet );
+	} );
+
+	it( 'is stable for the same input and suffix', () => {
+		const stylesheet = 'Version: 1.0';
+		expect( bumpStylesheetVersion( stylesheet, suffix ) ).toBe(
+			bumpStylesheetVersion( stylesheet, suffix )
+		);
+	} );
+} );

--- a/apps/cli/lib/import-export/export/exporters/tests/default-exporter.test.ts
+++ b/apps/cli/lib/import-export/export/exporters/tests/default-exporter.test.ts
@@ -1,43 +1,46 @@
 import { describe, it, expect } from 'vitest';
-import { bumpStylesheetVersion, isThemeStylesheet } from '../default-exporter';
+import { buildCacheBustMuPlugin, CACHE_BUST_MU_PLUGIN_PATH } from '../default-exporter';
 
-describe( 'isThemeStylesheet', () => {
-	it( 'matches a theme root stylesheet', () => {
-		expect( isThemeStylesheet( 'wp-content/themes/my-theme/style.css' ) ).toBe( true );
-	} );
-
-	it( 'does not match nested or non-stylesheet files', () => {
-		expect( isThemeStylesheet( 'wp-content/themes/my-theme/assets/style.css' ) ).toBe( false );
-		expect( isThemeStylesheet( 'wp-content/themes/my-theme/functions.php' ) ).toBe( false );
-		expect( isThemeStylesheet( 'wp-content/plugins/my-plugin/style.css' ) ).toBe( false );
+describe( 'CACHE_BUST_MU_PLUGIN_PATH', () => {
+	it( 'lands in mu-plugins so it auto-loads without activation', () => {
+		expect( CACHE_BUST_MU_PLUGIN_PATH ).toBe( 'wp-content/mu-plugins/studio-asset-cache-bust.php' );
 	} );
 } );
 
-describe( 'bumpStylesheetVersion', () => {
-	const suffix = 'studio-1718560000000';
+describe( 'buildCacheBustMuPlugin', () => {
+	const token = 'studio-1718560000000';
 
-	it( 'appends the cache-busting suffix to the Version header', () => {
-		const stylesheet = [ '/*', 'Theme Name: My Theme', 'Version: 1.4.2', '*/' ].join( '\n' );
-		const result = bumpStylesheetVersion( stylesheet, suffix );
-		expect( result ).toContain( `Version: 1.4.2-${ suffix }` );
+	it( 'embeds the per-push token as the asset version', () => {
+		const php = buildCacheBustMuPlugin( token );
+		expect( php ).toContain( `define( 'STUDIO_ASSET_CACHE_BUST_VERSION', '${ token }' )` );
 	} );
 
-	it( 'preserves indentation and only touches the version line', () => {
-		const stylesheet = [ '/*', ' * Theme Name: My Theme', ' * Version: 2.0', ' */' ].join( '\n' );
-		const result = bumpStylesheetVersion( stylesheet, suffix );
-		expect( result ).toContain( ` * Version: 2.0-${ suffix }` );
-		expect( result ).toContain( ' * Theme Name: My Theme' );
-	} );
-
-	it( 'returns the content unchanged when no Version header is present', () => {
-		const stylesheet = [ '/*', 'Theme Name: My Theme', '*/' ].join( '\n' );
-		expect( bumpStylesheetVersion( stylesheet, suffix ) ).toBe( stylesheet );
-	} );
-
-	it( 'is stable for the same input and suffix', () => {
-		const stylesheet = 'Version: 1.0';
-		expect( bumpStylesheetVersion( stylesheet, suffix ) ).toBe(
-			bumpStylesheetVersion( stylesheet, suffix )
+	it( 'filters both style and script srcs at runtime', () => {
+		const php = buildCacheBustMuPlugin( token );
+		expect( php ).toContain(
+			"add_filter( 'style_loader_src', 'studio_asset_cache_bust_src', 9999 )"
 		);
+		expect( php ).toContain(
+			"add_filter( 'script_loader_src', 'studio_asset_cache_bust_src', 9999 )"
+		);
+	} );
+
+	it( 'only versions local assets, leaving external URLs untouched', () => {
+		const php = buildCacheBustMuPlugin( token );
+		expect( php ).toContain( '/wp-content/' );
+		expect( php ).toContain( '/wp-includes/' );
+		expect( php ).toContain( "add_query_arg( 'ver', STUDIO_ASSET_CACHE_BUST_VERSION, $src )" );
+	} );
+
+	it( 'sanitizes the token so it cannot break out of the PHP string literal', () => {
+		const php = buildCacheBustMuPlugin( "abc'; system('x'); //" );
+		expect( php ).toContain( "define( 'STUDIO_ASSET_CACHE_BUST_VERSION', 'abcsystemx' )" );
+		expect( php ).not.toContain( 'system(' );
+	} );
+
+	it( 'guards against direct access and double definition', () => {
+		const php = buildCacheBustMuPlugin( token );
+		expect( php ).toContain( "defined( 'ABSPATH' ) || exit;" );
+		expect( php ).toContain( "if ( ! defined( 'STUDIO_ASSET_CACHE_BUST_VERSION' ) )" );
 	} );
 } );

--- a/apps/cli/lib/import-export/export/types.ts
+++ b/apps/cli/lib/import-export/export/types.ts
@@ -10,6 +10,10 @@ export interface ExportOptions {
 	splitDatabaseDumpByTable?: boolean;
 	specificSelectionPaths?: string[];
 	ignoreFilter?: Ignore;
+	// When set, bump the `Version:` header of each exported theme stylesheet so
+	// pushed asset changes invalidate the browser cache. Only the push/deploy
+	// path enables this; plain backups stay byte-for-byte faithful.
+	bumpAssetVersions?: boolean;
 }
 
 export type ExportOptionsIncludes = 'wpContent' | 'database';

--- a/apps/studio/src/modules/import-export/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/import-export/lib/ipc-handlers.ts
@@ -200,6 +200,7 @@ type ExportOptions = {
 	splitDatabaseDumpByTable?: boolean;
 	specificSelectionPaths?: string[];
 	applyDeployIgnore?: boolean;
+	bumpAssetVersions?: boolean;
 	abortSignal?: AbortSignal;
 };
 
@@ -222,6 +223,7 @@ export async function exportSite(
 		splitDatabaseDumpByTable = false,
 		specificSelectionPaths = [],
 		applyDeployIgnore = false,
+		bumpAssetVersions = false,
 		abortSignal,
 	} = options;
 
@@ -234,6 +236,10 @@ export async function exportSite(
 
 	if ( applyDeployIgnore ) {
 		args.push( '--apply-deploy-ignore' );
+	}
+
+	if ( bumpAssetVersions ) {
+		args.push( '--bump-asset-versions' );
 	}
 
 	if ( specificSelectionPaths.length > 0 ) {

--- a/apps/studio/src/modules/sync/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/sync/lib/ipc-handlers.ts
@@ -198,6 +198,7 @@ export async function exportSiteForPush(
 			splitDatabaseDumpByTable: true,
 			specificSelectionPaths: configuration?.specificSelectionPaths,
 			applyDeployIgnore: true,
+			bumpAssetVersions: true,
 			abortSignal: abortController.signal,
 		} );
 


### PR DESCRIPTION
### Related issues

Addresses STU-1845 (pushing changes can leave outdated assets cached).

### How AI was used in this PR

The code change, the unit tests, and this PR description were written by an AI agent (Claude) under the author's direction, and refined based on discussion with the team about the right approach.

### Proposed Changes

When you push a local site to WordPress.com, theme/plugin files are uploaded byte-for-byte. WordPress re-enqueues CSS/JS using each asset's version as its cache key (`?ver=`), so if those versions don't change, browsers keep serving previously cached files — and a freshly pushed design change looks "broken" (new markup, stale styles/scripts) until a hard refresh.

This makes a push **bump the version of every locally enqueued asset** at once. On push, Studio injects a tiny generated mu-plugin that filters `style_loader_src`/`script_loader_src` at runtime and stamps a single per-push token onto the `?ver=` of every asset served from the site (`/wp-content/` and `/wp-includes/`). Because it works at the enqueue layer rather than by parsing source files, it covers **all** assets uniformly — block-theme styles, plugin assets, auto-injected scripts, and hand-written `wp_enqueue_*` calls with hard-coded versions alike — with no guessing about which files changed and no fragile regex over theme/plugin headers.

The token changes once per push, so visitors re-download assets a single time after a deploy and cache normally in between. External URLs are left untouched. The push command also now tells the user that asset cache versions were refreshed.

This is scoped to the push/deploy path only (a `bumpAssetVersions` option): plain backups and exports stay faithful, byte-for-byte copies, and the mu-plugin is added straight to the upload archive — it is never written to the local site.

### Testing Instructions

1. From this branch, export a site for push (the push path sets `bumpAssetVersions`): `studio export out.tar.gz --path <site> --mode content --bump-asset-versions`.
2. Extract `out.tar.gz` and confirm `wp-content/mu-plugins/studio-asset-cache-bust.php` is present, embeds a `studio-<timestamp>` token, and filters `style_loader_src`/`script_loader_src`.
3. Run a plain export without the flag and confirm the mu-plugin is absent (backups stay faithful).
4. Unit tests: `npm test -- apps/cli/lib/import-export/export/exporters/tests/default-exporter.test.ts`.

> Note: verified at the archive level (what gets uploaded). End-to-end confirmation against a live WordPress.com site is still pending — the upload endpoint returned intermittent HTTP 413s during testing, tracked separately.

### Pre-merge Checklist

- [x] Have you written new tests for your changes?
- [ ] Have you confirmed the cache-bust on a live WordPress.com push (blocked on intermittent upload 413s)?
- [x] Have you checked that backups/exports are unaffected?

### Follow-ups / discussion

- A push-time **prompt** (vs. the always-on bump here) and a richer Studio Code-driven "only bump what changed" flow were discussed in the issue thread; this PR implements the simple, deterministic "bump all on push" baseline.
- Desktop app push UI could surface the same notice the CLI now prints.
