### PR TITLE
Disable Studio Windows E2E CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,7 +23,9 @@ e2e_config: &e2e_config
     setup: { platform: [], arch: [] }
     adjustments:
       - with: { platform: mac, arch: arm64 }
-      - with: { platform: windows, arch: x64 }
+      # Windows E2E temporarily disabled while AINFRA-2588 investigates Windows E2E hangs in Buildkite.
+      # See https://linear.app/a8c/issue/AINFRA-2588/investigate-studio-windows-e2e-hangs-in-buildkite
+      # - with: { platform: windows, arch: x64 }
   notify:
     - github_commit_status:
         context: E2E Tests


### PR DESCRIPTION
## Related issues

- Related to [AINFRA-2588](https://linear.app/a8c/issue/AINFRA-2588/investigate-studio-windows-e2e-hangs-in-buildkite)

## Proposed Changes

Temporarily disables only the **Windows** Studio E2E Buildkite job while the Windows E2E hangs are investigated. The earlier revert (#4029) did not resolve the failures.

## Testing Instructions

- Refer to CI.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors? — N.A.
