### PR TITLE
Add OpenAI-compatible CLI AI provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ If you've built a substantial new feature — especially one generated with AI a
 
 For in-depth information, see these docs:
 - **CLI Design**: `docs/design-docs/cli.md` - CLI architecture, installation, IPC communication, data flow
+- **Local AI Providers**: `docs/design-docs/local-ai-providers.md` - OpenAI-compatible gateway, context-window discovery, conversation compaction
 - **Custom Domains/SSL**: `docs/design-docs/custom-domains-and-ssl.md` - Proxy server, certificates, hosts file
 - **Localization**: `docs/localization.md` - GlotPress workflow, translation process
 - **Release Process**: `docs/release-process.md` - ReleasesV2 + Fastlane lifecycle, running lanes locally

--- a/apps/cli/ai/openai-compat-gateway.ts
+++ b/apps/cli/ai/openai-compat-gateway.ts
@@ -1,0 +1,574 @@
+import { randomUUID } from 'crypto';
+import http from 'http';
+import { Readable } from 'stream';
+
+/**
+ * Translates the Anthropic Messages API (spoken by the Claude Agent SDK / Claude Code
+ * runtime) into requests against an OpenAI-compatible `/chat/completions` endpoint, and
+ * translates the response back. This lets the AI agent be pointed at a local model server
+ * (vLLM, Ollama, LM Studio, etc.) that only understands the OpenAI wire format.
+ *
+ * Scope: text and tool-calling only. Image content blocks (e.g. from the screenshot tool)
+ * are replaced with a placeholder rather than forwarded, since most local models used with
+ * this provider are text-only.
+ */
+
+export interface OpenAiCompatibleConfig {
+	baseUrl: string;
+	apiKey?: string;
+	model: string;
+}
+
+export interface OpenAiCompatibleGatewayHandle {
+	url: string;
+	close(): Promise< void >;
+}
+
+interface AnthropicTextBlock {
+	type: 'text';
+	text: string;
+}
+
+interface AnthropicImageBlock {
+	type: 'image';
+	source?: { type: string; media_type?: string; data?: string };
+}
+
+interface AnthropicToolUseBlock {
+	type: 'tool_use';
+	id: string;
+	name: string;
+	input: unknown;
+}
+
+interface AnthropicToolResultBlock {
+	type: 'tool_result';
+	tool_use_id: string;
+	content?: string | Array< AnthropicTextBlock | AnthropicImageBlock >;
+	is_error?: boolean;
+}
+
+type AnthropicContentBlock =
+	| AnthropicTextBlock
+	| AnthropicImageBlock
+	| AnthropicToolUseBlock
+	| AnthropicToolResultBlock;
+
+interface AnthropicMessage {
+	role: 'user' | 'assistant';
+	content: string | AnthropicContentBlock[];
+}
+
+interface AnthropicTool {
+	name: string;
+	description?: string;
+	input_schema: Record< string, unknown >;
+}
+
+interface AnthropicToolChoice {
+	type: 'auto' | 'any' | 'tool' | 'none';
+	name?: string;
+}
+
+interface AnthropicMessagesRequest {
+	model: string;
+	max_tokens?: number;
+	system?: string | Array< { type: 'text'; text: string } >;
+	messages: AnthropicMessage[];
+	tools?: AnthropicTool[];
+	tool_choice?: AnthropicToolChoice;
+	stream?: boolean;
+	temperature?: number;
+}
+
+interface OpenAiToolCall {
+	id: string;
+	type: 'function';
+	function: { name: string; arguments: string };
+}
+
+interface OpenAiMessage {
+	role: 'system' | 'user' | 'assistant' | 'tool';
+	content: string | null;
+	tool_calls?: OpenAiToolCall[];
+	tool_call_id?: string;
+}
+
+interface OpenAiChatRequest {
+	model: string;
+	messages: OpenAiMessage[];
+	tools?: Array< {
+		type: 'function';
+		function: { name: string; description?: string; parameters: Record< string, unknown > };
+	} >;
+	tool_choice?: 'auto' | 'required' | 'none' | { type: 'function'; function: { name: string } };
+	stream?: boolean;
+	max_tokens?: number;
+	temperature?: number;
+}
+
+let activeGateway:
+	| { handle: OpenAiCompatibleGatewayHandle; config: OpenAiCompatibleConfig }
+	| undefined;
+
+/**
+ * Starts (or reuses) a local translation gateway for the given target config. Only one
+ * gateway runs at a time; if the config changes, the previous gateway is closed first.
+ */
+export async function ensureOpenAiCompatibleGateway(
+	config: OpenAiCompatibleConfig
+): Promise< OpenAiCompatibleGatewayHandle > {
+	if ( activeGateway && configsMatch( activeGateway.config, config ) ) {
+		return activeGateway.handle;
+	}
+
+	if ( activeGateway ) {
+		await activeGateway.handle.close();
+		activeGateway = undefined;
+	}
+
+	const handle = await startOpenAiCompatibleGateway( config );
+	activeGateway = { handle, config };
+	return handle;
+}
+
+function configsMatch( a: OpenAiCompatibleConfig, b: OpenAiCompatibleConfig ): boolean {
+	return a.baseUrl === b.baseUrl && a.apiKey === b.apiKey && a.model === b.model;
+}
+
+function startOpenAiCompatibleGateway(
+	config: OpenAiCompatibleConfig
+): Promise< OpenAiCompatibleGatewayHandle > {
+	return new Promise( ( resolve, reject ) => {
+		const server = http.createServer( ( req, res ) => {
+			handleRequest( req, res, config ).catch( ( error ) => {
+				if ( ! res.headersSent ) {
+					res.writeHead( 502, { 'content-type': 'application/json' } );
+					res.end(
+						JSON.stringify( {
+							type: 'error',
+							error: { type: 'api_error', message: getErrorMessage( error ) },
+						} )
+					);
+					return;
+				}
+				res.end();
+			} );
+		} );
+
+		server.once( 'error', reject );
+		server.listen( 0, '127.0.0.1', () => {
+			const address = server.address();
+			if ( ! address || typeof address === 'string' ) {
+				reject( new Error( 'Failed to determine local gateway port' ) );
+				return;
+			}
+
+			resolve( {
+				url: `http://127.0.0.1:${ address.port }`,
+				close: () =>
+					new Promise< void >( ( closeResolve ) => server.close( () => closeResolve() ) ),
+			} );
+		} );
+	} );
+}
+
+async function handleRequest(
+	req: http.IncomingMessage,
+	res: http.ServerResponse,
+	config: OpenAiCompatibleConfig
+): Promise< void > {
+	if ( req.method !== 'POST' || ! req.url?.startsWith( '/v1/messages' ) ) {
+		res.writeHead( 404 ).end();
+		return;
+	}
+
+	const rawBody = await readRequestBody( req );
+	const anthropicRequest = JSON.parse( rawBody ) as AnthropicMessagesRequest;
+	const openAiRequest = toOpenAiChatRequest( anthropicRequest, config );
+
+	const upstream = await fetch( joinUrl( config.baseUrl, '/chat/completions' ), {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			...( config.apiKey ? { authorization: `Bearer ${ config.apiKey }` } : {} ),
+		},
+		body: JSON.stringify( openAiRequest ),
+	} );
+
+	if ( ! upstream.ok || ! upstream.body ) {
+		const text = await upstream.text().catch( () => upstream.statusText );
+		throw new Error( `Local model server returned ${ upstream.status }: ${ text }` );
+	}
+
+	if ( anthropicRequest.stream ) {
+		res.writeHead( 200, {
+			'content-type': 'text/event-stream',
+			'cache-control': 'no-cache',
+			connection: 'keep-alive',
+		} );
+		await streamOpenAiToAnthropic( upstream.body, res, anthropicRequest.model );
+		res.end();
+		return;
+	}
+
+	const openAiResponse = await upstream.json();
+	const anthropicMessage = fromOpenAiCompletion( openAiResponse, anthropicRequest.model );
+	res.writeHead( 200, { 'content-type': 'application/json' } );
+	res.end( JSON.stringify( anthropicMessage ) );
+}
+
+function readRequestBody( req: http.IncomingMessage ): Promise< string > {
+	return new Promise( ( resolve, reject ) => {
+		const chunks: Buffer[] = [];
+		req.on( 'data', ( chunk ) => chunks.push( chunk ) );
+		req.on( 'end', () => resolve( Buffer.concat( chunks ).toString( 'utf8' ) ) );
+		req.on( 'error', reject );
+	} );
+}
+
+function joinUrl( base: string, pathname: string ): string {
+	return `${ base.replace( /\/+$/, '' ) }${ pathname }`;
+}
+
+function getErrorMessage( error: unknown ): string {
+	return error instanceof Error ? error.message : String( error );
+}
+
+function blockToText( block: AnthropicTextBlock | AnthropicImageBlock ): string {
+	if ( block.type === 'text' ) {
+		return block.text;
+	}
+	return '[image omitted: this model does not support image input]';
+}
+
+function toolResultContentToString( content: AnthropicToolResultBlock[ 'content' ] ): string {
+	if ( content === undefined ) {
+		return '';
+	}
+	if ( typeof content === 'string' ) {
+		return content;
+	}
+	return content.map( blockToText ).join( '\n' );
+}
+
+function toOpenAiToolChoice(
+	toolChoice: AnthropicToolChoice | undefined
+): OpenAiChatRequest[ 'tool_choice' ] {
+	if ( ! toolChoice ) {
+		return undefined;
+	}
+	if ( toolChoice.type === 'any' ) {
+		return 'required';
+	}
+	if ( toolChoice.type === 'tool' && toolChoice.name ) {
+		return { type: 'function', function: { name: toolChoice.name } };
+	}
+	if ( toolChoice.type === 'none' ) {
+		return 'none';
+	}
+	return 'auto';
+}
+
+function toOpenAiChatRequest(
+	anthropicRequest: AnthropicMessagesRequest,
+	config: OpenAiCompatibleConfig
+): OpenAiChatRequest {
+	const messages: OpenAiMessage[] = [];
+
+	const systemText = Array.isArray( anthropicRequest.system )
+		? anthropicRequest.system.map( ( block ) => block.text ).join( '\n' )
+		: anthropicRequest.system;
+	if ( systemText ) {
+		messages.push( { role: 'system', content: systemText } );
+	}
+
+	for ( const message of anthropicRequest.messages ) {
+		const blocks: AnthropicContentBlock[] =
+			typeof message.content === 'string'
+				? [ { type: 'text', text: message.content } ]
+				: message.content;
+
+		const toolResultBlocks = blocks.filter(
+			( block ): block is AnthropicToolResultBlock => block.type === 'tool_result'
+		);
+		if ( toolResultBlocks.length > 0 ) {
+			for ( const block of toolResultBlocks ) {
+				messages.push( {
+					role: 'tool',
+					tool_call_id: block.tool_use_id,
+					content: toolResultContentToString( block.content ),
+				} );
+			}
+			continue;
+		}
+
+		const toolUseBlocks = blocks.filter(
+			( block ): block is AnthropicToolUseBlock => block.type === 'tool_use'
+		);
+		const textBlocks = blocks.filter(
+			( block ): block is AnthropicTextBlock | AnthropicImageBlock =>
+				block.type === 'text' || block.type === 'image'
+		);
+		const text = textBlocks.map( blockToText ).join( '\n' );
+
+		if ( toolUseBlocks.length > 0 ) {
+			messages.push( {
+				role: 'assistant',
+				content: text.length > 0 ? text : null,
+				tool_calls: toolUseBlocks.map( ( block ) => ( {
+					id: block.id,
+					type: 'function' as const,
+					function: {
+						name: block.name,
+						arguments: JSON.stringify( block.input ?? {} ),
+					},
+				} ) ),
+			} );
+			continue;
+		}
+
+		messages.push( { role: message.role, content: text } );
+	}
+
+	const tools = anthropicRequest.tools?.map( ( tool ) => ( {
+		type: 'function' as const,
+		function: {
+			name: tool.name,
+			description: tool.description,
+			parameters: tool.input_schema,
+		},
+	} ) );
+
+	const toolChoice = toOpenAiToolChoice( anthropicRequest.tool_choice );
+
+	return {
+		model: config.model,
+		messages,
+		...( tools && tools.length > 0 ? { tools } : {} ),
+		...( toolChoice ? { tool_choice: toolChoice } : {} ),
+		stream: Boolean( anthropicRequest.stream ),
+		max_tokens: anthropicRequest.max_tokens,
+		temperature: anthropicRequest.temperature,
+	};
+}
+
+function mapFinishReason( reason: string | null | undefined ): string {
+	switch ( reason ) {
+		case 'tool_calls':
+			return 'tool_use';
+		case 'length':
+			return 'max_tokens';
+		default:
+			return 'end_turn';
+	}
+}
+
+function safeJsonParse( json: string ): unknown {
+	try {
+		return JSON.parse( json );
+	} catch {
+		return {};
+	}
+}
+
+function fromOpenAiCompletion(
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	openAiResponse: any,
+	model: string
+): Record< string, unknown > {
+	const choice = openAiResponse.choices?.[ 0 ];
+	const message = choice?.message ?? {};
+	const content: Array< Record< string, unknown > > = [];
+
+	if ( message.content ) {
+		content.push( { type: 'text', text: message.content } );
+	}
+	for ( const toolCall of message.tool_calls ?? [] ) {
+		content.push( {
+			type: 'tool_use',
+			id: toolCall.id,
+			name: toolCall.function.name,
+			input: safeJsonParse( toolCall.function.arguments ),
+		} );
+	}
+
+	return {
+		id: openAiResponse.id ?? `msg_${ randomUUID() }`,
+		type: 'message',
+		role: 'assistant',
+		model,
+		content,
+		stop_reason: mapFinishReason( choice?.finish_reason ),
+		stop_sequence: null,
+		usage: {
+			input_tokens: openAiResponse.usage?.prompt_tokens ?? 0,
+			output_tokens: openAiResponse.usage?.completion_tokens ?? 0,
+		},
+	};
+}
+
+async function streamOpenAiToAnthropic(
+	body: ReadableStream< Uint8Array >,
+	res: http.ServerResponse,
+	model: string
+): Promise< void > {
+	const messageId = `msg_${ randomUUID() }`;
+	let sentMessageStart = false;
+	let textBlockIndex: number | null = null;
+	let textOpen = false;
+	const toolBlocksByOpenAiIndex = new Map< number, { anthropicIndex: number; id: string } >();
+	let nextBlockIndex = 0;
+	let finishReason: string | null = null;
+	let outputTokens = 0;
+
+	const send = ( event: string, data: unknown ) => {
+		res.write( `event: ${ event }\ndata: ${ JSON.stringify( data ) }\n\n` );
+	};
+
+	const ensureMessageStart = () => {
+		if ( sentMessageStart ) {
+			return;
+		}
+		sentMessageStart = true;
+		send( 'message_start', {
+			type: 'message_start',
+			message: {
+				id: messageId,
+				type: 'message',
+				role: 'assistant',
+				model,
+				content: [],
+				stop_reason: null,
+				stop_sequence: null,
+				usage: { input_tokens: 0, output_tokens: 0 },
+			},
+		} );
+	};
+
+	const closeTextBlockIfOpen = () => {
+		if ( textOpen ) {
+			send( 'content_block_stop', { type: 'content_block_stop', index: textBlockIndex } );
+			textOpen = false;
+		}
+	};
+
+	const ensureTextBlock = (): number => {
+		ensureMessageStart();
+		if ( textOpen ) {
+			return textBlockIndex as number;
+		}
+		textBlockIndex = nextBlockIndex++;
+		textOpen = true;
+		send( 'content_block_start', {
+			type: 'content_block_start',
+			index: textBlockIndex,
+			content_block: { type: 'text', text: '' },
+		} );
+		return textBlockIndex;
+	};
+
+	const ensureToolBlock = (
+		openAiIndex: number,
+		id: string | undefined,
+		name: string | undefined
+	): { anthropicIndex: number; id: string } => {
+		ensureMessageStart();
+		const existing = toolBlocksByOpenAiIndex.get( openAiIndex );
+		if ( existing ) {
+			return existing;
+		}
+		closeTextBlockIfOpen();
+		const anthropicIndex = nextBlockIndex++;
+		const entry = { anthropicIndex, id: id ?? `toolu_${ randomUUID() }` };
+		toolBlocksByOpenAiIndex.set( openAiIndex, entry );
+		send( 'content_block_start', {
+			type: 'content_block_start',
+			index: anthropicIndex,
+			content_block: { type: 'tool_use', id: entry.id, name: name ?? '', input: {} },
+		} );
+		return entry;
+	};
+
+	const processSseEvent = ( rawEvent: string ) => {
+		const dataLine = rawEvent.split( '\n' ).find( ( line ) => line.startsWith( 'data:' ) );
+		if ( ! dataLine ) {
+			return;
+		}
+		const payload = dataLine.slice( 'data:'.length ).trim();
+		if ( ! payload || payload === '[DONE]' ) {
+			return;
+		}
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		let parsed: any;
+		try {
+			parsed = JSON.parse( payload );
+		} catch {
+			return;
+		}
+
+		if ( typeof parsed.usage?.completion_tokens === 'number' ) {
+			outputTokens = parsed.usage.completion_tokens;
+		}
+
+		const choice = parsed.choices?.[ 0 ];
+		if ( ! choice ) {
+			return;
+		}
+
+		const delta = choice.delta ?? {};
+
+		if ( typeof delta.content === 'string' && delta.content.length > 0 ) {
+			const index = ensureTextBlock();
+			send( 'content_block_delta', {
+				type: 'content_block_delta',
+				index,
+				delta: { type: 'text_delta', text: delta.content },
+			} );
+		}
+
+		for ( const toolCallDelta of delta.tool_calls ?? [] ) {
+			const entry = ensureToolBlock(
+				toolCallDelta.index ?? 0,
+				toolCallDelta.id,
+				toolCallDelta.function?.name
+			);
+			if ( toolCallDelta.function?.arguments ) {
+				send( 'content_block_delta', {
+					type: 'content_block_delta',
+					index: entry.anthropicIndex,
+					delta: { type: 'input_json_delta', partial_json: toolCallDelta.function.arguments },
+				} );
+			}
+		}
+
+		if ( choice.finish_reason ) {
+			finishReason = choice.finish_reason;
+		}
+	};
+
+	let buffer = '';
+	for await ( const chunk of Readable.fromWeb( body as never ) ) {
+		buffer += ( chunk as Buffer ).toString( 'utf8' );
+		let separatorIndex: number;
+		while ( ( separatorIndex = buffer.indexOf( '\n\n' ) ) !== -1 ) {
+			const rawEvent = buffer.slice( 0, separatorIndex );
+			buffer = buffer.slice( separatorIndex + 2 );
+			processSseEvent( rawEvent );
+		}
+	}
+
+	closeTextBlockIfOpen();
+	for ( const entry of toolBlocksByOpenAiIndex.values() ) {
+		send( 'content_block_stop', { type: 'content_block_stop', index: entry.anthropicIndex } );
+	}
+
+	ensureMessageStart();
+	send( 'message_delta', {
+		type: 'message_delta',
+		delta: { stop_reason: mapFinishReason( finishReason ), stop_sequence: null },
+		usage: { output_tokens: outputTokens },
+	} );
+	send( 'message_stop', { type: 'message_stop' } );
+}

