### PR TITLE
Fix incomplete multi-character HTML sanitization in AI tool result previews

### DIFF
--- a/packages/common/ai/tests/tools.test.ts
+++ b/packages/common/ai/tests/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getToolDetail, getToolDisplayName } from '../tools';
+import { getToolDetail, getToolDisplayName, getToolResultPreview } from '../tools';
 
 describe( 'tool display helpers', () => {
 	it( 'summarizes common WP-CLI commands from their input', () => {
@@ -113,5 +113,16 @@ describe( 'tool display helpers', () => {
 				],
 			} )
 		).toBe( 'What kind of visual direction should this site use?' );
+	} );
+
+	it( 'fully strips rendered HTML tags that recombine after a single pass', () => {
+		const preview = getToolResultPreview(
+			'wpcom_request',
+			{ method: 'GET', path: '/sites/1/posts/1' },
+			JSON.stringify( { title: { rendered: '<scr<script>ipt>alert(1)</scr</script>ipt>' } } )
+		);
+
+		expect( preview?.summaryLines[ 0 ] ).not.toContain( '<script' );
+		expect( preview?.summaryLines[ 0 ] ).not.toContain( '<' );
 	} );
 } );

--- a/packages/common/ai/tools.ts
+++ b/packages/common/ai/tools.ts
@@ -555,9 +555,19 @@ function getDisplayValue( value: unknown ): string {
 	}
 	if ( value && typeof value === 'object' && 'rendered' in value ) {
 		const rendered = ( value as { rendered?: unknown } ).rendered;
-		return typeof rendered === 'string' ? rendered.replace( /<[^>]*>/g, '' ) : '';
+		return typeof rendered === 'string' ? stripHtmlTags( rendered ) : '';
 	}
 	return '';
+}
+
+function stripHtmlTags( input: string ): string {
+	let previous: string;
+	let result = input;
+	do {
+		previous = result;
+		result = result.replace( /<[^>]*>/g, '' );
+	} while ( result !== previous );
+	return result;
 }
 
 function getResourceName( value: unknown ): string {


### PR DESCRIPTION
## Related issues

- Fixes [code scanning alert #205](https://github.com/Automattic/studio/security/code-scanning/205) (`js/incomplete-multi-character-sanitization`, CWE-20/80/116, high severity)

## How AI was used in this PR

Claude Code investigated the CodeQL alert, applied the fix, added a regression test, and ran lint / typecheck / the affected test suite. I reviewed the change.

## Proposed Changes

When rendering previews of WordPress.com API tool results in the AI chat, Studio strips HTML tags out of `rendered` fields (post titles, etc.) so the summary shows plain text. That stripping used a single-pass regex replacement, which is unsafe: for a crafted value such as `<scr<script>ipt>`, removing the inner match leaves the outer fragments to recombine back into a live `<script>` tag. A malicious or compromised API response could therefore smuggle a tag through the sanitizer.

The tag-stripping now runs iteratively until the output stops changing, so no tag can reappear after removal. This is display-only sanitization for the tool-result summary line; behavior for normal (non-adversarial) content is unchanged.

## Testing Instructions

- `npm test -- packages/common/ai/tests/tools.test.ts` — passes, including a new test that feeds a recombining `<scr<script>ipt>…` payload through `getToolResultPreview` and asserts no `<script` (nor any `<`) survives in the summary.
- `npm run typecheck` — passes.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
