### PR TITLE
Prevent clearing the language field in Agentic UI settings

### DIFF
--- a/apps/ui/src/components/settings-view/index.tsx
+++ b/apps/ui/src/components/settings-view/index.tsx
@@ -161,6 +161,9 @@ export function SettingsView( {
 				type: 'text',
 				label: __( 'Language' ),
 				elements: LOCALE_ELEMENTS,
+				// Force the native <select>. DataForm otherwise uses a clearable
+				// combobox for 10+ options, whose "x" could empty the language.
+				Edit: 'select',
 			},
 		],
 		[ installedApps ]


### PR DESCRIPTION
## Related issues

- Related to STU-1860

## How AI was used in this PR

Used Claude Code to trace why the language field behaved differently from the other settings dropdowns, identify the DataForm control-selection threshold as the root cause, and apply the fix. All changes were reviewed manually.

## Proposed Changes

In the Agentic UI Settings form, the **Language** field could be cleared entirely and saved as an empty value — which then errored, and which the classic UI never allows (the language must always be selected).

The cause: `@wordpress/dataviews`' `DataForm` silently renders a field as a custom, clearable combobox once it has 10+ options (Studio ships 20+ locales), instead of the native `<select>` used by the other fields. That combobox added a reset "x" that let the language be emptied, and it also looked and behaved differently from the surrounding native dropdowns (reopening on reset, showing a "please fill out this field" validation message).

This forces the Language field to use the native `<select>` control, matching Editor, Terminal and Appearance. The field can no longer be emptied, so an invalid empty locale can never be saved, and the control is now visually consistent with the rest of the form.

<img width="2016" height="1792" alt="CleanShot 2026-07-06 at 11 45 38@2x" src="https://github.com/user-attachments/assets/dff01357-b1d7-4bad-9334-4667fefb8c8c" />


## Testing Instructions

1. Open the Agentic UI and go to **Settings → Preferences**.
2. Confirm the **Language** dropdown is a native select that looks and behaves like the Editor / Terminal / Appearance dropdowns.
3. Confirm there is no "x" to clear the selection, and that the language cannot be left empty.
4. Change the language and save — it should persist and reload correctly.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
