### PR TITLE
Fix path-injection in /paths/compare by confining inputs to the sites root

### DIFF
--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -30,6 +30,7 @@ import {
 import {
 	arePathsEqual,
 	isEmptyDir,
+	isPathWithin,
 	isWordPressDirectory,
 	recursiveCopyDirectory,
 } from '@studio/common/lib/fs-utils';
@@ -503,7 +504,15 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 
 	api.post( '/paths/compare', ( req: Request, res: Response ) => {
 		const { path1, path2 } = req.body as { path1?: string; path2?: string };
-		res.json( { equal: !! path1 && !! path2 && arePathsEqual( path1, path2 ) } );
+		// Confine both operands to `sitesRoot`: nothing outside it can be a site, and
+		// this keeps untrusted input from reaching statSync (in arePathsEqual).
+		const equal =
+			!! path1 &&
+			!! path2 &&
+			isPathWithin( sitesRoot, path1 ) &&
+			isPathWithin( sitesRoot, path2 ) &&
+			arePathsEqual( path1, path2 );
+		res.json( { equal } );
 	} );
 
 	api.post(

--- a/packages/common/lib/fs-utils.ts
+++ b/packages/common/lib/fs-utils.ts
@@ -72,6 +72,16 @@ export function isWordPressDirectory( projectPath: string ): boolean {
 	);
 }
 
+// True when `candidate` resolves to `root` or a descendant. Used to confine
+// untrusted paths to a safe root, guarding against `../` traversal escapes.
+export function isPathWithin( root: string, candidate: string ): boolean {
+	const resolvedRoot = path.resolve( root );
+	const resolvedCandidate = path.resolve( candidate );
+	return (
+		resolvedCandidate === resolvedRoot || resolvedCandidate.startsWith( resolvedRoot + path.sep )
+	);
+}
+
 // Compare paths, preferring inode comparison when both paths exist on disk.
 // `fs.Stats.dev` signifies the device ID, and `fs.Stats.ino` signifies the inode number
 // that uniquely identifies the file or directory. This approach respects the current file

--- a/packages/common/lib/tests/fs-utils.test.ts
+++ b/packages/common/lib/tests/fs-utils.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { vi } from 'vitest';
-import { calculateDirectorySizeForArchive } from '@studio/common/lib/fs-utils';
+import { calculateDirectorySizeForArchive, isPathWithin } from '@studio/common/lib/fs-utils';
 
 describe( 'calculateDirectorySizeForArchive', () => {
 	let tempDir: string;
@@ -37,5 +37,25 @@ describe( 'calculateDirectorySizeForArchive', () => {
 		expect( warnSpy ).toHaveBeenCalledWith( expect.stringContaining( 'advanced-cache.php' ) );
 
 		warnSpy.mockRestore();
+	} );
+} );
+
+describe( 'isPathWithin', () => {
+	const root = path.join( os.tmpdir(), 'studio-sites' );
+
+	it( 'accepts the root itself and its descendants', () => {
+		expect( isPathWithin( root, root ) ).toBe( true );
+		expect( isPathWithin( root, path.join( root, 'my-site' ) ) ).toBe( true );
+		expect( isPathWithin( root, path.join( root, 'my-site', 'wp-content' ) ) ).toBe( true );
+	} );
+
+	it( 'rejects traversal escapes and unrelated paths', () => {
+		expect( isPathWithin( root, path.join( root, '..', 'secret' ) ) ).toBe( false );
+		expect( isPathWithin( root, path.join( root, '..', '..', 'etc', 'passwd' ) ) ).toBe( false );
+		expect( isPathWithin( root, '/etc/passwd' ) ).toBe( false );
+	} );
+
+	it( 'rejects a sibling directory sharing the root as a name prefix', () => {
+		expect( isPathWithin( root, `${ root }-other` ) ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
## Related issues

- Related to code scanning alerts [#207](https://github.com/Automattic/studio/security/code-scanning/207) and [#208](https://github.com/Automattic/studio/security/code-scanning/208)

## How AI was used in this PR

Claude Code fetched both CodeQL alerts, traced the taint flow, proposed the "confine to a safe root" mitigation, wrote the helper and tests, and ran lint/typecheck/tests. I reviewed the approach and the diff.

## Proposed Changes

Two high-severity CodeQL `js/path-injection` alerts flagged the unauthenticated, loopback-only `POST /api/paths/compare` endpoint in the local server: it passed request-body `path1`/`path2` straight into `arePathsEqual`, which calls `fs.statSync(path.resolve(...))`. A crafted `../` payload could probe arbitrary filesystem paths outside the sites directory.

This confines both operands to the server's `sitesRoot` before they reach any filesystem call. Anything outside `sitesRoot` cannot be a Studio site, so a non-match is the correct answer and the untrusted value never reaches `statSync` unguarded. The shared `arePathsEqual` helper is intentionally left untouched, since its other callers (CLI, desktop IPC) legitimately compare arbitrary absolute site paths that come from trusted local config.

No user-visible behavior change for legitimate use: the UI only ever compares real site paths under `sitesRoot`.

## Testing Instructions

- `npm test -- packages/common/lib/tests/fs-utils.test.ts` — new `isPathWithin` tests cover the root itself, descendants, `../` escapes, and the sibling-prefix edge case (`sites-other` must not count as inside `sites`).
- `npm run typecheck` passes across all workspaces.
- Manual: `POST /api/paths/compare` with two real site paths under the sites root returns `{ equal: true }` when they match; a body with a `../` traversal path returns `{ equal: false }`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
