### PR TITLE
Add CLI e2e tests for site navigation and content actions

### DIFF
--- a/.buildkite/commands/run-cli-e2e-tests.sh
+++ b/.buildkite/commands/run-cli-e2e-tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo '--- :package: Install deps'
+bash .buildkite/commands/install-node-dependencies.sh
+
+echo '--- :node: Build CLI'
+npm run cli:build
+
+echo '--- :wordpress: Seed server files'
+# Any CLI invocation copies the bundled WordPress into
+# ~/.studio/server-files/wordpress-versions/latest, which the e2e harness requires.
+node apps/cli/dist/cli/main.mjs site list
+
+echo '--- :vitest: Run CLI E2E Tests'
+npm test -- --tagsFilter='e2e'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,6 +118,21 @@ steps:
           DEBUG: "pw:browser"
         # TEMP(rsm-2593): if: removed to force E2E on every push while iterating on Linux E2E setup. Revert before merge.
 
+  # Manual-only and not a required GitHub check: it never runs until someone
+  # unblocks it in Buildkite, and it never gates PR merges.
+  - input: "🚦 Run CLI E2E Tests?"
+    prompt: "Run the CLI end-to-end test suite (creates real sites via the built CLI)?"
+    key: input-cli-e2e
+
+  - label: CLI E2E Tests
+    key: cli-e2e-tests
+    depends_on: input-cli-e2e
+    agents:
+      queue: mac
+    command: bash .buildkite/commands/run-cli-e2e-tests.sh
+    timeout_in_minutes: 30
+    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
+
   - label: ":chart_with_upwards_trend: Performance Metrics"
     key: metrics
     agents:

