### PR TITLE
Make steering a running turn an explicit per-message choice

### DIFF
--- a/apps/cli/ai/output-adapter.ts
+++ b/apps/cli/ai/output-adapter.ts
@@ -65,16 +65,19 @@ export class JsonAdapter implements AiOutputAdapter {
 			if ( ! message || typeof message !== 'object' ) {
 				return;
 			}
-			const typed = message as { type?: string; text?: unknown };
+			const typed = message as { type?: string; text?: unknown; id?: unknown };
 			if ( typed.type === 'interrupt' ) {
 				this.onInterrupt?.();
 				return;
 			}
 			// Mid-turn user message from the desktop app. Always answer with a
 			// steer.result event so the sender can stage the message for the
-			// next turn when it arrived too late to reach the live one.
+			// next turn when it arrived too late to reach the live one. The
+			// optional id is echoed back so the sender can match the result to
+			// the exact message it sent (the same text can be steered twice).
 			if ( typed.type === 'steer' && typeof typed.text === 'string' ) {
 				const text = typed.text;
+				const id = typeof typed.id === 'string' ? typed.id : undefined;
 				void ( async () => {
 					const delivered = ( await this.onSteer?.( text ).catch( () => false ) ) ?? false;
 					emitEvent( {
@@ -82,6 +85,7 @@ export class JsonAdapter implements AiOutputAdapter {
 						timestamp: new Date().toISOString(),
 						delivered,
 						text,
+						...( id !== undefined ? { id } : {} ),
 					} );
 				} )();
 			}

--- a/apps/cli/ai/sessions/replay.ts
+++ b/apps/cli/ai/sessions/replay.ts
@@ -46,7 +46,14 @@ export function replaySessionHistory( ui: AiChatUI, entries: SessionEntry[] ): v
 
 			if ( isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ) {
 				const data = entry.data;
-				if ( ! data || data.source !== 'prompt' ) continue;
+				if ( ! data ) continue;
+				// A steered message landed inside a live turn, so it renders in
+				// place without closing or opening one.
+				if ( data.source === 'steer' ) {
+					ui.addUserMessage( data.text );
+					continue;
+				}
+				if ( data.source !== 'prompt' ) continue;
 				if ( isTurnOpen ) {
 					flushPendingResults();
 					ui.endAgentTurn();

--- a/apps/cli/ai/sessions/tests/replay.test.ts
+++ b/apps/cli/ai/sessions/tests/replay.test.ts
@@ -81,4 +81,34 @@ describe( 'replaySessionHistory', () => {
 		expect( ui.endAgentTurn ).toHaveBeenCalledTimes( 1 );
 		expect( ui.finishReplay ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'replays steered messages inside the turn without opening a new one', () => {
+		const ui = createUiSpy();
+		const entries: SessionEntry[] = [
+			{
+				type: 'custom',
+				customType: 'studio.user_prompt',
+				timestamp: '2026-06-01T00:00:00.000Z',
+				data: { source: 'prompt', text: 'Create a landing page' },
+			} as SessionEntry,
+			{
+				type: 'custom',
+				customType: 'studio.user_prompt',
+				timestamp: '2026-06-01T00:00:01.000Z',
+				data: { source: 'steer', text: 'Make the hero darker' },
+			} as SessionEntry,
+			{
+				type: 'custom',
+				customType: 'studio.turn_closed',
+				timestamp: '2026-06-01T00:00:02.000Z',
+				data: { status: 'success' },
+			} as SessionEntry,
+		];
+
+		replaySessionHistory( ui as unknown as AiChatUI, entries );
+
+		expect( ui.addUserMessage ).toHaveBeenNthCalledWith( 1, 'Create a landing page' );
+		expect( ui.addUserMessage ).toHaveBeenNthCalledWith( 2, 'Make the hero darker' );
+		expect( ui.beginAgentTurn ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -31,6 +31,8 @@ export function buildSystemPrompt( options?: BuildSystemPromptOptions ): string 
 	if ( options?.remoteSite ) {
 		return `${ buildRemoteIntro( options.remoteSite ) }
 
+${ MID_TURN_MESSAGE_GUIDANCE }
+
 ${ REMOTE_CONTENT_GUIDELINES }
 
 ${ REMOTE_DESIGN_GUIDELINES }${ remoteSessionAddendum }
@@ -43,9 +45,16 @@ ${ REMOTE_DESIGN_GUIDELINES }${ remoteSessionAddendum }
 		runtime: options?.runtime,
 	} ) }
 
+${ MID_TURN_MESSAGE_GUIDANCE }
+
 ${ LOCAL_SKILL_ROUTING }${ remoteSessionAddendum }
 `;
 }
+
+// Users can deliver a message into a running turn (steering); without this
+// rule the model sometimes treats one as a brand-new request and starts the
+// whole task over.
+const MID_TURN_MESSAGE_GUIDANCE = `A user message that arrives while you are working is a course correction or an addition to the current task: apply it right away, keep the parts of the task it does not affect, and never restart completed work because of it.`;
 
 function buildRemoteIntro( site: RemoteSiteContext ): string {
 	return `${ AGENT_IDENTITY } You manage WordPress.com sites using the WordPress.com REST API.

--- a/apps/cli/ai/tests/output-adapter.test.ts
+++ b/apps/cli/ai/tests/output-adapter.test.ts
@@ -77,6 +77,29 @@ describe( 'JsonAdapter IPC messaging', () => {
 		expect( onSteer ).toHaveBeenCalledWith( 'make the hero darker' );
 	} );
 
+	it( 'echoes the steer correlation id in the result', async () => {
+		const sendSpy = vi.fn( () => true );
+		( process as unknown as { send: typeof process.send } ).send =
+			sendSpy as unknown as typeof process.send;
+
+		const adapter = new JsonAdapter();
+		adapter.onSteer = vi.fn().mockResolvedValue( true );
+
+		adapter.start();
+		listeners[ 0 ]( { type: 'steer', text: 'make the hero darker', id: 'steer-42' } );
+
+		await vi.waitFor( () =>
+			expect( sendSpy ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: 'steer.result',
+					delivered: true,
+					text: 'make the hero darker',
+					id: 'steer-42',
+				} )
+			)
+		);
+	} );
+
 	it( 'reports steer messages as undelivered when no turn is live', async () => {
 		const sendSpy = vi.fn( () => true );
 		( process as unknown as { send: typeof process.send } ).send =

--- a/apps/cli/ai/tests/system-prompt.test.ts
+++ b/apps/cli/ai/tests/system-prompt.test.ts
@@ -52,6 +52,16 @@ describe( 'buildSystemPrompt', () => {
 		expect( prompt ).toContain( '- pdf:' );
 	} );
 
+	it( 'tells the model to treat mid-turn messages as course corrections in both variants', () => {
+		const localPrompt = buildSystemPrompt( { chatArtifactsEnabled: true } );
+		const remotePrompt = buildSystemPrompt( { remoteSite } );
+
+		for ( const prompt of [ localPrompt, remotePrompt ] ) {
+			expect( prompt ).toContain( 'while you are working' );
+			expect( prompt ).toContain( 'never restart completed work' );
+		}
+	} );
+
 	it( 'routes plugin-specific feature work to the plugin recommendations skill', () => {
 		const prompt = buildSystemPrompt( { chatArtifactsEnabled: true } );
 

--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -215,6 +215,9 @@ describe( 'AiChatUI mid-turn steering', () => {
 	function createStubUi() {
 		const ui = Object.create( AiChatUI.prototype ) as {
 			submitMidTurn: ( text: string ) => void;
+			submitPrompt: ( text: string ) => void;
+			steerFromEditor: () => boolean;
+			updateHints: () => void;
 			queuedPrompts: string[];
 			[ key: string ]: unknown;
 		};
@@ -266,6 +269,110 @@ describe( 'AiChatUI mid-turn steering', () => {
 
 		expect( ui.queuedPrompts ).toEqual( [ 'add a contact page' ] );
 		expect( ui.addUserMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'queues a plain mid-turn submit even when steering is available', () => {
+		const ui = createStubUi();
+		const editor = { addToHistory: vi.fn(), setText: vi.fn() };
+		const steerCallback = vi.fn();
+		ui.steerCallback = steerCallback;
+		ui._inAgentTurn = true;
+		ui.submitResolve = null;
+		ui.editor = editor;
+
+		ui.submitPrompt( 'add a contact page' );
+
+		expect( ui.queuedPrompts ).toEqual( [ 'add a contact page' ] );
+		expect( steerCallback ).not.toHaveBeenCalled();
+		expect( editor.setText ).toHaveBeenCalledWith( '' );
+	} );
+
+	it( 'resolves a waiting prompt instead of queueing when not mid-turn', () => {
+		const ui = createStubUi();
+		const resolve = vi.fn();
+		ui.submitResolve = resolve;
+		ui._inAgentTurn = false;
+		ui.editor = { addToHistory: vi.fn(), setText: vi.fn() };
+
+		ui.submitPrompt( ' build a bakery site ' );
+
+		expect( resolve ).toHaveBeenCalledWith( 'build a bakery site' );
+		expect( ui.queuedPrompts ).toEqual( [] );
+	} );
+
+	it( 'steers the drafted prompt on the explicit gesture', async () => {
+		const ui = createStubUi();
+		const steerCallback = vi.fn().mockResolvedValue( true );
+		const editor = {
+			getText: () => ' make the hero darker ',
+			addToHistory: vi.fn(),
+			setText: vi.fn(),
+		};
+		ui.steerCallback = steerCallback;
+		ui._inAgentTurn = true;
+		ui.editorVisible = true;
+		ui.editor = editor;
+
+		expect( ui.steerFromEditor() ).toBe( true );
+
+		await vi.waitFor( () =>
+			expect( ui.addUserMessage ).toHaveBeenCalledWith( 'make the hero darker' )
+		);
+		expect( steerCallback ).toHaveBeenCalledWith( 'make the hero darker' );
+		expect( editor.addToHistory ).toHaveBeenCalledWith( 'make the hero darker' );
+		expect( editor.setText ).toHaveBeenCalledWith( '' );
+	} );
+
+	it( 'does not consume the steer gesture outside an agent turn', () => {
+		const ui = createStubUi();
+		const steerCallback = vi.fn();
+		ui.steerCallback = steerCallback;
+		ui._inAgentTurn = false;
+		ui.editorVisible = true;
+		ui.editor = { getText: () => 'hello', addToHistory: vi.fn(), setText: vi.fn() };
+
+		expect( ui.steerFromEditor() ).toBe( false );
+		expect( steerCallback ).not.toHaveBeenCalled();
+	} );
+
+	it( 'consumes the steer gesture without steering when the draft is empty', () => {
+		const ui = createStubUi();
+		const steerCallback = vi.fn();
+		ui.steerCallback = steerCallback;
+		ui._inAgentTurn = true;
+		ui.editorVisible = true;
+		ui.editor = { getText: () => '  ', addToHistory: vi.fn(), setText: vi.fn() };
+
+		expect( ui.steerFromEditor() ).toBe( true );
+		expect( steerCallback ).not.toHaveBeenCalled();
+	} );
+
+	it( 'advertises the steer gesture while a turn can be steered', () => {
+		const ui = createStubUi();
+		const editor = { hints: [] as string[] };
+		ui.editor = editor;
+		ui.steerCallback = vi.fn();
+		ui._inAgentTurn = true;
+		ui.interruptCallback = vi.fn();
+		ui.activeExpandablePreview = null;
+
+		ui.updateHints();
+
+		expect( editor.hints ).toContain( 'alt+enter to steer' );
+	} );
+
+	it( 'does not advertise the steer gesture when steering is unavailable', () => {
+		const ui = createStubUi();
+		const editor = { hints: [] as string[] };
+		ui.editor = editor;
+		ui.steerCallback = null;
+		ui._inAgentTurn = true;
+		ui.interruptCallback = vi.fn();
+		ui.activeExpandablePreview = null;
+
+		ui.updateHints();
+
+		expect( editor.hints ).not.toContain( 'alt+enter to steer' );
 	} );
 } );
 

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -481,26 +481,7 @@ export class AiChatUI implements AiOutputAdapter {
 			new DescriptionAwareAutocompleteProvider( getActiveSlashCommands(), process.cwd() )
 		);
 
-		this.editor.onSubmit = ( text ) => {
-			const trimmed = text.trim();
-			if ( ! trimmed ) {
-				return;
-			}
-			this.editor.addToHistory( trimmed );
-			if ( this.submitResolve ) {
-				const resolve = this.submitResolve;
-				this.submitResolve = null;
-				resolve( trimmed );
-				return;
-			}
-			// No waiter → we're mid-turn. Steer the running agent when
-			// possible; otherwise stage the prompt so it fires after the
-			// current run ends (`waitForInput` drains the head).
-			if ( this._inAgentTurn ) {
-				this.editor.setText( '' );
-				this.submitMidTurn( trimmed );
-			}
-		};
+		this.editor.onSubmit = ( text ) => this.submitPrompt( text );
 		// Ctrl+C to exit, Escape to interrupt/close picker, arrow keys for picker
 		this.tui.addInputListener( ( data ) => {
 			// Ignore key release events (Kitty protocol sends press + release)
@@ -609,6 +590,11 @@ export class AiChatUI implements AiOutputAdapter {
 				// Forward remaining input (up/down/enter) to SelectList
 				this.sitePickerSelectList.handleInput( data );
 				this.renderSitePicker();
+				return { consume: true };
+			}
+			// Alt+Enter sends the drafted prompt to the running agent as a
+			// steering message; plain Enter queues it for the next turn.
+			if ( matchesKey( data, 'alt+enter' ) && this.steerFromEditor() ) {
 				return { consume: true };
 			}
 			// Backspace on an empty editor pops the most recent queued prompt.
@@ -1196,6 +1182,44 @@ export class AiChatUI implements AiOutputAdapter {
 
 	set onSteer( fn: ( ( text: string ) => Promise< boolean > ) | null ) {
 		this.steerCallback = fn;
+		this.updateHints();
+	}
+
+	private submitPrompt( text: string ): void {
+		const trimmed = text.trim();
+		if ( ! trimmed ) {
+			return;
+		}
+		this.editor.addToHistory( trimmed );
+		if ( this.submitResolve ) {
+			const resolve = this.submitResolve;
+			this.submitResolve = null;
+			resolve( trimmed );
+			return;
+		}
+		// No waiter → we're mid-turn. Stage the prompt so it fires after the
+		// current run ends (`waitForInput` drains the head). Reaching the live
+		// run instead requires the explicit alt+enter gesture.
+		if ( this._inAgentTurn ) {
+			this.editor.setText( '' );
+			this.stagePrompt( trimmed );
+		}
+	}
+
+	// Alt+Enter mid-turn: submit the drafted prompt as a steering message.
+	// Returns whether the gesture was consumed; outside a turn it falls
+	// through so the key keeps its default (no-op) behavior.
+	private steerFromEditor(): boolean {
+		if ( ! this._inAgentTurn ) {
+			return false;
+		}
+		const text = this.editor.getText().trim();
+		if ( text ) {
+			this.editor.addToHistory( text );
+			this.editor.setText( '' );
+			this.submitMidTurn( text );
+		}
+		return true;
 	}
 
 	// Deliver a mid-turn prompt to the running agent as a steering message.
@@ -1382,6 +1406,9 @@ export class AiChatUI implements AiOutputAdapter {
 		}
 		if ( this.interruptCallback ) {
 			hints.push( __( 'esc to interrupt' ) );
+		}
+		if ( this.steerCallback && this._inAgentTurn ) {
+			hints.push( __( 'alt+enter to steer' ) );
 		}
 		this.editor.hints = hints;
 	}

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -569,12 +569,12 @@ export async function runCommand( options: {
 		ui.onSteer = async ( text ) => {
 			const delivered = await agentQuery.steer( text );
 			if ( delivered ) {
-				// `source: 'prompt'` so replay and the desktop transcript render
-				// the steered message like any other user message.
+				// `source: 'steer'` so replay and the transcripts render the
+				// message in place without treating it as a turn boundary.
 				await append( ( s ) =>
 					appendStudioEntry( s, 'studio.user_prompt', {
 						text,
-						source: 'prompt',
+						source: 'steer',
 						sitePath: site?.path,
 					} )
 				);

--- a/apps/studio/src/components/studio-code-session/conversation/index.test.tsx
+++ b/apps/studio/src/components/studio-code-session/conversation/index.test.tsx
@@ -89,6 +89,21 @@ function toolResultEntry( text: string ): SessionEntry {
 	} as unknown as SessionEntry;
 }
 
+describe( 'entriesToRenderItems – steered prompts', () => {
+	it( 'renders steered mid-turn messages as user prompts', () => {
+		const items = entriesToRenderItems( [
+			prompt( 'Build a bakery site' ),
+			customEntry( 'studio.user_prompt', { text: 'make the hero darker', source: 'steer' } ),
+		] );
+
+		const userTexts = items.filter( ( item ) => item.kind === 'user-text' );
+		expect( userTexts.map( ( item ) => ( item as { text: string } ).text ) ).toEqual( [
+			'Build a bakery site',
+			'make the hero darker',
+		] );
+	} );
+} );
+
 describe( 'entriesToRenderItems – persisted picked answers', () => {
 	it( 'pairs a question with its persisted ask_user answer', () => {
 		const items = entriesToRenderItems( [ question( 'Pick one', [ 'A', 'B' ] ), answer( 'B' ) ] );

--- a/apps/studio/src/components/studio-code-session/conversation/index.tsx
+++ b/apps/studio/src/components/studio-code-session/conversation/index.tsx
@@ -160,7 +160,7 @@ export function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {
 
 		if ( isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ) {
 			const data = ( entry as StudioCustomEntry< 'studio.user_prompt' > ).data;
-			if ( ! data || data.source !== 'prompt' ) return;
+			if ( ! data || ( data.source !== 'prompt' && data.source !== 'steer' ) ) return;
 			items.push( {
 				kind: 'user-text',
 				key: `${ entryIndex }:user`,

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
@@ -286,6 +286,22 @@ describe( 'Conversation chat artifacts', () => {
 		}
 	} );
 
+	it( 'renders steered mid-turn messages as user prompts', () => {
+		const steered = {
+			type: 'custom',
+			id: 'steer-1',
+			parentId: null,
+			timestamp: '2026-06-05T12:00:02.000Z',
+			customType: 'studio.user_prompt',
+			data: { text: 'make the hero darker', source: 'steer' },
+		} as unknown as SessionEntry;
+
+		const items = entriesToRenderItems( [ steered ] );
+
+		expect( items ).toHaveLength( 1 );
+		expect( items[ 0 ] ).toMatchObject( { kind: 'user-text', text: 'make the hero darker' } );
+	} );
+
 	it( 'drops local-only media widgets when the connector cannot read local files', () => {
 		const localOnly = chatArtifactEntry( [ localScreenshotWidget() ] );
 		const remote = chatArtifactEntry( [

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -233,7 +233,7 @@ export function entriesToRenderItems(
 		const entry = entries[ entryIndex ];
 		if ( isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ) {
 			const data = ( entry as StudioCustomEntry< 'studio.user_prompt' > ).data;
-			if ( ! data || data.source !== 'prompt' ) continue;
+			if ( ! data || ( data.source !== 'prompt' && data.source !== 'steer' ) ) continue;
 			items.push( {
 				kind: 'user-text',
 				key: `${ entryIndex }:user`,

--- a/packages/common/ai/json-events.ts
+++ b/packages/common/ai/json-events.ts
@@ -39,7 +39,8 @@ export type JsonEvent =
 	| { type: 'turn.started'; timestamp: string }
 	// Reply to a `steer` IPC message: whether the mid-turn user message reached
 	// the live turn. When false the sender should resend it as a normal prompt.
-	| { type: 'steer.result'; timestamp: string; delivered: boolean; text: string }
+	// `id` echoes the sender-chosen correlation id from the `steer` message.
+	| { type: 'steer.result'; timestamp: string; delivered: boolean; text: string; id?: string }
 	| {
 			type: 'turn.completed';
 			timestamp: string;

--- a/packages/common/ai/run-manager.ts
+++ b/packages/common/ai/run-manager.ts
@@ -70,6 +70,11 @@ export interface AgentRunManager {
 	listActiveAgentRuns(): ActiveAgentRun[];
 	interruptAgentRun( runId: string ): void;
 	answerAgentRun( runId: string, answers: Record< string, string > ): void;
+	// Deliver a mid-turn user message to the run's live turn. Returns whether
+	// the message was forwarded to the child; the definitive delivery outcome
+	// arrives as a `steer.result` event echoing the optional correlation id.
+	// A `false` return means the run is gone — treat it as not delivered.
+	steerAgentRun( runId: string, text: string, id?: string ): boolean;
 }
 
 const INTERRUPT_FORCE_KILL_TIMEOUT_MS = 2000;
@@ -306,5 +311,14 @@ export function createAgentRunManager( config: AgentRunManagerConfig ): AgentRun
 		run.child.send( { type: 'answer', answers } );
 	}
 
-	return { startAgentRun, listActiveAgentRuns, interruptAgentRun, answerAgentRun };
+	function steerAgentRun( runId: string, text: string, id?: string ): boolean {
+		const run = runsById.get( runId );
+		if ( ! run || ! run.child.connected ) {
+			return false;
+		}
+		run.child.send( { type: 'steer', text, ...( id !== undefined ? { id } : {} ) } );
+		return true;
+	}
+
+	return { startAgentRun, listActiveAgentRuns, interruptAgentRun, answerAgentRun, steerAgentRun };
 }

--- a/packages/common/ai/sessions/entry-types.ts
+++ b/packages/common/ai/sessions/entry-types.ts
@@ -69,11 +69,13 @@ export type StudioChatAttachmentSummary =
 	| StudioChatImageAttachmentSummary
 	| StudioChatFileAttachmentSummary;
 
-// `source` distinguishes a user-typed prompt from an `ask_user` answer the
-// runtime forwarded to the model — the renderer only shows `'prompt'`.
+// `source` distinguishes how the message reached the model: a user-typed
+// prompt starting a turn, a `steer` delivered into a live turn, or an
+// `ask_user` answer the runtime forwarded — renderers show `'prompt'` and
+// `'steer'` as user messages.
 export interface StudioUserPromptData {
 	text: string;
-	source: 'prompt' | 'ask_user';
+	source: 'prompt' | 'ask_user' | 'steer';
 	sitePath?: string;
 	attachments?: StudioChatAttachmentSummary[];
 }

--- a/packages/common/ai/tests/run-manager.test.ts
+++ b/packages/common/ai/tests/run-manager.test.ts
@@ -1,0 +1,90 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAgentRunManager } from '../run-manager';
+
+const forkMock = vi.hoisted( () => vi.fn() );
+
+vi.mock( 'node:child_process', () => ( {
+	default: { fork: forkMock },
+	fork: forkMock,
+} ) );
+
+vi.mock( '@studio/common/ai/agent-stats', () => ( {
+	recordAgentRun: vi.fn(),
+	recordAgentSend: vi.fn(),
+} ) );
+
+vi.mock( '@studio/common/ai/sessions/placement', () => ( {
+	getCreatedSiteFromArtifact: vi.fn( () => null ),
+	setAiSessionSitePlacement: vi.fn(),
+} ) );
+
+vi.mock( '@studio/common/lib/error-reporting', () => ( {
+	captureException: vi.fn(),
+} ) );
+
+class FakeChild extends EventEmitter {
+	connected = true;
+	killed = false;
+	send = vi.fn( () => true );
+	kill = vi.fn( () => {
+		this.killed = true;
+		return true;
+	} );
+}
+
+function createManager() {
+	return createAgentRunManager( {
+		cliBinary: '/fake/cli/main.mjs',
+		nodeBinary: '/fake/node',
+		surface: 'desktop',
+		emit: vi.fn(),
+	} );
+}
+
+describe( 'AgentRunManager.steerAgentRun', () => {
+	let child: FakeChild;
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		child = new FakeChild();
+		forkMock.mockReturnValue( child );
+	} );
+
+	it( 'forwards the steer message to the running child', () => {
+		const manager = createManager();
+		const { runId } = manager.startAgentRun( { sessionId: 'session-1', prompt: 'build a site' } );
+
+		const forwarded = manager.steerAgentRun( runId, 'make the hero darker', 'steer-1' );
+
+		expect( forwarded ).toBe( true );
+		expect( child.send ).toHaveBeenCalledWith( {
+			type: 'steer',
+			text: 'make the hero darker',
+			id: 'steer-1',
+		} );
+	} );
+
+	it( 'omits the correlation id when the caller does not pass one', () => {
+		const manager = createManager();
+		const { runId } = manager.startAgentRun( { sessionId: 'session-1', prompt: 'build a site' } );
+
+		expect( manager.steerAgentRun( runId, 'add a contact page' ) ).toBe( true );
+		expect( child.send ).toHaveBeenCalledWith( { type: 'steer', text: 'add a contact page' } );
+	} );
+
+	it( 'reports the steer as not forwarded when the run is unknown', () => {
+		const manager = createManager();
+
+		expect( manager.steerAgentRun( 'missing-run', 'too late' ) ).toBe( false );
+	} );
+
+	it( 'reports the steer as not forwarded when the child is disconnected', () => {
+		const manager = createManager();
+		const { runId } = manager.startAgentRun( { sessionId: 'session-1', prompt: 'build a site' } );
+		child.connected = false;
+
+		expect( manager.steerAgentRun( runId, 'too late' ) ).toBe( false );
+		expect( child.send ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Builds on #4216 (stacked on its branch). Related to the direction change discussed after #4214 was closed: the user, not the model, decides what a mid-turn message means.

## How AI was used in this PR

Authored end to end by Claude Code (Fable 5) in an interactive session directed by @draganescu: the investigation, the implementation, and the tests, following TDD (each change had a failing test first). Opened without prior human code review — this PR is the review request.

## Proposed Changes

#4216 gave Studio Code steering — a way to deliver a message into a running turn so the agent adjusts course without abandoning in-flight work. It also made steering the *default*: in the terminal, anything typed mid-turn was delivered into the live run.

This PR makes steering **opt-in, per message**. A mid-turn message can mean "change course now", but it can just as often mean "and after that, do this" — and delivering the latter into a live run derails work the user wanted to finish first. Rather than having the model guess the intent (the prompt guidance that would have carried that judgment, #4214, was closed), the user states it:

- **In the terminal chat**, typing and pressing Enter mid-turn goes back to the pre-#4216 behavior: the message is queued and runs as the next turn. Pressing **alt+enter** instead sends the draft into the live run as a steering message. The hint bar advertises `alt+enter to steer` whenever a turn can be steered, next to `esc to interrupt` — steering is now discoverable, which #4216 had left as a follow-up. If a steer loses the race with the end of the turn, it falls back to the queue; nothing typed is ever dropped.
- **On the wire**, steering was already explicit — a host process only steers by sending a distinct `steer` message — and this PR keeps it that way and hardens the contract: the sender can attach a correlation id that comes back on the `steer.result` reply, so a host can match each reply to the exact message it sent (the same text steered twice is otherwise ambiguous).
- **In the session log**, delivered steers are now recorded with their own source (`steer`) instead of masquerading as ordinary prompts. Resumed sessions and both transcripts render them in place inside the turn they steered — previously a replayed steer incorrectly closed and reopened a turn. This also lets UIs style steered messages distinctly later without a log migration.
- **In the shared run-manager** that the desktop app and `studio ui` server use to drive CLI runs, a new `steerAgentRun` forwards a steer to the running child and reports whether it could be forwarded at all — the piece #4216 left unwired, and the single entry point both GUI hosts need.
- **In the system prompt**, one new rule tells the model that a message arriving mid-work is a course correction or addition: apply it, keep unaffected work, never start the task over.

User impact (terminal today): typing while the agent works safely queues by default, and redirecting the live run is one deliberate keystroke away, advertised in the hint bar.

## How the desktop and `studio ui` apps loop in

Nothing in the GUIs changes in this PR — this section explains the contract so the follow-up UI work is mechanical.

Both GUIs already queue messages typed while the agent is busy (the composer's "Queue" button), and that stays the default. To offer steering, a host does three things:

1. **Offer an explicit gesture.** While a run is active, add a secondary send action — e.g. a "Steer now" option on the send button, or cmd+enter — so the user chooses steering deliberately, exactly like alt+enter in the terminal. Plain send keeps queueing.
2. **Send the steer and remember the id.** Call `steerAgentRun( runId, text, id )` (desktop: via a new IPC handler; `studio ui` server: via a new `POST /runs/:runId/steer` route next to `/interrupt` and `/answer`). It returns `false` when the run is already gone — treat that exactly like a failed delivery. Render the message optimistically in the transcript.
3. **Settle on `steer.result`.** The reply arrives on the same event channel the host already consumes (desktop IPC events / SSE `agent` channel), carrying `delivered` and the echoed `id`. On `delivered: true`, keep the optimistic message — the CLI has also persisted it to the session log, so reloads agree. On `delivered: false` (or a `false` return in step 2), push the text into the existing queue so it runs as the next turn instead.

Steered messages come back from session reloads as `studio.user_prompt` entries with `source: 'steer'`; both conversation renderers in this PR already display them as user messages.

## Testing Instructions

- `npm test -- apps/cli/ai/tests/ui.test.ts apps/cli/ai/tests/output-adapter.test.ts apps/cli/ai/tests/system-prompt.test.ts apps/cli/ai/sessions/tests/replay.test.ts packages/common/ai/tests/run-manager.test.ts apps/studio/src/components/studio-code-session/conversation/index.test.tsx apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts`
- Manual (terminal): `npm run cli:build && node apps/cli/dist/cli/main.mjs code`, ask for a site build. While the agent works: type a message and press **Enter** — it should render as a queued (faint) prompt and run after the turn ends; type another and press **alt+enter** — it should appear as a regular user message and the agent should react within a step or two without restarting. Check the hint bar shows `alt+enter to steer` during the turn and drops it after.
- Manual (resume): exit and `node apps/cli/dist/cli/main.mjs code sessions resume <id>` — the steered message should replay in place inside its turn.
- Note: alt+enter requires the terminal to send Alt properly (Kitty/Ghostty/iTerm2 with "Use Option as Meta"); macOS Terminal needs that option enabled.
- Pre-existing failure, unrelated: `apps/studio/.../composer/index.test.tsx` fails on the base branch too (`localStorage.clear is not a function`).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

