### PR TITLE
Agentic UI: fix expired previews

### DIFF
--- a/apps/cli/lib/snapshots.ts
+++ b/apps/cli/lib/snapshots.ts
@@ -1,5 +1,4 @@
 import { HOUR_MS, DAY_MS, DEMO_SITE_EXPIRATION_DAYS } from '@studio/common/constants';
-import { Snapshot } from '@studio/common/types/snapshot';
 import { __ } from '@wordpress/i18n';
 import { addDays, addHours, DurationUnit, formatDuration, intervalToDuration } from 'date-fns';
 
@@ -11,11 +10,7 @@ export {
 	pruneExpiredOrphanedSnapshots,
 } from 'cli/lib/cli-config/snapshots';
 
-export function isSnapshotExpired( snapshot: Snapshot ) {
-	const now = new Date();
-	const endDate = addDays( snapshot.date, DEMO_SITE_EXPIRATION_DAYS );
-	return endDate < now;
-}
+export { isSnapshotExpired } from '@studio/common/lib/snapshots';
 
 export function formatDurationUntilExpiry( lastUpdatedAt: number ) {
 	const now = new Date();

--- a/apps/ui/src/components/site-dropdown/main-view.test.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.test.tsx
@@ -3,13 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MainView } from './main-view';
 import type { SiteDetails, Snapshot, SyncSite } from '@/data/core';
 
