### PR TITLE
Let users steer a running Studio Code turn by typing mid-turn

### DIFF
--- a/apps/cli/ai/eval-runner.ts
+++ b/apps/cli/ai/eval-runner.ts
@@ -39,6 +39,16 @@ import type { AiProviderId } from 'cli/ai/providers';
 // Optional fixtures a test can pre-seed before the agent turn, so flows that
 // depend on connected remote sites and/or preview sites can be exercised
 // deterministically and offline (no real WordPress.com connection/preview).
+// Optional mid-turn steering instruction: after `afterToolResults` tool
+// results have come back, the runner delivers `text` to the running turn via
+// the turn handle's steer() (feature-detected, so builds without steering
+// support report `supported: false` instead of crashing).
+const evalSteerSchema = z.object( {
+	text: z.string(),
+	afterToolResults: z.number().int().min( 1 ).default( 2 ),
+} );
+type EvalSteer = z.infer< typeof evalSteerSchema >;
+
 const evalSeedSchema = z.object( {
 	localSite: z
 		.object( {
@@ -60,6 +70,10 @@ interface EvalRunnerInput {
 	timeoutMs?: number;
 	model?: AiModelId;
 	seed?: EvalSeed;
+	steer?: EvalSteer;
+	// Registers desks widget tools (studio_present) as if a Studio UI were
+	// attached, so widget-presentation behavior can be evaluated headless.
+	forceChatArtifacts?: boolean;
 }
 
 /**
@@ -217,11 +231,18 @@ function readInput(): EvalRunnerInput {
 		seed = evalSeedSchema.parse( vars.seed );
 	}
 
+	let steer: EvalSteer | undefined;
+	if ( vars.steer ) {
+		steer = evalSteerSchema.parse( vars.steer );
+	}
+
 	return {
 		prompt: ( vars.prompt as string ) ?? prompt,
 		timeoutMs: typeof vars.timeoutMs === 'number' ? vars.timeoutMs : undefined,
 		model,
 		seed,
+		steer,
+		forceChatArtifacts: vars.forceChatArtifacts === true,
 	};
 }
 
@@ -250,6 +271,9 @@ async function runEval( input: EvalRunnerInput ) {
 	};
 	// Allow running inside a Claude Code session
 	delete env.CLAUDECODE;
+	if ( input.forceChatArtifacts ) {
+		env.STUDIO_FORCE_CHAT_ARTIFACTS = '1';
+	}
 
 	const toolCalls: ToolCallRecord[] = [];
 	const toolResults: {
@@ -263,6 +287,11 @@ async function runEval( input: EvalRunnerInput ) {
 	const toolNameById = new Map< string, string >();
 	const toolEventById = new Map< string, ToolEvent >();
 	let firstToolError: FirstToolError | null = null;
+	let toolResultCount = 0;
+	const steerState: { requested: boolean; supported: boolean; delivered: boolean } | null =
+		input.steer ? { requested: true, supported: false, delivered: false } : null;
+	let steerPromise: Promise< void > | null = null;
+	let steerHandle: { steer?: ( text: string ) => Promise< boolean > } | null = null;
 	// Wall-clock per turn, measured between successive assistant messages.
 	const turnDurationsMs: number[] = [];
 	let turnIndex = 0;
@@ -315,6 +344,28 @@ async function runEval( input: EvalRunnerInput ) {
 		textSegments.push( ...extractTextSegments( event ) );
 
 		if ( event.type === 'tool_execution_end' ) {
+			toolResultCount += 1;
+			if (
+				input.steer &&
+				steerState &&
+				! steerPromise &&
+				toolResultCount >= input.steer.afterToolResults
+			) {
+				const steerFn = steerHandle?.steer;
+				if ( typeof steerFn === 'function' ) {
+					steerState.supported = true;
+					steerPromise = steerFn.call( steerHandle, input.steer.text ).then(
+						( delivered ) => {
+							steerState.delivered = delivered === true;
+						},
+						() => {
+							steerState.delivered = false;
+						}
+					);
+				} else {
+					steerPromise = Promise.resolve();
+				}
+			}
 			const tr = extractToolResult( event );
 			if ( tr ) {
 				const id = tr.toolUseId;
@@ -362,6 +413,7 @@ async function runEval( input: EvalRunnerInput ) {
 		onEvent: handleEvent,
 		...( input.model ? { model: input.model } : {} ),
 	} );
+	steerHandle = query as unknown as { steer?: ( text: string ) => Promise< boolean > };
 	phaseTimingsMs.start_ai_agent_ms = Date.now() - phaseStartedAt;
 
 	const timeout = setTimeout( () => {
@@ -371,6 +423,9 @@ async function runEval( input: EvalRunnerInput ) {
 
 	try {
 		await query.result;
+		if ( steerPromise ) {
+			await steerPromise;
+		}
 	} catch ( caught ) {
 		error = caught instanceof Error ? caught.message : String( caught );
 	} finally {
@@ -394,6 +449,7 @@ async function runEval( input: EvalRunnerInput ) {
 		toolEvents,
 		firstToolError,
 		textSegments,
+		steer: steerState,
 	};
 }
 

--- a/apps/cli/ai/output-adapter.ts
+++ b/apps/cli/ai/output-adapter.ts
@@ -11,6 +11,9 @@ export interface AiOutputAdapter {
 	activeSite: SiteInfo | null;
 	onSiteSelected: ( ( site: SiteInfo ) => void ) | null;
 	onInterrupt: ( () => void ) | null;
+	// Deliver a mid-turn user message to the running agent. Resolves to false
+	// when no turn is live (the caller should stage the message instead).
+	onSteer: ( ( text: string ) => Promise< boolean > ) | null;
 
 	start(): void;
 	stop(): void;
@@ -44,6 +47,7 @@ export class JsonAdapter implements AiOutputAdapter {
 	activeSite: SiteInfo | null = null;
 	onSiteSelected: ( ( site: SiteInfo ) => void ) | null = null;
 	onInterrupt: ( () => void ) | null = null;
+	onSteer: ( ( text: string ) => Promise< boolean > ) | null = null;
 	onBeforeExit: ( () => Promise< void > ) | null = null;
 	permissionResponse: Record< string, string > | null = null;
 
@@ -58,12 +62,28 @@ export class JsonAdapter implements AiOutputAdapter {
 			return;
 		}
 		this.ipcMessageListener = ( message ) => {
-			if (
-				message &&
-				typeof message === 'object' &&
-				( message as { type?: string } ).type === 'interrupt'
-			) {
+			if ( ! message || typeof message !== 'object' ) {
+				return;
+			}
+			const typed = message as { type?: string; text?: unknown };
+			if ( typed.type === 'interrupt' ) {
 				this.onInterrupt?.();
+				return;
+			}
+			// Mid-turn user message from the desktop app. Always answer with a
+			// steer.result event so the sender can stage the message for the
+			// next turn when it arrived too late to reach the live one.
+			if ( typed.type === 'steer' && typeof typed.text === 'string' ) {
+				const text = typed.text;
+				void ( async () => {
+					const delivered = ( await this.onSteer?.( text ).catch( () => false ) ) ?? false;
+					emitEvent( {
+						type: 'steer.result',
+						timestamp: new Date().toISOString(),
+						delivered,
+						text,
+					} );
+				} )();
 			}
 		};
 		process.on( 'message', this.ipcMessageListener );

--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -304,7 +304,10 @@ async function createStudioAgentSession(
 	const model = buildModel( config.model, family, creds );
 	const isRemoteSite = Boolean( config.activeSite?.remote && config.activeSite?.wpcomSiteId );
 	const remoteSession = config.env.STUDIO_REMOTE_SESSION === '1';
-	const chatArtifactsEnabled = typeof process.send === 'function';
+	// STUDIO_FORCE_CHAT_ARTIFACTS lets headless harnesses (the eval runner)
+	// register the desks widget tools without a Studio UI attached over IPC.
+	const chatArtifactsEnabled =
+		typeof process.send === 'function' || config.env.STUDIO_FORCE_CHAT_ARTIFACTS === '1';
 
 	const systemPrompt = buildSystemPrompt(
 		isRemoteSite

--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -92,6 +92,11 @@ interface ResolvedStudioAgentTurnConfig extends StudioAgentTurnConfig {
 export interface StudioAgentTurnHandle {
 	result: Promise< void >;
 	interrupt(): Promise< void >;
+	// Deliver a user message to the running turn (pi injects it before the next
+	// LLM call). Returns false when no turn is actively streaming — e.g. the
+	// session is still being created or the run just ended — so the caller can
+	// stage the message for the next turn instead.
+	steer( text: string ): Promise< boolean >;
 }
 
 export function runStudioAgentTurn( config: StudioAgentTurnConfig ): StudioAgentTurnHandle {
@@ -119,6 +124,13 @@ export function runStudioAgentTurn( config: StudioAgentTurnConfig ): StudioAgent
 		async interrupt() {
 			controller.abort();
 			await activeSession?.abort();
+		},
+		async steer( text: string ) {
+			if ( ! activeSession?.isStreaming ) {
+				return false;
+			}
+			await activeSession.steer( text );
+			return true;
 		},
 	};
 }

--- a/apps/cli/ai/tests/output-adapter.test.ts
+++ b/apps/cli/ai/tests/output-adapter.test.ts
@@ -53,6 +53,47 @@ describe( 'JsonAdapter IPC messaging', () => {
 		expect( onInterrupt ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'forwards steer messages to onSteer and reports the delivery result', async () => {
+		const sendSpy = vi.fn( () => true );
+		( process as unknown as { send: typeof process.send } ).send =
+			sendSpy as unknown as typeof process.send;
+
+		const adapter = new JsonAdapter();
+		const onSteer = vi.fn().mockResolvedValue( true );
+		adapter.onSteer = onSteer;
+
+		adapter.start();
+		listeners[ 0 ]( { type: 'steer', text: 'make the hero darker' } );
+
+		await vi.waitFor( () =>
+			expect( sendSpy ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: 'steer.result',
+					delivered: true,
+					text: 'make the hero darker',
+				} )
+			)
+		);
+		expect( onSteer ).toHaveBeenCalledWith( 'make the hero darker' );
+	} );
+
+	it( 'reports steer messages as undelivered when no turn is live', async () => {
+		const sendSpy = vi.fn( () => true );
+		( process as unknown as { send: typeof process.send } ).send =
+			sendSpy as unknown as typeof process.send;
+
+		const adapter = new JsonAdapter();
+		adapter.start();
+
+		listeners[ 0 ]( { type: 'steer', text: 'too late' } );
+
+		await vi.waitFor( () =>
+			expect( sendSpy ).toHaveBeenCalledWith(
+				expect.objectContaining( { type: 'steer.result', delivered: false, text: 'too late' } )
+			)
+		);
+	} );
+
 	it( 'ignores unrelated IPC messages', () => {
 		const adapter = new JsonAdapter();
 		const onInterrupt = vi.fn();

--- a/apps/cli/ai/tests/pi-runtime.test.ts
+++ b/apps/cli/ai/tests/pi-runtime.test.ts
@@ -8,6 +8,9 @@ const mocks = vi.hoisted( () => ( {
 	createAgentSession: vi.fn(),
 	createdSessions: [] as FakeSession[],
 	nextEvents: null as AgentSessionEvent[] | null,
+	// When set, FakeSession.prompt() stays streaming until this resolves,
+	// letting tests exercise mid-turn behavior such as steering.
+	promptGate: null as Promise< void > | null,
 	studioRoot: '/tmp/studio-ai-pi-runtime',
 	configRoot: '/tmp/studio-ai-pi-runtime-config',
 } ) );
@@ -136,6 +139,8 @@ class FakeSession {
 	public state: { model: { id: string; provider: string }; messages: unknown[] };
 	public aborted = false;
 	public disposed = false;
+	public isStreaming = false;
+	public steered: string[] = [];
 
 	constructor( public options: CreateAgentSessionOptions ) {
 		this.state = {
@@ -153,11 +158,23 @@ class FakeSession {
 	}
 
 	async prompt( _text: string ): Promise< void > {
-		const events = mocks.nextEvents ?? DEFAULT_MOCK_EVENTS;
-		mocks.nextEvents = null;
-		for ( const event of events ) {
-			this.listener?.( event );
+		this.isStreaming = true;
+		try {
+			if ( mocks.promptGate ) {
+				await mocks.promptGate;
+			}
+			const events = mocks.nextEvents ?? DEFAULT_MOCK_EVENTS;
+			mocks.nextEvents = null;
+			for ( const event of events ) {
+				this.listener?.( event );
+			}
+		} finally {
+			this.isStreaming = false;
 		}
+	}
+
+	async steer( text: string ): Promise< void > {
+		this.steered.push( text );
 	}
 
 	async abort(): Promise< void > {
@@ -212,6 +229,7 @@ describe( 'pi runtime', () => {
 	beforeEach( () => {
 		mocks.createdSessions.length = 0;
 		mocks.nextEvents = null;
+		mocks.promptGate = null;
 		mocks.createAgentSession.mockReset();
 		mocks.createAgentSession.mockImplementation( async ( options: CreateAgentSessionOptions ) => {
 			const session = new FakeSession( options );
@@ -256,6 +274,37 @@ describe( 'pi runtime', () => {
 		expect( findAssistantText( events ) ).toBe( 'mocked openai response' );
 		const final = events[ events.length - 1 ];
 		expect( final.type ).toBe( 'agent_end' );
+	} );
+
+	it( 'steers a live turn and rejects steering once the turn is over', async () => {
+		let release!: () => void;
+		mocks.promptGate = new Promise< void >( ( resolve ) => {
+			release = resolve;
+		} );
+
+		const handle = runStudioAgentTurn( {
+			prompt: 'hello',
+			env: {
+				OPENAI_API_KEY: 'sk-test',
+				OPENAI_BASE_URL: 'https://proxy.example.com/v1',
+			},
+			model: 'gpt-5.6-sol',
+			session: newSession(),
+			onEvent: () => {},
+		} );
+
+		await vi.waitFor( () =>
+			expect( mocks.createdSessions[ 0 ]?.isStreaming ?? false ).toBe( true )
+		);
+
+		await expect( handle.steer( 'make the hero darker' ) ).resolves.toBe( true );
+		expect( mocks.createdSessions[ 0 ].steered ).toEqual( [ 'make the hero darker' ] );
+
+		release();
+		await handle.result;
+
+		await expect( handle.steer( 'too late' ) ).resolves.toBe( false );
+		expect( mocks.createdSessions[ 0 ].steered ).toEqual( [ 'make the hero darker' ] );
 	} );
 
 	it( 'advertises image input support so screenshot tool results can be analyzed', async () => {

--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -211,6 +211,64 @@ describe( 'AiChatUI interrupt handling', () => {
 	} );
 } );
 
+describe( 'AiChatUI mid-turn steering', () => {
+	function createStubUi() {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			submitMidTurn: ( text: string ) => void;
+			queuedPrompts: string[];
+			[ key: string ]: unknown;
+		};
+		ui.queuedPrompts = [];
+		ui.renderQueuedContainer = vi.fn();
+		ui.addUserMessage = vi.fn();
+		return ui;
+	}
+
+	it( 'delivers mid-turn input to the running agent when steering succeeds', async () => {
+		const ui = createStubUi();
+		const steerCallback = vi.fn().mockResolvedValue( true );
+		ui.steerCallback = steerCallback;
+
+		ui.submitMidTurn( 'make the hero darker' );
+
+		await vi.waitFor( () =>
+			expect( ui.addUserMessage ).toHaveBeenCalledWith( 'make the hero darker' )
+		);
+		expect( steerCallback ).toHaveBeenCalledWith( 'make the hero darker' );
+		expect( ui.queuedPrompts ).toEqual( [] );
+	} );
+
+	it( 'stages the prompt for the next turn when steering is rejected', async () => {
+		const ui = createStubUi();
+		ui.steerCallback = vi.fn().mockResolvedValue( false );
+
+		ui.submitMidTurn( 'add a contact page' );
+
+		await vi.waitFor( () => expect( ui.queuedPrompts ).toEqual( [ 'add a contact page' ] ) );
+		expect( ui.addUserMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stages the prompt when steering fails', async () => {
+		const ui = createStubUi();
+		ui.steerCallback = vi.fn().mockRejectedValue( new Error( 'boom' ) );
+
+		ui.submitMidTurn( 'add a contact page' );
+
+		await vi.waitFor( () => expect( ui.queuedPrompts ).toEqual( [ 'add a contact page' ] ) );
+		expect( ui.addUserMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stages the prompt when no steer callback is registered', () => {
+		const ui = createStubUi();
+		ui.steerCallback = null;
+
+		ui.submitMidTurn( 'add a contact page' );
+
+		expect( ui.queuedPrompts ).toEqual( [ 'add a contact page' ] );
+		expect( ui.addUserMessage ).not.toHaveBeenCalled();
+	} );
+} );
+
 describe( 'AiChatUI.handleEvent', () => {
 	beforeEach( () => {
 		vi.clearAllMocks();

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -306,6 +306,7 @@ export class AiChatUI implements AiOutputAdapter {
 	private loaderVisible = false;
 	private editorVisible = false;
 	private interruptCallback: ( () => void ) | null = null;
+	private steerCallback: ( ( text: string ) => Promise< boolean > ) | null = null;
 	private wasInterrupted = false;
 	private interruptionNoticeShown = false;
 	private usageCapReached = false;
@@ -492,12 +493,12 @@ export class AiChatUI implements AiOutputAdapter {
 				resolve( trimmed );
 				return;
 			}
-			// No waiter → we're mid-turn. Stage the prompt so it fires after
-			// the current run ends; `waitForInput` drains the head.
+			// No waiter → we're mid-turn. Steer the running agent when
+			// possible; otherwise stage the prompt so it fires after the
+			// current run ends (`waitForInput` drains the head).
 			if ( this._inAgentTurn ) {
-				this.queuedPrompts.push( trimmed );
 				this.editor.setText( '' );
-				this.renderQueuedContainer();
+				this.submitMidTurn( trimmed );
 			}
 		};
 		// Ctrl+C to exit, Escape to interrupt/close picker, arrow keys for picker
@@ -1191,6 +1192,34 @@ export class AiChatUI implements AiOutputAdapter {
 	set onInterrupt( fn: ( () => void ) | null ) {
 		this.interruptCallback = fn;
 		this.updateHints();
+	}
+
+	set onSteer( fn: ( ( text: string ) => Promise< boolean > ) | null ) {
+		this.steerCallback = fn;
+	}
+
+	// Deliver a mid-turn prompt to the running agent as a steering message.
+	// Falls back to staging it for the next turn when steering is unavailable
+	// or the delivery raced the end of the run.
+	private submitMidTurn( text: string ): void {
+		if ( ! this.steerCallback ) {
+			this.stagePrompt( text );
+			return;
+		}
+		void this.steerCallback( text )
+			.catch( () => false )
+			.then( ( delivered ) => {
+				if ( delivered ) {
+					this.addUserMessage( text );
+				} else {
+					this.stagePrompt( text );
+				}
+			} );
+	}
+
+	private stagePrompt( text: string ): void {
+		this.queuedPrompts.push( text );
+		this.renderQueuedContainer();
 	}
 
 	private requestInterrupt(): boolean {

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -566,6 +566,22 @@ export async function runCommand( options: {
 			void agentQuery.interrupt();
 		};
 
+		ui.onSteer = async ( text ) => {
+			const delivered = await agentQuery.steer( text );
+			if ( delivered ) {
+				// `source: 'prompt'` so replay and the desktop transcript render
+				// the steered message like any other user message.
+				await append( ( s ) =>
+					appendStudioEntry( s, 'studio.user_prompt', {
+						text,
+						source: 'prompt',
+						sitePath: site?.path,
+					} )
+				);
+			}
+			return delivered;
+		};
+
 		const consumeAgentTurnResult = agentQuery.result.catch( ( error ) => {
 			turnState.status = 'error';
 			// If the UI already surfaced a descriptive terminal error (e.g.
@@ -584,6 +600,9 @@ export async function runCommand( options: {
 		try {
 			await consumeAgentTurnResult;
 		} finally {
+			// Steering a finished turn must fail fast so the UI stages the
+			// message for the next turn instead.
+			ui.onSteer = null;
 			await append( ( s ) =>
 				appendStudioEntry( s, 'studio.turn_closed', { status: turnState.status } )
 			);

--- a/packages/common/ai/json-events.ts
+++ b/packages/common/ai/json-events.ts
@@ -37,6 +37,9 @@ export type JsonEvent =
 			} >;
 	  }
 	| { type: 'turn.started'; timestamp: string }
+	// Reply to a `steer` IPC message: whether the mid-turn user message reached
+	// the live turn. When false the sender should resend it as a normal prompt.
+	| { type: 'steer.result'; timestamp: string; delivered: boolean; text: string }
 	| {
 			type: 'turn.completed';
 			timestamp: string;

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -23,6 +23,7 @@ Run one named test with `npm run eval -- --filter-pattern "preview sites"` (rege
 - **jetpack-catchall-slideshow** — Agent reaches for Jetpack on a slideshow request. Asserts the generated page content uses a `jetpack/*` block (i.e. the catch-all rule fired instead of the agent falling back to raw HTML).
 - **differentiate-preview-vs-remote** — Regression for STU-1775. Seeds one connected WordPress.com remote site and one preview site for a local site, then asserts the `site_connected_remote_sites` and `preview_list` tools tag their output with a `type` discriminator (`wpcom-remote` / `preview`) and that the agent's prose keeps the two categories distinct (preview sites are never described as connected WordPress.com remote sites).
 - **section-uses-theme-palette** — Agent adds sections to a site that keeps its default theme. Asserts the section block markup colors are drawn from the theme palette (color-slug attributes like `{"backgroundColor":"accent-1"}` or `var(--wp--preset--color--*)` in CSS) rather than hardcoded hex values. `theme.json` is excluded from the hex check since a palette is legitimately defined there.
+- **mid-turn-steering-honored** — Set a `steer` var (`{ text, afterToolResults }`) and the runner delivers that message to the running turn via the handle's `steer()`. Asserts the message was delivered to the live run and that the steered instruction shows up in the built content.
 
 ## Adding tests
 

--- a/scripts/eval/promptfoo.config.yaml
+++ b/scripts/eval/promptfoo.config.yaml
@@ -531,3 +531,45 @@ tests:
             }
             return { pass: true, score: 1, reason: `sections colored from the theme palette (${paletteRefs} palette color ref(s)) with no hardcoded hex` };
           });
+
+  # A user message delivered mid-turn (via the turn handle's steer()) must
+  # reach the live run and change the produced content. The runner delivers
+  # the `steer.text` after `steer.afterToolResults` tool results.
+  - description: mid-turn steering message is delivered and honored in the built content
+    vars:
+      caseId: mid-turn-steering-honored
+      timeoutMs: 600000
+      askUserPolicy: allow_all
+      steer:
+        afterToolResults: 2
+        text: "Important change of plan: the About page's main heading must be exactly 'Steering Works'. Use that exact heading text."
+      prompt: |
+        First check if a site named "Eval Steering Site" exists using site_list.
+        If it does, delete it with site_delete so we start from a clean slate.
+        Do NOT touch any other site.
+
+        Then create a new site named "Eval Steering Site" and add an About page
+        with a main heading and one short paragraph about a fictional bakery.
+    assert:
+      - type: javascript
+        value: |
+          return import('node:fs').then(({ readFileSync }) => {
+            const marker = output.split(/\r?\n/).map(l => l.trim()).find(l => l.startsWith('EVAL_RUNNER_RESULT_FILE='));
+            if (!marker) return { pass: false, score: 0, reason: `no result-file marker on stdout; got: ${output.slice(0, 200)}` };
+            const d = JSON.parse(readFileSync(marker.slice('EVAL_RUNNER_RESULT_FILE='.length), 'utf8'));
+            const s = d.steer;
+            if (!s || !s.requested) return { pass: false, score: 0, reason: 'runner did not attempt steering (steer var missing?)' };
+            if (!s.supported) return { pass: false, score: 0, reason: 'this build has no steer() on the turn handle — mid-turn steering unsupported' };
+            if (!s.delivered) return { pass: false, score: 0, reason: 'steer() was available but the message did not reach the live turn' };
+            return { pass: true, score: 1, reason: 'steering message delivered to the live turn' };
+          });
+      - type: javascript
+        value: |
+          return import('node:fs').then(({ readFileSync }) => {
+            const marker = output.split(/\r?\n/).map(l => l.trim()).find(l => l.startsWith('EVAL_RUNNER_RESULT_FILE='));
+            if (!marker) return { pass: false, score: 0, reason: `no result-file marker on stdout; got: ${output.slice(0, 200)}` };
+            const d = JSON.parse(readFileSync(marker.slice('EVAL_RUNNER_RESULT_FILE='.length), 'utf8'));
+            const allInputs = JSON.stringify((d.toolCalls || []).map(c => c.input));
+            const honored = allInputs.includes('Steering Works');
+            return { pass: honored, score: honored ? 1 : 0, reason: honored ? "steered heading 'Steering Works' found in built content" : 'the steered heading never appeared in any tool input — instruction not honored' };
+          });


### PR DESCRIPTION
## Related issues

None — follow-up from comparing Studio Code's chat experience with other desktop AI agents. Companion to #4214 and #4215.

## How AI was used in this PR

Authored by Claude Code (Fable 5): the design, the implementation, and the tests. Reviewed by a human before opening.

## Proposed Changes

Some context first: Studio Code (the AI assistant in the Studio CLI and desktop app) works in turns. You type a request, the model works — often for minutes on a site build, calling tools, writing theme files — and then it hands control back. Under the hood the model loop is run by an agent library ("pi"), and Studio wraps each run in a turn handle that until now exposed exactly one control: interrupt (the Escape key).

That created a frustrating gap. If you're watching a build go sideways — wrong color, wrong direction — your options were to kill the whole turn and lose the in-flight work, or wait it out. Typing mid-turn just staged your message to run *after* the current turn finished, when the damage was already done.

The agent library actually supports a third option that we never wired up: **steering**. A steering message is slipped into the running conversation as a normal user message, right before the model's next thinking step. The model reads it and adjusts course without abandoning what it's doing — the same way you'd redirect a colleague mid-task instead of telling them to start over.

This PR connects that capability end to end:

- The turn handle gains a `steer(text)` call. It reports back whether the message actually reached the live run (a run that just ended can't be steered — the caller needs to know).
- In the terminal chat, typing while the agent works now steers it. Your message shows up in the transcript like any other, and the model reacts within its next step. If delivery loses the race with the end of the turn, the message falls back to the old behavior: staged and run as the next turn, so nothing you type is ever dropped.
- The desktop app talks to the CLI over a message channel, and that channel now accepts a `steer` message and always answers with a delivered/not-delivered result — so the desktop can adopt the same feature without guessing whether a late message got through. (The desktop's send-while-busy UI is a follow-up; this PR makes the CLI side ready.)
- Steered messages are recorded in the session log like typed prompts, so resumed sessions and the desktop transcript replay them in place.

One thing this PR deliberately does *not* decide in code: whether your mid-turn message means "change course", "also do this", or "how's it going?". That judgment lives with the model, and #4214 adds the instruction telling it how to make that call.

User impact: you can redirect a running build by just typing — no more choosing between Escape (lose the work) and waiting (watch it finish wrong).

## Remaining follow-ups

- **Desktop, main process (apps/studio):** when the user submits a message while a turn is running, forward it to the CLI child process as a `{ type: 'steer', text }` IPC message instead of holding it until the turn ends. The CLI side of this channel ships in this PR.
- **Desktop, renderer (apps/studio / apps/ui):** keep the chat input enabled during a running turn, render the steered message in the transcript immediately, and listen for the `steer.result` reply — when `delivered: false` comes back (the message lost the race with the turn ending), resend the text as a regular next-turn prompt so nothing is dropped.
- **CLI, terminal:** add a hint in the editor's hint bar (next to "esc to interrupt") advertising that typing mid-turn steers the agent — the feature works but is currently undiscoverable.
- **Telegram remote bridge:** evaluate routing mid-turn Telegram messages through `steer` as well; today they arrive as separate follow-up turns.
- **Prompt:** none — the instruction telling the model how to interpret a mid-turn message (change course vs. addition vs. status question) lands in #4214.

## Testing Instructions

- `npm test -- apps/cli/ai/tests/pi-runtime.test.ts apps/cli/ai/tests/ui.test.ts apps/cli/ai/tests/output-adapter.test.ts` — covers steering a live run, rejecting a finished one, the terminal fallback to staging, and the desktop message-channel round trip.
- Manual: `npm run cli:build && node apps/cli/dist/cli/main.mjs code`, ask for a site build, and while the agent is working type e.g. "make the hero section dark blue" and press Enter. The message should appear in the transcript and the agent should pick it up within a step or two, without restarting the build.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