--- a/apps/cli/commands/site/tests/helpers/cli-e2e.ts
+++ b/apps/cli/commands/site/tests/helpers/cli-e2e.ts
@@ -123,16 +123,8 @@ export function readCliConfig( env: CliEnv ): {
 }
 
 /**
- * Polls a URL until the server accepts a connection, then resolves with the
- * response. A freshly started site can take a moment to begin listening, so
- * this retries the connection until the deadline; once it responds, the caller
- * asserts on the status and content type. Redirects are not followed so a
- * canonical 302 is observed as-is rather than chased to its target.
- *
- * Right after `site start` the proxy briefly answers `302 Location: /` while
- * PHP warms up, so pass `expectedStatus` to also poll past interim responses;
- * on deadline the last response is returned so the caller's status assertion
- * fails with the real value.
+ * Polls a URL until the freshly started server responds (redirects not followed). Pass
+ * `expectedStatus` to also poll past interim responses like the proxy's warm-up 302.
  */
 export async function waitForSiteResponse(
 	url: string,

--- a/apps/cli/commands/site/tests/helpers/cli-e2e.ts
+++ b/apps/cli/commands/site/tests/helpers/cli-e2e.ts
@@ -121,3 +121,45 @@ export function readCliConfig( env: CliEnv ): {
 } {
 	return JSON.parse( fs.readFileSync( env.cliConfigPath, 'utf-8' ) );
 }
+
+/**
+ * Polls a URL until the server accepts a connection, then resolves with the
+ * response. A freshly started site can take a moment to begin listening, so
+ * this retries the connection until the deadline; once it responds, the caller
+ * asserts on the status and content type. Redirects are not followed so a
+ * canonical 302 is observed as-is rather than chased to its target.
+ *
+ * Right after `site start` the proxy briefly answers `302 Location: /` while
+ * PHP warms up, so pass `expectedStatus` to also poll past interim responses;
+ * on deadline the last response is returned so the caller's status assertion
+ * fails with the real value.
+ */
+export async function waitForSiteResponse(
+	url: string,
+	{
+		timeoutMs = 30_000,
+		intervalMs = 500,
+		expectedStatus,
+	}: { timeoutMs?: number; intervalMs?: number; expectedStatus?: number } = {}
+): Promise< Response > {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	let lastResponse: Response | undefined;
+
+	while ( Date.now() < deadline ) {
+		try {
+			lastResponse = await fetch( url, { redirect: 'manual' } );
+			if ( expectedStatus === undefined || lastResponse.status === expectedStatus ) {
+				return lastResponse;
+			}
+		} catch ( error ) {
+			lastError = error;
+		}
+		await new Promise( ( resolve ) => setTimeout( resolve, intervalMs ) );
+	}
+
+	if ( lastResponse ) {
+		return lastResponse;
+	}
+	throw new Error( `Timed out waiting for a response from ${ url }: ${ String( lastError ) }` );
+}

--- a/apps/cli/commands/site/tests/site-navigation.e2e.test.ts
+++ b/apps/cli/commands/site/tests/site-navigation.e2e.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @vitest-environment node
+ *
+ * Real end-to-end tests for site navigation and content actions, migrated from
+ * the Playwright suite `apps/studio/e2e/site-navigation.test.ts`. Serving the
+ * homepage and wp-admin is verified over HTTP; content actions (posts, media,
+ * themes, plugins, permalinks) go through `studio wp`. Auto-login to wp-admin
+ * is a Studio desktop feature (magic URL via IPC) and stays in the UI suite.
+ *
+ * Requires the CLI to be built first (`npm run cli:build`); the suite skips
+ * itself otherwise. Tagged `e2e` so it runs in the slower (release/manual)
+ * suite rather than on every PR — run with `npm test -- --tagsFilter='e2e'`.
+ * The "adds new themes/plugin" cases download from wordpress.org (network).
+ */
+import fs from 'fs';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	cleanupCliEnv,
+	cliE2ePrerequisitesMet,
+	readCliConfig,
+	runCli,
+	setupCliEnv,
+	waitForSiteResponse,
+	type CliEnv,
+} from './helpers/cli-e2e';
+
+// 1x1 red-pixel PNG, the smallest valid image for `wp media import`.
+const TINY_PNG = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVQImWP4z8AAAAMBAQAY3YN1AAAAAElFTkSuQmCC',
+	'base64'
+);
+
+describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: site navigation', () => {
+	let env: CliEnv;
+	let sitePath: string;
+	let siteUrl: string;
+
+	// All cases exercise the same running site, mirroring the Playwright suite
+	// which ran against the single onboarding-created site.
+	beforeAll( async () => {
+		env = setupCliEnv();
+		sitePath = path.join( env.sitesDir, 'navigation-e2e-site' );
+
+		const result = await runCli(
+			[
+				'site',
+				'create',
+				'--name',
+				'Navigation E2E Site',
+				'--path',
+				sitePath,
+				'--wp',
+				'latest',
+				// Sandbox is bundled; the default native runtime downloads PHP on start.
+				'--runtime',
+				'sandbox',
+				'--skip-browser',
+				'--skip-log-details',
+			],
+			env
+		);
+		expect( result.code, result.stderr ).toBe( 0 );
+
+		const [ site ] = readCliConfig( env ).sites;
+		siteUrl = `http://localhost:${ String( site.port ) }`;
+	}, 240_000 );
+
+	afterAll( async () => {
+		if ( ! env ) {
+			return;
+		}
+		await runCli( [ 'site', 'stop', '--all' ], env );
+		cleanupCliEnv( env );
+	}, 60_000 );
+
+	/**
+	 * Runs `studio wp <args>` against the shared site and asserts it exited 0.
+	 * Returns stdout for further assertions.
+	 */
+	async function wp( ...args: string[] ): Promise< string > {
+		const result = await runCli( [ 'wp', ...args, '--path', sitePath ], env );
+		expect( result.code, result.stderr ).toBe( 0 );
+		return result.stdout;
+	}
+
+	it( 'opens site at homepage', { tags: [ 'e2e' ], timeout: 60_000 }, async () => {
+		// expectedStatus polls past the proxy's transient warm-up 302.
+		const response = await waitForSiteResponse( siteUrl, { expectedStatus: 200 } );
+		expect( response.status ).toBe( 200 );
+		expect( response.headers.get( 'content-type' ) ).toMatch( /text\/html/ );
+
+		const body = await response.text();
+		expect( body ).toContain( 'wp-' );
+		expect( body ).toMatch( /<title>[^<]+<\/title>/ );
+	} );
+
+	it( 'serves wp-admin behind the login screen', { tags: [ 'e2e' ], timeout: 60_000 }, async () => {
+		// Unauthenticated wp-admin must bounce to the login form — proves both
+		// wp-admin routing and auth work. Auto-login itself is desktop-only.
+		const adminResponse = await waitForSiteResponse( `${ siteUrl }/wp-admin/` );
+		expect( adminResponse.status ).toBe( 302 );
+		expect( adminResponse.headers.get( 'location' ) ).toContain( 'wp-login.php' );
+
+		const loginResponse = await waitForSiteResponse( `${ siteUrl }/wp-login.php` );
+		expect( loginResponse.status ).toBe( 200 );
+		expect( await loginResponse.text() ).toContain( 'loginform' );
+	} );
+
+	it( 'creates a post', { tags: [ 'e2e' ], timeout: 120_000 }, async () => {
+		await wp(
+			'post',
+			'create',
+			'--post_title=E2E Test Post',
+			'--post_content=This is a test post created by automated E2E tests.',
+			'--post_status=publish'
+		);
+
+		const titles = await wp( 'post', 'list', '--post_type=post', '--field=post_title' );
+		expect( titles ).toContain( 'E2E Test Post' );
+	} );
+
+	it( 'uploads media', { tags: [ 'e2e' ], timeout: 120_000 }, async () => {
+		// The Playground wp-cli only mounts the site directory (at /wordpress,
+		// its cwd), so the file must live inside the site and be referenced by
+		// a relative path.
+		fs.writeFileSync( path.join( sitePath, 'e2e-test-image.png' ), TINY_PNG );
+
+		await wp( 'media', 'import', 'e2e-test-image.png' );
+
+		const attachments = await wp( 'post', 'list', '--post_type=attachment', '--field=post_title' );
+		expect( attachments ).toContain( 'e2e-test-image' );
+	} );
+
+	it( 'activates themes', { tags: [ 'e2e' ], timeout: 120_000 }, async () => {
+		// Bundled WordPress ships several default themes, so activating an
+		// inactive one needs no network.
+		await wp( 'theme', 'activate', 'twentytwentyfour' );
+
+		const active = await wp( 'theme', 'list', '--status=active', '--field=name' );
+		expect( active ).toContain( 'twentytwentyfour' );
+	} );
+
+	it( 'adds new themes', { tags: [ 'e2e' ], timeout: 180_000 }, async () => {
+		await wp( 'theme', 'install', 'twentytwentytwo' );
+
+		const themes = await wp( 'theme', 'list', '--field=name' );
+		expect( themes ).toContain( 'twentytwentytwo' );
+	} );
+
+	it( 'activates plugin', { tags: [ 'e2e' ], timeout: 120_000 }, async () => {
+		// Hello Dolly ships with WordPress (slug `hello`).
+		await wp( 'plugin', 'activate', 'hello' );
+
+		const active = await wp( 'plugin', 'list', '--status=active', '--field=name' );
+		expect( active ).toContain( 'hello' );
+	} );
+
+	it( 'adds new plugin', { tags: [ 'e2e' ], timeout: 180_000 }, async () => {
+		await wp( 'plugin', 'install', 'classic-editor' );
+
+		const plugins = await wp( 'plugin', 'list', '--field=name' );
+		expect( plugins ).toContain( 'classic-editor' );
+	} );
+
+	it( '"Post name" permalink structure works', { tags: [ 'e2e' ], timeout: 120_000 }, async () => {
+		// `wp rewrite structure` hangs under Playground, so set the option
+		// directly and clear the cached rules — WordPress regenerates them on
+		// the next request.
+		await wp( 'option', 'update', 'permalink_structure', '/%postname%/' );
+		await wp( 'option', 'delete', 'rewrite_rules' );
+
+		await wp(
+			'post',
+			'create',
+			'--post_title=Permalink Test Post',
+			'--post_content=Testing permalink structure.',
+			'--post_status=publish'
+		);
+
+		const response = await waitForSiteResponse( `${ siteUrl }/permalink-test-post/` );
+		expect( response.status ).toBe( 200 );
+		const body = await response.text();
+		expect( body ).toContain( 'Permalink Test Post' );
+		expect( body ).toContain( 'Testing permalink structure.' );
+	} );
+} );

