### PR TITLE
Skip CI jobs on Linux when a PR only touches irrelevant files

### DIFF
--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -127,10 +127,51 @@ if [[ -z "$job_type" ]]; then
   exit 1
 fi
 
-# Check if pr_changed_files command is available
+# git-based drop-in for the a8c-ci-toolkit `pr_changed_files` command. That
+# command ships with the toolkit plugin, which loads only on the host agents;
+# Linux jobs run inside a Docker container without it. This replicates the two
+# modes we use with plain git, so the same diff is available everywhere. On any
+# uncertainty (not a PR, base fetch fails, empty diff) it returns non-zero so
+# the job runs, matching the plugin's fail-open behavior.
+git_pr_changed_files() {
+  local mode="$1"; shift
+
+  [[ "${BUILDKITE_PULL_REQUEST:-false}" =~ ^[0-9]+$ ]] || return 1
+
+  # Anonymous HTTPS fetch: the container has no SSH keys and origin may be an SSH
+  # URL. Studio is public, so this needs no credentials. Reference FETCH_HEAD to
+  # avoid mutating the checkout's remote.
+  # ponytail: falls open (returns 1) on shallow clones where --merge-base can't
+  # resolve; wire up unshallow only if that turns out to skip too little.
+  git fetch --no-tags "https://github.com/Automattic/studio.git" "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" &> /dev/null || return 1
+
+  local changed_files=()
+  while IFS= read -r -d '' file; do
+    changed_files+=("$file")
+  done < <(git --no-pager diff --name-only -z --merge-base FETCH_HEAD HEAD)
+  [[ ${#changed_files[@]} -gt 0 ]] || return 1
+
+  local file pattern matched
+  for file in "${changed_files[@]}"; do
+    matched="false"
+    for pattern in "$@"; do
+      # shellcheck disable=SC2053 # Unquoted rhs so */?/[…] are treated as a glob.
+      if [[ "$file" == ${pattern} ]]; then
+        matched="true"
+        break
+      fi
+    done
+    [[ "$mode" == "--all-match" && "$matched" == "false" ]] && return 1
+    [[ "$mode" == "--any-match" && "$matched" == "true" ]] && return 0
+  done
+
+  [[ "$mode" == "--all-match" ]] && return 0
+  return 1
+}
+
+# Use the plugin command on host agents; fall back to git inside containers.
 if ! command -v pr_changed_files &> /dev/null; then
-  echo "pr_changed_files command not found. Running job."
-  exit 1
+  pr_changed_files() { git_pr_changed_files "$@"; }
 fi
 
 case "$job_type" in

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -127,22 +127,11 @@ if [[ -z "$job_type" ]]; then
   exit 1
 fi
 
-# git-based drop-in for the a8c-ci-toolkit `pr_changed_files` command. That
-# command ships with the toolkit plugin, which loads only on the host agents;
-# Linux jobs run inside a Docker container without it. This replicates the two
-# modes we use with plain git, so the same diff is available everywhere. On any
-# uncertainty (not a PR, base fetch fails, empty diff) it returns non-zero so
-# the job runs, matching the plugin's fail-open behavior.
 git_pr_changed_files() {
   local mode="$1"; shift
 
   [[ "${BUILDKITE_PULL_REQUEST:-false}" =~ ^[0-9]+$ ]] || return 1
 
-  # Anonymous HTTPS fetch: the container has no SSH keys and origin may be an SSH
-  # URL. Studio is public, so this needs no credentials. Reference FETCH_HEAD to
-  # avoid mutating the checkout's remote.
-  # ponytail: falls open (returns 1) on shallow clones where --merge-base can't
-  # resolve; wire up unshallow only if that turns out to skip too little.
   git fetch --no-tags "https://github.com/Automattic/studio.git" "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" &> /dev/null || return 1
 
   local changed_files=()
@@ -155,7 +144,7 @@ git_pr_changed_files() {
   for file in "${changed_files[@]}"; do
     matched="false"
     for pattern in "$@"; do
-      # shellcheck disable=SC2053 # Unquoted rhs so */?/[…] are treated as a glob.
+      # shellcheck disable=SC2053
       if [[ "$file" == ${pattern} ]]; then
         matched="true"
         break
@@ -169,7 +158,6 @@ git_pr_changed_files() {
   return 1
 }
 
-# Use the plugin command on host agents; fall back to git inside containers.
 if ! command -v pr_changed_files &> /dev/null; then
   pr_changed_files() { git_pr_changed_files "$@"; }
 fi

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -51,6 +51,12 @@ xdg-mime default studio.desktop x-scheme-handler/wp-studio
 
 This depends on the `.desktop` file from the previous section. Without it, browsers will show "Open With… / No Apps Available" when WordPress.com OAuth redirects back, or hand the callback off to an installed `.deb` build (masking the bug you're trying to debug).
 
+## Continuous Integration
+
+Linux CI jobs (build, unit, and E2E) run inside a Debian Node container on Buildkite's shared `default` queue, since there is no dedicated Linux agent. The container provides `dpkg`/`fakeroot` for the `.deb` build and the Electron runtime libraries, `xvfb`, and Playwright browser dependencies that E2E needs.
+
+Jobs are skipped when a pull request only touches irrelevant files (docs, config, localization). On Mac and Windows this uses the `pr_changed_files` command from the `a8c-ci-toolkit` plugin, which loads only on the host. Because the Linux jobs run inside the container without that plugin, `should-skip-job.sh` falls back to computing the changed files with plain `git` so the same skip behavior applies on every platform.
+
 ## Troubleshooting
 
 If `./studio` fails with a permission error, ensure it has execute permissions:

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -51,12 +51,6 @@ xdg-mime default studio.desktop x-scheme-handler/wp-studio
 
 This depends on the `.desktop` file from the previous section. Without it, browsers will show "Open With… / No Apps Available" when WordPress.com OAuth redirects back, or hand the callback off to an installed `.deb` build (masking the bug you're trying to debug).
 
-## Continuous Integration
-
-Linux CI jobs (build, unit, and E2E) run inside a Debian Node container on Buildkite's shared `default` queue, since there is no dedicated Linux agent. The container provides `dpkg`/`fakeroot` for the `.deb` build and the Electron runtime libraries, `xvfb`, and Playwright browser dependencies that E2E needs.
-
-Jobs are skipped when a pull request only touches irrelevant files (docs, config, localization). On Mac and Windows this uses the `pr_changed_files` command from the `a8c-ci-toolkit` plugin, which loads only on the host. Because the Linux jobs run inside the container without that plugin, `should-skip-job.sh` falls back to computing the changed files with plain `git` so the same skip behavior applies on every platform.
-
 ## Troubleshooting
 
 If `./studio` fails with a permission error, ensure it has execute permissions:


### PR DESCRIPTION
## Related issues

- Fixes [STU-2042](https://linear.app/a8c/issue/STU-2042/should-skip-jobsh-doesnt-work-on-linux)

## How AI was used in this PR

Claude wrote the code, guided by the author. The author reviewed it and verified the diff and matching logic against a local git repo before pushing. CI-side behavior on Linux still needs a real Buildkite run to confirm.

## Proposed Changes

Linux CI jobs never skip, even when a PR only touches docs or other irrelevant files. They run the full suite and log `pr_changed_files command not found. Running job.` Mac and Windows skip correctly.

The cause is that `pr_changed_files` ships with the `a8c-ci-toolkit` plugin, which loads only on the host agents. Linux jobs run inside a Docker container without that plugin, so the command is missing.

This adds a git-based drop-in with the same interface, used only when the plugin command is absent. Host agents keep using the plugin unchanged. Linux now computes the same diff with plain git and skips irrelevant-only PRs, saving Buildkite time. If anything is uncertain (not a PR, base fetch fails, shallow clone), it falls open and runs the job, so there is no risk of wrongly skipping.

## Testing Instructions

- Open a PR that changes only a Markdown or docs file. 
- The Linux unit and E2E jobs should skip instead of running fully. Look for following line on E2E tests: 
```
⏩ Skipping E2E Tests on linux-x64 - no relevant files changed
```
- Open a PR that changes app source. All jobs should run as before.
- Confirm Mac and Windows skip behavior is unchanged.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
