### PR TITLE
Add site checkpoints: whole-site (files + database) save points with rollback

### DIFF
--- a/apps/cli/ai/tools/auto-checkpoint.test.ts
+++ b/apps/cli/ai/tools/auto-checkpoint.test.ts
@@ -128,4 +128,33 @@ describe( 'withAutoCheckpoint', () => {
 		expect( createCheckpoint ).not.toHaveBeenCalled();
 		expect( tool.rawHandler ).toHaveBeenCalled();
 	} );
+
+	it( 'coalesces concurrent tool calls into a single checkpoint and chip', async () => {
+		// Simulate a slow capture so the second call arrives while the first
+		// is still in flight (the agent often issues several wp_cli calls in
+		// one turn — this must not produce one checkpoint per call).
+		let releaseCapture!: ( manifest: typeof MANIFEST ) => void;
+		createCheckpoint.mockImplementation(
+			() => new Promise( ( resolve ) => ( releaseCapture = resolve ) )
+		);
+		const tool = makeTool( 'wp_cli' );
+		const wrapped = withAutoCheckpoint( tool );
+
+		const first = wrapped.rawHandler( { nameOrPath: 'site', command: 'wp option get x' } as never );
+		const second = wrapped.rawHandler( { nameOrPath: 'site', command: 'wp post list' } as never );
+		// Let both calls reach the in-flight gate before the capture resolves.
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
+		releaseCapture( MANIFEST );
+
+		const [ firstResult, secondResult ] = ( await Promise.all( [ first, second ] ) ) as Array< {
+			studioArtifacts?: Array< { type: string } >;
+		} >;
+
+		expect( createCheckpoint ).toHaveBeenCalledTimes( 1 );
+		// Exactly one of the two results carries the chip.
+		const chips = [ firstResult, secondResult ].filter(
+			( result ) => result.studioArtifacts?.[ 0 ]?.type === 'checkpoint'
+		);
+		expect( chips ).toHaveLength( 1 );
+	} );
 } );

--- a/apps/cli/ai/tools/auto-checkpoint.test.ts
+++ b/apps/cli/ai/tools/auto-checkpoint.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { withAutoCheckpoint, AUTO_CHECKPOINT_DEBOUNCE_MS } from './auto-checkpoint';
+import type { AnyStudioAgentTool } from './define-tool';
+
+const createCheckpoint = vi.hoisted( () => vi.fn() );
+const isCheckpointSupported = vi.hoisted( () => vi.fn() );
+const readCheckpointIndex = vi.hoisted( () => vi.fn() );
+const resolveSite = vi.hoisted( () => vi.fn() );
+
+vi.mock( 'cli/lib/checkpoints/create', () => ( { createCheckpoint, isCheckpointSupported } ) );
+vi.mock( 'cli/lib/checkpoints/manifest', () => ( { readCheckpointIndex } ) );
+vi.mock( './utils', () => ( {
+	resolveSite,
+	textResult: ( text: string ) => ( { content: [ { type: 'text', text } ] } ),
+} ) );
+
+const SITE = { id: 'site-1', path: '/tmp/site', name: 'site' };
+const MANIFEST = {
+	id: 'cp-auto',
+	siteId: 'site-1',
+	label: undefined,
+	trigger: 'auto-pre-tool',
+	toolName: 'wp_cli',
+	createdAt: 123,
+};
+
+function makeTool( name: string ): AnyStudioAgentTool {
+	return {
+		name,
+		description: '',
+		label: name,
+		parameters: {},
+		rawHandler: vi.fn( async () => ( { content: [ { type: 'text' as const, text: 'ok' } ] } ) ),
+		execute: vi.fn( async () => ( { content: [ { type: 'text' as const, text: 'ok' } ] } ) ),
+	};
+}
+
+beforeEach( () => {
+	vi.clearAllMocks();
+	resolveSite.mockResolvedValue( SITE );
+	isCheckpointSupported.mockReturnValue( true );
+	readCheckpointIndex.mockResolvedValue( { version: 1, checkpoints: [] } );
+	createCheckpoint.mockResolvedValue( MANIFEST );
+} );
+
+describe( 'withAutoCheckpoint', () => {
+	it( 'leaves non-destructive tools untouched', () => {
+		const tool = makeTool( 'site_info' );
+		expect( withAutoCheckpoint( tool ) ).toBe( tool );
+	} );
+
+	it( 'creates a checkpoint before wp_cli runs (rawHandler path)', async () => {
+		const tool = makeTool( 'wp_cli' );
+		const wrapped = withAutoCheckpoint( tool );
+		const result = await wrapped.rawHandler( {
+			nameOrPath: 'site',
+			command: 'wp option update x y',
+		} as never );
+
+		expect( createCheckpoint ).toHaveBeenCalledWith(
+			SITE,
+			expect.objectContaining( { trigger: 'auto-pre-tool', toolName: 'wp_cli' } )
+		);
+		expect( tool.rawHandler ).toHaveBeenCalled();
+		// The checkpoint chip is attached to the tool result.
+		expect(
+			( result as { studioArtifacts?: Array< { type: string } > } ).studioArtifacts?.[ 0 ]?.type
+		).toBe( 'checkpoint' );
+	} );
+
+	it( 'attaches the artifact through the execute path details', async () => {
+		const tool = makeTool( 'wp_cli' );
+		const wrapped = withAutoCheckpoint( tool );
+		const result = await wrapped.execute( 'call-1', { nameOrPath: 'site' } as never );
+
+		const details = result.details as { studioArtifacts?: Array< { type: string } > };
+		expect( details.studioArtifacts?.[ 0 ]?.type ).toBe( 'checkpoint' );
+	} );
+
+	it( 'debounces when a recent checkpoint exists', async () => {
+		readCheckpointIndex.mockResolvedValue( {
+			version: 1,
+			checkpoints: [
+				{
+					id: 'cp-recent',
+					createdAt: Date.now() - AUTO_CHECKPOINT_DEBOUNCE_MS / 2,
+					trigger: 'manual',
+				},
+			],
+		} );
+		const tool = makeTool( 'wp_cli' );
+		const wrapped = withAutoCheckpoint( tool );
+		const result = await wrapped.rawHandler( { nameOrPath: 'site' } as never );
+
+		expect( createCheckpoint ).not.toHaveBeenCalled();
+		// No chip when no checkpoint was actually captured.
+		expect( ( result as { studioArtifacts?: unknown[] } ).studioArtifacts ).toBeUndefined();
+	} );
+
+	it( 'lets the tool proceed when checkpointing fails', async () => {
+		createCheckpoint.mockRejectedValue( new Error( 'disk full' ) );
+		const tool = makeTool( 'wp_cli' );
+		const wrapped = withAutoCheckpoint( tool );
+		const result = await wrapped.rawHandler( { nameOrPath: 'site' } as never );
+
+		expect( tool.rawHandler ).toHaveBeenCalled();
+		expect( ( result as { content: Array< { text: string } > } ).content[ 0 ].text ).toBe( 'ok' );
+	} );
+
+	it( 'extracts the data_liberation site target from engine args', async () => {
+		const tool = makeTool( 'data_liberation' );
+		const wrapped = withAutoCheckpoint( tool );
+		await wrapped.rawHandler( {
+			tool: 'liberate_reconstruct_pages',
+			args: { target: { kind: 'studio', sitePath: '/tmp/site' } },
+		} as never );
+
+		expect( resolveSite ).toHaveBeenCalledWith( '/tmp/site' );
+		expect( createCheckpoint ).toHaveBeenCalled();
+	} );
+
+	it( 'skips checkpointing for unsupported (reprint) sites', async () => {
+		isCheckpointSupported.mockReturnValue( false );
+		const tool = makeTool( 'wp_cli' );
+		const wrapped = withAutoCheckpoint( tool );
+		await wrapped.rawHandler( { nameOrPath: 'site' } as never );
+
+		expect( createCheckpoint ).not.toHaveBeenCalled();
+		expect( tool.rawHandler ).toHaveBeenCalled();
+	} );
+} );

--- a/apps/cli/ai/tools/auto-checkpoint.ts
+++ b/apps/cli/ai/tools/auto-checkpoint.ts
@@ -47,10 +47,18 @@ const AUTO_CHECKPOINT_TOOLS: Record< string, SiteRefExtractor > = {
 	},
 };
 
+// Concurrent tool calls (the agent often issues several wp_cli calls in one
+// turn) must not each capture a checkpoint: the debounce reads the index
+// before the other call's entry lands. Track the in-flight capture per site;
+// later callers wait for it and get no chip — the first caller's chip already
+// says "checkpoint before <tool>".
+const inFlightBySiteId = new Map< string, Promise< unknown > >();
+
 // Captures a checkpoint before a destructive tool runs. Never throws — a
 // checkpoint failure must not block the tool — and returns the manifest only
