### PR TITLE
Increase Playground runtime PHP `memory_limit` to 512M

### DIFF
--- a/apps/cli/playground-server-child.ts
+++ b/apps/cli/playground-server-child.ts
@@ -469,10 +469,6 @@ const startServer = wrapWithStartingPromise(
 			await setPhpIniEntries( server.playground, {
 				'openssl.cafile': '/internal/shared/ca-bundle.crt',
 				'curl.cainfo': '/internal/shared/ca-bundle.crt',
-				// Match the native PHP runtime's 512M (apps/cli/lib/native-php/config.ts). The
-				// PHP-WASM default of 256M is exhausted by real WooCommerce + Jetpack sites when
-				// loading wp-admin (STU-1821). memory_limit is a per-request ceiling, not a
-				// reservation, so this does not increase baseline host memory use.
 				memory_limit: '512M',
 			} );
 

--- a/apps/cli/playground-server-child.ts
+++ b/apps/cli/playground-server-child.ts
@@ -469,6 +469,11 @@ const startServer = wrapWithStartingPromise(
 			await setPhpIniEntries( server.playground, {
 				'openssl.cafile': '/internal/shared/ca-bundle.crt',
 				'curl.cainfo': '/internal/shared/ca-bundle.crt',
+				// Match the native PHP runtime's 512M (apps/cli/lib/native-php/config.ts). The
+				// PHP-WASM default of 256M is exhausted by real WooCommerce + Jetpack sites when
+				// loading wp-admin (STU-1821). memory_limit is a per-request ceiling, not a
+				// reservation, so this does not increase baseline host memory use.
+				memory_limit: '512M',
 			} );
 
 			stopSignal.throwIfAborted();


### PR DESCRIPTION
## Related issues

- Related to #3766
- Related to STU-1821

This PR addresses "Problem 2 (fatal errors / memory exhaustion)" from that report.

## How AI was used in this PR

Used Claude Code to reproduce the wp-admin OOM locally, trace it to the Playground runtime's memory cap, and verify the fix against a heavy plugin stack.

## Proposed Changes

The reported issue is that when a site with numerous plugins is cloned into Studio, and then run with the Playground runtime, the front-end loads but wp-admin dies with `Fatal error: Allowed memory size of 268435456 bytes exhausted` (256 MB).

The PHP-WASM HTTP server serves every request with a hard-coded PHP `memory_limit` of 256 MB. A realistic production plugin stack (WooCommerce, WooPayments, Jetpack, Jetpack Boost, Jetpack CRM, MailPoet, Site Kit, etc.) already peaks at ~224 MB on an empty database, so wp-admin tips over 256 MB when the site's plugins and data load.

This PR raises the Playground serving `memory_limit` to 512 MB, matching the native runtime, so the two behave consistently, and heavier sites can open wp-admin.

| trunk | this branch |
|--------|--------|
| <img width="2358" height="2860" alt="CleanShot 2026-06-23 at 17 02 48@2x" src="https://github.com/user-attachments/assets/ba30257a-59c1-4218-9328-221f75a426a9" /> | <img width="2270" height="2772" alt="CleanShot 2026-06-23 at 16 59 14@2x" src="https://github.com/user-attachments/assets/cd1d36ef-00ea-4725-8214-337c42365224" /> | 

## Testing Instructions

- Visual review should be enough

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (`npm run typecheck` passes; eslint clean on the changed file.)
