### PR TITLE
Migrate overview customize links e2e test to CLI

### DIFF
--- a/.buildkite/commands/run-cli-e2e-tests.sh
+++ b/.buildkite/commands/run-cli-e2e-tests.sh
@@ -13,4 +13,6 @@ echo '--- :wordpress: Seed server files'
 node apps/cli/dist/cli/main.mjs site list
 
 echo '--- :vitest: Run CLI E2E Tests'
-npm test -- --tagsFilter='e2e'
+# Serialize the files: each spins up its own sandbox WordPress + daemon, and
+# booting several at once starves the CI host, flaking `site start`.
+npm test -- --tagsFilter='e2e' --no-file-parallelism

--- a/apps/cli/commands/site/tests/helpers/cli-e2e.ts
+++ b/apps/cli/commands/site/tests/helpers/cli-e2e.ts
@@ -123,6 +123,26 @@ export function readCliConfig( env: CliEnv ): {
 }
 
 /**
+ * Logs in as the site's admin through the `/studio-auto-login` mu-plugin and
+ * returns the auth cookies as a `Cookie` header value, so a plain `fetch` can
+ * request admin-only pages. Mirrors the desktop suite's auto-login.
+ */
+export async function autoLoginCookie( siteUrl: string ): Promise< string > {
+	const loginUrl = new URL( '/studio-auto-login', siteUrl );
+	loginUrl.searchParams.set( 'redirect_to', '/wp-admin/' );
+
+	const response = await fetch( loginUrl, { redirect: 'manual' } );
+	const cookies = ( response.headers.getSetCookie?.() ?? [] )
+		.map( ( cookie ) => cookie.split( ';' )[ 0 ] )
+		.filter( Boolean );
+
+	if ( cookies.length === 0 ) {
+		throw new Error( `Auto-login returned no cookies (status ${ String( response.status ) }).` );
+	}
+	return cookies.join( '; ' );
+}
+
+/**
  * Polls a URL until the freshly started server responds (redirects not followed). Pass
  * `expectedStatus` to also poll past interim responses like the proxy's warm-up 302.
  */

--- a/apps/cli/commands/site/tests/overview-customize-links.e2e.test.ts
+++ b/apps/cli/commands/site/tests/overview-customize-links.e2e.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment node
+ *
+ * Overview "Customize" shortcuts against the built CLI (`npm run cli:build`
+ * first), migrated from `apps/studio/e2e/overview-customize-links.test.ts`.
+ * The desktop suite's button clicks and in-editor navigation are UI-only, so
+ * this keeps the headless-verifiable core: a block theme is active and every
+ * Site Editor route the buttons target is served.
+ */
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	cleanupCliEnv,
+	cliE2ePrerequisitesMet,
+	readCliConfig,
+	runCli,
+	setupCliEnv,
+	waitForSiteResponse,
+	type CliEnv,
+} from './helpers/cli-e2e';
+
+// Server-side every route is the same core admin file; the `path=` query is a
+// client-only hint the Site Editor reads post-login.
+const CUSTOMIZE_ROUTES = [
+	{ label: 'Site Editor', route: '/wp-admin/site-editor.php' },
+	{ label: 'Styles', route: '/wp-admin/site-editor.php?path=%2Fwp_global_styles' },
+	{ label: 'Patterns', route: '/wp-admin/site-editor.php?path=%2Fpatterns' },
+	{ label: 'Navigation', route: '/wp-admin/site-editor.php?path=%2Fnavigation' },
+	{ label: 'Templates', route: '/wp-admin/site-editor.php?path=%2Fwp_template' },
+	{ label: 'Pages', route: '/wp-admin/site-editor.php?path=%2Fpage' },
+];
+
+describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: overview customize links', () => {
+	let env: CliEnv;
+	let sitePath: string;
+	let siteUrl: string;
+
+	beforeAll( async () => {
+		env = setupCliEnv();
+		sitePath = path.join( env.sitesDir, 'customize-links-e2e-site' );
+
+		const result = await runCli(
+			[
+				'site',
+				'create',
+				'--name',
+				'Customize Links E2E Site',
+				'--path',
+				sitePath,
+				'--wp',
+				'latest',
+				// Sandbox is bundled; the default native runtime downloads PHP on start.
+				'--runtime',
+				'sandbox',
+				'--skip-browser',
+				'--skip-log-details',
+			],
+			env
+		);
+		expect( result.code, result.stderr ).toBe( 0 );
+
+		const [ site ] = readCliConfig( env ).sites;
+		siteUrl = `http://localhost:${ String( site.port ) }`;
+
+		// Poll the homepage to 200 so the proxy's warm-up 302 is gone before the
+		// route checks assert on the real auth redirect (also a 302).
+		await waitForSiteResponse( siteUrl, { expectedStatus: 200 } );
+	}, 240_000 );
+
+	afterAll( async () => {
+		if ( ! env ) {
+			return;
+		}
+		await runCli( [ 'site', 'stop', '--all' ], env );
+		cleanupCliEnv( env );
+	}, 60_000 );
+
+	it( 'runs a block theme by default', { tags: [ 'e2e' ], timeout: 60_000 }, async () => {
+		const result = await runCli(
+			[ 'wp', 'eval', 'echo wp_is_block_theme() ? "yes" : "no";', '--path', sitePath ],
+			env
+		);
+		expect( result.code, result.stderr ).toBe( 0 );
+		expect( result.stdout ).toContain( 'yes' );
+	} );
+
+	it.each( CUSTOMIZE_ROUTES )(
+		'serves the $label customize route',
+		{ tags: [ 'e2e' ], timeout: 60_000 },
+		async ( { route } ) => {
+			// The route is served (not 404); unauthenticated it bounces to the login
+			// screen, since auto-login is desktop-only.
+			const response = await waitForSiteResponse( `${ siteUrl }${ route }` );
+			expect( response.status ).toBe( 302 );
+			expect( response.headers.get( 'location' ) ).toContain( 'wp-login.php' );
+		}
+	);
+} );

