### PR TITLE
Studio: Tweak system prompt to mention database

### DIFF
--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -170,6 +170,15 @@ ${ studioPresentToolBullet }${ automaticArtifactSection }
 - Scroll animations must use progressive enhancement: CSS defines elements in their **final visible state** by default (full opacity, final position). JavaScript on the frontend adds the initial hidden state (e.g. \`opacity: 0\`, \`transform\`) and scroll-triggered transitions. This ensures elements are fully visible in the block editor (which loads theme CSS but not custom JS).
 - All animations and transitions must respect \`prefers-reduced-motion\`. Add a \`@media (prefers-reduced-motion: reduce)\` block that disables or simplifies animations (e.g. \`animation: none; transition: none; scroll-behavior: auto;\`).
 
+## Database
+
+Studio sites use **SQLite**, not MySQL. The database file is at \`<site-path>/wp-content/database/.ht.sqlite\`. Key implications:
+
+- \`wp db query\` and other \`wp db\` subcommands do **not** work — they expect a MySQL connection that does not exist.
+- Use WP-CLI object commands to query WordPress data: \`wp post list\`, \`wp option get\`, \`wp user list\`, etc. These work because they go through WordPress's PHP layer, which handles the SQLite abstraction.
+- **phpMyAdmin** is available in the Studio desktop app under the Overview tab. Users can click the phpMyAdmin button to browse and manage the database visually while the site is running.
+- For direct SQL access from the terminal, users can run \`sqlite3 <site-path>/wp-content/database/.ht.sqlite\` (\`sqlite3\` is pre-installed on macOS). Useful commands: \`SELECT name FROM sqlite_master WHERE type='table';\` to list tables, or \`DROP TABLE IF EXISTS <table>;\` to remove plugin tables.
+
 ## Pull & Push (sync with WordPress.com or Pressable)
 
 ### Eligibility


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1924

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->
It was used to make the adjustments to the system prompt. 

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

This PR clarifies in system prompt how the user can access the database and how they can view it. Before the changes, this is what Studio Code was returning to me:

<img width="914" height="464" alt="Screenshot 2026-06-24 at 3 47 51 PM" src="https://github.com/user-attachments/assets/4517c95c-8a71-4eef-9b8b-4d3d61e11aa9" />

After modifying the system prompt:

<img width="952" height="582" alt="Screenshot 2026-06-25 at 3 52 42 PM" src="https://github.com/user-attachments/assets/9b9db8ae-07f9-4afa-a3c4-9c71a41b6947" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Navigate to Studio Code on one of the sites and ask different questions about database
* Confirm that it gives correct information 
* Confirm that it sends you to Overview tab where you can access phpMyAdmin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
