### PR TITLE
Restrict local imports to registered uploads

### DIFF
--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -853,7 +853,7 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 		'/sites/:id/import',
 		asyncHandler( async ( req: Request, res: Response ) => {
 			const requestedPath = req.body?.path;
-			if ( typeof requestedPath !== 'string' || ! requestedPath ) {
+			if ( typeof requestedPath !== 'string' ) {
 				res.status( 400 ).json( { error: 'Missing backup path' } );
 				return;
 			}

--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -186,6 +186,7 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 
 	const cliRunner = createCliRunner( { cliBinary, nodeBinary } );
 	const execute = cliRunner.executeCliCommand;
+	const uploads = new Map< string, { path: string; directory: string } >();
 
 	// --- Server-Sent Events: one stream carries live UI updates ----------------
 	const sseClients = new Set< Response >();
@@ -823,6 +824,7 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 				rm( dir, { recursive: true, force: true }, () => undefined );
 				throw error;
 			}
+			uploads.set( dest, { path: dest, directory: dir } );
 			res.json( { path: dest } );
 		} )
 	);
@@ -850,8 +852,8 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 	api.post(
 		'/sites/:id/import',
 		asyncHandler( async ( req: Request, res: Response ) => {
-			const archivePath = req.body?.path;
-			if ( typeof archivePath !== 'string' || ! archivePath ) {
+			const requestedPath = req.body?.path;
+			if ( typeof requestedPath !== 'string' || ! requestedPath ) {
 				res.status( 400 ).json( { error: 'Missing backup path' } );
 				return;
 			}
@@ -860,10 +862,16 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 				res.status( 404 ).json( { error: `Site ${ req.params.id } not found` } );
 				return;
 			}
+			const upload = uploads.get( requestedPath );
+			if ( ! upload ) {
+				res.status( 400 ).json( { error: 'Unknown backup path' } );
+				return;
+			}
+			uploads.delete( requestedPath );
 			try {
 				await new Promise< void >( ( resolve, reject ) => {
 					const [ emitter ] = execute(
-						[ 'import', '--path', site.path, archivePath, '--start-server' ],
+						[ 'import', '--path', site.path, upload.path, '--start-server' ],
 						{ output: 'capture' }
 					);
 					emitter.on( 'data', ( { data } ) => {
@@ -880,16 +888,7 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 					emitter.on( 'error', ( { error } ) => reject( error ) );
 				} );
 			} finally {
-				// Drop the uploaded temp copy — but only a temp dir we created: a
-				// direct child of the OS temp dir. Resolve first so `..` in the
-				// supplied path can't escape the temp root and delete elsewhere.
-				const uploadDir = path.dirname( path.resolve( archivePath ) );
-				if (
-					path.dirname( uploadDir ) === path.resolve( os.tmpdir() ) &&
-					path.basename( uploadDir ).startsWith( 'studio-upload-' )
-				) {
-					rm( uploadDir, { recursive: true, force: true }, () => undefined );
-				}
+				rm( upload.directory, { recursive: true, force: true }, () => undefined );
 			}
 			res.status( 204 ).end();
 		} )


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Related to code scanning alert [#221](https://github.com/Automattic/studio/security/code-scanning/221)

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Codex helped inspect the CodeQL taint flow, implement the upload registry, and run automated verification. I reviewed the diff and manually confirmed that fabricated upload paths are rejected.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and how the user experiences it. Avoid listing modified files or describing implementation mechanics; the diff already shows that.
-->

- Restrict local-web imports and cleanup to backup files created by the current server, preventing request-supplied paths from reaching filesystem operations.
- Make uploaded backup paths single-use so fabricated or replayed paths are rejected without affecting the normal import flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful.
-->

1. Build the CLI and start the local API server from this branch:

   ```sh
   npm run cli:build
   npm run cli:build:ui
   node apps/cli/dist/cli/main.mjs ui --no-open
   ```

2. In another terminal, get the ID of an existing Studio site:

   ```sh
   SITE_ID=$(curl -sS http://127.0.0.1:8081/api/sites | jq -r '.[0].id')
   echo "$SITE_ID"
   ```

3. Submit an import request with a fabricated upload path:

   ```sh
   curl -i -X POST \
     -H 'Content-Type: application/json' \
     -d '{"path":"/tmp/studio-upload-fake/backup.sql"}' \
     "http://127.0.0.1:8081/api/sites/$SITE_ID/import"
   ```

4. Confirm the response is `HTTP/1.1 400 Bad Request` with:

   ```json
   {"error":"Unknown backup path"}
   ```

5. Start the local web UI with `npm run dev:local --workspace=apps/ui`, open http://localhost:5400, import a backup through **Add site → Import from a backup**, and confirm the normal import flow still completes.

## Pre-merge Checklist

<!--
Complete applicable items before merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring this is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
