### PR TITLE
Agentic UI: Add Studio CLI toggle to application settings

### DIFF
--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -195,6 +195,7 @@ import type { WpCliResult } from 'src/site-server';
 
 export {
 	isStudioCliInstalled,
+	isStudioCliExternallyManaged,
 	installStudioCli,
 	uninstallStudioCli,
 } from 'src/modules/cli/lib/ipc-handlers';

--- a/apps/studio/src/modules/cli/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/cli/lib/ipc-handlers.ts
@@ -10,6 +10,7 @@ import { WindowsCliInstallationManager } from 'src/modules/cli/lib/windows-insta
  */
 export interface StudioCliInstallationManager {
 	isCliInstalled(): Promise< boolean >;
+	isCliExternallyManaged(): Promise< boolean >;
 	installCliWithConfirmation(): Promise< void >;
 	uninstallCliWithConfirmation(): Promise< void >;
 }
@@ -30,6 +31,11 @@ function getCliInstallationManager(): StudioCliInstallationManager {
 export async function isStudioCliInstalled(): Promise< boolean > {
 	const manager = getCliInstallationManager();
 	return await manager.isCliInstalled();
+}
+
+export async function isStudioCliExternallyManaged(): Promise< boolean > {
+	const manager = getCliInstallationManager();
+	return await manager.isCliExternallyManaged();
 }
 
 export async function installStudioCli(): Promise< void > {

--- a/apps/studio/src/modules/cli/lib/unix-installation-manager.ts
+++ b/apps/studio/src/modules/cli/lib/unix-installation-manager.ts
@@ -93,6 +93,10 @@ export class UnixCliInstallationManager implements StudioCliInstallationManager 
 		return await doesSymlinkLeadToPackagedCli( cliSymlinkPath, this.config.prodCliPackagedPath );
 	}
 
+	async isCliExternallyManaged(): Promise< boolean > {
+		return await this.isExternallyManagedCli( cliSymlinkPath );
+	}
+
 	async installCliWithConfirmation(): Promise< void > {
 		try {
 			await this.installCli();

--- a/apps/studio/src/modules/cli/lib/windows-installation-manager.ts
+++ b/apps/studio/src/modules/cli/lib/windows-installation-manager.ts
@@ -39,6 +39,15 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 		}
 	}
 
+	async isCliExternallyManaged(): Promise< boolean > {
+		try {
+			return await this.isStandaloneCli();
+		} catch ( error ) {
+			console.error( 'Failed to check for a standalone CLI', error );
+			return false;
+		}
+	}
+
 	async autoInstallIfNeeded(): Promise< void > {
 		const userData = await loadUserData();
 		if ( userData.cliUserUninstalled ) {

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -187,6 +187,7 @@ const api: IpcApi = {
 	startRemoteSessionDaemon: () => ipcRendererInvoke( 'startRemoteSessionDaemon' ),
 	stopRemoteSessionDaemon: () => ipcRendererInvoke( 'stopRemoteSessionDaemon' ),
 	isStudioCliInstalled: () => ipcRendererInvoke( 'isStudioCliInstalled' ),
+	isStudioCliExternallyManaged: () => ipcRendererInvoke( 'isStudioCliExternallyManaged' ),
 	installStudioCli: () => ipcRendererInvoke( 'installStudioCli' ),
 	uninstallStudioCli: () => ipcRendererInvoke( 'uninstallStudioCli' ),
 	getAgentInstructionsStatus: ( siteId ) =>

--- a/apps/ui/src/components/settings-view/index.test.tsx
+++ b/apps/ui/src/components/settings-view/index.test.tsx
@@ -78,6 +78,10 @@ vi.mock( './skills-panel', () => ( {
 	SkillsPanel: () => null,
 } ) );
 
+vi.mock( './studio-cli-section', () => ( {
+	StudioCliSection: () => null,
+} ) );
+
 vi.mock( '@/data/queries/use-auth-user', () => ( {
 	useAuthUser: () => ( { data: null, isLoading: false } ),
 	useLogin: () => ( { mutate: vi.fn(), isPending: false } ),
@@ -151,6 +155,7 @@ describe( 'SettingsView', () => {
 				quitSitesBehavior: undefined,
 				locale: 'en',
 				defaultSiteDirectory: '/Users/example/Studio',
+				studioCliInstalled: false,
 			},
 			isLoading: false,
 		} as never );

--- a/apps/ui/src/components/settings-view/index.test.tsx
+++ b/apps/ui/src/components/settings-view/index.test.tsx
@@ -156,6 +156,7 @@ describe( 'SettingsView', () => {
 				locale: 'en',
 				defaultSiteDirectory: '/Users/example/Studio',
 				studioCliInstalled: false,
+				studioCliExternallyManaged: false,
 			},
 			isLoading: false,
 		} as never );

--- a/apps/ui/src/components/settings-view/index.tsx
+++ b/apps/ui/src/components/settings-view/index.tsx
@@ -17,6 +17,7 @@ import { AccountSection } from './account-section';
 import { McpPanel } from './mcp-panel';
 import { UNSET, toPreferencesFormData, toPreferencesPatch } from './preferences';
 import { SkillsPanel } from './skills-panel';
+import { StudioCliSection } from './studio-cli-section';
 import styles from './style.module.css';
 import type { PreferencesFormData } from './preferences';
 import type {
@@ -305,6 +306,7 @@ function PreferencesPanel( {
 				</PreferenceRow>
 			</section>
 			<AccountSection />
+			<StudioCliSection />
 			<StudioExperienceSection />
 		</div>
 	);

--- a/apps/ui/src/components/settings-view/preferences.test.ts
+++ b/apps/ui/src/components/settings-view/preferences.test.ts
@@ -9,6 +9,7 @@ const SAVED_PREFERENCES: UserPreferences = {
 	quitSitesBehavior: 'stop',
 	locale: 'en',
 	defaultSiteDirectory: '/Users/example/Studio',
+	studioCliInstalled: false,
 };
 
 describe( 'settings preference helpers', () => {

--- a/apps/ui/src/components/settings-view/preferences.test.ts
+++ b/apps/ui/src/components/settings-view/preferences.test.ts
@@ -10,6 +10,7 @@ const SAVED_PREFERENCES: UserPreferences = {
 	locale: 'en',
 	defaultSiteDirectory: '/Users/example/Studio',
 	studioCliInstalled: false,
+	studioCliExternallyManaged: false,
 };
 
 describe( 'settings preference helpers', () => {

--- a/apps/ui/src/components/settings-view/studio-cli-section.test.tsx
+++ b/apps/ui/src/components/settings-view/studio-cli-section.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppGlobals } from '@/data/queries/use-app-globals';
+import { useSaveUserPreferences, useUserPreferences } from '@/data/queries/use-user-preferences';
+import { StudioCliSection } from './studio-cli-section';
+
+vi.mock( '@/components/learn-more', () => ( {
+	LearnMoreLink: () => null,
+} ) );
+
+vi.mock( '@/data/queries/use-app-globals', () => ( {
+	useAppGlobals: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-user-preferences', () => ( {
+	useSaveUserPreferences: vi.fn(),
+	useUserPreferences: vi.fn(),
+} ) );
+
+const useAppGlobalsMock = vi.mocked( useAppGlobals );
+const useSaveUserPreferencesMock = vi.mocked( useSaveUserPreferences );
+const useUserPreferencesMock = vi.mocked( useUserPreferences );
+
+describe( 'StudioCliSection', () => {
+	const mutate = vi.fn();
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+
+		useAppGlobalsMock.mockReturnValue( {
+			data: { platform: 'darwin', isWindowsStore: false },
+		} as never );
+		useSaveUserPreferencesMock.mockReturnValue( {
+			mutate,
+			isPending: false,
+			isError: false,
+		} as never );
+		useUserPreferencesMock.mockReturnValue( {
+			data: { studioCliInstalled: false },
+		} as never );
+	} );
+
+	it( 'saves as soon as the toggle is flipped', () => {
+		render( <StudioCliSection /> );
+
+		const toggle = screen.getByRole( 'checkbox', { name: 'Studio CLI for terminal' } );
+		expect( toggle ).not.toBeChecked();
+
+		fireEvent.click( toggle );
+
+		expect( mutate ).toHaveBeenCalledWith( { studioCliInstalled: true }, expect.any( Object ) );
+		expect( toggle ).toBeChecked();
+	} );
+
+	it( 'reverts the toggle to the saved state when the install fails', () => {
+		mutate.mockImplementation( ( _patch, options ) => options?.onSettled?.() );
+
+		render( <StudioCliSection /> );
+
+		const toggle = screen.getByRole( 'checkbox', { name: 'Studio CLI for terminal' } );
+		fireEvent.click( toggle );
+
+		expect( toggle ).not.toBeChecked();
+	} );
+
+	it( 'surfaces an install/uninstall error inline', () => {
+		useSaveUserPreferencesMock.mockReturnValue( {
+			mutate,
+			isPending: false,
+			isError: true,
+		} as never );
+
+		render( <StudioCliSection /> );
+
+		expect(
+			screen.getByText( 'An error occurred while updating the Studio CLI. Please try again.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'is hidden in the browser', () => {
+		useAppGlobalsMock.mockReturnValue( {
+			data: { platform: 'browser', isWindowsStore: false },
+		} as never );
+
+		const { container } = render( <StudioCliSection /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'is hidden in Windows Store builds', () => {
+		useAppGlobalsMock.mockReturnValue( {
+			data: { platform: 'win32', isWindowsStore: true },
+		} as never );
+
+		const { container } = render( <StudioCliSection /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/apps/ui/src/components/settings-view/studio-cli-section.test.tsx
+++ b/apps/ui/src/components/settings-view/studio-cli-section.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { Tooltip } from '@wordpress/ui';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAppGlobals } from '@/data/queries/use-app-globals';
 import { useSaveUserPreferences, useUserPreferences } from '@/data/queries/use-user-preferences';
@@ -37,7 +38,7 @@ describe( 'StudioCliSection', () => {
 			isError: false,
 		} as never );
 		useUserPreferencesMock.mockReturnValue( {
-			data: { studioCliInstalled: false },
+			data: { studioCliInstalled: false, studioCliExternallyManaged: false },
 		} as never );
 	} );
 
@@ -76,6 +77,26 @@ describe( 'StudioCliSection', () => {
 		expect(
 			screen.getByText( 'An error occurred while updating the Studio CLI. Please try again.' )
 		).toBeInTheDocument();
+	} );
+
+	it( 'disables the toggle for a standalone (externally managed) CLI', () => {
+		useUserPreferencesMock.mockReturnValue( {
+			data: { studioCliInstalled: true, studioCliExternallyManaged: true },
+		} as never );
+
+		render(
+			<Tooltip.Provider>
+				<StudioCliSection />
+			</Tooltip.Provider>
+		);
+
+		const toggle = screen.getByRole( 'checkbox', { name: 'Studio CLI for terminal' } );
+		expect( toggle ).toBeChecked();
+		expect( toggle ).toBeDisabled();
+
+		fireEvent.click( toggle );
+
+		expect( mutate ).not.toHaveBeenCalled();
 	} );
 
 	it( 'is hidden in the browser', () => {

--- a/apps/ui/src/components/settings-view/studio-cli-section.tsx
+++ b/apps/ui/src/components/settings-view/studio-cli-section.tsx
@@ -53,16 +53,23 @@ export function StudioCliSection() {
 					{ __( 'Studio CLI' ) }
 				</h2>
 				{ externallyManaged ? (
-					<Tooltip.Root>
-						<Tooltip.Trigger
-							render={ <span className={ styles.cliToggleTrigger }>{ toggle }</span> }
-						/>
-						<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
-							{ __(
-								'This studio command was installed with the standalone CLI installer, so Studio can’t manage it. Run studio uninstall in a terminal to remove it.'
-							) }
-						</Tooltip.Popup>
-					</Tooltip.Root>
+					// The default open delay reads as unresponsive on a disabled
+					// control, so this tooltip gets its own faster provider.
+					<Tooltip.Provider delay={ 200 }>
+						<Tooltip.Root>
+							<Tooltip.Trigger
+								render={ <span className={ styles.cliToggleTrigger }>{ toggle }</span> }
+							/>
+							<Tooltip.Popup
+								className={ styles.cliTooltip }
+								positioner={ <Tooltip.Positioner side="top" /> }
+							>
+								{ __(
+									'This studio command was installed with the standalone CLI installer, so Studio can’t manage it. Run studio uninstall in a terminal to remove it.'
+								) }
+							</Tooltip.Popup>
+						</Tooltip.Root>
+					</Tooltip.Provider>
 				) : (
 					toggle
 				) }

--- a/apps/ui/src/components/settings-view/studio-cli-section.tsx
+++ b/apps/ui/src/components/settings-view/studio-cli-section.tsx
@@ -1,5 +1,6 @@
 import { FormToggle } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Tooltip } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useState } from 'react';
 import { LearnMoreLink } from '@/components/learn-more';
@@ -22,12 +23,28 @@ export function StudioCliSection() {
 		return null;
 	}
 
+	// A standalone (curl) install is never touched by the app, so the toggle
+	// is read-only with a tooltip pointing at `studio uninstall`.
+	const externallyManaged = saved.studioCliExternallyManaged;
 	const checked = pending ?? saved.studioCliInstalled;
 
 	const handleChange = ( studioCliInstalled: boolean ) => {
+		if ( externallyManaged ) {
+			return;
+		}
 		setPending( studioCliInstalled );
 		savePreferences.mutate( { studioCliInstalled }, { onSettled: () => setPending( null ) } );
 	};
+
+	const toggle = (
+		<FormToggle
+			id="studio-cli-toggle"
+			aria-label={ __( 'Studio CLI for terminal' ) }
+			checked={ checked }
+			disabled={ savePreferences.isPending || externallyManaged }
+			onChange={ ( event ) => handleChange( event.target.checked ) }
+		/>
+	);
 
 	return (
 		<section className={ styles.preferenceSectionGroup }>
@@ -35,13 +52,20 @@ export function StudioCliSection() {
 				<h2 className={ clsx( styles.preferenceSectionHeading, styles.cliHeading ) }>
 					{ __( 'Studio CLI' ) }
 				</h2>
-				<FormToggle
-					id="studio-cli-toggle"
-					aria-label={ __( 'Studio CLI for terminal' ) }
-					checked={ checked }
-					disabled={ savePreferences.isPending }
-					onChange={ ( event ) => handleChange( event.target.checked ) }
-				/>
+				{ externallyManaged ? (
+					<Tooltip.Root>
+						<Tooltip.Trigger
+							render={ <span className={ styles.cliToggleTrigger }>{ toggle }</span> }
+						/>
+						<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+							{ __(
+								'This studio command was installed with the standalone CLI installer, so Studio can’t manage it. Run studio uninstall in a terminal to remove it.'
+							) }
+						</Tooltip.Popup>
+					</Tooltip.Root>
+				) : (
+					toggle
+				) }
 			</div>
 			{ savePreferences.isError ? (
 				<div className={ styles.errorMessage }>

--- a/apps/ui/src/components/settings-view/studio-cli-section.tsx
+++ b/apps/ui/src/components/settings-view/studio-cli-section.tsx
@@ -1,0 +1,57 @@
+import { FormToggle } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { clsx } from 'clsx';
+import { useState } from 'react';
+import { LearnMoreLink } from '@/components/learn-more';
+import { useAppGlobals } from '@/data/queries/use-app-globals';
+import { useSaveUserPreferences, useUserPreferences } from '@/data/queries/use-user-preferences';
+import styles from './style.module.css';
+
+export function StudioCliSection() {
+	const { data: appGlobals } = useAppGlobals();
+	const { data: saved } = useUserPreferences();
+	const savePreferences = useSaveUserPreferences();
+	// Optimistic toggle state while an install/uninstall is in flight. Cleared
+	// on settle: on success the query cache already holds the new value, on
+	// failure the toggle falls back to the saved state.
+	const [ pending, setPending ] = useState< boolean | null >( null );
+
+	// The CLI installer only exists in the desktop app, and Windows Store
+	// builds can't write to PATH.
+	if ( ! appGlobals || appGlobals.platform === 'browser' || appGlobals.isWindowsStore || ! saved ) {
+		return null;
+	}
+
+	const checked = pending ?? saved.studioCliInstalled;
+
+	const handleChange = ( studioCliInstalled: boolean ) => {
+		setPending( studioCliInstalled );
+		savePreferences.mutate( { studioCliInstalled }, { onSettled: () => setPending( null ) } );
+	};
+
+	return (
+		<section className={ styles.preferenceSectionGroup }>
+			<div className={ styles.cliHeader }>
+				<h2 className={ clsx( styles.preferenceSectionHeading, styles.cliHeading ) }>
+					{ __( 'Studio CLI' ) }
+				</h2>
+				<FormToggle
+					id="studio-cli-toggle"
+					aria-label={ __( 'Studio CLI for terminal' ) }
+					checked={ checked }
+					disabled={ savePreferences.isPending }
+					onChange={ ( event ) => handleChange( event.target.checked ) }
+				/>
+			</div>
+			{ savePreferences.isError ? (
+				<div className={ styles.errorMessage }>
+					{ __( 'An error occurred while updating the Studio CLI. Please try again.' ) }
+				</div>
+			) : null }
+			<p className={ styles.cliDescription }>
+				{ __( 'Use the studio command in any terminal to manage sites and run WP-CLI.' ) }{ ' ' }
+				<LearnMoreLink docsLinksKey="docsCli" />
+			</p>
+		</section>
+	);
+}

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -403,6 +403,51 @@
 	fill: currentColor;
 }
 
+.cliHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-padding-xl);
+}
+
+.cliHeading {
+	margin-block-end: 0;
+}
+
+.cliHeader :global(.components-form-toggle .components-form-toggle__track) {
+	background-color: var(--wpds-color-bg-track-neutral-weak);
+	border-color: var(--wpds-color-stroke-interactive-neutral);
+}
+
+.cliHeader :global(.components-form-toggle .components-form-toggle__thumb) {
+	background-color: var(--wpds-color-bg-thumb-neutral-weak);
+}
+
+.cliHeader :global(.components-form-toggle.is-checked .components-form-toggle__track) {
+	background-color: var(--wpds-color-bg-interactive-brand-strong);
+	border-color: var(--wpds-color-stroke-interactive-brand);
+}
+
+.cliHeader :global(.components-form-toggle.is-checked .components-form-toggle__thumb) {
+	background-color: var(--wpds-color-fg-interactive-brand-strong);
+}
+
+.cliHeader
+	:global(.components-form-toggle .components-form-toggle__input:focus
+		+ .components-form-toggle__track) {
+	box-shadow:
+		0 0 0 var(--wpds-border-width-focus) var(--wpds-color-bg-surface-neutral),
+		0 0 0 calc(2 * var(--wpds-border-width-focus)) var(--wpds-color-stroke-focus-brand);
+}
+
+.cliDescription {
+	max-inline-size: 460px;
+	margin: 0;
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+}
+
 .errorMessage {
 	margin-block-end: var(--wpds-dimension-padding-md);
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -440,6 +440,16 @@
 		0 0 0 calc(2 * var(--wpds-border-width-focus)) var(--wpds-color-stroke-focus-brand);
 }
 
+.cliToggleTrigger {
+	display: inline-flex;
+}
+
+/* Disabled form controls swallow hover events, which would keep the wrapper's
+   tooltip from ever opening. */
+.cliToggleTrigger :global(input:disabled) {
+	pointer-events: none;
+}
+
 .cliDescription {
 	max-inline-size: 460px;
 	margin: 0;

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -450,6 +450,11 @@
 	pointer-events: none;
 }
 
+.cliTooltip {
+	max-inline-size: 280px;
+	line-height: var(--wpds-typography-line-height-sm);
+}
+
 .cliDescription {
 	max-inline-size: 460px;
 	margin: 0;

--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -131,6 +131,8 @@ describe( 'SiteList', () => {
 				colorScheme: 'system',
 				locale: 'en',
 				defaultSiteDirectory: '',
+				studioCliInstalled: false,
+				studioCliExternallyManaged: false,
 			},
 		} );
 		useSitesMock.mockReturnValue( {
@@ -677,6 +679,8 @@ describe( 'SiteList', () => {
 				colorScheme: 'system',
 				locale: 'en',
 				defaultSiteDirectory: '',
+				studioCliInstalled: false,
+				studioCliExternallyManaged: false,
 			},
 		} );
 
@@ -699,6 +703,8 @@ describe( 'SiteList', () => {
 				colorScheme: 'system',
 				locale: undefined,
 				defaultSiteDirectory: '',
+				studioCliInstalled: false,
+				studioCliExternallyManaged: false,
 			},
 		} );
 

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -314,6 +314,7 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 				locale: undefined,
 				defaultSiteDirectory: '',
 				studioCliInstalled: false,
+				studioCliExternallyManaged: false,
 			};
 		},
 		async setUserPreferences() {

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -5,6 +5,7 @@ import type {
 	ActiveAgentRun,
 	AiSessionPlacementUpdatedEvent,
 	AiSessionSummary,
+	AppGlobals,
 	AuthUser,
 	Connector,
 	InstalledApps,
@@ -312,10 +313,14 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 				quitSitesBehavior: undefined,
 				locale: undefined,
 				defaultSiteDirectory: '',
+				studioCliInstalled: false,
 			};
 		},
 		async setUserPreferences() {
 			// No-op: preferences aren't persisted in the browser yet.
+		},
+		async getAppGlobals(): Promise< AppGlobals > {
+			return { platform: 'browser', isWindowsStore: false };
 		},
 		async selectDefaultSiteDirectory(): Promise< string | null > {
 			// No native folder picker in a browser.

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -559,6 +559,7 @@ export function createIpcConnector(): Connector {
 				locale,
 				defaultSiteDirectory,
 				studioCliInstalled,
+				studioCliExternallyManaged,
 			] = ( await Promise.all( [
 				ipcApi.getUserEditor(),
 				ipcApi.getUserTerminal(),
@@ -567,6 +568,7 @@ export function createIpcConnector(): Connector {
 				ipcApi.getUserLocale(),
 				ipcApi.getDefaultSiteDirectory(),
 				ipcApi.isStudioCliInstalled(),
+				ipcApi.isStudioCliExternallyManaged(),
 			] ) ) as [
 				SupportedEditor | null,
 				SupportedTerminal | null,
@@ -574,6 +576,7 @@ export function createIpcConnector(): Connector {
 				QuitSitesBehavior | undefined,
 				string | undefined,
 				string,
+				boolean,
 				boolean,
 			];
 			return {
@@ -584,6 +587,7 @@ export function createIpcConnector(): Connector {
 				locale,
 				defaultSiteDirectory,
 				studioCliInstalled,
+				studioCliExternallyManaged,
 			};
 		},
 

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -6,6 +6,7 @@ import type {
 	ActiveAgentRun,
 	AiSessionSummary,
 	AiSessionPlacementUpdatedEvent,
+	AppGlobals,
 	AuthUser,
 	ColorScheme,
 	Connector,
@@ -550,23 +551,40 @@ export function createIpcConnector(): Connector {
 		// per field; we fan out in parallel here so the UI can work with a
 		// single query/mutation pair.
 		async getUserPreferences(): Promise< UserPreferences > {
-			const [ editor, terminal, colorScheme, quitSitesBehavior, locale, defaultSiteDirectory ] =
-				( await Promise.all( [
-					ipcApi.getUserEditor(),
-					ipcApi.getUserTerminal(),
-					ipcApi.getColorScheme(),
-					ipcApi.getQuitSitesBehavior(),
-					ipcApi.getUserLocale(),
-					ipcApi.getDefaultSiteDirectory(),
-				] ) ) as [
-					SupportedEditor | null,
-					SupportedTerminal | null,
-					ColorScheme,
-					QuitSitesBehavior | undefined,
-					string | undefined,
-					string,
-				];
-			return { editor, terminal, colorScheme, quitSitesBehavior, locale, defaultSiteDirectory };
+			const [
+				editor,
+				terminal,
+				colorScheme,
+				quitSitesBehavior,
+				locale,
+				defaultSiteDirectory,
+				studioCliInstalled,
+			] = ( await Promise.all( [
+				ipcApi.getUserEditor(),
+				ipcApi.getUserTerminal(),
+				ipcApi.getColorScheme(),
+				ipcApi.getQuitSitesBehavior(),
+				ipcApi.getUserLocale(),
+				ipcApi.getDefaultSiteDirectory(),
+				ipcApi.isStudioCliInstalled(),
+			] ) ) as [
+				SupportedEditor | null,
+				SupportedTerminal | null,
+				ColorScheme,
+				QuitSitesBehavior | undefined,
+				string | undefined,
+				string,
+				boolean,
+			];
+			return {
+				editor,
+				terminal,
+				colorScheme,
+				quitSitesBehavior,
+				locale,
+				defaultSiteDirectory,
+				studioCliInstalled,
+			};
 		},
 
 		async setUserPreferences( partial ): Promise< void > {
@@ -589,6 +607,11 @@ export function createIpcConnector(): Connector {
 			if ( 'defaultSiteDirectory' in partial && partial.defaultSiteDirectory ) {
 				writes.push( ipcApi.saveDefaultSiteDirectory( partial.defaultSiteDirectory ) );
 			}
+			if ( 'studioCliInstalled' in partial && typeof partial.studioCliInstalled === 'boolean' ) {
+				writes.push(
+					partial.studioCliInstalled ? ipcApi.installStudioCli() : ipcApi.uninstallStudioCli()
+				);
+			}
 			await Promise.all( writes );
 		},
 
@@ -605,6 +628,10 @@ export function createIpcConnector(): Connector {
 
 		async getInstalledApps(): Promise< InstalledApps > {
 			return ( await ipcApi.getInstalledAppsAndTerminals() ) as InstalledApps;
+		},
+
+		async getAppGlobals(): Promise< AppGlobals > {
+			return ( await ipcApi.getAppGlobals() ) as AppGlobals;
 		},
 
 		async openSiteFolder( siteId ): Promise< void > {

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -8,6 +8,7 @@ import type {
 	ActiveAgentRun,
 	AiSessionPlacementUpdatedEvent,
 	AiSessionSummary,
+	AppGlobals,
 	AuthUser,
 	ColorScheme,
 	Connector,
@@ -602,6 +603,7 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 				quitSitesBehavior,
 				locale: undefined,
 				defaultSiteDirectory: '',
+				studioCliInstalled: false,
 			};
 		},
 		async setUserPreferences( partial ) {
@@ -634,6 +636,10 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 		// detection, server-side) so the preferences picker offers only what's there.
 		async getInstalledApps(): Promise< InstalledApps > {
 			return api< InstalledApps >( '/installed-apps' );
+		},
+
+		async getAppGlobals(): Promise< AppGlobals > {
+			return { platform: 'browser', isWindowsStore: false };
 		},
 
 		// The server runs on the user's machine, so it opens paths in OS apps on

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -604,6 +604,7 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 				locale: undefined,
 				defaultSiteDirectory: '',
 				studioCliInstalled: false,
+				studioCliExternallyManaged: false,
 			};
 		},
 		async setUserPreferences( partial ) {

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -3,6 +3,7 @@ export { queryClient, persistPromise } from './query-client';
 export type {
 	AiModelId,
 	AiSessionSummary,
+	AppGlobals,
 	AuthUser,
 	ColorScheme,
 	Connector,

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -413,6 +413,10 @@ export interface UserPreferences {
 	locale: string | undefined;
 	defaultSiteDirectory: string;
 	studioCliInstalled: boolean;
+	// True when the `studio` command on PATH is a standalone (curl) install the
+	// app never installs over or uninstalls — the settings toggle disables
+	// itself in that case.
+	studioCliExternallyManaged: boolean;
 }
 
 export interface AppGlobals {
@@ -423,7 +427,10 @@ export interface AppGlobals {
 // Subset of UserPreferences that callers can actually mutate. `locale` is
 // typed as `SupportedLocale` on the write side because only locales we ship
 // translations for can be persisted.
-export type WritableUserPreferences = Omit< UserPreferences, 'locale' > & {
+export type WritableUserPreferences = Omit<
+	UserPreferences,
+	'locale' | 'studioCliExternallyManaged'
+> & {
 	locale: SupportedLocale;
 };
 

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -321,6 +321,11 @@ export interface Connector {
 	// installed.
 	getInstalledApps(): Promise< InstalledApps >;
 
+	// Host environment facts used to gate native-only UI (e.g. the Studio CLI
+	// toggle is hidden in Windows Store builds). Browser connectors report
+	// platform 'browser'.
+	getAppGlobals(): Promise< AppGlobals >;
+
 	// Open the given site's folder in the system file manager, preferred
 	// editor, or preferred terminal. When no editor/terminal preference is
 	// set these reject — callers are expected to route the user to Settings.
@@ -407,6 +412,12 @@ export interface UserPreferences {
 	quitSitesBehavior?: QuitSitesBehavior;
 	locale: string | undefined;
 	defaultSiteDirectory: string;
+	studioCliInstalled: boolean;
+}
+
+export interface AppGlobals {
+	platform: string;
+	isWindowsStore: boolean;
 }
 
 // Subset of UserPreferences that callers can actually mutate. `locale` is

--- a/apps/ui/src/data/queries/use-app-globals.ts
+++ b/apps/ui/src/data/queries/use-app-globals.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+
+export const APP_GLOBALS_QUERY_KEY = [ 'app-globals' ] as const;
+
+export function useAppGlobals() {
+	const connector = useConnector();
+	return useQuery( {
+		queryKey: APP_GLOBALS_QUERY_KEY,
+		queryFn: () => connector.getAppGlobals(),
+		staleTime: Infinity,
+	} );
+}

--- a/apps/ui/src/data/queries/use-user-preferences.test.tsx
+++ b/apps/ui/src/data/queries/use-user-preferences.test.tsx
@@ -1,0 +1,80 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConnector } from '@/data/core';
+import { useSaveUserPreferences, useUserPreferences } from './use-user-preferences';
+import type { Connector, UserPreferences } from '@/data/core';
+import type { ReactNode } from 'react';
+
+vi.mock( '@/data/core', async ( importOriginal ) => {
+	const actual = await importOriginal< typeof import('@/data/core') >();
+	return {
+		...actual,
+		useConnector: vi.fn(),
+	};
+} );
+
+const useConnectorMock = vi.mocked( useConnector );
+
+const PREFERENCES: UserPreferences = {
+	editor: null,
+	terminal: null,
+	colorScheme: 'system',
+	quitSitesBehavior: undefined,
+	locale: 'en',
+	defaultSiteDirectory: '',
+	studioCliInstalled: true,
+};
+
+describe( 'useSaveUserPreferences', () => {
+	const getUserPreferences = vi.fn( () => Promise.resolve( PREFERENCES ) );
+	const setUserPreferences = vi.fn( () => Promise.resolve() );
+
+	function renderPreferenceHooks() {
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false } },
+		} );
+		const wrapper = ( { children }: { children: ReactNode } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+		return renderHook(
+			() => ( {
+				preferences: useUserPreferences(),
+				save: useSaveUserPreferences(),
+			} ),
+			{ wrapper }
+		);
+	}
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		useConnectorMock.mockReturnValue( {
+			getUserPreferences,
+			setUserPreferences,
+		} as unknown as Connector );
+	} );
+
+	it( 'merges saved fields into the cache without refetching', async () => {
+		const { result } = renderPreferenceHooks();
+		await waitFor( () => expect( result.current.preferences.data ).toBeDefined() );
+
+		await result.current.save.mutateAsync( { colorScheme: 'dark' } );
+
+		await waitFor( () => expect( result.current.preferences.data?.colorScheme ).toBe( 'dark' ) );
+		expect( getUserPreferences ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 're-fetches the CLI installed state instead of trusting the patch', async () => {
+		// An uninstall declined behind the main process's native dialog still
+		// resolves the IPC call; the refetch must restore the real state.
+		const { result } = renderPreferenceHooks();
+		await waitFor( () => expect( result.current.preferences.data ).toBeDefined() );
+
+		await result.current.save.mutateAsync( { studioCliInstalled: false } );
+
+		await waitFor( () =>
+			expect( result.current.preferences.data?.studioCliInstalled ).toBe( true )
+		);
+		expect( getUserPreferences ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/apps/ui/src/data/queries/use-user-preferences.test.tsx
+++ b/apps/ui/src/data/queries/use-user-preferences.test.tsx
@@ -24,6 +24,7 @@ const PREFERENCES: UserPreferences = {
 	locale: 'en',
 	defaultSiteDirectory: '',
 	studioCliInstalled: true,
+	studioCliExternallyManaged: false,
 };
 
 describe( 'useSaveUserPreferences', () => {

--- a/apps/ui/src/data/queries/use-user-preferences.ts
+++ b/apps/ui/src/data/queries/use-user-preferences.ts
@@ -29,6 +29,13 @@ export function useSaveUserPreferences() {
 			queryClient.setQueryData< UserPreferences >( USER_PREFERENCES_QUERY_KEY, ( prev ) =>
 				prev ? { ...prev, ...partial } : prev
 			);
+			// Except the CLI toggle: install/uninstall can be declined or fail
+			// behind a native main-process dialog while the IPC call still
+			// resolves. Refetch so the cache reflects the real installed state;
+			// returning the promise keeps the mutation pending until it lands.
+			if ( 'studioCliInstalled' in partial ) {
+				return queryClient.invalidateQueries( { queryKey: USER_PREFERENCES_QUERY_KEY } );
+			}
 		},
 	} );
 }

--- a/apps/ui/src/lib/docs-links.ts
+++ b/apps/ui/src/lib/docs-links.ts
@@ -8,6 +8,10 @@ type TranslatedLink = Partial< Record< SupportedLocale, string > > & { en: strin
  * `apps/ui` actually links to are duplicated here.
  */
 const DOCS_LINKS = {
+	docsCli: {
+		en: 'https://developer.wordpress.com/docs/developer-tools/studio/cli/',
+		es: 'https://developer.wordpress.com/es/docs/herramientas-para-desarrolladores/studio/cli/',
+	},
 	docsMcp: {
 		en: 'https://developer.wordpress.com/docs/developer-tools/studio/mcp-on-studio/',
 	},


### PR DESCRIPTION
## Related issues

- Related to STU-1882 (PR 3 of the agentic-UI application-settings series; ported from #3979)

## How AI was used in this PR

Implemented with Claude Code from a scoped brief: it ported the `StudioCliSection` from #3979 to the auto-save settings model, extended the connector contract across the three connectors, and wrote the tests. Two behaviors were hardened based on manual testing feedback: a "cancel behind the native dialog leaves the toggle stale" bug (fixed by refetching the installed state after saving) and standalone-CLI handling (toggle disabled with an explanatory tooltip). All code was human-reviewed and manually tested on macOS.

## Proposed Changes

Adds a **Studio CLI** section to the new (agentic UI) application settings, so users can install or uninstall the `studio` terminal command without switching back to the classic UI — the last preference from the classic settings that had no equivalent in the new experience.

- The toggle saves immediately (same auto-save behavior as the rest of the settings) and links to the CLI docs.
- Install/uninstall can be declined or fail behind native OS dialogs (permissions, dev-build warnings) while the IPC call still resolves, so after every change the UI re-checks the actual installed state and the toggle settles on reality — cancelling the native dialog returns the toggle to its saved position instead of showing a state that never happened. Failures surface an inline error in the section.
- When the `studio` command is a standalone (curl) install, the app never installs over or uninstalls it — previously the toggle would appear to work but silently no-op. The toggle is now disabled in that case, with a tooltip explaining that the CLI is managed outside the app and pointing at `studio uninstall`. This exposes the existing externally-managed detection from the installation managers over IPC (`isStudioCliExternallyManaged`).
- The section is hidden where installing a CLI isn't possible: browser hosts (`studio ui` / hosted) and Windows Store builds. This introduces a minimal `getAppGlobals()` connector method (platform + Windows Store flag) for that gating, since this part of #3979 hadn't landed with the earlier settings PRs.

| Light | Dark |
|--------|--------|
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/40d2aa41-30a9-4e09-adb3-bcac072e856b" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/520e4452-cb26-4eee-b560-4a54108f26e3" /> |
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/7510ed2c-ce07-46b4-a4b4-c970cc3b9506" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/69dcf281-8ddd-4e67-9a34-081bb188a4eb" /> | 

## Testing Instructions

Note: this PR adds a main-process IPC handler, so a full app restart (not hot reload) is required.

1. Enable the new Studio experience and open **Settings**.
2. Confirm a **Studio CLI** card appears below **Account**, with the toggle reflecting whether `~/.local/bin/studio` exists (`where studio`).
3. Turn the toggle **on**, accept the dev-build warning → `studio` resolves in a new terminal and the toggle stays on.
4. Turn it **off**, accept → the symlink is removed and the toggle stays off.
5. Toggle again but press **Cancel** in the native dialog → the toggle returns to its previous position (this was the stale-state bug fixed here).
6. With a standalone curl-installed CLI (symlink at `~/.local/bin/studio` pointing outside the app bundle): the toggle shows on but is disabled. Hovering it shows a tooltip pointing at `studio uninstall` — it should open quickly (~200ms, faster than the app's default tooltip delay, since the disabled control gives no other feedback) and wrap as a compact multi-line bubble (max width 280px) instead of one long line.
7. Check both light and dark mode, including the toggle's checked/unchecked, disabled, and focus styles, plus the tooltip in step 6.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
