### PR TITLE
Add CLI e2e tests for studio import formats

### DIFF
--- a/apps/cli/commands/site/tests/helpers/cli-e2e.ts
+++ b/apps/cli/commands/site/tests/helpers/cli-e2e.ts
@@ -100,6 +100,13 @@ export function runCli( args: string[], env: CliEnv ): Promise< CliResult > {
 				...process.env,
 				DEV_CONFIG_DIR: env.configDir,
 				STUDIO_PROCESS_MANAGER_HOME: env.daemonHome,
+				// Isolate the legacy Electron appdata lookup too: getAppdataDirectory()
+				// ignores DEV_CONFIG_DIR, so without these the 00-check-studio-compatibility
+				// migration finds the developer's real pre-split appdata-v1.json (when
+				// Studio is installed) and aborts the CLI — passing in CI, failing on dev
+				// machines. E2E=1 also disables bump-stats in the spawned CLI.
+				E2E: '1',
+				E2E_APP_DATA_PATH: env.root,
 			},
 		} );
 

--- a/apps/cli/commands/tests/import.e2e.test.ts
+++ b/apps/cli/commands/tests/import.e2e.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @vitest-environment node
+ *
+ * Real end-to-end tests for `studio import`: unlike import.test.ts (which
+ * mocks the importer and config layer), this spawns the built CLI and imports
+ * each supported minimal backup fixture into a real site, asserting the
+ * imported theme and database on disk and through WP-CLI.
+ *
+ * The fixtures under test-fixtures/backups/ were generated from a demo Studio
+ * site (blog name "MyPet") with a custom theme, so each test can prove the
+ * site serves the backup's content rather than a fresh install — see
+ * test-fixtures/backups/readme.md for their provenance and structure.
+ *
+ * Requires the CLI to be built first (`npm run cli:build`); the suite skips
+ * itself otherwise. Tagged `e2e` so it runs in the slower (release/manual)
+ * suite rather than on every PR — run with `npm test -- --tagsFilter='e2e'`.
+ */
+import fs from 'fs';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	cleanupCliEnv,
+	cliE2ePrerequisitesMet,
+	runCli,
+	setupCliEnv,
+	type CliEnv,
+} from '../site/tests/helpers/cli-e2e';
+
+// Repo root is four levels up from apps/cli/commands/tests.
+const FIXTURES_DIR = path.resolve(
+	import.meta.dirname,
+	'..',
+	'..',
+	'..',
+	'..',
+	'test-fixtures',
+	'backups'
+);
+const FIXTURE_BLOGNAME = 'MyPet';
+
+const BACKUP_FIXTURES = [
+	{ format: 'Jetpack', file: 'jetpack-backup.tar.gz' },
+	{ format: 'Local', file: 'local-backup.zip' },
+	{ format: 'Playground', file: 'playground-backup.zip' },
+	{ format: 'All-in-One WP Migration', file: 'aio-backup.wpress' },
+] as const;
+
+/**
+ * `--runtime sandbox` keeps the run hermetic; `--no-start` defers the slow
+ * WordPress install — `studio import` works against the stopped site.
+ */
+async function createStoppedSite( env: CliEnv, name: string, dirName: string ): Promise< string > {
+	const sitePath = path.join( env.sitesDir, dirName );
+	const result = await runCli(
+		[
+			'site',
+			'create',
+			'--name',
+			name,
+			'--path',
+			sitePath,
+			'--wp',
+			'latest',
+			'--runtime',
+			'sandbox',
+			'--no-start',
+			'--skip-browser',
+			'--skip-log-details',
+		],
+		env
+	);
+	expect( result.code, result.stderr ).toBe( 0 );
+	return sitePath;
+}
+
+/**
+ * Whether the CLI reports the site at `sitePath` as running, via
+ * `studio site list --format json` (stdout is clean JSON; progress goes to stderr).
+ */
+async function isSiteRunning( env: CliEnv, sitePath: string ): Promise< boolean > {
+	const result = await runCli( [ 'site', 'list', '--format', 'json' ], env );
+	expect( result.code, result.stderr ).toBe( 0 );
+	const sites = JSON.parse( result.stdout.trim() ) as Array< {
+		path?: string;
+		running?: boolean;
+	} >;
+	return sites.find( ( site ) => site.path === sitePath )?.running === true;
+}
+
+async function getBlogname( env: CliEnv, sitePath: string ): Promise< string | undefined > {
+	const result = await runCli( [ 'wp', 'option', 'get', 'blogname', '--path', sitePath ], env );
+	expect( result.code, result.stderr ).toBe( 0 );
+	// PHP notices can precede the value on stdout, so assert against the last
+	// non-empty line rather than the whole buffer.
+	const lines = result.stdout
+		.split( '\n' )
+		.map( ( line ) => line.trim() )
+		.filter( Boolean );
+	return lines.at( -1 );
+}
+
+/** The backup's wp-content and database landed on disk. */
+function assertImportedSiteOnDisk( sitePath: string ): void {
+	expect( fs.existsSync( path.join( sitePath, 'wp-content', 'themes', 'mypet-theme' ) ) ).toBe(
+		true
+	);
+	const databasePath = path.join( sitePath, 'wp-content', 'database', '.ht.sqlite' );
+	expect( fs.existsSync( databasePath ) ).toBe( true );
+	expect( fs.statSync( databasePath ).size ).toBeGreaterThan( 0 );
+}
+
+describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: studio import', () => {
+	let env: CliEnv | undefined;
+
+	beforeAll( () => {
+		env = setupCliEnv();
+	} );
+
+	// Stop everything and remove the isolated env even if a case failed, so no
+	// daemon/server/port leaks. `stop --all` also kills the isolated daemon.
+	afterAll( async () => {
+		if ( ! env ) {
+			return;
+		}
+		await runCli( [ 'site', 'stop', '--all' ], env );
+		cleanupCliEnv( env );
+		env = undefined;
+	}, 60_000 );
+
+	for ( const { format, file } of BACKUP_FIXTURES ) {
+		it(
+			`imports a ${ format } backup into a stopped site`,
+			{ tags: [ 'e2e' ], timeout: 240_000 },
+			async () => {
+				if ( ! env ) {
+					throw new Error( 'CLI e2e env was not initialised' );
+				}
+
+				const sitePath = await createStoppedSite(
+					env,
+					`${ format } Import E2E Site`,
+					`import-${ file.split( '.' )[ 0 ] }`
+				);
+
+				const result = await runCli(
+					[ 'import', path.join( FIXTURES_DIR, file ), '--path', sitePath ],
+					env
+				);
+				expect( result.code, result.stderr ).toBe( 0 );
+
+				assertImportedSiteOnDisk( sitePath );
+				expect( await getBlogname( env, sitePath ) ).toBe( FIXTURE_BLOGNAME );
+			}
+		);
+	}
+
+	it(
+		'imports a backup into a running site and restores it to running',
+		{ tags: [ 'e2e' ], timeout: 300_000 },
+		async () => {
+			if ( ! env ) {
+				throw new Error( 'CLI e2e env was not initialised' );
+			}
+
+			const sitePath = await createStoppedSite(
+				env,
+				'Running Import E2E Site',
+				'import-into-running-site'
+			);
+			const startResult = await runCli(
+				[ 'site', 'start', '--path', sitePath, '--skip-browser', '--skip-log-details' ],
+				env
+			);
+			expect( startResult.code, startResult.stderr ).toBe( 0 );
+			expect( await isSiteRunning( env, sitePath ) ).toBe( true );
+
+			const result = await runCli(
+				[ 'import', path.join( FIXTURES_DIR, 'local-backup.zip' ), '--path', sitePath ],
+				env
+			);
+			expect( result.code, result.stderr ).toBe( 0 );
+
+			// Importing into a running site stops it first, then restores the
+			// running state after the import completes.
+			expect( await isSiteRunning( env, sitePath ) ).toBe( true );
+			assertImportedSiteOnDisk( sitePath );
+			expect( await getBlogname( env, sitePath ) ).toBe( FIXTURE_BLOGNAME );
+		}
+	);
+} );

