### PR TITLE
Fix Windows E2E hangs: restore per-command CLI shutdown and isolate the daemon per home

### DIFF
--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# A Buildkite cancellation or timeout delivers SIGTERM. Exit non-zero explicitly:
+# a killed process tree can otherwise record exit status 0, and a timed-out job
+# with exit status 0 turns the whole build green (observed in build 18744).
+trap 'echo "Termination signal received — failing the job."; exit 1' TERM INT
+
 PLATFORM=${1:?Expected platform to be provided as first parameter}
 ARCH=${2:?Expected architecture to be provided as second parameter}
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,12 @@ env:
   IMAGE_ID: $IMAGE_ID
 
 e2e_config: &e2e_config
+  # TEMP(AINFRA-2588): fail hung diagnostic E2E jobs fast instead of waiting for the
+  # Buildkite agent's default 3h timeout. While ~20 Windows tests still fail (each
+  # burning a retry), a full run needs ~1h20 — 45m truncated build 18744 mid-suite.
+  # run-e2e-tests.sh traps the cancellation signal and exits non-zero so a
+  # timed-out job can't record exit status 0 and turn the build green.
+  timeout_in_minutes: 100
   command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix.platform}}" "{{matrix.arch}}"
   artifact_paths:
     - test-results/**/*.zip
@@ -17,18 +23,18 @@ e2e_config: &e2e_config
   agents:
     queue: "{{matrix.platform}}"
   env:
-    # See https://playwright.dev/docs/ci#debugging-browser-launches
-    DEBUG: "pw:browser"
+    # pw:browser logs browser launches (https://playwright.dev/docs/ci#debugging-browser-launches);
+    # pw:api logs every Playwright action (goto, click, waits) with timings, so a
+    # hung or failing test shows exactly which call it died on, in-stream.
+    DEBUG: "pw:api,pw:browser"
   matrix:
     setup: { platform: [], arch: [] }
     adjustments:
       - with: { platform: mac, arch: arm64 }
-      # Windows E2E temporarily disabled while AINFRA-2588 investigates Windows E2E hangs in Buildkite.
+      # Re-enabled to verify the AINFRA-2588 daemon-leak fix.
+      # This diagnostic PR also checks whether per-command CLI shutdown handling affects teardown.
       # See https://linear.app/a8c/issue/AINFRA-2588/investigate-studio-windows-e2e-hangs-in-buildkite
-      # - with: { platform: windows, arch: x64 }
-  notify:
-    - github_commit_status:
-        context: E2E Tests
+      - with: { platform: windows, arch: x64 }
 
 steps:
   - label: Lint
@@ -87,6 +93,12 @@ steps:
 
   - group: E2E Tests
     key: e2e-tests
+    # One combined GitHub status for all E2E jobs. Step-level notifies on the
+    # same context race (last writer wins), so a fast green mac job used to
+    # mask a still-running or failed Windows job.
+    notify:
+      - github_commit_status:
+          context: E2E Tests
     steps:
       # E2E tests run on supported platform/architecture combinations.
       # - mac-arm64: Native on Apple Silicon agents
@@ -116,11 +128,8 @@ steps:
           - test-results/**/*error-context.md
           - test-results/daemon-logs/**/*.log
         env:
-          DEBUG: "pw:browser"
+          DEBUG: "pw:api,pw:browser"
         # TEMP(rsm-2593): if: removed to force E2E on every push while iterating on Linux E2E setup. Revert before merge.
-        notify:
-          - github_commit_status:
-              context: E2E Tests
 
   - label: ":chart_with_upwards_trend: Performance Metrics"
     key: metrics

