### PR TITLE
Decrease windows build time caused by data-liberation-agent

### DIFF
--- a/apps/cli/ai/tools/data-liberation.ts
+++ b/apps/cli/ai/tools/data-liberation.ts
@@ -44,16 +44,16 @@ function getClient(): Promise< Client > {
 }
 
 async function connectClient(): Promise< Client > {
-	if ( ! existsSync( path.join( engineDir, 'dist', 'mcp-server.js' ) ) ) {
+	if ( ! existsSync( path.join( engineDir, 'dist', 'mcp-server.bundle.mjs' ) ) ) {
 		throw new Error(
 			'Data Liberation engine is not compiled. Run `npm run cli:build` — it builds the ' +
-				'`data-liberation` workspace and bundles it into `dist/cli`.'
+				'`data-liberation` MCP bundle and copies it into `dist/cli`.'
 		);
 	}
 
 	const transport = new StdioClientTransport( {
 		command: process.execPath,
-		args: [ path.join( engineDir, 'dist', 'mcp-server.js' ) ],
+		args: [ path.join( engineDir, 'dist', 'mcp-server.bundle.mjs' ) ],
 		cwd: engineDir,
 		stderr: 'pipe',
 	} );

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -44,7 +44,6 @@
 		"atomically": "^2.1.1",
 		"chokidar": "^5.0.0",
 		"cli-table3": "^0.6.5",
-		"data-liberation": "file:../../packages/data-liberation-agent",
 		"express": "^4.22.0",
 		"express-rate-limit": "^8.5.2",
 		"fs-extra": "^11.3.4",

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -48,19 +48,44 @@ const repoRoot = resolve( __dirname, '..', '..' );
 // or dev-server setups, which is fine.
 const localUiDistPath = resolve( __dirname, '../ui/dist-local' );
 
-function copyEngineRuntimeAssets( srcDir: string, destDir: string ) {
-	for ( const entry of readdirSync( srcDir, { withFileTypes: true } ) ) {
-		const from = resolve( srcDir, entry.name );
-		if ( entry.isDirectory() ) {
-			if ( /^__(tests|fixtures|snapshots)__$/.test( entry.name ) ) {
-				continue;
+// Ship only the self-contained engine bundle — its deps are inlined. Shipping
+// the tsc output + node_modules instead added ~10k files to the installer and
+// ~8 min to the Windows CI build (STU-2027).
+function copyDataLiberationEngine( outDir: string ) {
+	execSync( 'npm -w data-liberation run build:mcp-bundle', {
+		cwd: repoRoot,
+		stdio: 'inherit',
+	} );
+	const engineOutDir = resolve( outDir, 'data-liberation-agent' );
+	mkdirSync( resolve( engineOutDir, 'dist' ), { recursive: true } );
+	copyFileSync(
+		resolve( dataLiberationSourcePath, 'dist', 'mcp-server.bundle.mjs' ),
+		resolve( engineOutDir, 'dist', 'mcp-server.bundle.mjs' )
+	);
+	cpSync( resolve( dataLiberationSourcePath, 'skills' ), resolve( engineOutDir, 'skills' ), {
+		recursive: true,
+	} );
+
+	// The bundle resolves vendored runtime assets (.php helpers run via
+	// `wp eval-file`, .json data like core-block-attrs.json) relative to the
+	// engine's original src/ module paths — see the import.meta.url rewrite in
+	// packages/data-liberation-agent/scripts/build-mcp-bundle.mjs — so mirror
+	// those files (and nothing else) under src/.
+	const copyRuntimeAssets = ( srcDir: string, destDir: string ) => {
+		for ( const entry of readdirSync( srcDir, { withFileTypes: true } ) ) {
+			const from = resolve( srcDir, entry.name );
+			if ( entry.isDirectory() ) {
+				if ( /^__(tests|fixtures|snapshots)__$/.test( entry.name ) ) {
+					continue;
+				}
+				copyRuntimeAssets( from, resolve( destDir, entry.name ) );
+			} else if ( /\.(php|json)$/.test( entry.name ) ) {
+				mkdirSync( destDir, { recursive: true } );
+				copyFileSync( from, resolve( destDir, entry.name ) );
 			}
-			copyEngineRuntimeAssets( from, resolve( destDir, entry.name ) );
-		} else if ( /\.(php|json)$/.test( entry.name ) ) {
-			mkdirSync( destDir, { recursive: true } );
-			copyFileSync( from, resolve( destDir, entry.name ) );
 		}
-	}
+	};
+	copyRuntimeAssets( resolve( dataLiberationSourcePath, 'src' ), resolve( engineOutDir, 'src' ) );
 }
 
 export const baseConfig = defineConfig( {
@@ -88,36 +113,7 @@ export const baseConfig = defineConfig( {
 					cpSync( skillsSourcePath, resolve( outDir, 'skills' ), { recursive: true } );
 				}
 
-				// Ship the engine as its self-contained MCP bundle only — never the tsc
-				// output tree or its node_modules. The engine's dependencies are inlined
-				// in the bundle; shipping them as loose files added ~17k files to the
-				// installer payload and ~8 min to the Windows CI build (STU-2027).
-				execSync( 'npm -w data-liberation run build:mcp-bundle', {
-					cwd: repoRoot,
-					stdio: 'inherit',
-				} );
-				const engineOutDir = resolve( outDir, 'data-liberation-agent' );
-				mkdirSync( resolve( engineOutDir, 'dist' ), { recursive: true } );
-				copyFileSync(
-					resolve( dataLiberationSourcePath, 'dist', 'mcp-server.bundle.mjs' ),
-					resolve( engineOutDir, 'dist', 'mcp-server.bundle.mjs' )
-				);
-				copyFileSync(
-					resolve( dataLiberationSourcePath, 'package.json' ),
-					resolve( engineOutDir, 'package.json' )
-				);
-				cpSync( resolve( dataLiberationSourcePath, 'skills' ), resolve( engineOutDir, 'skills' ), {
-					recursive: true,
-				} );
-				// The bundle resolves vendored runtime assets (.php helpers run via
-				// `wp eval-file`, .json data like core-block-attrs.json) relative to the
-				// engine's original src/ module paths — see the import.meta.url rewrite in
-				// packages/data-liberation-agent/scripts/build-mcp-bundle.mjs — so mirror
-				// those files (and nothing else) under src/.
-				copyEngineRuntimeAssets(
-					resolve( dataLiberationSourcePath, 'src' ),
-					resolve( engineOutDir, 'src' )
-				);
+				copyDataLiberationEngine( outDir );
 
 				if ( existsSync( localUiDistPath ) ) {
 					cpSync( localUiDistPath, resolve( outDir, 'ui' ), { recursive: true } );

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
-import { cpSync, existsSync, mkdirSync, writeFileSync } from 'fs';
-import { relative, resolve, sep } from 'path';
+import { copyFileSync, cpSync, existsSync, mkdirSync, readdirSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
 import semver from 'semver';
 import { defineConfig } from 'vite';
 import packageJson from './package.json';
@@ -48,6 +48,21 @@ const repoRoot = resolve( __dirname, '..', '..' );
 // or dev-server setups, which is fine.
 const localUiDistPath = resolve( __dirname, '../ui/dist-local' );
 
+function copyEngineRuntimeAssets( srcDir: string, destDir: string ) {
+	for ( const entry of readdirSync( srcDir, { withFileTypes: true } ) ) {
+		const from = resolve( srcDir, entry.name );
+		if ( entry.isDirectory() ) {
+			if ( /^__(tests|fixtures|snapshots)__$/.test( entry.name ) ) {
+				continue;
+			}
+			copyEngineRuntimeAssets( from, resolve( destDir, entry.name ) );
+		} else if ( /\.(php|json)$/.test( entry.name ) ) {
+			mkdirSync( destDir, { recursive: true } );
+			copyFileSync( from, resolve( destDir, entry.name ) );
+		}
+	}
+}
+
 export const baseConfig = defineConfig( {
 	oxc: {
 		target: `node${ semver.major( minimumNodeVersion ) }`,
@@ -73,23 +88,36 @@ export const baseConfig = defineConfig( {
 					cpSync( skillsSourcePath, resolve( outDir, 'skills' ), { recursive: true } );
 				}
 
-				execSync( 'npm -w data-liberation run build', { cwd: repoRoot, stdio: 'inherit' } );
-				cpSync( dataLiberationSourcePath, resolve( outDir, 'data-liberation-agent' ), {
-					recursive: true,
-					filter: ( src ) => {
-						const rel = relative( dataLiberationSourcePath, src );
-						if ( rel === '' ) {
-							return true;
-						}
-
-						const top = rel.split( sep )[ 0 ];
-						if ( top !== 'dist' && top !== 'package.json' && top !== 'skills' ) {
-							return false;
-						}
-						// Within dist/, drop build-only artifacts (types, tests, cache, maps).
-						return ! /\.(d\.ts|test\.js|js\.map|tsbuildinfo)$/.test( rel );
-					},
+				// Ship the engine as its self-contained MCP bundle only — never the tsc
+				// output tree or its node_modules. The engine's dependencies are inlined
+				// in the bundle; shipping them as loose files added ~17k files to the
+				// installer payload and ~8 min to the Windows CI build (STU-2027).
+				execSync( 'npm -w data-liberation run build:mcp-bundle', {
+					cwd: repoRoot,
+					stdio: 'inherit',
 				} );
+				const engineOutDir = resolve( outDir, 'data-liberation-agent' );
+				mkdirSync( resolve( engineOutDir, 'dist' ), { recursive: true } );
+				copyFileSync(
+					resolve( dataLiberationSourcePath, 'dist', 'mcp-server.bundle.mjs' ),
+					resolve( engineOutDir, 'dist', 'mcp-server.bundle.mjs' )
+				);
+				copyFileSync(
+					resolve( dataLiberationSourcePath, 'package.json' ),
+					resolve( engineOutDir, 'package.json' )
+				);
+				cpSync( resolve( dataLiberationSourcePath, 'skills' ), resolve( engineOutDir, 'skills' ), {
+					recursive: true,
+				} );
+				// The bundle resolves vendored runtime assets (.php helpers run via
+				// `wp eval-file`, .json data like core-block-attrs.json) relative to the
+				// engine's original src/ module paths — see the import.meta.url rewrite in
+				// packages/data-liberation-agent/scripts/build-mcp-bundle.mjs — so mirror
+				// those files (and nothing else) under src/.
+				copyEngineRuntimeAssets(
+					resolve( dataLiberationSourcePath, 'src' ),
+					resolve( engineOutDir, 'src' )
+				);
 
 				if ( existsSync( localUiDistPath ) ) {
 					cpSync( localUiDistPath, resolve( outDir, 'ui' ), { recursive: true } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
 				"atomically": "^2.1.1",
 				"chokidar": "^5.0.0",
 				"cli-table3": "^0.6.5",
-				"data-liberation": "file:../../packages/data-liberation-agent",
 				"express": "^4.22.0",
 				"express-rate-limit": "^8.5.2",
 				"fs-extra": "^11.3.4",


### PR DESCRIPTION
## Related issues

- Fixes STU-2027, STU-2035

## How AI was used in this PR

AI assisted with investigation and writing code

## Proposed Changes

As mentioned in the issue STU-2027 - build time for Windows x64 increases by 8 minutes. Interesting results of the investigations are in comments under the Linear issue.

The sultion - we already have mcp-server.bundle.mjs so we can reuse it, additionally clone skills and otehr necessary files and remove direct dependency.
As a result:
1. data-liberation-agent takes just a few MB
2. Build time returned to the old numbers, see:

Example w/o data-liberations (it was taken from this test PR https://github.com/Automattic/studio/pull/4176):
<img width="1527" height="66" alt="Screenshot 2026-07-10 at 22 54 57" src="https://github.com/user-attachments/assets/2217243f-c6c1-40e3-8bc5-6ffc286acf5b" />

Example after changes in this PR(I did 2 tests):
<img width="1525" height="62" alt="Screenshot 2026-07-10 at 21 54 11" src="https://github.com/user-attachments/assets/c1346ba2-4beb-4647-a9c5-724a848a1b25" />
<img width="2162" height="63" alt="Screenshot 2026-07-13 at 14 55 55" src="https://github.com/user-attachments/assets/75478ff4-aecf-49f4-a9cb-bab0488d407f" />

## Testing Instructions
Visual review should suffice, but you can test with:
1. `npm run cli:build && node apps/cli/dist/cli/main.mjs code`
2. `/liberate https://neicss.wixsite.com/sunflower-valley-exp`
3. Assert that it works
4. Check the buildkite build for Windows x64 on this PR and assert that you see build time for Windows x64 as ~35 mins