### PR TITLE
Studio: Remove noop menu items from topbar

### DIFF
--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -122,8 +122,6 @@ export function buildViewMenuItems( {
 	onToggleSitePreview: () => void;
 } ): MenuItemConstructorOptions[] {
 	return [
-		{ label: __( 'Show Tab Bar' ), role: 'toggleTabBar' },
-		{ label: __( 'Show All Tabs' ), role: 'showAllTabs' },
 		{
 			label: __( 'Toggle Sidebar' ),
 			accelerator: 'CommandOrControl+B',
@@ -397,11 +395,6 @@ async function getAppMenu(
 						submenu: [
 							{ label: __( 'Minimize' ), role: 'minimize' },
 							{ label: __( 'Zoom' ), role: 'zoom' },
-							{ type: 'separator' },
-							{ label: __( 'Show Previous Tab' ), role: 'selectPreviousTab' },
-							{ label: __( 'Show Next Tab' ), role: 'selectNextTab' },
-							{ label: __( 'Move Tab to New Window' ), role: 'moveTabToNewWindow' },
-							{ label: __( 'Merge All Windows' ), role: 'mergeAllWindows' },
 						],
 					} as MenuItemConstructorOptions,
 			  ] ),

--- a/apps/studio/src/tests/menu.test.ts
+++ b/apps/studio/src/tests/menu.test.ts
@@ -84,8 +84,6 @@ describe( 'buildViewMenuItems', () => {
 				} )
 			)
 		).toEqual( [
-			'Show Tab Bar',
-			'Show All Tabs',
 			'Toggle Sidebar',
 			'Toggle Site Preview',
 			'Reload',


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1954

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->
It was used to update tests. Otherwise, not need as the change is simple.


## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

This PR remove noop menu items such as "Show Tab Bar", "Show All Tabs", "Show Previous Tab", "Show Next Tab", "Move Tab to New Window", "Merge All Windows"  as they are not needed with Studio being a single window application. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Confirm that the topbar does not contain the elements mentioned above:

<img width="622" height="219" alt="Screenshot 2026-07-01 at 3 07 07 PM" src="https://github.com/user-attachments/assets/a6286a30-ae10-4013-9107-835074fec5d0" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
