### PR TITLE
Disable automatic What's New modal on app updates

### DIFF
--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -75,4 +75,4 @@ export const IPC_VOID_HANDLERS = [
 // Flip to `true` when shipping new modal content so users who haven't seen the
 // current app version get the modal once. Keep at `false` otherwise — the modal
 // will only auto-show for first-time users of Studio.
-export const FORCE_SHOW_WHATS_NEW = true;
+export const FORCE_SHOW_WHATS_NEW = false;


### PR DESCRIPTION
## Related issues

- None

## How AI was used in this PR

AI located the `FORCE_SHOW_WHATS_NEW` toggle and verified behavior via the existing unit tests; the change was reviewed manually.

## Proposed Changes

- Let's turn off `FORCE_SHOW_WHATS_NEW` for next release.

## Testing Instructions

- Run the app with a stored `lastSeenVersion` older than the current version (or bump the app version locally): the What's New modal should no longer appear on launch.
- Delete the stored `lastSeenVersion` (fresh profile): the modal still appears once.
- Help menu → What's New still opens the modal.
- `npm test -- apps/studio/src/stores/tests/app-version-api.test.ts` passes (9/9).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)