### PR TITLE
Studio: The Preview button for blueprints is not visible in agentic UI

### DIFF
--- a/apps/ui/src/components/blueprint-selector/style.module.css
+++ b/apps/ui/src/components/blueprint-selector/style.module.css
@@ -66,16 +66,17 @@
 	top: 8px;
 	right: 8px;
 	gap: 4px;
-	background: rgba(255, 255, 255, 0.92);
+	background: color-mix(in srgb, var(--wpds-color-bg-surface-neutral-strong, #fff) 92%, transparent);
 	backdrop-filter: blur(6px);
 	border-radius: 4px;
+	box-shadow: var(--wpds-elevation-sm);
 }
 
 .cardImage {
 	width: 100%;
 	aspect-ratio: 16 / 9;
 	object-fit: cover;
-	background: #f0f0f0;
+	background: var(--wpds-color-bg-surface-neutral-weak);
 }
 
 .cardBody {


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1851

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

It was used to adjust the styling

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

This PR ensures that the `Preview` button for the blueprints in the blueprints galler in the agentic UI is visible.

**Dark mode**

<img width="1081" height="341" alt="Screenshot 2026-07-10 at 9 18 37 AM" src="https://github.com/user-attachments/assets/d273d478-be4c-4450-8903-32f11ff0e42c" />

**Light mode**

<img width="1121" height="343" alt="Screenshot 2026-07-10 at 9 18 12 AM" src="https://github.com/user-attachments/assets/c464de2a-5662-4a45-abd8-c7607c973cec" />

**Before the changes**

<img width="785" height="238" alt="Screenshot 2026-07-10 at 9 27 47 AM" src="https://github.com/user-attachments/assets/9d3861bf-56bb-4d4f-8789-faebb63dc210" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Enable the `Agentic UI` feature flag from `Studio -> Feature flags` from the topbar
* Click on the `New site ->  Start from a blueprint` option
* Scroll to the blueprints and confirm that the preview button is visible in both dark and light modes


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
