### PR TITLE
Fix MODULE_TYPELESS_PACKAGE_JSON warning on npm install

### DIFF
--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -46,11 +46,6 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS = 6;
 export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
-// SQLite
-const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.6';
-
-export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/releases/download/${ SQLITE_DATABASE_INTEGRATION_VERSION }/plugin-sqlite-database-integration.zip`;
-
 // IPC handlers that don't return anything (i.e. that are called with `ipcRenderer.send`)
 export const IPC_VOID_HANDLERS = [
 	'addSyncOperation',

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -7,9 +7,11 @@ import {
 } from '@wp-playground/tools';
 import fs from 'fs-extra';
 import { z } from 'zod';
-import { SQLITE_DATABASE_INTEGRATION_RELEASE_URL } from '../apps/studio/src/constants.ts';
 import { extractZip } from '../packages/common/lib/extract-zip.ts';
 import { fetch, sharedDispatcher, throwForHttpStatus, withRetry } from './lib/with-retry.ts';
+
+const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.6';
+const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/releases/download/${ SQLITE_DATABASE_INTEGRATION_VERSION }/plugin-sqlite-database-integration.zip`;
 
 async function fetchWithRetry( name: string, url: string ): Promise< Buffer > {
 	return withRetry( name, async () => {


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code diagnosed the `MODULE_TYPELESS_PACKAGE_JSON` warning emitted during `npm install`, traced it to the `postinstall` build script, and applied the fix. The change was verified with eslint, `--experimental-strip-types --check`, and `npm run typecheck`.

## Proposed Changes

Running `npm install` on `trunk` printed a noisy `MODULE_TYPELESS_PACKAGE_JSON` warning:

```
Warning: Module type of file:///.../apps/studio/src/constants.ts is not specified
and it doesn't parse as CommonJS. Reparsing as ES module because module syntax was
detected. This incurs a performance overhead.
```

The `postinstall` step runs `download-wp-server-files.ts` under Node's `--experimental-strip-types`, and that build script imported `SQLITE_DATABASE_INTEGRATION_RELEASE_URL` from `apps/studio/src/constants.ts`. Because the nearest `package.json` (`apps/studio/package.json`) has no `"type"` field, Node warned it had to reparse the imported `.ts` file as ESM.

Adding `"type": "module"` to `apps/studio/package.json` is not an option — the Electron main process is bundled as CommonJS into `dist/main/index.js`, which `main` points to, so that would break the packaged app.

The constant was used **only** by this build script and never by the app itself, so it didn't belong in the app's `constants.ts`. It now lives in the build script directly, removing the cross-boundary import and eliminating the warning at the source. No user-facing behavior changes.

## Testing Instructions

1. Run `npm install` on this branch.
2. Confirm the `MODULE_TYPELESS_PACKAGE_JSON` warning referencing `apps/studio/src/constants.ts` no longer appears.
3. Confirm `postinstall` still downloads the WordPress server files (including the SQLite integration plugin) successfully.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
