### PR TITLE
Studio Code: add recovery action to Session not found state

### DIFF
--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -371,9 +371,18 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 		);
 	} else if ( ! data ) {
 		body = (
-			<div className={ styles.state }>
-				<h1>{ __( 'Session not found' ) }</h1>
-				<p>{ sessionId }</p>
+			<div className="p-8 flex flex-col max-w-3xl">
+				<div className="a8c-subtitle mb-1">{ __( 'Session not found' ) }</div>
+				<div className="w-[40ch] text-frame-text-secondary a8c-body">
+					{ __(
+						'This conversation is no longer available. Start a new one to keep building with Studio Code.'
+					) }
+				</div>
+				<div className="mt-6">
+					<Button variant="primary" onClick={ handleNewConversation }>
+						{ __( 'Start a new conversation' ) }
+					</Button>
+				</div>
 			</div>
 		);
 	} else {

--- a/apps/studio/src/components/studio-code-session/style.module.css
+++ b/apps/studio/src/components/studio-code-session/style.module.css
@@ -14,11 +14,6 @@
 	min-height: 0;
 }
 
-.state {
-	padding: var(--wpds-dimension-padding-xl);
-	color: var(--color-frame-text-secondary);
-}
-
 .loading {
 	display: flex;
 	align-items: center;

--- a/apps/studio/src/components/studio-code-session/tests/session-not-found.test.tsx
+++ b/apps/studio/src/components/studio-code-session/tests/session-not-found.test.tsx
@@ -1,0 +1,112 @@
+// Run tests: npm test -- apps/studio/src/components/studio-code-session/tests/session-not-found.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StudioCodeSession } from '..';
+import { queryClient } from '../query-client';
+
+const STORAGE_KEY = 'studio_code_session_ids';
+
+const { mockIpc } = vi.hoisted( () => ( {
+	mockIpc: {
+		loadAiSession: vi.fn(),
+		createAiSession: vi.fn(),
+		markAiMessageEdited: vi.fn(),
+	},
+} ) );
+
+vi.mock( 'src/lib/get-ipc-api', () => ( {
+	getIpcApi: () => mockIpc,
+} ) );
+
+vi.mock( 'src/hooks/use-auth', () => ( {
+	useAuth: () => ( { isAuthenticated: true, authenticate: vi.fn() } ),
+} ) );
+
+vi.mock( '../use-agent-run', () => ( {
+	AgentRunProvider: ( { children }: { children: React.ReactNode } ) => children,
+	useAgentRun: () => ( {
+		isRunning: false,
+		hasActiveRun: false,
+		isInterrupting: false,
+		startedAt: undefined,
+		error: null,
+		usageCapReached: false,
+		pendingQuestions: [],
+		pendingAnswers: new Map(),
+		answeredQuestions: new Map(),
+		queuedPrompts: [],
+		sendMessage: vi.fn(),
+		interrupt: vi.fn(),
+		answerQuestion: vi.fn(),
+		removeQueuedPrompt: vi.fn(),
+	} ),
+} ) );
+
+vi.mock( '../composer', () => ( {
+	Composer: () => <div data-testid="composer" />,
+	ComposerSkeleton: () => <div data-testid="composer-skeleton" />,
+	clearSessionDraft: vi.fn(),
+} ) );
+
+vi.mock( '../conversation', () => ( {
+	Conversation: () => <div data-testid="conversation" />,
+	wasLastTurnInterrupted: () => false,
+} ) );
+
+vi.mock( '../queued-prompts', () => ( {
+	QueuedPrompts: () => null,
+} ) );
+
+vi.mock( '../use-site-creation-switch', () => ( {
+	useSiteCreationSwitch: () => ( { pending: null, openNewSite: vi.fn(), stayHere: vi.fn() } ),
+} ) );
+
+vi.mock( '../site-created-dialog', () => ( {
+	SiteCreatedDialog: () => null,
+} ) );
+
+vi.mock( '../use-example-prompts', () => ( {
+	useExamplePrompts: () => [],
+} ) );
+
+vi.mock( '../lock-unlock', () => ( {
+	unlock: () => ( {
+		ThemeProvider: ( { children }: { children: React.ReactNode } ) => children,
+	} ),
+} ) );
+
+const selectedSite = { id: 'site-1', name: 'Test Site', path: '/tmp/site-1' } as SiteDetails;
+
+beforeEach( () => {
+	vi.clearAllMocks();
+	localStorage.clear();
+	queryClient.clear();
+} );
+
+describe( 'StudioCodeSession session-not-found recovery', () => {
+	it( 'recovers from a stored session that no longer exists on disk', async () => {
+		localStorage.setItem( STORAGE_KEY, JSON.stringify( { 'site-1': 'missing-session' } ) );
+		mockIpc.loadAiSession.mockImplementation( async ( sessionId: string ) => {
+			if ( sessionId === 'missing-session' ) {
+				throw new Error( `Code session not found: ${ sessionId }` );
+			}
+			return { summary: { id: sessionId }, entries: [] };
+		} );
+		mockIpc.createAiSession.mockResolvedValue( { id: 'fresh-session' } );
+
+		render( <StudioCodeSession selectedSite={ selectedSite } /> );
+
+		await screen.findByText( 'Session not found' );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /new conversation/i } ) );
+
+		await waitFor( () => {
+			expect( mockIpc.createAiSession ).toHaveBeenCalledWith( 'site-1' );
+			expect( screen.getByTestId( 'composer' ) ).toBeInTheDocument();
+		} );
+		expect( JSON.parse( localStorage.getItem( STORAGE_KEY ) ?? '{}' ) ).toEqual( {
+			'site-1': 'fresh-session',
+		} );
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Fixes [STU-2067](https://linear.app/a8c/issue/STU-2067/studio-code-tab-shows-session-not-found-error)

The Studio Code tab remembers one session id per site. When that session can no longer be resolved on disk (deleted, emptied, or corrupted transcript file), the tab dead-ended on a bare "Session not found" screen with no way out — restarting Studio or signing out didn't help because the stale reference persists locally.

## How AI was used in this PR

AI helped trace the root cause, write the regression test, and draft this PR. All changes were reviewed manually.

## Proposed Changes

This PR turns that dead end into a recovery path: the state now explains that the conversation is no longer available and offers a **Start a new conversation** button, which creates a fresh session for the site and replaces the stale reference. The screen also adopts the same layout and typography as the other empty states in this tab.

## Testing Instructions

1. Open a site's Studio Code tab and confirm it loads normally.
2. Simulate a lost session: in DevTools run `localStorage.setItem('studio_code_session_ids', JSON.stringify({ '<siteId>': 'bogus' }))` (or delete the session's `.jsonl` file from the sessions directory), then reopen the tab, or break all your sessions by running this script in your chrome DevTools:
```js
const key = 'studio_code_session_ids';
const map = JSON.parse(localStorage.getItem(key) ?? '{}');

for (const k of Object.keys(map)) {
  map[k] = crypto.randomUUID(); // replacement value per entry
}

localStorage.setItem(key, JSON.stringify(map));
console.log(JSON.parse(localStorage.getItem(key)));
```
4. Confirm the "Session not found" state appears with the explanation and the **Start a new conversation** button.
5. Click the button: a fresh, working conversation should load, and it should survive app restarts.
6. Check the state renders correctly in both light and dark mode.

| Before | After |
|--------|--------|
|  <img width="1455" height="915" alt="5b4cccf84457a215129cefb10384eacf3aff70dcc1b565c1b4fbd29830c30336" src="https://github.com/user-attachments/assets/fe7a6c14-848d-4f56-a5de-59fbc25f41a2" /> | <img width="1455" height="915" alt="Screenshot 2026-07-17 at 10 29 00" src="https://github.com/user-attachments/assets/f6134120-98a8-4364-829b-6e084ede9608" /> |

## Pre-merge Checklist


- [x] Have you checked for TypeScript, React or other console errors?