### PR TITLE
Liberate: fix resolving sites as path instead of only real domains

### DIFF
--- a/packages/data-liberation-agent/src/lib/replicate/carry-page-list.test.ts
+++ b/packages/data-liberation-agent/src/lib/replicate/carry-page-list.test.ts
@@ -91,6 +91,20 @@ describe('joinCarryPageList', () => {
     expect(skipped[0]).toMatchObject({ postName: 'ghost', reason: 'no-manifest-match' });
   });
 
+  it('flags the homepage on a subpath-hosted site via the channel <link> base', () => {
+    const w = `<rss><channel>\n<link>https://builder.example/my-site</link>\n${[
+      item({ type: 'page', name: 'my-site', title: 'Home', link: 'https://builder.example/my-site/my-site' }),
+      item({ type: 'page', name: 'blog', title: 'Blog', link: 'https://builder.example/my-site/blog' }),
+    ].join('\n')}\n</channel></rss>`;
+    const entries = {
+      'https://builder.example/my-site': { slug: 'my-site' },
+      'https://builder.example/my-site/blog': { slug: 'my-site--blog' },
+    };
+    const { pages } = joinCarryPageList(w, entries, new Set(['my-site', 'my-site--blog']));
+    expect(pages.find((p) => p.isHome)).toMatchObject({ slug: 'my-site', htmlSlug: 'my-site', postType: 'page' });
+    expect(pages.find((p) => p.slug === 'blog')?.isHome).toBeUndefined();
+  });
+
   it('does NOT match a page against a WooCommerce `products--*` manifest slug', () => {
     const w = wxr([item({ type: 'page', name: 'widget', title: 'Widget', link: 'https://fictional.example/widget' })]);
     const { pages, skipped } = joinCarryPageList(w, { 'https://fictional.example/products/widget': { slug: 'products--widget' } }, new Set(['products--widget']));

--- a/packages/data-liberation-agent/src/lib/replicate/carry-page-list.ts
+++ b/packages/data-liberation-agent/src/lib/replicate/carry-page-list.ts
@@ -56,7 +56,8 @@ export interface BuildPageListOptions {
  *
  * Generic across platforms:
  *  - pages: WXR `post_name` → manifest slug; the front page is captured as `homepage` (matched by
- *    root-URL `<link>` OR `post_name` `home`/`homepage`).
+ *    root-URL `<link>`, `post_name` `home`/`homepage`, OR — for subpath-hosted sites like free
+ *    `*.wixsite.com/<site>` — a manifest sourceUrl equal to the channel `<link>` site base).
  *  - posts: WXR `post_name` → `post--<name>` (exact, then prefix-match for %-encoded / truncated slugs).
  *  - Shopify/Squarespace namespaced slugs (`pages--<name>`, `blogs--<blog>--<name>`): fall back to the
  *    last `--` segment (products `products--*` excluded — they're WooCommerce items, not carry pages).
@@ -68,6 +69,9 @@ export function joinCarryPageList(
   opts: BuildPageListOptions = {},
 ): BuildPageListResult {
   const excludeSet = new Set(opts.exclude ?? []);
+  // Site base URL from the channel <link> — identifies the front page on subpath-hosted
+  // sites (e.g. free *.wixsite.com/<site>), where the homepage URL path is not `/`.
+  const channelLink = (wxrText.split('<item>')[0].match(/<link>([^<]+)<\/link>/)?.[1] ?? '').replace(/\/+$/, '');
   const bySlug = new Map<string, { sourceUrl: string }>();
   for (const [url, e] of Object.entries(entries)) if (e.slug) bySlug.set(e.slug, { sourceUrl: url });
 
@@ -114,7 +118,8 @@ export function joinCarryPageList(
       skipped.push({ postType, postName, title, link, reason: htmlSlug ? 'html-missing' : 'no-manifest-match' });
       continue;
     }
-    const isHome = postType === 'page' && (htmlSlug === 'homepage' || rootLink);
+    const isHome = postType === 'page' &&
+      (htmlSlug === 'homepage' || rootLink || (!!channelLink && sourceUrl.replace(/\/+$/, '') === channelLink));
     const page: CarryPage = { slug: isHome ? (postName || 'home') : postName, sourceUrl, title, postType, htmlSlug, ...(isHome ? { isHome: true } : {}) };
     if (excludeSet.has(page.slug) || excludeSet.has(htmlSlug)) excluded.push(page);
     else pages.push(page);


### PR DESCRIPTION
## How AI was used in this PR

The fix was implemented in runtime by Claude Code while liberating the Wix site https://neicss.wixsite.com/sunflower-valley-exp

Output from AI while implementing it:
```
home=false is suspicious — the homepage should be flagged. Let me check the page list.

  Searched for 2 patterns, read 3 files, listed 1 directory

Without isHome, the theme loses front-page.html and the index fallback shell — worth fixing. Let me see whether the driver can take a page-list override.

  Searched for 3 patterns, read 3 files, ran 1 shell command

Now applying the fix (engine style: 2-space indent, no inner-paren spaces).
```

The problem with it is - Wix allows having sites as a path under the personal staging domain `https://neicss.wixsite.com/<site_kinda_dev_domain_example>` so we should parse it too, to determine the home-page.




## Testing Instructions
Visual review should suffice