### PR TITLE
Build the browser UI in release CLI builds so `studio ui` ships working

### DIFF
--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -58,9 +58,13 @@ export function buildLocalUiPlugin() {
 		name: 'build-local-ui',
 		apply: 'build' as const,
 		buildStart() {
-			execSync( 'npm run build:local --workspace=apps/ui', {
-				cwd: repoRoot,
+			// Equivalent to apps/ui's `build:local` script, but with the target set
+			// via the environment: the script's inline `STUDIO_TARGET=local` prefix
+			// is POSIX-only and fails under cmd.exe on Windows CI.
+			execSync( 'npx vite build', {
+				cwd: resolve( __dirname, '../ui' ),
 				stdio: 'inherit',
+				env: { ...process.env, STUDIO_TARGET: 'local' },
 			} );
 			if ( ! existsSync( localUiDistPath ) ) {
 				throw new Error(

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -45,8 +45,31 @@ const repoRoot = resolve( __dirname, '..', '..' );
 // The `studio ui` command serves the built browser UI (apps/ui `dist-local`)
 // from `<chunk dir>/ui`, so it must sit next to the built chunks too. Built
 // separately (`npm run build:local --workspace=apps/ui`); absent in API-only
-// or dev-server setups, which is fine.
+// or dev-server setups, which is fine — for dev builds. Release configs must
+// include `buildLocalUiPlugin` so the shipped CLI never lacks the UI.
 const localUiDistPath = resolve( __dirname, '../ui/dist-local' );
+
+// Builds the browser UI so the copy in `write-dist-extras` always has it.
+// Release configs (npm, prod, standalone) include this plugin; without it a
+// missing `dist-local` is silently skipped and `studio ui` ships broken
+// ("Cannot GET /", as happened with wp-studio@1.15.0 on npm).
+export function buildLocalUiPlugin() {
+	return {
+		name: 'build-local-ui',
+		apply: 'build' as const,
+		buildStart() {
+			execSync( 'npm run build:local --workspace=apps/ui', {
+				cwd: repoRoot,
+				stdio: 'inherit',
+			} );
+			if ( ! existsSync( localUiDistPath ) ) {
+				throw new Error(
+					`The browser UI build did not produce ${ localUiDistPath }; refusing to ship a CLI without the \`studio ui\` assets.`
+				);
+			}
+		},
+	};
+}
 
 // Ship only the self-contained engine bundle — its deps are inlined. Shipping
 // the tsc output + node_modules instead added ~10k files to the installer and

--- a/apps/cli/vite.config.npm.ts
+++ b/apps/cli/vite.config.npm.ts
@@ -1,9 +1,10 @@
 import { defineConfig, mergeConfig } from 'vite';
-import { baseConfig } from './vite.config.base';
+import { baseConfig, buildLocalUiPlugin } from './vite.config.base';
 
 export default mergeConfig(
 	baseConfig,
 	defineConfig( {
+		plugins: [ buildLocalUiPlugin() ],
 		build: {
 			sourcemap: false,
 		},

--- a/apps/cli/vite.config.prod.ts
+++ b/apps/cli/vite.config.prod.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import { globSync } from 'glob';
 import { defineConfig, mergeConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
-import { baseConfig } from './vite.config.base';
+import { baseConfig, buildLocalUiPlugin } from './vite.config.base';
 
 const cliNodeModulesPath = resolve( __dirname, 'node_modules' );
 const distCliNodeModulesPath = resolve( __dirname, 'dist/cli/node_modules' );
@@ -12,6 +12,7 @@ export default mergeConfig(
 	baseConfig,
 	defineConfig( {
 		plugins: [
+			buildLocalUiPlugin(),
 			...( existsSync( cliNodeModulesPath )
 				? [
 						viteStaticCopy( {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"make:dmg-arm64": "FILE_ARCHITECTURE=arm64 node ./scripts/make-dmg.mjs",
 		"publish": "npm -w studio-app run publish",
 		"cli:build": "npm -w wp-studio run build",
+		"cli:build:ui": "npm -w @studio/ui run build:local && npm -w wp-studio run build",
 		"cli:build:prod": "npm -w wp-studio run build:prod",
 		"cli:build:npm": "npm -w wp-studio run build:npm",
 		"cli:package": "npm -w wp-studio run package",


### PR DESCRIPTION
## Related issues

<!-- No tracked issue; gap found by inspecting the published npm package. -->

- Related to the `studio ui` command shipping broken in published CLIs (no issue filed).

## How AI was used in this PR

Claude Code investigated the release pipeline, confirmed the gap by inspecting the published `wp-studio@1.15.0` registry tarball, wrote the fix, and verified the builds end-to-end (build outputs, `npm pack` contents, and `studio ui` serving the UI).

## Proposed Changes

The published `wp-studio` npm package ships the `studio ui` command but not the browser UI it serves: `wp-studio@1.15.0` on npm contains no `ui/` assets, so running `studio ui` from an npm install responds with "Cannot GET /". The root cause is that nothing in the release pipeline ever builds `apps/ui` — the CLI build only copies `dist-local` if it happens to already exist, and silently skips it otherwise.

- Release CLI builds (npm, prod, and the standalone bundle) now build the browser UI themselves before bundling, and fail loudly if the UI output is missing — a broken `studio ui` can no longer ship silently.
- Dev builds are unchanged: the UI remains optional there, so API-only and Vite-dev-server workflows keep working without building the UI.
- Adds a root `npm run cli:build:ui` convenience script that chains the UI build and the CLI build for anyone who wants the full `studio ui` experience from a dev build.

## Testing Instructions

- `rm -rf apps/ui/dist-local && npm run cli:build:npm` — the build should build the UI itself, and `apps/cli/dist/cli/ui/index.local.html` should exist afterwards.
- `npm pack -w wp-studio --dry-run | grep dist/cli/ui` — the tarball file list should include the UI assets.
- `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui` — the browser should show the Studio UI at `/` (not "Cannot GET /").
- Dev flow still permissive: `rm -rf apps/ui/dist-local apps/cli/dist && npm run cli:build` should succeed without building the UI.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)