### PR TITLE
Fix flaky daemon log test on Windows

### DIFF
--- a/apps/cli/tests/daemon.test.ts
+++ b/apps/cli/tests/daemon.test.ts
@@ -9,28 +9,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const testProcessName = 'studio-site-process-manager-test';
 const tmpDir = path.join( os.tmpdir(), 'studio-daemon-test' );
 
-// The daemon pipes child output through readline into a buffered WriteStream, so the
-// bytes reach disk several async hops after we write them. Poll instead of relying on a
-// fixed sleep, which races on slower agents (notably Windows CI).
-async function waitForFileToContain(
-	filePath: string,
-	expected: string,
-	timeoutMs = 2000
-): Promise< string > {
+// Retries an assertion until it passes or the timeout elapses, rethrowing the last
+// failure. The daemon pipes child output through readline into a buffered WriteStream, so
+// the bytes reach disk several async hops after we write them — a fixed sleep races on
+// slower agents (notably Windows CI).
+async function waitFor( assertion: () => void, timeoutMs = 2000 ): Promise< void > {
 	const start = Date.now();
-	let contents = '';
-	do {
+	for (;;) {
 		try {
-			contents = fs.readFileSync( filePath, 'utf8' );
-		} catch {
-			contents = '';
+			assertion();
+			return;
+		} catch ( error ) {
+			if ( Date.now() - start >= timeoutMs ) {
+				throw error;
+			}
+			await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
 		}
-		if ( contents.includes( expected ) ) {
-			return contents;
-		}
-		await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
-	} while ( Date.now() - start < timeoutMs );
-	return contents;
+	}
 }
 
 class MockChildProcess extends EventEmitter {
@@ -147,18 +142,20 @@ describe( 'ProcessManagerDaemon', () => {
 			2,
 			'0'
 		) }${ String( now.getDate() ).padStart( 2, '0' ) }`;
-		expect(
-			await waitForFileToContain(
-				path.join( tmpDir, 'logs', `${ testProcessName }-out-${ dateTag }.log` ),
-				'fixture-stdout'
-			)
-		).toContain( 'fixture-stdout' );
-		expect(
-			await waitForFileToContain(
-				path.join( tmpDir, 'logs', `${ testProcessName }-error-${ dateTag }.log` ),
-				'fixture-stderr'
-			)
-		).toContain( 'fixture-stderr' );
+		await waitFor( () => {
+			expect(
+				fs.readFileSync(
+					path.join( tmpDir, 'logs', `${ testProcessName }-out-${ dateTag }.log` ),
+					'utf8'
+				)
+			).toContain( 'fixture-stdout' );
+			expect(
+				fs.readFileSync(
+					path.join( tmpDir, 'logs', `${ testProcessName }-error-${ dateTag }.log` ),
+					'utf8'
+				)
+			).toContain( 'fixture-stderr' );
+		} );
 	} );
 
 	it( 'includes captured stderr in the exit event payload', async () => {

--- a/apps/cli/tests/daemon.test.ts
+++ b/apps/cli/tests/daemon.test.ts
@@ -9,6 +9,30 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const testProcessName = 'studio-site-process-manager-test';
 const tmpDir = path.join( os.tmpdir(), 'studio-daemon-test' );
 
+// The daemon pipes child output through readline into a buffered WriteStream, so the
+// bytes reach disk several async hops after we write them. Poll instead of relying on a
+// fixed sleep, which races on slower agents (notably Windows CI).
+async function waitForFileToContain(
+	filePath: string,
+	expected: string,
+	timeoutMs = 2000
+): Promise< string > {
+	const start = Date.now();
+	let contents = '';
+	do {
+		try {
+			contents = fs.readFileSync( filePath, 'utf8' );
+		} catch {
+			contents = '';
+		}
+		if ( contents.includes( expected ) ) {
+			return contents;
+		}
+		await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
+	} while ( Date.now() - start < timeoutMs );
+	return contents;
+}
+
 class MockChildProcess extends EventEmitter {
 	pid = 4321;
 	connected = true;
@@ -124,15 +148,15 @@ describe( 'ProcessManagerDaemon', () => {
 			'0'
 		) }${ String( now.getDate() ).padStart( 2, '0' ) }`;
 		expect(
-			fs.readFileSync(
+			await waitForFileToContain(
 				path.join( tmpDir, 'logs', `${ testProcessName }-out-${ dateTag }.log` ),
-				'utf8'
+				'fixture-stdout'
 			)
 		).toContain( 'fixture-stdout' );
 		expect(
-			fs.readFileSync(
+			await waitForFileToContain(
 				path.join( tmpDir, 'logs', `${ testProcessName }-error-${ dateTag }.log` ),
-				'utf8'
+				'fixture-stderr'
 			)
 		).toContain( 'fixture-stderr' );
 	} );

--- a/apps/cli/tests/daemon.test.ts
+++ b/apps/cli/tests/daemon.test.ts
@@ -9,25 +9,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const testProcessName = 'studio-site-process-manager-test';
 const tmpDir = path.join( os.tmpdir(), 'studio-daemon-test' );
 
-// Retries an assertion until it passes or the timeout elapses, rethrowing the last
-// failure. The daemon pipes child output through readline into a buffered WriteStream, so
-// the bytes reach disk several async hops after we write them — a fixed sleep races on
-// slower agents (notably Windows CI).
-async function waitFor( assertion: () => void, timeoutMs = 2000 ): Promise< void > {
-	const start = Date.now();
-	for (;;) {
-		try {
-			assertion();
-			return;
-		} catch ( error ) {
-			if ( Date.now() - start >= timeoutMs ) {
-				throw error;
-			}
-			await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
-		}
-	}
-}
-
 class MockChildProcess extends EventEmitter {
 	pid = 4321;
 	connected = true;
@@ -142,20 +123,26 @@ describe( 'ProcessManagerDaemon', () => {
 			2,
 			'0'
 		) }${ String( now.getDate() ).padStart( 2, '0' ) }`;
-		await waitFor( () => {
-			expect(
-				fs.readFileSync(
-					path.join( tmpDir, 'logs', `${ testProcessName }-out-${ dateTag }.log` ),
-					'utf8'
-				)
-			).toContain( 'fixture-stdout' );
-			expect(
-				fs.readFileSync(
-					path.join( tmpDir, 'logs', `${ testProcessName }-error-${ dateTag }.log` ),
-					'utf8'
-				)
-			).toContain( 'fixture-stderr' );
-		} );
+		// The daemon pipes child output through readline into a buffered WriteStream, so the
+		// bytes reach disk several async hops after we write them. Poll the logs instead of
+		// relying on a fixed sleep, which races on slower agents (notably Windows CI).
+		await vi.waitFor(
+			() => {
+				expect(
+					fs.readFileSync(
+						path.join( tmpDir, 'logs', `${ testProcessName }-out-${ dateTag }.log` ),
+						'utf8'
+					)
+				).toContain( 'fixture-stdout' );
+				expect(
+					fs.readFileSync(
+						path.join( tmpDir, 'logs', `${ testProcessName }-error-${ dateTag }.log` ),
+						'utf8'
+					)
+				).toContain( 'fixture-stderr' );
+			},
+			{ timeout: 2000 }
+		);
 	} );
 
 	it( 'includes captured stderr in the exit event payload', async () => {

--- a/apps/cli/tests/daemon.test.ts
+++ b/apps/cli/tests/daemon.test.ts
@@ -124,8 +124,8 @@ describe( 'ProcessManagerDaemon', () => {
 			'0'
 		) }${ String( now.getDate() ).padStart( 2, '0' ) }`;
 		// The daemon pipes child output through readline into a buffered WriteStream, so the
-		// bytes reach disk several async hops after we write them. Poll the logs instead of
-		// relying on a fixed sleep, which races on slower agents (notably Windows CI).
+		// bytes reach disk several async hops after we write them. Poll until the output
+		// lands; the flush can lag on slower agents (notably Windows CI).
 		await vi.waitFor(
 			() => {
 				expect(


### PR DESCRIPTION
## Related issues

- Related to the Windows unit-tests CI failure (build 17839)

## How AI was used in this PR

Claude diagnosed the failing Windows CI log, traced it to a timing race in the daemon log test, wrote the polling fix, and verified lint, typecheck, and the test suite locally. I reviewed the changes and iterated to prevent re-creating the `waitFor` function.

## Proposed Changes

The Windows unit-tests job was failing on a single test — `ProcessManagerDaemon > starts a process, emits events, and writes logs` — with `expected '' to contain 'fixture-stdout'`.

The test wrote to a child process's stdout/stderr, waited a fixed 25 ms, then synchronously read the log file. But the daemon's write path is fully asynchronous: child output is piped through `readline`, then into a buffered `WriteStream` that must `open()` the file before flushing. On the slower Windows CI agent the file gets created (so the read returns an empty string rather than throwing) but the buffered bytes haven't flushed within 25 ms, so the assertion fails. The other ~2000 tests pass; this is purely a test-timing flake, not a product bug — in production the streams stay open and flush continuously.

This replaces the fixed sleep + single read with a small poll-until-content helper (2 s cap), making the assertion deterministic across platforms. The `broadcastEvent` assertions are unchanged, since those events fire synchronously during the request and were never the flaky part.

## Testing Instructions

- `npm test -- apps/cli/tests/daemon.test.ts` passes.
- The previously failing case is `ProcessManagerDaemon > starts a process, emits events, and writes logs`; it now waits for the flushed log output instead of guessing with a fixed delay, so it no longer races on Windows.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
