### PR TITLE
Fix failing @wordpress/ui postinstall patch

### DIFF
--- a/apps/studio/patches/@wordpress+ui+0.14.0.patch
+++ b/apps/studio/patches/@wordpress+ui+0.14.0.patch
@@ -1,106 +1,62 @@
-diff --git a/node_modules/@wordpress/ui/build-module/icon-button/icon-button.mjs b/node_modules/@wordpress/ui/build-module/icon-button/icon-button.mjs
-index 1623748..453b017 100644
---- a/node_modules/@wordpress/ui/build-module/icon-button/icon-button.mjs
-+++ b/node_modules/@wordpress/ui/build-module/icon-button/icon-button.mjs
-@@ -110,7 +110,7 @@ var IconButton = forwardRef(
-     ...restProps
-   }, ref) {
-     const classes = clsx(style_default["icon-button"], className);
--    return /* @__PURE__ */ jsx(Tooltip.Provider, { delay: 0, children: /* @__PURE__ */ jsxs(Tooltip.Root, { children: [
-+    return /* @__PURE__ */ jsxs(Tooltip.Root, { children: [
-       /* @__PURE__ */ jsx(
-         Tooltip.Trigger,
-         {
-@@ -145,7 +145,7 @@ var IconButton = forwardRef(
-           /* @__PURE__ */ jsx("span", { "aria-hidden": "true", children: shortcut.displayShortcut })
-         ] })
-       ] })
--    ] }) });
-+    ] });
-   }
- );
- export {
 diff --git a/node_modules/@wordpress/ui/build-module/tooltip/popup.mjs b/node_modules/@wordpress/ui/build-module/tooltip/popup.mjs
 index 8e6c432..c30308e 100644
 --- a/node_modules/@wordpress/ui/build-module/tooltip/popup.mjs
 +++ b/node_modules/@wordpress/ui/build-module/tooltip/popup.mjs
 @@ -94,7 +94,7 @@ function registerStyle(hash, css) {
- 
+
  // packages/ui/src/tooltip/style.module.css
  if (typeof process === "undefined" || process.env.NODE_ENV !== "test") {
 -  registerStyle("8293efbb49", '@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;@layer wp-ui-components{._480b748dd3510e64__positioner{z-index:var(--wp-ui-tooltip-z-index,initial)}._50096b232db7709d__popup{background-color:var(--wpds-color-bg-surface-neutral-strong,#fff);border-radius:var(--wpds-border-radius-sm,2px);box-shadow:var(--wpds-elevation-sm,0 1px 2px 0 #0000000d,0 2px 3px 0 #0000000a,0 6px 6px 0 #00000008,0 8px 8px 0 #00000005);color:var(--wpds-color-fg-content-neutral,#1e1e1e);font-family:var(--wpds-typography-font-family-body,-apple-system,system-ui,"Segoe UI","Roboto","Oxygen-Sans","Ubuntu","Cantarell","Helvetica Neue",sans-serif);font-size:var(--wpds-typography-font-size-sm,12px);line-height:1.4;padding:var(--wpds-dimension-padding-xs,4px) var(--wpds-dimension-padding-sm,8px);@media (forced-colors:active){border-bottom-color:CanvasText;border-bottom-style:solid;border-bottom-width:1px;border-left-color:CanvasText;border-left-style:solid;border-left-width:1px;border-right-color:CanvasText;border-right-style:solid;border-right-width:1px;border-top-color:CanvasText;border-top-style:solid;border-top-width:1px}}}');
 +  registerStyle("8293efbb49", '@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;@layer wp-ui-components{._480b748dd3510e64__positioner{z-index:var(--wp-ui-tooltip-z-index,initial)}._50096b232db7709d__popup{background-color:var(--wp-ui-tooltip-background-color,var(--wpds-color-bg-surface-neutral-strong,#fff));border-radius:var(--wpds-border-radius-sm,2px);box-shadow:var(--wpds-elevation-sm,0 1px 2px 0 #0000000d,0 2px 3px 0 #0000000a,0 6px 6px 0 #00000008,0 8px 8px 0 #00000005);color:var(--wp-ui-tooltip-color,var(--wpds-color-fg-content-neutral,#1e1e1e));font-family:var(--wpds-typography-font-family-body,-apple-system,system-ui,"Segoe UI","Roboto","Oxygen-Sans","Ubuntu","Cantarell","Helvetica Neue",sans-serif);font-size:var(--wpds-typography-font-size-sm,12px);line-height:1.4;padding:var(--wpds-dimension-padding-xs,4px) var(--wpds-dimension-padding-sm,8px);@media (forced-colors:active){border-bottom-color:CanvasText;border-bottom-style:solid;border-bottom-width:1px;border-left-color:CanvasText;border-left-style:solid;border-left-width:1px;border-right-color:CanvasText;border-right-style:solid;border-right-width:1px;border-top-color:CanvasText;border-top-style:solid;border-top-width:1px}}}');
  }
  var style_default = { "positioner": "_480b748dd3510e64__positioner", "popup": "_50096b232db7709d__popup" };
- 
+
 diff --git a/node_modules/@wordpress/ui/build-module/tooltip/positioner.mjs b/node_modules/@wordpress/ui/build-module/tooltip/positioner.mjs
 index 6d87c68..c4eddf9 100644
 --- a/node_modules/@wordpress/ui/build-module/tooltip/positioner.mjs
 +++ b/node_modules/@wordpress/ui/build-module/tooltip/positioner.mjs
 @@ -93,7 +93,7 @@ var resets_default = { "box-sizing": "_336cd3e4e743482f__box-sizing" };
- 
+
  // packages/ui/src/tooltip/style.module.css
  if (typeof process === "undefined" || process.env.NODE_ENV !== "test") {
 -  registerStyle("8293efbb49", '@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;@layer wp-ui-components{._480b748dd3510e64__positioner{z-index:var(--wp-ui-tooltip-z-index,initial)}._50096b232db7709d__popup{background-color:var(--wpds-color-bg-surface-neutral-strong,#fff);border-radius:var(--wpds-border-radius-sm,2px);box-shadow:var(--wpds-elevation-sm,0 1px 2px 0 #0000000d,0 2px 3px 0 #0000000a,0 6px 6px 0 #00000008,0 8px 8px 0 #00000005);color:var(--wpds-color-fg-content-neutral,#1e1e1e);font-family:var(--wpds-typography-font-family-body,-apple-system,system-ui,"Segoe UI","Roboto","Oxygen-Sans","Ubuntu","Cantarell","Helvetica Neue",sans-serif);font-size:var(--wpds-typography-font-size-sm,12px);line-height:1.4;padding:var(--wpds-dimension-padding-xs,4px) var(--wpds-dimension-padding-sm,8px);@media (forced-colors:active){border-bottom-color:CanvasText;border-bottom-style:solid;border-bottom-width:1px;border-left-color:CanvasText;border-left-style:solid;border-left-width:1px;border-right-color:CanvasText;border-right-style:solid;border-right-width:1px;border-top-color:CanvasText;border-top-style:solid;border-top-width:1px}}}');
 +  registerStyle("8293efbb49", '@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;@layer wp-ui-components{._480b748dd3510e64__positioner{z-index:var(--wp-ui-tooltip-z-index,initial)}._50096b232db7709d__popup{background-color:var(--wp-ui-tooltip-background-color,var(--wpds-color-bg-surface-neutral-strong,#fff));border-radius:var(--wpds-border-radius-sm,2px);box-shadow:var(--wpds-elevation-sm,0 1px 2px 0 #0000000d,0 2px 3px 0 #0000000a,0 6px 6px 0 #00000008,0 8px 8px 0 #00000005);color:var(--wp-ui-tooltip-color,var(--wpds-color-fg-content-neutral,#1e1e1e));font-family:var(--wpds-typography-font-family-body,-apple-system,system-ui,"Segoe UI","Roboto","Oxygen-Sans","Ubuntu","Cantarell","Helvetica Neue",sans-serif);font-size:var(--wpds-typography-font-size-sm,12px);line-height:1.4;padding:var(--wpds-dimension-padding-xs,4px) var(--wpds-dimension-padding-sm,8px);@media (forced-colors:active){border-bottom-color:CanvasText;border-bottom-style:solid;border-bottom-width:1px;border-left-color:CanvasText;border-left-style:solid;border-left-width:1px;border-right-color:CanvasText;border-right-style:solid;border-right-width:1px;border-top-color:CanvasText;border-top-style:solid;border-top-width:1px}}}');
  }
  var style_default = { "positioner": "_480b748dd3510e64__positioner", "popup": "_50096b232db7709d__popup" };
- 
-diff --git a/node_modules/@wordpress/ui/build/icon-button/icon-button.cjs b/node_modules/@wordpress/ui/build/icon-button/icon-button.cjs
-index 3f2a8a4..367733c 100644
---- a/node_modules/@wordpress/ui/build/icon-button/icon-button.cjs
-+++ b/node_modules/@wordpress/ui/build/icon-button/icon-button.cjs
-@@ -144,7 +144,7 @@ var IconButton = (0, import_element.forwardRef)(
-     ...restProps
-   }, ref) {
-     const classes = (0, import_clsx.default)(style_default["icon-button"], className);
--    return /* @__PURE__ */ (0, import_jsx_runtime.jsx)(Tooltip.Provider, { delay: 0, children: /* @__PURE__ */ (0, import_jsx_runtime.jsxs)(Tooltip.Root, { children: [
-+    return /* @__PURE__ */ (0, import_jsx_runtime.jsxs)(Tooltip.Root, { children: [
-       /* @__PURE__ */ (0, import_jsx_runtime.jsx)(
-         Tooltip.Trigger,
-         {
-@@ -179,7 +179,7 @@ var IconButton = (0, import_element.forwardRef)(
-           /* @__PURE__ */ (0, import_jsx_runtime.jsx)("span", { "aria-hidden": "true", children: shortcut.displayShortcut })
-         ] })
-       ] })
--    ] }) });
-+    ] });
-   }
- );
- // Annotate the CommonJS export names for ESM import in node:
+
 diff --git a/node_modules/@wordpress/ui/build/tooltip/popup.cjs b/node_modules/@wordpress/ui/build/tooltip/popup.cjs
 index 4f0758b..8349970 100644
 --- a/node_modules/@wordpress/ui/build/tooltip/popup.cjs
 +++ b/node_modules/@wordpress/ui/build/tooltip/popup.cjs
 @@ -126,7 +126,7 @@ function registerStyle(hash, css) {
- 
+
  // packages/ui/src/tooltip/style.module.css
  if (typeof process === "undefined" || process.env.NODE_ENV !== "test") {
 -  registerStyle("8293efbb49", '@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;@layer wp-ui-components{._480b748dd3510e64__positioner{z-index:var(--wp-ui-tooltip-z-index,initial)}._50096b232db7709d__popup{background-color:var(--wpds-color-bg-surface-neutral-strong,#fff);border-radius:var(--wpds-border-radius-sm,2px);box-shadow:var(--wpds-elevation-sm,0 1px 2px 0 #0000000d,0 2px 3px 0 #0000000a,0 6px 6px 0 #00000008,0 8px 8px 0 #00000005);color:var(--wpds-color-fg-content-neutral,#1e1e1e);font-family:var(--wpds-typography-font-family-body,-apple-system,system-ui,"Segoe UI","Roboto","Oxygen-Sans","Ubuntu","Cantarell","Helvetica Neue",sans-serif);font-size:var(--wpds-typography-font-size-sm,12px);line-height:1.4;padding:var(--wpds-dimension-padding-xs,4px) var(--wpds-dimension-padding-sm,8px);@media (forced-colors:active){border-bottom-color:CanvasText;border-bottom-style:solid;border-bottom-width:1px;border-left-color:CanvasText;border-left-style:solid;border-left-width:1px;border-right-color:CanvasText;border-right-style:solid;border-right-width:1px;border-top-color:CanvasText;border-top-style:solid;border-top-width:1px}}}');
 +  registerStyle("8293efbb49", '@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;@layer wp-ui-components{._480b748dd3510e64__positioner{z-index:var(--wp-ui-tooltip-z-index,initial)}._50096b232db7709d__popup{background-color:var(--wp-ui-tooltip-background-color,var(--wpds-color-bg-surface-neutral-strong,#fff));border-radius:var(--wpds-border-radius-sm,2px);box-shadow:var(--wpds-elevation-sm,0 1px 2px 0 #0000000d,0 2px 3px 0 #0000000a,0 6px 6px 0 #00000008,0 8px 8px 0 #00000005);color:var(--wp-ui-tooltip-color,var(--wpds-color-fg-content-neutral,#1e1e1e));font-family:var(--wpds-typography-font-family-body,-apple-system,system-ui,"Segoe UI","Roboto","Oxygen-Sans","Ubuntu","Cantarell","Helvetica Neue",sans-serif);font-size:var(--wpds-typography-font-size-sm,12px);line-height:1.4;padding:var(--wpds-dimension-padding-xs,4px) var(--wpds-dimension-padding-sm,8px);@media (forced-colors:active){border-bottom-color:CanvasText;border-bottom-style:solid;border-bottom-width:1px;border-left-color:CanvasText;border-left-style:solid;border-left-width:1px;border-right-color:CanvasText;border-right-style:solid;border-right-width:1px;border-top-color:CanvasText;border-top-style:solid;border-top-width:1px}}}');
  }
  var style_default = { "positioner": "_480b748dd3510e64__positioner", "popup": "_50096b232db7709d__popup" };
- 
+
 diff --git a/node_modules/@wordpress/ui/build/tooltip/positioner.cjs b/node_modules/@wordpress/ui/build/tooltip/positioner.cjs
 index 0e9965c..ffd416d 100644
 --- a/node_modules/@wordpress/ui/build/tooltip/positioner.cjs
 +++ b/node_modules/@wordpress/ui/build/tooltip/positioner.cjs
 @@ -127,7 +127,7 @@ var resets_default = { "box-sizing": "_336cd3e4e743482f__box-sizing" };
- 
+
  // packages/ui/src/tooltip/style.module.css
  if (typeof process === "undefined" || process.env.NODE_ENV !== "test") {
 -  registerStyle("8293efbb49", '@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;@layer wp-ui-components{._480b748dd3510e64__positioner{z-index:var(--wp-ui-tooltip-z-index,initial)}._50096b232db7709d__popup{background-color:var(--wpds-color-bg-surface-neutral-strong,#fff);border-radius:var(--wpds-border-radius-sm,2px);box-shadow:var(--wpds-elevation-sm,0 1px 2px 0 #0000000d,0 2px 3px 0 #0000000a,0 6px 6px 0 #00000008,0 8px 8px 0 #00000005);color:var(--wpds-color-fg-content-neutral,#1e1e1e);font-family:var(--wpds-typography-font-family-body,-apple-system,system-ui,"Segoe UI","Roboto","Oxygen-Sans","Ubuntu","Cantarell","Helvetica Neue",sans-serif);font-size:var(--wpds-typography-font-size-sm,12px);line-height:1.4;padding:var(--wpds-dimension-padding-xs,4px) var(--wpds-dimension-padding-sm,8px);@media (forced-colors:active){border-bottom-color:CanvasText;border-bottom-style:solid;border-bottom-width:1px;border-left-color:CanvasText;border-left-style:solid;border-left-width:1px;border-right-color:CanvasText;border-right-style:solid;border-right-width:1px;border-top-color:CanvasText;border-top-style:solid;border-top-width:1px}}}');
 +  registerStyle("8293efbb49", '@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;@layer wp-ui-components{._480b748dd3510e64__positioner{z-index:var(--wp-ui-tooltip-z-index,initial)}._50096b232db7709d__popup{background-color:var(--wp-ui-tooltip-background-color,var(--wpds-color-bg-surface-neutral-strong,#fff));border-radius:var(--wpds-border-radius-sm,2px);box-shadow:var(--wpds-elevation-sm,0 1px 2px 0 #0000000d,0 2px 3px 0 #0000000a,0 6px 6px 0 #00000008,0 8px 8px 0 #00000005);color:var(--wp-ui-tooltip-color,var(--wpds-color-fg-content-neutral,#1e1e1e));font-family:var(--wpds-typography-font-family-body,-apple-system,system-ui,"Segoe UI","Roboto","Oxygen-Sans","Ubuntu","Cantarell","Helvetica Neue",sans-serif);font-size:var(--wpds-typography-font-size-sm,12px);line-height:1.4;padding:var(--wpds-dimension-padding-xs,4px) var(--wpds-dimension-padding-sm,8px);@media (forced-colors:active){border-bottom-color:CanvasText;border-bottom-style:solid;border-bottom-width:1px;border-left-color:CanvasText;border-left-style:solid;border-left-width:1px;border-right-color:CanvasText;border-right-style:solid;border-right-width:1px;border-top-color:CanvasText;border-top-style:solid;border-top-width:1px}}}');
  }
  var style_default = { "positioner": "_480b748dd3510e64__positioner", "popup": "_50096b232db7709d__popup" };
- 
+
 diff --git a/node_modules/@wordpress/ui/src/tooltip/style.module.css b/node_modules/@wordpress/ui/src/tooltip/style.module.css
 index 8c3927e..d9918b2 100644
 --- a/node_modules/@wordpress/ui/src/tooltip/style.module.css
 +++ b/node_modules/@wordpress/ui/src/tooltip/style.module.css
 @@ -6,7 +6,10 @@
  	}
