### PR TITLE
Studio Web: SecexRuntime — run the agent in a hosted SecEx sandbox

### DIFF
--- a/apps/cli/web-server/agent-runs.ts
+++ b/apps/cli/web-server/agent-runs.ts
@@ -1,22 +1,25 @@
-import { fork, type ChildProcess } from 'node:child_process';
 import crypto from 'node:crypto';
+import { localRuntime } from './local-runtime';
+import type { AgentProcess, AgentRuntime } from './runtime';
 import type { ActiveAgentRun, AgentEvent, AgentRunEvent } from '@studio/common/ai/agent-events';
-import type { JsonEvent } from '@studio/common/ai/json-events';
 
 /**
  * Headless analog of the desktop `run-manager` (apps/studio/src/modules/
- * ai-agent/run-manager.ts). It forks the exact same CLI subcommand the desktop
- * forks — `code sessions resume <id> <prompt> --json` — relays the child's
- * `JsonEvent`s as `AgentRunEvent`s, and synthesizes the same lifecycle events
- * (`run.started`, `run.exited`, ...). The only difference is the sink: instead
- * of `webContents.send`, events go to a broadcaster (SSE) injected via
- * `setBroadcast`.
+ * ai-agent/run-manager.ts). It runs the same `studio code sessions resume <id>
+ * <prompt> --json` agent the desktop runs, relays the agent's `JsonEvent`s as
+ * `AgentRunEvent`s, and synthesizes the same lifecycle events (`run.started`,
+ * `run.exited`, ...). The sink is a broadcaster (SSE) injected via
+ * `setBroadcast` instead of `webContents.send`.
+ *
+ * Where the agent actually runs is behind the {@link AgentRuntime} seam. Today
+ * that's a local child process; the hosted backend swaps in a SecEx-sandbox
+ * runtime via `setAgentRuntime` without touching any of this orchestration.
  */
 
 interface AgentRun {
 	runId: string;
 	sessionId: string;
-	child: ChildProcess;
+	process: AgentProcess;
 	interrupted: boolean;
 	interruptAttempts: number;
 	startedAt: number;
@@ -32,12 +35,18 @@ export function setBroadcast( fn: Broadcast ): void {
 	broadcast = fn;
 }
 
+let runtime: AgentRuntime = localRuntime;
+
+export function setAgentRuntime( next: AgentRuntime ): void {
+	runtime = next;
+}
+
 function nowIso(): string {
 	return new Date().toISOString();
 }
 
-function send( run: AgentRun, event: AgentEvent ): void {
-	broadcast( { runId: run.runId, sessionId: run.sessionId, event } );
+function emit( runId: string, sessionId: string, event: AgentEvent ): void {
+	broadcast( { runId, sessionId, event } );
 }
 
 export interface StartAgentRunOptions {
@@ -55,64 +64,41 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 
 	const runId = crypto.randomUUID();
 	const startedAt = Date.now();
-	const args = [ 'code', 'sessions', 'resume', sessionId, prompt, '--json', '--avoid-telemetry' ];
-	if ( displayMessage ) {
-		args.push( '--display-message', displayMessage );
-	}
 
-	// Re-invoke this same CLI bundle. The child emits JSON transport events over
-	// the Node IPC channel (process.send), which we read via `message`.
-	const child = fork( process.argv[ 1 ], args, {
-		stdio: [ 'ignore', 'inherit', 'inherit', 'ipc' ],
-		execArgv: [ '--experimental-wasm-jspi' ],
-		env: { ...process.env },
+	const agentProcess = runtime.start( {
+		sessionId,
+		prompt,
+		displayMessage,
+		onSpawn: () => emit( runId, sessionId, { type: 'run.started', timestamp: nowIso() } ),
+		onEvent: ( event ) => emit( runId, sessionId, event ),
+		onError: ( message ) =>
+			emit( runId, sessionId, { type: 'error', timestamp: nowIso(), message } ),
+		onExit: ( code ) => {
+			const interrupted = runsById.get( runId )?.interrupted ?? false;
+			runsBySessionId.delete( sessionId );
+			runsById.delete( runId );
+			if ( interrupted ) {
+				emit( runId, sessionId, { type: 'run.interrupted', timestamp: nowIso() } );
+			}
+			emit( runId, sessionId, {
+				type: 'run.exited',
+				timestamp: nowIso(),
+				status: code === 0 ? 'success' : 'error',
+				code,
+			} );
+		},
 	} );
 
 	const run: AgentRun = {
 		runId,
 		sessionId,
-		child,
+		process: agentProcess,
 		interrupted: false,
 		interruptAttempts: 0,
 		startedAt,
 	};
-
 	runsBySessionId.set( sessionId, run );
 	runsById.set( runId, run );
-
-	child.on( 'spawn', () => {
-		send( run, { type: 'run.started', timestamp: nowIso() } );
-	} );
-
-	child.on( 'message', ( message ) => {
-		// The CLI's Logger also writes to this channel with a different shape;
-		// forward only messages that look like the JSON transport envelope.
-		if ( message && typeof message === 'object' && 'type' in message ) {
-			send( run, message as JsonEvent );
-		}
-	} );
-
-	child.on( 'error', ( error ) => {
-		send( run, {
-			type: 'error',
-			timestamp: nowIso(),
-			message: error.message || 'CLI subprocess failed to start',
-		} );
-	} );
-
-	child.on( 'exit', ( code ) => {
-		runsBySessionId.delete( sessionId );
-		runsById.delete( runId );
-		if ( run.interrupted ) {
-			send( run, { type: 'run.interrupted', timestamp: nowIso() } );
-		}
-		send( run, {
-			type: 'run.exited',
-			timestamp: nowIso(),
-			status: code === 0 ? 'success' : 'error',
-			code,
-		} );
-	} );
 
 	return { runId };
 }
@@ -139,29 +125,32 @@ export function interruptAgentRun( runId: string ): void {
 		runsBySessionId.delete( run.sessionId );
 	}
 
+	// A second interrupt request escalates straight to a force kill.
 	if ( run.interruptAttempts > 1 ) {
-		run.child.kill( 'SIGKILL' );
+		run.process.kill();
 		return;
 	}
 
-	if ( run.child.connected ) {
-		run.child.send( { type: 'interrupt' } );
-		send( run, { type: 'run.interrupting', timestamp: nowIso() } );
+	// First request: ask the agent to stop cleanly, then force-kill if it
+	// hasn't exited within the grace window. If it can't be reached, kill now.
+	if ( run.process.connected ) {
+		run.process.interrupt();
+		emit( run.runId, run.sessionId, { type: 'run.interrupting', timestamp: nowIso() } );
 		setTimeout( () => {
-			if ( runsById.get( runId ) === run && ! run.child.killed ) {
-				run.child.kill( 'SIGKILL' );
+			if ( runsById.get( runId ) === run ) {
+				run.process.kill();
 			}
 		}, INTERRUPT_FORCE_KILL_TIMEOUT_MS ).unref();
 		return;
 	}
 
-	run.child.kill( 'SIGKILL' );
+	run.process.kill();
 }
 
 export function answerAgentRun( runId: string, answers: Record< string, string > ): void {
 	const run = runsById.get( runId );
-	if ( ! run || ! run.child.connected ) {
+	if ( ! run ) {
 		return;
 	}
-	run.child.send( { type: 'answer', answers } );
+	run.process.answer( answers );
 }

--- a/apps/cli/web-server/index.ts
+++ b/apps/cli/web-server/index.ts
@@ -22,9 +22,11 @@ import {
 	answerAgentRun,
 	interruptAgentRun,
 	listActiveAgentRuns,
+	setAgentRuntime,
 	setBroadcast,
 	startAgentRun,
 } from './agent-runs';
+import { createSecexRuntime } from './secex-runtime';
 import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
 import type { SitesEndpointSite } from '@studio/common/types/sync';
@@ -65,6 +67,14 @@ function hydrateAiSessionSummary(
 }
 
 const root = getAiSessionsRootDirectory();
+
+// Where the agent runs. Default: a local child process (the dev backend). Set
+// `STUDIO_WEB_BACKEND=secex` to run it in a hosted SecEx sandbox via the wpcom
+// `studio-code` endpoint instead — the run-manager and the browser don't change.
+if ( process.env.STUDIO_WEB_BACKEND === 'secex' ) {
+	setAgentRuntime( createSecexRuntime( { runUrl: process.env.STUDIO_SECEX_RUN_URL } ) );
+}
+
 const app = express();
 // All API routes live under `/api` so they can't collide with the SPA's
 // real-path routes (`/sessions/:id` is both an app URL and an API resource).

--- a/apps/cli/web-server/local-runtime.ts
+++ b/apps/cli/web-server/local-runtime.ts
@@ -1,0 +1,63 @@
+import { fork } from 'node:child_process';
+import type { AgentProcess, AgentProcessOptions, AgentRuntime } from './runtime';
+import type { JsonEvent } from '@studio/common/ai/json-events';
+
+/**
+ * Runs the agent as a local child process: it re-invokes this same CLI bundle
+ * as `studio code sessions resume <id> <prompt> --json` — the exact subcommand
+ * the desktop app forks — and reads the JSON transport over the Node IPC
+ * channel. This is the local-development runtime; the hosted backend swaps in a
+ * runtime that runs the agent inside a per-session SecEx sandbox instead.
+ */
+export const localRuntime: AgentRuntime = {
+	start( {
+		sessionId,
+		prompt,
+		displayMessage,
+		onSpawn,
+		onEvent,
+		onError,
+		onExit,
+	}: AgentProcessOptions ): AgentProcess {
+		const args = [ 'code', 'sessions', 'resume', sessionId, prompt, '--json', '--avoid-telemetry' ];
+		if ( displayMessage ) {
+			args.push( '--display-message', displayMessage );
+		}
+
+		const child = fork( process.argv[ 1 ], args, {
+			stdio: [ 'ignore', 'inherit', 'inherit', 'ipc' ],
+			execArgv: [ '--experimental-wasm-jspi' ],
+			env: { ...process.env },
+		} );
+
+		child.on( 'spawn', onSpawn );
+		child.on( 'message', ( message ) => {
+			// The CLI's Logger also writes to this channel with a different shape;
+			// forward only messages that look like the JSON transport envelope.
+			if ( message && typeof message === 'object' && 'type' in message ) {
+				onEvent( message as JsonEvent );
+			}
+		} );
+		child.on( 'error', ( error ) => onError( error.message || 'CLI subprocess failed to start' ) );
+		child.on( 'exit', onExit );
+
+		return {
+			get connected() {
+				return child.connected;
+			},
+			interrupt() {
+				if ( child.connected ) {
+					child.send( { type: 'interrupt' } );
+				}
+			},
+			kill() {
+				child.kill( 'SIGKILL' );
+			},
+			answer( answers ) {
+				if ( child.connected ) {
+					child.send( { type: 'answer', answers } );
+				}
+			},
+		};
+	},
+};

--- a/apps/cli/web-server/runtime.ts
+++ b/apps/cli/web-server/runtime.ts
@@ -1,0 +1,48 @@
+import type { JsonEvent } from '@studio/common/ai/json-events';
+
+/**
+ * Where the agent actually runs, behind a seam.
+ *
+ * Today there is one implementation: {@link localRuntime}, which forks the
+ * `studio code` CLI as a local child process — the same thing the desktop app
+ * does. The hosted backend will add a second implementation that runs the agent
+ * inside a per-session SecEx sandbox. The run-manager (`agent-runs.ts`) owns all
+ * the run bookkeeping (ids, lifecycle events, the interrupt policy) and only
+ * delegates the spawn + control surface that genuinely differs per runtime.
+ */
+
+export interface AgentProcessOptions {
+	sessionId: string;
+	prompt: string;
+	displayMessage?: string;
+	// The process has started.
+	onSpawn: () => void;
+	// A JSON transport event the agent emitted.
+	onEvent: ( event: JsonEvent ) => void;
+	// The process failed to start, or errored before exiting.
+	onError: ( message: string ) => void;
+	// The process exited. `code` is null when it was terminated by a signal.
+	onExit: ( code: number | null ) => void;
+}
+
+/**
+ * A single in-flight agent run's control surface. The run-manager holds one of
+ * these per active run and drives it; the implementation hides whether that's a
+ * local child process or a remote sandbox.
+ */
+export interface AgentProcess {
+	// Whether the process can still receive control messages.
+	readonly connected: boolean;
+	// Cooperatively ask the agent to stop (it aborts the current turn cleanly).
+	interrupt(): void;
+	// Forcibly terminate the process.
+	kill(): void;
+	// Deliver answers to a question the agent asked.
+	answer( answers: Record< string, string > ): void;
+}
+
+export interface AgentRuntime {
+	// Start the agent for a session and return its control surface. Lifecycle is
+	// reported through the callbacks in `options`.
+	start( options: AgentProcessOptions ): AgentProcess;
+}

--- a/apps/cli/web-server/secex-runtime.ts
+++ b/apps/cli/web-server/secex-runtime.ts
@@ -1,0 +1,193 @@
+import { readAuthToken } from '@studio/common/lib/shared-config';
+import type { AgentProcess, AgentProcessOptions, AgentRuntime } from './runtime';
+import type { JsonEvent } from '@studio/common/ai/json-events';
+
+/**
+ * Runs the agent inside a hosted SecEx sandbox by driving the wpcom
+ * `studio-code` endpoint (Automattic/wpcom: `POST /wpcom/v2/studio-code/run`).
+ * The endpoint runs `studio code --json <prompt>` in a per-user sandbox and
+ * streams the CLI's events back over SSE; this runtime relays them through the
+ * same {@link AgentRuntime} callbacks the local runtime uses, so the run-manager
+ * and the browser don't change.
+ *
+ * One sandbox per user (the endpoint resolves it from the caller's token), the
+ * cloud analog of "your laptop" — same `~/Studio/` sites and `~/.claude` sessions
+ * inside it, like the desktop app.
+ *
+ * NOT YET VERIFIED against the live endpoint — written to the endpoint's
+ * documented contract; needs an end-to-end run once the endpoint + SecEx
+ * template are reachable.
+ */
+
+const DEFAULT_RUN_URL = 'https://public-api.wordpress.com/wpcom/v2/studio-code/run';
+
+// Maps our web-server session id to the CLI `session_id` the endpoint returns,
+// so the next turn resumes the same conversation in the sandbox.
+const cliSessionIds = new Map< string, string >();
+
+export interface SecexRuntimeOptions {
+	// The studio-code `/run` endpoint. Override for sandboxes / testing.
+	runUrl?: string;
+}
+
+export function createSecexRuntime( {
+	runUrl = DEFAULT_RUN_URL,
+}: SecexRuntimeOptions = {} ): AgentRuntime {
+	return {
+		start( {
+			sessionId,
+			prompt,
+			onSpawn,
+			onEvent,
+			onError,
+			onExit,
+		}: AgentProcessOptions ): AgentProcess {
+			const controller = new AbortController();
+			let open = true;
+
+			void runTurn( {
+				runUrl,
+				sessionId,
+				prompt,
+				signal: controller.signal,
+				onSpawn,
+				onEvent,
+				onError,
+			} )
+				.catch( ( error ) => {
+					if ( ! controller.signal.aborted ) {
+						onError( error instanceof Error ? error.message : String( error ) );
+					}
+					return { code: 1 };
+				} )
+				.then( ( result ) => {
+					open = false;
+					onExit( controller.signal.aborted ? null : result.code );
+				} );
+
+			return {
+				get connected() {
+					return open;
+				},
+				interrupt() {
+					// The endpoint has no interrupt route; closing the stream makes it
+					// kill the CLI in the sandbox (and still snapshot partial state).
+					controller.abort();
+				},
+				kill() {
+					controller.abort();
+				},
+				answer() {
+					// No-op: the endpoint runs `studio code --json` with --auto-approve,
+					// so the agent never blocks waiting for an answer.
+				},
+			};
+		},
+	};
+}
+
+interface RunTurnArgs {
+	runUrl: string;
+	sessionId: string;
+	prompt: string;
+	signal: AbortSignal;
+	onSpawn: () => void;
+	onEvent: ( event: JsonEvent ) => void;
+	onError: ( message: string ) => void;
+}
+
+async function runTurn( args: RunTurnArgs ): Promise< { code: number } > {
+	const { runUrl, sessionId, prompt, signal, onSpawn, onEvent, onError } = args;
+
+	const token = await readAuthToken().catch( () => null );
+	if ( ! token ) {
+		onError( 'Not signed in to WordPress.com — run `studio auth login` first.' );
+		return { code: 1 };
+	}
+
+	const response = await fetch( runUrl, {
+		method: 'POST',
+		signal,
+		headers: {
+			Authorization: `Bearer ${ token.accessToken }`,
+			'X-WPCOM-AI-Feature': 'studio-code',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify( { prompt, session_id: cliSessionIds.get( sessionId ) } ),
+	} );
+
+	if ( ! response.ok || ! response.body ) {
+		const text = await response.text().catch( () => '' );
+		onError( `studio-code /run failed (${ response.status }): ${ text }` );
+		return { code: 1 };
+	}
+
+	onSpawn();
+
+	let errored = false;
+	await readSse( response.body, ( event, data ) => {
+		if ( event === 'session' ) {
+			const id = ( data as { session_id?: string } ).session_id;
+			if ( id ) {
+				cliSessionIds.set( sessionId, id );
+			}
+		} else if ( event === 'data' ) {
+			onEvent( data as JsonEvent );
+		} else if ( event === 'error' ) {
+			errored = true;
+			const payload = data as { message?: string; stderr?: string };
+			onError( payload.message ?? payload.stderr ?? 'studio-code run error' );
+		}
+		// 'done' just marks the end of the stream; the loop ends on its own.
+	} );
+
+	return { code: errored ? 1 : 0 };
+}
+
+/**
+ * Reads a Server-Sent Events stream of named events (`event:` + `data:` lines,
+ * frames separated by a blank line), parsing each frame's `data` as JSON. The
+ * `studio-code` endpoint emits one JSON payload per frame, so frames don't need
+ * reassembly beyond joining multi-line `data:` fields.
+ */
+async function readSse(
+	body: ReadableStream< Uint8Array >,
+	onFrame: ( event: string, data: unknown ) => void
+): Promise< void > {
+	const reader = body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+	try {
+		for (;;) {
+			const { value, done } = await reader.read();
+			if ( done ) {
+				break;
+			}
+			buffer += decoder.decode( value, { stream: true } );
+			let sep: number;
+			while ( ( sep = buffer.indexOf( '\n\n' ) ) !== -1 ) {
+				const frame = buffer.slice( 0, sep );
+				buffer = buffer.slice( sep + 2 );
+				let event = 'message';
+				const dataLines: string[] = [];
+				for ( const line of frame.split( '\n' ) ) {
+					if ( line.startsWith( 'event:' ) ) {
+						event = line.slice( 6 ).trim();
+					} else if ( line.startsWith( 'data:' ) ) {
+						dataLines.push( line.slice( 5 ).replace( /^ /, '' ) );
+					}
+				}
+				if ( dataLines.length === 0 ) {
+					continue;
+				}
+				try {
+					onFrame( event, JSON.parse( dataLines.join( '\n' ) ) );
+				} catch {
+					// Ignore malformed frames.
+				}
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}


### PR DESCRIPTION
## Related issues

- **Stacked on #3877** (the `AgentRuntime` seam — review/merge that first; this PR targets its branch).
- Part of the Studio Web → hosted effort. Drives the wpcom `studio-code` endpoint (Automattic/wpcom#212555) server-side.

## How AI was used in this PR

The runtime and this description were drafted with Claude Code under close direction, written to the `studio-code` endpoint's documented contract. I reviewed the diff and ran the local verification (typecheck, lint, CLI build, and a smoke test of the failure path + that the default local runtime is unaffected).

## Proposed Changes

#3877 put the agent's execution behind an `AgentRuntime` seam. This adds the second implementation: instead of forking the agent as a local child process, `SecexRuntime` runs it inside a hosted **per-user SecEx sandbox** by driving the wpcom `POST /wpcom/v2/studio-code/run` endpoint and relaying the sandbox's streamed events through the same callbacks the local runtime uses. The run-manager, the HTTP/SSE API, and the browser don't change — only *where the agent runs*.

The model mirrors Studio App: one sandbox per user is the cloud analog of "your laptop", holding the user's sites and sessions, resolved from the caller's WordPress.com token. It's opt-in — nothing changes unless you start the backend with `STUDIO_WEB_BACKEND=secex`; the default local runtime is untouched.

Scope is deliberately narrow — **running a turn** (send prompt → stream the agent's events back). Two things are out of scope and tracked as follow-ups:
- **Session listing/history from the sandbox.** In SecEx mode the agent's sessions live inside the sandbox, not the web-server's local store, so the existing `/sessions` listing won't reflect them yet.
- **Interrupt/answer semantics.** The endpoint has no interrupt route, so interrupt closes the stream (the endpoint kills the CLI and snapshots partial state); answer is a no-op because the endpoint runs the CLI with `--auto-approve`.

> ⚠️ **Not yet verified against the live endpoint.** The code is written to the endpoint's documented contract, but an end-to-end run needs the `studio-code` endpoint deployed and a built SecEx template. The local failure path (auth missing / endpoint unreachable → `error` + `run.exited`, no crash) is verified; the happy path is not.

Known risk to handle later (flagged on the endpoint side too): long agent turns can drop the HTTP/2 connection mid-stream — needs heartbeats/resume.

## Testing Instructions

Local (failure path, no endpoint needed):
1. `npm install && npm run cli:build`.
2. `STUDIO_WEB_BACKEND=secex STUDIO_SECEX_RUN_URL=http://127.0.0.1:9/run node apps/cli/dist/cli/main.mjs web-server`.
3. Send a prompt; confirm the run streams an `error` then `run.exited` and the server stays up.
4. Without the env var, confirm the local runtime behaves exactly as before.

End-to-end (needs the live endpoint + a signed-in user):
5. `studio auth login`, then `STUDIO_WEB_BACKEND=secex node apps/cli/dist/cli/main.mjs web-server`, and send a prompt — the agent runs in the sandbox and its events stream into the browser.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
