### PR TITLE
Agentic UI: fix resizer for chat input

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
@@ -792,7 +792,9 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 						onPointerCancel={ finishComposerResize }
 						onLostPointerCapture={ finishComposerResize }
 						onKeyDown={ handleComposerResizeKeyDown }
-					/>
+					>
+						<span className={ styles.resizeHandleIndicator } aria-hidden="true" />
+					</div>
 					{ isDraggingOver ? (
 						<div className={ styles.dropOverlay } aria-hidden="true">
 							{ __( 'Drop files to attach' ) }

--- a/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
@@ -32,7 +32,7 @@
 	transition: outline-color 80ms ease, outline-width 80ms ease;
 }
 
-.shell:focus-within {
+.shell:focus-within:not(:has(.resizeHandle:focus-visible)) {
 	background-color: var(--wpds-color-bg-surface-neutral-strong);
 	background-image: none;
 	backdrop-filter: none;

--- a/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
@@ -58,16 +58,29 @@
 	right: var(--composer-inline-padding);
 	left: var(--composer-inline-padding);
 	z-index: 20;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	height: 10px;
 	cursor: ns-resize;
 	touch-action: none;
+	outline: none;
 	-webkit-app-region: no-drag;
 }
 
-.resizeHandle:focus-visible {
-	border-radius: 999px;
-	outline: 2px solid var(--composer-focus-ring);
-	outline-offset: 2px;
+/* Thin full-width line that lights up on hover, keyboard focus, and while dragging. */
+.resizeHandleIndicator {
+	width: 100%;
+	height: 2px;
+	background-color: var(--wpds-color-stroke-interactive-brand, #2563eb);
+	opacity: 0;
+	transition: opacity 120ms ease;
+}
+
+.resizeHandle:hover .resizeHandleIndicator,
+.resizeHandle:focus-visible .resizeHandleIndicator,
+.shellResizing .resizeHandleIndicator {
+	opacity: 1;
 }
 
 .dropOverlay {


### PR DESCRIPTION
## Related issues
- Fixes STU-2062

## How AI was used in this PR

AI assisted



## Proposed Changes
1. Electron -> Beta features -> Enable Agentic UI
2. Mouse over at the top chat input border and assert that you see a draggable line, with styles aligned with teh left sidebar resizer:<br /><img width="653" height="140" alt="Screenshot 2026-07-22 at 13 43 25" src="https://github.com/user-attachments/assets/f4dbe2fd-c89a-4fff-badc-de482ff2531c" />
3. Click anywhere in the UI to focus teh window and then click `tab` button a few times to reach the chat input resizer
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="666" height="153" alt="Screenshot 2026-07-22 at 13 44 27" src="https://github.com/user-attachments/assets/02783b20-f7cb-468d-ad0a-5df328dbd60e" />
<td><img width="667" height="119" alt="Screenshot 2026-07-22 at 13 43 38" src="https://github.com/user-attachments/assets/b665b6c6-0a16-4a41-afe6-08ddbc9990f2" />
</tr>
</table>
4. Click up/down buttons on your keyboard and assert that resizing works from the keyboard when the resizer is focused



