### PR TITLE
Fix Windows E2E test failures: bind native PHP site proxy to 127.0.0.1

### DIFF
--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -194,7 +194,7 @@ async function waitForServerReady( url: string, signal?: AbortSignal ): Promise<
 async function setAdminCredentials( config: ServerConfig, signal: AbortSignal ): Promise< void > {
 	try {
 		await requestSetAdminCredentials( config, async ( request ) => {
-			const response = await fetch( `http://localhost:${ config.port }${ request.url }`, {
+			const response = await fetch( `http://127.0.0.1:${ config.port }${ request.url }`, {
 				method: request.method,
 				body: toUrlSearchParams( request.body ),
 				signal,
@@ -435,7 +435,11 @@ async function startPhpProxyServer(
 			proxyServer.close();
 			reject( new DOMException( 'Aborted', 'AbortError' ) );
 		} );
-		proxyServer.listen( config.port, 'localhost', () => {
+		// Bind the IPv4 loopback explicitly rather than 'localhost'. On Windows Node resolves
+		// 'localhost' to ::1 and binds IPv6-only, so any client reaching 127.0.0.1 — and CI agents
+		// whose ::1 loopback is disabled — get ECONNREFUSED. 127.0.0.1 is always available and
+		// clients loading http://localhost fall back to it. The PHP workers already use 127.0.0.1.
+		proxyServer.listen( config.port, '127.0.0.1', () => {
 			resolve();
 		} );
 	} );
@@ -627,7 +631,7 @@ async function doStartServer(
 		phpWorkerProcesses = spawnedChildren;
 
 		stopSignal?.throwIfAborted();
-		await waitForServerReady( `http://localhost:${ config.port }/`, stopSignal );
+		await waitForServerReady( `http://127.0.0.1:${ config.port }/`, stopSignal );
 
 		// Watch for symlinks created after startup. open_basedir cannot be extended
 		// at runtime, so the watcher triggers a debounced restart with an updated


### PR DESCRIPTION
## Related issues

- Related to AINFRA-2588 (Investigate Studio Windows E2E hangs in Buildkite)
- Stacked on #4041 (daemon-leak hang fix) so the Windows E2E run isn't masked by the 3-hour hang. Retarget to trunk once #4041 merges.

## How AI was used in this PR

AI analyzed the Buildkite logs from the first post-hang-fix Windows runs (builds #18670/#18671), correlated the 24 identical `ERR_CONNECTION_REFUSED` test failures with the proxy's `listen( port, 'localhost' )` call, and proposed the reproduction script that confirmed the IPv6-only bind on a Windows VM. The fix and commit were reviewed and tested by a human on that VM.

## Proposed Changes

After #4041 stopped the 3-hour hang, Windows E2E runs finished but still failed 24 tests, all the same way: `page.goto( http://localhost:<port> )` gets `ERR_CONNECTION_REFUSED`, so every "open a site" assertion sees a blank page.

The cause is in the native PHP runtime's HTTP proxy (`apps/cli/php-server-child.ts`): it listens with hostname `'localhost'`, which Node resolves to `::1` on Windows and binds **IPv6-only**. Reproduced on a Windows VM: a server bound this way accepts connections on `::1` but refuses `127.0.0.1`. On the CI Windows agents, Chromium resolves `localhost` to `127.0.0.1`, so every navigation to a running site is refused — deterministically, which is why all 24 failures also failed their retry. (Linux E2E dodged the same class of problem with a `--host-resolver-rules=MAP localhost 127.0.0.1` browser flag; Windows has no such flag.)

The fix binds the proxy explicitly to `127.0.0.1`, which is always reachable — clients resolving `localhost` to `::1` fall back to IPv4. The internal admin-credentials and readiness requests now also target `127.0.0.1` so they check the address the proxy actually listens on, instead of passing via `::1` while browsers get refused.

## Testing Instructions

- **CI:** The `E2E Tests on windows-x64` job (enabled on the base branch) should no longer show `net::ERR_CONNECTION_REFUSED` failures; the ~24 "open a site" tests should pass and the run should complete in roughly the pre-regression time (~25-30 min) without retry inflation.
- **Local (Windows):** `npm run e2e -- site-creation` — previously failed at the site-page assertion, passes with this change.
- **Regression check (macOS/Linux):** sites still start and load normally; `127.0.0.1` is valid loopback on all supported platforms.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?