### PR TITLE
Add refresh_browser tool so the agent can reload the site preview

### DIFF
--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -148,6 +148,7 @@ For long CSS or page-content files (>~200 lines), load the \`block-content\` ski
 - preview_update: Update an existing preview site from a local site; this can take a few minutes, so tell the user to wait
 - preview_delete: Delete a preview site by hostname
 - wp_cli: Run WP-CLI commands on a running site
+- refresh_browser: Reload the in-app site preview so the user sees your latest changes. Reloads in place; never stop/start the site to refresh the preview.
 - scaffold_theme: Scaffold a minimal block theme (style.css, theme.json, functions.php with frontend + editor enqueue, default templates and parts, empty assets/fonts and patterns dirs) into a site and activate it. Use as the first step when starting a new custom theme; the agent fills design-specific content afterwards. Block themes only.
 - validate_blocks: Validate block content in two stages and return a combined report. First a static core/html policy check; if it finds invalid core/html blocks it returns only those (rewrite them as editable core or plugin blocks and call again) and skips the editor. Once it passes, validates in the running site's real block editor: with filePath, applies safe editor fixes directly to the file and returns a CSS-review diff; with inline content, returns exact fixed block content plus the diff. Requires a site name or path. Call after every file write/edit that contains block content.
 - take_screenshot: Take a full-page screenshot of a URL (supports desktop, mobile, or \`viewport: "all"\` for both). Use this to visually check the site after building it.
@@ -166,6 +167,7 @@ ${ studioPresentToolBullet }${ automaticArtifactSection }
 - Design quality and visual ambition are not in conflict with using core blocks. Custom CSS targeting block classNames can achieve any visual design. The block structure is for editability; the CSS is for aesthetics.
 - Do NOT modify WordPress core files. Only work within wp-content/.
 - Before running wp_cli, ensure the site is running (site_start if needed).
+- After a change that alters what the site renders (content, options/settings, theme, plugins, activation), call refresh_browser so the in-app preview shows the result. Never stop/start the site (site_stop/site_start) just to refresh the preview.
 - When building themes, always build block themes (NO CLASSIC THEMES).
 - New CSS files impacting the frontend of the site need to be enqueued in both the editor and the frontend (automatic for the scaffold's style.css when using \`scaffold_theme\`).
 - For theme and page content custom CSS, put the styles in the main style.css of the theme. No custom stylesheets.

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -294,6 +294,17 @@ describe( 'Studio AI MCP tools', () => {
 		expect( studioPresent?.description ).not.toContain( '- drawing:' );
 	} );
 
+	it( 'refresh_browser emits a preview.reload event and is registered', async () => {
+		expect( studioToolDefinitions.map( ( tool ) => tool.name ) ).toContain( 'refresh_browser' );
+		const emitEventMock = vi.mocked( emitEvent );
+		emitEventMock.mockClear();
+		const result = await getTool( 'refresh_browser' ).rawHandler( {} as never );
+		expect( getTextContent( result ) ).toBe( 'Reloaded the site preview.' );
+		expect( emitEventMock ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'preview.reload' } )
+		);
+	} );
+
 	it( 'keeps screenshot presentation guidance out of the screenshot tool description', () => {
 		const takeScreenshot = resolveStudioToolDefinitions( {
 			emitChatArtifacts: true,

--- a/apps/cli/ai/tools/index.ts
+++ b/apps/cli/ai/tools/index.ts
@@ -15,6 +15,7 @@ import { openAnnotationBrowserTool } from './open-annotation-browser';
 import { pullSiteTool } from './pull-site';
 import { pushSiteTool } from './push-site';
 import { auditSeoTool } from './rank-me-up';
+import { refreshBrowserTool } from './refresh-browser';
 import { scaffoldThemeTool } from './scaffold-theme';
 import { shareScreenshotTool } from './share-screenshot';
 import { getSiteInfoTool } from './site-info';
@@ -42,6 +43,7 @@ export const studioToolDefinitions: AnyStudioAgentTool[] = [
 	updatePreviewTool,
 	deletePreviewTool,
 	runWpCliTool,
+	refreshBrowserTool,
 	scaffoldThemeTool,
 	validateBlocksTool,
 	takeScreenshotTool,

--- a/apps/cli/ai/tools/refresh-browser.ts
+++ b/apps/cli/ai/tools/refresh-browser.ts
@@ -1,0 +1,13 @@
+import { emitEvent } from 'cli/ai/json-events';
+import { defineTool } from './define-tool';
+import { textResult } from './utils';
+
+export const refreshBrowserTool = defineTool(
+	'refresh_browser',
+	'Reloads the site preview browser in the Studio app so the user sees your latest changes. Call this after a change that alters what the site renders (content, options/settings, theme, plugins, activation). It reloads in place — never stop/start the site (site_stop/site_start) just to refresh the preview.',
+	{},
+	async () => {
+		emitEvent( { type: 'preview.reload', timestamp: new Date().toISOString() } );
+		return textResult( 'Reloaded the site preview.' );
+	}
+);

--- a/apps/ui/src/hooks/use-session-commands.test.tsx
+++ b/apps/ui/src/hooks/use-session-commands.test.tsx
@@ -1,0 +1,92 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConnector } from '@/data/core';
+import { useSessionCommands } from './use-session-commands';
+import { SessionUIProvider, useSessionPreviewUI } from './use-session-ui';
+import type { AgentRunEvent, Connector } from '@/data/core';
+import type { ReactNode } from 'react';
+
+vi.mock( '@/data/core', async ( importOriginal ) => {
+	const actual = await importOriginal< typeof import('@/data/core') >();
+	return {
+		...actual,
+		useConnector: vi.fn(),
+	};
+} );
+
+const useConnectorMock = vi.mocked( useConnector );
+
+function Harness( { sessionId }: { sessionId: string } ) {
+	useSessionCommands( sessionId );
+	const preview = useSessionPreviewUI();
+	return (
+		<>
+			<span data-testid="nonce">{ preview.reloadNonce }</span>
+			<span data-testid="open">{ String( preview.open ) }</span>
+			<button onClick={ () => preview.setOpen( false ) }>close</button>
+		</>
+	);
+}
+
+describe( 'useSessionCommands preview.reload', () => {
+	let agentListener: ( event: AgentRunEvent ) => void;
+
+	beforeEach( () => {
+		useConnectorMock.mockReturnValue( {
+			onAgentEvent: vi.fn( ( listener ) => {
+				agentListener = listener;
+				return vi.fn();
+			} ),
+			onToggleSitePreview: vi.fn( () => vi.fn() ),
+		} as unknown as Connector );
+	} );
+
+	afterEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	function renderHarness( sessionId = 'session-1' ) {
+		return render( <Harness sessionId={ sessionId } />, {
+			wrapper: ( { children }: { children: ReactNode } ) => (
+				<SessionUIProvider>{ children }</SessionUIProvider>
+			),
+		} );
+	}
+
+	it( 'reloads the preview and reveals the panel', async () => {
+		renderHarness();
+		await waitFor( () => expect( agentListener ).toBeDefined() );
+
+		// Collapse first to prove the reload re-opens the panel.
+		fireEvent.click( screen.getByText( 'close' ) );
+		expect( screen.getByTestId( 'open' ) ).toHaveTextContent( 'false' );
+		const before = Number( screen.getByTestId( 'nonce' ).textContent );
+
+		act( () => {
+			agentListener( {
+				runId: 'run-1',
+				sessionId: 'session-1',
+				event: { type: 'preview.reload', timestamp: '2026-07-01T00:00:00.000Z' },
+			} as AgentRunEvent );
+		} );
+
+		expect( Number( screen.getByTestId( 'nonce' ).textContent ) ).toBe( before + 1 );
+		expect( screen.getByTestId( 'open' ) ).toHaveTextContent( 'true' );
+	} );
+
+	it( 'ignores reload events for other sessions', async () => {
+		renderHarness( 'session-1' );
+		await waitFor( () => expect( agentListener ).toBeDefined() );
+		const before = Number( screen.getByTestId( 'nonce' ).textContent );
+
+		act( () => {
+			agentListener( {
+				runId: 'run-1',
+				sessionId: 'session-2',
+				event: { type: 'preview.reload', timestamp: '2026-07-01T00:00:00.000Z' },
+			} as AgentRunEvent );
+		} );
+
+		expect( Number( screen.getByTestId( 'nonce' ).textContent ) ).toBe( before );
+	} );
+} );

--- a/apps/ui/src/hooks/use-session-commands.ts
+++ b/apps/ui/src/hooks/use-session-commands.ts
@@ -15,6 +15,10 @@ export function useSessionCommands( sessionId: string ): void {
 		return connector.onAgentEvent( ( payload ) => {
 			if ( payload.sessionId !== sessionId ) return;
 			const event = payload.event;
+			if ( event.type === 'preview.reload' ) {
+				dispatch( { type: 'preview/reload' } );
+				return;
+			}
 			if ( event.type === 'chat.artifact' && isStudioChatArtifactData( event.artifact ) ) {
 				const previewPath = getSitePreviewArtifactPath( event.artifact );
 				if ( previewPath ) {

--- a/apps/ui/src/hooks/use-session-ui.tsx
+++ b/apps/ui/src/hooks/use-session-ui.tsx
@@ -39,6 +39,7 @@ export type SessionUIAction =
 	| { type: 'preview/set-open'; value: boolean }
 	| { type: 'preview/toggle' }
 	| { type: 'preview/navigate'; path: string }
+	| { type: 'preview/reload' }
 	| { type: 'preview/update-path'; path: string };
 
 const INITIAL_STATE: SessionUIState = {
@@ -59,6 +60,17 @@ function reducer( state: SessionUIState, action: SessionUIAction ): SessionUISta
 				preview: {
 					...state.preview,
 					path: action.path,
+					reloadNonce: state.preview.reloadNonce + 1,
+					open: true,
+				},
+			};
+		case 'preview/reload':
+			// Reload the current path in place (bump the nonce). Reveal the
+			// panel so the agent-triggered refresh is actually visible.
+			return {
+				...state,
+				preview: {
+					...state.preview,
 					reloadNonce: state.preview.reloadNonce + 1,
 					open: true,
 				},

--- a/packages/common/ai/json-events.ts
+++ b/packages/common/ai/json-events.ts
@@ -27,6 +27,7 @@ export type JsonEvent =
 	| { type: 'info'; timestamp: string; message: string }
 	| { type: 'error'; timestamp: string; message: string }
 	| { type: 'chat.artifact'; timestamp: string; artifact: StudioChatArtifactData }
+	| { type: 'preview.reload'; timestamp: string }
 	| {
 			type: 'question.asked';
 			timestamp: string;

--- a/packages/common/ai/tools.ts
+++ b/packages/common/ai/tools.ts
@@ -308,6 +308,7 @@ export function getToolDisplayName( name: string, input?: Record< string, unknow
 		preview_list: __( 'List previews' ),
 		preview_update: __( 'Update preview' ),
 		preview_delete: __( 'Delete preview' ),
+		refresh_browser: __( 'Refresh preview' ),
 		site_connected_remote_sites: __( 'List connected remote sites' ),
 		scaffold_theme: __( 'Scaffold theme' ),
 		inspect_design: __( 'Inspect design' ),


### PR DESCRIPTION
## Related issues

- Fixes STU-1904

## How AI was used in this PR

Built with Claude Code: explored the agent tool + site-preview architecture, implemented the tool and event wiring, and wrote the unit tests. I reviewed every change myself and validated the behavior manually in the app. No CSS/color changes, so there is nothing to review in dark mode.

## Proposed Changes

The Studio agent had no way to refresh the in-app site preview after making changes, so it fell back to stopping and starting the whole site just to force a fresh webview mount — slow, disruptive, and impossible when the site was already running (the preview would simply stay stale). This adds a `refresh_browser` tool that reloads the preview **in place** via a dedicated `preview.reload` event, and steers the agent through its system prompt to use it after user-visible changes instead of restarting the site. Users now see their agent-made changes reflected immediately, without a server restart.

## Testing Instructions

1. Start Studio, open the agentic UI, and select a **running** local site with the preview panel open.
2. Ask the agent to change something visible without navigating, e.g. `Run wp-cli option update blogname "Reloaded-1" on this site`. The preview still shows the old title.
3. Ask the agent to `refresh the browser preview`. It should call `refresh_browser` (shown as "Refresh preview") and the header should update in place — with **no** site stop/start.
4. Automated: `npm test -- apps/cli/ai/tests/tools.test.ts` and `npm test -- apps/ui/src/hooks/use-session-commands.test.tsx`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
