### PR TITLE
Show auto-retry progress in Studio Code TUI instead of silently queueing prompts

### DIFF
--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -591,6 +591,42 @@ describe( 'AiChatUI.handleEvent', () => {
 		expect( showInfo ).not.toHaveBeenCalled();
 	} );
 
+	it( 'keeps the turn alive on agent_end when the session will auto-retry', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			handleEvent: ( e: unknown ) => unknown;
+			[ key: string ]: unknown;
+		};
+		ui.hideLoader = vi.fn();
+		ui.showError = vi.fn();
+
+		ui.handleEvent( { type: 'agent_end', willRetry: true, messages: [] } );
+
+		expect( ui.hideLoader ).not.toHaveBeenCalled();
+		expect( ui.showError ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows a retry loader message on auto_retry_start', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			handleEvent: ( e: unknown ) => unknown;
+			[ key: string ]: unknown;
+		};
+		ui.showLoader = vi.fn();
+		ui.showInfo = vi.fn();
+
+		ui.handleEvent( {
+			type: 'auto_retry_start',
+			attempt: 2,
+			maxAttempts: 3,
+			delayMs: 4000,
+			errorMessage: 'API Error: 529 overloaded\nsecond line',
+		} );
+
+		expect( ui.showInfo ).toHaveBeenCalledWith( 'API Error: 529 overloaded' );
+		expect( ui.showLoader ).toHaveBeenCalledWith(
+			'Temporary provider error — retrying in 4s (attempt 2 of 3)…'
+		);
+	} );
+
 	it( 'does not trip the cap branch when an assistant error has no 429 marker', () => {
 		const ui = Object.create( AiChatUI.prototype ) as {
 			handleEvent: ( e: unknown ) => unknown;

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -2144,7 +2144,28 @@ export class AiChatUI implements AiOutputAdapter {
 				this.renderToolResults( event.toolResults );
 				return;
 			}
+			case 'auto_retry_start': {
+				const reason = event.errorMessage.split( '\n' )[ 0 ].trim();
+				if ( reason ) {
+					this.showInfo( reason );
+				}
+				this.showLoader(
+					sprintf(
+						/* translators: 1: retry attempt number, 2: maximum retry attempts, 3: delay in seconds */
+						__( 'Temporary provider error — retrying in %3$ds (attempt %1$d of %2$d)…' ),
+						event.attempt,
+						event.maxAttempts,
+						Math.round( event.delayMs / 1000 )
+					)
+				);
+				return;
+			}
 			case 'agent_end': {
+				// Not final when willRetry: the session auto-retries the turn
+				// after a backoff (`auto_retry_start` follows).
+				if ( event.willRetry ) {
+					return;
+				}
 				this.hideLoader();
 
 				if ( this.usageCapReached ) {
@@ -2189,9 +2210,9 @@ export class AiChatUI implements AiOutputAdapter {
 			}
 			default:
 				// agent_start / turn_start / message_start / message_update /
-				// tool_execution_* — UI doesn't act on these directly; pi
-				// events drive incremental state but the visible transitions
-				// happen at message_end / turn_end / agent_end.
+				// tool_execution_* / auto_retry_end — UI doesn't act on these
+				// directly; pi events drive incremental state but the visible
+				// transitions happen at message_end / turn_end / agent_end.
 				return;
 		}
 	}

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -550,7 +550,9 @@ export async function runCommand( options: {
 			onAskUser: ( questions ) => askUserAndPersistAnswers( questions ),
 			onEvent: ( event ) => {
 				ui.handleEvent( event );
-				if ( event.type !== 'agent_end' ) {
+				// An `agent_end` with `willRetry` is not final — the session
+				// restarts the turn after a backoff.
+				if ( event.type !== 'agent_end' || event.willRetry ) {
 					return;
 				}
 				const result = getAgentEndTurnResult( event );


### PR DESCRIPTION
## Related issues

<!-- No linked issue — reported directly while using the TUI. -->

## How AI was used in this PR

Entirely written with Claude Code: it diagnosed the reported behavior (prompts appearing \"scheduled\" after an agent error), implemented the fix, added the unit tests, and verified the result by driving the built TUI against a mock provider returning `529` errors.

## Proposed Changes

When a turn hits a transient provider error (overloaded, 429, 5xx, network drops), the pi agent session auto-retries with exponential backoff (up to 3 attempts: 2s/4s/8s). The TUI didn't surface this at all: it printed the error as if the turn had failed, hid the loader, and looked idle — while the turn was actually still alive. Any prompt typed during that window was silently queued instead of sent, which read as the CLI "scheduling" prompts for no reason.

Now the TUI keeps the turn visibly active across retries:

- On a retryable failure, the transient error is shown as a dim info line instead of a terminal error.
- The loader stays up with explicit progress: "Temporary provider error — retrying in 4s (attempt 2 of 3)…".
- The final error only appears once retries are exhausted, and intermediate (will-retry) turn endings no longer record an `error` status for the turn.

Queueing a prompt typed mid-turn is unchanged and intentional — it just no longer happens invisibly.

## Testing Instructions

1. Start a mock provider that always returns a retryable error:
   ```bash
   node -e 'require("http").createServer((q,s)=>{s.writeHead(529,{"content-type":"application/json"});s.end(JSON.stringify({type:"error",error:{type:"overloaded_error",message:"Overloaded"}}))}).listen(9529)'
   ```
2. Build and run the TUI pointed at it (requires a WordPress.com login; no real API calls go through):
   ```bash
   npm run cli:build
   WPCOM_AI_PROXY_BASE_URL=http://127.0.0.1:9529 node apps/cli/dist/cli/main.mjs ai
   ```
3. Send any prompt. You should see the dim error line and the retry loader escalate through 2s → 4s → 8s, with the red error only after attempt 3 of 3.
4. While it retries, type another prompt: it shows in the queued list with the "backspace to unqueue" hint and runs when the turn ends.
5. On `trunk`, the same steps show the old behavior: an immediate error, an idle-looking UI, and the next prompt silently queued.

Unit tests: `npm test -- apps/cli/ai/tests/ui.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)