### PR TITLE
Remove blueprint warnings leftovers

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -101,7 +101,7 @@ jobs:
 
             4. **Naming & Clarity**
                - Names should be specific and self-documenting
-               - Prefer `removeSiteFromConfig` over `remove`, `filterUnsupportedBlueprintFeatures` over `filterFeatures`
+               - Prefer `removeSiteFromConfig` over `remove`, `extractFormValuesFromBlueprint` over `extractValues`
                - Constants should include context: `DEFAULT_SKILLS_REPO_BRANCH` not `DEFAULT_BRANCH`
 
             5. **Type Safety & Schemas**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ For in-depth information, see these docs:
 
 ## Quick Reference
 
-**WP Playground**: CLI runs WordPress via PHP WASM, Blueprints for config, `filterUnsupportedBlueprintFeatures()` for compatibility
+**WP Playground**: CLI runs WordPress via PHP WASM, Blueprints for config, `validateBlueprintData()` for schema validation
 **Sync**: OAuth via `packages/common/lib/oauth.ts`, Redux `sync` slice, pull/push WordPress.com sites
 **Security**: Renderer sandboxed, IPC validation, strict CSP, no Node integration, self-signed HTTPS certs
 

--- a/apps/studio/src/modules/add-site/components/blueprints.tsx
+++ b/apps/studio/src/modules/add-site/components/blueprints.tsx
@@ -19,7 +19,6 @@ import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useI18nLocale } from 'src/stores';
 import { useGetBlueprints } from 'src/stores/wpcom-api';
-import type { BlueprintValidationWarning } from '@studio/common/lib/blueprint-validation';
 
 import './blueprints.css';
 
