### PR TITLE
Fix Studio Code syntax error in Node.js 22

### DIFF
--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -33,6 +33,9 @@ const phpSourceCodePath = resolve( __dirname, 'php' );
 const skillsSourcePath = resolve( __dirname, 'ai/skills' );
 
 export const baseConfig = defineConfig( {
+	oxc: {
+		target: `node${ semver.major( minimumNodeVersion ) }`,
+	},
 	plugins: [
 		{
 			name: 'write-dist-extras',


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-1857

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Claude was used to help identify and fix the issue.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

We recently updated to Vite 8 (see https://github.com/Automattic/studio/pull/3674 and related PRs). Previously, Vite transformed the JS output to support our targeted Node.js version. It still can, but Vite 8 wasn't picking up the transform target based on our existing config. This PR adds the necessary config to transform the output JS code so Node.js 22 supports it.

All of this is obviously related to Vite 8 swapping out esbuild/Rollup for Rolldown. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `npm run cli:build`
2. `nvm use 22`
3. `node apps/cli/dist/cli/main.mjs code`
4. Ensure Studio Code starts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
