### PR TITLE
Make the `wp studio get-site-icon` command runtime-agnostic

### DIFF
--- a/tools/common/lib/mu-plugins.ts
+++ b/tools/common/lib/mu-plugins.ts
@@ -497,10 +497,14 @@ function getStandardMuPlugins( options: MuPluginOptions ): MuPlugin[] {
 				return;
 			}
 
-			// get_attached_file() returns paths rooted at /wordpress
-			// (Studio's PHP-runtime mount point). Strip the leading
-			// /wordpress so the host can resolve against the site dir.
-			$relative = preg_replace( '#^/wordpress/?#', '', $path );
+			// get_attached_file() returns an absolute path. Strip ABSPATH
+			// to get a relative path rooted at the site folder.
+			$normalized_path = wp_normalize_path( $path );
+			$normalized_abspath = wp_normalize_path( ABSPATH );
+			$relative = str_starts_with( $normalized_path, $normalized_abspath )
+				? substr( $normalized_path, strlen( $normalized_abspath ) )
+				: $path;
+
 			echo json_encode( [
 				'relativePath' => ltrim( $relative, '/' ),
 			] );


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-1886

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

N/A

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

The new agentic UI fetches the WordPress site icon (if there is one) by calling the custom `studio get-site-icon` WP-CLI command. This command is supposed to return a relative path to the site icon, but it implicitly assumes a Playground PHP runtime by always looking for `/wordpress` at the start of the site icon path. This breaks the logic for native PHP sites, where the site path is not virtualized.

This PR fixes the problem by stripping `ABSPATH` from the start of the site icon path, rather than `/wordpress`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a site with a site icon that uses the native PHP runtime
2. Stop Studio
3. Delete `wp-content/mu-plugins/99-studio-loader.php` for that site
4. Run `ENABLE_AGENTIC_UI=true npm start`
5. Ensure that the site icon shows up in the sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