--- a/apps/cli/commands/site/tests/overview-customize-links.e2e.test.ts
+++ b/apps/cli/commands/site/tests/overview-customize-links.e2e.test.ts
@@ -3,13 +3,15 @@
  *
  * Overview "Customize" shortcuts against the built CLI (`npm run cli:build`
  * first), migrated from `apps/studio/e2e/overview-customize-links.test.ts`.
- * The desktop suite's button clicks and in-editor navigation are UI-only, so
- * this keeps the headless-verifiable core: a block theme is active and every
- * Site Editor route the buttons target is served.
+ * The desktop suite's button clicks are UI-only, but the URL each button opens
+ * is reproducible headless: this logs in via `/studio-auto-login` and confirms
+ * a block theme is active and every Site Editor route the buttons target loads
+ * for an authenticated admin.
  */
 import path from 'path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
+	autoLoginCookie,
 	cleanupCliEnv,
 	cliE2ePrerequisitesMet,
 	readCliConfig,
@@ -18,6 +20,11 @@ import {
 	waitForSiteResponse,
 	type CliEnv,
 } from './helpers/cli-e2e';
+
+// The Site Editor's server HTML is a shell it hydrates with JS; `id="site-editor"`
+// is the mount root, present for every route. The `path=` query only steers the
+// client, so headless we can confirm the editor loads but not the per-path view.
+const SITE_EDITOR_MARKER = 'id="site-editor"';
 
 // Server-side every route is the same core admin file; the `path=` query is a
 // client-only hint the Site Editor reads post-login.
@@ -34,6 +41,7 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: overview customize link
 	let env: CliEnv;
 	let sitePath: string;
 	let siteUrl: string;
+	let cookie: string;
 
 	beforeAll( async () => {
 		env = setupCliEnv();
@@ -63,8 +71,9 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: overview customize link
 		siteUrl = `http://localhost:${ String( site.port ) }`;
 
 		// Poll the homepage to 200 so the proxy's warm-up 302 is gone before the
-		// route checks assert on the real auth redirect (also a 302).
+		// authenticated route checks.
 		await waitForSiteResponse( siteUrl, { expectedStatus: 200 } );
+		cookie = await autoLoginCookie( siteUrl );
 	}, 240_000 );
 
 	afterAll( async () => {
@@ -85,14 +94,17 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: overview customize link
 	} );
 
 	it.each( CUSTOMIZE_ROUTES )(
-		'serves the $label customize route',
+		'loads the $label editor page for an authenticated admin',
 		{ tags: [ 'e2e' ], timeout: 60_000 },
 		async ( { route } ) => {
-			// The route is served (not 404); unauthenticated it bounces to the login
-			// screen, since auto-login is desktop-only.
-			const response = await waitForSiteResponse( `${ siteUrl }${ route }` );
-			expect( response.status ).toBe( 302 );
-			expect( response.headers.get( 'location' ) ).toContain( 'wp-login.php' );
+			// Follow redirects: WordPress canonicalizes the older `?path=` scheme to
+			// `?p=`, so several of these routes 302 to the equivalent editor URL.
+			const response = await fetch( `${ siteUrl }${ route }`, {
+				headers: { Cookie: cookie },
+				redirect: 'follow',
+			} );
+			expect( response.status ).toBe( 200 );
+			expect( await response.text() ).toContain( SITE_EDITOR_MARKER );
 		}
 	);
 } );