@@ -50,7 +49,7 @@ interface AddSiteBlueprintProps {
 	isLoading: boolean;
 	selectedBlueprint: string | null;
 	onBlueprintChange: ( blueprintId: string ) => void;
-	onFileBlueprintSelect?: ( blueprint: Blueprint, warnings?: BlueprintValidationWarning[] ) => void;
+	onFileBlueprintSelect?: ( blueprint: Blueprint ) => void;
 }
 
 export function AddSiteBlueprintSelector( {
@@ -189,10 +188,7 @@ export function AddSiteBlueprintSelector( {
 		fileName: string,
 		filePath: string,
 		onCleanup?: () => void
-	): Promise< {
-		blueprint: Blueprint;
-		warnings: BlueprintValidationWarning[] | undefined;
-	} | null > => {
+	): Promise< Blueprint | null > => {
 		const prepared = await prepareBlueprint( blueprintJson, {
 			fallbackTitle: fileName.replace( /\.(json|zip)$/i, '' ),
 			validate: ( candidate ) =>
@@ -204,7 +200,7 @@ export function AddSiteBlueprintSelector( {
 			return null;
 		}
 
-		const blueprint: Blueprint = {
+		return {
 			slug: `file:${ fileName }`,
 			title: prepared.title,
 			excerpt: prepared.excerpt,
@@ -213,8 +209,6 @@ export function AddSiteBlueprintSelector( {
 			blueprint: prepared.blueprint as Blueprint[ 'blueprint' ],
 			filePath,
 		};
-
-		return { blueprint, warnings: prepared.warnings };
 	};
 
 	const handleFileSelect = async ( event: React.ChangeEvent< HTMLInputElement > ) => {
@@ -237,7 +231,7 @@ export function AddSiteBlueprintSelector( {
 					getIpcApi().getPathForFile( file )
 				);
 				if ( result ) {
-					onFileBlueprintSelect( result.blueprint, result.warnings );
+					onFileBlueprintSelect( result );
 				}
 				setUploadedFileName( null );
 			} catch ( error ) {
@@ -269,7 +263,7 @@ export function AddSiteBlueprintSelector( {
 					() => void getIpcApi().cleanupBlueprintTempDir( extracted.tempDir )
 				);
 				if ( result ) {
-					onFileBlueprintSelect( result.blueprint, result.warnings );
+					onFileBlueprintSelect( result );
 				}
 				setUploadedFileName( null );
 			} catch ( error ) {

--- a/apps/studio/src/modules/add-site/index.tsx
+++ b/apps/studio/src/modules/add-site/index.tsx
@@ -4,10 +4,7 @@ import {
 	MINIMUM_WORDPRESS_VERSION,
 } from '@studio/common/constants';
 import { extractFormValuesFromBlueprint } from '@studio/common/lib/blueprint-settings';
-import {
-	BlueprintPreferredVersions,
-	BlueprintValidationWarning,
-} from '@studio/common/lib/blueprint-validation';
+import { BlueprintPreferredVersions } from '@studio/common/lib/blueprint-validation';
 import { isSupportedPHPVersion, SupportedPHPVersion } from '@studio/common/types/php-versions';
 import { SyncSite } from '@studio/common/types/sync';
 import { speak } from '@wordpress/a11y';
@@ -287,7 +284,7 @@ function NavigationContent( props: NavigationContentProps ) {
 	);
 
 	const handleFileBlueprintSelect = useCallback(
-		( blueprint: Blueprint, _warnings?: BlueprintValidationWarning[] ) => {
+		( blueprint: Blueprint ) => {
 			handleBlueprintFormValues( blueprint );
 			goTo( '/new/create' );
 		},

--- a/packages/common/lib/blueprint-selection.ts
+++ b/packages/common/lib/blueprint-selection.ts
@@ -3,7 +3,6 @@ import { generateDefaultBlueprintDescription } from '@studio/common/lib/blueprin
 import {
 	validateBlueprintData,
 	type BlueprintValidationResult,
-	type BlueprintValidationWarning,
 } from '@studio/common/lib/blueprint-validation';
 import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
 
@@ -11,7 +10,6 @@ export interface PreparedBlueprint {
 	blueprint: BlueprintV1Declaration;
 	title: string;
 	excerpt: string;
-	warnings?: BlueprintValidationWarning[];
 }
 
 export type PrepareBlueprintResult =
@@ -56,6 +54,5 @@ export async function prepareBlueprint(
 		valid: true,
 		blueprint,
 		...details,
-		warnings: validation.warnings?.length ? validation.warnings : undefined,
 	};
 }

--- a/packages/common/lib/blueprint-validation.ts
+++ b/packages/common/lib/blueprint-validation.ts
@@ -6,17 +6,12 @@ export type BlueprintPreferredVersions = {
 	wp?: string;
 };
 
-export type BlueprintValidationWarning = {
-	message: string;
-};
-
 type BlueprintValidationError = {
 	valid: false;
 	error: string;
 };
 type BlueprintValidationSuccess = {
 	valid: true;
-	warnings?: BlueprintValidationWarning[];
 };
 export type BlueprintValidationResult = BlueprintValidationError | BlueprintValidationSuccess;
 

--- a/packages/common/lib/tests/blueprint-selection.test.ts
+++ b/packages/common/lib/tests/blueprint-selection.test.ts
@@ -2,9 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { getBlueprintDisplayDetails, prepareBlueprint } from '../blueprint-selection';
 
 describe( 'prepareBlueprint', () => {
-	it( 'uses Blueprint metadata and preserves validation warnings', async () => {
-		const warning = { message: 'This Blueprint uses an experimental step.' };
-		const validate = vi.fn().mockResolvedValue( { valid: true, warnings: [ warning ] } );
+	it( 'uses Blueprint metadata', async () => {
+		const validate = vi.fn().mockResolvedValue( { valid: true } );
 		const blueprint = {
 			meta: { title: 'Portfolio', description: 'A portfolio site', author: 'Studio' },
 		};
@@ -16,7 +15,6 @@ describe( 'prepareBlueprint', () => {
 			blueprint,
 			title: 'Portfolio',
 			excerpt: 'A portfolio site',
-			warnings: [ warning ],
 		} );
 		expect( validate ).toHaveBeenCalledWith( blueprint );
 	} );


### PR DESCRIPTION
## Related issues

Follow-up to https://github.com/Automattic/studio/pull/3107

## How AI was used in this PR

AI helped with cleaning up the codebase



## Proposed Changes
We no longer have warnings for unsupported blueprint steps. This PR is just a follow-up to clean up the codebase.

## Testing Instructions
Visual review should suffice, and CI is green