### PR TITLE
Add code comment hygiene guideline to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ WordPress Studio - Electron desktop app for managing local WordPress sites. Buil
 
 **Branches**: Create from `trunk` using dash-separated lowercase names. Include a verb for clarity. Examples: `new-dark-mode`, `improve-agent-instructions`, `fix-login-bug`, `add-logout-button`. For Linear issues: `stu-123-update-sync-feature`.
 **Commits**: Single-line messages. Clear and descriptive. Focus on "what" and "why", not "how"
+**Code comments**: Before pushing the changes, remove any verbose code comments that narrate what the change does or why it was made (e.g. `// Added this to fix X`, `// Changed from Y to Z`, restating the code in prose). Such explanation belongs in the PR description, not the source. Only keep comments that a future reader genuinely needs — non-obvious rationale, gotchas, links to context — and match the comment density and style of the surrounding code.
 **PRs**: Create PR against `trunk` branch. Use the template from `.github/PULL_REQUEST_TEMPLATE.md` (include Related issues, How AI was used in this PR, Proposed Changes, Testing Instructions, Pre-merge Checklist). In **Proposed Changes**, focus on the intent of the change and the user impact (the "why" and how the user experiences it) — do not list modified files or describe implementation mechanics; the diff already shows that. MUST pass all CI checks before merge.
 **IMPORTANT**: Prefer merging `trunk` into your branch over rebasing. Avoid force pushes to trunk/main branches. Avoid force pushes to already-pushed branches - add new commits instead.
 


### PR DESCRIPTION
## Related issues

- None

## How AI was used in this PR

Claude ported the guideline text from the Calypso repository. The author reviewed it manually.

## Proposed Changes

Adds a guideline from Calypso's AGENTS.md to ours: before pushing, remove code comments that narrate the change (e.g. `// Added this to fix X`) and keep only comments a future reader genuinely needs. AI-assisted changes often introduce this kind of comment noise, and reviewers currently have to flag it manually.

## Testing Instructions

- Documentation-only change. Review the wording.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?