### PR TITLE
Fix flaky site duplication by tolerating transient files deleted mid-copy

### DIFF
--- a/apps/studio/e2e/sites.test.ts
+++ b/apps/studio/e2e/sites.test.ts
@@ -44,6 +44,30 @@ async function completeOnboardingWithParams( customSiteName?: string, customFold
 	};
 }
 
+type PersistedSite = { id: string; path: string };
+
+async function getPersistedSite( siteName: string ): Promise< PersistedSite | undefined > {
+	const cliConfig = await fs
+		.readJson( path.join( session.cliConfigPath, 'cli.json' ) )
+		.catch( () => ( { sites: [] } ) );
+	return cliConfig.sites.find( ( s: { name: string } ) => s.name === siteName );
+}
+
+/**
+ * The sidebar can show a copied site (optimistic placeholder, then the IPC
+ * result) slightly before the CLI's cli.json write is observable, so poll the
+ * on-disk config instead of sampling it once.
+ */
+async function waitForPersistedSite( siteName: string ): Promise< PersistedSite > {
+	await expect
+		.poll( async () => Boolean( await getPersistedSite( siteName ) ), {
+			message: `site "${ siteName }" was never persisted to cli.json`,
+			timeout: 30_000,
+		} )
+		.toBe( true );
+	return ( await getPersistedSite( siteName ) ) as PersistedSite;
+}
+
 /**
  * Drive the "Add site" modal through the create-site flow while selecting a
  * pre-existing local folder (returned by the mocked folder dialog via the
@@ -345,11 +369,7 @@ test.describe( 'Sites', () => {
 		const copiedSiteContent = new SiteContent( session.mainWindow, expectedCopyName );
 		await expect( copiedSiteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 
-		const cliConfig = await fs.readJson( path.join( session.cliConfigPath, 'cli.json' ) );
-		const copiedSite = cliConfig.sites.find(
-			( s: { name: string } ) => s.name === expectedCopyName
-		);
-		expect( copiedSite ).toBeDefined();
+		const copiedSite = await waitForPersistedSite( expectedCopyName );
 		expect( await pathExists( path.join( copiedSite.path, 'wp-config.php' ) ) ).toBe( true );
 	} );
 } );
@@ -405,12 +425,7 @@ test.describe( 'Sites without cleanup in-between', () => {
 		const copiedSiteContent = new SiteContent( session.mainWindow, expectedCopyName );
 		await expect( copiedSiteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 
-		const updatedCliConfig = await fs.readJson( cliConfigFile );
-		const copiedSite = updatedCliConfig.sites.find(
-			( s: { name: string } ) => s.name === expectedCopyName
-		);
-		expect( copiedSite ).toBeDefined();
-
+		const copiedSite = await waitForPersistedSite( expectedCopyName );
 		expect( await pathExists( path.join( copiedSite.path, 'wp-config.php' ) ) ).toBe( true );
 
 		const copiedThumbnailPath = path.join( thumbnailsDir, `${ copiedSite.id }.png` );

--- a/packages/common/lib/fs-utils.ts
+++ b/packages/common/lib/fs-utils.ts
@@ -98,27 +98,37 @@ export async function pathExists( path: string ): Promise< boolean > {
 	}
 }
 
+// The source may be mutated while copying (e.g. duplicating a running site whose
+// SQLite journal and cache files come and go), so entries that disappear between
+// enumeration and copy are skipped rather than failing the whole copy. A missing
+// top-level source still throws.
 export async function recursiveCopyDirectory(
 	source: string,
 	destination: string
 ): Promise< void > {
-	await fsPromises.mkdir( destination, { recursive: true } );
-
 	const entries = await fsPromises.readdir( source, { withFileTypes: true } );
 
+	await fsPromises.mkdir( destination, { recursive: true } );
+
 	await Promise.all(
-		entries.map( ( entry ) => {
+		entries.map( async ( entry ) => {
 			const sourcePath = path.join( source, entry.name );
 			const destinationPath = path.join( destination, entry.name );
 
-			if ( entry.isDirectory() ) {
-				return recursiveCopyDirectory( sourcePath, destinationPath );
-			}
-			if ( entry.isFile() ) {
-				return fsPromises.cp( sourcePath, destinationPath, {
-					mode: fs.constants.COPYFILE_FICLONE,
-					preserveTimestamps: true,
-				} );
+			try {
+				if ( entry.isDirectory() ) {
+					await recursiveCopyDirectory( sourcePath, destinationPath );
+				} else if ( entry.isFile() ) {
+					await fsPromises.cp( sourcePath, destinationPath, {
+						mode: fs.constants.COPYFILE_FICLONE,
+						preserveTimestamps: true,
+					} );
+				}
+			} catch ( error ) {
+				if ( isErrnoException( error ) && error.code === 'ENOENT' ) {
+					return;
+				}
+				throw error;
 			}
 		} )
 	);


### PR DESCRIPTION
## Related issues

<!-- No tracked issue; this addresses a flaky e2e test observed in CI. -->

## How AI was used in this PR

Claude Code investigated the flaky `duplicates a site from site settings` e2e failure, traced the duplicate-site flow end to end to find the root cause, and wrote the fix and test changes. The analysis and diff were reviewed and scoped by the author (the standalone unit regression tests were dropped on review).

## Proposed Changes

The `duplicates a site from site settings` e2e test (added in #4034) failed intermittently in CI: the sidebar showed the copied site, but `cli.json` never contained it. The investigation surfaced a real product race rather than a test-only timing issue:

- Duplicating a site copies its directory **while the site is running**. A running Playground site continuously creates and deletes transient files (SQLite journal files, cache, cron activity). If one of them disappears between directory enumeration and the copy of that entry, the whole duplication fails with ENOENT and the user gets the "Failed to copy site" dialog. `recursiveCopyDirectory` now skips entries that vanish mid-copy — the same result a copy started a moment later would produce — so duplicating a running site no longer fails randomly. A missing top-level source still throws.
- The e2e test masked that failure: the renderer optimistically shows the copy in the sidebar before the backend does any work, and on failure the content area falls back to the original (running) site, satisfying the unscoped "Running" assertion. Both duplicate tests now poll `cli.json` (the source of truth) for the copied site instead of sampling it once, so a genuine failure is reported at the right step with a clear message.

## Testing Instructions

- Create a site and leave it running, then use Settings → Duplicate site repeatedly; the duplication should succeed every time even while the source site is actively serving requests.
- Run the e2e suite: `npm run e2e -- sites.test.ts` — the two duplication tests should pass.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)