### PR TITLE
Add e2e test for full-site export and re-import round trip

### DIFF
--- a/apps/studio/e2e/import-export.test.ts
+++ b/apps/studio/e2e/import-export.test.ts
@@ -1,8 +1,12 @@
 import path from 'path';
 import { test, expect } from '@playwright/test';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import fs from 'fs-extra';
 import { E2ESession } from './e2e-helpers';
+import MainSidebar from './page-objects/main-sidebar';
 import Onboarding from './page-objects/onboarding';
 import SiteContent from './page-objects/site-content';
+import { getUrlWithAutoLogin } from './utils';
 import type { MessageBoxOptions } from 'electron';
 
 const global = globalThis as unknown as {
@@ -102,5 +106,92 @@ test.describe( 'Import / Export', () => {
 		expect( errorDialog ).toBeDefined();
 		expect( errorDialog?.type ).toBe( 'error' );
 		expect( errorDialog?.title || errorDialog?.message ).toContain( 'Failed importing site' );
+	} );
+} );
+
+// Separate session so the dialog mocks and failed-import state of the tests
+// above cannot leak into the round trip.
+test.describe( 'Export / Import round trip', () => {
+	const session = new E2ESession();
+	const defaultSiteName = 'My WordPress Website';
+
+	test.beforeAll( async () => {
+		await session.launch();
+
+		const onboarding = new Onboarding( session.mainWindow );
+		await onboarding.completeOnboarding();
+		await onboarding.closeWhatsNew();
+
+		const siteContent = new SiteContent( session.mainWindow, defaultSiteName );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
+	} );
+
+	test.afterEach( async ( { page: _page }, testInfo ) => {
+		await session.reportMainProcessLogsOnFailure( testInfo );
+	} );
+
+	test.afterAll( async () => {
+		await session.cleanup();
+	} );
+
+	test( 'exports a site and imports the export as a new site', async ( { page } ) => {
+		const exportedSiteTitle = 'E2E Export Round Trip';
+		const importedSiteName = 'Imported-Export-Site';
+		const exportPath = path.join( session.homePath, 'studio-e2e-export.zip' );
+
+		// Give the site a distinctive title so we can prove the imported site
+		// carries the exported content rather than a fresh install.
+		const siteContent = new SiteContent( session.mainWindow, defaultSiteName );
+		const settingsTab = await siteContent.navigateToTab( 'settings' );
+		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
+		await page.goto( getUrlWithAutoLogin( wpAdminUrl + '/options-general.php' ) );
+		const siteTitleInput = page.getByLabel( 'Site Title' );
+		await siteTitleInput.fill( exportedSiteTitle );
+		await siteTitleInput.press( 'Enter' );
+		await expect( page.locator( '#setting-error-settings_updated' ) ).toBeVisible();
+
+		// Playwright can't drive the native save dialog, so mock it to return our
+		// export path (same pattern as the delete-site dialog mocks).
+		await session.electronApp.evaluate(
+			( { dialog }, { exportPath } ) => {
+				dialog.showSaveDialog = async () => ( { canceled: false, filePath: exportPath } );
+			},
+			{ exportPath }
+		);
+
+		const tab = await siteContent.navigateToTab( 'import-export' );
+		if ( ! ( 'exportFullSiteButton' in tab ) ) {
+			throw new Error( 'Expected ImportExportTab but got a different tab type' );
+		}
+		await tab.exportFullSiteButton.click();
+		await expect( session.mainWindow.getByText( 'Site export completed' ) ).toBeVisible( {
+			timeout: 120_000,
+		} );
+
+		expect( await pathExists( exportPath ) ).toBe( true );
+		expect( ( await fs.stat( exportPath ) ).size ).toBeGreaterThan( 0 );
+
+		// Import the export back as a new site.
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+		await expect( modal.importButton ).toBeVisible();
+		await modal.selectBackupFile( exportPath );
+		await modal.siteNameInput.fill( importedSiteName );
+		await modal.addSiteButton.click();
+
+		await expect( session.mainWindow.getByText( 'Importing completed' ) ).toBeVisible( {
+			timeout: 120_000,
+		} );
+
+		const importedSiteContent = new SiteContent( session.mainWindow, importedSiteName );
+		await expect( importedSiteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
+
+		// The imported site serves the exported content.
+		const importedSettingsTab = await importedSiteContent.navigateToTab( 'settings' );
+		const importedFrontendUrl = await importedSettingsTab.copySiteUrlToClipboard(
+			session.electronApp
+		);
+		await page.goto( importedFrontendUrl );
+		expect( await page.title() ).toBe( exportedSiteTitle );
 	} );
 } );


### PR DESCRIPTION
## Related issues

- Related to the manual pre-release test sheet (Import / Export section — "Exports existing site" and "Imports exported Studio site")

## How AI was used in this PR

Claude Code identified the Import/Export rows of the manual pre-release test sheet with no automated coverage, wrote the round-trip test, and ran it against a real packaged build to confirm it passes.

## Proposed Changes

Adds automated end-to-end coverage for the full-site export → re-import round trip, which was previously manual-only:

- The site gets a distinctive title, is exported as a full-site archive (the native save dialog is mocked, following the existing dialog-mock pattern), and the resulting archive is imported back as a new site through the add-site backup flow.
- The test asserts the imported site boots and its frontend serves the exported content — proving exports produced by Studio are importable by Studio, not just that both buttons work in isolation.

Test-only change, cross-platform, and self-contained: unlike the Jetpack import test it needs no externally supplied fixture, since the export step produces the archive.

## Testing Instructions

- `npm run cli:build`
- `npm run package -w apps/studio`
- `npx playwright test apps/studio/e2e/import-export.test.ts -g "round trip"`
- Passes locally against a packaged build (1 passed, ~52s).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (eslint + typecheck clean for the changed file)