### PR TITLE
Fixes for offline mode

### DIFF
--- a/apps/studio/src/components/top-bar.tsx
+++ b/apps/studio/src/components/top-bar.tsx
@@ -91,24 +91,22 @@ function Authentication() {
 	}
 
 	return (
-		<Tooltip
-			disabled={ ! isOffline }
-			icon={ offlineIcon }
-			text={ __( 'Logging in requires an internet connection.' ) }
-			placement="bottom-end"
+		<Button
+			onClick={ () => getIpcApi().authenticate( false ) }
+			aria-label={ __( 'Log in to Studio with WordPress.com' ) }
+			variant="icon"
+			className="flex gap-x-2 justify-between w-full text-white !rounded-lg !px-2 !py-1.5 h-auto active:!text-white hover:!text-white hover:underline items-center"
+			disabled={ isOffline }
+			title={
+				isOffline
+					? `${ __( 'You’re currently offline.' ) } ${ __( 'Some features will be unavailable.' ) }`
+					: undefined
+			}
 		>
-			<Button
-				onClick={ () => getIpcApi().authenticate( false ) }
-				aria-label={ __( 'Log in to Studio with WordPress.com' ) }
-				variant="icon"
-				className="flex gap-x-2 justify-between w-full text-white !rounded-lg !px-2 !py-1.5 h-auto active:!text-white hover:!text-white hover:underline items-center"
-				disabled={ isOffline }
-			>
-				<WordPressLogo />
+			<WordPressLogo />
 
-				<div className="text-s text-right">{ __( 'Log in' ) }</div>
-			</Button>
-		</Tooltip>
+			<div className="text-s text-right">{ __( 'Log in' ) }</div>
+		</Button>
 	);
 }
 

--- a/apps/studio/src/components/top-bar.tsx
+++ b/apps/studio/src/components/top-bar.tsx
@@ -91,17 +91,24 @@ function Authentication() {
 	}
 
 	return (
-		<Button
-			onClick={ () => getIpcApi().authenticate( false ) }
-			aria-label={ __( 'Log in to Studio with WordPress.com' ) }
-			variant="icon"
-			className="flex gap-x-2 justify-between w-full text-white !rounded-lg !px-2 !py-1.5 h-auto active:!text-white hover:!text-white hover:underline items-center"
-			disabled={ isOffline }
+		<Tooltip
+			disabled={ ! isOffline }
+			icon={ offlineIcon }
+			text={ __( 'Logging in requires an internet connection.' ) }
+			placement="bottom-end"
 		>
-			<WordPressLogo />
+			<Button
+				onClick={ () => getIpcApi().authenticate( false ) }
+				aria-label={ __( 'Log in to Studio with WordPress.com' ) }
+				variant="icon"
+				className="flex gap-x-2 justify-between w-full text-white !rounded-lg !px-2 !py-1.5 h-auto active:!text-white hover:!text-white hover:underline items-center"
+				disabled={ isOffline }
+			>
+				<WordPressLogo />
 
-			<div className="text-s text-right">{ __( 'Log in' ) }</div>
-		</Button>
+				<div className="text-s text-right">{ __( 'Log in' ) }</div>
+			</Button>
+		</Tooltip>
 	);
 }
 

--- a/apps/studio/src/components/top-bar.tsx
+++ b/apps/studio/src/components/top-bar.tsx
@@ -91,22 +91,24 @@ function Authentication() {
 	}
 
 	return (
-		<Button
-			onClick={ () => getIpcApi().authenticate( false ) }
-			aria-label={ __( 'Log in to Studio with WordPress.com' ) }
-			variant="icon"
-			className="flex gap-x-2 justify-between w-full text-white !rounded-lg !px-2 !py-1.5 h-auto active:!text-white hover:!text-white hover:underline items-center"
-			disabled={ isOffline }
-			title={
-				isOffline
-					? `${ __( 'You’re currently offline.' ) } ${ __( 'Some features will be unavailable.' ) }`
-					: undefined
-			}
+		<Tooltip
+			disabled={ ! isOffline }
+			icon={ offlineIcon }
+			text={ __( 'Logging in requires an internet connection.' ) }
+			placement="bottom-end"
 		>
-			<WordPressLogo />
+			<Button
+				onClick={ () => getIpcApi().authenticate( false ) }
+				aria-label={ __( 'Log in to Studio with WordPress.com' ) }
+				variant="icon"
+				className="flex gap-x-2 justify-between w-full text-white !rounded-lg !px-2 !py-1.5 h-auto active:!text-white hover:!text-white hover:underline items-center"
+				disabled={ isOffline }
+			>
+				<WordPressLogo />
 
-			<div className="text-s text-right">{ __( 'Log in' ) }</div>
-		</Button>
+				<div className="text-s text-right">{ __( 'Log in' ) }</div>
+			</Button>
+		</Tooltip>
 	);
 }
 

