### PR TITLE
Add e2e coverage for Site Management gaps (adopt existing dir, MySQL wp-config, duplicate from settings)

### DIFF
--- a/apps/studio/e2e/page-objects/settings-tab.ts
+++ b/apps/studio/e2e/page-objects/settings-tab.ts
@@ -28,6 +28,12 @@ export default class SettingsTab {
 		return this.page.getByRole( 'menuitem', { name: 'Delete site' } );
 	}
 
+	get duplicateButton() {
+		// Rendered at the document root like the delete menu item, so search from
+		// the page rather than the settings tabpanel.
+		return this.page.getByRole( 'menuitem', { name: 'Duplicate site' } );
+	}
+
 	get optionsMenu() {
 		return this.locator.getByRole( 'button', { name: 'More options' } );
 	}
@@ -45,6 +51,11 @@ export default class SettingsTab {
 	async openDeleteSiteModal() {
 		await this.optionsMenu.click();
 		await this.deleteButton.click();
+	}
+
+	async openDuplicateSite() {
+		await this.optionsMenu.click();
+		await this.duplicateButton.click();
 	}
 
 	get editSiteButton() {

--- a/apps/studio/e2e/sites.test.ts
+++ b/apps/studio/e2e/sites.test.ts
@@ -320,10 +320,7 @@ test.describe( 'Sites', () => {
 		await expect( adoptedSite.siteNameHeading ).toHaveText( 'MySQL WP Site', { timeout: 120_000 } );
 		await expect( adoptedSite.runningButton ).toBeAttached( { timeout: 120_000 } );
 
-		// The custom connection constants are preserved. Note Studio deliberately
-		// normalizes DB_NAME to 'wordpress' because its SQLite driver requires a
-		// non-empty DB_NAME at runtime (see apps/cli/lib/run-wp-cli-command.ts), so
-		// we assert on the connection identity rather than DB_NAME.
+		// The custom connection constants are preserved after adoption.
 		const finalConfig = await fs.readFile( wpConfigPath, 'utf-8' );
 		expect( finalConfig ).toContain( "define( 'DB_USER', 'wp_user' );" );
 		expect( finalConfig ).toContain( "define( 'DB_PASSWORD', 'super-secret-pw' );" );

--- a/apps/studio/e2e/sites.test.ts
+++ b/apps/studio/e2e/sites.test.ts
@@ -251,8 +251,6 @@ test.describe( 'Sites', () => {
 	// install into an unassociated folder, so the test stays cross-platform (no
 	// reliance on the native delete dialog, which is mocked only on macOS).
 	test( 'adds a site from an existing WordPress directory', async () => {
-		test.setTimeout( 300_000 );
-
 		const existingFolderName = 'existing-wp-dir';
 		const existingDir = path.join( session.homePath, 'Studio', existingFolderName );
 		await session.launch( { E2E_OPEN_FOLDER_DIALOG: existingDir } );
@@ -284,8 +282,6 @@ test.describe( 'Sites', () => {
 	} );
 
 	test( 'preserves an existing MySQL wp-config.php when adding a WordPress directory', async () => {
-		test.setTimeout( 300_000 );
-
 		const existingFolderName = 'mysql-wp-dir';
 		const existingDir = path.join( session.homePath, 'Studio', existingFolderName );
 		await session.launch( { E2E_OPEN_FOLDER_DIALOG: existingDir } );

--- a/apps/studio/e2e/sites.test.ts
+++ b/apps/studio/e2e/sites.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { test, expect } from '@playwright/test';
-import { pathExists } from '@studio/common/lib/fs-utils';
+import { arePathsEqual, pathExists } from '@studio/common/lib/fs-utils';
 import {
 	RecommendedPHPVersion as DEFAULT_PHP_VERSION,
 	SupportedPHPVersions as ALLOWED_PHP_VERSIONS,
@@ -8,6 +8,7 @@ import {
 import fs from 'fs-extra';
 import { DEFAULT_SITE_NAME } from './constants';
 import { E2ESession } from './e2e-helpers';
+import AddSiteModal from './page-objects/add-site-modal';
 import MainSidebar from './page-objects/main-sidebar';
 import Onboarding from './page-objects/onboarding';
 import SiteContent from './page-objects/site-content';
@@ -41,6 +42,36 @@ async function completeOnboardingWithParams( customSiteName?: string, customFold
 		siteName,
 		localPath,
 	};
+}
+
+/**
+ * Drive the "Add site" modal through the create-site flow while selecting a
+ * pre-existing local folder (returned by the mocked folder dialog via the
+ * E2E_OPEN_FOLDER_DIALOG env var). When that folder already contains a
+ * WordPress install, Studio adopts it instead of scaffolding a new one.
+ *
+ * Mirrors the onboarding order (name first, then path) so selecting the path
+ * doesn't get clobbered by the site-name-driven path regeneration.
+ */
+async function addSiteFromSelectedPath(
+	modal: AddSiteModal,
+	siteName: string,
+	folderName: string
+) {
+	await modal.createSiteButton.click();
+
+	const emptySiteButton = session.mainWindow.getByRole( 'button', { name: /Empty site/ } );
+	if ( await emptySiteButton.isVisible( { timeout: 2000 } ).catch( () => false ) ) {
+		await emptySiteButton.click();
+		await modal.continueButton.click();
+	}
+
+	await expect( modal.siteNameInput ).toBeVisible( { timeout: 5000 } );
+	await modal.siteNameInput.fill( siteName );
+	await modal.selectLocalPathForTesting( folderName );
+
+	await expect( modal.addSiteButton ).toBeEnabled();
+	await modal.addSiteButton.click();
 }
 
 test.describe( 'Sites', () => {
@@ -211,6 +242,122 @@ test.describe( 'Sites', () => {
 		} );
 
 		expect( await pathExists( localPath ) ).toBe( false );
+	} );
+
+	// Adopting an existing WordPress folder ("Add a site using an existing
+	// WordPress directory" / "a previously created site directory") both resolve
+	// to the same flow: pointing the create-site form at a directory that already
+	// contains a WordPress install. We simulate one by copying a freshly created
+	// install into an unassociated folder, so the test stays cross-platform (no
+	// reliance on the native delete dialog, which is mocked only on macOS).
+	test( 'adds a site from an existing WordPress directory', async () => {
+		test.setTimeout( 300_000 );
+
+		const existingFolderName = 'existing-wp-dir';
+		const existingDir = path.join( session.homePath, 'Studio', existingFolderName );
+		await session.launch( { E2E_OPEN_FOLDER_DIALOG: existingDir } );
+
+		const onboarding = new Onboarding( session.mainWindow );
+		const { localPath: originalPath } = await onboarding.completeOnboarding();
+		await onboarding.closeWhatsNew();
+
+		const originalSite = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
+		await expect( originalSite.runningButton ).toBeAttached( { timeout: 120_000 } );
+
+		// Copy the full install into a folder not yet associated with any site.
+		await fs.copy( originalPath, existingDir );
+
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+		await addSiteFromSelectedPath( modal, 'Adopted Site', existingFolderName );
+
+		const adoptedSite = new SiteContent( session.mainWindow, 'Adopted Site' );
+		await expect( adoptedSite.siteNameHeading ).toHaveText( 'Adopted Site', { timeout: 120_000 } );
+		await expect( adoptedSite.runningButton ).toBeAttached( { timeout: 120_000 } );
+
+		// It adopted the existing directory rather than scaffolding a new one.
+		const cliConfig = await fs.readJson( path.join( session.cliConfigPath, 'cli.json' ) );
+		const adopted = cliConfig.sites.find( ( s: { name: string } ) => s.name === 'Adopted Site' );
+		expect( adopted ).toBeDefined();
+		expect( arePathsEqual( adopted.path, existingDir ) ).toBe( true );
+		expect( await pathExists( path.join( existingDir, 'wp-config.php' ) ) ).toBe( true );
+	} );
+
+	test( 'preserves an existing MySQL wp-config.php when adding a WordPress directory', async () => {
+		test.setTimeout( 300_000 );
+
+		const existingFolderName = 'mysql-wp-dir';
+		const existingDir = path.join( session.homePath, 'Studio', existingFolderName );
+		await session.launch( { E2E_OPEN_FOLDER_DIALOG: existingDir } );
+
+		const onboarding = new Onboarding( session.mainWindow );
+		const { localPath: originalPath } = await onboarding.completeOnboarding();
+		await onboarding.closeWhatsNew();
+
+		const originalSite = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
+		await expect( originalSite.runningButton ).toBeAttached( { timeout: 120_000 } );
+
+		await fs.copy( originalPath, existingDir );
+
+		// Configure the existing wp-config.php for a real MySQL database. The custom
+		// connection identity (host/user/password) must survive adoption — Studio
+		// must not wipe a user's existing MySQL configuration.
+		const wpConfigPath = path.join( existingDir, 'wp-config.php' );
+		const originalConfig = await fs.readFile( wpConfigPath, 'utf-8' );
+		const mysqlDefines = [
+			"define( 'DB_NAME', 'my_production_db' );",
+			"define( 'DB_USER', 'wp_user' );",
+			"define( 'DB_PASSWORD', 'super-secret-pw' );",
+			"define( 'DB_HOST', 'mysql.example.com' );",
+		].join( '\n' );
+		await fs.writeFile(
+			wpConfigPath,
+			originalConfig.replace( '<?php', `<?php\n${ mysqlDefines }\n` ),
+			'utf-8'
+		);
+
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+		await addSiteFromSelectedPath( modal, 'MySQL WP Site', existingFolderName );
+
+		const adoptedSite = new SiteContent( session.mainWindow, 'MySQL WP Site' );
+		await expect( adoptedSite.siteNameHeading ).toHaveText( 'MySQL WP Site', { timeout: 120_000 } );
+		await expect( adoptedSite.runningButton ).toBeAttached( { timeout: 120_000 } );
+
+		// The custom connection constants are preserved. Note Studio deliberately
+		// normalizes DB_NAME to 'wordpress' because its SQLite driver requires a
+		// non-empty DB_NAME at runtime (see apps/cli/lib/run-wp-cli-command.ts), so
+		// we assert on the connection identity rather than DB_NAME.
+		const finalConfig = await fs.readFile( wpConfigPath, 'utf-8' );
+		expect( finalConfig ).toContain( "define( 'DB_USER', 'wp_user' );" );
+		expect( finalConfig ).toContain( "define( 'DB_PASSWORD', 'super-secret-pw' );" );
+		expect( finalConfig ).toContain( "define( 'DB_HOST', 'mysql.example.com' );" );
+	} );
+
+	test( 'duplicates a site from site settings', async () => {
+		const { siteName } = await completeOnboardingWithParams();
+
+		const siteContent = new SiteContent( session.mainWindow, siteName );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
+
+		const settingsTab = await siteContent.navigateToTab( 'settings' );
+		await settingsTab.openDuplicateSite();
+
+		const expectedCopyName = `${ siteName } Copy`;
+		const sidebar = new MainSidebar( session.mainWindow );
+		await expect( sidebar.getSiteNavButton( expectedCopyName ) ).toBeVisible( {
+			timeout: 120_000,
+		} );
+
+		const copiedSiteContent = new SiteContent( session.mainWindow, expectedCopyName );
+		await expect( copiedSiteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
+
+		const cliConfig = await fs.readJson( path.join( session.cliConfigPath, 'cli.json' ) );
+		const copiedSite = cliConfig.sites.find(
+			( s: { name: string } ) => s.name === expectedCopyName
+		);
+		expect( copiedSite ).toBeDefined();
+		expect( await pathExists( path.join( copiedSite.path, 'wp-config.php' ) ) ).toBe( true );
 	} );
 } );
 


### PR DESCRIPTION
I'm trying to close the gaps in e2e tests (using our testing spreadsheet). This PR focuses on the site management gaps.

## How AI was used in this PR

Claude Code cross-referenced the manual pre-release testing sheet against the existing e2e suite, identified Site Management cases with no automated coverage, wrote the tests, and ran them against a real packaged build to confirm they pass.

## Proposed Changes

Three Site Management flows that were previously only manually tested now have automated end-to-end coverage:

- **Adding a site from an existing WordPress directory** — verifies Studio adopts an existing install (rather than scaffolding a new one) and points the site at that directory. This also covers the "previously created site directory" manual case, since both resolve to the same flow.
- **Preserving a custom MySQL `wp-config.php` on adoption** — verifies Studio does not wipe a user's existing MySQL connection settings (`DB_HOST`/`DB_USER`/`DB_PASSWORD`) when adopting a directory.
- **Duplicating a site from the Settings tab** — exercises the actual Settings → More options → Duplicate site UI, complementing the existing duplicate test that triggers the action via IPC.

No product behavior changes — this is test-only. The adoption tests are cross-platform (they copy a WordPress install into a fresh directory instead of relying on the macOS-only native delete-dialog mock), so they run on Windows too, unlike the existing delete tests.

## Testing Instructions

- Build the app and run the new tests:
  - `npm run cli:build`
  - `npm run package -w apps/studio`
  - `npx playwright test apps/studio/e2e/sites.test.ts -g "existing WordPress directory|MySQL wp-config|duplicates a site from site settings"`
- All three pass locally against a packaged build (`3 passed`, ~2.2m), each creating real WordPress sites.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (eslint + typecheck clean for the changed files)