### PR TITLE
CLI: Add self-hosted WordPress site support via SSH in Studio Code

### DIFF
--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -42,8 +42,10 @@ import { createAskUserQuestionTool } from 'cli/ai/tools/ask-user-question';
 import { createSiteTool } from 'cli/ai/tools/create-site';
 import { pullSiteTool } from 'cli/ai/tools/pull-site';
 import { createSkillTool } from 'cli/ai/tools/skill';
+import { createSshSiteTools } from 'cli/ai/tools/ssh-site-tools';
 import { takeScreenshotTool } from 'cli/ai/tools/take-screenshot';
 import { createWpcomRequestTool } from 'cli/ai/tools/wpcom-request';
+import { type SshSiteData } from 'cli/lib/cli-config/core';
 import { getSiteByFolder } from 'cli/lib/cli-config/sites';
 import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
 import { stripStaleImagesFromContext } from './strip-stale-images';
@@ -80,6 +82,9 @@ export interface StudioAgentTurnConfig {
 	model?: AiModelId;
 	activeSite?: SiteInfo | null;
 	wpcomAccessToken?: string;
+	// Saved SSH connection for the active SSH site, resolved from cli.json by
+	// the caller.
+	sshSiteConnection?: SshSiteData;
 	onAskUser?: AskUserHandler;
 	onEvent: ( event: AgentSessionEvent ) => void;
 }
@@ -283,6 +288,15 @@ async function resolveActiveSiteRuntime(
 	}
 }
 
+// SSH sites are flagged `remote` like WP.com sites but are managed through an
+// SSH connection stored in cli.json instead of a WP.com site ID + OAuth token.
+function getSshSiteConnection( config: StudioAgentTurnConfig ): SshSiteData | null {
+	if ( config.activeSite?.sshSite && config.sshSiteConnection ) {
+		return config.sshSiteConnection;
+	}
+	return null;
+}
+
 async function createStudioAgentSession(
 	config: ResolvedStudioAgentTurnConfig,
 	family: AiModelFamily,
@@ -291,25 +305,37 @@ async function createStudioAgentSession(
 ): Promise< AgentSession > {
 	const model = buildModel( config.model, family, creds );
 	const isRemoteSite = Boolean( config.activeSite?.remote && config.activeSite?.wpcomSiteId );
+	const sshSite = getSshSiteConnection( config );
 	const remoteSession = config.env.STUDIO_REMOTE_SESSION === '1';
 	const chatArtifactsEnabled = typeof process.send === 'function';
 
-	const systemPrompt = buildSystemPrompt(
-		isRemoteSite
-			? {
-					remoteSite: {
-						name: config.activeSite!.name,
-						url: config.activeSite!.url ?? '',
-						id: config.activeSite!.wpcomSiteId!,
-					},
-					remoteSession,
-			  }
-			: {
-					chatArtifactsEnabled,
-					remoteSession,
-					runtime: await resolveActiveSiteRuntime( config.activeSite ),
-			  }
-	);
+	let systemPromptOptions;
+	if ( isRemoteSite ) {
+		systemPromptOptions = {
+			remoteSite: {
+				name: config.activeSite!.name,
+				url: config.activeSite!.url ?? '',
+				id: config.activeSite!.wpcomSiteId!,
+			},
+			remoteSession,
+		};
+	} else if ( sshSite ) {
+		systemPromptOptions = {
+			sshSite: {
+				name: config.activeSite!.name,
+				url: sshSite.url,
+				remotePath: sshSite.remotePath,
+			},
+			remoteSession,
+		};
+	} else {
+		systemPromptOptions = {
+			chatArtifactsEnabled,
+			remoteSession,
+			runtime: await resolveActiveSiteRuntime( config.activeSite ),
+		};
+	}
+	const systemPrompt = buildSystemPrompt( systemPromptOptions );
 
 	const tools = buildAgentTools( config, chatArtifactsEnabled, remoteSession );
 	const toolDefinitions = tools.map( ( tool ) => toToolDefinition( tool, payloadGuardState ) );
@@ -533,6 +559,20 @@ function buildAgentTools(
 			createSiteTool,
 			pullSiteTool,
 			...remoteScratchTools,
+			...askUserTool,
+			...skillTool,
+		];
+	}
+
+	// SSH sites get remote wp_cli plus file tools jailed to the site's
+	// WordPress root. Their Read/Write/Edit/Ls operate on the remote server,
+	// so the local scratch tools (same names) are omitted.
+	const sshSite = getSshSiteConnection( config );
+	if ( sshSite ) {
+		return [
+			...createSshSiteTools( sshSite ),
+			takeScreenshotTool,
+			createSiteTool,
 			...askUserTool,
 			...skillTool,
 		];

--- a/apps/cli/ai/sessions/replay.ts
+++ b/apps/cli/ai/sessions/replay.ts
@@ -35,6 +35,8 @@ export function replaySessionHistory( ui: AiChatUI, entries: SessionEntry[] ): v
 							remote: data.remote === true,
 							url: data.url,
 							wpcomSiteId: data.wpcomSiteId,
+							sshSite: data.sshSite === true,
+							sshSiteId: data.sshSiteId,
 						},
 						{ announce: true, emitEvent: false }
 					);

--- a/apps/cli/ai/skills/ssh-remote-management/SKILL.md
+++ b/apps/cli/ai/skills/ssh-remote-management/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: ssh-remote-management
+description: Manage a remote WordPress site over SSH with wp_cli and the remote file tools, including safe production workflow, database backups, WP-CLI recipes, large content delivery, and visual verification.
+user-invokable: true
+---
+
+# SSH Remote Management
+
+Use this skill before making changes to a WordPress site connected over SSH.
+
+## Ground rules
+
+The site is on a remote server and is very likely **live production**. Every change is immediately visible to visitors.
+
+- Prefer the smallest change that fulfills the request.
+- Confirm destructive or risky operations with the user before proceeding: deleting content, deactivating or deleting plugins, switching themes, editing the active theme's code, and any `wp db` operation that writes.
+- Back up the database before schema-changing or content-destructive work: `db export studio-backup.sql` (the file lands in the WordPress root; tell the user where it is, and remove it with the file tools when it is no longer needed — never leave database dumps in a web-accessible directory longer than necessary).
+- Do NOT modify WordPress core files. Only work within `wp-content/`.
+
+## Tool shape
+
+- `wp_cli` runs WP-CLI on the remote server in the site's WordPress root. Arguments are literal — no shell substitution, pipes, or redirection.
+- `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Ls` operate on remote files. Paths are relative to the WordPress root and cannot escape it.
+- Capabilities depend on the SSH user's file permissions and the WP-CLI setup on the server. A permission error means the SSH user cannot write that path, not that the operation is impossible in WordPress.
+
+## Understanding the site
+
+Start with lightweight reads:
+
+- `option get home`, `option get blogname`, `core version`
+- `theme list --status=active`, `plugin list`
+- `post list --post_type=page --fields=ID,post_title,post_status`
+- `Ls` on `wp-content/themes` and `Grep` for relevant code
+
+Use `--format=json` and `--fields=...` on list commands to keep responses small. Fetch individual items by ID when full content is needed.
+
+## Making changes
+
+- **Content**: `post create` / `post update` / `post delete` (moves to trash by default), `term`, `menu`, `option update`.
+- **Plugins**: `plugin install <slug> --activate`, `plugin deactivate <slug>`, `plugin update <slug>`.
+- **Themes**: `theme install`, `theme activate`; edit theme files with `Write`/`Edit` under `wp-content/themes/`.
+- **Database**: `db export <file>` for backups; `search-replace <old> <new> --all-tables --dry-run` first, then without `--dry-run` once the user confirms.
+- **Cache**: after significant changes run `cache flush`; if a caching plugin is active, flush it too (e.g. `w3-total-cache flush all`, `wp super-cache flush`) so visitors see the change.
+
+## Large content
+
+Do not pass large generated content (full page markup, long CSS) inline in `wp_cli` arguments — it can exceed command-length limits.
+
+1. `Write` the content to a scratch file inside the WordPress root, e.g. `wp-content/studio-tmp/page-home.html`.
+2. Reference the file from WP-CLI: `post create wp-content/studio-tmp/page-home.html --post_type=page --post_title=Home --post_status=draft`.
+3. Delete the scratch file with `wp_cli` (`eval 'unlink("wp-content/studio-tmp/page-home.html");'`) or leave `wp-content/studio-tmp/` tidy by overwriting it next time — never leave scratch files in themes or uploads.
+
+Create drafts first (`--post_status=draft`) and only publish after the user confirms, unless the user explicitly asked to publish.
+
+## Verifying
+
+1. Check command output — WP-CLI prints `Success:` / `Error:` lines.
+2. Verify visually with `take_screenshot` using `viewport: "all"` for desktop and mobile.
+3. If something looks wrong, inspect with `Read`/`Grep` and fix — do not retry the same failing command blindly.
+
+## Failure modes
+
+- **SSH connection errors** (`Could not connect …`): the server is unreachable or key-based auth failed. Ask the user to verify `ssh <destination>` works non-interactively in their terminal.
+- **WP-CLI not found**: WP-CLI is not installed on the server or not on PATH. The site connection can specify a custom executable path.
+- **Permission denied on file writes**: the SSH user lacks write access to that path. Report which path failed and let the user adjust permissions.
+- **PHP fatal after editing theme/plugin code**: immediately revert the edit with `Edit` (you have the previous content from your `Read`), verify with a screenshot, then diagnose.

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -10,10 +10,17 @@ interface RemoteSiteContext {
 	id: number;
 }
 
