### PR TITLE
Fix standalone CLI bundle build failing with data-liberation E404

### DIFF
--- a/scripts/create-standalone-bundle.ts
+++ b/scripts/create-standalone-bundle.ts
@@ -138,6 +138,14 @@ async function main(): Promise< void > {
 	// prod build, but `package:standalone` stamps `__IS_PACKAGED_FOR_STANDALONE__` so the
 	// curl-installed CLI identifies itself at runtime (update notifier + launch stats).
 	console.log( '==> Step 1/4: Building CLI package...' );
+	// install:bundle can run twice per CI job (the desktop make's forge hook runs
+	// it first). npm's --install-links re-resolves the changed data-liberation
+	// file: dep from the registry (E404) when reinstalling over that tree, so
+	// start from a clean node_modules, same as forge.config.ts does.
+	fs.rmSync( path.join( repoRoot, 'apps', 'cli', 'node_modules' ), {
+		recursive: true,
+		force: true,
+	} );
 	run( 'npm run cli:package:standalone' );
 
 	// Step 2: Assemble the bundle layout in a staging dir


### PR DESCRIPTION
## Related issues

- Related to #3940 (introduced the `data-liberation` `file:` dependency in `apps/cli`)

## How AI was used in this PR

AI was used to investigate the CI failure (reproducing the npm behavior locally against a copy of the workspace tree) and to draft the fix and this PR description. The change was reviewed and verified manually.

## Proposed Changes

Trunk dev builds fail on all platforms at the "Building standalone CLI bundle" step with:

```
npm error 404 Not Found - GET https://registry.npmjs.org/data-liberation - Not found
```

**Root problem:** each dev-build CI job runs the CLI's `install:bundle` twice — first inside the desktop make (the forge hook starts it from a clean `apps/cli/node_modules`), then again inside `cli:bundle`. Between the two runs, the CLI build rebuilds `packages/data-liberation-agent/dist`, so the content of the `data-liberation` `file:` dependency changes. Reinstalling with `--install-links` over that tree hits an npm bug: instead of re-packing the local folder, npm re-resolves `data-liberation@0.1.0` from the public registry, where it doesn't exist → E404.

**Solution:** delete `apps/cli/node_modules` before the bundle's packaging step in `scripts/create-standalone-bundle.ts`, so it always starts from a clean tree — the same thing `forge.config.ts` already does for the desktop packaging path. Covers the Mac/Linux/Windows dev and release pipelines, which all go through this script. Cost is one extra fresh `npm install` (~40 s in CI with a warm cache); no user-facing behavior change.

## Testing Instructions

- Run `npm run cli:bundle -- darwin arm64` twice in a row (the second run reproduces CI's dirty-tree state). Without this fix the second run fails with the E404 above; with it, both runs produce `standalone-bundles/studio-cli-darwin-arm64.tgz`. Note: this mutates `apps/cli/node_modules`; run `npm ci` afterwards to restore your workspace.
- CI on this PR: trigger the dev build ("🚦 Build for Mac?" / Linux) and confirm the "Building standalone CLI bundle" step passes.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)