### PR TITLE
CLI: Add aliases for help, version and path 

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -62,12 +62,14 @@ async function main() {
 		.version( version )
 		.alias( 'v', 'version' )
 		.alias( 'h', 'help' )
+		.wrap( Math.min( 90, yargs().terminalWidth() ?? 90 ) )
 		.option( 'avoid-telemetry', {
 			type: 'boolean',
 			hidden: true,
 		} )
 		.option( 'path', {
 			type: 'string',
+			alias: 'p',
 			normalize: true,
 			default: process.cwd(),
 			defaultDescription: __( 'Current directory' ),

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -60,6 +60,8 @@ async function main() {
 		.usage( __( 'WordPress Studio CLI' ) )
 		.locale( yargsLocale )
 		.version( version )
+		.alias( 'v', 'version' )
+		.alias( 'h', 'help' )
 		.option( 'avoid-telemetry', {
 			type: 'boolean',
 			hidden: true,


### PR DESCRIPTION
## How AI was used in this PR

AI assisted

## Proposed Changes
All CLI tools have shortcuts as `-h` and `-v`. They're really useful, and it's a canonical way nowadays.
Alongside them, let's add `-p` for consistency, as this parameter is used in almost all commands, and I noticed that other CLI tools have shortcuts for frequently used commands.

<img width="325" height="54" alt="Screenshot 2026-07-21 at 11 24 30" src="https://github.com/user-attachments/assets/c19dcec9-33b7-40bd-ad9a-eb12791c3eab" />
<img width="635" height="59" alt="Screenshot 2026-07-21 at 11 25 13" src="https://github.com/user-attachments/assets/7367583e-0e94-4679-abb6-53d74bb43a1f" />
<img width="772" height="471" alt="Screenshot 2026-07-21 at 11 24 10" src="https://github.com/user-attachments/assets/e261f135-3597-46db-b510-e325e337c0dd" />


## Testing Instructions
Visual review should suffice
