### PR TITLE
Scope preview list --format json output to the authenticated user

### DIFF
--- a/apps/cli/commands/preview/list.ts
+++ b/apps/cli/commands/preview/list.ts
@@ -53,8 +53,10 @@ export async function runCommand(
 
 	try {
 		if ( outputFormat === 'json' ) {
-			const config = await readCliConfig();
-			const json = JSON.stringify( config.snapshots );
+			// Snapshots are per-user; when logged out emit an empty list instead of
+			// erroring so consumers (e.g. the desktop app) degrade gracefully.
+			const token = await readAuthToken();
+			const json = JSON.stringify( token ? await getSnapshotsFromConfig( token.id ) : [] );
 			console.log( json );
 			logger.reportKeyValuePair( 'snapshots', json );
 			return;

--- a/apps/cli/commands/preview/tests/list.test.ts
+++ b/apps/cli/commands/preview/tests/list.test.ts
@@ -376,6 +376,34 @@ describe( 'Preview List Command', () => {
 		} );
 	} );
 
+	describe( 'with --format json', () => {
+		let consoleLogSpy: ReturnType< typeof vi.spyOn >;
+
+		beforeEach( () => {
+			consoleLogSpy = vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		} );
+
+		it( 'should output only the authenticated user’s snapshots', async () => {
+			await runCommand( mockFolder, 'json' );
+
+			expect( getSnapshotsFromConfig ).toHaveBeenCalledWith( mockAuthToken.id );
+			const json = JSON.stringify( mockSnapshots );
+			expect( consoleLogSpy ).toHaveBeenCalledWith( json );
+			expect( mockReportKeyValuePair ).toHaveBeenCalledWith( 'snapshots', json );
+		} );
+
+		it( 'should output an empty array without erroring when logged out', async () => {
+			vi.mocked( readAuthToken ).mockResolvedValue( null );
+
+			await runCommand( mockFolder, 'json' );
+
+			expect( getSnapshotsFromConfig ).not.toHaveBeenCalled();
+			expect( consoleLogSpy ).toHaveBeenCalledWith( '[]' );
+			expect( mockReportKeyValuePair ).toHaveBeenCalledWith( 'snapshots', '[]' );
+			expect( mockReportError ).not.toHaveBeenCalled();
+		} );
+	} );
+
 	it( 'should prune expired orphaned snapshots even when running without --all', async () => {
 		await runCommand( mockFolder, 'table' );
 


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Implemented and verified with Claude Code under my direction; I reviewed the diff and the direction was agreed beforehand.

## Proposed Changes

Preview snapshots are per-user by design, but `studio preview list --format json` returned before the auth check and dumped every snapshot in `cli.json` unfiltered. A logged-out user (or a different account on the same machine) could see preview sites they don't own.

- The json path now behaves like the table path: snapshots are filtered by the authenticated user's ID.
- When logged out it emits an empty array (`[]`) instead of erroring, so the desktop app degrades gracefully
- Site scoping is unchanged: json output still covers all local sites, and `--all` semantics are untouched.

## Testing Instructions

1. `npm run cli:build`
2. Create a site + preview(s) site or use existing ones 
3. While logged in (`node apps/cli/dist/cli/main.mjs auth status`): run `node apps/cli/dist/cli/main.mjs preview list --format json` — your snapshots are listed.
4. Log out (`auth logout`) and run the same command — output is `[]` with exit code 0, no error.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
