### PR TITLE
Studio Web: run the agent behind an AgentRuntime seam

### DIFF
--- a/apps/cli/web-server/agent-runs.ts
+++ b/apps/cli/web-server/agent-runs.ts
@@ -1,22 +1,25 @@
-import { fork, type ChildProcess } from 'node:child_process';
 import crypto from 'node:crypto';
+import { localRuntime } from './local-runtime';
+import type { AgentProcess, AgentRuntime } from './runtime';
 import type { ActiveAgentRun, AgentEvent, AgentRunEvent } from '@studio/common/ai/agent-events';
-import type { JsonEvent } from '@studio/common/ai/json-events';
 
 /**
  * Headless analog of the desktop `run-manager` (apps/studio/src/modules/
- * ai-agent/run-manager.ts). It forks the exact same CLI subcommand the desktop
- * forks — `code sessions resume <id> <prompt> --json` — relays the child's
- * `JsonEvent`s as `AgentRunEvent`s, and synthesizes the same lifecycle events
- * (`run.started`, `run.exited`, ...). The only difference is the sink: instead
- * of `webContents.send`, events go to a broadcaster (SSE) injected via
- * `setBroadcast`.
+ * ai-agent/run-manager.ts). It runs the same `studio code sessions resume <id>
+ * <prompt> --json` agent the desktop runs, relays the agent's `JsonEvent`s as
+ * `AgentRunEvent`s, and synthesizes the same lifecycle events (`run.started`,
+ * `run.exited`, ...). The sink is a broadcaster (SSE) injected via
+ * `setBroadcast` instead of `webContents.send`.
+ *
+ * Where the agent actually runs is behind the {@link AgentRuntime} seam. Today
+ * that's a local child process; the hosted backend swaps in a SecEx-sandbox
+ * runtime via `setAgentRuntime` without touching any of this orchestration.
  */
 
 interface AgentRun {
 	runId: string;
 	sessionId: string;
-	child: ChildProcess;
+	process: AgentProcess;
 	interrupted: boolean;
 	interruptAttempts: number;
 	startedAt: number;
@@ -32,12 +35,18 @@ export function setBroadcast( fn: Broadcast ): void {
 	broadcast = fn;
 }
 
+let runtime: AgentRuntime = localRuntime;
+
+export function setAgentRuntime( next: AgentRuntime ): void {
+	runtime = next;
+}
+
 function nowIso(): string {
 	return new Date().toISOString();
 }
 
-function send( run: AgentRun, event: AgentEvent ): void {
-	broadcast( { runId: run.runId, sessionId: run.sessionId, event } );
+function emit( runId: string, sessionId: string, event: AgentEvent ): void {
+	broadcast( { runId, sessionId, event } );
 }
 
 export interface StartAgentRunOptions {
@@ -55,64 +64,41 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 
 	const runId = crypto.randomUUID();
 	const startedAt = Date.now();
-	const args = [ 'code', 'sessions', 'resume', sessionId, prompt, '--json', '--avoid-telemetry' ];
-	if ( displayMessage ) {
-		args.push( '--display-message', displayMessage );
-	}
 
-	// Re-invoke this same CLI bundle. The child emits JSON transport events over
-	// the Node IPC channel (process.send), which we read via `message`.
-	const child = fork( process.argv[ 1 ], args, {
-		stdio: [ 'ignore', 'inherit', 'inherit', 'ipc' ],
-		execArgv: [ '--experimental-wasm-jspi' ],
-		env: { ...process.env },
+	const agentProcess = runtime.start( {
+		sessionId,
+		prompt,
+		displayMessage,
+		onSpawn: () => emit( runId, sessionId, { type: 'run.started', timestamp: nowIso() } ),
+		onEvent: ( event ) => emit( runId, sessionId, event ),
+		onError: ( message ) =>
+			emit( runId, sessionId, { type: 'error', timestamp: nowIso(), message } ),
+		onExit: ( code ) => {
+			const interrupted = runsById.get( runId )?.interrupted ?? false;
+			runsBySessionId.delete( sessionId );
+			runsById.delete( runId );
+			if ( interrupted ) {
+				emit( runId, sessionId, { type: 'run.interrupted', timestamp: nowIso() } );
+			}
+			emit( runId, sessionId, {
+				type: 'run.exited',
+				timestamp: nowIso(),
+				status: code === 0 ? 'success' : 'error',
+				code,
+			} );
+		},
 	} );
 
 	const run: AgentRun = {
 		runId,
 		sessionId,
-		child,
+		process: agentProcess,
 		interrupted: false,
 		interruptAttempts: 0,
 		startedAt,
 	};
-
 	runsBySessionId.set( sessionId, run );
 	runsById.set( runId, run );
-
-	child.on( 'spawn', () => {
-		send( run, { type: 'run.started', timestamp: nowIso() } );
-	} );
-
-	child.on( 'message', ( message ) => {
-		// The CLI's Logger also writes to this channel with a different shape;
-		// forward only messages that look like the JSON transport envelope.
-		if ( message && typeof message === 'object' && 'type' in message ) {
-			send( run, message as JsonEvent );
-		}
-	} );
-
-	child.on( 'error', ( error ) => {
-		send( run, {
-			type: 'error',
-			timestamp: nowIso(),
-			message: error.message || 'CLI subprocess failed to start',
-		} );
-	} );
-
-	child.on( 'exit', ( code ) => {
-		runsBySessionId.delete( sessionId );
-		runsById.delete( runId );
-		if ( run.interrupted ) {
-			send( run, { type: 'run.interrupted', timestamp: nowIso() } );
-		}
-		send( run, {
-			type: 'run.exited',
-			timestamp: nowIso(),
-			status: code === 0 ? 'success' : 'error',
-			code,
-		} );
-	} );
 
 	return { runId };
 }
@@ -139,29 +125,32 @@ export function interruptAgentRun( runId: string ): void {
 		runsBySessionId.delete( run.sessionId );
 	}
 
+	// A second interrupt request escalates straight to a force kill.
 	if ( run.interruptAttempts > 1 ) {
-		run.child.kill( 'SIGKILL' );
+		run.process.kill();
 		return;
 	}
 
-	if ( run.child.connected ) {
-		run.child.send( { type: 'interrupt' } );
-		send( run, { type: 'run.interrupting', timestamp: nowIso() } );
+	// First request: ask the agent to stop cleanly, then force-kill if it
+	// hasn't exited within the grace window. If it can't be reached, kill now.
+	if ( run.process.connected ) {
+		run.process.interrupt();
+		emit( run.runId, run.sessionId, { type: 'run.interrupting', timestamp: nowIso() } );
 		setTimeout( () => {
-			if ( runsById.get( runId ) === run && ! run.child.killed ) {
-				run.child.kill( 'SIGKILL' );
+			if ( runsById.get( runId ) === run ) {
+				run.process.kill();
 			}
 		}, INTERRUPT_FORCE_KILL_TIMEOUT_MS ).unref();
 		return;
 	}
 
-	run.child.kill( 'SIGKILL' );
+	run.process.kill();
 }
 
 export function answerAgentRun( runId: string, answers: Record< string, string > ): void {
 	const run = runsById.get( runId );
-	if ( ! run || ! run.child.connected ) {
+	if ( ! run ) {
 		return;
 	}
-	run.child.send( { type: 'answer', answers } );
+	run.process.answer( answers );
 }

--- a/apps/cli/web-server/local-runtime.ts
+++ b/apps/cli/web-server/local-runtime.ts
@@ -1,0 +1,63 @@
+import { fork } from 'node:child_process';
+import type { AgentProcess, AgentProcessOptions, AgentRuntime } from './runtime';
+import type { JsonEvent } from '@studio/common/ai/json-events';
+
+/**
+ * Runs the agent as a local child process: it re-invokes this same CLI bundle
+ * as `studio code sessions resume <id> <prompt> --json` — the exact subcommand
+ * the desktop app forks — and reads the JSON transport over the Node IPC
+ * channel. This is the local-development runtime; the hosted backend swaps in a
+ * runtime that runs the agent inside a per-session SecEx sandbox instead.
+ */
+export const localRuntime: AgentRuntime = {
+	start( {
+		sessionId,
+		prompt,
+		displayMessage,
+		onSpawn,
+		onEvent,
+		onError,
+		onExit,
+	}: AgentProcessOptions ): AgentProcess {
+		const args = [ 'code', 'sessions', 'resume', sessionId, prompt, '--json', '--avoid-telemetry' ];
+		if ( displayMessage ) {
+			args.push( '--display-message', displayMessage );
+		}
+
+		const child = fork( process.argv[ 1 ], args, {
+			stdio: [ 'ignore', 'inherit', 'inherit', 'ipc' ],
+			execArgv: [ '--experimental-wasm-jspi' ],
+			env: { ...process.env },
+		} );
+
+		child.on( 'spawn', onSpawn );
+		child.on( 'message', ( message ) => {
+			// The CLI's Logger also writes to this channel with a different shape;
+			// forward only messages that look like the JSON transport envelope.
+			if ( message && typeof message === 'object' && 'type' in message ) {
+				onEvent( message as JsonEvent );
+			}
+		} );
+		child.on( 'error', ( error ) => onError( error.message || 'CLI subprocess failed to start' ) );
+		child.on( 'exit', onExit );
+
+		return {
+			get connected() {
+				return child.connected;
+			},
+			interrupt() {
+				if ( child.connected ) {
+					child.send( { type: 'interrupt' } );
+				}
+			},
+			kill() {
+				child.kill( 'SIGKILL' );
+			},
+			answer( answers ) {
+				if ( child.connected ) {
+					child.send( { type: 'answer', answers } );
+				}
+			},
+		};
+	},
+};

--- a/apps/cli/web-server/runtime.ts
+++ b/apps/cli/web-server/runtime.ts
@@ -1,0 +1,48 @@
+import type { JsonEvent } from '@studio/common/ai/json-events';
+
+/**
+ * Where the agent actually runs, behind a seam.
+ *
+ * Today there is one implementation: {@link localRuntime}, which forks the
+ * `studio code` CLI as a local child process — the same thing the desktop app
+ * does. The hosted backend will add a second implementation that runs the agent
+ * inside a per-session SecEx sandbox. The run-manager (`agent-runs.ts`) owns all
+ * the run bookkeeping (ids, lifecycle events, the interrupt policy) and only
+ * delegates the spawn + control surface that genuinely differs per runtime.
+ */
+
+export interface AgentProcessOptions {
+	sessionId: string;
+	prompt: string;
+	displayMessage?: string;
+	// The process has started.
+	onSpawn: () => void;
+	// A JSON transport event the agent emitted.
+	onEvent: ( event: JsonEvent ) => void;
+	// The process failed to start, or errored before exiting.
+	onError: ( message: string ) => void;
+	// The process exited. `code` is null when it was terminated by a signal.
+	onExit: ( code: number | null ) => void;
+}
+
+/**
+ * A single in-flight agent run's control surface. The run-manager holds one of
+ * these per active run and drives it; the implementation hides whether that's a
+ * local child process or a remote sandbox.
+ */
+export interface AgentProcess {
+	// Whether the process can still receive control messages.
+	readonly connected: boolean;
+	// Cooperatively ask the agent to stop (it aborts the current turn cleanly).
+	interrupt(): void;
+	// Forcibly terminate the process.
+	kill(): void;
+	// Deliver answers to a question the agent asked.
+	answer( answers: Record< string, string > ): void;
+}
+
+export interface AgentRuntime {
+	// Start the agent for a session and return its control surface. Lifecycle is
+	// reported through the callbacks in `options`.
+	start( options: AgentProcessOptions ): AgentProcess;
+}


### PR DESCRIPTION
## Related issues

- Part of the Studio Web effort (foundation #3816, live preview #3866). This is the first step toward running the agent on hosted infrastructure.

## How AI was used in this PR

The refactor and this description were drafted with Claude Code under close direction. I reviewed the diff and ran the verification steps (typecheck, lint, CLI build, and a live smoke test that the agent still forks and streams lifecycle events over SSE) on this branch.

## Proposed Changes

The Studio Web backend runs the agent by forking the `studio code` CLI as a local child process. To move toward the hosted product — where the agent runs inside a per-session SecEx sandbox rather than on the user's machine — that execution needs to sit behind a seam so the sandbox runtime can drop in without disturbing the rest of the backend.

This change introduces an `AgentRuntime` boundary: a small interface for *starting and controlling one agent run* (spawn, stream events, interrupt, answer). The existing local-child-process behavior moves into a `localRuntime` that implements it, and the run-manager keeps everything else it already owned — run ids, lifecycle events, the interrupt escalation policy, the active-run bookkeeping. Swapping in a SecEx-sandbox runtime later is then a one-line injection, with no change to the run-manager, the HTTP/SSE API, or the browser.

There is **no behavior change**: this is a pure refactor. The agent still forks the same subcommand, emits the same events, and interrupts the same way.

## Testing Instructions

1. `npm install && npm run cli:build`.
2. Start the backend: `node apps/cli/dist/cli/main.mjs web-server`.
3. Create a session and send a prompt; confirm the agent run starts and streams `run.started` / `run.exited` events exactly as before, and that interrupt still works.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