--- a/apps/cli/ai/openai-compat-gateway.ts
+++ b/apps/cli/ai/openai-compat-gateway.ts
@@ -24,6 +24,13 @@ export interface OpenAiCompatibleGatewayHandle {
 	close(): Promise< void >;
 }
 
+const DEFAULT_CONTEXT_WINDOW = 8192;
+const DEFAULT_MAX_TOKENS_RESERVE = 1024;
+const SAFETY_MARGIN_TOKENS = 500;
+const SUMMARY_RESERVE_TOKENS = 800;
+const SUMMARY_MAX_TOKENS = 500;
+const CHARS_PER_TOKEN_ESTIMATE = 4;
+
 interface AnthropicTextBlock {
 	type: 'text';
 	text: string;
@@ -34,14 +41,14 @@ interface AnthropicImageBlock {
 	source?: { type: string; media_type?: string; data?: string };
 }
 
-interface AnthropicToolUseBlock {
+export interface AnthropicToolUseBlock {
 	type: 'tool_use';
 	id: string;
 	name: string;
 	input: unknown;
 }
 
-interface AnthropicToolResultBlock {
+export interface AnthropicToolResultBlock {
 	type: 'tool_result';
 	tool_use_id: string;
 	content?: string | Array< AnthropicTextBlock | AnthropicImageBlock >;
@@ -54,7 +61,7 @@ type AnthropicContentBlock =
 	| AnthropicToolUseBlock
 	| AnthropicToolResultBlock;
 
-interface AnthropicMessage {
+export interface AnthropicMessage {
 	role: 'user' | 'assistant';
 	content: string | AnthropicContentBlock[];
 }
@@ -70,7 +77,7 @@ interface AnthropicToolChoice {
 	name?: string;
 }
 
-interface AnthropicMessagesRequest {
+export interface AnthropicMessagesRequest {
 	model: string;
 	max_tokens?: number;
 	system?: string | Array< { type: 'text'; text: string } >;
@@ -107,8 +114,22 @@ interface OpenAiChatRequest {
 	temperature?: number;
 }
 
+export interface CompactionState {
+	coveredMessages: AnthropicMessage[];
+	summary: string;
+}
+
+export interface GatewayState {
+	contextWindow: number;
+	compaction?: CompactionState;
+}
+
 let activeGateway:
-	| { handle: OpenAiCompatibleGatewayHandle; config: OpenAiCompatibleConfig }
+	| {
+			handle: OpenAiCompatibleGatewayHandle;
+			config: OpenAiCompatibleConfig;
+			state: GatewayState;
+	  }
 	| undefined;
 
 /**
@@ -127,9 +148,33 @@ export async function ensureOpenAiCompatibleGateway(
 		activeGateway = undefined;
 	}
 
-	const handle = await startOpenAiCompatibleGateway( config );
-	activeGateway = { handle, config };
+	const state: GatewayState = { contextWindow: await discoverContextWindow( config ) };
+	const handle = await startOpenAiCompatibleGateway( config, state );
+	activeGateway = { handle, config, state };
 	return handle;
+}
+
+export async function discoverContextWindow( config: OpenAiCompatibleConfig ): Promise< number > {
+	try {
+		const response = await fetch( joinUrl( config.baseUrl, '/models' ), {
+			headers: config.apiKey ? { authorization: `Bearer ${ config.apiKey }` } : {},
+			signal: AbortSignal.timeout( 3000 ),
+		} );
+		if ( ! response.ok ) {
+			return DEFAULT_CONTEXT_WINDOW;
+		}
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const body: any = await response.json();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const entry = ( body?.data ?? [] ).find( ( model: any ) => model?.id === config.model );
+		const contextWindow =
+			entry?.context_window ?? entry?.max_model_len ?? entry?.max_context_length;
+		return typeof contextWindow === 'number' && contextWindow > 0
+			? contextWindow
+			: DEFAULT_CONTEXT_WINDOW;
+	} catch {
+		return DEFAULT_CONTEXT_WINDOW;
+	}
 }
 
 function configsMatch( a: OpenAiCompatibleConfig, b: OpenAiCompatibleConfig ): boolean {
@@ -137,11 +182,12 @@ function configsMatch( a: OpenAiCompatibleConfig, b: OpenAiCompatibleConfig ): b
 }
 
 function startOpenAiCompatibleGateway(
-	config: OpenAiCompatibleConfig
+	config: OpenAiCompatibleConfig,
+	state: GatewayState
 ): Promise< OpenAiCompatibleGatewayHandle > {
 	return new Promise( ( resolve, reject ) => {
 		const server = http.createServer( ( req, res ) => {
-			handleRequest( req, res, config ).catch( ( error ) => {
+			handleRequest( req, res, config, state ).catch( ( error ) => {
 				if ( ! res.headersSent ) {
 					res.writeHead( 502, { 'content-type': 'application/json' } );
 					res.end(
@@ -176,7 +222,8 @@ function startOpenAiCompatibleGateway(
 async function handleRequest(
 	req: http.IncomingMessage,
 	res: http.ServerResponse,
-	config: OpenAiCompatibleConfig
+	config: OpenAiCompatibleConfig,
+	state: GatewayState
 ): Promise< void > {
 	if ( req.method !== 'POST' || ! req.url?.startsWith( '/v1/messages' ) ) {
 		res.writeHead( 404 ).end();
@@ -184,7 +231,8 @@ async function handleRequest(
 	}
 
 	const rawBody = await readRequestBody( req );
-	const anthropicRequest = JSON.parse( rawBody ) as AnthropicMessagesRequest;
+	const parsedRequest = JSON.parse( rawBody ) as AnthropicMessagesRequest;
+	const anthropicRequest = await compactMessagesIfNeeded( parsedRequest, config, state );
 	const openAiRequest = toOpenAiChatRequest( anthropicRequest, config );
 
 	const upstream = await fetch( joinUrl( config.baseUrl, '/chat/completions' ), {
@@ -268,6 +316,220 @@ function toOpenAiToolChoice(
 		return 'none';
 	}
 	return 'auto';
+}
+
+function estimateTokens( text: string ): number {
+	return Math.ceil( text.length / CHARS_PER_TOKEN_ESTIMATE );
+}
+
+function messageBlocks( message: AnthropicMessage ): AnthropicContentBlock[] {
+	return typeof message.content === 'string'
+		? [ { type: 'text', text: message.content } ]
+		: message.content;
+}
+
+function estimateMessageTokens( message: AnthropicMessage ): number {
+	const serialized = messageBlocks( message )
+		.map( ( block ) => {
+			if ( block.type === 'text' ) {
+				return block.text;
+			}
+			if ( block.type === 'image' ) {
+				return '[image]';
+			}
+			if ( block.type === 'tool_use' ) {
+				return JSON.stringify( block.input ?? {} );
+			}
+			return toolResultContentToString( block.content );
+		} )
+		.join( '\n' );
+	return estimateTokens( serialized ) + 4;
+}
+
+export function estimateRequestTokens( request: AnthropicMessagesRequest ): number {
+	const systemText = Array.isArray( request.system )
+		? request.system.map( ( block ) => block.text ).join( '\n' )
+		: request.system ?? '';
+	const toolsTokens = request.tools ? estimateTokens( JSON.stringify( request.tools ) ) : 0;
+	const messagesTokens = request.messages.reduce(
+		( sum, message ) => sum + estimateMessageTokens( message ),
+		0
+	);
+	return estimateTokens( systemText ) + toolsTokens + messagesTokens;
+}
+
+function messageToolUseIds( message: AnthropicMessage ): string[] {
+	return messageBlocks( message )
+		.filter( ( block ): block is AnthropicToolUseBlock => block.type === 'tool_use' )
+		.map( ( block ) => block.id );
+}
+
+function messageToolResultIds( message: AnthropicMessage ): string[] {
+	return messageBlocks( message )
+		.filter( ( block ): block is AnthropicToolResultBlock => block.type === 'tool_result' )
+		.map( ( block ) => block.tool_use_id );
+}
+
+/**
+ * Finds the largest suffix of `messages` whose estimated token count fits within
+ * `recentBudget`, then extends it backward as needed so a `tool_use` message is never
+ * separated from the `tool_result` message that answers it.
+ */
+export function findSplitIndex( messages: AnthropicMessage[], recentBudget: number ): number {
+	let accumulated = 0;
+	let splitIndex = messages.length;
+	for ( let i = messages.length - 1; i >= 0; i-- ) {
+		const tokens = estimateMessageTokens( messages[ i ] );
+		if ( accumulated + tokens > recentBudget ) {
+			break;
+		}
+		accumulated += tokens;
+		splitIndex = i;
+	}
+	return stabilizeSplitIndex( messages, splitIndex );
+}
+
+function stabilizeSplitIndex( messages: AnthropicMessage[], splitIndex: number ): number {
+	let index = splitIndex;
+	let changed = true;
+	while ( changed && index > 0 ) {
+		changed = false;
+		const resultIds = new Set( messages.slice( index ).flatMap( messageToolResultIds ) );
+		const precedingToolUseIds = messageToolUseIds( messages[ index - 1 ] );
+		if ( precedingToolUseIds.some( ( id ) => resultIds.has( id ) ) ) {
+			index -= 1;
+			changed = true;
+		}
+	}
+	return index;
+}
+
+function messagesEqual( a: AnthropicMessage, b: AnthropicMessage ): boolean {
+	return JSON.stringify( a ) === JSON.stringify( b );
+}
+
+function isPrefixOf( prefix: AnthropicMessage[], full: AnthropicMessage[] ): boolean {
+	if ( prefix.length > full.length ) {
+		return false;
+	}
+	return prefix.every( ( message, index ) => messagesEqual( message, full[ index ] ) );
+}
+
+function serializeMessageForSummary( message: AnthropicMessage ): string {
+	const parts = messageBlocks( message ).map( ( block ) => {
+		if ( block.type === 'text' ) {
+			return block.text;
+		}
+		if ( block.type === 'image' ) {
+			return '[image omitted]';
+		}
+		if ( block.type === 'tool_use' ) {
+			return `Called ${ block.name } with ${ JSON.stringify( block.input ?? {} ) }`;
+		}
+		return `Result: ${ toolResultContentToString( block.content ) }`;
+	} );
+	return `${ message.role }: ${ parts.join( '\n' ) }`;
+}
+
+async function summarizeConversation(
+	messages: AnthropicMessage[],
+	config: OpenAiCompatibleConfig,
+	previousSummary?: string
+): Promise< string > {
+	const fallback = previousSummary ?? '[Unable to summarize earlier conversation]';
+	const transcript = messages.map( serializeMessageForSummary ).join( '\n\n' );
+	const instruction = previousSummary
+		? `Here is a summary of earlier conversation:\n${ previousSummary }\n\nUpdate this summary to also incorporate the following additional conversation, staying concise and preserving key facts and decisions:\n\n${ transcript }`
+		: `Summarize the following conversation concisely, preserving key facts and decisions:\n\n${ transcript }`;
+
+	try {
+		const response = await fetch( joinUrl( config.baseUrl, '/chat/completions' ), {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				...( config.apiKey ? { authorization: `Bearer ${ config.apiKey }` } : {} ),
+			},
+			body: JSON.stringify( {
+				model: config.model,
+				stream: false,
+				max_tokens: SUMMARY_MAX_TOKENS,
+				temperature: 0.2,
+				messages: [
+					{ role: 'system', content: 'You summarize conversations concisely and factually.' },
+					{ role: 'user', content: instruction },
+				],
+			} ),
+		} );
+
+		if ( ! response.ok ) {
+			return fallback;
+		}
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const body: any = await response.json();
+		const summary = body?.choices?.[ 0 ]?.message?.content;
+		return typeof summary === 'string' && summary.trim().length > 0 ? summary.trim() : fallback;
+	} catch {
+		return fallback;
+	}
+}
+
+async function resolveSummary(
+	oldChunk: AnthropicMessage[],
+	config: OpenAiCompatibleConfig,
+	state: GatewayState
+): Promise< string > {
+	const existing = state.compaction;
+
+	if ( existing && isPrefixOf( existing.coveredMessages, oldChunk ) ) {
+		if ( existing.coveredMessages.length === oldChunk.length ) {
+			return existing.summary;
+		}
+		const newPortion = oldChunk.slice( existing.coveredMessages.length );
+		const summary = await summarizeConversation( newPortion, config, existing.summary );
+		state.compaction = { coveredMessages: oldChunk, summary };
+		return summary;
+	}
+
+	const summary = await summarizeConversation( oldChunk, config );
+	state.compaction = { coveredMessages: oldChunk, summary };
+	return summary;
+}
+
+/**
+ * Shrinks an over-budget conversation to fit the local model's discovered context window by
+ * summarizing the oldest messages into the system prompt and keeping the recent tail verbatim.
+ * A `tool_use`/`tool_result` pair is never split across the boundary.
+ */
+export async function compactMessagesIfNeeded(
+	request: AnthropicMessagesRequest,
+	config: OpenAiCompatibleConfig,
+	state: GatewayState
+): Promise< AnthropicMessagesRequest > {
+	const budget =
+		state.contextWindow -
+		( request.max_tokens ?? DEFAULT_MAX_TOKENS_RESERVE ) -
+		SAFETY_MARGIN_TOKENS;
+	if ( estimateRequestTokens( request ) <= budget ) {
+		return request;
+	}
+
+	const recentBudget = budget - SUMMARY_RESERVE_TOKENS;
+	const splitIndex = findSplitIndex( request.messages, recentBudget );
+	if ( splitIndex <= 0 ) {
+		return request;
+	}
+
+	const oldChunk = request.messages.slice( 0, splitIndex );
+	const recentTail = request.messages.slice( splitIndex );
+	const summary = await resolveSummary( oldChunk, config, state );
+
+	const systemText = Array.isArray( request.system )
+		? request.system.map( ( block ) => block.text ).join( '\n' )
+		: request.system ?? '';
+	const compactedSystem = `${ systemText }\n\n[Summary of earlier conversation, condensed to fit the local model's context window]\n${ summary }`;
+
+	return { ...request, system: compactedSystem, messages: recentTail };
 }
 
 function toOpenAiChatRequest(

--- a/apps/cli/ai/providers.ts
+++ b/apps/cli/ai/providers.ts
@@ -1,18 +1,24 @@
-import { password } from '@inquirer/prompts';
+import { input, password } from '@inquirer/prompts';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import { __ } from '@wordpress/i18n';
+import { ensureOpenAiCompatibleGateway } from 'cli/ai/openai-compat-gateway';
 import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
 import { LoggerError } from 'cli/logger';
 
 export const AI_PROVIDERS = {
 	wpcom: 'WordPress.com',
 	'anthropic-api-key': 'Anthropic · API key',
+	'openai-compatible': 'OpenAI-compatible',
 } as const;
 
 export type AiProviderId = keyof typeof AI_PROVIDERS;
 
 export const DEFAULT_AI_PROVIDER: AiProviderId = 'wpcom';
-export const AI_PROVIDER_PRIORITY: AiProviderId[] = [ 'wpcom', 'anthropic-api-key' ];
+export const AI_PROVIDER_PRIORITY: AiProviderId[] = [
+	'wpcom',
+	'anthropic-api-key',
+	'openai-compatible',
+];
 
 const DEFAULT_WPCOM_AI_GATEWAY_BASE_URL = 'https://public-api.wordpress.com/wpcom/v2/ai-api-proxy';
 const WPCOM_AI_FEATURE_HEADER = 'studio-assistant-anthropic';
@@ -47,6 +53,67 @@ async function resolveAnthropicApiKey( options?: {
 
 	await updateCliConfigWithPartial( { anthropicApiKey: apiKey } );
 	return apiKey;
+}
+
+interface OpenAiCompatibleProviderConfig {
+	baseUrl: string;
+	apiKey?: string;
+	model: string;
+}
+
+async function resolveOpenAiCompatibleProviderConfig( options?: {
+	force?: boolean;
+} ): Promise< OpenAiCompatibleProviderConfig > {
+	const {
+		openAiCompatibleBaseUrl: savedBaseUrl,
+		openAiCompatibleApiKey: savedApiKey,
+		openAiCompatibleModel: savedModel,
+	} = await readCliConfig();
+
+	if ( savedBaseUrl && savedModel && ! options?.force ) {
+		return { baseUrl: savedBaseUrl, apiKey: savedApiKey, model: savedModel };
+	}
+
+	const baseUrl = await input( {
+		message: __( 'Enter the OpenAI-compatible base URL (e.g. http://localhost:11435/v1):' ),
+		default: savedBaseUrl,
+		validate: ( value ) => {
+			if ( ! value.trim() ) {
+				return __( 'Base URL is required' );
+			}
+			return true;
+		},
+	} );
+
+	const apiKey = await password( {
+		message: __( 'Enter an API key, if required (leave blank if none):' ),
+		mask: '*',
+	} );
+
+	const model = await input( {
+		message: __( 'Enter the model name (e.g. qwen3.6-27b):' ),
+		default: savedModel,
+		validate: ( value ) => {
+			if ( ! value.trim() ) {
+				return __( 'Model name is required' );
+			}
+			return true;
+		},
+	} );
+
+	const config: OpenAiCompatibleProviderConfig = {
+		baseUrl: baseUrl.trim(),
+		apiKey: apiKey.trim() || undefined,
+		model: model.trim(),
+	};
+
+	await updateCliConfigWithPartial( {
+		openAiCompatibleBaseUrl: config.baseUrl,
+		openAiCompatibleApiKey: config.apiKey,
+		openAiCompatibleModel: config.model,
+	} );
+
+	return config;
 }
 
 function buildAnthropicCustomHeaders( headers: Record< string, string > ): string {
@@ -128,6 +195,41 @@ const AI_PROVIDER_DEFINITIONS: Record< AiProviderId, AiProviderDefinition > = {
 
 			const env = createBaseEnvironment();
 			env.ANTHROPIC_API_KEY = apiKey;
+			return env;
+		},
+	},
+	'openai-compatible': {
+		id: 'openai-compatible',
+		autoFallbackWhenUnavailable: false,
+		isVisible: async () => true,
+		isReady: async () => {
+			const { openAiCompatibleBaseUrl, openAiCompatibleModel } = await readCliConfig();
+			return Boolean( openAiCompatibleBaseUrl && openAiCompatibleModel );
+		},
+		prepare: async ( options ) => {
+			await resolveOpenAiCompatibleProviderConfig( options );
+		},
+		resolveEnv: async () => {
+			const {
+				openAiCompatibleBaseUrl: baseUrl,
+				openAiCompatibleApiKey: apiKey,
+				openAiCompatibleModel: model,
+			} = await readCliConfig();
+
+			if ( ! baseUrl || ! model ) {
+				throw new LoggerError(
+					__(
+						'OpenAI-compatible endpoint not configured. Switch to OpenAI-compatible with /provider to set one up.'
+					)
+				);
+			}
+
+			const gateway = await ensureOpenAiCompatibleGateway( { baseUrl, apiKey, model } );
+
+			const env = createBaseEnvironment();
+			env.ANTHROPIC_BASE_URL = gateway.url;
+			env.ANTHROPIC_AUTH_TOKEN = 'local-openai-compatible-gateway';
+			env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS = '1';
 			return env;
 		},
 	},

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -92,6 +92,32 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 		},
 	},
 	{
+		name: 'openai-config',
+		description: __( 'Set or update the OpenAI-compatible endpoint (base URL, API key, model)' ),
+		handler: async ( _prompt, ctx ) => {
+			try {
+				await ctx.prepareProviderSelection( 'openai-compatible', { force: true } );
+				ctx.ui.showInfo( __( 'OpenAI-compatible endpoint updated.' ) );
+				if ( ctx.showCapabilitiesOnConnect ) {
+					ctx.showCapabilitiesOnConnect = false;
+					await ctx.switchProvider( 'openai-compatible' );
+					ctx.ui.showCapabilities();
+				}
+			} catch ( error ) {
+				if ( isPromptAbortError( error ) ) {
+					ctx.ui.showInfo( __( 'OpenAI-compatible endpoint update canceled.' ) );
+					return 'continue';
+				}
+				if ( error instanceof LoggerError ) {
+					ctx.ui.showError( error.message );
+					return 'continue';
+				}
+				throw error;
+			}
+			return 'continue';
+		},
+	},
+	{
 		name: 'login',
 		description: __( 'Log in to WordPress.com' ),
 		handler: async ( _prompt, ctx ) => {

--- a/apps/cli/ai/tests/auth.test.ts
+++ b/apps/cli/ai/tests/auth.test.ts
@@ -85,7 +85,11 @@ describe( 'AI auth helpers', () => {
 	} );
 
 	it( 'lists available providers', async () => {
-		await expect( getAvailableAiProviders() ).resolves.toEqual( [ 'wpcom', 'anthropic-api-key' ] );
+		await expect( getAvailableAiProviders() ).resolves.toEqual( [
+			'wpcom',
+			'anthropic-api-key',
+			'openai-compatible',
+		] );
 	} );
 
 	it( 'configures the WP.com gateway environment', async () => {

--- a/apps/cli/ai/tests/openai-compat-gateway.test.ts
+++ b/apps/cli/ai/tests/openai-compat-gateway.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	compactMessagesIfNeeded,
+	discoverContextWindow,
+	estimateRequestTokens,
+	findSplitIndex,
+	type AnthropicMessage,
+	type AnthropicMessagesRequest,
+	type GatewayState,
+	type OpenAiCompatibleConfig,
+} from 'cli/ai/openai-compat-gateway';
+
+const CONFIG: OpenAiCompatibleConfig = {
+	baseUrl: 'http://localhost:9999/v1',
+	model: 'test-model',
+};
+
+function textMessage( role: 'user' | 'assistant', text: string ): AnthropicMessage {
+	return { role, content: text };
+}
+
+function toolUseMessage( id: string, name: string ): AnthropicMessage {
+	return { role: 'assistant', content: [ { type: 'tool_use', id, name, input: {} } ] };
+}
+
+function toolResultMessage( toolUseId: string, text: string ): AnthropicMessage {
+	return {
+		role: 'user',
+		content: [ { type: 'tool_result', tool_use_id: toolUseId, content: text } ],
+	};
+}
+
+function baseRequest( messages: AnthropicMessage[] ): AnthropicMessagesRequest {
+	return { model: 'test-model', messages, stream: false, max_tokens: 100 };
+}
+
+describe( 'discoverContextWindow', () => {
+	afterEach( () => {
+		vi.unstubAllGlobals();
+	} );
+
+	it( 'reads context_window (Apfel-style)', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue( {
+				ok: true,
+				json: async () => ( {
+					data: [ { id: 'test-model', context_window: 4096 } ],
+				} ),
+			} )
+		);
+
+		await expect( discoverContextWindow( CONFIG ) ).resolves.toBe( 4096 );
+	} );
+
+	it( 'reads max_model_len (vLLM-style)', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue( {
+				ok: true,
+				json: async () => ( {
+					data: [ { id: 'test-model', max_model_len: 65536 } ],
+				} ),
+			} )
+		);
+
+		await expect( discoverContextWindow( CONFIG ) ).resolves.toBe( 65536 );
+	} );
+
+	it( 'falls back to the default when the field is missing', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue( {
+				ok: true,
+				json: async () => ( { data: [ { id: 'test-model' } ] } ),
+			} )
+		);
+
+		await expect( discoverContextWindow( CONFIG ) ).resolves.toBe( 8192 );
+	} );
+
+	it( 'falls back to the default when the request fails', async () => {
+		vi.stubGlobal( 'fetch', vi.fn().mockRejectedValue( new Error( 'network error' ) ) );
+
+		await expect( discoverContextWindow( CONFIG ) ).resolves.toBe( 8192 );
+	} );
+} );
+
+describe( 'estimateRequestTokens', () => {
+	it( 'grows with message content length', () => {
+		const small = estimateRequestTokens( baseRequest( [ textMessage( 'user', 'hi' ) ] ) );
+		const large = estimateRequestTokens(
+			baseRequest( [ textMessage( 'user', 'x'.repeat( 4000 ) ) ] )
+		);
+
+		expect( large ).toBeGreaterThan( small );
+	} );
+} );
+
+describe( 'findSplitIndex', () => {
+	it( 'never separates a tool_use message from its tool_result', () => {
+		const messages = [
+			textMessage( 'user', 'y'.repeat( 2000 ) ),
+			toolUseMessage( 'tool_1', 'get_weather' ),
+			toolResultMessage( 'tool_1', 'sunny' ),
+			textMessage( 'assistant', 'done' ),
+		];
+
+		// A budget that would otherwise land the split between the tool_use and
+		// tool_result messages (indices 1 and 2).
+		const splitIndex = findSplitIndex( messages, 12 );
+
+		expect( splitIndex ).toBeLessThanOrEqual( 1 );
+	} );
+} );
+
+describe( 'compactMessagesIfNeeded', () => {
+	beforeEach( () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue( {
+				ok: true,
+				json: async () => ( {
+					choices: [ { message: { content: 'a concise summary' } } ],
+				} ),
+			} )
+		);
+	} );
+
+	afterEach( () => {
+		vi.unstubAllGlobals();
+	} );
+
+	it( 'leaves small requests untouched', async () => {
+		const request = baseRequest( [ textMessage( 'user', 'hello' ) ] );
+		const state: GatewayState = { contextWindow: 8192 };
+
+		const result = await compactMessagesIfNeeded( request, CONFIG, state );
+
+		expect( result ).toBe( request );
+		expect( fetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'summarizes the oldest messages and keeps the recent tail verbatim', async () => {
+		const oldMessages = Array.from( { length: 20 }, ( _, i ) =>
+			textMessage( i % 2 === 0 ? 'user' : 'assistant', `old message ${ i }`.repeat( 50 ) )
+		);
+		const recentMessage = textMessage( 'user', 'what is the weather today?' );
+		const request = baseRequest( [ ...oldMessages, recentMessage ] );
+		const state: GatewayState = { contextWindow: 1450 };
+
+		const result = await compactMessagesIfNeeded( request, CONFIG, state );
+
+		expect( fetch ).toHaveBeenCalledWith(
+			expect.stringContaining( '/chat/completions' ),
+			expect.any( Object )
+		);
+		expect( result.messages ).toEqual( [ recentMessage ] );
+		expect( result.system ).toContain( 'a concise summary' );
+		expect( state.compaction?.summary ).toBe( 'a concise summary' );
+	} );
+
+	it( 'reuses the cached summary when the old chunk is unchanged', async () => {
+		const oldMessages = Array.from( { length: 20 }, ( _, i ) =>
+			textMessage( i % 2 === 0 ? 'user' : 'assistant', `old message ${ i }`.repeat( 50 ) )
+		);
+		const request = baseRequest( [ ...oldMessages, textMessage( 'user', 'first question' ) ] );
+		const state: GatewayState = { contextWindow: 1450 };
+
+		await compactMessagesIfNeeded( request, CONFIG, state );
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+
+		const secondRequest = baseRequest( [
+			...oldMessages,
+			textMessage( 'user', 'first question' ),
+			textMessage( 'assistant', 'first answer' ),
+			textMessage( 'user', 'second question' ),
+		] );
+		await compactMessagesIfNeeded( secondRequest, CONFIG, state );
+
+		// The old chunk boundary hasn't grown, so no additional summarization call is made.
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 're-summarizes fully when the conversation diverges from the cached prefix', async () => {
+		const oldMessages = Array.from( { length: 20 }, ( _, i ) =>
+			textMessage( i % 2 === 0 ? 'user' : 'assistant', `old message ${ i }`.repeat( 50 ) )
+		);
+		const request = baseRequest( [ ...oldMessages, textMessage( 'user', 'first question' ) ] );
+		const state: GatewayState = { contextWindow: 1450 };
+
+		await compactMessagesIfNeeded( request, CONFIG, state );
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+
+		const divergedMessages = Array.from( { length: 20 }, ( _, i ) =>
+			textMessage( i % 2 === 0 ? 'user' : 'assistant', `different message ${ i }`.repeat( 50 ) )
+		);
+		const divergedRequest = baseRequest( [
+			...divergedMessages,
+			textMessage( 'user', 'a totally different question' ),
+		] );
+		await compactMessagesIfNeeded( divergedRequest, CONFIG, state );
+
+		expect( fetch ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/apps/cli/lib/cli-config/core.ts
+++ b/apps/cli/lib/cli-config/core.ts
@@ -29,7 +29,7 @@ const CLI_CONFIG_VERSION = 1;
 
 // IMPORTANT: Always consider that independently installed versions of the CLI (from npm) may also
 // read this file, and any updates to this schema may require updating the `version` field.
-export const aiProviderSchema = z.enum( [ 'wpcom', 'anthropic-api-key' ] );
+export const aiProviderSchema = z.enum( [ 'wpcom', 'anthropic-api-key', 'openai-compatible' ] );
 
 const cliConfigSchema = z.object( {
 	version: z.literal( CLI_CONFIG_VERSION ),
@@ -37,6 +37,9 @@ const cliConfigSchema = z.object( {
 	snapshots: z.array( snapshotSchema ).default( () => [] ),
 	aiProvider: aiProviderSchema.optional(),
 	anthropicApiKey: z.string().optional(),
+	openAiCompatibleBaseUrl: z.string().optional(),
+	openAiCompatibleApiKey: z.string().optional(),
+	openAiCompatibleModel: z.string().optional(),
 	lastBumpStats: z
 		.record( z.string(), z.partialRecord( z.enum( StatsMetric ), z.number() ) )
 		.optional(),

--- a/docs/design-docs/local-ai-providers.md
+++ b/docs/design-docs/local-ai-providers.md
@@ -1,0 +1,143 @@
+# Local AI providers (OpenAI-compatible gateway)
+
+## Overview
+
+This document describes how the Studio CLI AI agent can be pointed at a **local, self-hosted model server** instead of WordPress.com or the Anthropic API, and how the gateway that makes this possible keeps conversations within the local model's context window.
+
+The AI agent is built on the Claude Agent SDK, which speaks only Anthropic's native Messages API wire protocol. Local model servers (vLLM, Ollama, LM Studio, llama.cpp, Apple's on-device FoundationModels via Apfel, etc.) almost always expose the **OpenAI** `/chat/completions` wire format instead. The `openai-compatible` provider bridges that gap with a small local translation gateway, and layers context-window-aware compaction on top so that long conversations don't overflow the (typically much smaller) context window of a local model.
+
+Relevant code:
+
+- `apps/cli/ai/providers.ts` — provider registry, config resolution, `/openai-config` setup flow.
+- `apps/cli/ai/openai-compat-gateway.ts` — the translation gateway and compaction logic.
+- `apps/cli/ai/slash-commands.ts` — the `/openai-config` and `/provider` slash commands.
+- `apps/cli/ai/tests/openai-compat-gateway.test.ts` — unit tests for discovery and compaction.
+
+## Providers
+
+The agent supports three providers (`AI_PROVIDERS` in `providers.ts`):
+
+| Provider            | ID                  | Auth / config                                                        |
+| ------------------- | ------------------- | -------------------------------------------------------------------- |
+| WordPress.com       | `wpcom`             | WordPress.com OAuth token (`/login`)                                 |
+| Anthropic · API key | `anthropic-api-key` | Anthropic API key (`/api-key`)                                       |
+| OpenAI-compatible   | `openai-compatible` | Base URL + optional API key + model name (`/openai-config`)          |
+
+Switch providers with `/provider`. Configure the OpenAI-compatible endpoint with `/openai-config`, which prompts for:
+
+- **Base URL** — e.g. `http://localhost:11435/v1` (Apfel) or `http://<host>:8000/v1` (a vLLM server on your network).
+- **API key** — optional; sent as `Authorization: Bearer <key>` when present.
+- **Model name** — must match the server's advertised model id, e.g. `apple-foundationmodel`.
+
+These persist to the CLI config as `openAiCompatibleBaseUrl`, `openAiCompatibleApiKey`, and `openAiCompatibleModel`.
+
+## The translation gateway
+
+When the `openai-compatible` provider is activated, `ensureOpenAiCompatibleGateway()` starts a Node `http` server bound to `127.0.0.1` on an OS-assigned ephemeral port. The agent's environment is then pointed at it via `ANTHROPIC_BASE_URL`, so the SDK sends ordinary Anthropic Messages API calls to the local gateway, unaware anything unusual is happening.
+
+The gateway:
+
+1. Accepts `POST /v1/messages` (Anthropic wire format).
+2. Runs the request through **compaction** (see below).
+3. Translates it to an OpenAI `/chat/completions` request (`toOpenAiChatRequest`).
+4. Forwards it to the configured `baseUrl`, streaming or buffered as requested.
+5. Translates the response back to Anthropic format (`fromOpenAiCompletion` / `streamOpenAiToAnthropic`).
+
+Only one gateway runs at a time. If the config changes, the previous gateway is closed and a new one is started. Scope is **text and tool-calling only** — image content blocks are replaced with a placeholder, since local models used with this provider are typically text-only.
+
+## Context-window-aware compaction
+
+### The problem
+
+The Claude Agent SDK assumes Claude's large context window and has no knowledge of the local backend's real limit. A local model may only offer 4K–64K tokens, so as a conversation grows the SDK will eventually send a request larger than the backend can accept — producing an opaque `context_length_exceeded` error mid-conversation. The gateway solves this by discovering the real limit and proactively shrinking the transcript before forwarding it.
+
+Two design decisions shaped the implementation:
+
+- **Strategy: summarize-then-trim.** Mirroring Claude Code's own `/compact`, the oldest chunk of the conversation is summarized (by the local model itself) into a single synthetic note, and the recent tail is kept verbatim.
+- **Limit source: auto-discovery via `/v1/models`.** The backend is queried once for the model's advertised context window, rather than requiring the user to configure it by hand.
+
+### Context-window discovery
+
+`discoverContextWindow(config)` issues a `GET {baseUrl}/models` (with the same `Bearer` auth as the forwarding call and a 3-second `AbortSignal.timeout`), finds the `data[]` entry whose `id` matches the configured model, and reads the first present of:
+
+- `context_window` — Apfel's field name
+- `max_model_len` — vLLM's field name
+- `max_context_length` — an additional common alias
+
+If none is a positive number — or the endpoint is slow, missing, unauthorized, or malformed — it falls back to `DEFAULT_CONTEXT_WINDOW` (8192). Discovery **never throws**: a discovery failure must not block the provider from working. The result is cached once per gateway instance (in `GatewayState.contextWindow`), not re-fetched per request.
+
+### Token estimation
+
+No real tokenizer is available for an arbitrary backend, so a heuristic is used: `estimateTokens(text) = ceil(text.length / 4)` (~4 characters per token), applied to a serialized form of each message — text content, `JSON.stringify`'d tool-call input, and tool-result text — plus a small fixed per-message overhead. `estimateRequestTokens()` sums the system prompt, the (fixed, non-trimmable) tool definitions, and every message.
+
+This is deliberately conservative rather than exact; the safety margin constants below absorb the imprecision.
+
+### Budget and the fast path
+
+For each request, `compactMessagesIfNeeded()` computes:
+
+```
+budget = contextWindow − (request.max_tokens ?? DEFAULT_MAX_TOKENS_RESERVE) − SAFETY_MARGIN_TOKENS
+```
+
+If the estimated request already fits within `budget`, the request is returned **unchanged** — the common case, so most turns incur no extra work and no extra model call.
+
+### Splitting (pairing-safe)
+
+When over budget, the gateway keeps the largest recent suffix of messages that fits within `recentBudget = budget − SUMMARY_RESERVE_TOKENS` (reserving room for the summary itself). `findSplitIndex()` walks backward from the end accumulating estimated tokens, then `stabilizeSplitIndex()` pulls the boundary further back if it would fall between a `tool_use` message and the `tool_result` that answers it — the backend requires every `tool_use` to be immediately followed by its result, so such a pair is never separated across the old-chunk / recent-tail boundary.
+
+If nothing can be trimmed without breaking a pair (`splitIndex <= 0`), the request is forwarded as-is — graceful degradation, never an error.
+
+### Rolling summary
+
+Because the SDK resends the full conversation every turn, re-summarizing the entire old chunk on each over-budget request would be wasteful. The gateway keeps per-gateway `CompactionState { coveredMessages, summary }` and, in `resolveSummary()`, chooses one of three paths:
+
+1. **Reuse** — the cached `coveredMessages` exactly equals the new old chunk → reuse the cached summary, no model call.
+2. **Incremental update** — the cached `coveredMessages` is an exact prefix of the new old chunk → summarize only the newly-added portion, folding it into the existing summary ("update this summary with these additional turns").
+3. **Full re-summarize** — the conversation has diverged from the cached prefix (e.g. after `/clear` starts a fresh session) → summarize the whole old chunk from scratch.
+
+Prefix matching (`isPrefixOf` / `messagesEqual`) uses per-message `JSON.stringify` deep-equality.
+
+### The summarization call
+
+`summarizeConversation()` makes a plain, non-streaming, non-tool `POST {baseUrl}/chat/completions` against the same configured model, reusing the same auth-header pattern as the main forwarding call. The old chunk is serialized to readable text (tool calls rendered as `Called <name> with <args>`, results as `Result: <text>`), capped at `SUMMARY_MAX_TOKENS`. If the call fails or returns empty, it falls back to the previous summary (or a placeholder string) so a broken summarization call never crashes the request.
+
+### Applying the result
+
+The summary is appended to the **system** prompt as a clearly marked block:
+
+```
+<original system text>
+
+[Summary of earlier conversation, condensed to fit the local model's context window]
+<summary>
+```
+
+`messages` is then replaced with the recent tail. Injecting into the system prompt (rather than as a synthetic user/assistant message) sidesteps role-alternation edge cases entirely.
+
+### Constants
+
+Defined at the top of `openai-compat-gateway.ts`:
+
+| Constant                     | Value | Purpose                                                            |
+| ---------------------------- | ----- | ------------------------------------------------------------------ |
+| `DEFAULT_CONTEXT_WINDOW`     | 8192  | Fallback when discovery yields nothing usable                      |
+| `DEFAULT_MAX_TOKENS_RESERVE` | 1024  | Assumed output reservation when the request omits `max_tokens`     |
+| `SAFETY_MARGIN_TOKENS`       | 500   | Headroom absorbing token-estimate imprecision                      |
+| `SUMMARY_RESERVE_TOKENS`     | 800   | Space reserved in-budget for the injected summary                  |
+| `SUMMARY_MAX_TOKENS`         | 500   | Output cap on the summarization call                               |
+| `CHARS_PER_TOKEN_ESTIMATE`   | 4     | Characters-per-token heuristic                                     |
+
+## Testing
+
+Automated (`apps/cli/ai/tests/openai-compat-gateway.test.ts`, `fetch` stubbed via `vi.stubGlobal`):
+
+```bash
+nvm use            # matches .nvmrc (Node 24.x / npm 11)
+npm test -- apps/cli/ai/tests/openai-compat-gateway.test.ts
+npm run typecheck
+```
+
+Coverage: discovery field-name handling (`context_window`, `max_model_len`) and fallback; budget math triggering compaction only when over budget; `tool_use`/`tool_result` pairs never split across the boundary; rolling-summary reuse / incremental-update / divergence-reset.
+
+Manual (black-box, most telling): configure `/openai-config` against a **small-context** backend (e.g. Apfel at `http://localhost:11435/v1`, 4096 tokens), then hold a long conversation. It should keep responding coherently rather than erroring with `context_length_exceeded` once the history exceeds the window — older context is represented by the injected summary while recent turns stay verbatim. Against a large-context backend (e.g. a vLLM server with a 65536-token window), everyday short conversations are untouched; compaction engages only near the limit.


### PR DESCRIPTION
Introduces a new `openai-compatible` provider in the CLI, including persisted config fields (base URL, API key, model) and provider selection support. It adds a local Anthropic-to-OpenAI compatibility gateway that maps `/v1/messages` requests to `/chat/completions` responses, with support for tool calls and streaming SSE translation. Also adds a `/openai-config` slash command for updating endpoint settings and updates provider availability tests.

## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes #4198 

## How AI was used in this PR

The PR was built with the help of Claude Sonnet 5 operating in VSCode.  We also set up and ran local tests against Apfel running locally, as well as Qwen3.6-27b running on a networked vLLM install with a 64k context window.

For anyone unfamiliar with [Apfel](https://apfel.franzai.com/) -- it generally has a 4k context window, and if you're testing on a Mac is trivial to set up with the Foundation Model that MacOS generally already has in place.

> macOS Tahoe ships with a 3B parameter LLM. apfel gives you CLI access with one brew install. No model downloads, no API keys, no configuration needed, just works.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

- To enable self- and independently-hosted open-weight LLMs (as [discussed in the recent Code for the People documentary](https://youtu.be/8lQijrTaaGg?t=867)) this enables compatibility with any server running OpenAI-Compatible endpoints (a translation from the default Anthropic formats -- until such time as an acceptable standard such as the [circa 2024] [Open Message Format](https://github.com/open-llm-initiative/open-message-format) or the like gains adequate traction for better cross-compatibility)
- Due to the typically smaller context windows of various locally hosted models (often constrained by consumer-grade GPU VRAM limitations) this PR is also adding compaction tooling for context windows if an exchange gets overly long where it may cause overflows.  It detects the available context window based on the model listing on the host.

## Testing Instructions

**Prerequisites:** a local OpenAI-compatible server. Easiest two, both already on this machine:

- Apfel (`http://localhost:11435/v1`, model `apple-foundationmodel`) — 4096-token window, so compaction triggers almost immediately. Best for seeing the behavior.
- My Network vLLM install (`http://hostname:8000/v1`, model `qwen3.6-27b`) — 65536-token window. Best for confirming the fast-path (no needless compaction) and real summarization. -- if anyone wants to test against this machine, DM me on .org slack and I'll get you the port and an api key.

Any OpenAI-compatible backend works too (LM Studio, Ollama, llama.cpp `--server`).

1. Automated tests (fastest signal):

```
nvm use 24.13.1
npm test -- apps/cli/ai/tests/openai-compat-gateway.test.ts
npm run typecheck
```

Expect 10 passing tests covering discovery (`context_window` / `max_model_len` / fallback), budget-triggered compaction, tool_use↔tool_result pairing safety, and rolling-summary reuse/divergence.

2. In-app black-box test (the meaningful one):

```
npm run cli:build && node apps/cli/dist/cli/main.mjs
```

- In the chat, run `/openai-config` and point it at Apfel (base URL `http://localhost:11435/v1`, no key, model `apple-foundationmodel`).
- Have a long back-and-forth — paste large blocks of text, ~15-20 turns, enough to blow past 4096 tokens.
- Pass: the assistant keeps responding coherently and does not error with `context_length_exceeded`. Before this change, that same long conversation against a 4k backend would fail once history exceeded the window. The recent turns stay accurate; older context is represented by a summary the model folded into its system prompt.

3. Discovery + fast-path (no over-compaction):

- /openai-config → point at vLLM.
- Normal short conversations should behave exactly as before — compaction only engages once the transcript approaches ~64k tokens, so day-to-day chats are untouched.

4. Graceful degradation:

- Point at a backend whose `/v1/models` omits any context field, or an unreachable URL → gateway falls back to an 8192-token default and still works (verified: discovery never throws).

> I also have a standalone `tsx` harness (in scratchpad) that prints the discovered window, before/after message counts, and the injected summary. Confirmed live this session: Apfel discovered 4096 and compacted 41→10 messages; vLLM discovered 65536, correctly skipped an 11k-token request, and correctly summarized a 251-message / ~71k-token conversation down to ~64k with a real model-generated summary. I can promote that into a committed script under `apps/cli/ai/` if you'd like a repeatable manual harness.

## Pre-merge Checklist

- [X] Have you checked for TypeScript, React or other console errors?

Verification: 10 new unit tests + all 98 existing ai-module tests pass, lint and typecheck are clean, and manual smoke tests against both real backends confirm the whole pipeline — discovery, budget math, splitting, live summarization, and normal chat flow — works end to end.
