### PR TITLE
Migrate localization tests to CLI e2e and UI tests

### DIFF
--- a/apps/cli/commands/site/tests/localization.e2e.test.ts
+++ b/apps/cli/commands/site/tests/localization.e2e.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment node
+ *
+ * Localization logic against the built CLI, migrated from
+ * `apps/studio/e2e/localization.test.ts`. The desktop suite drives the settings
+ * UI; the locale-to-site logic is UI-independent and lives here: the CLI reads
+ * the Studio locale persisted in `shared.json` and applies it to a created site.
+ * RTL rendering and the settings flow stay in the renderer tests.
+ *
+ * Needs `npm run cli:build` and the bundled WordPress under `~/.studio/server-files`;
+ * the suite skips itself otherwise. Creating a non-English site downloads its
+ * language pack from wordpress.org, so this case needs network access.
+ */
+import fs from 'fs';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	cleanupCliEnv,
+	cliE2ePrerequisitesMet,
+	runCli,
+	setupCliEnv,
+	type CliEnv,
+} from './helpers/cli-e2e';
+
+const LOCALE = 'ja';
+
+describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: localization', () => {
+	let env: CliEnv;
+	let sitePath: string;
+
+	beforeAll( async () => {
+		env = setupCliEnv();
+		sitePath = path.join( env.sitesDir, 'localized-e2e-site' );
+
+		// The Studio locale the desktop app persists; the CLI reads it from here.
+		fs.writeFileSync(
+			path.join( env.configDir, 'shared.json' ),
+			JSON.stringify( { version: 1, locale: LOCALE } )
+		);
+
+		const result = await runCli(
+			[
+				'site',
+				'create',
+				'--name',
+				'Localized E2E Site',
+				'--path',
+				sitePath,
+				'--wp',
+				'latest',
+				'--runtime',
+				'sandbox',
+				'--skip-browser',
+				'--skip-log-details',
+			],
+			env
+		);
+		expect( result.code, result.stderr ).toBe( 0 );
+	}, 240_000 );
+
+	afterAll( async () => {
+		if ( ! env ) {
+			return;
+		}
+		await runCli( [ 'site', 'stop', '--all' ], env );
+		cleanupCliEnv( env );
+	}, 60_000 );
+
+	it(
+		"created site's WPLANG matches the Studio locale",
+		{ tags: [ 'e2e' ], timeout: 120_000 },
+		async () => {
+			const result = await runCli( [ 'wp', 'option', 'get', 'WPLANG', '--path', sitePath ], env );
+			expect( result.code, result.stderr ).toBe( 0 );
+			const value = result.stdout
+				.split( '\n' )
+				.map( ( line ) => line.trim() )
+				.filter( Boolean )
+				.at( -1 );
+			expect( value ).toBe( LOCALE );
+		}
+	);
+} );

--- a/apps/studio/src/hooks/tests/use-localization-support.test.tsx
+++ b/apps/studio/src/hooks/tests/use-localization-support.test.tsx
@@ -1,0 +1,48 @@
+// To run tests, execute `npm run test -- src/hooks/tests/use-localization-support.test.tsx` from the root directory
+/**
+ * RTL/visual localization check (STU-1872) — kept in the renderer because text
+ * direction is a rendering concern the CLI suite can't cover. Loading an RTL
+ * locale must flip `document.documentElement.dir` to `rtl`, and an LTR locale
+ * back to `ltr`.
+ */
+import { getLocaleData } from '@studio/common/lib/locale';
+import { render } from '@testing-library/react';
+import { defaultI18n } from '@wordpress/i18n';
+import { I18nProvider } from '@wordpress/react-i18n';
+import { Provider } from 'react-redux';
+import { afterEach } from 'vitest';
+import { useLocalizationSupport } from 'src/hooks/use-localization-support';
+import { store } from 'src/stores';
+
+function Probe() {
+	useLocalizationSupport();
+	return null;
+}
+
+function renderWithLocale( locale: string ) {
+	defaultI18n.setLocaleData( getLocaleData( locale )?.messages );
+	return render(
+		<Provider store={ store }>
+			<I18nProvider i18n={ defaultI18n }>
+				<Probe />
+			</I18nProvider>
+		</Provider>
+	);
+}
+
+afterEach( () => {
+	defaultI18n.resetLocaleData();
+	document.documentElement.dir = 'ltr';
+} );
+
+describe( 'useLocalizationSupport', () => {
+	it( 'sets the document direction to rtl for an RTL locale', () => {
+		renderWithLocale( 'ar' );
+		expect( document.documentElement.dir ).toBe( 'rtl' );
+	} );
+
+	it( 'sets the document direction to ltr for an LTR locale', () => {
+		renderWithLocale( 'fr' );
+		expect( document.documentElement.dir ).toBe( 'ltr' );
+	} );
+} );

