### PR TITLE
Fix IPC sender validation error when toggling the Agentic UI feature flag

### DIFF
--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -212,11 +212,14 @@ async function getAppMenu(
 				mainWindow &&
 				! mainWindow.isDestroyed()
 			) {
+				// The renderer is being replaced; it fetches fresh globals on boot,
+				// and asking the dying page to refresh fails IPC sender validation.
 				setTimeout( () => {
 					void loadMainWindowRenderer( mainWindow );
 				}, 0 );
+			} else {
+				void sendIpcEventToRenderer( 'refresh-app-globals' );
 			}
-			void sendIpcEventToRenderer( 'refresh-app-globals' );
 		},
 	} ) );
 


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code traced the console error to its root cause and authored the fix; the change was reviewed and verified locally (lint, typecheck, unit tests).

## Proposed Changes

Toggling the "Enable Agentic UI" feature flag logged a `Failed IPC sender validation check` error (surfacing as `Error occurred in handler for 'getAppGlobals'`) on every toggle.

When a UI-mode flag flips, the main window reloads into the other renderer and the allowed IPC origin switches immediately — but we also sent `refresh-app-globals` to the outgoing renderer, whose resulting `getAppGlobals` call then failed sender validation. The refresh is pointless for a page that's being replaced (the new renderer fetches fresh globals on boot), so we now skip it when the toggle triggers a renderer reload. Other feature-flag toggles still refresh app globals as before.

The error was benign (it came from the renderer being torn down), so this is a log-noise fix with no user-facing behavior change beyond cleaner consoles.

## Testing Instructions

1. Run `npm start`.
2. In the app menu, toggle **Enable Agentic UI** under the feature flags menu.
3. Watch the main process console: before this change it logged `Error: Failed IPC sender validation check: http://localhost:5173/` on each toggle; now it doesn't.
4. Confirm the window still swaps between the default and agentic renderers in both directions, and that app globals still refresh when toggling a non-UI-mode flag.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)