### PR TITLE
Add IPv6 loopback hosts entry for custom domains to fix slow .local DNS on macOS

### DIFF
--- a/apps/cli/lib/hosts-file.ts
+++ b/apps/cli/lib/hosts-file.ts
@@ -64,16 +64,31 @@ export const writeHostsFile = async ( content: string ): Promise< void > => {
 };
 
 /**
- * Create a regular expression matching the hosts entry for a given domain:
+ * Create a regular expression matching the hosts entries for a given domain,
+ * covering both the IPv4 and IPv6 loopback addresses:
  *
  * 	127.0.0.1 foo.wp.cloud # Port 8000
+ * 	::1 foo.wp.cloud # Port 8000
  *
  * 	Remove backslashes as a security measure and escape regex special characters.
  */
 export function createHostsEntryPattern( domain: string ): RegExp {
 	const sanitizedDomain = domain.replace( /\\/g, '' );
 	const escapedDomain = escapeRegex( sanitizedDomain );
-	return new RegExp( `127\\.0\\.0\\.1\\s+${ escapedDomain }(\\s|$)`, 'i' );
+	return new RegExp( `(?:127\\.0\\.0\\.1|::1)\\s+${ escapedDomain }(\\s|$)`, 'i' );
+}
+
+/**
+ * Build the canonical hosts entries for a domain. We add both an IPv4 and an
+ * IPv6 loopback entry: without the explicit `::1` line, macOS issues an IPv6
+ * (AAAA) lookup for `.local` domains that has to time out before the IPv4
+ * result is used, adding several seconds to every request.
+ */
+function createHostsEntries( encodedDomain: string, port: number ): string[] {
+	return [
+		`127.0.0.1 ${ encodedDomain } # Port ${ port }`,
+		`::1 ${ encodedDomain } # Port ${ port }`,
+	];
 }
 
 /**
@@ -86,13 +101,23 @@ export const addDomainToHosts = async ( domain: string, port: number ): Promise<
 
 		const newContent = updateStudioBlock( hostsContent, ( entries ) => {
 			const pattern = createHostsEntryPattern( encodedDomain );
+			const desired = createHostsEntries( encodedDomain, port );
+			const existing = entries.filter( ( entry ) => entry.match( pattern ) );
 
-			// No changes if domain already present
-			if ( entries.some( ( entry ) => entry.match( pattern ) ) ) {
+			// No changes if the canonical entries are already present. This also
+			// preserves ordering so unchanged sites don't trigger a write (and an
+			// elevated-permissions prompt) on every start.
+			if (
+				existing.length === desired.length &&
+				desired.every( ( entry, index ) => existing[ index ] === entry )
+			) {
 				return entries;
 			}
 
-			return [ ...entries, `127.0.0.1 ${ encodedDomain } # Port ${ port }` ];
+			// Otherwise drop any stale entries for this domain (e.g. a legacy
+			// IPv4-only line from before IPv6 support) and add the canonical pair.
+			const filtered = entries.filter( ( entry ) => ! entry.match( pattern ) );
+			return [ ...filtered, ...desired ];
 		} );
 
 		if ( newContent !== hostsContent ) {
@@ -157,7 +182,7 @@ export const updateDomainInHosts = async (
 		const oldPattern = createHostsEntryPattern( encodedOldDomain );
 		const newContent = updateStudioBlock( hostsContent, ( entries ) => {
 			const filtered = entries.filter( ( entry ) => ! entry.match( oldPattern ) );
-			return [ ...filtered, `127.0.0.1 ${ encodedNewDomain } # Port ${ port }` ];
+			return [ ...filtered, ...createHostsEntries( encodedNewDomain, port ) ];
 		} );
 
 		if ( newContent !== hostsContent ) {

--- a/apps/cli/lib/tests/hosts-file.test.ts
+++ b/apps/cli/lib/tests/hosts-file.test.ts
@@ -1,8 +1,13 @@
 import { platform } from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { writeHostsFile } from 'cli/lib/hosts-file';
+import { addDomainToHosts, removeDomainFromHosts, writeHostsFile } from 'cli/lib/hosts-file';
 import { sudoExec } from 'cli/lib/sudo-exec';
+
+const fsState = vi.hoisted( () => ( {
+	readContent: '',
+	writtenContent: null as string | null,
+} ) );
 
 vi.mock( 'os', async ( importOriginal ) => {
 	const actual = await importOriginal< typeof import('os') >();
@@ -18,13 +23,18 @@ vi.mock( 'os', async ( importOriginal ) => {
 
 vi.mock( 'fs', async ( importOriginal ) => {
 	const actual = await importOriginal< typeof import('fs') >();
-	const writeFile: typeof actual.writeFile = ( ( _p: unknown, _d: unknown, cb: unknown ) => {
+	const writeFile: typeof actual.writeFile = ( ( _p: unknown, data: unknown, cb: unknown ) => {
+		fsState.writtenContent = data as string;
 		( cb as ( err: null ) => void )( null );
 	} ) as typeof actual.writeFile;
+	const readFile: typeof actual.readFile = ( ( _p: unknown, _opts: unknown, cb: unknown ) => {
+		( cb as ( err: null, data: string ) => void )( null, fsState.readContent );
+	} ) as typeof actual.readFile;
 	return {
 		...actual,
-		default: { ...actual, writeFile },
+		default: { ...actual, writeFile, readFile },
 		writeFile,
+		readFile,
 	};
 } );
 
@@ -76,5 +86,70 @@ describe( 'writeHostsFile', () => {
 		expect( command ).toContain( 'hosts' );
 		expect( command ).not.toContain( 'tee ' );
 		expect( options ).toMatchObject( { name: 'WordPress Studio' } );
+	} );
+} );
+
+describe( 'addDomainToHosts', () => {
+	beforeEach( () => {
+		vi.mocked( platform ).mockReturnValue( 'darwin' );
+		fsState.readContent = '';
+		fsState.writtenContent = null;
+	} );
+
+	it( 'writes both an IPv4 and an IPv6 loopback entry for a new domain', async () => {
+		await addDomainToHosts( 'my-project.local', 8000 );
+
+		expect( fsState.writtenContent ).toContain( '127.0.0.1 my-project.local # Port 8000' );
+		expect( fsState.writtenContent ).toContain( '::1 my-project.local # Port 8000' );
+		expect( fsState.writtenContent ).toContain( '# BEGIN WordPress Studio' );
+		expect( fsState.writtenContent ).toContain( '# END WordPress Studio' );
+	} );
+
+	it( 'migrates a legacy IPv4-only entry by adding the IPv6 entry', async () => {
+		fsState.readContent = [
+			'# BEGIN WordPress Studio',
+			'127.0.0.1 my-project.local # Port 8000',
+			'# END WordPress Studio',
+		].join( '\n' );
+
+		await addDomainToHosts( 'my-project.local', 8000 );
+
+		expect( fsState.writtenContent ).toContain( '127.0.0.1 my-project.local # Port 8000' );
+		expect( fsState.writtenContent ).toContain( '::1 my-project.local # Port 8000' );
+	} );
+
+	it( 'does not rewrite the hosts file when the entries are already present', async () => {
+		fsState.readContent = [
+			'# BEGIN WordPress Studio',
+			'127.0.0.1 my-project.local # Port 8000',
+			'::1 my-project.local # Port 8000',
+			'# END WordPress Studio',
+		].join( '\n' );
+
+		await addDomainToHosts( 'my-project.local', 8000 );
+
+		expect( fsState.writtenContent ).toBeNull();
+		expect( vi.mocked( sudoExec ) ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'removeDomainFromHosts', () => {
+	beforeEach( () => {
+		vi.mocked( platform ).mockReturnValue( 'darwin' );
+		fsState.readContent = [
+			'# BEGIN WordPress Studio',
+			'127.0.0.1 my-project.local # Port 8000',
+			'::1 my-project.local # Port 8000',
+			'# END WordPress Studio',
+		].join( '\n' );
+		fsState.writtenContent = null;
+	} );
+
+	it( 'removes both the IPv4 and IPv6 entries', async () => {
+		await removeDomainFromHosts( 'my-project.local' );
+
+		// The block is emptied and removed entirely.
+		expect( fsState.writtenContent ).not.toContain( 'my-project.local' );
+		expect( fsState.writtenContent ).not.toContain( '# BEGIN WordPress Studio' );
 	} );
 } );


### PR DESCRIPTION
## Related issues

- Fixes #3655

## How AI was used in this PR

Claude Code investigated the reported `.local` slowdown, located the hosts-file logic, implemented the IPv6 entry plus the migration path for existing sites, and wrote the tests. The author reviewed the diff and reasoning.

## Proposed Changes

On macOS, resolving a `.local` custom domain that only has an IPv4 entry in the hosts file can stall on an IPv6 (AAAA) lookup that has to time out before the IPv4 result is used — adding several seconds to every request for affected users (see #3655). This writes a matching `::1` loopback entry alongside the existing `127.0.0.1` entry for each custom domain, which is the standard remedy for this behavior.

Users with existing custom-domain sites are migrated automatically: the IPv6 entry is added the next time the site starts. Already-correct entries are left untouched, so no spurious elevated-permission prompt appears on startup.

The slowdown is environment-dependent (the linked issue tags it as affecting "Some (< 50%)" of users), but the extra entry is harmless for unaffected users and is the cure for those who hit it.

## Testing Instructions

On a macOS machine that exhibits the slowdown:

1. Create a Studio site with a custom `.local` domain.
2. Measure: `time curl -sI http://your-domain.local/ > /dev/null` — note the time.
3. With this change, restart the site so the hosts file is rewritten.
4. Confirm `/etc/hosts` now contains both `127.0.0.1 your-domain.local` and `::1 your-domain.local` inside the `# BEGIN/END WordPress Studio` block.
5. Re-measure with the same `curl` command — the time should drop substantially.
6. Delete the site and confirm both entries are removed (no orphaned `::1` line).

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
