### PR TITLE
Keep CLI child close handlers alive when killing on quit

### DIFF
--- a/apps/studio/src/modules/cli/lib/execute-command.ts
+++ b/apps/studio/src/modules/cli/lib/execute-command.ts
@@ -179,10 +179,8 @@ export function executeCliCommand(
 		eventEmitter.emit( 'data', { data: message } );
 	} );
 
-	// Only kills the child here; the `close` handler still runs afterwards to
-	// settle the emitter and detach this listener. Removing the child's
-	// listeners at this point would leak the `will-quit` listener whenever the
-	// quit is prevented and the app keeps running.
+	// Only kills the child; the `close` handler still runs to settle the
+	// emitter and detach this listener if a prevented quit keeps the app alive.
 	function appQuitHandler() {
 		const pid = child.pid;
 

--- a/apps/studio/src/modules/cli/lib/execute-command.ts
+++ b/apps/studio/src/modules/cli/lib/execute-command.ts
@@ -179,9 +179,12 @@ export function executeCliCommand(
 		eventEmitter.emit( 'data', { data: message } );
 	} );
 
+	// Only kills the child here; the `close` handler still runs afterwards to
+	// settle the emitter and detach this listener. Removing the child's
+	// listeners at this point would leak the `will-quit` listener whenever the
+	// quit is prevented and the app keeps running.
 	function appQuitHandler() {
 		const pid = child.pid;
-		child.removeAllListeners();
 
 		// `child.kill()` only terminates the forked CLI process; on Windows its php.exe descendants
 		// would orphan and keep their DLLs locked. `taskkill /T` walks the whole tree instead.

--- a/packages/common/lib/cli-process.ts
+++ b/packages/common/lib/cli-process.ts
@@ -139,9 +139,11 @@ export function createCliRunner( config: CliRunnerConfig ): CliRunner {
 	const { cliBinary, nodeBinary, execArgv = [ '--experimental-wasm-jspi' ], onError } = config;
 	const liveChildren = new Set< ChildProcess >();
 
+	// Only kills the child; its `close` handler still runs afterwards so the
+	// emitter settles and callers awaiting the command see a failure instead
+	// of hanging forever.
 	function killChild( child: ChildProcess ): void {
 		const pid = child.pid;
-		child.removeAllListeners();
 
 		// `child.kill()` only terminates the forked CLI process; on Windows its
 		// php.exe descendants would orphan and keep their DLLs locked. `taskkill

--- a/packages/common/lib/cli-process.ts
+++ b/packages/common/lib/cli-process.ts
@@ -139,9 +139,8 @@ export function createCliRunner( config: CliRunnerConfig ): CliRunner {
 	const { cliBinary, nodeBinary, execArgv = [ '--experimental-wasm-jspi' ], onError } = config;
 	const liveChildren = new Set< ChildProcess >();
 
-	// Only kills the child; its `close` handler still runs afterwards so the
-	// emitter settles and callers awaiting the command see a failure instead
-	// of hanging forever.
+	// Only kills the child; its `close` handler still runs so awaiting callers
+	// see a failure instead of hanging forever.
 	function killChild( child: ChildProcess ): void {
 		const pid = child.pid;
 


### PR DESCRIPTION
## Related issues

- Follow-up of #4082

## How AI was used in this PR

Claude wrote the code, guided by the author. The author tested it locally and manually reviewed it before pushing.

## Proposed Changes

The quit-time kill paths (`appQuitHandler` in the desktop and `killChild` in the shared runner) called `child.removeAllListeners()` before killing the child, which also removed the `close` handler. Since `will-quit` can be prevented and the app can keep running, this left a stale `will-quit` listener attached and left callers awaiting the command hanging forever. The kill paths now only kill the child and let the `close` handler run: it detaches the `will-quit` listener and emits `failure`, so awaiting callers settle.

## Testing Instructions

- Run `npm start`, start a site, and quit the app. Child CLI processes should terminate as before, and the console should show a `failure` warning from the events subscriber instead of silence.
- `npm test -- apps/studio/src/tests/index.test.ts` passes.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?