--- a/apps/cli/lib/daemon-client.ts
+++ b/apps/cli/lib/daemon-client.ts
@@ -11,6 +11,7 @@ import {
 	PROCESS_MANAGER_EVENTS_SOCKET_PATH,
 	PROCESS_MANAGER_CONTROL_SOCKET_PATH,
 	PROCESS_MANAGER_HOME,
+	daemonPipePath,
 } from 'cli/lib/paths';
 import { SocketStreamClient, SocketMessageDecoder, SocketRequestClient } from 'cli/lib/socket';
 import {
@@ -33,7 +34,7 @@ const CONNECTION_TIMEOUT_MS = 10_000;
 const PROCESS_MANAGER_LOCKFILE_PATH = path.join( PROCESS_MANAGER_HOME, 'pm-connection.lock' );
 export const SITE_EVENTS_SOCKET_PATH =
 	process.platform === 'win32'
-		? '\\\\.\\pipe\\studio-events.sock'
+		? daemonPipePath( 'studio-events' )
 		: path.join( PROCESS_MANAGER_HOME, 'events.sock' );
 
 function ensureProcessManagerHome() {

--- a/apps/cli/lib/native-php/config.ts
+++ b/apps/cli/lib/native-php/config.ts
@@ -291,8 +291,13 @@ export function getDefaultPhpArgs(
 	// Run a PHP file before the main script — used to inject reprint's generated
 	// runtime.php (constants, SQLite loader, upload proxy) into imported sites
 	// without modifying their wp-config.php.
+	//
+	// The value MUST be quoted: `-d` values go through PHP's INI parser, and an
+	// unquoted Windows 8.3 short path (e.g. C:\Users\BUILDK~1\...) fails it with
+	// "syntax error, unexpected '~'". PHP then drops the directive, the SQLite
+	// loader never runs, and every request renders a database error page.
 	if ( autoPrependFile ) {
-		args.push( '-d', `auto_prepend_file=${ autoPrependFile }` );
+		args.push( '-d', `auto_prepend_file="${ toPhpIniPath( autoPrependFile ) }"` );
 	}
 
 	return args;

--- a/apps/cli/lib/native-php/php-process.ts
+++ b/apps/cli/lib/native-php/php-process.ts
@@ -73,7 +73,9 @@ export function spawnPhpProcess(
 	// crashes. Revert once the native-PHP-on-CI issue is diagnosed.
 	phpScriptProcess.once( 'exit', ( code, signal ) => {
 		if ( code !== 0 && code !== null ) {
-			console.error( `[PHP-DIAG] php process exited unexpectedly: code=${ code } signal=${ signal }` );
+			console.error(
+				`[PHP-DIAG] php process exited unexpectedly: code=${ code } signal=${ signal }`
+			);
 		}
 	} );
 

--- a/apps/cli/lib/native-php/php-process.ts
+++ b/apps/cli/lib/native-php/php-process.ts
@@ -67,6 +67,16 @@ export function spawnPhpProcess(
 	livePhpProcesses.add( phpScriptProcess );
 	phpScriptProcess.once( 'exit', () => livePhpProcesses.delete( phpScriptProcess ) );
 
+	// DIAGNOSTIC (temporary): surface unexpected php.exe exits. A Windows loader/DLL failure exits
+	// with 3221225781 (0xC0000135) and writes nothing to stderr, so the exit code is the only signal.
+	// Intentional shutdowns remove all 'exit' listeners before killing, so this only fires on genuine
+	// crashes. Revert once the native-PHP-on-CI issue is diagnosed.
+	phpScriptProcess.once( 'exit', ( code, signal ) => {
+		if ( code !== 0 && code !== null ) {
+			console.error( `[PHP-DIAG] php process exited unexpectedly: code=${ code } signal=${ signal }` );
+		}
+	} );
+
 	if ( mode === 'pipe' ) {
 		phpScriptProcess.stdout?.pipe( process.stdout, { end: false } );
 		phpScriptProcess.stderr?.pipe( process.stderr, { end: false } );

--- a/apps/cli/lib/paths.ts
+++ b/apps/cli/lib/paths.ts
@@ -1,16 +1,35 @@
+import crypto from 'crypto';
 import os from 'os';
 import path from 'path';
 
 export const STUDIO_CLI_HOME = path.join( os.homedir(), '.studio' );
 
+export const DEFAULT_PROCESS_MANAGER_HOME = path.join( STUDIO_CLI_HOME, 'daemon' );
+
 export const PROCESS_MANAGER_HOME =
-	process.env.STUDIO_PROCESS_MANAGER_HOME ?? path.join( STUDIO_CLI_HOME, 'daemon' );
+	process.env.STUDIO_PROCESS_MANAGER_HOME ?? DEFAULT_PROCESS_MANAGER_HOME;
 export const PROCESS_MANAGER_LOGS_DIR = path.join( PROCESS_MANAGER_HOME, 'logs' );
+
+// Windows named pipes live in a single, flat, machine-global namespace — unlike Unix domain sockets,
+// they can't be nested under PROCESS_MANAGER_HOME. A fixed pipe name therefore makes every process on
+// the machine bind/connect to the SAME daemon regardless of PROCESS_MANAGER_HOME, silently defeating
+// the per-run isolation that setting STUDIO_PROCESS_MANAGER_HOME gives on macOS/Linux (and that the CLI
+// test harness relies on). Derive the pipe name from the home when a custom one is set, so isolation
+// works on Windows too. The default home keeps its original fixed name, so the shipping desktop app and
+// CLI still share a single daemon exactly as before.
+export function daemonPipePath( baseName: string, home: string = PROCESS_MANAGER_HOME ): string {
+	if ( home === DEFAULT_PROCESS_MANAGER_HOME ) {
+		return `\\\\.\\pipe\\${ baseName }.sock`;
+	}
+	const homeHash = crypto.createHash( 'sha1' ).update( home ).digest( 'hex' ).slice( 0, 12 );
+	return `\\\\.\\pipe\\${ baseName }-${ homeHash }.sock`;
+}
+
 export const PROCESS_MANAGER_CONTROL_SOCKET_PATH =
 	process.platform === 'win32'
-		? '\\\\.\\pipe\\studio-daemon.sock'
+		? daemonPipePath( 'studio-daemon' )
 		: path.join( PROCESS_MANAGER_HOME, 'daemon.sock' );
 export const PROCESS_MANAGER_EVENTS_SOCKET_PATH =
 	process.platform === 'win32'
-		? '\\\\.\\pipe\\studio-daemon-events.sock'
+		? daemonPipePath( 'studio-daemon-events' )
 		: path.join( PROCESS_MANAGER_HOME, 'daemon-events.sock' );

--- a/apps/cli/tests/paths.test.ts
+++ b/apps/cli/tests/paths.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_PROCESS_MANAGER_HOME, daemonPipePath } from '../lib/paths';
+
+describe( 'daemonPipePath (Windows daemon socket isolation)', () => {
+	it( 'keeps the original fixed pipe name for the default home (desktop/CLI still share one daemon)', () => {
+		expect( daemonPipePath( 'studio-daemon', DEFAULT_PROCESS_MANAGER_HOME ) ).toBe(
+			'\\\\.\\pipe\\studio-daemon.sock'
+		);
+		expect( daemonPipePath( 'studio-daemon-events', DEFAULT_PROCESS_MANAGER_HOME ) ).toBe(
+			'\\\\.\\pipe\\studio-daemon-events.sock'
+		);
+	} );
+
+	it( 'derives a per-home pipe name for a custom home so runs are isolated on Windows', () => {
+		const a = daemonPipePath( 'studio-daemon', 'C:\\Temp\\home-a' );
+		const b = daemonPipePath( 'studio-daemon', 'C:\\Temp\\home-b' );
+
+		expect( a ).toMatch( /^\\\\\.\\pipe\\studio-daemon-[0-9a-f]{12}\.sock$/ );
+		expect( a ).not.toBe( b );
+		// Two custom homes must not collide with the default fixed pipe either.
+		expect( a ).not.toBe( '\\\\.\\pipe\\studio-daemon.sock' );
+	} );
+
+	it( 'is deterministic for a given home so repeated CLI invocations reach the same daemon', () => {
+		expect( daemonPipePath( 'studio-daemon', 'C:\\Temp\\home-a' ) ).toBe(
+			daemonPipePath( 'studio-daemon', 'C:\\Temp\\home-a' )
+		);
+	} );
+
+	it( 'namespaces distinct sockets so control/events/site-events do not collide for the same home', () => {
+		const home = 'C:\\Temp\\home-a';
+		const names = new Set( [
+			daemonPipePath( 'studio-daemon', home ),
+			daemonPipePath( 'studio-daemon-events', home ),
+			daemonPipePath( 'studio-events', home ),
+		] );
+		expect( names.size ).toBe( 3 );
+	} );
+} );

--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -17,6 +17,7 @@ export class E2ESession {
 	homePath: string;
 	cliConfigPath: string;
 	sharedConfigPath: string;
+	daemonHome: string;
 	private mainProcessLogs: string[] = [];
 	private readonly maxMainProcessLogChunks = 500;
 	private stdoutListener?: ( chunk: Buffer | string ) => void;
@@ -29,6 +30,17 @@ export class E2ESession {
 		this.homePath = path.join( this.sessionPath, 'home' );
 		this.cliConfigPath = path.join( this.sessionPath, 'cliConfig' );
 		this.sharedConfigPath = path.join( this.sessionPath, 'sharedConfig' );
+		// DIAGNOSTIC (temporary): put the process-manager daemon — and its per-process stdout/stderr
+		// logs — under test-results/daemon-logs so they upload as CI artifacts. This surfaces why
+		// native PHP fails to serve on Windows CI (the php.exe error currently goes to ~/.studio and
+		// is never uploaded). Relies on the Windows pipe-isolation fix so each session gets its own
+		// daemon. Revert once diagnosed.
+		this.daemonHome = path.join(
+			process.cwd(),
+			'test-results',
+			'daemon-logs',
+			path.basename( this.sessionPath )
+		);
 	}
 
 	async launch( testEnv: NodeJS.ProcessEnv = {} ) {
@@ -153,6 +165,8 @@ export class E2ESession {
 				E2E_HOME_PATH: this.homePath,
 				E2E_CLI_CONFIG_PATH: this.cliConfigPath,
 				E2E_SHARED_CONFIG_PATH: this.sharedConfigPath,
+				// DIAGNOSTIC (temporary): route the daemon + its logs into the uploaded artifacts dir.
+				STUDIO_PROCESS_MANAGER_HOME: this.daemonHome,
 			},
 			timeout: 60_000,
 		} );

--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -30,17 +30,15 @@ export class E2ESession {
 		this.homePath = path.join( this.sessionPath, 'home' );
 		this.cliConfigPath = path.join( this.sessionPath, 'cliConfig' );
 		this.sharedConfigPath = path.join( this.sessionPath, 'sharedConfig' );
-		// DIAGNOSTIC (temporary): put the process-manager daemon — and its per-process stdout/stderr
-		// logs — under test-results/daemon-logs so they upload as CI artifacts. This surfaces why
-		// native PHP fails to serve on Windows CI (the php.exe error currently goes to ~/.studio and
-		// is never uploaded). Relies on the Windows pipe-isolation fix so each session gets its own
-		// daemon. Revert once diagnosed.
-		this.daemonHome = path.join(
-			process.cwd(),
-			'test-results',
-			'daemon-logs',
-			path.basename( this.sessionPath )
-		);
+		// DIAGNOSTIC (temporary): give each session its own process-manager daemon so its
+		// per-process stdout/stderr logs can be collected as CI artifacts (see cleanup()).
+		// This surfaces why native PHP fails to serve on Windows CI (the php.exe error
+		// currently goes to ~/.studio and is never uploaded). Revert once diagnosed.
+		//
+		// The home must stay SHORT: the daemon's Unix control socket lives inside it, and
+		// macOS rejects socket paths over ~104 chars (Linux ~108) with connect EINVAL —
+		// pointing this at test-results/<session-uuid> broke every site creation on mac/linux.
+		this.daemonHome = path.join( tmpdir(), `studio-d-${ randomUUID().slice( 0, 8 ) }` );
 	}
 
 	async launch( testEnv: NodeJS.ProcessEnv = {} ) {
@@ -105,11 +103,37 @@ export class E2ESession {
 
 	async cleanup() {
 		await this.closeApp();
+		await this.collectDaemonLogs();
 		await rimraf( this.sessionPath, {
 			backoff: 2,
 			maxBackoff: 2500,
 			maxRetries: 50,
 		} );
+		await rimraf( this.daemonHome, {
+			backoff: 2,
+			maxBackoff: 2500,
+			maxRetries: 50,
+		} );
+	}
+
+	// DIAGNOSTIC (temporary): copy this session's daemon logs into test-results/daemon-logs
+	// so the CI artifact glob uploads them. The daemon home itself must live in a short tmp
+	// path (see constructor), so the logs are copied out rather than written here directly.
+	private async collectDaemonLogs() {
+		const logsDir = path.join( this.daemonHome, 'logs' );
+		try {
+			if ( await fs.pathExists( logsDir ) ) {
+				const dest = path.join(
+					process.cwd(),
+					'test-results',
+					'daemon-logs',
+					path.basename( this.sessionPath )
+				);
+				await fs.copy( logsDir, dest );
+			}
+		} catch ( error ) {
+			console.warn( 'Failed to collect daemon logs:', error );
+		}
 	}
 
 	private async launchFirstWindow( testEnv: NodeJS.ProcessEnv = {} ) {

--- a/apps/studio/src/modules/cli/lib/execute-command.ts
+++ b/apps/studio/src/modules/cli/lib/execute-command.ts
@@ -1,28 +1,237 @@
 import { app } from 'electron';
+import { fork, spawnSync, type ChildProcess, type StdioOptions } from 'node:child_process';
 import * as Sentry from '@sentry/electron/main';
-import { createCliRunner, type CliRunner } from '@studio/common/lib/cli-process';
+import { z } from 'zod';
+import { TypedEventEmitter } from 'src/modules/cli/lib/typed-event-emitter';
 import { getBundledNodeBinaryPath, getCliPath } from 'src/storage/paths';
 
-export { CliCommandError, type CliCommandResult } from '@studio/common/lib/cli-process';
+export type CliCommandResult = {
+	stdout: string;
+	stderr: string;
+};
 
-let runner: CliRunner | undefined;
+export class CliCommandError extends Error {
+	baseMessage = 'CLI command failed';
+	readonly lastErrorMessage: string | undefined;
+	readonly cliCommandResult: CliCommandResult | undefined;
+	readonly exitCode: number | null;
+	readonly signal: NodeJS.Signals | null;
 
-function getRunner(): CliRunner {
-	if ( ! runner ) {
-		const cliRunner = createCliRunner( {
-			cliBinary: getCliPath(),
-			nodeBinary: getBundledNodeBinaryPath(),
-			onError: ( error ) => Sentry.captureException( error ),
-		} );
-		// `child.kill()` only terminates the forked CLI; the runner's killAll walks
-		// the tree on Windows so php.exe descendants don't orphan.
-		app.on( 'will-quit', () => cliRunner.killAll() );
-		runner = cliRunner;
+	constructor( options: {
+		lastErrorMessage: string | undefined;
+		cliCommandResult: CliCommandResult | undefined;
+		exitCode: number | null;
+		signal: NodeJS.Signals | null;
+	} ) {
+		super();
+		this.lastErrorMessage = options.lastErrorMessage;
+		this.cliCommandResult = options.cliCommandResult;
+		this.exitCode = options.exitCode;
+		this.signal = options.signal;
+		this.name = 'CliCommandError';
+		// The stack trace for this error is misleading, because it's not actually thrown where the error
+		// happened - it's just a representation of an error that happened in a different process.
+		this.stack = undefined;
 	}
-	return runner;
+
+	get message(): string {
+		const messageParts: string[] = [];
+
+		if ( this.lastErrorMessage ) {
+			messageParts.push( `[Last error message] ${ this.lastErrorMessage }` );
+		}
+
+		if ( this.baseMessage ) {
+			messageParts.push( `[Base message] ${ this.baseMessage }` );
+		}
+
+		if ( this.cliCommandResult ) {
+			const stderr = this.cliCommandResult.stderr.trim();
+			const stdout = this.cliCommandResult.stdout.trim();
+			if ( stderr ) {
+				messageParts.push( `[stderr] ${ stderr }` );
+			} else if ( stdout ) {
+				messageParts.push( `[stdout] ${ stdout }` );
+			}
+		}
+
+		if ( this.signal !== null ) {
+			messageParts.push( `[Terminated by signal] ${ this.signal }` );
+		} else if ( this.exitCode !== null ) {
+			messageParts.push( `[Exit code] ${ this.exitCode }` );
+		}
+
+		return messageParts
+			.map( ( part, index ) => ( index === 0 ? part : `  ${ part }` ) )
+			.join( '\n' );
+	}
 }
 
-export const executeCliCommand: CliRunner[ 'executeCliCommand' ] = ( (
+type CliCommandEventMap< CapturesOutput extends boolean > = {
+	started: void;
+	error: { error: Error };
+	data: { data: unknown };
+	success: { result: CapturesOutput extends true ? CliCommandResult : undefined };
+	failure: CapturesOutput extends true
+		? { error: CliCommandError; result: CliCommandResult }
+		: { error: CliCommandError };
+};
+
+// Schema to detect error messages from CLI IPC regardless of the specific action type
+const cliErrorMessageSchema = z.object( {
+	status: z.literal( 'fail' ),
+	message: z.string(),
+} );
+type CliCommandEventEmitter< CapturesOutput extends boolean > = TypedEventEmitter<
+	CliCommandEventMap< CapturesOutput >
+>;
+
+type ExecuteCliCommandOptionsIgnore = {
+	output: 'ignore';
+	env?: NodeJS.ProcessEnv;
+};
+type ExecuteCliCommandOptionsCapture = {
+	output: 'capture';
+	logPrefix?: string;
+	env?: NodeJS.ProcessEnv;
+};
+type ExecuteCliCommandOptions = ExecuteCliCommandOptionsIgnore | ExecuteCliCommandOptionsCapture;
+
+export function executeCliCommand(
 	args: string[],
-	options?: Parameters< CliRunner[ 'executeCliCommand' ] >[ 1 ]
-) => getRunner().executeCliCommand( args, options ) ) as CliRunner[ 'executeCliCommand' ];
+	options: { output: 'capture'; logPrefix?: string; env?: NodeJS.ProcessEnv }
+): [ CliCommandEventEmitter< true >, ChildProcess ];
+export function executeCliCommand(
+	args: string[],
+	options: { output: 'ignore'; logPrefix?: string; env?: NodeJS.ProcessEnv }
+): [ CliCommandEventEmitter< false >, ChildProcess ];
+export function executeCliCommand(
+	args: string[],
+	options?: ExecuteCliCommandOptions
+): [ CliCommandEventEmitter< false >, ChildProcess ];
+export function executeCliCommand(
+	args: string[],
+	options: ExecuteCliCommandOptions = { output: 'ignore' }
+): [ CliCommandEventEmitter< boolean >, ChildProcess ] {
+	const cliPath = getCliPath();
+
+	let stdio: StdioOptions | undefined;
+	/**
+	 * If there's an IPC channel, the CLI `Logger` uses IPC to communicate all expected events. This
+	 * means that for many CLI commands, the captured stdout/stderr will be empty, unless something
+	 * unexpected was logged.
+	 */
+	if ( options.output === 'capture' ) {
+		stdio = [ 'ignore', 'pipe', 'pipe', 'ipc' ];
+	} else if ( options.output === 'ignore' ) {
+		stdio = [ 'ignore', 'ignore', 'ignore', 'ipc' ];
+	}
+
+	const child = fork( cliPath, [ ...args, '--avoid-telemetry' ], {
+		stdio,
+		execPath: getBundledNodeBinaryPath(),
+		execArgv: [ '--experimental-wasm-jspi' ],
+		env: { ...process.env, ...options.env },
+	} );
+	const eventEmitter = new TypedEventEmitter< CliCommandEventMap< boolean > >();
+
+	child.on( 'spawn', () => {
+		eventEmitter.emit( 'started' );
+	} );
+
+	child.on( 'error', ( error ) => {
+		console.error( 'Child process error:', error );
+		Sentry.captureException( error );
+		eventEmitter.emit( 'error', { error } );
+	} );
+
+	let stdout = '';
+	let stderr = '';
+	let lastErrorMessage: string | undefined;
+
+	if ( options.output === 'capture' ) {
+		// Only callers that opted-in with a `logPrefix` get stdout echoed to
+		// the main-process console. Commands like `preview list --format json`
+		// dump large structured payloads on stdout that would otherwise spam
+		// `npm start` output every time snapshots are fetched.
+		const logPrefix = options.logPrefix ? `[CLI - site ID ${ options.logPrefix }]` : null;
+		child.stdout?.on( 'data', ( data: Buffer ) => {
+			const text = data.toString();
+			stdout += text;
+			if ( logPrefix ) {
+				const trimmed = text.trimEnd();
+				if ( trimmed ) {
+					console.log( `${ logPrefix } ${ trimmed }` );
+				}
+			}
+		} );
+		child.stderr?.on( 'data', ( data: Buffer ) => {
+			stderr += data.toString();
+		} );
+	}
+
+	child.on( 'message', ( message: unknown ) => {
+		const errorParsed = cliErrorMessageSchema.safeParse( message );
+		if ( errorParsed.success ) {
+			lastErrorMessage = errorParsed.data.message;
+		}
+
+		eventEmitter.emit( 'data', { data: message } );
+	} );
+
+	function appQuitHandler() {
+		const pid = child.pid;
+		child.removeAllListeners();
+
+		// `child.kill()` only terminates the forked CLI process; on Windows its php.exe descendants
+		// would orphan and keep their DLLs locked. `taskkill /T` walks the whole tree instead.
+		if ( process.platform === 'win32' && pid ) {
+			spawnSync( 'taskkill', [ '/F', '/T', '/PID', String( pid ) ], {
+				windowsHide: true,
+				stdio: 'ignore',
+			} );
+			return;
+		}
+
+		const result = child.kill();
+		if ( result ) {
+			console.log( `Successfully killed child process with pid ${ pid }. Args:`, args );
+		} else {
+			console.error(
+				`Failed to kill child process with pid ${ pid }. This likely means the process is already terminated. CLI args:`,
+				args
+			);
+		}
+	}
+
+	child.on( 'close', ( exitCode, signal ) => {
+		child.removeAllListeners();
+		app.off( 'will-quit', appQuitHandler );
+
+		let result: CliCommandResult | undefined;
+
+		if ( options.output === 'capture' ) {
+			result = { stdout, stderr };
+		}
+
+		if ( exitCode === 0 ) {
+			eventEmitter.emit( 'success', { result } );
+		} else {
+			const error = new CliCommandError( {
+				lastErrorMessage,
+				cliCommandResult: result,
+				exitCode,
+				signal,
+			} );
+			if ( options.output === 'capture' ) {
+				eventEmitter.emit( 'failure', { error, result } );
+			} else {
+				eventEmitter.emit( 'failure', { error } );
+			}
+		}
+	} );
+
+	app.on( 'will-quit', appQuitHandler );
+
+	return [ eventEmitter, child ];
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,8 +11,14 @@ export default defineConfig( {
 	// Retry flaky tests once to improve CI reliability
 	retries: 1,
 
+	// 'list' prints every test start/finish with duration as it happens; the CI
+	// default 'dot' prints one character per test and holds all detail until the
+	// end of the run, which is useless when a job hangs or gets canceled mid-run.
+	reporter: 'list',
+
 	use: {
 		trace: 'retain-on-failure',
+		screenshot: 'only-on-failure',
 		// Action timeout for clicks, fills, etc. (prevents hanging on blocked elements)
 		actionTimeout: 30_000,
 	},

--- a/scripts/download-php-binary.ts
+++ b/scripts/download-php-binary.ts
@@ -68,12 +68,27 @@ async function main(): Promise< void > {
 		const downloadInfo = resolvePhpBinaryDownloadInfo();
 		const binDir = path.join( phpPackageRoot, downloadInfo.packageId );
 		const destPath = path.join( binDir, binaryName );
+		const shaMarkerPath = path.join( binDir, '.package-sha256' );
 
 		if ( fs.existsSync( destPath ) ) {
+			const installedSha = fs.existsSync( shaMarkerPath )
+				? fs.readFileSync( shaMarkerPath, 'utf8' ).trim()
+				: '';
+			if ( installedSha === downloadInfo.sha ) {
+				console.log(
+					`PHP ${ version } package ${ downloadInfo.packageId } already up to date at ${ binDir }.`
+				);
+				return;
+			}
+			// Same packageId but the archive SHA has changed — the package was republished in
+			// place (e.g. adding the Windows VC++ runtime DLLs). Without this, a stale bundle cached
+			// on a reused CI agent (apps/studio/php-bin is gitignored and not cleaned) would be
+			// packaged forever. Remove it so the current package is fetched.
 			console.log(
-				`PHP ${ version } package ${ downloadInfo.packageId } already exists at ${ binDir }. Delete it to re-download.`
+				`PHP ${ version } package ${ downloadInfo.packageId } at ${ binDir } is stale ` +
+					`(installed sha ${ installedSha || 'unknown' } != expected ${ downloadInfo.sha }); re-downloading.`
 			);
-			return;
+			fs.rmSync( binDir, { recursive: true, force: true } );
 		}
 
 		// Ensure the php-bin root exists, then atomically claim this version's slot.
@@ -123,6 +138,9 @@ async function main(): Promise< void > {
 					throw new Error( `${ extractedBinaryName } not found after extraction.` );
 				}
 				copyDirectoryContents( extractDir, binDir );
+				// Record the archive SHA so a later republish-in-place under the same packageId
+				// is detected as stale and re-downloaded (see the skip check above).
+				fs.writeFileSync( shaMarkerPath, downloadInfo.sha );
 				if ( ! isWindows ) {
 					fs.chmodSync( destPath, 0o755 );
 				}

--- a/scripts/download-php-binary.ts
+++ b/scripts/download-php-binary.ts
@@ -85,8 +85,8 @@ async function main(): Promise< void > {
 			// on a reused CI agent (apps/studio/php-bin is gitignored and not cleaned) would be
 			// packaged forever. Remove it so the current package is fetched.
 			console.log(
-				`PHP ${ version } package ${ downloadInfo.packageId } at ${ binDir } is stale ` +
-					`(installed sha ${ installedSha || 'unknown' } != expected ${ downloadInfo.sha }); re-downloading.`
+				`Stale PHP ${ version } package ${ downloadInfo.packageId } at ${ binDir } ` +
+					`(sha ${ installedSha || 'unknown' } != ${ downloadInfo.sha }); re-downloading.`
 			);
 			fs.rmSync( binDir, { recursive: true, force: true } );
 		}


### PR DESCRIPTION
## Related issues

- AINFRA-2588 (Investigate Studio Windows E2E hangs in Buildkite)
- Combines #4070 and #4061 (its own commits only — this branch deliberately excludes #4041, which #4061 is stacked on) on latest trunk

## Proposed Changes

Windows E2E has been broken since June 29 by **two independent regressions that merged the same day**, which is why earlier single-PR reverts never fixed it:

1. **#3954 caused the 3-hour hangs.** Its `killAll()` on `will-quit` runs one listener after the quit handler that spawns `site stop --all`, so the stop command is killed before it can stop any site. Sites leak into the machine-global process-manager daemon until its capacity cap is exhausted and every subsequent site creation times out. Fixed here by restoring per-command CLI shutdown handling (#4070): each CLI child registers its own quit-time kill handler when spawned, so the quit-time stop survives. Verified on CI: quit-time stops complete in under a second (previously a 20-second timeout on every session) and zero capacity errors.

2. **#3988 caused the ~25 test failures.** It made every native-PHP site start pass an `auto_prepend_file` (the site-url prepend that loads reprint's runtime, including the SQLite loader) as an **unquoted** `-d` directive. On CI Windows agents the file lives under an 8.3 short path (`C:\Users\BUILDK~1\...`), and the unquoted `~` fails PHP's INI parsing (`syntax error, unexpected '~' in Unknown on line 4` — visible in the daemon logs this PR now uploads). PHP drops the directive, WordPress boots without its SQLite driver, and every page renders an instant database error — which is why browser-driven tests saw non-WordPress pages while the app's own UI worked. Fixed by quoting the value like every other path directive. This never reproduced on developer machines because short usernames don't get 8.3-mangled.

Also included:

- **Isolate the process-manager daemon per home on Windows** (#4061): the daemon pipe is scoped per home directory instead of machine-global, so even if a session leaks it cannot poison other sessions or other builds on the same agent. Includes that branch's daemon-log diagnostics (adjusted here to keep the daemon home in a short tmp path — the original diagnostic placed the daemon's Unix socket under a long test-results path, which exceeds the macOS/Linux socket path limit and broke every site creation with `connect EINVAL`; logs are now copied into test-results at cleanup instead) and the PHP-binary re-download fix.
- **CI reporting fixes**: one combined "E2E Tests" GitHub status for all platforms (previously last-writer-wins let a green mac job mask a failing Windows job), a 100-minute job timeout, a cancellation trap so a timed-out job cannot record exit status 0 and turn the build green, and per-test/per-action log streaming with failure screenshots and daemon logs as artifacts.

## Testing Instructions

- **CI (Windows E2E)**: the job should finish well under the 100-minute cap with no `site stop --all command timed out` lines, no `CAPACITY_LIMIT_REACHED` errors, and no `syntax error, unexpected '~'` lines in the daemon logs. Browser-driven tests (blueprints, wp-admin shortcuts, homepage) should pass.
- **GitHub status**: the "E2E Tests" context stays pending until mac, Windows, and Linux all finish, then reports one combined result.
- **Unit**: `npm test -- apps/cli/tests/` (817 tests pass).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?