--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -45,7 +45,11 @@ function PreviewLink( { url }: { url: string } ) {
 		<a
 			href={ url }
 			aria-disabled={ isOffline }
-			title={ isOffline ? __( 'Previewing a site requires an internet connection.' ) : undefined }
+			title={
+				isOffline
+					? `${ __( 'You’re currently offline.' ) } ${ __( 'Some features will be unavailable.' ) }`
+					: undefined
+			}
 			onClick={ ( e: React.MouseEvent< HTMLAnchorElement > ) => {
 				e.preventDefault();
 				e.stopPropagation();

--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -9,6 +9,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import { EMPTY_SITE_PLAYGROUND_URL } from 'src/constants';
+import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
@@ -39,15 +40,26 @@ interface NewSiteOptionsProps {
 
 function PreviewLink( { url }: { url: string } ) {
 	const { __ } = useI18n();
+	const isOffline = useOffline();
 	return (
 		<a
 			href={ url }
+			aria-disabled={ isOffline }
+			title={ isOffline ? __( 'Previewing a site requires an internet connection.' ) : undefined }
 			onClick={ ( e: React.MouseEvent< HTMLAnchorElement > ) => {
 				e.preventDefault();
 				e.stopPropagation();
+				if ( isOffline ) {
+					return;
+				}
 				getIpcApi().openURL( url );
 			} }
-			className="!absolute bottom-2 right-2 z-10 inline-flex items-center gap-1 !px-2 !py-1 !h-auto !min-h-0 text-[11px] !bg-white/90 hover:!bg-white !text-a8c-gray-900 hover:!text-a8c-gray-900 !shadow-none whitespace-nowrap rounded-sm no-underline border border-a8c-gray-5"
+			className={ cx(
+				'!absolute bottom-2 right-2 z-10 inline-flex items-center gap-1 !px-2 !py-1 !h-auto !min-h-0 text-[11px] !text-a8c-gray-900 !shadow-none whitespace-nowrap rounded-sm no-underline border border-a8c-gray-5',
+				isOffline
+					? '!bg-white/60 opacity-60 cursor-not-allowed'
+					: '!bg-white/90 hover:!bg-white hover:!text-a8c-gray-900'
+			) }
 		>
 			{ __( 'Live Preview' ) }
 			<ArrowIcon />

--- a/apps/studio/src/modules/add-site/components/new-site-options.tsx
+++ b/apps/studio/src/modules/add-site/components/new-site-options.tsx
@@ -8,6 +8,8 @@ import {
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
+import offlineIcon from 'src/components/offline-icon';
+import { Tooltip } from 'src/components/tooltip';
 import { EMPTY_SITE_PLAYGROUND_URL } from 'src/constants';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
@@ -42,32 +44,34 @@ function PreviewLink( { url }: { url: string } ) {
 	const { __ } = useI18n();
 	const isOffline = useOffline();
 	return (
-		<a
-			href={ url }
-			aria-disabled={ isOffline }
-			title={
-				isOffline
-					? `${ __( 'You’re currently offline.' ) } ${ __( 'Some features will be unavailable.' ) }`
-					: undefined
-			}
-			onClick={ ( e: React.MouseEvent< HTMLAnchorElement > ) => {
-				e.preventDefault();
-				e.stopPropagation();
-				if ( isOffline ) {
-					return;
-				}
-				getIpcApi().openURL( url );
-			} }
-			className={ cx(
-				'!absolute bottom-2 right-2 z-10 inline-flex items-center gap-1 !px-2 !py-1 !h-auto !min-h-0 text-[11px] !text-a8c-gray-900 !shadow-none whitespace-nowrap rounded-sm no-underline border border-a8c-gray-5',
-				isOffline
-					? '!bg-white/60 opacity-60 cursor-not-allowed'
-					: '!bg-white/90 hover:!bg-white hover:!text-a8c-gray-900'
-			) }
+		<Tooltip
+			disabled={ ! isOffline }
+			icon={ offlineIcon }
+			text={ __( 'Previewing a site requires an internet connection.' ) }
+			className="!absolute bottom-2 right-2 z-10 inline-flex"
 		>
-			{ __( 'Live Preview' ) }
-			<ArrowIcon />
-		</a>
+			<a
+				href={ url }
+				aria-disabled={ isOffline }
+				onClick={ ( e: React.MouseEvent< HTMLAnchorElement > ) => {
+					e.preventDefault();
+					e.stopPropagation();
+					if ( isOffline ) {
+						return;
+					}
+					getIpcApi().openURL( url );
+				} }
+				className={ cx(
+					'inline-flex items-center gap-1 !px-2 !py-1 !h-auto !min-h-0 text-[11px] !text-a8c-gray-900 !shadow-none whitespace-nowrap rounded-sm no-underline border border-a8c-gray-5',
+					isOffline
+						? '!bg-white/60 opacity-60 cursor-not-allowed'
+						: '!bg-white/90 hover:!bg-white hover:!text-a8c-gray-900'
+				) }
+			>
+				{ __( 'Live Preview' ) }
+				<ArrowIcon />
+			</a>
+		</Tooltip>
 	);
 }
 

--- a/apps/studio/src/modules/add-site/components/options.tsx
+++ b/apps/studio/src/modules/add-site/components/options.tsx
@@ -7,6 +7,8 @@ import {
 } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useRef, useState } from 'react';
+import offlineIcon from 'src/components/offline-icon';
+import { Tooltip } from 'src/components/tooltip';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import {
@@ -28,7 +30,6 @@ function OptionCard( {
 	description,
 	onClick,
 	disabled = false,
-	disabledTitle,
 	testId,
 }: {
 	illustration: React.ReactNode;
@@ -36,7 +37,6 @@ function OptionCard( {
 	description: string;
 	onClick: () => void;
 	disabled?: boolean;
-	disabledTitle?: string;
 	testId?: string;
 } ) {
 	return (
@@ -49,7 +49,6 @@ function OptionCard( {
 			) }
 			onClick={ onClick }
 			disabled={ disabled }
-			title={ disabled ? disabledTitle : undefined }
 			data-testid={ testId }
 		>
 			<div>{ illustration }</div>
@@ -195,18 +194,22 @@ export default function AddSiteOptions( {
 					onClick={ () => onOptionSelect( 'new' ) }
 					testId="create-site-option-button"
 				/>
-				<OptionCard
-					illustration={ <ConnectSiteIllustration /> }
-					title={ __( 'Connect a site' ) }
-					description={ __(
-						'Edit a WordPress.com or Pressable site locally, then push changes back'
-					) }
-					onClick={ () => onOptionSelect( 'connect' ) }
-					disabled={ isOffline }
-					disabledTitle={ `${ __( 'You’re currently offline.' ) } ${ __(
-						'Some features will be unavailable.'
-					) }` }
-				/>
+				<Tooltip
+					disabled={ ! isOffline }
+					icon={ offlineIcon }
+					text={ __( 'Connecting a site requires an internet connection.' ) }
+					className="flex-1 flex"
+				>
+					<OptionCard
+						illustration={ <ConnectSiteIllustration /> }
+						title={ __( 'Connect a site' ) }
+						description={ __(
+							'Edit a WordPress.com or Pressable site locally, then push changes back'
+						) }
+						onClick={ () => onOptionSelect( 'connect' ) }
+						disabled={ isOffline }
+					/>
+				</Tooltip>
 				<ImportDropZone onValidated={ handleValidatedBackup } />
 			</div>
 		</VStack>

--- a/apps/studio/src/modules/add-site/components/options.tsx
+++ b/apps/studio/src/modules/add-site/components/options.tsx
@@ -7,8 +7,6 @@ import {
 } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useRef, useState } from 'react';
-import offlineIcon from 'src/components/offline-icon';
-import { Tooltip } from 'src/components/tooltip';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import {
@@ -30,6 +28,7 @@ function OptionCard( {
 	description,
 	onClick,
 	disabled = false,
+	disabledTitle,
 	testId,
 }: {
 	illustration: React.ReactNode;
@@ -37,6 +36,7 @@ function OptionCard( {
 	description: string;
 	onClick: () => void;
 	disabled?: boolean;
+	disabledTitle?: string;
 	testId?: string;
 } ) {
 	return (
@@ -49,6 +49,7 @@ function OptionCard( {
 			) }
 			onClick={ onClick }
 			disabled={ disabled }
+			title={ disabled ? disabledTitle : undefined }
 			data-testid={ testId }
 		>
 			<div>{ illustration }</div>
@@ -194,22 +195,18 @@ export default function AddSiteOptions( {
 					onClick={ () => onOptionSelect( 'new' ) }
 					testId="create-site-option-button"
 				/>
-				<Tooltip
-					disabled={ ! isOffline }
-					icon={ offlineIcon }
-					text={ __( 'Connecting a site requires an internet connection.' ) }
-					className="flex-1 flex"
-				>
-					<OptionCard
-						illustration={ <ConnectSiteIllustration /> }
-						title={ __( 'Connect a site' ) }
-						description={ __(
-							'Edit a WordPress.com or Pressable site locally, then push changes back'
-						) }
-						onClick={ () => onOptionSelect( 'connect' ) }
-						disabled={ isOffline }
-					/>
-				</Tooltip>
+				<OptionCard
+					illustration={ <ConnectSiteIllustration /> }
+					title={ __( 'Connect a site' ) }
+					description={ __(
+						'Edit a WordPress.com or Pressable site locally, then push changes back'
+					) }
+					onClick={ () => onOptionSelect( 'connect' ) }
+					disabled={ isOffline }
+					disabledTitle={ `${ __( 'You’re currently offline.' ) } ${ __(
+						'Some features will be unavailable.'
+					) }` }
+				/>
 				<ImportDropZone onValidated={ handleValidatedBackup } />
 			</div>
 		</VStack>

--- a/apps/studio/src/modules/add-site/components/options.tsx
+++ b/apps/studio/src/modules/add-site/components/options.tsx
@@ -7,6 +7,8 @@ import {
 } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useRef, useState } from 'react';
+import offlineIcon from 'src/components/offline-icon';
+import { Tooltip } from 'src/components/tooltip';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import {
@@ -192,15 +194,22 @@ export default function AddSiteOptions( {
 					onClick={ () => onOptionSelect( 'new' ) }
 					testId="create-site-option-button"
 				/>
-				<OptionCard
-					illustration={ <ConnectSiteIllustration /> }
-					title={ __( 'Connect a site' ) }
-					description={ __(
-						'Edit a WordPress.com or Pressable site locally, then push changes back'
-					) }
-					onClick={ () => onOptionSelect( 'connect' ) }
-					disabled={ isOffline }
-				/>
+				<Tooltip
+					disabled={ ! isOffline }
+					icon={ offlineIcon }
+					text={ __( 'Connecting a site requires an internet connection.' ) }
+					className="flex-1 flex"
+				>
+					<OptionCard
+						illustration={ <ConnectSiteIllustration /> }
+						title={ __( 'Connect a site' ) }
+						description={ __(
+							'Edit a WordPress.com or Pressable site locally, then push changes back'
+						) }
+						onClick={ () => onOptionSelect( 'connect' ) }
+						disabled={ isOffline }
+					/>
+				</Tooltip>
 				<ImportDropZone onValidated={ handleValidatedBackup } />
 			</div>
 		</VStack>


### PR DESCRIPTION
## How AI was used in this PR

AI assisted

## Proposed Changes
While smoke-testing whole Studio, I noticed that offline tooltips are not added to a few places and "Live preview" button is not disabled (See testing instructions).



## Testing Instructions
```diff
diff --git a/apps/studio/src/hooks/use-offline.ts b/apps/studio/src/hooks/use-offline.ts
index 296408e91..259725c5f 100644
--- a/apps/studio/src/hooks/use-offline.ts
+++ b/apps/studio/src/hooks/use-offline.ts
@@ -9,5 +9,5 @@ export function useOffline() {
        useWindowListener( 'offline', () => {
                setIsOffline( true );
        } );
-       return isOffline;
+       return true;
 }
```
1. Click "Add a site"
2. Assert that Connect a site has tooltip<br /><img width="848" height="330" alt="Screenshot 2026-07-20 at 18 16 39" src="https://github.com/user-attachments/assets/bc6cc1bf-0a9c-44f0-b543-3acd7670c5ff" />
3. Assert that "Live preview" is disabled and has tooltip<br /><img width="451" height="277" alt="Screenshot 2026-07-20 at 18 16 52" src="https://github.com/user-attachments/assets/de0c29ca-5488-47a4-93ea-afb1f3924813" />
4. Assert that "Login" button in top right correner of Studio has tooltip<br /><img width="309" height="95" alt="Screenshot 2026-07-20 at 18 16 25" src="https://github.com/user-attachments/assets/2176e07c-1fe2-407f-9c18-709c6643722c" />




