### PR TITLE
Studio: Fix the scroll that is stuck on blueprints gallery page in agentic UI

### DIFF
--- a/apps/ui/src/components/onboarding-layout/style.module.css
+++ b/apps/ui/src/components/onboarding-layout/style.module.css
@@ -1,12 +1,14 @@
 .root {
-	height: 100vh;
+	min-height: 100vh;
 	position: relative;
+	overflow-y: auto;
 }
 
 .content {
 	max-width: 640px;
 	width: 100%;
-	padding: var(--wpds-dimension-padding-3xl);
+	margin-block: auto;
+	padding: 64px var(--wpds-dimension-padding-3xl);
 }
 
 /* `wide` variant — used by content-heavy onboarding pages like the blueprint


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1852

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

It was used to help and identify the issue.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

This PR ensures that the blueprints gallery page is visible in the agentic UI and that the top is not cut off. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Enable the `Agentic UI` feature flag from `Studio -> Feature flags` from the topbar
* Click on the `New site -> Start from a blueprint option` option
* Confirm that the blueprints screen is not cut off on the top
* Confirm that there are no other regressions in the UI

<img width="1271" height="927" alt="Screenshot 2026-07-09 at 3 05 22 PM" src="https://github.com/user-attachments/assets/8dfc3247-c288-4f86-b730-7518f8a6a15a" />

**Before the changes** (where the top of the screen was not visible)

<img width="770" height="432" alt="Screenshot 2026-07-09 at 3 11 07 PM" src="https://github.com/user-attachments/assets/f44001f5-898c-49b4-a7ab-eaa224c2591b" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
