### PR TITLE
Include Visual C++ DLLs with Windows PHP builds and add `packageVersion` field to identify PHP packages

### DIFF
--- a/.github/workflows/build-php-cli-binaries.yml
+++ b/.github/workflows/build-php-cli-binaries.yml
@@ -75,7 +75,10 @@ jobs:
             artifact_arch: aarch64
             extensions: *unix_extensions
           - target: windows-x86_64
-            runner: windows-latest
+            # PHP 8.4+ Windows builds use the VS17 toolchain. Pin the runner so
+            # the matching VC143 app-local runtime remains available even as
+            # windows-latest moves to newer Visual Studio releases.
+            runner: windows-2022
             artifact_platform: windows
             artifact_arch: x86_64
             extensions: apcu,bcmath,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,ftp,gd,iconv,igbinary,intl,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pdo,pdo_mysql,pdo_sqlite,phar,redis,session,shmop,simplexml,sockets,sodium,sqlite3,ssh2,tokenizer,xdebug,xml,xmlreader,xmlwriter,yaml,zip,zlib
@@ -459,6 +462,36 @@ jobs:
           Add-PECLExtension -Name ssh2
           Add-PECLExtension -Name yaml
 
+          # PHP's stock Windows builds require the Visual C++ runtime. Deploy it
+          # app-locally so php.exe also works on systems without the machine-wide
+          # redistributable installed.
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+          $vsInstallPath = & $vswhere -latest -version '[17.0,18.0)' -products * -property installationPath
+          if ( -not $vsInstallPath ) {
+            throw 'Could not locate Visual Studio to package the Visual C++ runtime'
+          }
+
+          $vcRedistRoot = Join-Path $vsInstallPath 'VC\Redist\MSVC'
+          $vcRuntimeDir = Get-ChildItem -Path $vcRedistRoot -Directory |
+            Sort-Object { [version]$_.Name } -Descending |
+            ForEach-Object { Join-Path $_.FullName 'x64\Microsoft.VC143.CRT' } |
+            Where-Object { Test-Path $_ } |
+            Select-Object -First 1
+          if ( -not $vcRuntimeDir ) {
+            throw "Could not locate the x64 app-local Visual C++ runtime under $vcRedistRoot"
+          }
+
+          $requiredVcRuntimeDlls = @('vcruntime140.dll', 'vcruntime140_1.dll')
+          foreach ( $dll in $requiredVcRuntimeDlls ) {
+            if ( -not (Test-Path (Join-Path $vcRuntimeDir $dll)) ) {
+              throw "Required Visual C++ runtime DLL not found: $dll"
+            }
+          }
+
+          Copy-Item -Path (Join-Path $vcRuntimeDir '*.dll') -Destination $stagingDir
+          $vcRuntimeVersion = (Get-Item (Join-Path $vcRuntimeDir 'vcruntime140.dll')).VersionInfo.FileVersion
+          Set-Content -Path (Join-Path $stagingDir 'vc-runtime.version') -Value $vcRuntimeVersion -NoNewline
+
           $runtimeJson = @{
             phpVersion = $env:PHP_VERSION
             phpMinor = $env:PHP_MINOR
@@ -468,6 +501,7 @@ jobs:
             binary = 'php.exe'
             extensionDir = 'ext'
             xdebug = 'ext/php_xdebug.dll'
+            vcRuntimeVersion = $vcRuntimeVersion
           } | ConvertTo-Json -Depth 4
           Set-Content -Path (Join-Path $stagingDir 'runtime.json') -Value $runtimeJson
 

--- a/.github/workflows/build-php-cli-binaries.yml
+++ b/.github/workflows/build-php-cli-binaries.yml
@@ -473,9 +473,11 @@ jobs:
 
           $vcRedistRoot = Join-Path $vsInstallPath 'VC\Redist\MSVC'
           $vcRuntimeDir = Get-ChildItem -Path $vcRedistRoot -Directory |
-            Sort-Object { [version]$_.Name } -Descending |
             ForEach-Object { Join-Path $_.FullName 'x64\Microsoft.VC143.CRT' } |
