### PR TITLE
apps/ui: Unify url usage

### DIFF
--- a/apps/ui/src/components/settings-view/account-section.test.tsx
+++ b/apps/ui/src/components/settings-view/account-section.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
 import { useAuthUser, useLogin, useLogout } from '@/data/queries/use-auth-user';
+import { useUserLocale } from '@/data/queries/use-user-locale';
 import { AccountSection } from './account-section';
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
@@ -44,6 +45,10 @@ vi.mock( '@/data/queries/use-auth-user', () => ( {
 	useLogout: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-user-locale', () => ( {
+	useUserLocale: vi.fn(),
+} ) );
+
 vi.mock( '@/hooks/use-color-scheme', () => ( {
 	useColorScheme: () => 'light',
 } ) );
@@ -52,6 +57,7 @@ const useConnectorMock = vi.mocked( useConnector );
 const useAuthUserMock = vi.mocked( useAuthUser );
 const useLoginMock = vi.mocked( useLogin );
 const useLogoutMock = vi.mocked( useLogout );
+const useUserLocaleMock = vi.mocked( useUserLocale );
 
 describe( 'AccountSection', () => {
 	const loginMutate = vi.fn();
@@ -62,6 +68,7 @@ describe( 'AccountSection', () => {
 		vi.clearAllMocks();
 
 		useConnectorMock.mockReturnValue( { openExternalUrl } as never );
+		useUserLocaleMock.mockReturnValue( undefined );
 		useAuthUserMock.mockReturnValue( {
 			data: { id: 1, displayName: 'Ada Lovelace', email: 'ada@example.com' },
 			isLoading: false,
@@ -113,6 +120,18 @@ describe( 'AccountSection', () => {
 
 		expect( openExternalUrl ).toHaveBeenCalledWith(
 			'https://github.com/Automattic/studio/issues/new/choose'
+		);
+	} );
+
+	it( 'opens localized docs when the locale has a translation', () => {
+		useUserLocaleMock.mockReturnValue( 'es' );
+
+		render( <AccountSection /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Docs' } ) );
+
+		expect( openExternalUrl ).toHaveBeenCalledWith(
+			'https://developer.wordpress.com/es/docs/herramientas-para-desarrolladores/studio/'
 		);
 	} );
 } );

--- a/apps/ui/src/components/settings-view/account-section.tsx
+++ b/apps/ui/src/components/settings-view/account-section.tsx
@@ -4,14 +4,14 @@ import { clsx } from 'clsx';
 import { Gravatar } from '@/components/gravatar';
 import { useConnector } from '@/data/core';
 import { useAuthUser, useLogin, useLogout } from '@/data/queries/use-auth-user';
+import { useUserLocale } from '@/data/queries/use-user-locale';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { getLocalizedLink, REPORT_ISSUE_URL } from '@/lib/docs-links';
 import styles from './style.module.css';
-
-const DOCS_URL = 'https://developer.wordpress.com/docs/developer-tools/studio/';
-const REPORT_ISSUE_URL = 'https://github.com/Automattic/studio/issues/new/choose';
 
 function AccountHelpActions() {
 	const connector = useConnector();
+	const locale = useUserLocale();
 
 	const openLink = ( url: string ) => {
 		void connector.openExternalUrl( url );
@@ -24,7 +24,7 @@ function AccountHelpActions() {
 				variant="minimal"
 				tone="neutral"
 				size="small"
-				onClick={ () => openLink( DOCS_URL ) }
+				onClick={ () => openLink( getLocalizedLink( locale, 'docsStudio' ) ) }
 			>
 				{ __( 'Docs' ) }
 			</Button>

--- a/apps/ui/src/components/user-menu/index.tsx
+++ b/apps/ui/src/components/user-menu/index.tsx
@@ -7,13 +7,13 @@ import * as Menu from '@/components/menu';
 import { SidebarButton } from '@/components/sidebar-button';
 import { useConnector } from '@/data/core';
 import { useAuthUser, useLogin, useLogout } from '@/data/queries/use-auth-user';
+import { useUserLocale } from '@/data/queries/use-user-locale';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useOffline } from '@/hooks/use-offline';
+import { getLocalizedLink, REPORT_ISSUE_URL } from '@/lib/docs-links';
 import styles from './style.module.css';
 
 const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
-const DOCS_URL = 'https://developer.wordpress.com/docs/developer-tools/studio/';
-const REPORT_ISSUE_URL = 'https://github.com/Automattic/studio/issues/new/choose';
 
 export function UserMenu() {
 	const connector = useConnector();
@@ -23,6 +23,7 @@ export function UserMenu() {
 	const navigate = useNavigate();
 
 	const isOffline = useOffline();
+	const locale = useUserLocale();
 	const themeIsDark = useColorScheme() === 'dark';
 
 	const openLink = ( url: string ) => {
@@ -52,7 +53,10 @@ export function UserMenu() {
 							<Menu.Item disabled={ isOffline } onClick={ () => openLink( WPCOM_PROFILE_URL ) }>
 								{ __( 'Edit WordPress.com profile' ) }
 							</Menu.Item>
-							<Menu.Item disabled={ isOffline } onClick={ () => openLink( DOCS_URL ) }>
+							<Menu.Item
+								disabled={ isOffline }
+								onClick={ () => openLink( getLocalizedLink( locale, 'docsStudio' ) ) }
+							>
 								{ __( 'Documentation' ) }
 							</Menu.Item>
 							<Menu.Item disabled={ isOffline } onClick={ () => openLink( REPORT_ISSUE_URL ) }>

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -1,6 +1,7 @@
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
 import { fetchWordPressVersions } from '@studio/common/lib/wordpress-versions';
 import { __ } from '@wordpress/i18n';
+import { buildPublishCheckoutUrl } from '../publish-checkout-url';
 import type {
 	ActiveAgentRun,
 	AiSessionSummary,
@@ -467,14 +468,7 @@ export function createIpcConnector(): Connector {
 		},
 
 		getPublishCheckoutUrl( site ): string {
-			const url = new URL( 'https://wordpress.com/setup/new-hosted-site' );
-			url.searchParams.set( 'ref', 'studio' );
-			url.searchParams.set( 'section', 'publish-site' );
-			url.searchParams.set( 'showDomainStep', 'true' );
-			url.searchParams.set( 'studioSiteId', site.id );
-			url.searchParams.set( 'new', site.customDomain ?? site.name );
-			url.searchParams.set( 'autoOpenPush', 'true' );
-			return url.toString();
+			return buildPublishCheckoutUrl( site );
 		},
 
 		// AI sessions

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -2,6 +2,7 @@ import { getAuthenticationUrl } from '@studio/common/lib/oauth';
 import { fetchWordPressVersions } from '@studio/common/lib/wordpress-versions';
 import { __ } from '@wordpress/i18n';
 import { applyStoredSiteOrder, storeSiteOrder } from '../browser-site-order';
+import { buildPublishCheckoutUrl } from '../publish-checkout-url';
 import { UnsupportedError } from '../unsupported-error';
 import type {
 	ActiveAgentRun,
@@ -518,18 +519,10 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			} );
 		},
 		getPublishCheckoutUrl( site ): string {
-			// The same WordPress.com hosted-site checkout the desktop opens — a pure
-			// URL builder, so it ports verbatim. (The post-checkout auto-connect still
-			// relies on the deep-link listener, which a browser tab can't receive, so
-			// the user finishes by connecting the new site from the picker.)
-			const url = new URL( 'https://wordpress.com/setup/new-hosted-site' );
-			url.searchParams.set( 'ref', 'studio' );
-			url.searchParams.set( 'section', 'publish-site' );
-			url.searchParams.set( 'showDomainStep', 'true' );
-			url.searchParams.set( 'studioSiteId', site.id );
-			url.searchParams.set( 'new', site.customDomain ?? site.name );
-			url.searchParams.set( 'autoOpenPush', 'true' );
-			return url.toString();
+			// The post-checkout auto-connect relies on the deep-link listener, which
+			// a browser tab can't receive, so the user finishes by connecting the
+			// new site from the picker.
+			return buildPublishCheckoutUrl( site );
 		},
 
 		// AI sessions — the headline. HTTP routes on the local server, backed by

--- a/apps/ui/src/data/core/connectors/publish-checkout-url.ts
+++ b/apps/ui/src/data/core/connectors/publish-checkout-url.ts
@@ -1,0 +1,12 @@
+import type { SiteDetails } from '../types';
+
+export function buildPublishCheckoutUrl( site: SiteDetails ): string {
+	const url = new URL( 'https://wordpress.com/setup/new-hosted-site' );
+	url.searchParams.set( 'ref', 'studio1' );
+	url.searchParams.set( 'section', 'publish-site' );
+	url.searchParams.set( 'showDomainStep', 'true' );
+	url.searchParams.set( 'studioSiteId', site.id );
+	url.searchParams.set( 'new', site.customDomain ?? site.name );
+	url.searchParams.set( 'autoOpenPush', 'true' );
+	return url.toString();
+}

--- a/apps/ui/src/data/core/connectors/publish-checkout-url.ts
+++ b/apps/ui/src/data/core/connectors/publish-checkout-url.ts
@@ -2,7 +2,7 @@ import type { SiteDetails } from '../types';
 
 export function buildPublishCheckoutUrl( site: SiteDetails ): string {
 	const url = new URL( 'https://wordpress.com/setup/new-hosted-site' );
-	url.searchParams.set( 'ref', 'studio1' );
+	url.searchParams.set( 'ref', 'studio' );
 	url.searchParams.set( 'section', 'publish-site' );
 	url.searchParams.set( 'showDomainStep', 'true' );
 	url.searchParams.set( 'studioSiteId', site.id );

--- a/apps/ui/src/lib/docs-links.ts
+++ b/apps/ui/src/lib/docs-links.ts
@@ -18,7 +18,13 @@ const DOCS_LINKS = {
 	docsSslInStudio: {
 		en: 'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/',
 	},
+	docsStudio: {
+		en: 'https://developer.wordpress.com/docs/developer-tools/studio/',
+		es: 'https://developer.wordpress.com/es/docs/herramientas-para-desarrolladores/studio/',
+	},
 } as const satisfies Record< string, TranslatedLink >;
+
+export const REPORT_ISSUE_URL = 'https://github.com/Automattic/studio/issues/new/choose';
 
 export type DocsLinkKey = keyof typeof DOCS_LINKS;
 


### PR DESCRIPTION
## How AI was used in this PR

AI assisted

## Proposed Changes

Let's clean up URLs usage in `apps/ui`

## Testing Instructions
Visual review shoudl suffice, but JIC:

1. `npm run cli:build && npm start`
2. `Electron` -> `Feature flags` -> `Enable agentic UI`
1. Click on `Documentation` and `Report an issue`<br /><img width="256" height="146" alt="Screenshot 2026-07-21 at 16 38 40" src="https://github.com/user-attachments/assets/5cfcd44b-b911-4423-8614-6d58de5102b2" />
3. Assert that you are landed on the correct URLs
4. Switch language to Spanish
5. Click again and assert that Documentation leads to the Spanish version
6. Open Studio Settings and repeat the same steps with these two buttons:<br /><img width="581" height="140" alt="Screenshot 2026-07-21 at 16 41 15" src="https://github.com/user-attachments/assets/9500acdd-3726-4415-b794-afc6bc7bbebb" />
7. Open drop down menu here -> Click on Publish -> Click on `Create a new wordpress.com site...` and assert taht you are landed to `https://wordpress.com/setup/new-hosted-site/domains.....`<br /><img width="354" height="371" alt="Screenshot 2026-07-21 at 16 43 19" src="https://github.com/user-attachments/assets/966ba682-ada3-471f-8b52-15daa4e6c917" />
8 Repeat the 8-th step via browser:
```
npm run cli:build
node apps/cli/dist/cli/main.mjs ui --port 8081 --no-open
npm run dev:local --workspace=apps/ui
# Open http://localhost:5400
```