### PR TITLE
Inject a DB_NAME fallback for native WP-CLI commands

### DIFF
--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -1,4 +1,5 @@
 import { ChildProcess, spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { PassThrough, Readable } from 'node:stream';
 import { buffer, text } from 'node:stream/consumers';
@@ -167,6 +168,31 @@ type DisposableExitCode = Disposable & {
 	exitCode: Promise< number >;
 };
 
+// A Studio site's wp-config.php often omits DB_NAME: Playground provides the DB
+// connection at runtime, and sites that were pulled/imported (or only ever run
+// under Playground) can arrive without it. The v3+ SQLite integration drop-in
+// requires a non-empty DB_NAME, so a one-off native WP-CLI command that boots
+// WordPress (e.g. `plugin list` while building a full export's meta.json) would
+// otherwise fail with "Error establishing a database connection". The Playground
+// path injects this exact fallback via `php.defineConstant`; here we hand it to
+// WP-CLI's `--exec`, which runs before WordPress loads. We inject it only when
+// wp-config.php doesn't already define DB_NAME, so a real value is never
+// redefined and sites that do define it are untouched.
+export function getNativeDbNameFallbackArgs( sitePath: string ): string[] {
+	let wpConfig: string;
+	try {
+		wpConfig = readFileSync( path.join( sitePath, 'wp-config.php' ), 'utf8' );
+	} catch {
+		return [];
+	}
+
+	if ( /define\s*\(\s*['"]DB_NAME['"]/.test( wpConfig ) ) {
+		return [];
+	}
+
+	return [ "--exec=defined('DB_NAME') || define('DB_NAME', 'wordpress');" ];
+}
+
 async function runNativeWpCliCommand(
 	site: SiteData,
 	args: string[],
@@ -189,9 +215,16 @@ async function runNativeWpCliCommand(
 	// Don't apply open_basedir or disable_functions to the WP-CLI process
 	const defaultArgs = getDefaultPhpArgs( phpVersion );
 	const nativeArgs = applyWpCliCommandOptions( 'native', args, options );
+	const dbNameFallbackArgs = getNativeDbNameFallbackArgs( site.path );
 	const child = spawn(
 		getPhpBinaryPath( phpVersion ),
-		[ ...defaultArgs, getWpCliPharPath(), `--path=${ site.path }`, ...nativeArgs ],
+		[
+			...defaultArgs,
+			getWpCliPharPath(),
+			`--path=${ site.path }`,
+			...dbNameFallbackArgs,
+			...nativeArgs,
+		],
 		{
 			cwd: site.path,
 			stdio: options.stdio === 'inherit' ? 'inherit' : [ 'ignore', 'pipe', 'pipe' ],

--- a/apps/cli/lib/tests/run-wp-cli-command.test.ts
+++ b/apps/cli/lib/tests/run-wp-cli-command.test.ts
@@ -1,0 +1,43 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getNativeDbNameFallbackArgs } from 'cli/lib/run-wp-cli-command';
+
+const DB_NAME_EXEC_ARG = "--exec=defined('DB_NAME') || define('DB_NAME', 'wordpress');";
+
+describe( 'getNativeDbNameFallbackArgs', () => {
+	let siteDir: string;
+
+	beforeEach( () => {
+		siteDir = mkdtempSync( path.join( tmpdir(), 'studio-dbname-test-' ) );
+	} );
+
+	afterEach( () => {
+		rmSync( siteDir, { recursive: true, force: true } );
+	} );
+
+	function writeWpConfig( contents: string ): void {
+		writeFileSync( path.join( siteDir, 'wp-config.php' ), contents );
+	}
+
+	it( 'injects the DB_NAME fallback when wp-config.php does not define it', () => {
+		// Studio strips DB_NAME from wp-config.php; only comments reference it.
+		writeWpConfig( `<?php\n/**\n * DB_NAME\n */\n$table_prefix = 'wp_';\n` );
+		expect( getNativeDbNameFallbackArgs( siteDir ) ).toEqual( [ DB_NAME_EXEC_ARG ] );
+	} );
+
+	it( 'does not inject when wp-config.php defines DB_NAME (spaced form)', () => {
+		writeWpConfig( `<?php\ndefine( 'DB_NAME', 'wordpress' );\n` );
+		expect( getNativeDbNameFallbackArgs( siteDir ) ).toEqual( [] );
+	} );
+
+	it( 'does not inject when wp-config.php defines DB_NAME (compact / double-quoted form)', () => {
+		writeWpConfig( `<?php\ndefine("DB_NAME","wordpress");\n` );
+		expect( getNativeDbNameFallbackArgs( siteDir ) ).toEqual( [] );
+	} );
+
+	it( 'returns no args when wp-config.php is missing', () => {
+		expect( getNativeDbNameFallbackArgs( siteDir ) ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

Full-site export builds a `meta.json` by running native WP-CLI commands (e.g. `plugin list`) that boot WordPress. On sites whose `wp-config.php` omits `DB_NAME` — common for pulled/imported sites, or sites only ever run under Playground (which supplies the DB connection at runtime) — the v3+ SQLite integration drop-in requires a non-empty `DB_NAME`, so those commands fail with “Error establishing a database connection.”

This injects the same fallback the Playground path already defines (`define('DB_NAME','wordpress')`) into the native WP-CLI invocation via `--exec` — but only when `wp-config.php` doesn't already define `DB_NAME`, so a real value is never redefined and sites that define it are untouched.

## Testing Instructions

- `npm test -- apps/cli/lib/tests/run-wp-cli-command.test.ts` (4 tests).
- Full-export a site whose `wp-config.php` has no `DB_NAME` and confirm it no longer errors on the DB connection.