### PR TITLE
SSL: Fix macOS Trust Certificate button hidden for untrusted CAs

### DIFF
--- a/apps/cli/lib/certificate-manager.ts
+++ b/apps/cli/lib/certificate-manager.ts
@@ -177,7 +177,11 @@ export async function isRootCATrusted(): Promise< boolean > {
 		}
 	} else if ( process.platform === 'darwin' ) {
 		try {
-			await execFilePromise( 'security', [ 'verify-cert', '-r', CA_CERT_PATH, '-p', 'ssl' ] );
+			// Evaluate against the system trust store. Passing the CA as `-r`
+			// would make it its own trust anchor, so verification passes even
+			// when the cert isn't trusted in any keychain — hiding the Trust
+			// Certificate button. `-l` allows the self-signed CA as the leaf.
+			await execFilePromise( 'security', [ 'verify-cert', '-c', CA_CERT_PATH, '-p', 'ssl', '-l' ] );
 
 			return true;
 		} catch ( error ) {

--- a/apps/cli/lib/certificate-manager.ts
+++ b/apps/cli/lib/certificate-manager.ts
@@ -177,10 +177,6 @@ export async function isRootCATrusted(): Promise< boolean > {
 		}
 	} else if ( process.platform === 'darwin' ) {
 		try {
-			// Evaluate against the system trust store. Passing the CA as `-r`
-			// would make it its own trust anchor, so verification passes even
-			// when the cert isn't trusted in any keychain — hiding the Trust
-			// Certificate button. `-l` allows the self-signed CA as the leaf.
 			await execFilePromise( 'security', [ 'verify-cert', '-c', CA_CERT_PATH, '-p', 'ssl', '-l' ] );
 
 			return true;

--- a/apps/cli/lib/tests/certificate-manager.test.ts
+++ b/apps/cli/lib/tests/certificate-manager.test.ts
@@ -9,12 +9,6 @@ import sudo from '@vscode/sudo-prompt';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isRootCATrusted, trustRootCA } from 'cli/lib/certificate-manager';
 
-const { execFileMock } = vi.hoisted( () => ( { execFileMock: vi.fn() } ) );
-vi.mock( 'node:child_process', () => ( {
-	execFile: execFileMock,
-	default: { execFile: execFileMock },
-} ) );
-
 vi.mock( '@studio/common/lib/linux-trust-store', () => ( {
 	LINUX_TRUST_STORE_PATH: '/usr/local/share/ca-certificates/studio-ca.crt',
 	LINUX_NSS_NICKNAME: 'WordPress Studio CA',
@@ -112,44 +106,6 @@ describe( 'certificate-manager (Linux)', () => {
 			await expect( isRootCATrusted() ).resolves.toBe( false );
 			expect( mockedIsCATrustedOnLinux ).not.toHaveBeenCalled();
 			expect( mockedIsCAImportedInUserNssDbsLinux ).not.toHaveBeenCalled();
-		} );
-
-		describe( 'macOS', () => {
-			// Resolve or reject the promisified execFile via its trailing callback.
-			const stubExecFile = ( error?: Error ) => {
-				execFileMock.mockImplementation( ( ( ..._args: unknown[] ) => {
-					const cb = _args[ _args.length - 1 ] as ( e: Error | null, r: object ) => void;
-					cb( error ?? null, { stdout: '', stderr: '' } );
-				} ) as never );
-			};
-
-			beforeEach( () => {
-				setPlatform( 'darwin' );
-				execFileMock.mockReset();
-			} );
-
-			it( 'evaluates against the system trust store, not the CA as its own anchor', async () => {
-				stubExecFile();
-
-				await expect( isRootCATrusted() ).resolves.toBe( true );
-
-				const [ , args ] = execFileMock.mock.calls[ 0 ];
-				expect( args ).not.toContain( '-r' );
-				expect( args ).toEqual( [
-					'verify-cert',
-					'-c',
-					expect.stringContaining( 'studio-ca.crt' ),
-					'-p',
-					'ssl',
-					'-l',
-				] );
-			} );
-
-			it( 'returns false when the CA is not trusted by the system', async () => {
-				stubExecFile( new Error( 'CSSMERR_TP_NOT_TRUSTED' ) );
-
-				await expect( isRootCATrusted() ).resolves.toBe( false );
-			} );
 		} );
 	} );
 

--- a/apps/cli/lib/tests/certificate-manager.test.ts
+++ b/apps/cli/lib/tests/certificate-manager.test.ts
@@ -9,6 +9,12 @@ import sudo from '@vscode/sudo-prompt';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isRootCATrusted, trustRootCA } from 'cli/lib/certificate-manager';
 
+const { execFileMock } = vi.hoisted( () => ( { execFileMock: vi.fn() } ) );
+vi.mock( 'node:child_process', () => ( {
+	execFile: execFileMock,
+	default: { execFile: execFileMock },
+} ) );
+
 vi.mock( '@studio/common/lib/linux-trust-store', () => ( {
 	LINUX_TRUST_STORE_PATH: '/usr/local/share/ca-certificates/studio-ca.crt',
 	LINUX_NSS_NICKNAME: 'WordPress Studio CA',
@@ -106,6 +112,44 @@ describe( 'certificate-manager (Linux)', () => {
 			await expect( isRootCATrusted() ).resolves.toBe( false );
 			expect( mockedIsCATrustedOnLinux ).not.toHaveBeenCalled();
 			expect( mockedIsCAImportedInUserNssDbsLinux ).not.toHaveBeenCalled();
+		} );
+
+		describe( 'macOS', () => {
+			// Resolve or reject the promisified execFile via its trailing callback.
+			const stubExecFile = ( error?: Error ) => {
+				execFileMock.mockImplementation( ( ( ..._args: unknown[] ) => {
+					const cb = _args[ _args.length - 1 ] as ( e: Error | null, r: object ) => void;
+					cb( error ?? null, { stdout: '', stderr: '' } );
+				} ) as never );
+			};
+
+			beforeEach( () => {
+				setPlatform( 'darwin' );
+				execFileMock.mockReset();
+			} );
+
+			it( 'evaluates against the system trust store, not the CA as its own anchor', async () => {
+				stubExecFile();
+
+				await expect( isRootCATrusted() ).resolves.toBe( true );
+
+				const [ , args ] = execFileMock.mock.calls[ 0 ];
+				expect( args ).not.toContain( '-r' );
+				expect( args ).toEqual( [
+					'verify-cert',
+					'-c',
+					expect.stringContaining( 'studio-ca.crt' ),
+					'-p',
+					'ssl',
+					'-l',
+				] );
+			} );
+
+			it( 'returns false when the CA is not trusted by the system', async () => {
+				stubExecFile( new Error( 'CSSMERR_TP_NOT_TRUSTED' ) );
+
+				await expect( isRootCATrusted() ).resolves.toBe( false );
+			} );
 		} );
 	} );
 

--- a/apps/studio/src/lib/certificate-manager.ts
+++ b/apps/studio/src/lib/certificate-manager.ts
@@ -47,10 +47,6 @@ export async function isRootCATrusted(): Promise< boolean > {
 		}
 	} else if ( process.platform === 'darwin' ) {
 		try {
-			// Evaluate against the system trust store. Passing the CA as `-r`
-			// would make it its own trust anchor, so verification passes even
-			// when the cert isn't trusted in any keychain — hiding the Trust
-			// Certificate button. `-l` allows the self-signed CA as the leaf.
 			await execFilePromise( 'security', [ 'verify-cert', '-c', CA_CERT_PATH, '-p', 'ssl', '-l' ] );
 
 			return true;

--- a/apps/studio/src/lib/certificate-manager.ts
+++ b/apps/studio/src/lib/certificate-manager.ts
@@ -47,7 +47,11 @@ export async function isRootCATrusted(): Promise< boolean > {
 		}
 	} else if ( process.platform === 'darwin' ) {
 		try {
-			await execFilePromise( 'security', [ 'verify-cert', '-r', CA_CERT_PATH, '-p', 'ssl' ] );
+			// Evaluate against the system trust store. Passing the CA as `-r`
+			// would make it its own trust anchor, so verification passes even
+			// when the cert isn't trusted in any keychain — hiding the Trust
+			// Certificate button. `-l` allows the self-signed CA as the leaf.
+			await execFilePromise( 'security', [ 'verify-cert', '-c', CA_CERT_PATH, '-p', 'ssl', '-l' ] );
 
 			return true;
 		} catch ( error ) {


### PR DESCRIPTION
## Related issues

- Fixes STU-2053

## How AI was used in this PR

Claude wrote the code, guided by the author. The author tested it locally and manually reviewed it before pushing.

## Proposed Changes

On macOS, the Trust Certificate button disappeared after enabling HTTPS even when the certificate was not actually trusted, so the browser kept showing a security warning with no way to resolve it. The trust check validated the certificate against itself rather than the system Keychain, so it always reported success. It now evaluates against the real system trust store, so the button stays until the certificate is genuinely trusted.

## Testing Instructions

The bug reproduces only on macOS versions where `security verify-cert -r <ca> -p ssl` returns 0 for an untrusted certificate, so it may not appear on every Mac. To prove the fix deterministically, run the exact command the app uses in both trust states.

1. Check out this branch. 
2. Start the app
3. Enable HTTPS on a site so `~/.studio/certificates/studio-ca.crt` exists.
4. Now go to terminal and run following commands
5. Untrusted state, the fixed check must report not trusted:
   `security verify-cert -c ~/.studio/certificates/studio-ca.crt -p ssl -l; echo $?` returns `1`.
   In the app, the Trust Certificate button is shown.
6. Trust the certificate:
   `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/.studio/certificates/studio-ca.crt`
7. Trusted state, the fixed check must report trusted:
   `security verify-cert -c ~/.studio/certificates/studio-ca.crt -p ssl -l; echo $?` returns `0`.
   In the app, the button is hidden.
8. Regression: the Windows and Linux trust flows are untouched, so there is no behavior change there.

Tests: `npm test -- apps/cli/lib/tests/certificate-manager.test.ts` runs all 12 and they pass.

Reset (to re-test):

```bash
sudo security remove-trusted-cert -d ~/.studio/certificates/studio-ca.crt
sudo security delete-certificate -c "WordPress Studio CA" /Library/Keychains/System.keychain
```

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
