### PR TITLE
Better translator context for PHP runtime labels

### DIFF
--- a/apps/cli/commands/site/status.ts
+++ b/apps/cli/commands/site/status.ts
@@ -38,8 +38,11 @@ export async function runCommand( siteFolder: string, format: 'table' | 'json' )
 
 		const runtime = getSiteRuntime( site );
 		const fileAccess = getSiteFileAccess( site );
-		/* translators: value for the PHP runtime in the site status output */
-		const runtimeLabel = runtime === SITE_RUNTIME_NATIVE_PHP ? __( 'Native' ) : __( 'Sandbox' );
+		/* translators: As in an application that runs natively on a computer */
+		const nativeLabel = __( 'Native' );
+		/* translators: As in a secure, sandboxed environment */
+		const sandboxLabel = __( 'Sandbox' );
+		const runtimeLabel = runtime === SITE_RUNTIME_NATIVE_PHP ? nativeLabel : sandboxLabel;
 		const fileAccessLabel =
 			/* translators: value for the File access setting in the site status output */
 			fileAccess === SITE_FILE_ACCESS_ALL_FILES ? __( 'All files' ) : __( 'Site directory' );

--- a/apps/studio/src/components/content-tab-settings.tsx
+++ b/apps/studio/src/components/content-tab-settings.tsx
@@ -107,6 +107,12 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 		void checkDebugLogExists();
 	}, [ checkDebugLogExists ] );
 
+	/* translators: As in an application that runs natively on a computer */
+	const nativeLabel = __( 'Native' );
+	/* translators: As in a secure, sandboxed environment */
+	const sandboxLabel = __( 'Sandbox' );
+	const runtimeLabel = isNativePhpRuntime ? nativeLabel : sandboxLabel;
+
 	return (
 		<div className="p-8 ltr:pr-4 rtl:pl-4">
 			<div className="flex justify-between items-center mb-4">
@@ -205,8 +211,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 					</SettingsRow>
 					<SettingsRow label={ __( 'PHP runtime' ) }>
 						<div className="inline-flex items-center gap-2">
-							{ /* translators: value for the PHP runtime setting on the site settings screen */ }
-							<span>{ isNativePhpRuntime ? __( 'Native' ) : __( 'Sandbox' ) }</span>
+							<span>{ runtimeLabel }</span>
 							<Tooltip
 								text={ <RuntimeDescription runtime={ getSiteRuntime( selectedSite ) } /> }
 								placement="top-start"

--- a/apps/studio/src/modules/add-site/components/create-site-form.tsx
+++ b/apps/studio/src/modules/add-site/components/create-site-form.tsx
@@ -535,7 +535,9 @@ export const CreateSiteForm = ( {
 											id="php-runtime-select"
 											value={ selectedRuntime }
 											options={ [
+												/* translators: As in an application that runs natively on a computer */
 												{ label: __( 'Native' ), value: SITE_RUNTIME_NATIVE_PHP },
+												/* translators: As in a secure, sandboxed environment */
 												{ label: __( 'Sandbox' ), value: SITE_RUNTIME_PLAYGROUND },
 											] }
 											onChange={ ( value ) => setSelectedRuntime( value ) }

--- a/apps/studio/src/modules/site-settings/edit-site-details.tsx
+++ b/apps/studio/src/modules/site-settings/edit-site-details.tsx
@@ -471,7 +471,9 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 														disabled={ isEditingSite }
 														value={ selectedRuntime }
 														options={ [
+															/* translators: As in an application that runs natively on a computer */
 															{ label: __( 'Native' ), value: SITE_RUNTIME_NATIVE_PHP },
+															/* translators: As in a secure, sandboxed environment */
 															{ label: __( 'Sandbox' ), value: SITE_RUNTIME_PLAYGROUND },
 														] }
 														onChange={ ( value ) => setSelectedRuntime( value ) }


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- N/A

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

N/A

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

I noticed a poor translation of "Native" in Swedish. This PR adds `translators` comments everywhere where `Native` and `Sandbox` are used. I'll still need to fix the existing translation, but this'll be helpful regardless.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review is sufficient

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
