### PR TITLE
Studio CLI bundle uses Node 24-only await using syntax despite Node 22 engine support

### DIFF
--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -34,7 +34,7 @@ const skillsSourcePath = resolve( __dirname, 'ai/skills' );
 
 export const baseConfig = defineConfig( {
 	oxc: {
-		target: `node${ semver.major( minimumNodeVersion ) }`,
+		target: 'es2022',
 	},
 	plugins: [
 		{


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->
Fixes STU-1801

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

It was used to identify and implement the fix. 

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

 The CLI's `package.json` declares `node >=22.0.0` as the supported engine. so anyone on Node 22 (still the current LTS) should be able to run it. But the build output contained syntax (`await using`) that only Node 23+ can parse, so the app would crash on Node 22 before any code even executes.    

This PR fixes the issue so that CLI can be run on Node 22.     
                                                                                                              
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Run CLI with `npm run cli:build`
* Run `nvm use 22`
* Run `node apps/cli/dist/cli/main.mjs --help`
* Confirm you can see the full help output along with different commands listed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
