### PR TITLE
Run CLI e2e tests automatically on all PRs

### DIFF
--- a/.buildkite/commands/run-cli-e2e-tests.sh
+++ b/.buildkite/commands/run-cli-e2e-tests.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
+  exit 0
+fi
+
 echo '--- :package: Install deps'
 bash .buildkite/commands/install-node-dependencies.sh
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,7 +138,6 @@ steps:
     timeout_in_minutes: 30
     soft_fail: true
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
-    if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
 
   - label: ":chart_with_upwards_trend: Performance Metrics"
     key: metrics

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -128,8 +128,8 @@ steps:
           DEBUG: "pw:browser"
         if: (build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft) && !(build.pull_request.labels includes 'native-php')
 
-  # Advisory: "CLI E2E Tests" is deliberately absent from trunk's required status
-  # checks, so a red run shows on the PR without blocking the merge.
+  # No `if:` guard: a required status check must report on every build, or PRs
+  # that skip it hang waiting for it. Doc-only PRs exit early but still report.
   - label: CLI E2E Tests
     key: cli-e2e-tests
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -128,20 +128,22 @@ steps:
           DEBUG: "pw:browser"
         if: (build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft) && !(build.pull_request.labels includes 'native-php')
 
-  # Manual-only and not a required GitHub check: it never runs until someone
-  # unblocks it in Buildkite, and it never gates PR merges.
-  - input: "🚦 Run CLI E2E Tests?"
-    prompt: "Run the CLI end-to-end test suite (creates real sites via the built CLI)?"
-    key: input-cli-e2e
-
+  # Advisory: the suite runs on every non-draft PR but cannot gate a merge.
+  # `soft_fail` is what makes that true — Buildkite reports an overall build
+  # status to GitHub on top of the per-step `github_commit_status` contexts, so
+  # without it a failure here would block merges despite this step declaring no
+  # context of its own.
+  # Drop `soft_fail` (and add a `github_commit_status` notify) to promote this
+  # to a required check once the suite has proven stable.
   - label: CLI E2E Tests
     key: cli-e2e-tests
-    depends_on: input-cli-e2e
     agents:
       queue: mac
     command: bash .buildkite/commands/run-cli-e2e-tests.sh
     timeout_in_minutes: 30
+    soft_fail: true
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
+    if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
 
   - label: ":chart_with_upwards_trend: Performance Metrics"
     key: metrics

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -128,16 +128,18 @@ steps:
           DEBUG: "pw:browser"
         if: (build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft) && !(build.pull_request.labels includes 'native-php')
 
-  # `soft_fail` keeps this advisory: without it Buildkite's overall build status
-  # gates merges, even though the step declares no commit status of its own.
+  # Advisory: "CLI E2E Tests" is deliberately absent from trunk's required status
+  # checks, so a red run shows on the PR without blocking the merge.
   - label: CLI E2E Tests
     key: cli-e2e-tests
     agents:
       queue: mac
     command: bash .buildkite/commands/run-cli-e2e-tests.sh
     timeout_in_minutes: 30
-    soft_fail: true
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
+    notify:
+      - github_commit_status:
+          context: CLI E2E Tests
 
   - label: ":chart_with_upwards_trend: Performance Metrics"
     key: metrics

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -128,13 +128,8 @@ steps:
           DEBUG: "pw:browser"
         if: (build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft) && !(build.pull_request.labels includes 'native-php')
 
-  # Advisory: the suite runs on every non-draft PR but cannot gate a merge.
-  # `soft_fail` is what makes that true — Buildkite reports an overall build
-  # status to GitHub on top of the per-step `github_commit_status` contexts, so
-  # without it a failure here would block merges despite this step declaring no
-  # context of its own.
-  # Drop `soft_fail` (and add a `github_commit_status` notify) to promote this
-  # to a required check once the suite has proven stable.
+  # `soft_fail` keeps this advisory: without it Buildkite's overall build status
+  # gates merges, even though the step declares no commit status of its own.
   - label: CLI E2E Tests
     key: cli-e2e-tests
     agents:

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -1,5 +1,3 @@
-// TEMP: revert before merge. Touches apps/cli/ so should-skip-job.sh does not
-// skip validation on this .buildkite-only PR, letting CLI E2E Tests prove itself.
 import path from 'node:path';
 import { suppressPunycodeWarning } from '@studio/common/lib/suppress-punycode-warning';
 import { __, sprintf } from '@wordpress/i18n';

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -1,3 +1,5 @@
+// TEMP: revert before merge. Touches apps/cli/ so should-skip-job.sh does not
+// skip validation on this .buildkite-only PR, letting CLI E2E Tests prove itself.
 import path from 'node:path';
 import { suppressPunycodeWarning } from '@studio/common/lib/suppress-punycode-warning';
 import { __, sprintf } from '@wordpress/i18n';


### PR DESCRIPTION
## Related issues

- Fixes [STU-1937](https://linear.app/a8c/issue/STU-1937/run-cli-e2e-tests-in-ci)

## How AI was used in this PR

Claude wrote the code, guided by the author. The author tested it locally and manually reviewed it before pushing.

## Proposed Changes

The CLI e2e suite already had a Buildkite step, but it sat behind a manual input gate, so it only ran when someone remembered to unblock it. In practice that meant it never ran, and CLI regressions reached trunk unnoticed.

The suite now runs automatically on every PR, drafts included, and reports a `CLI E2E Tests` commit status so the result is visible on the PR. It passed here in 9 minutes and 39 seconds.

The step runs unconditionally, with no `if:` guard, so the status reports on every build. That is a prerequisite for making it a required check: a PR that never reports the status would hang waiting for it.

Making the check blocking is a branch protection change rather than a pipeline change. Add `CLI E2E Tests` to trunk's required status checks after this merges.

## Testing Instructions

Verified on [build 19476](https://buildkite.com/automattic/studio/builds/19476), which ran with a temporary commit touching `apps/cli/` so the step would not be skipped. `CLI E2E Tests` started with no manual unblock and passed in 9 minutes and 39 seconds. That commit has since been reverted, so later builds of this PR skip the step again: `.buildkite/**` counts as a non-code change.

The suite passes locally, run the way CI runs it: 8 files, 35 tests, about 6 minutes. That fits the step's existing 30 minute timeout with room for the dependency install and CLI build.

To reproduce:

```
npm run cli:build
node apps/cli/dist/cli/main.mjs site list
npm test -- --tagsFilter='e2e' --no-file-parallelism
```

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