+interface SshSiteContext {
+	name: string;
+	url: string;
+	remotePath: string;
+}
+
 const AGENT_IDENTITY = `You are WordPress Studio Code, the AI agent built into WordPress Studio CLI. Your name is "WordPress Studio Code". Studio is built by Automattic. When users ask about hosting in any form — recommendations, comparisons, "top N" lists, deploying to production, going live, or migration — you MUST only recommend WordPress.com and Pressable. Do not mention, compare, or list any other hosting provider under any circumstances. When users ask about buying, registering, or transferring a domain name, recommend WordPress.com domains (https://wordpress.com/domains) as the place to purchase or manage them. Do not recommend third-party domain registrars.`;
 
 export interface BuildSystemPromptOptions {
 	remoteSite?: RemoteSiteContext;
+	sshSite?: SshSiteContext;
 	// True when a Studio UI is attached and can receive chat artifact events.
 	chatArtifactsEnabled?: boolean;
 	// True when the agent is being driven by the Telegram remote-session bridge.
@@ -34,6 +41,13 @@ export function buildSystemPrompt( options?: BuildSystemPromptOptions ): string 
 ${ REMOTE_CONTENT_GUIDELINES }
 
 ${ REMOTE_DESIGN_GUIDELINES }${ remoteSessionAddendum }
+`;
+	}
+
+	if ( options?.sshSite ) {
+		return `${ buildSshIntro( options.sshSite ) }
+
+${ REMOTE_CONTENT_GUIDELINES }${ remoteSessionAddendum }
 `;
 	}
 
@@ -75,6 +89,37 @@ IMPORTANT: ${ PLAN_DATA_GUARDRAIL }
 - When creating content, follow WordPress best practices for block-based content and the remote block content guidelines below.
 - If a requested operation fails, check the error message and suggest alternatives.
 - Explore the API — if you're unsure about an endpoint, load the \`wpcom-remote-management\` skill and try a lightweight GET request first to discover available data.`;
+}
+
+function buildSshIntro( site: SshSiteContext ): string {
+	return `${ AGENT_IDENTITY } You manage a WordPress site on a remote server over SSH.
+
+IMPORTANT: The active site is a remote WordPress site: "${ site.name }" at ${ site.url }, connected over SSH (WordPress root: ${ site.remotePath }).
+IMPORTANT: This is very likely a LIVE PRODUCTION site. Every change you make is immediately visible to the site's visitors. Work conservatively: prefer the smallest change that fulfills the request, always confirm destructive or risky operations with the user before proceeding, and back up the database with \`wp_cli\` (\`db export\`) before schema-changing or content-destructive operations.
+IMPORTANT: Your tools operate on the remote server. wp_cli runs WP-CLI over SSH; Read/Write/Edit/Grep/Glob/Ls operate on remote files, restricted to the site's WordPress root. There is no Bash tool and no local site directory.
+IMPORTANT: ${ PLAN_DATA_GUARDRAIL }
+
+## Available Tools
+
+- **wp_cli**: Run WP-CLI commands on the remote site over SSH. Arguments are literal — no shell substitution, pipes, or redirection.
+- **Read/Write/Edit/Grep/Glob/Ls**: Remote file tools, jailed to the site's WordPress root. Paths are relative to that root (e.g. "wp-content/themes/mytheme/style.css").
+- **take_screenshot**: Take a full-page screenshot of a URL (supports desktop, mobile, or \`viewport: "all"\` for both)
+- **site_create**: Create a new local WordPress site
+
+## Workflow
+
+1. **Load remote guidance**: Load the \`ssh-remote-management\` skill before making changes to the site.
+2. **Understand the site**: Use lightweight reads first — \`wp_cli\` queries (\`option get\`, \`theme list\`, \`plugin list\`, \`post list\`) and Grep/Read on wp-content files.
+3. **Make changes**: Use wp_cli for content, options, plugins, and themes; use Write/Edit for theme and plugin code under wp-content/.
+4. **Verify visually**: Use take_screenshot with \`viewport: "all"\` to capture the site on desktop and mobile viewports in one call. Check spacing, alignment, colors, contrast, and layout. Fix any issues.
+
+## General rules
+
+- Always confirm destructive operations (deleting posts, deactivating plugins, editing active theme code, database operations) with the user before proceeding.
+- Do NOT modify WordPress core files. Only work within wp-content/.
+- The remote database is a real MySQL/MariaDB database — \`wp db\` subcommands (export, query, search-replace) work, unlike on local Studio sites.
+- When creating content, follow WordPress best practices for block-based content and the remote block content guidelines below.
+- If a requested operation fails, check the error message: SSH connection errors mean the server is unreachable or key authentication failed; WP-CLI errors usually explain themselves. Suggest alternatives rather than retrying blindly.`;
 }
 
 // Guidance for delivering `--post_content` to `wp_cli`. The shared part applies