- 
+
  	.popup {
 -		background-color: var(--wpds-color-bg-surface-neutral-strong);
 +		background-color: var(
@@ -120,5 +76,5 @@ index 8c3927e..d9918b2 100644
 +			var(--wpds-color-fg-content-neutral)
 +		);
  		box-shadow: var(--wpds-elevation-sm);
- 
+
  		/*


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code diagnosed the failing patch (using `git apply --check --verbose` to isolate the failing hunks), confirmed the target files' current state, regenerated the corrected patch, and verified it re-applies cleanly. The author reviewed the diff.

## Proposed Changes

`npm install`'s `postinstall` step was failing because the `@wordpress/ui@0.14.0` patch no longer applied. Upstream republished the same `0.14.0` version with its icon-button build output already changed — so the two icon-button hunks (which removed a `Tooltip.Provider` wrapper) had nothing left to match, and patch-package aborted the entire patch.

This drops those two now-obsolete icon-button hunks. The package itself now ships the end-state they were producing, so no behavior is lost. The remaining hunks — the actual Studio customization that adds `--wp-ui-tooltip-background-color` / `--wp-ui-tooltip-color` CSS-variable overrides to the tooltip — are unchanged and continue to apply.

Impact: contributors can install dependencies again without the postinstall failure; no runtime behavior change.

## Testing Instructions

1. Check out this branch and run a fresh install (or `npx patch-package --patch-dir apps/studio/patches` from the repo root).
2. Confirm it reports `@wordpress/ui@0.14.0 ✔` and finishes with no errors.
3. Optionally, `git apply --check --verbose apps/studio/patches/@wordpress+ui+0.14.0.patch` — all five hunks should pass.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?