### PR TITLE
Add header navigation UI tests for opening the site and wp-admin

### DIFF
--- a/apps/studio/src/components/tests/header.test.tsx
+++ b/apps/studio/src/components/tests/header.test.tsx
@@ -68,6 +68,37 @@ describe( 'Header', () => {
 		expect( vi.mocked( getIpcApi )().startServer ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	describe( 'site navigation links (IPC command boundary)', () => {
+		it( 'opens the local site homepage without auto-login', async () => {
+			const user = userEvent.setup();
+			mockGetIpcApi( { openSiteURL: vi.fn() } );
+			renderWithProvider( <Header /> );
+
+			await screen.findByText( 'test-1' );
+			await user.click( screen.getByRole( 'button', { name: /Open local site/ } ) );
+
+			expect( vi.mocked( getIpcApi )().startServer ).toHaveBeenCalledWith( 'mock-id' );
+			expect( vi.mocked( getIpcApi )().openSiteURL ).toHaveBeenCalledWith( 'mock-id', '', {
+				autoLogin: false,
+			} );
+		} );
+
+		it( 'opens wp-admin with auto-login', async () => {
+			const user = userEvent.setup();
+			mockGetIpcApi( { openSiteURL: vi.fn() } );
+			renderWithProvider( <Header /> );
+
+			await screen.findByText( 'test-1' );
+			await user.click( screen.getByRole( 'button', { name: /WP admin/ } ) );
+
+			expect( vi.mocked( getIpcApi )().startServer ).toHaveBeenCalledWith( 'mock-id' );
+			expect( vi.mocked( getIpcApi )().openSiteURL ).toHaveBeenCalledWith(
+				'mock-id',
+				'/wp-admin/'
+			);
+		} );
+	} );
+
 	describe( 'when starting a server fails', () => {
 		it( 'should display an error message', async () => {
 			const user = userEvent.setup();


### PR DESCRIPTION
## Related issues

- Related to [STU-1869](https://linear.app/a8c/issue/STU-1869)

## How AI was used in this PR

Claude wrote the code, guided by the author. The author tested it locally and manually reviewed it before pushing.

## Proposed Changes

The STU-1869 migration ported the Navigate Site e2e tests to a CLI suite, but left out the desktop-only half. Opening the local site and auto-logging into wp-admin happen through Studio's own IPC, which the CLI cannot exercise. This adds the missing companion coverage to `header.test.tsx`, matching the pattern used for other migrations.

The tests assert the exact `openSiteURL` command each header link fires:
- "Open local site" opens the homepage without auto-login.
- "WP admin" opens wp-admin with auto-login (the default).

Both also confirm a stopped site is started first.

## Testing Instructions

- Run `npm test -- src/components/tests/header.test.tsx`.
- All four cases should pass.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
