### PR TITLE
Add regression test for daemon disconnect after per-turn site check

### DIFF
--- a/apps/cli/commands/ai/tests/index.test.ts
+++ b/apps/cli/commands/ai/tests/index.test.ts
@@ -10,6 +10,7 @@ import {
 } from 'cli/ai/sessions/pi-session';
 import { readCliConfig } from 'cli/lib/cli-config/core';
 import { findSiteByFolder } from 'cli/lib/cli-config/sites';
+import { disconnectFromDaemon } from 'cli/lib/daemon-client';
 import { isSiteRunning } from 'cli/lib/site-utils';
 import { runCommand } from '../index';
 
@@ -40,6 +41,9 @@ vi.mock( 'cli/lib/cli-config/sites', () => ( {
 } ) );
 vi.mock( 'cli/lib/site-utils', () => ( {
 	isSiteRunning: vi.fn(),
+} ) );
+vi.mock( 'cli/lib/daemon-client', () => ( {
+	disconnectFromDaemon: vi.fn().mockResolvedValue( undefined ),
 } ) );
 vi.mock( 'cli/ai/sessions/context', () => ( {
 	resolveResumeSessionContext: () => ( { provider: undefined, model: undefined } ),
@@ -202,6 +206,29 @@ describe( 'AI runCommand — active site banner running state', () => {
 		expect( dispatchedPrompt() ).toContain(
 			'[Active site: "My Site" at /sites/my-site (running)]'
 		);
+	} );
+
+	// STU-2040 regression guard: the per-turn isSiteRunning check opens a
+	// DaemonBus socket; without a disconnect the headless (--json) process
+	// never exits after the turn, and the desktop UI hangs in "working".
+	it( 'closes the daemon socket after the per-turn running check so headless runs can exit', async () => {
+		( findSiteByFolder as Mock ).mockResolvedValue( {
+			id: 'site-1',
+			name: 'My Site',
+			path: '/sites/my-site',
+		} );
+		( isSiteRunning as Mock ).mockResolvedValue( true );
+
+		await runCommand( {
+			adapter: new JsonAdapter(),
+			initialMessage: 'hello',
+			activeSite: { name: 'My Site', path: '/sites/my-site' },
+		} );
+
+		expect( disconnectFromDaemon ).toHaveBeenCalled();
+		const checkOrder = ( isSiteRunning as Mock ).mock.invocationCallOrder[ 0 ];
+		const disconnectOrder = ( disconnectFromDaemon as Mock ).mock.invocationCallOrder[ 0 ];
+		expect( disconnectOrder ).toBeGreaterThan( checkOrder );
 	} );
 
 	it( 'reports the site as stopped when the daemon says it is not running', async () => {


### PR DESCRIPTION
## Related issues

- Related to https://linear.app/a8c/issue/STU-2034/studio-code-desktop-messages-get-stuck
- Related to https://linear.app/a8c/issue/STU-2040 (fixed by #4175)

Studio Code Desktop sessions got stuck in the "working" state after every response (STU-2034/STU-2040): a per-turn site running-state check left a daemon socket open, so the headless CLI child never exited and the UI never received the run-completion signal. #4175 fixed it by closing the socket after the check.

## How AI was used in this PR

AI was used to investigate the root cause of the stuck-message bug (trace the run lifecycle and git history) and to draft the regression test. The test was reviewed and mutation-verified locally.

## Proposed Changes

Add a test to avoid regressions that fails if that disconnect is ever removed again, so the same hang cannot silently return.

## Testing Instructions

- Run `npm test -- apps/cli/commands/ai/tests/index.test.ts` — all tests pass.
- To confirm the test guards the regression: comment out the `await disconnectFromDaemon();` line in `apps/cli/commands/ai/index.ts` (after the `isSiteRunning` check) and re-run — the new test fails.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
