### PR TITLE
Fix Studio Code annotate closing message that always referenced the CLI

### DIFF
--- a/apps/cli/ai/inspector/page-script.ts
+++ b/apps/cli/ai/inspector/page-script.ts
@@ -313,7 +313,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 		doneBtn.title =
 			annotations.length === 0
 				? 'Add at least one annotation first'
-				: 'Send annotations to the CLI and return';
+				: 'Send annotations and return';
 		doneBtn.addEventListener( 'click', () => {
 			if ( annotations.length === 0 ) return;
 			const sent = annotations.slice();
@@ -366,7 +366,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 				sentCount +
 				' annotation(s) — closing in ' +
 				secondsLeft +
-				's, return to the CLI';
+				's';
 		};
 		paint();
 		const interval = setInterval( () => {


### PR DESCRIPTION
## Related issues

- Fixes STU-1920

## How AI was used in this PR

Used Claude to trace the annotate flow, confirm the same page script serves both the standalone CLI and desktop-app Studio Code sessions, and pick the source-agnostic wording fix. All changes were reviewed by me.

## Proposed Changes

When a user finishes annotating in Studio Code's inspector, the closing countdown toast and the **Done** button tooltip told them to "return to the CLI". Most users reach this flow from the desktop app, so the message pointed them at the wrong place. The wording is now source-agnostic — the toast reads "Sent N annotation(s) — closing in Xs" and the tooltip reads "Send annotations and return" — so it's correct whether the session was launched from the app or the CLI.

## Testing Instructions

- In the Studio Code tab (desktop app), trigger the annotate flow and click **Annotate**.
- Pick an element, add a comment, and hover **Done** — the tooltip should read "Send annotations and return".
- Click **Done** — the countdown toast should read "Sent N annotation(s) — closing in Xs" with no "return to the CLI".

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
