### PR TITLE
Add CLI integration test for site create (custom name, domain, HTTPS)

### DIFF
--- a/apps/cli/commands/site/tests/create.e2e.test.ts
+++ b/apps/cli/commands/site/tests/create.e2e.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment node
+ *
+ * Real end-to-end test for `studio site create`. Unlike create.test.ts (which
+ * mocks the command's dependencies), this spawns the built CLI binary and
+ * creates an actual site, verifying the real persisted state on disk.
+ *
+ * Requires the CLI to be built first (`npm run cli:build`); the suite skips
+ * itself otherwise. Tagged `e2e` so it runs in the slower (release/manual)
+ * suite rather than on every PR — run with `npm test -- --tagsFilter='e2e'`.
+ */
+import fs from 'fs';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	cleanupCliEnv,
+	cliE2ePrerequisitesMet,
+	readCliConfig,
+	runCli,
+	setupCliEnv,
+	type CliEnv,
+} from './helpers/cli-e2e';
+
+describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: studio site create', () => {
+	let env: CliEnv | undefined;
+
+	afterEach( () => {
+		if ( env ) {
+			cleanupCliEnv( env );
+			env = undefined;
+		}
+	} );
+
+	it( 'creates a site with a custom name', { tags: [ 'e2e' ], timeout: 120_000 }, async () => {
+		env = setupCliEnv();
+		const siteName = 'Custom E2E Site';
+		const sitePath = path.join( env.sitesDir, 'custom-e2e-site' );
+
+		const result = await runCli(
+			[
+				'site',
+				'create',
+				'--name',
+				siteName,
+				'--path',
+				sitePath,
+				'--wp',
+				'latest',
+				'--no-start',
+				'--skip-browser',
+				'--skip-log-details',
+			],
+			env
+		);
+
+		expect( result.code, result.stderr ).toBe( 0 );
+
+		// The site is persisted to the real cli.json with the custom name.
+		const config = readCliConfig( env );
+		expect( config.sites ).toHaveLength( 1 );
+		const [ site ] = config.sites;
+		expect( site.name ).toBe( siteName );
+		expect( site.path ).toBe( sitePath );
+		expect( site.phpVersion ).toBeTruthy();
+		expect( site.running ).toBe( false );
+
+		// Real WordPress core files were copied into the site directory.
+		// (wp-config.php is generated at server start, which --no-start skips.)
+		expect( fs.existsSync( path.join( sitePath, 'wp-load.php' ) ) ).toBe( true );
+		expect( fs.existsSync( path.join( sitePath, 'wp-includes', 'version.php' ) ) ).toBe( true );
+	} );
+
+	it(
+		'creates a site with a custom domain and HTTPS',
+		{ tags: [ 'e2e' ], timeout: 120_000 },
+		async () => {
+			env = setupCliEnv();
+			const siteName = 'Domain E2E Site';
+			const sitePath = path.join( env.sitesDir, 'domain-e2e-site' );
+			const customDomain = 'custom-e2e.local';
+
+			const result = await runCli(
+				[
+					'site',
+					'create',
+					'--name',
+					siteName,
+					'--path',
+					sitePath,
+					'--wp',
+					'latest',
+					'--domain',
+					customDomain,
+					'--https',
+					'--no-start',
+					'--skip-browser',
+					'--skip-log-details',
+				],
+				env
+			);
+
+			expect( result.code, result.stderr ).toBe( 0 );
+
+			// The custom domain and HTTPS preference are persisted to cli.json.
+			// (--no-start skips the hosts-file / certificate setup that running would do.)
+			const config = readCliConfig( env );
+			expect( config.sites ).toHaveLength( 1 );
+			const [ site ] = config.sites;
+			expect( site.name ).toBe( siteName );
+			expect( site.customDomain ).toBe( customDomain );
+			expect( site.enableHttps ).toBe( true );
+			expect( site.running ).toBe( false );
+
+			expect( fs.existsSync( path.join( sitePath, 'wp-load.php' ) ) ).toBe( true );
+		}
+	);
+} );

