### PR TITLE
Surface monthly AI usage limit errors across Studio Code surfaces

### DIFF
--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -6,6 +6,7 @@ import {
 	stream as streamAnthropic,
 	type AnthropicOptions,
 } from '@earendil-works/pi-ai/api/anthropic-messages';
+import { streamSimple as streamOpenAiResponses } from '@earendil-works/pi-ai/api/openai-responses';
 import {
 	AuthStorage,
 	createAgentSession,
@@ -55,6 +56,7 @@ import {
 	type StudioToolPayloadGuardState,
 	updateStudioToolPayloadGuardState,
 } from './tool-safety';
+import { withUsageCapErrorRewrite } from './usage-cap';
 import type { StudioChatImage } from '@studio/common/ai/chat-images';
 import type { AskUserHandler, SiteInfo } from 'cli/ai/types';
 
@@ -64,6 +66,7 @@ type StudioModel = Model< 'openai-responses' > | Model< 'anthropic-messages' >;
 type ProviderConfigInput = Parameters< ModelRegistry[ 'registerProvider' ] >[ 1 ];
 
 const STUDIO_WPCOM_ANTHROPIC_PROVIDER = 'studio-wpcom-anthropic';
+const STUDIO_WPCOM_OPENAI_PROVIDER = 'studio-wpcom-openai';
 const STUDIO_AGENT_DIR = STUDIO_SITES_ROOT;
 const STUDIO_WPCOM_BODY_FILES_ROOT = getConfigDirectory();
 const STUDIO_WPCOM_BODY_FILES_DIR = getAiPayloadsPath();
@@ -379,10 +382,12 @@ function buildModel(
 		// the declared window minus its (post-compaction, sometimes stale)
 		// context estimate, and a too-small window can clamp all the way down
 		// to 1, which the API rejects with a 400.
+		// The openai family always rides the wpcom proxy (Studio has no
+		// direct-OpenAI provider), so it always uses the custom provider.
 		return {
 			...common,
 			api: 'openai-responses',
-			provider: 'openai',
+			provider: STUDIO_WPCOM_OPENAI_PROVIDER,
 			reasoning: true,
 			contextWindow: 272_000,
 			maxTokens: 32_000,
@@ -413,6 +418,14 @@ function createModelRegistry(
 		modelRegistry.registerProvider(
 			STUDIO_WPCOM_ANTHROPIC_PROVIDER,
 			createWpcomAnthropicProviderConfig( model as Model< 'anthropic-messages' >, creds )
+		);
+		return { authStorage, modelRegistry };
+	}
+
+	if ( family === 'openai' ) {
+		modelRegistry.registerProvider(
+			STUDIO_WPCOM_OPENAI_PROVIDER,
+			createWpcomOpenAiProviderConfig( model as Model< 'openai-responses' >, creds )
 		);
 		return { authStorage, modelRegistry };
 	}
@@ -451,13 +464,11 @@ function createWpcomAnthropicProviderConfig(
 				defaultHeaders: options?.headers,
 			} );
 			const clientForPi = client as unknown as AnthropicOptions[ 'client' ];
-			return streamAnthropic(
-				m as Model< 'anthropic-messages' >,
-				stripStaleImagesFromContext( ctx ),
-				{
+			return withUsageCapErrorRewrite(
+				streamAnthropic( m as Model< 'anthropic-messages' >, stripStaleImagesFromContext( ctx ), {
 					...( options as AnthropicOptions | undefined ),
 					client: clientForPi,
-				}
+				} )
 			);
 		},
 		models: [
@@ -465,6 +476,39 @@ function createWpcomAnthropicProviderConfig(
 				id: model.id,
 				name: model.name,
 				api: 'anthropic-messages',
+				baseUrl: model.baseUrl,
+				reasoning: model.reasoning,
+				input: model.input,
+				cost: model.cost,
+				contextWindow: model.contextWindow,
+				maxTokens: model.maxTokens,
+				headers: creds.extraHeaders,
+				compat: model.compat,
+			},
+		],
+	};
+}
+
+// The wpcom OpenAI path only needs pi's stock Responses streaming; the custom
+// provider exists to wrap the stream with the usage-cap 429 rewrite.
+function createWpcomOpenAiProviderConfig(
+	model: Model< 'openai-responses' >,
+	creds: ResolvedCredentials
+): ProviderConfigInput {
+	return {
+		baseUrl: creds.baseURL,
+		apiKey: escapePiConfigValue( creds.apiKey ),
+		api: 'openai-responses',
+		headers: creds.extraHeaders,
+		streamSimple: ( m, ctx, options?: SimpleStreamOptions ) =>
+			withUsageCapErrorRewrite(
+				streamOpenAiResponses( m as Model< 'openai-responses' >, ctx, options )
+			),
+		models: [
+			{
+				id: model.id,
+				name: model.name,
+				api: 'openai-responses',
 				baseUrl: model.baseUrl,
 				reasoning: model.reasoning,
 				input: model.input,

--- a/apps/cli/ai/runtimes/pi/tests/usage-cap.test.ts
+++ b/apps/cli/ai/runtimes/pi/tests/usage-cap.test.ts
@@ -1,0 +1,58 @@
+import { createAssistantMessageEventStream } from '@earendil-works/pi-ai';
+import { USAGE_CAP_ERROR_PREFIX } from '@studio/common/ai/json-events';
+import { describe, expect, it } from 'vitest';
+import { withUsageCapErrorRewrite } from '../usage-cap';
+import type { AssistantMessage } from '@earendil-works/pi-ai';
+
+function errorMessageWith( errorMessage: string ): AssistantMessage {
+	return {
+		role: 'assistant',
+		content: [],
+		api: 'anthropic-messages',
+		provider: 'studio-wpcom-anthropic',
+		model: 'claude-sonnet-5',
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: 'error',
+		errorMessage,
+		timestamp: 0,
+	} as AssistantMessage;
+}
+
+describe( 'withUsageCapErrorRewrite', () => {
+	it( 'stamps the usage-cap prefix on 429 error events', async () => {
+		const source = createAssistantMessageEventStream();
+		const wrapped = withUsageCapErrorRewrite( source );
+		source.push( {
+			type: 'error',
+			reason: 'error',
+			error: errorMessageWith( '429 {"error":{"type":"rate_limit_error"}}' ),
+		} );
+		source.end();
+
+		const result = await wrapped.result();
+		expect( result.errorMessage ).toBe(
+			`${ USAGE_CAP_ERROR_PREFIX }: 429 {"error":{"type":"rate_limit_error"}}`
+		);
+	} );
+
+	it( 'leaves non-429 errors untouched', async () => {
+		const source = createAssistantMessageEventStream();
+		const wrapped = withUsageCapErrorRewrite( source );
+		source.push( {
+			type: 'error',
+			reason: 'error',
+			error: errorMessageWith( '500 internal server error' ),
+		} );
+		source.end();
+
+		const result = await wrapped.result();
+		expect( result.errorMessage ).toBe( '500 internal server error' );
+	} );
+} );

--- a/apps/cli/ai/runtimes/pi/usage-cap.ts
+++ b/apps/cli/ai/runtimes/pi/usage-cap.ts
@@ -1,0 +1,28 @@
+import { createAssistantMessageEventStream } from '@earendil-works/pi-ai';
+import { buildUsageCapErrorMessage, isHttp429ErrorMessage } from '@studio/common/ai/json-events';
+import type { AssistantMessageEventStream } from '@earendil-works/pi-ai';
+
+/**
+ * On the WordPress.com AI proxy a 429 always means the account's monthly
+ * usage cap (see #3102), which retrying can't recover — but pi treats any
+ * bare 429 as a transient throttle and retries it with backoff. Rewriting
+ * the error with the canonical prefix makes pi classify it as a
+ * non-retryable provider limit and gives every surface a stable marker for
+ * the cap UI. Only wire this into wpcom-backed providers: on a user-supplied
+ * API key a 429 is a genuine rate limit and should keep retrying.
+ */
+export function withUsageCapErrorRewrite(
+	source: AssistantMessageEventStream
+): AssistantMessageEventStream {
+	const rewritten = createAssistantMessageEventStream();
+	void ( async () => {
+		for await ( const event of source ) {
+			if ( event.type === 'error' && isHttp429ErrorMessage( event.error.errorMessage ) ) {
+				event.error.errorMessage = buildUsageCapErrorMessage( event.error.errorMessage ?? '' );
+			}
+			rewritten.push( event );
+		}
+		rewritten.end();
+	} )();
+	return rewritten;
+}

--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -256,6 +256,7 @@ describe( 'AiChatUI.handleEvent', () => {
 		ui.hideLoader = hideLoader;
 		ui.showError = showError;
 		ui.showInfo = showInfo;
+		ui.showUsageCapResetDate = vi.fn( async () => undefined );
 		ui.currentProvider = 'wpcom';
 		ui.currentMarkdown = { setText: vi.fn() };
 		ui.currentResponseText = 'previous content';
@@ -264,13 +265,16 @@ describe( 'AiChatUI.handleEvent', () => {
 		ui.handleEvent(
 			buildAssistantMessageEnd( {
 				stopReason: 'error',
-				errorMessage: 'API Error: 429 {"error":{"message":"You have exceeded your AI usage cap."}}',
+				errorMessage: 'Monthly usage limit reached: 429 {"error":{"type":"rate_limit_error"}}',
 			} )
 		);
 
 		expect( hideLoader ).toHaveBeenCalled();
-		expect( showError ).toHaveBeenCalledWith( expect.stringContaining( 'AI usage cap reached' ) );
-		expect( showInfo ).toHaveBeenCalledWith( expect.stringContaining( '/provider' ) );
+		expect( showError ).toHaveBeenCalledWith(
+			expect.stringContaining( 'You’ve reached your monthly AI usage limit' )
+		);
+		expect( showInfo ).not.toHaveBeenCalled();
+		expect( ui.showUsageCapResetDate ).toHaveBeenCalled();
 		expect( ui.usageCapReached ).toBe( true );
 		expect( ui.currentMarkdown ).toBeNull();
 		expect( ui.currentResponseText ).toBe( '' );

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -33,6 +33,11 @@ import { randomThinkingMessage } from '@studio/common/ai/thinking-messages';
 import { getToolDetail, getToolDisplayName, getToolResultPreview } from '@studio/common/ai/tools';
 import chalk from '@studio/common/lib/chalk';
 import { readAuthToken } from '@studio/common/lib/shared-config';
+import {
+	fetchStudioAssistantQuota,
+	formatQuotaResetDate,
+	formatUsageCapNotice,
+} from '@studio/common/lib/studio-assistant-quota';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	DescriptionAwareAutocompleteProvider,
@@ -1418,6 +1423,28 @@ export class AiChatUI implements AiOutputAdapter {
 		return this.usageCapReached;
 	}
 
+	// Follows the usage-cap notice with the date the monthly limit resets,
+	// fetched from the WordPress.com quota endpoint. Silently skips when
+	// signed out or the quota can't be fetched — the cap notice on its own is
+	// already actionable.
+	private async showUsageCapResetDate(): Promise< void > {
+		const token = await readAuthToken();
+		if ( ! token?.accessToken ) {
+			return;
+		}
+		const quota = await fetchStudioAssistantQuota( token.accessToken );
+		if ( ! quota?.costResetDate ) {
+			return;
+		}
+		this.showInfo(
+			sprintf(
+				/* translators: %s: date the monthly AI usage limit resets (e.g. August 1, 2026). */
+				__( 'It resets on %s.' ),
+				formatQuotaResetDate( quota.costResetDate )
+			)
+		);
+	}
+
 	showOnboarding(): void {
 		const text =
 			' ' +
@@ -2086,14 +2113,10 @@ export class AiChatUI implements AiOutputAdapter {
 				) {
 					this.hideLoader();
 					this.usageCapReached = true;
-					this.showError(
-						__(
-							'AI usage cap reached. You can continue using Studio Code by switching to your own Anthropic API key.'
-						)
-					);
-					this.showInfo(
-						__( 'Use /provider to switch to Anthropic · API key, or try again later.' )
-					);
+					this.showError( formatUsageCapNotice() );
+					// Async on purpose: the reset date needs a wpcom round trip and
+					// must not block rendering the cap notice.
+					void this.showUsageCapResetDate();
 					this.currentMarkdown = null;
 					this.currentResponseText = '';
 					return;

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -4,6 +4,7 @@ import {
 	type StudioChatFileAttachment,
 } from '@studio/common/ai/chat-files';
 import { type StudioChatImage } from '@studio/common/ai/chat-images';
+import { getAgentEndFailure } from '@studio/common/ai/json-events';
 import { DEFAULT_MODEL, resolveSessionModel, type AiModelId } from '@studio/common/ai/models';
 import { getAgentEndTurnResult } from '@studio/common/ai/session-events';
 import { buildSkillInvocationPrompt } from '@studio/common/ai/slash-commands';
@@ -537,7 +538,7 @@ export async function runCommand( options: {
 			} )
 		);
 
-		const turnState: { status: TurnStatus } = { status: 'interrupted' };
+		const turnState: { status: TurnStatus; errorMessage?: string } = { status: 'interrupted' };
 
 		const agentQuery = runStudioAgentTurn( {
 			prompt: enrichedPrompt,
@@ -561,6 +562,7 @@ export async function runCommand( options: {
 				} else {
 					turnState.status = result.success ? 'success' : 'error';
 				}
+				turnState.errorMessage = getAgentEndFailure( event )?.message || undefined;
 			},
 		} );
 
@@ -587,7 +589,12 @@ export async function runCommand( options: {
 			await consumeAgentTurnResult;
 		} finally {
 			await append( ( s ) =>
-				appendStudioEntry( s, 'studio.turn_closed', { status: turnState.status } )
+				appendStudioEntry( s, 'studio.turn_closed', {
+					status: turnState.status,
+					...( turnState.status === 'error' && turnState.errorMessage
+						? { errorMessage: turnState.errorMessage }
+						: {} ),
+				} )
 			);
 			ui.endAgentTurn();
 		}

--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -50,6 +50,7 @@ import {
 	updateSharedConfig,
 	updateSharedSession,
 } from '@studio/common/lib/shared-config';
+import { fetchStudioAssistantQuota } from '@studio/common/lib/studio-assistant-quota';
 import { fetchSyncableSites } from '@studio/common/lib/sync/sync-api';
 import { detectInstalledApps } from '@studio/common/lib/user-settings/installed-apps';
 import { isWordPressDevVersion } from '@studio/common/lib/wordpress-version-utils';
@@ -960,6 +961,18 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 			}
 			await openInTerminal( terminal, site.path );
 			res.status( 204 ).end();
+		} )
+	);
+
+	// Studio Code AI quota for the signed-in account, proxied through the
+	// server so the browser UI can show usage-cap messaging (e.g. the reset
+	// date) without holding the wpcom token. `null` when signed out or the
+	// quota can't be fetched — callers fall back to static copy.
+	api.get(
+		'/quota',
+		asyncHandler( async ( _req: Request, res: Response ) => {
+			const token = await readAuthToken();
+			res.json( token?.accessToken ? await fetchStudioAssistantQuota( token.accessToken ) : null );
 		} )
 	);
 

--- a/apps/studio/src/components/studio-code-session/conversation/index.tsx
+++ b/apps/studio/src/components/studio-code-session/conversation/index.tsx
@@ -8,6 +8,7 @@ import {
 	type StudioChatArtifactWidgetDraft,
 } from '@studio/common/ai/chat-artifacts';
 import { readBlobAsDataUrl } from '@studio/common/ai/composer-attachments';
+import { isUsageCapError } from '@studio/common/ai/json-events';
 import {
 	isStudioCustomEntryOfType,
 	type StudioChatAttachmentSummary,
@@ -19,12 +20,14 @@ import {
 	getToolResultDiff,
 	type NormalizedToolResult,
 } from '@studio/common/ai/tools';
+import { formatUsageCapNotice } from '@studio/common/lib/studio-assistant-quota';
 import { __ } from '@wordpress/i18n';
 import { image, page } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { useGetStudioAssistantQuota } from 'src/stores/wpcom-api';
 import { CopyButton } from '../copy-button';
 import { Markdown } from '../markdown';
 import { ThinkingIndicator } from '../thinking-indicator';
@@ -60,7 +63,8 @@ type RenderItem =
 			key: string;
 			widgets: StudioChatArtifactWidgetDraft[];
 	  }
-	| { kind: 'interrupted-marker'; key: string };
+	| { kind: 'interrupted-marker'; key: string }
+	| { kind: 'error-marker'; key: string; message: string };
 
 interface PiAssistantContentBlock {
 	type: 'text' | 'toolCall' | 'thinking';
@@ -254,6 +258,12 @@ export function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {
 				items.push( {
 					kind: 'interrupted-marker',
 					key: `${ entryIndex }:interrupted`,
+				} );
+			} else if ( data?.status === 'error' ) {
+				items.push( {
+					kind: 'error-marker',
+					key: `${ entryIndex }:error`,
+					message: data.errorMessage ?? '',
 				} );
 			}
 			return;
@@ -636,6 +646,25 @@ function AgentQuestion( {
 	);
 }
 
+// In-flow marker for a turn that ended in an error. The monthly usage cap
+// gets dedicated copy — with the reset date once the quota query resolves —
+// instead of the raw provider message.
+function TurnErrorMarker( { message }: { message: string } ) {
+	const isUsageCap = isUsageCapError( message );
+	const { data: quota } = useGetStudioAssistantQuota( undefined, { skip: ! isUsageCap } );
+	let text: string;
+	if ( isUsageCap ) {
+		text = formatUsageCapNotice( quota?.costResetDate );
+	} else {
+		text = message || __( 'Something went wrong and this turn was stopped. Please try again.' );
+	}
+	return (
+		<div className={ styles.errorMarker } role="alert">
+			{ text }
+		</div>
+	);
+}
+
 export function Conversation( {
 	data,
 	isRunning,
@@ -756,6 +785,8 @@ export function Conversation( {
 								{ __( 'Interrupted by you' ) }
 							</div>
 						);
+					case 'error-marker':
+						return <TurnErrorMarker key={ item.key } message={ item.message } />;
 					default:
 						return null;
 				}

--- a/apps/studio/src/components/studio-code-session/conversation/style.module.css
+++ b/apps/studio/src/components/studio-code-session/conversation/style.module.css
@@ -366,6 +366,19 @@
 	text-align: center;
 }
 
+.errorMarker {
+	align-self: center;
+	max-width: 100%;
+	margin: var(--wpds-dimension-padding-sm) 0;
+	padding: 4px 12px;
+	border-radius: var(--wpds-dimension-radius-md, 8px);
+	background-color: color-mix(in srgb, var(--color-frame-error) 8%, transparent);
+	color: var(--color-frame-error);
+	font-size: var(--wpds-typography-font-size-xs);
+	text-align: center;
+	overflow-wrap: anywhere;
+}
+
 .mediaArtifactGrid {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));

--- a/apps/studio/src/components/studio-code-session/use-agent-run.tsx
+++ b/apps/studio/src/components/studio-code-session/use-agent-run.tsx
@@ -1,5 +1,6 @@
 import { buildChatAttachmentSummaries } from '@studio/common/ai/chat-attachments';
-import { isUsageCapError } from '@studio/common/ai/json-events';
+import { getAgentEndFailure, isUsageCapError } from '@studio/common/ai/json-events';
+import { formatUsageCapNotice } from '@studio/common/lib/studio-assistant-quota';
 import { useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import {
@@ -175,12 +176,16 @@ function reducer( state: State, action: Action ): State {
 			};
 		case 'run_ended':
 			// Preserve the queue across run boundaries so staged follow-ups
-			// survive the transition, and the answered-question map so picked
-			// options stay highlighted in history. Everything else resets.
+			// survive the transition, the answered-question map so picked
+			// options stay highlighted in history, and any turn error —
+			// `run.exited` lags the error event and must not wipe the banner
+			// before the user can read it. Everything else resets.
 			return {
 				...initialState,
 				queuedPrompts: state.queuedPrompts,
 				answeredQuestions: state.answeredQuestions,
+				error: state.error,
+				usageCapReached: state.usageCapReached,
 			};
 		case 'interrupt_requested':
 			return {
@@ -349,9 +354,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					return;
 				case 'error': {
 					const isUsageCap = isUsageCapError( event.message );
-					const message = isUsageCap
-						? __( 'You\u2019ve reached your AI usage limit. Try again later.' )
-						: event.message;
+					const message = isUsageCap ? formatUsageCapNotice() : event.message;
 					dispatchSession( payload.sessionId, {
 						type: 'error_set',
 						message,
@@ -390,8 +393,29 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					} );
 					return;
 				case 'message': {
-					// Only message-bearing pi event variants need optimistic entries.
 					const inner = event.message;
+					// A failed turn only surfaces through its final `agent_end` —
+					// the errored assistant message usually has no text content and
+					// no `error` transport event is emitted. Synthesize the
+					// `studio.turn_closed` error entry for immediate in-flow
+					// rendering; the CLI also writes a real one that replaces this
+					// on the post-run refetch.
+					const failure = getAgentEndFailure( inner );
+					if ( failure ) {
+						updateCache( payload.sessionId, ( entries ) => [
+							...entries,
+							{
+								type: 'custom',
+								id: shortEntryId(),
+								parentId: null,
+								timestamp: event.timestamp,
+								customType: 'studio.turn_closed',
+								data: { status: 'error', errorMessage: failure.message },
+							} as SessionEntry,
+						] );
+						return;
+					}
+					// Only message-bearing pi event variants need optimistic entries.
 					if (
 						inner.type === 'message_end' &&
 						( inner.message as { role?: string } ).role === 'assistant'
@@ -534,11 +558,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 				} );
 				const rawMessage = err instanceof Error ? err.message : String( err );
 				const isUsageCap = isUsageCapError( rawMessage );
-				const message = isUsageCap
-					? __(
-							'You\u2019ve reached your AI usage limit. Try again later or use your own Anthropic API key via the CLI (/provider).'
-					  )
-					: rawMessage;
+				const message = isUsageCap ? formatUsageCapNotice() : rawMessage;
 				dispatchSession( sessionId, { type: 'error_set', message, usageCapReached: isUsageCap } );
 				throw err;
 			}

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -22,6 +22,7 @@ import type {
 	SiteDetails,
 	Snapshot,
 	SnapshotUsage,
+	StudioAssistantQuota,
 	SupportedEditor,
 	SupportedTerminal,
 	SyncSite,
@@ -488,9 +489,9 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			return null;
 		},
 		async getStudioAssistantQuota() {
-			// No quota endpoint on the local server; callers fall back to
-			// static copy.
-			return null;
+			// The server proxies the WordPress.com quota endpoint and returns
+			// the already-parsed shape (or null when signed out).
+			return api< StudioAssistantQuota | null >( '/quota' );
 		},
 		async deleteAllSnapshots() {
 			// No-op: the local server has no delete-all route yet.

--- a/apps/ui/src/data/queries/use-agent-run.tsx
+++ b/apps/ui/src/data/queries/use-agent-run.tsx
@@ -1,4 +1,5 @@
 import { buildChatAttachmentSummaries } from '@studio/common/ai/chat-attachments';
+import { getAgentEndFailure } from '@studio/common/ai/json-events';
 import { useQueryClient } from '@tanstack/react-query';
 import {
 	createContext,
@@ -167,8 +168,14 @@ function reducer( state: State, action: Action ): State {
 			};
 		case 'run_ended':
 			// Preserve the queue across run boundaries so staged follow-ups
-			// survive the transition. Everything else resets.
-			return { ...initialState, queuedPrompts: state.queuedPrompts };
+			// survive the transition, and any transport error — `run.exited`
+			// lags the `error` event and must not wipe the banner before the
+			// user can read it. Everything else resets.
+			return {
+				...initialState,
+				queuedPrompts: state.queuedPrompts,
+				error: state.error,
+			};
 		case 'interrupt_requested':
 			return {
 				...state,
@@ -401,8 +408,29 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					return;
 				}
 				case 'message': {
-					// Only message-bearing pi event variants need optimistic entries.
 					const inner = event.message;
+					// A failed turn only surfaces through its final `agent_end` —
+					// the errored assistant message usually has no text content and
+					// no `error` transport event is emitted. Synthesize the
+					// `studio.turn_closed` error entry for immediate in-flow
+					// rendering; the CLI also writes a real one that replaces this
+					// on the post-run refetch.
+					const failure = getAgentEndFailure( inner );
+					if ( failure ) {
+						updateCache( payload.sessionId, ( entries ) => [
+							...entries,
+							{
+								type: 'custom',
+								id: shortEntryId(),
+								parentId: null,
+								timestamp: event.timestamp,
+								customType: 'studio.turn_closed',
+								data: { status: 'error', errorMessage: failure.message },
+							} as SessionEntry,
+						] );
+						return;
+					}
+					// Only message-bearing pi event variants need optimistic entries.
 					if (
 						inner.type === 'message_end' &&
 						( inner.message as { role?: string } ).role === 'assistant'

--- a/apps/ui/src/data/queries/use-assistant-quota.ts
+++ b/apps/ui/src/data/queries/use-assistant-quota.ts
@@ -4,7 +4,7 @@ import { useAuthUser } from '@/data/queries/use-auth-user';
 
 export const ASSISTANT_QUOTA_QUERY_KEY = [ 'assistant-quota' ] as const;
 
-export function useStudioAssistantQuota() {
+export function useStudioAssistantQuota( { enabled = true }: { enabled?: boolean } = {} ) {
 	const connector = useConnector();
 	const { data: authUser } = useAuthUser();
 	const query = useQuery( {
@@ -12,7 +12,7 @@ export function useStudioAssistantQuota() {
 		// account's cached quota within the stale window.
 		queryKey: [ ...ASSISTANT_QUOTA_QUERY_KEY, authUser?.id ],
 		queryFn: () => connector.getStudioAssistantQuota(),
-		enabled: !! authUser,
+		enabled: enabled && !! authUser,
 		// Quota moves slowly; avoid refetching on every panel mount and
 		// window focus.
 		staleTime: 5 * 60 * 1000,

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
@@ -606,6 +606,33 @@ describe( 'Conversation Ask User questions', () => {
 	} );
 } );
 
+describe( 'Conversation turn-closed markers', () => {
+	it( 'renders an error marker with the persisted message for errored turns', () => {
+		const items = entriesToRenderItems( [
+			turnClosedEntry( 'error', 'Monthly usage limit reached: 429 {"type":"error"}' ),
+		] );
+
+		expect( items ).toMatchObject( [
+			{ kind: 'error-marker', message: 'Monthly usage limit reached: 429 {"type":"error"}' },
+		] );
+	} );
+
+	it( 'renders no marker for successful turns', () => {
+		expect( entriesToRenderItems( [ turnClosedEntry( 'success' ) ] ) ).toEqual( [] );
+	} );
+} );
+
+function turnClosedEntry( status: string, errorMessage?: string ): SessionEntry {
+	return {
+		type: 'custom',
+		id: `turn-closed-${ status }`,
+		parentId: null,
+		timestamp: '2026-06-05T12:00:03.000Z',
+		customType: 'studio.turn_closed',
+		data: { status, ...( errorMessage !== undefined ? { errorMessage } : {} ) },
+	} as SessionEntry;
+}
+
 interface RenderConversationOptions {
 	isRunning?: boolean;
 	startedAt?: number | null;

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -7,6 +7,7 @@ import {
 	stripMediaWidgetPayloadLines,
 	type StudioChatArtifactWidgetDraft,
 } from '@studio/common/ai/chat-artifacts';
+import { isUsageCapError } from '@studio/common/ai/json-events';
 import {
 	isStudioCustomEntryOfType,
 	type StudioChatAttachmentSummary,
@@ -20,6 +21,7 @@ import {
 	splitCommandArgs,
 	type NormalizedToolResult,
 } from '@studio/common/ai/tools';
+import { formatUsageCapNotice } from '@studio/common/lib/studio-assistant-quota';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	blockDefault,
@@ -68,6 +70,7 @@ import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { CopyButton } from '@/components/copy-button';
 import { Markdown } from '@/components/markdown';
 import { useConnector, type LoadedAiSession } from '@/data/core';
+import { useStudioAssistantQuota } from '@/data/queries/use-assistant-quota';
 import { useLocalMediaDataUrl } from '@/data/queries/use-local-media';
 import { refreshIcon } from '@/lib/icons';
 import { ThinkingIndicator } from '../thinking-indicator';
@@ -106,7 +109,8 @@ type RenderItem =
 			key: string;
 			widgets: StudioChatArtifactWidgetDraft[];
 	  }
-	| { kind: 'interrupted-marker'; key: string };
+	| { kind: 'interrupted-marker'; key: string }
+	| { kind: 'error-marker'; key: string; message: string };
 
 interface PiAssistantContentBlock {
 	type: 'text' | 'toolCall' | 'thinking';
@@ -354,6 +358,12 @@ export function entriesToRenderItems(
 				items.push( {
 					kind: 'interrupted-marker',
 					key: `${ entryIndex }:interrupted`,
+				} );
+			} else if ( data?.status === 'error' ) {
+				items.push( {
+					kind: 'error-marker',
+					key: `${ entryIndex }:error`,
+					message: data.errorMessage ?? '',
 				} );
 			}
 			continue;
@@ -1132,6 +1142,25 @@ function AgentQuestionBatch( {
 	);
 }
 
+// In-flow marker for a turn that ended in an error. The monthly usage cap
+// gets dedicated copy — with the reset date once the quota query resolves —
+// instead of the raw provider message.
+function TurnErrorMarker( { message }: { message: string } ) {
+	const isUsageCap = isUsageCapError( message );
+	const { data: quota } = useStudioAssistantQuota( { enabled: isUsageCap } );
+	let text: string;
+	if ( isUsageCap ) {
+		text = formatUsageCapNotice( quota?.costResetDate );
+	} else {
+		text = message || __( 'Something went wrong and this turn was stopped. Please try again.' );
+	}
+	return (
+		<div className={ styles.errorMarker } role="alert">
+			{ text }
+		</div>
+	);
+}
+
 export function Conversation( {
 	data,
 	isRunning,
@@ -1195,6 +1224,8 @@ export function Conversation( {
 								{ __( 'Interrupted by you' ) }
 							</div>
 						);
+					case 'error-marker':
+						return <TurnErrorMarker key={ item.key } message={ item.message } />;
 					default:
 						return null;
 				}

--- a/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
@@ -672,6 +672,19 @@
 	text-align: center;
 }
 
+.errorMarker {
+	align-self: center;
+	max-width: 100%;
+	margin: var(--wpds-dimension-padding-sm) 0;
+	padding: 4px 12px;
+	border-radius: var(--wpds-dimension-radius-md, 8px);
+	background-color: color-mix(in srgb, var(--wpds-color-fg-content-error) 8%, transparent);
+	color: var(--wpds-color-fg-content-error);
+	font-size: var(--wpds-typography-font-size-xs);
+	text-align: center;
+	overflow-wrap: anywhere;
+}
+
 /* Assistant response wrapper: the copy button stays hidden until the turn is
    hovered (or a control inside it is focused). */
 .assistantTurn {

--- a/packages/common/ai/json-events.ts
+++ b/packages/common/ai/json-events.ts
@@ -46,12 +46,77 @@ export type JsonEvent =
 	  }
 	| MediaShareEvent;
 
-const USAGE_CAP_PATTERN = /(?:API Error:\s*429\b|status code\s+429\b|"status"\s*:\s*429\b)/i;
+/**
+ * Canonical prefix the Studio agent runtime stamps on 429 errors from the
+ * WordPress.com AI proxy. The exact phrase is load-bearing: pi's retry
+ * classifier treats "Monthly usage limit reached" as a non-retryable
+ * provider-limit error, and `isUsageCapError` keys on it across surfaces.
+ */
+export const USAGE_CAP_ERROR_PREFIX = 'Monthly usage limit reached';
+
+export function buildUsageCapErrorMessage( originalMessage: string ): string {
+	return `${ USAGE_CAP_ERROR_PREFIX }: ${ originalMessage }`;
+}
+
+// Raw HTTP 429 shapes as the SDKs format them: the Anthropic SDK produces
+// "429 <body>", pi-ai's OpenAI path "OpenAI API error (429): <body>", plus
+// legacy Claude Code SDK forms.
+const HTTP_429_ERROR_PATTERN =
+	/(?:^429\b|\(429\)|API Error:\s*429\b|status code\s+429\b|"status"\s*:\s*429\b)/i;
+
+/**
+ * Returns true when an error message reports an HTTP 429, whatever SDK
+ * formatted it. Callers are responsible for provider gating: only on the
+ * WordPress.com proxy does a 429 mean the usage cap.
+ */
+export function isHttp429ErrorMessage( message: string | undefined | null ): boolean {
+	return HTTP_429_ERROR_PATTERN.test( message ?? '' );
+}
+
+const USAGE_CAP_PATTERN = new RegExp(
+	`(?:${ USAGE_CAP_ERROR_PREFIX }|API Error:\\s*429\\b|status code\\s+429\\b|"status"\\s*:\\s*429\\b)`,
+	'i'
+);
 
 /**
  * Returns true when an error message indicates the user hit the AI usage cap
- * (HTTP 429 from the WordPress.com proxy).
+ * (HTTP 429 from the WordPress.com proxy). Raw, un-rewritten 429 messages
+ * (e.g. from a user-supplied Anthropic API key, where a 429 is a transient
+ * rate limit rather than a monthly cap) intentionally don't match.
  */
 export function isUsageCapError( message: string | undefined | null ): boolean {
 	return USAGE_CAP_PATTERN.test( message ?? '' );
+}
+
+/**
+ * Extract the failure of a completed turn from its final `agent_end` event.
+ * The error text lives on the last assistant message's `errorMessage`
+ * (streamed API failures) or its text blocks (synthetic pre-flight errors).
+ * Returns `null` for successful, interrupted, or will-retry ends — and a
+ * possibly-empty `message` for failures, so callers can show fallback copy.
+ */
+export function getAgentEndFailure( event: AgentSessionEvent ): { message: string } | null {
+	if ( event.type !== 'agent_end' || event.willRetry ) {
+		return null;
+	}
+	for ( let index = event.messages.length - 1; index >= 0; index -= 1 ) {
+		const message = event.messages[ index ];
+		if ( message.role !== 'assistant' ) {
+			continue;
+		}
+		if ( message.stopReason !== 'error' ) {
+			return null;
+		}
+		const fromErrorField = message.errorMessage?.trim();
+		if ( fromErrorField ) {
+			return { message: fromErrorField };
+		}
+		const fromTextBlocks = message.content
+			.filter( ( block ): block is { type: 'text'; text: string } => block.type === 'text' )
+			.map( ( block ) => block.text )
+			.join( '\n' )
+			.trim();
+		return { message: fromTextBlocks };
+	}
+	return null;
 }

--- a/packages/common/ai/sessions/entry-types.ts
+++ b/packages/common/ai/sessions/entry-types.ts
@@ -41,6 +41,9 @@ export type StudioTurnStatus = 'success' | 'error' | 'max_turns' | 'interrupted'
 
 export interface StudioTurnClosedData {
 	status: StudioTurnStatus;
+	// Raw error text for `status: 'error'` turns, so the transcript can
+	// render an in-flow failure marker after reload. Absent on older entries.
+	errorMessage?: string;
 }
 
 export interface StudioSessionContextData {

--- a/packages/common/ai/tests/json-events.test.ts
+++ b/packages/common/ai/tests/json-events.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildUsageCapErrorMessage,
+	getAgentEndFailure,
+	isHttp429ErrorMessage,
+	isUsageCapError,
+	USAGE_CAP_ERROR_PREFIX,
+} from '../json-events';
+import type { AgentSessionEvent } from '@earendil-works/pi-coding-agent';
+
+function assistantMessage(
+	overrides: Partial< {
+		stopReason: string;
+		errorMessage: string;
+		content: Array< { type: string; text?: string } >;
+	} >
+) {
+	return {
+		role: 'assistant',
+		content: [],
+		api: 'anthropic-messages',
+		provider: 'anthropic',
+		model: 'claude-sonnet-5',
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: 'stop',
+		timestamp: 0,
+		...overrides,
+	};
+}
+
+function agentEnd(
+	messages: unknown[],
+	{ willRetry = false }: { willRetry?: boolean } = {}
+): AgentSessionEvent {
+	return { type: 'agent_end', willRetry, messages } as unknown as AgentSessionEvent;
+}
+
+describe( 'isHttp429ErrorMessage', () => {
+	it.each( [
+		// Anthropic SDK: "<status> <message or JSON body>".
+		'429 {"type":"error","error":{"type":"rate_limit_error","message":"exceeded"}}',
+		'429 Number of requests has exceeded your monthly limit',
+		'429 status code (no body)',
+		// pi-ai OpenAI Responses formatting.
+		'OpenAI API error (429): {"error":{"message":"exceeded"}}',
+		// Legacy Claude Code SDK formatting.
+		'API Error: 429 {"error":"exceeded"}',
+	] )( 'matches %s', ( message ) => {
+		expect( isHttp429ErrorMessage( message ) ).toBe( true );
+	} );
+
+	it.each( [
+		'500 internal server error',
+		'Request took 429 ms',
+		'API Error: 500 upstream failure',
+		undefined,
+		null,
+		'',
+	] )( 'does not match %s', ( message ) => {
+		expect( isHttp429ErrorMessage( message ) ).toBe( false );
+	} );
+} );
+
+describe( 'isUsageCapError', () => {
+	it( 'matches the canonical runtime-stamped prefix', () => {
+		expect( isUsageCapError( buildUsageCapErrorMessage( '429 exceeded' ) ) ).toBe( true );
+		expect( isUsageCapError( `${ USAGE_CAP_ERROR_PREFIX }: OpenAI API error (429): x` ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'matches legacy Claude Code SDK formats', () => {
+		expect( isUsageCapError( 'API Error: 429 {"error":"x"}' ) ).toBe( true );
+		expect( isUsageCapError( 'Request failed with status code 429' ) ).toBe( true );
+		expect( isUsageCapError( '{"status": 429}' ) ).toBe( true );
+	} );
+
+	it( 'does not match raw un-rewritten 429s (non-wpcom rate limits)', () => {
+		expect( isUsageCapError( '429 rate limited' ) ).toBe( false );
+		expect( isUsageCapError( 'OpenAI API error (429): rate limited' ) ).toBe( false );
+	} );
+} );
+
+describe( 'getAgentEndFailure', () => {
+	it( 'returns the errorMessage of the final errored assistant message', () => {
+		const event = agentEnd( [
+			assistantMessage( {} ),
+			assistantMessage( { stopReason: 'error', errorMessage: '429 exceeded' } ),
+		] );
+		expect( getAgentEndFailure( event ) ).toEqual( { message: '429 exceeded' } );
+	} );
+
+	it( 'falls back to text blocks for synthetic errors without errorMessage', () => {
+		const event = agentEnd( [
+			assistantMessage( {
+				stopReason: 'error',
+				content: [ { type: 'text', text: 'Login required.' } ],
+			} ),
+		] );
+		expect( getAgentEndFailure( event ) ).toEqual( { message: 'Login required.' } );
+	} );
+
+	it( 'returns an empty message for errors with no text at all', () => {
+		const event = agentEnd( [ assistantMessage( { stopReason: 'error' } ) ] );
+		expect( getAgentEndFailure( event ) ).toEqual( { message: '' } );
+	} );
+
+	it( 'returns null for successful and interrupted turns', () => {
+		expect( getAgentEndFailure( agentEnd( [ assistantMessage( {} ) ] ) ) ).toBeNull();
+		expect(
+			getAgentEndFailure( agentEnd( [ assistantMessage( { stopReason: 'aborted' } ) ] ) )
+		).toBeNull();
+	} );
+
+	it( 'returns null when the turn will be retried', () => {
+		const event = agentEnd(
+			[ assistantMessage( { stopReason: 'error', errorMessage: '500 flaky' } ) ],
+			{ willRetry: true }
+		);
+		expect( getAgentEndFailure( event ) ).toBeNull();
+	} );
+} );

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -1,3 +1,4 @@
+import { __, sprintf } from '@wordpress/i18n';
 import { z } from 'zod';
 
 export const STUDIO_ASSISTANT_QUOTA_URL =
@@ -17,6 +18,27 @@ export const studioAssistantQuotaSchema = z
 
 export type StudioAssistantQuota = z.infer< typeof studioAssistantQuotaSchema >;
 
+/**
+ * Fetch the account's Studio AI quota from WordPress.com. Resolves `null` on
+ * any failure (network, auth, unexpected shape) so callers can fall back to
+ * static copy.
+ */
+export async function fetchStudioAssistantQuota(
+	accessToken: string
+): Promise< StudioAssistantQuota | null > {
+	try {
+		const response = await fetch( STUDIO_ASSISTANT_QUOTA_URL, {
+			headers: { Authorization: `Bearer ${ accessToken }` },
+		} );
+		if ( ! response.ok ) {
+			return null;
+		}
+		return studioAssistantQuotaSchema.parse( await response.json() );
+	} catch {
+		return null;
+	}
+}
+
 export function clampQuotaFraction( value: number, maxValue: number ): number {
 	return maxValue > 0 ? Math.max( 0, Math.min( 1, value / maxValue ) ) : 0;
 }
@@ -34,4 +56,20 @@ export function formatQuotaResetDate( date: string, locale?: string ): string {
 		month: 'long',
 		year: 'numeric',
 	} ).format( new Date( date ) );
+}
+
+/**
+ * User-facing copy for hitting the monthly AI usage cap. Shared by every
+ * surface (CLI, desktop, browser UI) so the wording stays consistent. Pass
+ * the quota's reset date when known to make the copy actionable.
+ */
+export function formatUsageCapNotice( resetDate?: string | null, locale?: string ): string {
+	if ( resetDate ) {
+		return sprintf(
+			/* translators: %s: date the monthly AI usage limit resets (e.g. August 1, 2026). */
+			__( 'You’ve reached your monthly AI usage limit. It resets on %s.' ),
+			formatQuotaResetDate( resetDate, locale )
+		);
+	}
+	return __( 'You’ve reached your monthly AI usage limit. Try again later.' );
 }


### PR DESCRIPTION
## Related issues

<!-- No tracked issue; reported directly. -->

## How AI was used in this PR

Investigated, implemented, and tested with Claude Code, including live simulation of the 429 responses against a local fake proxy. Reviewed by the author.

## Proposed Changes

When a user hits their monthly AI usage limit, the Studio Code agent silently stopped replying: the WordPress.com proxy's 429 was classified as a transient error and retried with backoff, and the final failure never reached the UI — the spinner just stopped with no message.

This PR makes hitting the limit fail fast and communicate clearly, consistently across every surface:

- **No pointless retries**: a 429 from the WordPress.com proxy (always the monthly cap there) now fails the turn immediately instead of burning ~15s of doomed retries. 429s on a user-supplied Anthropic API key keep retrying, since those are genuine transient rate limits.
- **Errors are part of the conversation**: a failed turn now renders an in-flow marker in the transcript — like the existing "Interrupted by you" marker — in the desktop app, the desktop agentic UI, and `studio ui`. The error is persisted on the session's `turn_closed` entry, so the marker survives reload. Non-cap errors show their actual message instead of nothing.
- **Actionable, consistent copy**: all surfaces share the same wording — *"You've reached your monthly AI usage limit. It resets on \<date\>."* — with the reset date fetched from the account's quota (the `studio ui` server gained a small quota proxy route for this). The CLI shows the same notice inline.

## Testing Instructions

1. `npm run cli:build`
2. Start a fake proxy that returns the cap response:
   ```bash
   node -e 'require("http").createServer((q,s)=>{s.writeHead(429,{"Content-Type":"application/json"});s.end(JSON.stringify({type:"error",error:{type:"rate_limit_error",message:"Number of requests has exceeded your monthly limit."}}))}).listen(8931)'
   ```
3. Point any surface at it with `WPCOM_AI_PROXY_BASE_URL=http://127.0.0.1:8931`:
   - **Desktop**: `WPCOM_AI_PROXY_BASE_URL=http://127.0.0.1:8931 npm start`, open a site → Studio Code, send a message.
   - **Local UI**: `npm run build:local -w @studio/ui`, then `WPCOM_AI_PROXY_BASE_URL=http://127.0.0.1:8931 node --experimental-wasm-jspi apps/cli/dist/cli/main.mjs ui`, send a message.
   - **CLI**: `WPCOM_AI_PROXY_BASE_URL=http://127.0.0.1:8931 node --experimental-wasm-jspi apps/cli/dist/cli/main.mjs code`, send a message.
4. Verify the turn fails immediately (single request, no retry stall) and the usage-limit notice appears in the conversation flow with your account's reset date. Reload the session and verify the marker is still there.

> ⚠️ Visual change: the in-flow error marker needs human review in light + dark mode (verified in the browser UI in both schemes; the desktop renderer uses the equivalent `--color-frame-error` token).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)