### PR TITLE
Use a neutral CLI log prefix instead of hard-coded 'site ID'

### DIFF
--- a/apps/studio/src/modules/cli/lib/execute-command.ts
+++ b/apps/studio/src/modules/cli/lib/execute-command.ts
@@ -154,7 +154,7 @@ export function executeCliCommand(
 		// the main-process console. Commands like `preview list --format json`
 		// dump large structured payloads on stdout that would otherwise spam
 		// `npm start` output every time snapshots are fetched.
-		const logPrefix = options.logPrefix ? `[CLI - site ID ${ options.logPrefix }]` : null;
+		const logPrefix = options.logPrefix ? `[CLI - ${ options.logPrefix }]` : null;
 		child.stdout?.on( 'data', ( data: Buffer ) => {
 			const text = data.toString();
 			stdout += text;

--- a/packages/common/lib/cli-process.ts
+++ b/packages/common/lib/cli-process.ts
@@ -201,7 +201,7 @@ export function createCliRunner( config: CliRunnerConfig ): CliRunner {
 			// the host console. Commands like `preview list --format json` dump
 			// large structured payloads on stdout that would otherwise spam the
 			// console every time snapshots are fetched.
-			const logPrefix = options.logPrefix ? `[CLI - site ID ${ options.logPrefix }]` : null;
+			const logPrefix = options.logPrefix ? `[CLI - ${ options.logPrefix }]` : null;
 			child.stdout?.on( 'data', ( data: Buffer ) => {
 				const text = data.toString();
 				stdout += text;


### PR DESCRIPTION
## Related issues

- Follow-up of #4082

## How AI was used in this PR

Claude wrote the code, guided by the author. The author tested it locally and manually reviewed it before pushing.

## Proposed Changes

The stdout echo prefix hard-coded the words "site ID", but `logPrefix` is also used for non-site contexts. For example, the CLI events subscriber passes "events", which produced the misleading line `[CLI - site ID events]`. The prefix is now the neutral `[CLI - <prefix>]`, which matches the format `CliServerProcess` already uses for its own log lines.

## Testing Instructions

- Run `npm start` and start a site. CLI stdout lines should be prefixed with `[CLI - <site ID>]`, and events subscriber lines with `[CLI - events]`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?