### PR TITLE
Replace "Set your next instruction" placeholder with catchier copy

### DIFF
--- a/apps/studio/src/components/studio-code-session/composer/index.tsx
+++ b/apps/studio/src/components/studio-code-session/composer/index.tsx
@@ -194,6 +194,33 @@ export function clearSessionDraft( sessionId: string | undefined ): void {
 	saveDraft( getDraftStorageKey( sessionId ), '' );
 }
 
+function getIdlePlaceholderOptions(): string[] {
+	return [
+		__( 'What should we make better?' ),
+		__( 'What’s the next move?' ),
+		__( 'Tell me what to change next…' ),
+		__( 'Drop the next idea here…' ),
+		__( 'What are we tuning now?' ),
+	];
+}
+
+/**
+ * Pick a placeholder for the session. The choice is derived from the session id
+ * so it stays stable for the lifetime of a chat instead of changing on every
+ * render, while still varying between chats.
+ */
+function getSessionPlaceholder( sessionId: string | undefined ): string {
+	const options = getIdlePlaceholderOptions();
+	if ( ! sessionId ) {
+		return options[ 0 ];
+	}
+	let hash = 0;
+	for ( let i = 0; i < sessionId.length; i++ ) {
+		hash = ( hash * 31 + sessionId.charCodeAt( i ) ) | 0;
+	}
+	return options[ Math.abs( hash ) % options.length ];
+}
+
 export function Composer( {
 	busy,
 	isInterrupting = false,
@@ -410,7 +437,7 @@ export function Composer( {
 	const canSend = value.trim().length > 0 || attachments.length > 0;
 	const placeholder = busy
 		? __( 'Queue a follow-up instruction…' )
-		: __( 'Set your next instruction…' );
+		: getSessionPlaceholder( sessionId );
 	const sendAriaLabel = busy ? __( 'Queue' ) : __( 'Send' );
 	const modKey = isMacPlatform ? '⌘' : 'Ctrl';
 	const hoveredAttachment = hoverPreview


### PR DESCRIPTION
## Related issues

- Fixes [STU-2013](https://linear.app/a8c/issue/STU-2013/replace-set-your-next-instructions-with-catchier-copy)

## How AI was used in this PR

Used Claude Code to locate the placeholder in the old Studio Code composer, borrow the prompt copy already used in the agentic UI (`apps/ui`), and implement a per-session stable pick. I reviewed the change, ran lint/typecheck, and confirmed the existing composer tests pass.

## Proposed Changes

The Studio Code composer showed the flat placeholder "Set your next instruction…". This swaps it for one of the friendlier, catchier prompts already used in the new agentic UI (e.g. "What should we make better?", "What's the next move?"). Rather than porting the dynamic rotation/scramble logic, each chat gets a single prompt chosen once and kept stable for the life of that chat, while different chats vary. The choice is derived from the session id so it doesn't flicker while typing. The busy/queue placeholder is unchanged.

## Testing Instructions

1. Open Studio Code and start a chat.
2. Confirm the empty composer shows one of the catchier prompts instead of "Set your next instruction…".
3. Confirm the placeholder stays the same across renders within a chat, and that a different chat may show a different prompt.
4. While the agent is working, confirm the composer still shows the "Queue a follow-up instruction…" placeholder.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