--- a/apps/cli/commands/tests/import.e2e.test.ts
+++ b/apps/cli/commands/tests/import.e2e.test.ts
@@ -77,7 +77,7 @@ async function createStoppedSite( env: CliEnv, name: string, dirName: string ): 
  * Whether the CLI reports the site at `sitePath` as running, via
  * `studio site list --format json` (stdout is clean JSON; progress goes to stderr).
  */
-async function isSiteRunning( env: CliEnv, sitePath: string ): Promise< boolean > {
+async function isSiteRunningPerCliList( env: CliEnv, sitePath: string ): Promise< boolean > {
 	const result = await runCli( [ 'site', 'list', '--format', 'json' ], env );
 	expect( result.code, result.stderr ).toBe( 0 );
 	const sites = JSON.parse( result.stdout.trim() ) as Array< {
@@ -172,7 +172,7 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: studio import', () => {
 				env
 			);
 			expect( startResult.code, startResult.stderr ).toBe( 0 );
-			expect( await isSiteRunning( env, sitePath ) ).toBe( true );
+			expect( await isSiteRunningPerCliList( env, sitePath ) ).toBe( true );
 
 			const result = await runCli(
 				[ 'import', path.join( FIXTURES_DIR, 'local-backup.zip' ), '--path', sitePath ],
@@ -182,7 +182,7 @@ describe.skipIf( ! cliE2ePrerequisitesMet() )( 'CLI e2e: studio import', () => {
 
 			// Importing into a running site stops it first, then restores the
 			// running state after the import completes.
-			expect( await isSiteRunning( env, sitePath ) ).toBe( true );
+			expect( await isSiteRunningPerCliList( env, sitePath ) ).toBe( true );
 			assertImportedSiteOnDisk( sitePath );
 			expect( await getBlogname( env, sitePath ) ).toBe( FIXTURE_BLOGNAME );
 		}


### PR DESCRIPTION
## Related issues

- Related to STU-1870
- The running-site case is the regression test for STU-1982 / #4106

## How AI was used in this PR

Claude Code planned and implemented the suite under my direction. The running-site case caught the STU-1982 bug independently before we found the existing issue and fix. I reviewed the result.

## Proposed Changes

Import coverage currently lives only in the Playwright desktop suite, which the migrate-E2E-to-CLI project is moving away from.

This PR adds real end-to-end CLI coverage using the minimal in-repo fixtures from #4151 (generated from the "MyPet" demo site):

- Each supported backup format is imported into a freshly created site via the built CLI. Each case asserts the import exists cleanly, the backup's custom theme lands on disk, the SQLite database is created, and the imported content is really served (`wp option get blogname` → `MyPet`) against a stopped site, exercising the in-process PHP-WASM path.
- The running-site case verifies that importing into a running site stops it and restores it to running afterward. This is the symptom of STU-1982 (`site list` reporting Offline after import), now guarded against regression.
- It also fixes a dev-machine-only gap in the shared e2e harness: `runCli` didn't isolate the legacy Electron appdata lookup, so the `00-check-studio-compatibility` migration could find a developer's real pre-split `appdata-v1.json` and abort the CLI — passing in CI (clean machines), failing locally. The same fix rides the STU-1871 blueprint-tests branch; whichever merges second drops its copy in a trivial merge.

The new tests are tagged `e2e`: they're skipped in the per-PR unit job (which doesn't build the CLI), so they add zero per-PR CI cost, and run in the manual "CLI E2E Tests" Buildkite job alongside the other migrated suites.

## Testing Instructions

1. `npm run cli:build`
2. `npm test -- apps/cli/commands/tests/import.e2e.test.ts`
3. Optionally run the whole slow suite: `npm test -- --tagsFilter='e2e' --no-file-parallelism`

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?