--- a/apps/studio/src/hooks/tests/use-localization-support.test.tsx
+++ b/apps/studio/src/hooks/tests/use-localization-support.test.tsx
@@ -7,7 +7,7 @@
  */
 import { getLocaleData } from '@studio/common/lib/locale';
 import { render } from '@testing-library/react';
-import { defaultI18n } from '@wordpress/i18n';
+import { createI18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
 import { Provider } from 'react-redux';
 import { afterEach } from 'vitest';
@@ -19,11 +19,13 @@ function Probe() {
 	return null;
 }
 
+// A fresh i18n instance per render keeps each case isolated and avoids mutating
+// the shared `defaultI18n` singleton, which would fire cross-test updates.
 function renderWithLocale( locale: string ) {
-	defaultI18n.setLocaleData( getLocaleData( locale )?.messages );
+	const i18n = createI18n( getLocaleData( locale )?.messages );
 	return render(
 		<Provider store={ store }>
-			<I18nProvider i18n={ defaultI18n }>
+			<I18nProvider i18n={ i18n }>
 				<Probe />
 			</I18nProvider>
 		</Provider>
@@ -31,7 +33,6 @@ function renderWithLocale( locale: string ) {
 }
 
 afterEach( () => {
-	defaultI18n.resetLocaleData();
 	document.documentElement.dir = 'ltr';
 } );
 

--- a/apps/studio/src/modules/user-settings/components/tests/preferences-tab.actions.test.tsx
+++ b/apps/studio/src/modules/user-settings/components/tests/preferences-tab.actions.test.tsx
@@ -40,6 +40,7 @@ beforeEach( () => {
 		getColorScheme: vi.fn().mockResolvedValue( 'light' ),
 		getUserEditor: vi.fn().mockResolvedValue( null ),
 		getUserTerminal: vi.fn().mockResolvedValue( 'terminal' ),
+		getInstalledAppsAndTerminals: vi.fn().mockResolvedValue( { terminals: [], editors: [] } ),
 		isStudioCliInstalled: vi.fn().mockResolvedValue( false ),
 		getDefaultSiteDirectory: vi.fn().mockResolvedValue( '/mock/sites' ),
 		// Save path.

--- a/apps/studio/src/modules/user-settings/components/tests/preferences-tab.actions.test.tsx
+++ b/apps/studio/src/modules/user-settings/components/tests/preferences-tab.actions.test.tsx
@@ -8,6 +8,7 @@
  * `saveUserLocale` command. Following the #3950 pattern it mounts the real
  * component and store and mocks only the IPC bridge.
  */
+import { DEFAULT_LOCALE } from '@studio/common/lib/locale';
 import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { Provider } from 'react-redux';
@@ -15,6 +16,7 @@ import { beforeEach, vi } from 'vitest';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { PreferencesTab } from 'src/modules/user-settings/components/preferences-tab';
 import { store } from 'src/stores';
+import { saveUserLocale } from 'src/stores/i18n-slice';
 
 vi.mock( 'src/lib/get-ipc-api' );
 vi.mock( 'src/lib/app-globals', () => ( {
@@ -33,7 +35,7 @@ function renderPreferences() {
 	);
 }
 
-beforeEach( () => {
+beforeEach( async () => {
 	vi.clearAllMocks();
 	vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
 		// RTK Query mount-time reads.
@@ -49,6 +51,10 @@ beforeEach( () => {
 		resetDefaultLocaleData: vi.fn().mockResolvedValue( undefined ),
 		setupAppMenu: vi.fn().mockResolvedValue( undefined ),
 	} );
+
+	// Saving mutates the shared singleton store's locale; restore it so tests
+	// don't depend on run order.
+	await store.dispatch( saveUserLocale( DEFAULT_LOCALE ) );
 } );
 
 describe( 'PreferencesTab — language (IPC command boundary)', () => {

--- a/apps/studio/src/modules/user-settings/components/tests/preferences-tab.actions.test.tsx
+++ b/apps/studio/src/modules/user-settings/components/tests/preferences-tab.actions.test.tsx
@@ -1,0 +1,79 @@
+// To run tests, execute `npm run test -- src/modules/user-settings/components/tests/preferences-tab.actions.test.tsx` from the root directory
+/**
+ * Localization settings UI tests (STU-1872).
+ *
+ * Companion to the CLI e2e suite (localization.e2e.test.ts): that proves a
+ * created site inherits the Studio locale; this proves the UI half — the
+ * language picker lists the supported languages and saving one fires the
+ * `saveUserLocale` command. Following the #3950 pattern it mounts the real
+ * component and store and mocks only the IPC bridge.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { beforeEach, vi } from 'vitest';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { PreferencesTab } from 'src/modules/user-settings/components/preferences-tab';
+import { store } from 'src/stores';
+
+vi.mock( 'src/lib/get-ipc-api' );
+vi.mock( 'src/lib/app-globals', () => ( {
+	getAppGlobals: () => ( { platform: 'darwin' } ),
+	isMac: () => true,
+	isWindows: () => false,
+	isLinux: () => false,
+	isWindowsStore: () => false,
+} ) );
+
+function renderPreferences() {
+	return render(
+		<Provider store={ store }>
+			<PreferencesTab onClose={ vi.fn() } />
+		</Provider>
+	);
+}
+
+beforeEach( () => {
+	vi.clearAllMocks();
+	vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+		// RTK Query mount-time reads.
+		getColorScheme: vi.fn().mockResolvedValue( 'light' ),
+		getUserEditor: vi.fn().mockResolvedValue( null ),
+		getUserTerminal: vi.fn().mockResolvedValue( 'terminal' ),
+		isStudioCliInstalled: vi.fn().mockResolvedValue( false ),
+		getDefaultSiteDirectory: vi.fn().mockResolvedValue( '/mock/sites' ),
+		// Save path.
+		saveUserLocale: vi.fn().mockResolvedValue( undefined ),
+		setDefaultLocaleData: vi.fn().mockResolvedValue( undefined ),
+		resetDefaultLocaleData: vi.fn().mockResolvedValue( undefined ),
+		setupAppMenu: vi.fn().mockResolvedValue( undefined ),
+	} );
+} );
+
+describe( 'PreferencesTab — language (IPC command boundary)', () => {
+	it( 'lists the supported languages', () => {
+		renderPreferences();
+
+		const select = screen.getByTestId( 'language-select' );
+		// A representative spread, including an RTL locale.
+		for ( const name of [ 'English', 'Français', '日本語', 'العربية' ] ) {
+			expect( screen.getByRole( 'option', { name } ) ).toBeInTheDocument();
+		}
+		expect( select ).toHaveValue( 'en' );
+	} );
+
+	it( 'saving a new language fires saveUserLocale with the selected locale', async () => {
+		const user = userEvent.setup();
+		renderPreferences();
+
+		await user.selectOptions( screen.getByTestId( 'language-select' ), 'fr' );
+
+		const save = screen.getByTestId( 'preferences-save-button' );
+		await waitFor( () => expect( save ).toBeEnabled() );
+		await user.click( save );
+
+		await waitFor( () => {
+			expect( getIpcApi().saveUserLocale ).toHaveBeenCalledWith( 'fr' );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Fixes [STU-1872](https://linear.app/a8c/issue/STU-1872/migrate-localization-tests)

## How AI was used in this PR

Claude wrote the code, guided by the author. The author tested it locally and manually reviewed it before pushing.

## Proposed Changes

- Migrate the localization coverage from the desktop Playwright suite: locale logic to a CLI e2e test, RTL and the settings flow to renderer tests.
- CLI e2e asserts a created site's `WPLANG` matches the Studio locale from `shared.json`.
- UI tests assert the language picker lists supported languages, saving fires `saveUserLocale`, and an RTL locale flips the document direction.

## Testing Instructions

- `npm run cli:build`
- CLI e2e: `npm test -- apps/cli/commands/site/tests/localization.e2e.test.ts --tagsFilter='e2e'` (creating a non-English site downloads its language pack, so this needs network).
- UI: `npm test -- src/modules/user-settings/components/tests/preferences-tab.actions.test.tsx src/hooks/tests/use-localization-support.test.tsx`

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
