### PR TITLE
Point contributors to GlotPress for translations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,10 @@ Please see our [security policy](./SECURITY.md).
 
 If you find a bug or have a feature request, please [open an issue](https://github.com/Automattic/studio/issues/new/choose).
 
+### Translations
+
+Studio is translated using [GlotPress](https://translate.wordpress.com/projects/studio/). To correct an existing translation or help translate Studio into your language, submit your suggestions there.
+
 ### Code Contributions
 
 For information on setting up your development environment for contributing code, see the [Code Contributions](./docs/code-contributions.md).

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ We’d love to hear about your experience using Studio. If you have questions, s
 
 - Open a GitHub Issue to to [suggest ideas](https://github.com/Automattic/studio/issues/new?assignees=&labels=%5BType%5D+Feature+Request&projects=&template=feature_request.yml&title=Feature+Request%3A) or [report bugs](https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml)  
 - Submit pull requests for bug fixes and enhancements  
+- Help translate Studio into your language via [GlotPress](https://translate.wordpress.com/projects/studio/)  
 - Proposals for new features may require additional review and discussion
 
 For details, please see our [Contributing Guidelines](CONTRIBUTING.md) and [Code Contributions](docs/code-contributions.md) guide.


### PR DESCRIPTION
## Related issues

<!-- Reported in a GitHub discussion: a user testing the Linux release found translation issues and asked where to submit corrections. -->

- Related to translation-correction feedback from the community

## How AI was used in this PR

Used Claude Code to confirm that neither the README's "Give feedback and contribute" section nor CONTRIBUTING.md mentioned translations (GlotPress is only referenced in the internal `docs/localization.md` pipeline doc), and to draft the additions. Changes reviewed by me.

## Proposed Changes

A user testing Studio found translation strings they wanted to correct but had no clear path to do so — the contributor-facing docs never mentioned GlotPress. This adds a pointer to the [Studio GlotPress project](https://translate.wordpress.com/projects/studio/) in the two places contributors actually look:

- A bullet in the README's "Give feedback and contribute" list.
- A new "Translations" subsection in CONTRIBUTING.md.

Translators now have a discoverable entry point for submitting corrections and new translations.

## Testing Instructions

- Review the rendered Markdown in README.md and CONTRIBUTING.md and confirm the GlotPress links resolve to https://translate.wordpress.com/projects/studio/.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors? (N/A — docs-only change)