### PR TITLE
Show Studio Code AI usage quota in the agentic Usage settings tab

### DIFF
--- a/apps/studio/src/stores/wpcom-api.ts
+++ b/apps/studio/src/stores/wpcom-api.ts
@@ -1,5 +1,6 @@
 import { createApi, TypedUseQuery, TypedUseMutation } from '@reduxjs/toolkit/query/react';
 import * as Sentry from '@sentry/electron/renderer';
+import { studioAssistantQuotaSchema } from '@studio/common/lib/studio-assistant-quota';
 import { blueprintSchema, type Blueprint } from '@studio/common/lib/studio-blueprints-api';
 import wpcomFactory from '@studio/common/lib/wpcom-factory';
 import wpcomXhrRequest from '@studio/common/lib/wpcom-xhr-request-factory';
@@ -33,18 +34,6 @@ const snapshotStatusSchema = z
 		atomicSiteId: data.atomic_site_id,
 		status: data.status,
 		isDeleted: data.is_deleted === '1',
-	} ) );
-
-const studioAssistantQuotaSchema = z
-	.object( {
-		cost_usage: z.number(),
-		cost_cap: z.number(),
-		cost_reset_date: z.string(),
-	} )
-	.transform( ( data ) => ( {
-		costUsage: data.cost_usage,
-		costCap: data.cost_cap,
-		costResetDate: data.cost_reset_date,
 	} ) );
 
 export type { Blueprint };

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -2,12 +2,14 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
+import { useStudioAssistantQuota } from '@/data/queries/use-assistant-quota';
 import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
 import {
 	useDeleteAllSnapshots,
 	useSnapshotUsage,
 	useSnapshots,
 } from '@/data/queries/use-snapshots';
+import { useUserLocale } from '@/data/queries/use-user-locale';
 import { useOffline } from '@/hooks/use-offline';
 import { UsagePanel } from './usage-panel';
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
@@ -77,6 +79,14 @@ vi.mock( '@/hooks/use-offline', () => ( {
 	useOffline: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-assistant-quota', () => ( {
+	useStudioAssistantQuota: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-user-locale', () => ( {
+	useUserLocale: vi.fn(),
+} ) );
+
 const useConnectorMock = vi.mocked( useConnector );
 const useAuthUserMock = vi.mocked( useAuthUser );
 const useLoginMock = vi.mocked( useLogin );
@@ -84,6 +94,8 @@ const useDeleteAllSnapshotsMock = vi.mocked( useDeleteAllSnapshots );
 const useSnapshotUsageMock = vi.mocked( useSnapshotUsage );
 const useSnapshotsMock = vi.mocked( useSnapshots );
 const useOfflineMock = vi.mocked( useOffline );
