### PR TITLE
Add .codex folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ bin/studio-cli.exe
 scripts/eval/output/
 scripts/eval/test-sites/
 .promptfoo/
+
+# Codex
+.codex/


### PR DESCRIPTION
### Related issues
N/A

### How AI was used in this PR
Used Claude Code to add the ignore entry.

### Proposed Changes
Ignores the local `.codex/` directory so Codex CLI working files don't show up as untracked changes in everyone's working tree. It's consistent with .claude folder.

https://github.com/Automattic/studio/blob/ae5eb720f90b74933c598c8100178529ca5e4243/.gitignore#L131

### Testing Instructions
1. Create a `.codex/` directory in the repo root.
2. Run `git status` — `.codex/` should not appear as untracked.

### Pre-merge Checklist
- [ ] Verified `git check-ignore .codex/` matches the new rule.