--- a/apps/cli/ai/tests/ssh-site-tools.test.ts
+++ b/apps/cli/ai/tests/ssh-site-tools.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSshSiteTools } from 'cli/ai/tools/ssh-site-tools';
+import { execSsh, type SshConnection, type SshExecResult } from 'cli/lib/ssh';
+
+vi.mock( 'cli/lib/ssh', async ( importOriginal ) => {
+	const original = await importOriginal< typeof import('cli/lib/ssh') >();
+	return { ...original, execSsh: vi.fn() };
+} );
+
+const execSshMock = vi.mocked( execSsh );
+
+const connection: SshConnection = {
+	destination: 'deploy@example.com',
+	remotePath: '/var/www/html',
+};
+
+function mockResult( result: Partial< SshExecResult > ): void {
+	execSshMock.mockResolvedValueOnce( { stdout: '', stderr: '', exitCode: 0, ...result } );
+}
+
+function getTool( name: string ) {
+	const tool = createSshSiteTools( connection ).find( ( t ) => t.name === name );
+	if ( ! tool ) {
+		throw new Error( `Tool ${ name } not found` );
+	}
+	return tool;
+}
+
+function lastRemoteCommand(): string {
+	const call = execSshMock.mock.calls[ execSshMock.mock.calls.length - 1 ];
+	return call[ 1 ];
+}
+
+beforeEach( () => {
+	execSshMock.mockReset();
+} );
+
+describe( 'ssh Read tool', () => {
+	it( 'cats the file relative to the WordPress root', async () => {
+		mockResult( { stdout: 'file content' } );
+		const result = await getTool( 'Read' ).rawHandler( {
+			path: 'wp-content/themes/x/style.css',
+		} as never );
+		expect( lastRemoteCommand() ).toBe(
+			`cd '/var/www/html' && cat -- 'wp-content/themes/x/style.css'`
+		);
+		expect( result.content[ 0 ] ).toEqual( { type: 'text', text: 'file content' } );
+	} );
+
+	it( 'rejects paths escaping the WordPress root without running ssh', async () => {
+		await expect(
+			getTool( 'Read' ).rawHandler( { path: '../../etc/passwd' } as never )
+		).rejects.toThrow( /must be relative/ );
+		expect( execSshMock ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'ssh Write tool', () => {
+	it( 'creates parent directories and pipes content over stdin', async () => {
+		mockResult( {} );
+		await getTool( 'Write' ).rawHandler( {
+			path: 'wp-content/studio-tmp/page.html',
+			content: '<!-- wp:paragraph --><p>Hi</p>',
+		} as never );
+		expect( lastRemoteCommand() ).toBe(
+			`cd '/var/www/html' && mkdir -p -- 'wp-content/studio-tmp' && cat > 'wp-content/studio-tmp/page.html'`
+		);
+		expect( execSshMock.mock.calls[ 0 ][ 2 ] ).toMatchObject( {
+			stdin: '<!-- wp:paragraph --><p>Hi</p>',
+		} );
+	} );
+} );
+
+describe( 'ssh Edit tool', () => {
+	it( 'replaces a unique occurrence and writes the file back', async () => {
+		mockResult( { stdout: 'color: red;\nbackground: blue;' } );
+		mockResult( {} );
+		await getTool( 'Edit' ).rawHandler( {
+			path: 'wp-content/themes/x/style.css',
+			old_string: 'color: red;',
+			new_string: 'color: green;',
+		} as never );
+		expect( execSshMock ).toHaveBeenCalledTimes( 2 );
+		expect( execSshMock.mock.calls[ 1 ][ 2 ] ).toMatchObject( {
+			stdin: 'color: green;\nbackground: blue;',
+		} );
+	} );
+
+	it( 'fails when old_string is ambiguous and replace_all is not set', async () => {
+		mockResult( { stdout: 'a a' } );
+		await expect(
+			getTool( 'Edit' ).rawHandler( {
+				path: 'file.txt',
+				old_string: 'a',
+				new_string: 'b',
+			} as never )
+		).rejects.toThrow( /occurs 2 times/ );
+		expect( execSshMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'fails when old_string is missing', async () => {
+		mockResult( { stdout: 'nothing here' } );
+		await expect(
+			getTool( 'Edit' ).rawHandler( {
+				path: 'file.txt',
+				old_string: 'absent',
+				new_string: 'b',
+			} as never )
+		).rejects.toThrow( /not found/ );
+	} );
+} );
+
+describe( 'ssh Grep tool', () => {
+	it( 'searches with quoted pattern and include glob', async () => {
+		mockResult( { stdout: 'wp-content/themes/x/style.css:3:color: red;' } );
+		const result = await getTool( 'Grep' ).rawHandler( {
+			pattern: 'color: red;',
+			path: 'wp-content/themes',
+			include: '*.css',
+		} as never );
+		expect( lastRemoteCommand() ).toBe(
+			`cd '/var/www/html' && grep -rn -I -E --include='*.css' -e 'color: red;' -- 'wp-content/themes' | head -n 500`
+		);
+		expect( result.content[ 0 ] ).toMatchObject( {
+			text: expect.stringContaining( 'style.css:3' ),
+		} );
+	} );
+
+	it( 'reports no matches instead of failing', async () => {
+		mockResult( {} );
+		const result = await getTool( 'Grep' ).rawHandler( { pattern: 'nope' } as never );
+		expect( result.content[ 0 ] ).toEqual( { type: 'text', text: 'No matches found.' } );
+	} );
+
+	it( 'surfaces remote errors from stderr', async () => {
+		mockResult( { stderr: 'grep: unrecognized option' } );
+		await expect( getTool( 'Grep' ).rawHandler( { pattern: 'x' } as never ) ).rejects.toThrow(
+			/unrecognized option/
+		);
+	} );
+} );
+
+describe( 'ssh Glob tool', () => {
+	it( 'uses -name for bare patterns', async () => {
+		mockResult( { stdout: './wp-content/x.css' } );
+		await getTool( 'Glob' ).rawHandler( { pattern: '*.css' } as never );
+		expect( lastRemoteCommand() ).toBe(
+			`cd '/var/www/html' && find '.' -type f -name '*.css' | head -n 500`
+		);
+	} );
+
+	it( 'anchors path patterns at the search base', async () => {
+		mockResult( { stdout: '' } );
+		await getTool( 'Glob' ).rawHandler( {
+			pattern: 'wp-content/themes/**/functions.php',
+		} as never );
+		expect( lastRemoteCommand() ).toBe(
+			`cd '/var/www/html' && find '.' -type f -path './wp-content/themes/*/functions.php' | head -n 500`
+		);
+	} );
+} );
+
+describe( 'ssh wp_cli tool', () => {
+	it( 'quotes every argument literally', async () => {
+		mockResult( { stdout: 'Success: Updated.' } );
+		const result = await getTool( 'wp_cli' ).rawHandler( {
+			command: 'option update blogname "Ember & Oak"',
+		} as never );
+		expect( lastRemoteCommand() ).toBe(
+			`cd '/var/www/html' && 'wp' 'option' 'update' 'blogname' 'Ember & Oak'`
+		);
+		expect( result.content[ 0 ] ).toEqual( { type: 'text', text: 'Success: Updated.' } );
+	} );
+
+	it( 'uses the configured WP-CLI path', async () => {
+		mockResult( { stdout: 'ok' } );
+		const tool = createSshSiteTools( { ...connection, wpCliPath: '/usr/local/bin/wp' } ).find(
+			( t ) => t.name === 'wp_cli'
+		);
+		await tool!.rawHandler( { command: 'core version' } as never );
+		expect( lastRemoteCommand() ).toContain( `'/usr/local/bin/wp' 'core' 'version'` );
+	} );
+
+	it( 'rejects typographic dashes before running ssh', async () => {
+		await expect(
+			getTool( 'wp_cli' ).rawHandler( { command: 'plugin list –status=active' } as never )
+		).rejects.toThrow( /ASCII hyphens/ );
+		expect( execSshMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'throws with output and guidance on failure', async () => {
+		mockResult( { stderr: 'Error: Plugin not found.', exitCode: 1 } );
+		await expect(
+			getTool( 'wp_cli' ).rawHandler( { command: 'plugin activate nope' } as never )
+		).rejects.toThrow( /Plugin not found/ );
+	} );
+} );

--- a/apps/cli/ai/tests/system-prompt.test.ts
+++ b/apps/cli/ai/tests/system-prompt.test.ts
@@ -13,6 +13,12 @@ const remoteSite = {
 	id: 123,
 };
 
+const sshSite = {
+	name: 'SSH Studio Test',
+	url: 'https://example.com',
+	remotePath: '/var/www/html',
+};
+
 function extractReferencedSkillNames( prompt: string ): string[] {
 	return [
 		...new Set( Array.from( prompt.matchAll( /`([a-z0-9-]+)` skill/g ), ( match ) => match[ 1 ] ) ),
@@ -80,6 +86,27 @@ describe( 'buildSystemPrompt', () => {
 		expect( prompt ).not.toContain( '## Common wp/v2 Endpoints' );
 	} );
 
+	it( 'routes SSH-site guidance to the ssh remote management skill', () => {
+		const prompt = buildSystemPrompt( { sshSite } );
+
+		expect( prompt ).toContain( 'ssh-remote-management' );
+		expect( prompt ).toContain( 'remote WordPress site: "SSH Studio Test"' );
+		expect( prompt ).toContain( 'WordPress root: /var/www/html' );
+		expect( prompt ).toContain( 'LIVE PRODUCTION' );
+		expect( prompt ).toContain( 'wp_cli' );
+		expect( prompt ).not.toContain( 'wpcom_request' );
+		// No plan gating on SSH sites.
+		expect( prompt ).not.toContain( 'plan.product_slug' );
+		expect( prompt ).not.toContain( '## Design capabilities by plan' );
+	} );
+
+	it( 'prefers the WP.com remote prompt when both remote and SSH contexts are set', () => {
+		const prompt = buildSystemPrompt( { remoteSite, sshSite } );
+
+		expect( prompt ).toContain( 'wpcom_request' );
+		expect( prompt ).not.toContain( 'ssh-remote-management' );
+	} );
+
 	it( 'guards plan/pricing/feature answers behind the hosting-plans-helper skill (local)', () => {
 		const prompt = buildSystemPrompt( { chatArtifactsEnabled: true } );
 
@@ -100,6 +127,7 @@ describe( 'buildSystemPrompt', () => {
 		const prompts = [
 			buildSystemPrompt( { chatArtifactsEnabled: true } ),
 			buildSystemPrompt( { remoteSite } ),
+			buildSystemPrompt( { sshSite } ),
 		];
 		const availableSkillNames = new Set( loadSkills().map( ( skill ) => skill.name ) );
 		const missingSkillNames = prompts

--- a/apps/cli/ai/tools/ssh-site-tools.ts
+++ b/apps/cli/ai/tools/ssh-site-tools.ts
@@ -1,0 +1,322 @@
+import path from 'path';
+import { Type } from 'typebox';
+import {
+	buildRemoteShellCommand,
+	describeSshFailure,
+	ensureRelativeSitePath,
+	execSsh,
+	shellQuote,
+	type SshConnection,
+	type SshExecOptions,
+} from 'cli/lib/ssh';
+import { defineTool } from './define-tool';
+import { textResult } from './utils';
+import { getUnsupportedWpCliOptionMessage, splitCommandArgs } from './wp-cli';
+
+/**
+ * Agent tools for a third-party WordPress site managed over SSH. Each tool is
+ * bound to one saved connection and executes on the remote server through the
+ * system `ssh` binary. There is deliberately no general-purpose remote Bash
+ * tool: the agent gets WP-CLI plus file operations jailed to the WordPress
+ * root, nothing else.
+ *
+ * The file tools reuse the local tool names (Read/Write/Edit/Grep/Glob/Ls) so
+ * the agent's habits — and Studio's per-tool payload guards, which are keyed
+ * by tool name — carry over unchanged.
+ */
+
+const FILE_READ_MAX_BYTES = 100 * 1024;
+const LISTING_MAX_LINES = 500;
+
+interface RunRemoteOptions extends SshExecOptions {
+	// When set, a non-zero exit code produces this error prefix + stderr.
+	errorContext?: string;
+}
+
+async function runRemote(
+	connection: SshConnection,
+	command: string,
+	options: RunRemoteOptions = {}
+): Promise< string > {
+	const { errorContext, ...execOptions } = options;
+	const result = await execSsh(
+		connection,
+		buildRemoteShellCommand( connection, command ),
+		execOptions
+	);
+	if ( result.exitCode !== 0 ) {
+		const failure = describeSshFailure( result, connection );
+		throw new Error( errorContext ? `${ errorContext }: ${ failure }` : failure );
+	}
+	return result.stdout;
+}
+
+// Remote commands `cd` into the WordPress root, so file paths stay relative.
+function quotedSitePath( relativePath: string ): string {
+	return shellQuote( ensureRelativeSitePath( relativePath ) );
+}
+
+const RELATIVE_PATH_DESCRIPTION =
+	'File path relative to the WordPress root of the remote site, e.g. "wp-content/themes/mytheme/style.css".';
+
+export function createSshReadTool( connection: SshConnection ) {
+	return defineTool(
+		'Read',
+		`Reads a file from the remote WordPress site over SSH. Paths are relative to the WordPress root (${ connection.remotePath }). Files larger than ${ FILE_READ_MAX_BYTES } bytes are rejected — use Grep to locate the relevant part instead.`,
+		{
+			path: Type.String( { description: RELATIVE_PATH_DESCRIPTION } ),
+		},
+		async ( args ) => {
+			const stdout = await runRemote( connection, `cat -- ${ quotedSitePath( args.path ) }`, {
+				maxOutputBytes: FILE_READ_MAX_BYTES,
+				errorContext: `Failed to read ${ args.path }`,
+			} );
+			return textResult( stdout );
+		}
+	);
+}
+
+async function writeRemoteFile(
+	connection: SshConnection,
+	relativePath: string,
+	content: string
+): Promise< void > {
+	const sitePath = ensureRelativeSitePath( relativePath );
+	const directory = path.posix.dirname( sitePath );
+	await runRemote(
+		connection,
+		`mkdir -p -- ${ shellQuote( directory ) } && cat > ${ shellQuote( sitePath ) }`,
+		{ stdin: content, errorContext: `Failed to write ${ relativePath }` }
+	);
+}
+
+export function createSshWriteTool( connection: SshConnection ) {
+	return defineTool(
+		'Write',
+		`Writes a file on the remote WordPress site over SSH, creating parent directories as needed and overwriting any existing file. Paths are relative to the WordPress root (${ connection.remotePath }).`,
+		{
+			path: Type.String( { description: RELATIVE_PATH_DESCRIPTION } ),
+			content: Type.String( { description: 'The full content to write to the file.' } ),
+		},
+		async ( args ) => {
+			await writeRemoteFile( connection, args.path, args.content );
+			return textResult( `Wrote ${ args.path }` );
+		}
+	);
+}
+
+function countOccurrences( haystack: string, needle: string ): number {
+	if ( ! needle ) {
+		return 0;
+	}
+	return haystack.split( needle ).length - 1;
+}
+
+export function createSshEditTool( connection: SshConnection ) {
+	return defineTool(
+		'Edit',
+		`Performs an exact string replacement in a file on the remote WordPress site over SSH. old_string must match the file content exactly (including whitespace) and must be unique in the file unless replace_all is true. Paths are relative to the WordPress root (${ connection.remotePath }).`,
+		{
+			path: Type.String( { description: RELATIVE_PATH_DESCRIPTION } ),
+			old_string: Type.String( { description: 'The exact text to replace.' } ),
+			new_string: Type.String( { description: 'The replacement text.' } ),
+			replace_all: Type.Optional(
+				Type.Boolean( {
+					description: 'Replace every occurrence of old_string instead of exactly one.',
+				} )
+			),
+		},
+		async ( args ) => {
+			if ( args.old_string === args.new_string ) {
+				throw new Error( 'old_string and new_string must be different.' );
+			}
+			const content = await runRemote( connection, `cat -- ${ quotedSitePath( args.path ) }`, {
+				maxOutputBytes: FILE_READ_MAX_BYTES,
+				errorContext: `Failed to read ${ args.path }`,
+			} );
+			const occurrences = countOccurrences( content, args.old_string );
+			if ( occurrences === 0 ) {
+				throw new Error( `old_string was not found in ${ args.path }.` );
+			}
+			if ( occurrences > 1 && ! args.replace_all ) {
+				throw new Error(
+					`old_string occurs ${ occurrences } times in ${ args.path }. Provide a longer, unique old_string or set replace_all to true.`
+				);
+			}
+			const updated = args.replace_all
+				? content.split( args.old_string ).join( args.new_string )
+				: content.replace( args.old_string, args.new_string );
+			await writeRemoteFile( connection, args.path, updated );
+			return textResult(
+				`Replaced ${ args.replace_all ? occurrences : 1 } occurrence(s) in ${ args.path }`
+			);
+		}
+	);
+}
+
+// Listing/search commands are piped through `head` on the remote, so the exit
+// code is head's; success/no-match are distinguished by output, and remote
+// errors by stderr.
+async function runRemoteListing(
+	connection: SshConnection,
+	command: string,
+	noMatchMessage: string
+): Promise< string > {
+	const result = await execSsh(
+		connection,
+		buildRemoteShellCommand( connection, `${ command } | head -n ${ LISTING_MAX_LINES }` ),
+		{ maxOutputBytes: FILE_READ_MAX_BYTES }
+	);
+	if ( result.exitCode !== 0 ) {
+		throw new Error( describeSshFailure( result, connection ) );
+	}
+	const stdout = result.stdout.trim();
+	if ( ! stdout ) {
+		const stderr = result.stderr.trim();
+		if ( stderr ) {
+			throw new Error( stderr );
+		}
+		return noMatchMessage;
+	}
+	return stdout;
+}
+
+export function createSshGrepTool( connection: SshConnection ) {
+	return defineTool(
+		'Grep',
+		`Searches file contents on the remote WordPress site over SSH using extended regular expressions (grep -E). Returns matching lines with file names and line numbers, capped at ${ LISTING_MAX_LINES } lines. Paths are relative to the WordPress root (${ connection.remotePath }).`,
+		{
+			pattern: Type.String( { description: 'Extended regular expression to search for.' } ),
+			path: Type.Optional(
+				Type.String( {
+					description:
+						'Directory or file to search, relative to the WordPress root. Defaults to the whole site.',
+				} )
+			),
+			include: Type.Optional(
+				Type.String( {
+					description: 'Only search files matching this glob, e.g. "*.php" or "*.css".',
+				} )
+			),
+		},
+		async ( args ) => {
+			const searchPath = quotedSitePath( args.path ?? '.' );
+			const include = args.include ? ` --include=${ shellQuote( args.include ) }` : '';
+			const command = `grep -rn -I -E${ include } -e ${ shellQuote(
+				args.pattern
+			) } -- ${ searchPath }`;
+			const output = await runRemoteListing( connection, command, 'No matches found.' );
+			return textResult( output );
+		}
+	);
+}
+
+export function createSshGlobTool( connection: SshConnection ) {
+	return defineTool(
+		'Glob',
+		`Finds files by name pattern on the remote WordPress site over SSH, capped at ${ LISTING_MAX_LINES } results. Use a bare pattern like "*.php" to match file names anywhere under the search path, or a slash-separated pattern like "wp-content/themes/*/functions.php" to match whole paths.`,
+		{
+			pattern: Type.String( {
+				description:
+					'File name glob (e.g. "*.css") or path glob (e.g. "wp-content/plugins/*/readme.txt").',
+			} ),
+			path: Type.Optional(
+				Type.String( {
+					description:
+						'Directory to search, relative to the WordPress root. Defaults to the whole site.',
+				} )
+			),
+		},
+		async ( args ) => {
+			const base = ensureRelativeSitePath( args.path ?? '.' );
+			// `find -path` matches the full emitted path (which starts with the
+			// search base), so anchor path-style patterns there; `**` has no
+			// meaning to find — a plain `*` already crosses directory boundaries
+			// in -path matching.
+			const matcher = args.pattern.includes( '/' )
+				? `-path ${ shellQuote( `${ base }/${ args.pattern.replace( /\*\*/g, '*' ) }` ) }`
+				: `-name ${ shellQuote( args.pattern ) }`;
+			const command = `find ${ shellQuote( base ) } -type f ${ matcher }`;
+			const output = await runRemoteListing( connection, command, 'No files found.' );
+			return textResult( output );
+		}
+	);
+}
+
+export function createSshLsTool( connection: SshConnection ) {
+	return defineTool(
+		'Ls',
+		`Lists a directory on the remote WordPress site over SSH (ls -la, capped at ${ LISTING_MAX_LINES } entries). Paths are relative to the WordPress root (${ connection.remotePath }).`,
+		{
+			path: Type.Optional(
+				Type.String( {
+					description: 'Directory to list, relative to the WordPress root. Defaults to the root.',
+				} )
+			),
+		},
+		async ( args ) => {
+			const command = `ls -la -- ${ quotedSitePath( args.path ?? '.' ) }`;
+			const output = await runRemoteListing( connection, command, 'Empty directory.' );
+			return textResult( output );
+		}
+	);
+}
+
+export function createSshWpCliTool( connection: SshConnection ) {
+	return defineTool(
+		'wp_cli',
+		`Runs a WP-CLI command on the remote WordPress site over SSH (in ${ connection.remotePath }). ` +
+			'Examples: "plugin list --status=active", "option get blogname", "post list --post_type=page". ' +
+			'Arguments are passed literally — shell substitution, pipes, and redirection are not available.',
+		{
+			command: Type.String( {
+				description:
+					'The WP-CLI command to run (without the "wp" prefix). Example: "plugin list --status=active"',
+			} ),
+		},
+		async ( args ) => {
+			const wpCliArgs = splitCommandArgs( args.command );
+			const unsupportedOptionMessage = getUnsupportedWpCliOptionMessage( wpCliArgs );
+			if ( unsupportedOptionMessage ) {
+				throw new Error( unsupportedOptionMessage );
+			}
+
+			const wp = shellQuote( connection.wpCliPath ?? 'wp' );
+			const remoteCommand = [ wp, ...wpCliArgs.map( shellQuote ) ].join( ' ' );
+			const result = await execSsh(
+				connection,
+				buildRemoteShellCommand( connection, remoteCommand ),
+				{}
+			);
+
+			let output = '';
+			if ( result.stdout ) {
+				output += result.stdout;
+			}
+			if ( result.stderr ) {
+				output += ( output ? '\n' : '' ) + `stderr: ${ result.stderr }`;
+			}
+			if ( result.exitCode !== 0 ) {
+				throw new Error(
+					`Failed to run WP-CLI command: ${ output ? `${ output }\n` : '' }${ describeSshFailure(
+						result,
+						connection
+					) }`
+				);
+			}
+			return textResult( output || 'Command completed with no output.' );
+		}
+	);
+}
+
+export function createSshSiteTools( connection: SshConnection ) {
+	return [
+		createSshWpCliTool( connection ),
+		createSshReadTool( connection ),
+		createSshWriteTool( connection ),
+		createSshEditTool( connection ),
+		createSshGrepTool( connection ),
+		createSshGlobTool( connection ),
+		createSshLsTool( connection ),
+	];
+}

--- a/apps/cli/ai/tools/wp-cli.ts
+++ b/apps/cli/ai/tools/wp-cli.ts
@@ -94,7 +94,7 @@ function splitPostContentCommandArgs( command: string, postContentIndex: number 
 	];
 }
 
-function splitCommandArgs( command: string ): string[] {
+export function splitCommandArgs( command: string ): string[] {
 	const postContentMarker = '--post_content=';
 	const postContentIndex = command.indexOf( postContentMarker );
 
@@ -107,7 +107,7 @@ function splitCommandArgs( command: string ): string[] {
 
 // LLMs sometimes emit en/em dashes (`‐porcelain`, `–color`); WP-CLI silently
 // ignores them, so reject up-front and let the agent retry with ASCII hyphens.
-function getUnsupportedWpCliOptionMessage( args: string[] ): string | null {
+export function getUnsupportedWpCliOptionMessage( args: string[] ): string | null {
 	const unsupportedOption = args.find( ( arg ) => /^[‐-―]\S+/.test( arg ) );
 	if ( ! unsupportedOption ) {
 		return null;

--- a/apps/cli/ai/types.ts
+++ b/apps/cli/ai/types.ts
@@ -15,4 +15,9 @@ export interface SiteInfo {
 	remote?: boolean;
 	url?: string;
 	wpcomSiteId?: number;
+	// SSH sites are flagged `remote` like WP.com sites but carry the id of
+	// their saved connection in cli.json; the connection details are resolved
+	// from the config at turn time and never stored on SiteInfo.
+	sshSite?: boolean;
+	sshSiteId?: string;
 }

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import {
 	TUI,
 	ProcessTerminal,
@@ -34,9 +35,17 @@ import { AI_PROVIDERS, DEFAULT_AI_PROVIDER, type AiProviderId } from 'cli/ai/pro
 import { getActiveSlashCommands } from 'cli/ai/slash-commands';
 import { getWpComSites } from 'cli/lib/api';
 import { openBrowser } from 'cli/lib/browser';
-import { readCliConfig, type SiteData } from 'cli/lib/cli-config/core';
+import {
+	lockCliConfig,
+	readCliConfig,
+	saveCliConfig,
+	unlockCliConfig,
+	type SiteData,
+	type SshSiteData,
+} from 'cli/lib/cli-config/core';
 import { getSiteUrl } from 'cli/lib/cli-config/sites';
 import { getSitesRunningStatus, isSiteRunning } from 'cli/lib/site-utils';
+import { isValidSshDestination, probeSshWordPressSite } from 'cli/lib/ssh';
 import { formatTosNoticeLines } from 'cli/lib/tos-notice';
 import type { ToolResultMessage } from '@earendil-works/pi-ai';
 import type { AgentSessionEvent } from '@earendil-works/pi-coding-agent';
@@ -44,7 +53,25 @@ import type { AskUserQuestion, SiteInfo } from 'cli/ai/types';
 
 const SITE_PICKER_TAB_LOCAL = 'local' as const;
 const SITE_PICKER_TAB_REMOTE = 'remote' as const;
-type SitePickerTab = typeof SITE_PICKER_TAB_LOCAL | typeof SITE_PICKER_TAB_REMOTE;
+const SITE_PICKER_TAB_SSH = 'ssh' as const;
+type SitePickerTab =
+	| typeof SITE_PICKER_TAB_LOCAL
+	| typeof SITE_PICKER_TAB_REMOTE
+	| typeof SITE_PICKER_TAB_SSH;
+
+const SSH_ADD_NEW_VALUE = '__add_new_ssh_site__';
+
+function sshSiteDataToSiteInfo( site: SshSiteData ): SiteInfo {
+	return {
+		name: site.name,
+		path: '',
+		running: false,
+		remote: true,
+		url: site.url,
+		sshSite: true,
+		sshSiteId: site.id,
+	};
+}
 
 const sitePickerTheme: SelectListTheme = {
 	selectedPrefix: ( text ) => chalk.blue( text ),
@@ -339,6 +366,8 @@ export class AiChatUI implements AiOutputAdapter {
 	private sitePickerTab: SitePickerTab = SITE_PICKER_TAB_LOCAL;
 	private sitePickerRemoteItems: SiteInfo[] = [];
 	private sitePickerRemoteLoading = false;
+	private sitePickerRemoteError: string | null = null;
+	private sitePickerSshItems: SiteInfo[] = [];
 	private sitePickerQuery = '';
 
 	get activeSite(): SiteInfo | null {
@@ -568,13 +597,25 @@ export class AiChatUI implements AiOutputAdapter {
 					void this.openSelectedSite();
 					return { consume: true };
 				}
-				if ( matchesKey( data, 'right' ) && this.sitePickerTab === SITE_PICKER_TAB_LOCAL ) {
-					void this.switchToRemoteSites();
-					return { consume: true };
+				if ( matchesKey( data, 'right' ) ) {
+					if ( this.sitePickerTab === SITE_PICKER_TAB_LOCAL ) {
+						void this.switchToRemoteSites();
+						return { consume: true };
+					}
+					if ( this.sitePickerTab === SITE_PICKER_TAB_REMOTE ) {
+						this.switchToSshSites();
+						return { consume: true };
+					}
 				}
-				if ( matchesKey( data, 'left' ) && this.sitePickerTab === SITE_PICKER_TAB_REMOTE ) {
-					this.switchToLocalSites();
-					return { consume: true };
+				if ( matchesKey( data, 'left' ) ) {
+					if ( this.sitePickerTab === SITE_PICKER_TAB_SSH ) {
+						void this.switchToRemoteSites();
+						return { consume: true };
+					}
+					if ( this.sitePickerTab === SITE_PICKER_TAB_REMOTE ) {
+						this.switchToLocalSites();
+						return { consume: true };
+					}
 				}
 				if ( matchesKey( data, 'escape' ) ) {
 					if ( this.sitePickerQuery ) {
@@ -587,6 +628,8 @@ export class AiChatUI implements AiOutputAdapter {
 				if ( matchesKey( data, 'backspace' ) ) {
 					if ( this.sitePickerQuery ) {
 						this.setSitePickerQuery( this.sitePickerQuery.slice( 0, -1 ) );
+					} else if ( this.sitePickerTab === SITE_PICKER_TAB_SSH ) {
+						void this.confirmDeleteSshSite();
 					}
 					return { consume: true };
 				}
@@ -624,7 +667,8 @@ export class AiChatUI implements AiOutputAdapter {
 	private async openSitePicker(): Promise< void > {
 		const config = await readCliConfig();
 		const sites: SiteData[] = config.sites ?? [];
-		if ( sites.length === 0 ) {
+		const sshSites: SshSiteData[] = config.sshSites ?? [];
+		if ( sites.length === 0 && sshSites.length === 0 ) {
 			this.messages.addChild(
 				new Text( chalk.dim( '  ' + __( 'No sites found. Create one first.' ) ), 1, 0 )
 			);
@@ -639,6 +683,7 @@ export class AiChatUI implements AiOutputAdapter {
 			path: site.path,
 			running: runningStatus.get( site.id ) ?? false,
 		} ) );
+		this.sitePickerSshItems = sshSites.map( ( site ) => sshSiteDataToSiteInfo( site ) );
 		this.sitePickerVisible = true;
 		this.editor.showBottomBar = false;
 		this.sitePickerContainer = new Container();
@@ -677,25 +722,213 @@ export class AiChatUI implements AiOutputAdapter {
 		}
 	}
 
+	// Shows the error inline on the WordPress.com tab (instead of closing or
+	// resetting the picker) so ←/→ navigation to the other tabs keeps working —
+	// the SSH tab must stay reachable without a WordPress.com login.
 	private showSitePickerError( message: string ): void {
-		this.resetSitePickerTab( SITE_PICKER_TAB_LOCAL );
-		this.sitePickerRemoteItems = [];
+		this.sitePickerRemoteLoading = false;
+		this.sitePickerRemoteError = message;
 		this.rebuildSitePickerList();
 		this.renderSitePicker();
-		this.messages.addChild( new Text( `\n${ chalk.dim( message ) }\n`, 1, 0 ) );
-		this.tui.requestRender();
 	}
 
 	private resetSitePickerTab( tab: SitePickerTab ): void {
 		this.sitePickerTab = tab;
 		this.sitePickerQuery = '';
 		this.sitePickerRemoteLoading = false;
+		this.sitePickerRemoteError = null;
 	}
 
 	private switchToLocalSites(): void {
 		this.resetSitePickerTab( SITE_PICKER_TAB_LOCAL );
 		this.rebuildSitePickerList();
 		this.renderSitePicker();
+	}
+
+	private switchToSshSites(): void {
+		this.resetSitePickerTab( SITE_PICKER_TAB_SSH );
+		this.rebuildSitePickerList();
+		this.renderSitePicker();
+	}
+
+	// `askUser` ends each call by starting a "thinking" loader because it is
+	// built for mid-agent-turn questions. The SSH connect/delete flows use it
+	// for plain input outside any agent turn, so the loader would be left
+	// spinning ("Drafting…") after they finish. These wrappers clear it on every
+	// exit path — success, validation error, or connection failure.
+	private async confirmDeleteSshSite(): Promise< void > {
+		try {
+			await this.confirmDeleteSshSiteFlow();
+		} finally {
+			this.hideLoader();
+		}
+	}
+
+	private async confirmDeleteSshSiteFlow(): Promise< void > {
+		const selectedItem = this.sitePickerSelectList?.getSelectedItem();
+		if ( ! selectedItem || selectedItem.value === SSH_ADD_NEW_VALUE ) {
+			return;
+		}
+		const site = this.sitePickerItemMap.get( selectedItem.value );
+		if ( ! site?.sshSite ) {
+			return;
+		}
+
+		this.closeSitePicker();
+		const answers = await this.askUser( [
+			{
+				question: sprintf(
+					/* translators: %s: site name */
+					__( 'Remove "%s" from saved sites?' ),
+					site.name
+				),
+				options: [
+					{ label: __( 'Yes' ), description: __( 'Remove this site' ) },
+					{ label: __( 'No' ), description: __( 'Keep this site' ) },
+				],
+			},
+		] );
+		const answer = Object.values( answers )[ 0 ]?.toLowerCase();
+		if ( answer !== __( 'yes' ).toLowerCase() ) {
+			return;
+		}
+		try {
+			await lockCliConfig();
+			const config = await readCliConfig();
+			config.sshSites = ( config.sshSites ?? [] ).filter( ( s ) => s.id !== site.sshSiteId );
+			await saveCliConfig( config );
+		} finally {
+			await unlockCliConfig();
+		}
+		// Clear the active site if we just deleted it
+		if ( this._activeSite?.sshSite && this._activeSite?.sshSiteId === site.sshSiteId ) {
+			this.clearActiveSite();
+		}
+		this.showInfo(
+			sprintf(
+				/* translators: %s: site name */
+				__( 'Removed "%s"' ),
+				site.name
+			)
+		);
+	}
+
+	private async connectSshSite(): Promise< void > {
+		try {
+			await this.connectSshSiteFlow();
+		} finally {
+			this.hideLoader();
+		}
+	}
+
+	private async connectSshSiteFlow(): Promise< void > {
+		this.closeSitePicker();
+
+		this.showInfo(
+			__(
+				'To connect a WordPress site over SSH, you need:\n' +
+					'  - key-based SSH access to the server (`ssh user@host` must work without a password prompt),\n' +
+					'  - WP-CLI installed on the server (https://wp-cli.org).'
+			)
+		);
+
+		const destinationAnswers = await this.askUser( [
+			{
+				question: __( 'SSH destination (user@host, user@host:2222, or an ~/.ssh/config alias)' ),
+				options: [],
+				allowFreeForm: true,
+			},
+		] );
+		const destinationInput = Object.values( destinationAnswers )[ 0 ]?.trim() ?? '';
+		if ( ! destinationInput ) {
+			this.showError( __( 'SSH destination is required.' ) );
+			return;
+		}
+		// A trailing `:2222` selects a non-default port.
+		let destination = destinationInput;
+		let port: number | undefined;
+		const portMatch = destinationInput.match( /^(.+):(\d{1,5})$/ );
+		if ( portMatch ) {
+			destination = portMatch[ 1 ];
+			port = Number.parseInt( portMatch[ 2 ], 10 );
+			if ( port <= 0 || port > 65535 ) {
+				this.showError( __( 'Invalid SSH port.' ) );
+				return;
+			}
+		}
+		if ( ! isValidSshDestination( destination ) ) {
+			this.showError(
+				__(
+					'Invalid SSH destination. Use "host", "user@host", "user@host:2222", or an ~/.ssh/config alias.'
+				)
+			);
+			return;
+		}
+
+		const pathAnswers = await this.askUser( [
+			{
+				question: __( 'WordPress root path on the server (e.g. /var/www/html or public_html)' ),
+				options: [],
+				allowFreeForm: true,
+			},
+		] );
+		const remotePath = Object.values( pathAnswers )[ 0 ]?.trim() ?? '';
+		if ( ! remotePath ) {
+			this.showError( __( 'WordPress root path is required.' ) );
+			return;
+		}
+
+		// One SSH round-trip validates reachability, key auth, WP-CLI presence,
+		// and the WordPress root, and reads the site URL and name.
+		this.showInfo( __( 'Connecting…' ) );
+		let homeUrl: string;
+		let siteName: string;
+		try {
+			const probe = await probeSshWordPressSite( { destination, port, remotePath } );
+			homeUrl = probe.homeUrl;
+			siteName = probe.siteName;
+		} catch ( error ) {
+			this.showError(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Connection failed: %s' ),
+					error instanceof Error ? error.message : String( error )
+				)
+			);
+			return;
+		}
+
+		const newSite: SshSiteData = {
+			id: randomUUID(),
+			name: siteName,
+			url: homeUrl,
+			destination,
+			port,
+			remotePath,
+		};
+
+		try {
+			await lockCliConfig();
+			const config = await readCliConfig();
+			config.sshSites = [ ...( config.sshSites ?? [] ), newSite ];
+			await saveCliConfig( config );
+		} finally {
+			await unlockCliConfig();
+		}
+
+		this._activeSiteData = null;
+		this.setActiveSite( sshSiteDataToSiteInfo( newSite ) );
+	}
+
+	private handleSshSitePickerSelect( item: SelectItem ): void {
+		if ( item.value === SSH_ADD_NEW_VALUE ) {
+			void this.connectSshSite();
+			return;
+		}
+		const site = this.sitePickerItemMap.get( item.value );
+		if ( site ) {
+			this.selectFilteredSite( site );
+		}
 	}
 
 	private setSitePickerQuery( query: string ): void {
@@ -717,6 +950,13 @@ export class AiChatUI implements AiOutputAdapter {
 	}
 
 	private siteInfoToSelectItem( site: SiteInfo ): SelectItem {
+		if ( site.sshSite ) {
+			return {
+				value: site.sshSiteId ?? site.url ?? site.name,
+				label: site.name,
+				description: site.url?.replace( /^https?:\/\//, '' ),
+			};
+		}
 		if ( site.remote ) {
 			return {
 				value: site.url ?? site.name,
@@ -732,10 +972,14 @@ export class AiChatUI implements AiOutputAdapter {
 	}
 
 	private rebuildSitePickerList(): void {
-		const allItems =
-			this.sitePickerTab === SITE_PICKER_TAB_REMOTE
-				? this.sitePickerRemoteItems
-				: this.sitePickerItems;
+		let allItems: SiteInfo[];
+		if ( this.sitePickerTab === SITE_PICKER_TAB_REMOTE ) {
+			allItems = this.sitePickerRemoteItems;
+		} else if ( this.sitePickerTab === SITE_PICKER_TAB_SSH ) {
+			allItems = this.sitePickerSshItems;
+		} else {
+			allItems = this.sitePickerItems;
+		}
 		const filtered = this.sitePickerQuery
 			? allItems.filter( ( site ) => {
 					const query = this.sitePickerQuery.toLowerCase();
@@ -749,14 +993,29 @@ export class AiChatUI implements AiOutputAdapter {
 		this.sitePickerItemMap = new Map(
 			filtered.map( ( site, i ) => [ selectItems[ i ].value, site ] )
 		);
+
+		// Append the "Add new site" entry for the SSH tab
+		if ( this.sitePickerTab === SITE_PICKER_TAB_SSH ) {
+			selectItems.push( {
+				value: SSH_ADD_NEW_VALUE,
+				label: `${ chalk.green( '+' ) } ${ __( 'Add new site' ) }`,
+			} );
+		}
+
 		const maxVisible = Math.max( 5, ( process.stdout.rows ?? 24 ) - 4 );
 		this.sitePickerSelectList = new SelectList( selectItems, maxVisible, sitePickerTheme );
-		this.sitePickerSelectList.onSelect = ( item ) => {
-			const site = this.sitePickerItemMap.get( item.value );
-			if ( site ) {
-				this.selectFilteredSite( site );
-			}
-		};
+		if ( this.sitePickerTab === SITE_PICKER_TAB_SSH ) {
+			this.sitePickerSelectList.onSelect = ( item ) => {
+				this.handleSshSitePickerSelect( item );
+			};
+		} else {
+			this.sitePickerSelectList.onSelect = ( item ) => {
+				const site = this.sitePickerItemMap.get( item.value );
+				if ( site ) {
+					this.selectFilteredSite( site );
+				}
+			};
+		}
 		this.sitePickerSelectList.onCancel = () => {
 			this.closeSitePicker();
 		};
@@ -768,31 +1027,39 @@ export class AiChatUI implements AiOutputAdapter {
 		}
 		this.sitePickerContainer.clear();
 
-		const isLocal = this.sitePickerTab === SITE_PICKER_TAB_LOCAL;
-		const localTab = isLocal ? chalk.bold( __( '[Local]' ) ) : chalk.dim( __( 'Local' ) );
-		const remoteTab = isLocal ? chalk.dim( 'WordPress.com' ) : chalk.bold( '[WordPress.com]' );
+		const currentTab = this.sitePickerTab;
+		const tabLabel = ( label: string, active: boolean ) =>
+			active ? chalk.bold( `[${ label }]` ) : chalk.dim( label );
+		const localTab = tabLabel( __( 'Local' ), currentTab === SITE_PICKER_TAB_LOCAL );
+		const remoteTab = tabLabel( 'WordPress.com', currentTab === SITE_PICKER_TAB_REMOTE );
+		const sshTab = tabLabel( __( 'SSH' ), currentTab === SITE_PICKER_TAB_SSH );
 		const pad = ' ';
-		const header = `${ pad }${ localTab }  ${ remoteTab }`;
+		const header = `${ pad }${ localTab }  ${ remoteTab }  ${ sshTab }`;
 
 		const searchLine = this.sitePickerQuery
 			? `${ pad }${ chalk.dim( __( 'Search:' ) ) } ${ this.sitePickerQuery }`
 			: '';
 
-		const hints = isLocal
-			? `${ pad }${ __(
-					'↑↓ navigate · → remote sites · enter select · tab open in browser · esc cancel'
-			  ) }`
-			: `${ pad }${ __(
-					'↑↓ navigate · ← local sites · enter select · tab open in browser · esc cancel'
-			  ) }`;
+		let hints: string;
+		if ( currentTab === SITE_PICKER_TAB_SSH ) {
+			hints = `${ pad }${ __(
+				'↑↓ navigate · ←→ switch tabs · enter select · backspace remove · esc cancel'
+			) }`;
+		} else {
+			hints = `${ pad }${ __(
+				'↑↓ navigate · ←→ switch tabs · enter select · tab open in browser · esc cancel'
+			) }`;
+		}
 
 		const lines = [ header, '' ];
 		if ( searchLine ) {
 			lines.push( searchLine, '' );
 		}
 
-		if ( ! isLocal && this.sitePickerRemoteLoading ) {
+		if ( currentTab === SITE_PICKER_TAB_REMOTE && this.sitePickerRemoteLoading ) {
 			lines.push( chalk.dim( `${ pad }  ${ __( 'Loading WordPress.com sites…' ) }` ) );
+		} else if ( currentTab === SITE_PICKER_TAB_REMOTE && this.sitePickerRemoteError ) {
+			lines.push( chalk.dim( `${ pad }  ${ this.sitePickerRemoteError }` ) );
 		} else if ( this.sitePickerSelectList ) {
 			const termWidth = process.stdout.columns ?? 80;
 			lines.push(
@@ -813,17 +1080,26 @@ export class AiChatUI implements AiOutputAdapter {
 		this._activeSite = site;
 		this.editor.activeSiteName = site.name;
 		this.refreshPromptChrome();
-		const label = site.remote
-			? sprintf(
-					/* translators: %s: site name */
-					__( ' Selected site: %s (WordPress.com)' ),
-					site.name
-			  )
-			: sprintf(
-					/* translators: %s: site name */
-					__( ' Selected site: %s' ),
-					site.name
-			  );
+		let label: string;
+		if ( site.sshSite ) {
+			label = sprintf(
+				/* translators: %s: site name */
+				__( ' Selected site: %s (SSH)' ),
+				site.name
+			);
+		} else if ( site.remote ) {
+			label = sprintf(
+				/* translators: %s: site name */
+				__( ' Selected site: %s (WordPress.com)' ),
+				site.name
+			);
+		} else {
+			label = sprintf(
+				/* translators: %s: site name */
+				__( ' Selected site: %s' ),
+				site.name
+			);
+		}
 		if ( announce ) {
 			this.messages.addChild( new Text( `\n${ chalk.hex( '#8839ef' )( label ) }\n`, 0, 0 ) );
 		}
@@ -1013,6 +1289,7 @@ export class AiChatUI implements AiOutputAdapter {
 		this.sitePickerItems = [];
 		this.sitePickerSiteData = [];
 		this.sitePickerRemoteItems = [];
+		this.sitePickerSshItems = [];
 		this.sitePickerSelectList = null;
 		this.sitePickerItemMap = new Map();
 		this.resetSitePickerTab( SITE_PICKER_TAB_LOCAL );

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -36,7 +36,7 @@ import { setLocalSiteSelectedCallback } from 'cli/ai/site-selection';
 import { getActiveSlashCommands, type SlashCommandContext } from 'cli/ai/slash-commands';
 import { AiChatUI } from 'cli/ai/ui';
 import { runCommand as runLoginCommand } from 'cli/commands/auth/login';
-import { readCliConfig } from 'cli/lib/cli-config/core';
+import { readCliConfig, type SshSiteData } from 'cli/lib/cli-config/core';
 import { findSiteByFolder } from 'cli/lib/cli-config/sites';
 import { maybeShowTosNotice } from 'cli/lib/tos-notice';
 import { Logger, LoggerError, setProgressCallback } from 'cli/logger';
@@ -208,6 +208,8 @@ export async function runCommand( options: {
 				remote: site.remote,
 				url: site.url,
 				wpcomSiteId: site.wpcomSiteId,
+				sshSite: site.sshSite,
+				sshSiteId: site.sshSiteId,
 			} )
 		);
 	};
@@ -459,10 +461,12 @@ export async function runCommand( options: {
 		ui.beginAgentTurn( sessionId );
 
 		// Prepend active site context to the prompt.
-		// Remote (WordPress.com) sites only have a URL and site ID; local sites have a filesystem path and running state.
+		// Remote sites only have a URL; local sites have a filesystem path and running state.
 		let enrichedPrompt = prompt;
 		const site = ui.activeSite;
-		if ( site?.remote && site?.url ) {
+		if ( site?.sshSite && site?.url ) {
+			enrichedPrompt = `[Active site: "${ site.name }" at ${ site.url } (remote, connected over SSH)]\n\n${ prompt }`;
+		} else if ( site?.remote && site?.url ) {
 			enrichedPrompt = `[Active site: "${ site.name }" (ID: ${ site.wpcomSiteId }) at ${ site.url } (WordPress.com)]\n\n${ prompt }`;
 		} else if ( site ) {
 			enrichedPrompt = `[Active site: "${ site.name }" at ${ site.path }${
@@ -476,11 +480,34 @@ export async function runCommand( options: {
 			enrichedPrompt = `${ enrichedPrompt }${ buildAttachedFilesPromptBlock( files ) }`;
 		}
 
-		// Read the WP.com access token for remote sites
+		// Read the WP.com access token for WordPress.com remote sites
 		let wpcomAccessToken: string | undefined;
-		if ( site?.remote ) {
+		if ( site?.remote && ! site?.sshSite ) {
 			const token = await readAuthToken();
 			wpcomAccessToken = token?.accessToken;
+		}
+
+		// Resolve the saved SSH connection for SSH sites. SiteInfo only carries
+		// the connection id; the connection details live in cli.json.
+		let sshSiteConnection: SshSiteData | undefined;
+		if ( site?.sshSite ) {
+			const config = await readCliConfig();
+			const sshSites = config.sshSites ?? [];
+			sshSiteConnection =
+				sshSites.find( ( s ) => s.id === site.sshSiteId ) ??
+				sshSites.find( ( s ) => s.url === site.url );
+			if ( ! sshSiteConnection ) {
+				ui.showError(
+					sprintf(
+						/* translators: %s: site name */
+						__(
+							'No saved SSH connection found for "%s". Reconnect the site from the site picker.'
+						),
+						site.name
+					)
+				);
+				return { status: 'error', sessionId };
+			}
 		}
 
 		await persistSessionContext();
@@ -505,6 +532,7 @@ export async function runCommand( options: {
 			session: sm,
 			activeSite: site,
 			wpcomAccessToken,
+			sshSiteConnection,
 			onAskUser: ( questions ) => askUserAndPersistAnswers( questions ),
 			onEvent: ( event ) => {
 				ui.handleEvent( event );

--- a/apps/cli/lib/cli-config/core.ts
+++ b/apps/cli/lib/cli-config/core.ts
@@ -73,6 +73,25 @@ export const updateCheckSchema = z.object( {
 	latestVersion: z.string(),
 } );
 
+/**
+ * A third-party WordPress site the Studio Code agent manages over SSH.
+ * Authentication is delegated entirely to the system `ssh` binary (keys,
+ * agent, ~/.ssh/config) — no credential is ever stored here.
+ */
+export const sshSiteSchema = z.object( {
+	id: z.string(),
+	name: z.string(),
+	// Home URL read from the remote at connect time (`wp option get home`).
+	url: z.string(),
+	// SSH destination: `host`, `user@host`, or an ~/.ssh/config alias.
+	destination: z.string(),
+	port: z.number().optional(),
+	// Absolute path of the WordPress root on the remote server.
+	remotePath: z.string(),
+	// WP-CLI executable on the remote; defaults to `wp` on PATH.
+	wpCliPath: z.string().optional(),
+} );
+
 const cliConfigSchema = z.looseObject( {
 	version: z.literal( CLI_CONFIG_VERSION ),
 	sites: z.array( siteSchema ).default( () => [] ),
@@ -92,10 +111,12 @@ const cliConfigSchema = z.looseObject( {
 	standaloneUpdateCheck: updateCheckSchema.optional(),
 	// Unix ms timestamp of when the one-time ToS/Privacy notice was displayed.
 	tosNoticeShownAt: z.number().optional(),
+	sshSites: z.array( sshSiteSchema ).optional(),
 } );
 
 type CliConfig = z.infer< typeof cliConfigSchema >;
 export type SiteData = z.infer< typeof siteSchema >;
+export type SshSiteData = z.infer< typeof sshSiteSchema >;
 
 const DEFAULT_CLI_CONFIG: CliConfig = {
 	version: CLI_CONFIG_VERSION,

--- a/apps/cli/lib/ssh.ts
+++ b/apps/cli/lib/ssh.ts
@@ -1,0 +1,274 @@
+import { spawn } from 'child_process';
+import path from 'path';
+
+/**
+ * SSH transport for third-party WordPress sites.
+ *
+ * Studio delegates the entire connection to the system `ssh` binary so that
+ * keys, agents, `~/.ssh/config` aliases, and jump hosts work exactly as they
+ * do in the user's terminal — no credential is stored or handled by Studio.
+ * Commands run non-interactively (`BatchMode=yes`) so a missing key fails
+ * fast instead of hanging the TUI on a password prompt.
+ *
+ * Each command is a one-off connection. We deliberately do NOT use
+ * `ControlMaster`/`ControlPersist` multiplexing: a persistent master lingers
+ * in the background holding the command's stdout/stderr pipes open, so Node's
+ * child `close` event never fires until the master expires (up to
+ * `ControlPersist` seconds) — which froze the agent for minutes on the first
+ * remote tool call. Reconnecting per command is cheap and non-interactive when
+ * the key is loaded in ssh-agent. Turn-scoped connection reuse could be
+ * reintroduced later, but only via a master whose stdio is detached so it
+ * cannot hold command pipes.
+ */
+
+export interface SshConnection {
+	// `host`, `user@host`, or an ~/.ssh/config alias.
+	destination: string;
+	port?: number;
+	// Absolute path of the WordPress root on the remote server.
+	remotePath: string;
+	// WP-CLI executable on the remote; defaults to `wp` on PATH.
+	wpCliPath?: string;
+}
+
+export interface SshExecOptions {
+	stdin?: string;
+	timeoutMs?: number;
+	maxOutputBytes?: number;
+	spawnImplementation?: typeof spawn;
+}
+
+export interface SshExecResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number | null;
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_MAX_OUTPUT_BYTES = 512 * 1024;
+
+// `[user@]host` where host is a hostname, IPv4 address, or ssh-config alias.
+// Deliberately strict: rejects whitespace, shell metacharacters, and
+// option-injection via a leading `-`.
+const SSH_DESTINATION_PATTERN = /^(?:[A-Za-z0-9._-]+@)?[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export function isValidSshDestination( destination: string ): boolean {
+	return SSH_DESTINATION_PATTERN.test( destination );
+}
+
+// POSIX single-quoting: safe for any byte except that embedded single quotes
+// must be closed, escaped, and reopened.
+export function shellQuote( value: string ): string {
+	return `'${ value.replace( /'/g, `'\\''` ) }'`;
+}
+
+/**
+ * Normalizes an agent-supplied path relative to the WordPress root, rejecting
+ * absolute paths and `..` traversal so every file operation stays jailed to
+ * the site directory. Remote commands `cd` into the WordPress root first, so
+ * the returned path is used as-is against that working directory (this also
+ * keeps home-relative roots like `public_html` working).
+ */
+export function ensureRelativeSitePath( relativePath: string ): string {
+	const normalized = path.posix.normalize( relativePath.replace( /\\/g, '/' ) );
+	if (
+		path.posix.isAbsolute( normalized ) ||
+		normalized === '..' ||
+		normalized.startsWith( '../' )
+	) {
+		throw new Error(
+			`Path must be relative to the WordPress root and must not escape it: "${ relativePath }"`
+		);
+	}
+	return normalized;
+}
+
+export function buildSshCommandArgs(
+	connection: Pick< SshConnection, 'destination' | 'port' >,
+	remoteCommand: string
+): string[] {
+	if ( ! isValidSshDestination( connection.destination ) ) {
+		throw new Error( `Invalid SSH destination: "${ connection.destination }"` );
+	}
+
+	const args = [
+		'-o',
+		'BatchMode=yes',
+		'-o',
+		'StrictHostKeyChecking=accept-new',
+		'-o',
+		'ConnectTimeout=15',
+		'-o',
+		'LogLevel=ERROR',
+	];
+
+	if ( connection.port ) {
+		args.push( '-p', String( connection.port ) );
+	}
+
+	args.push( '--', connection.destination, remoteCommand );
+	return args;
+}
+
+/**
+ * Builds a remote command that runs inside the site's WordPress root. The
+ * caller is responsible for quoting every dynamic fragment of `command` with
+ * `shellQuote` — only `remotePath` is quoted here.
+ */
+export function buildRemoteShellCommand( connection: SshConnection, command: string ): string {
+	return `cd ${ shellQuote( connection.remotePath ) } && ${ command }`;
+}
+
+export async function execSsh(
+	connection: Pick< SshConnection, 'destination' | 'port' >,
+	remoteCommand: string,
+	options: SshExecOptions = {}
+): Promise< SshExecResult > {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+	const spawnImplementation = options.spawnImplementation ?? spawn;
+
+	const args = buildSshCommandArgs( connection, remoteCommand );
+
+	return new Promise< SshExecResult >( ( resolve, reject ) => {
+		const child = spawnImplementation( 'ssh', args, {
+			stdio: [ options.stdin === undefined ? 'ignore' : 'pipe', 'pipe', 'pipe' ],
+		} );
+
+		let stdout = '';
+		let stderr = '';
+		let outputBytes = 0;
+		let timedOut = false;
+		let truncated = false;
+		let settled = false;
+
+		const timeout = setTimeout( () => {
+			timedOut = true;
+			child.kill( 'SIGTERM' );
+			setTimeout( () => child.kill( 'SIGKILL' ), 5_000 ).unref();
+		}, timeoutMs );
+
+		const collect = ( chunk: Buffer, target: 'stdout' | 'stderr' ) => {
+			outputBytes += chunk.length;
+			if ( outputBytes > maxOutputBytes ) {
+				if ( ! truncated ) {
+					truncated = true;
+					child.kill( 'SIGTERM' );
+				}
+				return;
+			}
+			if ( target === 'stdout' ) {
+				stdout += chunk.toString( 'utf8' );
+			} else {
+				stderr += chunk.toString( 'utf8' );
+			}
+		};
+
+		child.stdout?.on( 'data', ( chunk: Buffer ) => collect( chunk, 'stdout' ) );
+		child.stderr?.on( 'data', ( chunk: Buffer ) => collect( chunk, 'stderr' ) );
+
+		child.on( 'error', ( error: NodeJS.ErrnoException ) => {
+			if ( settled ) return;
+			settled = true;
+			clearTimeout( timeout );
+			if ( error.code === 'ENOENT' ) {
+				reject(
+					new Error(
+						'The `ssh` command was not found. Install an OpenSSH client (on Windows: Settings → Apps → Optional features → OpenSSH Client) and try again.'
+					)
+				);
+				return;
+			}
+			reject( error );
+		} );
+
+		child.on( 'close', ( exitCode ) => {
+			if ( settled ) return;
+			settled = true;
+			clearTimeout( timeout );
+			if ( timedOut ) {
+				reject( new Error( `SSH command timed out after ${ Math.round( timeoutMs / 1000 ) }s` ) );
+				return;
+			}
+			if ( truncated ) {
+				reject(
+					new Error(
+						`SSH command output exceeded ${ maxOutputBytes } bytes and was aborted. Narrow the command (e.g. read a smaller range or add filters) and try again.`
+					)
+				);
+				return;
+			}
+			resolve( { stdout, stderr, exitCode } );
+		} );
+
+		if ( options.stdin !== undefined && child.stdin ) {
+			child.stdin.on( 'error', () => {
+				// EPIPE when the remote command exits before consuming stdin; the
+				// close handler reports the real outcome.
+			} );
+			child.stdin.write( options.stdin );
+			child.stdin.end();
+		}
+	} );
+}
+
+// ssh exits with 255 for its own failures (connection, auth, host key);
+// remote commands exit 127 when the shell can't find the executable.
+const SSH_TRANSPORT_EXIT_CODE = 255;
+const COMMAND_NOT_FOUND_EXIT_CODE = 127;
+
+export function describeSshFailure( result: SshExecResult, connection: SshConnection ): string {
+	const detail = result.stderr.trim() || result.stdout.trim();
+	if ( result.exitCode === SSH_TRANSPORT_EXIT_CODE ) {
+		return `Could not connect to ${ connection.destination } over SSH: ${
+			detail || 'connection failed'
+		}. Check the destination, and make sure key-based authentication works non-interactively (e.g. \`ssh ${
+			connection.destination
+		}\` in a terminal, using a key or ssh-agent — password prompts are not supported).`;
+	}
+	if ( result.exitCode === COMMAND_NOT_FOUND_EXIT_CODE ) {
+		return `WP-CLI was not found on ${ connection.destination } (${
+			detail || 'command not found'
+		}). Studio manages SSH sites through WP-CLI on the server — install it (https://wp-cli.org) or set the correct executable path for this site.`;
+	}
+	return detail || `SSH command failed with exit code ${ result.exitCode }`;
+}
+
+export interface SshWordPressProbe {
+	homeUrl: string;
+	siteName: string;
+}
+
+/**
+ * Verifies in one round-trip that the destination is reachable, WP-CLI exists,
+ * and `remotePath` is a working WordPress install — and reads the site's home
+ * URL and name while at it. Mirrors the connect-time validation used by
+ * cove.run's pull/push (`ssh <dest> "cd <path> && wp option get home"`).
+ */
+export async function probeSshWordPressSite(
+	connection: SshConnection,
+	options: SshExecOptions = {}
+): Promise< SshWordPressProbe > {
+	const wp = shellQuote( connection.wpCliPath ?? 'wp' );
+	const command = buildRemoteShellCommand(
+		connection,
+		`${ wp } option get home && ${ wp } option get blogname`
+	);
+	const result = await execSsh( connection, command, { timeoutMs: 45_000, ...options } );
+
+	if ( result.exitCode !== 0 ) {
+		throw new Error( describeSshFailure( result, connection ) );
+	}
+
+	const lines = result.stdout
+		.split( '\n' )
+		.map( ( line ) => line.trim() )
+		.filter( Boolean );
+	const homeUrl = lines[ 0 ];
+	if ( ! homeUrl || ! /^https?:\/\//.test( homeUrl ) ) {
+		throw new Error(
+			`Could not read the site URL from ${ connection.remotePath } on ${ connection.destination }. Is it the root directory of a WordPress install?`
+		);
+	}
+	return { homeUrl, siteName: lines[ 1 ] || new URL( homeUrl ).hostname };
+}

--- a/apps/cli/tests/ssh.test.ts
+++ b/apps/cli/tests/ssh.test.ts
@@ -1,0 +1,260 @@
+import { spawn as realSpawn, type spawn } from 'child_process';
+import { EventEmitter } from 'events';
+import { mkdtemp, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	buildSshCommandArgs,
+	describeSshFailure,
+	ensureRelativeSitePath,
+	execSsh,
+	isValidSshDestination,
+	probeSshWordPressSite,
+	shellQuote,
+	type SshConnection,
+} from 'cli/lib/ssh';
+
+interface FakeProcessBehavior {
+	stdout?: string;
+	stderr?: string;
+	exitCode?: number;
+}
+
+function createSpawnMock( behavior: FakeProcessBehavior = {} ) {
+	const stdinWrites: string[] = [];
+	const spawnMock = vi.fn( () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const child = new EventEmitter() as any;
+		child.stdout = new EventEmitter();
+		child.stderr = new EventEmitter();
+		child.stdin = {
+			on: vi.fn(),
+			write: ( data: string ) => stdinWrites.push( data ),
+			end: vi.fn(),
+		};
+		child.kill = vi.fn();
+		process.nextTick( () => {
+			if ( behavior.stdout ) {
+				child.stdout.emit( 'data', Buffer.from( behavior.stdout ) );
+			}
+			if ( behavior.stderr ) {
+				child.stderr.emit( 'data', Buffer.from( behavior.stderr ) );
+			}
+			child.emit( 'close', behavior.exitCode ?? 0 );
+		} );
+		return child;
+	} );
+	return { spawnMock: spawnMock as unknown as typeof spawn, stdinWrites };
+}
+
+const connection: SshConnection = {
+	destination: 'deploy@example.com',
+	remotePath: '/var/www/html',
+};
+
+describe( 'isValidSshDestination', () => {
+	it( 'accepts hosts, user@host, and ssh-config aliases', () => {
+		expect( isValidSshDestination( 'example.com' ) ).toBe( true );
+		expect( isValidSshDestination( 'deploy@example.com' ) ).toBe( true );
+		expect( isValidSshDestination( 'my-prod-alias' ) ).toBe( true );
+		expect( isValidSshDestination( 'user@192.168.1.10' ) ).toBe( true );
+	} );
+
+	it( 'rejects option injection, whitespace, and shell metacharacters', () => {
+		expect( isValidSshDestination( '-oProxyCommand=evil' ) ).toBe( false );
+		expect( isValidSshDestination( 'host -p 2222' ) ).toBe( false );
+		expect( isValidSshDestination( 'host;rm -rf /' ) ).toBe( false );
+		expect( isValidSshDestination( '' ) ).toBe( false );
+	} );
+} );
+
+describe( 'shellQuote', () => {
+	it( 'single-quotes values and escapes embedded single quotes', () => {
+		expect( shellQuote( 'plain' ) ).toBe( "'plain'" );
+		expect( shellQuote( 'a b; rm -rf /' ) ).toBe( "'a b; rm -rf /'" );
+		expect( shellQuote( "it's" ) ).toBe( `'it'\\''s'` );
+	} );
+} );
+
+describe( 'ensureRelativeSitePath', () => {
+	it( 'normalizes paths relative to the WordPress root', () => {
+		expect( ensureRelativeSitePath( 'wp-content/themes/./x/style.css' ) ).toBe(
+			'wp-content/themes/x/style.css'
+		);
+		expect( ensureRelativeSitePath( '.' ) ).toBe( '.' );
+	} );
+
+	it( 'rejects absolute paths and traversal outside the root', () => {
+		expect( () => ensureRelativeSitePath( '/etc/passwd' ) ).toThrow( /must be relative/ );
+		expect( () => ensureRelativeSitePath( '../other-site' ) ).toThrow( /must be relative/ );
+		expect( () => ensureRelativeSitePath( 'wp-content/../../escape' ) ).toThrow(
+			/must be relative/
+		);
+	} );
+} );
+
+describe( 'buildSshCommandArgs', () => {
+	it( 'runs non-interactively with safe host-key handling', () => {
+		const args = buildSshCommandArgs( connection, 'wp option get home' );
+		const options = args.join( ' ' );
+		expect( options ).toContain( 'BatchMode=yes' );
+		expect( options ).toContain( 'StrictHostKeyChecking=accept-new' );
+		expect( options ).toContain( 'ConnectTimeout=15' );
+		expect( args.slice( -3 ) ).toEqual( [ '--', 'deploy@example.com', 'wp option get home' ] );
+	} );
+
+	// A lingering ControlMaster holds the command's stdout/stderr pipes open,
+	// so Node's child `close` never fires and execSsh hangs. Commands must be
+	// one-off connections with no persistent master.
+	it( 'never enables ControlMaster/ControlPersist multiplexing', () => {
+		const args = buildSshCommandArgs( connection, 'wp option get home' ).join( ' ' );
+		expect( args ).not.toContain( 'ControlMaster' );
+		expect( args ).not.toContain( 'ControlPersist' );
+		expect( args ).not.toContain( 'ControlPath' );
+	} );
+
+	it( 'includes the port when provided', () => {
+		const args = buildSshCommandArgs( { destination: 'example.com', port: 2222 }, 'true' );
+		expect( args ).toContain( '-p' );
+		expect( args ).toContain( '2222' );
+	} );
+
+	it( 'rejects invalid destinations', () => {
+		expect( () => buildSshCommandArgs( { destination: '-oProxyCommand=evil' }, 'true' ) ).toThrow(
+			/Invalid SSH destination/
+		);
+	} );
+} );
+
+describe( 'execSsh', () => {
+	let configDir: string;
+
+	beforeEach( async () => {
+		configDir = await mkdtemp( path.join( os.tmpdir(), 'studio-ssh-test-' ) );
+		vi.stubEnv( 'DEV_CONFIG_DIR', configDir );
+	} );
+
+	afterEach( async () => {
+		vi.unstubAllEnvs();
+		await rm( configDir, { recursive: true, force: true } );
+	} );
+
+	it( 'resolves with stdout, stderr, and exit code', async () => {
+		const { spawnMock } = createSpawnMock( { stdout: 'ok\n', exitCode: 0 } );
+		const result = await execSsh( connection, 'echo ok', { spawnImplementation: spawnMock } );
+		expect( result ).toEqual( { stdout: 'ok\n', stderr: '', exitCode: 0 } );
+	} );
+
+	// Regression for the ControlMaster hang: with a real child process and real
+	// pipes, execSsh must resolve as soon as the command exits — not wait on a
+	// lingering connection. Runs `sh` in place of `ssh` via spawnImplementation.
+	it( 'resolves promptly against a real one-off child process', async () => {
+		const shAsSsh = ( ( _bin: string, _args: string[], opts: object ) =>
+			realSpawn( 'sh', [ '-c', 'printf hello-remote' ], opts ) ) as unknown as typeof spawn;
+		const start = Date.now();
+		const result = await execSsh( connection, 'ignored', { spawnImplementation: shAsSsh } );
+		expect( result.stdout ).toBe( 'hello-remote' );
+		expect( result.exitCode ).toBe( 0 );
+		expect( Date.now() - start ).toBeLessThan( 3000 );
+	} );
+
+	it( 'pipes stdin to the remote command', async () => {
+		const { spawnMock, stdinWrites } = createSpawnMock( { exitCode: 0 } );
+		await execSsh( connection, 'cat > file', {
+			stdin: 'file content',
+			spawnImplementation: spawnMock,
+		} );
+		expect( stdinWrites ).toEqual( [ 'file content' ] );
+	} );
+
+	it( 'fails with install guidance when ssh is missing', async () => {
+		const spawnMock = vi.fn( () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const child = new EventEmitter() as any;
+			child.stdout = new EventEmitter();
+			child.stderr = new EventEmitter();
+			child.kill = vi.fn();
+			process.nextTick( () => {
+				const error: NodeJS.ErrnoException = new Error( 'spawn ssh ENOENT' );
+				error.code = 'ENOENT';
+				child.emit( 'error', error );
+			} );
+			return child;
+		} );
+		await expect(
+			execSsh( connection, 'true', { spawnImplementation: spawnMock as unknown as typeof spawn } )
+		).rejects.toThrow( /OpenSSH/ );
+	} );
+} );
+
+describe( 'describeSshFailure', () => {
+	it( 'explains ssh transport failures (exit 255)', () => {
+		const message = describeSshFailure(
+			{ stdout: '', stderr: 'Permission denied (publickey).', exitCode: 255 },
+			connection
+		);
+		expect( message ).toContain( 'Could not connect to deploy@example.com' );
+		expect( message ).toContain( 'Permission denied (publickey).' );
+	} );
+
+	it( 'explains missing WP-CLI (exit 127)', () => {
+		const message = describeSshFailure(
+			{ stdout: '', stderr: 'sh: wp: command not found', exitCode: 127 },
+			connection
+		);
+		expect( message ).toContain( 'WP-CLI was not found' );
+	} );
+} );
+
+describe( 'probeSshWordPressSite', () => {
+	let configDir: string;
+
+	beforeEach( async () => {
+		configDir = await mkdtemp( path.join( os.tmpdir(), 'studio-ssh-test-' ) );
+		vi.stubEnv( 'DEV_CONFIG_DIR', configDir );
+	} );
+
+	afterEach( async () => {
+		vi.unstubAllEnvs();
+		await rm( configDir, { recursive: true, force: true } );
+	} );
+
+	it( 'reads the home URL and site name in one round-trip', async () => {
+		const { spawnMock } = createSpawnMock( {
+			stdout: 'https://example.com\nMy Site\n',
+			exitCode: 0,
+		} );
+		const probe = await probeSshWordPressSite( connection, { spawnImplementation: spawnMock } );
+		expect( probe ).toEqual( { homeUrl: 'https://example.com', siteName: 'My Site' } );
+
+		const remoteCommand = ( spawnMock as ReturnType< typeof vi.fn > ).mock
+			.calls[ 0 ][ 1 ] as string[];
+		expect( remoteCommand[ remoteCommand.length - 1 ] ).toBe(
+			`cd '/var/www/html' && 'wp' option get home && 'wp' option get blogname`
+		);
+	} );
+
+	it( 'falls back to the hostname when the site name is empty', async () => {
+		const { spawnMock } = createSpawnMock( { stdout: 'https://example.com\n', exitCode: 0 } );
+		const probe = await probeSshWordPressSite( connection, { spawnImplementation: spawnMock } );
+		expect( probe.siteName ).toBe( 'example.com' );
+	} );
+
+	it( 'rejects when the output is not a WordPress home URL', async () => {
+		const { spawnMock } = createSpawnMock( { stdout: 'not-a-url\n', exitCode: 0 } );
+		await expect(
+			probeSshWordPressSite( connection, { spawnImplementation: spawnMock } )
+		).rejects.toThrow( /Could not read the site URL/ );
+	} );
+
+	it( 'surfaces connection failures with guidance', async () => {
+		const { spawnMock } = createSpawnMock( {
+			stderr: 'Permission denied (publickey).',
+			exitCode: 255,
+		} );
+		await expect(
+			probeSshWordPressSite( connection, { spawnImplementation: spawnMock } )
+		).rejects.toThrow( /Could not connect/ );
+	} );
+} );

--- a/packages/common/ai/sessions/entry-types.ts
+++ b/packages/common/ai/sessions/entry-types.ts
@@ -21,6 +21,8 @@ export interface StudioSiteSelectedData {
 	remote?: boolean;
 	url?: string;
 	wpcomSiteId?: number;
+	sshSite?: boolean;
+	sshSiteId?: string;
 }
 
 export interface StudioToolProgressData {


### PR DESCRIPTION
## Related issues

- Related to self-hosted site editing support in Studio Code
- Alternative transport to the Application Passwords approach in #3105

## How AI was used in this PR

This PR was co-authored with Claude. The design was informed by studying how cove.run implements SSH-based pull/push (system `ssh` + remote WP-CLI). All code was reviewed by the developer, and the transport, tools, and picker flow were exercised end-to-end (unit tests + live CLI runs).

## Proposed Changes

Studio Code can currently edit local sites and WordPress.com sites, but not arbitrary third-party WordPress installs. This adds a way to connect **any WordPress server you can reach over SSH** and have the agent work on it directly.

- A new **"SSH" tab** in the Studio Code site picker (alongside Local and WordPress.com). You add a site by entering its SSH destination (`user@host`, `user@host:2222`, or an `~/.ssh/config` alias) and the WordPress root path; the connection is validated over SSH at connect time before it's saved.
- With an SSH site active, the agent gets a **remote `wp_cli`** plus **file tools** (`Read`/`Write`/`Edit`/`Grep`/`Glob`/`Ls`) that operate on the remote server, jailed to the WordPress root. This gives the full local-site editing experience — file changes, WP-CLI, and a real MySQL database (`wp db`) — over SSH, which the REST/Application-Passwords path in #3105 cannot offer.
- **Authentication is delegated entirely to the system `ssh` binary.** Keys, `ssh-agent`, `~/.ssh/config` aliases, and jump hosts work exactly as in your terminal, and **no credential is stored** — only the connection metadata (destination, port, remote path) lives in `cli.json`. Commands run non-interactively (`BatchMode`), so a site is expected to authenticate without a password prompt (i.e. via a loaded key).
- A dedicated system prompt and an `ssh-remote-management` skill guide the agent to treat the site as **live production**: prefer minimal changes, confirm destructive operations, and back up the database before risky work.

**Trade-offs / scope for reviewers:**
- Each remote tool call opens a one-off SSH connection. Connection multiplexing (`ControlMaster`) was intentionally **not** used: a persistent master holds the command's stdio pipes open and hangs Node's `close` event. Turn-scoped reuse could be added later, but only with the master's stdio detached.
- No `validate_blocks` for SSH sites (it's coupled to a local, auto-logged-in editor) — same limitation as the WordPress.com remote path. The agent relies on the `block-content` skill and screenshots instead.

## Testing Instructions

- `npm run cli:build && node apps/cli/dist/cli/main.mjs code`
- Open the site picker (down arrow with an empty prompt) and press → to reach the **SSH** tab.
- Select **"+ Add new site"** and enter an SSH destination and WordPress root path for a server where `ssh <destination>` works non-interactively (key in `ssh-agent`) and WP-CLI is installed.
- Verify a bad destination/path is rejected at connect time with a clear error, and that the TUI returns to the prompt (no stuck loader).
- With the site connected, verify the agent can run `wp_cli` (e.g. list posts/plugins), read and edit theme files under `wp-content/`, and take screenshots.
- Backspace on a saved SSH site prompts to remove it; resume a session (`--resume`) and verify the agent still targets the SSH site.

Automated: `npm test -- apps/cli` (adds `apps/cli/tests/ssh.test.ts` and `apps/cli/ai/tests/ssh-site-tools.test.ts`, including path-traversal/shell-injection guards and a regression test for the connection-close behavior).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
