### PR TITLE
Add devcontainer for faster GitHub Codespaces setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,6 @@
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": { "version": "24.15.0" }
 	},
-	"postCreateCommand": "npm ci && npm run cli:build && node apps/cli/dist/cli/main.mjs --help",
+	"postCreateCommand": "npm ci && npm run cli:build",
 	"hostRequirements": { "cpus": 4, "memory": "8gb" }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"name": "WordPress Studio",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": { "version": "24.15.0" }
+	},
+	"postCreateCommand": "npm ci && npm run cli:build && node apps/cli/dist/cli/main.mjs --help",
+	"hostRequirements": { "cpus": 4, "memory": "8gb" }
+}


### PR DESCRIPTION
## Related issues

<!-- none -->

## How AI was used in this PR

- AI helped to write the dev container definition

## Proposed Changes

I suggest adding a GitHub dev container definition to launch GitHub Codespaces easily. It just installs the correct node version and project dependencies. We can consider installing more things like Claude CLI, or creating alias.
I find it especially useful for code reviews.

## Testing Instructions

- Create a codespace from this branch (Code → Codespaces → + Create a codespace on add-devcontainer)
- Wait for `postCreateCommand` to finish
- Run `node apps/cli/dist/cli/main.mjs --help` — should print CLI help without any manual setup
- `node --version` should report v24.15.0

<img width="1398" height="500" alt="Screenshot 2026-07-06 at 15 32 55" src="https://github.com/user-attachments/assets/08f31c2c-4650-43ee-b9dc-0fec8b06c843" />

<img width="844" height="769" alt="Screenshot 2026-07-06 at 15 32 35" src="https://github.com/user-attachments/assets/96d006fb-b8d3-473f-9fe3-142b67671129" />



## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?