### PR TITLE
Retry AppX signing on transient timestamp server failures

### DIFF
--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -203,9 +203,23 @@ for ( const appxFile of appxFiles ) {
 	const appxPath = path.join( appxOutputPathSigned, appxFile );
 	console.log( `Signing ${ appxPath }...` );
 	const { signtoolPath } = getAzureSigningConfig();
-	execFileSync( signtoolPath, getAzureSignArgs( appxPath ), {
-		stdio: 'inherit',
-	} );
+	// The Microsoft timestamp server (timestamp.acs.microsoft.com) fails
+	// intermittently, so retry a few times before giving up.
+	const maxAttempts = 3;
+	for ( let attempt = 1; ; attempt++ ) {
+		try {
+			execFileSync( signtoolPath, getAzureSignArgs( appxPath ), {
+				stdio: 'inherit',
+			} );
+			break;
+		} catch ( error ) {
+			if ( attempt >= maxAttempts ) {
+				throw error;
+			}
+			console.log( `Signing attempt ${ attempt } of ${ maxAttempts } failed, retrying in 30s...` );
+			await new Promise( ( resolve ) => setTimeout( resolve, 30_000 ) );
+		}
+	}
 	console.log( `Signed ${ appxFile } successfully.` );
 
 	// Rename to remove misleading "unsigned" from the filename

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -206,6 +206,7 @@ for ( const appxFile of appxFiles ) {
 	// The Microsoft timestamp server (timestamp.acs.microsoft.com) fails
 	// intermittently, so retry a few times before giving up.
 	const maxAttempts = 3;
+	const retryDelaySeconds = 30;
 	for ( let attempt = 1; ; attempt++ ) {
 		try {
 			execFileSync( signtoolPath, getAzureSignArgs( appxPath ), {
@@ -216,8 +217,8 @@ for ( const appxFile of appxFiles ) {
 			if ( attempt >= maxAttempts ) {
 				throw error;
 			}
-			console.log( `Signing attempt ${ attempt } of ${ maxAttempts } failed, retrying in 30s...` );
-			await new Promise( ( resolve ) => setTimeout( resolve, 30_000 ) );
+			console.log( `Signing attempt ${ attempt } of ${ maxAttempts } failed, retrying in ${ retryDelaySeconds }s...` );
+			await new Promise( ( resolve ) => setTimeout( resolve, retryDelaySeconds * 1000 ) );
 		}
 	}
 	console.log( `Signed ${ appxFile } successfully.` );

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -217,7 +217,9 @@ for ( const appxFile of appxFiles ) {
 			if ( attempt >= maxAttempts ) {
 				throw error;
 			}
-			console.log( `Signing attempt ${ attempt } of ${ maxAttempts } failed, retrying in ${ retryDelaySeconds }s...` );
+			console.log(
+				`Signing attempt ${ attempt } of ${ maxAttempts } failed, retrying in ${ retryDelaySeconds }s...`
+			);
 			await new Promise( ( resolve ) => setTimeout( resolve, retryDelaySeconds * 1000 ) );
 		}
 	}


### PR DESCRIPTION
## Related issues

- Related to Windows dev build failures on Buildkite (e.g. [build 18999](https://buildkite.com/automattic/studio/builds/18999#019f4196-9620-4835-b53a-1dcdaf989671))

## How AI was used in this PR

AI analyzed the Buildkite failure log, identified the root cause, and wrote the retry logic. Reviewed by the author.

## Proposed Changes

Windows builds intermittently fail during AppX sideload signing: Azure Trusted Signing itself succeeds, but signtool's follow-up call to the Microsoft timestamp server (`timestamp.acs.microsoft.com`) occasionally can't be reached or returns an invalid response, killing the whole build.

I suggest adding three retries before failing the Windows build. That will make it less flaky.

## Testing Instructions

- CI: the Windows Dev Build steps run this script; a green build covers the happy path.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
