### PR TITLE
Trim release Slack message to installer download links only

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -166,7 +166,13 @@ lane :distribute_release_build do |version: read_package_json_version|
     success: true,
     slack_url: get_required_env('SLACK_WEBHOOK'),
     payload: {
-      ':studio-app-icon-mac: Release available for': builds.each_value.map { |b| "[#{b[:name]}](#{b[:cdn_url]})" }.join(', ')
+      # Link only the installers users download: "Full Install" builds plus the Linux .debs
+      # (tagged "Update" but the sole Linux installer). Skip the Mac/Windows "Update" payloads,
+      # and the unsigned Appx builds (grabbed from Buildkite for the Microsoft Store publish).
+      ':studio-app-icon-mac: Release available for': builds.each_value
+        .reject { |b| b[:install_type] == 'Update' && !b[:platform].to_s.start_with?('Linux') }
+        .reject { |b| b[:platform].to_s.start_with?('Microsoft Store') }
+        .map { |b| "[#{b[:name]}](#{b[:cdn_url]})" }.join(', ')
     },
     default_payloads: []
   )


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code located the Slack notification logic in the release Fastfile, implemented the filter, and validated it against a simulated `builds` hash. All output was reviewed by the author.

## Proposed Changes

The release announcement in `#studio` currently lists every artifact uploaded to the CDN — around 17 links — including auto-update payloads and unsigned Appx builds that nobody downloads by hand. The message overflows and buries the links people actually click.

This trims the Slack message to only the installers a human downloads:

- **Dropped:** the Mac `.zip` and Windows `.nupkg` "Update" payloads (auto-updater only), and the unsigned Appx builds (fetched from Buildkite during the Microsoft Store publish, never from Slack).
- **Kept:** the Mac DMGs, Windows installers, all Studio CLI bundles, and the Linux `.deb`s — the `.deb` is tagged `install_type: "Update"` only because it doubles as both the update payload and the sole Linux installer, so it's explicitly retained.

The filter applies only to the Slack payload. The full build list still flows unchanged into the Buildkite CDN annotation.

## Testing Instructions

- Review the filter logic at the Slack `payload` in `fastlane/distribute_release_build`.
- `ruby -c fastlane/Fastfile` passes.
- Simulating the release `builds` hash, the kept links are: Mac Intel/Silicon (DMG), Windows x64/ARM64, all CLI bundles, and both Linux `.deb`s; dropped are the two Mac Update, two Windows Update, and two Unsigned Appx entries.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?