### PR TITLE
Delete site confirmation layout is broken in agentic UI

### DIFF
--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -314,20 +314,22 @@ function DeleteSiteDialog( {
 				<Dialog.Header>
 					<Dialog.Title>{ sprintf( __( 'Delete %s' ), site.name ) }</Dialog.Title>
 				</Dialog.Header>
-				<p className={ styles.dialogText }>
-					{ __(
-						"The site's database will be lost, including all posts, pages, comments, and media."
-					) }
-				</p>
-				<label className={ styles.dialogCheckbox }>
-					<input
-						type="checkbox"
-						checked={ deleteFiles }
-						onChange={ ( event ) => setDeleteFiles( event.target.checked ) }
-					/>
-					<span>{ __( 'Delete site files from my computer' ) }</span>
-				</label>
-				{ error ? <div className={ styles.dialogError }>{ error }</div> : null }
+				<Dialog.Content>
+					<p className={ styles.dialogText }>
+						{ __(
+							"The site's database will be lost, including all posts, pages, comments, and media."
+						) }
+					</p>
+					<label className={ styles.dialogCheckbox }>
+						<input
+							type="checkbox"
+							checked={ deleteFiles }
+							onChange={ ( event ) => setDeleteFiles( event.target.checked ) }
+						/>
+						<span>{ __( 'Delete site files from my computer' ) }</span>
+					</label>
+					{ error ? <div className={ styles.dialogError }>{ error }</div> : null }
+				</Dialog.Content>
 				<Dialog.Footer>
 					<Dialog.Action variant="minimal" tone="neutral" disabled={ deleteSite.isPending }>
 						{ __( 'Cancel' ) }


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1921

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Not needed

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

This PR ensures that the layout of the delete confirmation dialog for a site has appropriate paddings and margins.

**Before**

<img width="609" height="321" alt="Screenshot 2026-07-10 at 9 55 34 AM" src="https://github.com/user-attachments/assets/27f246d0-fc3a-4e0e-9aba-c343aa8eb44d" />

**After**

<img width="706" height="412" alt="Screenshot 2026-07-10 at 9 59 05 AM" src="https://github.com/user-attachments/assets/c43a3ac1-cee8-460a-b7a8-af0870e04746" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Enable the `Agentic UI` feature flag from `Studio -> Feature flags` from the topbar
* Click on the ellipsis menu by a site
* Select an option to delete a site
* Confirm that the dialog to delete a site has correct margins and paddings

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
