### PR TITLE
Update how to run a single named eval test by description

### DIFF
--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -12,6 +12,8 @@ npm run eval:view
 
 `npm run eval -- -n 1` to run a single test.
 
+Run one named test with `npm run eval -- --filter-pattern "preview sites"` (regex against the test description). Note: the flag is `--filter-pattern`, **not** `--filter-description` (which is not a valid promptfoo flag).
+
 ## Tests
 
 - **identity** — Agent identifies itself correctly (verified by an LLM judge).


### PR DESCRIPTION
## Related issues

None.

## Proposed Changes

Documents how to run a single named eval test by its description, using promptfoo's `--filter-pattern` flag (a regex matched against the test description).

When asked to run just one eval test, coding agents (and humans) reasonably guess at a flag like `--filter-description`, which promptfoo silently does not accept — so the eval still runs the full suite. This note records the correct flag so the right test runs the first time.

Examples this enables:

- "Run the preview sites eval test" → `npm run eval -- --filter-pattern "preview sites"`
- "Run only the identity eval" → `npm run eval -- --filter-pattern "identity"`
- "Run the screenshot timing eval test" → `npm run eval -- --filter-pattern "screenshot"`

Without this note, the agent was reaching for `--filter-description "..."`, which is not a valid promptfoo flag — the command ran every test instead of the one requested.

## How AI was used in this PR

Used an AI coding agent to author the documentation note.

## Testing Instructions

1. Ask claude or any other agent to run a single Promptfoo test
2. Observe it suggest using filter-pattern flag

## Pre-merge Checklist

- [x] Docs-only change
- [ ] Reviewed
