### PR TITLE
Add opt-in terminal notifications for Studio Code (Proof of Concept)

### DIFF
--- a/apps/cli/ai/output-adapter.ts
+++ b/apps/cli/ai/output-adapter.ts
@@ -1,5 +1,7 @@
 import { DEFAULT_MODEL, type AiModelId } from '@studio/common/ai/models';
+import { __ } from '@wordpress/i18n';
 import { emitEvent, type TurnCompletedStatus } from 'cli/ai/json-events';
+import { notifyTerminal } from 'cli/lib/notify';
 import { formatTosNoticeLines } from 'cli/lib/tos-notice';
 import type { AgentSessionEvent } from '@earendil-works/pi-coding-agent';
 import type { AiProviderId } from 'cli/ai/providers';
@@ -151,6 +153,11 @@ export class JsonAdapter implements AiOutputAdapter {
 		sessionId: string,
 		usage?: { numTurns: number; costUsd?: number }
 	): void {
+		if ( status === 'success' ) {
+			void notifyTerminal( __( 'Studio Code response is ready' ) );
+		} else if ( status === 'paused' ) {
+			void notifyTerminal( __( 'Studio Code is waiting for your answer' ) );
+		}
 		emitEvent( {
 			type: 'turn.completed',
 			timestamp: new Date().toISOString(),

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -12,6 +12,7 @@ import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/crea
 import { runCommand as runUpdatePreviewCommand } from 'cli/commands/preview/update';
 import { runCommand as runPushCommand } from 'cli/commands/push';
 import { openBrowser } from 'cli/lib/browser';
+import { areNotificationsEnabled, setNotificationsEnabled } from 'cli/lib/notify';
 import { getSnapshotsFromConfig, isSnapshotExpired } from 'cli/lib/snapshots';
 import { fetchSyncableSites } from 'cli/lib/sync-api';
 import { LoggerError } from 'cli/logger';
@@ -251,6 +252,20 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 		description: __( 'Clear the conversation and start a fresh session' ),
 		handler: async ( _prompt, ctx ) => {
 			await ctx.clearSession();
+			return 'continue';
+		},
+	},
+	{
+		name: 'notifications',
+		description: __(
+			'Toggle terminal notifications when a response is ready or your input is needed (off by default)'
+		),
+		handler: async ( _prompt, ctx ) => {
+			const enabled = await areNotificationsEnabled();
+			await setNotificationsEnabled( ! enabled );
+			ctx.ui.showInfo(
+				! enabled ? __( 'Notifications enabled.' ) : __( 'Notifications disabled.' )
+			);
 			return 'continue';
 		},
 	},

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -12,7 +12,11 @@ import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/crea
 import { runCommand as runUpdatePreviewCommand } from 'cli/commands/preview/update';
 import { runCommand as runPushCommand } from 'cli/commands/push';
 import { openBrowser } from 'cli/lib/browser';
-import { areNotificationsEnabled, setNotificationsEnabled } from 'cli/lib/notify';
+import {
+	areNotificationsEnabled,
+	getNotificationsPreference,
+	setNotificationsEnabled,
+} from 'cli/lib/notify';
 import { getSnapshotsFromConfig, isSnapshotExpired } from 'cli/lib/snapshots';
 import { fetchSyncableSites } from 'cli/lib/sync-api';
 import { LoggerError } from 'cli/logger';
@@ -258,14 +262,26 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 	{
 		name: 'notifications',
 		description: __(
-			'Toggle terminal notifications when a response is ready or your input is needed (off by default)'
+			'Cycle terminal notifications when a response is ready or your input is needed (auto-detect → always on → always off)'
 		),
 		handler: async ( _prompt, ctx ) => {
-			const enabled = await areNotificationsEnabled();
-			await setNotificationsEnabled( ! enabled );
-			ctx.ui.showInfo(
-				! enabled ? __( 'Notifications enabled.' ) : __( 'Notifications disabled.' )
-			);
+			// Cycle: unset (auto-detect) → true (always on) → false (always off) → back to unset.
+			const preference = await getNotificationsPreference();
+			if ( preference === undefined ) {
+				await setNotificationsEnabled( true );
+				ctx.ui.showInfo( __( 'Notifications enabled.' ) );
+			} else if ( preference === true ) {
+				await setNotificationsEnabled( false );
+				ctx.ui.showInfo( __( 'Notifications disabled.' ) );
+			} else {
+				await setNotificationsEnabled( undefined );
+				const autoDetected = await areNotificationsEnabled();
+				ctx.ui.showInfo(
+					autoDetected
+						? __( 'Notifications set to auto-detect (on for this terminal).' )
+						: __( 'Notifications set to auto-detect (off for this terminal).' )
+				);
+			}
 			return 'continue';
 		},
 	},

--- a/apps/cli/ai/tests/output-adapter.test.ts
+++ b/apps/cli/ai/tests/output-adapter.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import { JsonAdapter } from 'cli/ai/output-adapter';
+import { notifyTerminal } from 'cli/lib/notify';
 import { PRIVACY_POLICY_URL, TOS_URL } from 'cli/lib/tos-notice';
+
+vi.mock( 'cli/lib/notify', () => ( {
+	notifyTerminal: vi.fn().mockResolvedValue( undefined ),
+} ) );
 
 describe( 'JsonAdapter IPC messaging', () => {
 	let originalSend: typeof process.send;
@@ -121,5 +126,56 @@ describe( 'JsonAdapter showTosNotice', () => {
 		expect( output ).toContain( TOS_URL );
 		expect( output ).toContain( PRIVACY_POLICY_URL );
 		expect( stdoutWriteSpy ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'JsonAdapter terminal notifications', () => {
+	const originalSend = process.send;
+
+	beforeEach( () => {
+		vi.mocked( notifyTerminal ).mockClear();
+	} );
+
+	afterEach( () => {
+		( process as unknown as { send: typeof process.send } ).send = originalSend;
+	} );
+
+	it( 'notifies "response is ready" on a successful turn', () => {
+		new JsonAdapter().emitTurnCompleted( 'success', 'session-1' );
+		expect( notifyTerminal ).toHaveBeenCalledExactlyOnceWith(
+			expect.stringContaining( 'response is ready' )
+		);
+	} );
+
+	it( 'notifies "waiting for your answer" on a paused turn', () => {
+		new JsonAdapter().emitTurnCompleted( 'paused', 'session-1' );
+		expect( notifyTerminal ).toHaveBeenCalledExactlyOnceWith(
+			expect.stringContaining( 'waiting for your answer' )
+		);
+	} );
+
+	it.each( [ 'error', 'max_turns' ] as const )( 'does not notify on a %s turn', ( status ) => {
+		new JsonAdapter().emitTurnCompleted( status, 'session-1' );
+		expect( notifyTerminal ).not.toHaveBeenCalled();
+	} );
+
+	it( 'notifies exactly once when askUser pauses a standalone (non-IPC) session', async () => {
+		( process as unknown as { send: typeof process.send } ).send =
+			undefined as unknown as typeof process.send;
+
+		const adapter = new JsonAdapter();
+		adapter.onBeforeExit = vi.fn().mockResolvedValue( undefined );
+		// askUser() never resolves in standalone mode (process.exitCode is set
+		// instead); don't await it, just let the microtasks up to that point run.
+		void adapter.askUser( [ { question: 'q', options: [] } ] );
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// Regression guard: askUser() used to fire its own "waiting for your
+		// answer" notification AND emitTurnCompleted('paused', ...) fired a
+		// second, identical one - a double OS notification/bell for one event.
+		expect( notifyTerminal ).toHaveBeenCalledExactlyOnceWith(
+			expect.stringContaining( 'waiting for your answer' )
+		);
 	} );
 } );

--- a/apps/cli/ai/tests/slash-commands.test.ts
+++ b/apps/cli/ai/tests/slash-commands.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AI_CHAT_SLASH_COMMANDS, type SlashCommandContext } from 'cli/ai/slash-commands';
-import { areNotificationsEnabled, setNotificationsEnabled } from 'cli/lib/notify';
+import {
+	areNotificationsEnabled,
+	getNotificationsPreference,
+	setNotificationsEnabled,
+} from 'cli/lib/notify';
 
 describe( '/remote-session slash command registration', () => {
 	const cmd = AI_CHAT_SLASH_COMMANDS.find( ( c ) => c.name === 'remote-session' );
@@ -41,6 +45,7 @@ vi.mock( 'cli/commands/preview/update', () => ( { runCommand: vi.fn() } ) );
 vi.mock( '@studio/common/lib/shared-config', () => ( { readAuthToken: vi.fn() } ) );
 vi.mock( 'cli/lib/notify', () => ( {
 	areNotificationsEnabled: vi.fn(),
+	getNotificationsPreference: vi.fn(),
 	setNotificationsEnabled: vi.fn().mockResolvedValue( undefined ),
 } ) );
 
@@ -429,16 +434,36 @@ describe( '/notifications slash command', () => {
 
 	afterEach( () => {
 		vi.mocked( areNotificationsEnabled ).mockReset();
+		vi.mocked( getNotificationsPreference ).mockReset();
 		vi.mocked( setNotificationsEnabled ).mockClear();
 	} );
 
-	it( 'enables notifications and reports the new state when currently disabled', async () => {
-		vi.mocked( areNotificationsEnabled ).mockResolvedValue( false );
+	it( 'from unset (auto-detect), forces notifications on', async () => {
+		vi.mocked( getNotificationsPreference ).mockResolvedValue( undefined );
 		const ui = makeUi();
 		const result = await cmd.handler!( '/notifications', makeCtx( ui ) );
 
 		expect( setNotificationsEnabled ).toHaveBeenCalledWith( true );
 		expect( ui.showInfo ).toHaveBeenCalledWith( expect.stringContaining( 'enabled' ) );
 		expect( result ).toBe( 'continue' );
+	} );
+
+	it( 'from always on, forces notifications off', async () => {
+		vi.mocked( getNotificationsPreference ).mockResolvedValue( true );
+		const ui = makeUi();
+		await cmd.handler!( '/notifications', makeCtx( ui ) );
+
+		expect( setNotificationsEnabled ).toHaveBeenCalledWith( false );
+		expect( ui.showInfo ).toHaveBeenCalledWith( expect.stringContaining( 'disabled' ) );
+	} );
+
+	it( 'from always off, resets to auto-detect and reports what that means for this terminal', async () => {
+		vi.mocked( getNotificationsPreference ).mockResolvedValue( false );
+		vi.mocked( areNotificationsEnabled ).mockResolvedValue( true );
+		const ui = makeUi();
+		await cmd.handler!( '/notifications', makeCtx( ui ) );
+
+		expect( setNotificationsEnabled ).toHaveBeenCalledWith( undefined );
+		expect( ui.showInfo ).toHaveBeenCalledWith( expect.stringContaining( 'auto-detect' ) );
 	} );
 } );

--- a/apps/cli/ai/tests/slash-commands.test.ts
+++ b/apps/cli/ai/tests/slash-commands.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-	AI_CHAT_SLASH_COMMANDS,
-	getActiveSlashCommands,
-	type SlashCommandContext,
-} from 'cli/ai/slash-commands';
+import { AI_CHAT_SLASH_COMMANDS, type SlashCommandContext } from 'cli/ai/slash-commands';
 import { areNotificationsEnabled, setNotificationsEnabled } from 'cli/lib/notify';
 
 describe( '/remote-session slash command registration', () => {
@@ -436,21 +432,6 @@ describe( '/notifications slash command', () => {
 		vi.mocked( setNotificationsEnabled ).mockClear();
 	} );
 
-	it( 'is registered with a handler and a discoverable description', () => {
-		expect( cmd ).toBeDefined();
-		expect( typeof cmd.handler ).toBe( 'function' );
-		expect( cmd.description ).toBeTruthy();
-	} );
-
-	// Regression test: the interactive autocomplete (DescriptionAwareAutocompleteProvider
-	// in ai/ui.ts) is wired directly to getActiveSlashCommands() — there is no separate
-	// list to keep in sync. If this ever stops finding the command, autocomplete broke too.
-	it( 'shows up in the list the interactive autocomplete reads from', () => {
-		const active = getActiveSlashCommands().find( ( c ) => c.name === 'notifications' );
-		expect( active ).toBeDefined();
-		expect( typeof active!.handler ).toBe( 'function' );
-	} );
-
 	it( 'enables notifications and reports the new state when currently disabled', async () => {
 		vi.mocked( areNotificationsEnabled ).mockResolvedValue( false );
 		const ui = makeUi();
@@ -459,14 +440,5 @@ describe( '/notifications slash command', () => {
 		expect( setNotificationsEnabled ).toHaveBeenCalledWith( true );
 		expect( ui.showInfo ).toHaveBeenCalledWith( expect.stringContaining( 'enabled' ) );
 		expect( result ).toBe( 'continue' );
-	} );
-
-	it( 'disables notifications and reports the new state when currently enabled', async () => {
-		vi.mocked( areNotificationsEnabled ).mockResolvedValue( true );
-		const ui = makeUi();
-		await cmd.handler!( '/notifications', makeCtx( ui ) );
-
-		expect( setNotificationsEnabled ).toHaveBeenCalledWith( false );
-		expect( ui.showInfo ).toHaveBeenCalledWith( expect.stringContaining( 'disabled' ) );
 	} );
 } );

--- a/apps/cli/ai/tests/slash-commands.test.ts
+++ b/apps/cli/ai/tests/slash-commands.test.ts
@@ -1,5 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AI_CHAT_SLASH_COMMANDS, type SlashCommandContext } from 'cli/ai/slash-commands';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	AI_CHAT_SLASH_COMMANDS,
+	getActiveSlashCommands,
+	type SlashCommandContext,
+} from 'cli/ai/slash-commands';
+import { areNotificationsEnabled, setNotificationsEnabled } from 'cli/lib/notify';
 
 describe( '/remote-session slash command registration', () => {
 	const cmd = AI_CHAT_SLASH_COMMANDS.find( ( c ) => c.name === 'remote-session' );
@@ -38,6 +43,10 @@ vi.mock( 'cli/commands/auth/logout', () => ( { runCommand: vi.fn() } ) );
 vi.mock( 'cli/commands/preview/create', () => ( { runCommand: vi.fn() } ) );
 vi.mock( 'cli/commands/preview/update', () => ( { runCommand: vi.fn() } ) );
 vi.mock( '@studio/common/lib/shared-config', () => ( { readAuthToken: vi.fn() } ) );
+vi.mock( 'cli/lib/notify', () => ( {
+	areNotificationsEnabled: vi.fn(),
+	setNotificationsEnabled: vi.fn().mockResolvedValue( undefined ),
+} ) );
 
 vi.mock( 'cli/remote-session/daemon', () => {
 	return {
@@ -399,5 +408,65 @@ describe( '/model slash command', () => {
 		// Same model picked → no swap, no persist.
 		expect( ctx.currentModel ).toBe( 'gpt-5.5' );
 		expect( persistMock ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( '/notifications slash command', () => {
+	const cmd = AI_CHAT_SLASH_COMMANDS.find( ( c ) => c.name === 'notifications' )!;
+
+	function makeUi() {
+		return { showInfo: vi.fn() };
+	}
+	function makeCtx( ui: ReturnType< typeof makeUi > ): SlashCommandContext {
+		return {
+			ui: ui as unknown as SlashCommandContext[ 'ui' ],
+			currentModel: 'claude-sonnet-4-5' as SlashCommandContext[ 'currentModel' ],
+			currentProvider: 'wpcom' as SlashCommandContext[ 'currentProvider' ],
+			showCapabilitiesOnConnect: false,
+			switchProvider: vi.fn().mockResolvedValue( undefined ),
+			prepareProviderSelection: vi.fn().mockResolvedValue( undefined ),
+			maybeAutoSwitchProvider: vi.fn().mockResolvedValue( undefined ),
+			persistSessionContext: vi.fn().mockResolvedValue( undefined ),
+			clearSession: vi.fn().mockResolvedValue( undefined ),
+		};
+	}
+
+	afterEach( () => {
+		vi.mocked( areNotificationsEnabled ).mockReset();
+		vi.mocked( setNotificationsEnabled ).mockClear();
+	} );
+
+	it( 'is registered with a handler and a discoverable description', () => {
+		expect( cmd ).toBeDefined();
+		expect( typeof cmd.handler ).toBe( 'function' );
+		expect( cmd.description ).toBeTruthy();
+	} );
+
+	// Regression test: the interactive autocomplete (DescriptionAwareAutocompleteProvider
+	// in ai/ui.ts) is wired directly to getActiveSlashCommands() — there is no separate
+	// list to keep in sync. If this ever stops finding the command, autocomplete broke too.
+	it( 'shows up in the list the interactive autocomplete reads from', () => {
+		const active = getActiveSlashCommands().find( ( c ) => c.name === 'notifications' );
+		expect( active ).toBeDefined();
+		expect( typeof active!.handler ).toBe( 'function' );
+	} );
+
+	it( 'enables notifications and reports the new state when currently disabled', async () => {
+		vi.mocked( areNotificationsEnabled ).mockResolvedValue( false );
+		const ui = makeUi();
+		const result = await cmd.handler!( '/notifications', makeCtx( ui ) );
+
+		expect( setNotificationsEnabled ).toHaveBeenCalledWith( true );
+		expect( ui.showInfo ).toHaveBeenCalledWith( expect.stringContaining( 'enabled' ) );
+		expect( result ).toBe( 'continue' );
+	} );
+
+	it( 'disables notifications and reports the new state when currently enabled', async () => {
+		vi.mocked( areNotificationsEnabled ).mockResolvedValue( true );
+		const ui = makeUi();
+		await cmd.handler!( '/notifications', makeCtx( ui ) );
+
+		expect( setNotificationsEnabled ).toHaveBeenCalledWith( false );
+		expect( ui.showInfo ).toHaveBeenCalledWith( expect.stringContaining( 'disabled' ) );
 	} );
 } );

--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -4,6 +4,7 @@ import { AiChatUI } from 'cli/ai/ui';
 import { openBrowser } from 'cli/lib/browser';
 import { readCliConfig } from 'cli/lib/cli-config/core';
 import { getSiteUrl } from 'cli/lib/cli-config/sites';
+import { notifyTerminal } from 'cli/lib/notify';
 import { isSiteRunning } from 'cli/lib/site-utils';
 
 const ANSI_PATTERN = new RegExp( String.fromCharCode( 27 ) + '\\[[0-9;]*m', 'g' );
@@ -38,6 +39,10 @@ vi.mock( 'cli/lib/browser', () => ( {
 
 vi.mock( 'cli/lib/site-utils', () => ( {
 	isSiteRunning: vi.fn(),
+} ) );
+
+vi.mock( 'cli/lib/notify', () => ( {
+	notifyTerminal: vi.fn().mockResolvedValue( undefined ),
 } ) );
 
 describe( 'AiChatUI.openActiveSiteInBrowser', () => {
@@ -674,6 +679,52 @@ describe( 'AiChatUI.renderToolResultImages', () => {
 		);
 
 		expect( target.render( 120 ) ).toHaveLength( 0 );
+	} );
+} );
+
+describe( 'AiChatUI notify hooks', () => {
+	beforeEach( () => {
+		vi.mocked( notifyTerminal ).mockClear();
+	} );
+
+	it( 'notifies "response is ready" on agent_end', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			handleEvent: ( e: unknown ) => unknown;
+			[ key: string ]: unknown;
+		};
+		ui.hideLoader = vi.fn();
+		ui.showInfo = vi.fn();
+		ui.usageCapReached = false;
+		ui.wasInterrupted = false;
+		ui.hasShownResponseMarker = true;
+		ui.nowMs = () => 5000;
+		ui.turnStartTime = 0;
+		ui.numTurns = 1;
+		ui.messages = { addChild: vi.fn() };
+
+		ui.handleEvent( { type: 'agent_end', messages: [] } );
+
+		expect( notifyTerminal ).toHaveBeenCalledExactlyOnceWith(
+			expect.stringContaining( 'response is ready' )
+		);
+	} );
+
+	it( 'notifies "waiting for your answer" when askUser pauses for a question', async () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			askUser: ( q: unknown[] ) => Promise< Record< string, string > >;
+			[ key: string ]: unknown;
+		};
+		ui.hideLoader = vi.fn();
+		ui.showLoader = vi.fn();
+		ui.currentMarkdown = { setText: vi.fn() };
+		ui.currentResponseText = '';
+
+		const answers = await ui.askUser( [] );
+
+		expect( notifyTerminal ).toHaveBeenCalledExactlyOnceWith(
+			expect.stringContaining( 'waiting for your answer' )
+		);
+		expect( answers ).toEqual( {} );
 	} );
 } );
 

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -45,6 +45,7 @@ import { getWpComSites } from 'cli/lib/api';
 import { openBrowser } from 'cli/lib/browser';
 import { readCliConfig, type SiteData } from 'cli/lib/cli-config/core';
 import { getSiteUrl } from 'cli/lib/cli-config/sites';
+import { notifyTerminal } from 'cli/lib/notify';
 import { getSitesRunningStatus, isSiteRunning } from 'cli/lib/site-utils';
 import { formatTosNoticeLines } from 'cli/lib/tos-notice';
 import type { ToolResultMessage } from '@earendil-works/pi-ai';
@@ -1971,6 +1972,8 @@ export class AiChatUI implements AiOutputAdapter {
 		this.currentMarkdown = null;
 		this.currentResponseText = '';
 
+		void notifyTerminal( __( 'Studio Code is waiting for your answer' ) );
+
 		const answers: Record< string, string > = {};
 
 		for ( const q of questions ) {
@@ -2182,6 +2185,7 @@ export class AiChatUI implements AiOutputAdapter {
 						this.numTurns
 					)
 				);
+				void notifyTerminal( __( 'Studio Code response is ready' ) );
 				return;
 			}
 			default:

--- a/apps/cli/lib/cli-config/core.ts
+++ b/apps/cli/lib/cli-config/core.ts
@@ -90,6 +90,8 @@ const cliConfigSchema = z.looseObject( {
 	standaloneUpdateCheck: updateCheckSchema.optional(),
 	// Unix ms timestamp of when the one-time ToS/Privacy notice was displayed.
 	tosNoticeShownAt: z.number().optional(),
+	// Opt-in terminal notifications for `studio code` (see `lib/notify.ts`).
+	notificationsEnabled: z.boolean().optional(),
 } );
 
 type CliConfig = z.infer< typeof cliConfigSchema >;

--- a/apps/cli/lib/cli-config/core.ts
+++ b/apps/cli/lib/cli-config/core.ts
@@ -90,7 +90,7 @@ const cliConfigSchema = z.looseObject( {
 	standaloneUpdateCheck: updateCheckSchema.optional(),
 	// Unix ms timestamp of when the one-time ToS/Privacy notice was displayed.
 	tosNoticeShownAt: z.number().optional(),
-	// Opt-in terminal notifications for `studio code` (see `lib/notify.ts`).
+	// Terminal notifications override for `studio code` (see `lib/notify.ts`).
 	notificationsEnabled: z.boolean().optional(),
 } );
 

--- a/apps/cli/lib/notify.ts
+++ b/apps/cli/lib/notify.ts
@@ -1,0 +1,45 @@
+import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
+
+/**
+ * Opt-in terminal notifications for `studio code`: writes BEL + OSC 9 to
+ * stderr when an agent turn finishes or pauses to ask a question, so
+ * terminals that support it (Warp, iTerm2, etc.) can flash a tab or show a
+ * system notification. Unsupported terminals just ignore the escape codes.
+ *
+ * Off by default; enable with the `/notifications` slash command.
+ *
+ * Suppressed when forked by the Studio desktop app over IPC (it has its own
+ * native OS notification path) or when stderr isn't a TTY. Uses stderr
+ * rather than stdout because stdout is the documented NDJSON event stream
+ * for `studio code --json` — see `tos-notice.ts` for the same split.
+ */
+export async function areNotificationsEnabled(): Promise< boolean > {
+	const config = await readCliConfig();
+	return config.notificationsEnabled === true;
+}
+
+export async function setNotificationsEnabled( enabled: boolean ): Promise< void > {
+	await updateCliConfigWithPartial( { notificationsEnabled: enabled } );
+}
+
+export async function notifyTerminal( message: string ): Promise< void > {
+	if ( typeof process.send === 'function' ) {
+		// Running under the Studio desktop app's IPC — not a real terminal.
+		return;
+	}
+
+	if ( ! process.stderr.isTTY ) {
+		// No attached terminal to notify (piped/redirected stderr).
+		return;
+	}
+
+	try {
+		if ( ! ( await areNotificationsEnabled() ) ) {
+			return;
+		}
+		process.stderr.write( `\x1b]9;${ message }\x07` );
+		process.stderr.write( '\x07' );
+	} catch {
+		// Never let a notification failure break the CLI.
+	}
+}

--- a/apps/cli/lib/notify.ts
+++ b/apps/cli/lib/notify.ts
@@ -1,24 +1,61 @@
 import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
 
 /**
- * Opt-in terminal notifications for `studio code`: writes BEL + OSC 9 to
- * stderr when an agent turn finishes or pauses to ask a question, so
- * terminals that support it (Warp, iTerm2, etc.) can flash a tab or show a
- * system notification. Unsupported terminals just ignore the escape codes.
+ * Terminal notifications for `studio code`: writes OSC 9 to stderr when an
+ * agent turn finishes or pauses to ask a question, so terminals that
+ * support it (Warp, iTerm2, etc.) can show a system notification.
+ * Unsupported terminals just ignore the escape code.
  *
- * Off by default; enable with the `/notifications` slash command.
+ * Auto-enabled on terminals known to render OSC 9 well (see
+ * NOTIFICATION_CAPABLE_TERM_PROGRAMS below); silent everywhere else by
+ * default. The `/notifications` command cycles a three-way override on top
+ * of detection: unset (auto-detect) → true (always on) → false (always
+ * off) → back to unset.
  *
  * Suppressed when forked by the Studio desktop app over IPC (it has its own
  * native OS notification path) or when stderr isn't a TTY. Uses stderr
  * rather than stdout because stdout is the documented NDJSON event stream
  * for `studio code --json` — see `tos-notice.ts` for the same split.
  */
-export async function areNotificationsEnabled(): Promise< boolean > {
-	const config = await readCliConfig();
-	return config.notificationsEnabled === true;
+
+// Terminals confirmed to render OSC 9 as a system notification rather than
+// ignoring it outright. Matched against `TERM_PROGRAM`, which each of these
+// sets to identify itself.
+const NOTIFICATION_CAPABLE_TERM_PROGRAMS = new Set( [
+	'WarpTerminal',
+	'iTerm.app',
+	'WezTerm',
+	'ghostty',
+] );
+
+// Kitty doesn't set TERM_PROGRAM; it identifies itself via TERM instead. Ghostty
+// is matched here too as a fallback: TERM_PROGRAM isn't forwarded over SSH by
+// default, but TERM always is, so this still catches Ghostty-over-SSH.
+const NOTIFICATION_CAPABLE_TERMS = new Set( [ 'xterm-ghostty', 'xterm-kitty' ] );
+
+export function isNotificationCapableTerminal(): boolean {
+	const termProgram = process.env.TERM_PROGRAM;
+	if ( termProgram !== undefined && NOTIFICATION_CAPABLE_TERM_PROGRAMS.has( termProgram ) ) {
+		return true;
+	}
+	const term = process.env.TERM;
+	return term !== undefined && NOTIFICATION_CAPABLE_TERMS.has( term );
 }
 
-export async function setNotificationsEnabled( enabled: boolean ): Promise< void > {
+export async function getNotificationsPreference(): Promise< boolean | undefined > {
+	const config = await readCliConfig();
+	return config.notificationsEnabled;
+}
+
+export async function areNotificationsEnabled(): Promise< boolean > {
+	const preference = await getNotificationsPreference();
+	if ( preference !== undefined ) {
+		return preference;
+	}
+	return isNotificationCapableTerminal();
+}
+
+export async function setNotificationsEnabled( enabled: boolean | undefined ): Promise< void > {
 	await updateCliConfigWithPartial( { notificationsEnabled: enabled } );
 }
 
@@ -37,8 +74,9 @@ export async function notifyTerminal( message: string ): Promise< void > {
 		if ( ! ( await areNotificationsEnabled() ) ) {
 			return;
 		}
+		// No bare BEL: on unsupported terminals it's an audible beep, unlike
+		// OSC 9 alone, which is silently ignored.
 		process.stderr.write( `\x1b]9;${ message }\x07` );
-		process.stderr.write( '\x07' );
 	} catch {
 		// Never let a notification failure break the CLI.
 	}

--- a/apps/cli/lib/tests/notify.test.ts
+++ b/apps/cli/lib/tests/notify.test.ts
@@ -1,0 +1,137 @@
+import { type MockInstance, vi } from 'vitest';
+import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
+import { areNotificationsEnabled, notifyTerminal, setNotificationsEnabled } from 'cli/lib/notify';
+
+vi.mock( 'cli/lib/cli-config/core', () => ( {
+	readCliConfig: vi.fn(),
+	updateCliConfigWithPartial: vi.fn().mockResolvedValue( undefined ),
+} ) );
+
+describe( 'areNotificationsEnabled', () => {
+	beforeEach( () => {
+		vi.mocked( readCliConfig ).mockReset();
+	} );
+
+	it( 'is false by default (flag absent from config)', async () => {
+		vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
+		expect( await areNotificationsEnabled() ).toBe( false );
+	} );
+
+	it( 'is false when the flag is explicitly false', async () => {
+		vi.mocked( readCliConfig ).mockResolvedValue( {
+			version: 1,
+			sites: [],
+			snapshots: [],
+			notificationsEnabled: false,
+		} );
+		expect( await areNotificationsEnabled() ).toBe( false );
+	} );
+
+	it( 'is true when the flag is explicitly true', async () => {
+		vi.mocked( readCliConfig ).mockResolvedValue( {
+			version: 1,
+			sites: [],
+			snapshots: [],
+			notificationsEnabled: true,
+		} );
+		expect( await areNotificationsEnabled() ).toBe( true );
+	} );
+} );
+
+describe( 'setNotificationsEnabled', () => {
+	it( 'persists true', async () => {
+		await setNotificationsEnabled( true );
+		expect( updateCliConfigWithPartial ).toHaveBeenCalledWith( { notificationsEnabled: true } );
+	} );
+
+	it( 'persists false', async () => {
+		await setNotificationsEnabled( false );
+		expect( updateCliConfigWithPartial ).toHaveBeenCalledWith( { notificationsEnabled: false } );
+	} );
+} );
+
+describe( 'notifyTerminal', () => {
+	const originalSend = process.send;
+	let stderrWriteSpy: MockInstance;
+
+	// process.stderr.isTTY is a plain own property (absent when stdio is piped,
+	// as in the test runner). Override it per-test and restore the original shape.
+	const originalIsTTYDescriptor = Object.getOwnPropertyDescriptor( process.stderr, 'isTTY' );
+
+	function setStderrIsTTY( value: boolean | undefined ): void {
+		Object.defineProperty( process.stderr, 'isTTY', { value, configurable: true, writable: true } );
+	}
+
+	function restoreStderrIsTTY(): void {
+		if ( originalIsTTYDescriptor ) {
+			Object.defineProperty( process.stderr, 'isTTY', originalIsTTYDescriptor );
+		} else {
+			delete ( process.stderr as { isTTY?: boolean } ).isTTY;
+		}
+	}
+
+	beforeEach( () => {
+		process.send = undefined;
+		stderrWriteSpy = vi.spyOn( process.stderr, 'write' ).mockImplementation( () => true );
+		setStderrIsTTY( true );
+		vi.mocked( readCliConfig ).mockReset();
+	} );
+
+	afterEach( () => {
+		process.send = originalSend;
+		restoreStderrIsTTY();
+		stderrWriteSpy.mockRestore();
+	} );
+
+	it( 'writes nothing when notifications are disabled (default)', async () => {
+		vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
+		await notifyTerminal( 'hello' );
+		expect( stderrWriteSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'writes the OSC9 + BEL sequence when notifications are enabled', async () => {
+		vi.mocked( readCliConfig ).mockResolvedValue( {
+			version: 1,
+			sites: [],
+			snapshots: [],
+			notificationsEnabled: true,
+		} );
+		await notifyTerminal( 'Studio Code response is ready' );
+		expect( stderrWriteSpy ).toHaveBeenCalledWith( '\x1b]9;Studio Code response is ready\x07' );
+		expect( stderrWriteSpy ).toHaveBeenCalledWith( '\x07' );
+	} );
+
+	it( 'stays silent when forked by the desktop app over IPC, even if enabled', async () => {
+		process.send = vi.fn();
+		vi.mocked( readCliConfig ).mockResolvedValue( {
+			version: 1,
+			sites: [],
+			snapshots: [],
+			notificationsEnabled: true,
+		} );
+		await notifyTerminal( 'hello' );
+		expect( stderrWriteSpy ).not.toHaveBeenCalled();
+		// The IPC guard short-circuits before the config is even read.
+		expect( readCliConfig ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stays silent when stderr is not a TTY (piped/redirected), even if enabled', async () => {
+		setStderrIsTTY( undefined );
+		vi.mocked( readCliConfig ).mockResolvedValue( {
+			version: 1,
+			sites: [],
+			snapshots: [],
+			notificationsEnabled: true,
+		} );
+		await notifyTerminal( 'hello' );
+		expect( stderrWriteSpy ).not.toHaveBeenCalled();
+		// The TTY guard short-circuits before the config is even read.
+		expect( readCliConfig ).not.toHaveBeenCalled();
+	} );
+
+	it( 'never throws when reading the config fails', async () => {
+		vi.mocked( readCliConfig ).mockRejectedValue( new Error( 'locked' ) );
+		await expect( notifyTerminal( 'hello' ) ).resolves.toBeUndefined();
+		expect( stderrWriteSpy ).not.toHaveBeenCalled();
+	} );
+} );

--- a/apps/cli/lib/tests/notify.test.ts
+++ b/apps/cli/lib/tests/notify.test.ts
@@ -1,19 +1,95 @@
 import { type MockInstance, vi } from 'vitest';
 import { readCliConfig } from 'cli/lib/cli-config/core';
-import { areNotificationsEnabled, notifyTerminal } from 'cli/lib/notify';
+import {
+	areNotificationsEnabled,
+	isNotificationCapableTerminal,
+	notifyTerminal,
+} from 'cli/lib/notify';
 
 vi.mock( 'cli/lib/cli-config/core', () => ( {
 	readCliConfig: vi.fn(),
 	updateCliConfigWithPartial: vi.fn().mockResolvedValue( undefined ),
 } ) );
 
+const originalTermProgram = process.env.TERM_PROGRAM;
+const originalTerm = process.env.TERM;
+
+function setTerminalEnv( termProgram: string | undefined, term: string | undefined ): void {
+	if ( termProgram === undefined ) {
+		delete process.env.TERM_PROGRAM;
+	} else {
+		process.env.TERM_PROGRAM = termProgram;
+	}
+	if ( term === undefined ) {
+		delete process.env.TERM;
+	} else {
+		process.env.TERM = term;
+	}
+}
+
+function restoreTerminalEnv(): void {
+	setTerminalEnv( originalTermProgram, originalTerm );
+}
+
+describe( 'isNotificationCapableTerminal', () => {
+	afterEach( restoreTerminalEnv );
+
+	it( 'is true for a known TERM_PROGRAM (e.g. Warp)', () => {
+		setTerminalEnv( 'WarpTerminal', undefined );
+		expect( isNotificationCapableTerminal() ).toBe( true );
+	} );
+
+	it( 'is true for Ghostty via its lowercase TERM_PROGRAM value or via TERM', () => {
+		setTerminalEnv( 'ghostty', undefined );
+		expect( isNotificationCapableTerminal() ).toBe( true );
+
+		setTerminalEnv( undefined, 'xterm-ghostty' );
+		expect( isNotificationCapableTerminal() ).toBe( true );
+	} );
+
+	it( 'is true for Kitty, which identifies via TERM instead of TERM_PROGRAM', () => {
+		setTerminalEnv( undefined, 'xterm-kitty' );
+		expect( isNotificationCapableTerminal() ).toBe( true );
+	} );
+
+	it( 'is false for an unrecognized or absent terminal', () => {
+		setTerminalEnv( undefined, 'xterm-256color' );
+		expect( isNotificationCapableTerminal() ).toBe( false );
+	} );
+} );
+
 describe( 'areNotificationsEnabled', () => {
 	beforeEach( () => {
 		vi.mocked( readCliConfig ).mockReset();
 	} );
+	afterEach( restoreTerminalEnv );
 
-	it( 'is false by default (flag absent from config)', async () => {
+	it( 'falls back to terminal detection when the flag is unset', async () => {
 		vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
+		setTerminalEnv( 'WarpTerminal', undefined );
+		expect( await areNotificationsEnabled() ).toBe( true );
+
+		setTerminalEnv( undefined, 'xterm-256color' );
+		expect( await areNotificationsEnabled() ).toBe( false );
+	} );
+
+	it( 'an explicit flag overrides terminal detection either way', async () => {
+		setTerminalEnv( undefined, 'xterm-256color' );
+		vi.mocked( readCliConfig ).mockResolvedValue( {
+			version: 1,
+			sites: [],
+			snapshots: [],
+			notificationsEnabled: true,
+		} );
+		expect( await areNotificationsEnabled() ).toBe( true );
+
+		setTerminalEnv( 'WarpTerminal', undefined );
+		vi.mocked( readCliConfig ).mockResolvedValue( {
+			version: 1,
+			sites: [],
+			snapshots: [],
+			notificationsEnabled: false,
+		} );
 		expect( await areNotificationsEnabled() ).toBe( false );
 	} );
 } );
@@ -48,16 +124,25 @@ describe( 'notifyTerminal', () => {
 	afterEach( () => {
 		process.send = originalSend;
 		restoreStderrIsTTY();
+		restoreTerminalEnv();
 		stderrWriteSpy.mockRestore();
 	} );
 
-	it( 'writes nothing when notifications are disabled (default)', async () => {
+	it( 'writes nothing when the flag is unset on an unrecognized terminal', async () => {
+		setTerminalEnv( undefined, 'xterm-256color' );
 		vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
 		await notifyTerminal( 'hello' );
 		expect( stderrWriteSpy ).not.toHaveBeenCalled();
 	} );
 
-	it( 'writes the OSC9 + BEL sequence when notifications are enabled', async () => {
+	it( 'writes the OSC9 sequence when the flag is unset but the terminal is capable', async () => {
+		setTerminalEnv( 'WarpTerminal', undefined );
+		vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
+		await notifyTerminal( 'hello' );
+		expect( stderrWriteSpy ).toHaveBeenCalledWith( '\x1b]9;hello\x07' );
+	} );
+
+	it( 'writes only the OSC9 sequence (no bare BEL) when enabled', async () => {
 		vi.mocked( readCliConfig ).mockResolvedValue( {
 			version: 1,
 			sites: [],
@@ -66,7 +151,7 @@ describe( 'notifyTerminal', () => {
 		} );
 		await notifyTerminal( 'Studio Code response is ready' );
 		expect( stderrWriteSpy ).toHaveBeenCalledWith( '\x1b]9;Studio Code response is ready\x07' );
-		expect( stderrWriteSpy ).toHaveBeenCalledWith( '\x07' );
+		expect( stderrWriteSpy ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'stays silent when forked by the desktop app over IPC, even if enabled', async () => {

--- a/apps/cli/lib/tests/notify.test.ts
+++ b/apps/cli/lib/tests/notify.test.ts
@@ -1,6 +1,6 @@
 import { type MockInstance, vi } from 'vitest';
-import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
-import { areNotificationsEnabled, notifyTerminal, setNotificationsEnabled } from 'cli/lib/notify';
+import { readCliConfig } from 'cli/lib/cli-config/core';
+import { areNotificationsEnabled, notifyTerminal } from 'cli/lib/notify';
 
 vi.mock( 'cli/lib/cli-config/core', () => ( {
 	readCliConfig: vi.fn(),
@@ -15,38 +15,6 @@ describe( 'areNotificationsEnabled', () => {
 	it( 'is false by default (flag absent from config)', async () => {
 		vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
 		expect( await areNotificationsEnabled() ).toBe( false );
-	} );
-
-	it( 'is false when the flag is explicitly false', async () => {
-		vi.mocked( readCliConfig ).mockResolvedValue( {
-			version: 1,
-			sites: [],
-			snapshots: [],
-			notificationsEnabled: false,
-		} );
-		expect( await areNotificationsEnabled() ).toBe( false );
-	} );
-
-	it( 'is true when the flag is explicitly true', async () => {
-		vi.mocked( readCliConfig ).mockResolvedValue( {
-			version: 1,
-			sites: [],
-			snapshots: [],
-			notificationsEnabled: true,
-		} );
-		expect( await areNotificationsEnabled() ).toBe( true );
-	} );
-} );
-
-describe( 'setNotificationsEnabled', () => {
-	it( 'persists true', async () => {
-		await setNotificationsEnabled( true );
-		expect( updateCliConfigWithPartial ).toHaveBeenCalledWith( { notificationsEnabled: true } );
-	} );
-
-	it( 'persists false', async () => {
-		await setNotificationsEnabled( false );
-		expect( updateCliConfigWithPartial ).toHaveBeenCalledWith( { notificationsEnabled: false } );
 	} );
 } );
 


### PR DESCRIPTION
## Related issues

* Related to Automattic/studio#4178

## How AI was used in this PR

This entire PR — code, tests, and this description — was written in an AI pair-programming session (Studio Code itself, dogfooding the agent on its own CLI source). I reviewed  <br>every file change myself: read each diff, questioned the design decisions (why two output adapters need separate hooks, why stderr over stdout, why the `--json` guard checks both  <br>`process.send` and `isTTY`), and manually verified the terminal behavior across Warp/Git Bash/PowerShell/CMD myself rather than trusting the agent's claims. I did not write the  <br>implementation by hand.

**This is a Proof of Concept** (see `AGENTS.md`'s "Large & Exploratory Contributions" section) — opened as a draft since I couldn't apply the `Proof of Concept` label myself as  <br>an external contributor. Please add it if a maintainer agrees this is worth exploring further.

## Proposed Changes

Adds a terminal notification (OSC 9 written to stderr) when a `studio code` agent turn finishes or pauses on an `AskUserQuestion`, so users don't have to keep watching the  <br>terminal during long-running turns.

Auto-detected: on by default for terminals confirmed to render OSC 9 as a system notification — Warp, iTerm2, WezTerm, Ghostty, Kitty — and silent everywhere else. The  <br>`/notifications` slash command cycles a manual override on top of detection: auto-detect → always on → always off → back to auto-detect.

No bare BEL: earlier versions of this PR also wrote a bare BEL as a fallback. Dropped per review feedback.

## Testing Instructions

1. Run `npm run cli:build && node apps/cli/dist/cli/main.mjs code`
2. Run `/notifications` a few times — it should cycle through "auto-detect", "always on", and "always off" messages.
3. On a capable terminal (Warp, iTerm2, WezTerm, Ghostty, Kitty), send a message and wait for the turn to finish, or ask something that triggers `AskUserQuestion` — you should  <br>see a system notification.
4. Set `/notifications` to "always off" and confirm no signal on the next turn, even on a capable terminal.
5. Unit tests: `npm test -- apps/cli/lib/tests/notify.test.ts apps/cli/ai/tests/output-adapter.test.ts apps/cli/ai/tests/ui.test.ts apps/cli/ai/tests/slash-commands.test.ts`

> Manual terminal verification, on Windows: Warp shows a system notification, both on auto-detect and with "always on". Windows Terminal and ConEmu show nothing even with  <br>"always on" forced — both use the OSC 9 slot for a progress indicator, not notifications, so this is expected and correctly excluded from auto-detect. Git Bash, PowerShell, and  <br>CMD show nothing either — none of them render OSC 9 as a notification. macOS/Linux terminals (iTerm2, WezTerm, Ghostty, Kitty) are in the auto-detect list based on source/docs  <br>review but untested by me directly — would appreciate confirmation from someone on those platforms.

## Pre-merge Checklist

- [X] Have you checked for TypeScript, React or other console errors?