--- a/apps/cli/commands/site/tests/site-navigation.e2e.test.ts
+++ b/apps/cli/commands/site/tests/site-navigation.e2e.test.ts
@@ -36,8 +36,8 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: site navigation', () =>
 	let sitePath: string;
 	let siteUrl: string;
 
-	// All cases exercise the same running site, mirroring the Playwright suite
-	// which ran against the single onboarding-created site.
+	// All cases share one running site; creating and starting WordPress is the
+	// slow part.
 	beforeAll( async () => {
 		env = setupCliEnv();
 		sitePath = path.join( env.sitesDir, 'navigation-e2e-site' );
@@ -85,7 +85,6 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: site navigation', () =>
 	}
 
 	it( 'opens site at homepage', { tags: [ 'e2e' ], timeout: 60_000 }, async () => {
-		// expectedStatus polls past the proxy's transient warm-up 302.
 		const response = await waitForSiteResponse( siteUrl, { expectedStatus: 200 } );
 		expect( response.status ).toBe( 200 );
 		expect( response.headers.get( 'content-type' ) ).toMatch( /text\/html/ );

--- a/apps/cli/commands/site/tests/site-navigation.e2e.test.ts
+++ b/apps/cli/commands/site/tests/site-navigation.e2e.test.ts
@@ -1,16 +1,8 @@
 /**
  * @vitest-environment node
  *
- * Real end-to-end tests for site navigation and content actions, migrated from
- * the Playwright suite `apps/studio/e2e/site-navigation.test.ts`. Serving the
- * homepage and wp-admin is verified over HTTP; content actions (posts, media,
- * themes, plugins, permalinks) go through `studio wp`. Auto-login to wp-admin
- * is a Studio desktop feature (magic URL via IPC) and stays in the UI suite.
- *
- * Requires the CLI to be built first (`npm run cli:build`); the suite skips
- * itself otherwise. Tagged `e2e` so it runs in the slower (release/manual)
- * suite rather than on every PR — run with `npm test -- --tagsFilter='e2e'`.
- * The "adds new themes/plugin" cases download from wordpress.org (network).
+ * Site navigation and content actions against the built CLI (`npm run cli:build` first),
+ * migrated from `apps/studio/e2e/site-navigation.test.ts`; auto-login stays in the UI suite.
  */
 import fs from 'fs';
 import path from 'path';
@@ -74,10 +66,7 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: site navigation', () =>
 		cleanupCliEnv( env );
 	}, 60_000 );
 
-	/**
-	 * Runs `studio wp <args>` against the shared site and asserts it exited 0.
-	 * Returns stdout for further assertions.
-	 */
+	/** Runs `studio wp <args>` against the shared site, asserts exit 0, and returns stdout. */
 	async function wp( ...args: string[] ): Promise< string > {
 		const result = await runCli( [ 'wp', ...args, '--path', sitePath ], env );
 		expect( result.code, result.stderr ).toBe( 0 );
@@ -120,9 +109,8 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: site navigation', () =>
 	} );
 
 	it( 'uploads media', { tags: [ 'e2e' ], timeout: 120_000 }, async () => {
-		// The Playground wp-cli only mounts the site directory (at /wordpress,
-		// its cwd), so the file must live inside the site and be referenced by
-		// a relative path.
+		// Playground wp-cli only mounts the site directory (its cwd), so the
+		// file must live there and be passed as a relative path.
 		fs.writeFileSync( path.join( sitePath, 'e2e-test-image.png' ), TINY_PNG );
 
 		await wp( 'media', 'import', 'e2e-test-image.png' );
@@ -163,9 +151,8 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: site navigation', () =>
 	} );
 
 	it( '"Post name" permalink structure works', { tags: [ 'e2e' ], timeout: 120_000 }, async () => {
-		// `wp rewrite structure` hangs under Playground, so set the option
-		// directly and clear the cached rules — WordPress regenerates them on
-		// the next request.
+		// `wp rewrite structure` hangs under Playground; set the option and clear
+		// the cached rules instead — WordPress regenerates them on the next request.
 		await wp( 'option', 'update', 'permalink_structure', '/%postname%/' );
 		await wp( 'option', 'delete', 'rewrite_rules' );
 

--- a/apps/cli/commands/site/tests/site-navigation.e2e.test.ts
+++ b/apps/cli/commands/site/tests/site-navigation.e2e.test.ts
@@ -151,8 +151,8 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: site navigation', () =>
 	} );
 
 	it( '"Post name" permalink structure works', { tags: [ 'e2e' ], timeout: 120_000 }, async () => {
-		// `wp rewrite structure` hangs under Playground; set the option and clear
-		// the cached rules instead — WordPress regenerates them on the next request.
+		// `wp rewrite structure` spawns a child `wp rewrite flush` process, which hangs
+		// under Playground; set the option and clear the cached rules instead.
 		await wp( 'option', 'update', 'permalink_structure', '/%postname%/' );
 		await wp( 'option', 'delete', 'rewrite_rules' );
 


### PR DESCRIPTION
## Related issues

- Related to [STU-1869](https://linear.app/a8c/issue/STU-1869/migrate-navigate-site-tests)

## How AI was used in this PR

Claude wrote the code, guided by the author. The author tested it locally and manually reviewed it before pushing.

## Proposed Changes

- Migrate the Navigate Site checks from the Playwright desktop suite to CLI e2e tests so they can run headless, without the desktop app.
- The new suite creates one sandbox-runtime site, verifies the homepage and wp-admin over HTTP, and exercises posts, media, themes, plugins, and permalinks through `studio wp`.
- Add an `expectedStatus` option to `waitForSiteResponse` because the proxy briefly returns a 302 while PHP warms up after `site start`.

## Testing Instructions

- Run `npm run cli:build`.
- Run `npm test -- apps/cli/commands/site/tests/site-navigation.e2e.test.ts --tagsFilter='e2e'`.
- All nine tests should pass. The theme and plugin install cases need network access.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

