### PR TITLE
Fix liberate_extract timeout

### DIFF
--- a/apps/cli/ai/tools/data-liberation.ts
+++ b/apps/cli/ai/tools/data-liberation.ts
@@ -9,6 +9,10 @@ import { textResult } from './utils';
 
 const engineDir = path.join( import.meta.dirname, 'data-liberation-agent' );
 
+// Engine ops (extract/screenshot/reconstruct) routinely run for minutes; the MCP SDK's
+// 60 s default times them out (-32001) even though the engine keeps working.
+const ENGINE_CALL_TIMEOUT_MS = 600_000;
+
 let chromiumPromise: Promise< void > | null = null;
 
 function ensureEngineChromium(): Promise< void > {
@@ -147,10 +151,14 @@ export const dataLiberationTool = defineTool(
 
 		await ensureEngineChromium();
 
-		const result = await client.callTool( {
-			name: args.tool,
-			arguments: normalizeArgs( args.args ),
-		} );
+		const result = await client.callTool(
+			{
+				name: args.tool,
+				arguments: normalizeArgs( args.args ),
+			},
+			undefined,
+			{ timeout: ENGINE_CALL_TIMEOUT_MS, resetTimeoutOnProgress: true }
+		);
 
 		const rawContent = Array.isArray( result.content )
 			? ( result.content as DataLiberationResultContent[] )


### PR DESCRIPTION
## Related issues

- Fixes STU-2000

## How AI was used in this PR

AI helped to implement, and I checked



## Proposed Changes

Let's increase the default mcp 60-second timeout since liberate_extract takes a long time. It will prevent redundant checks of the status, avoid flooding the output in the terminal, and save tokens.

<img width="700" height="117" alt="Screenshot 2026-07-06 at 19 23 27" src="https://github.com/user-attachments/assets/7852a8b6-baf2-4437-8d9d-1d943a3ca57d" />

## Testing Instructions

1. `npm run cli:build`
2. `node apps/cli/dist/cli/main.mjs code`
3. `/liberate https://neicss.wixsite.com/sunflower-valley-exp`
4. Assert that you see one request and response that it's completed, instead of error and checkign status a lot of times
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr> 
<tr>
<td><img width="692" height="617" alt="Screenshot 2026-07-06 at 19 25 28" src="https://github.com/user-attachments/assets/e521ac93-dc12-4f2b-a919-008015d4ee29" />
<td><img width="731" height="263" alt="Screenshot 2026-07-06 at 19 24 46" src="https://github.com/user-attachments/assets/035de4cb-af2e-4c77-a50e-7488bb6e952a" />
</tr> 
</table>


