### PR TITLE
Dev-stamp the standalone CLI version in nightly builds

### DIFF
--- a/scripts/prepare-dev-build-version.mjs
+++ b/scripts/prepare-dev-build-version.mjs
@@ -20,7 +20,9 @@ if ( ! commitCount && commitCount !== 0 ) {
 // Build a dev version targeting the next minor release (major.(minor+1).0-devN) from a base
 // version, so trunk builds sort above any stable or beta of that base. Strips a leading 'v'.
 function toDevVersion( baseVersion, source ) {
-	const parsed = semver.parse( baseVersion.startsWith( 'v' ) ? baseVersion.slice( 1 ) : baseVersion );
+	const parsed = semver.parse(
+		baseVersion.startsWith( 'v' ) ? baseVersion.slice( 1 ) : baseVersion
+	);
 	if ( ! parsed ) {
 		throw new Error( `Invalid version in ${ source }: ${ baseVersion }` );
 	}

--- a/scripts/prepare-dev-build-version.mjs
+++ b/scripts/prepare-dev-build-version.mjs
@@ -17,27 +17,26 @@ if ( ! commitCount && commitCount !== 0 ) {
 	throw new Error( 'Missing commit count' );
 }
 
-// Use version from latestTag (strip leading 'v' if present)
-const tagVersion = latestTag.startsWith( 'v' ) ? latestTag.slice( 1 ) : latestTag;
-const parsedVersion = semver.parse( tagVersion );
-if ( ! parsedVersion ) {
-	throw new Error( `Invalid version in latestTag: ${ latestTag }` );
+// Build a dev version targeting the next minor release (major.(minor+1).0-devN) from a base
+// version, so trunk builds sort above any stable or beta of that base. Strips a leading 'v'.
+function toDevVersion( baseVersion, source ) {
+	const parsed = semver.parse( baseVersion.startsWith( 'v' ) ? baseVersion.slice( 1 ) : baseVersion );
+	if ( ! parsed ) {
+		throw new Error( `Invalid version in ${ source }: ${ baseVersion }` );
+	}
+	return `${ parsed.major }.${ parsed.minor + 1 }.0-dev${ commitCount }`;
 }
 
-// Create dev version targeting the next minor release (major.minor+1.0-devN),
-// so trunk builds sort above any stable or beta of the last release.
-const devVersion = `${ parsedVersion.major }.${ parsedVersion.minor + 1 }.0-dev${ commitCount }`;
-
-packageJson.version = devVersion;
-
+// Desktop app: based on the latest release tag.
+packageJson.version = toDevVersion( latestTag, 'latestTag' );
 const packageJsonPath = path.resolve( 'apps', 'studio', 'package.json' );
 await fs.writeFile( packageJsonPath, JSON.stringify( packageJson, null, '\t' ) + '\n' );
 
-// Also stamp the standalone Studio CLI so its baked `__STUDIO_CLI_VERSION__` matches this dev
-// build. The CLI's version drives its update channel (a `-devN` version → nightly), so without
-// this a nightly bundle reports the static base version, looks like production to the update
-// endpoint, and never sees nightly updates.
+// Standalone CLI: based on its OWN current version — the CLI and app aren't guaranteed to share a
+// version line. Its baked `__STUDIO_CLI_VERSION__` drives the update channel (a `-devN` version →
+// nightly); without this a nightly bundle reports the static base version, looks like production
+// to the update endpoint, and never sees nightly updates.
 const cliPackageJsonPath = path.resolve( 'apps', 'cli', 'package.json' );
 const cliPackageJson = JSON.parse( await fs.readFile( cliPackageJsonPath, 'utf8' ) );
-cliPackageJson.version = devVersion;
+cliPackageJson.version = toDevVersion( cliPackageJson.version, 'apps/cli/package.json' );
 await fs.writeFile( cliPackageJsonPath, JSON.stringify( cliPackageJson, null, '\t' ) + '\n' );

--- a/scripts/prepare-dev-build-version.mjs
+++ b/scripts/prepare-dev-build-version.mjs
@@ -32,3 +32,12 @@ packageJson.version = devVersion;
 
 const packageJsonPath = path.resolve( 'apps', 'studio', 'package.json' );
 await fs.writeFile( packageJsonPath, JSON.stringify( packageJson, null, '\t' ) + '\n' );
+
+// Also stamp the standalone Studio CLI so its baked `__STUDIO_CLI_VERSION__` matches this dev
+// build. The CLI's version drives its update channel (a `-devN` version → nightly), so without
+// this a nightly bundle reports the static base version, looks like production to the update
+// endpoint, and never sees nightly updates.
+const cliPackageJsonPath = path.resolve( 'apps', 'cli', 'package.json' );
+const cliPackageJson = JSON.parse( await fs.readFile( cliPackageJsonPath, 'utf8' ) );
+cliPackageJson.version = devVersion;
+await fs.writeFile( cliPackageJsonPath, JSON.stringify( cliPackageJson, null, '\t' ) + '\n' );


### PR DESCRIPTION
## Related issues

- Related to [STU-1772](https://linear.app/a8c/issue/STU-1772) — the standalone CLI update workflow depends on this.

## How AI was used in this PR

Caught during real-world testing: installing a published nightly CLI showed `studio --version` → `1.11.0`, even though the Apps CDN publishes that same nightly as `1.12.0-dev103`. Traced it to `prepare-dev-build-version.mjs` dev-stamping only `apps/studio/package.json`. I reviewed the change myself.

## Proposed Changes

`prepare-dev-build-version.mjs` rewrites the version to the `X.(Y+1).0-devN` dev form for nightly/dev builds — but only for the desktop app (`apps/studio/package.json`). The standalone CLI (`apps/cli/package.json`) was left at the static base version, so its baked `__STUDIO_CLI_VERSION__` (what `studio --version` reports) didn't match the version the bundle is actually published under on the CDN.

This stamps `apps/cli/package.json` with the same dev version. After it:
- `studio --version` on a nightly reports its real version (e.g. `1.12.0-dev103`) instead of a static, meaningless `1.11.0`.
- It unblocks the standalone CLI update notifier (STU-1772): the CLI derives its update channel from its own version (`-devN` → nightly), so it needs the real dev version baked in to check the right channel. Without this, a nightly install looks like "production" to the update endpoint and never sees nightly updates.

## Testing Instructions

```sh
GITHUB_SHA=$(git rev-parse HEAD) node ./scripts/prepare-dev-build-version.mjs
grep '"version"' apps/studio/package.json apps/cli/package.json
# → both show the same X.(Y+1).0-devN (e.g. 1.12.0-dev103), matching the CDN-published nightly
git checkout -- apps/studio/package.json apps/cli/package.json   # revert the local mutation
```

The CLI build (`cli:bundle`) runs after this script in the build pipelines, so the bundle bakes the stamped version.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? — build script only; ran it and verified both files stamp to the same dev version.
