### PR TITLE
Keep locally installed files when pulling onto an existing site

### DIFF
--- a/apps/cli/commands/pull-reprint.ts
+++ b/apps/cli/commands/pull-reprint.ts
@@ -553,6 +553,9 @@ export async function runCommand(
 				verbose,
 				selection
 			);
+			// The tail landed in the raw directory after flat-docroot ran, so
+			// link the files that just arrived into the flattened site.
+			await relinkFlattenedSite( getSiteRuntime( site ), studioMetadata, verbose );
 		}
 
 		// The pull is done: drop the selection sidecar so the next pull asks
@@ -1138,6 +1141,15 @@ export async function runFullPull(
 		'flat-docroot',
 		'-',
 		`--flatten-to=${ metadata.sitePath }`,
+		// `--force` replaces the blank install `studio create` produced, but on
+		// its own it would also delete everything the user had added to
+		// wp-content. `--preserve-local-content` merges wp-content instead:
+		// the remote wins on conflicts, local-only plugins/themes/uploads stay.
+		//
+		// It is passed on *every* pull, not just the first: once the first pull
+		// merges, wp-content is a real directory, and a delta re-pull without
+		// the flag would fail trying to symlink over it.
+		'--preserve-local-content',
 		...( force ? [ '--force' ] : [] ),
 		`--state-dir=${ metadata.stateDirectory }`,
 		`--fs-root=${ metadata.rawDirectory }`,
@@ -1215,6 +1227,45 @@ export async function downloadSkippedFiles(
 		}
 	);
 	logger.reportSuccess( __( 'Remaining files downloaded' ) );
+}
+
+/**
+ * Re-link the flattened site after the deferred file tail.
+ *
+ * `downloadSkippedFiles` lands media in the raw directory *after*
+ * `flat-docroot` already ran. The flattened site links the remote's entries
+ * individually rather than aliasing the whole `wp-content`, so anything that
+ * arrives late has no link yet and would stay invisible until the next pull.
+ *
+ * Re-running the flatten is idempotent and cheap: it refreshes the links that
+ * are already correct, adds links for the newly-arrived files, and prunes the
+ * ones whose target the remote dropped. `--force` is deliberately omitted —
+ * the site is already assembled, so nothing should be replaced here.
+ */
+export async function relinkFlattenedSite(
+	runtime: SiteRuntime,
+	metadata: PullSession,
+	verbose: boolean
+): Promise< void > {
+	await runReprintCommandUntilComplete(
+		metadata.stateDirectory,
+		metadata.rawDirectory,
+		[
+			'flat-docroot',
+			'-',
+			`--flatten-to=${ metadata.sitePath }`,
+			'--preserve-local-content',
+			`--state-dir=${ metadata.stateDirectory }`,
+			`--fs-root=${ metadata.rawDirectory }`,
+		],
+		( progress ) => logger.reportProgress( progress ),
+		{
+			progressLabel: __( 'Linking new files' ),
+			mounts: [ { hostPath: metadata.sitePath, vfsPath: metadata.sitePath } ],
+			verboseCommands: verbose,
+			runtime,
+		}
+	);
 }
 
 export function normalizeSiteUrl( url: string ): string {

--- a/apps/cli/commands/tests/pull-reprint.test.ts
+++ b/apps/cli/commands/tests/pull-reprint.test.ts
@@ -391,10 +391,13 @@ describe( 'CLI: studio pull-reprint single pull phase', () => {
 		] );
 		// Local flatten: `-` URL placeholder; --force only on a first pull
 		// (this call passed force=true) to overwrite the blank install.
+		// --preserve-local-content goes on every pull so wp-content is merged
+		// rather than replaced and locally installed files survive.
 		expect( flattenArgs ).toEqual( [
 			'flat-docroot',
 			'-',
 			`--flatten-to=${ sitePath }`,
+			'--preserve-local-content',
 			'--force',
 			`--state-dir=${ stateDirectory }`,
 			`--fs-root=${ rawDirectory }`,
@@ -464,6 +467,9 @@ describe( 'CLI: studio pull-reprint single pull phase', () => {
 		expect( commands ).toEqual( [ 'pull-files', 'flat-docroot', 'apply-runtime' ] );
 		const flattenArgs = reprint.mock.calls[ 1 ][ 2 ] as string[];
 		expect( flattenArgs ).not.toContain( '--force' );
+		// Once merged, wp-content is a real directory; a delta pull without
+		// the flag would fail trying to symlink over it.
+		expect( flattenArgs ).toContain( '--preserve-local-content' );
 
 		fs.rmSync( technicalSiteDirectory, { recursive: true, force: true } );
 	} );


### PR DESCRIPTION
## Related issues

- Related to STU-1951
- **Depends on WordPress/reprint#383**

> **Merge order matters.** reprint exits 1 on an unknown option, so this must not land until reprint#383 is released **and** the bundled phar is bumped — otherwise every pull fails with `Unknown option: --preserve-local-content`.

## How AI was used in this PR

Claude Code was used to investigate the root cause, implement the change here and in reprint#383, and run the end-to-end verification below. The diff was reviewed by hand; an earlier revision of the reprint docblocks referenced Studio commands and was rewritten, since reprint is a library and shouldn't document its consumers.

## Proposed Changes

Pulling onto a site that already has content deleted everything the user had installed. Create a site, install a plugin, pull → the plugin is gone. Themes, uploads and any custom `wp-content` folder went with it.

The first pull passes `--force` to `flat-docroot` so it can overwrite the blank install. But for the common layout, `flat-docroot` wants `wp-content` to be a single symlink into the raw scratch dir, and `--force` makes it *recursively delete* the existing real `wp-content` before creating that link. Incremental pulls were unaffected, because `--force` isn't passed and `wp-content` is already a symlink — which is why this only ever showed up on the first pull.

This passes reprint's new `--preserve-local-content`, so `wp-content` is **merged** instead of replaced: entries the remote also has are linked (the remote wins), and entries that exist only locally are left alone.

Two things worth flagging for review:

- The flag goes on **every** pull, not just the first. Once merged, `wp-content` is a real directory, and a later pull without the flag fails trying to symlink over it.
- `flat-docroot` is re-run after the deferred file tail. Those files land in the raw dir *after* the flatten, and the site now links entries individually rather than aliasing the whole `wp-content`, so without a second pass late-arriving media would stay unlinked until the next pull.

**Behaviour change:** `wp-content` is now a real directory rather than a single symlink, so plugins installed *after* a pull live in the site directory instead of reprint's raw scratch. That's the cleaner ownership split and is what makes them survive, but it is a change in where files land.

Note this is a different problem from `preserveUnselectedLocalContent`, which protects content the user *chose not to pull*; this protects content the remote never had.

## Testing Instructions

Requires a build with reprint#383 in the bundled phar.

1. `studio create --name test --path ~/Studio/test --start`
2. Install a plugin that is **not** on the remote (drop a folder in `wp-content/plugins/`). Optionally add a theme, an upload and a custom `wp-content` folder.
3. `studio pull-reprint --path ~/Studio/test --url <a connected site>`
4. The plugin, theme, upload and custom folder are all still there, alongside the remote's content. `ls -ld ~/Studio/test/wp-content` shows a real directory.
5. Install a second local-only plugin and pull again — it survives, and the pull exits cleanly.

Verified end-to-end on a real connected site: first pull and incremental pull both exit 0, all local-only content preserved, remote content linked, no dangling symlinks, site returns 200. `npm -w wp-studio run build` is clean.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
