### PR TITLE
Add copy button and selectable text to agent code blocks

### DIFF
--- a/apps/studio/src/components/studio-code-session/markdown/index.test.tsx
+++ b/apps/studio/src/components/studio-code-session/markdown/index.test.tsx
@@ -22,9 +22,16 @@ describe( 'Studio Code Markdown', () => {
 		fireEvent.click( button );
 
 		expect( copyText ).toHaveBeenCalledWith( 'body { color: red; }' );
-		await waitFor( () =>
-			expect( screen.getByRole( 'button', { name: 'Copied' } ) ).toBeInTheDocument()
-		);
+		await waitFor( () => expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Copied' ) );
+		expect( screen.getByRole( 'button', { name: 'Copy code' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows a tooltip for the copy button', async () => {
+		render( <Markdown>{ '```css\nbody { color: red; }\n```' }</Markdown> );
+
+		fireEvent.mouseOver( screen.getByRole( 'button', { name: 'Copy code' } ) );
+
+		await waitFor( () => expect( screen.getByRole( 'tooltip' ) ).toHaveTextContent( 'Copy code' ) );
 	} );
 
 	it( 'does not render a copy button for inline code', () => {

--- a/apps/studio/src/components/studio-code-session/markdown/index.test.tsx
+++ b/apps/studio/src/components/studio-code-session/markdown/index.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { Markdown } from '.';
+
+vi.mock( 'src/lib/get-ipc-api' );
+
+describe( 'Studio Code Markdown', () => {
+	const copyText = vi.fn();
+
+	beforeEach( () => {
+		copyText.mockClear();
+		vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( { copyText } );
+	} );
+
+	it( 'renders a copy button for fenced code blocks and copies the code', async () => {
+		render( <Markdown>{ '```css\nbody { color: red; }\n```' }</Markdown> );
+
+		const button = screen.getByRole( 'button', { name: 'Copy code' } );
+		expect( button ).toBeInTheDocument();
+
+		fireEvent.click( button );
+
+		expect( copyText ).toHaveBeenCalledWith( 'body { color: red; }' );
+		await waitFor( () =>
+			expect( screen.getByRole( 'button', { name: 'Copied' } ) ).toBeInTheDocument()
+		);
+	} );
+
+	it( 'does not render a copy button for inline code', () => {
+		render( <Markdown>{ 'this is `inline` code' }</Markdown> );
+
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/apps/studio/src/components/studio-code-session/markdown/index.tsx
+++ b/apps/studio/src/components/studio-code-session/markdown/index.tsx
@@ -3,6 +3,7 @@ import { check, copy, Icon } from '@wordpress/icons';
 import { isValidElement, useCallback, useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { Tooltip } from 'src/components/tooltip';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import styles from './style.module.css';
@@ -57,16 +58,26 @@ function CopyButton( { text }: { text: string } ) {
 		setCopied( true );
 	}, [ text ] );
 
+	const copyLabel = __( 'Copy code' );
+	const copiedLabel = __( 'Copied' );
+	const tooltipLabel = copied ? copiedLabel : copyLabel;
+
 	return (
-		<button
-			type="button"
-			className={ styles.copyButton }
-			onClick={ handleCopy }
-			aria-label={ copied ? __( 'Copied' ) : __( 'Copy code' ) }
-		>
-			<Icon icon={ copied ? check : copy } size={ 16 } fill="currentColor" />
-			<span>{ copied ? __( 'Copied' ) : __( 'Copy' ) }</span>
-		</button>
+		<div className={ styles.copyButtonContainer }>
+			<Tooltip text={ tooltipLabel }>
+				<button
+					type="button"
+					className={ styles.copyButton }
+					onClick={ handleCopy }
+					aria-label={ copyLabel }
+				>
+					<Icon icon={ copied ? check : copy } size={ 16 } fill="currentColor" aria-hidden="true" />
+				</button>
+			</Tooltip>
+			<span className={ styles.visuallyHidden } role="status" aria-live="polite" aria-atomic="true">
+				{ copied ? copiedLabel : '' }
+			</span>
+		</div>
 	);
 }
 

--- a/apps/studio/src/components/studio-code-session/markdown/index.tsx
+++ b/apps/studio/src/components/studio-code-session/markdown/index.tsx
@@ -1,10 +1,12 @@
-import { useMemo } from 'react';
+import { __ } from '@wordpress/i18n';
+import { check, copy, Icon } from '@wordpress/icons';
+import { isValidElement, useCallback, useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import styles from './style.module.css';
-import type { MouseEvent } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import type { Components } from 'react-markdown';
 
 // Only hand http(s) links to the OS. Guards against the agent emitting links
@@ -19,6 +21,65 @@ function isSafeExternalUrl( href: string ): boolean {
 		// Relative or malformed — never hand to the OS.
 		return false;
 	}
+}
+
+/** Recursively collect the plain-text content of a React node tree. */
+function extractText( node: ReactNode ): string {
+	if ( typeof node === 'string' ) {
+		return node;
+	}
+	if ( typeof node === 'number' ) {
+		return String( node );
+	}
+	if ( Array.isArray( node ) ) {
+		return node.map( extractText ).join( '' );
+	}
+	if ( isValidElement< { children?: ReactNode } >( node ) ) {
+		return extractText( node.props.children );
+	}
+	return '';
+}
+
+function CopyButton( { text }: { text: string } ) {
+	const [ copied, setCopied ] = useState( false );
+
+	// Reset back to the idle state a short while after a successful copy.
+	useEffect( () => {
+		if ( ! copied ) {
+			return;
+		}
+		const timer = setTimeout( () => setCopied( false ), 2000 );
+		return () => clearTimeout( timer );
+	}, [ copied ] );
+
+	const handleCopy = useCallback( () => {
+		void getIpcApi().copyText( text );
+		setCopied( true );
+	}, [ text ] );
+
+	return (
+		<button
+			type="button"
+			className={ styles.copyButton }
+			onClick={ handleCopy }
+			aria-label={ copied ? __( 'Copied' ) : __( 'Copy code' ) }
+		>
+			<Icon icon={ copied ? check : copy } size={ 16 } fill="currentColor" />
+			<span>{ copied ? __( 'Copied' ) : __( 'Copy' ) }</span>
+		</button>
+	);
+}
+
+function CodeBlock( { children }: { children?: ReactNode } ) {
+	// Strip the single trailing newline react-markdown appends to fenced code.
+	const text = useMemo( () => extractText( children ).replace( /\n$/, '' ), [ children ] );
+
+	return (
+		<div className={ styles.codeBlock }>
+			<pre className={ styles.pre }>{ children }</pre>
+			{ text ? <CopyButton text={ text } /> : null }
+		</div>
+	);
 }
 
 const baseComponents: Components = {
@@ -57,7 +118,7 @@ const baseComponents: Components = {
 			</code>
 		);
 	},
-	pre: ( { children } ) => <pre className={ styles.pre }>{ children }</pre>,
+	pre: ( { children } ) => <CodeBlock>{ children }</CodeBlock>,
 };
 
 export function Markdown( { children, className }: { children: string; className?: string } ) {

--- a/apps/studio/src/components/studio-code-session/markdown/style.module.css
+++ b/apps/studio/src/components/studio-code-session/markdown/style.module.css
@@ -143,10 +143,20 @@
 	color: var(--color-frame-text);
 	/* Discourage code from breaking awkwardly across lines. */
 	white-space: nowrap;
+	/* Code is meant to be copied — keep it selectable. */
+	-webkit-user-select: text;
+	user-select: text;
+}
+
+/* Wrapper anchors the overlaid copy button and carries the block spacing that
+   used to live on the <pre>. */
+.codeBlock {
+	position: relative;
+	margin: 0.75em 0 1.25em;
 }
 
 .pre {
-	margin: 0.75em 0 1.25em;
+	margin: 0;
 	padding: 0.875em 1em;
 	border-radius: var(--wpds-border-radius-md, 8px);
 	background-color: var(--color-frame-surface);
@@ -154,6 +164,10 @@
 	font-size: 0.85em;
 	line-height: 1.55;
 	overflow-x: auto;
+	/* Ensure code stays selectable even when an ancestor opts out of selection
+	   (the app shell sets `select-none` on its drag region). */
+	-webkit-user-select: text;
+	user-select: text;
 }
 
 .pre > code {
@@ -163,6 +177,33 @@
 	font-size: inherit;
 	color: inherit;
 	white-space: pre;
+}
+
+.copyButton {
+	position: absolute;
+	top: 0.5em;
+	inset-inline-end: 0.5em;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25em;
+	margin: 0;
+	padding: 0.25em 0.5em;
+	border: 1px solid var(--color-frame-border);
+	border-radius: var(--wpds-border-radius-sm, 4px);
+	background-color: var(--color-frame-bg);
+	color: var(--color-frame-text-secondary);
+	font-family: inherit;
+	font-size: 0.75rem;
+	line-height: 1;
+	cursor: pointer;
+	/* Always fully visible; color/background emphasize on hover/focus. */
+	transition: color 0.12s ease, background-color 0.12s ease;
+}
+
+.copyButton:hover,
+.copyButton:focus-visible {
+	color: var(--color-frame-text);
+	background-color: var(--color-frame-surface-alt);
 }
 
 .tableWrap {

--- a/apps/studio/src/components/studio-code-session/markdown/style.module.css
+++ b/apps/studio/src/components/studio-code-session/markdown/style.module.css
@@ -179,24 +179,30 @@
 	white-space: pre;
 }
 
-.copyButton {
+.copyButtonContainer {
 	position: absolute;
 	top: 0.5em;
 	inset-inline-end: 0.5em;
+	z-index: 1;
+}
+
+.copyButton {
 	display: inline-flex;
 	align-items: center;
-	gap: 0.25em;
+	justify-content: center;
+	width: 1.75rem;
+	height: 1.75rem;
 	margin: 0;
-	padding: 0.25em 0.5em;
-	border: 1px solid var(--color-frame-border);
+	padding: 0;
+	border: 0;
 	border-radius: var(--wpds-border-radius-sm, 4px);
 	background-color: var(--color-frame-bg);
+	background-color: color-mix(in srgb, var(--color-frame-bg) 82%, transparent);
+	-webkit-backdrop-filter: blur(4px);
+	backdrop-filter: blur(4px);
 	color: var(--color-frame-text-secondary);
-	font-family: inherit;
-	font-size: 0.75rem;
 	line-height: 1;
 	cursor: pointer;
-	/* Always fully visible; color/background emphasize on hover/focus. */
 	transition: color 0.12s ease, background-color 0.12s ease;
 }
 
@@ -204,6 +210,18 @@
 .copyButton:focus-visible {
 	color: var(--color-frame-text);
 	background-color: var(--color-frame-surface-alt);
+}
+
+.visuallyHidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 }
 
 .tableWrap {

--- a/apps/ui/src/components/markdown/index.test.tsx
+++ b/apps/ui/src/components/markdown/index.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Markdown } from '.';
+
+const { copyText } = vi.hoisted( () => ( { copyText: vi.fn() } ) );
+
+vi.mock( '@/data/core', () => ( {
+	useConnector: () => ( {
+		openExternalUrl: vi.fn(),
+		copyText,
+	} ),
+} ) );
+
+describe( 'Markdown', () => {
+	beforeEach( () => {
+		copyText.mockClear();
+	} );
+
+	it( 'renders a copy button for fenced code blocks and copies the code', async () => {
+		render( <Markdown>{ '```js\nconst a = 1;\n```' }</Markdown> );
+
+		const button = screen.getByRole( 'button', { name: 'Copy code' } );
+		expect( button ).toBeInTheDocument();
+
+		fireEvent.click( button );
+
+		expect( copyText ).toHaveBeenCalledWith( 'const a = 1;' );
+		await waitFor( () =>
+			expect( screen.getByRole( 'button', { name: 'Copied' } ) ).toBeInTheDocument()
+		);
+	} );
+
+	it( 'does not render a copy button for inline code', () => {
+		render( <Markdown>{ 'this is `inline` code' }</Markdown> );
+
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/apps/ui/src/components/markdown/index.test.tsx
+++ b/apps/ui/src/components/markdown/index.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Tooltip } from '@wordpress/ui';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Markdown } from '.';
 
@@ -11,13 +12,21 @@ vi.mock( '@/data/core', () => ( {
 	} ),
 } ) );
 
+function renderMarkdown( children: string ) {
+	return render(
+		<Tooltip.Provider>
+			<Markdown>{ children }</Markdown>
+		</Tooltip.Provider>
+	);
+}
+
 describe( 'Markdown', () => {
 	beforeEach( () => {
 		copyText.mockClear();
 	} );
 
 	it( 'renders a copy button for fenced code blocks and copies the code', async () => {
-		render( <Markdown>{ '```js\nconst a = 1;\n```' }</Markdown> );
+		renderMarkdown( '```js\nconst a = 1;\n```' );
 
 		const button = screen.getByRole( 'button', { name: 'Copy code' } );
 		expect( button ).toBeInTheDocument();
@@ -25,13 +34,22 @@ describe( 'Markdown', () => {
 		fireEvent.click( button );
 
 		expect( copyText ).toHaveBeenCalledWith( 'const a = 1;' );
-		await waitFor( () =>
-			expect( screen.getByRole( 'button', { name: 'Copied' } ) ).toBeInTheDocument()
-		);
+		await waitFor( () => expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Copied' ) );
+		expect( screen.getByRole( 'button', { name: 'Copy code' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows a tooltip for the copy button', async () => {
+		renderMarkdown( '```js\nconst a = 1;\n```' );
+
+		const button = screen.getByRole( 'button', { name: 'Copy code' } );
+		fireEvent.mouseEnter( button );
+		fireEvent.mouseMove( button, { movementX: 1, movementY: 1 } );
+
+		expect( await screen.findByText( 'Copy code', {}, { timeout: 2000 } ) ).toBeVisible();
 	} );
 
 	it( 'does not render a copy button for inline code', () => {
-		render( <Markdown>{ 'this is `inline` code' }</Markdown> );
+		renderMarkdown( 'this is `inline` code' );
 
 		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
 	} );

--- a/apps/ui/src/components/markdown/index.tsx
+++ b/apps/ui/src/components/markdown/index.tsx
@@ -1,11 +1,76 @@
+import { __ } from '@wordpress/i18n';
+import { check, copy, Icon } from '@wordpress/icons';
 import { clsx } from 'clsx';
-import { useMemo } from 'react';
+import { isValidElement, useCallback, useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useConnector } from '@/data/core';
 import styles from './style.module.css';
-import type { MouseEvent } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import type { Components } from 'react-markdown';
+
+/** Recursively collect the plain-text content of a React node tree. */
+function extractText( node: ReactNode ): string {
+	if ( typeof node === 'string' ) {
+		return node;
+	}
+	if ( typeof node === 'number' ) {
+		return String( node );
+	}
+	if ( Array.isArray( node ) ) {
+		return node.map( extractText ).join( '' );
+	}
+	if ( isValidElement< { children?: ReactNode } >( node ) ) {
+		return extractText( node.props.children );
+	}
+	return '';
+}
+
+function CopyButton( { text }: { text: string } ) {
+	const connector = useConnector();
+	const [ copied, setCopied ] = useState( false );
+
+	// Reset back to the idle state a short while after a successful copy.
+	useEffect( () => {
+		if ( ! copied ) {
+			return;
+		}
+		const timer = setTimeout( () => setCopied( false ), 2000 );
+		return () => clearTimeout( timer );
+	}, [ copied ] );
+
+	// Route through the connector (host clipboard) — the renderer's
+	// `navigator.clipboard` is denied in the Electron desktop, which left the
+	// copy silently failing and the button stuck on "Copy".
+	const handleCopy = useCallback( () => {
+		void connector.copyText( text );
+		setCopied( true );
+	}, [ connector, text ] );
+
+	return (
+		<button
+			type="button"
+			className={ styles.copyButton }
+			onClick={ handleCopy }
+			aria-label={ copied ? __( 'Copied' ) : __( 'Copy code' ) }
+		>
+			<Icon icon={ copied ? check : copy } size={ 16 } fill="currentColor" />
+			<span>{ copied ? __( 'Copied' ) : __( 'Copy' ) }</span>
+		</button>
+	);
+}
+
+function CodeBlock( { children }: { children?: ReactNode } ) {
+	// Strip the single trailing newline react-markdown appends to fenced code.
+	const text = useMemo( () => extractText( children ).replace( /\n$/, '' ), [ children ] );
+
+	return (
+		<div className={ styles.codeBlock }>
+			<pre className={ styles.pre }>{ children }</pre>
+			{ text ? <CopyButton text={ text } /> : null }
+		</div>
+	);
+}
 
 const baseComponents: Components = {
 	h1: ( { children } ) => <h1 className={ styles.h1 }>{ children }</h1>,
@@ -43,7 +108,7 @@ const baseComponents: Components = {
 			</code>
 		);
 	},
-	pre: ( { children } ) => <pre className={ styles.pre }>{ children }</pre>,
+	pre: ( { children } ) => <CodeBlock>{ children }</CodeBlock>,
 };
 
 export function Markdown( { children, className }: { children: string; className?: string } ) {

--- a/apps/ui/src/components/markdown/index.tsx
+++ b/apps/ui/src/components/markdown/index.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { check, copy, Icon } from '@wordpress/icons';
+import { Tooltip } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { isValidElement, useCallback, useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -47,16 +48,38 @@ function CopyButton( { text }: { text: string } ) {
 		setCopied( true );
 	}, [ connector, text ] );
 
+	const copyLabel = __( 'Copy code' );
+	const copiedLabel = __( 'Copied' );
+	const tooltipLabel = copied ? copiedLabel : copyLabel;
+
 	return (
-		<button
-			type="button"
-			className={ styles.copyButton }
-			onClick={ handleCopy }
-			aria-label={ copied ? __( 'Copied' ) : __( 'Copy code' ) }
-		>
-			<Icon icon={ copied ? check : copy } size={ 16 } fill="currentColor" />
-			<span>{ copied ? __( 'Copied' ) : __( 'Copy' ) }</span>
-		</button>
+		<div className={ styles.copyButtonContainer }>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					render={
+						<button
+							type="button"
+							className={ styles.copyButton }
+							onClick={ handleCopy }
+							aria-label={ copyLabel }
+						>
+							<Icon
+								icon={ copied ? check : copy }
+								size={ 16 }
+								fill="currentColor"
+								aria-hidden="true"
+							/>
+						</button>
+					}
+				/>
+				<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+					{ tooltipLabel }
+				</Tooltip.Popup>
+			</Tooltip.Root>
+			<span className={ styles.visuallyHidden } role="status" aria-live="polite" aria-atomic="true">
+				{ copied ? copiedLabel : '' }
+			</span>
+		</div>
 	);
 }
 

--- a/apps/ui/src/components/markdown/style.module.css
+++ b/apps/ui/src/components/markdown/style.module.css
@@ -143,10 +143,20 @@
 	color: var(--wpds-color-fg-content-neutral);
 	/* Discourage code from breaking awkwardly across lines. */
 	white-space: nowrap;
+	/* Code is meant to be copied — keep it selectable. */
+	-webkit-user-select: text;
+	user-select: text;
+}
+
+/* Wrapper anchors the overlaid copy button and carries the block spacing that
+   used to live on the <pre>. */
+.codeBlock {
+	position: relative;
+	margin: 0.75em 0 1.25em;
 }
 
 .pre {
-	margin: 0.75em 0 1.25em;
+	margin: 0;
 	padding: 0.875em 1em;
 	border-radius: var(--wpds-border-radius-md, 8px);
 	background-color: var(--wpds-color-bg-surface-neutral-weak);
@@ -154,6 +164,10 @@
 	font-size: 0.85em;
 	line-height: 1.55;
 	overflow-x: auto;
+	/* Ensure code stays selectable even when an ancestor surface (e.g. the
+	   desks canvas) opts out of text selection. */
+	-webkit-user-select: text;
+	user-select: text;
 }
 
 .pre > code {
@@ -163,6 +177,33 @@
 	font-size: inherit;
 	color: inherit;
 	white-space: pre;
+}
+
+.copyButton {
+	position: absolute;
+	top: 0.5em;
+	inset-inline-end: 0.5em;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25em;
+	margin: 0;
+	padding: 0.25em 0.5em;
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-sm, 4px);
+	background-color: var(--wpds-color-bg-surface-neutral);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-family: inherit;
+	font-size: 0.75rem;
+	line-height: 1;
+	cursor: pointer;
+	/* Always fully visible; color/background emphasize on hover/focus. */
+	transition: color 0.12s ease, background-color 0.12s ease;
+}
+
+.copyButton:hover,
+.copyButton:focus-visible {
+	color: var(--wpds-color-fg-content-neutral);
+	background-color: var(--wpds-color-bg-surface-neutral-weak);
 }
 
 .tableWrap {

--- a/apps/ui/src/components/markdown/style.module.css
+++ b/apps/ui/src/components/markdown/style.module.css
@@ -179,24 +179,30 @@
 	white-space: pre;
 }
 
-.copyButton {
+.copyButtonContainer {
 	position: absolute;
 	top: 0.5em;
 	inset-inline-end: 0.5em;
+	z-index: 1;
+}
+
+.copyButton {
 	display: inline-flex;
 	align-items: center;
-	gap: 0.25em;
+	justify-content: center;
+	width: 1.75rem;
+	height: 1.75rem;
 	margin: 0;
-	padding: 0.25em 0.5em;
-	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	padding: 0;
+	border: 0;
 	border-radius: var(--wpds-border-radius-sm, 4px);
 	background-color: var(--wpds-color-bg-surface-neutral);
+	background-color: color-mix(in srgb, var(--wpds-color-bg-surface-neutral) 82%, transparent);
+	-webkit-backdrop-filter: blur(4px);
+	backdrop-filter: blur(4px);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-family: inherit;
-	font-size: 0.75rem;
 	line-height: 1;
 	cursor: pointer;
-	/* Always fully visible; color/background emphasize on hover/focus. */
 	transition: color 0.12s ease, background-color 0.12s ease;
 }
 
@@ -204,6 +210,18 @@
 .copyButton:focus-visible {
 	color: var(--wpds-color-fg-content-neutral);
 	background-color: var(--wpds-color-bg-surface-neutral-weak);
+}
+
+.visuallyHidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 }
 
 .tableWrap {

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -344,6 +344,9 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		async openExternalUrl( url ) {
 			window.open( url, '_blank', 'noopener,noreferrer' );
 		},
+		async copyText( text ) {
+			await navigator.clipboard.writeText( text );
+		},
 		async openSiteUrl( siteId, relativeUrl = '' ) {
 			const sites = lastSites ?? ( await api< SiteDetails[] >( '/sites' ) );
 			const target = new URL( relativeUrl || '/', findSiteUrl( sites, siteId ) ).toString();

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -657,6 +657,10 @@ export function createIpcConnector(): Connector {
 			ipcApi.openURL( url );
 		},
 
+		async copyText( text: string ): Promise< void > {
+			await ipcApi.copyText( text );
+		},
+
 		async openSiteUrl( siteId, relativeUrl = '', options ): Promise< void > {
 			await ipcApi.openSiteURL( siteId, relativeUrl, options );
 		},

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -285,6 +285,10 @@ export interface Connector {
 
 	// External links
 	openExternalUrl( url: string ): Promise< void >;
+
+	// Clipboard — routed to the host so it works where the renderer's
+	// `navigator.clipboard` is unavailable (e.g. Electron permission denial).
+	copyText( text: string ): Promise< void >;
 	openSiteUrl(
 		siteId: string,
 		relativeUrl?: string,


### PR DESCRIPTION
## Related issues

- Related to: none — surfaced while testing the Studio Code agent; no tracking issue.

## How AI was used in this PR

Authored end-to-end with Claude Code. It diagnosed two separate root causes (the Electron renderer denies `navigator.clipboard`, so the agentic-UI copy silently failed; and code blocks needed an explicit `user-select` since the desks canvas/app shell opt out of selection) and implemented the fix across both markdown renderers plus the connector. Reviewers should sanity-check the new `StudioConnector.copyText` method and confirm the visual result in light + dark (see note below).

## Proposed Changes

When the Studio Code agent renders a code snippet, you previously couldn't reliably select or copy it. This makes code blocks first-class to copy from, in **both** surfaces that render agent output — the agentic UI conversation and the Studio Code tab:

- Code blocks are now explicitly **selectable** (text selection no longer suppressed by the surrounding canvas/app-shell).
- Each fenced code block gets an always-visible **Copy** button (top-right) that flips to “Copied” for a moment after use.
- Copying is routed through the **host clipboard** via a new `StudioConnector.copyText` (desktop → main-process clipboard; web → `navigator.clipboard`). This is why the agentic-UI button now actually copies and updates — the renderer's own `navigator.clipboard` is denied in the Electron desktop.

## Testing Instructions

1. Open a Studio Code agent session and ask for a code snippet (e.g. “give me a small CSS snippet”).
2. In the **Studio Code tab** and in the **agentic UI** conversation:
   - Select text inside the code block with the mouse — it should highlight.
   - Click the **Copy** button — it should switch to **Copied**, and pasting elsewhere should yield the code.
3. Verify both **light and dark** appearance of the button.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (typecheck, ESLint, and unit tests pass; visual/dark-mode pass still needs a human.)
