### PR TITLE
Add e2e coverage for the Sandbox (Playground) runtime

### DIFF
--- a/apps/studio/e2e/page-objects/add-site-modal.ts
+++ b/apps/studio/e2e/page-objects/add-site-modal.ts
@@ -1,5 +1,6 @@
 import { type Page } from '@playwright/test';
 import { ACCEPTED_IMPORT_FILE_TYPES } from '@studio/common/constants';
+import { type SiteRuntime } from '@studio/common/lib/site-runtime';
 import SiteForm from './site-form';
 
 export default class AddSiteModal {
@@ -54,6 +55,10 @@ export default class AddSiteModal {
 
 	async selectLocalPathForTesting( partialExpectedPath: string ) {
 		await this.siteForm.clickLocalPathButtonAndSelectFromEnv( partialExpectedPath );
+	}
+
+	async selectRuntime( runtime: SiteRuntime ) {
+		await this.siteForm.selectRuntime( runtime );
 	}
 
 	async selectBlueprintFile( filePath: string ) {

--- a/apps/studio/e2e/page-objects/onboarding.ts
+++ b/apps/studio/e2e/page-objects/onboarding.ts
@@ -1,5 +1,6 @@
 import { type Page } from '@playwright/test';
 import { expect } from '@playwright/test';
+import { type SiteRuntime } from '@studio/common/lib/site-runtime';
 import AddSiteModal from './add-site-modal';
 import WhatsNewModal from './whats-new-modal';
 
@@ -14,8 +15,12 @@ export default class Onboarding {
 		return this.locator.getByTestId( 'onboarding-welcome-title' );
 	}
 
-	async completeOnboarding( options?: { customSiteName?: string; customFolderName?: string } ) {
-		const { customSiteName, customFolderName } = options ?? {};
+	async completeOnboarding( options?: {
+		customSiteName?: string;
+		customFolderName?: string;
+		runtime?: SiteRuntime;
+	} ) {
+		const { customSiteName, customFolderName, runtime } = options ?? {};
 
 		await expect( this.heading ).toBeVisible();
 		await this.locator.getByRole( 'button', { name: 'Skip' } ).click();
@@ -38,6 +43,10 @@ export default class Onboarding {
 			await modal.selectLocalPathForTesting( customFolderName );
 		}
 		const localPath = await modal.localPathInput.inputValue();
+
+		if ( runtime ) {
+			await modal.selectRuntime( runtime );
+		}
 
 		await modal.continueButton.click();
 

--- a/apps/studio/e2e/page-objects/settings-tab.ts
+++ b/apps/studio/e2e/page-objects/settings-tab.ts
@@ -75,6 +75,12 @@ export default class SettingsTab {
 		return this.locator.getByRole( 'row', { name: /PHP version/i } );
 	}
 
+	// Read-only "PHP runtime" row on the Settings tab body. Reports "Native" or
+	// "Sandbox" for the site's configured runtime.
+	get phpRuntimeDisplay() {
+		return this.locator.getByRole( 'row', { name: /PHP runtime/i } );
+	}
+
 	get saveButton() {
 		return this.editSiteDialog.getByRole( 'button', { name: 'Save' } );
 	}

--- a/apps/studio/e2e/page-objects/site-form.ts
+++ b/apps/studio/e2e/page-objects/site-form.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from '@playwright/test';
+import { type SiteRuntime } from '@studio/common/lib/site-runtime';
 
 export default class SiteForm {
 	private page: Page;
@@ -18,12 +19,31 @@ export default class SiteForm {
 		return this.page.getByTestId( 'local-path-input' );
 	}
 
+	get phpRuntimeSelect() {
+		return this.page.locator( '#php-runtime-select' );
+	}
+
 	private get localPathButton() {
 		return this.page.getByTestId( 'select-path-button' );
 	}
 
 	private get advancedSettingsToggle() {
 		return this.page.getByTestId( 'advanced-settings-button' );
+	}
+
+	// The runtime/file-access controls live inside the collapsed "Advanced
+	// settings" section. Expanding is idempotent: only toggle when the runtime
+	// dropdown isn't already revealed.
+	async openAdvancedSettings() {
+		if ( ! ( await this.phpRuntimeSelect.isVisible().catch( () => false ) ) ) {
+			await this.advancedSettingsToggle.click();
+			await expect( this.phpRuntimeSelect ).toBeVisible();
+		}
+	}
+
+	async selectRuntime( runtime: SiteRuntime ) {
+		await this.openAdvancedSettings();
+		await this.phpRuntimeSelect.selectOption( runtime );
 	}
 
 	// This usually opens an OS folder dialog, except we can't interact with it in Playwright.

--- a/apps/studio/e2e/sandbox.test.ts
+++ b/apps/studio/e2e/sandbox.test.ts
@@ -34,5 +34,13 @@ test.describe( 'Sandbox runtime', () => {
 		// The Settings tab reports the site as running on the Sandbox runtime.
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 		await expect( settingsTab.phpRuntimeDisplay ).toContainText( 'Sandbox' );
+
+		// The Sandbox site actually serves its home page over HTTP.
+		await expect( siteContent.frontendButton ).toBeVisible();
+		const frontendUrl = await siteContent.frontendButton.textContent();
+		expect( frontendUrl ).not.toBeNull();
+		const response = await fetch( `http://${ frontendUrl }` );
+		expect( [ 200, 302 ] ).toContain( response.status );
+		expect( response.headers.get( 'content-type' ) ).toMatch( /text\/html/ );
 	} );
 } );

--- a/apps/studio/e2e/sandbox.test.ts
+++ b/apps/studio/e2e/sandbox.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { SITE_RUNTIME_PLAYGROUND } from '@studio/common/lib/site-runtime';
+import { E2ESession } from './e2e-helpers';
+import Onboarding from './page-objects/onboarding';
+import SiteContent from './page-objects/site-content';
+
+test.describe( 'Sandbox runtime', () => {
+	const session = new E2ESession();
+
+	test.afterEach( async ( { page: _page }, testInfo ) => {
+		await session.reportMainProcessLogsOnFailure( testInfo );
+		await session.cleanup();
+	} );
+
+	test( 'create and run a site with the Sandbox runtime', async () => {
+		// Playground sites download the PHP WASM build and WordPress on first
+		// run, so allow extra room on top of the launch + onboarding steps.
+		test.setTimeout( 300_000 );
+
+		await session.launch();
+
+		const onboarding = new Onboarding( session.mainWindow );
+		const { siteName } = await onboarding.completeOnboarding( {
+			customSiteName: 'Sandbox-Site',
+			runtime: SITE_RUNTIME_PLAYGROUND,
+		} );
+		await onboarding.closeWhatsNew();
+
+		// The site boots under the Playground runtime.
+		const siteContent = new SiteContent( session.mainWindow, siteName );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 180_000 } );
+		await expect( siteContent.siteNameHeading ).toHaveText( siteName );
+
+		// The Settings tab reports the site as running on the Sandbox runtime.
+		const settingsTab = await siteContent.navigateToTab( 'Settings' );
+		await expect( settingsTab.phpRuntimeDisplay ).toContainText( 'Sandbox' );
+	} );
+} );


### PR DESCRIPTION
## Related issues

_No linked issue._ Addresses the gap where the Sandbox (WordPress Playground) runtime had no end-to-end coverage after Native PHP became the default site runtime in #3786.

## How AI was used in this PR

Investigated the e2e harness, the Add Site modal UI, and the runtime plumbing, then wrote the test and page-object helpers with Claude Code (Opus 4.8). Selectors were checked against the real components (the `#php-runtime-select` dropdown and the Settings "PHP runtime" row), the additive `completeOnboarding` change was confirmed backward-compatible with all existing callers, and ESLint + `tsc` were run clean on the changed files.

## Proposed Changes

Studio supports two per-site PHP runtimes: Native PHP (the default since #3786) and the Sandbox (WordPress Playground / PHP-WASM). Every existing e2e test runs against the default runtime, so the Sandbox path had **zero** end-to-end coverage — and site/blueprint creation on Playground lost the implicit coverage it had back when Playground was the default.

This adds a single e2e test that exercises the Sandbox runtime through the real UI:

- Creates a site via onboarding with **Sandbox** selected under Advanced settings.
- Verifies the site actually boots under Playground (waits for the "Running" state).
- Verifies the Settings tab reports the site's PHP runtime as **"Sandbox"**.

It runs as part of the normal e2e suite on every platform/arch — no dedicated CI job and no gating. The supporting page-object additions (runtime selection, the runtime display row) are reusable for future runtime-specific tests. No product code is changed.

## Testing Instructions

1. Build the app and run just this test:
   ```
   npm run e2e -- sandbox.test.ts
   ```
   (or `npx playwright test sandbox.test.ts` against an existing build)
2. The test creates a Playground site, waits up to ~3 min for first-run asset downloads, then asserts the Settings tab shows **PHP runtime = Sandbox**.
3. Requires network access — Playground downloads the PHP-WASM build and WordPress on first run.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? — ESLint `--fix` and `tsc` are clean for the changed e2e files. The test is statically verified but **not yet run green**; please run it locally before merging.