-// when a checkpoint was actually created (not when debounced), so chat chips
-// never imply a fresh capture that didn't happen.
+// when a checkpoint was actually created (not when debounced or coalesced
+// with a concurrent capture), so chat chips never imply a fresh capture that
+// didn't happen.
 async function maybeCreateAutoCheckpoint(
 	toolName: string,
 	siteRef: string | undefined
@@ -64,16 +72,35 @@ async function maybeCreateAutoCheckpoint(
 			return undefined;
 		}
 
-		const index = await readCheckpointIndex( site.id );
-		const newest = index.checkpoints[ index.checkpoints.length - 1 ];
-		if ( newest && Date.now() - newest.createdAt < AUTO_CHECKPOINT_DEBOUNCE_MS ) {
+		const inFlight = inFlightBySiteId.get( site.id );
+		if ( inFlight ) {
+			// Wait so the tool runs against the checkpointed state, but let the
+			// concurrent caller own the chip.
+			await inFlight.catch( () => {} );
 			return undefined;
 		}
 
-		return await createCheckpoint( site, {
-			trigger: 'auto-pre-tool',
-			toolName,
-		} );
+		const capture = ( async () => {
+			const index = await readCheckpointIndex( site.id );
+			const newest = index.checkpoints[ index.checkpoints.length - 1 ];
+			if ( newest && Date.now() - newest.createdAt < AUTO_CHECKPOINT_DEBOUNCE_MS ) {
+				return undefined;
+			}
+
+			return await createCheckpoint( site, {
+				trigger: 'auto-pre-tool',
+				toolName,
+			} );
+		} )();
+		inFlightBySiteId.set(
+			site.id,
+			capture.catch( () => {} )
+		);
+		try {
+			return await capture;
+		} finally {
+			inFlightBySiteId.delete( site.id );
+		}
 	} catch ( error ) {
 		console.warn(
 			`[checkpoints] auto-checkpoint before ${ toolName } failed:`,

--- a/apps/cli/ai/tools/auto-checkpoint.ts
+++ b/apps/cli/ai/tools/auto-checkpoint.ts
@@ -1,0 +1,131 @@
+import { createCheckpoint, isCheckpointSupported } from 'cli/lib/checkpoints/create';
+import { readCheckpointIndex, type CheckpointManifest } from 'cli/lib/checkpoints/manifest';
+import { checkpointArtifact } from './checkpoints';
+import { resolveSite } from './utils';
+import type { AnyStudioAgentTool, StudioToolResultDetails, ToolResult } from './define-tool';
+
+// Skip the auto-checkpoint when the site's newest checkpoint (of any kind) is
+// younger than this: a burst of wp_cli calls is one logical operation and
+// shouldn't stack a checkpoint per call. The trade-off: restoring during a
+// burst rolls back the whole burst, not just the last tool.
+export const AUTO_CHECKPOINT_DEBOUNCE_MS = 2 * 60 * 1000;
+
+type SiteRefExtractor = ( params: Record< string, unknown > ) => string | undefined;
+
+// Tools that mutate site state get a checkpoint captured before they run.
+// Each entry extracts the site name/path from that tool's own params.
+// Not listed: checkpoint_restore (takes its own pre-restore checkpoint),
+// site_delete (the store is deleted with the site), push/preview tools
+// (remote-side effects only), and read-only tools.
+const nameOrPath: SiteRefExtractor = ( params ) =>
+	typeof params.nameOrPath === 'string' ? params.nameOrPath : undefined;
+
+const AUTO_CHECKPOINT_TOOLS: Record< string, SiteRefExtractor > = {
+	wp_cli: nameOrPath,
+	site_import: nameOrPath,
+	site_pull: nameOrPath,
+	scaffold_theme: nameOrPath,
+	install_taxonomy_scripts: nameOrPath,
+	// Data Liberation site-targeting tools receive a Studio target inside the
+	// forwarded engine args: { kind: 'studio', sitePath: '…' }.
+	data_liberation: ( params ) => {
+		const args = params.args;
+		if ( args && typeof args === 'object' ) {
+			const target = ( args as Record< string, unknown > ).target;
+			if ( target && typeof target === 'object' ) {
+				const sitePath = ( target as Record< string, unknown > ).sitePath;
+				if ( typeof sitePath === 'string' ) {
+					return sitePath;
+				}
+			}
+			const sitePath = ( args as Record< string, unknown > ).sitePath;
+			if ( typeof sitePath === 'string' ) {
+				return sitePath;
+			}
+		}
+		return undefined;
+	},
+};
+
+// Captures a checkpoint before a destructive tool runs. Never throws — a
+// checkpoint failure must not block the tool — and returns the manifest only
+// when a checkpoint was actually created (not when debounced), so chat chips
+// never imply a fresh capture that didn't happen.
+async function maybeCreateAutoCheckpoint(
+	toolName: string,
+	siteRef: string | undefined
+): Promise< CheckpointManifest | undefined > {
+	if ( ! siteRef ) {
+		return undefined;
+	}
+	try {
+		const site = await resolveSite( siteRef );
+		if ( ! isCheckpointSupported( site ) ) {
+			return undefined;
+		}
+
+		const index = await readCheckpointIndex( site.id );
+		const newest = index.checkpoints[ index.checkpoints.length - 1 ];
+		if ( newest && Date.now() - newest.createdAt < AUTO_CHECKPOINT_DEBOUNCE_MS ) {
+			return undefined;
+		}
+
+		return await createCheckpoint( site, {
+			trigger: 'auto-pre-tool',
+			toolName,
+		} );
+	} catch ( error ) {
+		console.warn(
+			`[checkpoints] auto-checkpoint before ${ toolName } failed:`,
+			error instanceof Error ? error.message : error
+		);
+		return undefined;
+	}
+}
+
+function withCheckpointArtifact( result: ToolResult, manifest: CheckpointManifest ): ToolResult {
+	return {
+		...result,
+		studioArtifacts: [ checkpointArtifact( manifest ), ...( result.studioArtifacts ?? [] ) ],
+	};
+}
+
+// Wraps a destructive tool so a checkpoint is captured before it executes.
+// Both entry points are wrapped: `rawHandler` (MCP dispatch) and `execute`
+// (the pi agent loop) — they don't share a code path.
+export function withAutoCheckpoint< TTool extends AnyStudioAgentTool >( tool: TTool ): TTool {
+	const extractSiteRef = AUTO_CHECKPOINT_TOOLS[ tool.name ];
+	if ( ! extractSiteRef ) {
+		return tool;
+	}
+
+	return {
+		...tool,
+		rawHandler: async ( params: never ) => {
+			const manifest = await maybeCreateAutoCheckpoint(
+				tool.name,
+				extractSiteRef( params as Record< string, unknown > )
+			);
+			const result = await tool.rawHandler( params );
+			return manifest ? withCheckpointArtifact( result, manifest ) : result;
+		},
+		execute: async ( toolCallId, params, signal, onUpdate ) => {
+			const manifest = await maybeCreateAutoCheckpoint(
+				tool.name,
+				extractSiteRef( params as Record< string, unknown > )
+			);
+			const result = await tool.execute( toolCallId, params, signal, onUpdate );
+			if ( ! manifest ) {
+				return result;
+			}
+			const details = ( result.details ?? {} ) as StudioToolResultDetails;
+			return {
+				...result,
+				details: {
+					...details,
+					studioArtifacts: [ checkpointArtifact( manifest ), ...( details.studioArtifacts ?? [] ) ],
+				},
+			};
+		},
+	};
+}

--- a/apps/cli/ai/tools/checkpoints.ts
+++ b/apps/cli/ai/tools/checkpoints.ts
@@ -1,0 +1,238 @@
+import { Type } from 'typebox';
+import { createCheckpoint, isCheckpointSupported } from 'cli/lib/checkpoints/create';
+import { diffCheckpoints, type CheckpointDiff } from 'cli/lib/checkpoints/diff';
+import { readCheckpointIndex, readRestoreJournal } from 'cli/lib/checkpoints/manifest';
+import { restoreCheckpoint } from 'cli/lib/checkpoints/restore';
+import { Logger } from 'cli/logger';
+import { defineTool, type ToolResult } from './define-tool';
+import { resolveSite, textResult } from './utils';
+import type { StudioChatArtifactWidgetDraft } from '@studio/common/ai/chat-artifacts';
+import type { CheckpointManifest } from 'cli/lib/checkpoints/manifest';
+
+function checkpointArtifact(
+	manifest: Pick< CheckpointManifest, 'id' | 'siteId' | 'label' | 'createdAt' | 'trigger' > & {
+		toolName?: string;
+	}
+): StudioChatArtifactWidgetDraft {
+	return {
+		type: 'checkpoint',
+		widgetProps: {
+			checkpointId: manifest.id,
+			siteId: manifest.siteId,
+			label: manifest.label ?? null,
+			trigger: manifest.trigger,
+			toolName: manifest.toolName ?? null,
+			createdAt: manifest.createdAt,
+		},
+	};
+}
+
+export function formatDiffSummary( diff: CheckpointDiff ): string {
+	const lines: string[] = [];
+	const { added, modified, deleted } = diff.files;
+
+	if ( added.length === 0 && modified.length === 0 && deleted.length === 0 ) {
+		lines.push( 'Files: no changes.' );
+	} else {
+		lines.push(
+			`Files: ${ added.length } added, ${ modified.length } modified, ${ deleted.length } deleted.`
+		);
+		const sample = ( entries: Array< { path: string } >, verb: string ) => {
+			for ( const entry of entries.slice( 0, 15 ) ) {
+				lines.push( `  ${ verb } ${ entry.path }` );
+			}
+			if ( entries.length > 15 ) {
+				lines.push( `  …and ${ entries.length - 15 } more ${ verb.toLowerCase() }` );
+			}
+		};
+		sample( added, 'added' );
+		sample( modified, 'modified' );
+		sample( deleted, 'deleted' );
+	}
+
+	if ( diff.database.detailed ) {
+		const {
+			changedTables = [],
+			addedTables = [],
+			removedTables = [],
+			changedOptions = [],
+		} = diff.database;
+		if (
+			changedTables.length === 0 &&
+			addedTables.length === 0 &&
+			removedTables.length === 0 &&
+			changedOptions.length === 0
+		) {
+			lines.push( 'Database: no changes.' );
+		} else {
+			lines.push( 'Database changes:' );
+			for ( const change of changedTables ) {
+				lines.push( `  ${ change.table }: ${ change.fromRows } → ${ change.toRows } rows` );
+			}
+			for ( const table of addedTables ) {
+				lines.push( `  ${ table }: table added` );
+			}
+			for ( const table of removedTables ) {
+				lines.push( `  ${ table }: table removed` );
+			}
+			if ( changedOptions.length > 0 ) {
+				lines.push(
+					`  changed options: ${ changedOptions.slice( 0, 20 ).join( ', ' ) }${
+						changedOptions.length > 20 ? `, …and ${ changedOptions.length - 20 } more` : ''
+					}`
+				);
+			}
+		}
+	} else {
+		lines.push(
+			`Database: changed by ${ diff.database.sizeDelta ?? 0 } bytes (detailed diff unavailable).`
+		);
+	}
+
+	return lines.join( '\n' );
+}
+
+export const createCheckpointTool = defineTool(
+	'checkpoint_create',
+	'Captures the entire current state of a local site — all files AND the database — as a checkpoint ' +
+		'that can be restored later with checkpoint_restore. Create one after completing meaningful work ' +
+		'(a plugin configured, a theme change finished) or before starting something risky. ' +
+		'Cheap to create: unchanged files are deduplicated, so only new data costs disk space.',
+	{
+		nameOrPath: Type.String( { description: 'The site name or file system path' } ),
+		label: Type.Optional(
+			Type.String( {
+				description:
+					'A short human-readable description of the state, e.g. "Contact form plugin configured".',
+			} )
+		),
+	},
+	async ( args ): Promise< ToolResult > => {
+		const site = await resolveSite( args.nameOrPath );
+		const manifest = await createCheckpoint( site, {
+			label: args.label,
+			trigger: 'agent',
+		} );
+		return {
+			content: [
+				{
+					type: 'text',
+					text:
+						`Checkpoint ${ manifest.id } created` +
+						( manifest.label ? ` ("${ manifest.label }")` : '' ) +
+						`. ${ manifest.stats.fileCount } files + database captured; ` +
+						`${ Math.round( manifest.stats.newObjectBytes / 1024 ) } KB of new data stored.`,
+				},
+			],
+			studioArtifacts: [ checkpointArtifact( manifest ) ],
+		};
+	}
+);
+
+export const listCheckpointsTool = defineTool(
+	'checkpoint_list',
+	'Lists the checkpoints of a local site (files + database save points), newest first. ' +
+		'Use checkpoint_diff to see what changed since one, or checkpoint_restore to roll back.',
+	{
+		nameOrPath: Type.String( { description: 'The site name or file system path' } ),
+	},
+	async ( args ): Promise< ToolResult > => {
+		const site = await resolveSite( args.nameOrPath );
+		const index = await readCheckpointIndex( site.id );
+		const journal = await readRestoreJournal( site.id );
+
+		if ( index.checkpoints.length === 0 ) {
+			return textResult( 'This site has no checkpoints yet. Create one with checkpoint_create.' );
+		}
+
+		const lines = [ ...index.checkpoints ].reverse().map( ( entry ) => {
+			const label = entry.label ?? ( entry.toolName ? `before ${ entry.toolName }` : 'no label' );
+			return `${ entry.id } — ${ label } [${ entry.trigger }] ${ new Date(
+				entry.createdAt
+			).toISOString() }`;
+		} );
+		if ( journal ) {
+			lines.push(
+				`WARNING: a restore of ${ journal.checkpointId } was interrupted; the site may be in a mixed state. Re-run checkpoint_restore with that id.`
+			);
+		}
+		return textResult( lines.join( '\n' ) );
+	}
+);
+
+export const restoreCheckpointTool = defineTool(
+	'checkpoint_restore',
+	'Restores a local site — all files AND the database — to a previous checkpoint. ' +
+		'A safety checkpoint of the current state is created first, so the restore itself can be undone. ' +
+		'If the site is running it is stopped and restarted automatically. ' +
+		'Everything done after the checkpoint (posts, settings, plugin installs) is rolled back.',
+	{
+		nameOrPath: Type.String( { description: 'The site name or file system path' } ),
+		checkpointId: Type.String( {
+			description: 'The checkpoint id to restore, from checkpoint_list or checkpoint_create.',
+		} ),
+	},
+	async ( args ): Promise< ToolResult > => {
+		const site = await resolveSite( args.nameOrPath );
+		const journal = await readRestoreJournal( site.id );
+		const logger = new Logger< string >();
+		const result = await restoreCheckpoint( site, args.checkpointId, logger, {
+			skipSafetyCheckpoint: journal?.checkpointId === args.checkpointId,
+		} );
+		return textResult(
+			`Site restored to checkpoint ${ result.checkpointId } (files + database).` +
+				( result.safetyCheckpointId
+					? ` The pre-restore state was saved as ${ result.safetyCheckpointId }; restore it to undo this.`
+					: '' )
+		);
+	}
+);
+
+export const diffCheckpointTool = defineTool(
+	'checkpoint_diff',
+	'Shows what changed between a checkpoint and the current site state (or between two checkpoints): ' +
+		'files added/modified/deleted, database tables with changed row counts, and changed wp_options entries. ' +
+		'Useful for debugging — "what changed since things last worked?" — before deciding whether to restore.',
+	{
+		nameOrPath: Type.String( { description: 'The site name or file system path' } ),
+		fromCheckpointId: Type.Optional(
+			Type.String( {
+				description:
+					'The baseline checkpoint id. Defaults to the most recent manual or agent checkpoint.',
+			} )
+		),
+		toCheckpointId: Type.Optional(
+			Type.String( {
+				description: 'The comparison checkpoint id. Defaults to the current site state.',
+			} )
+		),
+	},
+	async ( args ): Promise< ToolResult > => {
+		const site = await resolveSite( args.nameOrPath );
+
+		let fromId = args.fromCheckpointId;
+		if ( ! fromId ) {
+			const index = await readCheckpointIndex( site.id );
+			const lastGood = [ ...index.checkpoints ]
+				.reverse()
+				.find( ( entry ) => entry.trigger === 'manual' || entry.trigger === 'agent' );
+			if ( ! lastGood ) {
+				return textResult(
+					'This site has no manual or agent checkpoints to compare against. Create one with checkpoint_create, or pass fromCheckpointId explicitly.'
+				);
+			}
+			fromId = lastGood.id;
+		}
+
+		const diff = await diffCheckpoints( site, fromId, args.toCheckpointId ?? 'current' );
+		return textResult(
+			`Changes from ${ fromId } to ${
+				args.toCheckpointId ?? 'the current state'
+			}:\n${ formatDiffSummary( diff ) }`
+		);
+	}
+);
+
+// Used by the auto-checkpoint decorator to know whether a site can be
+// checkpointed at all before a destructive tool runs.
+export { isCheckpointSupported, checkpointArtifact };

--- a/apps/cli/ai/tools/index.ts
+++ b/apps/cli/ai/tools/index.ts
@@ -1,4 +1,11 @@
 import { emitChatArtifactWidgets } from 'cli/ai/chat-artifacts';
+import { withAutoCheckpoint } from './auto-checkpoint';
+import {
+	createCheckpointTool,
+	diffCheckpointTool,
+	listCheckpointsTool,
+	restoreCheckpointTool,
+} from './checkpoints';
 import { createPreviewTool } from './create-preview';
 import { createSiteTool } from './create-site';
 import { dataLiberationTool } from './data-liberation';
@@ -59,6 +66,10 @@ export const studioToolDefinitions: AnyStudioAgentTool[] = [
 	pullSiteTool,
 	importSiteTool,
 	exportSiteTool,
+	createCheckpointTool,
+	listCheckpointsTool,
+	restoreCheckpointTool,
+	diffCheckpointTool,
 	openAnnotationBrowserTool,
 	waitForAnnotationsTool,
 ];
@@ -87,7 +98,14 @@ export function resolveStudioToolDefinitions(
 		if ( candidate.name === shareScreenshotTool.name && ! options.remoteSession ) {
 			return [];
 		}
-		return [ withChatArtifactEmission( candidate, options.emitChatArtifacts === true ) ];
+		// Auto-checkpoint wraps first so the emission wrapper sees (and emits)
+		// any checkpoint artifact the decorator attaches to the tool result.
+		return [
+			withChatArtifactEmission(
+				withAutoCheckpoint( candidate ),
+				options.emitChatArtifacts === true
+			),
+		];
 	} );
 }
 

--- a/apps/cli/commands/checkpoint.ts
+++ b/apps/cli/commands/checkpoint.ts
@@ -1,0 +1,498 @@
+import fsPromises from 'fs/promises';
+import { confirm } from '@inquirer/prompts';
+import { CheckpointEvents, type CheckpointIpcEvent } from '@studio/common/lib/checkpoint-events';
+import { SiteCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
+import { __, sprintf } from '@wordpress/i18n';
+import Table from 'cli-table3';
+import {
+	createCheckpoint,
+	isCheckpointSupported,
+	runGarbageCollection,
+} from 'cli/lib/checkpoints/create';
+import { diffCheckpoints } from 'cli/lib/checkpoints/diff';
+import { CheckpointEventEmitter } from 'cli/lib/checkpoints/events';
+import {
+	getManifestPath,
+	readCheckpointIndex,
+	readRestoreJournal,
+	updateCheckpointIndex,
+} from 'cli/lib/checkpoints/manifest';
+import { restoreCheckpoint } from 'cli/lib/checkpoints/restore';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
+import { untildify } from 'cli/lib/utils';
+import { Logger, LoggerError } from 'cli/logger';
+import { StudioArgv } from 'cli/types';
+
+const logger = new Logger< LoggerAction >();
+
+function createReportingEmitter(): CheckpointEventEmitter {
+	const emitter = new CheckpointEventEmitter();
+	const sendIpcEvent = ( eventTuple: CheckpointIpcEvent[ 'checkpointEvent' ] ) => {
+		const ipcEvent: CheckpointIpcEvent = { checkpointEvent: eventTuple };
+		process.send!( ipcEvent );
+	};
+
+	if ( process.send ) {
+		emitter.on( CheckpointEvents.CHECKPOINT_CREATE_START, ( data ) =>
+			sendIpcEvent( [ CheckpointEvents.CHECKPOINT_CREATE_START, data ] )
+		);
+		emitter.on( CheckpointEvents.CHECKPOINT_CREATE_PROGRESS, ( data ) =>
+			sendIpcEvent( [ CheckpointEvents.CHECKPOINT_CREATE_PROGRESS, data ] )
+		);
+		emitter.on( CheckpointEvents.CHECKPOINT_CREATE_COMPLETE, ( data ) =>
+			sendIpcEvent( [ CheckpointEvents.CHECKPOINT_CREATE_COMPLETE, data ] )
+		);
+		emitter.on( CheckpointEvents.CHECKPOINT_CREATE_ERROR, ( data ) =>
+			sendIpcEvent( [ CheckpointEvents.CHECKPOINT_CREATE_ERROR, data ] )
+		);
+		emitter.on( CheckpointEvents.CHECKPOINT_RESTORE_START, ( data ) =>
+			sendIpcEvent( [ CheckpointEvents.CHECKPOINT_RESTORE_START, data ] )
+		);
+		emitter.on( CheckpointEvents.CHECKPOINT_RESTORE_PROGRESS, ( data ) =>
+			sendIpcEvent( [ CheckpointEvents.CHECKPOINT_RESTORE_PROGRESS, data ] )
+		);
+		emitter.on( CheckpointEvents.CHECKPOINT_RESTORE_COMPLETE, ( data ) =>
+			sendIpcEvent( [ CheckpointEvents.CHECKPOINT_RESTORE_COMPLETE, data ] )
+		);
+		emitter.on( CheckpointEvents.CHECKPOINT_RESTORE_ERROR, ( data ) =>
+			sendIpcEvent( [ CheckpointEvents.CHECKPOINT_RESTORE_ERROR, data ] )
+		);
+	} else {
+		emitter.on( CheckpointEvents.CHECKPOINT_CREATE_PROGRESS, ( data ) => {
+			if ( data.processed && data.total ) {
+				logger.reportProgress(
+					sprintf( __( 'Capturing site files… (%1$d/%2$d)' ), data.processed, data.total )
+				);
+			}
+		} );
+		emitter.on( CheckpointEvents.CHECKPOINT_RESTORE_PROGRESS, ( data ) => {
+			if ( data.processed && data.total ) {
+				logger.reportProgress(
+					sprintf( __( 'Restoring site files… (%1$d/%2$d)' ), data.processed, data.total )
+				);
+			}
+		} );
+	}
+
+	return emitter;
+}
+
+function formatBytes( bytes: number ): string {
+	if ( bytes < 1024 ) {
+		return `${ bytes } B`;
+	}
+	if ( bytes < 1024 * 1024 ) {
+		return `${ ( bytes / 1024 ).toFixed( 1 ) } KB`;
+	}
+	if ( bytes < 1024 * 1024 * 1024 ) {
+		return `${ ( bytes / ( 1024 * 1024 ) ).toFixed( 1 ) } MB`;
+	}
+	return `${ ( bytes / ( 1024 * 1024 * 1024 ) ).toFixed( 2 ) } GB`;
+}
+
+function getTriggerLabel( trigger: string ): string {
+	switch ( trigger ) {
+		case 'manual':
+			return __( 'Manual' );
+		case 'agent':
+			return __( 'Agent' );
+		case 'auto-pre-tool':
+			return __( 'Auto' );
+		case 'pre-restore':
+			return __( 'Safety' );
+		default:
+			return trigger;
+	}
+}
+
+export async function runCreateCommand( siteFolder: string, label?: string ): Promise< void > {
+	try {
+		await connectToDaemon();
+		const site = await getSiteByFolder( siteFolder );
+		if ( ! isCheckpointSupported( site ) ) {
+			throw new LoggerError(
+				__( 'Checkpoints are not yet supported for sites imported with `studio pull-reprint`.' )
+			);
+		}
+
+		logger.reportStart( LoggerAction.EXPORT_SITE, __( 'Creating checkpoint…' ) );
+		const manifest = await createCheckpoint( site, {
+			label,
+			trigger: 'manual',
+			emitter: createReportingEmitter(),
+		} );
+		logger.reportSuccess(
+			sprintf(
+				__( 'Checkpoint %1$s created (%2$s new data, %3$d files)' ),
+				manifest.id,
+				formatBytes( manifest.stats.newObjectBytes ),
+				manifest.stats.fileCount
+			)
+		);
+	} finally {
+		await disconnectFromDaemon();
+	}
+}
+
+export async function runListCommand( siteFolder: string, asJson: boolean ): Promise< void > {
+	const site = await getSiteByFolder( siteFolder );
+	const index = await readCheckpointIndex( site.id );
+	const journal = await readRestoreJournal( site.id );
+
+	if ( asJson ) {
+		console.log(
+			JSON.stringify( { checkpoints: index.checkpoints, interruptedRestore: journal }, null, 2 )
+		);
+		return;
+	}
+
+	if ( index.checkpoints.length === 0 ) {
+		console.log( __( 'No checkpoints yet. Create one with `studio checkpoint create`.' ) );
+		return;
+	}
+
+	const table = new Table( {
+		head: [ __( 'ID' ), __( 'Label' ), __( 'Type' ), __( 'Created' ), __( 'New data' ) ],
+	} );
+	for ( const entry of [ ...index.checkpoints ].reverse() ) {
+		table.push( [
+			entry.id,
+			entry.label ?? ( entry.toolName ? sprintf( __( 'Before %s' ), entry.toolName ) : '—' ),
+			getTriggerLabel( entry.trigger ),
+			new Date( entry.createdAt ).toLocaleString(),
+			formatBytes( entry.stats.newObjectBytes ),
+		] );
+	}
+	console.log( table.toString() );
+
+	if ( journal ) {
+		console.warn(
+			sprintf(
+				__(
+					'Warning: a restore of %s was interrupted. Run `studio checkpoint restore %s` to re-apply it.'
+				),
+				journal.checkpointId,
+				journal.checkpointId
+			)
+		);
+	}
+}
+
+export async function runRestoreCommand(
+	siteFolder: string,
+	checkpointId: string,
+	skipConfirm: boolean
+): Promise< void > {
+	try {
+		await connectToDaemon();
+		const site = await getSiteByFolder( siteFolder );
+
+		if ( ! skipConfirm ) {
+			const confirmed = await confirm( {
+				message: sprintf(
+					__(
+						'Restore site files AND database to checkpoint %s? A safety checkpoint of the current state will be created first.'
+					),
+					checkpointId
+				),
+				default: false,
+			} );
+			if ( ! confirmed ) {
+				return;
+			}
+		}
+
+		const journal = await readRestoreJournal( site.id );
+		const resumingInterrupted = journal?.checkpointId === checkpointId;
+
+		logger.reportStart( LoggerAction.IMPORT_SITE, __( 'Restoring checkpoint…' ) );
+		const result = await restoreCheckpoint( site, checkpointId, logger, {
+			emitter: createReportingEmitter(),
+			// Re-applying an interrupted restore reuses the safety checkpoint
+			// from the first attempt instead of capturing the half-restored tree.
+			skipSafetyCheckpoint: resumingInterrupted,
+		} );
+		logger.reportSuccess(
+			result.safetyCheckpointId
+				? sprintf(
+						__( 'Checkpoint %1$s restored. Undo with `studio checkpoint restore %2$s`.' ),
+						result.checkpointId,
+						result.safetyCheckpointId
+				  )
+				: sprintf( __( 'Checkpoint %s restored.' ), result.checkpointId )
+		);
+	} finally {
+		await disconnectFromDaemon();
+	}
+}
+
+export async function runDeleteCommand(
+	siteFolder: string,
+	checkpointId: string | undefined,
+	autoOnly: boolean
+): Promise< void > {
+	const site = await getSiteByFolder( siteFolder );
+
+	const removedIds: string[] = [];
+	await updateCheckpointIndex( site.id, ( index ) => {
+		const shouldRemove = ( entry: { id: string; trigger: string; pinned?: boolean } ) => {
+			if ( entry.pinned ) {
+				return false;
+			}
+			if ( autoOnly ) {
+				return entry.trigger === 'auto-pre-tool' || entry.trigger === 'pre-restore';
+			}
+			return entry.id === checkpointId;
+		};
+		index.checkpoints = index.checkpoints.filter( ( entry ) => {
+			if ( shouldRemove( entry ) ) {
+				removedIds.push( entry.id );
+				return false;
+			}
+			return true;
+		} );
+		return index;
+	} );
+
+	if ( ! autoOnly && removedIds.length === 0 ) {
+		throw new LoggerError( sprintf( __( 'Checkpoint not found: %s' ), checkpointId ?? '' ) );
+	}
+
+	for ( const removedId of removedIds ) {
+		await fsPromises.rm( getManifestPath( site.id, removedId ), { force: true } );
+	}
+	const swept = await runGarbageCollection( site.id );
+	logger.reportSuccess(
+		sprintf(
+			__( 'Deleted %1$d checkpoint(s), reclaimed %2$d object(s).' ),
+			removedIds.length,
+			swept
+		)
+	);
+}
+
+export async function runDiffCommand(
+	siteFolder: string,
+	fromId: string,
+	toId: string,
+	asJson: boolean
+): Promise< void > {
+	try {
+		await connectToDaemon();
+		const site = await getSiteByFolder( siteFolder );
+		const diff = await diffCheckpoints( site, fromId, toId );
+
+		if ( asJson ) {
+			console.log( JSON.stringify( diff, null, 2 ) );
+			return;
+		}
+
+		const summarize = ( entries: Array< { path: string } >, verb: string ) => {
+			if ( entries.length === 0 ) {
+				return;
+			}
+			console.log( `${ verb } (${ entries.length }):` );
+			for ( const entry of entries.slice( 0, 25 ) ) {
+				console.log( `  ${ entry.path }` );
+			}
+			if ( entries.length > 25 ) {
+				console.log( sprintf( __( '  …and %d more' ), entries.length - 25 ) );
+			}
+		};
+		summarize( diff.files.added, __( 'Added' ) );
+		summarize( diff.files.modified, __( 'Modified' ) );
+		summarize( diff.files.deleted, __( 'Deleted' ) );
+		if (
+			diff.files.added.length === 0 &&
+			diff.files.modified.length === 0 &&
+			diff.files.deleted.length === 0
+		) {
+			console.log( __( 'No file changes.' ) );
+		}
+
+		if ( diff.database.detailed ) {
+			const {
+				changedTables = [],
+				addedTables = [],
+				removedTables = [],
+				changedOptions = [],
+			} = diff.database;
+			if (
+				changedTables.length === 0 &&
+				addedTables.length === 0 &&
+				removedTables.length === 0 &&
+				changedOptions.length === 0
+			) {
+				console.log( __( 'No database changes.' ) );
+			} else {
+				console.log( __( 'Database changes:' ) );
+				for ( const change of changedTables ) {
+					console.log( `  ${ change.table }: ${ change.fromRows } → ${ change.toRows } rows` );
+				}
+				for ( const table of addedTables ) {
+					console.log( sprintf( __( '  %s: table added' ), table ) );
+				}
+				for ( const table of removedTables ) {
+					console.log( sprintf( __( '  %s: table removed' ), table ) );
+				}
+				if ( changedOptions.length > 0 ) {
+					console.log(
+						sprintf( __( '  Changed options: %s' ), changedOptions.slice( 0, 15 ).join( ', ' ) )
+					);
+				}
+			}
+		} else {
+			console.log(
+				sprintf(
+					__( 'Database size change: %s bytes (detailed diff unavailable).' ),
+					String( diff.database.sizeDelta ?? 0 )
+				)
+			);
+		}
+	} finally {
+		await disconnectFromDaemon();
+	}
+}
+
+export const registerCommand = ( yargs: StudioArgv ) => {
+	return yargs.command(
+		'checkpoint',
+		__( 'Manage site checkpoints (files + database save points)' ),
+		( checkpointYargs ) => {
+			const withPath = < T >( commandYargs: StudioArgv & T ) =>
+				commandYargs.option( 'path', {
+					type: 'string',
+					description: __( 'Path to the site directory' ),
+					default: process.cwd(),
+					coerce: untildify,
+				} );
+
+			checkpointYargs
+				.command( {
+					command: 'create',
+					describe: __( 'Capture the current site state (files + database)' ),
+					builder: ( commandYargs ) =>
+						withPath( commandYargs ).option( 'label', {
+							type: 'string',
+							description: __( 'A short description of this checkpoint' ),
+						} ),
+					handler: async ( argv ) => {
+						try {
+							await runCreateCommand( argv.path as string, argv.label as string | undefined );
+						} catch ( error ) {
+							logger.reportError(
+								error instanceof LoggerError
+									? error
+									: new LoggerError( __( 'Failed to create checkpoint' ), error )
+							);
+						}
+					},
+				} )
+				.command( {
+					command: 'list',
+					describe: __( 'List checkpoints for a site' ),
+					builder: ( commandYargs ) =>
+						withPath( commandYargs ).option( 'json', {
+							type: 'boolean',
+							default: false,
+							description: __( 'Output as JSON' ),
+						} ),
+					handler: async ( argv ) => {
+						try {
+							await runListCommand( argv.path as string, argv.json as boolean );
+						} catch ( error ) {
+							logger.reportError(
+								error instanceof LoggerError
+									? error
+									: new LoggerError( __( 'Failed to list checkpoints' ), error )
+							);
+						}
+					},
+				} )
+				.command( {
+					command: 'restore <checkpoint-id>',
+					describe: __( 'Restore the site to a checkpoint (files + database)' ),
+					builder: ( commandYargs ) =>
+						withPath( commandYargs ).option( 'yes', {
+							type: 'boolean',
+							default: false,
+							description: __( 'Skip the confirmation prompt' ),
+						} ),
+					handler: async ( argv ) => {
+						try {
+							await runRestoreCommand(
+								argv.path as string,
+								argv[ 'checkpoint-id' ] as string,
+								argv.yes as boolean
+							);
+						} catch ( error ) {
+							logger.reportError(
+								error instanceof LoggerError
+									? error
+									: new LoggerError( __( 'Failed to restore checkpoint' ), error )
+							);
+						}
+					},
+				} )
+				.command( {
+					command: 'delete [checkpoint-id]',
+					describe: __( 'Delete a checkpoint, or all automatic ones with --auto-only' ),
+					builder: ( commandYargs ) =>
+						withPath( commandYargs ).option( 'auto-only', {
+							type: 'boolean',
+							default: false,
+							description: __( 'Delete all automatic and safety checkpoints' ),
+						} ),
+					handler: async ( argv ) => {
+						try {
+							const checkpointId = argv[ 'checkpoint-id' ] as string | undefined;
+							if ( ! checkpointId && ! argv[ 'auto-only' ] ) {
+								throw new LoggerError( __( 'Provide a checkpoint id or use --auto-only.' ) );
+							}
+							await runDeleteCommand(
+								argv.path as string,
+								checkpointId,
+								argv[ 'auto-only' ] as boolean
+							);
+						} catch ( error ) {
+							logger.reportError(
+								error instanceof LoggerError
+									? error
+									: new LoggerError( __( 'Failed to delete checkpoint' ), error )
+							);
+						}
+					},
+				} )
+				.command( {
+					command: 'diff <from-id> [to-id]',
+					describe: __(
+						'Show what changed between two checkpoints, or a checkpoint and the current state'
+					),
+					builder: ( commandYargs ) =>
+						withPath( commandYargs ).option( 'json', {
+							type: 'boolean',
+							default: false,
+							description: __( 'Output as JSON' ),
+						} ),
+					handler: async ( argv ) => {
+						try {
+							await runDiffCommand(
+								argv.path as string,
+								argv[ 'from-id' ] as string,
+								( argv[ 'to-id' ] as string | undefined ) ?? 'current',
+								argv.json as boolean
+							);
+						} catch ( error ) {
+							logger.reportError(
+								error instanceof LoggerError
+									? error
+									: new LoggerError( __( 'Failed to diff checkpoints' ), error )
+							);
+						}
+					},
+				} )
+				.demandCommand( 1, __( 'Specify a checkpoint subcommand.' ) );
+		}
+	);
+};

--- a/apps/cli/commands/site/delete.ts
+++ b/apps/cli/commands/site/delete.ts
@@ -7,6 +7,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import trash from 'trash';
 import { deleteSnapshot } from 'cli/lib/api';
 import { deleteSiteCertificate } from 'cli/lib/certificate-manager';
+import { removeCheckpointStore } from 'cli/lib/checkpoints/manifest';
 import {
 	lockCliConfig,
 	readCliConfig,
@@ -132,6 +133,10 @@ export async function runCommand(
 				logger.reportSuccess( __( 'Site files already removed' ) );
 			}
 		}
+
+		// Remove the site's checkpoint store; checkpoints are meaningless once
+		// the site itself is gone.
+		await removeCheckpointStore( site.id ).catch( () => {} );
 
 		await emitCliEvent( { event: SITE_EVENTS.DELETED, data: { siteId: site.id } } );
 	} finally {

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -3,6 +3,7 @@ import { suppressPunycodeWarning } from '@studio/common/lib/suppress-punycode-wa
 import { __, sprintf } from '@wordpress/i18n';
 import semver from 'semver';
 import yargs from 'yargs';
+import { registerCommand as registerCheckpointCommand } from 'cli/commands/checkpoint';
 import { registerCommand as registerExportCommand } from 'cli/commands/export';
 import { registerCommand as registerImportCommand } from 'cli/commands/import';
 import { registerCommand as registerMcpCommand } from 'cli/commands/mcp';
@@ -216,6 +217,7 @@ async function main() {
 
 	registerImportCommand( studioArgv );
 	registerExportCommand( studioArgv );
+	registerCheckpointCommand( studioArgv );
 
 	registerUiCommand( studioArgv );
 	registerUninstallCommand( studioArgv );

--- a/apps/cli/lib/checkpoints/capture-database.ts
+++ b/apps/cli/lib/checkpoints/capture-database.ts
@@ -1,0 +1,194 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import path from 'path';
+import { __, sprintf } from '@wordpress/i18n';
+import { runWpCliCommandWithMessaging } from 'cli/lib/run-wp-cli-command';
+import { validatePhpVersion } from 'cli/lib/utils';
+import { getStoreTmpDirectory } from './manifest';
+import { CHECKPOINT_TEMP_FILE_PREFIX } from './walker';
+import type { SiteData } from 'cli/lib/cli-config/core';
+
+export const SITE_DATABASE_RELATIVE_PATH = path.join( 'wp-content', 'database', '.ht.sqlite' );
+
+export interface DatabaseCaptureResult {
+	// Consolidated, integrity-verified database file. Lives in the store's tmp
+	// directory; the caller stores it as an object and removes it.
+	capturedPath: string;
+	capture: 'vacuum' | 'file-copy';
+}
+
+interface SqliteDatabase {
+	exec( sql: string ): void;
+	prepare( sql: string ): { get(): Record< string, unknown > | undefined };
+	close(): void;
+}
+
+// `node:sqlite` is available in the runtimes Studio ships (Node >= 22 for the
+// CLI, Electron 41 = Node 24), but load it dynamically so environments
+// without it degrade gracefully instead of failing at import time.
+async function openSqlite( filePath: string ): Promise< SqliteDatabase | undefined > {
+	try {
+		const sqlite = await import( 'node:sqlite' );
+		return new sqlite.DatabaseSync( filePath ) as unknown as SqliteDatabase;
+	} catch ( error ) {
+		return undefined;
+	}
+}
+
+// IMPORTANT: only ever call on checkpoint artifacts/copies, never on a live
+// site database — host-process SQLite locks don't coordinate with the
+// runtimes that serve the site.
+export async function verifySqliteIntegrity( filePath: string ): Promise< boolean > {
+	const db = await openSqlite( filePath );
+	if ( ! db ) {
+		// Without node:sqlite we can't verify; treat as passing so capture
+		// still works, relying on retries having nothing to detect failures.
+		return true;
+	}
+	try {
+		const row = db.prepare( 'PRAGMA integrity_check' ).get();
+		return row !== undefined && Object.values( row )[ 0 ] === 'ok';
+	} catch ( error ) {
+		return false;
+	} finally {
+		db.close();
+	}
+}
+
+// Folds any WAL residue on a database COPY into its main file so the stored
+// artifact is a single self-contained .sqlite file.
+async function consolidateWal( copyPath: string ): Promise< void > {
+	const db = await openSqlite( copyPath );
+	if ( ! db ) {
+		return;
+	}
+	try {
+		db.exec( 'PRAGMA wal_checkpoint(TRUNCATE)' );
+	} finally {
+		db.close();
+	}
+	await fsPromises.rm( `${ copyPath }-wal`, { force: true } );
+	await fsPromises.rm( `${ copyPath }-shm`, { force: true } );
+}
+
+async function captureFromStoppedSite( site: SiteData ): Promise< string > {
+	const sourcePath = path.join( site.path, SITE_DATABASE_RELATIVE_PATH );
+	if ( ! fs.existsSync( sourcePath ) ) {
+		throw new Error( __( 'The site has no SQLite database to capture.' ) );
+	}
+
+	const destinationPath = path.join(
+		getStoreTmpDirectory( site.id ),
+		`db-${ crypto.randomUUID() }.sqlite`
+	);
+
+	// Copy the database and any WAL residue as a pair (a crashed or
+	// force-stopped server can leave unmerged frames in the -wal file), then
+	// fold the WAL into the copy so the artifact is one file.
+	await fsPromises.copyFile( sourcePath, destinationPath, fs.constants.COPYFILE_FICLONE );
+	if ( fs.existsSync( `${ sourcePath }-wal` ) ) {
+		await fsPromises.copyFile(
+			`${ sourcePath }-wal`,
+			`${ destinationPath }-wal`,
+			fs.constants.COPYFILE_FICLONE
+		);
+	}
+	await consolidateWal( destinationPath );
+
+	return destinationPath;
+}
+
+// Captures the database of a RUNNING site by executing `VACUUM INTO` from a
+// PHP process appropriate to the site's runtime:
+//  - native: a separate wp-cli PHP process; POSIX locks coordinate with the
+//    server's PHP, so the copy is transactionally consistent.
+//  - sandbox (Playground): routed into the running daemon over IPC. The
+//    daemon may still run wp-cli commands in parallel WASM instances whose
+//    SQLite locks do NOT coordinate, so the artifact is verified host-side
+//    and the capture retried on failure.
+// `--skip-wordpress` keeps WordPress (and the SQLite integration's own
+// connection) out of the eval entirely; paths are relative to the PHP cwd,
+// which is the site root for native and /wordpress for the sandbox.
+async function captureFromRunningSite( site: SiteData ): Promise< string > {
+	const tempFileName = `${ CHECKPOINT_TEMP_FILE_PREFIX }db-${ crypto.randomUUID() }.sqlite`;
+	const relativeSource = 'wp-content/database/.ht.sqlite';
+	const phpCode = [
+		'error_reporting(0);',
+		`$src = getcwd() . '/${ relativeSource }';`,
+		`$dst = getcwd() . '/${ tempFileName }';`,
+		'try {',
+		'$pdo = new PDO("sqlite:$src");',
+		'$pdo->exec("VACUUM INTO " . $pdo->quote($dst));',
+		'echo "studio-checkpoint-capture-ok";',
+		'} catch (Throwable $e) { echo "studio-checkpoint-capture-error: " . $e->getMessage(); }',
+	].join( ' ' );
+
+	await using command = await runWpCliCommandWithMessaging(
+		site,
+		[ 'eval', phpCode, '--skip-wordpress' ],
+		{ phpVersion: validatePhpVersion( site.phpVersion ) }
+	);
+	const stdout = await command.response.stdoutText;
+	const hostTempPath = path.join( site.path, tempFileName );
+
+	if ( ! stdout.includes( 'studio-checkpoint-capture-ok' ) || ! fs.existsSync( hostTempPath ) ) {
+		await fsPromises.rm( hostTempPath, { force: true } );
+		throw new Error(
+			sprintf( __( 'Database capture failed: %s' ), stdout.trim() || __( 'no output' ) )
+		);
+	}
+
+	// Move the artifact out of the site tree into the store's tmp directory.
+	const destinationPath = path.join(
+		getStoreTmpDirectory( site.id ),
+		`db-${ crypto.randomUUID() }.sqlite`
+	);
+	await fsPromises.rename( hostTempPath, destinationPath ).catch( async () => {
+		// Cross-device fallback (site and store on different volumes).
+		await fsPromises.copyFile( hostTempPath, destinationPath );
+		await fsPromises.rm( hostTempPath, { force: true } );
+	} );
+
+	return destinationPath;
+}
+
+const RUNNING_CAPTURE_ATTEMPTS = 3;
+
+export async function captureDatabase(
+	site: SiteData,
+	isRunning: boolean
+): Promise< DatabaseCaptureResult > {
+	await fsPromises.mkdir( getStoreTmpDirectory( site.id ), { recursive: true } );
+
+	if ( ! isRunning ) {
+		const capturedPath = await captureFromStoppedSite( site );
+		if ( ! ( await verifySqliteIntegrity( capturedPath ) ) ) {
+			await fsPromises.rm( capturedPath, { force: true } );
+			throw new Error( __( 'The captured database copy failed its integrity check.' ) );
+		}
+		return { capturedPath, capture: 'file-copy' };
+	}
+
+	let lastError: unknown;
+	for ( let attempt = 1; attempt <= RUNNING_CAPTURE_ATTEMPTS; attempt++ ) {
+		let capturedPath: string | undefined;
+		try {
+			capturedPath = await captureFromRunningSite( site );
+			if ( await verifySqliteIntegrity( capturedPath ) ) {
+				return { capturedPath, capture: 'vacuum' };
+			}
+			lastError = new Error( __( 'The captured database copy failed its integrity check.' ) );
+			await fsPromises.rm( capturedPath, { force: true } );
+		} catch ( error ) {
+			lastError = error;
+			if ( capturedPath ) {
+				await fsPromises.rm( capturedPath, { force: true } );
+			}
+		}
+	}
+
+	throw lastError instanceof Error
+		? lastError
+		: new Error( __( 'Database capture failed after multiple attempts.' ) );
+}

--- a/apps/cli/lib/checkpoints/checkpoints.test.ts
+++ b/apps/cli/lib/checkpoints/checkpoints.test.ts
@@ -1,0 +1,295 @@
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	checkpointIndexSchema,
+	checkpointManifestSchema,
+	readCheckpointIndex,
+	updateCheckpointIndex,
+	ensureStoreDirectories,
+	getObjectsDirectory,
+	CHECKPOINT_STORE_VERSION,
+	type CheckpointManifest,
+} from './manifest';
+import { DEFAULT_RETENTION_POLICY, selectPrunableCheckpoints } from './retention';
+import {
+	collectGarbage,
+	collectReferencedHashes,
+	getObjectPath,
+	readObjectToFile,
+	shouldCompress,
+	writeObject,
+} from './store';
+import { canReusePreviousEntry, walkSite } from './walker';
+
+const SITE_ID = 'test-site';
+let tmpDir: string;
+
+beforeEach( async () => {
+	tmpDir = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio-checkpoints-test-' ) );
+	process.env.DEV_CONFIG_DIR = tmpDir;
+	await ensureStoreDirectories( SITE_ID );
+} );
+
+afterEach( async () => {
+	delete process.env.DEV_CONFIG_DIR;
+	await fsPromises.rm( tmpDir, { recursive: true, force: true } );
+} );
+
+async function writeSourceFile( name: string, contents: string ): Promise< string > {
+	const filePath = path.join( tmpDir, name );
+	await fsPromises.mkdir( path.dirname( filePath ), { recursive: true } );
+	await fsPromises.writeFile( filePath, contents );
+	return filePath;
+}
+
+function makeManifest( overrides: Partial< CheckpointManifest > = {} ): CheckpointManifest {
+	return checkpointManifestSchema.parse( {
+		version: CHECKPOINT_STORE_VERSION,
+		id: overrides.id ?? 'cp-test',
+		siteId: SITE_ID,
+		createdAt: Date.now(),
+		trigger: 'manual',
+		db: { hash: 'db-hash', size: 1, z: true, capture: 'file-copy' },
+		files: {},
+		stats: { fileCount: 0, logicalBytes: 0, newObjectBytes: 0 },
+		...overrides,
+	} );
+}
+
+describe( 'store', () => {
+	it( 'stores and round-trips compressed and raw objects', async () => {
+		const phpSource = await writeSourceFile( 'src/sample.php', '<?php echo "hello";' );
+		const compressed = await writeObject( SITE_ID, phpSource );
+		expect( compressed.z ).toBe( true );
+
+		const binarySource = await writeSourceFile( 'src/image.jpg', 'JPEGDATA' );
+		const raw = await writeObject( SITE_ID, binarySource );
+		expect( raw.z ).toBe( false );
+
+		const restoredPhp = path.join( tmpDir, 'restored.php' );
+		await readObjectToFile( SITE_ID, compressed, restoredPhp );
+		expect( await fsPromises.readFile( restoredPhp, 'utf8' ) ).toBe( '<?php echo "hello";' );
+
+		const restoredJpg = path.join( tmpDir, 'restored.jpg' );
+		await readObjectToFile( SITE_ID, raw, restoredJpg );
+		expect( await fsPromises.readFile( restoredJpg, 'utf8' ) ).toBe( 'JPEGDATA' );
+	} );
+
+	it( 'deduplicates identical content', async () => {
+		const first = await writeObject( SITE_ID, await writeSourceFile( 'a.php', 'same' ) );
+		const second = await writeObject( SITE_ID, await writeSourceFile( 'b.php', 'same' ) );
+		expect( second.hash ).toBe( first.hash );
+
+		const objectsDir = getObjectsDirectory( SITE_ID );
+		const fanouts = await fsPromises.readdir( objectsDir );
+		let objectCount = 0;
+		for ( const fanout of fanouts ) {
+			objectCount += ( await fsPromises.readdir( path.join( objectsDir, fanout ) ) ).length;
+		}
+		expect( objectCount ).toBe( 1 );
+	} );
+
+	it( 'hashes original bytes, not compressed bytes', async () => {
+		const source = await writeSourceFile( 'c.php', 'content-for-hash' );
+		const asCompressed = await writeObject( SITE_ID, source, { compress: true } );
+		// Same content stored raw in a fresh store dir must produce the same hash.
+		const rawStoreId = 'other-site';
+		await ensureStoreDirectories( rawStoreId );
+		const asRaw = await writeObject( rawStoreId, source, { compress: false } );
+		expect( asRaw.hash ).toBe( asCompressed.hash );
+	} );
+
+	it( 'garbage collects unreferenced objects but honors the grace window', async () => {
+		const keep = await writeObject( SITE_ID, await writeSourceFile( 'keep.php', 'keep' ) );
+		const drop = await writeObject( SITE_ID, await writeSourceFile( 'drop.php', 'drop' ) );
+
+		const manifest = makeManifest( {
+			files: {
+				'keep.php': { ...keep, mode: 0o644, mtimeMs: 1, logicalSize: 4 },
+			},
+			db: { ...keep, capture: 'file-copy' },
+		} );
+		const referenced = collectReferencedHashes( [ manifest ] );
+
+		// Inside the grace window nothing is swept.
+		expect( await collectGarbage( SITE_ID, referenced, 60_000 ) ).toBe( 0 );
+		expect( fs.existsSync( getObjectPath( SITE_ID, drop.hash ) ) ).toBe( true );
+
+		// With no grace, the unreferenced object goes and the referenced stays.
+		expect( await collectGarbage( SITE_ID, referenced, 0 ) ).toBe( 1 );
+		expect( fs.existsSync( getObjectPath( SITE_ID, drop.hash ) ) ).toBe( false );
+		expect( fs.existsSync( getObjectPath( SITE_ID, keep.hash ) ) ).toBe( true );
+	} );
+
+	it( 'keeps objects shared across manifests while any manifest references them', async () => {
+		const shared = await writeObject( SITE_ID, await writeSourceFile( 'shared.php', 'shared' ) );
+		const manifestA = makeManifest( { id: 'cp-a', db: { ...shared, capture: 'file-copy' } } );
+		const referenced = collectReferencedHashes( [ manifestA ] );
+		await collectGarbage( SITE_ID, referenced, 0 );
+		expect( fs.existsSync( getObjectPath( SITE_ID, shared.hash ) ) ).toBe( true );
+	} );
+
+	it( 'compresses by extension policy', () => {
+		expect( shouldCompress( 'x/y/file.php' ) ).toBe( true );
+		expect( shouldCompress( 'x/.htaccess' ) ).toBe( true );
+		expect( shouldCompress( 'wp-content/database/.ht.sqlite' ) ).toBe( true );
+		expect( shouldCompress( 'x/photo.jpg' ) ).toBe( false );
+		expect( shouldCompress( 'x/archive.zip' ) ).toBe( false );
+	} );
+} );
+
+describe( 'walker', () => {
+	async function makeSite(): Promise< string > {
+		const sitePath = path.join( tmpDir, 'site' );
+		await fsPromises.mkdir( path.join( sitePath, 'wp-content', 'plugins', 'demo' ), {
+			recursive: true,
+		} );
+		await fsPromises.mkdir( path.join( sitePath, 'wp-content', 'database' ), { recursive: true } );
+		await fsPromises.mkdir( path.join( sitePath, 'node_modules', 'junk' ), { recursive: true } );
+		await fsPromises.writeFile( path.join( sitePath, 'wp-config.php' ), '<?php // config' );
+		await fsPromises.writeFile(
+			path.join( sitePath, 'wp-content', 'plugins', 'demo', 'demo.php' ),
+			'<?php // demo'
+		);
+		await fsPromises.writeFile(
+			path.join( sitePath, 'wp-content', 'database', '.ht.sqlite' ),
+			'FAKE-DB'
+		);
+		await fsPromises.writeFile( path.join( sitePath, 'wp-content', 'db.php' ), '<?php // dropin' );
+		await fsPromises.writeFile( path.join( sitePath, 'node_modules', 'junk', 'x.js' ), 'excluded' );
+		await fsPromises.writeFile(
+			path.join( sitePath, '.studio-checkpoint-db-temp.sqlite' ),
+			'temp'
+		);
+		return sitePath;
+	}
+
+	it( 'excludes the database dir, db.php, node_modules, and checkpoint temp files', async () => {
+		const sitePath = await makeSite();
+		const walk = await walkSite( sitePath );
+		const paths = walk.files.map( ( file ) => file.relPath );
+		expect( paths ).toContain( 'wp-config.php' );
+		expect( paths ).toContain( 'wp-content/plugins/demo/demo.php' );
+		expect( paths ).not.toContain( 'wp-content/database/.ht.sqlite' );
+		expect( paths ).not.toContain( 'wp-content/db.php' );
+		expect( paths.some( ( p ) => p.startsWith( 'node_modules' ) ) ).toBe( false );
+		expect( paths.some( ( p ) => p.includes( '.studio-checkpoint-' ) ) ).toBe( false );
+	} );
+
+	it( 'records symlinks without following them', async () => {
+		const sitePath = await makeSite();
+		const linkPath = path.join( sitePath, 'wp-content', 'plugins', 'linked' );
+		await fsPromises.symlink( '../themes', linkPath );
+		const walk = await walkSite( sitePath );
+		expect( walk.symlinks ).toContainEqual( {
+			relPath: 'wp-content/plugins/linked',
+			target: '../themes',
+		} );
+	} );
+
+	it( 'reuses previous entries only when size and mtime match', async () => {
+		const sitePath = await makeSite();
+		const walk = await walkSite( sitePath );
+		const demo = walk.files.find( ( file ) => file.relPath.endsWith( 'demo.php' ) )!;
+
+		const previous = makeManifest( {
+			files: {
+				[ demo.relPath ]: {
+					hash: 'previous-hash',
+					size: 10,
+					z: true,
+					mode: demo.mode,
+					mtimeMs: demo.mtimeMs,
+					logicalSize: demo.size,
+				},
+			},
+		} );
+
+		expect( canReusePreviousEntry( demo, previous )?.hash ).toBe( 'previous-hash' );
+		expect( canReusePreviousEntry( { ...demo, size: demo.size + 1 }, previous ) ).toBeUndefined();
+		expect(
+			canReusePreviousEntry( { ...demo, mtimeMs: demo.mtimeMs + 1 }, previous )
+		).toBeUndefined();
+		expect( canReusePreviousEntry( demo, undefined ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'retention', () => {
+	function indexWith( triggers: Array< [ string, string, boolean? ] > ) {
+		return checkpointIndexSchema.parse( {
+			version: CHECKPOINT_STORE_VERSION,
+			checkpoints: triggers.map( ( [ id, trigger, pinned ], position ) => ( {
+				id,
+				createdAt: position,
+				trigger,
+				pinned,
+				stats: { fileCount: 0, logicalBytes: 0, newObjectBytes: 0 },
+			} ) ),
+		} );
+	}
+
+	it( 'never prunes manual or agent checkpoints', () => {
+		const index = indexWith( [
+			...Array.from( { length: 30 }, ( _, i ): [ string, string ] => [ `m${ i }`, 'manual' ] ),
+			...Array.from( { length: 30 }, ( _, i ): [ string, string ] => [ `a${ i }`, 'agent' ] ),
+		] );
+		expect( selectPrunableCheckpoints( index, DEFAULT_RETENTION_POLICY ) ).toHaveLength( 0 );
+	} );
+
+	it( 'prunes oldest auto checkpoints beyond the cap', () => {
+		const index = indexWith(
+			Array.from( { length: 13 }, ( _, i ): [ string, string ] => [
+				`auto${ i }`,
+				'auto-pre-tool',
+			] )
+		);
+		const prunable = selectPrunableCheckpoints( index, DEFAULT_RETENTION_POLICY );
+		expect( prunable.map( ( entry ) => entry.id ) ).toEqual( [ 'auto0', 'auto1', 'auto2' ] );
+	} );
+
+	it( 'never prunes pinned checkpoints', () => {
+		const index = indexWith(
+			Array.from( { length: 13 }, ( _, i ): [ string, string, boolean ] => [
+				`auto${ i }`,
+				'auto-pre-tool',
+				i === 0,
+			] )
+		);
+		const prunable = selectPrunableCheckpoints( index, DEFAULT_RETENTION_POLICY );
+		expect( prunable.map( ( entry ) => entry.id ) ).toEqual( [ 'auto1', 'auto2' ] );
+	} );
+} );
+
+describe( 'index', () => {
+	it( 'returns an empty index when none exists', async () => {
+		const index = await readCheckpointIndex( SITE_ID );
+		expect( index.checkpoints ).toEqual( [] );
+	} );
+
+	it( 'persists mutations through updateCheckpointIndex', async () => {
+		await updateCheckpointIndex( SITE_ID, ( index ) => {
+			index.checkpoints.push( {
+				id: 'cp-1',
+				createdAt: 1,
+				trigger: 'manual',
+				stats: { fileCount: 0, logicalBytes: 0, newObjectBytes: 0 },
+			} );
+			return index;
+		} );
+		const index = await readCheckpointIndex( SITE_ID );
+		expect( index.checkpoints.map( ( entry ) => entry.id ) ).toEqual( [ 'cp-1' ] );
+	} );
+
+	it( 'rejects indexes written by a newer format version', async () => {
+		await updateCheckpointIndex( SITE_ID, ( index ) => index );
+		const indexPath = path.join( tmpDir, 'checkpoints', SITE_ID, 'index.json' );
+		await fsPromises.writeFile(
+			indexPath,
+			JSON.stringify( { version: CHECKPOINT_STORE_VERSION + 1, checkpoints: [] } )
+		);
+		await expect( readCheckpointIndex( SITE_ID ) ).rejects.toThrow( /newer version/ );
+	} );
+} );

--- a/apps/cli/lib/checkpoints/create.ts
+++ b/apps/cli/lib/checkpoints/create.ts
@@ -1,0 +1,225 @@
+import crypto from 'crypto';
+import fsPromises from 'fs/promises';
+import { CheckpointEvents } from '@studio/common/lib/checkpoint-events';
+import { __ } from '@wordpress/i18n';
+import { getWordPressVersionFromInstallation } from 'cli/lib/dependency-management/wordpress';
+import { isServerRunning } from 'cli/lib/wordpress-server-manager';
+import { captureDatabase } from './capture-database';
+import { CheckpointEventEmitter } from './events';
+import {
+	ensureStoreDirectories,
+	readCheckpointIndex,
+	readCheckpointManifest,
+	updateCheckpointIndex,
+	writeCheckpointManifest,
+	getManifestPath,
+	CHECKPOINT_STORE_VERSION,
+	type CheckpointManifest,
+	type CheckpointTrigger,
+	type ManifestFileEntry,
+} from './manifest';
+import {
+	DEFAULT_RETENTION_POLICY,
+	selectPrunableCheckpoints,
+	type RetentionPolicy,
+} from './retention';
+import { collectGarbage, collectReferencedHashes, writeObject } from './store';
+import { canReusePreviousEntry, walkSite } from './walker';
+import type { SiteData } from 'cli/lib/cli-config/core';
+
+// Objects younger than this are never garbage collected, so an in-flight
+// create in another process can't have its freshly written objects swept
+// before its manifest lands.
+export const GC_GRACE_MS = 30 * 60 * 1000;
+
+export interface CreateCheckpointOptions {
+	label?: string;
+	trigger?: CheckpointTrigger;
+	agentRunId?: string;
+	toolName?: string;
+	retentionPolicy?: RetentionPolicy;
+	emitter?: CheckpointEventEmitter;
+	// Skip pruning/GC — used by the safety checkpoint inside restore, which
+	// must not sweep objects mid-restore.
+	skipMaintenance?: boolean;
+}
+
+export function isCheckpointSupported( site: SiteData ): boolean {
+	// Reprint-pulled sites wire SQLite through runtime.php and ship no db.php
+	// drop-in; their runtime wiring lives outside the standard site layout, so
+	// checkpoints don't support them yet.
+	return ! site.runtimeBlueprintPath;
+}
+
+export async function createCheckpoint(
+	site: SiteData,
+	options: CreateCheckpointOptions = {}
+): Promise< CheckpointManifest > {
+	const emitter = options.emitter ?? new CheckpointEventEmitter();
+	const trigger = options.trigger ?? 'manual';
+
+	if ( ! isCheckpointSupported( site ) ) {
+		throw new Error(
+			__( 'Checkpoints are not yet supported for sites imported with `studio pull-reprint`.' )
+		);
+	}
+
+	await ensureStoreDirectories( site.id );
+	emitter.emit( CheckpointEvents.CHECKPOINT_CREATE_START, { siteId: site.id } );
+
+	try {
+		const index = await readCheckpointIndex( site.id );
+		const previousEntry = index.checkpoints[ index.checkpoints.length - 1 ];
+		const previousManifest = previousEntry
+			? await readCheckpointManifest( site.id, previousEntry.id ).catch( () => undefined )
+			: undefined;
+
+		const isRunning = !! ( await isServerRunning( site.id ) );
+
+		// Capture the database first so its snapshot is closest to the moment
+		// the checkpoint was requested; file churn during a running capture is
+		// accepted best-effort.
+		emitter.emit( CheckpointEvents.CHECKPOINT_CREATE_PROGRESS, { phase: 'database' } );
+		const dbCapture = await captureDatabase( site, isRunning );
+
+		let newObjectBytes = 0;
+		let dbRef;
+		try {
+			dbRef = await writeObject( site.id, dbCapture.capturedPath, { compress: true } );
+			newObjectBytes += dbRef.size;
+		} finally {
+			await fsPromises.rm( dbCapture.capturedPath, { force: true } );
+		}
+
+		emitter.emit( CheckpointEvents.CHECKPOINT_CREATE_PROGRESS, { phase: 'files' } );
+		const walk = await walkSite( site.path );
+
+		const files: Record< string, ManifestFileEntry > = {};
+		let logicalBytes = 0;
+		let processed = 0;
+
+		for ( const file of walk.files ) {
+			logicalBytes += file.size;
+			const reusable = canReusePreviousEntry( file, previousManifest );
+			if ( reusable ) {
+				files[ file.relPath ] = {
+					...reusable,
+					mode: file.mode,
+					mtimeMs: file.mtimeMs,
+					logicalSize: file.size,
+				};
+			} else {
+				try {
+					const ref = await writeObject( site.id, file.fullPath );
+					newObjectBytes += ref.size;
+					files[ file.relPath ] = {
+						...ref,
+						mode: file.mode,
+						mtimeMs: file.mtimeMs,
+						logicalSize: file.size,
+					};
+				} catch ( error ) {
+					// The file disappeared mid-capture (running site); skip it.
+				}
+			}
+
+			processed++;
+			if ( processed % 500 === 0 ) {
+				emitter.emit( CheckpointEvents.CHECKPOINT_CREATE_PROGRESS, {
+					phase: 'files',
+					processed,
+					total: walk.files.length,
+				} );
+			}
+		}
+
+		for ( const symlink of walk.symlinks ) {
+			files[ symlink.relPath ] = { symlink: symlink.target };
+		}
+
+		emitter.emit( CheckpointEvents.CHECKPOINT_CREATE_PROGRESS, { phase: 'finalizing' } );
+
+		const wpVersion = await getWordPressVersionFromInstallation( site.path ).catch(
+			() => undefined
+		);
+
+		const manifest: CheckpointManifest = {
+			version: CHECKPOINT_STORE_VERSION,
+			id: `cp-${ Date.now() }-${ crypto.randomUUID().slice( 0, 8 ) }`,
+			siteId: site.id,
+			label: options.label,
+			createdAt: Date.now(),
+			trigger,
+			agentRunId: options.agentRunId,
+			toolName: options.toolName,
+			phpVersion: site.phpVersion,
+			wpVersion: wpVersion || undefined,
+			db: { ...dbRef, capture: dbCapture.capture },
+			files,
+			stats: {
+				fileCount: walk.files.length,
+				logicalBytes,
+				newObjectBytes,
+			},
+		};
+
+		await writeCheckpointManifest( manifest );
+
+		// The checkpoint exists once its index entry lands (under the store
+		// lock). Prune decisions happen in the same critical section.
+		let pruned: string[] = [];
+		await updateCheckpointIndex( site.id, ( current ) => {
+			current.checkpoints.push( {
+				id: manifest.id,
+				label: manifest.label,
+				createdAt: manifest.createdAt,
+				trigger: manifest.trigger,
+				toolName: manifest.toolName,
+				stats: manifest.stats,
+			} );
+			if ( ! options.skipMaintenance ) {
+				const prunable = selectPrunableCheckpoints(
+					current,
+					options.retentionPolicy ?? DEFAULT_RETENTION_POLICY
+				);
+				pruned = prunable.map( ( entry ) => entry.id );
+				current.checkpoints = current.checkpoints.filter(
+					( entry ) => ! pruned.includes( entry.id )
+				);
+			}
+			return current;
+		} );
+
+		for ( const prunedId of pruned ) {
+			await fsPromises.rm( getManifestPath( site.id, prunedId ), { force: true } );
+		}
+
+		if ( ! options.skipMaintenance ) {
+			await runGarbageCollection( site.id );
+		}
+
+		emitter.emit( CheckpointEvents.CHECKPOINT_CREATE_COMPLETE, {
+			checkpointId: manifest.id,
+			siteId: site.id,
+		} );
+
+		return manifest;
+	} catch ( error ) {
+		emitter.emit( CheckpointEvents.CHECKPOINT_CREATE_ERROR, {
+			message: error instanceof Error ? error.message : String( error ),
+		} );
+		throw error;
+	}
+}
+
+export async function runGarbageCollection( siteId: string ): Promise< number > {
+	const index = await readCheckpointIndex( siteId );
+	const manifests: CheckpointManifest[] = [];
+	for ( const entry of index.checkpoints ) {
+		const manifest = await readCheckpointManifest( siteId, entry.id ).catch( () => undefined );
+		if ( manifest ) {
+			manifests.push( manifest );
+		}
+	}
+	return collectGarbage( siteId, collectReferencedHashes( manifests ), GC_GRACE_MS );
+}

--- a/apps/cli/lib/checkpoints/diff.ts
+++ b/apps/cli/lib/checkpoints/diff.ts
@@ -1,0 +1,287 @@
+import crypto from 'crypto';
+import fsPromises from 'fs/promises';
+import path from 'path';
+import { isServerRunning } from 'cli/lib/wordpress-server-manager';
+import { captureDatabase } from './capture-database';
+import { getStoreTmpDirectory, readCheckpointManifest, type CheckpointManifest } from './manifest';
+import { readObjectToFile } from './store';
+import { walkSite } from './walker';
+import type { SiteData } from 'cli/lib/cli-config/core';
+
+export interface FileDiffEntry {
+	path: string;
+	size?: number;
+}
+
+export interface CheckpointDiff {
+	from: string;
+	to: string;
+	files: {
+		added: FileDiffEntry[];
+		modified: FileDiffEntry[];
+		deleted: FileDiffEntry[];
+	};
+	database: {
+		// False when node:sqlite is unavailable; only size info is provided.
+		detailed: boolean;
+		sizeDelta?: number;
+		changedTables?: Array< { table: string; fromRows: number; toRows: number } >;
+		addedTables?: string[];
+		removedTables?: string[];
+		changedOptions?: string[];
+	};
+}
+
+interface ComparableState {
+	// path → { mtimeMs, logicalSize, hash? }
+	files: Map< string, { mtimeMs: number; logicalSize: number; hash?: string } >;
+	symlinks: Map< string, string >;
+}
+
+function manifestToComparable( manifest: CheckpointManifest ): ComparableState {
+	const files = new Map< string, { mtimeMs: number; logicalSize: number; hash?: string } >();
+	const symlinks = new Map< string, string >();
+	for ( const [ relPath, entry ] of Object.entries( manifest.files ) ) {
+		if ( 'symlink' in entry ) {
+			symlinks.set( relPath, entry.symlink );
+		} else {
+			files.set( relPath, {
+				mtimeMs: entry.mtimeMs,
+				logicalSize: entry.logicalSize,
+				hash: entry.hash,
+			} );
+		}
+	}
+	return { files, symlinks };
+}
+
+async function siteToComparable( site: SiteData ): Promise< ComparableState > {
+	const walk = await walkSite( site.path );
+	return {
+		files: new Map(
+			walk.files.map( ( file ) => [
+				file.relPath,
+				{ mtimeMs: file.mtimeMs, logicalSize: file.size },
+			] )
+		),
+		symlinks: new Map( walk.symlinks.map( ( link ) => [ link.relPath, link.target ] ) ),
+	};
+}
+
+function diffStates( from: ComparableState, to: ComparableState ): CheckpointDiff[ 'files' ] {
+	const added: FileDiffEntry[] = [];
+	const modified: FileDiffEntry[] = [];
+	const deleted: FileDiffEntry[] = [];
+
+	for ( const [ relPath, toEntry ] of to.files ) {
+		const fromEntry = from.files.get( relPath );
+		if ( ! fromEntry ) {
+			added.push( { path: relPath, size: toEntry.logicalSize } );
+			continue;
+		}
+		// When both sides carry content hashes, compare those; otherwise fall
+		// back to mtime+size (sufficient for "what changed" summaries).
+		const sameContent =
+			fromEntry.hash && toEntry.hash
+				? fromEntry.hash === toEntry.hash
+				: fromEntry.mtimeMs === toEntry.mtimeMs && fromEntry.logicalSize === toEntry.logicalSize;
+		if ( ! sameContent ) {
+			modified.push( { path: relPath, size: toEntry.logicalSize } );
+		}
+	}
+	for ( const relPath of from.files.keys() ) {
+		if ( ! to.files.has( relPath ) ) {
+			deleted.push( { path: relPath } );
+		}
+	}
+	for ( const [ relPath, target ] of to.symlinks ) {
+		if ( ! from.symlinks.has( relPath ) ) {
+			added.push( { path: relPath } );
+		} else if ( from.symlinks.get( relPath ) !== target ) {
+			modified.push( { path: relPath } );
+		}
+	}
+	for ( const relPath of from.symlinks.keys() ) {
+		if ( ! to.symlinks.has( relPath ) ) {
+			deleted.push( { path: relPath } );
+		}
+	}
+
+	const byPath = ( a: FileDiffEntry, b: FileDiffEntry ) => a.path.localeCompare( b.path );
+	added.sort( byPath );
+	modified.sort( byPath );
+	deleted.sort( byPath );
+	return { added, modified, deleted };
+}
+
+interface SqliteDatabase {
+	prepare( sql: string ): {
+		all( ...params: unknown[] ): Array< Record< string, unknown > >;
+		get( ...params: unknown[] ): Record< string, unknown > | undefined;
+	};
+	close(): void;
+}
+
+async function openSqliteReadonly( filePath: string ): Promise< SqliteDatabase | undefined > {
+	try {
+		const sqlite = await import( 'node:sqlite' );
+		return new sqlite.DatabaseSync( filePath, { readOnly: true } ) as unknown as SqliteDatabase;
+	} catch ( error ) {
+		return undefined;
+	}
+}
+
+function readTableRowCounts( db: SqliteDatabase ): Map< string, number > {
+	const counts = new Map< string, number >();
+	const tables = db
+		.prepare( "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'" )
+		.all();
+	for ( const row of tables ) {
+		const table = String( row.name );
+		try {
+			const result = db.prepare( `SELECT COUNT(*) AS n FROM "${ table }"` ).get();
+			counts.set( table, Number( result?.n ?? 0 ) );
+		} catch ( error ) {
+			counts.set( table, -1 );
+		}
+	}
+	return counts;
+}
+
+// wp_options fingerprint: option name → value length. Cheap to compute and
+// catches the changes agents most often make (settings, active plugins).
+function readOptionsFingerprint( db: SqliteDatabase ): Map< string, number > | undefined {
+	try {
+		const rows = db
+			.prepare( 'SELECT option_name, LENGTH(option_value) AS len FROM wp_options' )
+			.all();
+		return new Map( rows.map( ( row ) => [ String( row.option_name ), Number( row.len ) ] ) );
+	} catch ( error ) {
+		return undefined;
+	}
+}
+
+async function diffDatabases(
+	fromPath: string,
+	toPath: string
+): Promise< CheckpointDiff[ 'database' ] > {
+	const [ fromStat, toStat ] = await Promise.all( [
+		fsPromises.stat( fromPath ),
+		fsPromises.stat( toPath ),
+	] );
+	const sizeDelta = toStat.size - fromStat.size;
+
+	const fromDb = await openSqliteReadonly( fromPath );
+	const toDb = await openSqliteReadonly( toPath );
+	if ( ! fromDb || ! toDb ) {
+		fromDb?.close();
+		toDb?.close();
+		return { detailed: false, sizeDelta };
+	}
+
+	try {
+		const fromCounts = readTableRowCounts( fromDb );
+		const toCounts = readTableRowCounts( toDb );
+
+		const changedTables: Array< { table: string; fromRows: number; toRows: number } > = [];
+		const addedTables: string[] = [];
+		const removedTables: string[] = [];
+
+		for ( const [ table, toRows ] of toCounts ) {
+			if ( ! fromCounts.has( table ) ) {
+				addedTables.push( table );
+			} else if ( fromCounts.get( table ) !== toRows ) {
+				changedTables.push( { table, fromRows: fromCounts.get( table )!, toRows } );
+			}
+		}
+		for ( const table of fromCounts.keys() ) {
+			if ( ! toCounts.has( table ) ) {
+				removedTables.push( table );
+			}
+		}
+
+		const changedOptions: string[] = [];
+		const fromOptions = readOptionsFingerprint( fromDb );
+		const toOptions = readOptionsFingerprint( toDb );
+		if ( fromOptions && toOptions ) {
+			for ( const [ name, len ] of toOptions ) {
+				if ( ! fromOptions.has( name ) || fromOptions.get( name ) !== len ) {
+					changedOptions.push( name );
+				}
+			}
+			for ( const name of fromOptions.keys() ) {
+				if ( ! toOptions.has( name ) ) {
+					changedOptions.push( name );
+				}
+			}
+			changedOptions.sort();
+		}
+
+		return {
+			detailed: true,
+			sizeDelta,
+			changedTables,
+			addedTables: addedTables.sort(),
+			removedTables: removedTables.sort(),
+			changedOptions,
+		};
+	} finally {
+		fromDb.close();
+		toDb.close();
+	}
+}
+
+async function materializeDatabase(
+	site: SiteData,
+	manifest: CheckpointManifest
+): Promise< string > {
+	const destination = path.join(
+		getStoreTmpDirectory( site.id ),
+		`diff-${ crypto.randomUUID() }.sqlite`
+	);
+	await readObjectToFile( site.id, manifest.db, destination );
+	return destination;
+}
+
+// Diffs two checkpoints, or a checkpoint against the site's current state
+// (`toId === 'current'`).
+export async function diffCheckpoints(
+	site: SiteData,
+	fromId: string,
+	toId: string | 'current' = 'current'
+): Promise< CheckpointDiff > {
+	const fromManifest = await readCheckpointManifest( site.id, fromId );
+	const cleanupPaths: string[] = [];
+
+	try {
+		const fromDbPath = await materializeDatabase( site, fromManifest );
+		cleanupPaths.push( fromDbPath );
+
+		let files: CheckpointDiff[ 'files' ];
+		let toDbPath: string;
+
+		if ( toId === 'current' ) {
+			files = diffStates( manifestToComparable( fromManifest ), await siteToComparable( site ) );
+			const isRunning = !! ( await isServerRunning( site.id ) );
+			const capture = await captureDatabase( site, isRunning );
+			toDbPath = capture.capturedPath;
+			cleanupPaths.push( toDbPath );
+		} else {
+			const toManifest = await readCheckpointManifest( site.id, toId );
+			files = diffStates(
+				manifestToComparable( fromManifest ),
+				manifestToComparable( toManifest )
+			);
+			toDbPath = await materializeDatabase( site, toManifest );
+			cleanupPaths.push( toDbPath );
+		}
+
+		const database = await diffDatabases( fromDbPath, toDbPath );
+
+		return { from: fromId, to: toId, files, database };
+	} finally {
+		for ( const cleanupPath of cleanupPaths ) {
+			await fsPromises.rm( cleanupPath, { force: true } );
+		}
+	}
+}

--- a/apps/cli/lib/checkpoints/events.ts
+++ b/apps/cli/lib/checkpoints/events.ts
@@ -1,0 +1,32 @@
+import { EventEmitter } from 'events';
+import type { CheckpointEventTuple } from '@studio/common/lib/checkpoint-events';
+
+type CheckpointEventType = CheckpointEventTuple[ 0 ];
+type CheckpointEventData< T extends CheckpointEventType > = Extract<
+	CheckpointEventTuple,
+	[ T, unknown ]
+>[ 1 ];
+
+export type CheckpointEventListener< T extends CheckpointEventType > = (
+	data: CheckpointEventData< T >
+) => void;
+
+export class CheckpointEventEmitter extends EventEmitter {
+	on< T extends CheckpointEventType >(
+		eventName: T,
+		listener: CheckpointEventListener< T >
+	): this {
+		return super.on( eventName, listener );
+	}
+
+	off< T extends CheckpointEventType >(
+		eventName: T,
+		listener: CheckpointEventListener< T >
+	): this {
+		return super.off( eventName, listener );
+	}
+
+	emit< T extends CheckpointEventType >( eventName: T, data: CheckpointEventData< T > ): boolean {
+		return super.emit( eventName, data );
+	}
+}

--- a/apps/cli/lib/checkpoints/manifest.ts
+++ b/apps/cli/lib/checkpoints/manifest.ts
@@ -1,0 +1,255 @@
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import path from 'path';
+import { LOCKFILE_STALE_TIME, LOCKFILE_WAIT_TIME } from '@studio/common/constants';
+import { lockFileAsync, unlockFileAsync } from '@studio/common/lib/lockfile';
+import { getConfigDirectory } from '@studio/common/lib/well-known-paths';
+import { __, sprintf } from '@wordpress/i18n';
+import { writeFile } from 'atomically';
+import { z } from 'zod';
+
+// Bump when the manifest/index format changes incompatibly. Readers refuse
+// higher versions: independently installed CLI builds (npm + bundled) share
+// `~/.studio`, so an old build must never misread a newer store.
+export const CHECKPOINT_STORE_VERSION = 1;
+
+export const checkpointTriggerSchema = z.enum( [
+	'manual',
+	'agent',
+	'auto-pre-tool',
+	'pre-restore',
+] );
+export type CheckpointTrigger = z.infer< typeof checkpointTriggerSchema >;
+
+// A stored object reference. `z` records whether the object's bytes are
+// gzip-compressed — readers and the garbage collector never guess encoding.
+export const objectRefSchema = z.object( {
+	hash: z.string(),
+	size: z.number(),
+	z: z.boolean(),
+} );
+export type ObjectRef = z.infer< typeof objectRefSchema >;
+
+export const manifestFileEntrySchema = z.union( [
+	objectRefSchema.extend( {
+		mode: z.number(),
+		mtimeMs: z.number(),
+		// Original (pre-compression) size; with mtimeMs it forms the
+		// skip-rehash fast path for unchanged files.
+		logicalSize: z.number(),
+	} ),
+	z.object( {
+		symlink: z.string(),
+	} ),
+] );
+export type ManifestFileEntry = z.infer< typeof manifestFileEntrySchema >;
+export type ManifestFileObjectEntry = Extract< ManifestFileEntry, { hash: string } >;
+
+export const databaseCaptureMethodSchema = z.enum( [ 'vacuum', 'file-copy' ] );
+
+export const checkpointManifestSchema = z.object( {
+	version: z.literal( CHECKPOINT_STORE_VERSION ),
+	id: z.string(),
+	siteId: z.string(),
+	label: z.string().optional(),
+	createdAt: z.number(),
+	trigger: checkpointTriggerSchema,
+	agentRunId: z.string().optional(),
+	toolName: z.string().optional(),
+	phpVersion: z.string().optional(),
+	wpVersion: z.string().optional(),
+	db: objectRefSchema.extend( {
+		capture: databaseCaptureMethodSchema,
+	} ),
+	// Keys are `/`-normalized paths relative to the site root.
+	files: z.record( z.string(), manifestFileEntrySchema ),
+	stats: z.object( {
+		fileCount: z.number(),
+		logicalBytes: z.number(),
+		newObjectBytes: z.number(),
+	} ),
+} );
+export type CheckpointManifest = z.infer< typeof checkpointManifestSchema >;
+
+// The index is the source of truth for which checkpoints exist. A manifest
+// with no index entry is garbage (an interrupted create), never corruption.
+export const checkpointIndexEntrySchema = z.object( {
+	id: z.string(),
+	label: z.string().optional(),
+	createdAt: z.number(),
+	trigger: checkpointTriggerSchema,
+	toolName: z.string().optional(),
+	// Pinned entries are exempt from retention pruning. Restore pins its
+	// target so a concurrent create's prune can't evict it mid-restore.
+	pinned: z.boolean().optional(),
+	stats: z.object( {
+		fileCount: z.number(),
+		logicalBytes: z.number(),
+		newObjectBytes: z.number(),
+	} ),
+} );
+export type CheckpointIndexEntry = z.infer< typeof checkpointIndexEntrySchema >;
+
+export const checkpointIndexSchema = z.object( {
+	version: z.literal( CHECKPOINT_STORE_VERSION ),
+	// Ordered oldest → newest.
+	checkpoints: z.array( checkpointIndexEntrySchema ).default( () => [] ),
+} );
+export type CheckpointIndex = z.infer< typeof checkpointIndexSchema >;
+
+export const restoreJournalSchema = z.object( {
+	version: z.literal( CHECKPOINT_STORE_VERSION ),
+	checkpointId: z.string(),
+	safetyCheckpointId: z.string().optional(),
+	startedAt: z.number(),
+} );
+export type RestoreJournal = z.infer< typeof restoreJournalSchema >;
+
+export function getCheckpointsRootDirectory(): string {
+	return path.join( getConfigDirectory(), 'checkpoints' );
+}
+
+export function getCheckpointStoreDirectory( siteId: string ): string {
+	return path.join( getCheckpointsRootDirectory(), siteId );
+}
+
+export function getObjectsDirectory( siteId: string ): string {
+	return path.join( getCheckpointStoreDirectory( siteId ), 'objects' );
+}
+
+export function getManifestsDirectory( siteId: string ): string {
+	return path.join( getCheckpointStoreDirectory( siteId ), 'manifests' );
+}
+
+export function getStoreTmpDirectory( siteId: string ): string {
+	return path.join( getCheckpointStoreDirectory( siteId ), 'tmp' );
+}
+
+function getIndexPath( siteId: string ): string {
+	return path.join( getCheckpointStoreDirectory( siteId ), 'index.json' );
+}
+
+function getStoreLockPath( siteId: string ): string {
+	return path.join( getCheckpointStoreDirectory( siteId ), 'checkpoints.lock' );
+}
+
+export function getRestoreJournalPath( siteId: string ): string {
+	return path.join( getCheckpointStoreDirectory( siteId ), 'restore-journal.json' );
+}
+
+export async function ensureStoreDirectories( siteId: string ): Promise< void > {
+	await fsPromises.mkdir( getObjectsDirectory( siteId ), { recursive: true } );
+	await fsPromises.mkdir( getManifestsDirectory( siteId ), { recursive: true } );
+	await fsPromises.mkdir( getStoreTmpDirectory( siteId ), { recursive: true } );
+}
+
+// The store lock guards metadata mutations only (index read-modify-write,
+// pin/unpin, prune) — always sub-second critical sections. The `lockfile`
+// package steals locks held longer than LOCKFILE_STALE_TIME (5s), so long
+// work (walking, hashing, object writes) must run lock-free; that's safe
+// because objects are immutable and a checkpoint only exists once its index
+// entry lands.
+async function withStoreLock< T >( siteId: string, fn: () => Promise< T > ): Promise< T > {
+	await lockFileAsync( getStoreLockPath( siteId ), {
+		wait: LOCKFILE_WAIT_TIME,
+		stale: LOCKFILE_STALE_TIME,
+	} );
+	try {
+		return await fn();
+	} finally {
+		await unlockFileAsync( getStoreLockPath( siteId ) );
+	}
+}
+
+export async function readCheckpointIndex( siteId: string ): Promise< CheckpointIndex > {
+	const indexPath = getIndexPath( siteId );
+	if ( ! fs.existsSync( indexPath ) ) {
+		return { version: CHECKPOINT_STORE_VERSION, checkpoints: [] };
+	}
+	const raw = JSON.parse( await fsPromises.readFile( indexPath, 'utf8' ) );
+	if ( typeof raw?.version === 'number' && raw.version > CHECKPOINT_STORE_VERSION ) {
+		throw new Error(
+			sprintf(
+				__(
+					'The checkpoint store for this site was created by a newer version of Studio (format v%d). Update Studio to use it.'
+				),
+				raw.version
+			)
+		);
+	}
+	return checkpointIndexSchema.parse( raw );
+}
+
+// Read-modify-write the index under the store lock.
+export async function updateCheckpointIndex(
+	siteId: string,
+	mutate: ( index: CheckpointIndex ) => CheckpointIndex | Promise< CheckpointIndex >
+): Promise< CheckpointIndex > {
+	return withStoreLock( siteId, async () => {
+		const index = await readCheckpointIndex( siteId );
+		const updated = await mutate( index );
+		await writeFile( getIndexPath( siteId ), JSON.stringify( updated, null, '\t' ) );
+		return updated;
+	} );
+}
+
+export function getManifestPath( siteId: string, checkpointId: string ): string {
+	return path.join( getManifestsDirectory( siteId ), `${ checkpointId }.json` );
+}
+
+export async function readCheckpointManifest(
+	siteId: string,
+	checkpointId: string
+): Promise< CheckpointManifest > {
+	const manifestPath = getManifestPath( siteId, checkpointId );
+	if ( ! fs.existsSync( manifestPath ) ) {
+		throw new Error( sprintf( __( 'Checkpoint not found: %s' ), checkpointId ) );
+	}
+	const raw = JSON.parse( await fsPromises.readFile( manifestPath, 'utf8' ) );
+	if ( typeof raw?.version === 'number' && raw.version > CHECKPOINT_STORE_VERSION ) {
+		throw new Error(
+			sprintf(
+				__( 'Checkpoint %s was created by a newer version of Studio. Update Studio to use it.' ),
+				checkpointId
+			)
+		);
+	}
+	return checkpointManifestSchema.parse( raw );
+}
+
+export async function writeCheckpointManifest( manifest: CheckpointManifest ): Promise< void > {
+	await writeFile(
+		getManifestPath( manifest.siteId, manifest.id ),
+		JSON.stringify( manifest, null, '\t' )
+	);
+}
+
+export async function readRestoreJournal( siteId: string ): Promise< RestoreJournal | undefined > {
+	const journalPath = getRestoreJournalPath( siteId );
+	if ( ! fs.existsSync( journalPath ) ) {
+		return undefined;
+	}
+	try {
+		return restoreJournalSchema.parse(
+			JSON.parse( await fsPromises.readFile( journalPath, 'utf8' ) )
+		);
+	} catch ( error ) {
+		return undefined;
+	}
+}
+
+export async function writeRestoreJournal(
+	siteId: string,
+	journal: RestoreJournal
+): Promise< void > {
+	await writeFile( getRestoreJournalPath( siteId ), JSON.stringify( journal, null, '\t' ) );
+}
+
+export async function removeRestoreJournal( siteId: string ): Promise< void > {
+	await fsPromises.rm( getRestoreJournalPath( siteId ), { force: true } );
+}
+
+// Removes the whole per-site store. Called when the site itself is deleted.
+export async function removeCheckpointStore( siteId: string ): Promise< void > {
+	await fsPromises.rm( getCheckpointStoreDirectory( siteId ), { recursive: true, force: true } );
+}

--- a/apps/cli/lib/checkpoints/restore.ts
+++ b/apps/cli/lib/checkpoints/restore.ts
@@ -1,0 +1,289 @@
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import path from 'path';
+import { CheckpointEvents } from '@studio/common/lib/checkpoint-events';
+import { __, sprintf } from '@wordpress/i18n';
+import { clearSiteLatestCliPid, updateSitePhpVersion } from 'cli/lib/cli-config/sites';
+import { updateSiteUrl } from 'cli/lib/import-export/import/update-site-url';
+import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
+import {
+	isServerRunning,
+	startWordPressServer,
+	stopWordPressServer,
+} from 'cli/lib/wordpress-server-manager';
+import { SITE_DATABASE_RELATIVE_PATH } from './capture-database';
+import { createCheckpoint } from './create';
+import { CheckpointEventEmitter } from './events';
+import {
+	readCheckpointManifest,
+	removeRestoreJournal,
+	updateCheckpointIndex,
+	writeRestoreJournal,
+	CHECKPOINT_STORE_VERSION,
+	type CheckpointManifest,
+} from './manifest';
+import { objectExists, readObjectToFile } from './store';
+import { walkSite } from './walker';
+import type { SiteData } from 'cli/lib/cli-config/core';
+import type { Logger } from 'cli/logger';
+
+export interface RestoreCheckpointOptions {
+	emitter?: CheckpointEventEmitter;
+	// Skip the automatic safety checkpoint. Only for crash-recovery re-apply,
+	// where the pre-restore checkpoint from the interrupted attempt already
+	// exists.
+	skipSafetyCheckpoint?: boolean;
+}
+
+export interface RestoreCheckpointResult {
+	checkpointId: string;
+	safetyCheckpointId?: string;
+}
+
+async function setCheckpointPinned(
+	siteId: string,
+	checkpointId: string,
+	pinned: boolean
+): Promise< void > {
+	await updateCheckpointIndex( siteId, ( index ) => {
+		const entry = index.checkpoints.find( ( candidate ) => candidate.id === checkpointId );
+		if ( ! entry ) {
+			throw new Error( sprintf( __( 'Checkpoint not found: %s' ), checkpointId ) );
+		}
+		if ( pinned ) {
+			entry.pinned = true;
+		} else {
+			delete entry.pinned;
+		}
+		return index;
+	} );
+}
+
+async function verifyManifestObjects(
+	siteId: string,
+	manifest: CheckpointManifest
+): Promise< void > {
+	if ( ! ( await objectExists( siteId, manifest.db.hash ) ) ) {
+		throw new Error( __( 'The checkpoint is incomplete: its database object is missing.' ) );
+	}
+	for ( const [ relPath, entry ] of Object.entries( manifest.files ) ) {
+		if ( 'hash' in entry && ! ( await objectExists( siteId, entry.hash ) ) ) {
+			throw new Error(
+				sprintf( __( 'The checkpoint is incomplete: object for %s is missing.' ), relPath )
+			);
+		}
+	}
+}
+
+async function applyFiles(
+	site: SiteData,
+	manifest: CheckpointManifest,
+	emitter: CheckpointEventEmitter
+): Promise< void > {
+	// Deletions are computed from a FRESH walk taken after the server stopped —
+	// not from the safety checkpoint's earlier walk — so files created in
+	// between are still removed. The walk only sees captured scope, so
+	// excluded paths (.git, node_modules, the SQLite integration, logs) are
+	// never touched.
+	const currentWalk = await walkSite( site.path );
+	const targetPaths = new Set( Object.keys( manifest.files ) );
+
+	for ( const file of currentWalk.files ) {
+		if ( ! targetPaths.has( file.relPath ) ) {
+			await fsPromises.rm( file.fullPath, { force: true } );
+		}
+	}
+	for ( const symlink of currentWalk.symlinks ) {
+		if ( ! targetPaths.has( symlink.relPath ) ) {
+			await fsPromises.rm( path.join( site.path, symlink.relPath ), { force: true } );
+		}
+	}
+
+	// Prune directories that hold no target entries — including empty shells
+	// left by the deletions above (e.g. a plugin folder whose only file was
+	// removed). Deepest-first; rmdir refuses non-empty dirs, so anything that
+	// still has content (excluded paths and all) survives untouched.
+	const targetDirectories = new Set< string >();
+	for ( const relPath of targetPaths ) {
+		let parent = relPath;
+		while ( parent.includes( '/' ) ) {
+			parent = parent.slice( 0, parent.lastIndexOf( '/' ) );
+			targetDirectories.add( parent );
+		}
+	}
+	const removableDirectories = currentWalk.directories
+		.filter( ( dir ) => ! targetDirectories.has( dir ) )
+		.sort( ( a, b ) => b.length - a.length );
+	for ( const dir of removableDirectories ) {
+		try {
+			await fsPromises.rmdir( path.join( site.path, dir ) );
+		} catch ( error ) {
+			// Non-empty or already gone — leave it.
+		}
+	}
+
+	// Build a lookup of on-disk state for skip-unchanged fast pathing.
+	const currentByPath = new Map( currentWalk.files.map( ( file ) => [ file.relPath, file ] ) );
+
+	const entries = Object.entries( manifest.files );
+	let processed = 0;
+	for ( const [ relPath, entry ] of entries ) {
+		const destination = path.join( site.path, relPath );
+
+		if ( 'symlink' in entry ) {
+			try {
+				await fsPromises.rm( destination, { force: true } );
+				await fsPromises.mkdir( path.dirname( destination ), { recursive: true } );
+				await fsPromises.symlink( entry.symlink, destination );
+			} catch ( error ) {
+				// Symlink creation can fail on Windows without elevation; warn and
+				// continue rather than failing the whole restore.
+				console.warn( sprintf( __( 'Could not restore symlink %s; skipping.' ), relPath ) );
+			}
+		} else {
+			const current = currentByPath.get( relPath );
+			const unchanged =
+				current && current.mtimeMs === entry.mtimeMs && current.size === entry.logicalSize;
+			if ( ! unchanged ) {
+				await readObjectToFile( site.id, entry, destination, { mode: entry.mode } );
+			}
+		}
+
+		processed++;
+		if ( processed % 500 === 0 ) {
+			emitter.emit( CheckpointEvents.CHECKPOINT_RESTORE_PROGRESS, {
+				phase: 'files',
+				processed,
+				total: entries.length,
+			} );
+		}
+	}
+}
+
+async function applyDatabase( site: SiteData, manifest: CheckpointManifest ): Promise< void > {
+	const databasePath = path.join( site.path, SITE_DATABASE_RELATIVE_PATH );
+	await fsPromises.mkdir( path.dirname( databasePath ), { recursive: true } );
+	// Remove stale WAL residue so SQLite can't pair the restored main file
+	// with frames from the pre-restore database.
+	await fsPromises.rm( `${ databasePath }-wal`, { force: true } );
+	await fsPromises.rm( `${ databasePath }-shm`, { force: true } );
+	await fsPromises.rm( databasePath, { force: true } );
+	await readObjectToFile( site.id, manifest.db, databasePath );
+}
+
+export async function restoreCheckpoint(
+	site: SiteData,
+	checkpointId: string,
+	logger: Logger< string >,
+	options: RestoreCheckpointOptions = {}
+): Promise< RestoreCheckpointResult > {
+	const emitter = options.emitter ?? new CheckpointEventEmitter();
+	let restoreError: unknown;
+	let restartError: unknown;
+	let wasRunning = false;
+	let safetyCheckpointId: string | undefined;
+
+	const manifest = await readCheckpointManifest( site.id, checkpointId );
+
+	// Pin the target before anything else so a concurrent create's prune can't
+	// evict it, then fail fast if any object is missing.
+	await setCheckpointPinned( site.id, checkpointId, true );
+
+	try {
+		await verifyManifestObjects( site.id, manifest );
+
+		emitter.emit( CheckpointEvents.CHECKPOINT_RESTORE_START, {
+			siteId: site.id,
+			checkpointId,
+		} );
+
+		if ( ! options.skipSafetyCheckpoint ) {
+			const safetyCheckpoint = await createCheckpoint( site, {
+				trigger: 'pre-restore',
+				label: sprintf( __( 'Before restoring “%s”' ), manifest.label ?? checkpointId ),
+				skipMaintenance: true,
+				emitter,
+			} );
+			safetyCheckpointId = safetyCheckpoint.id;
+		}
+
+		await writeRestoreJournal( site.id, {
+			version: CHECKPOINT_STORE_VERSION,
+			checkpointId,
+			safetyCheckpointId,
+			startedAt: Date.now(),
+		} );
+
+		// Re-check the running state now (after the safety checkpoint) — the
+		// user or an agent could have started or stopped the site meanwhile.
+		wasRunning = !! ( await isServerRunning( site.id ) );
+		if ( wasRunning ) {
+			await stopWordPressServer( site.id );
+			await clearSiteLatestCliPid( site.id );
+		}
+
+		emitter.emit( CheckpointEvents.CHECKPOINT_RESTORE_PROGRESS, { phase: 'files' } );
+		await applyFiles( site, manifest, emitter );
+
+		emitter.emit( CheckpointEvents.CHECKPOINT_RESTORE_PROGRESS, { phase: 'database' } );
+		await applyDatabase( site, manifest );
+
+		emitter.emit( CheckpointEvents.CHECKPOINT_RESTORE_PROGRESS, { phase: 'finalizing' } );
+		await keepSqliteIntegrationUpdated( site.path );
+
+		if ( manifest.phpVersion && manifest.phpVersion !== site.phpVersion ) {
+			await updateSitePhpVersion( site.id, manifest.phpVersion );
+			site.phpVersion = manifest.phpVersion;
+		}
+
+		// Serialization-aware search-replace fixes any port/URL drift between
+		// checkpoint time and now. Runs via wp-cli while the site is stopped.
+		await updateSiteUrl( site );
+
+		await removeRestoreJournal( site.id );
+
+		emitter.emit( CheckpointEvents.CHECKPOINT_RESTORE_COMPLETE, {
+			checkpointId,
+			siteId: site.id,
+		} );
+	} catch ( error ) {
+		restoreError = error;
+		emitter.emit( CheckpointEvents.CHECKPOINT_RESTORE_ERROR, {
+			message: error instanceof Error ? error.message : String( error ),
+		} );
+	} finally {
+		try {
+			if ( wasRunning && ! restoreError ) {
+				await startWordPressServer( site, logger );
+				// Prime the site: the first request after a Playground start can
+				// return a transient error page.
+				const { getSiteUrl } = await import( 'cli/lib/cli-config/sites' );
+				await fetch( getSiteUrl( site ) ).catch( () => {} );
+			}
+		} catch ( error ) {
+			restartError = error;
+		} finally {
+			await setCheckpointPinned( site.id, checkpointId, false ).catch( () => {} );
+		}
+	}
+
+	if ( restoreError instanceof Error ) {
+		throw restoreError;
+	}
+	if ( restartError instanceof Error ) {
+		throw restartError;
+	}
+
+	return { checkpointId, safetyCheckpointId };
+}
+
+// Returns the journal if the previous restore for this site was interrupted.
+export async function findInterruptedRestore( siteId: string ) {
+	const { readRestoreJournal } = await import( './manifest' );
+	const journal = await readRestoreJournal( siteId );
+	return journal;
+}
+
+export function siteHasDatabase( site: SiteData ): boolean {
+	return fs.existsSync( path.join( site.path, SITE_DATABASE_RELATIVE_PATH ) );
+}

--- a/apps/cli/lib/checkpoints/retention.ts
+++ b/apps/cli/lib/checkpoints/retention.ts
@@ -1,0 +1,40 @@
+import type { CheckpointIndex, CheckpointIndexEntry } from './manifest';
+
+// Retention policy: manual and agent checkpoints are kept until explicitly
+// deleted; automatic checkpoints are pruned by count per trigger type.
+// Pinned entries (a restore in flight) are never pruned.
+export const DEFAULT_MAX_AUTO_CHECKPOINTS = 10;
+export const DEFAULT_MAX_PRE_RESTORE_CHECKPOINTS = 5;
+
+export interface RetentionPolicy {
+	maxAutoPerSite: number;
+	maxPreRestorePerSite: number;
+}
+
+export const DEFAULT_RETENTION_POLICY: RetentionPolicy = {
+	maxAutoPerSite: DEFAULT_MAX_AUTO_CHECKPOINTS,
+	maxPreRestorePerSite: DEFAULT_MAX_PRE_RESTORE_CHECKPOINTS,
+};
+
+// Returns the index entries that should be removed under the policy. The
+// index is ordered oldest → newest; we keep the newest N of each pruned type.
+export function selectPrunableCheckpoints(
+	index: CheckpointIndex,
+	policy: RetentionPolicy = DEFAULT_RETENTION_POLICY
+): CheckpointIndexEntry[] {
+	const prunable: CheckpointIndexEntry[] = [];
+
+	for ( const [ trigger, max ] of [
+		[ 'auto-pre-tool', policy.maxAutoPerSite ],
+		[ 'pre-restore', policy.maxPreRestorePerSite ],
+	] as const ) {
+		const candidates = index.checkpoints.filter(
+			( entry ) => entry.trigger === trigger && ! entry.pinned
+		);
+		if ( candidates.length > max ) {
+			prunable.push( ...candidates.slice( 0, candidates.length - max ) );
+		}
+	}
+
+	return prunable;
+}

--- a/apps/cli/lib/checkpoints/store.ts
+++ b/apps/cli/lib/checkpoints/store.ts
@@ -1,0 +1,231 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import { pipeline } from 'node:stream/promises';
+import path from 'path';
+import zlib from 'zlib';
+import {
+	getObjectsDirectory,
+	getStoreTmpDirectory,
+	type CheckpointManifest,
+	type ObjectRef,
+} from './manifest';
+
+// Content-addressed object store: immutable file contents keyed by sha-256,
+// fanned out into two-character subdirectories. Objects are written to tmp/
+// and renamed into place, so a partial write is garbage, never corruption.
+
+// File extensions whose contents compress well. Media and archives are stored
+// raw so `copyFile` can use copy-on-write cloning where the filesystem
+// supports it (APFS; NTFS/ext4 silently fall back to a real copy).
+const COMPRESSIBLE_EXTENSIONS = new Set( [
+	'.php',
+	'.js',
+	'.mjs',
+	'.cjs',
+	'.ts',
+	'.css',
+	'.scss',
+	'.json',
+	'.html',
+	'.htm',
+	'.svg',
+	'.txt',
+	'.md',
+	'.sql',
+	'.xml',
+	'.yml',
+	'.yaml',
+	'.pot',
+	'.po',
+	'.sqlite',
+	'.htaccess',
+] );
+
+export function shouldCompress( filePath: string ): boolean {
+	const base = path.basename( filePath );
+	if ( base.startsWith( '.ht' ) ) {
+		// .htaccess and the SQLite database family compress well.
+		return true;
+	}
+	return COMPRESSIBLE_EXTENSIONS.has( path.extname( filePath ).toLowerCase() );
+}
+
+export function getObjectPath( siteId: string, hash: string ): string {
+	return path.join( getObjectsDirectory( siteId ), hash.slice( 0, 2 ), hash.slice( 2 ) );
+}
+
+export async function objectExists( siteId: string, hash: string ): Promise< boolean > {
+	try {
+		await fsPromises.access( getObjectPath( siteId, hash ) );
+		return true;
+	} catch ( error ) {
+		return false;
+	}
+}
+
+async function hashFile( sourcePath: string ): Promise< string > {
+	const hash = crypto.createHash( 'sha256' );
+	for await ( const chunk of fs.createReadStream( sourcePath ) ) {
+		hash.update( chunk as Buffer );
+	}
+	return hash.digest( 'hex' );
+}
+
+// Stores a file's contents as an object, deduplicating against existing
+// objects. Returns the object reference (content hash of the ORIGINAL bytes,
+// stored size, and compression flag).
+export async function writeObject(
+	siteId: string,
+	sourcePath: string,
+	options: { compress?: boolean } = {}
+): Promise< ObjectRef > {
+	const compress = options.compress ?? shouldCompress( sourcePath );
+	const hash = await hashFile( sourcePath );
+	const objectPath = getObjectPath( siteId, hash );
+
+	if ( await objectExists( siteId, hash ) ) {
+		const { size } = await fsPromises.stat( objectPath );
+		return { hash, size, z: compress };
+	}
+
+	await fsPromises.mkdir( path.dirname( objectPath ), { recursive: true } );
+	const tmpPath = path.join(
+		getStoreTmpDirectory( siteId ),
+		`obj-${ process.pid }-${ crypto.randomUUID() }`
+	);
+
+	try {
+		if ( compress ) {
+			await pipeline(
+				fs.createReadStream( sourcePath ),
+				zlib.createGzip( { level: 6 } ),
+				fs.createWriteStream( tmpPath )
+			);
+		} else {
+			// COPYFILE_FICLONE clones on copy-on-write filesystems (APFS) and
+			// silently falls back to a regular copy elsewhere.
+			await fsPromises.copyFile( sourcePath, tmpPath, fs.constants.COPYFILE_FICLONE );
+		}
+
+		try {
+			await fsPromises.rename( tmpPath, objectPath );
+		} catch ( error ) {
+			// A concurrent writer may have stored the same object first; content
+			// addressing makes that outcome identical to ours.
+			if ( ! ( await objectExists( siteId, hash ) ) ) {
+				throw error;
+			}
+		}
+	} finally {
+		await fsPromises.rm( tmpPath, { force: true } );
+	}
+
+	const { size } = await fsPromises.stat( objectPath );
+	return { hash, size, z: compress };
+}
+
+// Materializes an object's original bytes at `destinationPath`.
+export async function readObjectToFile(
+	siteId: string,
+	ref: ObjectRef,
+	destinationPath: string,
+	options: { mode?: number } = {}
+): Promise< void > {
+	const objectPath = getObjectPath( siteId, ref.hash );
+	await fsPromises.mkdir( path.dirname( destinationPath ), { recursive: true } );
+
+	if ( ref.z ) {
+		await pipeline(
+			fs.createReadStream( objectPath ),
+			zlib.createGunzip(),
+			fs.createWriteStream( destinationPath )
+		);
+	} else {
+		await fsPromises.copyFile( objectPath, destinationPath, fs.constants.COPYFILE_FICLONE );
+	}
+
+	if ( options.mode !== undefined && process.platform !== 'win32' ) {
+		await fsPromises.chmod( destinationPath, options.mode );
+	}
+}
+
+export function collectReferencedHashes( manifests: CheckpointManifest[] ): Set< string > {
+	const referenced = new Set< string >();
+	for ( const manifest of manifests ) {
+		referenced.add( manifest.db.hash );
+		for ( const entry of Object.values( manifest.files ) ) {
+			if ( 'hash' in entry ) {
+				referenced.add( entry.hash );
+			}
+		}
+	}
+	return referenced;
+}
+
+// Deletes objects referenced by no manifest. Only objects older than
+// `graceMs` are eligible so an in-flight create's freshly written objects
+// (whose manifest hasn't landed yet) are never swept. Runs lock-free — see
+// the locking notes in manifest.ts.
+export async function collectGarbage(
+	siteId: string,
+	referencedHashes: Set< string >,
+	graceMs: number
+): Promise< number > {
+	const objectsDir = getObjectsDirectory( siteId );
+	let removed = 0;
+	let fanoutDirs: string[];
+	try {
+		fanoutDirs = await fsPromises.readdir( objectsDir );
+	} catch ( error ) {
+		return 0;
+	}
+
+	const now = Date.now();
+	for ( const fanout of fanoutDirs ) {
+		const fanoutPath = path.join( objectsDir, fanout );
+		let entries: string[];
+		try {
+			entries = await fsPromises.readdir( fanoutPath );
+		} catch ( error ) {
+			continue;
+		}
+		for ( const entry of entries ) {
+			const hash = `${ fanout }${ entry }`;
+			if ( referencedHashes.has( hash ) ) {
+				continue;
+			}
+			const objectPath = path.join( fanoutPath, entry );
+			try {
+				const { mtimeMs } = await fsPromises.stat( objectPath );
+				if ( now - mtimeMs < graceMs ) {
+					continue;
+				}
+				await fsPromises.rm( objectPath, { force: true } );
+				removed++;
+			} catch ( error ) {
+				// Another process may have removed it; nothing to do.
+			}
+		}
+	}
+
+	// Clear stale tmp files from interrupted writes, with the same grace window.
+	try {
+		const tmpDir = getStoreTmpDirectory( siteId );
+		for ( const entry of await fsPromises.readdir( tmpDir ) ) {
+			const tmpPath = path.join( tmpDir, entry );
+			try {
+				const { mtimeMs } = await fsPromises.stat( tmpPath );
+				if ( now - mtimeMs >= graceMs ) {
+					await fsPromises.rm( tmpPath, { force: true, recursive: true } );
+				}
+			} catch ( error ) {
+				// Ignore races with other cleaners.
+			}
+		}
+	} catch ( error ) {
+		// tmp dir may not exist yet.
+	}
+
+	return removed;
+}

--- a/apps/cli/lib/checkpoints/walker.ts
+++ b/apps/cli/lib/checkpoints/walker.ts
@@ -1,0 +1,119 @@
+import fsPromises from 'fs/promises';
+import path from 'path';
+import {
+	isExactPathExcluded,
+	isExcludedDirectoryName,
+} from 'cli/lib/import-export/export/exporters/path-exclusions';
+import type { CheckpointManifest } from './manifest';
+
+// Temp files the checkpoint engine itself writes into the site root during
+// database capture; never part of a checkpoint.
+export const CHECKPOINT_TEMP_FILE_PREFIX = '.studio-checkpoint-';
+
+export interface WalkedFile {
+	// `/`-normalized path relative to the site root.
+	relPath: string;
+	fullPath: string;
+	size: number;
+	mtimeMs: number;
+	mode: number;
+}
+
+export interface WalkedSymlink {
+	relPath: string;
+	target: string;
+}
+
+export interface WalkResult {
+	files: WalkedFile[];
+	symlinks: WalkedSymlink[];
+	// All directories visited (`/`-normalized, relative), deepest last. Used
+	// by restore to prune directories that shouldn't exist in the target
+	// state, including empty ones the file list can't reveal.
+	directories: string[];
+}
+
+function toPosix( relPath: string ): string {
+	return relPath.split( path.sep ).join( '/' );
+}
+
+// Walks the site tree producing checkpoint entries. Applies the shared
+// export/checkpoint exclusions. Symlinks are recorded, never followed.
+export async function walkSite( sitePath: string ): Promise< WalkResult > {
+	const files: WalkedFile[] = [];
+	const symlinks: WalkedSymlink[] = [];
+	const directories: string[] = [];
+
+	async function walkDirectory( currentPath: string ): Promise< void > {
+		const entries = await fsPromises.readdir( currentPath, { withFileTypes: true } );
+		for ( const entry of entries ) {
+			const fullPath = path.join( currentPath, entry.name );
+			const relPath = path.relative( sitePath, fullPath );
+			const posixRelPath = toPosix( relPath );
+
+			if ( entry.isDirectory() ) {
+				if ( isExcludedDirectoryName( entry.name ) || isExactPathExcluded( relPath ) ) {
+					continue;
+				}
+				directories.push( posixRelPath );
+				await walkDirectory( fullPath );
+				continue;
+			}
+
+			if ( isExactPathExcluded( relPath ) ) {
+				continue;
+			}
+			if ( entry.name.startsWith( CHECKPOINT_TEMP_FILE_PREFIX ) ) {
+				continue;
+			}
+
+			if ( entry.isSymbolicLink() ) {
+				try {
+					const target = await fsPromises.readlink( fullPath );
+					symlinks.push( { relPath: posixRelPath, target } );
+				} catch ( error ) {
+					// Broken link readback; skip it rather than fail the walk.
+				}
+				continue;
+			}
+
+			if ( ! entry.isFile() ) {
+				continue;
+			}
+
+			try {
+				const stat = await fsPromises.lstat( fullPath );
+				files.push( {
+					relPath: posixRelPath,
+					fullPath,
+					size: stat.size,
+					mtimeMs: stat.mtimeMs,
+					mode: stat.mode & 0o777,
+				} );
+			} catch ( error ) {
+				// The file disappeared between readdir and lstat (running site);
+				// captures are best-effort for in-flight file churn.
+			}
+		}
+	}
+
+	await walkDirectory( sitePath );
+	return { files, symlinks, directories };
+}
+
+// Returns true when a walked file can reuse the previous manifest's object
+// without re-hashing: same size and mtime (git-index trick). A restored or
+// touched file re-hashes; only genuinely unchanged files skip.
+export function canReusePreviousEntry(
+	file: WalkedFile,
+	previousManifest: CheckpointManifest | undefined
+): { hash: string; size: number; z: boolean } | undefined {
+	const previous = previousManifest?.files[ file.relPath ];
+	if ( ! previous || ! ( 'hash' in previous ) ) {
+		return undefined;
+	}
+	if ( previous.mtimeMs === file.mtimeMs && previous.logicalSize === file.size ) {
+		return { hash: previous.hash, size: previous.size, z: previous.z };
+	}
+	return undefined;
+}

--- a/apps/cli/lib/import-export/export/exporters/default-exporter.ts
+++ b/apps/cli/lib/import-export/export/exporters/default-exporter.ts
@@ -5,11 +5,6 @@ import path from 'path';
 import { ARCHIVER_OPTIONS, DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { generateBackupFilename } from '@studio/common/lib/generate-backup-filename';
 import { createExportErrorPayload, ExportEvents } from '@studio/common/lib/import-export-events';
-import {
-	LEGACY_MU_PLUGIN_FILENAMES,
-	STUDIO_ERROR_LOG_FILENAME,
-	STUDIO_LOADER_MU_PLUGIN_FILENAME,
-} from '@studio/common/lib/mu-plugins';
 import { parseJsonFromPhpOutput } from '@studio/common/lib/php-output-parser';
 import {
 	hasDefaultDbBlock,
@@ -31,11 +26,8 @@ import {
 	StudioJson,
 	StudioJsonPluginOrTheme,
 } from '../types';
+import { isExactPathExcluded, isPathExcludedByPattern } from './path-exclusions';
 import type { SiteData } from 'cli/lib/cli-config/core';
-
-const prefixedLegacyMuPluginNames = LEGACY_MU_PLUGIN_FILENAMES.map(
-	( name ) => `wp-content/mu-plugins/${ name }`
-);
 
 export class DefaultExporter extends ImportExportEventEmitter implements Exporter {
 	private archiveBuilder!: Archiver;
@@ -43,42 +35,13 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 	private readonly options: ExportOptions;
 
 	isExactPathExcluded( pathToCheck: string ) {
-		const PATHS_TO_EXCLUDE = [
-			'wp-content/mu-plugins/sqlite-database-integration',
-			'wp-content/database',
-			'wp-content/db.php',
-			'wp-content/debug.log',
-			`wp-content/${ STUDIO_ERROR_LOG_FILENAME }`,
-			...prefixedLegacyMuPluginNames,
-			`wp-content/mu-plugins/${ STUDIO_LOADER_MU_PLUGIN_FILENAME }`,
-		];
-
-		return PATHS_TO_EXCLUDE.some( ( pathToExclude ) =>
-			pathToCheck.startsWith( path.normalize( pathToExclude ) )
-		);
+		return isExactPathExcluded( pathToCheck );
 	}
 
 	// Look for disallowed directory names in a given path. If found, determine whether that part of
 	// the path is a directory or not.
 	isPathExcludedByPattern( pathToCheck: string ) {
-		const DIRECTORY_NAMES_TO_EXCLUDE = [ '.git', 'node_modules', 'cache' ];
-		const pathParts = pathToCheck.split( path.sep );
-
-		for ( const directoryName of DIRECTORY_NAMES_TO_EXCLUDE ) {
-			if ( ! pathParts.includes( directoryName ) ) {
-				continue;
-			}
-			const offenderIndex = pathToCheck.lastIndexOf( directoryName );
-			const offenderPath = pathToCheck.substring( 0, offenderIndex + directoryName.length );
-			try {
-				const stat = fs.statSync( offenderPath );
-				return stat.isDirectory();
-			} catch ( error ) {
-				return false;
-			}
-		}
-
-		return false;
+		return isPathExcludedByPattern( pathToCheck );
 	}
 
 	constructor( options: ExportOptions ) {

--- a/apps/cli/lib/import-export/export/exporters/path-exclusions.ts
+++ b/apps/cli/lib/import-export/export/exporters/path-exclusions.ts
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+import {
+	LEGACY_MU_PLUGIN_FILENAMES,
+	STUDIO_ERROR_LOG_FILENAME,
+	STUDIO_LOADER_MU_PLUGIN_FILENAME,
+} from '@studio/common/lib/mu-plugins';
+
+// Paths excluded from site exports AND checkpoints, relative to the site root.
+// The database directory is excluded because both features capture the
+// database separately; the SQLite integration and Studio loader mu-plugins are
+// runtime-managed and reinstalled by `keepSqliteIntegrationUpdated`.
+const EXACT_PATHS_TO_EXCLUDE = [
+	'wp-content/mu-plugins/sqlite-database-integration',
+	'wp-content/database',
+	'wp-content/db.php',
+	'wp-content/debug.log',
+	`wp-content/${ STUDIO_ERROR_LOG_FILENAME }`,
+	...LEGACY_MU_PLUGIN_FILENAMES.map( ( name ) => `wp-content/mu-plugins/${ name }` ),
+	`wp-content/mu-plugins/${ STUDIO_LOADER_MU_PLUGIN_FILENAME }`,
+];
+
+const DIRECTORY_NAMES_TO_EXCLUDE = [ '.git', 'node_modules', 'cache' ];
+
+export function isExactPathExcluded( pathToCheck: string ): boolean {
+	return EXACT_PATHS_TO_EXCLUDE.some( ( pathToExclude ) =>
+		pathToCheck.startsWith( path.normalize( pathToExclude ) )
+	);
+}
+
+// Look for disallowed directory names in a given path. If found, determine
+// whether that part of the path is a directory or not.
+export function isPathExcludedByPattern( pathToCheck: string ): boolean {
+	const pathParts = pathToCheck.split( path.sep );
+
+	for ( const directoryName of DIRECTORY_NAMES_TO_EXCLUDE ) {
+		if ( ! pathParts.includes( directoryName ) ) {
+			continue;
+		}
+		const offenderIndex = pathToCheck.lastIndexOf( directoryName );
+		const offenderPath = pathToCheck.substring( 0, offenderIndex + directoryName.length );
+		try {
+			const stat = fs.statSync( offenderPath );
+			return stat.isDirectory();
+		} catch ( error ) {
+			return false;
+		}
+	}
+
+	return false;
+}
+
+// Directory names pruned during checkpoint walks without stat-ing every child.
+// Mirrors DIRECTORY_NAMES_TO_EXCLUDE but usable directly on Dirent names.
+export function isExcludedDirectoryName( name: string ): boolean {
+	return DIRECTORY_NAMES_TO_EXCLUDE.includes( name );
+}

--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -14,6 +14,7 @@ import {
 import {
 	deleteAiSessionPlacement,
 	readAiSessionPlacement,
+	readAiSessionPlacements,
 } from '@studio/common/ai/sessions/placement';
 import {
 	appendModelChangeEntry,
@@ -858,6 +859,121 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 			}
 			const imported = ( await listSites( execute ) ).find( ( s ) => s.id === req.params.id );
 			res.json( toSiteDetails( imported ?? site ) );
+		} )
+	);
+
+	// --- Site checkpoints ------------------------------------------------------
+	// Files + database save points, backed by the CLI checkpoint engine. Every
+	// route forks the same `studio checkpoint` command the terminal user runs.
+
+	// Runs a checkpoint CLI command to completion, resolving with the captured
+	// stdout (used by `list --json`; the mutations ignore it).
+	function runCheckpointCommand( args: string[] ): Promise< string > {
+		return new Promise< string >( ( resolve, reject ) => {
+			const [ emitter ] = execute( args, { output: 'capture' } );
+			emitter.on( 'success', ( { result } ) => resolve( result?.stdout ?? '' ) );
+			emitter.on( 'failure', ( { error } ) => reject( error ) );
+			emitter.on( 'error', ( { error } ) => reject( error ) );
+		} );
+	}
+
+	api.get(
+		'/sites/:id/checkpoints',
+		asyncHandler( async ( req: Request, res: Response ) => {
+			const site = ( await listSites( execute ) ).find( ( s ) => s.id === req.params.id );
+			if ( ! site ) {
+				res.status( 404 ).json( { error: `Site ${ req.params.id } not found` } );
+				return;
+			}
+			const stdout = await runCheckpointCommand( [
+				'checkpoint',
+				'list',
+				'--path',
+				site.path,
+				'--json',
+			] );
+			// `checkpoint list --json` prints a single JSON object on stdout:
+			// `{ checkpoints: [...], interruptedRestore: ... }`. Parse from the
+			// first `{` so any stray CLI output before it can't break the parse.
+			const jsonStart = stdout.indexOf( '{' );
+			const parsed = JSON.parse( jsonStart >= 0 ? stdout.slice( jsonStart ) : stdout ) as {
+				checkpoints?: unknown[];
+			};
+			res.json( parsed.checkpoints ?? [] );
+		} )
+	);
+
+	api.post(
+		'/sites/:id/checkpoints',
+		asyncHandler( async ( req: Request, res: Response ) => {
+			const site = ( await listSites( execute ) ).find( ( s ) => s.id === req.params.id );
+			if ( ! site ) {
+				res.status( 404 ).json( { error: `Site ${ req.params.id } not found` } );
+				return;
+			}
+			const label = typeof req.body?.label === 'string' ? req.body.label.trim() : '';
+			const args = [ 'checkpoint', 'create', '--path', site.path ];
+			if ( label ) {
+				args.push( '--label', label );
+			}
+			await runCheckpointCommand( args );
+			res.status( 204 ).end();
+		} )
+	);
+
+	api.post(
+		'/sites/:id/checkpoints/:checkpointId/restore',
+		asyncHandler( async ( req: Request, res: Response ) => {
+			const site = ( await listSites( execute ) ).find( ( s ) => s.id === req.params.id );
+			if ( ! site ) {
+				res.status( 404 ).json( { error: `Site ${ req.params.id } not found` } );
+				return;
+			}
+			// Refuse to rewrite the site tree under an agent that is actively
+			// working on it — restoring mid-run would yank files out from under
+			// the run's tools. Active runs are matched to the site through their
+			// session placement.
+			const activeRuns = runManager.listActiveAgentRuns();
+			if ( activeRuns.length > 0 ) {
+				const placements = await readAiSessionPlacements();
+				const busy = activeRuns.some(
+					( run ) => placements[ run.sessionId ]?.siteId === req.params.id
+				);
+				if ( busy ) {
+					res.status( 409 ).json( {
+						error: 'An agent is currently working on this site. Stop the run before restoring.',
+					} );
+					return;
+				}
+			}
+			await runCheckpointCommand( [
+				'checkpoint',
+				'restore',
+				req.params.checkpointId,
+				'--path',
+				site.path,
+				'--yes',
+			] );
+			res.status( 204 ).end();
+		} )
+	);
+
+	api.delete(
+		'/sites/:id/checkpoints/:checkpointId',
+		asyncHandler( async ( req: Request, res: Response ) => {
+			const site = ( await listSites( execute ) ).find( ( s ) => s.id === req.params.id );
+			if ( ! site ) {
+				res.status( 404 ).json( { error: `Site ${ req.params.id } not found` } );
+				return;
+			}
+			await runCheckpointCommand( [
+				'checkpoint',
+				'delete',
+				req.params.checkpointId,
+				'--path',
+				site.path,
+			] );
+			res.status( 204 ).end();
 		} )
 	);
 

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -240,6 +240,13 @@ export { getDefaultSiteDirectory, saveDefaultSiteDirectory };
 
 export { importSite, exportSite } from 'src/modules/import-export/lib/ipc-handlers';
 
+export {
+	listSiteCheckpoints,
+	createSiteCheckpoint,
+	restoreSiteCheckpoint,
+	deleteSiteCheckpoint,
+} from 'src/modules/checkpoints/lib/ipc-handlers';
+
 export { fetchSiteRest as fetchSiteRestApi } from 'src/lib/wordpress-rest-api';
 
 export async function listAiSessions( _event: IpcMainInvokeEvent ): Promise< AiSessionSummary[] > {

--- a/apps/studio/src/modules/checkpoints/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/checkpoints/lib/ipc-handlers.ts
@@ -1,0 +1,119 @@
+import { IpcMainInvokeEvent } from 'electron';
+import { readAiSessionPlacements } from '@studio/common/ai/sessions/placement';
+import { listActiveAgentRuns } from 'src/modules/ai-agent/run-manager';
+import { executeCliCommand } from 'src/modules/cli/lib/execute-command';
+import { SiteServer } from 'src/site-server';
+
+// One entry of a site's checkpoint index, as reported by the CLI's
+// `checkpoint list --json` (mirrors the engine's `CheckpointIndexEntry`).
+// `createdAt` is epoch milliseconds.
+export interface SiteCheckpointEntry {
+	id: string;
+	label?: string;
+	createdAt: number;
+	trigger: 'manual' | 'agent' | 'auto-pre-tool' | 'pre-restore';
+	toolName?: string;
+	pinned?: boolean;
+	stats: {
+		fileCount: number;
+		logicalBytes: number;
+		newObjectBytes: number;
+	};
+}
+
+function getSitePath( siteId: string ): string {
+	const site = SiteServer.get( siteId );
+	if ( ! site ) {
+		throw new Error( 'Site not found.' );
+	}
+	return site.details.path;
+}
+
+// Forks the same `studio checkpoint` CLI command the terminal user runs and
+// resolves with the captured stdout (used by `list --json`; mutations ignore it).
+function runCheckpointCliCommand( args: string[] ): Promise< string > {
+	return new Promise< string >( ( resolve, reject ) => {
+		const [ emitter ] = executeCliCommand( args, { output: 'capture' } );
+		emitter.on( 'success', ( { result } ) => resolve( result.stdout ) );
+		emitter.on( 'failure', ( { error } ) => reject( error ) );
+		emitter.on( 'error', ( { error } ) => reject( error ) );
+	} );
+}
+
+export async function listSiteCheckpoints(
+	_event: IpcMainInvokeEvent,
+	siteId: string
+): Promise< SiteCheckpointEntry[] > {
+	const sitePath = getSitePath( siteId );
+	const stdout = await runCheckpointCliCommand( [
+		'checkpoint',
+		'list',
+		'--path',
+		sitePath,
+		'--json',
+	] );
+	// `checkpoint list --json` prints a single JSON object on stdout:
+	// `{ checkpoints: [...], interruptedRestore: ... }`. Parse from the first
+	// `{` so any stray CLI output before it can't break the parse.
+	const jsonStart = stdout.indexOf( '{' );
+	const parsed = JSON.parse( jsonStart >= 0 ? stdout.slice( jsonStart ) : stdout ) as {
+		checkpoints?: SiteCheckpointEntry[];
+	};
+	return parsed.checkpoints ?? [];
+}
+
+export async function createSiteCheckpoint(
+	_event: IpcMainInvokeEvent,
+	siteId: string,
+	label?: string
+): Promise< void > {
+	const sitePath = getSitePath( siteId );
+	const args = [ 'checkpoint', 'create', '--path', sitePath ];
+	const trimmedLabel = label?.trim();
+	if ( trimmedLabel ) {
+		args.push( '--label', trimmedLabel );
+	}
+	await runCheckpointCliCommand( args );
+}
+
+export async function restoreSiteCheckpoint(
+	_event: IpcMainInvokeEvent,
+	siteId: string,
+	checkpointId: string
+): Promise< void > {
+	const sitePath = getSitePath( siteId );
+	// Refuse to rewrite the site tree under an agent that is actively working
+	// on it — restoring mid-run would yank files out from under the run's
+	// tools. Active runs are matched to the site through their session
+	// placement.
+	const activeRuns = listActiveAgentRuns();
+	if ( activeRuns.length > 0 ) {
+		const placements = await readAiSessionPlacements();
+		const busy = activeRuns.some( ( run ) => placements[ run.sessionId ]?.siteId === siteId );
+		if ( busy ) {
+			throw new Error(
+				'An agent is currently working on this site. Stop the run before restoring.'
+			);
+		}
+	}
+	// The CLI restore stops the site server, applies files + database, and
+	// restarts it — plus captures a safety checkpoint of the current state
+	// first, so the restore itself is undoable.
+	await runCheckpointCliCommand( [
+		'checkpoint',
+		'restore',
+		checkpointId,
+		'--path',
+		sitePath,
+		'--yes',
+	] );
+}
+
+export async function deleteSiteCheckpoint(
+	_event: IpcMainInvokeEvent,
+	siteId: string,
+	checkpointId: string
+): Promise< void > {
+	const sitePath = getSitePath( siteId );
+	await runCheckpointCliCommand( [ 'checkpoint', 'delete', checkpointId, '--path', sitePath ] );
+}

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -104,6 +104,13 @@ const api: IpcApi = {
 	getInstalledAppsAndTerminals: () => ipcRendererInvoke( 'getInstalledAppsAndTerminals' ),
 	importSite: ( siteId, importArchivePath, options ) =>
 		ipcRendererInvoke( 'importSite', siteId, importArchivePath, options ),
+	listSiteCheckpoints: ( siteId ) => ipcRendererInvoke( 'listSiteCheckpoints', siteId ),
+	createSiteCheckpoint: ( siteId, label ) =>
+		ipcRendererInvoke( 'createSiteCheckpoint', siteId, label ),
+	restoreSiteCheckpoint: ( siteId, checkpointId ) =>
+		ipcRendererInvoke( 'restoreSiteCheckpoint', siteId, checkpointId ),
+	deleteSiteCheckpoint: ( siteId, checkpointId ) =>
+		ipcRendererInvoke( 'deleteSiteCheckpoint', siteId, checkpointId ),
 	executeWPCLiInline: ( options ) => ipcRendererInvoke( 'executeWPCLiInline', options ),
 	getOnboardingData: () => ipcRendererInvoke( 'getOnboardingData' ),
 	saveOnboarding: ( onboardingCompleted ) =>

--- a/apps/ui/src/components/checkpoint-timeline/artifact-chip.tsx
+++ b/apps/ui/src/components/checkpoint-timeline/artifact-chip.tsx
@@ -1,0 +1,50 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { backup } from '@wordpress/icons';
+import { Button, Icon } from '@wordpress/ui';
+import { useState } from 'react';
+import { formatRelativeTime } from '@/lib/format-relative-time';
+import styles from './style.module.css';
+import { RestoreCheckpointDialog } from './index';
+import type { CheckpointArtifactProps } from '@studio/common/ai/chat-artifacts';
+
+/**
+ * Compact chip for a checkpoint artifact in the chat transcript — emitted by
+ * the agent's checkpoint tools (and the automatic pre-tool captures). Restore
+ * opens the same confirmation dialog the site's checkpoint timeline uses.
+ */
+export function CheckpointArtifactChip( { artifact }: { artifact: CheckpointArtifactProps } ) {
+	const [ restoreOpen, setRestoreOpen ] = useState( false );
+
+	let title = artifact.label;
+	if ( ! title ) {
+		title = artifact.toolName
+			? /* translators: %s: the agent tool a checkpoint was captured before (e.g. "wp_cli") */
+			  sprintf( __( 'Checkpoint before %s' ), artifact.toolName )
+			: __( 'Checkpoint' );
+	}
+
+	return (
+		<div className={ styles.chip }>
+			<Icon icon={ backup } size={ 16 } className={ styles.chipIcon } />
+			<span className={ styles.chipTitle }>{ title }</span>
+			<span className={ styles.chipTime }>
+				{ formatRelativeTime( new Date( artifact.createdAt ).toISOString() ) }
+			</span>
+			<Button
+				variant="minimal"
+				tone="neutral"
+				size="compact"
+				onClick={ () => setRestoreOpen( true ) }
+			>
+				{ __( 'Restore' ) }
+			</Button>
+			<RestoreCheckpointDialog
+				siteId={ artifact.siteId }
+				checkpointId={ artifact.checkpointId }
+				title={ title }
+				open={ restoreOpen }
+				onOpenChange={ setRestoreOpen }
+			/>
+		</div>
+	);
+}

--- a/apps/ui/src/components/checkpoint-timeline/index.tsx
+++ b/apps/ui/src/components/checkpoint-timeline/index.tsx
@@ -1,0 +1,390 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { backup } from '@wordpress/icons';
+import { Badge, Button, Dialog, Icon } from '@wordpress/ui';
+import { useMemo, useState } from 'react';
+import {
+	useCheckpoints,
+	useCreateCheckpoint,
+	useDeleteCheckpoint,
+	useRestoreCheckpoint,
+} from '@/data/queries/use-checkpoints';
+import { formatRelativeTime } from '@/lib/format-relative-time';
+import styles from './style.module.css';
+import type { SiteCheckpoint, SiteCheckpointTrigger } from '@/data/core';
+import type { FormEvent } from 'react';
+
+// Display name for a checkpoint: its label when the user gave one, the tool
+// the automatic pre-tool capture ran before, or a generic fallback.
+export function checkpointTitle( checkpoint: {
+	label?: string | null;
+	toolName?: string | null;
+} ): string {
+	if ( checkpoint.label ) {
+		return checkpoint.label;
+	}
+	if ( checkpoint.toolName ) {
+		/* translators: %s: the agent tool an automatic checkpoint was captured before (e.g. "wp_cli") */
+		return sprintf( __( 'Before %s' ), checkpoint.toolName );
+	}
+	return __( 'Checkpoint' );
+}
+
+function triggerLabel( trigger: SiteCheckpointTrigger ): string {
+	switch ( trigger ) {
+		case 'manual':
+			return __( 'Manual' );
+		case 'agent':
+			return __( 'Agent' );
+		case 'auto-pre-tool':
+			return __( 'Auto' );
+		case 'pre-restore':
+			return __( 'Safety' );
+	}
+}
+
+function formatCheckpointBytes( bytes: number ): string {
+	if ( bytes < 1024 ) {
+		/* translators: %d: a number of bytes */
+		return sprintf( __( '%d B' ), bytes );
+	}
+	if ( bytes < 1024 * 1024 ) {
+		/* translators: %s: a number of kilobytes */
+		return sprintf( __( '%s KB' ), ( bytes / 1024 ).toFixed( 1 ) );
+	}
+	if ( bytes < 1024 * 1024 * 1024 ) {
+		/* translators: %s: a number of megabytes */
+		return sprintf( __( '%s MB' ), ( bytes / ( 1024 * 1024 ) ).toFixed( 1 ) );
+	}
+	/* translators: %s: a number of gigabytes */
+	return sprintf( __( '%s GB' ), ( bytes / ( 1024 * 1024 * 1024 ) ).toFixed( 2 ) );
+}
+
+/**
+ * Confirmation dialog for restoring a checkpoint. Shared by the timeline and
+ * the chat's checkpoint chips, so both surfaces explain the same thing: the
+ * restore replaces files AND database, and a safety checkpoint of the current
+ * state is captured first.
+ */
+export function RestoreCheckpointDialog( {
+	siteId,
+	checkpointId,
+	title,
+	open,
+	onOpenChange,
+}: {
+	siteId: string;
+	checkpointId: string;
+	title: string;
+	open: boolean;
+	onOpenChange: ( open: boolean ) => void;
+} ) {
+	const restoreCheckpoint = useRestoreCheckpoint();
+	const [ error, setError ] = useState< string | null >( null );
+
+	const handleConfirm = () => {
+		setError( null );
+		restoreCheckpoint.mutate(
+			{ siteId, checkpointId },
+			{
+				onSuccess: () => onOpenChange( false ),
+				onError: ( err: Error ) => {
+					setError( err.message ?? __( 'Unable to restore the checkpoint. Please try again.' ) );
+				},
+			}
+		);
+	};
+
+	return (
+		<Dialog.Root
+			open={ open }
+			onOpenChange={ ( next ) => {
+				if ( ! restoreCheckpoint.isPending ) {
+					onOpenChange( next );
+					if ( ! next ) {
+						setError( null );
+					}
+				}
+			} }
+		>
+			<Dialog.Popup size="small">
+				<Dialog.Header>
+					{ /* translators: %s: the checkpoint's name */ }
+					<Dialog.Title>{ sprintf( __( 'Restore “%s”?' ), title ) }</Dialog.Title>
+				</Dialog.Header>
+				<Dialog.Content>
+					<p className={ styles.dialogText }>
+						{ __(
+							'The site’s files and database will be returned to the state captured in this checkpoint. Changes made since then will be replaced.'
+						) }
+					</p>
+					<p className={ styles.dialogText }>
+						{ __(
+							'A safety checkpoint of the current state is captured first, so you can undo this restore.'
+						) }
+					</p>
+					{ error ? <div className={ styles.dialogError }>{ error }</div> : null }
+				</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action variant="minimal" tone="neutral" disabled={ restoreCheckpoint.isPending }>
+						{ __( 'Cancel' ) }
+					</Dialog.Action>
+					<Button
+						variant="solid"
+						tone="brand"
+						loading={ restoreCheckpoint.isPending }
+						loadingAnnouncement={ __( 'Restoring checkpoint' ) }
+						onClick={ handleConfirm }
+					>
+						{ __( 'Restore checkpoint' ) }
+					</Button>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
+	);
+}
+
+// "Mark as good": capture the current site state, optionally with a label.
+function CreateCheckpointDialog( {
+	siteId,
+	open,
+	onOpenChange,
+}: {
+	siteId: string;
+	open: boolean;
+	onOpenChange: ( open: boolean ) => void;
+} ) {
+	const createCheckpoint = useCreateCheckpoint();
+	const [ label, setLabel ] = useState( '' );
+	const [ error, setError ] = useState< string | null >( null );
+
+	const handleSubmit = ( event: FormEvent ) => {
+		event.preventDefault();
+		if ( createCheckpoint.isPending ) {
+			return;
+		}
+		setError( null );
+		createCheckpoint.mutate(
+			{ siteId, label: label.trim() || undefined },
+			{
+				onSuccess: () => {
+					onOpenChange( false );
+					setLabel( '' );
+				},
+				onError: ( err: Error ) => {
+					setError( err.message ?? __( 'Unable to create the checkpoint. Please try again.' ) );
+				},
+			}
+		);
+	};
+
+	return (
+		<Dialog.Root
+			open={ open }
+			onOpenChange={ ( next ) => {
+				if ( ! createCheckpoint.isPending ) {
+					onOpenChange( next );
+					if ( ! next ) {
+						setError( null );
+					}
+				}
+			} }
+		>
+			<Dialog.Popup size="small">
+				<Dialog.Header>
+					<Dialog.Title>{ __( 'Create checkpoint' ) }</Dialog.Title>
+				</Dialog.Header>
+				<Dialog.Content>
+					<form onSubmit={ handleSubmit }>
+						<p className={ styles.dialogText }>
+							{ __(
+								'Captures the site’s files and database so you can return to this exact state later.'
+							) }
+						</p>
+						<label className={ styles.dialogField }>
+							<span>{ __( 'Label (optional)' ) }</span>
+							<input
+								type="text"
+								value={ label }
+								placeholder={ __( 'e.g. Before homepage redesign' ) }
+								onChange={ ( event ) => setLabel( event.target.value ) }
+								autoFocus
+							/>
+						</label>
+						{ error ? <div className={ styles.dialogError }>{ error }</div> : null }
+					</form>
+				</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action variant="minimal" tone="neutral" disabled={ createCheckpoint.isPending }>
+						{ __( 'Cancel' ) }
+					</Dialog.Action>
+					<Button
+						variant="solid"
+						tone="brand"
+						loading={ createCheckpoint.isPending }
+						loadingAnnouncement={ __( 'Creating checkpoint' ) }
+						onClick={ handleSubmit }
+					>
+						{ __( 'Create checkpoint' ) }
+					</Button>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
+	);
+}
+
+function CheckpointRow( {
+	siteId,
+	checkpoint,
+	onRestore,
+}: {
+	siteId: string;
+	checkpoint: SiteCheckpoint;
+	onRestore: ( checkpoint: SiteCheckpoint ) => void;
+} ) {
+	const deleteCheckpoint = useDeleteCheckpoint();
+	const [ deleteError, setDeleteError ] = useState< string | null >( null );
+
+	const handleDelete = () => {
+		setDeleteError( null );
+		deleteCheckpoint.mutate(
+			{ siteId, checkpointId: checkpoint.id },
+			{
+				onError: ( err: Error ) => {
+					setDeleteError( err.message ?? __( 'Unable to delete the checkpoint.' ) );
+				},
+			}
+		);
+	};
+
+	return (
+		<li className={ styles.row }>
+			<div className={ styles.rowMain }>
+				<div className={ styles.rowTitleLine }>
+					<span className={ styles.rowTitle }>{ checkpointTitle( checkpoint ) }</span>
+					<Badge intent={ checkpoint.trigger === 'manual' ? 'informational' : 'none' }>
+						{ triggerLabel( checkpoint.trigger ) }
+					</Badge>
+				</div>
+				<div className={ styles.rowMeta }>
+					<span>{ formatRelativeTime( new Date( checkpoint.createdAt ).toISOString() ) }</span>
+					<span aria-hidden="true">·</span>
+					{ /* translators: %s: amount of new data this checkpoint added (e.g. "1.2 MB") */ }
+					<span>
+						{ sprintf(
+							__( '%s new data' ),
+							formatCheckpointBytes( checkpoint.stats.newObjectBytes )
+						) }
+					</span>
+				</div>
+				{ deleteError ? <div className={ styles.rowError }>{ deleteError }</div> : null }
+			</div>
+			<div className={ styles.rowActions }>
+				<Button
+					variant="outline"
+					tone="neutral"
+					size="compact"
+					onClick={ () => onRestore( checkpoint ) }
+				>
+					{ __( 'Restore' ) }
+				</Button>
+				<Button
+					variant="minimal"
+					tone="neutral"
+					size="compact"
+					loading={ deleteCheckpoint.isPending }
+					loadingAnnouncement={ __( 'Deleting checkpoint' ) }
+					onClick={ handleDelete }
+				>
+					{ __( 'Delete' ) }
+				</Button>
+			</div>
+		</li>
+	);
+}
+
+/**
+ * The site's checkpoint history: every captured save point (manual, agent,
+ * automatic pre-tool, and pre-restore safety), newest first, with restore and
+ * delete actions plus the "Create checkpoint" entry point.
+ */
+export function CheckpointTimeline( { siteId }: { siteId: string } ) {
+	const { data: checkpoints, isLoading, isError } = useCheckpoints( siteId );
+	const [ createOpen, setCreateOpen ] = useState( false );
+	const [ restoreTarget, setRestoreTarget ] = useState< SiteCheckpoint | null >( null );
+
+	// The index is stored oldest → newest; the timeline reads newest first.
+	const orderedCheckpoints = useMemo(
+		() => [ ...( checkpoints ?? [] ) ].reverse(),
+		[ checkpoints ]
+	);
+
+	let content;
+	if ( isLoading ) {
+		content = <p className={ styles.stateText }>{ __( 'Loading checkpoints…' ) }</p>;
+	} else if ( isError ) {
+		content = <p className={ styles.stateText }>{ __( 'Checkpoints could not be loaded.' ) }</p>;
+	} else if ( orderedCheckpoints.length === 0 ) {
+		content = (
+			<div className={ styles.empty }>
+				<Icon icon={ backup } size={ 24 } />
+				<p className={ styles.stateText }>
+					{ __(
+						'No checkpoints yet. Create one to capture the site’s files and database, so you can always come back to a known-good state.'
+					) }
+				</p>
+				<Button variant="outline" tone="neutral" onClick={ () => setCreateOpen( true ) }>
+					{ __( 'Create checkpoint' ) }
+				</Button>
+			</div>
+		);
+	} else {
+		content = (
+			<ul className={ styles.list }>
+				{ orderedCheckpoints.map( ( checkpoint ) => (
+					<CheckpointRow
+						key={ checkpoint.id }
+						siteId={ siteId }
+						checkpoint={ checkpoint }
+						onRestore={ setRestoreTarget }
+					/>
+				) ) }
+			</ul>
+		);
+	}
+
+	return (
+		<section className={ styles.root } aria-label={ __( 'Checkpoints' ) }>
+			<div className={ styles.header }>
+				<p className={ styles.headerDescription }>
+					{ __(
+						'Checkpoints capture the site’s files and database. Restore one at any time to rewind the site to that state.'
+					) }
+				</p>
+				{ orderedCheckpoints.length > 0 ? (
+					<Button variant="outline" tone="neutral" onClick={ () => setCreateOpen( true ) }>
+						{ __( 'Create checkpoint' ) }
+					</Button>
+				) : null }
+			</div>
+			{ content }
+			<CreateCheckpointDialog
+				siteId={ siteId }
+				open={ createOpen }
+				onOpenChange={ setCreateOpen }
+			/>
+			{ restoreTarget ? (
+				<RestoreCheckpointDialog
+					siteId={ siteId }
+					checkpointId={ restoreTarget.id }
+					title={ checkpointTitle( restoreTarget ) }
+					open
+					onOpenChange={ ( next ) => {
+						if ( ! next ) {
+							setRestoreTarget( null );
+						}
+					} }
+				/>
+			) : null }
+		</section>
+	);
+}

--- a/apps/ui/src/components/checkpoint-timeline/style.module.css
+++ b/apps/ui/src/components/checkpoint-timeline/style.module.css
@@ -1,0 +1,195 @@
+.root {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-lg);
+}
+
+.header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-padding-lg);
+}
+
+.header button {
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+.headerDescription {
+	margin: 0;
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	text-wrap: pretty;
+}
+
+.stateText {
+	margin: 0;
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	text-wrap: pretty;
+}
+
+.empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-md);
+	padding: var(--wpds-dimension-padding-2xl) var(--wpds-dimension-padding-xl);
+	border: 1px dashed var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-md);
+	text-align: center;
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.empty .stateText {
+	max-width: 46ch;
+}
+
+.empty button {
+	white-space: nowrap;
+}
+
+.list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-md);
+	overflow: hidden;
+}
+
+.row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-padding-lg);
+	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
+}
+
+.row + .row {
+	border-top: 1px solid var(--wpds-color-stroke-surface-neutral);
+}
+
+.rowMain {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.rowTitleLine {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+	min-width: 0;
+}
+
+.rowTitle {
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.rowMeta {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+	font-size: var(--wpds-typography-font-size-xs);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	white-space: nowrap;
+}
+
+.rowError {
+	font-size: var(--wpds-typography-font-size-xs);
+	color: var(--wpds-color-fg-content-error);
+}
+
+.rowActions {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+	flex-shrink: 0;
+}
+
+.rowActions button {
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+/* Compact chip for a checkpoint artifact in the chat transcript. */
+.chip {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+	max-width: 100%;
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm)
+		var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-md);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-md);
+	background: var(--wpds-color-bg-surface-neutral);
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.chipIcon {
+	flex-shrink: 0;
+	fill: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.chipTitle {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.chipTime {
+	flex-shrink: 0;
+	font-size: var(--wpds-typography-font-size-xs);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	white-space: nowrap;
+}
+
+.chip button {
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+.dialogText {
+	margin: 0 0 var(--wpds-dimension-padding-md);
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral);
+	text-wrap: pretty;
+}
+
+.dialogField {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-xs);
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.dialogField input {
+	font: inherit;
+	color: inherit;
+	background: transparent;
+	padding: 6px 8px;
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-sm);
+}
+
+.dialogField input:focus-visible {
+	outline: 2px solid var(--wpds-color-stroke-interactive-focus);
+	outline-offset: -1px;
+}
+
+.dialogError {
+	margin-top: var(--wpds-dimension-padding-md);
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-error);
+}

--- a/apps/ui/src/components/checkpoint-timeline/style.module.css
+++ b/apps/ui/src/components/checkpoint-timeline/style.module.css
@@ -184,7 +184,7 @@
 }
 
 .dialogField input:focus-visible {
-	outline: 2px solid var(--wpds-color-stroke-interactive-focus);
+	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus-brand);
 	outline-offset: -1px;
 }
 

--- a/apps/ui/src/components/site-settings-view/index.tsx
+++ b/apps/ui/src/components/site-settings-view/index.tsx
@@ -7,6 +7,7 @@ import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CheckpointTimeline } from '@/components/checkpoint-timeline';
 import { LearnHowLink } from '@/components/learn-more';
 import { SiteDropdown } from '@/components/site-dropdown';
 import {
@@ -23,6 +24,7 @@ import {
 	wpVersionField,
 } from '@/components/site-fields';
 import * as Tabs from '@/components/tabs';
+import { useConnector } from '@/data/core';
 import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
 import { useSites, useUpdateSite, useXdebugEnabledSite } from '@/data/queries/use-sites';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
@@ -33,7 +35,7 @@ import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
 import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
 import type { FormEvent } from 'react';
 
-type TabId = 'general' | 'debugging';
+type TabId = 'general' | 'debugging' | 'checkpoints';
 
 interface FormData {
 	name: string;
@@ -151,6 +153,9 @@ function SiteSettingsBody( {
 	activeTab: TabId;
 	onTabChange: ( tab: TabId ) => void;
 } ) {
+	// Checkpoints run on the user's machine (the CLI checkpoint engine), so the
+	// tab only exists where the connector can reach it.
+	const supportsCheckpoints = useConnector().capabilities.siteCheckpoints;
 	const allDomains = useExistingCustomDomains();
 	const existingDomainNames = useMemo(
 		() => allDomains.filter( ( domain ) => domain !== site.customDomain ),
@@ -314,6 +319,9 @@ function SiteSettingsBody( {
 						<Tabs.List>
 							<Tabs.Tab tabId="general">{ __( 'General' ) }</Tabs.Tab>
 							<Tabs.Tab tabId="debugging">{ __( 'Debugging' ) }</Tabs.Tab>
+							{ supportsCheckpoints ? (
+								<Tabs.Tab tabId="checkpoints">{ __( 'Checkpoints' ) }</Tabs.Tab>
+							) : null }
 						</Tabs.List>
 					</div>
 				</div>
@@ -340,21 +348,30 @@ function SiteSettingsBody( {
 								/>
 							</Tabs.Panel>
 
-							{ submitError && <div className={ styles.submitError }>{ submitError }</div> }
+							{ activeTab !== 'checkpoints' && (
+								<>
+									{ submitError && <div className={ styles.submitError }>{ submitError }</div> }
 
-							<div className={ styles.actions }>
-								<Button
-									type="submit"
-									variant="solid"
-									tone="brand"
-									disabled={ ! canSubmit }
-									loading={ updateSite.isPending }
-									loadingAnnouncement={ __( 'Saving settings' ) }
-								>
-									{ __( 'Save settings' ) }
-								</Button>
-							</div>
+									<div className={ styles.actions }>
+										<Button
+											type="submit"
+											variant="solid"
+											tone="brand"
+											disabled={ ! canSubmit }
+											loading={ updateSite.isPending }
+											loadingAnnouncement={ __( 'Saving settings' ) }
+										>
+											{ __( 'Save settings' ) }
+										</Button>
+									</div>
+								</>
+							) }
 						</form>
+						{ supportsCheckpoints ? (
+							<Tabs.Panel tabId="checkpoints">
+								<CheckpointTimeline siteId={ site.id } />
+							</Tabs.Panel>
+						) : null }
 					</div>
 				</div>
 			</Tabs.Root>
@@ -363,7 +380,7 @@ function SiteSettingsBody( {
 }
 
 export function isSiteSettingsTab( value: string ): value is TabId {
-	return value === 'general' || value === 'debugging';
+	return value === 'general' || value === 'debugging' || value === 'checkpoints';
 }
 
 export type SiteSettingsTabId = TabId;

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -9,6 +9,7 @@ import type {
 	FeaturedBlueprint,
 	InstalledApps,
 	LoadedAiSession,
+	SiteCheckpoint,
 	SiteDetails,
 	Snapshot,
 	SyncSite,
@@ -113,6 +114,7 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 			openInOS: false,
 			annotatePreview: false,
 			readLocalMedia: false,
+			siteCheckpoints: false,
 		},
 
 		// Auth — runs unauthenticated, like the desktop app. WordPress.com login
@@ -207,6 +209,21 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		},
 		async importSiteFromBackup(): Promise< SiteDetails > {
 			throw new UnsupportedError( 'importSiteFromBackup' );
+		},
+
+		// Site checkpoints — local-machine only (the CLI checkpoint engine).
+		// The list returns a benign default so mount-time queries don't throw.
+		async listCheckpoints(): Promise< SiteCheckpoint[] > {
+			return [];
+		},
+		async createCheckpoint() {
+			throw new UnsupportedError( 'createCheckpoint' );
+		},
+		async restoreCheckpoint() {
+			throw new UnsupportedError( 'restoreCheckpoint' );
+		},
+		async deleteCheckpoint() {
+			throw new UnsupportedError( 'deleteCheckpoint' );
 		},
 
 		// Preview snapshots / sync — out of scope for this increment.

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -14,6 +14,7 @@ import type {
 	LoadedAiSession,
 	ProposedSitePath,
 	SelectedSiteFolder,
+	SiteCheckpoint,
 	SiteDetails,
 	Snapshot,
 	SupportedEditor,
@@ -205,6 +206,7 @@ export function createIpcConnector(): Connector {
 			openInOS: true,
 			annotatePreview: true,
 			readLocalMedia: true,
+			siteCheckpoints: true,
 		},
 
 		// Auth — optional in Electron, delegated to main process
@@ -391,6 +393,21 @@ export function createIpcConnector(): Connector {
 				id: siteId,
 				backupFile: backup,
 			} ) ) as SiteDetails;
+		},
+
+		// Site checkpoints — the main process forks the same `studio checkpoint`
+		// CLI commands the terminal user runs.
+		async listCheckpoints( siteId ): Promise< SiteCheckpoint[] > {
+			return ( await ipcApi.listSiteCheckpoints( siteId ) ) as SiteCheckpoint[];
+		},
+		async createCheckpoint( siteId, label ) {
+			await ipcApi.createSiteCheckpoint( siteId, label );
+		},
+		async restoreCheckpoint( siteId, checkpointId ) {
+			await ipcApi.restoreSiteCheckpoint( siteId, checkpointId );
+		},
+		async deleteCheckpoint( siteId, checkpointId ) {
+			await ipcApi.deleteSiteCheckpoint( siteId, checkpointId );
 		},
 
 		async startSite( id ) {

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -16,6 +16,7 @@ import type {
 	LocalMediaFile,
 	ProposedSitePath,
 	SelectedSiteFolder,
+	SiteCheckpoint,
 	SiteDetails,
 	Snapshot,
 	SupportedEditor,
@@ -214,6 +215,7 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			openInOS: true,
 			annotatePreview: false,
 			readLocalMedia: false,
+			siteCheckpoints: true,
 		},
 
 		// Auth — surfaces the WordPress.com user the CLI is already logged in as
@@ -437,6 +439,34 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 				method: 'POST',
 				body: JSON.stringify( { path: backup.path, type: backup.type } ),
 			} );
+		},
+
+		// Site checkpoints — the server forks the same `studio checkpoint`
+		// commands the terminal user runs.
+		async listCheckpoints( siteId ): Promise< SiteCheckpoint[] > {
+			return api< SiteCheckpoint[] >( `/sites/${ encodeURIComponent( siteId ) }/checkpoints` );
+		},
+		async createCheckpoint( siteId, label ) {
+			await api( `/sites/${ encodeURIComponent( siteId ) }/checkpoints`, {
+				method: 'POST',
+				body: JSON.stringify( { label } ),
+			} );
+		},
+		async restoreCheckpoint( siteId, checkpointId ) {
+			await api(
+				`/sites/${ encodeURIComponent( siteId ) }/checkpoints/${ encodeURIComponent(
+					checkpointId
+				) }/restore`,
+				{ method: 'POST' }
+			);
+		},
+		async deleteCheckpoint( siteId, checkpointId ) {
+			await api(
+				`/sites/${ encodeURIComponent( siteId ) }/checkpoints/${ encodeURIComponent(
+					checkpointId
+				) }`,
+				{ method: 'DELETE' }
+			);
 		},
 
 		// Preview snapshots + WordPress.com sync — backed by the server's snapshot

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -15,6 +15,8 @@ export type {
 	ProposedSitePath,
 	SelectedSiteFolder,
 	SessionEntry,
+	SiteCheckpoint,
+	SiteCheckpointTrigger,
 	SiteDetails,
 	Snapshot,
 	StudioAgentQuestionData,

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -83,6 +83,28 @@ export interface LocalMediaFile {
 	data: ArrayBuffer;
 }
 
+// What captured a checkpoint: a user action, an agent tool call, the automatic
+// pre-tool capture, or the safety capture taken right before a restore.
+export type SiteCheckpointTrigger = 'manual' | 'agent' | 'auto-pre-tool' | 'pre-restore';
+
+// One entry of a site's checkpoint index (mirrors the CLI engine's
+// `CheckpointIndexEntry`). `createdAt` is epoch milliseconds.
+export interface SiteCheckpoint {
+	id: string;
+	label?: string;
+	createdAt: number;
+	trigger: SiteCheckpointTrigger;
+	// Set for `auto-pre-tool` checkpoints: the agent tool that was about to run.
+	toolName?: string;
+	pinned?: boolean;
+	stats: {
+		fileCount: number;
+		logicalBytes: number;
+		// Bytes of data unique to this checkpoint (not shared with earlier ones).
+		newObjectBytes: number;
+	};
+}
+
 export interface AuthUser {
 	id: number;
 	email: string;
@@ -114,6 +136,10 @@ export interface ConnectorCapabilities {
 	// render local screenshot artifacts inline). Only the desktop IPC connector
 	// supports it; the browser connectors reject local file reads.
 	readLocalMedia: boolean;
+	// Site checkpoints (files + database save points) are available. True on
+	// the desktop and the local server (both run the CLI checkpoint engine on
+	// the user's machine); false when hosted remotely.
+	siteCheckpoints: boolean;
 }
 
 export interface Connector {
@@ -197,6 +223,14 @@ export interface Connector {
 		siteId: string,
 		backup: { path: string; type: string }
 	): Promise< SiteDetails >;
+
+	// Site checkpoints — content-addressed save points of a site's files +
+	// database, captured and restored by the CLI checkpoint engine. Restore
+	// automatically captures a safety checkpoint of the current state first.
+	listCheckpoints( siteId: string ): Promise< SiteCheckpoint[] >;
+	createCheckpoint( siteId: string, label?: string ): Promise< void >;
+	restoreCheckpoint( siteId: string, checkpointId: string ): Promise< void >;
+	deleteCheckpoint( siteId: string, checkpointId: string ): Promise< void >;
 
 	// Preview snapshots (WordPress.com hosted previews of local sites)
 	getSnapshots(): Promise< Snapshot[] >;

--- a/apps/ui/src/data/queries/use-checkpoints.ts
+++ b/apps/ui/src/data/queries/use-checkpoints.ts
@@ -1,0 +1,70 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+import { SITES_QUERY_KEY } from './use-sites';
+
+export const checkpointsQueryKey = ( siteId: string ) => [ 'site-checkpoints', siteId ] as const;
+
+export function useCheckpoints( siteId: string | undefined ) {
+	const connector = useConnector();
+	return useQuery( {
+		queryKey: checkpointsQueryKey( siteId ?? '' ),
+		queryFn: () => connector.listCheckpoints( siteId! ),
+		enabled: !! siteId && connector.capabilities.siteCheckpoints,
+	} );
+}
+
+export interface CreateCheckpointInput {
+	siteId: string;
+	label?: string;
+}
+
+export function useCreateCheckpoint() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( { siteId, label }: CreateCheckpointInput ) =>
+			connector.createCheckpoint( siteId, label ),
+		onSuccess: ( _data, { siteId } ) =>
+			queryClient.invalidateQueries( { queryKey: checkpointsQueryKey( siteId ) } ),
+	} );
+}
+
+export interface RestoreCheckpointInput {
+	siteId: string;
+	checkpointId: string;
+}
+
+/**
+ * Restores a site to a checkpoint (files + database). The engine captures a
+ * safety checkpoint of the current state first, so the list is invalidated to
+ * pick it up — and the site list too, since restore stops/starts the server
+ * and may change the site's PHP/WordPress versions.
+ */
+export function useRestoreCheckpoint() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( { siteId, checkpointId }: RestoreCheckpointInput ) =>
+			connector.restoreCheckpoint( siteId, checkpointId ),
+		onSuccess: ( _data, { siteId } ) => {
+			void queryClient.invalidateQueries( { queryKey: checkpointsQueryKey( siteId ) } );
+			void queryClient.invalidateQueries( { queryKey: SITES_QUERY_KEY } );
+		},
+	} );
+}
+
+export interface DeleteCheckpointInput {
+	siteId: string;
+	checkpointId: string;
+}
+
+export function useDeleteCheckpoint() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( { siteId, checkpointId }: DeleteCheckpointInput ) =>
+			connector.deleteCheckpoint( siteId, checkpointId ),
+		onSuccess: ( _data, { siteId } ) =>
+			queryClient.invalidateQueries( { queryKey: checkpointsQueryKey( siteId ) } ),
+	} );
+}

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -1,7 +1,9 @@
 import {
+	getCheckpointArtifactProps,
 	getLocalMediaPath,
 	getMediaAltText,
 	getSafeMediaUrl,
+	isCheckpointArtifactWidget,
 	isRenderableMediaWidget,
 	isStudioChatArtifactData,
 	stripMediaWidgetPayloadLines,
@@ -65,6 +67,7 @@ import {
 import { Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { CheckpointArtifactChip } from '@/components/checkpoint-timeline/artifact-chip';
 import { Markdown } from '@/components/markdown';
 import { useConnector, type LoadedAiSession } from '@/data/core';
 import { useLocalMediaDataUrl } from '@/data/queries/use-local-media';
@@ -319,10 +322,11 @@ export function entriesToRenderItems(
 			}
 			const widgets = data.widgets.filter(
 				( widget ) =>
-					isRenderableMediaWidget( widget ) &&
-					// Without local media access (browser builds), only widgets
-					// with a renderable remote URL are worth showing.
-					( options.canReadLocalMedia !== false || Boolean( getSafeMediaUrl( widget ) ) )
+					isCheckpointArtifactWidget( widget ) ||
+					( isRenderableMediaWidget( widget ) &&
+						// Without local media access (browser builds), only widgets
+						// with a renderable remote URL are worth showing.
+						( options.canReadLocalMedia !== false || Boolean( getSafeMediaUrl( widget ) ) ) )
 			);
 			if ( widgets.length > 0 ) {
 				items.push( {
@@ -721,12 +725,24 @@ function ToolUseRow( {
 }
 
 function ChatArtifact( { widgets }: { widgets: StudioChatArtifactWidgetDraft[] } ) {
+	// Checkpoint chips render standalone; everything else is media in a grid.
+	const checkpointArtifacts = widgets
+		.map( getCheckpointArtifactProps )
+		.filter( ( artifact ): artifact is NonNullable< typeof artifact > => artifact !== null );
+	const mediaWidgets = widgets.filter( ( widget ) => ! isCheckpointArtifactWidget( widget ) );
 	return (
-		<div className={ styles.mediaArtifactGrid }>
-			{ widgets.map( ( widget, index ) => (
-				<MediaArtifactImage key={ `${ widget.type }:${ index }` } widget={ widget } />
+		<>
+			{ checkpointArtifacts.map( ( artifact ) => (
+				<CheckpointArtifactChip key={ artifact.checkpointId } artifact={ artifact } />
 			) ) }
-		</div>
+			{ mediaWidgets.length > 0 ? (
+				<div className={ styles.mediaArtifactGrid }>
+					{ mediaWidgets.map( ( widget, index ) => (
+						<MediaArtifactImage key={ `${ widget.type }:${ index }` } widget={ widget } />
+					) ) }
+				</div>
+			) : null }
+		</>
 	);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4863,7 +4863,7 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "./dist/cli.js"
+				"pi-ai": "dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"

--- a/packages/common/ai/chat-artifacts.ts
+++ b/packages/common/ai/chat-artifacts.ts
@@ -92,3 +92,44 @@ export function isRenderableMediaWidget( widget: StudioChatArtifactWidgetDraft )
 		( Boolean( getLocalMediaPath( widget ) ) || Boolean( getSafeMediaUrl( widget ) ) )
 	);
 }
+
+// The widgetProps the checkpoint agent tools attach to their results (see
+// `apps/cli/ai/tools/checkpoints.ts`), rendered as a chip in the transcript.
+export interface CheckpointArtifactProps {
+	checkpointId: string;
+	siteId: string;
+	label: string | null;
+	trigger: string;
+	toolName: string | null;
+	// Epoch milliseconds.
+	createdAt: number;
+}
+
+export function getCheckpointArtifactProps(
+	widget: StudioChatArtifactWidgetDraft
+): CheckpointArtifactProps | null {
+	if ( widget.type !== 'checkpoint' ) {
+		return null;
+	}
+	const { checkpointId, siteId, label, trigger, toolName, createdAt } = widget.widgetProps;
+	if (
+		typeof checkpointId !== 'string' ||
+		typeof siteId !== 'string' ||
+		typeof trigger !== 'string' ||
+		typeof createdAt !== 'number'
+	) {
+		return null;
+	}
+	return {
+		checkpointId,
+		siteId,
+		label: typeof label === 'string' && label ? label : null,
+		trigger,
+		toolName: typeof toolName === 'string' && toolName ? toolName : null,
+		createdAt,
+	};
+}
+
+export function isCheckpointArtifactWidget( widget: StudioChatArtifactWidgetDraft ): boolean {
+	return getCheckpointArtifactProps( widget ) !== null;
+}

--- a/packages/common/lib/checkpoint-events.ts
+++ b/packages/common/lib/checkpoint-events.ts
@@ -1,0 +1,54 @@
+// Typed event tuples for checkpoint create/restore progress, mirroring the
+// import/export event pattern in `import-export-events.ts`. Events are emitted
+// by the CLI and forwarded over IPC (`process.send`) when the CLI runs as a
+// child of the desktop app or the local server.
+
+export enum CheckpointEvents {
+	CHECKPOINT_CREATE_START = 'checkpoint_create_start',
+	CHECKPOINT_CREATE_PROGRESS = 'checkpoint_create_progress',
+	CHECKPOINT_CREATE_COMPLETE = 'checkpoint_create_complete',
+	CHECKPOINT_CREATE_ERROR = 'checkpoint_create_error',
+	CHECKPOINT_RESTORE_START = 'checkpoint_restore_start',
+	CHECKPOINT_RESTORE_PROGRESS = 'checkpoint_restore_progress',
+	CHECKPOINT_RESTORE_COMPLETE = 'checkpoint_restore_complete',
+	CHECKPOINT_RESTORE_ERROR = 'checkpoint_restore_error',
+}
+
+// Phases progress through in order. `database` covers DB capture/restore,
+// `files` covers walking/hashing/applying the site tree.
+export type CheckpointProgressPhase = 'database' | 'files' | 'finalizing';
+
+export interface CheckpointProgressPayload {
+	phase: CheckpointProgressPhase;
+	// Files processed so far and the total when known. Totals are unknown
+	// during the first walk of a site, so consumers must tolerate `undefined`.
+	processed?: number;
+	total?: number;
+}
+
+export interface CheckpointErrorPayload {
+	message: string;
+}
+
+export interface CheckpointCompletePayload {
+	checkpointId: string;
+	siteId: string;
+}
+
+export type CheckpointEventTuple =
+	| [ CheckpointEvents.CHECKPOINT_CREATE_START, { siteId: string } ]
+	| [ CheckpointEvents.CHECKPOINT_CREATE_PROGRESS, CheckpointProgressPayload ]
+	| [ CheckpointEvents.CHECKPOINT_CREATE_COMPLETE, CheckpointCompletePayload ]
+	| [ CheckpointEvents.CHECKPOINT_CREATE_ERROR, CheckpointErrorPayload ]
+	| [ CheckpointEvents.CHECKPOINT_RESTORE_START, { siteId: string; checkpointId: string } ]
+	| [ CheckpointEvents.CHECKPOINT_RESTORE_PROGRESS, CheckpointProgressPayload ]
+	| [ CheckpointEvents.CHECKPOINT_RESTORE_COMPLETE, CheckpointCompletePayload ]
+	| [ CheckpointEvents.CHECKPOINT_RESTORE_ERROR, CheckpointErrorPayload ];
+
+export interface CheckpointIpcEvent {
+	checkpointEvent: CheckpointEventTuple;
+}
+
+export function createCheckpointErrorPayload( error: unknown ): CheckpointErrorPayload {
+	return { message: error instanceof Error ? error.message : String( error ) };
+}


### PR DESCRIPTION
## Related issues

- None yet — this is an exploratory proof of concept for whole-site checkpoints (files + database). A companion issue write-up can follow if the direction holds.

## How AI was used in this PR

Built end-to-end with Claude Code from a reviewed plan: research passes over the codebase and prior art (Cline, Replit, DDEV, Jetpack Backup), an adversarial design review, four validation spikes run against real sites before any implementation, then implementation with unit tests and a scripted Playwright pass over the packaged app for light/dark visual verification. All code was verified by running it: full create → mutate → diff → restore round trips on live sites of both runtimes.

## Proposed Changes

When the agent (or you) makes big changes to a site, there's currently no way back. This adds **checkpoints**: capture the entire state of a site — every file *and* the SQLite database — at "known good" moments, and roll back to any of them later. This closes the gap that desktop AI coding tools document as a limitation: Cursor/Claude Code/Cline checkpoint only the files their own edit tools touch; Studio owns the whole site directory and its database, so it can checkpoint everything, including wp-cli side effects and uploads.

How it behaves:

- **Users** get a Checkpoints tab in site settings: create with a label ("mark as good"), see a timeline (manual / agent / auto / safety), restore, delete. Restore always captures a safety checkpoint of the current state first, so a restore can itself be undone — rollback is never one-way.
- **The agent** gets `checkpoint_create/list/restore/diff` tools, and destructive tools (`wp_cli`, imports, pulls, scaffolding, data liberation) automatically capture a checkpoint before running (debounced to one per 2 minutes). Checkpoint chips render in the chat transcript with a restore affordance.
- **The CLI** gets `studio checkpoint create|list|restore|delete|diff`. The diff answers "what changed since things last worked": files added/modified/deleted plus per-table row-count deltas and changed `wp_options` names.

Storage is a content-addressed store per site under `~/.studio/checkpoints/` — git-like dedupe without a git dependency (Studio ships to machines without git). Unchanged files cost nothing after the first checkpoint: measured on a ~96 MB site, the first checkpoint stored 30 MB compressed in 3.5 s, the next one 58 KB in 0.8 s. Restores are transactional about the database: while a site runs, capture executes `VACUUM INTO` inside the site's own PHP runtime, and every artifact is integrity-verified host-side with retries (the validation spike reproduced a torn read on the Playground runtime under concurrent writes — the daemon runs wp-cli in parallel WASM instances whose SQLite locks don't coordinate — so verification is load-bearing, not paranoia).

Trade-offs and deliberate v1 boundaries, so reviewers know what they're evaluating: restore is always files+database together (files-only invites plugin/DB mismatches); reprint-pulled sites are refused with a clear message; retention is fixed policy (manual/agent kept forever, last 10 auto, last 5 safety) with no settings UI yet; create/restore progress in the desktop UI is pending/complete rather than granular; a crash-interrupted restore is recoverable via the journal from the CLI but has no desktop dialog yet.

This spans a new architectural boundary (CLI engine + agent tool decorator + local-server routes + desktop IPC + UI), which is why it's a draft PoC rather than a merge-ready change.

## Testing Instructions

1. `npm install && npm run cli:build`
2. CLI round trip: `node apps/cli/dist/cli/main.mjs checkpoint create --path ~/Studio/<site> --label "known good"`, change something (`studio wp option update blogname broken`, add/delete a plugin file), then `checkpoint diff <id>` and `checkpoint restore <id>` — the site should come back exactly, running or stopped, with an undo hint pointing at the safety checkpoint.
3. Desktop: `npm start`, open a site → Settings → Checkpoints. Create, restore (note the confirm dialog copy), delete.
4. Agent: ask the agent to run a destructive `wp_cli` command and watch the auto-checkpoint chip appear in the transcript; try `checkpoint_diff` ("what changed since the last checkpoint?").
5. Unit tests: `npm test -- apps/cli/lib/checkpoints apps/cli/ai/tools/auto-checkpoint`.

UI was visually verified in light and dark via a scripted run of the packaged app; a second pair of human eyes on the timeline, dialogs, and chips is still welcome.

## Pre-merge Checklist

- [x] Typecheck, lint, and unit tests pass (`npm run typecheck`, `npx eslint`, `npm test`)
- [x] New/changed UI verified in light and dark color schemes
- [ ] e2e suite run
- [ ] Team alignment on architecture (this is a draft PoC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