--- a/apps/cli/commands/site/tests/helpers/cli-e2e.ts
+++ b/apps/cli/commands/site/tests/helpers/cli-e2e.ts
@@ -1,0 +1,110 @@
+/**
+ * Harness for real end-to-end CLI integration tests.
+ *
+ * Spawns the built CLI binary (`dist/cli/main.mjs`) against an isolated config
+ * directory so tests exercise the real `studio site create` flow — real file
+ * copying, real `cli.json` persistence — without mocking, touching the
+ * developer's `~/.studio`, or needing the desktop app.
+ */
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// `dist/cli/main.mjs` relative to this file (apps/cli/commands/site/tests/helpers).
+const CLI_MAIN = path.resolve( import.meta.dirname, '../../../../dist/cli/main.mjs' );
+
+// The real bundled WordPress that ships with Studio. `getServerFilesPath()`
+// derives from the config directory, so the harness symlinks this into the
+// isolated config dir to let `--wp latest` copy it offline and deterministically.
+const REAL_SERVER_FILES = path.join( os.homedir(), '.studio', 'server-files' );
+const BUNDLED_LATEST_WP = path.join( REAL_SERVER_FILES, 'wordpress-versions', 'latest' );
+
+export interface CliEnv {
+	root: string;
+	configDir: string;
+	sitesDir: string;
+	cliConfigPath: string;
+}
+
+export interface CliResult {
+	code: number | null;
+	stdout: string;
+	stderr: string;
+}
+
+/**
+ * Whether the prerequisites for spawning the CLI are present: the built binary
+ * and the bundled WordPress files. Used to skip the suite with a clear signal
+ * when the CLI hasn't been built (run `npm run cli:build` first).
+ */
+export function cliE2ePrerequisitesMet(): boolean {
+	return fs.existsSync( CLI_MAIN ) && fs.existsSync( BUNDLED_LATEST_WP );
+}
+
+/**
+ * Creates an isolated config + sites directory for a single CLI run.
+ */
+export function setupCliEnv(): CliEnv {
+	const root = path.join( os.tmpdir(), `studio-cli-e2e-${ randomUUID() }` );
+	const configDir = path.join( root, 'config' );
+	const sitesDir = path.join( root, 'sites' );
+	fs.mkdirSync( configDir, { recursive: true } );
+	fs.mkdirSync( sitesDir, { recursive: true } );
+
+	// Reuse the real bundled WordPress without copying hundreds of MB. The copy
+	// the CLI performs only reads from here, so the symlink is never written to.
+	fs.symlinkSync( REAL_SERVER_FILES, path.join( configDir, 'server-files' ), 'junction' );
+
+	// Pre-seed cli.json with a recent dependency-check timestamp so the spawned
+	// CLI skips its 24h WordPress-version update: keeps the run offline and
+	// deterministic, and avoids writing through the server-files symlink.
+	const cliConfigPath = path.join( configDir, 'cli.json' );
+	fs.writeFileSync(
+		cliConfigPath,
+		JSON.stringify( {
+			version: 1,
+			sites: [],
+			snapshots: [],
+			lastDependencyCheckTime: Date.now(),
+		} )
+	);
+
+	return { root, configDir, sitesDir, cliConfigPath };
+}
+
+export function cleanupCliEnv( env: CliEnv ): void {
+	fs.rmSync( env.root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 } );
+}
+
+/**
+ * Runs the built CLI with the given arguments against the isolated environment.
+ * Resolves with the exit code and captured output once the process exits.
+ */
+export function runCli( args: string[], env: CliEnv ): Promise< CliResult > {
+	return new Promise( ( resolve, reject ) => {
+		const child = spawn( process.execPath, [ CLI_MAIN, ...args ], {
+			// Non-TTY stdio so the CLI runs fully non-interactively.
+			stdio: [ 'ignore', 'pipe', 'pipe' ],
+			env: { ...process.env, DEV_CONFIG_DIR: env.configDir },
+		} );
+
+		let stdout = '';
+		let stderr = '';
+		child.stdout.on( 'data', ( chunk ) => ( stdout += chunk.toString() ) );
+		child.stderr.on( 'data', ( chunk ) => ( stderr += chunk.toString() ) );
+		child.on( 'error', reject );
+		child.on( 'close', ( code ) => resolve( { code, stdout, stderr } ) );
+	} );
+}
+
+/**
+ * Reads the persisted cli.json from the isolated environment.
+ */
+export function readCliConfig( env: CliEnv ): {
+	sites: Array< Record< string, unknown > >;
+	[ key: string ]: unknown;
+} {
+	return JSON.parse( fs.readFileSync( env.cliConfigPath, 'utf-8' ) );
+}

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -5,6 +5,15 @@ export default defineConfig( {
 	test: {
 		pool: 'threads',
 		globals: true,
+		// Registered test tags for selective runs, e.g. `npm test -- --tagsFilter='e2e'`
+		// or excluding the slow real-CLI tests with `--tagsFilter='!e2e'`.
+		tags: [
+			{
+				name: 'e2e',
+				description:
+					'Real end-to-end tests that spawn the built CLI and create real sites. Require `npm run cli:build` first; run in the slower (release/manual) suite, not per-PR.',
+			},
+		],
 		environment: 'jsdom',
 		environmentOptions: {
 			customExportConditions: [ 'node', 'node-addons' ],


### PR DESCRIPTION
## Related issues

- Related to STU-1867

## How AI was used in this PR



## Proposed Changes

The end-to-end suite drives every site action through the Studio UI, which is slow, flaky, and ties coverage to the UI. This adds the first real CLI integration test for `studio site create`: it runs the actual command against an isolated config directory and asserts on the persisted result, covering a site with a custom name and a site with a custom domain plus HTTPS. The tests are tagged `e2e` so they run in the slower release or manual suite rather than on every pull request.

## Testing Instructions

1. Build the CLI with `npm run cli:build`.
2. Run `npm test -- --tagsFilter='e2e'` and confirm both tests pass.
3. Run `npm test -- --tagsFilter='!e2e'` and confirm these tests are skipped, so the fast suite is unaffected.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
