### PR TITLE
⚠️ DO NOT MERGE — AINFRA-2588 diagnostic: run last-good commit on Windows CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,9 @@ env:
   IMAGE_ID: $IMAGE_ID
 
 e2e_config: &e2e_config
+  # AINFRA-2588 experiment: cap the E2E job so a hang fails fast instead of blocking the
+  # queue for the 3h default. A healthy run is ~21 min.
+  timeout_in_minutes: 45
   command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix.platform}}" "{{matrix.arch}}"
   artifact_paths:
     - test-results/**/*.zip


### PR DESCRIPTION
## ⚠️ Do not merge — diagnostic experiment only

This branch is the **last-known-good commit** (`b76bf7288`, Jun 29 11:35, immediately before #3961) plus a single CI-only change: the E2E job timeout is capped at 45 min so a hang fails fast instead of blocking the Windows queue for 3h.

**The diff looks like it reverts everything since June 29 — that is expected.** The whole point is to run *old* product code on *today's* CI. Nothing here is meant to land on trunk.

## Why

To separate a **code regression** from an **environment change** as the cause of the Windows E2E 3-hour hangs (AINFRA-2588). This commit was in the healthy ~21-min era.

## How to read the `E2E Tests on windows-x64` job

- **Passes (~21 min)** → environment is fine today; the hang is a code regression introduced *after* this commit.
- **Hangs / killed at 45 min** → the environment changed since June 29 (AMI / infra / external dep); old code that passed then fails now.

Ignore the linux E2E step (mid-development at this commit) and the aggregate "E2E Tests" GitHub status (last-write-wins across platforms) — read the windows-x64 job directly.

Only `.buildkite/pipeline.yml` differs from `b76bf7288` (the 45-min cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)