### PR TITLE
Update SQLite database integration to v3.0.0-rc.4

### DIFF
--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -47,7 +47,7 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.3';
+const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.4';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/releases/download/${ SQLITE_DATABASE_INTEGRATION_VERSION }/plugin-sqlite-database-integration.zip`;
 


### PR DESCRIPTION
## Related issues

- https://github.com/WordPress/sqlite-database-integration/releases/tag/v3.0.0-rc.4

## How AI was used in this PR

Used Claude Code to locate the SQLite version constant, confirm it is the single source of truth, verify the new release asset exists, and bump the version.

## Proposed Changes

- Bumps the bundled WordPress SQLite database integration plugin from `v3.0.0-rc.3` to `v3.0.0-rc.4`. This is the release downloaded into the WordPress server files at build time, so local sites will run the latest release candidate of the SQLite integration plugin.

## Testing Instructions

- Run the server-files download step and confirm `plugin-sqlite-database-integration.zip` is fetched from the `v3.0.0-rc.4` release and extracted into `wp-files/sqlite-database-integration/`.
- Start a local site and confirm it boots and operates normally against SQLite.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