+const useStudioAssistantQuotaMock = vi.mocked( useStudioAssistantQuota );
+const useUserLocaleMock = vi.mocked( useUserLocale );
 
 describe( 'UsagePanel', () => {
 	const loginMutate = vi.fn();
@@ -96,6 +108,11 @@ describe( 'UsagePanel', () => {
 		confirmDeleteAllPreviewSites.mockResolvedValue( true );
 		useConnectorMock.mockReturnValue( { confirmDeleteAllPreviewSites } as never );
 		useOfflineMock.mockReturnValue( false );
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: undefined,
+			isLoading: false,
+		} as never );
+		useUserLocaleMock.mockReturnValue( 'en' );
 		useAuthUserMock.mockReturnValue( {
 			data: { id: 1, displayName: 'Ada Lovelace', email: 'ada@example.com' },
 			isLoading: false,
@@ -126,6 +143,58 @@ describe( 'UsagePanel', () => {
 		expect( useSnapshotsMock ).toHaveBeenCalledWith( 1 );
 		expect( useSnapshotUsageMock ).toHaveBeenCalledWith( 1 );
 		expect( useDeleteAllSnapshotsMock ).toHaveBeenCalledWith( 1 );
+	} );
+
+	it( 'renders AI usage when a quota with a cost cap is available', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: { costUsage: 25, costCap: 100, costResetDate: '2026-08-01T12:00:00' },
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect(
+			screen.getByText( '25% of monthly limit used (resets on August 1, 2026)' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				'AI credits are currently free while Studio Code is in Alpha. Build, iterate, and experiment, but know that credits will eventually have a cost.'
+			)
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'shows an unavailable message when the quota fetch fails', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: undefined,
+			isLoading: false,
+			isError: true,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect(
+			screen.getByText( 'Studio Code limits are temporarily unavailable.' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				'AI credits are currently free while Studio Code is in Alpha. Build, iterate, and experiment, but know that credits will eventually have a cost.'
+			)
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'falls back to the Alpha copy when the quota has no cost cap', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: { costUsage: 0, costCap: 0 },
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect(
+			screen.getByText(
+				'AI credits are currently free while Studio Code is in Alpha. Build, iterate, and experiment, but know that credits will eventually have a cost.'
+			)
+		).toBeInTheDocument();
 	} );
 
 	it( 'confirms through the connector before deleting all preview sites', async () => {

--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -4,16 +4,37 @@ import { Button, IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import * as Menu from '@/components/menu';
 import { useConnector } from '@/data/core';
+import { useStudioAssistantQuota } from '@/data/queries/use-assistant-quota';
 import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
 import {
 	useDeleteAllSnapshots,
 	useSnapshotUsage,
 	useSnapshots,
 } from '@/data/queries/use-snapshots';
+import { useUserLocale } from '@/data/queries/use-user-locale';
 import { useOffline } from '@/hooks/use-offline';
 import styles from './style.module.css';
 
 const DEFAULT_PREVIEW_SITE_LIMIT = 10;
+
+function clampFraction( value: number, maxValue: number ) {
+	return maxValue > 0 ? Math.max( 0, Math.min( 1, value / maxValue ) ) : 0;
+}
+
+function formatPercentage( fraction: number, locale?: string ) {
+	return new Intl.NumberFormat( locale, {
+		style: 'percent',
+		maximumFractionDigits: 2,
+	} ).format( fraction );
+}
+
+function formatResetDate( date: string, locale?: string ) {
+	return new Intl.DateTimeFormat( locale, {
+		day: 'numeric',
+		month: 'long',
+		year: 'numeric',
+	} ).format( new Date( date ) );
+}
 
 function getDeletePreviewSitesLabel( isOffline: boolean, isDeleting: boolean ): string {
 	if ( isOffline ) {
@@ -23,6 +44,70 @@ function getDeletePreviewSitesLabel( isOffline: boolean, isDeleting: boolean ): 
 		return __( 'Deleting preview sites...' );
 	}
 	return __( 'Delete all preview sites' );
+}
+
+function UsageProgressBar( { fraction }: { fraction: number } ) {
+	return (
+		<div className={ styles.progressTrack } aria-hidden="true">
+			<div className={ styles.progressValue } style={ { inlineSize: `${ fraction * 100 }%` } } />
+		</div>
+	);
+}
+
+function AiCreditsSummary() {
+	const locale = useUserLocale();
+	const isOffline = useOffline();
+	const { data: quota, isLoading, isError } = useStudioAssistantQuota();
+
+	let content;
+	if ( isOffline ) {
+		content = <div className={ styles.previewUsageText }>{ __( "You're currently offline" ) }</div>;
+	} else if ( isLoading ) {
+		content = <div className={ styles.previewUsageText }>{ __( 'Loading...' ) }</div>;
+	} else if ( isError ) {
+		content = (
+			<div className={ styles.previewUsageText }>
+				{ __( 'Studio Code limits are temporarily unavailable.' ) }
+			</div>
+		);
+	} else if ( quota && quota.costCap > 0 ) {
+		const fraction = clampFraction( quota.costUsage, quota.costCap );
+		content = (
+			<>
+				<div className={ styles.previewUsageText }>
+					{ sprintf(
+						/* translators: %1$s: percentage of monthly limit used (e.g. 7.5%). %2$s: date the limit resets (e.g. July 1, 2026). */
+						__( '%1$s of monthly limit used (resets on %2$s)' ),
+						formatPercentage( fraction, locale ),
+						formatResetDate( quota.costResetDate, locale )
+					) }
+				</div>
+				<UsageProgressBar fraction={ fraction } />
+			</>
+		);
+	} else {
+		content = (
+			<>
+				<p>
+					{ __(
+						'AI credits are currently free while Studio Code is in Alpha. Build, iterate, and experiment, but know that credits will eventually have a cost.'
+					) }
+				</p>
+				<div className={ clsx( styles.progressTrack, styles.aiCreditsTrack ) } aria-hidden="true">
+					<div className={ styles.aiCreditsMeterValue } />
+				</div>
+			</>
+		);
+	}
+
+	return (
+		<section className={ styles.usageSection }>
+			<div className={ styles.usageSectionHeader }>
+				<h2>{ __( 'AI credits' ) }</h2>
+			</div>
+			{ content }
+		</section>
+	);
 }
 
 function PreviewSitesSummary( { userId }: { userId: number } ) {
@@ -37,7 +122,7 @@ function PreviewSitesSummary( { userId }: { userId: number } ) {
 	const isLoadingPreviewUsage = isLoading || isLoadingSnapshotUsage || deleteAllSnapshots.isPending;
 	const isDisabled =
 		siteCount === 0 || snapshotCreationBlocked || isLoadingPreviewUsage || isOffline;
-	const progress = Math.min( siteCount / Math.max( siteLimit, 1 ), 1 ) * 100;
+	const fraction = clampFraction( siteCount, siteLimit );
 	const deletePreviewSitesLabel = getDeletePreviewSitesLabel(
 		isOffline,
 		deleteAllSnapshots.isPending
@@ -100,9 +185,7 @@ function PreviewSitesSummary( { userId }: { userId: number } ) {
 									siteLimit
 							  ) }
 					</div>
-					<div className={ styles.progressTrack } aria-hidden="true">
-						<div className={ styles.progressValue } style={ { inlineSize: `${ progress }%` } } />
-					</div>
+					<UsageProgressBar fraction={ fraction } />
 				</>
 			) }
 			{ deleteAllSnapshots.error ? (
@@ -125,19 +208,7 @@ export function UsagePanel() {
 					<h2>{ __( 'Usage' ) }</h2>
 					<p>{ __( 'Track your preview site usage and Studio Code AI credits.' ) }</p>
 				</div>
-				<section className={ styles.usageSection }>
-					<div className={ styles.usageSectionHeader }>
-						<h2>{ __( 'AI credits' ) }</h2>
-					</div>
-					<p>
-						{ __(
-							'AI credits are currently free while Studio Code is in Alpha. Build, iterate, and experiment, but know that credits will eventually have a cost.'
-						) }
-					</p>
-					<div className={ clsx( styles.progressTrack, styles.aiCreditsTrack ) } aria-hidden="true">
-						<div className={ styles.aiCreditsMeterValue } />
-					</div>
-				</section>
+				<AiCreditsSummary />
 				{ user ? (
 					<PreviewSitesSummary userId={ user.id } />
 				) : (

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -220,6 +220,9 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		async getSnapshotUsage(): Promise< SnapshotUsage | null > {
 			return { siteCount: 0, siteLimit: 10, siteCreationBlocked: false };
 		},
+		async getStudioAssistantQuota() {
+			return null;
+		},
 		async deleteAllSnapshots() {
 			// No-op: hosted mode does not create WordPress.com preview sites.
 		},

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -1,4 +1,8 @@
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
+import {
+	STUDIO_ASSISTANT_QUOTA_URL,
+	studioAssistantQuotaSchema,
+} from '@studio/common/lib/studio-assistant-quota';
 import { fetchWordPressVersions } from '@studio/common/lib/wordpress-versions';
 import { __ } from '@wordpress/i18n';
 import { buildPublishCheckoutUrl } from '../publish-checkout-url';
@@ -20,6 +24,7 @@ import type {
 	SkillStatus,
 	Snapshot,
 	SnapshotUsage,
+	StudioAssistantQuota,
 	SupportedEditor,
 	SupportedTerminal,
 	SyncSite,
@@ -75,6 +80,22 @@ export function createIpcConnector(): Connector {
 	// The IPC connector only runs in Electron, so `navigator` reflects the
 	// desktop OS.
 	const isMacOS = /mac/i.test( navigator.platform || navigator.userAgent );
+
+	// Fetches an authenticated WordPress.com endpoint with the stored OAuth
+	// token. Resolves `null` when signed out so callers can degrade gracefully.
+	async function fetchWpcomJson( url: string, errorLabel: string ): Promise< unknown > {
+		const token = ( await ipcApi.getAuthenticationToken() ) as StoredAuthToken | null;
+		if ( ! token ) {
+			return null;
+		}
+		const response = await fetch( url, {
+			headers: { Authorization: `Bearer ${ token.accessToken }` },
+		} );
+		if ( ! response.ok ) {
+			throw new Error( `Failed to fetch ${ errorLabel }: ${ response.status }` );
+		}
+		return response.json();
+	}
 
 	// Preview CLI commands are path-based, not id-based. Look up the matching
 	// site once per call so UI code can keep working with the stable site id.
@@ -434,18 +455,16 @@ export function createIpcConnector(): Connector {
 		},
 
 		async getSnapshotUsage(): Promise< SnapshotUsage | null > {
-			const token = ( await ipcApi.getAuthenticationToken() ) as StoredAuthToken | null;
-			if ( ! token ) {
-				return null;
-			}
-			const response = await fetch(
+			const data = await fetchWpcomJson(
 				'https://public-api.wordpress.com/wpcom/v2/jurassic-ninja/usage',
-				{ headers: { Authorization: `Bearer ${ token.accessToken }` } }
+				'snapshot usage'
 			);
-			if ( ! response.ok ) {
-				throw new Error( `Failed to fetch snapshot usage: ${ response.status }` );
-			}
-			return parseSnapshotUsage( await response.json() );
+			return data === null ? null : parseSnapshotUsage( data );
+		},
+
+		async getStudioAssistantQuota(): Promise< StudioAssistantQuota | null > {
+			const data = await fetchWpcomJson( STUDIO_ASSISTANT_QUOTA_URL, 'Studio assistant quota' );
+			return data === null ? null : studioAssistantQuotaSchema.parse( data );
 		},
 
 		async deleteAllSnapshots(): Promise< void > {

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -468,6 +468,11 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			// counting snapshots.
 			return null;
 		},
+		async getStudioAssistantQuota() {
+			// No quota endpoint on the local server; callers fall back to
+			// static copy.
+			return null;
+		},
 		async deleteAllSnapshots() {
 			// No-op: the local server has no delete-all route yet.
 		},

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -5,6 +5,7 @@ import type { AiModelId } from '@studio/common/ai/models';
 import type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessions/types';
 import type { SiteEvent } from '@studio/common/lib/cli-events';
 import type { SupportedLocale } from '@studio/common/lib/locale';
+import type { StudioAssistantQuota } from '@studio/common/lib/studio-assistant-quota';
 import type { SupportedEditor } from '@studio/common/lib/user-settings/editor';
 import type { SupportedTerminal } from '@studio/common/lib/user-settings/terminal';
 import type { WordPressVersion } from '@studio/common/lib/wordpress-versions';
@@ -35,6 +36,7 @@ export type { SyncSite } from '@studio/common/types/sync';
 export type { SupportedEditor } from '@studio/common/lib/user-settings/editor';
 export type { SupportedTerminal } from '@studio/common/lib/user-settings/terminal';
 export type { SupportedLocale } from '@studio/common/lib/locale';
+export type { StudioAssistantQuota } from '@studio/common/lib/studio-assistant-quota';
 
 export type InstalledApps = Record< SupportedEditor | SupportedTerminal, boolean >;
 
@@ -219,6 +221,10 @@ export interface Connector {
 	// `null` when usage can't be determined (signed out, or the host has no
 	// usage source) so callers can fall back to counting snapshots.
 	getSnapshotUsage(): Promise< SnapshotUsage | null >;
+	// Studio Code AI usage quota for the signed-in account. Resolves `null`
+	// when the quota can't be determined (signed out, or the host has no
+	// quota source) so callers can fall back to static copy.
+	getStudioAssistantQuota(): Promise< StudioAssistantQuota | null >;
 	deleteAllSnapshots(): Promise< void >;
 	// Asks the user to confirm deleting every preview site on their account.
 	// Resolves `true` only when they explicitly confirm.

--- a/apps/ui/src/data/queries/use-assistant-quota.ts
+++ b/apps/ui/src/data/queries/use-assistant-quota.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+import { useAuthUser } from '@/data/queries/use-auth-user';
+
+export const ASSISTANT_QUOTA_QUERY_KEY = [ 'assistant-quota' ] as const;
+
+export function useStudioAssistantQuota() {
+	const connector = useConnector();
+	const { data: authUser } = useAuthUser();
+	const query = useQuery( {
+		// Keyed by user id so an account switch never surfaces the previous
+		// account's cached quota within the stale window.
+		queryKey: [ ...ASSISTANT_QUOTA_QUERY_KEY, authUser?.id ],
+		queryFn: () => connector.getStudioAssistantQuota(),
+		enabled: !! authUser,
+		// Quota moves slowly; avoid refetching on every panel mount and
+		// window focus.
+		staleTime: 5 * 60 * 1000,
+		meta: { persist: false },
+	} );
+	// The quota belongs to the signed-in WordPress.com account; hide any
+	// cached value while signed out.
+	return { ...query, data: authUser ? query.data : undefined };
+}

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const STUDIO_ASSISTANT_QUOTA_URL =
+	'https://public-api.wordpress.com/wpcom/v2/studio-app/ai-assistant/quota';
+
+export const studioAssistantQuotaSchema = z
+	.object( {
+		cost_usage: z.number(),
+		cost_cap: z.number(),
+		cost_reset_date: z.string(),
+	} )
+	.transform( ( data ) => ( {
+		costUsage: data.cost_usage,
+		costCap: data.cost_cap,
+		costResetDate: data.cost_reset_date,
+	} ) );
+
+export type StudioAssistantQuota = z.infer< typeof studioAssistantQuotaSchema >;


### PR DESCRIPTION
## Related issues

- Related to the agentic Settings Usage tab work on `agentic-settings-usage-tab`

## How AI was used in this PR

AI assisted with porting the quota logic from the legacy settings panel and with automated review passes (simplification + code review); all changes were verified with typecheck, lint, and unit tests.

## Proposed Changes

- Add AI Usage progress bar to Usage tab

## Testing Instructions

1. `npm start` with the agentic UI enabled and log in to a WordPress.com account that has a Studio Code cost cap.
2. Open Settings → Usage: the AI credits section should show "X% of monthly limit used (resets on DATE)" with a progress bar reflecting the percentage.
3. Go offline (e.g. disable network): the section should show "You're currently offline".
5. Verify the legacy settings dialog (classic UI → Settings) still shows the same quota line — it now reads the schema from the shared module.

| Before | After |
|--------|--------|
|  <img width="1431" height="925" alt="Screenshot 2026-07-22 at 11 15 26" src="https://github.com/user-attachments/assets/c7242431-4cf9-4738-bde3-30d12bbf378a" /> | <img width="1431" height="925" alt="Screenshot 2026-07-22 at 11 48 10" src="https://github.com/user-attachments/assets/12ca74c1-6e3c-4574-9d05-6ab03f94baa0" /> |

## Pre-merge Checklist


- [x] Have you checked for TypeScript, React or other console errors?
