### PR TITLE
Add global instructions config for the Studio Code agent

### DIFF
--- a/apps/cli/ai/eval-runner.ts
+++ b/apps/cli/ai/eval-runner.ts
@@ -7,15 +7,21 @@
  */
 
 import { mkdirSync, writeFileSync, writeSync as fsWriteSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { SessionManager } from '@earendil-works/pi-coding-agent';
+import {
+	readGlobalInstructionsFile,
+	writeGlobalInstructions,
+} from '@studio/common/ai/global-instructions';
 import { DEFAULT_MODEL, isAiModelId, type AiModelId } from '@studio/common/ai/models';
 import { findLastAssistant } from '@studio/common/ai/session-events';
 import {
 	addConnectedWpcomSite,
 	removeConnectedWpcomSite,
 } from '@studio/common/lib/connected-sites';
+import { getGlobalInstructionsPath } from '@studio/common/lib/well-known-paths';
 import { snapshotSchema } from '@studio/common/types/snapshot';
 import { syncSiteSchema, type SyncSite } from '@studio/common/types/sync';
 import { z } from 'zod';
@@ -52,6 +58,7 @@ const evalSeedSchema = z.object( {
 		.optional(),
 	connectedWpcomSites: z.array( syncSiteSchema ).optional(),
 	snapshots: z.array( snapshotSchema ).optional(),
+	globalInstructions: z.string().optional(),
 } );
 type EvalSeed = z.infer< typeof evalSeedSchema >;
 
@@ -66,9 +73,21 @@ interface EvalRunnerInput {
  * Writes the requested fixtures into cli.json (local site + snapshots) and
  * shared.json (connected WordPress.com sites). Returns a cleanup function that
  * removes exactly what was added, so reruns start from a clean slate.
+ * `globalInstructions` is the exception: it overwrites the user's real
+ * instructions file, so cleanup restores the prior content instead.
  */
 async function seedFixtures( seed: EvalSeed ): Promise< () => Promise< void > > {
-	const { localSite, connectedWpcomSites = [], snapshots = [] } = seed;
+	const { localSite, connectedWpcomSites = [], snapshots = [], globalInstructions } = seed;
+
+	let restoreInstructions: ( () => Promise< void > ) | null = null;
+	if ( typeof globalInstructions === 'string' ) {
+		const prior = await readGlobalInstructionsFile();
+		restoreInstructions =
+			prior === null
+				? () => rm( getGlobalInstructionsPath(), { force: true } )
+				: () => writeGlobalInstructions( prior );
+		await writeGlobalInstructions( globalInstructions );
+	}
 
 	if ( localSite || snapshots.length > 0 ) {
 		try {
@@ -100,6 +119,7 @@ async function seedFixtures( seed: EvalSeed ): Promise< () => Promise< void > > 
 	}
 
 	return async () => {
+		await restoreInstructions?.().catch( () => undefined );
 		for ( const site of seededConnections ) {
 			await removeConnectedWpcomSite( site.localSiteId, site.id ).catch( () => undefined );
 		}

--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -24,6 +24,7 @@ import {
 	type SessionManager,
 	type ToolDefinition,
 } from '@earendil-works/pi-coding-agent';
+import { readGlobalInstructions } from '@studio/common/ai/global-instructions';
 import {
 	DEFAULT_MODEL,
 	getAiModelFamily,
@@ -293,6 +294,10 @@ async function createStudioAgentSession(
 	const isRemoteSite = Boolean( config.activeSite?.remote && config.activeSite?.wpcomSiteId );
 	const remoteSession = config.env.STUDIO_REMOTE_SESSION === '1';
 	const chatArtifactsEnabled = typeof process.send === 'function';
+	const [ userInstructions, runtime ] = await Promise.all( [
+		readGlobalInstructions(),
+		isRemoteSite ? undefined : resolveActiveSiteRuntime( config.activeSite ),
+	] );
 
 	const systemPrompt = buildSystemPrompt(
 		isRemoteSite
@@ -303,11 +308,13 @@ async function createStudioAgentSession(
 						id: config.activeSite!.wpcomSiteId!,
 					},
 					remoteSession,
+					userInstructions,
 			  }
 			: {
 					chatArtifactsEnabled,
 					remoteSession,
-					runtime: await resolveActiveSiteRuntime( config.activeSite ),
+					runtime,
+					userInstructions,
 			  }
 	);
 

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -1,3 +1,4 @@
+import { GLOBAL_INSTRUCTIONS_MAX_LENGTH } from '@studio/common/ai/global-instructions';
 import {
 	getStudioPresentationRulesPrompt,
 	getStudioWidgetPromptManifest,
@@ -27,10 +28,6 @@ export interface BuildSystemPromptOptions {
 	userInstructions?: string;
 }
 
-// Keep the always-injected instructions small enough that they can't crowd out
-// the rest of the system prompt.
-const USER_INSTRUCTIONS_MAX_LENGTH = 16_000;
-
 export function buildSystemPrompt( options?: BuildSystemPromptOptions ): string {
 	const remoteSessionAddendum = options?.remoteSession ? `\n\n${ REMOTE_SESSION_GUIDANCE }` : '';
 	const userInstructionsSection = buildUserInstructionsSection( options?.userInstructions );
@@ -59,10 +56,10 @@ function buildUserInstructionsSection( userInstructions?: string ): string {
 		return '';
 	}
 	const instructions =
-		userInstructions.length > USER_INSTRUCTIONS_MAX_LENGTH
+		userInstructions.length > GLOBAL_INSTRUCTIONS_MAX_LENGTH
 			? `${ userInstructions.slice(
 					0,
-					USER_INSTRUCTIONS_MAX_LENGTH
+					GLOBAL_INSTRUCTIONS_MAX_LENGTH
 			  ) }\n\n[Note: the global instructions file exceeds the size limit and was truncated here. Let the user know they should shorten it in Studio settings.]`
 			: userInstructions;
 	return `

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -23,17 +23,24 @@ export interface BuildSystemPromptOptions {
 	// Runtime of the active local site. Playground (PHP WASM) needs extra WP-CLI
 	// constraints that the native PHP runtime does not. Defaults to native-php.
 	runtime?: SiteRuntime;
+	// The user's global instructions (~/.studio/knowledge/instructions.md).
+	userInstructions?: string;
 }
+
+// Keep the always-injected instructions small enough that they can't crowd out
+// the rest of the system prompt.
+const USER_INSTRUCTIONS_MAX_LENGTH = 16_000;
 
 export function buildSystemPrompt( options?: BuildSystemPromptOptions ): string {
 	const remoteSessionAddendum = options?.remoteSession ? `\n\n${ REMOTE_SESSION_GUIDANCE }` : '';
+	const userInstructionsSection = buildUserInstructionsSection( options?.userInstructions );
 
 	if ( options?.remoteSite ) {
 		return `${ buildRemoteIntro( options.remoteSite ) }
 
 ${ REMOTE_CONTENT_GUIDELINES }
 
-${ REMOTE_DESIGN_GUIDELINES }${ remoteSessionAddendum }
+${ REMOTE_DESIGN_GUIDELINES }${ remoteSessionAddendum }${ userInstructionsSection }
 `;
 	}
 
@@ -43,8 +50,28 @@ ${ REMOTE_DESIGN_GUIDELINES }${ remoteSessionAddendum }
 		runtime: options?.runtime,
 	} ) }
 
-${ LOCAL_SKILL_ROUTING }${ remoteSessionAddendum }
+${ LOCAL_SKILL_ROUTING }${ remoteSessionAddendum }${ userInstructionsSection }
 `;
+}
+
+function buildUserInstructionsSection( userInstructions?: string ): string {
+	if ( ! userInstructions ) {
+		return '';
+	}
+	const instructions =
+		userInstructions.length > USER_INSTRUCTIONS_MAX_LENGTH
+			? `${ userInstructions.slice(
+					0,
+					USER_INSTRUCTIONS_MAX_LENGTH
+			  ) }\n\n[Note: the global instructions file exceeds the size limit and was truncated here. Let the user know they should shorten it in Studio settings.]`
+			: userInstructions;
+	return `
+
+## User's global instructions
+
+The user saved these standing instructions in Studio's settings. They apply to every conversation. Follow them unless they conflict with the guidance above or ask you to skip safety, plan, or validation requirements.
+
+${ instructions }`;
 }
 
 function buildRemoteIntro( site: RemoteSiteContext ): string {

--- a/apps/cli/ai/tests/system-prompt.test.ts
+++ b/apps/cli/ai/tests/system-prompt.test.ts
@@ -163,6 +163,32 @@ describe( 'buildSystemPrompt', () => {
 		expect( prompt ).not.toContain( 'Do not respond as though the user is looking at the capture' );
 	} );
 
+	it( 'appends the user global instructions for local and remote sessions', () => {
+		const variants = [ { chatArtifactsEnabled: true }, { remoteSite } ];
+		for ( const variant of variants ) {
+			const prompt = buildSystemPrompt( {
+				...variant,
+				userInstructions: 'Always answer in French.',
+			} );
+			expect( prompt ).toContain( "## User's global instructions" );
+			expect( prompt ).toContain( 'Always answer in French.' );
+		}
+	} );
+
+	it( 'omits the global instructions section when none are set', () => {
+		const prompts = [ buildSystemPrompt( {} ), buildSystemPrompt( { remoteSite } ) ];
+		for ( const prompt of prompts ) {
+			expect( prompt ).not.toContain( "## User's global instructions" );
+		}
+	} );
+
+	it( 'truncates oversized global instructions with a visible notice', () => {
+		const prompt = buildSystemPrompt( { userInstructions: 'a'.repeat( 20_000 ) } );
+
+		expect( prompt ).toContain( 'was truncated here' );
+		expect( prompt ).not.toContain( 'a'.repeat( 17_000 ) );
+	} );
+
 	it( 'omits the terminal screenshot caveat for remote-bridge sessions', () => {
 		// The Telegram user cannot open local file paths; delivery is covered
 		// by the remote-session share_screenshot guidance instead.

--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -3,6 +3,10 @@ import { createWriteStream, existsSync, mkdtempSync, rm } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
+import {
+	readGlobalInstructionsFile,
+	writeGlobalInstructions,
+} from '@studio/common/ai/global-instructions';
 import { isAiModelId } from '@studio/common/ai/models';
 import { createAgentRunManager } from '@studio/common/ai/run-manager';
 import {
@@ -419,6 +423,27 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 				} ).catch( () => undefined );
 			}
 			await updateSharedConfig( { authToken: undefined } );
+			res.status( 204 ).end();
+		} )
+	);
+
+	// --- Agent instructions — the shared ~/.studio/knowledge/instructions.md --
+	api.get(
+		'/agent-instructions',
+		asyncHandler( async ( _req: Request, res: Response ) => {
+			res.json( { content: ( await readGlobalInstructionsFile() ) ?? '' } );
+		} )
+	);
+
+	api.post(
+		'/agent-instructions',
+		asyncHandler( async ( req: Request, res: Response ) => {
+			const content = req.body?.content;
+			if ( typeof content !== 'string' ) {
+				res.status( 400 ).json( { error: 'content required' } );
+				return;
+			}
+			await writeGlobalInstructions( content );
 			res.status( 204 ).end();
 		} )
 	);

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -229,6 +229,7 @@ export {
 
 export {
 	getColorScheme,
+	getGlobalAgentInstructions,
 	getInstalledAppsAndTerminals,
 	getQuitSitesBehavior,
 	getUserEditor,
@@ -237,6 +238,7 @@ export {
 	getWapuuScore,
 	previewColorScheme,
 	saveColorScheme,
+	saveGlobalAgentInstructions,
 	saveQuitSitesBehavior,
 	saveUserEditor,
 	saveUserLocale,

--- a/apps/studio/src/modules/user-settings/components/studio-code-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/studio-code-tab.tsx
@@ -1,3 +1,4 @@
+import { GLOBAL_INSTRUCTIONS_MAX_LENGTH } from '@studio/common/ai/global-instructions';
 import { getErrorMessage } from '@studio/common/lib/error-formatting';
 import { TextareaControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
@@ -10,6 +11,7 @@ export function StudioCodeTab() {
 	const [ content, setContent ] = useState< string | null >( null );
 	const [ savedContent, setSavedContent ] = useState( '' );
 	const [ isSaving, setIsSaving ] = useState( false );
+	const [ justSaved, setJustSaved ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
 
 	useEffect( () => {
@@ -32,6 +34,14 @@ export function StudioCodeTab() {
 		};
 	}, [] );
 
+	useEffect( () => {
+		if ( ! justSaved ) {
+			return;
+		}
+		const timer = setTimeout( () => setJustSaved( false ), 2500 );
+		return () => clearTimeout( timer );
+	}, [ justSaved ] );
+
 	const handleSave = async () => {
 		if ( content === null ) {
 			return;
@@ -41,12 +51,21 @@ export function StudioCodeTab() {
 		try {
 			await getIpcApi().saveGlobalAgentInstructions( content );
 			setSavedContent( content );
+			setJustSaved( true );
 		} catch ( err ) {
 			setError( getErrorMessage( err ) ?? String( err ) );
 		} finally {
 			setIsSaving( false );
 		}
 	};
+
+	const isDirty = content !== null && content !== savedContent;
+	const showCounter = content !== null && content.length >= GLOBAL_INSTRUCTIONS_MAX_LENGTH * 0.8;
+	const buttonLabel = isSaving
+		? __( 'Saving…' )
+		: justSaved && ! isDirty
+		? __( 'Saved' )
+		: __( 'Save instructions' );
 
 	return (
 		<div className="flex flex-col gap-4 pb-2">
@@ -59,19 +78,25 @@ export function StudioCodeTab() {
 					'Global instructions for the Studio Code agent. They are included in every new conversation, across all sites.'
 				) }
 				rows={ 12 }
+				maxLength={ GLOBAL_INSTRUCTIONS_MAX_LENGTH }
 				value={ content ?? '' }
 				onChange={ setContent }
 				disabled={ content === null }
 				placeholder={ __( 'e.g. Always answer in French. My sites are for restaurants.' ) }
 			/>
 
-			<div className="flex justify-end">
+			<div className="flex items-center justify-end gap-3">
+				{ showCounter && (
+					<span className="text-xs text-frame-text-secondary">
+						{ `${ content.length.toLocaleString() } / ${ GLOBAL_INSTRUCTIONS_MAX_LENGTH.toLocaleString() }` }
+					</span>
+				) }
 				<Button
 					variant="primary"
 					onClick={ handleSave }
-					disabled={ content === null || isSaving || content === savedContent }
+					disabled={ content === null || isSaving || ! isDirty }
 				>
-					{ isSaving ? __( 'Saving…' ) : __( 'Save instructions' ) }
+					{ buttonLabel }
 				</Button>
 			</div>
 		</div>

--- a/apps/studio/src/modules/user-settings/components/studio-code-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/studio-code-tab.tsx
@@ -1,0 +1,79 @@
+import { getErrorMessage } from '@studio/common/lib/error-formatting';
+import { TextareaControl } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect, useState } from 'react';
+import Button from 'src/components/button';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+
+export function StudioCodeTab() {
+	const { __ } = useI18n();
+	const [ content, setContent ] = useState< string | null >( null );
+	const [ savedContent, setSavedContent ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ error, setError ] = useState< string | null >( null );
+
+	useEffect( () => {
+		let cancelled = false;
+		getIpcApi()
+			.getGlobalAgentInstructions()
+			.then( ( instructions ) => {
+				if ( ! cancelled ) {
+					setContent( instructions );
+					setSavedContent( instructions );
+				}
+			} )
+			.catch( ( err ) => {
+				if ( ! cancelled ) {
+					setError( getErrorMessage( err ) ?? String( err ) );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	const handleSave = async () => {
+		if ( content === null ) {
+			return;
+		}
+		setIsSaving( true );
+		setError( null );
+		try {
+			await getIpcApi().saveGlobalAgentInstructions( content );
+			setSavedContent( content );
+		} catch ( err ) {
+			setError( getErrorMessage( err ) ?? String( err ) );
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	return (
+		<div className="flex flex-col gap-4 pb-2">
+			{ error && <div className="text-sm text-frame-error">{ error }</div> }
+
+			<TextareaControl
+				__nextHasNoMarginBottom
+				label={ __( 'Instructions' ) }
+				help={ __(
+					'Global instructions for the Studio Code agent. They are included in every new conversation, across all sites.'
+				) }
+				rows={ 12 }
+				value={ content ?? '' }
+				onChange={ setContent }
+				disabled={ content === null }
+				placeholder={ __( 'e.g. Always answer in French. My sites are for restaurants.' ) }
+			/>
+
+			<div className="flex justify-end">
+				<Button
+					variant="primary"
+					onClick={ handleSave }
+					disabled={ content === null || isSaving || content === savedContent }
+				>
+					{ isSaving ? __( 'Saving…' ) : __( 'Save instructions' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/studio/src/modules/user-settings/components/tests/user-settings.test.tsx
+++ b/apps/studio/src/modules/user-settings/components/tests/user-settings.test.tsx
@@ -1,5 +1,5 @@
 // To run tests, execute `npm run test -- src/modules/user-settings/components/tests/user-settings.test.tsx` from the root directory
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { vi } from 'vitest';
@@ -48,6 +48,8 @@ const mockIpcApi = {
 	saveColorScheme: vi.fn().mockResolvedValue( undefined ),
 	getQuitSitesBehavior: vi.fn().mockResolvedValue( undefined ),
 	saveQuitSitesBehavior: vi.fn().mockResolvedValue( undefined ),
+	getGlobalAgentInstructions: vi.fn().mockResolvedValue( '' ),
+	saveGlobalAgentInstructions: vi.fn().mockResolvedValue( undefined ),
 };
 
 vi.mock( 'src/lib/get-ipc-api', () => ( {
@@ -161,11 +163,24 @@ describe( 'UserSettings', () => {
 				expect( screen.getByText( 'Account' ) ).toHaveAttribute( 'aria-selected', 'true' );
 				expect( screen.getByText( 'Log out' ) ).toBeInTheDocument();
 				expect( screen.getByText( 'Preview sites' ) ).toBeInTheDocument();
-				expect( screen.getByText( 'Studio Code' ) ).toBeInTheDocument();
+				// Scoped to the panel: "Studio Code" also names a settings tab.
+				expect(
+					within( screen.getByRole( 'tabpanel' ) ).getByText( 'Studio Code' )
+				).toBeInTheDocument();
 				expect(
 					screen.getByText( 'Studio Code limits are temporarily unavailable.' )
 				).toBeInTheDocument();
 				expect( screen.queryByText( /monthly prompts used/ ) ).not.toBeInTheDocument();
+			} );
+
+			await user.click( screen.getByRole( 'tab', { name: 'Studio Code' } ) );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'tab', { name: 'Studio Code' } ) ).toHaveAttribute(
+					'aria-selected',
+					'true'
+				);
+				expect( screen.getByLabelText( 'Instructions' ) ).toBeInTheDocument();
 			} );
 		} );
 	} );

--- a/apps/studio/src/modules/user-settings/components/user-settings.tsx
+++ b/apps/studio/src/modules/user-settings/components/user-settings.tsx
@@ -11,6 +11,7 @@ import { McpSettings } from 'src/modules/mcp/components/mcp-settings';
 import { AccountTab } from 'src/modules/user-settings/components/account-tab';
 import { PreferencesTab } from 'src/modules/user-settings/components/preferences-tab';
 import { SkillsTab } from 'src/modules/user-settings/components/skills-tab';
+import { StudioCodeTab } from 'src/modules/user-settings/components/studio-code-tab';
 import { UserSettingsTab } from 'src/modules/user-settings/user-settings-types';
 import { useRootSelector } from 'src/stores';
 import { snapshotSelectors } from 'src/stores/snapshot-slice';
@@ -85,6 +86,11 @@ export default function UserSettings() {
 		} );
 
 		result.push( {
+			name: 'studio-code',
+			title: __( 'Studio Code' ),
+		} );
+
+		result.push( {
 			name: 'skills',
 			title: __( 'Skills' ),
 		} );
@@ -119,6 +125,7 @@ export default function UserSettings() {
 						{ ( { name } ) => (
 							<div className="mt-6 px-8 pb-8 flex gap-4 flex-col">
 								{ name === 'general' && <PreferencesTab onClose={ resetLocalState } /> }
+								{ name === 'studio-code' && <StudioCodeTab /> }
 								{ name === 'skills' && <SkillsTab /> }
 								{ name === 'mcp' && <McpSettings /> }
 								{ name === 'account' && (

--- a/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
@@ -1,4 +1,8 @@
 import { BrowserWindow, IpcMainInvokeEvent, nativeTheme } from 'electron';
+import {
+	readGlobalInstructionsFile,
+	writeGlobalInstructions,
+} from '@studio/common/ai/global-instructions';
 import { updateSharedConfig } from '@studio/common/lib/shared-config';
 import { DEFAULT_TERMINAL } from 'src/constants';
 import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
@@ -140,6 +144,17 @@ export async function saveWapuuScore( _event: IpcMainInvokeEvent, score: number 
 export async function getWapuuScore(): Promise< number | undefined > {
 	const userData = await loadUserData();
 	return userData.wapuuScore;
+}
+
+export async function getGlobalAgentInstructions(): Promise< string > {
+	return ( await readGlobalInstructionsFile() ) ?? '';
+}
+
+export async function saveGlobalAgentInstructions(
+	_event: IpcMainInvokeEvent,
+	content: string
+): Promise< void > {
+	await writeGlobalInstructions( content );
 }
 
 export function showUserSettings( event: IpcMainInvokeEvent, tabName?: UserSettingsTabName ) {

--- a/apps/studio/src/modules/user-settings/user-settings-types.ts
+++ b/apps/studio/src/modules/user-settings/user-settings-types.ts
@@ -1,4 +1,4 @@
-export type UserSettingsTabName = 'general' | 'skills' | 'account' | 'mcp';
+export type UserSettingsTabName = 'general' | 'skills' | 'studio-code' | 'account' | 'mcp';
 export type UserSettingsTab = {
 	name: UserSettingsTabName;
 	title: string;

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -159,6 +159,9 @@ const api: IpcApi = {
 	saveUserTerminal: ( preferredTerminal ) =>
 		ipcRendererInvoke( 'saveUserTerminal', preferredTerminal ),
 	getUserTerminal: () => ipcRendererInvoke( 'getUserTerminal' ),
+	getGlobalAgentInstructions: () => ipcRendererInvoke( 'getGlobalAgentInstructions' ),
+	saveGlobalAgentInstructions: ( content ) =>
+		ipcRendererInvoke( 'saveGlobalAgentInstructions', content ),
 	previewColorScheme: ( colorScheme ) => ipcRendererInvoke( 'previewColorScheme', colorScheme ),
 	saveColorScheme: ( colorScheme ) => ipcRendererInvoke( 'saveColorScheme', colorScheme ),
 	getColorScheme: () => ipcRendererInvoke( 'getColorScheme' ),

--- a/apps/ui/src/components/create-site-form/index.test.tsx
+++ b/apps/ui/src/components/create-site-form/index.test.tsx
@@ -107,6 +107,7 @@ describe( 'CreateSiteForm', () => {
 				openInOS: false,
 				annotatePreview: false,
 				readLocalMedia: false,
+				agentInstructions: false,
 			},
 		} );
 		useSitesMock.mockReturnValue( { data: [] } );
@@ -377,6 +378,7 @@ describe( 'CreateSiteForm', () => {
 				openInOS: false,
 				annotatePreview: false,
 				readLocalMedia: false,
+				agentInstructions: false,
 			},
 		} );
 		usePathValidatorMock.mockReturnValue( {

--- a/apps/ui/src/components/settings-view/index.test.tsx
+++ b/apps/ui/src/components/settings-view/index.test.tsx
@@ -134,7 +134,11 @@ describe( 'SettingsView', () => {
 			configurable: true,
 		} );
 
-		useConnectorMock.mockReturnValue( { disableAgenticUi, selectDefaultSiteDirectory } as never );
+		useConnectorMock.mockReturnValue( {
+			disableAgenticUi,
+			selectDefaultSiteDirectory,
+			capabilities: { agentInstructions: false },
+		} as never );
 		useInstalledAppsMock.mockReturnValue( {
 			data: { vscode: true, terminal: true, iterm: true },
 		} as never );

--- a/apps/ui/src/components/settings-view/index.tsx
+++ b/apps/ui/src/components/settings-view/index.tsx
@@ -18,6 +18,7 @@ import { KeyboardPanel } from './keyboard-panel';
 import { McpPanel } from './mcp-panel';
 import { UNSET, toPreferencesFormData, toPreferencesPatch } from './preferences';
 import { SkillsPanel } from './skills-panel';
+import { StudioCodePanel } from './studio-code-panel';
 import styles from './style.module.css';
 import type { PreferencesFormData } from './preferences';
 import type {
@@ -30,7 +31,7 @@ import type {
 } from '@/data/core';
 import type { ReactNode } from 'react';
 
-const SETTINGS_TABS = [ 'preferences', 'keyboard', 'skills', 'mcp' ] as const;
+const SETTINGS_TABS = [ 'preferences', 'keyboard', 'skills', 'mcp', 'studio-code' ] as const;
 
 type TabId = ( typeof SETTINGS_TABS )[ number ];
 
@@ -86,6 +87,7 @@ const LOCALE_ELEMENTS: { value: SupportedLocale; label: string }[] = Object.entr
 ).map( ( [ value, label ] ) => ( { value: value as SupportedLocale, label } ) );
 
 function SettingsHeader() {
+	const connector = useConnector();
 	const sidebarCollapsed = useSidebarCollapsed();
 	const reserveTrafficLightSpace = useTrafficLightSpace();
 	const toggleSpacerClass = sidebarCollapsed
@@ -106,6 +108,9 @@ function SettingsHeader() {
 					<Tabs.Tab tabId="keyboard">{ __( 'Keyboard' ) }</Tabs.Tab>
 					<Tabs.Tab tabId="skills">{ __( 'Skills' ) }</Tabs.Tab>
 					<Tabs.Tab tabId="mcp">{ __( 'MCP' ) }</Tabs.Tab>
+					{ connector.capabilities.agentInstructions && (
+						<Tabs.Tab tabId="studio-code">{ __( 'Studio Code' ) }</Tabs.Tab>
+					) }
 				</Tabs.List>
 			</div>
 		</div>
@@ -419,6 +424,11 @@ export function SettingsView( {
 						<Tabs.Panel tabId="mcp">
 							<McpPanel />
 						</Tabs.Panel>
+						{ connector.capabilities.agentInstructions && (
+							<Tabs.Panel tabId="studio-code">
+								<StudioCodePanel />
+							</Tabs.Panel>
+						) }
 					</div>
 				</div>
 			</Tabs.Root>

--- a/apps/ui/src/components/settings-view/studio-code-panel.tsx
+++ b/apps/ui/src/components/settings-view/studio-code-panel.tsx
@@ -1,0 +1,82 @@
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
+import { useState } from 'react';
+import {
+	useAgentInstructions,
+	useSaveAgentInstructions,
+} from '@/data/queries/use-agent-instructions';
+import styles from './style.module.css';
+import type { Field, Form } from '@wordpress/dataviews';
+import type { FormEvent } from 'react';
+
+interface FormData {
+	content: string;
+}
+
+const FIELDS: Field< FormData >[] = [
+	{
+		id: 'content',
+		type: 'text',
+		label: __( 'Instructions' ),
+		description: __(
+			'Global instructions for the Studio Code agent. They are included in every new conversation, across all sites.'
+		),
+		placeholder: __( 'e.g. Always answer in French. My sites are for restaurants.' ),
+		Edit: { control: 'textarea', rows: 12 },
+	},
+];
+
+const FORM: Form = {
+	layout: { type: 'regular', labelPosition: 'top' },
+	fields: [ 'content' ],
+};
+
+export function StudioCodePanel() {
+	const { data: saved } = useAgentInstructions();
+	const saveInstructions = useSaveAgentInstructions();
+	const [ edits, setEdits ] = useState< string | null >( null );
+
+	if ( saved === undefined ) {
+		return <div className={ styles.state }>{ __( 'Loading…' ) }</div>;
+	}
+
+	const content = edits ?? saved;
+	const canSubmit = content !== saved && ! saveInstructions.isPending;
+
+	const handleSubmit = ( event: FormEvent ) => {
+		event.preventDefault();
+		if ( ! canSubmit ) {
+			return;
+		}
+		saveInstructions.mutate( content, { onSuccess: () => setEdits( null ) } );
+	};
+
+	return (
+		<form onSubmit={ handleSubmit } className={ styles.preferencesPanel }>
+			<DataForm< FormData >
+				data={ { content } }
+				fields={ FIELDS }
+				form={ FORM }
+				onChange={ ( update ) => setEdits( ( update.content as string ) ?? '' ) }
+			/>
+			{ saveInstructions.isError && (
+				<p className={ styles.instructionsError }>
+					{ __( 'Saving the instructions failed. Please try again.' ) }
+				</p>
+			) }
+			<div className={ styles.actions }>
+				<Button
+					type="submit"
+					variant="solid"
+					tone="brand"
+					disabled={ ! canSubmit }
+					loading={ saveInstructions.isPending }
+					loadingAnnouncement={ __( 'Saving instructions' ) }
+				>
+					{ __( 'Save instructions' ) }
+				</Button>
+			</div>
+		</form>
+	);
+}

--- a/apps/ui/src/components/settings-view/studio-code-panel.tsx
+++ b/apps/ui/src/components/settings-view/studio-code-panel.tsx
@@ -1,7 +1,8 @@
+import { GLOBAL_INSTRUCTIONS_MAX_LENGTH } from '@studio/common/ai/global-instructions';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
 	useAgentInstructions,
 	useSaveAgentInstructions,
@@ -36,20 +37,36 @@ export function StudioCodePanel() {
 	const { data: saved } = useAgentInstructions();
 	const saveInstructions = useSaveAgentInstructions();
 	const [ edits, setEdits ] = useState< string | null >( null );
+	const [ justSaved, setJustSaved ] = useState( false );
+
+	useEffect( () => {
+		if ( ! justSaved ) {
+			return;
+		}
+		const timer = setTimeout( () => setJustSaved( false ), 2500 );
+		return () => clearTimeout( timer );
+	}, [ justSaved ] );
 
 	if ( saved === undefined ) {
 		return <div className={ styles.state }>{ __( 'Loading…' ) }</div>;
 	}
 
 	const content = edits ?? saved;
-	const canSubmit = content !== saved && ! saveInstructions.isPending;
+	const isDirty = content !== saved;
+	const canSubmit = isDirty && ! saveInstructions.isPending;
+	const showCounter = content.length >= GLOBAL_INSTRUCTIONS_MAX_LENGTH * 0.8;
 
 	const handleSubmit = ( event: FormEvent ) => {
 		event.preventDefault();
 		if ( ! canSubmit ) {
 			return;
 		}
-		saveInstructions.mutate( content, { onSuccess: () => setEdits( null ) } );
+		saveInstructions.mutate( content, {
+			onSuccess: () => {
+				setEdits( null );
+				setJustSaved( true );
+			},
+		} );
 	};
 
 	return (
@@ -58,7 +75,11 @@ export function StudioCodePanel() {
 				data={ { content } }
 				fields={ FIELDS }
 				form={ FORM }
-				onChange={ ( update ) => setEdits( ( update.content as string ) ?? '' ) }
+				onChange={ ( update ) =>
+					setEdits(
+						( ( update.content as string ) ?? '' ).slice( 0, GLOBAL_INSTRUCTIONS_MAX_LENGTH )
+					)
+				}
 			/>
 			{ saveInstructions.isError && (
 				<p className={ styles.instructionsError }>
@@ -66,6 +87,11 @@ export function StudioCodePanel() {
 				</p>
 			) }
 			<div className={ styles.actions }>
+				{ showCounter && (
+					<span className={ styles.instructionsCounter }>
+						{ `${ content.length.toLocaleString() } / ${ GLOBAL_INSTRUCTIONS_MAX_LENGTH.toLocaleString() }` }
+					</span>
+				) }
 				<Button
 					type="submit"
 					variant="solid"
@@ -74,7 +100,7 @@ export function StudioCodePanel() {
 					loading={ saveInstructions.isPending }
 					loadingAnnouncement={ __( 'Saving instructions' ) }
 				>
-					{ __( 'Save instructions' ) }
+					{ justSaved && ! isDirty ? __( 'Saved' ) : __( 'Save instructions' ) }
 				</Button>
 			</div>
 		</form>

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -129,8 +129,14 @@
 
 .actions {
 	display: flex;
+	align-items: center;
 	justify-content: flex-end;
-	gap: var(--wpds-dimension-padding-sm);
+	gap: var(--wpds-dimension-padding-md);
+}
+
+.instructionsCounter {
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
 .instructionsError {

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -127,6 +127,18 @@
 	margin: 0 auto;
 }
 
+.actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--wpds-dimension-padding-sm);
+}
+
+.instructionsError {
+	margin: 0;
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-error);
+}
+
 .preferenceSectionGroup {
 	box-sizing: border-box;
 	display: flex;

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -113,6 +113,7 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 			openInOS: false,
 			annotatePreview: false,
 			readLocalMedia: false,
+			agentInstructions: false,
 		},
 
 		// Auth — runs unauthenticated, like the desktop app. WordPress.com login
@@ -321,6 +322,13 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 			// No native folder picker in a browser.
 			return null;
 		},
+		async getAgentInstructions(): Promise< string > {
+			throw new UnsupportedError( 'getAgentInstructions' );
+		},
+		async saveAgentInstructions(): Promise< void > {
+			throw new UnsupportedError( 'saveAgentInstructions' );
+		},
+
 		async getInstalledApps(): Promise< InstalledApps > {
 			return {} as InstalledApps;
 		},

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -169,6 +169,7 @@ export function createIpcConnector(): Connector {
 			openInOS: true,
 			annotatePreview: true,
 			readLocalMedia: true,
+			agentInstructions: true,
 		},
 
 		// Auth — optional in Electron, delegated to main process
@@ -601,6 +602,13 @@ export function createIpcConnector(): Connector {
 				return response || null;
 			}
 			return response?.path ?? null;
+		},
+
+		async getAgentInstructions(): Promise< string > {
+			return ( await ipcApi.getGlobalAgentInstructions() ) as string;
+		},
+		async saveAgentInstructions( content: string ): Promise< void > {
+			await ipcApi.saveGlobalAgentInstructions( content );
 		},
 
 		async getInstalledApps(): Promise< InstalledApps > {

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -222,6 +222,7 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			openInOS: true,
 			annotatePreview: false,
 			readLocalMedia: false,
+			agentInstructions: true,
 		},
 
 		// Auth — surfaces the WordPress.com user the CLI is already logged in as
@@ -634,6 +635,17 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 		// detection, server-side) so the preferences picker offers only what's there.
 		async getInstalledApps(): Promise< InstalledApps > {
 			return api< InstalledApps >( '/installed-apps' );
+		},
+
+		async getAgentInstructions(): Promise< string > {
+			const { content } = await api< { content: string } >( '/agent-instructions' );
+			return content;
+		},
+		async saveAgentInstructions( content: string ): Promise< void > {
+			await api< void >( '/agent-instructions', {
+				method: 'POST',
+				body: JSON.stringify( { content } ),
+			} );
 		},
 
 		// The server runs on the user's machine, so it opens paths in OS apps on

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -122,6 +122,10 @@ export interface ConnectorCapabilities {
 	// render local screenshot artifacts inline). Only the desktop IPC connector
 	// supports it; the browser connectors reject local file reads.
 	readLocalMedia: boolean;
+	// The host can read/write the user's global Studio Code instructions file
+	// (~/.studio/knowledge/instructions.md). False when hosted remotely, which
+	// hides the Studio Code settings tab.
+	agentInstructions: boolean;
 }
 
 export interface Connector {
@@ -315,6 +319,11 @@ export interface Connector {
 	// Resolves with the chosen path, or `null` when the user cancels (or the
 	// host has no native picker — see capabilities.nativeFolderPicker).
 	selectDefaultSiteDirectory( defaultPath: string ): Promise< string | null >;
+
+	// The user's global Studio Code instructions, a markdown file injected into
+	// every agent session. Gated by `capabilities.agentInstructions`.
+	getAgentInstructions(): Promise< string >;
+	saveAgentInstructions( content: string ): Promise< void >;
 
 	// Apps detected on disk (editors + terminals). Options in the preferences
 	// form are filtered against this so users can't pick something that isn't

--- a/apps/ui/src/data/queries/use-agent-instructions.ts
+++ b/apps/ui/src/data/queries/use-agent-instructions.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+
+export const AGENT_INSTRUCTIONS_QUERY_KEY = [ 'agent-instructions' ] as const;
+
+export function useAgentInstructions() {
+	const connector = useConnector();
+	return useQuery( {
+		queryKey: AGENT_INSTRUCTIONS_QUERY_KEY,
+		queryFn: () => connector.getAgentInstructions(),
+		enabled: connector.capabilities.agentInstructions,
+		staleTime: Infinity,
+	} );
+}
+
+export function useSaveAgentInstructions() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( content: string ) =>
+			connector.saveAgentInstructions( content ).then( () => content ),
+		onSuccess: ( content ) => {
+			queryClient.setQueryData< string >( AGENT_INSTRUCTIONS_QUERY_KEY, content );
+		},
+	} );
+}

--- a/packages/common/ai/global-instructions.ts
+++ b/packages/common/ai/global-instructions.ts
@@ -3,6 +3,11 @@ import path from 'path';
 import { isErrnoException } from '../lib/is-errno-exception';
 import { getGlobalInstructionsPath } from '../lib/well-known-paths';
 
+// Keep the always-injected instructions small enough that they can't crowd out
+// the rest of the system prompt. The prompt builder truncates anything longer;
+// the settings UIs cap their textareas at the same length.
+export const GLOBAL_INSTRUCTIONS_MAX_LENGTH = 16_000;
+
 /**
  * Read the user's global agent instructions (`~/.studio/knowledge/instructions.md`)
  * for injection into the system prompt. Returns `undefined` when the file is

--- a/packages/common/ai/global-instructions.ts
+++ b/packages/common/ai/global-instructions.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+import { isErrnoException } from '../lib/is-errno-exception';
+import { getGlobalInstructionsPath } from '../lib/well-known-paths';
+
+/**
+ * Read the user's global agent instructions (`~/.studio/knowledge/instructions.md`)
+ * for injection into the system prompt. Returns `undefined` when the file is
+ * missing, empty, or unreadable — the agent must keep working without
+ * instructions.
+ */
+export async function readGlobalInstructions(): Promise< string | undefined > {
+	let content: string;
+	try {
+		content = await fs.promises.readFile( getGlobalInstructionsPath(), 'utf8' );
+	} catch ( error ) {
+		if ( ! isErrnoException( error ) || error.code !== 'ENOENT' ) {
+			console.error( '[global-instructions] Failed to read instructions file:', error );
+		}
+		return undefined;
+	}
+	return content.trim() || undefined;
+}
+
+/**
+ * Read the raw file content for editing surfaces (settings UI). Returns `null`
+ * when the file doesn't exist; other read errors propagate so the UI can
+ * surface them.
+ */
+export async function readGlobalInstructionsFile(): Promise< string | null > {
+	try {
+		return await fs.promises.readFile( getGlobalInstructionsPath(), 'utf8' );
+	} catch ( error ) {
+		if ( isErrnoException( error ) && error.code === 'ENOENT' ) {
+			return null;
+		}
+		throw error;
+	}
+}
+
+export async function writeGlobalInstructions( content: string ): Promise< void > {
+	const filePath = getGlobalInstructionsPath();
+	await fs.promises.mkdir( path.dirname( filePath ), { recursive: true } );
+	await fs.promises.writeFile( filePath, content, 'utf8' );
+}

--- a/packages/common/ai/tests/global-instructions.test.ts
+++ b/packages/common/ai/tests/global-instructions.test.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	readGlobalInstructions,
+	readGlobalInstructionsFile,
+	writeGlobalInstructions,
+} from '../global-instructions';
+
+describe( 'global-instructions', () => {
+	let configDir: string;
+	let previousDevConfigDir: string | undefined;
+
+	beforeEach( () => {
+		configDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-global-instructions-' ) );
+		previousDevConfigDir = process.env.DEV_CONFIG_DIR;
+		process.env.DEV_CONFIG_DIR = configDir;
+	} );
+
+	afterEach( () => {
+		if ( previousDevConfigDir === undefined ) {
+			delete process.env.DEV_CONFIG_DIR;
+		} else {
+			process.env.DEV_CONFIG_DIR = previousDevConfigDir;
+		}
+		fs.rmSync( configDir, { recursive: true, force: true } );
+	} );
+
+	it( 'returns undefined when the instructions file does not exist', async () => {
+		expect( await readGlobalInstructions() ).toBeUndefined();
+	} );
+
+	it( 'returns undefined when the instructions file is empty or whitespace', async () => {
+		await writeGlobalInstructions( '  \n\t\n' );
+		expect( await readGlobalInstructions() ).toBeUndefined();
+	} );
+
+	it( 'round-trips written instructions, trimmed for the prompt', async () => {
+		await writeGlobalInstructions( '\nAlways answer in French.\n' );
+		expect( await readGlobalInstructions() ).toBe( 'Always answer in French.' );
+	} );
+
+	it( 'reads the raw file content for editing, preserving whitespace', async () => {
+		await writeGlobalInstructions( '\n# Notes\n' );
+		expect( await readGlobalInstructionsFile() ).toBe( '\n# Notes\n' );
+	} );
+
+	it( 'returns null for editing when the file does not exist', async () => {
+		expect( await readGlobalInstructionsFile() ).toBeNull();
+	} );
+} );

--- a/packages/common/lib/well-known-paths.ts
+++ b/packages/common/lib/well-known-paths.ts
@@ -38,6 +38,14 @@ export function getSessionsDirectory(): string {
 	return path.join( getConfigDirectory(), 'sessions' );
 }
 
+export function getKnowledgeDirectory(): string {
+	return path.join( getConfigDirectory(), 'knowledge' );
+}
+
+export function getGlobalInstructionsPath(): string {
+	return path.join( getKnowledgeDirectory(), 'instructions.md' );
+}
+
 export function getCertificatesPath(): string {
 	return path.join( getConfigDirectory(), 'certificates' );
 }

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -17,6 +17,7 @@ Run one named test with `npm run eval -- --filter-pattern "preview sites"` (rege
 ## Tests
 
 - **identity** — Agent identifies itself correctly (verified by an LLM judge).
+- **global-instructions** — Agent follows the user's global instructions (`~/.studio/knowledge/instructions.md`). Seeds the file with a sentinel-token rule and asserts the reply carries the token; the file's prior content is restored after the turn.
 - **site-creation** — Agent calls `site_create` and it succeeds.
 - **screenshot-all-timing** — Agent creates a minimal site and visually verifies the homepage on desktop and mobile. Asserts the agent uses one `take_screenshot` call with `viewport: "all"`, returns valid desktop/mobile PNG payloads, and keeps the screenshot tool under 15s.
 - **single-page-build-turn-cadence** — Agent builds a simple one-page site. Asserts (a) the default flow scaffolds a fresh blank theme (`scaffold_theme` without `parentTheme`, successfully), (b) every individual turn stays under 60s (wall-clock between successive assistant messages) and (c) no `wp_cli` call uses `--post_content-file=` (which silently fails inside PHP-WASM).
@@ -31,6 +32,6 @@ Tests live in `promptfoo.config.yaml`. The runner returns raw JSON (`toolCalls`,
 
 ### Seeding fixtures
 
-Set a `seed` var on a test to pre-populate config files before the agent turn — useful for flows that depend on connected remote sites or preview sites without making a real WordPress.com connection or preview. The seed accepts `localSite` (written to `cli.json`), `connectedWpcomSites` (written to `shared.json`, requires `studio auth login`), and `snapshots` (written to `cli.json`). Everything seeded is removed automatically after the turn so reruns start clean.
+Set a `seed` var on a test to pre-populate config files before the agent turn — useful for flows that depend on connected remote sites or preview sites without making a real WordPress.com connection or preview. The seed accepts `localSite` (written to `cli.json`), `connectedWpcomSites` (written to `shared.json`, requires `studio auth login`), `snapshots` (written to `cli.json`), and `globalInstructions` (written to `~/.studio/knowledge/instructions.md`; the file's prior content — or absence — is restored after the turn). Everything seeded is removed automatically after the turn so reruns start clean.
 
 The grader (`grader-provider.mjs`) handles `llm-rubric` assertions via the WP.com AI proxy. No extra API key needed if you're logged into Studio.

--- a/scripts/eval/promptfoo.config.yaml
+++ b/scripts/eval/promptfoo.config.yaml
@@ -49,6 +49,35 @@ tests:
             };
           });
 
+  # The global instructions file (~/.studio/knowledge/instructions.md) is
+  # seeded with a sentinel-token rule for the turn and restored afterwards.
+  # A compliant agent ends its reply with the token; an agent that never saw
+  # the instructions can't produce it.
+  - description: agent follows the user's global instructions
+    vars:
+      caseId: global-instructions
+      timeoutMs: 60000
+      prompt: In one short sentence, say hello. Do not call any tools.
+      seed:
+        globalInstructions: |
+          Always end every reply with the exact token STUDIO-EVAL-TOKEN-7319.
+    assert:
+      - type: javascript
+        value: |
+          return import('node:fs').then(({ readFileSync }) => {
+            const marker = output.split(/\r?\n/).map(l => l.trim()).find(l => l.startsWith('EVAL_RUNNER_RESULT_FILE='));
+            if (!marker) return { pass: false, score: 0, reason: `no result-file marker on stdout; got: ${output.slice(0, 200)}` };
+            const d = JSON.parse(readFileSync(marker.slice('EVAL_RUNNER_RESULT_FILE='.length), 'utf8'));
+            if (d.success !== true) return { pass: false, score: 0, reason: `runner success=${d.success}` };
+            const text = (d.textSegments || []).join('\n');
+            const pass = text.includes('STUDIO-EVAL-TOKEN-7319');
+            return {
+              pass,
+              score: pass ? 1 : 0,
+              reason: pass ? 'reply carries the token from the global instructions' : `token missing from reply: ${text.slice(0, 300)}`,
+            };
+          });
+
   - description: agent calls site_create when asked to make a site
     vars:
       caseId: site-creation


### PR DESCRIPTION
## Why

A user asked me for the possibility to move his instructions/context from a conversation to another. I think what we really need ultimately is a wp.com user tied knowledge base, but there's a small thing we could provider users without building all of that, an instructions file config where users can provide global instructions injected in the Studio Code system prompt.

## Related issues

- Related to the Studio Code knowledge-base direction (no linked issue yet).

## How AI was used in this PR

Designed and implemented in a Claude Code session pair-driven by @youknowriad: exploration, implementation, tests, and the eval were AI-authored, with direction and design decisions (file location, remote-session inclusion, dedicated settings tab, local-UI support) made by the human. A four-angle AI cleanup review pass is being applied as a follow-up commit on this branch.

## Proposed Changes

Users can now give the Studio Code agent standing, global instructions — preferences that apply to every conversation across all sites, e.g. "always answer in French" or "I prefer light background colors". Until now, such preferences had to be repeated in every session.

- Instructions live in a plain markdown file at `~/.studio/knowledge/instructions.md`, editable in a new **Studio Code** settings tab in the classic desktop UI, the agentic UI, and the `studio ui` web UI (served through a small local-server API). Power users can edit the file directly; edits take effect on the next agent message.
- The instructions are injected into the agent system prompt for both local and remote (WordPress.com) sessions, framed so they cannot override safety or validation guardrails, size-capped (16 KB, truncated with a visible notice) so they can't crowd out the rest of the prompt, and resilient (a missing or unreadable file never breaks the agent).
- The `knowledge/` directory is the deliberate seed of a future knowledge base: sibling markdown files with an injected index and on-demand retrieval can be added later without migrating anything.
- The hosted (cloud) web UI hides the tab — there's no user filesystem there.

## Testing Instructions

1. `npm run cli:build && npm start`, open Settings → Studio Code, save an easily observable instruction (e.g. "End every reply with the word BANANA"), start a new Studio Code conversation, and confirm the agent follows it.
2. Same flow in the agentic UI (Settings → Studio Code tab).
3. Local web UI: `npm run build:local --workspace=apps/ui && npm run cli:build && node apps/cli/dist/cli/main.mjs ui` → Settings → Studio Code.
4. Terminal agent: `node apps/cli/dist/cli/main.mjs ai "say hello"` picks up the same file.
5. Automated: `npm test -- packages/common/ai/tests/global-instructions.test.ts apps/cli/ai/tests/system-prompt.test.ts`, and `npm run eval -- --filter-pattern "global instructions"` (requires `studio auth login`; passed locally).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)