### PR TITLE
Add Studio extension system prototype

### DIFF
--- a/apps/studio/electron.vite.config.ts
+++ b/apps/studio/electron.vite.config.ts
@@ -1,11 +1,12 @@
-import { resolve } from 'path';
 import { createRequire } from 'module';
+import { resolve } from 'path';
+import { sentryVitePlugin } from '@sentry/vite-plugin';
+import react from '@vitejs/plugin-react';
 import { defineConfig } from 'electron-vite';
 import { normalizePath } from 'vite';
-import react from '@vitejs/plugin-react';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import wasm from 'vite-plugin-wasm';
-import { sentryVitePlugin } from '@sentry/vite-plugin';
+import { getStudioExtensionsDirectory } from '../../tools/common/lib/well-known-paths';
 import { getSentryReleaseInfo } from './src/lib/sentry-release';
 
 const version = process.env.npm_package_version || '';
@@ -45,7 +46,7 @@ export default defineConfig( {
 				output: {
 					entryFileNames: '[name].js',
 				},
-				external: [ /^@php-wasm\/.*/ ],
+				external: [ /^@php-wasm\/.*/, 'esbuild' ],
 			},
 		},
 	},
@@ -130,7 +131,7 @@ export default defineConfig( {
 		},
 		server: {
 			fs: {
-				allow: [ '..', '../..' ],
+				allow: [ '..', '../..', normalizePath( getStudioExtensionsDirectory() ) ],
 			},
 		},
 		build: {
@@ -147,10 +148,18 @@ export default defineConfig( {
 					},
 					// Optimize chunk splitting for better caching
 					manualChunks: ( id ) => {
-						if ( [ 'react', 'react-dom', '@wordpress/components', '@wordpress/element' ].some( ( pkg ) => id.includes( `/node_modules/${ pkg }/` ) ) ) {
+						if (
+							[ 'react', 'react-dom', '@wordpress/components', '@wordpress/element' ].some(
+								( pkg ) => id.includes( `/node_modules/${ pkg }/` )
+							)
+						) {
 							return 'vendor';
 						}
-						if ( [ '@sentry/react', '@sentry/electron' ].some( ( pkg ) => id.includes( `/node_modules/${ pkg }/` ) ) ) {
+						if (
+							[ '@sentry/react', '@sentry/electron' ].some( ( pkg ) =>
+								id.includes( `/node_modules/${ pkg }/` )
+							)
+						) {
 							return 'sentry';
 						}
 					},

--- a/apps/studio/src/components/app.tsx
+++ b/apps/studio/src/components/app.tsx
@@ -9,6 +9,10 @@ import MainSidebar from 'src/components/main-sidebar';
 import { NoStudioSites } from 'src/components/no-studio-sites';
 import { SiteContentTabs } from 'src/components/site-content-tabs';
 import TopBar from 'src/components/top-bar';
+import {
+	StudioExtensionMainContent,
+	useHasActiveStudioExtensions,
+} from 'src/extensions/components/studio-extension-main-content';
 import { useListenDeepLinkConnection } from 'src/hooks/sync-sites/use-listen-deep-link-connection';
 import { useAuth } from 'src/hooks/use-auth';
 import { useLocalizationSupport } from 'src/hooks/use-localization-support';
@@ -41,7 +45,9 @@ export default function App() {
 	);
 	const { showWhatsNew, closeWhatsNew } = useWhatsNew();
 	const { sites: localSites, loadingSites } = useSiteDetails();
-	const isEmpty = ! loadingSites && ! localSites.length;
+	const { hasActiveExtensions, isLoading: loadingExtensions } = useHasActiveStudioExtensions();
+	const isEmpty =
+		! loadingSites && ! loadingExtensions && ! localSites.length && ! hasActiveExtensions;
 	const shouldShowWhatsNew = showWhatsNew && ! isEmpty;
 	const { client } = useAuth();
 	const dispatch = useAppDispatch();
@@ -120,7 +126,7 @@ export default function App() {
 							data-testid="site-content"
 							className="bg-frame text-frame-text h-full flex-grow rounded-chrome overflow-hidden z-10"
 						>
-							<SiteContentTabs />
+							<StudioExtensionMainContent fallback={ <SiteContentTabs /> } />
 						</main>
 					</HStack>
 				</VStack>

--- a/apps/studio/src/components/form-path-input.tsx
+++ b/apps/studio/src/components/form-path-input.tsx
@@ -9,6 +9,7 @@ export interface FormPathInputComponentProps {
 	error?: string;
 	tipMessage?: string;
 	id?: string;
+	disabled?: boolean;
 }
 
 export function FormPathInputComponent( {
@@ -17,6 +18,7 @@ export function FormPathInputComponent( {
 	error,
 	tipMessage,
 	id = 'site-path',
+	disabled = false,
 }: FormPathInputComponentProps ) {
 	const { __ } = useI18n();
 	const errorId = `${ id }-error`;
@@ -43,6 +45,7 @@ export function FormPathInputComponent( {
 				data-testid="select-path-button"
 				onClick={ onClick }
 				id={ id }
+				disabled={ disabled }
 			>
 				<div
 					aria-hidden="true"

--- a/apps/studio/src/components/main-sidebar.tsx
+++ b/apps/studio/src/components/main-sidebar.tsx
@@ -1,6 +1,10 @@
 import { __ } from '@wordpress/i18n';
 import { RunningSites } from 'src/components/running-sites';
 import SiteMenu from 'src/components/site-menu';
+import {
+	StudioExtensionSidebarSections,
+	useStudioExtensionSidebarSections,
+} from 'src/extensions/components/studio-extension-sidebar-sections';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { isMac } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
@@ -13,6 +17,10 @@ interface MainSidebarProps {
 
 export default function MainSidebar( { className, style }: MainSidebarProps ) {
 	const { sites: localSites } = useSiteDetails();
+	const { sections: extensionSections, isLoading: loadingExtensions } =
+		useStudioExtensionSidebarSections();
+	const hasSidebarItems =
+		localSites.length > 0 || extensionSections.length > 0 || loadingExtensions;
 
 	return (
 		<div
@@ -20,9 +28,9 @@ export default function MainSidebar( { className, style }: MainSidebarProps ) {
 			className={ cx( 'text-chrome-inverted relative pt-[10px]', className ) }
 			style={ style }
 		>
-			{ ! localSites.length ? (
+			{ ! hasSidebarItems ? (
 				<div className="flex h-full px-[20px] justify-center items-center app-no-drag-region text-center text-[12px] text-a8c-gray-50">
-					{ __( 'Your sites will show up here once you create them' ) }
+					{ __( 'Your sites and extensions will show up here once you add them' ) }
 				</div>
 			) : (
 				<div className="flex flex-col h-full">
@@ -32,7 +40,8 @@ export default function MainSidebar( { className, style }: MainSidebarProps ) {
 							isMac() ? 'ms-4' : 'ms-3'
 						) }
 					>
-						<SiteMenu />
+						{ localSites.length > 0 && <SiteMenu /> }
+						<StudioExtensionSidebarSections />
 					</div>
 					<div className="flex flex-col gap-4 pt-5 border-white border-t border-opacity-10 app-no-drag-region">
 						<RunningSites />

--- a/apps/studio/src/components/root.tsx
+++ b/apps/studio/src/components/root.tsx
@@ -9,6 +9,7 @@ import AuthProvider from 'src/components/auth-provider';
 import CrashTester from 'src/components/crash-tester';
 import ErrorBoundary from 'src/components/error-boundary';
 import { WordPressStyles } from 'src/components/wordpress-styles';
+import { StudioExtensionProviders } from 'src/extensions/components/studio-extension-providers';
 import { ContentTabsProvider } from 'src/hooks/use-content-tabs';
 import { FeatureFlagsProvider } from 'src/hooks/use-feature-flags';
 import { ImportExportProvider } from 'src/hooks/use-import-export';
@@ -40,11 +41,13 @@ const Root = () => {
 								<ContentTabsProvider>
 									<SiteDetailsProvider>
 										<ThemeDetailsProvider>
-											<OnboardingProvider>
-												<ImportExportProvider>
-													<App />
-												</ImportExportProvider>
-											</OnboardingProvider>
+											<StudioExtensionProviders>
+												<OnboardingProvider>
+													<ImportExportProvider>
+														<App />
+													</ImportExportProvider>
+												</OnboardingProvider>
+											</StudioExtensionProviders>
 										</ThemeDetailsProvider>
 									</SiteDetailsProvider>
 								</ContentTabsProvider>

--- a/apps/studio/src/components/site-menu.tsx
+++ b/apps/studio/src/components/site-menu.tsx
@@ -5,6 +5,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
 import { XDebugIcon } from 'src/components/icons/xdebug-icon';
 import { Tooltip } from 'src/components/tooltip';
+import {
+	STUDIO_MAIN_CONTENT_SELECTION_EVENT,
+	type StudioMainContentSelectionEventDetail,
+} from 'src/extensions/types';
 import { useContentTabs } from 'src/hooks/use-content-tabs';
 import { useDeleteSite } from 'src/hooks/use-delete-site';
 import { useImportExport } from 'src/hooks/use-import-export';
@@ -227,6 +231,12 @@ function SiteItem( {
 				className="p-2 text-xs rounded-tl rounded-bl whitespace-nowrap overflow-hidden text-ellipsis w-full text-left rtl:text-right focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-frame-theme"
 				onClick={ () => {
 					setSelectedSiteId( site.id );
+					window.dispatchEvent(
+						new CustomEvent< StudioMainContentSelectionEventDetail >(
+							STUDIO_MAIN_CONTENT_SELECTION_EVENT,
+							{ detail: { source: 'site', id: site.id } }
+						)
+					);
 				} }
 			>
 				{ site.name }

--- a/apps/studio/src/components/tests/app.test.tsx
+++ b/apps/studio/src/components/tests/app.test.tsx
@@ -14,6 +14,7 @@ import { connectedSitesApi } from 'src/stores/sync/connected-sites';
 import { wpcomSitesApi } from 'src/stores/sync/wpcom-sites';
 import { wordpressVersionsApi } from 'src/stores/wordpress-versions-api';
 import { wpcomApi, wpcomPublicApi } from 'src/stores/wpcom-api';
+import type { ReactNode } from 'react';
 
 vi.mock( 'src/index.css', () => ( {} ) );
 vi.mock( 'src/components/dot-grid', () => ( {
@@ -28,6 +29,17 @@ vi.mock( 'src/stores/onboarding-slice', async () => {
 } );
 vi.mock( 'src/modules/onboarding/hooks/use-onboarding' );
 vi.mock( 'src/hooks/use-site-details' );
+
+const mockExtensionState = vi.hoisted( () => ( {
+	hasActiveExtensions: false,
+	isLoading: false,
+} ) );
+
+vi.mock( 'src/extensions/components/studio-extension-main-content', () => ( {
+	StudioExtensionMainContent: ( { fallback }: { fallback: ReactNode } ) => fallback,
+	useHasActiveStudioExtensions: () => mockExtensionState,
+} ) );
+
 vi.mock( 'src/modules/whats-new/hooks/use-whats-new', () => ( {
 	useWhatsNew: () => ( {
 		showWhatsNew: false,
@@ -94,6 +106,16 @@ vi.mock( 'src/stores/wpcom-api', async () => {
 describe( 'App', () => {
 	beforeEach( () => {
 		vi.clearAllMocks();
+		Object.defineProperty( globalThis, 'localStorage', {
+			value: {
+				getItem: vi.fn().mockReturnValue( null ),
+				setItem: vi.fn(),
+				removeItem: vi.fn(),
+			},
+			configurable: true,
+		} );
+		mockExtensionState.hasActiveExtensions = false;
+		mockExtensionState.isLoading = false;
 	} );
 
 	const renderWithProvider = ( component: React.ReactElement ) => {

--- a/apps/studio/src/components/tests/main-sidebar.test.tsx
+++ b/apps/studio/src/components/tests/main-sidebar.test.tsx
@@ -6,8 +6,26 @@ import MainSidebar from 'src/components/main-sidebar';
 import { useAuth } from 'src/hooks/use-auth';
 import { ContentTabsProvider } from 'src/hooks/use-content-tabs';
 import { store } from 'src/stores';
+import type { StudioExtensionSidebarSection } from 'src/extensions/types';
 
 vi.mock( 'src/hooks/use-auth' );
+
+const mockExtensionSidebar = vi.hoisted( () => ( {
+	sections: [] as StudioExtensionSidebarSection[],
+	isLoading: false,
+} ) );
+
+vi.mock( 'src/extensions/components/studio-extension-sidebar-sections', () => ( {
+	useStudioExtensionSidebarSections: () => mockExtensionSidebar,
+	StudioExtensionSidebarSections: () => (
+		<>
+			{ mockExtensionSidebar.sections.map( ( section ) => {
+				const Section = section.component;
+				return <Section key={ section.id } />;
+			} ) }
+		</>
+	),
+} ) );
 
 vi.mock( 'src/stores/wordpress-versions-api', () => ( {
 	wordpressVersionsApi: {
@@ -109,6 +127,8 @@ const renderWithProvider = ( children: React.ReactElement ) => {
 describe( 'MainSidebar Footer', () => {
 	beforeEach( () => {
 		vi.clearAllMocks();
+		mockExtensionSidebar.sections = [];
+		mockExtensionSidebar.isLoading = false;
 	} );
 	it( 'Has add site button', async () => {
 		vi.mocked( useAuth, { partial: true } ).mockReturnValue( { isAuthenticated: false } );
@@ -133,6 +153,44 @@ describe( 'MainSidebar Footer', () => {
 		await act( async () => renderWithProvider( <MainSidebar /> ) );
 		expect( screen.getByRole( 'button', { name: 'Stop all' } ) ).toBeVisible();
 		site2.running = false;
+	} );
+
+	it( 'shows extension sidebar sections when an extension contributes one', async () => {
+		mockExtensionSidebar.sections = [
+			{
+				id: 'test-plugin-projects',
+				component: () => (
+					<nav aria-label="Plugin projects">
+						<button type="button">Add plugin project</button>
+					</nav>
+				),
+			},
+		];
+		await act( async () => renderWithProvider( <MainSidebar /> ) );
+		expect( screen.getByRole( 'navigation', { name: 'Plugin projects' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Add plugin project' } ) ).toBeVisible();
+	} );
+
+	it( 'keeps extension section interactions inside contributed UI', async () => {
+		const user = userEvent.setup();
+		const selectRemotePlugin = vi.fn();
+		mockExtensionSidebar.sections = [
+			{
+				id: 'test-remote-plugins',
+				component: () => (
+					<nav aria-label="Plugin projects">
+						<button type="button" onClick={ () => selectRemotePlugin( 'remote-sample-plugin' ) }>
+							Remote Sample Plugin
+						</button>
+					</nav>
+				),
+			},
+		];
+
+		await act( async () => renderWithProvider( <MainSidebar /> ) );
+		await user.click( screen.getByRole( 'button', { name: 'Remote Sample Plugin' } ) );
+
+		expect( selectRemotePlugin ).toHaveBeenCalledWith( 'remote-sample-plugin' );
 	} );
 } );
 

--- a/apps/studio/src/extensions/components/extensions-settings-tab.tsx
+++ b/apps/studio/src/extensions/components/extensions-settings-tab.tsx
@@ -1,0 +1,259 @@
+import { CheckboxControl, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { FormEvent, useState } from 'react';
+import Button from 'src/components/button';
+import { FormPathInputComponent } from 'src/components/form-path-input';
+import TextControl from 'src/components/text-control';
+import { cx } from 'src/lib/cx';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { SettingsFormField } from 'src/modules/user-settings/components/settings-form-field';
+import {
+	useGetStudioExtensionsQuery,
+	useInstallStudioExtensionMutation,
+	useInstallStudioExtensionFromPathMutation,
+	useInstallStudioExtensionFromUrlMutation,
+	useSetStudioExtensionEnabledMutation,
+	useUninstallStudioExtensionMutation,
+} from 'src/stores/installed-apps-api';
+import type { StudioExtensionListItem } from '../types';
+
+type InstallSourceMode = 'directory' | 'git';
+
+function getInstallErrorMessage( error: unknown ): string {
+	if ( error instanceof Error ) {
+		return error.message;
+	}
+	if ( typeof error === 'object' && error && 'data' in error ) {
+		const data = error.data;
+		if ( typeof data === 'string' ) {
+			return data;
+		}
+	}
+	if ( typeof error === 'object' && error && 'error' in error ) {
+		const message = error.error;
+		if ( typeof message === 'string' ) {
+			return message;
+		}
+	}
+	if ( typeof error === 'object' && error && 'message' in error ) {
+		const message = error.message;
+		if ( typeof message === 'string' ) {
+			return message;
+		}
+	}
+	return __( 'Unable to install extension.' );
+}
+
+function getExtensionStatusLabel( extension: StudioExtensionListItem ): string {
+	if ( extension.status === 'unsupported' ) {
+		return __( 'Installed, unsupported' );
+	}
+	if ( extension.status === 'missing' ) {
+		return __( 'Missing from disk' );
+	}
+	if ( extension.installed ) {
+		return extension.enabled ? __( 'Enabled' ) : __( 'Installed' );
+	}
+	return extension.kind === 'built-in' ? __( 'Available' ) : __( 'Not installed' );
+}
+
+function getExtensionActionLabel( extension: StudioExtensionListItem ): string {
+	if ( extension.status === 'missing' ) {
+		return __( 'Remove' );
+	}
+	return extension.installed ? __( 'Uninstall' ) : __( 'Install' );
+}
+
+function shouldUninstallExtension( extension: StudioExtensionListItem ): boolean {
+	return extension.installed || extension.status === 'missing';
+}
+
+export function ExtensionsSettingsTab() {
+	const { data: extensions = [], isLoading } = useGetStudioExtensionsQuery();
+	const [ installExtension, installState ] = useInstallStudioExtensionMutation();
+	const [ installExtensionFromPath, installFromPathState ] =
+		useInstallStudioExtensionFromPathMutation();
+	const [ installExtensionFromUrl, installFromUrlState ] =
+		useInstallStudioExtensionFromUrlMutation();
+	const [ uninstallExtension, uninstallState ] = useUninstallStudioExtensionMutation();
+	const [ setExtensionEnabled, enabledState ] = useSetStudioExtensionEnabledMutation();
+	const [ installMode, setInstallMode ] = useState< InstallSourceMode >( 'git' );
+	const [ gitSourceUrl, setGitSourceUrl ] = useState( '' );
+	const [ directoryPath, setDirectoryPath ] = useState( '' );
+	const [ installError, setInstallError ] = useState< string | null >( null );
+	const isSaving =
+		installState.isLoading ||
+		installFromPathState.isLoading ||
+		installFromUrlState.isLoading ||
+		uninstallState.isLoading ||
+		enabledState.isLoading;
+	const installSourceValue = installMode === 'git' ? gitSourceUrl : directoryPath;
+	const selectedDirectoryLabel = directoryPath || __( 'Choose extension folder…' );
+
+	async function handleChooseDirectory() {
+		const response = await getIpcApi().showOpenFolderDialog(
+			__( 'Select extension folder' ),
+			directoryPath
+		);
+		if ( response?.path ) {
+			setDirectoryPath( response.path );
+			setInstallError( null );
+		}
+	}
+
+	async function handleInstallFromSource( event: FormEvent< HTMLFormElement > ) {
+		event.preventDefault();
+		const trimmedSource = installSourceValue.trim();
+		if ( ! trimmedSource ) {
+			return;
+		}
+		setInstallError( null );
+		try {
+			if ( installMode === 'git' ) {
+				await installExtensionFromUrl( trimmedSource ).unwrap();
+				setGitSourceUrl( '' );
+			} else {
+				await installExtensionFromPath( trimmedSource ).unwrap();
+				setDirectoryPath( '' );
+			}
+		} catch ( error ) {
+			setInstallError( getInstallErrorMessage( error ) );
+		}
+	}
+
+	if ( isLoading ) {
+		return (
+			<div className="flex items-center gap-2 text-sm text-frame-text-secondary">
+				<Spinner className="!m-0" />
+				{ __( 'Loading extensions…' ) }
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-4">
+			<form
+				className="rounded-sm border border-frame-border bg-frame-surface p-4"
+				onSubmit={ handleInstallFromSource }
+			>
+				<div
+					className="mb-4 inline-flex rounded-sm border border-frame-border bg-frame-bg p-0.5"
+					role="tablist"
+					aria-label={ __( 'Extension install source' ) }
+				>
+					{ (
+						[
+							[ 'git', __( 'Git URL' ) ],
+							[ 'directory', __( 'Local directory' ) ],
+						] as const
+					 ).map( ( [ mode, label ] ) => {
+						const isSelected = installMode === mode;
+						return (
+							<button
+								key={ mode }
+								type="button"
+								role="tab"
+								aria-selected={ isSelected }
+								className={ cx(
+									'rounded-[2px] px-3 py-1.5 text-sm',
+									'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-frame-theme',
+									isSelected
+										? 'bg-frame-surface text-frame-text shadow-[0_0_0_1px_var(--color-frame-border)]'
+										: 'text-frame-text-secondary hover:text-frame-text'
+								) }
+								onClick={ () => {
+									setInstallMode( mode );
+									setInstallError( null );
+								} }
+							>
+								{ label }
+							</button>
+						);
+					} ) }
+				</div>
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+					<div className="min-w-0 flex-1">
+						{ installMode === 'git' ? (
+							<TextControl
+								label={ __( 'Git URL' ) }
+								value={ gitSourceUrl }
+								placeholder="https://github.com/example/studio-extension"
+								disabled={ isSaving }
+								onChange={ setGitSourceUrl }
+							/>
+						) : (
+							<SettingsFormField label={ __( 'Local directory' ) }>
+								<FormPathInputComponent
+									id="extension-directory-path"
+									value={ selectedDirectoryLabel }
+									onClick={ handleChooseDirectory }
+									disabled={ isSaving }
+								/>
+							</SettingsFormField>
+						) }
+					</div>
+					<Button
+						type="submit"
+						variant="primary"
+						disabled={ isSaving || installSourceValue.trim() === '' }
+					>
+						{ __( 'Install' ) }
+					</Button>
+				</div>
+				{ installError && <p className="mt-3 text-sm text-frame-error">{ installError }</p> }
+			</form>
+			{ extensions.map( ( extension ) => (
+				<section
+					key={ extension.id }
+					className="rounded-sm border border-frame-border bg-frame-surface p-4"
+				>
+					<div className="flex items-start justify-between gap-5">
+						<div className="min-w-0">
+							<h2 className="a8c-subtitle-small">{ extension.name }</h2>
+							<p className="mt-1 text-sm text-frame-text-secondary">{ extension.description }</p>
+							<p className="mt-2 text-xs text-frame-text-secondary">
+								{ extension.kind === 'built-in' ? __( 'Built-in extension' ) : __( 'Extension' ) } ·{ ' ' }
+								{ extension.version } · { getExtensionStatusLabel( extension ) }
+							</p>
+							{ extension.sourceUrl && (
+								<p className="mt-2 break-all text-xs text-frame-text-secondary">
+									{ extension.sourceUrl }
+								</p>
+							) }
+							{ extension.installedPath && (
+								<p className="mt-1 break-all text-xs text-frame-text-secondary">
+									{ extension.installedPath }
+								</p>
+							) }
+						</div>
+						<Button
+							variant={ shouldUninstallExtension( extension ) ? 'secondary' : 'primary' }
+							disabled={
+								isSaving ||
+								( ! extension.installed &&
+									! [ 'available', 'missing' ].includes( extension.status ) )
+							}
+							onClick={ () =>
+								shouldUninstallExtension( extension )
+									? uninstallExtension( extension.id )
+									: installExtension( extension.id )
+							}
+						>
+							{ getExtensionActionLabel( extension ) }
+						</Button>
+					</div>
+					<div className="mt-4">
+						<CheckboxControl
+							label={ __( 'Enabled' ) }
+							checked={ extension.enabled }
+							disabled={ isSaving || ! extension.installed || ! extension.isSupported }
+							onChange={ ( checked ) =>
+								setExtensionEnabled( { extensionId: extension.id, enabled: checked } )
+							}
+						/>
+					</div>
+				</section>
+			) ) }
+		</div>
+	);
+}

--- a/apps/studio/src/extensions/components/studio-extension-main-content.tsx
+++ b/apps/studio/src/extensions/components/studio-extension-main-content.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useActiveStudioExtensions } from '../hooks/use-active-studio-extensions';
+import type { StudioExtensionMainContentPanel } from '../types';
+
+function filterPanelIds( current: Set< string >, stablePanelIds: Set< string > ) {
+	const next = new Set( [ ...current ].filter( ( panelId ) => stablePanelIds.has( panelId ) ) );
+	return next.size === current.size ? current : next;
+}
+
+function MainContentPanel( {
+	onPanelStateChange,
+	panel,
+}: {
+	onPanelStateChange: ( panelId: string, isActive: boolean, isMounted: boolean ) => void;
+	panel: StudioExtensionMainContentPanel;
+} ) {
+	const isActive = panel.useIsActive();
+	const Panel = panel.component;
+
+	useEffect( () => {
+		onPanelStateChange( panel.id, isActive, true );
+		return () => onPanelStateChange( panel.id, false, false );
+	}, [ isActive, onPanelStateChange, panel.id ] );
+
+	return isActive ? <Panel /> : null;
+}
+
+export function useHasActiveStudioExtensions() {
+	const { extensions, isLoading } = useActiveStudioExtensions();
+	return {
+		isLoading,
+		hasActiveExtensions: extensions.length > 0,
+	};
+}
+
+export function StudioExtensionMainContent( { fallback }: { fallback: ReactNode } ) {
+	const { extensions } = useActiveStudioExtensions();
+	const panels = useMemo(
+		() => extensions.flatMap( ( extension ) => extension.mainContentPanels ?? [] ),
+		[ extensions ]
+	);
+	const [ activePanelIds, setActivePanelIds ] = useState< Set< string > >( new Set() );
+	const [ mountedPanelIds, setMountedPanelIds ] = useState< Set< string > >( new Set() );
+
+	const handlePanelStateChange = useCallback(
+		( panelId: string, isActive: boolean, isMounted: boolean ) => {
+			setMountedPanelIds( ( current ) => {
+				const next = new Set( current );
+				if ( isMounted ) {
+					next.add( panelId );
+				} else {
+					next.delete( panelId );
+				}
+				return next;
+			} );
+
+			setActivePanelIds( ( current ) => {
+				const next = new Set( current );
+				if ( isActive ) {
+					next.add( panelId );
+				} else {
+					next.delete( panelId );
+				}
+				return next;
+			} );
+		},
+		[]
+	);
+
+	const shouldRenderFallback =
+		panels.length === 0 || ( mountedPanelIds.size === panels.length && activePanelIds.size === 0 );
+
+	const stablePanels = useMemo( () => new Set( panels.map( ( panel ) => panel.id ) ), [ panels ] );
+
+	useEffect( () => {
+		setMountedPanelIds( ( current ) => filterPanelIds( current, stablePanels ) );
+		setActivePanelIds( ( current ) => filterPanelIds( current, stablePanels ) );
+	}, [ stablePanels ] );
+
+	return (
+		<>
+			{ panels.map( ( panel ) => (
+				<MainContentPanel
+					key={ panel.id }
+					panel={ panel }
+					onPanelStateChange={ handlePanelStateChange }
+				/>
+			) ) }
+			{ shouldRenderFallback && fallback }
+		</>
+	);
+}

--- a/apps/studio/src/extensions/components/studio-extension-providers.tsx
+++ b/apps/studio/src/extensions/components/studio-extension-providers.tsx
@@ -1,0 +1,15 @@
+import { useMemo, type ReactNode } from 'react';
+import { useActiveStudioExtensions } from '../hooks/use-active-studio-extensions';
+
+export function StudioExtensionProviders( { children }: { children: ReactNode } ) {
+	const { extensions } = useActiveStudioExtensions();
+	const providers = useMemo(
+		() => extensions.flatMap( ( extension ) => extension.providers ?? [] ),
+		[ extensions ]
+	);
+
+	return providers.reduceRight(
+		( wrappedChildren, Provider ) => <Provider>{ wrappedChildren }</Provider>,
+		children
+	);
+}

--- a/apps/studio/src/extensions/components/studio-extension-sidebar-sections.tsx
+++ b/apps/studio/src/extensions/components/studio-extension-sidebar-sections.tsx
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import { useActiveStudioExtensions } from '../hooks/use-active-studio-extensions';
+
+export function useStudioExtensionSidebarSections() {
+	const { extensions, isLoading } = useActiveStudioExtensions();
+	return {
+		isLoading,
+		sections: useMemo(
+			() => extensions.flatMap( ( extension ) => extension.sidebarSections ?? [] ),
+			[ extensions ]
+		),
+	};
+}
+
+export function StudioExtensionSidebarSections() {
+	const { sections } = useStudioExtensionSidebarSections();
+
+	return (
+		<>
+			{ sections.map( ( section ) => {
+				const Section = section.component;
+				return <Section key={ section.id } />;
+			} ) }
+		</>
+	);
+}

--- a/apps/studio/src/extensions/hooks/use-active-studio-extensions.ts
+++ b/apps/studio/src/extensions/hooks/use-active-studio-extensions.ts
@@ -1,0 +1,87 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useGetStudioExtensionsQuery } from 'src/stores/installed-apps-api';
+import {
+	loadStudioRendererExtension,
+	registeredStudioRendererExtensions,
+} from '../renderer-registry';
+import type { StudioExtensionListItem, StudioRendererExtension } from '../types';
+
+const EMPTY_EXTENSIONS: StudioExtensionListItem[] = [];
+const EMPTY_RENDERER_EXTENSIONS: StudioRendererExtension[] = [];
+
+function isActiveExtension( extension: StudioExtensionListItem ): boolean {
+	return extension.installed && extension.enabled && extension.isSupported;
+}
+
+export function useActiveStudioExtensions() {
+	const { data: extensions = EMPTY_EXTENSIONS, isLoading } = useGetStudioExtensionsQuery();
+	const activeIds = useMemo(
+		() => new Set( extensions.filter( isActiveExtension ).map( ( extension ) => extension.id ) ),
+		[ extensions ]
+	);
+	const externalExtensions = useMemo(
+		() =>
+			extensions.filter(
+				( extension ) =>
+					isActiveExtension( extension ) && extension.renderer && extension.installedPath
+			),
+		[ extensions ]
+	);
+	const [ loadedExtensions, setLoadedExtensions ] =
+		useState< StudioRendererExtension[] >( EMPTY_RENDERER_EXTENSIONS );
+	const [ isLoadingRendererExtensions, setIsLoadingRendererExtensions ] = useState( false );
+	const activeRegisteredExtensions = useMemo(
+		() =>
+			registeredStudioRendererExtensions.filter( ( extension ) =>
+				activeIds.has( extension.manifest.id )
+			),
+		[ activeIds ]
+	);
+	const activeExtensions = useMemo(
+		() => [ ...activeRegisteredExtensions, ...loadedExtensions ],
+		[ activeRegisteredExtensions, loadedExtensions ]
+	);
+
+	useEffect( () => {
+		let isCurrent = true;
+
+		if ( externalExtensions.length === 0 ) {
+			setLoadedExtensions( EMPTY_RENDERER_EXTENSIONS );
+			setIsLoadingRendererExtensions( false );
+			return () => {
+				isCurrent = false;
+			};
+		}
+
+		setIsLoadingRendererExtensions( true );
+		void Promise.all(
+			externalExtensions.map( async ( extension ) => {
+				try {
+					return await loadStudioRendererExtension( extension );
+				} catch ( error ) {
+					console.error( `Failed to load Studio extension renderer: ${ extension.id }`, error );
+					return undefined;
+				}
+			} )
+		).then( ( loadedRendererExtensions ) => {
+			if ( ! isCurrent ) {
+				return;
+			}
+			setLoadedExtensions(
+				loadedRendererExtensions.filter( ( extension ): extension is StudioRendererExtension =>
+					Boolean( extension )
+				)
+			);
+			setIsLoadingRendererExtensions( false );
+		} );
+
+		return () => {
+			isCurrent = false;
+		};
+	}, [ externalExtensions ] );
+
+	return {
+		isLoading: isLoading || isLoadingRendererExtensions,
+		extensions: activeExtensions,
+	};
+}

--- a/apps/studio/src/extensions/hooks/use-studio-extension-settings.ts
+++ b/apps/studio/src/extensions/hooks/use-studio-extension-settings.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import { useActiveStudioExtensions } from './use-active-studio-extensions';
+
+export function useStudioExtensionSettingsTabs() {
+	const { extensions } = useActiveStudioExtensions();
+	return useMemo(
+		() => extensions.flatMap( ( extension ) => extension.settingsTabs ?? [] ),
+		[ extensions ]
+	);
+}
+
+export function useStudioExtensionAccountSections() {
+	const { extensions } = useActiveStudioExtensions();
+	return useMemo(
+		() => extensions.flatMap( ( extension ) => extension.accountSections ?? [] ),
+		[ extensions ]
+	);
+}

--- a/apps/studio/src/extensions/ipc-handlers.ts
+++ b/apps/studio/src/extensions/ipc-handlers.ts
@@ -1,0 +1,305 @@
+import { sendIpcEventToRenderer } from 'src/ipc-utils';
+import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
+import { clearStudioMainExtensionCache, getStudioExtensionHandler } from './main-registry';
+import {
+	getStudioExtensionInstallPath,
+	installStudioExtensionFromDirectorySource,
+	installStudioExtensionFromGitSource,
+	listInstalledStudioExtensionPackages,
+	normalizeGitSourceUrl,
+	removeInstalledStudioExtensionPackage,
+} from './package-manager';
+import type {
+	InstalledStudioExtensionPackage,
+	StudioExtensionInstallSource,
+	StudioExtensionListItem,
+	StudioExtensionManifest,
+	StudioExtensionState,
+	StudioExtensionStorageState,
+} from './types';
+import type { IpcMainInvokeEvent } from 'electron';
+
+function getDefaultExtensionState(): StudioExtensionState {
+	return {
+		installed: false,
+		enabled: false,
+	};
+}
+
+function normalizeExtensionState(
+	state: Partial< StudioExtensionState > | undefined,
+	extensionPackage: InstalledStudioExtensionPackage | undefined,
+	isSupported: boolean
+): StudioExtensionState {
+	const fallback = getDefaultExtensionState();
+	const packageInstalled = Boolean( extensionPackage );
+	const installed = packageInstalled;
+	return {
+		installed,
+		enabled: installed && isSupported ? state?.enabled ?? fallback.enabled : false,
+		installedPath: extensionPackage?.installedPath ?? state?.installedPath,
+		sourceUrl: state?.sourceUrl,
+		sourceType: state?.sourceType ?? ( extensionPackage ? 'directory' : undefined ),
+		installedAt: state?.installedAt,
+		updatedAt: state?.updatedAt,
+	};
+}
+
+async function readExtensionStorageState(): Promise< StudioExtensionStorageState > {
+	const userData = await loadUserData();
+	return userData.extensions ?? {};
+}
+
+async function saveExtensionState(
+	extensionId: string,
+	update: Partial< StudioExtensionState >
+): Promise< void > {
+	try {
+		await lockAppdata();
+		const userData = await loadUserData();
+		const extensions = userData.extensions ?? {};
+		extensions[ extensionId ] = {
+			...extensions[ extensionId ],
+			...update,
+		};
+		await saveUserData( { ...userData, extensions } );
+		await sendIpcEventToRenderer( 'user-preference-changed' );
+	} finally {
+		await unlockAppdata();
+	}
+}
+
+function createListItem(
+	manifest: StudioExtensionManifest,
+	extensionPackage: InstalledStudioExtensionPackage | undefined,
+	storedState: Partial< StudioExtensionState > | undefined,
+	isSupported: boolean,
+	fallbackKind: StudioExtensionListItem[ 'kind' ]
+): StudioExtensionListItem {
+	const state = normalizeExtensionState( storedState, extensionPackage, isSupported );
+	const wasPreviouslyInstalled = storedState?.installed ?? false;
+	const kind =
+		state.sourceType === 'directory' || state.sourceType === 'git' || state.sourceType === 'manual'
+			? 'user'
+			: manifest.kind ?? fallbackKind;
+	const status = ! state.installed
+		? wasPreviouslyInstalled
+			? 'missing'
+			: 'available'
+		: isSupported
+		? 'installed'
+		: 'unsupported';
+
+	return {
+		...manifest,
+		kind,
+		...state,
+		status,
+		isSupported,
+	};
+}
+
+async function getExtensionListItems(): Promise< StudioExtensionListItem[] > {
+	const [ states, installedPackages ] = await Promise.all( [
+		readExtensionStorageState(),
+		listInstalledStudioExtensionPackages(),
+	] );
+	const packagesById = new Map(
+		installedPackages.map( ( extensionPackage ) => [
+			extensionPackage.manifest.id,
+			extensionPackage,
+		] )
+	);
+	const installedItems = Array.from( packagesById.values() ).map( ( extensionPackage ) =>
+		createListItem(
+			extensionPackage.manifest,
+			extensionPackage,
+			states[ extensionPackage.manifest.id ],
+			true,
+			'user'
+		)
+	);
+	const missingItems = Object.entries( states )
+		.filter( ( [ extensionId, state ] ) => state?.installed && ! packagesById.has( extensionId ) )
+		.map( ( [ extensionId, state ] ) =>
+			createListItem(
+				{
+					id: extensionId,
+					name: extensionId,
+					description: 'Extension package is missing from disk.',
+					version: 'unknown',
+				},
+				undefined,
+				state,
+				false,
+				'user'
+			)
+		);
+
+	return [ ...installedItems, ...missingItems ].sort( ( a, b ) => a.name.localeCompare( b.name ) );
+}
+
+async function getExtensionListItem( extensionId: string ): Promise< StudioExtensionListItem > {
+	const extension = ( await getExtensionListItems() ).find( ( item ) => item.id === extensionId );
+	if ( ! extension ) {
+		throw new Error( `Unknown Studio extension: ${ extensionId }` );
+	}
+	return extension;
+}
+
+async function getInstalledExtensionPackage(
+	extensionId: string
+): Promise< InstalledStudioExtensionPackage > {
+	const extensionPackage = ( await listInstalledStudioExtensionPackages() ).find(
+		( installedPackage ) => installedPackage.manifest.id === extensionId
+	);
+	if ( ! extensionPackage ) {
+		throw new Error( `Unknown Studio extension: ${ extensionId }` );
+	}
+	return extensionPackage;
+}
+
+async function persistInstalledExtension(
+	manifest: StudioExtensionManifest,
+	installedPath: string,
+	sourceType: StudioExtensionInstallSource,
+	options: { sourceUrl?: string; enabled: boolean }
+): Promise< StudioExtensionListItem > {
+	const now = new Date().toISOString();
+	await saveExtensionState( manifest.id, {
+		installed: true,
+		enabled: options.enabled,
+		installedPath,
+		sourceType,
+		sourceUrl: options.sourceUrl,
+		installedAt: now,
+		updatedAt: now,
+	} );
+	return getExtensionListItem( manifest.id );
+}
+
+export async function listStudioExtensions(
+	_event: IpcMainInvokeEvent
+): Promise< StudioExtensionListItem[] > {
+	return getExtensionListItems();
+}
+
+export async function installStudioExtension(
+	_event: IpcMainInvokeEvent,
+	extensionId: string
+): Promise< StudioExtensionListItem > {
+	const extensionPackage = await getInstalledExtensionPackage( extensionId );
+	return persistInstalledExtension(
+		extensionPackage.manifest,
+		extensionPackage.installedPath,
+		extensionPackage.manifest.kind === 'built-in' ? 'bundled' : 'manual',
+		{ enabled: true }
+	);
+}
+
+export async function installStudioExtensionFromUrl(
+	_event: IpcMainInvokeEvent,
+	sourceUrl: string
+): Promise< StudioExtensionListItem > {
+	const normalizedSourceUrl = normalizeGitSourceUrl( sourceUrl );
+	const extensionPackage = await installStudioExtensionFromGitSource( normalizedSourceUrl );
+	return persistInstalledExtension(
+		extensionPackage.manifest,
+		extensionPackage.installedPath,
+		'git',
+		{
+			enabled: true,
+			sourceUrl: normalizedSourceUrl,
+		}
+	);
+}
+
+export async function installStudioExtensionFromPath(
+	_event: IpcMainInvokeEvent,
+	sourcePath: string
+): Promise< StudioExtensionListItem > {
+	const extensionPackage = await installStudioExtensionFromDirectorySource( sourcePath );
+	return persistInstalledExtension(
+		extensionPackage.manifest,
+		extensionPackage.installedPath,
+		'directory',
+		{ enabled: true }
+	);
+}
+
+export async function uninstallStudioExtension(
+	_event: IpcMainInvokeEvent,
+	extensionId: string
+): Promise< StudioExtensionListItem > {
+	const extension = await getExtensionListItem( extensionId );
+	await removeInstalledStudioExtensionPackage(
+		extensionId,
+		extension.installedPath ?? getStudioExtensionInstallPath( extensionId )
+	);
+	await saveExtensionState( extensionId, {
+		installed: false,
+		enabled: false,
+		installedPath: undefined,
+		updatedAt: new Date().toISOString(),
+	} );
+	clearStudioMainExtensionCache( extensionId );
+
+	return {
+		...extension,
+		installed: false,
+		enabled: false,
+		installedPath: undefined,
+		status: 'missing',
+	};
+}
+
+export async function setStudioExtensionEnabled(
+	_event: IpcMainInvokeEvent,
+	extensionId: string,
+	enabled: boolean
+): Promise< StudioExtensionListItem > {
+	const extension = await getExtensionListItem( extensionId );
+	if ( ! extension.installed ) {
+		throw new Error( `Studio extension is not installed: ${ extensionId }` );
+	}
+	if ( enabled && ! extension.isSupported ) {
+		throw new Error( `Studio extension is not supported: ${ extensionId }` );
+	}
+
+	await saveExtensionState( extensionId, {
+		installed: true,
+		enabled,
+		installedPath: extension.installedPath,
+		sourceType:
+			extension.sourceType === 'git'
+				? 'git'
+				: extension.kind === 'built-in'
+				? 'bundled'
+				: 'directory',
+		updatedAt: new Date().toISOString(),
+	} );
+	if ( ! enabled ) {
+		clearStudioMainExtensionCache( extensionId );
+	}
+	return getExtensionListItem( extensionId );
+}
+
+export async function invokeStudioExtensionHandler(
+	event: IpcMainInvokeEvent,
+	extensionId: string,
+	handlerName: string,
+	...args: unknown[]
+): Promise< unknown > {
+	const extension = await getExtensionListItem( extensionId );
+	if ( ! extension.installed || ! extension.enabled || ! extension.isSupported ) {
+		throw new Error( `Studio extension is not enabled: ${ extensionId }` );
+	}
+
+	const extensionPackage = await getInstalledExtensionPackage( extensionId );
+	const handler = await getStudioExtensionHandler( extensionPackage, handlerName );
+	if ( ! handler ) {
+		throw new Error( `Unknown Studio extension handler: ${ extensionId }/${ handlerName }` );
+	}
+
+	return handler( event, ...args );
+}

--- a/apps/studio/src/extensions/main-registry.ts
+++ b/apps/studio/src/extensions/main-registry.ts
@@ -1,0 +1,258 @@
+import crypto from 'node:crypto';
+import { existsSync, statSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type {
+	InstalledStudioExtensionPackage,
+	StudioExtensionMainHandler,
+	StudioMainExtension,
+} from './types';
+
+type StudioMainExtensionModule = Partial<
+	Pick< StudioMainExtension, 'handlers' | 'isNavigationAllowed' >
+> & {
+	default?: StudioMainExtension | StudioMainExtensionFactory;
+	extension?: StudioMainExtension;
+	activate?: StudioMainExtensionFactory;
+};
+
+type StudioMainExtensionFactory = (
+	context: StudioMainExtensionContext
+) => StudioMainExtension | Promise< StudioMainExtension >;
+
+interface StudioMainExtensionContext {
+	installedPath: string;
+	manifest: InstalledStudioExtensionPackage[ 'manifest' ];
+}
+
+const loadedMainExtensions = new Map< string, Promise< StudioMainExtension > >();
+const resolvedMainExtensions = new Map< string, StudioMainExtension >();
+const requireExtensionModule = createRequire( import.meta.url );
+
+export function clearStudioMainExtensionCache( extensionId?: string ): void {
+	if ( extensionId ) {
+		loadedMainExtensions.delete( extensionId );
+		resolvedMainExtensions.delete( extensionId );
+		return;
+	}
+	loadedMainExtensions.clear();
+	resolvedMainExtensions.clear();
+}
+
+export async function getStudioExtensionHandler(
+	extensionPackage: InstalledStudioExtensionPackage,
+	handlerName: string
+): Promise< StudioExtensionMainHandler | undefined > {
+	const extension = await loadStudioMainExtension( extensionPackage );
+	return extension.handlers?.[ handlerName ];
+}
+
+export function isStudioExtensionNavigationAllowed(
+	context: Parameters< NonNullable< StudioMainExtension[ 'isNavigationAllowed' ] > >[ 0 ],
+	navigationUrl: string
+): boolean {
+	for ( const extension of resolvedMainExtensions.values() ) {
+		if ( extension.isNavigationAllowed?.( context, navigationUrl ) ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+async function loadStudioMainExtension(
+	extensionPackage: InstalledStudioExtensionPackage
+): Promise< StudioMainExtension > {
+	const cached = loadedMainExtensions.get( extensionPackage.manifest.id );
+	if ( cached ) {
+		return cached;
+	}
+
+	const loading = loadStudioMainExtensionUncached( extensionPackage );
+	void loading
+		.then( ( extension ) => {
+			resolvedMainExtensions.set( extensionPackage.manifest.id, extension );
+		} )
+		.catch( () => {
+			clearStudioMainExtensionCache( extensionPackage.manifest.id );
+		} );
+	loadedMainExtensions.set( extensionPackage.manifest.id, loading );
+	return loading;
+}
+
+async function loadStudioMainExtensionUncached(
+	extensionPackage: InstalledStudioExtensionPackage
+): Promise< StudioMainExtension > {
+	const modulePath = resolveMainModulePath( extensionPackage );
+	if ( ! modulePath ) {
+		return {
+			manifest: extensionPackage.manifest,
+		};
+	}
+
+	const moduleExports = ( await loadStudioMainExtensionModule(
+		modulePath
+	) ) as StudioMainExtensionModule;
+	const activatedExtension = await activateStudioMainExtension( moduleExports, {
+		installedPath: extensionPackage.installedPath,
+		manifest: extensionPackage.manifest,
+	} );
+
+	return {
+		...activatedExtension,
+		manifest: {
+			...extensionPackage.manifest,
+			...activatedExtension.manifest,
+			id: extensionPackage.manifest.id,
+		},
+	};
+}
+
+async function loadStudioMainExtensionModule( modulePath: string ): Promise< unknown > {
+	if ( path.extname( modulePath ) === '.cjs' ) {
+		return requireExtensionModule( modulePath ) as unknown;
+	}
+	if ( [ '.ts', '.tsx' ].includes( path.extname( modulePath ) ) ) {
+		return loadStudioMainExtensionTypeScriptModule( modulePath );
+	}
+	const moduleUrl = pathToFileURL( modulePath ).toString();
+	return import( /* @vite-ignore */ moduleUrl ) as Promise< unknown >;
+}
+
+async function loadStudioMainExtensionTypeScriptModule( modulePath: string ): Promise< unknown > {
+	if ( process.env.NODE_ENV !== 'development' ) {
+		throw new Error(
+			'Studio extension TypeScript main entries are only supported in development.'
+		);
+	}
+
+	const { build } = await import( 'esbuild' );
+	const result = await build( {
+		entryPoints: [ modulePath ],
+		bundle: true,
+		write: false,
+		platform: 'node',
+		format: 'cjs',
+		target: 'node20',
+		sourcemap: 'inline',
+		nodePaths: [
+			path.resolve( process.cwd(), 'node_modules' ),
+			path.resolve( process.cwd(), '../../node_modules' ),
+		],
+		external: [ 'electron' ],
+		plugins: [ studioMainExtensionAliasPlugin() ],
+	} );
+	const output = result.outputFiles[ 0 ]?.text;
+	if ( ! output ) {
+		throw new Error( 'Studio extension TypeScript main entry did not produce output.' );
+	}
+
+	const cacheKey = crypto
+		.createHash( 'sha256' )
+		.update( modulePath )
+		.update( output )
+		.digest( 'hex' );
+	const cacheDirectory = path.join( os.tmpdir(), 'studio-extension-main' );
+	const cachePath = path.join( cacheDirectory, `${ cacheKey }.cjs` );
+	await fs.mkdir( cacheDirectory, { recursive: true } );
+	await fs.writeFile( cachePath, output, 'utf8' );
+
+	return requireExtensionModule( cachePath ) as unknown;
+}
+
+async function activateStudioMainExtension(
+	moduleExports: StudioMainExtensionModule,
+	context: StudioMainExtensionContext
+): Promise< StudioMainExtension > {
+	if ( typeof moduleExports.default === 'function' ) {
+		return moduleExports.default( context );
+	}
+	if ( moduleExports.default && 'manifest' in moduleExports.default ) {
+		return moduleExports.default;
+	}
+	if ( moduleExports.extension ) {
+		return moduleExports.extension;
+	}
+	if ( moduleExports.activate ) {
+		return moduleExports.activate( context );
+	}
+	return {
+		manifest: context.manifest,
+		handlers: moduleExports.handlers,
+		isNavigationAllowed: moduleExports.isNavigationAllowed,
+	};
+}
+
+function resolveMainModulePath(
+	extensionPackage: InstalledStudioExtensionPackage
+): string | undefined {
+	if ( ! extensionPackage.manifest.main ) {
+		return undefined;
+	}
+	if ( path.isAbsolute( extensionPackage.manifest.main ) ) {
+		throw new Error( 'Studio extension main entry must be relative to the extension directory.' );
+	}
+
+	const resolvedPath = path.resolve(
+		extensionPackage.installedPath,
+		extensionPackage.manifest.main
+	);
+	const relativePath = path.relative( extensionPackage.installedPath, resolvedPath );
+	if ( relativePath.startsWith( '..' ) || path.isAbsolute( relativePath ) ) {
+		throw new Error( 'Studio extension main entry must stay inside the extension directory.' );
+	}
+	if ( ! [ '.cjs', '.js', '.mjs', '.ts', '.tsx' ].includes( path.extname( resolvedPath ) ) ) {
+		throw new Error( 'Studio extension main entry must be a JavaScript or TypeScript module.' );
+	}
+
+	return resolvedPath;
+}
+
+function studioMainExtensionAliasPlugin() {
+	const aliases = new Map( [
+		[ 'src', path.resolve( process.cwd(), 'src' ) ],
+		[ '@studio/common', path.resolve( process.cwd(), '../../tools/common' ) ],
+		[ 'cli', path.resolve( process.cwd(), '../cli' ) ],
+		[ 'vendor', path.resolve( process.cwd(), '../../vendor' ) ],
+	] );
+
+	return {
+		name: 'studio-main-extension-aliases',
+		setup( build: import('esbuild').PluginBuild ) {
+			build.onResolve( { filter: /^(src|@studio\/common|cli|vendor)(\/.*)?$/ }, ( args ) => {
+				const [ alias, ...rest ] = args.path.split( '/' );
+				const aliasKey = alias === '@studio' ? `${ alias }/${ rest.shift() }` : alias;
+				const aliasPath = aliases.get( aliasKey );
+				if ( ! aliasPath ) {
+					return undefined;
+				}
+				return {
+					path: resolveAliasedStudioModulePath( path.join( aliasPath, ...rest ) ),
+				};
+			} );
+		},
+	};
+}
+
+function resolveAliasedStudioModulePath( modulePath: string ): string {
+	const candidates = [
+		modulePath,
+		...[ '.ts', '.tsx', '.js', '.mjs', '.cjs', '.json' ].map(
+			( extension ) => `${ modulePath }${ extension }`
+		),
+		...[ 'index.ts', 'index.tsx', 'index.js', 'index.mjs', 'index.cjs', 'index.json' ].map(
+			( filename ) => path.join( modulePath, filename )
+		),
+	];
+	return candidates.find( isExistingFile ) ?? modulePath;
+}
+
+function isExistingFile( filePath: string ): boolean {
+	try {
+		return existsSync( filePath ) && statSync( filePath ).isFile();
+	} catch {
+		return false;
+	}
+}

--- a/apps/studio/src/extensions/package-manager.ts
+++ b/apps/studio/src/extensions/package-manager.ts
@@ -1,0 +1,313 @@
+import { spawn } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { getStudioExtensionsDirectory } from '@studio/common/lib/well-known-paths';
+import type { InstalledStudioExtensionPackage, StudioExtensionManifest } from './types';
+import type { Dirent } from 'node:fs';
+
+export const STUDIO_EXTENSION_MANIFEST_FILE = 'studio-extension.json';
+const SUPPORTED_STUDIO_EXTENSION_API_VERSION = 1;
+const EXTENSION_ID_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+
+export function getStudioExtensionInstallPath( extensionId: string ): string {
+	assertValidStudioExtensionId( extensionId );
+	return path.join( getStudioExtensionsDirectory(), extensionId );
+}
+
+export function assertValidStudioExtensionId( extensionId: string ): void {
+	if ( ! EXTENSION_ID_PATTERN.test( extensionId ) ) {
+		throw new Error( `Invalid Studio extension id: ${ extensionId }` );
+	}
+}
+
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	return typeof value === 'object' && value !== null && ! Array.isArray( value );
+}
+
+function readRequiredString( manifest: Record< string, unknown >, key: string ): string {
+	const value = manifest[ key ];
+	if ( typeof value !== 'string' || value.trim() === '' ) {
+		throw new Error( `Studio extension manifest must include a ${ key } string.` );
+	}
+	return value.trim();
+}
+
+function readOptionalStringArray(
+	manifest: Record< string, unknown >,
+	key: string
+): string[] | undefined {
+	const value = manifest[ key ];
+	if ( value === undefined ) {
+		return undefined;
+	}
+	if ( ! Array.isArray( value ) || value.some( ( item ) => typeof item !== 'string' ) ) {
+		throw new Error( `Studio extension manifest ${ key } must be an array of strings.` );
+	}
+	return value.map( ( item ) => item.trim() ).filter( Boolean );
+}
+
+export async function readStudioExtensionManifest(
+	extensionPath: string
+): Promise< StudioExtensionManifest > {
+	const manifestPath = path.join( extensionPath, STUDIO_EXTENSION_MANIFEST_FILE );
+	const manifestContents = await fs.readFile( manifestPath, 'utf8' );
+	const parsed = JSON.parse( manifestContents ) as unknown;
+
+	if ( ! isRecord( parsed ) ) {
+		throw new Error( 'Studio extension manifest must be a JSON object.' );
+	}
+
+	const id = readRequiredString( parsed, 'id' );
+	assertValidStudioExtensionId( id );
+
+	const studioExtensionApiVersion =
+		typeof parsed.studioExtensionApiVersion === 'number'
+			? parsed.studioExtensionApiVersion
+			: SUPPORTED_STUDIO_EXTENSION_API_VERSION;
+	if ( studioExtensionApiVersion !== SUPPORTED_STUDIO_EXTENSION_API_VERSION ) {
+		throw new Error( `Unsupported Studio extension API version: ${ studioExtensionApiVersion }` );
+	}
+
+	return {
+		id,
+		name: readRequiredString( parsed, 'name' ),
+		description: readRequiredString( parsed, 'description' ),
+		version: readRequiredString( parsed, 'version' ),
+		studioExtensionApiVersion,
+		publisher: typeof parsed.publisher === 'string' ? parsed.publisher : undefined,
+		repository: typeof parsed.repository === 'string' ? parsed.repository : undefined,
+		kind: parsed.kind === 'built-in' || parsed.kind === 'user' ? parsed.kind : undefined,
+		main: typeof parsed.main === 'string' && parsed.main.trim() ? parsed.main.trim() : undefined,
+		renderer:
+			typeof parsed.renderer === 'string' && parsed.renderer.trim()
+				? parsed.renderer.trim()
+				: undefined,
+		allowedNavigationOrigins: readOptionalStringArray( parsed, 'allowedNavigationOrigins' ),
+	};
+}
+
+export async function writeBundledStudioExtensionPackage(
+	manifest: StudioExtensionManifest
+): Promise< InstalledStudioExtensionPackage > {
+	assertValidStudioExtensionId( manifest.id );
+	const installedPath = getStudioExtensionInstallPath( manifest.id );
+	await fs.mkdir( installedPath, { recursive: true } );
+	await fs.writeFile(
+		path.join( installedPath, STUDIO_EXTENSION_MANIFEST_FILE ),
+		JSON.stringify(
+			{
+				studioExtensionApiVersion: SUPPORTED_STUDIO_EXTENSION_API_VERSION,
+				...manifest,
+				kind: 'built-in',
+			},
+			null,
+			2
+		) + '\n',
+		'utf8'
+	);
+	return {
+		manifest: { ...manifest, kind: 'built-in' },
+		installedPath,
+	};
+}
+
+export async function listInstalledStudioExtensionPackages(): Promise<
+	InstalledStudioExtensionPackage[]
+> {
+	const extensionsDirectory = getStudioExtensionsDirectory();
+	let entries: Dirent[];
+
+	try {
+		entries = await fs.readdir( extensionsDirectory, { withFileTypes: true } );
+	} catch ( error ) {
+		if ( isErrnoException( error ) && error.code === 'ENOENT' ) {
+			return [];
+		}
+		throw error;
+	}
+
+	const packages = await Promise.all(
+		entries
+			.filter( ( entry ) => entry.isDirectory() && ! entry.name.startsWith( '.' ) )
+			.map( async ( entry ) => {
+				const installedPath = path.join( extensionsDirectory, entry.name );
+				try {
+					return {
+						manifest: await readStudioExtensionManifest( installedPath ),
+						installedPath,
+					};
+				} catch ( error ) {
+					console.warn( `Failed to read Studio extension from ${ installedPath }:`, error );
+					return undefined;
+				}
+			} )
+	);
+
+	return packages.filter(
+		( extensionPackage ): extensionPackage is InstalledStudioExtensionPackage =>
+			Boolean( extensionPackage )
+	);
+}
+
+export async function installStudioExtensionFromGitSource(
+	sourceUrl: string
+): Promise< InstalledStudioExtensionPackage > {
+	const normalizedSourceUrl = normalizeGitSourceUrl( sourceUrl );
+	const extensionsDirectory = getStudioExtensionsDirectory();
+	const installTempDirectory = path.join( extensionsDirectory, '.installing' );
+	const tempPath = path.join( installTempDirectory, `${ Date.now() }-${ crypto.randomUUID() }` );
+
+	await fs.mkdir( installTempDirectory, { recursive: true } );
+
+	try {
+		await runGit( [ 'clone', '--depth', '1', normalizedSourceUrl, tempPath ] );
+		const manifest = await readStudioExtensionManifest( tempPath );
+		const installedPath = getStudioExtensionInstallPath( manifest.id );
+
+		await fs.rm( installedPath, { recursive: true, force: true } );
+		await fs.mkdir( path.dirname( installedPath ), { recursive: true } );
+		await fs.rename( tempPath, installedPath );
+
+		return {
+			manifest: { ...manifest, kind: 'user' },
+			installedPath,
+		};
+	} catch ( error ) {
+		await fs.rm( tempPath, { recursive: true, force: true } ).catch( () => undefined );
+		throw error;
+	}
+}
+
+export async function installStudioExtensionFromDirectorySource(
+	sourcePath: string
+): Promise< InstalledStudioExtensionPackage > {
+	const resolvedSourcePath = resolveLocalExtensionPath( sourcePath );
+	const sourceStat = await fs.stat( resolvedSourcePath );
+	if ( ! sourceStat.isDirectory() ) {
+		throw new Error( 'Studio extension path must be a directory.' );
+	}
+
+	const manifest = await readStudioExtensionManifest( resolvedSourcePath );
+	const installedPath = getStudioExtensionInstallPath( manifest.id );
+	const [ realSourcePath, realInstalledPath ] = await Promise.all( [
+		resolveExistingPath( resolvedSourcePath ),
+		resolveExistingPath( installedPath ),
+	] );
+
+	if ( realInstalledPath && realSourcePath === realInstalledPath ) {
+		return {
+			manifest: { ...manifest, kind: 'user' },
+			installedPath,
+		};
+	}
+
+	await fs.rm( installedPath, { recursive: true, force: true } );
+	await fs.mkdir( path.dirname( installedPath ), { recursive: true } );
+	await fs.cp( resolvedSourcePath, installedPath, {
+		recursive: true,
+		filter: ( source ) => path.basename( source ) !== '.git',
+	} );
+
+	return {
+		manifest: { ...manifest, kind: 'user' },
+		installedPath,
+	};
+}
+
+export async function removeInstalledStudioExtensionPackage(
+	extensionId: string,
+	installedPath?: string
+): Promise< void > {
+	assertValidStudioExtensionId( extensionId );
+	const resolvedInstalledPath = path.resolve(
+		installedPath ?? getStudioExtensionInstallPath( extensionId )
+	);
+	const extensionsDirectory = path.resolve( getStudioExtensionsDirectory() );
+	const relativePath = path.relative( extensionsDirectory, resolvedInstalledPath );
+
+	if ( relativePath.startsWith( '..' ) || path.isAbsolute( relativePath ) ) {
+		throw new Error( `Refusing to remove extension outside Studio extensions directory.` );
+	}
+
+	await fs.rm( resolvedInstalledPath, { recursive: true, force: true } );
+}
+
+export function normalizeGitSourceUrl( sourceUrl: string ): string {
+	const trimmed = sourceUrl.trim();
+	if ( trimmed === '' ) {
+		throw new Error( 'Enter a Git or GitHub URL.' );
+	}
+
+	if ( /^github\.com\//i.test( trimmed ) ) {
+		return `https://${ trimmed }`;
+	}
+
+	if ( /^[a-z0-9_.-]+\/[a-z0-9_.-]+(?:\.git)?$/i.test( trimmed ) ) {
+		return `https://github.com/${ trimmed }`;
+	}
+
+	if ( /^(https?|ssh|git|file):\/\//i.test( trimmed ) || /^git@[^:]+:.+$/i.test( trimmed ) ) {
+		return trimmed;
+	}
+
+	throw new Error( 'Enter a Git or GitHub URL.' );
+}
+
+export function resolveLocalExtensionPath( sourcePath: string ): string {
+	const trimmed = sourcePath.trim();
+	if ( trimmed === '' ) {
+		throw new Error( 'Enter a Studio extension directory path.' );
+	}
+	if ( trimmed === '~' ) {
+		return os.homedir();
+	}
+	if ( trimmed.startsWith( `~${ path.sep }` ) || trimmed.startsWith( '~/' ) ) {
+		return path.resolve( os.homedir(), trimmed.slice( 2 ) );
+	}
+	return path.resolve( trimmed );
+}
+
+async function runGit( args: string[] ): Promise< void > {
+	await new Promise< void >( ( resolve, reject ) => {
+		const child = spawn( 'git', args, {
+			stdio: [ 'ignore', 'pipe', 'pipe' ],
+			windowsHide: true,
+		} );
+		let stdout = '';
+		let stderr = '';
+
+		child.stdout?.setEncoding( 'utf8' );
+		child.stderr?.setEncoding( 'utf8' );
+		child.stdout?.on( 'data', ( chunk ) => {
+			stdout += chunk;
+		} );
+		child.stderr?.on( 'data', ( chunk ) => {
+			stderr += chunk;
+		} );
+		child.on( 'error', reject );
+		child.on( 'close', ( code ) => {
+			if ( code === 0 ) {
+				resolve();
+				return;
+			}
+			reject( new Error( stderr.trim() || stdout.trim() || `git exited with code ${ code }` ) );
+		} );
+	} );
+}
+
+async function resolveExistingPath( targetPath: string ): Promise< string | undefined > {
+	try {
+		return await fs.realpath( targetPath );
+	} catch ( error ) {
+		if ( isErrnoException( error ) && error.code === 'ENOENT' ) {
+			return undefined;
+		}
+		throw error;
+	}
+}
+
+function isErrnoException( error: unknown ): error is NodeJS.ErrnoException {
+	return error instanceof Error && 'code' in error;
+}

--- a/apps/studio/src/extensions/renderer-registry.ts
+++ b/apps/studio/src/extensions/renderer-registry.ts
@@ -1,0 +1,212 @@
+import type { StudioExtensionListItem, StudioRendererExtension } from './types';
+
+export const registeredStudioRendererExtensions: StudioRendererExtension[] = [];
+
+type StudioRendererExtensionFactory = (
+	context: StudioRendererExtensionContext
+) => StudioRendererExtension | Promise< StudioRendererExtension >;
+
+type StudioRendererExtensionModule = Partial< StudioRendererExtension > & {
+	default?: StudioRendererExtension | StudioRendererExtensionFactory;
+	extension?: StudioRendererExtension;
+	rendererExtension?: StudioRendererExtension;
+	activate?: StudioRendererExtensionFactory;
+};
+
+interface StudioRendererExtensionContext {
+	installedPath: string;
+	manifest: StudioExtensionListItem;
+}
+
+const loadedRendererExtensions = new Map<
+	string,
+	Promise< StudioRendererExtension | undefined >
+>();
+
+export function clearStudioRendererExtensionCache( extensionId?: string ): void {
+	if ( extensionId ) {
+		loadedRendererExtensions.delete( extensionId );
+		return;
+	}
+	loadedRendererExtensions.clear();
+}
+
+export async function loadStudioRendererExtension(
+	extension: StudioExtensionListItem
+): Promise< StudioRendererExtension | undefined > {
+	if ( ! extension.renderer || ! extension.installedPath ) {
+		return undefined;
+	}
+
+	const cacheKey = [
+		extension.id,
+		extension.installedPath,
+		extension.renderer,
+		extension.updatedAt ?? '',
+	].join( ':' );
+	const cached = loadedRendererExtensions.get( cacheKey );
+	if ( cached ) {
+		return cached;
+	}
+
+	const loading = loadStudioRendererExtensionUncached( extension );
+	void loading.catch( () => {
+		loadedRendererExtensions.delete( cacheKey );
+	} );
+	loadedRendererExtensions.set( cacheKey, loading );
+	return loading;
+}
+
+async function loadStudioRendererExtensionUncached(
+	extension: StudioExtensionListItem
+): Promise< StudioRendererExtension | undefined > {
+	const moduleUrl = resolveRendererModuleUrl( extension );
+	if ( ! moduleUrl ) {
+		return undefined;
+	}
+
+	const moduleExports = ( await import(
+		/* @vite-ignore */ moduleUrl
+	) ) as StudioRendererExtensionModule;
+	const activatedExtension = await activateStudioRendererExtension( moduleExports, {
+		installedPath: extension.installedPath ?? '',
+		manifest: extension,
+	} );
+
+	return {
+		...activatedExtension,
+		manifest: {
+			...extension,
+			...activatedExtension.manifest,
+			id: extension.id,
+		},
+	};
+}
+
+async function activateStudioRendererExtension(
+	moduleExports: StudioRendererExtensionModule,
+	context: StudioRendererExtensionContext
+): Promise< StudioRendererExtension > {
+	if ( typeof moduleExports.default === 'function' ) {
+		return moduleExports.default( context );
+	}
+	if ( moduleExports.default && isStudioRendererExtension( moduleExports.default ) ) {
+		return moduleExports.default;
+	}
+	if ( moduleExports.extension ) {
+		return moduleExports.extension;
+	}
+	if ( moduleExports.rendererExtension ) {
+		return moduleExports.rendererExtension;
+	}
+	if ( moduleExports.activate ) {
+		return moduleExports.activate( context );
+	}
+	if ( isStudioRendererExtension( moduleExports ) ) {
+		return moduleExports;
+	}
+
+	const namedRendererExtension = Object.values( moduleExports ).find( isStudioRendererExtension );
+	if ( namedRendererExtension ) {
+		return namedRendererExtension;
+	}
+
+	return {
+		manifest: context.manifest,
+	};
+}
+
+function isStudioRendererExtension( value: unknown ): value is StudioRendererExtension {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'manifest' in value &&
+		typeof ( value as { manifest?: { id?: unknown } } ).manifest?.id === 'string'
+	);
+}
+
+function resolveRendererModuleUrl( extension: StudioExtensionListItem ): string | undefined {
+	if ( ! extension.renderer || ! extension.installedPath ) {
+		return undefined;
+	}
+	if ( isAbsolutePath( extension.renderer ) ) {
+		throw new Error(
+			'Studio extension renderer entry must be relative to the extension directory.'
+		);
+	}
+
+	const installedPath = normalizePath( extension.installedPath );
+	const rendererPath = normalizePath( `${ installedPath }/${ extension.renderer }` );
+	const relativePath = getRelativePath( installedPath, rendererPath );
+	if (
+		relativePath.startsWith( '../' ) ||
+		relativePath === '..' ||
+		isAbsolutePath( relativePath )
+	) {
+		throw new Error( 'Studio extension renderer entry must stay inside the extension directory.' );
+	}
+
+	if ( process.env.NODE_ENV !== 'development' ) {
+		console.warn(
+			`Skipping Studio extension renderer source for ${ extension.id }. External renderer loading currently requires the development server.`
+		);
+		return undefined;
+	}
+
+	return encodeURI( `/@fs/${ rendererPath }` );
+}
+
+function normalizePath( value: string ): string {
+	const normalizedSeparators = value.replace( /\\/g, '/' ).replace( /\/+/g, '/' );
+	const driveMatch = normalizedSeparators.match( /^([A-Za-z]:)(?:\/|$)/ );
+	const drive = driveMatch?.[ 1 ];
+	const rest = drive ? normalizedSeparators.slice( drive.length ) : normalizedSeparators;
+	const isAbsolute = rest.startsWith( '/' );
+	const parts: string[] = [];
+
+	for ( const segment of rest.split( '/' ) ) {
+		if ( ! segment || segment === '.' ) {
+			continue;
+		}
+		if ( segment === '..' ) {
+			if ( parts.length > 0 && parts[ parts.length - 1 ] !== '..' ) {
+				parts.pop();
+			} else if ( ! isAbsolute ) {
+				parts.push( '..' );
+			}
+			continue;
+		}
+		parts.push( segment );
+	}
+
+	if ( drive ) {
+		return `${ drive }/${ parts.join( '/' ) }`;
+	}
+	if ( isAbsolute ) {
+		return `/${ parts.join( '/' ) }`;
+	}
+	return parts.join( '/' ) || '.';
+}
+
+function isAbsolutePath( value: string ): boolean {
+	return value.startsWith( '/' ) || /^[A-Za-z]:[\\/]/.test( value );
+}
+
+function getRelativePath( from: string, to: string ): string {
+	const fromParts = from.split( '/' ).filter( Boolean );
+	const toParts = to.split( '/' ).filter( Boolean );
+	let commonParts = 0;
+
+	while (
+		commonParts < fromParts.length &&
+		commonParts < toParts.length &&
+		fromParts[ commonParts ] === toParts[ commonParts ]
+	) {
+		commonParts++;
+	}
+
+	return [
+		...Array.from( { length: fromParts.length - commonParts }, () => '..' ),
+		...toParts.slice( commonParts ),
+	].join( '/' );
+}

--- a/apps/studio/src/extensions/tests/ipc-handlers.test.ts
+++ b/apps/studio/src/extensions/tests/ipc-handlers.test.ts
@@ -1,0 +1,314 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	installStudioExtension,
+	installStudioExtensionFromPath,
+	installStudioExtensionFromUrl,
+	invokeStudioExtensionHandler,
+	listStudioExtensions,
+	setStudioExtensionEnabled,
+	uninstallStudioExtension,
+} from 'src/extensions/ipc-handlers';
+import { sendIpcEventToRenderer } from 'src/ipc-utils';
+import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
+import type { IpcMainInvokeEvent } from 'electron';
+import type { InstalledStudioExtensionPackage } from 'src/extensions/types';
+
+const mockExtensionHandler = vi.hoisted( () => vi.fn() );
+const mockPackages = vi.hoisted( () => ( {
+	value: [] as InstalledStudioExtensionPackage[],
+} ) );
+const mockDirectoryInstall = vi.hoisted( () => vi.fn() );
+const mockGitInstall = vi.hoisted( () => vi.fn() );
+const mockRemovePackage = vi.hoisted( () => vi.fn() );
+const mockUserData = vi.hoisted( () => ( {
+	value: {
+		version: 1,
+		siteMetadata: {},
+		extensions: {},
+	},
+} ) );
+
+const testManifest = vi.hoisted( () => ( {
+	id: 'sample-extension',
+	name: 'Sample Extension',
+	description: 'Adds sample contributions.',
+	version: '1.0.0',
+	kind: 'user' as const,
+} ) );
+
+function createPackage(
+	overrides: Partial< InstalledStudioExtensionPackage > = {}
+): InstalledStudioExtensionPackage {
+	return {
+		manifest: testManifest,
+		installedPath: `/mock/extensions/${ testManifest.id }`,
+		...overrides,
+	};
+}
+
+vi.mock( 'src/extensions/main-registry', () => ( {
+	clearStudioMainExtensionCache: vi.fn(),
+	getStudioExtensionHandler: vi.fn( async ( extensionPackage, handlerName ) => {
+		if ( extensionPackage.manifest.id === 'sample-extension' && handlerName === 'echo' ) {
+			return mockExtensionHandler;
+		}
+		return undefined;
+	} ),
+} ) );
+
+vi.mock( 'src/extensions/package-manager', () => ( {
+	getStudioExtensionInstallPath: ( extensionId: string ) => `/mock/extensions/${ extensionId }`,
+	installStudioExtensionFromDirectorySource: mockDirectoryInstall,
+	installStudioExtensionFromGitSource: mockGitInstall,
+	listInstalledStudioExtensionPackages: vi.fn( async () => structuredClone( mockPackages.value ) ),
+	normalizeGitSourceUrl: ( sourceUrl: string ) => sourceUrl.trim(),
+	removeInstalledStudioExtensionPackage: mockRemovePackage,
+} ) );
+
+vi.mock( 'src/storage/user-data', () => ( {
+	loadUserData: vi.fn( async () => structuredClone( mockUserData.value ) ),
+	lockAppdata: vi.fn( async () => undefined ),
+	saveUserData: vi.fn( async ( nextUserData ) => {
+		mockUserData.value = structuredClone( nextUserData );
+	} ),
+	unlockAppdata: vi.fn( async () => undefined ),
+} ) );
+
+vi.mock( 'src/ipc-utils', () => ( {
+	sendIpcEventToRenderer: vi.fn( async () => undefined ),
+} ) );
+
+const ipcEvent = {} as IpcMainInvokeEvent;
+
+describe( 'Studio extension IPC handlers', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		mockExtensionHandler.mockResolvedValue( 'handled' );
+		mockPackages.value = [];
+		mockDirectoryInstall.mockImplementation( async () => {
+			const extensionPackage = createPackage();
+			mockPackages.value = [ extensionPackage ];
+			return extensionPackage;
+		} );
+		mockGitInstall.mockImplementation( async () => {
+			const extensionPackage = createPackage();
+			mockPackages.value = [ extensionPackage ];
+			return extensionPackage;
+		} );
+		mockRemovePackage.mockResolvedValue( undefined );
+		mockUserData.value = {
+			version: 1,
+			siteMetadata: {},
+			extensions: {},
+		};
+	} );
+
+	it( 'lists installed extension packages from disk as disabled by default', async () => {
+		mockPackages.value = [ createPackage() ];
+
+		const extensions = await listStudioExtensions( ipcEvent );
+
+		expect( extensions ).toHaveLength( 1 );
+		expect( extensions[ 0 ] ).toMatchObject( {
+			...testManifest,
+			installed: true,
+			enabled: false,
+			sourceType: 'directory',
+			status: 'installed',
+			isSupported: true,
+		} );
+		expect( loadUserData ).toHaveBeenCalled();
+	} );
+
+	it( 'marks a discovered extension installed and enabled', async () => {
+		mockPackages.value = [ createPackage() ];
+
+		await expect( installStudioExtension( ipcEvent, 'sample-extension' ) ).resolves.toMatchObject( {
+			id: 'sample-extension',
+			installed: true,
+			enabled: true,
+			installedPath: '/mock/extensions/sample-extension',
+			sourceType: 'manual',
+		} );
+
+		expect( lockAppdata ).toHaveBeenCalled();
+		expect( saveUserData ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				extensions: {
+					'sample-extension': expect.objectContaining( {
+						installed: true,
+						enabled: true,
+						installedPath: '/mock/extensions/sample-extension',
+						sourceType: 'manual',
+					} ),
+				},
+			} )
+		);
+		expect( unlockAppdata ).toHaveBeenCalled();
+		expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'user-preference-changed' );
+	} );
+
+	it( 'installs extensions from a Git URL and enables them', async () => {
+		await expect(
+			installStudioExtensionFromUrl( ipcEvent, 'https://github.com/example/sample-extension' )
+		).resolves.toMatchObject( {
+			id: 'sample-extension',
+			installed: true,
+			enabled: true,
+			sourceType: 'git',
+			sourceUrl: 'https://github.com/example/sample-extension',
+		} );
+
+		expect( mockGitInstall ).toHaveBeenCalledWith( 'https://github.com/example/sample-extension' );
+		expect( saveUserData ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				extensions: {
+					'sample-extension': expect.objectContaining( {
+						sourceType: 'git',
+						sourceUrl: 'https://github.com/example/sample-extension',
+						enabled: true,
+					} ),
+				},
+			} )
+		);
+	} );
+
+	it( 'installs extensions from a local directory and enables them', async () => {
+		await expect(
+			installStudioExtensionFromPath( ipcEvent, '~/Code/sample-extension' )
+		).resolves.toMatchObject( {
+			id: 'sample-extension',
+			installed: true,
+			enabled: true,
+			sourceType: 'directory',
+		} );
+
+		expect( mockDirectoryInstall ).toHaveBeenCalledWith( '~/Code/sample-extension' );
+		expect( saveUserData ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				extensions: {
+					'sample-extension': expect.objectContaining( {
+						sourceType: 'directory',
+						enabled: true,
+					} ),
+				},
+			} )
+		);
+	} );
+
+	it( 'normalizes installed package state when enabling an extension', async () => {
+		mockPackages.value = [ createPackage() ];
+		mockUserData.value.extensions = {
+			'sample-extension': {
+				installed: false,
+				enabled: false,
+				sourceType: 'bundled',
+			},
+		};
+
+		await expect(
+			setStudioExtensionEnabled( ipcEvent, 'sample-extension', true )
+		).resolves.toMatchObject( {
+			id: 'sample-extension',
+			installed: true,
+			enabled: true,
+			sourceType: 'directory',
+		} );
+		expect( saveUserData ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				extensions: {
+					'sample-extension': expect.objectContaining( {
+						installed: true,
+						enabled: true,
+						installedPath: '/mock/extensions/sample-extension',
+						sourceType: 'directory',
+					} ),
+				},
+			} )
+		);
+	} );
+
+	it( 'does not activate an unknown extension when enabling is requested', async () => {
+		await expect( setStudioExtensionEnabled( ipcEvent, 'sample-extension', true ) ).rejects.toThrow(
+			'Unknown Studio extension: sample-extension'
+		);
+
+		await expect(
+			invokeStudioExtensionHandler( ipcEvent, 'sample-extension', 'echo' )
+		).rejects.toThrow( 'Unknown Studio extension: sample-extension' );
+		expect( mockExtensionHandler ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rejects RPC calls to disabled extensions', async () => {
+		mockPackages.value = [ createPackage() ];
+		mockUserData.value.extensions = {
+			'sample-extension': {
+				installed: true,
+				enabled: false,
+			},
+		};
+
+		await expect(
+			invokeStudioExtensionHandler( ipcEvent, 'sample-extension', 'echo' )
+		).rejects.toThrow( 'Studio extension is not enabled: sample-extension' );
+		expect( mockExtensionHandler ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rejects unknown extension RPC handlers for active extensions', async () => {
+		mockPackages.value = [ createPackage() ];
+		mockUserData.value.extensions = {
+			'sample-extension': {
+				installed: true,
+				enabled: true,
+			},
+		};
+
+		await expect(
+			invokeStudioExtensionHandler( ipcEvent, 'sample-extension', 'missing' )
+		).rejects.toThrow( 'Unknown Studio extension handler: sample-extension/missing' );
+	} );
+
+	it( 'invokes namespaced RPC handlers for installed and enabled extensions', async () => {
+		mockPackages.value = [ createPackage() ];
+		mockUserData.value.extensions = {
+			'sample-extension': {
+				installed: true,
+				enabled: true,
+			},
+		};
+
+		await expect(
+			invokeStudioExtensionHandler( ipcEvent, 'sample-extension', 'echo', 'first', 2 )
+		).resolves.toBe( 'handled' );
+		expect( mockExtensionHandler ).toHaveBeenCalledWith( ipcEvent, 'first', 2 );
+	} );
+
+	it( 'uninstalls extensions by removing the package and clearing enabled state', async () => {
+		mockPackages.value = [ createPackage() ];
+		mockUserData.value.extensions = {
+			'sample-extension': {
+				installed: true,
+				enabled: true,
+				installedPath: '/mock/extensions/sample-extension',
+			},
+		};
+
+		await uninstallStudioExtension( ipcEvent, 'sample-extension' );
+
+		expect( mockRemovePackage ).toHaveBeenCalledWith(
+			'sample-extension',
+			'/mock/extensions/sample-extension'
+		);
+		expect( saveUserData ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				extensions: {
+					'sample-extension': expect.objectContaining( {
+						installed: false,
+						enabled: false,
+						installedPath: undefined,
+					} ),
+				},
+			} )
+		);
+	} );
+} );

--- a/apps/studio/src/extensions/tests/main-registry.test.ts
+++ b/apps/studio/src/extensions/tests/main-registry.test.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	clearStudioMainExtensionCache,
+	getStudioExtensionHandler,
+} from 'src/extensions/main-registry';
+import type { IpcMainInvokeEvent } from 'electron';
+import type { InstalledStudioExtensionPackage } from 'src/extensions/types';
+
+let testDirectory: string;
+
+describe( 'Studio extension main registry', () => {
+	beforeEach( async () => {
+		testDirectory = await fs.mkdtemp( path.join( os.tmpdir(), 'studio-extension-main-' ) );
+		clearStudioMainExtensionCache();
+	} );
+
+	afterEach( async () => {
+		clearStudioMainExtensionCache();
+		await fs.rm( testDirectory, { recursive: true, force: true } );
+	} );
+
+	it( 'loads namespaced handlers from an installed extension directory', async () => {
+		const mainPath = path.join( testDirectory, 'main.cjs' );
+		await fs.writeFile(
+			mainPath,
+			`
+				module.exports.handlers = {
+					echo: async (_event, value) => value,
+				};
+			`,
+			'utf8'
+		);
+
+		const extensionPackage: InstalledStudioExtensionPackage = {
+			manifest: {
+				id: 'sample-extension',
+				name: 'Sample Extension',
+				description: 'Adds sample contributions.',
+				version: '1.0.0',
+				main: 'main.cjs',
+			},
+			installedPath: testDirectory,
+		};
+
+		const handler = await getStudioExtensionHandler( extensionPackage, 'echo' );
+
+		await expect( handler?.( {} as IpcMainInvokeEvent, 'loaded' ) ).resolves.toBe( 'loaded' );
+	} );
+
+	it( 'rejects main entries outside the extension directory', async () => {
+		const extensionPackage: InstalledStudioExtensionPackage = {
+			manifest: {
+				id: 'sample-extension',
+				name: 'Sample Extension',
+				description: 'Adds sample contributions.',
+				version: '1.0.0',
+				main: '../main.mjs',
+			},
+			installedPath: testDirectory,
+		};
+
+		await expect( getStudioExtensionHandler( extensionPackage, 'echo' ) ).rejects.toThrow(
+			'Studio extension main entry must stay inside the extension directory.'
+		);
+	} );
+} );

--- a/apps/studio/src/extensions/tests/package-manager.test.ts
+++ b/apps/studio/src/extensions/tests/package-manager.test.ts
@@ -1,0 +1,133 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	STUDIO_EXTENSION_MANIFEST_FILE,
+	installStudioExtensionFromDirectorySource,
+	normalizeGitSourceUrl,
+	readStudioExtensionManifest,
+	resolveLocalExtensionPath,
+} from 'src/extensions/package-manager';
+
+const mockExtensionsDirectory = vi.hoisted( () => ( {
+	value: '',
+} ) );
+
+vi.mock( '@studio/common/lib/well-known-paths', () => ( {
+	getStudioExtensionsDirectory: () => mockExtensionsDirectory.value,
+} ) );
+
+let testDirectory: string;
+
+describe( 'Studio extension package manager', () => {
+	beforeEach( async () => {
+		testDirectory = await fs.mkdtemp( path.join( os.tmpdir(), 'studio-extension-' ) );
+		mockExtensionsDirectory.value = path.join( testDirectory, 'installed' );
+	} );
+
+	afterEach( async () => {
+		await fs.rm( testDirectory, { recursive: true, force: true } );
+	} );
+
+	it( 'reads a valid Studio extension manifest', async () => {
+		await fs.writeFile(
+			path.join( testDirectory, STUDIO_EXTENSION_MANIFEST_FILE ),
+			JSON.stringify( {
+				studioExtensionApiVersion: 1,
+				id: 'example-extension',
+				name: 'Example Extension',
+				description: 'Adds an example contribution.',
+				version: '1.0.0',
+				main: 'main.js',
+				renderer: 'renderer.js',
+			} ),
+			'utf8'
+		);
+
+		await expect( readStudioExtensionManifest( testDirectory ) ).resolves.toMatchObject( {
+			id: 'example-extension',
+			name: 'Example Extension',
+			description: 'Adds an example contribution.',
+			version: '1.0.0',
+			main: 'main.js',
+			renderer: 'renderer.js',
+			studioExtensionApiVersion: 1,
+		} );
+	} );
+
+	it( 'rejects unsafe manifest ids', async () => {
+		await fs.writeFile(
+			path.join( testDirectory, STUDIO_EXTENSION_MANIFEST_FILE ),
+			JSON.stringify( {
+				studioExtensionApiVersion: 1,
+				id: '../unsafe',
+				name: 'Unsafe Extension',
+				description: 'Should not install.',
+				version: '1.0.0',
+			} ),
+			'utf8'
+		);
+
+		await expect( readStudioExtensionManifest( testDirectory ) ).rejects.toThrow(
+			'Invalid Studio extension id: ../unsafe'
+		);
+	} );
+
+	it( 'normalizes GitHub shorthand URLs', () => {
+		expect( normalizeGitSourceUrl( 'github.com/example/studio-extension' ) ).toBe(
+			'https://github.com/example/studio-extension'
+		);
+		expect( normalizeGitSourceUrl( 'example/studio-extension' ) ).toBe(
+			'https://github.com/example/studio-extension'
+		);
+		expect( normalizeGitSourceUrl( 'git@github.com:example/studio-extension.git' ) ).toBe(
+			'git@github.com:example/studio-extension.git'
+		);
+	} );
+
+	it( 'resolves tilde-prefixed local extension paths', () => {
+		expect( resolveLocalExtensionPath( '~/Code/example-extension' ) ).toBe(
+			path.join( os.homedir(), 'Code/example-extension' )
+		);
+	} );
+
+	it( 'installs extensions from a local directory into the Studio extensions directory', async () => {
+		const sourceDirectory = path.join( testDirectory, 'source-extension' );
+		await fs.mkdir( sourceDirectory, { recursive: true } );
+		await fs.writeFile(
+			path.join( sourceDirectory, STUDIO_EXTENSION_MANIFEST_FILE ),
+			JSON.stringify( {
+				studioExtensionApiVersion: 1,
+				id: 'example-extension',
+				name: 'Example Extension',
+				description: 'Adds an example contribution.',
+				version: '1.0.0',
+			} ),
+			'utf8'
+		);
+		await fs.writeFile(
+			path.join( sourceDirectory, 'main.mjs' ),
+			'export const handlers = {};',
+			'utf8'
+		);
+
+		await expect( installStudioExtensionFromDirectorySource( sourceDirectory ) ).resolves.toEqual( {
+			manifest: expect.objectContaining( {
+				id: 'example-extension',
+				kind: 'user',
+			} ),
+			installedPath: path.join( mockExtensionsDirectory.value, 'example-extension' ),
+		} );
+		await expect(
+			fs.readFile(
+				path.join(
+					mockExtensionsDirectory.value,
+					'example-extension',
+					STUDIO_EXTENSION_MANIFEST_FILE
+				),
+				'utf8'
+			)
+		).resolves.toContain( 'Example Extension' );
+	} );
+} );

--- a/apps/studio/src/extensions/tests/renderer-contributions.test.tsx
+++ b/apps/studio/src/extensions/tests/renderer-contributions.test.tsx
@@ -1,0 +1,203 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useStudioExtensionSidebarSections } from 'src/extensions/components/studio-extension-sidebar-sections';
+import { useActiveStudioExtensions } from 'src/extensions/hooks/use-active-studio-extensions';
+import {
+	useStudioExtensionAccountSections,
+	useStudioExtensionSettingsTabs,
+} from 'src/extensions/hooks/use-studio-extension-settings';
+
+const SAMPLE_EXTENSION_ID = 'sample-development-extension';
+
+const sampleRendererExtension = vi.hoisted( () => ( {
+	manifest: {
+		id: 'sample-development-extension',
+		name: 'Sample Development Extension',
+		description: 'Adds sample extension contributions.',
+		version: '1.0.0',
+	},
+	sidebarSections: [
+		{
+			id: 'sample-sidebar',
+			component: () => null,
+		},
+	],
+	settingsTabs: [
+		{
+			name: 'sample-settings',
+			title: 'Sample',
+			component: () => null,
+		},
+	],
+	accountSections: [
+		{
+			id: 'sample-account',
+			title: 'Sample Account',
+			description: 'Adds a sample account section.',
+			component: () => null,
+		},
+	],
+} ) );
+const dynamicRendererExtension = vi.hoisted( () => ( {
+	manifest: {
+		id: 'dynamic-development-extension',
+		name: 'Dynamic Development Extension',
+		description: 'Adds dynamic extension contributions.',
+		version: '1.0.0',
+	},
+	sidebarSections: [
+		{
+			id: 'dynamic-sidebar',
+			component: () => null,
+		},
+	],
+} ) );
+const mockLoadStudioRendererExtension = vi.hoisted( () => vi.fn() );
+
+const mockExtensionsQuery = vi.hoisted( () => ( {
+	data: [] as {
+		id: string;
+		name: string;
+		description: string;
+		version: string;
+		kind: 'user';
+		installed: boolean;
+		enabled: boolean;
+		status: 'available' | 'installed' | 'missing' | 'unsupported';
+		isSupported: boolean;
+		installedPath?: string;
+		renderer?: string;
+	}[],
+	isLoading: false,
+} ) );
+
+vi.mock( 'src/extensions/renderer-registry', () => ( {
+	registeredStudioRendererExtensions: [ sampleRendererExtension ],
+	loadStudioRendererExtension: mockLoadStudioRendererExtension,
+} ) );
+
+vi.mock( 'src/stores/installed-apps-api', () => ( {
+	useGetStudioExtensionsQuery: () => mockExtensionsQuery,
+} ) );
+
+const sampleListItem = {
+	id: SAMPLE_EXTENSION_ID,
+	name: 'Sample Development Extension',
+	description: 'Adds sample extension contributions.',
+	version: '1.0.0',
+	kind: 'user' as const,
+	installed: false,
+	enabled: false,
+	status: 'available' as const,
+	isSupported: true,
+};
+
+function renderContributionHooks() {
+	return renderHook( () => ( {
+		active: useActiveStudioExtensions(),
+		sidebar: useStudioExtensionSidebarSections(),
+		settingsTabs: useStudioExtensionSettingsTabs(),
+		accountSections: useStudioExtensionAccountSections(),
+	} ) );
+}
+
+describe( 'Studio extension renderer contributions', () => {
+	beforeEach( () => {
+		mockExtensionsQuery.data = [ sampleListItem ];
+		mockExtensionsQuery.isLoading = false;
+		mockLoadStudioRendererExtension.mockReset();
+		mockLoadStudioRendererExtension.mockResolvedValue( dynamicRendererExtension );
+	} );
+
+	it( 'does not expose renderer contributions before an extension is installed', () => {
+		const { result } = renderContributionHooks();
+
+		expect( result.current.active.extensions ).toEqual( [] );
+		expect( result.current.sidebar.sections ).toEqual( [] );
+		expect( result.current.settingsTabs ).toEqual( [] );
+		expect( result.current.accountSections ).toEqual( [] );
+	} );
+
+	it( 'does not expose renderer contributions when an extension is installed but disabled', () => {
+		mockExtensionsQuery.data = [
+			{ ...sampleListItem, installed: true, enabled: false, status: 'installed' },
+		];
+
+		const { result } = renderContributionHooks();
+
+		expect( result.current.active.extensions ).toEqual( [] );
+		expect( result.current.sidebar.sections ).toEqual( [] );
+		expect( result.current.settingsTabs ).toEqual( [] );
+		expect( result.current.accountSections ).toEqual( [] );
+	} );
+
+	it( 'does not expose renderer contributions when an installed extension is unsupported', () => {
+		mockExtensionsQuery.data = [
+			{
+				...sampleListItem,
+				installed: true,
+				enabled: true,
+				status: 'unsupported',
+				isSupported: false,
+			},
+		];
+
+		const { result } = renderContributionHooks();
+
+		expect( result.current.active.extensions ).toEqual( [] );
+		expect( result.current.sidebar.sections ).toEqual( [] );
+		expect( result.current.settingsTabs ).toEqual( [] );
+		expect( result.current.accountSections ).toEqual( [] );
+	} );
+
+	it( 'exposes renderer contributions when an extension is installed and enabled', () => {
+		mockExtensionsQuery.data = [
+			{ ...sampleListItem, installed: true, enabled: true, status: 'installed' },
+		];
+
+		const { result } = renderContributionHooks();
+
+		expect(
+			result.current.active.extensions.map( ( extension ) => extension.manifest.id )
+		).toEqual( [ SAMPLE_EXTENSION_ID ] );
+		expect( result.current.sidebar.sections.map( ( section ) => section.id ) ).toEqual( [
+			'sample-sidebar',
+		] );
+		expect( result.current.settingsTabs.map( ( tab ) => tab.name ) ).toEqual( [
+			'sample-settings',
+		] );
+		expect( result.current.accountSections.map( ( section ) => section.id ) ).toEqual( [
+			'sample-account',
+		] );
+	} );
+
+	it( 'loads renderer contributions from enabled installed extension packages', async () => {
+		mockExtensionsQuery.data = [
+			{
+				...sampleListItem,
+				id: 'dynamic-development-extension',
+				name: 'Dynamic Development Extension',
+				installed: true,
+				enabled: true,
+				status: 'installed',
+				installedPath: '/mock/extensions/dynamic-development-extension',
+				renderer: 'renderer.js',
+			},
+		];
+
+		const { result } = renderContributionHooks();
+
+		await waitFor( () => {
+			expect( result.current.sidebar.sections.map( ( section ) => section.id ) ).toEqual( [
+				'dynamic-sidebar',
+			] );
+		} );
+		expect( mockLoadStudioRendererExtension ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				id: 'dynamic-development-extension',
+				installedPath: '/mock/extensions/dynamic-development-extension',
+				renderer: 'renderer.js',
+			} )
+		);
+	} );
+} );

--- a/apps/studio/src/extensions/types.ts
+++ b/apps/studio/src/extensions/types.ts
@@ -1,0 +1,109 @@
+import type { Session, WebContents } from 'electron';
+import type { ComponentType, ReactNode } from 'react';
+
+export type StudioExtensionKind = 'built-in' | 'user';
+export type StudioExtensionInstallSource = 'bundled' | 'directory' | 'git' | 'manual';
+export type StudioExtensionStatus = 'available' | 'installed' | 'missing' | 'unsupported';
+
+export const STUDIO_MAIN_CONTENT_SELECTION_EVENT = 'studio-main-content-selection';
+
+export interface StudioMainContentSelectionEventDetail {
+	source: 'site' | 'extension';
+	id: string;
+}
+
+export interface StudioExtensionManifest {
+	id: string;
+	name: string;
+	description: string;
+	version: string;
+	kind?: StudioExtensionKind;
+	studioExtensionApiVersion?: number;
+	publisher?: string;
+	repository?: string;
+	main?: string;
+	renderer?: string;
+	allowedNavigationOrigins?: string[];
+}
+
+export interface StudioExtensionState {
+	installed: boolean;
+	enabled: boolean;
+	installedPath?: string;
+	sourceUrl?: string;
+	sourceType?: StudioExtensionInstallSource;
+	installedAt?: string;
+	updatedAt?: string;
+}
+
+export interface StudioExtensionListItem extends StudioExtensionManifest, StudioExtensionState {
+	kind: StudioExtensionKind;
+	status: StudioExtensionStatus;
+	isSupported: boolean;
+}
+
+export interface InstalledStudioExtensionPackage {
+	manifest: StudioExtensionManifest;
+	installedPath: string;
+}
+
+export interface StudioExtensionProviderProps {
+	children: ReactNode;
+}
+
+export interface StudioExtensionSidebarSection {
+	id: string;
+	component: ComponentType;
+}
+
+export interface StudioExtensionMainContentPanel {
+	id: string;
+	component: ComponentType;
+	useIsActive: () => boolean;
+}
+
+export interface StudioExtensionSettingsTab {
+	name: string;
+	title: string;
+	component: ComponentType;
+}
+
+export interface StudioExtensionAccountSection {
+	id: string;
+	title: string;
+	description: string;
+	component: ComponentType;
+}
+
+export interface StudioRendererExtension {
+	manifest: StudioExtensionManifest;
+	providers?: ComponentType< StudioExtensionProviderProps >[];
+	sidebarSections?: StudioExtensionSidebarSection[];
+	mainContentPanels?: StudioExtensionMainContentPanel[];
+	settingsTabs?: StudioExtensionSettingsTab[];
+	accountSections?: StudioExtensionAccountSection[];
+}
+
+export type StudioExtensionMainHandler = (
+	event: Electron.IpcMainInvokeEvent,
+	...args: unknown[]
+) => unknown;
+
+export interface StudioExtensionNavigationContext {
+	webContents: WebContents;
+	session: Session;
+}
+
+export interface StudioMainExtension {
+	manifest: StudioExtensionManifest;
+	handlers?: Record< string, StudioExtensionMainHandler >;
+	isNavigationAllowed?: (
+		context: StudioExtensionNavigationContext,
+		navigationUrl: string
+	) => boolean;
+}
+
+export type StudioExtensionStorageState = Record<
+	string,
+	Partial< StudioExtensionState > | undefined
+>;

--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -23,6 +23,7 @@ import {
 	REDUX_DEVTOOLS,
 } from 'electron-devtools-installer';
 import { IPC_VOID_HANDLERS } from 'src/constants';
+import { isStudioExtensionNavigationAllowed } from 'src/extensions/main-registry';
 import * as ipcHandlers from 'src/ipc-handlers';
 import { markAppQuitting } from 'src/ipc-utils';
 import {
@@ -198,7 +199,13 @@ async function appBoot() {
 		const isSitePreviewWebview = contents.getType() === 'webview';
 
 		contents.on( 'will-navigate', ( event, navigationUrl ) => {
-			if ( isSitePreviewWebview ) {
+			if (
+				isSitePreviewWebview ||
+				isStudioExtensionNavigationAllowed(
+					{ webContents: contents, session: contents.session },
+					navigationUrl
+				)
+			) {
 				return;
 			}
 			const { origin } = new URL( navigationUrl );

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -237,6 +237,16 @@ export { importSite, exportSite } from 'src/modules/import-export/lib/ipc-handle
 
 export { fetchSiteRest as fetchSiteRestApi } from 'src/lib/wordpress-rest-api';
 
+export {
+	installStudioExtension,
+	installStudioExtensionFromPath,
+	installStudioExtensionFromUrl,
+	invokeStudioExtensionHandler,
+	listStudioExtensions,
+	setStudioExtensionEnabled,
+	uninstallStudioExtension,
+} from 'src/extensions/ipc-handlers';
+
 function hydrateAiSessionSummary(
 	summary: AiSessionSummary,
 	metadata?: Pick< AiSessionSummary, 'starred' | 'archived' >

--- a/apps/studio/src/modules/user-settings/components/account-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/account-tab.tsx
@@ -1,9 +1,32 @@
+import { useI18n } from '@wordpress/react-i18n';
 import { useAuth } from 'src/hooks/use-auth';
 import { NonAuthenticatedAccountTab } from './non-authenticated-account-tab';
 import { PromptInfo } from './prompt-info';
 import { SnapshotInfo } from './snapshot-info';
 import { UserInfo } from './user-info';
 import { WapuuScore } from './wapuu-score';
+import type { ReactNode } from 'react';
+import type { StudioExtensionAccountSection } from 'src/extensions/types';
+
+function AccountSection( {
+	children,
+	description,
+	title,
+}: {
+	children: ReactNode;
+	description: string;
+	title: string;
+} ) {
+	return (
+		<section className="flex flex-col gap-4">
+			<div>
+				<h2 className="a8c-subtitle-small">{ title }</h2>
+				<p className="mt-1 text-sm text-frame-text-secondary">{ description }</p>
+			</div>
+			<div className="flex flex-col gap-4">{ children }</div>
+		</section>
+	);
+}
 
 export const AccountTab = ( {
 	loadingDeletingAllSnapshots,
@@ -12,6 +35,7 @@ export const AccountTab = ( {
 	isOffline,
 	snapshotQuota,
 	onRemoveSnapshots,
+	accountSections = [],
 }: {
 	loadingDeletingAllSnapshots: boolean;
 	activeSnapshotCount: number;
@@ -19,10 +43,12 @@ export const AccountTab = ( {
 	isOffline: boolean;
 	snapshotQuota: number;
 	onRemoveSnapshots: () => void;
+	accountSections?: StudioExtensionAccountSection[];
 } ) => {
+	const { __ } = useI18n();
 	const { isAuthenticated, user, logout } = useAuth();
 
-	return (
+	const wordpressComAccount = (
 		<>
 			{ isAuthenticated ? (
 				<>
@@ -46,5 +72,32 @@ export const AccountTab = ( {
 				<NonAuthenticatedAccountTab />
 			) }
 		</>
+	);
+
+	if ( ! accountSections.length ) {
+		return wordpressComAccount;
+	}
+
+	return (
+		<div className="flex flex-col gap-7">
+			<AccountSection
+				title={ __( 'WordPress.com' ) }
+				description={ __( 'Used for Studio sync, preview sites, and Studio Code.' ) }
+			>
+				{ wordpressComAccount }
+			</AccountSection>
+			{ accountSections.map( ( section ) => {
+				const Section = section.component;
+				return (
+					<AccountSection
+						key={ section.id }
+						title={ section.title }
+						description={ section.description }
+					>
+						<Section />
+					</AccountSection>
+				);
+			} ) }
+		</div>
 	);
 };

--- a/apps/studio/src/modules/user-settings/components/tests/user-settings.test.tsx
+++ b/apps/studio/src/modules/user-settings/components/tests/user-settings.test.tsx
@@ -8,6 +8,8 @@ import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useOffline } from 'src/hooks/use-offline';
 import { UserSettings } from 'src/modules/user-settings';
 import { store } from 'src/stores';
+import { installedAppsApi } from 'src/stores/installed-apps-api';
+import type { ComponentType } from 'react';
 
 vi.mock( 'src/lib/app-globals', () => ( {
 	getAppGlobals: vi.fn( () => ( {
@@ -22,19 +24,49 @@ vi.mock( 'src/hooks/use-auth' );
 vi.mock( 'src/hooks/use-ipc-listener' );
 vi.mock( 'src/hooks/use-offline' );
 
+const mockExtensionSettingsTabs = vi.hoisted( () => ( {
+	value: [] as {
+		name: string;
+		title: string;
+		component: ComponentType;
+	}[],
+} ) );
+const mockExtensionAccountSections = vi.hoisted( () => ( {
+	value: [] as {
+		id: string;
+		title: string;
+		description: string;
+		component: ComponentType;
+	}[],
+} ) );
+
+vi.mock( 'src/extensions/hooks/use-studio-extension-settings', () => ( {
+	useStudioExtensionSettingsTabs: () => mockExtensionSettingsTabs.value,
+	useStudioExtensionAccountSections: () => mockExtensionAccountSections.value,
+} ) );
+
+const mockIpcApi = vi.hoisted( () => ( {
+	getUserTerminal: vi.fn(),
+	getUserEditor: vi.fn(),
+	getInstalledAppsAndTerminals: vi.fn(),
+	isStudioCliInstalled: vi.fn(),
+	copyText: vi.fn(),
+	getDefaultSiteDirectory: vi.fn(),
+	getWapuuScore: vi.fn(),
+	getColorScheme: vi.fn(),
+	showOpenFolderDialog: vi.fn(),
+	listStudioExtensions: vi.fn(),
+	installStudioExtension: vi.fn(),
+	installStudioExtensionFromPath: vi.fn(),
+	installStudioExtensionFromUrl: vi.fn(),
+	uninstallStudioExtension: vi.fn(),
+	setStudioExtensionEnabled: vi.fn(),
+	invokeStudioExtensionHandler: vi.fn(),
+	openURL: vi.fn(),
+} ) );
+
 vi.mock( 'src/lib/get-ipc-api', () => ( {
-	getIpcApi: () => ( {
-		getUserTerminal: vi.fn().mockResolvedValue( 'terminal' ),
-		getUserEditor: vi.fn().mockResolvedValue( 'vscode' ),
-		getInstalledAppsAndTerminals: vi.fn().mockResolvedValue( {
-			terminals: [ 'terminal' ],
-			editors: [ 'vscode' ],
-		} ),
-		isStudioCliInstalled: vi.fn().mockResolvedValue( true ),
-		copyText: vi.fn().mockResolvedValue( undefined ),
-		getDefaultSiteDirectory: vi.fn().mockResolvedValue( '/mock/default/site/path' ),
-		getWapuuScore: vi.fn().mockResolvedValue( undefined ),
-	} ),
+	getIpcApi: () => mockIpcApi,
 } ) );
 
 function renderWithProvider( component: React.ReactElement ) {
@@ -48,9 +80,82 @@ const mockIpcEvent = {
 	defaultPrevented: false,
 };
 
+function SampleAccountConnection() {
+	return <p>Sample account is connected.</p>;
+}
+
+function SampleDevelopmentSettings() {
+	return <p>Sample extension development settings.</p>;
+}
+
+const sampleExtension = {
+	id: 'sample-development-extension',
+	name: 'Sample Development Extension',
+	description: 'Adds sample extension development tools.',
+	version: '0.1.0',
+	kind: 'user' as const,
+	installed: false,
+	enabled: false,
+	status: 'available' as const,
+	isSupported: true,
+};
+
 describe( 'UserSettings', () => {
 	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.mocked( useAuth ).mockReset();
+		vi.mocked( useIpcListener ).mockReset();
+		vi.mocked( useOffline ).mockReset();
+		store.dispatch( installedAppsApi.util.resetApiState() );
+		mockIpcApi.getUserTerminal.mockResolvedValue( 'terminal' );
+		mockIpcApi.getUserEditor.mockResolvedValue( 'vscode' );
+		mockIpcApi.getInstalledAppsAndTerminals.mockResolvedValue( {
+			terminals: [ 'terminal' ],
+			editors: [ 'vscode' ],
+		} );
+		mockIpcApi.isStudioCliInstalled.mockResolvedValue( true );
+		mockIpcApi.copyText.mockResolvedValue( undefined );
+		mockIpcApi.getDefaultSiteDirectory.mockResolvedValue( '/mock/default/site/path' );
+		mockIpcApi.getWapuuScore.mockResolvedValue( undefined );
+		mockIpcApi.getColorScheme.mockResolvedValue( 'light' );
+		mockIpcApi.showOpenFolderDialog.mockResolvedValue( {
+			path: '~/Code/sample-extension',
+		} );
+		mockIpcApi.listStudioExtensions.mockResolvedValue( [ sampleExtension ] );
+		mockIpcApi.installStudioExtension.mockResolvedValue( {
+			...sampleExtension,
+			installed: true,
+			enabled: true,
+			status: 'installed',
+		} );
+		mockIpcApi.installStudioExtensionFromPath.mockResolvedValue( {
+			...sampleExtension,
+			installed: true,
+			enabled: true,
+			status: 'installed',
+			sourceType: 'directory',
+		} );
+		mockIpcApi.installStudioExtensionFromUrl.mockResolvedValue( {
+			...sampleExtension,
+			installed: true,
+			enabled: true,
+			status: 'installed',
+			sourceType: 'git',
+			sourceUrl: 'https://github.com/example/sample-development-extension',
+		} );
+		mockIpcApi.uninstallStudioExtension.mockResolvedValue( sampleExtension );
+		mockIpcApi.setStudioExtensionEnabled.mockResolvedValue( {
+			...sampleExtension,
+			installed: true,
+			enabled: true,
+			status: 'installed',
+		} );
+		mockIpcApi.invokeStudioExtensionHandler.mockResolvedValue( undefined );
+		mockIpcApi.openURL.mockResolvedValue( undefined );
+		mockExtensionSettingsTabs.value = [];
+		mockExtensionAccountSections.value = [];
 		vi.mocked( useOffline ).mockReturnValue( false );
+
 		// Triggers IPC listener to show modal
 		vi.mocked( useIpcListener ).mockImplementationOnce( ( listener, callback ) => {
 			if ( listener === 'user-settings' ) {
@@ -130,10 +235,25 @@ describe( 'UserSettings', () => {
 
 			// General tab (renamed from Preferences) should be selected first
 			await waitFor( () => {
+				expect( screen.getAllByRole( 'tab' ).map( ( tab ) => tab.textContent ) ).toEqual( [
+					'General',
+					'Account',
+					'Skills',
+					'MCP',
+					'Extensions',
+				] );
 				expect( screen.getByText( 'General' ) ).toHaveAttribute( 'aria-selected', 'true' );
 				expect( screen.getByText( 'Language' ) ).toBeInTheDocument();
 				expect( screen.getByText( 'Terminal application' ) ).toBeInTheDocument();
 				expect( screen.getByText( 'Studio CLI for terminal' ) ).toBeInTheDocument();
+			} );
+
+			await user.click( screen.getByRole( 'tab', { name: 'Extensions' } ) );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Extensions' ) ).toHaveAttribute( 'aria-selected', 'true' );
+				expect( screen.getByText( 'Sample Development Extension' ) ).toBeInTheDocument();
+				expect( screen.getAllByRole( 'button', { name: 'Install' } ).length ).toBeGreaterThan( 0 );
 			} );
 
 			await user.click( screen.getByText( 'Account' ) );
@@ -141,12 +261,55 @@ describe( 'UserSettings', () => {
 			await waitFor( () => {
 				expect( screen.getByText( 'Account' ) ).toHaveAttribute( 'aria-selected', 'true' );
 				expect( screen.getByText( 'Log out' ) ).toBeInTheDocument();
+				expect( screen.queryByText( 'Example Account' ) ).not.toBeInTheDocument();
 				expect( screen.getByText( 'Preview sites' ) ).toBeInTheDocument();
 				expect( screen.getByText( 'Studio Code' ) ).toBeInTheDocument();
 				expect(
 					screen.getByText( 'Studio Code limits are temporarily unavailable.' )
 				).toBeInTheDocument();
 				expect( screen.queryByText( /monthly prompts used/ ) ).not.toBeInTheDocument();
+			} );
+		} );
+
+		it( 'shows Accounts when an extension contributes an account section', async () => {
+			const user = userEvent.setup();
+			mockExtensionAccountSections.value = [
+				{
+					id: 'sample-account',
+					title: 'Example Account',
+					description: 'Used by the sample extension for publishing workflows.',
+					component: SampleAccountConnection,
+				},
+			];
+			vi.mocked( useAuth ).mockReturnValue( {
+				isAuthenticated: true,
+				authenticate: vi.fn(),
+				logout: vi.fn(),
+				client: undefined,
+			} );
+
+			renderWithProvider( <UserSettings /> );
+
+			await waitFor( () => {
+				expect( screen.getAllByRole( 'tab' ).map( ( tab ) => tab.textContent ) ).toEqual( [
+					'General',
+					'Accounts',
+					'Skills',
+					'MCP',
+					'Extensions',
+				] );
+			} );
+
+			await user.click( screen.getByRole( 'tab', { name: 'Accounts' } ) );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Accounts' ) ).toHaveAttribute( 'aria-selected', 'true' );
+				expect( screen.getByText( 'WordPress.com' ) ).toBeInTheDocument();
+				expect( screen.getByText( 'Example Account' ) ).toBeInTheDocument();
+				expect(
+					screen.getByText( 'Used by the sample extension for publishing workflows.' )
+				).toBeInTheDocument();
+				expect( screen.getByText( 'Sample account is connected.' ) ).toBeInTheDocument();
 			} );
 		} );
 	} );
@@ -191,6 +354,116 @@ describe( 'UserSettings', () => {
 			await waitFor( () => {
 				expect( screen.getByText( 'Account' ) ).toHaveAttribute( 'aria-selected', 'true' );
 				expect( screen.getByText( 'Preview sites' ) ).toBeInTheDocument();
+			} );
+		} );
+
+		it( 'should open with an extension settings tab when tabName matches it', async () => {
+			mockExtensionSettingsTabs.value = [
+				{
+					name: 'development',
+					title: 'Development',
+					component: SampleDevelopmentSettings,
+				},
+			];
+			vi.mocked( useIpcListener ).mockImplementation( ( listener, callback ) => {
+				if ( listener === 'user-settings' ) {
+					setTimeout( () => callback( mockIpcEvent, { tabName: 'development' } ), 0 );
+				}
+			} );
+			vi.mocked( useAuth ).mockReturnValue( {
+				isAuthenticated: true,
+				authenticate: vi.fn(),
+				logout: vi.fn(),
+				client: undefined,
+			} );
+
+			renderWithProvider( <UserSettings /> );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Development' ) ).toHaveAttribute( 'aria-selected', 'true' );
+				expect( screen.getByText( 'Sample extension development settings.' ) ).toBeInTheDocument();
+			} );
+		} );
+
+		it( 'installs an extension from the Extensions tab', async () => {
+			const user = userEvent.setup();
+			vi.mocked( useAuth ).mockReturnValue( {
+				isAuthenticated: true,
+				authenticate: vi.fn(),
+				logout: vi.fn(),
+				client: undefined,
+			} );
+
+			renderWithProvider( <UserSettings /> );
+
+			await user.click( screen.getByRole( 'tab', { name: 'Extensions' } ) );
+			const installButtons = await screen.findAllByRole( 'button', { name: 'Install' } );
+
+			await user.click( installButtons[ 1 ] );
+
+			await waitFor( () => {
+				expect( mockIpcApi.installStudioExtension ).toHaveBeenCalledWith(
+					'sample-development-extension'
+				);
+			} );
+		} );
+
+		it( 'installs an extension from a Git URL', async () => {
+			const user = userEvent.setup();
+			vi.mocked( useAuth ).mockReturnValue( {
+				isAuthenticated: true,
+				authenticate: vi.fn(),
+				logout: vi.fn(),
+				client: undefined,
+			} );
+
+			renderWithProvider( <UserSettings /> );
+
+			await user.click( screen.getByRole( 'tab', { name: 'Extensions' } ) );
+			await user.type(
+				await screen.findByLabelText( 'Git URL' ),
+				'https://github.com/example/sample-development-extension'
+			);
+			await user.click( screen.getAllByRole( 'button', { name: 'Install' } )[ 0 ] );
+
+			await waitFor( () => {
+				expect( mockIpcApi.installStudioExtensionFromUrl ).toHaveBeenCalledWith(
+					'https://github.com/example/sample-development-extension'
+				);
+			} );
+		} );
+
+		it( 'installs an extension from a local directory', async () => {
+			const user = userEvent.setup();
+			vi.mocked( useAuth ).mockReturnValue( {
+				isAuthenticated: true,
+				authenticate: vi.fn(),
+				logout: vi.fn(),
+				client: undefined,
+			} );
+
+			renderWithProvider( <UserSettings /> );
+
+			await user.click( screen.getByRole( 'tab', { name: 'Extensions' } ) );
+			await user.click( await screen.findByRole( 'tab', { name: 'Local directory' } ) );
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Choose extension folder…, Select different local path',
+				} )
+			);
+			await waitFor( () => {
+				expect( mockIpcApi.showOpenFolderDialog ).toHaveBeenCalledWith(
+					'Select extension folder',
+					''
+				);
+				expect( screen.getByText( '~/Code/sample-extension' ) ).toBeInTheDocument();
+			} );
+			await user.click( screen.getAllByRole( 'button', { name: 'Install' } )[ 0 ] );
+
+			await waitFor( () => {
+				expect( mockIpcApi.installStudioExtensionFromPath ).toHaveBeenCalledWith(
+					'~/Code/sample-extension'
+				);
 			} );
 		} );
 

--- a/apps/studio/src/modules/user-settings/components/user-settings.tsx
+++ b/apps/studio/src/modules/user-settings/components/user-settings.tsx
@@ -2,6 +2,11 @@ import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useState } from 'react';
 import Modal from 'src/components/modal';
+import { ExtensionsSettingsTab } from 'src/extensions/components/extensions-settings-tab';
+import {
+	useStudioExtensionAccountSections,
+	useStudioExtensionSettingsTabs,
+} from 'src/extensions/hooks/use-studio-extension-settings';
 import { useAuth } from 'src/hooks/use-auth';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useOffline } from 'src/hooks/use-offline';
@@ -25,6 +30,8 @@ export default function UserSettings() {
 	const snapshotQuota = useRootSelector( ( state ) => state.snapshot.snapshotQuota );
 	const { data: snapshotUsage, isLoading: isLoadingSnapshotUsage } = useGetSnapshotUsage();
 	const definitiveSnapshotCount = snapshotUsage?.siteCount ?? snapshotsByUser?.length ?? 0;
+	const extensionSettingsTabs = useStudioExtensionSettingsTabs();
+	const extensionAccountSections = useStudioExtensionAccountSections();
 
 	const [ needsToOpenUserSettings, setNeedsToOpenUserSettings ] = useState( false );
 	const [ selectedTabName, setSelectedTabName ] = useState< string | undefined >();
@@ -81,7 +88,7 @@ export default function UserSettings() {
 
 		result.push( {
 			name: 'account',
-			title: __( 'Account' ),
+			title: extensionAccountSections.length ? __( 'Accounts' ) : __( 'Account' ),
 		} );
 
 		result.push( {
@@ -94,8 +101,15 @@ export default function UserSettings() {
 			title: __( 'MCP' ),
 		} );
 
+		result.push( {
+			name: 'extensions',
+			title: __( 'Extensions' ),
+		} );
+
+		result.push( ...extensionSettingsTabs );
+
 		return result;
-	}, [ __ ] );
+	}, [ __, extensionAccountSections.length, extensionSettingsTabs ] );
 
 	return (
 		<>
@@ -121,6 +135,7 @@ export default function UserSettings() {
 								{ name === 'general' && <PreferencesTab onClose={ resetLocalState } /> }
 								{ name === 'skills' && <SkillsTab /> }
 								{ name === 'mcp' && <McpSettings /> }
+								{ name === 'extensions' && <ExtensionsSettingsTab /> }
 								{ name === 'account' && (
 									<AccountTab
 										loadingDeletingAllSnapshots={ isDeletingAllSnapshots }
@@ -129,8 +144,16 @@ export default function UserSettings() {
 										isOffline={ isOffline }
 										snapshotQuota={ snapshotQuota }
 										onRemoveSnapshots={ onRemoveSnapshots }
+										accountSections={ extensionAccountSections }
 									/>
 								) }
+								{ extensionSettingsTabs.map( ( tab ) => {
+									if ( tab.name !== name ) {
+										return null;
+									}
+									const Tab = tab.component;
+									return <Tab key={ tab.name } />;
+								} ) }
 							</div>
 						) }
 					</TabPanel>

--- a/apps/studio/src/modules/user-settings/user-settings-types.ts
+++ b/apps/studio/src/modules/user-settings/user-settings-types.ts
@@ -1,4 +1,4 @@
-export type UserSettingsTabName = 'general' | 'skills' | 'account' | 'mcp';
+export type UserSettingsTabName = string;
 export type UserSettingsTab = {
 	name: UserSettingsTabName;
 	title: string;

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -79,6 +79,19 @@ const api: IpcApi = {
 	getDefaultSiteDirectory: () => ipcRendererInvoke( 'getDefaultSiteDirectory' ),
 	saveDefaultSiteDirectory: ( directory ) =>
 		ipcRendererInvoke( 'saveDefaultSiteDirectory', directory ),
+	listStudioExtensions: () => ipcRendererInvoke( 'listStudioExtensions' ),
+	installStudioExtension: ( extensionId ) =>
+		ipcRendererInvoke( 'installStudioExtension', extensionId ),
+	installStudioExtensionFromPath: ( sourcePath ) =>
+		ipcRendererInvoke( 'installStudioExtensionFromPath', sourcePath ),
+	installStudioExtensionFromUrl: ( sourceUrl ) =>
+		ipcRendererInvoke( 'installStudioExtensionFromUrl', sourceUrl ),
+	uninstallStudioExtension: ( extensionId ) =>
+		ipcRendererInvoke( 'uninstallStudioExtension', extensionId ),
+	setStudioExtensionEnabled: ( extensionId, enabled ) =>
+		ipcRendererInvoke( 'setStudioExtensionEnabled', extensionId, enabled ),
+	invokeStudioExtensionHandler: ( extensionId, handlerName, ...args ) =>
+		ipcRendererInvoke( 'invokeStudioExtensionHandler', extensionId, handlerName, ...args ),
 	showUserSettings: ( tabName ) => ipcRendererInvoke( 'showUserSettings', tabName ),
 	startServer: ( id ) => ipcRendererInvoke( 'startServer', id ),
 	stopServer: ( id ) => ipcRendererInvoke( 'stopServer', id ),

--- a/apps/studio/src/storage/storage-types.ts
+++ b/apps/studio/src/storage/storage-types.ts
@@ -1,5 +1,6 @@
 import { StatsMetric } from 'src/lib/bump-stats';
 import { SupportedEditor } from 'src/modules/user-settings/lib/editor';
+import type { StudioExtensionStorageState } from 'src/extensions/types';
 import type { SupportedTerminal } from 'src/modules/user-settings/lib/terminal';
 
 export interface WindowBounds {
@@ -49,6 +50,7 @@ export interface UserData {
 	betaFeatures?: BetaFeatures;
 	stopSitesOnQuit?: boolean;
 	defaultSiteDirectory?: string;
+	extensions?: StudioExtensionStorageState;
 	/** @deprecated Used only for migration to cliUserUninstalled. Do not write; remove after one release cycle. */
 	cliAutoInstalled?: boolean;
 	cliUserUninstalled?: boolean;

--- a/apps/studio/src/storage/user-data.ts
+++ b/apps/studio/src/storage/user-data.ts
@@ -73,6 +73,7 @@ type UserDataSafeKeys =
 	| 'betaFeatures'
 	| 'colorScheme'
 	| 'defaultSiteDirectory'
+	| 'extensions'
 	| 'cliAutoInstalled'
 	| 'cliUserUninstalled'
 	| 'wapuuScore'

--- a/apps/studio/src/stores/installed-apps-api.ts
+++ b/apps/studio/src/stores/installed-apps-api.ts
@@ -11,6 +11,7 @@ import {
 	terminalConfig,
 	getTerminalsSupportedOnPlatform,
 } from 'src/modules/user-settings/lib/terminal';
+import type { StudioExtensionListItem } from 'src/extensions/types';
 
 export const installedAppsApi = createApi( {
 	reducerPath: 'installedAppsApi',
@@ -22,6 +23,7 @@ export const installedAppsApi = createApi( {
 		'UserTerminal',
 		'ColorScheme',
 		'DefaultSiteDirectory',
+		'StudioExtensions',
 	],
 	endpoints: ( builder ) => ( {
 		getStudioCliIsInstalled: builder.query< boolean, void >( {
@@ -105,6 +107,51 @@ export const installedAppsApi = createApi( {
 			},
 			invalidatesTags: [ 'DefaultSiteDirectory' ],
 		} ),
+		getStudioExtensions: builder.query< StudioExtensionListItem[], void >( {
+			queryFn: async () => {
+				const extensions = await getIpcApi().listStudioExtensions();
+				return { data: extensions };
+			},
+			providesTags: [ 'StudioExtensions' ],
+		} ),
+		installStudioExtension: builder.mutation< StudioExtensionListItem, string >( {
+			queryFn: async ( extensionId ) => {
+				const extension = await getIpcApi().installStudioExtension( extensionId );
+				return { data: extension };
+			},
+			invalidatesTags: [ 'StudioExtensions' ],
+		} ),
+		installStudioExtensionFromUrl: builder.mutation< StudioExtensionListItem, string >( {
+			queryFn: async ( sourceUrl ) => {
+				const extension = await getIpcApi().installStudioExtensionFromUrl( sourceUrl );
+				return { data: extension };
+			},
+			invalidatesTags: [ 'StudioExtensions' ],
+		} ),
+		installStudioExtensionFromPath: builder.mutation< StudioExtensionListItem, string >( {
+			queryFn: async ( sourcePath ) => {
+				const extension = await getIpcApi().installStudioExtensionFromPath( sourcePath );
+				return { data: extension };
+			},
+			invalidatesTags: [ 'StudioExtensions' ],
+		} ),
+		uninstallStudioExtension: builder.mutation< StudioExtensionListItem, string >( {
+			queryFn: async ( extensionId ) => {
+				const extension = await getIpcApi().uninstallStudioExtension( extensionId );
+				return { data: extension };
+			},
+			invalidatesTags: [ 'StudioExtensions' ],
+		} ),
+		setStudioExtensionEnabled: builder.mutation<
+			StudioExtensionListItem,
+			{ extensionId: string; enabled: boolean }
+		>( {
+			queryFn: async ( { extensionId, enabled } ) => {
+				const extension = await getIpcApi().setStudioExtensionEnabled( extensionId, enabled );
+				return { data: extension };
+			},
+			invalidatesTags: [ 'StudioExtensions' ],
+		} ),
 	} ),
 } );
 
@@ -120,6 +167,12 @@ export const {
 	useSaveColorSchemeMutation,
 	useGetDefaultSiteDirectoryQuery,
 	useSaveDefaultSiteDirectoryMutation,
+	useGetStudioExtensionsQuery,
+	useInstallStudioExtensionMutation,
+	useInstallStudioExtensionFromPathMutation,
+	useInstallStudioExtensionFromUrlMutation,
+	useUninstallStudioExtensionMutation,
+	useSetStudioExtensionEnabledMutation,
 } = installedAppsApi;
 
 export const selectInstalledEditors = createSelector(

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,7 @@ export default defineConfig(
 				projectService: {
 					allowDefaultProject: [
 						'apps/studio/forge.config.ts',
+						'apps/studio/electron.vite.config.ts',
 						'apps/studio/windowsSign.ts',
 						'apps/studio/tailwind.config.js',
 						'apps/ui/vite.config.ts',

--- a/tools/common/lib/well-known-paths.ts
+++ b/tools/common/lib/well-known-paths.ts
@@ -43,6 +43,10 @@ export function getAiPayloadsPath(): string {
 	return path.join( getConfigDirectory(), 'tmp', 'ai-payloads' );
 }
 
+export function getStudioExtensionsDirectory(): string {
+	return path.join( getConfigDirectory(), 'extensions' );
+}
+
 export function getRemoteSessionConfigPath(): string {
 	return path.join( getConfigDirectory(), 'remote-session.json' );
 }


### PR DESCRIPTION
## Related issues

- Related to #3917

## How AI was used in this PR

This is an AI-assisted proof of concept. I used Codex to explore the existing Studio architecture, implement the extension host prototype, keep the UI aligned with the current Studio settings/sidebar patterns, and add focused tests around the proposed extension boundaries. I reviewed the generated changes, removed the earlier workflow-specific prototype from core, and kept this PR focused on generic extension infrastructure.

## Proposed Changes

- Introduces a proof-of-concept extension system so Studio can stay lean while still making room for advanced, opt-in workflows.
- Adds an Extensions settings pane where users can install trusted extensions from a Git URL or local directory, then enable, disable, or uninstall them.
- Supports early contribution points for sidebar sections, main content panels, settings tabs, account sections, root providers, and extension-owned main-process work through a namespaced RPC bridge.
- Stores extension install/enabled state in Studio app data using the existing locked app config path.
- Keeps the initial model intentionally constrained to trusted local/Git-installed extensions, with no marketplace or arbitrary remote runtime loading in this prototype.

Because this touches core application architecture and UI extension points, this PR is intended as a Proof of Concept and discussion anchor rather than a merge-ready change.

## Testing Instructions

- Ran `npx eslint --fix` on the modified TypeScript/TSX/MJS files.
- Ran focused tests:

```sh
npm test -- apps/studio/src/extensions/tests/ipc-handlers.test.ts apps/studio/src/extensions/tests/main-registry.test.ts apps/studio/src/extensions/tests/package-manager.test.ts apps/studio/src/extensions/tests/renderer-contributions.test.tsx apps/studio/src/modules/user-settings/components/tests/user-settings.test.tsx apps/studio/src/components/tests/main-sidebar.test.tsx apps/studio/src/components/tests/app.test.tsx
```

- Ran `npm run typecheck`; it currently fails on the updated base branch in `apps/studio/e2e/sandbox.test.ts`, which is not changed by this PR. The failure is that the test calls `navigateToTab( 'Settings' )` while the current page object overload accepts `settings`.
- Start Studio with `npm start` and verify Settings -> Extensions in light mode.
- Switch Appearance to Dark and verify Settings -> Extensions, extension-contributed settings tabs, and sidebar contributions remain readable.
- Install or point Studio at a local trusted extension directory under `~/.studio/extensions`, enable it, and verify its sidebar/settings/account/content contributions appear only while enabled.
- Disable the extension and verify its renderer contributions and RPC handlers fail closed.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