-            Where-Object { Test-Path $_ } |
+            Where-Object { Test-Path (Join-Path $_ 'vcruntime140.dll') } |
+            Sort-Object {
+              [version]( (Get-Item (Join-Path $_ 'vcruntime140.dll')).VersionInfo.FileVersion )
+            } -Descending |
             Select-Object -First 1
           if ( -not $vcRuntimeDir ) {
             throw "Could not locate the x64 app-local Visual C++ runtime under $vcRedistRoot"

--- a/.github/workflows/build-php-cli-binaries.yml
+++ b/.github/workflows/build-php-cli-binaries.yml
@@ -1,5 +1,5 @@
 name: Build PHP CLI Binaries
-run-name: Build PHP ${{ inputs.php_version }} with Xdebug ${{ inputs.xdebug_version }}
+run-name: Build PHP ${{ inputs.php_version }} package ${{ inputs.package_version }} with Xdebug ${{ inputs.xdebug_version }}
 
 on:
   workflow_dispatch:
@@ -8,6 +8,10 @@ on:
         description: PHP patch version to build
         required: true
         default: 8.4.20
+      package_version:
+        description: Required immutable package identifier; choose a new value when rebuilding a PHP version
+        required: true
+        default: studio-1
       xdebug_version:
         description: Xdebug version to package
         required: true
@@ -84,6 +88,7 @@ jobs:
             extensions: apcu,bcmath,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,ftp,gd,iconv,igbinary,intl,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pdo,pdo_mysql,pdo_sqlite,phar,redis,session,shmop,simplexml,sockets,sodium,sqlite3,ssh2,tokenizer,xdebug,xml,xmlreader,xmlwriter,yaml,zip,zlib
     env:
       PHP_VERSION: ${{ inputs.php_version }}
+      PHP_PACKAGE_VERSION: ${{ inputs.package_version }}
       XDEBUG_VERSION: ${{ inputs.xdebug_version }}
       SPC_REF: ${{ inputs.spc_ref }}
       PHP_CLI_EXTENSIONS: ${{ matrix.extensions }}
@@ -113,8 +118,14 @@ jobs:
             exit 1
           fi
 
+          if [[ ! "$PHP_PACKAGE_VERSION" =~ ^[a-z0-9][a-z0-9._-]{0,63}$ ]]; then
+            echo "Unsupported package version: $PHP_PACKAGE_VERSION (use 1-64 lowercase letters, numbers, dots, underscores, or dashes)" >&2
+            exit 1
+          fi
+
           php_minor="${PHP_VERSION%.*}"
           echo "PHP_MINOR=$php_minor" >> "$GITHUB_ENV"
+          echo "PHP_PACKAGE_ID=$PHP_VERSION-$PHP_PACKAGE_VERSION" >> "$GITHUB_ENV"
 
       - name: Setup PHP for static-php-cli
         # Linux runs SPC inside the spc-gnu-docker container, which ships
@@ -255,6 +266,8 @@ jobs:
           cat > "$staging_dir/runtime.json" <<JSON
           {
             "phpVersion": "$PHP_VERSION",
+            "packageVersion": "$PHP_PACKAGE_VERSION",
+            "packageId": "$PHP_PACKAGE_ID",
             "phpMinor": "$PHP_MINOR",
             "threadSafety": "nts",
             "platform": "$PHP_CLI_ARTIFACT_PLATFORM",
@@ -320,6 +333,8 @@ jobs:
           cat > "$staging_dir/runtime.json" <<JSON
           {
             "phpVersion": "$PHP_VERSION",
+            "packageVersion": "$PHP_PACKAGE_VERSION",
+            "packageId": "$PHP_PACKAGE_ID",
             "phpMinor": "$PHP_MINOR",
             "threadSafety": "nts",
             "platform": "$PHP_CLI_ARTIFACT_PLATFORM",
@@ -496,6 +511,8 @@ jobs:
 
           $runtimeJson = @{
             phpVersion = $env:PHP_VERSION
+            packageVersion = $env:PHP_PACKAGE_VERSION
+            packageId = $env:PHP_PACKAGE_ID
             phpMinor = $env:PHP_MINOR
             threadSafety = 'nts'
             platform = $env:PHP_CLI_ARTIFACT_PLATFORM
@@ -575,6 +592,7 @@ jobs:
       pull-requests: write
     env:
       PHP_VERSION: ${{ inputs.php_version }}
+      PHP_PACKAGE_VERSION: ${{ inputs.package_version }}
       PHP_CLI_VISIBILITY: ${{ inputs.apps_cdn_visibility }}
       WPCOM_API_TOKEN: ${{ secrets.WPCOM_API_TOKEN }}
     steps:
@@ -606,13 +624,14 @@ jobs:
 
           bundle exec fastlane publish_php_cli_binaries \
             version:"${PHP_VERSION}" \
+            package_version:"${PHP_PACKAGE_VERSION}" \
             artifacts_dir:"${PWD}/out/php-binaries" \
             visibility:"${PHP_CLI_VISIBILITY}" \
             output_file:"${upload_results_file}"
 
           echo "### Apps CDN PHP CLI upload" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Uploaded or updated PHP ${PHP_VERSION} CLI artifacts with ${PHP_CLI_VISIBILITY} visibility." >> "$GITHUB_STEP_SUMMARY"
+          echo "Uploaded PHP ${PHP_VERSION} package ${PHP_PACKAGE_VERSION} CLI artifacts with ${PHP_CLI_VISIBILITY} visibility." >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           PHP_CLI_UPLOAD_RESULTS_FILE="$upload_results_file" ruby -rjson -e '
@@ -635,6 +654,7 @@ jobs:
 
           node scripts/update-php-binary-cdn-metadata.mjs \
             --version "${PHP_VERSION}" \
+            --package-version "${PHP_PACKAGE_VERSION}" \
             --upload-results "${PWD}/out/php-binaries/apps-cdn-upload-results.json"
 
           if git diff --quiet -- packages/common/lib/php-binary-cdn-metadata.json; then
@@ -650,16 +670,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          branch="update-php-cli-metadata-${PHP_VERSION}-${GITHUB_RUN_ID}"
+          branch="update-php-cli-metadata-${PHP_VERSION}-${PHP_PACKAGE_VERSION}-${GITHUB_RUN_ID}"
           # Standard GitHub Actions bot noreply identity for workflow-created commits.
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$branch"
           git add packages/common/lib/php-binary-cdn-metadata.json
-          git commit -m "Update PHP ${PHP_VERSION} binary metadata"
+          git commit -m "Update PHP ${PHP_VERSION} package ${PHP_PACKAGE_VERSION} metadata"
           git push --set-upstream origin "$branch"
           gh pr create \
             --base "${GITHUB_REF_NAME}" \
             --head "$branch" \
-            --title "Update PHP ${PHP_VERSION} binary metadata" \
-            --body "Updates PHP CLI binary CDN metadata after a successful Apps CDN upload."
+            --title "Update PHP ${PHP_VERSION} package ${PHP_PACKAGE_VERSION} metadata" \
+            --body "Updates PHP CLI binary CDN metadata after a successful immutable Apps CDN upload."

--- a/.github/workflows/build-php-cli-binaries.yml
+++ b/.github/workflows/build-php-cli-binaries.yml
@@ -1,5 +1,5 @@
 name: Build PHP CLI Binaries
-run-name: Build PHP ${{ inputs.php_version }} package ${{ inputs.package_version }} with Xdebug ${{ inputs.xdebug_version }}
+run-name: Build PHP ${{ inputs.php_version }}-${{ inputs.package_version }} with Xdebug ${{ inputs.xdebug_version }}
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
         required: true
         default: 8.4.20
       package_version:
-        description: Required immutable package identifier; choose a new value when rebuilding a PHP version
+        description: Package version (choose a new value when rebuilding a PHP version)
         required: true
         default: studio-1
       xdebug_version:

--- a/apps/cli/lib/dependency-management/paths.ts
+++ b/apps/cli/lib/dependency-management/paths.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import {
-	getConfiguredPhpBinaryVersion,
+	getConfiguredPhpBinaryPackageId,
 	NativePhpSupportedVersions,
 	type NativePhpSupportedVersion,
 } from '@studio/common/lib/php-binary-metadata';
@@ -20,15 +20,15 @@ function isNativePhpSupportedVersion( version: string ): version is NativePhpSup
 	return ( NativePhpSupportedVersions as readonly string[] ).includes( version );
 }
 
-// PHP binaries live in ~/.studio/php-bin/<patch>/. The default version also ships with
+// PHP binaries live in ~/.studio/php-bin/<package-id>/. The default version also ships with
 // Studio and is copied into this writable location by a CLI migration.
 export function getPhpBinaryPath( version: NativePhpSupportedVersion | string ): string {
 	if ( ! isNativePhpSupportedVersion( version ) ) {
 		return getExactPhpBinaryPath( version );
 	}
 
-	const configuredVersion = getConfiguredPhpBinaryVersion( version );
-	return getExactPhpBinaryPath( configuredVersion ?? version );
+	const packageId = getConfiguredPhpBinaryPackageId( version );
+	return getExactPhpBinaryPath( packageId ?? version );
 }
 
 const WP_CLI_PHAR_FILENAME = 'wp-cli.phar';

--- a/apps/cli/lib/dependency-management/php-binary.ts
+++ b/apps/cli/lib/dependency-management/php-binary.ts
@@ -64,7 +64,7 @@ async function downloadAndInstall(
 	}
 
 	const downloadInfo = await resolvePhpBinaryDownloadInfo( version, platform, arch );
-	const destPath = getPhpBinaryPath( downloadInfo.patchVersion );
+	const destPath = getPhpBinaryPath( downloadInfo.packageId );
 	const destDir = path.dirname( destPath );
 	const phpBinRoot = path.dirname( destDir );
 
@@ -90,7 +90,7 @@ async function downloadAndInstall(
 	try {
 		await downloadFile( downloadInfo.url, downloadPath, onProgress );
 		await verifyHash( downloadPath, downloadInfo.sha, version, platform, arch );
-		await extractAndInstall( downloadPath, destPath, downloadInfo.patchVersion, platform );
+		await extractAndInstall( downloadPath, destPath, downloadInfo.packageId, platform );
 	} catch ( err ) {
 		fs.rmSync( destDir, { recursive: true, force: true } );
 		throw err;
@@ -143,14 +143,14 @@ async function verifyHash(
 async function extractAndInstall(
 	archivePath: string,
 	destPath: string,
-	patchVersion: string,
+	packageId: string,
 	platform: NodeJS.Platform
 ): Promise< void > {
 	const isWindows = platform === 'win32';
 	const tmpDir = os.tmpdir();
 	const fallbackBinaryName = isWindows ? 'php.exe' : 'php';
 
-	const extractDir = fs.mkdtempSync( path.join( tmpDir, `php-${ patchVersion }-` ) );
+	const extractDir = fs.mkdtempSync( path.join( tmpDir, `php-${ packageId }-` ) );
 	try {
 		await extractZip( archivePath, extractDir );
 		const binaryName = getRuntimeBinaryName( extractDir ) ?? fallbackBinaryName;

--- a/apps/cli/lib/dependency-management/tests/paths.test.ts
+++ b/apps/cli/lib/dependency-management/tests/paths.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { getConfiguredPhpBinaryVersion } from '@studio/common/lib/php-binary-metadata';
+import { getConfiguredPhpBinaryPackageId } from '@studio/common/lib/php-binary-metadata';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getPhpBinaryPath } from 'cli/lib/dependency-management/paths';
 
@@ -30,19 +30,19 @@ describe( 'getPhpBinaryPath', () => {
 		fs.rmSync( configDir, { recursive: true, force: true } );
 	} );
 
-	it( 'uses the configured patch directory for a PHP minor', () => {
+	it( 'uses the configured package directory for a PHP minor', () => {
 		expect( getPhpBinaryPath( '8.4' ) ).toBe(
 			path.join(
 				configDir,
 				'php-bin',
-				getConfiguredPhpBinaryVersion( '8.4' )!,
+				getConfiguredPhpBinaryPackageId( '8.4' )!,
 				process.platform === 'win32' ? 'php.exe' : 'php'
 			)
 		);
 	} );
 
 	it( 'does not let existing local patch folders override metadata', () => {
-		const configuredVersion = getConfiguredPhpBinaryVersion( '8.4' )!;
+		const configuredVersion = getConfiguredPhpBinaryPackageId( '8.4' )!;
 		const localBinary = writePhpBinary( configuredVersion === '8.4.20' ? '8.4.21' : '8.4.20' );
 
 		expect( getPhpBinaryPath( '8.4' ) ).not.toBe( localBinary );
@@ -59,6 +59,17 @@ describe( 'getPhpBinaryPath', () => {
 	it( 'uses an exact patch path when called with a PHP patch version', () => {
 		expect( getPhpBinaryPath( '8.4.21' ) ).toBe(
 			path.join( configDir, 'php-bin', '8.4.21', process.platform === 'win32' ? 'php.exe' : 'php' )
+		);
+	} );
+
+	it( 'uses an exact package path when called with a Studio package ID', () => {
+		expect( getPhpBinaryPath( '8.4.21-1.0.0' ) ).toBe(
+			path.join(
+				configDir,
+				'php-bin',
+				'8.4.21-1.0.0',
+				process.platform === 'win32' ? 'php.exe' : 'php'
+			)
 		);
 	} );
 } );

--- a/apps/cli/lib/dependency-management/tests/php-binary.test.ts
+++ b/apps/cli/lib/dependency-management/tests/php-binary.test.ts
@@ -1,5 +1,7 @@
 import {
 	resolveNativePhpVersion,
+	getConfiguredPhpBinaryPackageId,
+	getConfiguredPhpBinaryPackageVersion,
 	getConfiguredPhpBinaryVersion,
 	getPhpBinaryDownloadInfo,
 } from '@studio/common/lib/php-binary-metadata';
@@ -11,6 +13,8 @@ describe( 'getPhpBinaryDownloadInfo', () => {
 		expect( getPhpBinaryDownloadInfo( '8.4', 'darwin', 'arm64' ) ).toEqual(
 			expect.objectContaining( {
 				patchVersion: getConfiguredPhpBinaryVersion( '8.4' ),
+				packageId: getConfiguredPhpBinaryPackageId( '8.4' ),
+				packageVersion: getConfiguredPhpBinaryPackageVersion( '8.4' ),
 				url: expect.stringContaining( '/downloads/wordpress-com-studio-php-cli/mac-silicon/' ),
 				sha: expect.stringMatching( /^[a-f0-9]{64}$/ ),
 			} )
@@ -21,6 +25,8 @@ describe( 'getPhpBinaryDownloadInfo', () => {
 		expect( getPhpBinaryDownloadInfo( '8.4', 'win32', 'arm64' ) ).toEqual(
 			expect.objectContaining( {
 				patchVersion: getConfiguredPhpBinaryVersion( '8.4' ),
+				packageId: getConfiguredPhpBinaryPackageId( '8.4' ),
+				packageVersion: getConfiguredPhpBinaryPackageVersion( '8.4' ),
 				url: expect.stringContaining( '/downloads/wordpress-com-studio-php-cli/windows-x64/' ),
 				sha: expect.stringMatching( /^[a-f0-9]{64}$/ ),
 			} )
@@ -29,6 +35,15 @@ describe( 'getPhpBinaryDownloadInfo', () => {
 
 	it( 'returns the configured patch version for a PHP minor', () => {
 		expect( getConfiguredPhpBinaryVersion( '8.4' ) ).toMatch( /^\d+\.\d+\.\d+$/ );
+	} );
+
+	it( 'returns a package ID composed from the PHP patch and optional package version', () => {
+		const patchVersion = getConfiguredPhpBinaryVersion( '8.4' );
+		const packageVersion = getConfiguredPhpBinaryPackageVersion( '8.4' );
+
+		expect( getConfiguredPhpBinaryPackageId( '8.4' ) ).toBe(
+			packageVersion ? `${ patchVersion }-${ packageVersion }` : patchVersion
+		);
 	} );
 
 	it( 'returns undefined when metadata is missing for the platform', () => {

--- a/apps/cli/migrations/06-install-bundled-default-php.ts
+++ b/apps/cli/migrations/06-install-bundled-default-php.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import {
-	getConfiguredPhpBinaryVersion,
+	getConfiguredPhpBinaryPackageId,
 	resolveNativePhpVersion,
 } from '@studio/common/lib/php-binary-metadata';
 import { getPhpBinaryPath } from 'cli/lib/dependency-management/paths';
@@ -16,13 +16,13 @@ function getBundledPhpBinaryRoot(): string {
 	);
 }
 
-function getDefaultPhpPatchVersion(): string {
+function getDefaultPhpPackageId(): string {
 	const nativeVersion = resolveNativePhpVersion( DEFAULT_PHP_VERSION );
-	return getConfiguredPhpBinaryVersion( nativeVersion ) ?? nativeVersion;
+	return getConfiguredPhpBinaryPackageId( nativeVersion ) ?? nativeVersion;
 }
 
 function getBundledDefaultPhpDir(): string {
-	return path.join( getBundledPhpBinaryRoot(), getDefaultPhpPatchVersion() );
+	return path.join( getBundledPhpBinaryRoot(), getDefaultPhpPackageId() );
 }
 
 function getBundledDefaultPhpPath(): string {

--- a/apps/cli/migrations/tests/06-install-bundled-default-php.test.ts
+++ b/apps/cli/migrations/tests/06-install-bundled-default-php.test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import {
-	getConfiguredPhpBinaryVersion,
+	getConfiguredPhpBinaryPackageId,
 	resolveNativePhpVersion,
 } from '@studio/common/lib/php-binary-metadata';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -16,16 +16,16 @@ function getBinaryName(): string {
 	return process.platform === 'win32' ? 'php.exe' : 'php';
 }
 
-function getDefaultPhpPatchVersion(): string {
-	return getConfiguredPhpBinaryVersion( resolveNativePhpVersion( DEFAULT_PHP_VERSION ) )!;
+function getDefaultPhpPackageId(): string {
+	return getConfiguredPhpBinaryPackageId( resolveNativePhpVersion( DEFAULT_PHP_VERSION ) )!;
 }
 
 function getBundledDefaultPhpDir(): string {
-	return path.join( bundledPhpDir, getDefaultPhpPatchVersion() );
+	return path.join( bundledPhpDir, getDefaultPhpPackageId() );
 }
 
 function getDefaultPhpDestinationDir(): string {
-	return path.join( configDir, 'php-bin', getDefaultPhpPatchVersion() );
+	return path.join( configDir, 'php-bin', getDefaultPhpPackageId() );
 }
 
 function writeBundledDefaultPhp(): void {

--- a/docs/design-docs/native-php-binaries.md
+++ b/docs/design-docs/native-php-binaries.md
@@ -21,7 +21,10 @@ The artifact shapes diverge as a result: the macOS `ext/` directory contains
 only `xdebug.so`, while the Windows `ext/` directory contains a
 `php_<name>.dll` for every non-built-in extension. Both archives still expose
 a stable `runtime.json` manifest with `phpVersion`, `extensionDir`, and
-`xdebug` paths, and both ship with `.sha256` sidecars.
+`xdebug` paths. The manifest also records `packageVersion`, the required
+engineer-chosen immutable packaging identifier, and `packageId`, its
+PHP-qualified CDN and local-directory identifier. All artifacts ship with
+`.sha256` sidecars.
 
 The Studio consumer needs to know this divergence when launching the binary:
 on macOS the baked-in extensions are implicit and need no `extension=…` flags,
@@ -48,7 +51,10 @@ For internal Studio validation, the workflow can upload the unsigned `.zip`
 archives directly to Apps CDN:
 
 1. Run the manual GitHub Actions `Build PHP CLI Binaries` workflow.
-2. Set `apps_cdn_visibility` to `none` to skip the upload (lane validation
+2. Set `package_version` to an immutable identifier. It defaults to `studio-1`
+   and does not need to be SemVer. Choose a new value whenever rebuilding the
+   same upstream PHP release.
+3. Set `apps_cdn_visibility` to `none` to skip the upload (lane validation
    only), `internal` for internal testing, or `external` for public
    publishing.
 
@@ -58,6 +64,7 @@ artifacts and calls:
 ```sh
 bundle exec fastlane publish_php_cli_binaries \
   version:"${PHP_VERSION}" \
+  package_version:"${PHP_PACKAGE_VERSION}" \
   artifacts_dir:"${PWD}/out/php-binaries" \
   visibility:"${PHP_CLI_VISIBILITY:-internal}"
 ```
@@ -71,8 +78,8 @@ PHP CLI artifacts use a separate lane so they do not look like Studio app
 builds:
 
 ```sh
-DRY_RUN=true bundle exec fastlane publish_php_cli_binaries version:8.4.20 artifacts_dir:out/php-binaries
-bundle exec fastlane publish_php_cli_binaries version:8.4.20 artifacts_dir:out/php-binaries visibility:external
+DRY_RUN=true bundle exec fastlane publish_php_cli_binaries version:8.4.20 package_version:1.0.0 artifacts_dir:out/php-binaries
+bundle exec fastlane publish_php_cli_binaries version:8.4.20 package_version:1.0.0 artifacts_dir:out/php-binaries visibility:external
 ```
 
 The lane publishes the existing archive filenames without renaming them, reads
@@ -85,26 +92,33 @@ them as:
 - install type: `Full Install`
 - platform: `Mac - Silicon`, `Mac - Intel`, or `Windows - x64`
 
-The upload is update-friendly by default. If a matching PHP CLI build already
-exists on Apps CDN, the lane lets the CDN replace the existing build artifact
-instead of failing on the duplicate version.
+PHP CLI package identifiers are immutable. Duplicate uploads fail rather than
+replacing an existing Apps CDN artifact, because released Studio versions
+retain that artifact's URL and SHA-256. Replacing its bytes would cause
+checksum failures in those installations.
 
 After a successful Apps CDN upload, the workflow updates
 `packages/common/lib/php-binary-cdn-metadata.json` and opens a PR with the new CDN
 URLs and SHA-256 hashes. The metadata keeps one patch version per PHP minor
-version; uploading a newer patch replaces the tracked patch for that minor.
+version and may include a separate `packageVersion`. A different package
+identifier changes both the Apps CDN URL and local installation directory
+without pretending that upstream PHP published another patch.
 
 At runtime, Studio uses `packages/common/lib/php-binary-cdn-metadata.json` as the
 source of truth for the requested PHP minor version. Packaged Studio builds
-ship the recommended PHP version under the app resources `php-bin/<patch>/`;
+ship the recommended PHP version under the app resources
+`php-bin/<package-id>/`;
 a CLI migration copies that directory into the writable install location if the
-destination patch folder does not exist. Studio downloads other PHP versions
+destination package folder does not exist. Studio downloads other PHP versions
 on demand from manifest URLs, then verifies the checked-in SHA-256 before
 extracting the archive. If metadata is missing for the requested device, native
 PHP install fails for that version.
 
-Downloaded binaries are installed under `~/.studio/php-bin/<patch>/`, for
-example `~/.studio/php-bin/8.4.20/php`. This lets Studio download a new patch
-without replacing a binary that an existing native PHP process is still using.
+Downloaded binaries are installed under
+`~/.studio/php-bin/<package-id>/`, for example
+`~/.studio/php-bin/8.4.20-studio-1/php`. Metadata without a `packageVersion`
+falls back to the PHP patch for backward compatibility. This lets Studio
+download either a new PHP patch or a new packaging revision without replacing
+a binary that an existing native PHP process is still using.
 
 Apps CDN PHP CLI artifacts are ZIP files for macOS and Windows.

--- a/docs/design-docs/native-php-binaries.md
+++ b/docs/design-docs/native-php-binaries.md
@@ -78,8 +78,8 @@ PHP CLI artifacts use a separate lane so they do not look like Studio app
 builds:
 
 ```sh
-DRY_RUN=true bundle exec fastlane publish_php_cli_binaries version:8.4.20 package_version:1.0.0 artifacts_dir:out/php-binaries
-bundle exec fastlane publish_php_cli_binaries version:8.4.20 package_version:1.0.0 artifacts_dir:out/php-binaries visibility:external
+DRY_RUN=true bundle exec fastlane publish_php_cli_binaries version:8.4.20 package_version:studio-1 artifacts_dir:out/php-binaries
+bundle exec fastlane publish_php_cli_binaries version:8.4.20 package_version:studio-1 artifacts_dir:out/php-binaries visibility:external
 ```
 
 The lane publishes the existing archive filenames without renaming them, reads

--- a/docs/design-docs/native-php-binaries.md
+++ b/docs/design-docs/native-php-binaries.md
@@ -13,7 +13,9 @@ static-php-cli only supports shared extensions on Unix-like targets:
   the Xdebug DLL from `xdebug.org`, and fetches each missing PECL extension
   (apcu, igbinary, redis, ssh2, yaml) from `downloads.php.net/~windows/pecl`
   with the newest published version that has a build for the requested
-  `PHP_MINOR` + VS toolchain.
+  `PHP_MINOR` + VS toolchain. It also copies the matching x64 VC143 runtime
+  from the Visual Studio 2022 runner beside `php.exe`, so the package does not
+  depend on a machine-wide Visual C++ Redistributable installation.
 
 The artifact shapes diverge as a result: the macOS `ext/` directory contains
 only `xdebug.so`, while the Windows `ext/` directory contains a

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -292,13 +292,14 @@ lane :publish_npm_package do |version: nil, skip_confirm: false|
   trigger_npm_publish(ref: release_tag, npm_tag: npm_tag)
 end
 
-desc 'Upload or update Studio PHP CLI binaries on Apps CDN'
-lane :publish_php_cli_binaries do |version:, artifacts_dir: PHP_CLI_BUILDS_FOLDER, visibility: 'internal', error_on_duplicate: false, output_file: nil|
+desc 'Upload immutable Studio PHP CLI packages to Apps CDN'
+lane :publish_php_cli_binaries do |version:, package_version:, artifacts_dir: PHP_CLI_BUILDS_FOLDER,
+                                   visibility: 'internal', output_file: nil|
   upload_php_cli_binaries_to_apps_cdn(
     version:,
+    package_version:,
     artifacts_dir:,
     visibility:,
-    error_on_duplicate: error_on_duplicate.to_s != 'false',
     output_file:
   )
 end
@@ -919,11 +920,16 @@ def read_sha256_sidecar(file_path:)
   sha
 end
 
-def upload_php_cli_binaries_to_apps_cdn(version:, artifacts_dir:, visibility:, error_on_duplicate:, output_file: nil, dry_run: DRY_RUN)
+def upload_php_cli_binaries_to_apps_cdn(version:, package_version:, artifacts_dir:, visibility:,
+                                        output_file: nil, dry_run: DRY_RUN)
   normalized_visibility = visibility.to_s.downcase
   unless %w[internal external].include?(normalized_visibility)
     UI.user_error!("visibility must be 'internal' or 'external'")
   end
+  unless package_version.match?(/\A[a-z0-9][a-z0-9._-]{0,63}\z/)
+    UI.user_error!('package_version must be a 1-64 character lowercase package identifier')
+  end
+  package_id = "#{version}-#{package_version}"
 
   builds = {}
   php_cli_cdn_builds(version:).each do |build|
@@ -931,8 +937,8 @@ def upload_php_cli_binaries_to_apps_cdn(version:, artifacts_dir:, visibility:, e
     UI.user_error!("File #{file_path} does not exist") unless File.exist?(file_path)
 
     sha = read_sha256_sidecar(file_path:)
-    release_notes = "PHP #{version} CLI binary for #{build[:name]}"
-    UI.message("Uploading or updating PHP CLI binary: #{build[:file_name]}")
+    release_notes = "PHP #{version} CLI package #{package_id} for #{build[:name]}"
+    UI.message("Uploading immutable PHP CLI package: #{build[:file_name]} as #{package_id}")
     media_url = nil
 
     if dry_run
@@ -944,10 +950,12 @@ def upload_php_cli_binaries_to_apps_cdn(version:, artifacts_dir:, visibility:, e
       UI.message('           build type: Production')
       UI.message('           install type: Full Install')
       UI.message("           visibility: #{normalized_visibility.capitalize}")
-      UI.message("           version: #{version}")
+      UI.message("           PHP version: #{version}")
+      UI.message("           package version: #{package_version}")
+      UI.message("           package/CDN ID: #{package_id}")
       UI.message("           release notes: #{release_notes}")
       UI.message("           sha: #{sha}")
-      UI.message("           error on duplicate: #{error_on_duplicate}")
+      UI.message('           error on duplicate: true')
     else
       result = upload_build_to_apps_cdn(
         site_id: WPCOM_STUDIO_SITE_ID,
@@ -956,18 +964,18 @@ def upload_php_cli_binaries_to_apps_cdn(version:, artifacts_dir:, visibility:, e
         build_type: 'Production',
         install_type: 'Full Install',
         visibility: normalized_visibility.capitalize,
-        version:,
+        version: package_id,
         build_number: nil,
         release_notes:,
         sha:,
         file_path:,
-        error_on_duplicate:
+        error_on_duplicate: true
       )
       media_url = result[:media_url] || result['media_url']
       UI.user_error!('Apps CDN upload response did not include media_url') if media_url.to_s.empty?
 
       UI.message('--------------------------------')
-      UI.message("✅ Uploaded or updated PHP CLI binary: #{file_path} to #{media_url}")
+      UI.message("✅ Uploaded PHP CLI package: #{file_path} to #{media_url}")
     end
 
     builds[build[:file_name]] = {

--- a/packages/common/lib/php-binary-metadata.ts
+++ b/packages/common/lib/php-binary-metadata.ts
@@ -52,6 +52,10 @@ const phpBinaryCdnMetadataSchema = z.object( {
 		z.string(),
 		z.object( {
 			version: z.string().regex( /^\d+\.\d+\.\d+$/ ),
+			packageVersion: z
+				.string()
+				.regex( /^[a-z0-9][a-z0-9._-]{0,63}$/ )
+				.optional(),
 			artifacts: z.record( z.string(), phpBinaryArtifactSchema ),
 		} )
 	),
@@ -61,6 +65,8 @@ const phpBinaryCdnMetadata = phpBinaryCdnMetadataSchema.parse( phpBinaryCdnMetad
 
 export type PhpBinaryDownloadInfo = z.infer< typeof phpBinaryArtifactSchema > & {
 	patchVersion: string;
+	packageVersion?: string;
+	packageId: string;
 };
 
 export function getEffectivePhpBinaryArch( platform: NodeJS.Platform, arch: string ): string {
@@ -73,6 +79,24 @@ export function getConfiguredPhpBinaryVersion(
 	return version in phpBinaryCdnMetadata.versions
 		? phpBinaryCdnMetadata.versions[ version ]?.version
 		: undefined;
+}
+
+export function getConfiguredPhpBinaryPackageVersion(
+	version: NativePhpSupportedVersion
+): string | undefined {
+	return phpBinaryCdnMetadata.versions[ version ]?.packageVersion;
+}
+
+export function getConfiguredPhpBinaryPackageId(
+	version: NativePhpSupportedVersion
+): string | undefined {
+	const versionMetadata = phpBinaryCdnMetadata.versions[ version ];
+	if ( ! versionMetadata ) {
+		return undefined;
+	}
+	return versionMetadata.packageVersion
+		? `${ versionMetadata.version }-${ versionMetadata.packageVersion }`
+		: versionMetadata.version;
 }
 
 export function getPhpBinaryDownloadInfo(
@@ -93,6 +117,10 @@ export function getPhpBinaryDownloadInfo(
 
 	return {
 		patchVersion: versionMetadata.version,
+		packageVersion: versionMetadata.packageVersion,
+		packageId: versionMetadata.packageVersion
+			? `${ versionMetadata.version }-${ versionMetadata.packageVersion }`
+			: versionMetadata.version,
 		url: artifact.url,
 		sha: artifact.sha,
 	};

--- a/packages/common/lib/tests/php-binary-package-version.test.ts
+++ b/packages/common/lib/tests/php-binary-package-version.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	getConfiguredPhpBinaryPackageId,
+	getConfiguredPhpBinaryPackageVersion,
+	getConfiguredPhpBinaryVersion,
+	getPhpBinaryDownloadInfo,
+} from '../php-binary-metadata';
+
+vi.mock( '../php-binary-cdn-metadata.json', () => ( {
+	default: {
+		versions: {
+			'8.4': {
+				version: '8.4.22',
+				packageVersion: '1.0.0',
+				artifacts: {
+					'win32-x64': {
+						url: 'https://example.com/8.4.22-1.0.0/full-install',
+						sha: 'a'.repeat( 64 ),
+					},
+				},
+			},
+		},
+	},
+} ) );
+
+describe( 'PHP binary package versions', () => {
+	it( 'keeps the upstream PHP version separate from the package version', () => {
+		expect( getConfiguredPhpBinaryVersion( '8.4' ) ).toBe( '8.4.22' );
+		expect( getConfiguredPhpBinaryPackageVersion( '8.4' ) ).toBe( '1.0.0' );
+		expect( getConfiguredPhpBinaryPackageId( '8.4' ) ).toBe( '8.4.22-1.0.0' );
+		expect( getPhpBinaryDownloadInfo( '8.4', 'win32', 'x64' ) ).toEqual(
+			expect.objectContaining( {
+				patchVersion: '8.4.22',
+				packageVersion: '1.0.0',
+				packageId: '8.4.22-1.0.0',
+			} )
+		);
+	} );
+} );

--- a/packages/common/lib/tests/update-php-binary-cdn-metadata.test.ts
+++ b/packages/common/lib/tests/update-php-binary-cdn-metadata.test.ts
@@ -1,0 +1,114 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const scriptPath = path.resolve( 'scripts/update-php-binary-cdn-metadata.mjs' );
+const sha = 'a'.repeat( 64 );
+let tempDir: string;
+let metadataPath: string;
+let uploadResultsPath: string;
+
+function writeJson( filePath: string, value: unknown ): void {
+	fs.writeFileSync( filePath, `${ JSON.stringify( value, null, '\t' ) }\n` );
+}
+
+function runUpdater( packageVersion: string ): void {
+	execFileSync(
+		process.execPath,
+		[
+			scriptPath,
+			'--version',
+			'8.4.22',
+			'--package-version',
+			packageVersion,
+			'--upload-results',
+			uploadResultsPath,
+			'--metadata',
+			metadataPath,
+		],
+		{ stdio: 'pipe' }
+	);
+}
+
+describe( 'update PHP binary CDN metadata', () => {
+	beforeEach( () => {
+		tempDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-php-metadata-' ) );
+		metadataPath = path.join( tempDir, 'metadata.json' );
+		uploadResultsPath = path.join( tempDir, 'upload-results.json' );
+
+		writeJson( metadataPath, {
+			versions: {
+				'8.4': {
+					version: '8.4.22',
+					artifacts: {
+						'win32-x64': {
+							url: 'https://example.com/8.4.22/full-install',
+							sha: 'b'.repeat( 64 ),
+						},
+					},
+				},
+			},
+		} );
+		writeJson( uploadResultsPath, {
+			'php-8.4.22-cli-windows-x86_64.zip': {
+				cdn_url: 'https://example.com/8.4.22-1.0.0/full-install',
+				sha,
+			},
+		} );
+	} );
+
+	afterEach( () => {
+		fs.rmSync( tempDir, { recursive: true, force: true } );
+	} );
+
+	it( 'tracks an immutable package revision separately from the PHP version', () => {
+		runUpdater( '1.0.0' );
+
+		const metadata = JSON.parse( fs.readFileSync( metadataPath, 'utf8' ) );
+		expect( metadata.versions[ '8.4' ] ).toEqual( {
+			version: '8.4.22',
+			packageVersion: '1.0.0',
+			artifacts: {
+				'win32-x64': {
+					url: 'https://example.com/8.4.22-1.0.0/full-install',
+					sha,
+				},
+			},
+		} );
+	} );
+
+	it( 'stores the explicit package identifier even when it matches the PHP version', () => {
+		runUpdater( '8.4.22' );
+
+		const metadata = JSON.parse( fs.readFileSync( metadataPath, 'utf8' ) );
+		expect( metadata.versions[ '8.4' ].packageVersion ).toBe( '8.4.22' );
+	} );
+
+	it( 'allows an engineer to select a different immutable package identifier', () => {
+		runUpdater( 'vc-runtime-2' );
+		runUpdater( 'vc-runtime-1' );
+
+		const metadata = JSON.parse( fs.readFileSync( metadataPath, 'utf8' ) );
+		expect( metadata.versions[ '8.4' ].packageVersion ).toBe( 'vc-runtime-1' );
+	} );
+
+	it( 'records updated artifact metadata for an existing package identifier', () => {
+		runUpdater( '1.0.0' );
+		writeJson( uploadResultsPath, {
+			'php-8.4.22-cli-windows-x86_64.zip': {
+				cdn_url: 'https://example.com/8.4.22-1.0.0/replaced',
+				sha: 'c'.repeat( 64 ),
+			},
+		} );
+
+		runUpdater( '1.0.0' );
+
+		const metadata = JSON.parse( fs.readFileSync( metadataPath, 'utf8' ) );
+		expect( metadata.versions[ '8.4' ].artifacts[ 'win32-x64' ] ).toEqual( {
+			url: 'https://example.com/8.4.22-1.0.0/replaced',
+			sha: 'c'.repeat( 64 ),
+		} );
+	} );
+} );

--- a/scripts/download-php-binary.ts
+++ b/scripts/download-php-binary.ts
@@ -66,12 +66,12 @@ async function main(): Promise< void > {
 
 	try {
 		const downloadInfo = resolvePhpBinaryDownloadInfo();
-		const binDir = path.join( phpPackageRoot, downloadInfo.patchVersion );
+		const binDir = path.join( phpPackageRoot, downloadInfo.packageId );
 		const destPath = path.join( binDir, binaryName );
 
 		if ( fs.existsSync( destPath ) ) {
 			console.log(
-				`PHP ${ version } (${ downloadInfo.patchVersion }) package already exists at ${ binDir }. Delete it to re-download.`
+				`PHP ${ version } package ${ downloadInfo.packageId } already exists at ${ binDir }. Delete it to re-download.`
 			);
 			return;
 		}
@@ -92,7 +92,7 @@ async function main(): Promise< void > {
 
 		try {
 			console.log(
-				`Downloading PHP ${ version } (${ downloadInfo.patchVersion }) for ${ platformKey }…`
+				`Downloading PHP ${ downloadInfo.patchVersion } package ${ downloadInfo.packageId } for ${ platformKey }…`
 			);
 			console.log( `  URL: ${ downloadInfo.url }` );
 			await downloadFile( downloadInfo.url, downloadPath, ( downloaded, total ) => {
@@ -114,9 +114,7 @@ async function main(): Promise< void > {
 
 			console.log( 'Extracting PHP package…' );
 			const tmpDir = os.tmpdir();
-			const extractDir = fs.mkdtempSync(
-				path.join( tmpDir, `php-${ downloadInfo.patchVersion }-` )
-			);
+			const extractDir = fs.mkdtempSync( path.join( tmpDir, `php-${ downloadInfo.packageId }-` ) );
 			try {
 				await extractZip( downloadPath, extractDir );
 				const extractedBinaryName = getRuntimeBinaryName( extractDir ) ?? binaryName;
@@ -132,7 +130,9 @@ async function main(): Promise< void > {
 				fs.rmSync( extractDir, { recursive: true, force: true } );
 			}
 
-			console.log( `\nPHP ${ version } package installed: ${ binDir }` );
+			console.log(
+				`\nPHP ${ version } package ${ downloadInfo.packageId } installed: ${ binDir }`
+			);
 		} catch ( err ) {
 			fs.rmSync( binDir, { recursive: true, force: true } );
 			throw err;

--- a/scripts/update-php-binary-cdn-metadata.mjs
+++ b/scripts/update-php-binary-cdn-metadata.mjs
@@ -32,14 +32,16 @@ function parseArgs() {
 			throw new Error(
 				`Invalid arguments. Usage: ${ path.basename(
 					process.argv[ 1 ]
-				) } --version 8.4.20 --upload-results out/php-binaries/apps-cdn-upload-results.json`
+				) } --version 8.4.20 --package-version 1.0.0 --upload-results out/php-binaries/apps-cdn-upload-results.json`
 			);
 		}
 		options[ key.slice( 2 ) ] = value;
 	}
 
-	if ( ! options.version || ! options[ 'upload-results' ] ) {
-		throw new Error( 'Missing required --version or --upload-results argument.' );
+	if ( ! options.version || ! options[ 'package-version' ] || ! options[ 'upload-results' ] ) {
+		throw new Error(
+			'Missing required --version, --package-version, or --upload-results argument.'
+		);
 	}
 
 	return options;
@@ -137,12 +139,17 @@ function validateUploadResult( fileName, result ) {
 function main() {
 	const options = parseArgs();
 	const version = options.version;
+	const packageVersion = options[ 'package-version' ];
+	if ( ! /^[a-z0-9][a-z0-9._-]{0,63}$/.test( packageVersion ) ) {
+		throw new Error( `Invalid package version: ${ packageVersion }` );
+	}
 	const minorVersion = minorVersionFor( version );
 	const metadataPath = path.resolve( options.metadata || DEFAULT_METADATA_PATH );
 	const metadata = normalizeMetadata( JSON.parse( fs.readFileSync( metadataPath, 'utf8' ) ) );
 	const uploadResults = JSON.parse( fs.readFileSync( options[ 'upload-results' ], 'utf8' ) );
 	const uploadEntries = Object.entries( uploadResults );
 	const currentVersion = metadata.versions[ minorVersion ]?.version;
+	const currentPackageVersion = metadata.versions[ minorVersion ]?.packageVersion;
 
 	if ( uploadEntries.length === 0 ) {
 		throw new Error( 'Upload results do not include any PHP binary artifacts.' );
@@ -155,8 +162,8 @@ function main() {
 		return;
 	}
 
-	const isNewPatch = currentVersion !== version;
-	const currentArtifacts = isNewPatch ? {} : metadata.versions[ minorVersion ]?.artifacts || {};
+	const isNewPackage = currentVersion !== version || currentPackageVersion !== packageVersion;
+	const currentArtifacts = isNewPackage ? {} : metadata.versions[ minorVersion ]?.artifacts || {};
 	const artifacts = { ...currentArtifacts };
 
 	for ( const [ fileName, result ] of uploadEntries ) {
@@ -169,17 +176,18 @@ function main() {
 		};
 	}
 
-	metadata.versions[ minorVersion ] = {
-		version,
-		artifacts: orderedObject( artifacts, ARTIFACT_ORDER ),
-	};
+	const versionMetadata = { version, packageVersion };
+	versionMetadata.artifacts = orderedObject( artifacts, ARTIFACT_ORDER );
+	metadata.versions[ minorVersion ] = versionMetadata;
 	metadata.versions = orderedObject(
 		metadata.versions,
 		Object.keys( metadata.versions ).sort( ( a, b ) => comparePatchVersions( b, a ) )
 	);
 
 	fs.writeFileSync( metadataPath, `${ JSON.stringify( metadata, null, '\t' ) }\n` );
-	console.log( `Updated PHP ${ minorVersion } CDN metadata to ${ version }.` );
+	console.log(
+		`Updated PHP ${ minorVersion } CDN metadata to PHP ${ version }, package ${ packageVersion }.`
+	);
 }
 
 try {


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Related to STU-1972

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Codex drove the implementation based on previous diagnosis.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

Sentry shows that some users are running into `PHP command failed (code: 3221225781)` errors. This is because of missing DLLs on their system – very likely the Visual C++ Redistributable ones, as PHP explicitly [names that dependency](https://www.php.net/downloads.php?os=windows#instructions). This PR updates the native PHP build workflow to include the necessary DLLs next to `php.exe`. 

Because there aren't new PHP patch versions available yet for every minor PHP version we offer, I also had to find a way to rebuild PHP versions that already exist on appscdn. This cannot be done today without breaking local Studio installations, because they expect the appscdn package to have a predefined checksum. If the checksum of the appscdn package changes, the Studio client will refuse to install it.

The solution is to add a `packageVersion` field that identifies the package version separately from the PHP version. The workflow sets this to `studio-1` by default – meaning a typical workflow run (that builds a new PHP version) can just use the default. Moreover, I've set `error_on_duplicate` to always be true (same as in https://github.com/Automattic/studio/pull/4026, which I mistakenly merged to another branch than trunk)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I'll manually verify that these builds do what we want on Windows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
