### PR TITLE
Fix flaky e2e: import a backup into an existing site

### DIFF
--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -59,6 +59,37 @@ export class E2ESession {
 		await this.launchFirstWindow( testEnv );
 	}
 
+	/**
+	 * Stub native message boxes to auto-answer with the given response index,
+	 * recording each dialog's text so tests can assert on what was shown (see
+	 * `getRecordedDialogs`). The stub handles both `showMessageBox( options )`
+	 * and `showMessageBox( parentWindow, options )` call shapes.
+	 */
+	async stubMessageBox( response = 0 ) {
+		await this.electronApp.evaluate( ( { dialog }, autoResponse ) => {
+			const dialogGlobal = globalThis as typeof globalThis & { __e2eDialogs: string[] };
+			dialogGlobal.__e2eDialogs = [];
+			dialog.showMessageBox = ( async ( ...args: unknown[] ) => {
+				const options = ( args.length > 1 ? args[ 1 ] : args[ 0 ] ) as {
+					title?: string;
+					message?: string;
+					detail?: string;
+				};
+				dialogGlobal.__e2eDialogs.push(
+					[ options?.title, options?.message, options?.detail ].filter( Boolean ).join( ' — ' )
+				);
+				return { response: autoResponse, checkboxChecked: false };
+			} ) as typeof dialog.showMessageBox;
+		}, response );
+	}
+
+	/** Dialog texts recorded by the `stubMessageBox` stub, oldest first. */
+	async getRecordedDialogs(): Promise< string[] > {
+		return this.electronApp.evaluate(
+			() => ( globalThis as typeof globalThis & { __e2eDialogs?: string[] } ).__e2eDialogs ?? []
+		);
+	}
+
 	async closeApp() {
 		console.log( 'Closing app...' );
 		const childProcess = this.electronApp.process();

--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -61,15 +61,14 @@ export class E2ESession {
 
 	/**
 	 * Stub native message boxes to auto-answer with the given response index,
-	 * recording each dialog's text so tests can assert on what was shown (see
-	 * `getRecordedDialogs`). The stub handles both `showMessageBox( options )`
-	 * and `showMessageBox( parentWindow, options )` call shapes.
+	 * recording each dialog's text for `getRecordedDialogs`.
 	 */
 	async stubMessageBox( response = 0 ) {
 		await this.electronApp.evaluate( ( { dialog }, autoResponse ) => {
 			const dialogGlobal = globalThis as typeof globalThis & { __e2eDialogs: string[] };
 			dialogGlobal.__e2eDialogs = [];
 			dialog.showMessageBox = ( async ( ...args: unknown[] ) => {
+				// Options are the last arg: showMessageBox( [parentWindow,] options ).
 				const options = ( args.length > 1 ? args[ 1 ] : args[ 0 ] ) as {
 					title?: string;
 					message?: string;

--- a/apps/studio/e2e/import-formats.test.ts
+++ b/apps/studio/e2e/import-formats.test.ts
@@ -149,17 +149,37 @@ test.describe( 'Import backup formats', () => {
 	} );
 
 	test( 'imports a backup file into an existing site', async ( { page } ) => {
-		// Restart the onboarding site; a successful import is observable as its
-		// title changing from the fresh-install one to the fixture's.
+		// Import into the stopped onboarding site; a successful import is
+		// observable as its title changing from the fresh-install one to the
+		// fixture's. The site must not be started first: on every
+		// stopped→running transition the app spawns WP-CLI processes (theme
+		// details, site icon) that intermittently make the import's database
+		// step exit non-zero when both touch the SQLite file. The import itself
+		// starts the server on completion (`alwaysStartServer`).
 		const sidebar = new MainSidebar( session.mainWindow );
 		await sidebar.getSiteNavButton( DEFAULT_SITE_NAME ).click();
 		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
-		await siteContent.locator.getByRole( 'button', { name: 'Start' } ).click();
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
+		// On a retry in a fresh worker, beforeAll leaves the onboarding site
+		// running — stop it so both attempts follow the same stopped-site flow.
+		await stopAllSites();
 
 		// The tab's import flow asks for confirmation via a native dialog.
+		// Record every dialog so a failed import surfaces its message below
+		// instead of silently timing out on the completion banner.
 		await session.electronApp.evaluate( ( { dialog } ) => {
-			dialog.showMessageBox = async () => ( { response: 0, checkboxChecked: false } );
+			const dialogGlobal = globalThis as typeof globalThis & { __e2eDialogs?: string[] };
+			dialogGlobal.__e2eDialogs = [];
+			dialog.showMessageBox = ( async ( ...args: unknown[] ) => {
+				const options = ( args.length > 1 ? args[ 1 ] : args[ 0 ] ) as {
+					title?: string;
+					message?: string;
+					detail?: string;
+				};
+				dialogGlobal.__e2eDialogs?.push(
+					[ options?.title, options?.message, options?.detail ].filter( Boolean ).join( ' — ' )
+				);
+				return { response: 0, checkboxChecked: false };
+			} ) as typeof dialog.showMessageBox;
 		} );
 
 		const tab = await siteContent.navigateToTab( 'import-export' );
@@ -168,10 +188,25 @@ test.describe( 'Import backup formats', () => {
 		}
 		await tab.uploadFile( path.join( FIXTURES_DIR, 'local-backup.zip' ) );
 		// Unlike the new-site flow, the tab's import UI reports completion with
-		// "Import complete!".
-		await expect( session.mainWindow.getByText( 'Import complete!' ) ).toBeVisible( {
-			timeout: 120_000,
-		} );
+		// "Import complete!". Errors are reported via a (stubbed) native dialog,
+		// so fail fast with the dialog's message rather than timing out.
+		const completeBanner = session.mainWindow.getByText( 'Import complete!' );
+		await expect
+			.poll(
+				async () => {
+					const dialogs = await session.electronApp.evaluate(
+						() =>
+							( globalThis as typeof globalThis & { __e2eDialogs?: string[] } ).__e2eDialogs ?? []
+					);
+					const failure = dialogs.find( ( entry ) => entry.includes( 'Failed importing site' ) );
+					if ( failure ) {
+						throw new Error( `Import failed: ${ failure }` );
+					}
+					return completeBanner.isVisible();
+				},
+				{ timeout: 120_000 }
+			)
+			.toBe( true );
 
 		await assertImportedSiteContent( page, siteContent );
 	} );

--- a/apps/studio/e2e/import-formats.test.ts
+++ b/apps/studio/e2e/import-formats.test.ts
@@ -166,21 +166,7 @@ test.describe( 'Import backup formats', () => {
 		// The tab's import flow asks for confirmation via a native dialog.
 		// Record every dialog so a failed import surfaces its message below
 		// instead of silently timing out on the completion banner.
-		await session.electronApp.evaluate( ( { dialog } ) => {
-			const dialogGlobal = globalThis as typeof globalThis & { __e2eDialogs?: string[] };
-			dialogGlobal.__e2eDialogs = [];
-			dialog.showMessageBox = ( async ( ...args: unknown[] ) => {
-				const options = ( args.length > 1 ? args[ 1 ] : args[ 0 ] ) as {
-					title?: string;
-					message?: string;
-					detail?: string;
-				};
-				dialogGlobal.__e2eDialogs?.push(
-					[ options?.title, options?.message, options?.detail ].filter( Boolean ).join( ' — ' )
-				);
-				return { response: 0, checkboxChecked: false };
-			} ) as typeof dialog.showMessageBox;
-		} );
+		await session.stubMessageBox();
 
 		const tab = await siteContent.navigateToTab( 'import-export' );
 		if ( ! ( 'uploadFile' in tab ) ) {
@@ -190,19 +176,16 @@ test.describe( 'Import backup formats', () => {
 		// Unlike the new-site flow, the tab's import UI reports completion with
 		// "Import complete!". Errors are reported via a (stubbed) native dialog,
 		// so fail fast with the dialog's message rather than timing out.
-		const completeBanner = session.mainWindow.getByText( 'Import complete!' );
 		await expect
 			.poll(
 				async () => {
-					const dialogs = await session.electronApp.evaluate(
-						() =>
-							( globalThis as typeof globalThis & { __e2eDialogs?: string[] } ).__e2eDialogs ?? []
+					const failure = ( await session.getRecordedDialogs() ).find( ( entry ) =>
+						entry.includes( 'Failed importing site' )
 					);
-					const failure = dialogs.find( ( entry ) => entry.includes( 'Failed importing site' ) );
 					if ( failure ) {
 						throw new Error( `Import failed: ${ failure }` );
 					}
-					return completeBanner.isVisible();
+					return tab.importCompleteBanner.isVisible();
 				},
 				{ timeout: 120_000 }
 			)

--- a/apps/studio/e2e/import-formats.test.ts
+++ b/apps/studio/e2e/import-formats.test.ts
@@ -149,23 +149,18 @@ test.describe( 'Import backup formats', () => {
 	} );
 
 	test( 'imports a backup file into an existing site', async ( { page } ) => {
-		// Import into the stopped onboarding site; a successful import is
-		// observable as its title changing from the fresh-install one to the
-		// fixture's. The site must not be started first: on every
-		// stopped→running transition the app spawns WP-CLI processes (theme
-		// details, site icon) that intermittently make the import's database
-		// step exit non-zero when both touch the SQLite file. The import itself
-		// starts the server on completion (`alwaysStartServer`).
+		// Import into the onboarding site while it's stopped: starting it first
+		// spawns WP-CLI processes (theme details, site icon) that race the
+		// database import and intermittently fail it. The import starts the
+		// server itself on completion.
 		const sidebar = new MainSidebar( session.mainWindow );
 		await sidebar.getSiteNavButton( DEFAULT_SITE_NAME ).click();
 		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
-		// On a retry in a fresh worker, beforeAll leaves the onboarding site
-		// running — stop it so both attempts follow the same stopped-site flow.
+		// On retries, beforeAll leaves the site running — stop it.
 		await stopAllSites();
 
-		// The tab's import flow asks for confirmation via a native dialog.
-		// Record every dialog so a failed import surfaces its message below
-		// instead of silently timing out on the completion banner.
+		// Auto-confirm the import's native confirmation dialog, recording all
+		// dialogs so a failure surfaces its message below.
 		await session.stubMessageBox();
 
 		const tab = await siteContent.navigateToTab( 'import-export' );
@@ -173,9 +168,8 @@ test.describe( 'Import backup formats', () => {
 			throw new Error( 'Expected ImportExportTab but got a different tab type' );
 		}
 		await tab.uploadFile( path.join( FIXTURES_DIR, 'local-backup.zip' ) );
-		// Unlike the new-site flow, the tab's import UI reports completion with
-		// "Import complete!". Errors are reported via a (stubbed) native dialog,
-		// so fail fast with the dialog's message rather than timing out.
+		// Wait for the completion banner, but fail fast with the recorded
+		// dialog message if the import errors instead.
 		await expect
 			.poll(
 				async () => {

--- a/apps/studio/e2e/page-objects/import-export-tab.ts
+++ b/apps/studio/e2e/page-objects/import-export-tab.ts
@@ -19,6 +19,10 @@ export default class ImportExportTab {
 		return this.locator.getByRole( 'progressbar' );
 	}
 
+	get importCompleteBanner() {
+		return this.locator.getByText( 'Import complete!' );
+	}
+
 	get importStatusMessage() {
 		return this.locator.getByText( /Import/i );
 	}


### PR DESCRIPTION
## Related issues

- Related to trunk E2E failures on linux-x64: builds [18960](https://buildkite.com/automattic/studio/builds/18960), [18971](https://buildkite.com/automattic/studio/builds/18971), [18974](https://buildkite.com/automattic/studio/builds/18974)

## How AI was used in this PR

AI analyzed the Buildkite failures (logs, Playwright error contexts, daemon site logs), traced the race in the import flow, and wrote the test fix. I reviewed and directed the work.

## Proposed Changes

**Problem:**
E2E test #4057 (backup import into existing site) flakes on linux-x64, and every retry fails deterministically, so one flake means a red build.
The test started the site right before importing. Site startup spawns WP-CLI processes (theme details, site icon) that race wp sqlite import on the same SQLite, the import exits non-zero even though the data actually lands. With dialog.showMessageBox stubbed, the only symptom was "Import complete!" timing out at 120s.
A retry spawns a fresh worker where beforeAll leaves the onboarding site running, so the test's first click,the Start button, waits 30s for a button that doesn't exist on a running site.

**Solution:**
This PR removes both sources of nondeterminism.
- The test now stops all sites first and imports into the stopped site, so no startup WP-CLI processes race the import (the import flow already passes `alwaysStartServer`, so the server comes up afterwards and the content
  assertions still run).
- The dialog stub also records each dialog's text — via new reusable `E2ESession` helpers (`stubMessageBox` / `getRecordedDialogs`) — so a failed import now fails the test immediately with the real error message instead of timing out silently after 120s.

## Testing Instructions

- `npm run package && npx playwright test apps/studio/e2e/import-formats.test.ts -g "existing site"` — passes locally (26s), including with the onboarding site already running (the previous retry-failure state).
- CI: the linux-x64 E2E job should stay green across rebuilds.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
