### PR TITLE
Studio Code: Close daemon socket after per-turn site status check so headless runs can exit

### DIFF
--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -39,6 +39,7 @@ import { AiChatUI } from 'cli/ai/ui';
 import { runCommand as runLoginCommand } from 'cli/commands/auth/login';
 import { readCliConfig } from 'cli/lib/cli-config/core';
 import { findSiteByFolder } from 'cli/lib/cli-config/sites';
+import { disconnectFromDaemon } from 'cli/lib/daemon-client';
 import { isSiteRunning } from 'cli/lib/site-utils';
 import { maybeShowTosNotice } from 'cli/lib/tos-notice';
 import { Logger, LoggerError, setProgressCallback } from 'cli/logger';
@@ -482,6 +483,10 @@ export async function runCommand( options: {
 		if ( site && ! site.remote ) {
 			const siteData = await findSiteByFolder( site.path );
 			site.running = siteData ? await isSiteRunning( siteData ) : false;
+			// isSiteRunning leaves a DaemonBus socket open, which keeps headless
+			// (--json) runs alive after turn.completed; close it so the process
+			// can exit naturally.
+			await disconnectFromDaemon();
 		}
 		if ( site?.remote && site?.url ) {
 			enrichedPrompt = `[Active site: "${ site.name }" (ID: ${ site.wpcomSiteId }) at ${ site.url } (WordPress.com)]\n\n${ prompt }`;


### PR DESCRIPTION
## Related issues

- Fixes [STU-2040](https://linear.app/a8c/issue/STU-2040/headless-code-sessions-never-exit-after-turncompleted-leaving-desktop)
- Related to [STU-2001](https://linear.app/a8c/issue/STU-2001/agent-always-sees-local-sites-as-stopped-in-desktop-studio-code) / #4096

## How AI was used in this PR

Claude Code applied the fix, verified it end-to-end in both directions (fixed build exits, unfixed build hangs), and drafted this PR. I reviewed and directed the work.

## Proposed Changes

Since #4096, every headless `studio code … --json` turn on a local site leaves the CLI process alive after it reports `turn.completed`. The per-turn site running-state check opens a connection to the process-manager daemon and never closes it, and that open socket keeps the process from exiting.

The desktop app feels this the most: each turn forks a headless `code sessions resume` child and treats the child's exit as the end of the turn. Because the child never exits, the session appears stuck in the working state forever — the stop button and the sidebar agent-activity indicator never clear — and an orphaned node process piles up for every turn taken on a running-or-stopped local site.

The fix closes the daemon connection as soon as the running-state check completes, the same way every other daemon consumer in the CLI already does. The connection is a singleton, so anything later in the turn that needs the daemon (like the WP-CLI tool) reconnects transparently.

## Testing Instructions

1. `npm run cli:build`
2. Run a headless turn against a local site: `node apps/cli/dist/cli/main.mjs code --json --path ~/Studio/<site> "Reply with only the word OK."`
3. The process should exit on its own a moment after the `turn.completed` event (on trunk it hangs indefinitely and must be killed).
4. In the desktop app, take a turn in a Studio Code session on a local site and confirm the working indicator clears when the turn finishes.
5. Tests: `npm test -- apps/cli/commands/ai/sessions/tests/resume.test.ts apps/cli/commands/ai/tests/index.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
