### PR TITLE
Fix /me/sites filtering and environment labels, keeping Pressable sites

### DIFF
--- a/apps/cli/lib/api.ts
+++ b/apps/cli/lib/api.ts
@@ -216,7 +216,7 @@ export async function getWpComSites( token: string ): Promise< WpComSiteInfo[] >
 			},
 			{
 				fields: 'ID,name,URL,is_deleted,is_a8c',
-				filter: 'atomic,wpcom',
+				filters: 'jetpack,atomic,wpcom',
 				site_activity: 'active',
 			}
 		);

--- a/apps/studio/src/modules/sync/index.tsx
+++ b/apps/studio/src/modules/sync/index.tsx
@@ -155,8 +155,8 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 	// Derived inline from Redux + connectedSites (storage) rather than stored in local state.
 	// Local state would reset on remount — SiteContentTabs causes a second TabPanel remount
 	// on programmatic tab changes, which would lose the value before the dialog could open.
-	// connectedSites is used instead of syncSites because the /me/sites?filter=atomic,wpcom
-	// endpoint excludes some site types (e.g. Pressable) that can still be connected.
+	// connectedSites is used instead of syncSites because syncSites is paginated
+	// and a deep-linked connected site may not be on the fetched page.
 	const deepLinkRemoteSite =
 		selectedRemoteSiteId && selectedLocalSiteId === selectedSite.id
 			? connectedSites.find( ( site ) => site.id === selectedRemoteSiteId ) ?? null

