### PR TITLE
Clarify Sync tab intro copy to describe connecting existing sites

### DIFF
--- a/apps/studio/src/modules/sync/index.tsx
+++ b/apps/studio/src/modules/sync/index.tsx
@@ -42,7 +42,7 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 				</div>
 				<div className="max-w-[40ch] text-frame-text-secondary a8c-body">
 					{ __(
-						'Launch your existing WordPress.com or Jetpack-activated Pressable sites, or import an existing one. Then, share your work with the world.'
+						'Connect your existing WordPress.com or Jetpack-activated Pressable sites to keep your local and live work in sync.'
 					) }
 				</div>
 				<div className="mt-6">


### PR DESCRIPTION
## Related issues

- Fixes [STU-1512](https://linear.app/a8c/issue/STU-1512/sync-tab-confusing-copy-for-launch-your-existing-phrasing)

## How AI was used in this PR

Claude Code located the Sync tab intro string, rewrote the copy, and ran lint + typecheck. The wording was reviewed by a human.

## Proposed Changes

The Sync tab's introductory paragraph said "Launch your existing WordPress.com or Jetpack-activated Pressable sites, or import an existing one." This was misleading: you don't "launch" sites that already exist — the feature connects and syncs them, and "launch" implies creating something new. "or import an existing one" was also redundant with "your existing sites."

The copy now reads: "Connect your existing WordPress.com or Jetpack-activated Pressable sites to keep your local and live work in sync." This accurately describes what the feature does and matches the clarity of the bullet points below it (push/pull changes, staging/production support, database and file sync).

## Testing Instructions

1. Open Studio and go to the Sync tab (when not yet authenticated/connected).
2. Confirm the intro paragraph reads "Connect your existing WordPress.com or Jetpack-activated Pressable sites to keep your local and live work in sync."

<img width="2048" height="1424" alt="CleanShot 2026-06-23 at 15 36 25@2x" src="https://github.com/user-attachments/assets/738d9fae-440a-4772-8b87-53b48f6d613b" />

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
