### PR TITLE
Add Linux to bug report Platform field and split out Architecture

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -86,10 +86,17 @@ body:
       label: Platform
       description: (You may select more than one)
       options:
-        - Mac Silicon
-        - Mac Intel
+        - Mac
         - Windows
+        - Linux
       multiple: true
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: Architecture
+      options:
+        - x64 (Intel, AMD)
+        - ARM64 (Apple Silicon, Windows or Linux on ARM)
   - type: textarea
     id: logs
     attributes:


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code drafted the template edits and iterated on the option wording; I reviewed the final labels for clarity and cross-platform coverage.

## Proposed Changes

The bug report form previously offered only `Mac Silicon`, `Mac Intel`, and `Windows` under a single **Platform** field, which both omitted Linux and conflated operating system with CPU architecture.

- **Platform** is now a clean OS selector: `Mac`, `Windows`, `Linux` (still multi-select), so reporters on Linux can accurately describe their environment.
- A dedicated **Architecture** field captures the CPU: `x64 (Intel, AMD)` and `ARM64 (Apple Silicon, Windows or Linux on ARM)`. The labels name the recognizable CPU families and cover ARM cases across all three platforms.

The result is more precise triage information without conflating the two dimensions.

## Testing Instructions

- Open the "New issue" flow on the repo (or preview `.github/ISSUE_TEMPLATE/bug_report.yml`) and confirm the **Platform** field lists `Mac`, `Windows`, `Linux` as a multi-select, and that a separate **Architecture** dropdown offers the two options above.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
