### PR TITLE
Build gd with additional libraries

### DIFF
--- a/.github/workflows/build-php-cli-binaries.yml
+++ b/.github/workflows/build-php-cli-binaries.yml
@@ -175,6 +175,8 @@ jobs:
           )
           build_args=(
             "$static_extensions"
+            # Give gd JPEG/WebP image support and FreeType (TrueType text).
+            --with-libs=freetype,libjpeg,libwebp
             --build-shared=xdebug
             --build-cli
           )


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes RSM-4476

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Scarcely

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

static-php-cli builds gd without libjpeg by default. See [docs](https://github.com/crazywhalecc/static-php-cli/blob/b4ed673261548dcc0caa5b61ed782de1ccbe971f/docs/en/guide/extension-notes.md#gd). This means WordPress can't edit these images, which is a critical bug.

This PR fixes the problem by passing `--with-libs=freetype,libjpeg,libwebp` to static-php-cli when building the binaries.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I'll manually verify that this gives the result we want.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
