### PR TITLE
Migrate 'renames a site' e2e test to a mocked-IPC renderer test

### DIFF
--- a/apps/studio/e2e/sites.test.ts
+++ b/apps/studio/e2e/sites.test.ts
@@ -118,27 +118,6 @@ test.describe( 'Sites', () => {
 		await settingsTab.editSiteDialog.getByRole( 'button', { name: 'Cancel' } ).click();
 	} );
 
-	test( 'renames a site', async () => {
-		const { siteName } = await completeOnboardingWithParams();
-
-		const newSiteName = 'E2E-Test-Site-Renamed';
-		const siteContent = new SiteContent( session.mainWindow, siteName );
-		const settingsTab = await siteContent.navigateToTab( 'Settings' );
-
-		await settingsTab.editSiteButton.click();
-		await expect( settingsTab.editSiteDialog ).toBeVisible();
-
-		await settingsTab.siteNameInput.fill( newSiteName );
-		await settingsTab.saveButton.click();
-		await expect( settingsTab.editSiteDialog ).not.toBeVisible( { timeout: 20_000 } );
-
-		// Explicitly wait for the rename to propagate
-		const renamedSiteContent = new SiteContent( session.mainWindow, newSiteName );
-		await expect( renamedSiteContent.siteNameHeading ).toHaveText( newSiteName, {
-			timeout: 10000,
-		} );
-	} );
-
 	test( "edit site's settings in wp-admin", async ( { page } ) => {
 		const { siteName } = await completeOnboardingWithParams();
 

--- a/apps/studio/src/components/tests/content-tab-settings.test.tsx
+++ b/apps/studio/src/components/tests/content-tab-settings.test.tsx
@@ -467,4 +467,92 @@ describe( 'ContentTabSettings', () => {
 			} );
 		} );
 	} );
+
+	describe( 'Site name', () => {
+		it( 'renames the site', async () => {
+			const user = userEvent.setup();
+
+			const updateSite = vi.fn();
+			const startServer = vi.fn();
+			const stopServer = vi.fn();
+
+			vi.mocked( useSiteDetails, { partial: true } ).mockReturnValue( {
+				selectedSite: { ...selectedSite, running: false } as SiteDetails,
+				updateSite,
+				startServer,
+				stopServer,
+				isEditModalOpen: false,
+				setIsEditModalOpen: vi.fn(),
+				editModalInitialTab: 'general',
+				setEditModalInitialTab: vi.fn(),
+			} );
+
+			const { rerender } = renderWithProvider(
+				<ContentTabSettings selectedSite={ selectedSite } />
+			);
+
+			// The current name is shown on the Settings tab.
+			expect( screen.getByText( 'Test Site' ) ).toBeVisible();
+
+			// Open the Edit site dialog. Its visibility is driven by
+			// `isEditModalOpen` from the (mocked) useSiteDetails hook, so we
+			// re-mock the hook as open and re-render to reflect the click.
+			await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+			vi.mocked( useSiteDetails, { partial: true } ).mockReturnValue( {
+				selectedSite: { ...selectedSite, running: false } as SiteDetails,
+				updateSite,
+				startServer,
+				stopServer,
+				isEditModalOpen: true,
+				setIsEditModalOpen: vi.fn(),
+				editModalInitialTab: 'general',
+				setEditModalInitialTab: vi.fn(),
+			} );
+			rerenderWithProvider( rerender, <ContentTabSettings selectedSite={ selectedSite } /> );
+			await waitFor( () => {
+				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			} );
+
+			const dialog = screen.getByRole( 'dialog' );
+			const nameInput = within( dialog ).getByLabelText( 'Site name' );
+			await user.clear( nameInput );
+			await user.type( nameInput, 'Renamed Site' );
+			await user.click( within( dialog ).getByRole( 'button', { name: 'Save' } ) );
+
+			// The renderer delegates persistence (and any restart) to the backend
+			// via updateSite; no WordPress version change → second arg is undefined.
+			await waitFor( () => {
+				expect( updateSite ).toHaveBeenCalledWith(
+					expect.objectContaining( { name: 'Renamed Site' } ),
+					undefined
+				);
+			} );
+			expect( stopServer ).not.toHaveBeenCalled();
+			expect( startServer ).not.toHaveBeenCalled();
+
+			// Simulate the saved name propagating back: the modal closes and the
+			// selected site re-renders with the new name shown on the Settings tab.
+			vi.mocked( useSiteDetails, { partial: true } ).mockReturnValue( {
+				selectedSite: {
+					...selectedSite,
+					running: false,
+					name: 'Renamed Site',
+				} as SiteDetails,
+				updateSite,
+				startServer,
+				stopServer,
+				isEditModalOpen: false,
+				setIsEditModalOpen: vi.fn(),
+				editModalInitialTab: 'general',
+				setEditModalInitialTab: vi.fn(),
+			} );
+			rerenderWithProvider(
+				rerender,
+				<ContentTabSettings selectedSite={ { ...selectedSite, name: 'Renamed Site' } } />
+			);
+			await waitFor( () => {
+				expect( screen.getByText( 'Renamed Site' ) ).toBeVisible();
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
## Related issues

- No related Linear issue yet. This is a reference PR raised ahead of formalizing the e2e to CLI test migration as a project.

## How AI was used in this PR

- Claude mapped the existing test architecture, confirmed the rename behavior is already covered at the CLI layer (`set.test.ts`), wrote the new renderer test by mirroring the sibling PHP version test, and removed the redundant e2e block. I reviewed the output and ran the test, type, and lint checks locally.

## Proposed Changes

Studio e2e tests boot the full Electron app and run sites through Playground, which makes them slow and prone to flaky CLI event round-trips. Now that site operations run through the CLI, UI behavior can be verified against a mocked IPC layer while the backend behavior is covered by CLI command tests. This PR migrates the "renames a site" case as a small, low-risk reference for that pattern.

- Adds a mocked-IPC renderer test that drives the Edit site dialog and asserts the UI delegates the rename to `updateSite`, then reflects the new name once the change propagates back.
- Removes the now-redundant "renames a site" e2e test. Its backend behavior is already covered by the CLI `site set` command test (`should update site name without restart`).

## Testing Instructions

- Run `npm run test -- src/components/tests/content-tab-settings.test.tsx` and confirm the new `Site name > renames the site` test passes.
- Run `npm run test -- apps/cli/commands/site/tests/set.test.ts` and confirm the existing `should update site name without restart` test still passes (the backend half of the coverage).
- Confirm the `renames a site` test no longer exists in `apps/studio/e2e/sites.test.ts`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
