### PR TITLE
Fix typecheck break in Sandbox e2e test (navigateToTab casing)

### DIFF
--- a/apps/studio/e2e/sandbox.test.ts
+++ b/apps/studio/e2e/sandbox.test.ts
@@ -32,7 +32,7 @@ test.describe( 'Sandbox runtime', () => {
 		await expect( siteContent.siteNameHeading ).toHaveText( siteName );
 
 		// The Settings tab reports the site as running on the Sandbox runtime.
-		const settingsTab = await siteContent.navigateToTab( 'Settings' );
+		const settingsTab = await siteContent.navigateToTab( 'settings' );
 		await expect( settingsTab.phpRuntimeDisplay ).toContainText( 'Sandbox' );
 
 		// The Sandbox site actually serves its home page over HTTP.


### PR DESCRIPTION
## Related issues

- Related to #3893 (introduced the failing test)

## How AI was used in this PR

Diagnosed the CI break with Claude Code (Opus 4.8): traced the Buildkite **Lint** step's `npm run typecheck` failure to a cross-file overload mismatch in the newly-added Sandbox e2e test, then verified the fix with `tsc` and ESLint on the changed file.

## Proposed Changes

PR #3893 added the first e2e test for the Sandbox (Playground) runtime, but it called `navigateToTab( 'Settings' )` with a capitalized label. The `SiteContent` page object only accepts the lowercase tab ids (`'settings'`, `'import-export'`, `'preview'`), so no overload matched and typecheck failed — turning the **Lint** CI step (which runs `npm run typecheck`) red on trunk:

```
sandbox.test.ts(35,56): error TS2769: No overload matches this call.
sandbox.test.ts(36,29): error TS2339: Property 'phpRuntimeDisplay' does not exist on type 'never'.
```

The second error cascaded from the first (no matching overload → `never` return type). The capitalized value would also have failed at runtime, since the tab selector resolves to `[role="tab"][id$="-settings"]`.

This restores a green build by using the correct lowercase `'settings'` tab id. No product code changes.

## Testing Instructions

1. `npm run typecheck` — passes (no `sandbox.test.ts` errors).
2. `npx eslint apps/studio/e2e/sandbox.test.ts` — clean.
3. CI **Lint** + **E2E Tests** steps go green on this branch.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? — `tsc` and ESLint are clean on the changed file; this PR specifically fixes the TypeScript break.
