### PR TITLE
Refactor remote site picking in `pull-reprint`

### DIFF
--- a/apps/cli/commands/pull-reprint.ts
+++ b/apps/cli/commands/pull-reprint.ts
@@ -39,12 +39,7 @@ import {
 	type ReprintProcessResult,
 	runReprintCommandUntilComplete,
 } from 'cli/lib/pull/migration-client';
-import {
-	getContentDirFromState,
-	hasSkippedFiles,
-	readReprintState,
-	writeReprintState,
-} from 'cli/lib/pull/reprint-state';
+import { getContentDirFromState, hasSkippedFiles } from 'cli/lib/pull/reprint-state';
 import {
 	ensureImportedSiteSqliteReady,
 	loadImportedRuntimeStartOptions,
@@ -314,7 +309,6 @@ export async function runCommand(
 		// prepare_repull(). Always re-invoked: the pull is idempotent and
 		// reprint resumes its own pipeline from `.import-state.json`, so
 		// there is no Studio-side guard to skip it.
-		normalizeReprintStateForEssentialFilesPull( studioMetadata.stateDirectory );
 		await runFullPull(
 			SITE_RUNTIME_NATIVE_PHP,
 			studioMetadata,
@@ -583,25 +577,6 @@ async function runPreflight(
 }
 
 /**
- * Reprint refuses to resume a files sync with a different --filter than
- * the one stored in its state. A completed Studio pull may leave that
- * state on the post-pull skipped-earlier pass; mark that pass complete
- * and restore the filter expected by the next essential-files pull
- * without deleting the cursor/index files reprint needs for deltas.
- */
-function normalizeReprintStateForEssentialFilesPull( stateDirectory: string ): void {
-	const reprintState = readReprintState( stateDirectory );
-	if ( reprintState?.filter && reprintState.filter !== 'essential-files' ) {
-		writeReprintState( stateDirectory, {
-			...reprintState,
-			status: 'complete',
-			stage: null,
-			filter: 'essential-files',
-		} );
-	}
-}
-
-/**
  * The `~/.studio/pulls/<siteId>` scratch root for a site's pull. Keyed
  * by `siteId` (not a URL hash) so it follows the site, not the remote.
  */
@@ -708,39 +683,18 @@ export async function downloadSkippedFiles(
 	secret: string,
 	verbose: boolean
 ): Promise< void > {
-	const reprintState = readReprintState( metadata.stateDirectory );
-	const isResumingSkipped =
-		reprintState?.stage === 'fetch-skipped' && reprintState?.status !== 'complete';
-
-	// Rewrite the reprint state so the next files-sync understands it
-	// should download the entries the essential-files pass skipped.  No-op
-	// when reprint is already mid-way through that run (its state file
-	// encodes the resume cursor; overwriting would break validation) or
-	// when no skipped entries exist.
-	if ( ! isResumingSkipped && hasSkippedFiles( metadata.stateDirectory ) ) {
-		writeReprintState( metadata.stateDirectory, {
-			...reprintState,
-			command: 'files-sync',
-			status: 'complete',
-			stage: null,
-			filter: 'essential-files',
-		} );
-	}
-
 	logger.reportStart( LoggerAction.DOWNLOAD_FILES, __( 'Downloading remaining files…' ) );
 
-	const args = [ 'files-sync', apiUrl, `--secret=${ secret }` ];
-
-	if ( isResumingSkipped ) {
-		args.push( '--filter=skipped-earlier' );
-	}
-
-	args.push(
+	const args = [
+		'files-sync',
+		apiUrl,
+		`--secret=${ secret }`,
+		'--filter=skipped-earlier',
 		'--max-exec=30',
 		'--no-adaptive',
 		`--state-dir=${ metadata.stateDirectory }`,
-		`--fs-root=${ metadata.rawDirectory }`
-	);
+		`--fs-root=${ metadata.rawDirectory }`,
+	];
 
 	await runReprintCommandUntilComplete(
 		metadata.stateDirectory,

--- a/apps/cli/commands/pull-reprint.ts
+++ b/apps/cli/commands/pull-reprint.ts
@@ -31,7 +31,6 @@ import {
 	readCliConfig,
 	saveCliConfig,
 	type SiteData,
-	type SiteStatus,
 	unlockCliConfig,
 } from 'cli/lib/cli-config/core';
 import { getSiteByFolder, getSiteUrl, updateSiteLatestCliPid } from 'cli/lib/cli-config/sites';
@@ -79,12 +78,6 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					type: 'string',
 					describe: __( 'URL of the remote WordPress site to pull from (remote source)' ),
 				} )
-				.option( 'secret', {
-					type: 'string',
-					describe: __(
-						'Shared HMAC secret configured in the migration plugin on the remote source'
-					),
-				} )
 				.option( 'verbose', {
 					type: 'boolean',
 					describe: __( 'Show detailed error information and executed commands' ),
@@ -95,12 +88,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 			const verbose = argv.verbose as boolean;
 
 			try {
-				await runCommand(
-					argv.path as string,
-					argv.url as string | undefined,
-					argv.secret as string | undefined,
-					verbose
-				);
+				await runCommand( argv.path as string, argv.url as string | undefined, verbose );
 			} catch ( error ) {
 				if ( error instanceof PullError ) {
 					logger.spinner.fail( __( 'Pull failed' ) );
@@ -150,17 +138,15 @@ interface PullSession {
 
 /**
  * Normalized result of turning CLI arguments into something the pull
- * pipeline can act on: a remote URL to fetch from and the HMAC secret
- * the exporter will check.  For WordPress.com sources we also stash
- * the matched `SyncSite` and auth token so the preflight failure
- * path can rotate a fresh secret without loading the full site list a
- * second time.
+ * pipeline can act on: a WordPress.com/Pressable site URL to fetch from,
+ * the HMAC secret the exporter will check, and the API identity needed to
+ * enable the exporter.
  */
 interface PullSource {
 	secret: string;
 	url: string;
-	wpComSite?: SyncSite;
-	wpComToken?: StoredAuthToken;
+	wpComSite: SyncSite;
+	wpComToken: StoredAuthToken;
 }
 
 class PullError extends LoggerError {
@@ -177,7 +163,7 @@ class PullError extends LoggerError {
  *
  *   resolveSourceSite (remote source only) →
  *   getPullSession (scratch layout from siteId) →
- *   runPreflight (with secret-rotate retry on WP.com) →
+ *   runPreflight →
  *   saveReprintOrigin (durable origin onto SiteData) →
  *   runFullPull (one `reprint pull`: files-pull → db-pull → db-apply →
  *     flat-docroot → apply-runtime) →
@@ -208,20 +194,19 @@ class PullError extends LoggerError {
 export async function runCommand(
 	localPath: string,
 	remoteUrl?: string,
-	remoteSecret?: string,
 	verbose = false
 ): Promise< void > {
 	logger.reportStart( LoggerAction.LOAD_SITES, __( 'Loading site…' ) );
 	const site = await getSiteByFolder( localPath );
 	logger.reportSuccess( __( 'Site loaded' ) );
 
-	const sourceSite = await resolveSourceSite( site, remoteUrl, remoteSecret, verbose );
+	const sourceSite = await resolveSourceSite( remoteUrl ?? site.reprintOrigin?.remoteUrl );
 	if ( ! sourceSite ) {
 		return;
 	}
 
 	const { url: sourceSiteUrl } = sourceSite;
-	let secret = sourceSite.secret;
+	const secret = sourceSite.secret;
 	const normalizedRemoteUrl = normalizeSiteUrl( sourceSiteUrl );
 	const studioMetadata = getPullSession( site );
 	const apiUrl = getReprintApiUrlForSite( normalizedRemoteUrl );
@@ -244,9 +229,8 @@ export async function runCommand(
 		fs.readdirSync( studioMetadata.stateDirectory ).length > 0;
 
 	if ( isRepull ) {
-		// Re-verify connectivity (and give the secret-rotation retry path
-		// a chance to run) instead of trusting the cached preflight from
-		// the original pull, which may be days old.
+		// Re-verify connectivity instead of trusting the cached preflight
+		// from the original pull, which may be days old.
 		fs.rmSync( path.join( studioMetadata.stateDirectory, 'preflight.json' ), { force: true } );
 	}
 
@@ -289,82 +273,27 @@ export async function runCommand(
 		// 60 minutes; without this the first preflight would be refused.
 		// Runs on every pull (including resumes) since the sliding
 		// window may have expired between runs.
-		if ( sourceSite.wpComSite && sourceSite.wpComToken ) {
-			await enableReprintExporter(
-				sourceSite.wpComSite.id,
-				sourceSite.wpComToken.accessToken,
-				verbose
-			);
-		}
+		await enableReprintExporter(
+			sourceSite.wpComSite.id,
+			sourceSite.wpComToken.accessToken,
+			verbose
+		);
 
-		let preflight;
-		try {
-			preflight = await runPreflight(
-				SITE_RUNTIME_NATIVE_PHP,
-				studioMetadata,
-				apiUrl,
-				secret,
-				verbose
-			);
-		} catch ( preflightError ) {
-			// Preflight against ?reprint-api can fail for two reasons we can
-			// recover from on WP.com: the stored secret expired, or the
-			// wpcomsh exporter gate (`reprint_exporter_enabled`, a 60-minute
-			// sliding window) closed since the last run.  A cached-secret
-			// resume skips the happy-path enable above, so this is the common
-			// case on a delta re-pull.  Resolve the WP.com site (loading the
-			// site list only now, if we haven't already), then both rotate the
-			// secret AND re-enable the exporter before retrying.
-			if ( sourceSite.wpComSite && sourceSite.wpComToken ) {
-				secret = await rotateReprintSecret(
-					sourceSite.wpComSite.id,
-					sourceSite.wpComToken.accessToken
-				);
-			} else {
-				let token: StoredAuthToken | null;
-				try {
-					token = await readAuthToken();
-				} catch {
-					token = null;
-				}
-				if ( ! token ) {
-					throw preflightError;
-				}
-				const sites = await fetchSyncableSites( token.accessToken );
-				const matched = findMatchingWpComSite( sites, sourceSiteUrl );
-				// Only syncable sites (hosting features enabled) can run the
-				// reprint exporter and rotate a secret.
-				if ( ! matched || matched.syncSupport !== 'syncable' ) {
-					throw preflightError;
-				}
-				sourceSite.wpComSite = matched;
-				sourceSite.wpComToken = token;
-				secret = await rotateReprintSecret( matched.id, token.accessToken );
-			}
-			// Rotating the secret does not bump `reprint_exporter_enabled`, so
-			// re-open the gate explicitly; otherwise the retry hits the same
-			// closed window and ?reprint-api falls through to an HTML page.
-			await enableReprintExporter(
-				sourceSite.wpComSite.id,
-				sourceSite.wpComToken.accessToken,
-				verbose
-			);
-			preflight = await runPreflight(
-				SITE_RUNTIME_NATIVE_PHP,
-				studioMetadata,
-				apiUrl,
-				secret,
-				verbose
-			);
-		}
+		const preflight = await runPreflight(
+			SITE_RUNTIME_NATIVE_PHP,
+			studioMetadata,
+			apiUrl,
+			secret,
+			verbose
+		);
 		// Persist the durable origin onto the site record: where it syncs
-		// from, the remote's self-reported siteurl, the table prefix, and the
-		// (possibly rotated) secret a resume will reuse.
+		// from, the remote's self-reported siteurl, and the table prefix.
+		// The Reprint secret is intentionally rotated for each run, not
+		// stored for later reuse.
 		const origin = {
 			remoteUrl: normalizedRemoteUrl,
 			remoteSiteUrl: preflight.siteurl || normalizedRemoteUrl,
 			tablePrefix: preflight.table_prefix || undefined,
-			secret,
 		};
 		site.status = 'pulling';
 		site.reprintOrigin = origin;
@@ -543,9 +472,6 @@ export async function runCommand(
 		}
 
 		const resumeCommand = [ 'studio pull-reprint', `--path "${ localPath }"` ];
-		if ( remoteSecret ) {
-			resumeCommand.push( '--secret <secret>' );
-		}
 		console.log( '' );
 		console.log( 'To resume this pull, re-run the same command:' );
 		console.log( `  ${ resumeCommand.join( ' ' ) }` );
@@ -562,12 +488,10 @@ export async function runCommand(
  * Runs `reprint preflight` against the remote site and caches the
  * response envelope at `stateDirectory/preflight.json`.
  *
- * The first direct request to the site happens here — a failure from
- * an expired secret or a disabled exporter surfaces as a recognizable
- * PullError that the pull orchestrator turns into a secret-rotation
- * retry (for WP.com sources) or a user-facing abort.  Returns the
- * handful of site-identity fields runCommand needs to record on the
- * metadata before the download stages begin.
+ * The first direct request to the site happens here. Failures surface as
+ * recognizable PullErrors with technical details for verbose output.
+ * Returns the handful of site-identity fields runCommand needs to record
+ * on the metadata before the download stages begin.
  */
 async function runPreflight(
 	runtime: SiteRuntime,
@@ -877,62 +801,25 @@ export function findMatchingWpComSite< T extends { url: string } >(
 }
 
 /**
- * Resolves the **remote source** to pull from — never the local site,
- * which `runCommand` resolves separately by `--path` and passes in as
- * `site` (used only to read its cached origin secret).  Returns the
- * remote `url`/`secret` (plus the matched WordPress.com site + token
- * when applicable).  Handles three input patterns:
+ * Resolves the **remote source** to pull from. A valid source must be
+ * present in the user's WordPress.com Jetpack API site list, which also
+ * includes Pressable sites on the same platform. Handles two input
+ * patterns:
  *
- *   1. `--url` + `--secret` — trusted pair, used as-is (self-hosted
- *      sites and arbitrary URLs).
- *   2. A site with a saved `reprintOrigin` (set by a previous pull),
- *      with either no `--url` or a `--url` that matches that origin —
- *      reuse the saved remote URL and HMAC secret so a re-pull needs no
- *      remote re-selection or secret re-rotation. An explicit `--secret`
- *      still overrides the stored one. If the stored secret is stale,
- *      preflight 403s and the WP.com retry path rotates a fresh one.
- *   3. `--url` with no matching stored secret — resolve it against the
- *      connected WordPress.com sites and rotate a fresh secret.
- *   4. No `--url` and no saved origin — among pullable (`syncable`)
- *      sites only: if the user has exactly one, pick it; with several,
- *      show an interactive picker in a TTY (returning `null` if the user
- *      cancels) or error out when run non-interactively. Non-pullable
- *      sites (Simple, or missing hosting features) are surfaced as
- *      disabled in the picker.
+ *   1. URL provided — resolve it against the connected WordPress.com/
+ *      Pressable sites and rotate a fresh secret.
+ *   2. No URL — among pullable (`syncable`) sites only: if the user has
+ *      exactly one, pick it; with several, show an interactive picker in a
+ *      TTY (returning `null` if the user cancels) or error out when run
+ *      non-interactively. Non-pullable sites (Simple, or missing hosting
+ *      features) are surfaced as disabled in the picker.
  */
-export async function resolveSourceSite(
-	site: SiteData,
-	url?: string,
-	providedSecret?: string,
-	_verbose = false
-): Promise< PullSource | null > {
-	// When the caller provides an explicit secret, use it directly.
-	if ( url && providedSecret ) {
-		return { url, secret: providedSecret };
-	}
-
-	// Reuse the site's saved origin from its last successful pull when no
-	// `--url` is given (default to the same remote) or when `--url` points
-	// at that same remote — so a re-pull doesn't force the user to
-	// re-select the remote or re-rotate the secret on every run. An
-	// explicit `--secret` still overrides the stored one.
-	if (
-		site.reprintOrigin &&
-		( ! url || normalizeSiteUrl( url ) === site.reprintOrigin.remoteUrl )
-	) {
-		return {
-			url: url ?? site.reprintOrigin.remoteUrl,
-			secret: providedSecret ?? site.reprintOrigin.secret,
-		};
-	}
-
-	// Need the full site list: either no URL was given (interactive pick) or
-	// no stored secret exists and we need the site ID to rotate one.
+export async function resolveSourceSite( url?: string ): Promise< PullSource | null > {
 	const token = await readAuthToken();
 	if ( ! token ) {
 		throw new LoggerError(
 			__(
-				'WordPress.com authentication is required. Run `studio auth login` to pull a connected WordPress.com site, or provide both `--url` and `--secret` for a non-WordPress.com site.'
+				'WordPress.com authentication is required. Run `studio auth login` to pull a WordPress.com or Pressable site.'
 			)
 		);
 	}
@@ -950,9 +837,7 @@ export async function resolveSourceSite(
 		const matched = findMatchingWpComSite( sites, url );
 		if ( ! matched ) {
 			throw new LoggerError(
-				__(
-					'No secret was provided, and this URL is not one of your connected WordPress.com sites. Provide `--secret` for a non-WordPress.com site.'
-				)
+				__( 'This URL is not a WordPress.com or Pressable site connected to your account.' )
 			);
 		}
 		if ( matched.syncSupport !== 'syncable' ) {
@@ -960,13 +845,13 @@ export async function resolveSourceSite(
 				sprintf(
 					// translators: %s: the site URL.
 					__(
-						'%s cannot be pulled. Pulling requires a WordPress.com site with hosting features enabled, or a self-hosted site (with `--url` and `--secret`).'
+						'%s cannot be pulled. Pulling requires a WordPress.com or Pressable site with hosting features enabled.'
 					),
 					matched.url
 				)
 			);
 		}
-		resolvedUrl = url;
+		resolvedUrl = matched.url;
 		wpComSite = matched;
 	} else {
 		// Only sites that can run the reprint exporter — those with hosting
@@ -975,7 +860,7 @@ export async function resolveSourceSite(
 		if ( pullableSites.length === 0 ) {
 			throw new LoggerError(
 				__(
-					'No pullable WordPress.com sites found. Pulling requires a WordPress.com site with hosting features; provide both `--url` and `--secret` to pull a self-hosted site.'
+					'No pullable WordPress.com or Pressable sites found. Pulling requires a site with hosting features enabled.'
 				)
 			);
 		}

--- a/apps/cli/commands/pull-reprint.ts
+++ b/apps/cli/commands/pull-reprint.ts
@@ -80,10 +80,10 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				} );
 		},
 		handler: async ( argv ) => {
-			const verbose = argv.verbose as boolean;
+			const verbose = argv.verbose;
 
 			try {
-				await runCommand( argv.path as string, argv.url as string | undefined, verbose );
+				await runCommand( argv.path, argv.url, verbose );
 			} catch ( error ) {
 				if ( error instanceof PullError ) {
 					logger.spinner.fail( __( 'Pull failed' ) );

--- a/apps/cli/commands/tests/pull-reprint.test.ts
+++ b/apps/cli/commands/tests/pull-reprint.test.ts
@@ -134,7 +134,7 @@ describe( 'CLI: studio pull-reprint helpers', () => {
 		).toEqual( { id: 1, name: 'Example', url: 'https://example.wordpress.com/' } );
 	} );
 
-	it( 'rewrites the reprint state before downloading skipped-earlier files', async () => {
+	it( 'invokes reprint to download skipped-earlier files', async () => {
 		const technicalSiteDirectory = fs.mkdtempSync(
 			path.join( os.tmpdir(), 'studio-import-skipped-' )
 		);
@@ -143,29 +143,13 @@ describe( 'CLI: studio pull-reprint helpers', () => {
 		fs.mkdirSync( stateDirectory, { recursive: true } );
 		fs.mkdirSync( rawDirectory, { recursive: true } );
 
-		// Pre-existing state from a previous db-apply run + a non-empty
-		// skipped-download list is the signal that there's a tail of files
-		// to fetch.
-		fs.writeFileSync(
-			path.join( stateDirectory, '.import-state.json' ),
-			JSON.stringify( {
-				command: 'db-apply',
-				status: 'complete',
-				stage: 'sql',
-				filter: 'skipped-earlier',
-				preflight: { data: { ok: true } },
-			} )
-		);
-		fs.writeFileSync(
-			path.join( stateDirectory, '.import-download-list-skipped.jsonl' ),
-			'{"path":"foo"}\n'
-		);
-
-		vi.spyOn( migrationClient, 'runReprintCommandUntilComplete' ).mockResolvedValue( {
-			stdout: '{"ok":true}',
-			stderr: '',
-			exitCode: 0,
-		} );
+		const reprintSpy = vi
+			.spyOn( migrationClient, 'runReprintCommandUntilComplete' )
+			.mockResolvedValue( {
+				stdout: '{"ok":true}',
+				stderr: '',
+				exitCode: 0,
+			} );
 
 		await downloadSkippedFiles(
 			SITE_RUNTIME_PLAYGROUND,
@@ -179,16 +163,9 @@ describe( 'CLI: studio pull-reprint helpers', () => {
 			false
 		);
 
-		// Reprint state was rewritten to the shape reprint's next
-		// files-sync call expects when resuming into skipped-earlier.
-		const nextState = JSON.parse(
-			fs.readFileSync( path.join( stateDirectory, '.import-state.json' ), 'utf-8' )
+		expect( reprintSpy.mock.calls[ 0 ][ 2 ] ).toEqual(
+			expect.arrayContaining( [ 'files-sync', '--filter=skipped-earlier' ] )
 		);
-		expect( nextState.command ).toBe( 'files-sync' );
-		expect( nextState.status ).toBe( 'complete' );
-		expect( nextState.stage ).toBeNull();
-		expect( nextState.filter ).toBe( 'essential-files' );
-		expect( nextState.preflight ).toEqual( { data: { ok: true } } );
 
 		fs.rmSync( technicalSiteDirectory, { recursive: true, force: true } );
 	} );
@@ -810,47 +787,21 @@ describe( 'CLI: studio pull-reprint delta re-pull of a completed pull', () => {
 		expect( logSpy.mock.calls.flat().join( '\n' ) ).toContain( 'Updating "My Completed Site"' );
 	} );
 
-	it( 'normalizes stale skipped-earlier reprint state before starting an essential-files re-pull', async () => {
+	it( 'runs an essential-files reprint pull for a completed site without forcing', async () => {
 		const { runCommand } = await loadRunCommandWithFakeHome();
 		mockWpComPullSource();
 
-		const pullsRoot = path.join( fakeHome, '.studio', 'pulls' );
-		const technicalSiteDirectory = path.join( pullsRoot, 'stale-filter-id' );
-		const stateDirectory = path.join( technicalSiteDirectory, 'state' );
 		const sitePath = path.join( fakeHome, 'Studio', 'Stale-Filter-Site' );
 
 		seedCliConfigSite( fakeHome, [
-			makeSiteRecord( { id: 'stale-filter-id', name: 'Stale Filter Site', path: sitePath } ),
+			makeSiteRecord( {
+				id: 'stale-filter-id',
+				name: 'Stale Filter Site',
+				path: sitePath,
+				importComplete: true,
+				status: 'ready',
+			} ),
 		] );
-
-		fs.mkdirSync( stateDirectory, { recursive: true } );
-		fs.mkdirSync( sitePath, { recursive: true } );
-		fs.writeFileSync(
-			path.join( technicalSiteDirectory, 'pull.json' ),
-			JSON.stringify( { version: 1, stage: 'completed' } )
-		);
-		fs.writeFileSync(
-			path.join( stateDirectory, '.import-state.json' ),
-			JSON.stringify( {
-				command: 'files-pull',
-				status: 'in_progress',
-				filter: 'skipped-earlier',
-				preflight: {
-					data: {
-						database: {
-							wp: {
-								paths_urls: { content_dir: '/srv/htdocs/wp-content' },
-							},
-						},
-					},
-				},
-			} )
-		);
-		fs.writeFileSync( path.join( stateDirectory, '.import-index.jsonl' ), '{"path":"old"}\n' );
-		fs.writeFileSync(
-			path.join( stateDirectory, '.import-download-list-skipped.jsonl' ),
-			'{"path":"tail"}\n'
-		);
 
 		const migrationClientMod = await import( 'cli/lib/pull/migration-client' );
 		const reprintSpy = vi
@@ -876,28 +827,9 @@ describe( 'CLI: studio pull-reprint delta re-pull of a completed pull', () => {
 				}
 
 				if ( args[ 0 ] === 'pull' ) {
-					const state = JSON.parse(
-						fs.readFileSync( path.join( stateDirectory, '.import-state.json' ), 'utf-8' )
-					);
-					expect( state ).toMatchObject( {
-						command: 'files-pull',
-						status: 'complete',
-						stage: null,
-						filter: 'essential-files',
-						preflight: {
-							data: {
-								database: {
-									wp: {
-										paths_urls: { content_dir: '/srv/htdocs/wp-content' },
-									},
-								},
-							},
-						},
-					} );
-					expect( fs.existsSync( path.join( stateDirectory, '.import-index.jsonl' ) ) ).toBe(
-						true
-					);
-					throw new Error( 'stop after essential-files state normalization' );
+					expect( args ).toEqual( expect.arrayContaining( [ '--filter=essential-files' ] ) );
+					expect( args ).not.toContain( '--force' );
+					throw new Error( 'stop after essential-files pull invocation' );
 				}
 
 				throw new Error( `Unexpected reprint command: ${ args[ 0 ] }` );
@@ -906,7 +838,7 @@ describe( 'CLI: studio pull-reprint delta re-pull of a completed pull', () => {
 		vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
 
 		await expect( runCommand( sitePath, 'https://example.com', false ) ).rejects.toThrow(
-			/stop after essential-files state normalization/
+			/stop after essential-files pull invocation/
 		);
 
 		expect( reprintSpy.mock.calls.map( ( call ) => call[ 2 ][ 0 ] ) ).toEqual( [

--- a/apps/cli/commands/tests/pull-reprint.test.ts
+++ b/apps/cli/commands/tests/pull-reprint.test.ts
@@ -60,6 +60,35 @@ function makeSiteRecord( over: Record< string, unknown > = {} ): Record< string,
 	};
 }
 
+function mockWpComPullSource( url = 'https://example.com' ): SyncSite {
+	const token = {
+		accessToken: 'access-token',
+		id: 1,
+		email: 'user@example.com',
+		displayName: 'User',
+		expiresIn: 1209600,
+		expirationTime: Date.now() + 1209600000,
+	};
+	const site: SyncSite = {
+		id: 22,
+		name: 'Example',
+		url,
+		localSiteId: '',
+		isStaging: false,
+		isPressable: false,
+		syncSupport: 'syncable',
+		lastPullTimestamp: null,
+		lastPushTimestamp: null,
+	};
+
+	vi.mocked( readAuthToken ).mockResolvedValue( token );
+	vi.mocked( fetchSyncableSites ).mockResolvedValue( [ site ] );
+	vi.mocked( rotateReprintSecret ).mockResolvedValue( 'hmac-secret' );
+	vi.mocked( enableReprintExporter ).mockResolvedValue( undefined );
+
+	return site;
+}
+
 /** Seeds `~/.studio/cli.json` (under the fake home) with the given sites. */
 function seedCliConfigSite( homeDir: string, sites: Record< string, unknown >[] ): void {
 	const configDir = path.join( homeDir, '.studio' );
@@ -451,10 +480,6 @@ describe( 'CLI: studio pull-reprint source resolution', () => {
 		syncSite( { id: 22, name: 'Two', url: 'https://two.wordpress.com', isStaging: true } ),
 	];
 
-	// A local site with no stored origin, so the cached-secret short-circuit
-	// is skipped and resolution proceeds to the WordPress.com path.
-	const localSite = makeSiteRecord() as never;
-
 	const originalIsTTY = process.stdin.isTTY;
 
 	function setTTY( value: boolean ): void {
@@ -480,7 +505,7 @@ describe( 'CLI: studio pull-reprint source resolution', () => {
 		vi.mocked( fetchSyncableSites ).mockResolvedValue( sites );
 		vi.mocked( pickSyncSite ).mockResolvedValue( sites[ 1 ] );
 
-		const source = await resolveSourceSite( localSite );
+		const source = await resolveSourceSite();
 
 		expect( pickSyncSite ).toHaveBeenCalledWith( sites, expect.any( String ) );
 		expect( source ).toMatchObject( {
@@ -497,7 +522,7 @@ describe( 'CLI: studio pull-reprint source resolution', () => {
 		vi.mocked( fetchSyncableSites ).mockResolvedValue( sites );
 		vi.mocked( pickSyncSite ).mockResolvedValue( undefined );
 
-		const source = await resolveSourceSite( localSite );
+		const source = await resolveSourceSite();
 
 		expect( source ).toBeNull();
 		expect( rotateReprintSecret ).not.toHaveBeenCalled();
@@ -507,7 +532,7 @@ describe( 'CLI: studio pull-reprint source resolution', () => {
 		setTTY( false );
 		vi.mocked( fetchSyncableSites ).mockResolvedValue( sites );
 
-		await expect( resolveSourceSite( localSite ) ).rejects.toThrow( /Re-run with `--url/ );
+		await expect( resolveSourceSite() ).rejects.toThrow( /Re-run with `--url/ );
 		expect( pickSyncSite ).not.toHaveBeenCalled();
 		expect( rotateReprintSecret ).not.toHaveBeenCalled();
 	} );
@@ -516,7 +541,7 @@ describe( 'CLI: studio pull-reprint source resolution', () => {
 		setTTY( true );
 		vi.mocked( fetchSyncableSites ).mockResolvedValue( [ sites[ 0 ] ] );
 
-		const source = await resolveSourceSite( localSite );
+		const source = await resolveSourceSite();
 
 		expect( pickSyncSite ).not.toHaveBeenCalled();
 		expect( source ).toMatchObject( {
@@ -530,8 +555,8 @@ describe( 'CLI: studio pull-reprint source resolution', () => {
 		setTTY( true );
 		vi.mocked( fetchSyncableSites ).mockResolvedValue( [] );
 
-		await expect( resolveSourceSite( localSite ) ).rejects.toThrow(
-			/No pullable WordPress\.com sites/
+		await expect( resolveSourceSite() ).rejects.toThrow(
+			/No pullable WordPress\.com or Pressable sites/
 		);
 		expect( pickSyncSite ).not.toHaveBeenCalled();
 	} );
@@ -548,7 +573,7 @@ describe( 'CLI: studio pull-reprint source resolution', () => {
 		vi.mocked( fetchSyncableSites ).mockResolvedValue( all );
 		vi.mocked( pickSyncSite ).mockResolvedValue( sites[ 1 ] );
 
-		const source = await resolveSourceSite( localSite );
+		const source = await resolveSourceSite();
 
 		// pickSyncSite itself disables non-syncable entries, so it receives the
 		// full list rather than a pre-filtered one.
@@ -566,7 +591,7 @@ describe( 'CLI: studio pull-reprint source resolution', () => {
 		} );
 		vi.mocked( fetchSyncableSites ).mockResolvedValue( [ nonSyncable, sites[ 0 ] ] );
 
-		const source = await resolveSourceSite( localSite );
+		const source = await resolveSourceSite();
 
 		expect( pickSyncSite ).not.toHaveBeenCalled();
 		expect( source ).toMatchObject( { url: 'https://one.wordpress.com', wpComSite: sites[ 0 ] } );
@@ -576,7 +601,7 @@ describe( 'CLI: studio pull-reprint source resolution', () => {
 		setTTY( true );
 		vi.mocked( fetchSyncableSites ).mockResolvedValue( sites );
 
-		const source = await resolveSourceSite( localSite, 'https://two.wordpress.com' );
+		const source = await resolveSourceSite( 'https://two.wordpress.com' );
 
 		expect( source ).toMatchObject( {
 			url: 'https://two.wordpress.com',
@@ -585,34 +610,6 @@ describe( 'CLI: studio pull-reprint source resolution', () => {
 		} );
 		expect( rotateReprintSecret ).toHaveBeenCalledWith( 22, token.accessToken );
 		expect( pickSyncSite ).not.toHaveBeenCalled();
-	} );
-
-	it( 'reuses the secret stored on the site origin for a matching --url, skipping rotation', async () => {
-		setTTY( true );
-		const siteWithOrigin = makeSiteRecord( {
-			reprintOrigin: { remoteUrl: 'https://two.wordpress.com/', secret: 'stored-secret' },
-		} ) as never;
-
-		const source = await resolveSourceSite( siteWithOrigin, 'https://two.wordpress.com' );
-
-		expect( source ).toEqual( { url: 'https://two.wordpress.com', secret: 'stored-secret' } );
-		// The cached origin short-circuits before any WordPress.com round-trip.
-		expect( fetchSyncableSites ).not.toHaveBeenCalled();
-		expect( rotateReprintSecret ).not.toHaveBeenCalled();
-	} );
-
-	it( 'ignores the stored origin secret when --url points at a different remote', async () => {
-		setTTY( true );
-		vi.mocked( fetchSyncableSites ).mockResolvedValue( sites );
-		const siteWithOrigin = makeSiteRecord( {
-			reprintOrigin: { remoteUrl: 'https://old.wordpress.com/', secret: 'stored-secret' },
-		} ) as never;
-
-		const source = await resolveSourceSite( siteWithOrigin, 'https://two.wordpress.com' );
-
-		// Origin URL mismatch → fall through to rotating a fresh WP.com secret.
-		expect( source ).toMatchObject( { secret: 'fresh-secret', wpComSite: sites[ 1 ] } );
-		expect( rotateReprintSecret ).toHaveBeenCalledWith( 22, token.accessToken );
 	} );
 
 	it( 'rejects a non-syncable site passed via --url with a clear message', async () => {
@@ -626,23 +623,21 @@ describe( 'CLI: studio pull-reprint source resolution', () => {
 			} ),
 		] );
 
-		await expect(
-			resolveSourceSite( localSite, 'https://only-simple.example.com' )
-		).rejects.toThrow( /cannot be pulled/ );
+		await expect( resolveSourceSite( 'https://only-simple.example.com' ) ).rejects.toThrow(
+			/cannot be pulled/
+		);
 		expect( rotateReprintSecret ).not.toHaveBeenCalled();
 	} );
 
-	it( 'bypasses the picker entirely when --url and --secret are provided', async () => {
+	it( 'rejects a URL that is not connected to the WordPress.com account', async () => {
 		setTTY( true );
+		vi.mocked( fetchSyncableSites ).mockResolvedValue( sites );
 
-		const source = await resolveSourceSite( localSite, 'https://self-hosted.example', 'my-secret' );
-
-		expect( source ).toEqual( {
-			url: 'https://self-hosted.example',
-			secret: 'my-secret',
-		} );
-		expect( fetchSyncableSites ).not.toHaveBeenCalled();
+		await expect( resolveSourceSite( 'https://third-party.example' ) ).rejects.toThrow(
+			/not a WordPress\.com or Pressable site connected to your account/
+		);
 		expect( pickSyncSite ).not.toHaveBeenCalled();
+		expect( rotateReprintSecret ).not.toHaveBeenCalled();
 	} );
 } );
 
@@ -690,9 +685,9 @@ describe( 'CLI: studio pull-reprint requires an existing site', () => {
 		const migrationClientMod = await import( 'cli/lib/pull/migration-client' );
 		const reprintSpy = vi.spyOn( migrationClientMod, 'runReprintCommandUntilComplete' );
 
-		await expect(
-			runCommand( sitePath, 'https://example.com', 'hmac-secret', false )
-		).rejects.toThrow( 'The specified directory is not added to Studio.' );
+		await expect( runCommand( sitePath, 'https://example.com', false ) ).rejects.toThrow(
+			'The specified directory is not added to Studio.'
+		);
 
 		// The site lookup fails up front, so the remote is never contacted and
 		// no pull scratch directory is created.
@@ -702,6 +697,7 @@ describe( 'CLI: studio pull-reprint requires an existing site', () => {
 
 	it( 'pulls into the site resolved by --path, sourcing identity from the record and creating no new site', async () => {
 		const { runCommand } = await loadRunCommandWithFakeHome();
+		mockWpComPullSource();
 		const sitePath = path.join( fakeHome, 'Studio', 'Existing-Site' );
 		seedCliConfigSite( fakeHome, [
 			makeSiteRecord( { id: 'existing-id', name: 'Existing Site', path: sitePath } ),
@@ -717,9 +713,7 @@ describe( 'CLI: studio pull-reprint requires an existing site', () => {
 		const logSpy = vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
 		vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
 
-		await expect(
-			runCommand( sitePath, 'https://example.com', 'hmac-secret', false )
-		).rejects.toThrow();
+		await expect( runCommand( sitePath, 'https://example.com', false ) ).rejects.toThrow();
 
 		// The pipeline reached the remote (preflight is its first reprint call).
 		expect( reprintSpy ).toHaveBeenCalled();
@@ -787,6 +781,7 @@ describe( 'CLI: studio pull-reprint delta re-pull of a completed pull', () => {
 
 	it( 'runs a delta re-pull for a site that already completed a full import', async () => {
 		const { runCommand } = await loadRunCommandWithFakeHome();
+		mockWpComPullSource();
 
 		const pullsRoot = path.join( fakeHome, '.studio', 'pulls' );
 		// Scratch is keyed by siteId now.
@@ -827,9 +822,7 @@ describe( 'CLI: studio pull-reprint delta re-pull of a completed pull', () => {
 		const logSpy = vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
 		vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
 
-		await expect(
-			runCommand( sitePath, 'https://example.com', 'hmac-secret', false )
-		).rejects.toThrow();
+		await expect( runCommand( sitePath, undefined, false ) ).rejects.toThrow();
 
 		// A delta re-pull re-enters the pipeline (preflight is its first call)
 		// rather than short-circuiting on the existing import.
@@ -856,6 +849,7 @@ describe( 'CLI: studio pull-reprint delta re-pull of a completed pull', () => {
 
 	it( 'normalizes stale skipped-earlier reprint state before starting an essential-files re-pull', async () => {
 		const { runCommand } = await loadRunCommandWithFakeHome();
+		mockWpComPullSource();
 
 		const pullsRoot = path.join( fakeHome, '.studio', 'pulls' );
 		const technicalSiteDirectory = path.join( pullsRoot, 'stale-filter-id' );
@@ -948,120 +942,14 @@ describe( 'CLI: studio pull-reprint delta re-pull of a completed pull', () => {
 		vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
 		vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
 
-		await expect(
-			runCommand( sitePath, 'https://example.com', 'hmac-secret', false )
-		).rejects.toThrow( /stop after essential-files state normalization/ );
+		await expect( runCommand( sitePath, 'https://example.com', false ) ).rejects.toThrow(
+			/stop after essential-files state normalization/
+		);
 
 		expect( reprintSpy.mock.calls.map( ( call ) => call[ 2 ][ 0 ] ) ).toEqual( [
 			'preflight',
 			'pull',
 		] );
-	} );
-} );
-
-describe( 'CLI: studio pull-reprint preflight retry re-enables the exporter', () => {
-	let fakeHome: string;
-
-	const token = {
-		accessToken: 'access-token',
-		id: 1,
-		email: 'user@example.com',
-		displayName: 'User',
-		expiresIn: 1209600,
-		expirationTime: Date.now() + 1209600000,
-	};
-
-	const sites: SyncSite[] = [
-		{
-			id: 22,
-			name: 'Example',
-			url: 'https://example.com',
-			localSiteId: '',
-			isStaging: false,
-			isPressable: false,
-			syncSupport: 'syncable',
-			lastPullTimestamp: null,
-			lastPushTimestamp: null,
-		},
-	];
-
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.resetModules();
-		if ( fakeHome ) {
-			fs.rmSync( fakeHome, { recursive: true, force: true } );
-		}
-	} );
-
-	async function loadRunCommandWithFakeHome() {
-		fakeHome = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-pull-retry-home-' ) );
-
-		vi.resetModules();
-		vi.doMock( 'os', async () => {
-			const actual = await vi.importActual< typeof import('os') >( 'os' );
-			return {
-				...actual,
-				default: { ...actual, homedir: () => fakeHome },
-				homedir: () => fakeHome,
-			};
-		} );
-
-		const mod = await import( '../pull-reprint' );
-		return mod;
-	}
-
-	it( 're-enables the exporter (not just rotates the secret) before retrying a failed preflight', async () => {
-		const { runCommand, normalizeSiteUrl } = await loadRunCommandWithFakeHome();
-
-		// Seed a site whose stored origin holds a cached secret but no
-		// wpComSite/wpComToken — exactly the delta-re-pull shape that makes
-		// resolveSourceSite short-circuit on the cached secret and skip the
-		// happy-path exporter enable.
-		const normalizedUrl = normalizeSiteUrl( 'https://example.com' );
-		const pullsRoot = path.join( fakeHome, '.studio', 'pulls' );
-		const technicalSiteDirectory = path.join( pullsRoot, 'retry-id' );
-		const stateDirectory = path.join( technicalSiteDirectory, 'state' );
-		const sitePath = path.join( fakeHome, 'Studio', 'My-Retry-Site' );
-
-		// The local site (with its cached origin secret) is resolved by --path.
-		seedCliConfigSite( fakeHome, [
-			makeSiteRecord( {
-				id: 'retry-id',
-				name: 'My Retry Site',
-				path: sitePath,
-				importComplete: true,
-				reprintOrigin: { remoteUrl: normalizedUrl, secret: 'cached-secret' },
-			} ),
-		] );
-
-		fs.mkdirSync( stateDirectory, { recursive: true } );
-		fs.mkdirSync( sitePath, { recursive: true } );
-		fs.writeFileSync( path.join( sitePath, 'wp-config.php' ), '<?php // flattened output' );
-
-		vi.mocked( readAuthToken ).mockResolvedValue( token );
-		vi.mocked( fetchSyncableSites ).mockResolvedValue( sites );
-		vi.mocked( rotateReprintSecret ).mockResolvedValue( 'fresh-secret' );
-		vi.mocked( enableReprintExporter ).mockResolvedValue( undefined );
-
-		// Every preflight attempt fails (the closed wpcomsh gate returns HTML),
-		// so the command ultimately rejects — but the retry path must still
-		// rotate the secret AND re-enable the exporter before giving up.
-		const migrationClientMod = await import( 'cli/lib/pull/migration-client' );
-		vi.spyOn( migrationClientMod, 'runReprintCommandUntilComplete' ).mockRejectedValue(
-			new Error( 'preflight failed: HTML response' )
-		);
-		vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
-		vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
-
-		await expect(
-			runCommand( sitePath, 'https://example.com', undefined, false )
-		).rejects.toThrow();
-
-		// The fix: the retry resolves the WP.com site, rotates the secret, AND
-		// re-opens the exporter gate. Without the enable call the retry would
-		// hit the same closed window and fail identically.
-		expect( rotateReprintSecret ).toHaveBeenCalledWith( 22, token.accessToken );
-		expect( enableReprintExporter ).toHaveBeenCalledWith( 22, token.accessToken, false );
 	} );
 } );
 

--- a/apps/cli/commands/tests/pull-reprint.test.ts
+++ b/apps/cli/commands/tests/pull-reprint.test.ts
@@ -6,7 +6,6 @@ import { SITE_RUNTIME_PLAYGROUND } from '@studio/common/lib/site-runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { enableReprintExporter, rotateReprintSecret } from 'cli/lib/api';
 import * as migrationClient from 'cli/lib/pull/migration-client';
-import { shouldRestartFilesSyncIndex } from 'cli/lib/pull/reprint-state';
 import { fetchSyncableSites } from 'cli/lib/sync-api';
 import { pickSyncSite } from 'cli/lib/sync-site-picker';
 import {
@@ -133,42 +132,6 @@ describe( 'CLI: studio pull-reprint helpers', () => {
 				'https://example.wordpress.com'
 			)
 		).toEqual( { id: 1, name: 'Example', url: 'https://example.wordpress.com/' } );
-	} );
-
-	it( 'restarts files-sync indexing only when the saved state has no resumable cursor', () => {
-		const stateDirectory = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-import-state-' ) );
-
-		try {
-			fs.writeFileSync(
-				path.join( stateDirectory, '.import-state.json' ),
-				JSON.stringify( {
-					command: 'files-sync',
-					status: 'in_progress',
-					stage: 'index',
-					cursor: null,
-				} )
-			);
-			fs.writeFileSync(
-				path.join( stateDirectory, '.import-remote-index.jsonl' ),
-				'{"type":"file"}\n'
-			);
-
-			expect( shouldRestartFilesSyncIndex( stateDirectory ) ).toBe( true );
-
-			fs.writeFileSync(
-				path.join( stateDirectory, '.import-state.json' ),
-				JSON.stringify( {
-					command: 'files-sync',
-					status: 'in_progress',
-					stage: 'index',
-					cursor: { path: 'saved' },
-				} )
-			);
-
-			expect( shouldRestartFilesSyncIndex( stateDirectory ) ).toBe( false );
-		} finally {
-			fs.rmSync( stateDirectory, { recursive: true, force: true } );
-		}
 	} );
 
 	it( 'rewrites the reprint state before downloading skipped-earlier files', async () => {

--- a/apps/cli/lib/cli-config/core.ts
+++ b/apps/cli/lib/cli-config/core.ts
@@ -18,14 +18,12 @@ import { LoggerError } from 'cli/logger';
 
 /**
  * Durable origin of a site that was populated by `studio pull-reprint`:
- * where it syncs from and the credential needed to talk to that remote.
- * Present only on reprint-pulled sites.
+ * where it syncs from. Present only on reprint-pulled sites.
  */
 export const reprintOriginSchema = z.object( {
 	remoteUrl: z.string(),
 	remoteSiteUrl: z.string().optional(),
 	tablePrefix: z.string().optional(),
-	secret: z.string(),
 } );
 
 /**

--- a/apps/cli/lib/pull/reprint-state.test.ts
+++ b/apps/cli/lib/pull/reprint-state.test.ts
@@ -1,30 +1,18 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import {
-	getReprintStatePath,
-	readReprintState,
-	writeReprintState,
-} from 'cli/lib/pull/reprint-state';
+import { getContentDirFromState, hasSkippedFiles } from 'cli/lib/pull/reprint-state';
 
 describe( 'reprint state accessors', () => {
-	it( 'reads a valid reprint state and preserves unknown fields', () => {
+	it( 'reads the remote wp-content path from preflight state', () => {
 		const stateDirectory = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-reprint-state-' ) );
 
 		try {
 			fs.writeFileSync(
-				getReprintStatePath( stateDirectory ),
+				path.join( stateDirectory, '.import-state.json' ),
 				JSON.stringify( {
-					command: 'files-sync',
-					status: 'complete',
-					stage: null,
-					cursor: { path: 'wp-content/uploads/image.jpg' },
 					preflight: {
 						data: {
-							runtime: {
-								document_root: '/srv/htdocs',
-								extra_runtime_field: true,
-							},
 							database: {
 								wp: {
 									paths_urls: {
@@ -34,58 +22,27 @@ describe( 'reprint state accessors', () => {
 							},
 						},
 					},
-					next_reprint_field: 'preserved',
 				} )
 			);
 
-			expect( readReprintState( stateDirectory ) ).toEqual( {
-				command: 'files-sync',
-				status: 'complete',
-				stage: null,
-				cursor: { path: 'wp-content/uploads/image.jpg' },
-				preflight: {
-					data: {
-						runtime: {
-							document_root: '/srv/htdocs',
-							extra_runtime_field: true,
-						},
-						database: {
-							wp: {
-								paths_urls: {
-									content_dir: '/srv/htdocs/wp-content',
-								},
-							},
-						},
-					},
-				},
-				next_reprint_field: 'preserved',
-			} );
+			expect( getContentDirFromState( stateDirectory ) ).toBe( '/srv/htdocs/wp-content' );
 		} finally {
 			fs.rmSync( stateDirectory, { recursive: true, force: true } );
 		}
 	} );
 
-	it( 'writes a validated reprint state snapshot', () => {
+	it( 'detects whether reprint left skipped files to download', () => {
 		const stateDirectory = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-reprint-state-' ) );
+		const skippedListPath = path.join( stateDirectory, '.import-download-list-skipped.jsonl' );
 
 		try {
-			writeReprintState( stateDirectory, {
-				command: 'files-sync',
-				status: 'complete',
-				stage: null,
-				filter: 'essential-files',
-				preflight: { data: { database: { ok: true } } },
-			} );
+			expect( hasSkippedFiles( stateDirectory ) ).toBe( false );
 
-			const raw = fs.readFileSync( getReprintStatePath( stateDirectory ), 'utf-8' );
-			expect( raw.endsWith( '\n' ) ).toBe( true );
-			expect( JSON.parse( raw ) ).toEqual( {
-				command: 'files-sync',
-				status: 'complete',
-				stage: null,
-				filter: 'essential-files',
-				preflight: { data: { database: { ok: true } } },
-			} );
+			fs.writeFileSync( skippedListPath, '' );
+			expect( hasSkippedFiles( stateDirectory ) ).toBe( false );
+
+			fs.writeFileSync( skippedListPath, '{"path":"wp-content/cache/file"}\n' );
+			expect( hasSkippedFiles( stateDirectory ) ).toBe( true );
 		} finally {
 			fs.rmSync( stateDirectory, { recursive: true, force: true } );
 		}

--- a/apps/cli/lib/pull/reprint-state.ts
+++ b/apps/cli/lib/pull/reprint-state.ts
@@ -2,14 +2,12 @@
  * Accessors for reprint.phar's on-disk state files.
  *
  * reprint.phar writes a JSON progress file (`.import-state.json`) and a
- * JSONL index (`.import-remote-index.jsonl`) under each pull's state
- * directory.  Studio reads those files to decide whether to resume or
- * restart a phase, detect stale layouts, etc.
+ * skipped-download list under each pull's state directory. Studio reads
+ * only the fields it needs to wire the imported runtime and decide
+ * whether to invoke the follow-up skipped-files sync.
  *
- * This module is the single seam where Studio couples to reprint's
- * internal schema.  When reprint renames a field or moves data around,
- * the fix is scoped to this file — every other caller goes through
- * these accessors.
+ * This module is the single place where Studio couples to reprint's
+ * on-disk output. Reprint owns its own state machine.
  */
 import fs from 'fs';
 import path from 'path';
@@ -17,23 +15,13 @@ import { isErrnoException } from '@studio/common/lib/is-errno-exception';
 import { z } from 'zod';
 
 const STATE_FILE = '.import-state.json';
-export const SKIPPED_DOWNLOAD_LIST = '.import-download-list-skipped.jsonl';
+const SKIPPED_DOWNLOAD_LIST = '.import-download-list-skipped.jsonl';
 
-export const reprintStateSnapshotSchema = z.looseObject( {
-	command: z.string().nullish(),
-	status: z.string().nullish(),
-	cursor: z.unknown().optional(),
-	stage: z.string().nullish(),
-	filter: z.string().nullish(),
+const reprintStateSnapshotSchema = z.looseObject( {
 	preflight: z
 		.looseObject( {
 			data: z
 				.looseObject( {
-					runtime: z
-						.looseObject( {
-							document_root: z.string().nullish(),
-						} )
-						.optional(),
 					database: z
 						.looseObject( {
 							wp: z
@@ -53,13 +41,13 @@ export const reprintStateSnapshotSchema = z.looseObject( {
 		.optional(),
 } );
 
-export type ReprintStateSnapshot = z.infer< typeof reprintStateSnapshotSchema >;
+type ReprintStateSnapshot = z.infer< typeof reprintStateSnapshotSchema >;
 
-export function getReprintStatePath( stateDirectory: string ): string {
+function getReprintStatePath( stateDirectory: string ): string {
 	return path.join( stateDirectory, STATE_FILE );
 }
 
-export function readReprintState( stateDirectory: string ): ReprintStateSnapshot | null {
+function readReprintState( stateDirectory: string ): ReprintStateSnapshot | null {
 	let raw: string;
 	try {
 		raw = fs.readFileSync( getReprintStatePath( stateDirectory ), 'utf-8' );
@@ -73,14 +61,6 @@ export function readReprintState( stateDirectory: string ): ReprintStateSnapshot
 	const parsedJson = JSON.parse( raw );
 	const parsed = reprintStateSnapshotSchema.safeParse( parsedJson );
 	return parsed.success ? parsed.data : null;
-}
-
-export function writeReprintState( stateDirectory: string, state: ReprintStateSnapshot ): void {
-	const parsedState = reprintStateSnapshotSchema.parse( state );
-	fs.writeFileSync(
-		getReprintStatePath( stateDirectory ),
-		JSON.stringify( parsedState, null, 2 ) + '\n'
-	);
 }
 
 /**

--- a/apps/cli/lib/pull/reprint-state.ts
+++ b/apps/cli/lib/pull/reprint-state.ts
@@ -17,7 +17,6 @@ import { isErrnoException } from '@studio/common/lib/is-errno-exception';
 import { z } from 'zod';
 
 const STATE_FILE = '.import-state.json';
-const REMOTE_INDEX_FILE = '.import-remote-index.jsonl';
 export const SKIPPED_DOWNLOAD_LIST = '.import-download-list-skipped.jsonl';
 
 export const reprintStateSnapshotSchema = z.looseObject( {
@@ -35,6 +34,19 @@ export const reprintStateSnapshotSchema = z.looseObject( {
 							document_root: z.string().nullish(),
 						} )
 						.optional(),
+					database: z
+						.looseObject( {
+							wp: z
+								.looseObject( {
+									paths_urls: z
+										.looseObject( {
+											content_dir: z.string().nullish(),
+										} )
+										.optional(),
+								} )
+								.optional(),
+						} )
+						.optional(),
 				} )
 				.optional(),
 		} )
@@ -45,10 +57,6 @@ export type ReprintStateSnapshot = z.infer< typeof reprintStateSnapshotSchema >;
 
 export function getReprintStatePath( stateDirectory: string ): string {
 	return path.join( stateDirectory, STATE_FILE );
-}
-
-export function getRemoteIndexPath( stateDirectory: string ): string {
-	return path.join( stateDirectory, REMOTE_INDEX_FILE );
 }
 
 export function readReprintState( stateDirectory: string ): ReprintStateSnapshot | null {
@@ -83,80 +91,11 @@ export function writeReprintState( stateDirectory: string, state: ReprintStateSn
  */
 export function getContentDirFromState( stateDirectory: string ): string | null {
 	const state = readReprintState( stateDirectory );
-	const preflight = state?.preflight?.data as Record< string, unknown > | undefined;
-	const database = preflight?.database as Record< string, unknown > | undefined;
-	const wp = database?.wp as Record< string, unknown > | undefined;
-	const pathsUrls = wp?.paths_urls as Record< string, unknown > | undefined;
-	const contentDir = pathsUrls?.content_dir;
+	const contentDir = state?.preflight?.data?.database?.wp?.paths_urls?.content_dir;
 	return typeof contentDir === 'string' ? contentDir : null;
-}
-
-/**
- * True when the reprint state says files-sync indexing started but
- * didn't get far enough to checkpoint a cursor — in that case the
- * next run must restart indexing from scratch rather than trying to
- * resume from a non-existent cursor.
- *
- * This handles a real crash-recovery scenario: the user kills the
- * process (Ctrl-C, laptop sleep, OOM) during the first indexing
- * pass before reprint writes its first cursor checkpoint. Reprint
- * itself doesn't auto-detect this — it needs the caller to send
- * `files-sync --abort` first to clear the broken state. Studio
- * detects the condition here so pull-reprint can issue that abort
- * automatically before retrying.
- */
-export function shouldRestartFilesSyncIndex( stateDirectory: string ): boolean {
-	const state = readReprintState( stateDirectory );
-	if ( ! state ) {
-		return false;
-	}
-
-	// reprint canonicalizes the legacy 'files-sync' command name to
-	// 'files-pull' when it saves state; accept both so this check keeps
-	// working across reprint versions.
-	if (
-		( state.command !== 'files-sync' && state.command !== 'files-pull' ) ||
-		state.status === 'complete'
-	) {
-		return false;
-	}
-
-	if ( state.stage !== 'index' || state.cursor !== null ) {
-		return false;
-	}
-
-	const remoteIndexPath = getRemoteIndexPath( stateDirectory );
-	return fs.existsSync( remoteIndexPath ) && fs.statSync( remoteIndexPath ).size > 0;
 }
 
 export function hasSkippedFiles( stateDirectory: string ): boolean {
 	const skippedListPath = path.join( stateDirectory, SKIPPED_DOWNLOAD_LIST );
 	return fs.existsSync( skippedListPath ) && fs.statSync( skippedListPath ).size > 0;
-}
-
-/**
- * Wipe the reprint state + derived indexes so the next run starts an
- * essential-files sync from scratch — but preserve preflight data so
- * we don't have to round-trip the remote for it again.
- */
-export function resetEssentialFilesState( stateDirectory: string ): void {
-	const existingState = readReprintState( stateDirectory );
-	const preflight = existingState?.preflight;
-
-	for ( const fileName of [
-		'.import-index.jsonl',
-		'.import-remote-index.jsonl',
-		'.import-download-list.jsonl',
-		'.import-download-list-skipped.jsonl',
-		'.import-status.json',
-	] ) {
-		fs.rmSync( path.join( stateDirectory, fileName ), { force: true } );
-	}
-
-	const statePath = getReprintStatePath( stateDirectory );
-	if ( preflight ) {
-		writeReprintState( stateDirectory, { preflight } );
-	} else {
-		fs.rmSync( statePath, { force: true } );
-	}
 }

--- a/docs/design-docs/cli.md
+++ b/docs/design-docs/cli.md
@@ -61,7 +61,7 @@ Long-term, we might want to move in that direction, but for now, we are still bu
 The flow is:
 
 1. `studio create` — create the local site (a full `SiteData` record plus a blank WordPress install). This is a prerequisite; `pull-reprint` never creates a site.
-2. `studio pull-reprint --path <site> --url <remote>` — pull the remote into the local site resolved by `--path`. `--url` identifies only the remote source; if omitted, `pull-reprint` first reuses the site's saved `reprintOrigin.remoteUrl`, and if there is no saved origin, a WordPress.com/Pressable source picker runs (remote discovery only — it never identifies the local site). The matched remote must be `syncable`. Each run rotates a fresh Reprint secret through the WordPress.com API, enables the exporter, then runs preflight once. The pull is idempotent: re-running it resumes an interrupted pull or performs a delta re-pull of an already-imported site.
+2. `studio pull-reprint --path <site> --url <remote>` — pull the remote into the local site resolved by `--path`. `--url` identifies only the remote source; if omitted, `pull-reprint` first reuses the site's saved `reprintOrigin.remoteUrl`, and if there is no saved origin, a WordPress.com/Pressable source picker runs (Pressable support is still WIP). The matched remote must be `syncable`. Each run rotates a fresh Reprint secret through the WordPress.com API, enables the exporter, then runs preflight once. The pull is idempotent: re-running it resumes an interrupted pull or performs a delta re-pull of an already-imported site.
 3. `studio delete --path <site>` — the only teardown path. It trashes the site folder and the site's `technicalSiteDirectory`, which for a reprint-pulled site is the `siteId`-keyed scratch under `~/.studio/pulls/<siteId>` (reprint's `.import-state.json`, the preflight cache, and the raw/runtime working dirs). `pull-reprint` records `technicalSiteDirectory` on the site at pull *start*, so the scratch is cleaned up even for a pull that failed before linking. There is no `--abort` verb.
 
 #### State model
@@ -69,7 +69,7 @@ The flow is:
 All durable state lives on the `SiteData` record in `cli.json`. The pull-relevant fields are:
 
 - `status: 'ready' | 'pulling' | 'pull-failed'` — health of the local install. `site create` produces `ready`; a pull sets `pulling` up front, `ready` on success, and `pull-failed` if it errors or is killed. A missing value (legacy records) is treated as `ready`. `site start` refuses to start a non-`ready` site rather than serving a half-written install.
-- `reprintOrigin` — durable origin metadata for a pulled site (`remoteUrl`, `remoteSiteUrl`, `tablePrefix`), so a re-pull can reuse the remote source. Credentials are not stored; the Reprint secret is rotated fresh on every run.
+- `reprintOrigin` — durable origin metadata for a pulled site (`remoteUrl`, `remoteSiteUrl`, `tablePrefix`), so a re-pull can reuse the remote source.
 - `importComplete: boolean` — true once a full pull has completed at least once; selects first-full-pull vs. delta on the next run.
 
 #### Resume by derivation

--- a/docs/design-docs/cli.md
+++ b/docs/design-docs/cli.md
@@ -56,12 +56,12 @@ Long-term, we might want to move in that direction, but for now, we are still bu
 
 ### Pulling a remote site (`pull-reprint`)
 
-`studio pull-reprint` refreshes an **existing** local Studio site from a remote WordPress source using the reprint pull tool. It is a state-transition on a site, not a site creator — the same shape as the WordPress.com sync `pull`.
+`studio pull-reprint` refreshes an **existing** local Studio site from a connected WordPress.com or Pressable source using the reprint pull tool. It is a state-transition on a site, not a site creator — the same shape as the WordPress.com sync `pull`. Third-party WordPress hosts are not supported: a source URL must resolve to a site returned by the user's authenticated WordPress.com Jetpack API site list.
 
 The flow is:
 
 1. `studio create` — create the local site (a full `SiteData` record plus a blank WordPress install). This is a prerequisite; `pull-reprint` never creates a site.
-2. `studio pull-reprint --path <site> --url <remote> [--secret <S>]` — pull the remote into the local site resolved by `--path`. `--url`/`--secret` identify only the remote source; with neither, a WordPress.com source picker runs (remote discovery only — it never identifies the local site). The pull is idempotent: re-running it resumes an interrupted pull or performs a delta re-pull of an already-imported site.
+2. `studio pull-reprint --path <site> --url <remote>` — pull the remote into the local site resolved by `--path`. `--url` identifies only the remote source; if omitted, `pull-reprint` first reuses the site's saved `reprintOrigin.remoteUrl`, and if there is no saved origin, a WordPress.com/Pressable source picker runs (remote discovery only — it never identifies the local site). The matched remote must be `syncable`. Each run rotates a fresh Reprint secret through the WordPress.com API, enables the exporter, then runs preflight once. The pull is idempotent: re-running it resumes an interrupted pull or performs a delta re-pull of an already-imported site.
 3. `studio delete --path <site>` — the only teardown path. It trashes the site folder and the site's `technicalSiteDirectory`, which for a reprint-pulled site is the `siteId`-keyed scratch under `~/.studio/pulls/<siteId>` (reprint's `.import-state.json`, the preflight cache, and the raw/runtime working dirs). `pull-reprint` records `technicalSiteDirectory` on the site at pull *start*, so the scratch is cleaned up even for a pull that failed before linking. There is no `--abort` verb.
 
 #### State model
@@ -69,7 +69,7 @@ The flow is:
 All durable state lives on the `SiteData` record in `cli.json`. The pull-relevant fields are:
 
 - `status: 'ready' | 'pulling' | 'pull-failed'` — health of the local install. `site create` produces `ready`; a pull sets `pulling` up front, `ready` on success, and `pull-failed` if it errors or is killed. A missing value (legacy records) is treated as `ready`. `site start` refuses to start a non-`ready` site rather than serving a half-written install.
-- `reprintOrigin` — durable origin of a pulled site (`remoteUrl`, `remoteSiteUrl`, `tablePrefix`, `secret`), so a re-pull can reuse the remote source and credentials.
+- `reprintOrigin` — durable origin metadata for a pulled site (`remoteUrl`, `remoteSiteUrl`, `tablePrefix`), so a re-pull can reuse the remote source. Credentials are not stored; the Reprint secret is rotated fresh on every run.
 - `importComplete: boolean` — true once a full pull has completed at least once; selects first-full-pull vs. delta on the next run.
 
 #### Resume by derivation


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-2002

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

I used Codex to drive the implementation in relatively short increments, and given a detailed initial prompt.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

The `pull-reprint` command shouldn't support third-party hosts. After the https://github.com/Automattic/studio/pull/4007 refactor landed, the most ambiguous remaining logic regarding which types of remote sites are supported is the site loading and secret rotation.

This PR refactors and greatly simplifies `resolveSourceSite()`. It will now always return a `wpComSite` property, and it'll always rotate the secret. Consequently, we can also clean up the error-handling logic around `runPreflight()`, because we aren't trying to use a stored (and potentially stale) secret to begin with – we're always starting fresh.

Moreover, this PR follows up on https://github.com/WordPress/reprint/pull/292 by removing the related hacks where `pull-reprint` modified Reprint's internal state. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `npm run cli:build`
2. `node apps/cli/dist/cli/main.mjs site create` to create a fresh site that we can use for pulling
3. cd into the newly created site
4. `STUDIO_ENABLE_PULL_REPRINT=1 node apps/cli/dist/cli/main.mjs pull-reprint`
5. Ensure that pulling a site works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
