### PR TITLE
Agentic UI: Show the app menu button only on Windows and Linux

### DIFF
--- a/apps/ui/src/components/sidebar-header/index.test.tsx
+++ b/apps/ui/src/components/sidebar-header/index.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useConnector } from '@/data/core';
+import { SidebarHeader } from './index';
+
+vi.mock( '@tanstack/react-router', () => ( {
+	useNavigate: () => vi.fn(),
+} ) );
+
+vi.mock( '@/data/core', () => ( {
+	useConnector: vi.fn(),
+} ) );
+
+vi.mock( '@/hooks/use-traffic-light-space', () => ( {
+	useTrafficLightSpace: () => false,
+} ) );
+
+const useConnectorMock = vi.mocked( useConnector, { partial: true } );
+
+describe( 'SidebarHeader', () => {
+	it( 'shows the app menu button when the host has no native menu bar', () => {
+		useConnectorMock.mockReturnValue( { showsAppMenuButton: true, popupAppMenu: vi.fn() } );
+
+		render( <SidebarHeader onToggleSidebar={ () => {} } /> );
+
+		expect( screen.getByRole( 'button', { name: 'Menu' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the app menu button when the host has a native menu bar', () => {
+		useConnectorMock.mockReturnValue( { showsAppMenuButton: false } );
+
+		render( <SidebarHeader onToggleSidebar={ () => {} } /> );
+
+		expect( screen.queryByRole( 'button', { name: 'Menu' } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/apps/ui/src/components/sidebar-header/index.tsx
+++ b/apps/ui/src/components/sidebar-header/index.tsx
@@ -23,15 +23,17 @@ export function SidebarHeader( { onToggleSidebar }: Props ) {
 	};
 	return (
 		<div className={ `${ styles.root } ${ reserveTrafficLightSpace ? '' : styles.flush }` }>
-			<IconButton
-				variant="minimal"
-				tone="neutral"
-				size="small"
-				className={ styles.menuButton }
-				icon={ menu }
-				label={ __( 'Menu' ) }
-				onClick={ handleOpenAppMenu }
-			/>
+			{ connector.showsAppMenuButton && (
+				<IconButton
+					variant="minimal"
+					tone="neutral"
+					size="small"
+					className={ styles.menuButton }
+					icon={ menu }
+					label={ __( 'Menu' ) }
+					onClick={ handleOpenAppMenu }
+				/>
+			) }
 			<div className={ styles.actions }>
 				<Menu.Root modal={ false }>
 					<Menu.Trigger

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -341,6 +341,7 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 			window.open( url, '_blank', 'noopener,noreferrer' );
 		},
 		async popupAppMenu() {},
+		showsAppMenuButton: false,
 		async copyText( text ) {
 			await navigator.clipboard.writeText( text );
 		},

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -93,6 +93,10 @@ export function createIpcConnector(): Connector {
 		);
 	}
 
+	// The IPC connector only runs in Electron, so `navigator` reflects the
+	// desktop OS.
+	const isMacOS = /mac/i.test( navigator.platform || navigator.userAgent );
+
 	// Preview CLI commands are path-based, not id-based. Look up the matching
 	// site once per call so UI code can keep working with the stable site id.
 	async function resolveSiteFolder( siteId: string ): Promise< string > {
@@ -684,6 +688,10 @@ export function createIpcConnector(): Connector {
 			ipcApi.popupAppMenu( position );
 		},
 
+		// Windows/Linux have no native menu bar, so the UI provides the entry
+		// point; macOS keeps the native application menu.
+		showsAppMenuButton: ! isMacOS,
+
 		async copyText( text: string ): Promise< void > {
 			await ipcApi.copyText( text );
 		},
@@ -693,10 +701,9 @@ export function createIpcConnector(): Connector {
 		},
 
 		// Window state
-		// The IPC connector only runs in Electron, so `navigator` reflects the
-		// desktop OS. macOS overlays the traffic lights on the content (so we
-		// reserve space for them); Windows and Linux don't.
-		reservesTrafficLightSpace: /mac/i.test( navigator.platform || navigator.userAgent ),
+		// macOS overlays the traffic lights on the content (so we reserve
+		// space for them); Windows and Linux don't.
+		reservesTrafficLightSpace: isMacOS,
 
 		async isFullscreen(): Promise< boolean > {
 			return ipcApi.isFullscreen();

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -656,6 +656,7 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			window.open( url, '_blank', 'noopener,noreferrer' );
 		},
 		async popupAppMenu() {},
+		showsAppMenuButton: false,
 		async openSiteUrl( siteId, relativeUrl = '' ) {
 			const sites = lastSites ?? ( await api< SiteDetails[] >( '/sites' ) );
 			const target = new URL( relativeUrl || '/', findSiteUrl( sites, siteId ) ).toString();

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -322,6 +322,12 @@ export interface Connector {
 
 	popupAppMenu( position: { x: number; y: number } ): Promise< void >;
 
+	// Whether the UI should render a button that opens the app menu via
+	// `popupAppMenu`. True only in the Windows/Linux desktop app, which has no
+	// native menu bar; macOS has the native application menu and the browser
+	// (`studio ui` / hosted) has no app menu at all.
+	showsAppMenuButton: boolean;
+
 	// Clipboard — routed to the host so it works where the renderer's
 	// `navigator.clipboard` is unavailable (e.g. Electron permission denial).
 	copyText( text: string ): Promise< void >;


### PR DESCRIPTION
## Related issues

- Fixes STU-2052

## How AI was used in this PR

Root-cause investigation, the fix, and the component test were written with Claude Code, guided and reviewed by the author.

## Proposed Changes

#4172 added an app menu (hamburger) button to the agentic UI sidebar so Windows and Linux users can reach the app menu — those platforms have no native menu bar in production. The button rendered unconditionally, so it also appeared on macOS, duplicating the native application menu (p1784109157531499/1784109157.531499-slack-C06DRMD6VPZ), and in the browser-hosted UI (`studio ui`), where it did nothing.

The connector now declares whether the host needs an in-UI app menu entry point, and the sidebar only shows the button when it does: Windows/Linux desktop keeps it, macOS and the browser don't.

| Windows | macOS |
|--------|--------|
| <img width="1360" height="1032" alt="image" src="https://github.com/user-attachments/assets/3f29fd8a-c3af-4389-95e2-2ed8b7b8d4e2" /> | <img width="1260" height="984" alt="image" src="https://github.com/user-attachments/assets/7cd7b10c-0292-4f8d-b3a4-5d6a125b376f" /> | 

## Testing Instructions

- On macOS, launch Studio with the Agentic UI beta feature enabled → the sidebar header shows **no** hamburger menu button, and the native application menu bar works as before.
- On Windows or Linux, same setup → the hamburger button is present at the top of the sidebar and opens the app menu (unchanged from #4172).
- Run `studio ui` in a browser → no hamburger button.
- Legacy (non-agentic) UI is untouched.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)