### PR TITLE
Fix contrast issues in the agentic UI

### DIFF
--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -469,7 +469,6 @@
 	margin-inline-end: var(--wpds-dimension-padding-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font-size: var(--wpds-typography-font-size-sm);
-	opacity: 0.55;
 	transition: opacity 100ms ease;
 }
 

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -60,6 +60,15 @@ body:lang( ckb ) [class*='components-'] {
 	}
 }
 
+/* @wordpress/components and @wordpress/dataviews render help text and field
+   descriptions with hardcoded light-mode colors that don't adapt to the
+   ThemeProvider's dark palette. Force them to the design-system's weak
+   foreground so they match the surrounding UI in both schemes. */
+.components-base-control__help,
+[class*='dataforms-layouts'] [class*='description'] {
+	color: var( --wpds-color-fg-content-neutral-weak ) !important;
+}
+
 /* Universal heading styles derived from the design system's font-size /
    line-height ramp. Each level steps down one token (h1 = 2xl, h6 = xs),
    keeping the rest of the type contract — family, weight, color, zero


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to STU-1970

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->
It was used to audit the contrast issues and raise contrast on problematic items.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

This PR ensures that we don't have the contrast issues for accessibility reasons in the agentic UI. It fixes the contast on the time displayed in the sidebar for the sessions as well as the low contrast on the site form descriptions:

**Before**

<img width="764" height="131" alt="Screenshot 2026-07-15 at 9 10 46 AM" src="https://github.com/user-attachments/assets/37d5bee8-7c21-44da-8202-d1f06a59c427" />

**After**

<img width="823" height="137" alt="Screenshot 2026-07-15 at 10 23 49 AM" src="https://github.com/user-attachments/assets/bd5fce85-2710-4289-9d82-e5d27958d66d" />

For now, they were no other contrast issues flagged.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visually review the changes and confirm they look good

Alternatively:

* Install axe tools with `npm install --save-dev @axe-core/react --workspace=apps/ui` 
* Add this code to `apps/ui/src/main.tsx`:

```
  import React from 'react';                                                                                                          
  import ReactDOM from 'react-dom';                                                                                                   
                                                                                                                                      
  if ( import.meta.env.DEV ) {                              
      void import( '@axe-core/react' ).then( ( axe ) => {                                                                             
          void axe.default( React, ReactDOM, 1000 );                                                                                  
      } );
  } 
```
* Start Studio with `npm start`
* Enable the `Agentic UI` feature flag from `Studio -> Feature flags` from the topbar
* Click on the `New site -> Create new` option
* Open the dev tools
* Run this bit in the console:

```
axe.run().then(results => console.table(results.violations.flatMap(v =>
v.nodes.map(n => ({ rule: v.id, impact: v.impact, element: n.html, message:
n.failureSummary })))))   
```

* Confirm there are no issues regarding the contrast in the site form in the console
* Close the add site form and start a chat
* Confirm that there are no contrast issues related to the duration of the chat session in the console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
