### PR TITLE
Harden site REST proxy against SSRF via redirects and origin drift

### DIFF
--- a/apps/studio/src/lib/tests/wordpress-rest-api.test.ts
+++ b/apps/studio/src/lib/tests/wordpress-rest-api.test.ts
@@ -133,4 +133,49 @@ describe( 'fetchSiteRest', () => {
 		expect( response.status ).toBe( 400 );
 		expect( response.body ).toContain( 'REST URL must target the selected site REST API.' );
 	} );
+
+	it( 'always targets the loopback origin regardless of the requested path', async () => {
+		mockRunningSite();
+		const fetchMock = mockRestFetch();
+
+		await fetchSiteRest( mockIpcMainInvokeEvent, 'site-id', {
+			path: '/wp/v2/pages',
+		} );
+
+		const restUrls = getRequestedUrls( fetchMock ).filter( ( url ) => url.includes( '/wp-json/' ) );
+		expect( restUrls ).toEqual( [ 'http://127.0.0.1:8903/wp-json/wp/v2/pages' ] );
+		for ( const url of restUrls ) {
+			expect( new URL( url ).origin ).toBe( 'http://127.0.0.1:8903' );
+		}
+	} );
+
+	it( 'does not follow redirects on the proxied REST request', async () => {
+		mockRunningSite();
+		const redirectingFetch = vi.fn( async ( input: Parameters< typeof fetch >[ 0 ] ) => {
+			const url = String( input );
+			if ( url.includes( '/studio-auto-login' ) ) {
+				return new Response( '', {
+					status: 302,
+					headers: { 'set-cookie': 'wordpress_logged_in_test=token; Path=/; HttpOnly' },
+				} );
+			}
+			if ( url.includes( '/wp-admin/admin-ajax.php' ) ) {
+				return new Response( 'test-nonce', { status: 200 } );
+			}
+			return new Response( '', {
+				status: 302,
+				headers: { location: 'https://attacker.example/secret' },
+			} );
+		} );
+		vi.stubGlobal( 'fetch', redirectingFetch );
+
+		const response = await fetchSiteRest( mockIpcMainInvokeEvent, 'site-id', {
+			path: '/wp/v2/pages',
+		} );
+
+		expect( response.status ).toBe( 302 );
+		expect( getRequestedUrls( redirectingFetch ) ).not.toContain(
+			'https://attacker.example/secret'
+		);
+	} );
 } );

--- a/packages/common/lib/wordpress-rest.ts
+++ b/packages/common/lib/wordpress-rest.ts
@@ -72,11 +72,18 @@ async function fetchSiteRestWithAuth(
 	if ( request.data !== undefined && ! hasHeader( headers, 'content-type' ) ) {
 		headers[ 'Content-Type' ] = 'application/json';
 	}
-	const response = await fetch( url, {
+	// SSRF barrier: keep the host/protocol server-controlled, carrying over only
+	// the already-validated path, query and fragment.
+	const safeUrl = new URL( target.baseUrl );
+	safeUrl.pathname = url.pathname;
+	safeUrl.search = url.search;
+	safeUrl.hash = url.hash;
+	// Don't follow redirects: a 3xx could send the auth cookie + nonce to another host.
+	const response = await fetch( safeUrl, {
 		method: request.method ?? 'GET',
 		headers,
 		body: getRequestBody( request ),
-		redirect: 'follow',
+		redirect: 'manual',
 	} );
 
 	if ( allowAuthRefresh && ( response.status === 401 || response.status === 403 ) ) {


### PR DESCRIPTION
## Related issues

- Related to [code scanning alert #206](https://github.com/Automattic/studio/security/code-scanning/206) (SSRF / CWE-918, critical)

## How AI was used in this PR

Claude Code investigated the CodeQL alert, traced the taint flow from the `/sites/:id/rest` endpoint into the shared REST proxy, implemented the hardening, and added unit tests. All changes were reviewed by the author.

## Proposed Changes

The shared "proxy a REST request to a running local site" helper takes a caller-supplied request. It's the transport behind `@wordpress/api-fetch`/`core-data`, reachable both over IPC (desktop) and over HTTP via `POST /sites/:id/rest` on the local CLI server (`studio ui` / agent surface) — so its input is not fully trusted. It already rejected paths/URLs that escape the selected site's REST root, but two gaps remained that let a request be redirected off that origin, carrying the site's auth cookie and REST nonce with it:

- The proxied `fetch` used `redirect: 'follow'`, so a `3xx` response from the site could silently send the authenticated request to an arbitrary host, with the response fed back to the caller.
- The final fetch relied on the URL object built during validation, leaving no guarantee at the point of use that host/protocol were still server-controlled.

This PR adds a final SSRF barrier: the request target is rebuilt from the server-controlled loopback base, carrying over only the already-validated path/query/fragment, and redirects are no longer followed. There is no behavior change for legitimate same-origin REST requests.

## Testing Instructions

- `npm test -- apps/studio/src/lib/tests/wordpress-rest-api.test.ts` — passes (5/5), including new cases asserting the request always targets the loopback origin and that redirects are not followed.
- `npm run typecheck` — passes.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
