### PR TITLE
Agentic UI: Remove horizontal scroll in Settings

### DIFF
--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -278,7 +278,11 @@
 	max-inline-size: 100%;
 }
 
-.selectControl > * {
+/* Stretch the trigger to the control's width, but skip the visually-hidden
+   label `hideLabelFromVision` renders: it's absolutely positioned, so
+   stretching it makes it hang past the layout and create horizontal
+   overflow. */
+.selectControl > *:not([data-visually-hidden]) {
 	inline-size: 100%;
 }
 


### PR DESCRIPTION
## How AI was used in this PR

AI investigated, and I tested. Looks rational.



## Proposed Changes
Let's remove redundant scroll:<br /><img width="1288" height="743" alt="Screenshot 2026-07-21 at 12 25 03" src="https://github.com/user-attachments/assets/0661d486-eabb-4a64-8c33-71007cefd91a" />


## Testing Instructions
1. Electron -> feature flags -> Enable Agentic UI
2. Click on your name in the bottom-left corner -> Settings
3. Assert that you don't see horizontal scroll anymore