### PR TITLE
Restore E2E CI gate removed during Linux E2E iteration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -93,7 +93,7 @@ steps:
       - <<: *e2e_config
         label: E2E Tests on {{matrix.platform}}-{{matrix.arch}}
         key: e2e_tests
-        # TEMP(rsm-2593): if: removed to force E2E on every push while iterating on Linux E2E setup. Revert before merge.
+        if: (build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft) && !(build.pull_request.labels includes 'native-php')
 
       # Linux E2E tests run on the shared `default` queue inside a Debian Node
       # container — the same pattern the Linux build/unit-test steps use. Kept as
@@ -116,7 +116,7 @@ steps:
           - test-results/daemon-logs/**/*.log
         env:
           DEBUG: "pw:browser"
-        # TEMP(rsm-2593): if: removed to force E2E on every push while iterating on Linux E2E setup. Revert before merge.
+        if: (build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft) && !(build.pull_request.labels includes 'native-php')
 
   # Manual-only and not a required GitHub check: it never runs until someone
   # unblocks it in Buildkite, and it never gates PR merges.


### PR DESCRIPTION
## Related issues

- Related to [RSM-2593](https://linear.app/a8c/issue/RSM-2593/run-e2e-tests-on-linux-in-buildkite)

## How AI was used in this PR

Claude wrote the code, guided by the author. The author manually reviewed it before pushing.

## Proposed Changes

While iterating on Linux E2E setup under [RSM-2593](https://linear.app/a8c/issue/RSM-2593/run-e2e-tests-on-linux-in-buildkite), the `if:` gate on both E2E steps (mac/windows matrix and Linux) was temporarily removed to force E2E on every push. That change was never reverted, so E2E now runs on draft PRs and on `native-php`-labeled PRs, adding unnecessary Buildkite load.

This restores the original condition on both steps, so E2E again runs only on trunk, tags, and non-draft PRs, and is skipped for `native-php` PRs.

## Testing Instructions

- Confirm `.buildkite/pipeline.yml` parses and both E2E steps carry the same `if:` condition.
- On a draft PR, the two E2E steps should not run; marking it ready for review should schedule them.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
