### PR TITLE
Agentic UI: fix preview buttons size

### DIFF
--- a/apps/ui/src/components/site-dropdown/main-view.module.css
+++ b/apps/ui/src/components/site-dropdown/main-view.module.css
@@ -270,15 +270,20 @@
 }
 
 .rowActionButton,
+.rowViewButton,
 .environmentActionButton_outline {
 	border-radius: var(--wpds-border-radius-md);
 }
 
+.rowActionButton,
+.rowViewButton {
+	height: 28px;
+	color: var(--wpds-color-fg-interactive-neutral);
+}
+
 .rowActionButton {
 	width: 28px;
-	height: 28px;
 	padding: 0;
-	color: var(--wpds-color-fg-interactive-neutral);
 }
 
 .rowActionButton svg {

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -243,7 +243,8 @@ export function MainView( { site, activity, onSetupClick, onDisconnectClick }: P
 								tooltip: __( 'Open preview site in your browser' ),
 								variant: 'minimal',
 								tone: 'neutral',
-								size: 'compact',
+								size: 'small',
+								className: styles.rowViewButton,
 								onClick: () => openExternal( ensureProtocol( previewSnapshot.url ) ),
 								children: __( 'View' ),
 							} ) }


### PR DESCRIPTION
## Related issues
- Fixes STU-2080

## How AI was used in this PR
AI assisted


## Proposed Changes

Let's align size of the Preview buttons

## Testing Instructions
Visual review should suffice
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="131" height="43" alt="Screenshot 2026-07-22 at 15 00 58" src="https://github.com/user-attachments/assets/22600ab6-6305-4de8-9d2b-b39e3fbf6fae" />
<td><img width="123" height="42" alt="Screenshot 2026-07-22 at 15 00 36" src="https://github.com/user-attachments/assets/23845043-05e9-461d-8d59-0fc1f4618fa6" />
</tr>
</table>