--- a/apps/cli/commands/site/tests/overview-customize-links.e2e.test.ts
+++ b/apps/cli/commands/site/tests/overview-customize-links.e2e.test.ts
@@ -1,8 +1,10 @@
 /**
  * @vitest-environment node
  *
- * Overview "Customize" shortcuts against the built CLI (`npm run cli:build`
- * first), migrated from `apps/studio/e2e/overview-customize-links.test.ts`.
+ * Overview "Customize" shortcuts against the built CLI, migrated from
+ * `apps/studio/e2e/overview-customize-links.test.ts`. Needs `npm run cli:build`
+ * and the bundled WordPress under `~/.studio/server-files` (seeded by running
+ * Studio once); the suite skips itself otherwise.
  * The desktop suite's button clicks are UI-only, but the URL each button opens
  * is reproducible headless: this logs in via `/studio-auto-login` and confirms
  * a block theme is active and every Site Editor route the buttons target loads
@@ -67,7 +69,9 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: overview customize link
 		);
 		expect( result.code, result.stderr ).toBe( 0 );
 
-		const [ site ] = readCliConfig( env ).sites;
+		const { sites } = readCliConfig( env );
+		expect( sites ).toHaveLength( 1 );
+		const [ site ] = sites;
 		siteUrl = `http://localhost:${ String( site.port ) }`;
 
 		// Poll the homepage to 200 so the proxy's warm-up 302 is gone before the

--- a/apps/studio/src/components/tests/content-tab-overview.actions.test.tsx
+++ b/apps/studio/src/components/tests/content-tab-overview.actions.test.tsx
@@ -1,0 +1,137 @@
+// To run tests, execute `npm run test -- src/components/tests/content-tab-overview.actions.test.tsx` from the root directory
+/**
+ * Overview "Customize" link UI tests — the command each block-theme shortcut fires (STU-1875).
+ *
+ * Companion to the CLI e2e suite (overview-customize-links.e2e.test.ts): that
+ * proves the Site Editor routes load; this proves the UI half the CLI can't —
+ * that clicking each Customize button opens the right URL. Following the #3950
+ * pattern, it mounts the real Site/ThemeDetails providers and mocks only the IPC
+ * bridge, then asserts the exact `openSiteURL` command each click generates.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { ReactNode } from 'react';
+import { Provider } from 'react-redux';
+import { beforeAll, beforeEach, vi } from 'vitest';
+import { ContentTabOverview } from 'src/components/content-tab-overview';
+import { ContentTabsProvider } from 'src/hooks/use-content-tabs';
+import { SiteDetailsProvider } from 'src/hooks/use-site-details';
+import { ThemeDetailsProvider } from 'src/hooks/use-theme-details';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { store } from 'src/stores';
+
+vi.mock( 'src/lib/get-ipc-api' );
+vi.mock( 'src/lib/app-globals', () => ( {
+	isWindows: () => false,
+	isLinux: () => false,
+	getAppGlobals: () => ( { platform: 'darwin' } ),
+} ) );
+vi.mock( 'src/lib/file-manager', () => ( {
+	getFileManagerLabel: () => 'Finder',
+} ) );
+
+const SITE_ID = 'site-id';
+const site: StartedSiteDetails = {
+	id: SITE_ID,
+	name: 'Test Site',
+	path: '/path/to/site',
+	port: 8881,
+	phpVersion: '8.4',
+	running: true,
+	url: 'http://localhost:8881',
+	themeDetails: {
+		name: 'Twenty Twenty-Five',
+		path: '/path/to/theme',
+		slug: 'twentytwentyfive',
+		isBlockTheme: true,
+		supportsWidgets: false,
+		supportsMenus: false,
+	},
+};
+
+// Each block-theme Customize button and the URL it opens (content-tab-overview.tsx).
+const CUSTOMIZE_LINKS = [
+	{ label: 'Site Editor', url: '/wp-admin/site-editor.php' },
+	{ label: 'Styles', url: '/wp-admin/site-editor.php?path=%2Fwp_global_styles' },
+	{ label: 'Patterns', url: '/wp-admin/site-editor.php?path=%2Fpatterns' },
+	{ label: 'Navigation', url: '/wp-admin/site-editor.php?path=%2Fnavigation' },
+	{ label: 'Templates', url: '/wp-admin/site-editor.php?path=%2Fwp_template' },
+	{ label: 'Pages', url: '/wp-admin/site-editor.php?path=%2Fpage' },
+];
+
+const wrapper = ( { children }: { children: ReactNode } ) => (
+	<Provider store={ store }>
+		<ContentTabsProvider>
+			<SiteDetailsProvider>
+				<ThemeDetailsProvider>{ children }</ThemeDetailsProvider>
+			</SiteDetailsProvider>
+		</ContentTabsProvider>
+	</Provider>
+);
+
+function renderOverview( selectedSite: SiteDetails = site ) {
+	return render( <ContentTabOverview selectedSite={ selectedSite } />, { wrapper } );
+}
+
+// A Customize button is enabled only after the provider has loaded and the server
+// is no longer marked as starting; wait for that before clicking.
+async function findEnabledButton( label: string ) {
+	return waitFor( () => {
+		const button = screen.getByRole( 'button', { name: label } );
+		expect( button ).toBeEnabled();
+		return button;
+	} );
+}
+
+beforeAll( () => {
+	Object.defineProperty( window, 'ipcListener', {
+		value: { subscribe: vi.fn().mockReturnValue( () => {} ) },
+		writable: true,
+	} );
+} );
+
+beforeEach( () => {
+	vi.clearAllMocks();
+	vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+		getSiteDetails: vi.fn().mockResolvedValue( [ site ] ),
+		getConnectedWpcomSites: vi.fn().mockResolvedValue( [] ),
+		getThumbnailData: vi.fn().mockResolvedValue( undefined ),
+		getUserEditor: vi.fn().mockResolvedValue( undefined ),
+		getUserTerminal: vi.fn().mockResolvedValue( undefined ),
+		startServer: vi.fn().mockResolvedValue( { ...site, running: true } ),
+		openSiteURL: vi.fn(),
+	} );
+} );
+
+describe( 'ContentTabOverview — Customize links (IPC command boundary)', () => {
+	it.each( CUSTOMIZE_LINKS )( '$label opens $url', async ( { label, url } ) => {
+		const user = userEvent.setup();
+		renderOverview();
+
+		await user.click( await findEnabledButton( label ) );
+
+		await waitFor( () => {
+			expect( getIpcApi().openSiteURL ).toHaveBeenCalledWith( SITE_ID, url );
+		} );
+	} );
+
+	it( 'starts the server before opening when the site is stopped', async () => {
+		const user = userEvent.setup();
+		const stoppedSite: SiteDetails = { ...site, running: false };
+		vi.mocked( getIpcApi().getSiteDetails ).mockResolvedValue( [ stoppedSite ] );
+
+		renderOverview( stoppedSite );
+
+		await user.click( await findEnabledButton( 'Site Editor' ) );
+
+		await waitFor( () => {
+			expect( getIpcApi().startServer ).toHaveBeenCalledWith( SITE_ID );
+		} );
+		await waitFor( () => {
+			expect( getIpcApi().openSiteURL ).toHaveBeenCalledWith(
+				SITE_ID,
+				'/wp-admin/site-editor.php'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Fixes [STU-1875](https://linear.app/a8c/issue/STU-1875/migrate-overview-customize-links-block-theme)

## How AI was used in this PR

Claude wrote the code, guided by the author. The author tested it locally and manually reviewed it before pushing.

## Proposed Changes

- Migrate the Overview "Customize" links coverage from the desktop Playwright suite to a headless CLI e2e test.
- Add UI IPC-mock tests (the #3950 pattern) asserting each Customize button fires the right `openSiteURL` command.
- Run the CLI e2e files serially on CI to avoid flakes from concurrent sandbox boots.

## Testing Instructions

- `npm run cli:build`
- CLI e2e: `npm test -- apps/cli/commands/site/tests/overview-customize-links.e2e.test.ts --tagsFilter='e2e'` — expect 7 passing tests.
- UI: `npm test -- src/components/tests/content-tab-overview.actions.test.tsx` — expect 7 passing tests.
- To confirm serialization: `npm test -- apps/cli/commands/site/tests --tagsFilter='e2e' --no-file-parallelism` runs the e2e files one at a time.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
