### PR TITLE
Add in-app feedback system (PoC)

### DIFF
--- a/apps/studio/src/components/app.tsx
+++ b/apps/studio/src/components/app.tsx
@@ -19,6 +19,7 @@ import { useSiteDetails } from 'src/hooks/use-site-details';
 import { isLinux, isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { FeedbackModalContainer } from 'src/modules/feedback';
 import { Onboarding } from 'src/modules/onboarding';
 import { useOnboarding } from 'src/modules/onboarding/hooks/use-onboarding';
 import { UserSettings } from 'src/modules/user-settings';
@@ -134,6 +135,7 @@ export default function App() {
 				</VStack>
 			) }
 			<UserSettings />
+			<FeedbackModalContainer />
 			<WhatsNewModal showModal={ shouldShowWhatsNew } onClose={ closeWhatsNew } />
 			{ isWapuuWorldOpen && <WapuuWorldGame /> }
 		</>

--- a/apps/studio/src/components/default-error-fallback.tsx
+++ b/apps/studio/src/components/default-error-fallback.tsx
@@ -4,12 +4,14 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
 import Button from 'src/components/button';
 import { DynamicStylesheet } from 'src/components/dynamic-stylesheet';
 import { getWordpressStylesHref } from 'src/components/wordpress-styles';
 import { isLinux, isMac, isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { FeedbackModal } from 'src/modules/feedback';
 
 const SiteItemSkeleton = () => {
 	return (
@@ -50,6 +52,7 @@ const GravatarSkeleton = () => {
 
 const RightPanel = () => {
 	const { __ } = useI18n();
+	const [ showFeedback, setShowFeedback ] = useState( false );
 	const locale = DEFAULT_LOCALE;
 	const openLocalizedSupport = () => {
 		getIpcApi().openURL( `https://wordpress.com/${ locale }/support/contact` );
@@ -76,7 +79,7 @@ const RightPanel = () => {
 					</Button>
 				</p>
 			</div>
-			<div>
+			<div className="flex items-center gap-3">
 				<Button
 					className="bg-frame-theme hover:text-white text-white"
 					variant="primary"
@@ -84,7 +87,17 @@ const RightPanel = () => {
 				>
 					{ __( 'Restart' ) }
 				</Button>
+				<Button variant="secondary" onClick={ () => setShowFeedback( true ) }>
+					{ __( 'Share feedback' ) }
+				</Button>
 			</div>
+			{ showFeedback && (
+				<FeedbackModal
+					identity={ undefined }
+					source="crash"
+					onClose={ () => setShowFeedback( false ) }
+				/>
+			) }
 		</div>
 	);
 };

--- a/apps/studio/src/components/tests/topbar.test.tsx
+++ b/apps/studio/src/components/tests/topbar.test.tsx
@@ -72,19 +72,32 @@ describe( 'TopBar', () => {
 		);
 	} );
 
-	it( 'opens the support URL', async () => {
+	it( 'opens the docs URL from the help menu', async () => {
 		const user = userEvent.setup();
 		vi.mocked( useAuth, { partial: true } ).mockReturnValue( { isAuthenticated: true } );
 
 		renderWithProvider( <TopBar onToggleSidebar={ vi.fn() } /> );
 
-		const helpIconButton = screen.getByRole( 'button', { name: 'Get help' } );
-		await user.click( helpIconButton );
+		await user.click( screen.getByRole( 'button', { name: 'Help' } ) );
+		await user.click( await screen.findByRole( 'menuitem', { name: 'Docs' } ) );
+
 		await waitFor( () =>
 			expect( mockOpenURL ).toHaveBeenCalledWith(
 				`https://developer.wordpress.com/docs/developer-tools/studio/`
 			)
 		);
+	} );
+
+	it( 'opens the feedback modal from the help menu', async () => {
+		const user = userEvent.setup();
+		vi.mocked( useAuth, { partial: true } ).mockReturnValue( { isAuthenticated: true } );
+
+		renderWithProvider( <TopBar onToggleSidebar={ vi.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Help' } ) );
+		await user.click( await screen.findByRole( 'menuitem', { name: 'Send feedback' } ) );
+
+		expect( await screen.findByText( 'Share feedback' ) ).toBeVisible();
 	} );
 
 	it( 'calls toggleMinWindowWidth when sidebar toggle button is clicked', async () => {

--- a/apps/studio/src/components/top-bar.tsx
+++ b/apps/studio/src/components/top-bar.tsx
@@ -1,5 +1,7 @@
-import { Icon, help, drawerLeft, cog } from '@wordpress/icons';
+import { Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { Icon, help, drawerLeft, cog, external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
 import Button from 'src/components/button';
 import { Gravatar } from 'src/components/gravatar';
 import offlineIcon from 'src/components/offline-icon';
@@ -10,6 +12,7 @@ import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { getLocalizedLink } from 'src/lib/get-localized-link';
+import { FeedbackModal } from 'src/modules/feedback';
 import { useI18nLocale } from 'src/stores';
 
 interface TopBarProps {
@@ -126,33 +129,76 @@ function SettingsButton() {
 export default function TopBar( { onToggleSidebar }: TopBarProps ) {
 	const { __ } = useI18n();
 	const locale = useI18nLocale();
+	const { isAuthenticated, user } = useAuth();
+	const [ isFeedbackOpen, setIsFeedbackOpen ] = useState( false );
 
 	const openDocs = () => {
 		getIpcApi().openURL( getLocalizedLink( locale, 'docsStudio' ) );
 	};
 
 	return (
-		<div className="flex justify-between items-center text-white pl-2 pr-0.5">
-			<div className="flex items-center space-x-1.5 rtl:space-x-reverse">
-				<ToggleSidebar onToggleSidebar={ onToggleSidebar } />
-				<OfflineIndicator />
-			</div>
+		<>
+			<div className="flex justify-between items-center text-white pl-2 pr-0.5">
+				<div className="flex items-center space-x-1.5 rtl:space-x-reverse">
+					<ToggleSidebar onToggleSidebar={ onToggleSidebar } />
+					<OfflineIndicator />
+				</div>
 
-			<div className="app-no-drag-region flex items-center space-x-1.5 rtl:space-x-reverse">
-				<Authentication />
-				<SettingsButton />
-				<Tooltip text={ __( 'Get help' ) } placement="bottom-end">
-					<Button
-						onClick={ openDocs }
-						aria-label={ __( 'Get help' ) }
-						variant="icon"
-						className="!p-1.5 !rounded-lg"
-					>
-						<Icon className="text-white" size={ 24 } icon={ help } />
-					</Button>
-				</Tooltip>
-				<RemoteSessionIndicator />
+				<div className="app-no-drag-region flex items-center space-x-1.5 rtl:space-x-reverse">
+					<Authentication />
+					<SettingsButton />
+					<Dropdown
+						popoverProps={ { placement: 'bottom-end' } }
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<Tooltip text={ __( 'Help' ) } placement="bottom-end">
+								<Button
+									onClick={ onToggle }
+									aria-label={ __( 'Help' ) }
+									aria-expanded={ isOpen }
+									variant="icon"
+									className="!p-1.5 !rounded-lg"
+								>
+									<Icon className="text-white" size={ 24 } icon={ help } />
+								</Button>
+							</Tooltip>
+						) }
+						renderContent={ ( { onClose } ) => (
+							<MenuGroup className="w-48">
+								<MenuItem
+									icon={ external }
+									iconPosition="right"
+									onClick={ () => {
+										onClose();
+										openDocs();
+									} }
+								>
+									{ __( 'Docs' ) }
+								</MenuItem>
+								<MenuItem
+									onClick={ () => {
+										onClose();
+										setIsFeedbackOpen( true );
+									} }
+								>
+									{ __( 'Send feedback' ) }
+								</MenuItem>
+							</MenuGroup>
+						) }
+					/>
+					<RemoteSessionIndicator />
+				</div>
 			</div>
-		</div>
+			{ isFeedbackOpen && (
+				<FeedbackModal
+					identity={ {
+						isAuthenticated,
+						email: user?.email,
+						displayName: user?.displayName,
+					} }
+					source="menu"
+					onClose={ () => setIsFeedbackOpen( false ) }
+				/>
+			) }
+		</>
 	);
 }

--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -69,6 +69,7 @@ export const IPC_VOID_HANDLERS = [
 	'showItemInFolder',
 	'showNotification',
 	'authenticate',
+	'openApplicationLogs',
 ] as const;
 
 // What's New

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -241,6 +241,8 @@ export { getDefaultSiteDirectory, saveDefaultSiteDirectory };
 
 export { importSite, exportSite } from 'src/modules/import-export/lib/ipc-handlers';
 
+export { submitFeedback, openApplicationLogs } from 'src/modules/feedback/lib/ipc-handlers';
+
 export { fetchSiteRest as fetchSiteRestApi } from 'src/lib/wordpress-rest-api';
 
 export async function listAiSessions( _event: IpcMainInvokeEvent ): Promise< AiSessionSummary[] > {

--- a/apps/studio/src/ipc-utils.ts
+++ b/apps/studio/src/ipc-utils.ts
@@ -60,6 +60,7 @@ export interface IpcEvents {
 	'thumbnail-loaded': [ { id: string; imageData: string | null } ];
 	'thumbnail-load-error': [ { id: string } ];
 	'user-settings': [ { tabName?: string } ];
+	'feedback-modal': [ { source?: 'menu' } ];
 	'window-fullscreen-change': [ boolean ];
 	'user-preference-changed': [ void ];
 	'refresh-app-globals': [ void ];

--- a/apps/studio/src/lib/bump-stats.ts
+++ b/apps/studio/src/lib/bump-stats.ts
@@ -31,6 +31,8 @@ export enum StatsGroup {
 	STUDIO_CODE_UI_RUN = 'studio-code-ui-run',
 	STUDIO_CODE_UI_WKLY_UNQ = 'studio-code-ui-wk-unq',
 	STUDIO_CODE_UI_MON_UNQ = 'studio-code-ui-mon-unq',
+	// In-app feedback submissions (success/failure) from the desktop UI.
+	STUDIO_APP_FEEDBACK = 'studio-app-feedback',
 }
 
 export enum StatsMetric {

--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -439,6 +439,12 @@ async function getAppMenu(
 				},
 				{ type: 'separator' },
 				{
+					label: __( 'Share Feedback…' ),
+					click: () => {
+						void sendIpcEventToRenderer( 'feedback-modal', { source: 'menu' } );
+					},
+				},
+				{
 					label: __( 'Report an Issue' ),
 					click: () => {
 						void shellOpenExternalWrapper( BUG_REPORT_URL );

--- a/apps/studio/src/modules/feedback/components/feedback-form.tsx
+++ b/apps/studio/src/modules/feedback/components/feedback-form.tsx
@@ -140,17 +140,16 @@ export default function FeedbackForm( { identity, onSubmitted }: FeedbackFormPro
 				/>
 			) }
 
-			<div>
+			<div className="flex items-center justify-between gap-3">
 				<CheckboxControl
 					__nextHasNoMarginBottom
-					label={ __( 'Include logs & diagnostics' ) }
-					help={ __( 'Attaches recent app logs and version info so we can debug your report.' ) }
+					label={ __( 'Include recent app logs & diagnostics to help us debug' ) }
 					checked={ includeLogs }
 					onChange={ setIncludeLogs }
 				/>
 				<Button
 					variant="link"
-					className="text-[13px] !text-frame-theme"
+					className="!text-frame-theme shrink-0"
 					onClick={ () => getIpcApi().openApplicationLogs() }
 				>
 					{ __( 'View logs' ) }

--- a/apps/studio/src/modules/feedback/components/feedback-form.tsx
+++ b/apps/studio/src/modules/feedback/components/feedback-form.tsx
@@ -1,0 +1,180 @@
+import {
+	CheckboxControl,
+	SelectControl,
+	TextareaControl,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import Button from 'src/components/button';
+import TextControl from 'src/components/text-control';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import {
+	MAX_FEEDBACK_MESSAGE_LENGTH,
+	type FeedbackCategory,
+	type FeedbackErrorCode,
+} from 'src/modules/feedback/lib/feedback-schema';
+
+export interface FeedbackIdentityProp {
+	isAuthenticated: boolean;
+	email?: string;
+	displayName?: string;
+}
+
+interface FeedbackFormProps {
+	identity?: FeedbackIdentityProp;
+	source?: 'menu' | 'settings' | 'crash';
+	onSubmitted?: () => void;
+}
+
+function categoryOptions(): { label: string; value: FeedbackCategory }[] {
+	return [
+		{ label: __( 'General feedback' ), value: 'general' },
+		{ label: __( 'Bug report' ), value: 'bug' },
+		{ label: __( 'Feature request' ), value: 'feature' },
+		{ label: __( 'Something else' ), value: 'other' },
+	];
+}
+
+function errorMessage( code: FeedbackErrorCode ): string {
+	switch ( code ) {
+		case 'validation':
+			return __( 'Please enter a message before sending.' );
+		case 'server':
+			return __( 'Something went wrong on our end. Please try again.' );
+		case 'network':
+		case 'offline':
+		default:
+			return __( "Couldn't send feedback. Check your connection and try again." );
+	}
+}
+
+export default function FeedbackForm( { identity, onSubmitted }: FeedbackFormProps ) {
+	const [ message, setMessage ] = useState( '' );
+	const [ email, setEmail ] = useState( '' );
+	const [ category, setCategory ] = useState< FeedbackCategory >( 'general' );
+	const [ includeLogs, setIncludeLogs ] = useState( true );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ errorCode, setErrorCode ] = useState< FeedbackErrorCode | null >( null );
+	const [ isSubmitted, setIsSubmitted ] = useState( false );
+
+	const isLoggedOut = ! identity?.isAuthenticated;
+
+	const resetForm = () => {
+		setMessage( '' );
+		setEmail( '' );
+		setCategory( 'general' );
+		setIncludeLogs( true );
+		setErrorCode( null );
+		setIsSubmitted( false );
+	};
+
+	const handleSubmit = async () => {
+		if ( ! message.trim() || isSubmitting ) {
+			return;
+		}
+		setIsSubmitting( true );
+		setErrorCode( null );
+		const result = await getIpcApi().submitFeedback( {
+			message,
+			email: isLoggedOut && email.trim() ? email.trim() : undefined,
+			includeLogs,
+			category,
+		} );
+		setIsSubmitting( false );
+		if ( result.success ) {
+			setIsSubmitted( true );
+			onSubmitted?.();
+		} else {
+			setErrorCode( result.error );
+		}
+	};
+
+	if ( isSubmitted ) {
+		return (
+			<VStack spacing="4" className="text-frame-text">
+				<p className="text-frame-text">{ __( 'Thanks for your feedback!' ) }</p>
+				<p className="text-frame-text-secondary text-[13px]">
+					{ isLoggedOut
+						? __(
+								'If you left an email, we may reach out when there’s an update related to your report.'
+						  )
+						: __( 'We’ll reach out through your WordPress.com account if we have an update.' ) }
+				</p>
+				<div>
+					<Button variant="secondary" onClick={ resetForm }>
+						{ __( 'Send more feedback' ) }
+					</Button>
+				</div>
+			</VStack>
+		);
+	}
+
+	return (
+		<VStack spacing="4">
+			<SelectControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'What kind of feedback is this?' ) }
+				value={ category }
+				options={ categoryOptions() }
+				onChange={ ( value ) => setCategory( value as FeedbackCategory ) }
+			/>
+
+			<TextareaControl
+				__nextHasNoMarginBottom
+				label={ __( 'Your feedback' ) }
+				placeholder={ __( 'What’s working well? What could be better?' ) }
+				value={ message }
+				onChange={ setMessage }
+				rows={ 5 }
+				maxLength={ MAX_FEEDBACK_MESSAGE_LENGTH }
+			/>
+
+			{ isLoggedOut && (
+				<TextControl
+					type="email"
+					label={ __( 'Email (optional, so we can follow up)' ) }
+					value={ email }
+					onChange={ setEmail }
+				/>
+			) }
+
+			<div>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label={ __( 'Include logs & diagnostics' ) }
+					help={ __( 'Attaches recent app logs and version info so we can debug your report.' ) }
+					checked={ includeLogs }
+					onChange={ setIncludeLogs }
+				/>
+				<Button
+					variant="link"
+					className="text-[13px] !text-frame-theme"
+					onClick={ () => getIpcApi().openApplicationLogs() }
+				>
+					{ __( 'View logs' ) }
+				</Button>
+			</div>
+
+			{ errorCode && (
+				<p role="alert" className="text-a8c-red-50 text-[13px]">
+					{ errorMessage( errorCode ) }
+				</p>
+			) }
+
+			<div className="flex items-center gap-3">
+				<Button
+					variant="primary"
+					className="bg-frame-theme text-white hover:text-white"
+					onClick={ handleSubmit }
+					disabled={ ! message.trim() || isSubmitting }
+					aria-disabled={ ! message.trim() || isSubmitting }
+					isBusy={ isSubmitting }
+				>
+					{ __( 'Send feedback' ) }
+				</Button>
+			</div>
+		</VStack>
+	);
+}

--- a/apps/studio/src/modules/feedback/components/feedback-modal-container.tsx
+++ b/apps/studio/src/modules/feedback/components/feedback-modal-container.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { useAuth } from 'src/hooks/use-auth';
+import { useIpcListener } from 'src/hooks/use-ipc-listener';
+import FeedbackModal from 'src/modules/feedback/components/feedback-modal';
+
+// App-context entry point for the feedback modal, opened via the `feedback-modal`
+// IPC event (e.g. the Help menu). This lives inside the provider tree, so it can
+// read auth state — unlike the crash-screen entry point, which renders the modal
+// directly with no identity.
+export default function FeedbackModalContainer() {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const { isAuthenticated, user } = useAuth();
+
+	useIpcListener( 'feedback-modal', () => {
+		setIsOpen( true );
+	} );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<FeedbackModal
+			identity={ {
+				isAuthenticated,
+				email: user?.email,
+				displayName: user?.displayName,
+			} }
+			source="menu"
+			onClose={ () => setIsOpen( false ) }
+		/>
+	);
+}

--- a/apps/studio/src/modules/feedback/components/feedback-modal.tsx
+++ b/apps/studio/src/modules/feedback/components/feedback-modal.tsx
@@ -1,0 +1,27 @@
+import { __ } from '@wordpress/i18n';
+import Modal from 'src/components/modal';
+import FeedbackForm, {
+	type FeedbackIdentityProp,
+} from 'src/modules/feedback/components/feedback-form';
+
+interface FeedbackModalProps {
+	identity?: FeedbackIdentityProp;
+	source?: 'menu' | 'settings' | 'crash';
+	onClose: () => void;
+}
+
+export default function FeedbackModal( { identity, source, onClose }: FeedbackModalProps ) {
+	return (
+		<Modal
+			title={ __( 'Share feedback' ) }
+			isDismissible
+			onRequestClose={ onClose }
+			size="medium"
+			className="app-no-drag-region"
+		>
+			<div className="px-2 pb-2">
+				<FeedbackForm identity={ identity } source={ source } onSubmitted={ onClose } />
+			</div>
+		</Modal>
+	);
+}

--- a/apps/studio/src/modules/feedback/components/tests/feedback-form.test.tsx
+++ b/apps/studio/src/modules/feedback/components/tests/feedback-form.test.tsx
@@ -1,0 +1,83 @@
+// To run: npm run test -- src/modules/feedback/components/tests/feedback-form.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import FeedbackForm from 'src/modules/feedback/components/feedback-form';
+
+const submitFeedback = vi.fn();
+
+vi.mock( 'src/lib/get-ipc-api', () => ( {
+	getIpcApi: vi.fn(),
+} ) );
+
+beforeEach( () => {
+	vi.clearAllMocks();
+	submitFeedback.mockResolvedValue( { success: true } );
+	vi.mocked( getIpcApi ).mockReturnValue( {
+		submitFeedback,
+		openApplicationLogs: vi.fn(),
+	} as unknown as ReturnType< typeof getIpcApi > );
+} );
+
+describe( 'FeedbackForm', () => {
+	it( 'renders with no providers (crash-screen mode)', () => {
+		render( <FeedbackForm identity={ undefined } source="crash" /> );
+		expect( screen.getByLabelText( 'Your feedback' ) ).toBeVisible();
+	} );
+
+	it( 'disables the submit button until a message is entered', async () => {
+		render( <FeedbackForm identity={ undefined } /> );
+		const submit = screen.getByRole( 'button', { name: 'Send feedback' } );
+		expect( submit ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		await userEvent.type( screen.getByLabelText( 'Your feedback' ), 'Hello there' );
+		expect( submit ).not.toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'shows the optional email field only when logged out', () => {
+		const { rerender } = render( <FeedbackForm identity={ undefined } /> );
+		expect( screen.getByLabelText( /Email/ ) ).toBeVisible();
+
+		rerender( <FeedbackForm identity={ { isAuthenticated: true, email: 'me@example.com' } } /> );
+		expect( screen.queryByLabelText( /Email/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'defaults the include-logs checkbox to checked', () => {
+		render( <FeedbackForm identity={ undefined } /> );
+		expect( screen.getByRole( 'checkbox', { name: 'Include logs & diagnostics' } ) ).toBeChecked();
+	} );
+
+	it( 'submits the entered feedback and calls onSubmitted on success', async () => {
+		const onSubmitted = vi.fn();
+		render( <FeedbackForm identity={ undefined } onSubmitted={ onSubmitted } /> );
+
+		await userEvent.type( screen.getByLabelText( 'Your feedback' ), 'Nice work' );
+		await userEvent.type( screen.getByLabelText( /Email/ ), 'reply@example.com' );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
+
+		await waitFor( () => {
+			expect( submitFeedback ).toHaveBeenCalledWith( {
+				message: 'Nice work',
+				email: 'reply@example.com',
+				includeLogs: true,
+				category: 'general',
+			} );
+		} );
+		expect( onSubmitted ).toHaveBeenCalled();
+		expect( screen.getByText( 'Thanks for your feedback!' ) ).toBeVisible();
+	} );
+
+	it( 'keeps the form open and shows an error when submission fails', async () => {
+		submitFeedback.mockResolvedValue( { success: false, error: 'network' } );
+		render( <FeedbackForm identity={ undefined } /> );
+
+		await userEvent.type( screen.getByLabelText( 'Your feedback' ), 'Broken' );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
+
+		expect( await screen.findByRole( 'alert' ) ).toHaveTextContent(
+			"Couldn't send feedback. Check your connection and try again."
+		);
+		expect( screen.getByLabelText( 'Your feedback' ) ).toBeVisible();
+	} );
+} );

--- a/apps/studio/src/modules/feedback/components/tests/feedback-form.test.tsx
+++ b/apps/studio/src/modules/feedback/components/tests/feedback-form.test.tsx
@@ -45,7 +45,11 @@ describe( 'FeedbackForm', () => {
 
 	it( 'defaults the include-logs checkbox to checked', () => {
 		render( <FeedbackForm identity={ undefined } /> );
-		expect( screen.getByRole( 'checkbox', { name: 'Include logs & diagnostics' } ) ).toBeChecked();
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Include recent app logs & diagnostics to help us debug',
+			} )
+		).toBeChecked();
 	} );
 
 	it( 'submits the entered feedback and calls onSubmitted on success', async () => {

--- a/apps/studio/src/modules/feedback/index.ts
+++ b/apps/studio/src/modules/feedback/index.ts
@@ -1,0 +1,3 @@
+export { default as FeedbackForm } from 'src/modules/feedback/components/feedback-form';
+export { default as FeedbackModal } from 'src/modules/feedback/components/feedback-modal';
+export { default as FeedbackModalContainer } from 'src/modules/feedback/components/feedback-modal-container';

--- a/apps/studio/src/modules/feedback/lib/feedback-schema.ts
+++ b/apps/studio/src/modules/feedback/lib/feedback-schema.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+export const FEEDBACK_CATEGORIES = [ 'general', 'bug', 'feature', 'other' ] as const;
+export type FeedbackCategory = ( typeof FEEDBACK_CATEGORIES )[ number ];
+
+export const MAX_FEEDBACK_MESSAGE_LENGTH = 5000;
+
+// Recent-log tail attached to a submission. Bounded so large multi-MB log files
+// don't inflate the payload; the tail keeps the most relevant (latest) lines.
+export const LOG_TAIL_BYTES = 256 * 1024;
+
+export const FEEDBACK_API_PATH = '/studio-app/feedback';
+export const FEEDBACK_API_URL = `https://public-api.wordpress.com/wpcom/v2${ FEEDBACK_API_PATH }`;
+
+// Renderer → main input. Identity is deliberately absent: it is resolved
+// authoritatively in the main process so the flow works even from the crash
+// screen, where the auth/Redux providers are unmounted.
+export const feedbackSubmissionSchema = z.object( {
+	message: z.string().trim().min( 1 ).max( MAX_FEEDBACK_MESSAGE_LENGTH ),
+	email: z.string().email().optional(),
+	includeLogs: z.boolean().default( true ),
+	category: z.enum( FEEDBACK_CATEGORIES ).default( 'general' ),
+} );
+
+export type FeedbackSubmission = z.infer< typeof feedbackSubmissionSchema >;
+
+export type FeedbackErrorCode = 'offline' | 'validation' | 'network' | 'server';
+export type FeedbackResult = { success: true } | { success: false; error: FeedbackErrorCode };
+
+export type FeedbackIdentity =
+	| { type: 'wpcom'; wpcomUserId: number; email: string; displayName: string }
+	| { type: 'anonymous'; anonymousId: string; contactEmail?: string };
+
+// Main → backend payload. A superset of the submission, assembled in the handler.
+export interface FeedbackWirePayload {
+	message: string;
+	category: FeedbackCategory;
+	appVersion: string;
+	platform: string;
+	electronVersion: string;
+	osVersion?: string;
+	identity: FeedbackIdentity;
+	logs?: string;
+}

--- a/apps/studio/src/modules/feedback/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/feedback/lib/ipc-handlers.ts
@@ -1,0 +1,130 @@
+import crypto from 'crypto';
+import { app, shell, type IpcMainInvokeEvent } from 'electron';
+import fs from 'fs/promises';
+import wpcomFactory from '@studio/common/lib/wpcom-factory';
+import wpcomXhrRequest from '@studio/common/lib/wpcom-xhr-request-factory';
+import { bumpStat, StatsGroup, StatsMetric } from 'src/lib/bump-stats';
+import { getAuthenticationToken } from 'src/lib/oauth';
+import { sanitizeUnstructuredData, sanitizeUserpath } from 'src/lib/sanitize-for-logging';
+import { getLogsFilePath } from 'src/logging';
+import {
+	FEEDBACK_API_PATH,
+	FEEDBACK_API_URL,
+	LOG_TAIL_BYTES,
+	feedbackSubmissionSchema,
+	type FeedbackIdentity,
+	type FeedbackResult,
+	type FeedbackWirePayload,
+} from 'src/modules/feedback/lib/feedback-schema';
+import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
+
+export async function submitFeedback(
+	_event: IpcMainInvokeEvent,
+	input: unknown
+): Promise< FeedbackResult > {
+	const parsed = feedbackSubmissionSchema.safeParse( input );
+	if ( ! parsed.success ) {
+		return { success: false, error: 'validation' };
+	}
+	const { message, email, includeLogs, category } = parsed.data;
+
+	const token = await getAuthenticationToken();
+	const identity: FeedbackIdentity = token
+		? { type: 'wpcom', wpcomUserId: token.id, email: token.email, displayName: token.displayName }
+		: { type: 'anonymous', anonymousId: await getAnonymousId(), contactEmail: email };
+
+	const payload: FeedbackWirePayload = {
+		message,
+		category,
+		appVersion: app.getVersion(),
+		platform: process.platform,
+		electronVersion: process.versions.electron,
+		osVersion: process.getSystemVersion?.(),
+		identity,
+	};
+
+	if ( includeLogs ) {
+		const logs = await readSanitizedLogTail();
+		if ( logs ) {
+			payload.logs = logs;
+		}
+	}
+
+	try {
+		if ( token ) {
+			const wpcom = wpcomFactory( token.accessToken, wpcomXhrRequest );
+			await wpcom.req.post( { path: FEEDBACK_API_PATH, apiNamespace: 'wpcom/v2', body: payload } );
+		} else {
+			const response = await fetch( FEEDBACK_API_URL, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify( payload ),
+			} );
+			if ( ! response.ok ) {
+				bumpStat( StatsGroup.STUDIO_APP_FEEDBACK, StatsMetric.FAILURE );
+				return { success: false, error: 'server' };
+			}
+		}
+	} catch ( error ) {
+		console.error( 'Failed to submit feedback:', error );
+		bumpStat( StatsGroup.STUDIO_APP_FEEDBACK, StatsMetric.FAILURE );
+		return { success: false, error: mapPostError( error ) };
+	}
+
+	bumpStat( StatsGroup.STUDIO_APP_FEEDBACK, StatsMetric.SUCCESS );
+	return { success: true };
+}
+
+export async function openApplicationLogs(): Promise< void > {
+	try {
+		const logFilePath = getLogsFilePath();
+		const err = await shell.openPath( logFilePath );
+		if ( err ) {
+			console.error( `Error opening logs file: ${ logFilePath } ${ err }` );
+		}
+	} catch ( error ) {
+		console.error( 'Failed to open application logs:', error );
+	}
+}
+
+// The feedback anonymous id is the same persistent per-installation UUID used for
+// Sentry (generated at boot in index.ts). Reused here so anonymous reports can be
+// correlated without introducing a second stored identifier.
+async function getAnonymousId(): Promise< string > {
+	const userData = await loadUserData();
+	if ( userData.sentryUserId ) {
+		return userData.sentryUserId;
+	}
+
+	await lockAppdata();
+	try {
+		const latest = await loadUserData();
+		if ( latest.sentryUserId ) {
+			return latest.sentryUserId;
+		}
+		const anonymousId = crypto.randomUUID();
+		await saveUserData( { ...latest, sentryUserId: anonymousId } );
+		return anonymousId;
+	} finally {
+		await unlockAppdata();
+	}
+}
+
+async function readSanitizedLogTail(): Promise< string | undefined > {
+	try {
+		const raw = await fs.readFile( getLogsFilePath(), 'utf-8' );
+		const tail = raw.length > LOG_TAIL_BYTES ? raw.slice( -LOG_TAIL_BYTES ) : raw;
+		return sanitizeUserpath( sanitizeUnstructuredData( tail ) );
+	} catch ( error ) {
+		// A missing/unreadable log file must not fail the submission — just omit logs.
+		console.error( 'Failed to read logs for feedback:', error );
+		return undefined;
+	}
+}
+
+function mapPostError( error: unknown ): 'network' | 'server' {
+	if ( error && typeof error === 'object' && ( 'statusCode' in error || 'status' in error ) ) {
+		return 'server';
+	}
+	return 'network';
+}

--- a/apps/studio/src/modules/feedback/lib/tests/ipc-handlers.test.ts
+++ b/apps/studio/src/modules/feedback/lib/tests/ipc-handlers.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @vitest-environment node
+ *
+ * To run: npm run test -- src/modules/feedback/lib/tests/ipc-handlers.test.ts
+ */
+import { vi } from 'vitest';
+import { getAuthenticationToken } from 'src/lib/oauth';
+import { FEEDBACK_API_URL, LOG_TAIL_BYTES } from 'src/modules/feedback/lib/feedback-schema';
+import { submitFeedback } from 'src/modules/feedback/lib/ipc-handlers';
+import { loadUserData, saveUserData } from 'src/storage/user-data';
+
+const mockWpcomPost = vi.fn();
+const mockReadFile = vi.fn();
+
+vi.mock( 'electron', () => ( {
+	app: { getVersion: () => '9.9.9' },
+	shell: { openPath: vi.fn( async () => '' ) },
+} ) );
+vi.mock( 'fs/promises', () => ( {
+	default: { readFile: ( ...args: unknown[] ) => mockReadFile( ...args ) },
+} ) );
+vi.mock( 'src/lib/oauth', () => ( { getAuthenticationToken: vi.fn() } ) );
+vi.mock( 'src/logging', () => ( { getLogsFilePath: vi.fn( () => '/mock/studio.log' ) } ) );
+vi.mock( '@studio/common/lib/wpcom-factory', () => ( {
+	default: () => ( { req: { post: mockWpcomPost } } ),
+} ) );
+vi.mock( '@studio/common/lib/wpcom-xhr-request-factory', () => ( { default: vi.fn() } ) );
+vi.mock( 'src/storage/user-data', () => ( {
+	loadUserData: vi.fn( async () => ( { sentryUserId: 'anon-uuid' } ) ),
+	lockAppdata: vi.fn(),
+	unlockAppdata: vi.fn(),
+	saveUserData: vi.fn(),
+} ) );
+vi.mock( 'src/lib/bump-stats', async ( importOriginal ) => ( {
+	...( await importOriginal< object >() ),
+	bumpStat: vi.fn(),
+} ) );
+
+const AUTH_TOKEN = {
+	accessToken: 'tok',
+	id: 42,
+	email: 'user@example.com',
+	displayName: 'Test User',
+	expiresIn: 3600,
+	expirationTime: Date.now() + 10_000,
+};
+
+const VALID_INPUT = {
+	message: 'The app is great',
+	includeLogs: false,
+	category: 'general' as const,
+};
+
+const event = {} as Electron.IpcMainInvokeEvent;
+const originalFetch = global.fetch;
+
+beforeEach( () => {
+	vi.clearAllMocks();
+	vi.mocked( getAuthenticationToken ).mockResolvedValue( null );
+	vi.mocked( loadUserData ).mockResolvedValue( { sentryUserId: 'anon-uuid' } as never );
+	mockReadFile.mockResolvedValue( 'log line one\nlog line two\n' );
+	global.fetch = vi.fn( async () => ( { ok: true, status: 200 } ) as Response );
+} );
+
+afterEach( () => {
+	global.fetch = originalFetch;
+} );
+
+describe( 'submitFeedback', () => {
+	it( 'rejects invalid input without making a network request', async () => {
+		const result = await submitFeedback( event, { message: '   ' } );
+
+		expect( result ).toEqual( { success: false, error: 'validation' } );
+		expect( global.fetch ).not.toHaveBeenCalled();
+		expect( mockWpcomPost ).not.toHaveBeenCalled();
+	} );
+
+	it( 'posts anonymously with the installation id and optional contact email', async () => {
+		const result = await submitFeedback( event, {
+			...VALID_INPUT,
+			email: 'reply@example.com',
+		} );
+
+		expect( result ).toEqual( { success: true } );
+		expect( mockWpcomPost ).not.toHaveBeenCalled();
+		const [ url, options ] = vi.mocked( global.fetch ).mock.calls[ 0 ];
+		expect( url ).toBe( FEEDBACK_API_URL );
+		const body = JSON.parse( ( options as RequestInit ).body as string );
+		expect( body.identity ).toEqual( {
+			type: 'anonymous',
+			anonymousId: 'anon-uuid',
+			contactEmail: 'reply@example.com',
+		} );
+		expect( body.appVersion ).toBe( '9.9.9' );
+	} );
+
+	it( 'posts as the wpcom user through the authenticated client when logged in', async () => {
+		vi.mocked( getAuthenticationToken ).mockResolvedValue( AUTH_TOKEN );
+
+		const result = await submitFeedback( event, VALID_INPUT );
+
+		expect( result ).toEqual( { success: true } );
+		expect( global.fetch ).not.toHaveBeenCalled();
+		expect( mockWpcomPost ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/studio-app/feedback',
+				apiNamespace: 'wpcom/v2',
+				body: expect.objectContaining( {
+					identity: {
+						type: 'wpcom',
+						wpcomUserId: 42,
+						email: 'user@example.com',
+						displayName: 'Test User',
+					},
+				} ),
+			} )
+		);
+	} );
+
+	it( 'attaches a sanitized, truncated log tail when includeLogs is set', async () => {
+		const filler = 'x'.repeat( LOG_TAIL_BYTES );
+		mockReadFile.mockResolvedValue( `password=hunter2\n${ filler }` );
+
+		await submitFeedback( event, { ...VALID_INPUT, includeLogs: true } );
+
+		const body = JSON.parse(
+			( vi.mocked( global.fetch ).mock.calls[ 0 ][ 1 ] as RequestInit ).body as string
+		);
+		expect( body.logs.length ).toBeLessThanOrEqual( LOG_TAIL_BYTES );
+		// The oldest line (with the secret) is dropped by tail truncation.
+		expect( body.logs ).not.toContain( 'hunter2' );
+	} );
+
+	it( 'redacts sensitive lines in the attached logs', async () => {
+		mockReadFile.mockResolvedValue( 'token=abc123\nnormal line\n' );
+
+		await submitFeedback( event, { ...VALID_INPUT, includeLogs: true } );
+
+		const body = JSON.parse(
+			( vi.mocked( global.fetch ).mock.calls[ 0 ][ 1 ] as RequestInit ).body as string
+		);
+		expect( body.logs ).toContain( 'REDACTED' );
+		expect( body.logs ).not.toContain( 'abc123' );
+	} );
+
+	it( 'omits logs but still succeeds when the log file cannot be read', async () => {
+		mockReadFile.mockRejectedValue( new Error( 'ENOENT' ) );
+
+		const result = await submitFeedback( event, { ...VALID_INPUT, includeLogs: true } );
+
+		expect( result ).toEqual( { success: true } );
+		const body = JSON.parse(
+			( vi.mocked( global.fetch ).mock.calls[ 0 ][ 1 ] as RequestInit ).body as string
+		);
+		expect( body.logs ).toBeUndefined();
+	} );
+
+	it( 'does not read logs when includeLogs is false', async () => {
+		await submitFeedback( event, VALID_INPUT );
+
+		expect( mockReadFile ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns a server error on a non-ok anonymous response', async () => {
+		global.fetch = vi.fn( async () => ( { ok: false, status: 500 } ) as Response );
+
+		const result = await submitFeedback( event, VALID_INPUT );
+
+		expect( result ).toEqual( { success: false, error: 'server' } );
+	} );
+
+	it( 'returns a network error when the request throws', async () => {
+		global.fetch = vi.fn( async () => {
+			throw new Error( 'offline' );
+		} );
+
+		const result = await submitFeedback( event, VALID_INPUT );
+
+		expect( result ).toEqual( { success: false, error: 'network' } );
+	} );
+
+	it( 'lazily generates and persists an anonymous id when none exists', async () => {
+		vi.mocked( loadUserData ).mockResolvedValue( {} as never );
+
+		const result = await submitFeedback( event, VALID_INPUT );
+
+		expect( result ).toEqual( { success: true } );
+		expect( saveUserData ).toHaveBeenCalledWith(
+			expect.objectContaining( { sentryUserId: expect.any( String ) } )
+		);
+	} );
+} );

--- a/apps/studio/src/modules/user-settings/components/user-settings.tsx
+++ b/apps/studio/src/modules/user-settings/components/user-settings.tsx
@@ -7,6 +7,7 @@ import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { FeedbackForm } from 'src/modules/feedback';
 import { McpSettings } from 'src/modules/mcp/components/mcp-settings';
 import { AccountTab } from 'src/modules/user-settings/components/account-tab';
 import { PreferencesTab } from 'src/modules/user-settings/components/preferences-tab';
@@ -94,6 +95,11 @@ export default function UserSettings() {
 			title: __( 'MCP' ),
 		} );
 
+		result.push( {
+			name: 'feedback',
+			title: __( 'Feedback' ),
+		} );
+
 		return result;
 	}, [ __ ] );
 
@@ -121,6 +127,16 @@ export default function UserSettings() {
 								{ name === 'general' && <PreferencesTab onClose={ resetLocalState } /> }
 								{ name === 'skills' && <SkillsTab /> }
 								{ name === 'mcp' && <McpSettings /> }
+								{ name === 'feedback' && (
+									<FeedbackForm
+										identity={ {
+											isAuthenticated: !! user,
+											email: user?.email,
+											displayName: user?.displayName,
+										} }
+										source="settings"
+									/>
+								) }
 								{ name === 'account' && (
 									<AccountTab
 										loadingDeletingAllSnapshots={ isDeletingAllSnapshots }

--- a/apps/studio/src/modules/user-settings/components/user-settings.tsx
+++ b/apps/studio/src/modules/user-settings/components/user-settings.tsx
@@ -7,7 +7,6 @@ import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { FeedbackForm } from 'src/modules/feedback';
 import { McpSettings } from 'src/modules/mcp/components/mcp-settings';
 import { AccountTab } from 'src/modules/user-settings/components/account-tab';
 import { PreferencesTab } from 'src/modules/user-settings/components/preferences-tab';
@@ -95,11 +94,6 @@ export default function UserSettings() {
 			title: __( 'MCP' ),
 		} );
 
-		result.push( {
-			name: 'feedback',
-			title: __( 'Feedback' ),
-		} );
-
 		return result;
 	}, [ __ ] );
 
@@ -127,16 +121,6 @@ export default function UserSettings() {
 								{ name === 'general' && <PreferencesTab onClose={ resetLocalState } /> }
 								{ name === 'skills' && <SkillsTab /> }
 								{ name === 'mcp' && <McpSettings /> }
-								{ name === 'feedback' && (
-									<FeedbackForm
-										identity={ {
-											isAuthenticated: !! user,
-											email: user?.email,
-											displayName: user?.displayName,
-										} }
-										source="settings"
-									/>
-								) }
 								{ name === 'account' && (
 									<AccountTab
 										loadingDeletingAllSnapshots={ isDeletingAllSnapshots }

--- a/apps/studio/src/modules/user-settings/user-settings-types.ts
+++ b/apps/studio/src/modules/user-settings/user-settings-types.ts
@@ -1,4 +1,4 @@
-export type UserSettingsTabName = 'general' | 'skills' | 'account' | 'mcp';
+export type UserSettingsTabName = 'general' | 'skills' | 'account' | 'mcp' | 'feedback';
 export type UserSettingsTab = {
 	name: UserSettingsTabName;
 	title: string;

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -220,6 +220,8 @@ const api: IpcApi = {
 	setSessionEnvironment: ( sessionId, environment ) =>
 		ipcRendererInvoke( 'setSessionEnvironment', sessionId, environment ),
 	fetchSiteRestApi: ( siteId, request ) => ipcRendererInvoke( 'fetchSiteRestApi', siteId, request ),
+	submitFeedback: ( input ) => ipcRendererInvoke( 'submitFeedback', input ),
+	openApplicationLogs: () => ipcRendererSend( 'openApplicationLogs' ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );


### PR DESCRIPTION
> [!IMPORTANT]
> This is a PoC, meant more as a discussion starter than a merge-ready change. We can and should iterate on this idea before landing this.

## Related issues

- Related to 228442-ghe-Automattic/wpcom
- Related to pfHvTO-1Ad-p2

## How AI was used in this PR

I used Claude to iterate on the idea and to implement the client flow, the toolbar entry point, and the tests. I've reviewed the code myself and verified the full end-to-end round trip against my sandbox.

## Proposed Changes

Studio users hit errors and crashes while often logged out, so we have no reliable way to identify them or follow up. The only feedback paths today are external GitHub issue links in the Help menu and a "contact support" link on the crash screen — high friction, no logs, no identity, no way to close the loop with the reporter.

This PR adds a low-friction, in-app feedback flow, which posts a structured, identity-tagged payload (with optional app logs + diagnostics) to a WordPress.com backend.

- Entry points:
	- a button on the crash screen
	- a "Share Feedback…" item in the native Help menu
	- a "Send feedback" item in the toolbar Help dropdown
- Identity is resolved in the main process. The crash screen mounts the error boundary above the auth/Redux/i18n providers, so `useAuth()` and Redux hooks throw. The handler reads the auth token itself, and the renderer only sends user-authored content — so the same form works both in-app and on the crash screen.
- Optional logs & diagnostics (default on): a sanitized, tail-capped log tail can be sent to help with debugging

Reviewers should look most closely at the crash-screen provider handling, the default-ON logs toggle (privacy), and the identity/payload shape.

## Testing Instructions

Full end-to-end needs the backend endpoint, see the testing steps of 228442-ghe-Automattic/wpcom. You can still verify the UI and the outgoing request shape:

- Start Studio with `npm start`
- Open the feedback form three ways:
	- the toolbar Help button → Send feedback
	- the native Help menu → Share Feedback…
	- simulate a crash using the "Test Render Failure" menu item, then Share feedback button on the crash screen
- Confirm the form renders in both light and dark mode, check the logs-checkbox default and the "View logs" link
- With the backend available (or a stubbed endpoint), submit and confirm a `200` and that the payload carries the expected identity + metadata

| Screen | Screenshot |
|--------|--------|
| Toolbar entry point | <img width="550" height="314" alt="CleanShot 2026-07-15 at 16 18 24@2x" src="https://github.com/user-attachments/assets/86a7a5e8-a32c-4fac-bf22-8827fee54df4" /> | 
| Help menu entry point | <img width="748" height="488" alt="CleanShot 2026-07-15 at 16 18 38@2x" src="https://github.com/user-attachments/assets/454cced0-c9b4-4cf8-b34d-aef348581a48" /> | 
| Crash screen entry point | <img width="1864" height="1424" alt="CleanShot 2026-07-15 at 16 19 28@2x" src="https://github.com/user-attachments/assets/633916cb-0ac3-48f9-bdb9-49a6e91f1d54" /> | 
| Logged-in modal | <img width="1136" height="858" alt="CleanShot 2026-07-15 at 16 18 06@2x" src="https://github.com/user-attachments/assets/e56355b5-7c6b-4d2a-9c5d-172259d4bbb2" /> | 
| Logged-out modal | <img width="1138" height="1014" alt="CleanShot 2026-07-15 at 16 23 01@2x" src="https://github.com/user-attachments/assets/134072ec-2a8d-44e6-ac70-a7f9df9aa8b0" /> |