--- a/apps/studio/src/stores/sync/wpcom-sites.ts
+++ b/apps/studio/src/stores/sync/wpcom-sites.ts
@@ -58,9 +58,7 @@ export const wpcomSitesApi = createApi( {
 					const allConnectedSites = await getIpcApi().getConnectedWpcomSites();
 
 					// Determine if staging by checking environment_type (can't access parent site's staging IDs without fetching /me/sites)
-					const isStaging =
-						parsedSite.environment_type === 'staging' ||
-						parsedSite.environment_type === 'development';
+					const isStaging = parsedSite.environment_type === 'staging';
 
 					const syncSupport = getSyncSupport(
 						parsedSite,
@@ -107,7 +105,7 @@ export const wpcomSitesApi = createApi( {
 
 					const queryParams: Record< string, string | number | boolean > = {
 						fields: SITE_FIELDS,
-						filter: 'atomic,wpcom',
+						filters: 'jetpack,atomic,wpcom',
 						options: 'created_at,wpcom_staging_blog_ids,software_version',
 						site_activity: 'active',
 						include_a8c_owned: false,
@@ -166,9 +164,7 @@ export const wpcomSitesApi = createApi( {
 									);
 									const parsed = sitesEndpointSiteSchema.parse( singleResponse );
 									const syncSupport = getSyncSupport( parsed, connectedIds );
-									const isStaging =
-										parsed.environment_type === 'staging' ||
-										parsed.environment_type === 'development';
+									const isStaging = parsed.environment_type === 'staging';
 									supplementalSites.push(
 										transformSingleSiteResponse( parsed, syncSupport, isStaging )
 									);

--- a/packages/common/lib/sync/sync-api.ts
+++ b/packages/common/lib/sync/sync-api.ts
@@ -40,7 +40,7 @@ export async function fetchSyncableSites( token: string ): Promise< SyncSite[] >
 		},
 		{
 			fields: SITE_FIELDS,
-			filter: 'atomic,wpcom',
+			filters: 'jetpack,atomic,wpcom',
 			options: 'created_at,wpcom_staging_blog_ids',
 			site_activity: 'active',
 		}

--- a/packages/common/lib/sync/sync-api.ts
+++ b/packages/common/lib/sync/sync-api.ts
@@ -30,24 +30,118 @@ const SITE_FIELDS = [
 	'environment_type',
 ].join( ',' );
 
-export async function fetchSyncableSites( token: string ): Promise< SyncSite[] > {
+interface FetchSyncableSitesOptions {
+	connectedSiteIds?: number[];
+	search?: string;
+	page?: number;
+	perPage?: number;
+	// Called for each site dropped because it failed schema validation —
+	// without it drops are silent and the returned list quietly shrinks.
+	onParseError?: ( error: unknown ) => void;
+}
+
+export interface SyncableSitesPage {
+	sites: SyncSite[];
+	total: number;
+	page: number;
+	perPage: number;
+	hasMore: boolean;
+	nextPage: number | null;
+}
+
+async function fetchRawSitesPage(
+	token: string,
+	options: { page: number; perPage: number; search?: string }
+) {
 	const wpcom = wpcomFactory( token, wpcomXhrRequest );
+	const queryParams: Record< string, string | number | boolean > = {
+		fields: SITE_FIELDS,
+		filters: 'jetpack,atomic,wpcom',
+		options: 'created_at,wpcom_staging_blog_ids,software_version',
+		site_activity: 'active',
+		include_a8c_owned: false,
+		page: options.page,
+		per_page: options.perPage,
+	};
+
+	const search = options.search?.trim();
+	if ( search ) {
+		queryParams.search = search;
+	}
 
 	const rawResponse = await wpcom.req.get(
 		{
-			apiNamespace: 'rest/v1.2',
+			apiNamespace: 'rest/v1.3',
 			path: '/me/sites',
 		},
-		{
-			fields: SITE_FIELDS,
-			filters: 'jetpack,atomic,wpcom',
-			options: 'created_at,wpcom_staging_blog_ids',
-			site_activity: 'active',
-		}
+		queryParams
 	);
 
-	const parsed = sitesEndpointResponseSchema.parse( rawResponse );
-	return transformSitesResponse( parsed.sites );
+	return sitesEndpointResponseSchema.parse( rawResponse );
+}
+
+export async function fetchSyncableSites(
+	token: string,
+	options?: Pick< FetchSyncableSitesOptions, 'connectedSiteIds' | 'search' | 'onParseError' >
+): Promise< SyncSite[] > {
+	// Mirrors the desktop renderer's site-picker query (wpcomSitesApi), but
+	// drains every page so callers get the full account in one call — the
+	// unpaginated v1.2 endpoint silently returned only a subset of sites.
+	const PER_PAGE = 100;
+	const MAX_PAGES = 20;
+	const allSites: unknown[] = [];
+
+	for ( let page = 1; page <= MAX_PAGES; page++ ) {
+		const parsed = await fetchRawSitesPage( token, {
+			page,
+			perPage: PER_PAGE,
+			search: options?.search,
+		} );
+		allSites.push( ...parsed.sites );
+		// The endpoint may clamp the requested page size, so judge "last page"
+		// by the server-reported per_page when it's present.
+		if ( parsed.sites.length < ( parsed.per_page ?? PER_PAGE ) ) {
+			break;
+		}
+	}
+
+	return transformSitesResponse( allSites, {
+		connectedSiteIds: options?.connectedSiteIds,
+		onParseError: options?.onParseError,
+	} );
+}
+
+export async function fetchSyncableSitesPage(
+	token: string,
+	options: FetchSyncableSitesOptions = {}
+): Promise< SyncableSitesPage > {
+	const page = options.page ?? 1;
+	const perPage = options.perPage ?? 100;
+	const parsed = await fetchRawSitesPage( token, {
+		page,
+		perPage,
+		search: options.search,
+	} );
+	const responsePage = parsed.page ?? page;
+	const responsePerPage = parsed.per_page ?? perPage;
+	const sites = transformSitesResponse( parsed.sites, {
+		connectedSiteIds: options.connectedSiteIds,
+		onParseError: options.onParseError,
+	} );
+	const total = parsed.total ?? ( responsePage - 1 ) * responsePerPage + sites.length;
+	const hasMore =
+		parsed.total !== undefined
+			? responsePage * responsePerPage < parsed.total
+			: parsed.sites.length >= responsePerPage;
+
+	return {
+		sites,
+		total,
+		page: responsePage,
+		perPage: responsePerPage,
+		hasMore,
+		nextPage: hasMore ? responsePage + 1 : null,
+	};
 }
 
 export async function initiateBackup(

--- a/packages/common/lib/sync/transform-sites.ts
+++ b/packages/common/lib/sync/transform-sites.ts
@@ -63,7 +63,8 @@ export function transformSitesResponse(
 				( connectedSiteIds.length > 0 && connectedSiteIds.some( ( id ) => id === site.ID ) )
 		)
 		.map( ( site ) => {
-			const isStaging = allStagingSiteIds.includes( site.ID );
+			const isStaging =
+				site.environment_type === 'staging' || allStagingSiteIds.includes( site.ID );
 			const syncSupport = getSyncSupport( site, connectedSiteIds );
 
 			return transformSingleSiteResponse( site, syncSupport, isStaging );


### PR DESCRIPTION
## Related issues

- Related to #3941 — extracted from it per [review feedback](https://github.com/Automattic/studio/pull/3941#pullrequestreview-4603592245) so the filtering/label changes land with focused testing. Re-applies 756ed7cee and 12c975ad5 by @shaunandrews with a corrected `filters` value.

## How AI was used in this PR

AI (Claude) extracted the change from #3941, traced the Pressable regression, and validated the corrected `filters` value against Calypso/Jetpack Cloud source; lint, typecheck, and sync tests were run locally. Manually reviewed.

## Proposed Changes

- Our `/me/sites` requests have always sent `filter=` (singular), which the API silently ignores — no server-side filtering ever happened, and non-syncable site types were only weeded out client-side.
- This switches to the real `filters=jetpack,atomic,wpcom` param — the same set Jetpack Cloud sends in production. Including `jetpack` is what keeps Pressable (Jetpack-connected) sites in every picker; the earlier `filters=atomic,wpcom` attempt in #3941 dropped them, which is the regression that got it pulled out of that PR.
- Pressable development environments are no longer treated as staging — they now show their own "Development" label instead of "Staging" in the default UI pickers.
- Sites with `environment_type=staging` are now labeled Staging even when their parent production site isn't in the fetched list (previously they showed as Production).

## Testing Instructions

- Sign in with an account that has a Pressable site plus wpcom simple/Atomic sites.
- Default UI → site → Sync: verify the Pressable site still appears and is connectable (this is the key regression check vs the `atomic,wpcom` value).
- Verify a Pressable development environment shows a "Development" badge (not "Staging"), and staging sites show "Staging".
- CLI: `studio pull` / `studio push` against the Pressable site still resolve it.
- Regression: A8C-owned and deleted sites remain excluded from pickers.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Manually verified with a Pressable-connected account (see Testing Instructions).

