### PR TITLE
Remove envelope icon from admin email field in agentic UI

### DIFF
--- a/apps/ui/src/components/site-fields/index.ts
+++ b/apps/ui/src/components/site-fields/index.ts
@@ -75,6 +75,9 @@ export function adminEmailField< T extends { adminEmail: string } >(): Field< T 
 	return {
 		id: 'adminEmail',
 		type: 'email',
+		// The default email control prefixes the input with an envelope icon;
+		// use the plain text control instead (email-type validation still applies).
+		Edit: 'text',
 		label: __( 'Admin email' ),
 		isValid: {
 			required: true,


### PR DESCRIPTION
## Related issues

- Fixes [STU-2039](https://linear.app/a8c/issue/STU-2039/remove-envelope-icon-from-admin-email-field-in-agentic-ui)

## How AI was used in this PR

Written entirely with Claude Code: it traced the icon to the DataViews `email` edit control, made the change, and verified it in the running local UI (`studio ui` + `dev:local`) in both color schemes, including confirming email validation still fires. Screenshots below were captured during that verification.

## Proposed Changes

The admin email field in the agentic UI (site creation and site settings) rendered with an envelope icon inside the input. The icon comes from DataViews' built-in `email` edit control, and it has two problems: it doesn't adapt to dark mode (a dark icon on a dark input, so it reads as a smudge), and it adds nothing — the field is already labeled "Admin email". The field now renders as a plain input, matching every other text field in the form. Email-format validation is unchanged, since it comes from the field's `email` type rather than the edit control.

| | Before | After |
|---|---|---|
| **Dark** | ![before dark](https://raw.githubusercontent.com/Automattic/studio/stu-2039-screenshots/before-dark.png) | ![after dark](https://raw.githubusercontent.com/Automattic/studio/stu-2039-screenshots/after-dark.png) |
| **Light** | ![before light](https://raw.githubusercontent.com/Automattic/studio/stu-2039-screenshots/before-light.png) | ![after light](https://raw.githubusercontent.com/Automattic/studio/stu-2039-screenshots/after-light.png) |

(Screenshots live on the throwaway `stu-2039-screenshots` branch — safe to delete after merge.)

## Testing Instructions

1. Run the agentic UI (e.g. `npm start` with agentic UI enabled, or `npm run dev:local --workspace=apps/ui` against `studio ui`).
2. Start creating a new site and expand **Advanced settings**.
3. Confirm the **Admin email** input has no envelope icon and looks consistent with the other inputs, in both light and dark mode.
4. Enter an invalid email (e.g. `not-an-email`) and confirm the validation error still appears.
5. Repeat the check in an existing site's **Settings** view, which shares the same field.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
