### PR TITLE
Studio: Fix line clamp warning

### DIFF
--- a/apps/ui/src/components/blueprint-selector/style.module.css
+++ b/apps/ui/src/components/blueprint-selector/style.module.css
@@ -98,6 +98,7 @@
 	line-height: 1.4;
 	display: -webkit-box;
 	-webkit-line-clamp: 3;
+	line-clamp: 3;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
 }


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

N/A

It was something that I noticed while working on other things.

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->
It was used to make the change.


## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

This PR ensures that there is no warning regarding `-webkit-line-clamp` in style.module.css

<img width="790" height="324" alt="Screenshot 2026-07-10 at 10 03 24 AM" src="https://github.com/user-attachments/assets/a6a59f37-b626-4cc5-9fab-32edcb2c82a8" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visual review should be enough but you can also check `apps/ui/src/components/blueprint-selector/style.module.css` to confirm that there is no warning in that file.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
