### PR TITLE
Shrink the connector API: derive custom-domains + xdebug-site from the site list

### DIFF
--- a/apps/ui/src/components/site-settings-view/index.tsx
+++ b/apps/ui/src/components/site-settings-view/index.tsx
@@ -151,9 +151,9 @@ function SiteSettingsBody( {
 	activeTab: TabId;
 	onTabChange: ( tab: TabId ) => void;
 } ) {
-	const { data: allDomains } = useExistingCustomDomains();
+	const allDomains = useExistingCustomDomains();
 	const existingDomainNames = useMemo(
-		() => ( allDomains ?? [] ).filter( ( domain ) => domain !== site.customDomain ),
+		() => allDomains.filter( ( domain ) => domain !== site.customDomain ),
 		[ allDomains, site.customDomain ]
 	);
 	const { data: xdebugEnabledSite } = useXdebugEnabledSite();

--- a/apps/ui/src/components/site-settings-view/index.tsx
+++ b/apps/ui/src/components/site-settings-view/index.tsx
@@ -156,7 +156,7 @@ function SiteSettingsBody( {
 		() => allDomains.filter( ( domain ) => domain !== site.customDomain ),
 		[ allDomains, site.customDomain ]
 	);
-	const { data: xdebugEnabledSite } = useXdebugEnabledSite();
+	const xdebugEnabledSite = useXdebugEnabledSite();
 	const xdebugConflictSiteName =
 		xdebugEnabledSite && xdebugEnabledSite.id !== site.id ? xdebugEnabledSite.name : undefined;
 

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -183,9 +183,6 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		async comparePaths() {
 			throw new WebUnsupportedError( 'comparePaths' );
 		},
-		async getAllCustomDomains(): Promise< string[] > {
-			return [];
-		},
 
 		// Featured blueprints — public endpoint, same source as the desktop app.
 		async getFeaturedBlueprints( locale ): Promise< FeaturedBlueprint[] > {

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -162,9 +162,6 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		async refreshSiteIcon() {
 			// No-op: icons come back with getSites().
 		},
-		async getXdebugEnabledSite(): Promise< SiteDetails | null > {
-			return null;
-		},
 		async exportFullSite(): Promise< string | null > {
 			throw new WebUnsupportedError( 'exportFullSite' );
 		},

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -310,10 +310,6 @@ export function createIpcConnector(): Connector {
 			return ( await ipcApi.comparePaths( path1, path2 ) ) as boolean;
 		},
 
-		async getAllCustomDomains(): Promise< string[] > {
-			return ( await ipcApi.getAllCustomDomains() ) as string[];
-		},
-
 		async getFeaturedBlueprints( locale ) {
 			const url = new URL( 'https://public-api.wordpress.com/wpcom/v2/studio-app/blueprints' );
 			if ( locale ) {

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -400,10 +400,6 @@ export function createIpcConnector(): Connector {
 			await ipcApi.loadSiteIcon( siteId );
 		},
 
-		async getXdebugEnabledSite() {
-			return ( await ipcApi.getXdebugEnabledSite() ) as SiteDetails | null;
-		},
-
 		async exportFullSite( siteId ): Promise< string | null > {
 			const sites = ( await ipcApi.getSiteDetails() ) as SiteDetails[];
 			const site = sites.find( ( candidate ) => candidate.id === siteId );

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -137,13 +137,11 @@ export interface Connector {
 	exportDatabase( siteId: string ): Promise< string | null >;
 
 	// Site-creation helpers — surface the same main-process capabilities the
-	// desktop app's add-site flow relies on (folder pickers, path validation,
-	// and domain lookups).
+	// desktop app's add-site flow relies on (folder pickers and path validation).
 	generateProposedSitePath( siteName: string ): Promise< ProposedSitePath >;
 	generateProposedSiteName( usedSites: SiteDetails[] ): Promise< string >;
 	selectSiteFolder( defaultPath: string ): Promise< SelectedSiteFolder | null >;
 	comparePaths( path1: string, path2: string ): Promise< boolean >;
-	getAllCustomDomains(): Promise< string[] >;
 
 	// Featured blueprints gallery for the "Start from blueprint" onboarding
 	// flow. Sourced from the public wpcom/v2/studio-app/blueprints endpoint —

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -124,9 +124,6 @@ export interface Connector {
 	// Refreshes the cached WordPress Site Icon path after a site-level icon
 	// change. The renderer receives image bytes through getSites().
 	refreshSiteIcon( siteId: string ): Promise< void >;
-	// Xdebug is exclusive across sites; returns the one site currently using
-	// it (or null) so the settings form can block a conflicting toggle.
-	getXdebugEnabledSite(): Promise< SiteDetails | null >;
 
 	// Exports a site as a full backup archive (files + database). Prompts the
 	// user for a destination via a save-as dialog; resolves with the chosen

--- a/apps/ui/src/data/queries/use-create-site-helpers.ts
+++ b/apps/ui/src/data/queries/use-create-site-helpers.ts
@@ -1,22 +1,27 @@
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useConnector } from '@/data/core';
+import { useSites } from '@/data/queries/use-sites';
 import type { ProposedSitePath, SelectedSiteFolder, SiteDetails } from '@/data/core';
 
-const CUSTOM_DOMAINS_QUERY_KEY = [ 'customDomains' ] as const;
 const PROPOSED_SITE_NAME_QUERY_KEY = [ 'proposedSiteName' ] as const;
 
 /**
- * Fetches all custom domains already assigned to local sites so the create
- * form can flag conflicts before the user submits.
+ * Custom domains already assigned to local sites, derived from the loaded site
+ * list so the create/edit forms can flag conflicts before submit. The site list
+ * already carries every site's `customDomain`, so no separate backend call is
+ * needed.
  */
-export function useExistingCustomDomains() {
-	const connector = useConnector();
-	return useQuery( {
-		queryKey: CUSTOM_DOMAINS_QUERY_KEY,
-		queryFn: () => connector.getAllCustomDomains(),
-	} );
+export function useExistingCustomDomains(): string[] {
+	const { data: sites } = useSites();
+	return useMemo(
+		() =>
+			( sites ?? [] )
+				.map( ( site ) => site.customDomain )
+				.filter( ( domain ): domain is string => !! domain ),
+		[ sites ]
+	);
 }
 
 /**

--- a/apps/ui/src/data/queries/use-sites.ts
+++ b/apps/ui/src/data/queries/use-sites.ts
@@ -1,5 +1,5 @@
 import { useIsMutating, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useConnector } from '@/data/core';
 import type { CreateSiteParams, SiteDetails } from '@/data/core';
 
@@ -116,14 +116,14 @@ export function useUpdateSite() {
 	} );
 }
 
-const XDEBUG_ENABLED_SITE_QUERY_KEY = [ 'xdebugEnabledSite' ] as const;
-
-export function useXdebugEnabledSite() {
-	const connector = useConnector();
-	return useQuery( {
-		queryKey: XDEBUG_ENABLED_SITE_QUERY_KEY,
-		queryFn: () => connector.getXdebugEnabledSite(),
-	} );
+/**
+ * The site that currently has Xdebug enabled — exclusive across sites — derived
+ * from the loaded site list so the settings form can warn before enabling it
+ * elsewhere. `enableXdebug` is already on every SiteDetails, so no separate call.
+ */
+export function useXdebugEnabledSite(): SiteDetails | null {
+	const { data: sites } = useSites();
+	return useMemo( () => sites?.find( ( site ) => site.enableXdebug ) ?? null, [ sites ] );
 }
 
 function useIsSiteMutating( siteId: string | undefined, mutationKey: readonly string[] ): boolean {

--- a/apps/ui/src/ui-classic/router/route-onboarding-blueprint/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-onboarding-blueprint/index.tsx
@@ -30,7 +30,7 @@ function OnboardingBlueprintPage() {
 	const activeStep: Step = step === 'configure' ? 'configure' : 'select';
 
 	const featured = useFeaturedBlueprints();
-	const { data: existingDomainNames } = useExistingCustomDomains();
+	const existingDomainNames = useExistingCustomDomains();
 	const createSite = useCreateSite();
 
 	// Picked blueprint lives in component state — survives navigation between
@@ -162,7 +162,7 @@ function OnboardingBlueprintPage() {
 			{ picked.excerpt && <p className={ styles.subtitle }>{ picked.excerpt }</p> }
 			<CreateSiteForm
 				initialValues={ initialValues }
-				existingDomainNames={ existingDomainNames ?? [] }
+				existingDomainNames={ existingDomainNames }
 				onSubmit={ handleSubmit }
 				onCancel={ () => void navigate( { to: '/onboarding' } ) }
 				isSubmitting={ createSite.isPending }

--- a/apps/ui/src/ui-classic/router/route-onboarding-create/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-onboarding-create/index.tsx
@@ -14,7 +14,7 @@ import type { CreateSiteFormValues } from '@/components/create-site-form';
 function CreateSitePage() {
 	const navigate = useNavigate();
 	const { data: sites } = useSites();
-	const { data: existingDomainNames } = useExistingCustomDomains();
+	const existingDomainNames = useExistingCustomDomains();
 	const { data: proposedName } = useProposedSiteName( sites );
 	const createSite = useCreateSite();
 	const [ submitError, setSubmitError ] = useState( '' );
@@ -49,7 +49,7 @@ function CreateSitePage() {
 			</p>
 			<CreateSiteForm
 				initialValues={ proposedName ? { name: proposedName } : undefined }
-				existingDomainNames={ existingDomainNames ?? [] }
+				existingDomainNames={ existingDomainNames }
 				onSubmit={ handleSubmit }
 				onCancel={ () => void navigate( { to: '/onboarding' } ) }
 				isSubmitting={ createSite.isPending }

--- a/apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx
@@ -56,7 +56,7 @@ function OnboardingImportPage() {
 	const connector = useConnector();
 	const activeStep: Step = step === 'configure' ? 'configure' : 'select';
 
-	const { data: existingDomainNames } = useExistingCustomDomains();
+	const existingDomainNames = useExistingCustomDomains();
 	const createSite = useCreateSite();
 	const importSite = useImportSite();
 
@@ -200,7 +200,7 @@ function OnboardingImportPage() {
 			</p>
 			<CreateSiteForm
 				initialValues={ initialValues }
-				existingDomainNames={ existingDomainNames ?? [] }
+				existingDomainNames={ existingDomainNames }
 				onSubmit={ handleSubmit }
 				onCancel={ () => void navigate( { to: '/onboarding' } ) }
 				isSubmitting={ isSubmitting }


### PR DESCRIPTION
## Related issues

- Extracted from the `studio ui` surface PR (#3953) so it can land independently.

## How AI was used in this PR

Built with Claude Code. While auditing the agentic UI's connector surface we noticed two methods were pure derivations over the site list; this splits that cleanup out of the larger surface PR. I reviewed the diff.

## Proposed Changes

Shrinks the agentic UI's `Connector` API by removing two methods that returned data the UI already holds.

`getAllCustomDomains()` and `getXdebugEnabledSite()` were each just a `map`/`find` over the full site list on the desktop side (`SiteServer.getAllDetails().map/find(...)`), and every `SiteDetails` from `getSites()` already carries `customDomain` and `enableXdebug`. So the UI now derives both from the existing `useSites()` query instead of a separate IPC round-trip:

- `useExistingCustomDomains()` → `sites.map( s => s.customDomain ).filter( … )`
- `useXdebugEnabledSite()` → `sites.find( s => s.enableXdebug ) ?? null`

The methods are removed from the `Connector` interface and its implementations. The desktop main-process IPC handlers stay — the legacy `apps/studio` renderer still calls them directly. **User impact: none** — behavior is identical (the create/edit forms still flag duplicate custom domains and the Xdebug conflict); this just removes two redundant data round-trips and trims the connector surface.

## Testing Instructions

- `npm run typecheck --workspace=apps/ui` is clean.
- In the agentic UI: the create/edit site forms still warn on a duplicate custom domain and on enabling Xdebug when another site already has it — now derived from the loaded site list.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? — typecheck clean; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
