### PR TITLE
Studio Web: run the agent in a hosted SecEx sandbox (opt-in runtime)

### DIFF
--- a/apps/cli/web-server/agent-runs.ts
+++ b/apps/cli/web-server/agent-runs.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import { wdbg } from './debug';
 import { localRuntime } from './local-runtime';
 import type { AgentProcess, AgentRuntime } from './runtime';
 import type { ActiveAgentRun, AgentEvent, AgentRunEvent } from '@studio/common/ai/agent-events';
@@ -65,15 +66,26 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 	const runId = crypto.randomUUID();
 	const startedAt = Date.now();
 
+	wdbg( 'run', 'start', { sessionId, runId, prompt: prompt.slice( 0, 80 ) } );
+
 	const agentProcess = runtime.start( {
 		sessionId,
 		prompt,
 		displayMessage,
-		onSpawn: () => emit( runId, sessionId, { type: 'run.started', timestamp: nowIso() } ),
-		onEvent: ( event ) => emit( runId, sessionId, event ),
-		onError: ( message ) =>
-			emit( runId, sessionId, { type: 'error', timestamp: nowIso(), message } ),
+		onSpawn: () => {
+			wdbg( 'run', 'spawned', { runId } );
+			emit( runId, sessionId, { type: 'run.started', timestamp: nowIso() } );
+		},
+		onEvent: ( event ) => {
+			wdbg( 'event', event.type, event.type === 'message' ? event.message?.type : '' );
+			emit( runId, sessionId, event );
+		},
+		onError: ( message ) => {
+			wdbg( 'run', 'error', { runId, message } );
+			emit( runId, sessionId, { type: 'error', timestamp: nowIso(), message } );
+		},
 		onExit: ( code ) => {
+			wdbg( 'run', 'exit', { runId, code } );
 			const interrupted = runsById.get( runId )?.interrupted ?? false;
 			runsBySessionId.delete( sessionId );
 			runsById.delete( runId );
@@ -150,7 +162,9 @@ export function interruptAgentRun( runId: string ): void {
 export function answerAgentRun( runId: string, answers: Record< string, string > ): void {
 	const run = runsById.get( runId );
 	if ( ! run ) {
+		wdbg( 'run', 'answer (no run found)', { runId } );
 		return;
 	}
+	wdbg( 'run', 'answer', { runId, answers } );
 	run.process.answer( answers );
 }

--- a/apps/cli/web-server/debug.ts
+++ b/apps/cli/web-server/debug.ts
@@ -1,0 +1,14 @@
+// Lightweight diagnostic logging for the web-server, opt-in via
+// `STUDIO_WEB_DEBUG=1`. The server is a loopback-only dev backend, so logs go
+// straight to stderr. Useful while bringing up the hosted (SecEx) backend,
+// where the run streams from a remote sandbox and the failure modes aren't
+// visible in the browser.
+const ENABLED = process.env.STUDIO_WEB_DEBUG === '1' || process.env.STUDIO_WEB_DEBUG === 'true';
+
+export function wdbg( scope: string, ...args: unknown[] ): void {
+	if ( ! ENABLED ) {
+		return;
+	}
+
+	console.error( `[web-server:${ scope }]`, ...args );
+}

--- a/apps/cli/web-server/index.ts
+++ b/apps/cli/web-server/index.ts
@@ -374,17 +374,36 @@ api.post( '/sessions/:id/messages', ( req: Request, res: Response ) => {
 	res.json( { runId } );
 } );
 
+// The agent's site path inside the sandbox, remembered per session once seen.
+// A resume turn re-caches the session and can drop the `studio.site_selected`
+// entry, so we cache the first successful resolution and keep using it.
+const sandboxSitePaths = new Map< string, string >();
+
 // On the SecEx backend, the agent's site lives inside the sandbox; its path is
-// recorded in the session's most recent `studio.site_selected` entry. We resolve
-// it server-side so the browser never has to know sandbox internals. (On the
-// local backend there is no sandbox, so any such path is local and must NOT be
-// sent to `/export` — hence the backend gate.)
+// recorded in the session's `studio.site_selected` entry. We resolve it
+// server-side so the browser never has to know sandbox internals. (On the local
+// backend there is no sandbox, so any such path is local and must NOT be sent to
+// `/export` — hence the backend gate.)
 async function resolveSandboxSitePath( sessionId: string ): Promise< string | undefined > {
 	if ( process.env.STUDIO_WEB_BACKEND !== 'secex' ) {
 		return undefined;
 	}
+	const remembered = sandboxSitePaths.get( sessionId );
+	if ( remembered ) {
+		return remembered;
+	}
 	const { entries } = await loadAiSession( root, sessionId );
-	return resolveActiveSiteFromEntries( entries )?.path;
+	// Prefer the structured entry; fall back to any sandbox site path left in the
+	// transcript (survives a re-cache that dropped the structured entry).
+	const resolved =
+		resolveActiveSiteFromEntries( entries )?.path ??
+		JSON.stringify( entries )
+			.match( /\/home\/user\/Studio\/[A-Za-z0-9._-]+/g )
+			?.at( -1 );
+	if ( resolved ) {
+		sandboxSitePaths.set( sessionId, resolved );
+	}
+	return resolved;
 }
 
 // Serve the session's site from the broker (the desktop's Playground server runs

--- a/apps/cli/web-server/index.ts
+++ b/apps/cli/web-server/index.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isAiModelId } from '@studio/common/ai/models';
+import { resolveActiveSiteFromEntries } from '@studio/common/ai/sessions/active-site';
 import {
 	appendModelChangeEntry,
 	createAiSession,
@@ -28,11 +29,32 @@ import {
 } from './agent-runs';
 import { wdbg } from './debug';
 import { createSecexRuntime } from './secex-runtime';
-import { serveSiteForSession, syncSiteFromSandbox } from './site-server';
+import {
+	getServedSite,
+	listServedSites,
+	serveSiteForSession,
+	syncSiteFromSandbox,
+} from './site-server';
+import type { ServedSite } from './site-server';
 import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
 import type { SitesEndpointSite } from '@studio/common/types/sync';
 import type { Request, Response } from 'express';
+
+// A site the broker is currently serving, shaped as the UI's `SiteDetails`. It's
+// a real running WordPress (Playground in this Node process), so `running: true`
+// with a real `url`; the shared site-preview widget needs nothing more.
+function servedSiteToDetails( served: ServedSite ) {
+	return {
+		id: served.site.id,
+		name: served.site.name,
+		path: served.site.path,
+		port: served.site.port,
+		running: true,
+		url: served.url,
+		phpVersion: served.site.phpVersion,
+	};
+}
 
 /**
  * Studio Web's **local development backend**.
@@ -65,7 +87,18 @@ function hydrateAiSessionSummary(
 	summary: AiSessionSummary,
 	metadata?: Pick< AiSessionSummary, 'starred' | 'archived' >
 ): AiSessionSummary {
-	return { ...summary, starred: metadata?.starred, archived: metadata?.archived };
+	// Bind the session to the site the broker is serving for it, the same way the
+	// desktop binds via its placement record. The shared UI resolves the session's
+	// owner site by matching `ownerSitePath` against `getSites()` and renders the
+	// site-preview widget for it — so this binding is all Studio Web needs.
+	const served = getServedSite( summary.id );
+	return {
+		...summary,
+		starred: metadata?.starred,
+		archived: metadata?.archived,
+		ownerSitePath: served?.site.path ?? summary.ownerSitePath,
+		ownerSiteName: served?.site.name ?? summary.ownerSiteName,
+	};
 }
 
 const root = getAiSessionsRootDirectory();
@@ -135,16 +168,22 @@ api.get( '/events', ( req: Request, res: Response ) => {
 	} );
 } );
 
-// Broadcast every agent event to all connected SSE clients, in the same
-// envelope the web connector expects (channel + payload).
-setBroadcast( ( event: AgentRunEvent ) => {
+// Write one envelope (channel + payload) to every connected SSE client. The web
+// connector demultiplexes on `channel` — 'agent' for run events, 'placement' for
+// session→site bindings.
+function broadcastSse( envelope: { channel: string; payload: unknown } ): void {
 	if ( sseClients.size === 0 ) {
 		return;
 	}
-	const data = JSON.stringify( { channel: 'agent', payload: event } );
+	const data = JSON.stringify( envelope );
 	for ( const client of sseClients ) {
 		client.write( `data: ${ data }\n\n` );
 	}
+}
+
+// Broadcast every agent event to all connected SSE clients.
+setBroadcast( ( event: AgentRunEvent ) => {
+	broadcastSse( { channel: 'agent', payload: event } );
 } );
 
 // --- Health ------------------------------------------------------------------
@@ -179,10 +218,15 @@ const WPCOM_SITE_FIELDS = [
 api.get(
 	'/sites',
 	asyncHandler( async ( _req: Request, res: Response ) => {
+		// Sites the broker is actively serving (the agent's work, rendered by a real
+		// WordPress in this process). They're local to the broker, so they show up
+		// regardless of WordPress.com auth.
+		const brokerSites = listServedSites().map( servedSiteToDetails );
+
 		const token = await readAuthToken();
 		if ( ! token ) {
-			// Not signed in to WordPress.com — no sites to show.
-			res.json( [] );
+			// Not signed in to WordPress.com — only broker-served sites to show.
+			res.json( brokerSites );
 			return;
 		}
 
@@ -237,7 +281,8 @@ api.get(
 					siteIcon: site.icon?.img ?? null,
 				};
 			} );
-		res.json( sites );
+		// Broker-served sites first: they're the live preview of the current work.
+		res.json( [ ...brokerSites, ...sites ] );
 	} )
 );
 
@@ -329,17 +374,50 @@ api.post( '/sessions/:id/messages', ( req: Request, res: Response ) => {
 	res.json( { runId } );
 } );
 
+// On the SecEx backend, the agent's site lives inside the sandbox; its path is
+// recorded in the session's most recent `studio.site_selected` entry. We resolve
+// it server-side so the browser never has to know sandbox internals. (On the
+// local backend there is no sandbox, so any such path is local and must NOT be
+// sent to `/export` — hence the backend gate.)
+async function resolveSandboxSitePath( sessionId: string ): Promise< string | undefined > {
+	if ( process.env.STUDIO_WEB_BACKEND !== 'secex' ) {
+		return undefined;
+	}
+	const { entries } = await loadAiSession( root, sessionId );
+	return resolveActiveSiteFromEntries( entries )?.path;
+}
+
 // Serve the session's site from the broker (the desktop's Playground server runs
 // in Node, where PHP-WASM works) and return its URL for the browser to iframe.
-// With `sandboxSitePath`, first overlay the agent's site (theme via /export) so
-// the served WordPress reflects what the agent built in the sandbox.
+// When the agent built its site in a SecEx sandbox, first overlay that site
+// (theme via /export) so the served WordPress reflects what the agent built.
 api.post(
 	'/sessions/:id/preview',
 	asyncHandler( async ( req: Request, res: Response ) => {
-		const { sandboxSitePath } = req.body as { sandboxSitePath?: string };
+		const { sandboxSitePath: requestedPath } = req.body as { sandboxSitePath?: string };
+		const sandboxSitePath = requestedPath ?? ( await resolveSandboxSitePath( req.params.id ) );
 		const url = sandboxSitePath
 			? await syncSiteFromSandbox( req.params.id, sandboxSitePath )
 			: await serveSiteForSession( req.params.id );
+
+		// Tell any open UI the session is now bound to this site, so the shared
+		// site-preview widget can render it live without waiting for a refetch.
+		const served = getServedSite( req.params.id );
+		if ( served ) {
+			broadcastSse( {
+				channel: 'placement',
+				payload: {
+					sessionId: req.params.id,
+					placement: {
+						kind: 'site',
+						siteId: served.site.id,
+						sitePath: served.site.path,
+						siteName: served.site.name,
+					},
+				},
+			} );
+		}
+
 		res.json( { url } );
 	} )
 );

--- a/apps/cli/web-server/index.ts
+++ b/apps/cli/web-server/index.ts
@@ -388,22 +388,22 @@ async function resolveSandboxSitePath( sessionId: string ): Promise< string | un
 	if ( process.env.STUDIO_WEB_BACKEND !== 'secex' ) {
 		return undefined;
 	}
-	const remembered = sandboxSitePaths.get( sessionId );
-	if ( remembered ) {
-		return remembered;
-	}
 	const { entries } = await loadAiSession( root, sessionId );
 	// Prefer the structured entry; fall back to any sandbox site path left in the
-	// transcript (survives a re-cache that dropped the structured entry).
+	// transcript.
 	const resolved =
 		resolveActiveSiteFromEntries( entries )?.path ??
 		JSON.stringify( entries )
 			.match( /\/home\/user\/Studio\/[A-Za-z0-9._-]+/g )
 			?.at( -1 );
 	if ( resolved ) {
+		// Always prefer the latest active site — the agent can switch sites within
+		// a session, so a fresh `studio.site_selected` wins over what we cached.
 		sandboxSitePaths.set( sessionId, resolved );
+		return resolved;
 	}
-	return resolved;
+	// A re-cache can drop the structured entry; fall back to the last one we saw.
+	return sandboxSitePaths.get( sessionId );
 }
 
 // Serve the session's site from the broker (the desktop's Playground server runs

--- a/apps/cli/web-server/index.ts
+++ b/apps/cli/web-server/index.ts
@@ -28,7 +28,7 @@ import {
 } from './agent-runs';
 import { wdbg } from './debug';
 import { createSecexRuntime } from './secex-runtime';
-import { serveSiteForSession } from './site-server';
+import { serveSiteForSession, syncSiteFromSandbox } from './site-server';
 import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
 import type { SitesEndpointSite } from '@studio/common/types/sync';
@@ -331,10 +331,15 @@ api.post( '/sessions/:id/messages', ( req: Request, res: Response ) => {
 
 // Serve the session's site from the broker (the desktop's Playground server runs
 // in Node, where PHP-WASM works) and return its URL for the browser to iframe.
+// With `sandboxSitePath`, first overlay the agent's site (theme via /export) so
+// the served WordPress reflects what the agent built in the sandbox.
 api.post(
 	'/sessions/:id/preview',
 	asyncHandler( async ( req: Request, res: Response ) => {
-		const url = await serveSiteForSession( req.params.id );
+		const { sandboxSitePath } = req.body as { sandboxSitePath?: string };
+		const url = sandboxSitePath
+			? await syncSiteFromSandbox( req.params.id, sandboxSitePath )
+			: await serveSiteForSession( req.params.id );
 		res.json( { url } );
 	} )
 );

--- a/apps/cli/web-server/index.ts
+++ b/apps/cli/web-server/index.ts
@@ -22,9 +22,11 @@ import {
 	answerAgentRun,
 	interruptAgentRun,
 	listActiveAgentRuns,
+	setAgentRuntime,
 	setBroadcast,
 	startAgentRun,
 } from './agent-runs';
+import { createSecexRuntime } from './secex-runtime';
 import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
 import type { SitesEndpointSite } from '@studio/common/types/sync';
@@ -65,6 +67,14 @@ function hydrateAiSessionSummary(
 }
 
 const root = getAiSessionsRootDirectory();
+
+// Where the agent runs. Default: a local child process (this dev backend). Set
+// `STUDIO_WEB_BACKEND=secex` to run it in a hosted SecEx sandbox via the wpcom
+// `studio-code` endpoint instead — the run-manager and the browser don't change.
+if ( process.env.STUDIO_WEB_BACKEND === 'secex' ) {
+	setAgentRuntime( createSecexRuntime( { runUrl: process.env.STUDIO_SECEX_RUN_URL } ) );
+}
+
 const app = express();
 // All API routes live under `/api` so they can't collide with the SPA's
 // real-path routes (`/sessions/:id` is both an app URL and an API resource).

--- a/apps/cli/web-server/index.ts
+++ b/apps/cli/web-server/index.ts
@@ -26,6 +26,7 @@ import {
 	setBroadcast,
 	startAgentRun,
 } from './agent-runs';
+import { wdbg } from './debug';
 import { createSecexRuntime } from './secex-runtime';
 import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
@@ -272,6 +273,10 @@ api.get(
 			loadAiSession( root, req.params.id ),
 			readSharedSessions(),
 		] );
+		wdbg( 'session', 'getSession', {
+			id: req.params.id,
+			entries: Array.isArray( loaded.entries ) ? loaded.entries.length : 'n/a',
+		} );
 		res.json( {
 			...loaded,
 			summary: hydrateAiSessionSummary( loaded.summary, sessionMetadata[ loaded.summary.id ] ),
@@ -318,6 +323,7 @@ api.post( '/sessions/:id/messages', ( req: Request, res: Response ) => {
 		res.status( 400 ).json( { error: 'prompt is required' } );
 		return;
 	}
+	wdbg( 'session', 'message', { id: req.params.id, prompt: prompt.slice( 0, 80 ) } );
 	const { runId } = startAgentRun( { sessionId: req.params.id, prompt, displayMessage } );
 	res.json( { runId } );
 } );

--- a/apps/cli/web-server/index.ts
+++ b/apps/cli/web-server/index.ts
@@ -28,6 +28,7 @@ import {
 } from './agent-runs';
 import { wdbg } from './debug';
 import { createSecexRuntime } from './secex-runtime';
+import { serveSiteForSession } from './site-server';
 import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { AiSessionSummary } from '@studio/common/ai/sessions/types';
 import type { SitesEndpointSite } from '@studio/common/types/sync';
@@ -327,6 +328,16 @@ api.post( '/sessions/:id/messages', ( req: Request, res: Response ) => {
 	const { runId } = startAgentRun( { sessionId: req.params.id, prompt, displayMessage } );
 	res.json( { runId } );
 } );
+
+// Serve the session's site from the broker (the desktop's Playground server runs
+// in Node, where PHP-WASM works) and return its URL for the browser to iframe.
+api.post(
+	'/sessions/:id/preview',
+	asyncHandler( async ( req: Request, res: Response ) => {
+		const url = await serveSiteForSession( req.params.id );
+		res.json( { url } );
+	} )
+);
 
 // --- Runs --------------------------------------------------------------------
 

--- a/apps/cli/web-server/index.ts
+++ b/apps/cli/web-server/index.ts
@@ -389,20 +389,19 @@ async function resolveSandboxSitePath( sessionId: string ): Promise< string | un
 		return undefined;
 	}
 	const { entries } = await loadAiSession( root, sessionId );
-	// Prefer the structured entry; fall back to any sandbox site path left in the
-	// transcript.
-	const resolved =
-		resolveActiveSiteFromEntries( entries )?.path ??
-		JSON.stringify( entries )
-			.match( /\/home\/user\/Studio\/[A-Za-z0-9._-]+/g )
-			?.at( -1 );
+	// Only the structured `studio.site_selected` is authoritative — scanning the
+	// transcript for any `/home/user/Studio/...` path would wrongly latch onto
+	// sites mentioned in tool output (e.g. a `site list`) that the agent isn't
+	// working on.
+	const resolved = resolveActiveSiteFromEntries( entries )?.path;
 	if ( resolved ) {
 		// Always prefer the latest active site — the agent can switch sites within
 		// a session, so a fresh `studio.site_selected` wins over what we cached.
 		sandboxSitePaths.set( sessionId, resolved );
 		return resolved;
 	}
-	// A re-cache can drop the structured entry; fall back to the last one we saw.
+	// The entry can be momentarily absent mid-stream; fall back to the last site
+	// we resolved for this session (kept warm in memory by the daemon).
 	return sandboxSitePaths.get( sessionId );
 }
 

--- a/apps/cli/web-server/secex-runtime.ts
+++ b/apps/cli/web-server/secex-runtime.ts
@@ -210,12 +210,25 @@ export function createSecexRuntime( {
 	};
 }
 
+// True when a JSONL line is the session header (`{"type":"session",...}`).
+function isSessionHeaderLine( line: string ): boolean {
+	try {
+		return 'session' === ( JSON.parse( line ) as { type?: string } ).type;
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Cache the sandbox's canonical session JSONL into the broker's local session
  * store, so the web-server's own `getSession` returns the conversation that ran
- * remotely (the sandbox snapshot remains the source of truth). The sandbox file
- * headers the session with the SDK's id; rewrite it to the web-server session id
- * so `loadAiSession` resolves the cache by the id the browser already uses.
+ * remotely (the sandbox snapshot remains the source of truth).
+ *
+ * The local file (from createAiSession) is headed with a `session` line carrying
+ * the web-server session id — the id getSession resolves by. The sandbox JSONL
+ * holds only the SDK's conversation entries (no such header). So we KEEP the
+ * local header and replace the body with the sandbox's entries, rather than
+ * overwriting (which would drop the id and break resolution).
  *
  * @param webSessionId The web-server session id (what the browser holds).
  * @param jsonl        The canonical session JSONL read from the sandbox.
@@ -227,20 +240,15 @@ async function cacheSandboxSession( webSessionId: string, jsonl: string ): Promi
 	// by createAiSession). If it's gone, there's nothing to cache into.
 	const { summary } = await loadAiSession( root, webSessionId );
 
-	const lines = jsonl.split( '\n' );
-	if ( lines.length > 0 ) {
-		try {
-			const header = JSON.parse( lines[ 0 ] ) as { type?: string; id?: string };
-			if ( 'session' === header.type ) {
-				header.id = webSessionId;
-				lines[ 0 ] = JSON.stringify( header );
-			}
-		} catch {
-			// Header isn't JSON; leave the snapshot untouched.
-		}
-	}
+	const existing = await fs.readFile( summary.filePath, 'utf8' );
+	const header = existing.split( '\n' ).find( isSessionHeaderLine );
 
-	await fs.writeFile( summary.filePath, lines.join( '\n' ) + '\n', 'utf8' );
+	const body = jsonl
+		.split( '\n' )
+		.filter( ( line ) => line.trim() && ! isSessionHeaderLine( line ) );
+
+	const out = [ header, ...body ].filter( Boolean ).join( '\n' ) + '\n';
+	await fs.writeFile( summary.filePath, out, 'utf8' );
 }
 
 /**

--- a/apps/cli/web-server/secex-runtime.ts
+++ b/apps/cli/web-server/secex-runtime.ts
@@ -273,7 +273,7 @@ async function cacheSandboxSession( webSessionId: string, jsonl: string ): Promi
 
 	// Resolve the local file the browser's session id maps to (created up front
 	// by createAiSession). If it's gone, there's nothing to cache into.
-	const { summary } = await loadAiSession( root, webSessionId );
+	const { summary, entries: cached } = await loadAiSession( root, webSessionId );
 
 	const lines = jsonl.split( '\n' ).filter( ( line ) => line.trim() );
 	if ( 0 === lines.length ) {
@@ -296,6 +296,16 @@ async function cacheSandboxSession( webSessionId: string, jsonl: string ): Promi
 			header.id = webSessionId;
 			break;
 		}
+	}
+
+	// Never let a lagging run-boundary snapshot shrink the cached conversation —
+	// overwriting with fewer entries makes the UI jump back to an earlier state.
+	if ( Array.isArray( cached ) && entries.length < cached.length ) {
+		wdbg( 'secex', 'skip stale session snapshot', {
+			incoming: entries.length,
+			cached: cached.length,
+		} );
+		return;
 	}
 
 	const out = entries.map( ( entry ) => JSON.stringify( entry ) ).join( '\n' ) + '\n';

--- a/apps/cli/web-server/secex-runtime.ts
+++ b/apps/cli/web-server/secex-runtime.ts
@@ -116,6 +116,10 @@ export function createSecexRuntime( {
 
 				let paused = false;
 				let errored = false;
+				// The session cache write must finish before this turn resolves, so
+				// the run-end `getSession` the UI fires doesn't read a half-written
+				// file. Captured here and awaited after the stream drains.
+				let cacheWrite: Promise< void > | undefined;
 
 				await readSse( response.body, ( event, data ) => {
 					if ( event === 'data' ) {
@@ -146,13 +150,21 @@ export function createSecexRuntime( {
 						const payload = data as { jsonl?: string };
 						if ( typeof payload.jsonl === 'string' && payload.jsonl ) {
 							wdbg( 'secex', 'session snapshot', { bytes: payload.jsonl.length } );
-							void cacheSandboxSession( sessionId, payload.jsonl ).catch( ( cacheError ) => {
-								wdbg( 'secex', 'session cache failed', { error: String( cacheError ) } );
-							} );
+							cacheWrite = cacheSandboxSession( sessionId, payload.jsonl ).catch(
+								( cacheError ) => {
+									wdbg( 'secex', 'session cache failed', { error: String( cacheError ) } );
+								}
+							);
 						}
 					}
 					// 'done' just marks the end of the stream; the loop ends on its own.
 				} );
+
+				// Finish persisting the cache before the turn resolves and onExit
+				// triggers the UI's getSession refetch.
+				if ( cacheWrite ) {
+					await cacheWrite;
+				}
 
 				return { done: ! paused, code: errored ? 1 : 0 };
 			};

--- a/apps/cli/web-server/secex-runtime.ts
+++ b/apps/cli/web-server/secex-runtime.ts
@@ -1,4 +1,8 @@
+import fs from 'node:fs/promises';
+import { loadAiSession } from '@studio/common/ai/sessions/store';
 import { readAuthToken } from '@studio/common/lib/shared-config';
+import { getAiSessionsRootDirectory } from 'cli/ai/sessions/paths';
+import { wdbg } from './debug';
 import type { AgentProcess, AgentProcessOptions, AgentRuntime } from './runtime';
 import type { JsonEvent } from '@studio/common/ai/json-events';
 
@@ -74,6 +78,13 @@ export function createSecexRuntime( {
 					return { done: true, code: 1 };
 				}
 
+				const resumeId = cliSessionIds.get( sessionId );
+				wdbg( 'secex', 'POST /run', {
+					runUrl,
+					resume: resumeId ?? '(new)',
+					message: message.slice( 0, 80 ),
+				} );
+
 				const response = await fetch( runUrl, {
 					method: 'POST',
 					signal: controller.signal,
@@ -84,9 +95,11 @@ export function createSecexRuntime( {
 					},
 					body: JSON.stringify( {
 						prompt: message,
-						session_id: cliSessionIds.get( sessionId ),
+						session_id: resumeId,
 					} ),
 				} );
+
+				wdbg( 'secex', 'response', { status: response.status, ok: response.ok } );
 
 				if ( ! response.ok || ! response.body ) {
 					const text = await response.text().catch( () => '' );
@@ -113,12 +126,28 @@ export function createSecexRuntime( {
 							// asked a question and is waiting for the next message.
 							paused = jsonEvent.status === 'paused';
 							errored = jsonEvent.status === 'error';
+							wdbg( 'secex', 'turn.completed', {
+								status: jsonEvent.status,
+								cliSessionId: jsonEvent.sessionId,
+							} );
 						}
 						onEvent( jsonEvent );
 					} else if ( event === 'error' ) {
 						errored = true;
 						const payload = data as { message?: string; stderr?: string };
 						onError( payload.message ?? payload.stderr ?? 'studio-code run error' );
+					} else if ( event === 'session' ) {
+						// The endpoint's run-boundary sync: the canonical session
+						// JSONL from the sandbox. Cache it locally so the broker's own
+						// getSession returns the conversation (the sandbox stays the
+						// source of truth). Fire-and-forget; never blocks the stream.
+						const payload = data as { jsonl?: string };
+						if ( typeof payload.jsonl === 'string' && payload.jsonl ) {
+							wdbg( 'secex', 'session snapshot', { bytes: payload.jsonl.length } );
+							void cacheSandboxSession( sessionId, payload.jsonl ).catch( ( cacheError ) => {
+								wdbg( 'secex', 'session cache failed', { error: String( cacheError ) } );
+							} );
+						}
 					}
 					// 'done' just marks the end of the stream; the loop ends on its own.
 				} );
@@ -138,11 +167,15 @@ export function createSecexRuntime( {
 					} )
 					.then( ( result ) => {
 						if ( controller.signal.aborted ) {
+							wdbg( 'secex', 'drive: aborted' );
 							connected = false;
 							onExit( null );
 						} else if ( result.done ) {
+							wdbg( 'secex', 'drive: done', { code: result.code } );
 							connected = false;
 							onExit( result.code );
+						} else {
+							wdbg( 'secex', 'drive: paused (awaiting answer)' );
 						}
 						// Paused: stay connected; answer() will resume.
 					} );
@@ -167,6 +200,7 @@ export function createSecexRuntime( {
 					// The agent paused on a question; the user's choice resumes the
 					// conversation as the next message on the same sandbox session.
 					const message = Object.values( answers ).join( '\n' ).trim();
+					wdbg( 'secex', 'answer', { answers, message: message.slice( 0, 80 ) } );
 					if ( message ) {
 						drive( message );
 					}
@@ -174,6 +208,39 @@ export function createSecexRuntime( {
 			};
 		},
 	};
+}
+
+/**
+ * Cache the sandbox's canonical session JSONL into the broker's local session
+ * store, so the web-server's own `getSession` returns the conversation that ran
+ * remotely (the sandbox snapshot remains the source of truth). The sandbox file
+ * headers the session with the SDK's id; rewrite it to the web-server session id
+ * so `loadAiSession` resolves the cache by the id the browser already uses.
+ *
+ * @param webSessionId The web-server session id (what the browser holds).
+ * @param jsonl        The canonical session JSONL read from the sandbox.
+ */
+async function cacheSandboxSession( webSessionId: string, jsonl: string ): Promise< void > {
+	const root = getAiSessionsRootDirectory();
+
+	// Resolve the local file the browser's session id maps to (created up front
+	// by createAiSession). If it's gone, there's nothing to cache into.
+	const { summary } = await loadAiSession( root, webSessionId );
+
+	const lines = jsonl.split( '\n' );
+	if ( lines.length > 0 ) {
+		try {
+			const header = JSON.parse( lines[ 0 ] ) as { type?: string; id?: string };
+			if ( 'session' === header.type ) {
+				header.id = webSessionId;
+				lines[ 0 ] = JSON.stringify( header );
+			}
+		} catch {
+			// Header isn't JSON; leave the snapshot untouched.
+		}
+	}
+
+	await fs.writeFile( summary.filePath, lines.join( '\n' ) + '\n', 'utf8' );
 }
 
 /**

--- a/apps/cli/web-server/secex-runtime.ts
+++ b/apps/cli/web-server/secex-runtime.ts
@@ -142,6 +142,13 @@ export function createSecexRuntime( {
 								status: jsonEvent.status,
 								cliSessionId: jsonEvent.sessionId,
 							} );
+							// Don't surface a paused completion to the UI: the agent is
+							// waiting on an answer, and a `turn.completed` there would
+							// clear the just-asked question and make its answer options
+							// non-interactive. The `question.asked` event already drove it.
+							if ( paused ) {
+								return;
+							}
 						}
 						onEvent( jsonEvent );
 					} else if ( event === 'error' ) {

--- a/apps/cli/web-server/secex-runtime.ts
+++ b/apps/cli/web-server/secex-runtime.ts
@@ -87,7 +87,7 @@ export function createSecexRuntime( {
 					message: message.slice( 0, 80 ),
 				} );
 
-				const response = await fetch( runUrl, {
+				const requestInit: RequestInit = {
 					method: 'POST',
 					signal: controller.signal,
 					headers: {
@@ -99,7 +99,17 @@ export function createSecexRuntime( {
 						prompt: message,
 						session_id: resumeId,
 					} ),
-				} );
+				};
+
+				// The endpoint holds a per-user run lock; the just-ended turn's lock
+				// can linger briefly, so resuming right after answering a question may
+				// 429. Back off and retry a few times before giving up.
+				let response = await fetch( runUrl, requestInit );
+				for ( let attempt = 0; response.status === 429 && attempt < 6; attempt++ ) {
+					wdbg( 'secex', 'run busy (429) — backing off', { attempt } );
+					await new Promise( ( resolve ) => setTimeout( resolve, 3000 ) );
+					response = await fetch( runUrl, requestInit );
+				}
 
 				wdbg( 'secex', 'response', { status: response.status, ok: response.ok } );
 

--- a/apps/cli/web-server/secex-runtime.ts
+++ b/apps/cli/web-server/secex-runtime.ts
@@ -1,0 +1,192 @@
+import { readAuthToken } from '@studio/common/lib/shared-config';
+import type { AgentProcess, AgentProcessOptions, AgentRuntime } from './runtime';
+import type { JsonEvent } from '@studio/common/ai/json-events';
+
+/**
+ * Runs the agent inside a hosted SecEx sandbox by driving the wpcom
+ * `studio-code` endpoint (Automattic/wpcom: `POST /wpcom/v2/studio-code/run`).
+ * The endpoint runs `studio code --json <prompt>` in a per-user sandbox and
+ * streams the CLI's events back over SSE; this runtime relays them through the
+ * same {@link AgentRuntime} callbacks the local runtime uses, so the run-manager
+ * and the browser don't change.
+ *
+ * One sandbox per user (the endpoint resolves it from the caller's token), the
+ * cloud analog of "your laptop" — the same `~/Studio/` sites and `~/.claude`
+ * sessions live inside it, like the desktop app.
+ *
+ * Opt-in: the web-server only installs this runtime when `STUDIO_WEB_BACKEND=secex`,
+ * so the default (local child process) path is untouched.
+ */
+
+const DEFAULT_RUN_URL = 'https://public-api.wordpress.com/wpcom/v2/studio-code/run';
+
+// Maps our web-server session id to the CLI `session_id` the endpoint returns,
+// so the next turn resumes the same conversation in the sandbox.
+const cliSessionIds = new Map< string, string >();
+
+export interface SecexRuntimeOptions {
+	// The studio-code `/run` endpoint. Override for sandboxes / testing.
+	runUrl?: string;
+}
+
+export function createSecexRuntime( {
+	runUrl = DEFAULT_RUN_URL,
+}: SecexRuntimeOptions = {} ): AgentRuntime {
+	return {
+		start( {
+			sessionId,
+			prompt,
+			onSpawn,
+			onEvent,
+			onError,
+			onExit,
+		}: AgentProcessOptions ): AgentProcess {
+			const controller = new AbortController();
+			let open = true;
+
+			void runTurn( {
+				runUrl,
+				sessionId,
+				prompt,
+				signal: controller.signal,
+				onSpawn,
+				onEvent,
+				onError,
+			} )
+				.catch( ( error ) => {
+					if ( ! controller.signal.aborted ) {
+						onError( error instanceof Error ? error.message : String( error ) );
+					}
+					return { code: 1 };
+				} )
+				.then( ( result ) => {
+					open = false;
+					onExit( controller.signal.aborted ? null : result.code );
+				} );
+
+			return {
+				get connected() {
+					return open;
+				},
+				interrupt() {
+					// The endpoint has no interrupt route; closing the stream makes it
+					// kill the CLI in the sandbox (and still snapshot partial state).
+					controller.abort();
+				},
+				kill() {
+					controller.abort();
+				},
+				answer() {
+					// No-op: the endpoint runs `studio code --json` with --auto-approve,
+					// so the agent never blocks waiting for an answer.
+				},
+			};
+		},
+	};
+}
+
+interface RunTurnArgs {
+	runUrl: string;
+	sessionId: string;
+	prompt: string;
+	signal: AbortSignal;
+	onSpawn: () => void;
+	onEvent: ( event: JsonEvent ) => void;
+	onError: ( message: string ) => void;
+}
+
+async function runTurn( args: RunTurnArgs ): Promise< { code: number } > {
+	const { runUrl, sessionId, prompt, signal, onSpawn, onEvent, onError } = args;
+
+	const token = await readAuthToken().catch( () => null );
+	if ( ! token ) {
+		onError( 'Not signed in to WordPress.com — run `studio auth login` first.' );
+		return { code: 1 };
+	}
+
+	const response = await fetch( runUrl, {
+		method: 'POST',
+		signal,
+		headers: {
+			Authorization: `Bearer ${ token.accessToken }`,
+			'X-WPCOM-AI-Feature': 'studio-code',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify( { prompt, session_id: cliSessionIds.get( sessionId ) } ),
+	} );
+
+	if ( ! response.ok || ! response.body ) {
+		const text = await response.text().catch( () => '' );
+		onError( `studio-code /run failed (${ response.status }): ${ text }` );
+		return { code: 1 };
+	}
+
+	onSpawn();
+
+	let errored = false;
+	await readSse( response.body, ( event, data ) => {
+		if ( event === 'session' ) {
+			const id = ( data as { session_id?: string } ).session_id;
+			if ( id ) {
+				cliSessionIds.set( sessionId, id );
+			}
+		} else if ( event === 'data' ) {
+			onEvent( data as JsonEvent );
+		} else if ( event === 'error' ) {
+			errored = true;
+			const payload = data as { message?: string; stderr?: string };
+			onError( payload.message ?? payload.stderr ?? 'studio-code run error' );
+		}
+		// 'done' just marks the end of the stream; the loop ends on its own.
+	} );
+
+	return { code: errored ? 1 : 0 };
+}
+
+/**
+ * Reads a Server-Sent Events stream of named events (`event:` + `data:` lines,
+ * frames separated by a blank line), parsing each frame's `data` as JSON. The
+ * `studio-code` endpoint emits one JSON payload per frame, so frames don't need
+ * reassembly beyond joining multi-line `data:` fields.
+ */
+async function readSse(
+	body: ReadableStream< Uint8Array >,
+	onFrame: ( event: string, data: unknown ) => void
+): Promise< void > {
+	const reader = body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+	try {
+		for (;;) {
+			const { value, done } = await reader.read();
+			if ( done ) {
+				break;
+			}
+			buffer += decoder.decode( value, { stream: true } );
+			let sep: number;
+			while ( ( sep = buffer.indexOf( '\n\n' ) ) !== -1 ) {
+				const frame = buffer.slice( 0, sep );
+				buffer = buffer.slice( sep + 2 );
+				let event = 'message';
+				const dataLines: string[] = [];
+				for ( const line of frame.split( '\n' ) ) {
+					if ( line.startsWith( 'event:' ) ) {
+						event = line.slice( 6 ).trim();
+					} else if ( line.startsWith( 'data:' ) ) {
+						dataLines.push( line.slice( 5 ).replace( /^ /, '' ) );
+					}
+				}
+				if ( dataLines.length === 0 ) {
+					continue;
+				}
+				try {
+					onFrame( event, JSON.parse( dataLines.join( '\n' ) ) );
+				} catch {
+					// Ignore malformed frames.
+				}
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}

--- a/apps/cli/web-server/secex-runtime.ts
+++ b/apps/cli/web-server/secex-runtime.ts
@@ -5,14 +5,22 @@ import type { JsonEvent } from '@studio/common/ai/json-events';
 /**
  * Runs the agent inside a hosted SecEx sandbox by driving the wpcom
  * `studio-code` endpoint (Automattic/wpcom: `POST /wpcom/v2/studio-code/run`).
- * The endpoint runs `studio code --json <prompt>` in a per-user sandbox and
- * streams the CLI's events back over SSE; this runtime relays them through the
- * same {@link AgentRuntime} callbacks the local runtime uses, so the run-manager
- * and the browser don't change.
+ * The endpoint runs `studio code --json` in a per-user sandbox and streams the
+ * CLI's events back over SSE; this runtime relays them through the same
+ * {@link AgentRuntime} callbacks the local runtime uses, so the run-manager and
+ * the browser don't change.
  *
  * One sandbox per user (the endpoint resolves it from the caller's token), the
  * cloud analog of "your laptop" — the same `~/Studio/` sites and `~/.claude`
  * sessions live inside it, like the desktop app.
+ *
+ * Interactive questions work like the desktop, despite there being no live
+ * process to answer: when a turn pauses on a question, the CLI ends the turn
+ * with `status: 'paused'`; the agent process here stays "connected" rather than
+ * exiting, and a later {@link AgentProcess.answer} re-drives the endpoint with
+ * the user's choice as the next message on the same sandbox session (the proven
+ * headless resume pattern — see apps/cli/remote-session/turn-runner.ts). The
+ * web-server and UI see an ordinary live run that asks and gets answered.
  *
  * Opt-in: the web-server only installs this runtime when `STUDIO_WEB_BACKEND=secex`,
  * so the default (local child process) path is untouched.
@@ -20,13 +28,23 @@ import type { JsonEvent } from '@studio/common/ai/json-events';
 
 const DEFAULT_RUN_URL = 'https://public-api.wordpress.com/wpcom/v2/studio-code/run';
 
-// Maps our web-server session id to the CLI `session_id` the endpoint returns,
-// so the next turn resumes the same conversation in the sandbox.
+// Maps the web-server session id to the CLI/SDK session id the endpoint reports
+// (via `turn.completed.sessionId`), so the next message resumes the same
+// conversation in the sandbox.
 const cliSessionIds = new Map< string, string >();
 
 export interface SecexRuntimeOptions {
 	// The studio-code `/run` endpoint. Override for sandboxes / testing.
 	runUrl?: string;
+}
+
+// Outcome of one turn (one `/run` request/stream).
+interface TurnResult {
+	// True when the turn reached a terminal state (the agent is done for now);
+	// false when it paused on a question and is waiting for an answer.
+	done: boolean;
+	// Exit code for terminal turns. Ignored while paused.
+	code: number;
 }
 
 export function createSecexRuntime( {
@@ -41,106 +59,121 @@ export function createSecexRuntime( {
 			onError,
 			onExit,
 		}: AgentProcessOptions ): AgentProcess {
-			const controller = new AbortController();
-			let open = true;
+			let controller = new AbortController();
+			let connected = true;
+			let spawned = false;
 
-			void runTurn( {
-				runUrl,
-				sessionId,
-				prompt,
-				signal: controller.signal,
-				onSpawn,
-				onEvent,
-				onError,
-			} )
-				.catch( ( error ) => {
-					if ( ! controller.signal.aborted ) {
-						onError( error instanceof Error ? error.message : String( error ) );
-					}
-					return { code: 1 };
-				} )
-				.then( ( result ) => {
-					open = false;
-					onExit( controller.signal.aborted ? null : result.code );
+			// Run a single turn against the endpoint and report whether it ended
+			// terminally or paused on a question.
+			const runTurn = async ( message: string ): Promise< TurnResult > => {
+				controller = new AbortController();
+
+				const token = await readAuthToken().catch( () => null );
+				if ( ! token ) {
+					onError( 'Not signed in to WordPress.com — run `studio auth login` first.' );
+					return { done: true, code: 1 };
+				}
+
+				const response = await fetch( runUrl, {
+					method: 'POST',
+					signal: controller.signal,
+					headers: {
+						Authorization: `Bearer ${ token.accessToken }`,
+						'X-WPCOM-AI-Feature': 'studio-code',
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify( {
+						prompt: message,
+						session_id: cliSessionIds.get( sessionId ),
+					} ),
 				} );
+
+				if ( ! response.ok || ! response.body ) {
+					const text = await response.text().catch( () => '' );
+					onError( `studio-code /run failed (${ response.status }): ${ text }` );
+					return { done: true, code: 1 };
+				}
+
+				if ( ! spawned ) {
+					spawned = true;
+					onSpawn();
+				}
+
+				let paused = false;
+				let errored = false;
+
+				await readSse( response.body, ( event, data ) => {
+					if ( event === 'data' ) {
+						const jsonEvent = data as JsonEvent;
+						if ( jsonEvent.type === 'turn.completed' ) {
+							if ( jsonEvent.sessionId ) {
+								cliSessionIds.set( sessionId, jsonEvent.sessionId );
+							}
+							// A paused turn isn't an error or an ending — the agent
+							// asked a question and is waiting for the next message.
+							paused = jsonEvent.status === 'paused';
+							errored = jsonEvent.status === 'error';
+						}
+						onEvent( jsonEvent );
+					} else if ( event === 'error' ) {
+						errored = true;
+						const payload = data as { message?: string; stderr?: string };
+						onError( payload.message ?? payload.stderr ?? 'studio-code run error' );
+					}
+					// 'done' just marks the end of the stream; the loop ends on its own.
+				} );
+
+				return { done: ! paused, code: errored ? 1 : 0 };
+			};
+
+			// Drive one turn; exit only when it ends terminally. While paused we
+			// stay connected and wait for answer() to drive the next turn.
+			const drive = ( message: string ): void => {
+				void runTurn( message )
+					.catch( ( error ): TurnResult => {
+						if ( ! controller.signal.aborted ) {
+							onError( error instanceof Error ? error.message : String( error ) );
+						}
+						return { done: true, code: 1 };
+					} )
+					.then( ( result ) => {
+						if ( controller.signal.aborted ) {
+							connected = false;
+							onExit( null );
+						} else if ( result.done ) {
+							connected = false;
+							onExit( result.code );
+						}
+						// Paused: stay connected; answer() will resume.
+					} );
+			};
+
+			drive( prompt );
 
 			return {
 				get connected() {
-					return open;
+					return connected;
 				},
 				interrupt() {
-					// The endpoint has no interrupt route; closing the stream makes it
-					// kill the CLI in the sandbox (and still snapshot partial state).
+					// No interrupt route on the endpoint; aborting the stream makes
+					// the sandbox kill the CLI (and still snapshot partial state).
 					controller.abort();
 				},
 				kill() {
+					connected = false;
 					controller.abort();
 				},
-				answer() {
-					// No-op: the endpoint runs `studio code --json` with --auto-approve,
-					// so the agent never blocks waiting for an answer.
+				answer( answers: Record< string, string > ) {
+					// The agent paused on a question; the user's choice resumes the
+					// conversation as the next message on the same sandbox session.
+					const message = Object.values( answers ).join( '\n' ).trim();
+					if ( message ) {
+						drive( message );
+					}
 				},
 			};
 		},
 	};
-}
-
-interface RunTurnArgs {
-	runUrl: string;
-	sessionId: string;
-	prompt: string;
-	signal: AbortSignal;
-	onSpawn: () => void;
-	onEvent: ( event: JsonEvent ) => void;
-	onError: ( message: string ) => void;
-}
-
-async function runTurn( args: RunTurnArgs ): Promise< { code: number } > {
-	const { runUrl, sessionId, prompt, signal, onSpawn, onEvent, onError } = args;
-
-	const token = await readAuthToken().catch( () => null );
-	if ( ! token ) {
-		onError( 'Not signed in to WordPress.com — run `studio auth login` first.' );
-		return { code: 1 };
-	}
-
-	const response = await fetch( runUrl, {
-		method: 'POST',
-		signal,
-		headers: {
-			Authorization: `Bearer ${ token.accessToken }`,
-			'X-WPCOM-AI-Feature': 'studio-code',
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify( { prompt, session_id: cliSessionIds.get( sessionId ) } ),
-	} );
-
-	if ( ! response.ok || ! response.body ) {
-		const text = await response.text().catch( () => '' );
-		onError( `studio-code /run failed (${ response.status }): ${ text }` );
-		return { code: 1 };
-	}
-
-	onSpawn();
-
-	let errored = false;
-	await readSse( response.body, ( event, data ) => {
-		if ( event === 'session' ) {
-			const id = ( data as { session_id?: string } ).session_id;
-			if ( id ) {
-				cliSessionIds.set( sessionId, id );
-			}
-		} else if ( event === 'data' ) {
-			onEvent( data as JsonEvent );
-		} else if ( event === 'error' ) {
-			errored = true;
-			const payload = data as { message?: string; stderr?: string };
-			onError( payload.message ?? payload.stderr ?? 'studio-code run error' );
-		}
-		// 'done' just marks the end of the stream; the loop ends on its own.
-	} );
-
-	return { code: errored ? 1 : 0 };
 }
 
 /**

--- a/apps/cli/web-server/secex-runtime.ts
+++ b/apps/cli/web-server/secex-runtime.ts
@@ -1,9 +1,11 @@
 import fs from 'node:fs/promises';
+import { detectSessionFormat, migrateLegacyEvents } from '@studio/common/ai/sessions/migration';
 import { loadAiSession } from '@studio/common/ai/sessions/store';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import { getAiSessionsRootDirectory } from 'cli/ai/sessions/paths';
 import { wdbg } from './debug';
 import type { AgentProcess, AgentProcessOptions, AgentRuntime } from './runtime';
+import type { SessionEntry } from '@earendil-works/pi-coding-agent';
 import type { JsonEvent } from '@studio/common/ai/json-events';
 
 /**
@@ -210,25 +212,16 @@ export function createSecexRuntime( {
 	};
 }
 
-// True when a JSONL line is the session header (`{"type":"session",...}`).
-function isSessionHeaderLine( line: string ): boolean {
-	try {
-		return 'session' === ( JSON.parse( line ) as { type?: string } ).type;
-	} catch {
-		return false;
-	}
-}
-
 /**
- * Cache the sandbox's canonical session JSONL into the broker's local session
- * store, so the web-server's own `getSession` returns the conversation that ran
+ * Cache the sandbox's canonical session into the broker's local session store,
+ * so the web-server's own `getSession` returns the conversation that ran
  * remotely (the sandbox snapshot remains the source of truth).
  *
- * The local file (from createAiSession) is headed with a `session` line carrying
- * the web-server session id — the id getSession resolves by. The sandbox JSONL
- * holds only the SDK's conversation entries (no such header). So we KEEP the
- * local header and replace the body with the sandbox's entries, rather than
- * overwriting (which would drop the id and break resolution).
+ * The sandbox writes Studio sessions in the on-disk legacy format. We run the
+ * same legacy→pi migration `loadAiSession` applies on read, then re-id the
+ * session header to the web-server's session id — the id getSession resolves by,
+ * and the one thing the read-time migration can't fix. The result is written to
+ * the local file the browser's session id already maps to.
  *
  * @param webSessionId The web-server session id (what the browser holds).
  * @param jsonl        The canonical session JSONL read from the sandbox.
@@ -240,14 +233,30 @@ async function cacheSandboxSession( webSessionId: string, jsonl: string ): Promi
 	// by createAiSession). If it's gone, there's nothing to cache into.
 	const { summary } = await loadAiSession( root, webSessionId );
 
-	const existing = await fs.readFile( summary.filePath, 'utf8' );
-	const header = existing.split( '\n' ).find( isSessionHeaderLine );
+	const lines = jsonl.split( '\n' ).filter( ( line ) => line.trim() );
+	if ( 0 === lines.length ) {
+		return;
+	}
 
-	const body = jsonl
-		.split( '\n' )
-		.filter( ( line ) => line.trim() && ! isSessionHeaderLine( line ) );
+	let entries: SessionEntry[];
+	if ( 'legacy' === detectSessionFormat( lines[ 0 ] ) ) {
+		const events = lines.map( ( line ) => JSON.parse( line ) ) as Parameters<
+			typeof migrateLegacyEvents
+		>[ 0 ];
+		entries = migrateLegacyEvents( events, '~/Studio' ) as unknown as SessionEntry[];
+	} else {
+		entries = lines.map( ( line ) => JSON.parse( line ) as SessionEntry );
+	}
 
-	const out = [ header, ...body ].filter( Boolean ).join( '\n' ) + '\n';
+	for ( const entry of entries ) {
+		const header = entry as { type?: string; id?: string };
+		if ( 'session' === header.type ) {
+			header.id = webSessionId;
+			break;
+		}
+	}
+
+	const out = entries.map( ( entry ) => JSON.stringify( entry ) ).join( '\n' ) + '\n';
 	await fs.writeFile( summary.filePath, out, 'utf8' );
 }
 

--- a/apps/cli/web-server/secex-runtime.ts
+++ b/apps/cli/web-server/secex-runtime.ts
@@ -116,6 +116,11 @@ export function createSecexRuntime( {
 
 				let paused = false;
 				let errored = false;
+				// True once a turn.completed with status 'success' arrives. The
+				// studio-code resume command can exit non-zero AFTER a successful
+				// turn, emitting a trailing (often empty) `error` frame; that tail
+				// must not flip a turn the agent actually finished into a failure.
+				let completedOk = false;
 				// The session cache write must finish before this turn resolves, so
 				// the run-end `getSession` the UI fires doesn't read a half-written
 				// file. Captured here and awaited after the stream drains.
@@ -132,6 +137,7 @@ export function createSecexRuntime( {
 							// asked a question and is waiting for the next message.
 							paused = jsonEvent.status === 'paused';
 							errored = jsonEvent.status === 'error';
+							completedOk = jsonEvent.status === 'success';
 							wdbg( 'secex', 'turn.completed', {
 								status: jsonEvent.status,
 								cliSessionId: jsonEvent.sessionId,
@@ -139,9 +145,16 @@ export function createSecexRuntime( {
 						}
 						onEvent( jsonEvent );
 					} else if ( event === 'error' ) {
-						errored = true;
-						const payload = data as { message?: string; stderr?: string };
-						onError( payload.message ?? payload.stderr ?? 'studio-code run error' );
+						// Ignore a trailing error frame once the turn already finished
+						// successfully — the resume command's non-zero exit shouldn't
+						// fail a completed turn (the change is already applied).
+						if ( completedOk ) {
+							wdbg( 'secex', 'ignoring trailing error after successful turn', {} );
+						} else {
+							errored = true;
+							const payload = data as { message?: string; stderr?: string };
+							onError( payload.message ?? payload.stderr ?? 'studio-code run error' );
+						}
 					} else if ( event === 'session' ) {
 						// The endpoint's run-boundary sync: the canonical session
 						// JSONL from the sandbox. Cache it locally so the broker's own

--- a/apps/cli/web-server/site-server.ts
+++ b/apps/cli/web-server/site-server.ts
@@ -1,13 +1,24 @@
 import { fork } from 'node:child_process';
+import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { readAuthToken } from '@studio/common/lib/shared-config';
 import { findSiteByFolder, getSiteUrl } from 'cli/lib/cli-config/sites';
-import { isServerRunning } from 'cli/lib/wordpress-server-manager';
+import { isServerRunning, sendWpCliCommand } from 'cli/lib/wordpress-server-manager';
 import { wdbg } from './debug';
 import type { SiteData } from 'cli/lib/cli-config/core';
 
 // Where Studio keeps local sites (same root the desktop uses).
 const SITES_ROOT = path.join( os.homedir(), 'Studio' );
+
+// The wpcom studio-code /export route (reads the agent's site from the sandbox).
+const DEFAULT_EXPORT_URL = 'https://public-api.wordpress.com/wpcom/v2/studio-code/export';
+
+// The sandbox's own SQLite DB. Skipped on overlay for now: applying it needs a
+// server restart (Playground caches the connection) plus a siteurl/home rewrite
+// to the broker's origin — a follow-up. Theme files alone give a live render of
+// the agent's design on the broker's clean WordPress.
+const SANDBOX_DB_PATH = 'wp-content/database/.ht.sqlite';
 
 /**
  * The broker serves the agent's site itself, with the SAME WordPress Playground
@@ -78,5 +89,95 @@ export async function serveSiteForSession( sessionId: string ): Promise< string 
 
 	const url = getSiteUrl( site );
 	wdbg( 'site', 'serving', { name, url } );
+	return url;
+}
+
+// Pull the agent's site files from the sandbox via the wpcom /export route.
+async function exportSandboxSite( sandboxSitePath: string ): Promise< Record< string, string > > {
+	const token = await readAuthToken().catch( () => null );
+	if ( ! token ) {
+		throw new Error( 'Not signed in to WordPress.com — run `studio auth login` first.' );
+	}
+
+	const exportUrl = process.env.STUDIO_SECEX_EXPORT_URL ?? DEFAULT_EXPORT_URL;
+	const response = await fetch( exportUrl, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${ token.accessToken }`,
+			'X-WPCOM-AI-Feature': 'studio-code',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify( { path: sandboxSitePath } ),
+	} );
+	if ( ! response.ok ) {
+		throw new Error( `studio-code /export failed (${ response.status })` );
+	}
+
+	const data = ( await response.json() ) as { files?: Record< string, string > };
+	return data.files ?? {};
+}
+
+// Write the exported files into the local site, skipping the DB (for now) and
+// anything that would escape the site directory. Returns the overlaid theme's
+// slug, if any, so the caller can activate it.
+async function overlayFiles(
+	sitePath: string,
+	files: Record< string, string >
+): Promise< string | undefined > {
+	const root = path.resolve( sitePath );
+	let themeSlug: string | undefined;
+
+	for ( const [ relativePath, base64 ] of Object.entries( files ) ) {
+		if ( SANDBOX_DB_PATH === relativePath ) {
+			continue;
+		}
+
+		const dest = path.resolve( root, relativePath );
+		if ( dest !== root && ! dest.startsWith( root + path.sep ) ) {
+			continue; // never write outside the site dir.
+		}
+
+		await fs.mkdir( path.dirname( dest ), { recursive: true } );
+		await fs.writeFile( dest, Buffer.from( base64, 'base64' ) );
+
+		const themeMatch = relativePath.match( /^wp-content\/themes\/([^/]+)\// );
+		if ( themeMatch ) {
+			themeSlug = themeMatch[ 1 ];
+		}
+	}
+
+	return themeSlug;
+}
+
+/**
+ * Overlay the agent's site (the most-recently-edited theme, via /export) onto
+ * the broker's local site and activate that theme, so the served WordPress
+ * renders what the agent built. The site is created/started if needed.
+ *
+ * @param sessionId        The web-server session id.
+ * @param sandboxSitePath  The site's path inside the sandbox (e.g. /home/user/Studio/<name>).
+ * @return The site URL.
+ */
+export async function syncSiteFromSandbox(
+	sessionId: string,
+	sandboxSitePath: string
+): Promise< string > {
+	const url = await serveSiteForSession( sessionId );
+	const sitePath = sitePathForSession( sessionId );
+	const site = await findSiteByFolder( sitePath );
+	if ( ! site ) {
+		throw new Error( `Could not resolve the local site for session ${ sessionId }` );
+	}
+
+	const files = await exportSandboxSite( sandboxSitePath );
+	const themeSlug = await overlayFiles( sitePath, files );
+	wdbg( 'site', 'overlay', { fileCount: Object.keys( files ).length, theme: themeSlug } );
+
+	if ( themeSlug ) {
+		await sendWpCliCommand( site.id, [ 'theme', 'activate', themeSlug ] ).catch( ( error ) => {
+			wdbg( 'site', 'theme activate failed', { error: String( error ) } );
+		} );
+	}
+
 	return url;
 }

--- a/apps/cli/web-server/site-server.ts
+++ b/apps/cli/web-server/site-server.ts
@@ -27,6 +27,27 @@ const SANDBOX_DB_PATH = 'wp-content/database/.ht.sqlite';
  * serving moves here.) The browser then iframes a real, running WordPress.
  */
 
+export interface ServedSite {
+	sessionId: string;
+	site: SiteData;
+	url: string;
+}
+
+// Sites the broker is currently serving, keyed by web-server session id. The
+// daemon is long-lived, so this stays warm across requests. The web-server reads
+// it to (a) list these as running sites via `/api/sites` and (b) bind a session
+// to its served site (`ownerSitePath`), which is exactly how the shared UI's
+// site-preview widget discovers a site to render — no Studio-Web-specific UI.
+const servedSites = new Map< string, ServedSite >();
+
+export function listServedSites(): ServedSite[] {
+	return [ ...servedSites.values() ];
+}
+
+export function getServedSite( sessionId: string ): ServedSite | undefined {
+	return servedSites.get( sessionId );
+}
+
 // Run a `studio <args>` subcommand in a child of the same CLI bundle the
 // web-server runs from, resolving on a clean exit. `--experimental-wasm-jspi`
 // matches how the agent is forked — the PHP-WASM server needs it.
@@ -88,6 +109,7 @@ export async function serveSiteForSession( sessionId: string ): Promise< string 
 	}
 
 	const url = getSiteUrl( site );
+	servedSites.set( sessionId, { sessionId, site, url } );
 	wdbg( 'site', 'serving', { name, url } );
 	return url;
 }

--- a/apps/cli/web-server/site-server.ts
+++ b/apps/cli/web-server/site-server.ts
@@ -14,10 +14,10 @@ const SITES_ROOT = path.join( os.homedir(), 'Studio' );
 // The wpcom studio-code /export route (reads the agent's site from the sandbox).
 const DEFAULT_EXPORT_URL = 'https://public-api.wordpress.com/wpcom/v2/studio-code/export';
 
-// The sandbox's own SQLite DB. Skipped on overlay for now: applying it needs a
-// server restart (Playground caches the connection) plus a siteurl/home rewrite
-// to the broker's origin — a follow-up. Theme files alone give a live render of
-// the agent's design on the broker's clean WordPress.
+// The sandbox's own SQLite DB. When present in the export we apply it (so the
+// agent's content, active theme, and customizations show), but only while the
+// server is stopped — Playground caches the connection — and we then repoint the
+// DB's siteurl/home from the sandbox origin to the broker's.
 const SANDBOX_DB_PATH = 'wp-content/database/.ht.sqlite';
 
 /**
@@ -139,18 +139,22 @@ async function exportSandboxSite( sandboxSitePath: string ): Promise< Record< st
 	return data.files ?? {};
 }
 
-// Write the exported files into the local site, skipping the DB (for now) and
-// anything that would escape the site directory. Returns the overlaid theme's
-// slug, if any, so the caller can activate it.
+// Write the exported files into the local site, skipping the DB unless
+// `includeDb` is set, and never writing outside the site directory. Returns the
+// overlaid theme's slug, if any, so the caller can activate it when no DB came
+// across (the DB already records the active theme).
 async function overlayFiles(
 	sitePath: string,
-	files: Record< string, string >
+	files: Record< string, string >,
+	includeDb: boolean,
+	brokerUrl: string
 ): Promise< string | undefined > {
 	const root = path.resolve( sitePath );
 	let themeSlug: string | undefined;
 
 	for ( const [ relativePath, base64 ] of Object.entries( files ) ) {
-		if ( SANDBOX_DB_PATH === relativePath ) {
+		const isDb = SANDBOX_DB_PATH === relativePath;
+		if ( isDb && ! includeDb ) {
 			continue;
 		}
 
@@ -159,8 +163,10 @@ async function overlayFiles(
 			continue; // never write outside the site dir.
 		}
 
+		const raw = Buffer.from( base64, 'base64' );
+		const buffer = isDb ? repointDbBuffer( raw, brokerUrl ) : raw;
 		await fs.mkdir( path.dirname( dest ), { recursive: true } );
-		await fs.writeFile( dest, Buffer.from( base64, 'base64' ) );
+		await fs.writeFile( dest, buffer );
 
 		const themeMatch = relativePath.match( /^wp-content\/themes\/([^/]+)\// );
 		if ( themeMatch ) {
@@ -171,10 +177,45 @@ async function overlayFiles(
 	return themeSlug;
 }
 
+// The exported DB carries the sandbox's own origin in siteurl/home (and any
+// hard-coded links), so a freshly-loaded copy would 301 the browser to the
+// unreachable sandbox URL. The broker's forked WordPress server doesn't accept
+// WP-CLI over IPC, so we repoint by rewriting the origin directly in the SQLite
+// bytes before writing the file. This is only safe when the two origins are the
+// same byte length (SQLite/PHP length prefixes stay valid) — both are
+// `http://localhost:<4-digit port>` in practice, so they match; if they ever
+// don't, we skip the rewrite rather than corrupt the DB.
+function repointDbBuffer( db: Buffer, brokerUrl: string ): Buffer {
+	const text = db.toString( 'latin1' );
+	const origins = text.match( /https?:\/\/localhost:\d+/g );
+	if ( ! origins ) {
+		return db;
+	}
+	// The real siteurl recurs throughout the DB; a spurious match (a URL glued to
+	// a trailing number, where greedy `\d+` overshoots the port) appears once.
+	// Pick the most frequent origin so we rewrite the true one.
+	const counts = new Map< string, number >();
+	for ( const origin of origins ) {
+		counts.set( origin, ( counts.get( origin ) ?? 0 ) + 1 );
+	}
+	const sandboxUrl = [ ...counts.entries() ].sort( ( a, b ) => b[ 1 ] - a[ 1 ] )[ 0 ][ 0 ];
+	if ( sandboxUrl === brokerUrl ) {
+		return db;
+	}
+	if ( sandboxUrl.length !== brokerUrl.length ) {
+		wdbg( 'site', 'db repoint skipped (origin length mismatch)', { sandboxUrl, brokerUrl } );
+		return db;
+	}
+	wdbg( 'site', 'db repoint', { from: sandboxUrl, to: brokerUrl } );
+	return Buffer.from( text.split( sandboxUrl ).join( brokerUrl ), 'latin1' );
+}
+
 /**
- * Overlay the agent's site (the most-recently-edited theme, via /export) onto
- * the broker's local site and activate that theme, so the served WordPress
- * renders what the agent built. The site is created/started if needed.
+ * Overlay the agent's site (theme files + SQLite DB, via /export) onto the
+ * broker's local site so the served WordPress renders exactly what the agent
+ * built — content, active theme, and customizations included. The site is
+ * created/started if needed. Applying the DB requires stopping the server first
+ * (Playground caches the connection) and repointing its origin afterwards.
  *
  * @param sessionId        The web-server session id.
  * @param sandboxSitePath  The site's path inside the sandbox (e.g. /home/user/Studio/<name>).
@@ -184,22 +225,38 @@ export async function syncSiteFromSandbox(
 	sessionId: string,
 	sandboxSitePath: string
 ): Promise< string > {
-	const url = await serveSiteForSession( sessionId );
+	const brokerUrl = await serveSiteForSession( sessionId );
 	const sitePath = sitePathForSession( sessionId );
-	const site = await findSiteByFolder( sitePath );
+	let site = await findSiteByFolder( sitePath );
 	if ( ! site ) {
 		throw new Error( `Could not resolve the local site for session ${ sessionId }` );
 	}
 
 	const files = await exportSandboxSite( sandboxSitePath );
-	const themeSlug = await overlayFiles( sitePath, files );
-	wdbg( 'site', 'overlay', { fileCount: Object.keys( files ).length, theme: themeSlug } );
+	const hasDb = Object.prototype.hasOwnProperty.call( files, SANDBOX_DB_PATH );
+	wdbg( 'site', 'overlay', { fileCount: Object.keys( files ).length, db: hasDb } );
 
-	if ( themeSlug ) {
+	// Replace files (and the DB) with the server stopped — a running Playground
+	// holds the SQLite connection open and would never see a swapped DB file. The
+	// DB's origin is repointed to the broker inside overlayFiles before it lands.
+	if ( await isServerRunning( site.id ) ) {
+		await runCli( [ 'site', 'stop', '--path', sitePath ] );
+	}
+	const themeSlug = await overlayFiles( sitePath, files, hasDb, brokerUrl );
+	await runCli( [ 'site', 'start', '--path', sitePath ] );
+
+	site = ( await findSiteByFolder( sitePath ) ) ?? site;
+	const liveUrl = getSiteUrl( site );
+	servedSites.set( sessionId, { sessionId, site, url: liveUrl } );
+
+	// Without a DB, the active theme isn't carried over — activate the overlaid
+	// one so at least the design renders. (Best-effort: the broker's forked
+	// server may not accept WP-CLI; failures are non-fatal.)
+	if ( ! hasDb && themeSlug ) {
 		await sendWpCliCommand( site.id, [ 'theme', 'activate', themeSlug ] ).catch( ( error ) => {
 			wdbg( 'site', 'theme activate failed', { error: String( error ) } );
 		} );
 	}
 
-	return url;
+	return liveUrl;
 }

--- a/apps/cli/web-server/site-server.ts
+++ b/apps/cli/web-server/site-server.ts
@@ -1,0 +1,82 @@
+import { fork } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { findSiteByFolder, getSiteUrl } from 'cli/lib/cli-config/sites';
+import { isServerRunning } from 'cli/lib/wordpress-server-manager';
+import { wdbg } from './debug';
+import type { SiteData } from 'cli/lib/cli-config/core';
+
+// Where Studio keeps local sites (same root the desktop uses).
+const SITES_ROOT = path.join( os.homedir(), 'Studio' );
+
+/**
+ * The broker serves the agent's site itself, with the SAME WordPress Playground
+ * server the desktop runs — a Node process, where PHP-WASM works. (It does NOT
+ * boot reliably inside the SecEx sandbox, so the sandbox only runs the agent;
+ * serving moves here.) The browser then iframes a real, running WordPress.
+ */
+
+// Run a `studio <args>` subcommand in a child of the same CLI bundle the
+// web-server runs from, resolving on a clean exit. `--experimental-wasm-jspi`
+// matches how the agent is forked — the PHP-WASM server needs it.
+function runCli( args: string[] ): Promise< void > {
+	return new Promise( ( resolve, reject ) => {
+		const child = fork( process.argv[ 1 ], args, {
+			stdio: [ 'ignore', 'inherit', 'inherit', 'ipc' ],
+			execArgv: [ '--experimental-wasm-jspi' ],
+			env: { ...process.env },
+		} );
+		child.on( 'error', reject );
+		child.on( 'exit', ( code ) =>
+			0 === code
+				? resolve()
+				: reject( new Error( `studio ${ args.join( ' ' ) } exited with ${ code }` ) )
+		);
+	} );
+}
+
+// The local site directory backing a web-server session.
+function sitePathForSession( sessionId: string ): string {
+	return path.join( SITES_ROOT, `studio-web-${ sessionId.slice( 0, 8 ) }` );
+}
+
+/**
+ * Ensure a real local WordPress site exists and is running for this session, and
+ * return its URL for the browser to iframe. The site persists across runs in the
+ * daemon, so repeated calls just confirm it's up.
+ *
+ * @param sessionId The web-server session id.
+ * @return The site URL (e.g. http://localhost:8881).
+ */
+export async function serveSiteForSession( sessionId: string ): Promise< string > {
+	const sitePath = sitePathForSession( sessionId );
+	const name = path.basename( sitePath );
+
+	let site: SiteData | undefined = await findSiteByFolder( sitePath );
+	if ( ! site ) {
+		wdbg( 'site', 'create', { name, sitePath } );
+		await runCli( [
+			'site',
+			'create',
+			'--name',
+			name,
+			'--path',
+			sitePath,
+			'--skip-browser',
+			'--skip-log-details',
+		] );
+		site = await findSiteByFolder( sitePath );
+	} else if ( ! ( await isServerRunning( site.id ) ) ) {
+		wdbg( 'site', 'start', { name } );
+		await runCli( [ 'site', 'start', '--path', sitePath ] );
+		site = await findSiteByFolder( sitePath );
+	}
+
+	if ( ! site ) {
+		throw new Error( `Could not resolve the local site for session ${ sessionId }` );
+	}
+
+	const url = getSiteUrl( site );
+	wdbg( 'site', 'serving', { name, url } );
+	return url;
+}

--- a/apps/ui/src/components/sidebar-header/index.tsx
+++ b/apps/ui/src/components/sidebar-header/index.tsx
@@ -1,8 +1,11 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { comment, download, globe, plus } from '@wordpress/icons';
 import { Icon, IconButton } from '@wordpress/ui';
 import * as Menu from '@/components/menu';
+import { useConnector } from '@/data/core';
+import { SESSIONS_QUERY_KEY } from '@/data/queries/use-sessions';
 import { useFullscreen } from '@/hooks/use-fullscreen';
 import { drawerIcon } from '@/lib/icons';
 import styles from './style.module.css';
@@ -14,6 +17,17 @@ type Props = {
 export function SidebarHeader( { onToggleSidebar }: Props ) {
 	const isFullscreen = useFullscreen();
 	const navigate = useNavigate();
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+
+	// Create a fresh unbound chat and open it. Mirrors `newSessionRoute`, which
+	// is site-scoped; this is the no-site equivalent for the top-level menu.
+	const startNewChat = async () => {
+		const session = await connector.createSession();
+		void queryClient.invalidateQueries( { queryKey: SESSIONS_QUERY_KEY } );
+		await navigate( { to: '/sessions/$sessionId', params: { sessionId: session.id } } );
+	};
+
 	return (
 		<div className={ `${ styles.root } ${ isFullscreen ? styles.fullscreen : '' }` }>
 			<span className={ styles.title }>{ __( 'Studio' ) }</span>
@@ -31,17 +45,7 @@ export function SidebarHeader( { onToggleSidebar }: Props ) {
 						}
 					/>
 					<Menu.Popup side="bottom" align="end" className={ styles.popup }>
-						<Menu.Item
-							onClick={ () =>
-								void navigate( {
-									to: '.',
-									search: ( prev: Record< string, unknown > ) => ( {
-									...prev,
-									newChat: Date.now(),
-								} ),
-								} )
-							}
-						>
+						<Menu.Item onClick={ () => void startNewChat() }>
 							<Icon icon={ comment } />
 							<span>{ __( 'New chat' ) }</span>
 						</Menu.Item>

--- a/apps/ui/src/components/sidebar-header/index.tsx
+++ b/apps/ui/src/components/sidebar-header/index.tsx
@@ -31,7 +31,17 @@ export function SidebarHeader( { onToggleSidebar }: Props ) {
 						}
 					/>
 					<Menu.Popup side="bottom" align="end" className={ styles.popup }>
-						<Menu.Item>
+						<Menu.Item
+							onClick={ () =>
+								void navigate( {
+									to: '.',
+									search: ( prev: Record< string, unknown > ) => ( {
+									...prev,
+									newChat: Date.now(),
+								} ),
+								} )
+							}
+						>
 							<Icon icon={ comment } />
 							<span>{ __( 'New chat' ) }</span>
 						</Menu.Item>

--- a/apps/ui/src/data/core/connectors/web/index.ts
+++ b/apps/ui/src/data/core/connectors/web/index.ts
@@ -99,6 +99,24 @@ export function createWebConnector( { apiBaseUrl }: WebConnectorOptions ): Conne
 		return site.url;
 	}
 
+	// When a run finishes successfully, ask the backend to serve the session's
+	// site and bind it. The backend replies with a `placement` SSE event, which
+	// lights up the same site-preview widget the desktop uses — so the live
+	// preview needs no Studio-Web-specific UI, just this trigger.
+	async function maybeServePreview( event: AgentRunEvent ): Promise< void > {
+		if ( event.event.type !== 'run.exited' || event.event.status !== 'success' ) {
+			return;
+		}
+		try {
+			await api( `/sessions/${ encodeURIComponent( event.sessionId ) }/preview`, {
+				method: 'POST',
+				body: JSON.stringify( {} ),
+			} );
+		} catch {
+			// Preview is best-effort; a failure here must never disrupt the chat.
+		}
+	}
+
 	return {
 		async init() {
 			// One SSE connection carries both agent and placement events; the
@@ -114,6 +132,7 @@ export function createWebConnector( { apiBaseUrl }: WebConnectorOptions ): Conne
 				}
 				if ( parsed.channel === 'agent' ) {
 					agentListeners.forEach( ( listener ) => listener( parsed.payload ) );
+					void maybeServePreview( parsed.payload );
 				} else if ( parsed.channel === 'placement' ) {
 					placementListeners.forEach( ( listener ) => listener( parsed.payload ) );
 				}

--- a/apps/ui/src/data/core/connectors/web/index.ts
+++ b/apps/ui/src/data/core/connectors/web/index.ts
@@ -107,14 +107,21 @@ export function createWebConnector( { apiBaseUrl }: WebConnectorOptions ): Conne
 		if ( event.event.type !== 'run.exited' || event.event.status !== 'success' ) {
 			return;
 		}
-		try {
-			await api( `/sessions/${ encodeURIComponent( event.sessionId ) }/preview`, {
-				method: 'POST',
-				body: JSON.stringify( {} ),
-			} );
-		} catch {
-			// Preview is best-effort; a failure here must never disrupt the chat.
-		}
+		const servePreview = async () => {
+			try {
+				await api( `/sessions/${ encodeURIComponent( event.sessionId ) }/preview`, {
+					method: 'POST',
+					body: JSON.stringify( {} ),
+				} );
+			} catch {
+				// Preview is best-effort; a failure here must never disrupt the chat.
+			}
+		};
+		// Fire immediately for fast feedback, then once more after a short delay:
+		// the sandbox's session cache and export snapshot can lag the run boundary
+		// by a few seconds, so the first pass may miss the agent's final state.
+		await servePreview();
+		setTimeout( () => void servePreview(), 12_000 );
 	}
 
 	return {

--- a/apps/ui/src/data/core/connectors/web/index.ts
+++ b/apps/ui/src/data/core/connectors/web/index.ts
@@ -104,7 +104,10 @@ export function createWebConnector( { apiBaseUrl }: WebConnectorOptions ): Conne
 	// lights up the same site-preview widget the desktop uses — so the live
 	// preview needs no Studio-Web-specific UI, just this trigger.
 	async function maybeServePreview( event: AgentRunEvent ): Promise< void > {
-		if ( event.event.type !== 'run.exited' || event.event.status !== 'success' ) {
+		// Refresh on any run end, not just success: a build that erred or timed out
+		// partway (e.g. a long site build) may still have produced a usable site, so
+		// it's worth attempting to render what's there.
+		if ( event.event.type !== 'run.exited' ) {
 			return;
 		}
 		const servePreview = async () => {

--- a/apps/ui/src/ui-desks/chats/provider.tsx
+++ b/apps/ui/src/ui-desks/chats/provider.tsx
@@ -166,13 +166,18 @@ export function ChatsProvider( { siteId, children }: ChatsProviderProps ) {
 	);
 
 	const ensureAuthenticatedForChat = useCallback( async () => {
+		// Backends that don't gate on WordPress.com auth (e.g. Studio Web) have no
+		// auth user; chatting is always allowed there.
+		if ( ! connector.requiresAuth ) {
+			return true;
+		}
 		if ( authUser ) {
 			return true;
 		}
 
 		const result = await refetchAuthUser();
 		return !! result.data;
-	}, [ authUser, refetchAuthUser ] );
+	}, [ authUser, connector, refetchAuthUser ] );
 
 	const startNewChat = useCallback( async () => {
 		if ( ! ( await ensureAuthenticatedForChat() ) ) {


### PR DESCRIPTION
## Related issues

Continues the Studio Web effort that landed the web-server + web connector (#3816) and the `AgentRuntime` seam.

## How AI was used in this PR

The runtime, the SSE reader, the pause/answer/resume handling, and this description were drafted with Claude Code, then reviewed; the change typechecks and builds locally.

## Proposed Changes

Studio Web can now run the agent in a **hosted SecEx sandbox** instead of a local child process, so the browser build of Studio works without anything running on the user's machine. Each user gets one sandbox — the cloud analog of "your laptop", with the same `~/Studio/` sites and `~/.claude` sessions inside it, like the desktop app.

It plugs into the existing `AgentRuntime` seam: a new runtime drives the wpcom `studio-code` endpoint (`POST /wpcom/v2/studio-code/run`), which runs `studio code --json` in the sandbox and streams its events back over SSE. The web-server relays those through the same callbacks the local runtime already uses, so the run-manager and the browser UI are untouched.

**Interactive questions and multi-turn work like the desktop.** There's no live process in the sandbox to answer over IPC, so the runtime mirrors the proven headless pattern: when a turn pauses on a question the agent process stays "connected" instead of exiting, and answering re-drives the endpoint with the user's choice as the next message on the same sandbox session (resolved from `turn.completed.sessionId`). To the web-server and the UI it looks like an ordinary live run that asks and gets answered.

It's **opt-in and zero-risk by default**: the local child-process backend stays the default, and the SecEx runtime is only installed when `STUDIO_WEB_BACKEND=secex` is set.

## Testing Instructions

```bash
npm run cli:build
STUDIO_WEB_BACKEND=secex node apps/cli/dist/cli/main.mjs web-server
# (sign in first with `auth login`; open the printed URL and send a prompt;
#  when the agent asks a question, answer it in the UI and the turn resumes)
```

Without the env var, `web-server` behaves exactly as before (local agent).

> Note: full end-to-end depends on the wpcom `studio-code` `/run` route being deployed; the runtime is written to that endpoint's contract.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (`npm run typecheck` and `npm run cli:build` pass.)