-const { connector, snapshots, connectedSites } = vi.hoisted( () => ( {
+const { connector, snapshots, connectedSites, publishPreviewMutate } = vi.hoisted( () => ( {
 	connector: {
 		copyText: vi.fn(),
 		openExternalUrl: vi.fn(),
 	},
 	snapshots: [] as Snapshot[],
 	connectedSites: [] as SyncSite[],
+	publishPreviewMutate: vi.fn(),
 } ) );
 
 vi.mock( '@tanstack/react-query', async ( importOriginal ) => {
@@ -37,7 +38,7 @@ vi.mock( '@/data/queries/use-auth-user', () => ( {
 } ) );
 
 vi.mock( '@/data/queries/use-preview-site', () => ( {
-	usePublishPreviewSite: () => ( { isPending: false, mutate: vi.fn() } ),
+	usePublishPreviewSite: () => ( { isPending: false, mutate: publishPreviewMutate } ),
 } ) );
 
 vi.mock( '@/data/queries/use-sites', () => ( {
@@ -82,11 +83,12 @@ describe( 'MainView', () => {
 	beforeEach( () => {
 		connector.copyText.mockReset();
 		connector.openExternalUrl.mockReset();
+		publishPreviewMutate.mockReset();
 		snapshots.splice( 0, snapshots.length, {
 			url: 'preview.example.com',
 			atomicSiteId: 123,
 			localSiteId: site.id,
-			date: 1,
+			date: Date.now(),
 		} );
 		connectedSites.splice( 0, connectedSites.length );
 	} );
@@ -106,5 +108,38 @@ describe( 'MainView', () => {
 		} );
 
 		consoleError.mockRestore();
+	} );
+
+	it( 'updates the existing preview site while the snapshot is fresh', () => {
+		renderMainView();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Update preview site' } ) );
+
+		expect( publishPreviewMutate ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				siteId: site.id,
+				existingHostname: 'preview.example.com',
+			} ),
+			expect.anything()
+		);
+	} );
+
+	it( 'offers to share a new preview once the snapshot expired', () => {
+		snapshots[ 0 ].date = Date.now() - 8 * 24 * 60 * 60 * 1000;
+
+		renderMainView();
+
+		expect( screen.getByText( 'The previous preview has expired.' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Copy preview URL' } ) ).not.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Share a new one' } ) );
+
+		expect( publishPreviewMutate ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				siteId: site.id,
+				existingHostname: undefined,
+			} ),
+			expect.anything()
+		);
 	} );
 } );

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -31,6 +31,7 @@ import {
 	deriveSiteStatus,
 	ensureProtocol,
 	getSnapshotHostname,
+	isSnapshotExpired,
 	pickLatestSnapshot,
 	pickLiveSite,
 	stripProtocol,
@@ -72,9 +73,15 @@ function useIsSiteSyncing( siteId: string ): { push: boolean; pull: boolean } {
 	return { push, pull };
 }
 
-function getPreviewPanelCopy( agenticEnabled: boolean, isOffline: boolean ): string {
+function getPreviewPanelCopy(
+	agenticEnabled: boolean,
+	isOffline: boolean,
+	isPreviewExpired: boolean
+): string {
 	if ( agenticEnabled ) {
-		return __( 'Share a review link for this version.' );
+		return isPreviewExpired
+			? __( 'The previous preview has expired.' )
+			: __( 'Share a review link for this version.' );
 	}
 	if ( isOffline ) {
 		return __( 'Go online to share a review link.' );
@@ -104,6 +111,7 @@ export function MainView( { site, activity, onSetupClick, onDisconnectClick }: P
 		() => pickLatestSnapshot( snapshots, site.id ),
 		[ snapshots, site.id ]
 	);
+	const isPreviewExpired = previewSnapshot !== undefined && isSnapshotExpired( previewSnapshot );
 	const liveSite = useMemo( () => pickLiveSite( connectedSites ), [ connectedSites ] );
 
 	const startSite = useStartSite();
@@ -134,7 +142,11 @@ export function MainView( { site, activity, onSetupClick, onDisconnectClick }: P
 		publishPreviewSite.mutate(
 			{
 				siteId: site.id,
-				existingHostname: previewSnapshot ? getSnapshotHostname( previewSnapshot ) : undefined,
+				// The CLI cannot update an expired preview site — create a new one.
+				existingHostname:
+					previewSnapshot && ! isPreviewExpired
+						? getSnapshotHostname( previewSnapshot )
+						: undefined,
 			},
 			{ onSuccess: ( { url } ) => openExternal( ensureProtocol( url ) ) }
 		);
@@ -233,7 +245,7 @@ export function MainView( { site, activity, onSetupClick, onDisconnectClick }: P
 				}
 			/>
 
-			{ previewSnapshot ? (
+			{ previewSnapshot && ! isPreviewExpired ? (
 				<PopoverRow
 					label={ __( 'Preview' ) }
 					sublabel={ __( 'Ready to share for feedback.' ) }
@@ -275,8 +287,8 @@ export function MainView( { site, activity, onSetupClick, onDisconnectClick }: P
 			) : (
 				<EnvironmentActionPanel
 					title={ __( 'Preview' ) }
-					copy={ getPreviewPanelCopy( agenticEnabled, isOffline ) }
-					buttonLabel={ __( 'Share' ) }
+					copy={ getPreviewPanelCopy( agenticEnabled, isOffline, isPreviewExpired ) }
+					buttonLabel={ isPreviewExpired ? __( 'Share a new one' ) : __( 'Share' ) }
 					variant="outline"
 					tone="neutral"
 					loading={ isPreviewPending }

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -1,3 +1,4 @@
+import { isSnapshotExpired } from '@studio/common/lib/snapshots';
 import { useIsMutating } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { arrowDown, arrowUp, copy, external, Icon, moreHorizontal } from '@wordpress/icons';
@@ -31,7 +32,6 @@ import {
 	deriveSiteStatus,
 	ensureProtocol,
 	getSnapshotHostname,
-	isSnapshotExpired,
 	pickLatestSnapshot,
 	pickLiveSite,
 	stripProtocol,

--- a/apps/ui/src/components/site-dropdown/trigger-secondary.test.ts
+++ b/apps/ui/src/components/site-dropdown/trigger-secondary.test.ts
@@ -41,21 +41,6 @@ describe( 'getSiteDropdownSecondary', () => {
 		} );
 	} );
 
-	it( 'normalizes preview timestamps stored as unix seconds', () => {
-		expect(
-			getSiteDropdownSecondary( {
-				activity: null,
-				activeEnvironment: 'local',
-				previewSnapshot: createSnapshot( {
-					date: Date.parse( '2026-05-03T11:55:00.000Z' ) / 1000,
-				} ),
-			} )
-		).toEqual( {
-			label: 'Preview updated 5m ago',
-			tone: 'neutral',
-		} );
-	} );
-
 	it( 'reports expiry instead of recency once the snapshot is too old', () => {
 		expect(
 			getSiteDropdownSecondary( {

--- a/apps/ui/src/components/site-dropdown/trigger-secondary.test.ts
+++ b/apps/ui/src/components/site-dropdown/trigger-secondary.test.ts
@@ -56,6 +56,19 @@ describe( 'getSiteDropdownSecondary', () => {
 		} );
 	} );
 
+	it( 'reports expiry instead of recency once the snapshot is too old', () => {
+		expect(
+			getSiteDropdownSecondary( {
+				activity: null,
+				activeEnvironment: 'local',
+				previewSnapshot: createSnapshot( { date: Date.parse( '2026-04-25T12:00:00.000Z' ) } ),
+			} )
+		).toEqual( {
+			label: 'Preview expired',
+			tone: 'neutral',
+		} );
+	} );
+
 	it( 'uses live push recency while the session targets live', () => {
 		expect(
 			getSiteDropdownSecondary( {

--- a/apps/ui/src/components/site-dropdown/trigger-secondary.ts
+++ b/apps/ui/src/components/site-dropdown/trigger-secondary.ts
@@ -1,10 +1,10 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { formatRelativeTime } from '@/lib/format-relative-time';
+import { isSnapshotExpired, normalizeSnapshotTimestamp } from './utils';
 import type { Snapshot, SyncSite } from '@/data/core';
 import type { SyncActivity } from '@/data/sync-activity';
 
 const MINUTE_MS = 60_000;
-const UNIX_SECONDS_CUTOFF = 10_000_000_000;
 
 export type TriggerSecondaryTone = 'neutral' | 'pending' | 'success' | 'error';
 
@@ -50,10 +50,6 @@ function getSyncActivityTone( activity: SyncActivity ): TriggerSecondaryTone {
 	return activity.kind === 'success' ? 'success' : 'error';
 }
 
-function normalizeSnapshotTimestamp( timestamp: number ): number {
-	return timestamp < UNIX_SECONDS_CUTOFF ? timestamp * 1000 : timestamp;
-}
-
 function formatTimestampPhrase(
 	timestampMs: number,
 	nowLabel: string,
@@ -90,6 +86,10 @@ function formatIsoTimestampPhrase(
 function getPreviewLabel( previewSnapshot: Snapshot | undefined ): string | null {
 	if ( ! previewSnapshot ) {
 		return null;
+	}
+
+	if ( isSnapshotExpired( previewSnapshot ) ) {
+		return __( 'Preview expired' );
 	}
 
 	return formatTimestampPhrase(

--- a/apps/ui/src/components/site-dropdown/trigger-secondary.ts
+++ b/apps/ui/src/components/site-dropdown/trigger-secondary.ts
@@ -1,6 +1,6 @@
+import { isSnapshotExpired } from '@studio/common/lib/snapshots';
 import { __, sprintf } from '@wordpress/i18n';
 import { formatRelativeTime } from '@/lib/format-relative-time';
-import { isSnapshotExpired, normalizeSnapshotTimestamp } from './utils';
 import type { Snapshot, SyncSite } from '@/data/core';
 import type { SyncActivity } from '@/data/sync-activity';
 
@@ -93,7 +93,7 @@ function getPreviewLabel( previewSnapshot: Snapshot | undefined ): string | null
 	}
 
 	return formatTimestampPhrase(
-		normalizeSnapshotTimestamp( previewSnapshot.date ),
+		previewSnapshot.date,
 		__( 'Preview updated now' ),
 		( relativeTime ) =>
 			sprintf(

--- a/apps/ui/src/components/site-dropdown/utils.ts
+++ b/apps/ui/src/components/site-dropdown/utils.ts
@@ -1,7 +1,25 @@
+import { DAY_MS, DEMO_SITE_EXPIRATION_DAYS } from '@studio/common/constants';
 import { __ } from '@wordpress/i18n';
 import { getSiteDisplayUrl } from '@/lib/get-site-url';
 import type { SiteStatus } from './dropdown-trigger';
 import type { SiteDetails, Snapshot, SyncSite } from '@/data/core';
+
+const UNIX_SECONDS_CUTOFF = 10_000_000_000;
+
+// Older CLI versions stored snapshot dates as unix seconds; newer ones use
+// milliseconds. Values below the cutoff can only be seconds.
+export function normalizeSnapshotTimestamp( timestamp: number ): number {
+	return timestamp < UNIX_SECONDS_CUTOFF ? timestamp * 1000 : timestamp;
+}
+
+// Mirrors the CLI's isSnapshotExpired (apps/cli/lib/snapshots.ts). The CLI
+// refuses to update an expired preview site, so the UI must offer creating a
+// new one instead of an update.
+export function isSnapshotExpired( snapshot: Snapshot ): boolean {
+	return (
+		normalizeSnapshotTimestamp( snapshot.date ) + DEMO_SITE_EXPIRATION_DAYS * DAY_MS < Date.now()
+	);
+}
 
 export function stripProtocol( url: string ): string {
 	return url.replace( /^https?:\/\//, '' ).replace( /\/$/, '' );

--- a/apps/ui/src/components/site-dropdown/utils.ts
+++ b/apps/ui/src/components/site-dropdown/utils.ts
@@ -1,25 +1,7 @@
-import { DAY_MS, DEMO_SITE_EXPIRATION_DAYS } from '@studio/common/constants';
 import { __ } from '@wordpress/i18n';
 import { getSiteDisplayUrl } from '@/lib/get-site-url';
 import type { SiteStatus } from './dropdown-trigger';
 import type { SiteDetails, Snapshot, SyncSite } from '@/data/core';
-
-const UNIX_SECONDS_CUTOFF = 10_000_000_000;
-
-// Older CLI versions stored snapshot dates as unix seconds; newer ones use
-// milliseconds. Values below the cutoff can only be seconds.
-export function normalizeSnapshotTimestamp( timestamp: number ): number {
-	return timestamp < UNIX_SECONDS_CUTOFF ? timestamp * 1000 : timestamp;
-}
-
-// Mirrors the CLI's isSnapshotExpired (apps/cli/lib/snapshots.ts). The CLI
-// refuses to update an expired preview site, so the UI must offer creating a
-// new one instead of an update.
-export function isSnapshotExpired( snapshot: Snapshot ): boolean {
-	return (
-		normalizeSnapshotTimestamp( snapshot.date ) + DEMO_SITE_EXPIRATION_DAYS * DAY_MS < Date.now()
-	);
-}
 
 export function stripProtocol( url: string ): string {
 	return url.replace( /^https?:\/\//, '' ).replace( /\/$/, '' );

--- a/packages/common/lib/snapshots.ts
+++ b/packages/common/lib/snapshots.ts
@@ -1,0 +1,6 @@
+import { DAY_MS, DEMO_SITE_EXPIRATION_DAYS } from '@studio/common/constants';
+import type { Snapshot } from '@studio/common/types/snapshot';
+
+export function isSnapshotExpired( snapshot: Snapshot ): boolean {
+	return snapshot.date + DEMO_SITE_EXPIRATION_DAYS * DAY_MS < Date.now();
+}


### PR DESCRIPTION
## Related issues
- Fixes STU-1978

## How AI was used in this PR

AI assisted

## Proposed Changes

In the issue STU-1978 we needed to come up with an approach for expired previews. The solution in testing instructions.

## Testing Instructions
1. Electron -> Feature Flags -> Enable Agentic UI
2. Create a new site
3. Click on:<br /><img width="217" height="54" alt="Screenshot 2026-07-22 at 12 52 50" src="https://github.com/user-attachments/assets/f7df908d-4534-4fe8-9e09-84b3ab84c66c" />
4. Assert that everythign looks as before<br /><img width="339" height="62" alt="Screenshot 2026-07-22 at 12 51 19" src="https://github.com/user-attachments/assets/3241ba7e-7893-4816-ba32-15193b3fd0a5" />
5. Click on `Share` and wait till the preview is created
6. Assert that you see "Preview published" and teh next content for preview section<br /><img width="841" height="551" alt="Screenshot 2026-07-22 at 12 56 12" src="https://github.com/user-attachments/assets/2f17b593-cb36-4201-812b-1fe879863625" />
7. Open `~/.studio/cli.json`
8. Set `date` for your `snapshot` as `1784209999143`
9. Assert that you see "Preview updated 5 days ago"<br /><img width="238" height="55" alt="Screenshot 2026-07-22 at 12 58 24" src="https://github.com/user-attachments/assets/acdf208a-73e8-4ce7-8def-c2747bffa96a" />
10. Set `date` for your `snapshot` as `1784109999143`
11. Assert that you see "Preview Expired", "The previous preview has expired." and button "Share a new one"
12. Click on "Share a new one"
13. Assert that it creates a preview