### PR TITLE
CLI: highlight the matched query in slash-command autocomplete

### DIFF
--- a/apps/cli/ai/description-autocomplete.ts
+++ b/apps/cli/ai/description-autocomplete.ts
@@ -4,7 +4,7 @@ import { escapeRegex } from '@studio/common/lib/escape-regex';
 import type { AutocompleteSuggestions } from '@earendil-works/pi-tui';
 import type { SlashCommandDef } from 'cli/ai/slash-commands';
 
-const wordPressBlue = chalk.hex( '#3858e9' );
+const highlightBlue = chalk.hex( '#a4cafa' );
 
 export function highlightMatch( text: string, query: string ): string {
 	const index = text.toLowerCase().indexOf( query.toLowerCase() );
@@ -13,7 +13,7 @@ export function highlightMatch( text: string, query: string ): string {
 	}
 	return (
 		text.slice( 0, index ) +
-		wordPressBlue( text.slice( index, index + query.length ) ) +
+		highlightBlue( text.slice( index, index + query.length ) ) +
 		text.slice( index + query.length )
 	);
 }
@@ -23,7 +23,7 @@ export function highlightMatch( text: string, query: string ): string {
 let highlightSpan: RegExp | null | undefined;
 function getHighlightSpan(): RegExp | null {
 	if ( highlightSpan === undefined ) {
-		const [ open, close ] = wordPressBlue( ' ' ).split( ' ' );
+		const [ open, close ] = highlightBlue( ' ' ).split( ' ' );
 		highlightSpan = open
 			? new RegExp( `(${ escapeRegex( open ) }.*?${ escapeRegex( close ) })` )
 			: null;

--- a/apps/cli/ai/description-autocomplete.ts
+++ b/apps/cli/ai/description-autocomplete.ts
@@ -1,6 +1,52 @@
 import { CombinedAutocompleteProvider } from '@earendil-works/pi-tui';
+import chalk from '@studio/common/lib/chalk';
+import { escapeRegex } from '@studio/common/lib/escape-regex';
 import type { AutocompleteSuggestions } from '@earendil-works/pi-tui';
 import type { SlashCommandDef } from 'cli/ai/slash-commands';
+
+const wordPressBlue = chalk.hex( '#3858e9' );
+
+export function highlightMatch( text: string, query: string ): string {
+	const index = text.toLowerCase().indexOf( query.toLowerCase() );
+	if ( index === -1 ) {
+		return text;
+	}
+	return (
+		text.slice( 0, index ) +
+		wordPressBlue( text.slice( index, index + query.length ) ) +
+		text.slice( index + query.length )
+	);
+}
+
+// Matches one highlightMatch span. Built once from the codes the chalk
+// wrapper actually emits; null when colors are off.
+let highlightSpan: RegExp | null | undefined;
+function getHighlightSpan(): RegExp | null {
+	if ( highlightSpan === undefined ) {
+		const [ open, close ] = wordPressBlue( ' ' ).split( ' ' );
+		highlightSpan = open
+			? new RegExp( `(${ escapeRegex( open ) }.*?${ escapeRegex( close ) })` )
+			: null;
+	}
+	return highlightSpan;
+}
+
+/**
+ * Select-list `description` theme function: dims the text like `chalk.dim`,
+ * but keeps `highlightMatch` spans at full intensity — wrapping the whole
+ * string in `chalk.dim` would dim the highlight too.
+ */
+export function dimUnhighlighted( text: string ): string {
+	const span = getHighlightSpan();
+	if ( ! span ) {
+		return chalk.dim( text );
+	}
+	// Captured highlight spans land at odd indices of split().
+	return text
+		.split( span )
+		.map( ( part, i ) => ( i % 2 ? part : part && chalk.dim( part ) ) )
+		.join( '' );
+}
 
 /**
  * Autocomplete provider that extends pi-tui's slash-command matching (command
@@ -53,11 +99,16 @@ export class DescriptionAwareAutocompleteProvider extends CombinedAutocompletePr
 				label: command.name,
 				description: command.description,
 			} ) );
-		if ( descriptionItems.length === 0 ) {
-			return suggestions;
+		if ( descriptionItems.length === 0 && ! suggestions ) {
+			return null;
 		}
+		const items = [ ...( suggestions?.items ?? [] ), ...descriptionItems ].map( ( item ) => ( {
+			...item,
+			label: highlightMatch( item.label ?? item.value, query ),
+			...( item.description && { description: highlightMatch( item.description, query ) } ),
+		} ) );
 		return {
-			items: [ ...( suggestions?.items ?? [] ), ...descriptionItems ],
+			items,
 			prefix: textBeforeCursor,
 		};
 	}

--- a/apps/cli/ai/tests/description-autocomplete.test.ts
+++ b/apps/cli/ai/tests/description-autocomplete.test.ts
@@ -11,7 +11,7 @@ import type { SlashCommandDef } from 'cli/ai/slash-commands';
 // Vitest isolates env changes per test file.
 process.env.FORCE_COLOR = '3';
 
-const highlight = ( text: string ) => chalk.hex( '#3858e9' )( text );
+const highlight = ( text: string ) => chalk.hex( '#a4cafa' )( text );
 
 const COMMANDS: SlashCommandDef[] = [
 	{ name: 'exit', description: 'Exit the chat' },

--- a/apps/cli/ai/tests/description-autocomplete.test.ts
+++ b/apps/cli/ai/tests/description-autocomplete.test.ts
@@ -1,6 +1,17 @@
+import chalk from '@studio/common/lib/chalk';
 import { describe, expect, it } from 'vitest';
-import { DescriptionAwareAutocompleteProvider } from 'cli/ai/description-autocomplete';
+import {
+	DescriptionAwareAutocompleteProvider,
+	dimUnhighlighted,
+	highlightMatch,
+} from 'cli/ai/description-autocomplete';
 import type { SlashCommandDef } from 'cli/ai/slash-commands';
+
+// Force truecolor so styled output is observable in the non-TTY test env.
+// Vitest isolates env changes per test file.
+process.env.FORCE_COLOR = '3';
+
+const highlight = ( text: string ) => chalk.hex( '#3858e9' )( text );
 
 const COMMANDS: SlashCommandDef[] = [
 	{ name: 'exit', description: 'Exit the chat' },
@@ -50,5 +61,42 @@ describe( 'DescriptionAwareAutocompleteProvider', () => {
 	it( 'returns null when nothing matches', async () => {
 		const result = await suggest( '/zzz' );
 		expect( result ).toBeNull();
+	} );
+
+	it( 'colors the query match in names and descriptions', async () => {
+		const result = await suggest( '/migrate' );
+		const item = result?.items[ 0 ];
+		expect( item?.label ).toBe( 'liberate' );
+		expect( item?.description ).toBe(
+			`${ highlight( 'Migrate' ) } & rebuild a site from a closed platform`
+		);
+	} );
+
+	it( 'colors the query match in a name-matched command', async () => {
+		const result = await suggest( '/liber' );
+		expect( result?.items[ 0 ]?.label ).toBe( `${ highlight( 'liber' ) }ate` );
+	} );
+} );
+
+describe( 'highlightMatch', () => {
+	it( 'colors the first case-insensitive occurrence', () => {
+		expect( highlightMatch( 'Exit the chat', 'exit' ) ).toBe( `${ highlight( 'Exit' ) } the chat` );
+	} );
+
+	it( 'returns text unchanged when the query is absent', () => {
+		expect( highlightMatch( 'liberate', 'xyz' ) ).toBe( 'liberate' );
+	} );
+} );
+
+describe( 'dimUnhighlighted', () => {
+	it( 'dims text around a highlight but not the highlight itself', () => {
+		const input = `before ${ highlight( 'match' ) } after`;
+		expect( dimUnhighlighted( input ) ).toBe(
+			`${ chalk.dim( 'before ' ) }${ highlight( 'match' ) }${ chalk.dim( ' after' ) }`
+		);
+	} );
+
+	it( 'dims the whole text when there is no highlight', () => {
+		expect( dimUnhighlighted( 'plain text' ) ).toBe( chalk.dim( 'plain text' ) );
 	} );
 } );

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -33,7 +33,10 @@ import { getToolDetail, getToolDisplayName, getToolResultPreview } from '@studio
 import chalk from '@studio/common/lib/chalk';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { DescriptionAwareAutocompleteProvider } from 'cli/ai/description-autocomplete';
+import {
+	DescriptionAwareAutocompleteProvider,
+	dimUnhighlighted,
+} from 'cli/ai/description-autocomplete';
 import { type AiOutputAdapter } from 'cli/ai/output-adapter';
 import { AI_PROVIDERS, DEFAULT_AI_PROVIDER, type AiProviderId } from 'cli/ai/providers';
 import { getActiveSlashCommands } from 'cli/ai/slash-commands';
@@ -252,7 +255,7 @@ const editorTheme: EditorTheme = {
 	selectList: {
 		selectedPrefix: ( text ) => chalk.cyan( text ),
 		selectedText: ( text ) => chalk.bold( text ),
-		description: ( text ) => chalk.dim( text ),
+		description: ( text ) => dimUnhighlighted( text ),
 		scrollInfo: ( text ) => chalk.dim( text ),
 		noMatch: ( text ) => chalk.dim( text ),
 	},


### PR DESCRIPTION
## Related issues

- Related to STU-1973 (follow-up to #4111)

## How AI was used in this PR

Implemented with Claude Code: iterated on the highlight styling (underline → WordPress blue → fixed dimming on unselected rows), ran parallel review agents for reuse/simplification/efficiency cleanup, and a code-review agent pass over the final diff. All changes reviewed and verified locally.

## Proposed Changes

- Highlight matching strings when typing a skill name or description.
- The highlight stays at full intensity on unselected rows too: descriptions are still dimmed, but the matched substring is not.
- On terminals without truecolor support the list renders exactly as before (no highlight, plain dim).

## Testing Instructions

- `npm run cli:build && node apps/cli/dist/cli/main.mjs ai`
- Type `/mig` → the `liberate` suggestion appears and `Mig` in its description is blue.
- Type `/liber` → `liber` in the command name is blue.
- Arrow through suggestions: highlight remains visible on the selected row; unselected descriptions stay dim around the match.


https://github.com/user-attachments/assets/7c81fa05-a672-4ef2-931b-7d488230c90d



## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)