### PR TITLE
Studio Code TUI: sort slash command autocomplete alphabetically

### DIFF
--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -53,7 +53,9 @@ export interface SlashCommandDef {
 }
 
 export function getActiveSlashCommands(): SlashCommandDef[] {
-	return AI_CHAT_SLASH_COMMANDS;
+	// Alphabetical order is what the autocomplete shows for a bare `/`; once
+	// the user types a query, fuzzy-match scoring takes over the ordering.
+	return [ ...AI_CHAT_SLASH_COMMANDS ].sort( ( a, b ) => a.name.localeCompare( b.name ) );
 }
 
 function isPromptAbortError( error: unknown ): boolean {

--- a/apps/cli/ai/tests/slash-commands.test.ts
+++ b/apps/cli/ai/tests/slash-commands.test.ts
@@ -1,20 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-	AI_CHAT_SLASH_COMMANDS,
-	getActiveSlashCommands,
-	type SlashCommandContext,
-} from 'cli/ai/slash-commands';
-
-describe( 'getActiveSlashCommands', () => {
-	it( 'returns commands in alphabetical order', () => {
-		const names = getActiveSlashCommands().map( ( c ) => c.name );
-		expect( names ).toEqual( [ ...names ].sort( ( a, b ) => a.localeCompare( b ) ) );
-	} );
-
-	it( 'includes every registered command', () => {
-		expect( getActiveSlashCommands() ).toHaveLength( AI_CHAT_SLASH_COMMANDS.length );
-	} );
-} );
+import { AI_CHAT_SLASH_COMMANDS, type SlashCommandContext } from 'cli/ai/slash-commands';
 
 describe( '/remote-session slash command registration', () => {
 	const cmd = AI_CHAT_SLASH_COMMANDS.find( ( c ) => c.name === 'remote-session' );

--- a/apps/cli/ai/tests/slash-commands.test.ts
+++ b/apps/cli/ai/tests/slash-commands.test.ts
@@ -1,5 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AI_CHAT_SLASH_COMMANDS, type SlashCommandContext } from 'cli/ai/slash-commands';
+import {
+	AI_CHAT_SLASH_COMMANDS,
+	getActiveSlashCommands,
+	type SlashCommandContext,
+} from 'cli/ai/slash-commands';
+
+describe( 'getActiveSlashCommands', () => {
+	it( 'returns commands in alphabetical order', () => {
+		const names = getActiveSlashCommands().map( ( c ) => c.name );
+		expect( names ).toEqual( [ ...names ].sort( ( a, b ) => a.localeCompare( b ) ) );
+	} );
+
+	it( 'includes every registered command', () => {
+		expect( getActiveSlashCommands() ).toHaveLength( AI_CHAT_SLASH_COMMANDS.length );
+	} );
+} );
 
 describe( '/remote-session slash command registration', () => {
 	const cmd = AI_CHAT_SLASH_COMMANDS.find( ( c ) => c.name === 'remote-session' );


### PR DESCRIPTION
## Related issues

<!-- None — small UX improvement noticed while using the TUI. -->

## How AI was used in this PR

The change and tests were written by Claude Code (Fable 5), guided and reviewed by the author. AI also traced how `pi-tui`'s `fuzzyFilter` orders suggestions to confirm the scoring behavior is unaffected.

## Proposed Changes

- When you type a bare `/` in the Studio Code TUI, the command popup previously listed commands in their source-definition order, which was almost-but-not-quite alphabetical (e.g. `api-key` after `clear`) and always showed skill commands last. It now lists them alphabetically, making commands easier to scan and predict.
- Once you start typing a query, ordering is unchanged: fuzzy-match scoring still ranks best matches first. Equal-score matches now tie-break alphabetically instead of by definition order.

## Testing Instructions

- `npm run cli:build && node apps/cli/dist/cli/main.mjs ai`
- Type `/` in the composer — the command list should be alphabetical (`api-key`, `browser`, `clear`, …) with skill commands interleaved rather than appended at the end.
- Type `/p` — fuzzy ranking still applies (`preview`, `provider`, `publish` ranked by match quality).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
