### PR TITLE
Agentic UI: Add signed-out sign-in experience

### DIFF
--- a/apps/studio/src/modules/add-site/components/pull-remote-site.tsx
+++ b/apps/studio/src/modules/add-site/components/pull-remote-site.tsx
@@ -28,7 +28,7 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 	return (
 		<div className="p-8 flex justify-center gap-12">
 			<div className="flex flex-col max-w-sm">
-				<div className="a8c-subtitle text-pretty">{ __( 'Sign in to get started' ) }</div>
+				<div className="a8c-subtitle text-pretty">{ __( 'Log in to get started' ) }</div>
 				<div className="max-w-[40ch] text-frame-text-secondary a8c-body mt-2">
 					{ __( 'Connect your WordPress.com account to access your sites.' ) }
 				</div>

--- a/apps/ui/src/components/agentic-signin-banner/index.tsx
+++ b/apps/ui/src/components/agentic-signin-banner/index.tsx
@@ -1,15 +1,35 @@
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
-import { useEffect, useRef } from 'react';
+import { Button, Tooltip } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import { useEffect, useRef, useState } from 'react';
+import { DotGrid } from '@/components/dot-grid';
+import { ProgressiveBlur } from '@/components/progressive-blur';
 import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
 import { useLogin } from '@/data/queries/use-auth-user';
+import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
+import { EmptyBackground } from '@/ui-classic/components/session-view/empty-background';
 import styles from './style.module.css';
 import type { AgenticFeatureReason } from '@/data/queries/use-agentic-features';
 
+const TAGLINE_INTERVAL_MS = 4000;
+
+// The illustrated, collapsible sign-in band pinned to the bottom of the site overview.
 export function AgenticSigninBanner() {
 	const { enabled, reason } = useAgenticFeatures();
+	const login = useLogin();
 	const navigate = useNavigate();
+	const sidebarCollapsed = useSidebarCollapsed();
+	const [ minimized, setMinimized ] = useState( false );
+	const [ taglineIndex, setTaglineIndex ] = useState( 0 );
+
+	const taglines = [
+		__( 'Let Studio code it for you' ),
+		__( 'Share a preview online' ),
+		__( 'Push to your live site' ),
+		__( 'Build a theme or plugin' ),
+	];
+	const taglineCount = taglines.length;
 
 	// `authenticate()` resolves when the browser opens, not when OAuth
 	// completes, so a finished login only surfaces here as a signed-out →
@@ -23,29 +43,112 @@ export function AgenticSigninBanner() {
 		}
 	}, [ enabled, reason, navigate ] );
 
+	// Rotate the tagline while collapsed.
+	useEffect( () => {
+		if ( ! minimized ) {
+			return;
+		}
+		const id = window.setInterval( () => {
+			setTaglineIndex( ( index ) => ( index + 1 ) % taglineCount );
+		}, TAGLINE_INTERVAL_MS );
+		return () => window.clearInterval( id );
+	}, [ minimized, taglineCount ] );
+
 	if ( reason !== 'signed-out' ) {
 		return null;
 	}
 
-	return <SigninNotice />;
+	const loginButton = (
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<Button
+						type="button"
+						variant="solid"
+						tone="brand"
+						size="small"
+						loading={ login.isPending }
+						onClick={ () => login.mutate() }
+					>
+						{ minimized ? __( 'Log in' ) : __( 'Log in with WordPress.com' ) }
+					</Button>
+				}
+			/>
+			<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+				{ minimized ? __( 'Log in to WordPress.com' ) : __( 'Opens your browser to log in' ) }
+			</Tooltip.Popup>
+		</Tooltip.Root>
+	);
+
+	// Hidden: a rotating tagline next to the log-in button, pinned clear of the
+	// preview toggle and above the footer blur.
+	if ( minimized ) {
+		return (
+			<section
+				className={ clsx( styles.root, styles.minimized ) }
+				aria-label={ __( 'Log in to Studio' ) }
+			>
+				<span key={ taglineIndex } className={ styles.tagline } aria-hidden="true">
+					{ taglines[ taglineIndex ] }
+				</span>
+				{ loginButton }
+			</section>
+		);
+	}
+
+	return (
+		<section
+			className={ clsx( styles.root, sidebarCollapsed && styles.collapsed ) }
+			aria-label={ __( 'Log in to Studio' ) }
+		>
+			<DotGrid className={ styles.grid } opacity={ 0.35 } />
+			<ProgressiveBlur direction="down" fadeToSurface className={ styles.topBlur } />
+			<div className={ styles.lockup }>
+				<div className={ styles.mark } aria-hidden="true">
+					<EmptyBackground />
+				</div>
+				<div className={ styles.copy }>
+					<h2 className={ styles.heading }>{ __( 'Let Studio code it for you' ) }</h2>
+					<p className={ styles.subline }>
+						{ __(
+							'An AI powered WordPress expert that can build a site, theme, or plugin, and help you share and publish.'
+						) }
+					</p>
+					<div className={ styles.actions }>
+						{ loginButton }
+						<Button
+							type="button"
+							variant="minimal"
+							tone="neutral"
+							size="small"
+							onClick={ () => setMinimized( true ) }
+						>
+							{ __( 'Hide' ) }
+						</Button>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
 }
 
-// The banner without the route-aware behaviour, for surfaces that must stay
-// put once the user signs in (e.g. Settings).
+// A compact inline notice (no route-aware redirect) for surfaces that keep the
+// prompt in the content flow and must stay put once the user signs in — e.g. the
+// Settings Usage panel.
 export function SigninNotice() {
 	const login = useLogin();
 
 	return (
-		<section className={ styles.root } aria-label={ __( 'Sign in to Studio' ) }>
-			<div className={ styles.text }>
-				<h2 className={ styles.heading }>{ __( 'Sign in to do more with Studio' ) }</h2>
-				<ul className={ styles.benefits }>
+		<section className={ styles.notice } aria-label={ __( 'Log in to Studio' ) }>
+			<div className={ styles.noticeText }>
+				<h2 className={ styles.noticeHeading }>{ __( 'Log in to do more with Studio' ) }</h2>
+				<ul className={ styles.noticeBenefits }>
 					<li>{ __( 'Chat with a WordPress expert that builds and edits your site for you' ) }</li>
 					<li>{ __( 'Share your work instantly with preview links' ) }</li>
 					<li>{ __( "Publish to a real WordPress.com site when you're ready" ) }</li>
 				</ul>
 			</div>
-			<div className={ styles.actions }>
+			<div className={ styles.noticeActions }>
 				<Button
 					type="button"
 					variant="solid"

--- a/apps/ui/src/components/agentic-signin-banner/style.module.css
+++ b/apps/ui/src/components/agentic-signin-banner/style.module.css
@@ -1,4 +1,120 @@
+/* Signed-out call to action: a full-width band across the bottom of the overview
+   panel. The particle "W" is a square anchored near the band's top-left, bleeding off
+   the leading edge and hanging off the bottom — so its round top always shows and it's
+   never squeezed. It scales with the band's width; the copy sits to its right,
+   vertically centred. Row → stacked → copy-only as the band narrows. */
 .root {
+	container-type: inline-size;
+	position: relative;
+	display: flex;
+	align-items: stretch;
+	min-block-size: 172px;
+	background: var(--wpds-color-bg-surface-neutral);
+}
+
+/* Sidebar collapsed: a sidebar-expand toggle joins the preview toggle along the
+   panel's bottom edge — reserve room below so neither sits under the content. */
+.collapsed {
+	min-block-size: calc(172px + 46px);
+	padding-block-end: 46px;
+}
+
+/* Static plus-grid backdrop behind everything, full-bleed. */
+.grid {
+	z-index: 0;
+}
+
+/* Softens and fades the grid's top edge into the plain panel surface above. */
+.topBlur {
+	inset-inline: 0;
+	inset-block-start: 0;
+	height: 80px;
+	z-index: 1;
+}
+
+/* The content block. Stretches to the band height, fills the width up to a max, then
+   centres — so on a wide band the whole lockup pulls in from the leading edge and the
+   W stops bleeding, sitting fully on the grid with room to its side. */
+.lockup {
+	/* Square W that scales with the band width, capped. cqw resolves against .root, so
+	   it tracks the band regardless of this element's own (centred, capped) width. */
+	--w-size: clamp(160px, 36cqw, 240px);
+	--w-gap: clamp(28px, 6cqw, 52px);
+	--w-bleed: 31px;
+	--w-top: var(--wpds-dimension-padding-3xl);
+	position: relative;
+	z-index: 2;
+	width: 100%;
+	max-width: 780px;
+	margin-inline: auto;
+	display: flex;
+	align-items: center;
+	/* Reserve the W's visible width + a gap on the leading side so the copy clears it;
+	   the W itself is absolute and ignores this padding, bleeding off the leading edge. */
+	padding-inline: calc(var(--w-size) - var(--w-bleed) + var(--w-gap))
+		calc(var(--wpds-dimension-padding-3xl) + var(--wpds-dimension-padding-xl));
+}
+
+/* The particle "W": a square holding the whole glyph. Absolutely positioned and pinned
+   near the top so it hangs off the band's bottom edge (clipped there) rather than being
+   sliced top-and-bottom — the round top always reads. Its size never drives the band
+   height. */
+.mark {
+	position: absolute;
+	inset-block-start: var(--w-top);
+	inset-inline-start: calc(-1 * var(--w-bleed));
+	inline-size: var(--w-size);
+	aspect-ratio: 1;
+	z-index: 0;
+}
+
+/* Scale the canvas up so the glyph fills the square (EmptyBackground pads its own
+   canvas heavily); the surplus is transparent and clipped to the square. Equal
+   width/height keep it perfectly circular — never stretched. */
+.mark canvas {
+	width: 175%;
+	height: 175%;
+	max-width: none;
+}
+
+.copy {
+	position: relative;
+	z-index: 1;
+	max-width: 460px;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--wpds-dimension-padding-xs);
+}
+
+.heading {
+	margin: 0;
+	font-size: var(--wpds-typography-font-size-lg);
+	line-height: var(--wpds-typography-line-height-lg);
+	font-weight: var(--wpds-typography-font-weight-medium);
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.subline {
+	margin: 0;
+	font-size: var(--wpds-typography-font-size-md);
+	line-height: 1.35;
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.actions {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: var(--wpds-dimension-padding-sm);
+	margin-block-start: var(--wpds-dimension-padding-md);
+}
+
+/* SigninNotice: a compact inline card (heading + benefits + button) for surfaces
+   that keep the prompt in the content flow, e.g. the Settings Usage panel. Kept
+   separate from the .root band above so the two treatments don't collide. */
+.notice {
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
@@ -11,12 +127,12 @@
 	background: var(--wpds-color-bg-surface-neutral-weak);
 }
 
-.text {
+.noticeText {
 	flex: 1 1 auto;
 	min-width: 0;
 }
 
-.heading {
+.noticeHeading {
 	margin: 0 0 var(--wpds-dimension-padding-sm);
 	font-size: var(--wpds-typography-font-size-md);
 	line-height: var(--wpds-typography-line-height-md);
@@ -24,7 +140,7 @@
 	color: var(--wpds-color-fg-content-neutral);
 }
 
-.benefits {
+.noticeBenefits {
 	margin: 0;
 	padding-inline-start: var(--wpds-dimension-padding-lg);
 	display: flex;
@@ -35,7 +151,88 @@
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
-.actions {
+.noticeActions {
 	flex-shrink: 0;
 	align-self: center;
+}
+
+/* Hidden: no band — a rotating tagline plus the log-in button, right-aligned and
+   padded clear of the preview toggle at the panel's bottom-right corner. */
+.minimized {
+	min-block-size: 0;
+	/* Sit above the panel's footer blur so the tagline and button stay crisp. */
+	z-index: 2;
+	background: transparent;
+	align-items: center;
+	justify-content: flex-end;
+	gap: var(--wpds-dimension-padding-lg);
+	padding-block: var(--wpds-dimension-padding-lg);
+	padding-inline: var(--wpds-dimension-padding-3xl) calc(46px + var(--wpds-dimension-padding-lg));
+}
+
+.tagline {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: var(--wpds-typography-font-size-md);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	animation: agentic-tagline-in 400ms ease;
+}
+
+@keyframes agentic-tagline-in {
+	from {
+		opacity: 0;
+		transform: translateY(2px);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.tagline {
+		animation: none;
+	}
+}
+
+/* Stacked: not enough width for a bleeding W — a small, whole W sits on top of the
+   copy, both left-aligned within symmetric padding. (Padding lives on .lockup, not
+   .root: .root establishes the query container, so its own @container rules never
+   apply.) */
+@container (max-width: 459px) {
+	.lockup {
+		max-width: none;
+		margin-inline: 0;
+		padding: var(--wpds-dimension-padding-3xl);
+		flex-direction: column;
+		align-items: flex-start;
+		gap: var(--wpds-dimension-padding-lg);
+	}
+
+	.mark {
+		position: relative;
+		inset: auto;
+		inline-size: 96px;
+	}
+
+	.copy {
+		max-width: none;
+	}
+}
+
+/* Copy only. */
+@container (max-width: 359px) {
+	.mark {
+		display: none;
+	}
+}
+
+/* Only drop the tagline when the panel is genuinely tiny. */
+@container (max-width: 300px) {
+	.tagline {
+		display: none;
+	}
 }

--- a/apps/ui/src/components/settings-view/account-section.test.tsx
+++ b/apps/ui/src/components/settings-view/account-section.test.tsx
@@ -29,6 +29,12 @@ vi.mock( '@wordpress/ui', () => ( {
 		void size;
 		return <button { ...props }>{ loading ? loadingAnnouncement : children }</button>;
 	},
+	Tooltip: {
+		Root: ( { children }: { children?: ReactNode } ) => <>{ children }</>,
+		Trigger: ( { render }: { render?: ReactNode } ) => <>{ render }</>,
+		Popup: () => null,
+		Positioner: () => null,
+	},
 } ) );
 
 vi.mock( '@/components/gravatar', () => ( {

--- a/apps/ui/src/components/settings-view/account-section.tsx
+++ b/apps/ui/src/components/settings-view/account-section.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
+import { Button, Tooltip } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { Gravatar } from '@/components/gravatar';
 import { useConnector } from '@/data/core';
@@ -19,24 +19,42 @@ function AccountHelpActions() {
 
 	return (
 		<div className={ styles.accountActions }>
-			<Button
-				type="button"
-				variant="minimal"
-				tone="neutral"
-				size="small"
-				onClick={ () => openLink( getLocalizedLink( locale, 'docsStudio' ) ) }
-			>
-				{ __( 'Docs' ) }
-			</Button>
-			<Button
-				type="button"
-				variant="minimal"
-				tone="neutral"
-				size="small"
-				onClick={ () => openLink( REPORT_ISSUE_URL ) }
-			>
-				{ __( 'Report an issue' ) }
-			</Button>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					render={
+						<Button
+							type="button"
+							variant="minimal"
+							tone="neutral"
+							size="small"
+							onClick={ () => openLink( getLocalizedLink( locale, 'docsStudio' ) ) }
+						>
+							{ __( 'Docs' ) }
+						</Button>
+					}
+				/>
+				<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+					{ __( 'Documentation' ) }
+				</Tooltip.Popup>
+			</Tooltip.Root>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					render={
+						<Button
+							type="button"
+							variant="minimal"
+							tone="neutral"
+							size="small"
+							onClick={ () => openLink( REPORT_ISSUE_URL ) }
+						>
+							{ __( 'Report an issue' ) }
+						</Button>
+					}
+				/>
+				<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+					{ __( 'Report an issue or request a feature' ) }
+				</Tooltip.Popup>
+			</Tooltip.Root>
 		</div>
 	);
 }

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -259,7 +259,7 @@ describe( 'UsagePanel', () => {
 		expect(
 			screen.queryByRole( 'button', { name: 'Delete all preview sites' } )
 		).not.toBeInTheDocument();
-		expect( screen.queryByLabelText( 'Sign in to Studio' ) ).not.toBeInTheDocument();
+		expect( screen.queryByLabelText( 'Log in to Studio' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'surfaces a deletion error inline', () => {
@@ -281,7 +281,7 @@ describe( 'UsagePanel', () => {
 
 		render( <UsagePanel /> );
 
-		expect( screen.getByLabelText( 'Sign in to Studio' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Log in to Studio' ) ).toBeInTheDocument();
 		expect( screen.queryByText( /active preview site/ ) ).not.toBeInTheDocument();
 		expect( screen.getAllByRole( 'img', { name: 'Unavailable' } ) ).toHaveLength( 2 );
 		// Studio Code needs an account, so the Alpha pricing copy stays hidden.

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -87,7 +87,7 @@ function getPreviewPanelCopy(
 	if ( isOffline ) {
 		return __( 'Go online to share a review link.' );
 	}
-	return __( 'Sign in to share a review link.' );
+	return __( 'Log in to share a review link.' );
 }
 
 function getLivePanelCopy( agenticEnabled: boolean, isOffline: boolean ): string {
@@ -97,7 +97,7 @@ function getLivePanelCopy( agenticEnabled: boolean, isOffline: boolean ): string
 	if ( isOffline ) {
 		return __( 'Go online to publish your site.' );
 	}
-	return __( 'Sign in to publish your site.' );
+	return __( 'Log in to publish your site.' );
 }
 
 export function MainView( { site, activity, onSetupClick, onDisconnectClick }: Props ) {

--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -232,6 +232,25 @@ describe( 'SiteList', () => {
 		} );
 	} );
 
+	it( 'shows the selected site solid without the overview shortcut when signed out', () => {
+		vi.mocked( useAgenticFeatures ).mockReturnValue( {
+			enabled: false,
+			reason: 'signed-out',
+			isReady: true,
+		} );
+		paramsMock = { siteId: 'stopped-site' };
+		pathnameMock = '/sites/stopped-site/overview';
+
+		render( <SiteList /> );
+
+		const stoppedRow = screen.getByText( 'Stopped Site' ).closest( 'section' )!;
+		const className = stoppedRow.getAttribute( 'class' ) ?? '';
+
+		expect( className ).toContain( 'siteActive' );
+		expect( className ).not.toContain( 'siteContextActive' );
+		expect( screen.queryByRole( 'button', { name: 'Site overview' } ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'opens the site overview from the row gear without opening the latest chat', () => {
 		render( <SiteList /> );
 

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -505,6 +505,11 @@ function SiteSection( {
 	const navigate = useNavigate();
 	const sectionRef = useRef< HTMLElement >( null );
 	const isActive = isChatActive || isContextActive;
+	// Signed out, a site's home is its overview, so the context-active row is
+	// simply "the selected site" — show it solid-selected (no dashed outline,
+	// no overview shortcut), matching how chat-active looks when signed in.
+	const showSelected = isChatActive || ( isContextActive && ! agenticEnabled );
+	const showContextOutline = isContextActive && agenticEnabled;
 	// Keep the active site visible — e.g. when launch restores a site that
 	// sits below the sidebar's fold. `nearest` no-ops when already visible.
 	useEffect( () => {
@@ -555,8 +560,8 @@ function SiteSection( {
 			ref={ sectionRef }
 			className={ clsx(
 				styles.site,
-				isChatActive && styles.siteActive,
-				isContextActive && styles.siteContextActive
+				showSelected && styles.siteActive,
+				showContextOutline && styles.siteContextActive
 			) }
 		>
 			<SiteActionsMenu
@@ -574,7 +579,7 @@ function SiteSection( {
 									event.stopPropagation();
 									handleOpenSite();
 								} }
-								aria-current={ isChatActive ? 'page' : undefined }
+								aria-current={ showSelected ? 'page' : undefined }
 							>
 								<span
 									className={ clsx(
@@ -588,7 +593,7 @@ function SiteSection( {
 							</SidebarButton>
 						</div>
 						<div className={ styles.siteActions } data-reorder-exclude>
-							<SiteOverviewButton site={ site } />
+							{ agenticEnabled ? <SiteOverviewButton site={ site } /> : null }
 							<SiteStatusButton site={ site } isStarting={ isStarting } isStopping={ isStopping } />
 						</div>
 					</header>

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Tooltip } from '@wordpress/ui';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
 import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
@@ -34,6 +35,16 @@ vi.mock( '@tanstack/react-router', () => ( {
 vi.mock( '@/components/delete-site-dialog', () => ( {
 	DeleteSiteDialog: ( { open }: { open: boolean } ) =>
 		open ? <div role="dialog">Delete dialog</div> : null,
+} ) );
+
+// Canvas-backed W background; jsdom has no 2D context, so stub it out.
+vi.mock( '@/ui-classic/components/session-view/empty-background', () => ( {
+	EmptyBackground: () => null,
+} ) );
+
+// Canvas-backed dot-grid backdrop; jsdom has no 2D context, so stub it out.
+vi.mock( '@/components/dot-grid', () => ( {
+	DotGrid: () => null,
 } ) );
 
 vi.mock( '@/components/site-dropdown', () => ( {
@@ -138,7 +149,9 @@ describe( 'SiteOverviewView', () => {
 
 	function renderView( activeTab: 'overview' | 'general' | 'debugging' = 'overview' ) {
 		return render(
-			<SiteOverviewView siteId="site-1" activeTab={ activeTab } onTabChange={ onTabChange } />
+			<Tooltip.Provider>
+				<SiteOverviewView siteId="site-1" activeTab={ activeTab } onTabChange={ onTabChange } />
+			</Tooltip.Provider>
 		);
 	}
 
@@ -241,9 +254,7 @@ describe( 'SiteOverviewView', () => {
 
 		renderView();
 
-		expect(
-			screen.getByRole( 'heading', { name: 'Sign in to do more with Studio' } )
-		).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: 'Let Studio code it for you' } ) ).toBeVisible();
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Log in with WordPress.com' } ) );
 
@@ -254,7 +265,7 @@ describe( 'SiteOverviewView', () => {
 		renderView();
 
 		expect(
-			screen.queryByRole( 'heading', { name: 'Sign in to do more with Studio' } )
+			screen.queryByRole( 'heading', { name: 'Let Studio code it for you' } )
 		).not.toBeInTheDocument();
 	} );
 

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -165,9 +165,8 @@ function SiteOverviewBody( {
 					</div>
 					<div className={ styles.scroll }>
 						<main className={ styles.content }>
-							<Tabs.Panel tabId="overview" className={ styles.panel }>
+							<Tabs.Panel tabId="overview" className={ styles.overviewPanel }>
 								<OfflineBanner />
-								<AgenticSigninBanner />
 								<div className={ styles.actionsColumn }>
 									<ButtonSection title={ __( 'Customize' ) }>
 										{ isBlockTheme ? (
@@ -274,6 +273,7 @@ function SiteOverviewBody( {
 					</div>
 				</Tabs.Root>
 			</div>
+			{ activeTab === 'overview' ? <AgenticSigninBanner /> : null }
 			<ProgressiveBlur direction="up" className={ styles.footerBlur } />
 			<div className={ styles.footerBar }>
 				<PreviewToggleButton />

--- a/apps/ui/src/components/site-overview-view/style.module.css
+++ b/apps/ui/src/components/site-overview-view/style.module.css
@@ -69,6 +69,19 @@
 	outline: none;
 }
 
+/* Fills the scroll viewport so the sign-in banner (margin-top: auto) can sit
+   at the very bottom of the panel when the content above is short. */
+.overviewPanel {
+	outline: none;
+	flex: 1 0 auto;
+	display: flex;
+	flex-direction: column;
+}
+
+.overviewPanel[hidden] {
+	display: none;
+}
+
 .scroll {
 	flex: 1;
 	min-height: 0;
@@ -112,10 +125,14 @@
 	box-sizing: border-box;
 	width: 100%;
 	max-width: 760px;
-	/* Extra bottom padding keeps the last content clear of the overlaid
-	   footer toolbar. */
-	padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-xl)
-		calc(var(--wpds-dimension-padding-2xl) + 46px);
+	/* Fill the scroll viewport so a short overview still lets the sign-in
+	   banner settle against the bottom. */
+	min-height: 100%;
+	display: flex;
+	flex-direction: column;
+	/* Bottom padding == the overlaid footer toolbar height, so the composer
+	   rests right above the footer controls like the chat composer does. */
+	padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-xl) 46px;
 }
 
 .buttonSection h2 {
@@ -200,7 +217,6 @@
 
 @media (max-width: 760px) {
 	.content {
-		padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-md)
-			calc(var(--wpds-dimension-padding-2xl) + 46px);
+		padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-md) 46px;
 	}
 }

--- a/apps/ui/src/components/user-menu/index.tsx
+++ b/apps/ui/src/components/user-menu/index.tsx
@@ -1,98 +1,39 @@
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { cog } from '@wordpress/icons';
+import { Icon, settings } from '@wordpress/icons';
 import { IconButton } from '@wordpress/ui';
 import { Gravatar } from '@/components/gravatar';
-import * as Menu from '@/components/menu';
 import { SidebarButton } from '@/components/sidebar-button';
-import { useConnector } from '@/data/core';
-import { useAuthUser, useLogin, useLogout } from '@/data/queries/use-auth-user';
-import { useUserLocale } from '@/data/queries/use-user-locale';
+import { useAuthUser } from '@/data/queries/use-auth-user';
 import { useColorScheme } from '@/hooks/use-color-scheme';
-import { useOffline } from '@/hooks/use-offline';
-import { getLocalizedLink, REPORT_ISSUE_URL } from '@/lib/docs-links';
 import { drawerIcon } from '@/lib/icons';
 import styles from './style.module.css';
-
-const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
 
 type Props = {
 	onToggleSidebar: () => void;
 };
 
 export function UserMenu( { onToggleSidebar }: Props ) {
-	const connector = useConnector();
 	const { data: user } = useAuthUser();
-	const login = useLogin();
-	const logout = useLogout();
 	const navigate = useNavigate();
-
-	const isOffline = useOffline();
-	const locale = useUserLocale();
 	const themeIsDark = useColorScheme() === 'dark';
-
-	const openLink = ( url: string ) => {
-		void connector.openExternalUrl( url );
-	};
 
 	return (
 		<div className={ styles.root }>
 			<div className={ styles.row }>
-				{ user ? (
-					<Menu.Root modal={ false }>
-						<Menu.Trigger
-							render={
-								<SidebarButton className={ styles.userTrigger }>
-									<Gravatar email={ user.email } isDark={ themeIsDark } />
-									<span className={ styles.userName }>{ user.displayName }</span>
-								</SidebarButton>
-							}
-						/>
-						<Menu.Popup side="top" align="start" className={ styles.popup }>
-							<div className={ styles.email } title={ user.email }>
-								{ user.email }
-							</div>
-							<Menu.Item onClick={ () => void navigate( { to: '/settings' } ) }>
-								{ __( 'Settings' ) }
-							</Menu.Item>
-							<Menu.Item disabled={ isOffline } onClick={ () => openLink( WPCOM_PROFILE_URL ) }>
-								{ __( 'Edit WordPress.com profile' ) }
-							</Menu.Item>
-							<Menu.Item
-								disabled={ isOffline }
-								onClick={ () => openLink( getLocalizedLink( locale, 'docsStudio' ) ) }
-							>
-								{ __( 'Documentation' ) }
-							</Menu.Item>
-							<Menu.Item disabled={ isOffline } onClick={ () => openLink( REPORT_ISSUE_URL ) }>
-								{ __( 'Report an issue' ) }
-							</Menu.Item>
-							<Menu.Separator />
-							<Menu.Item onClick={ () => logout.mutate() }>{ __( 'Log out' ) }</Menu.Item>
-						</Menu.Popup>
-					</Menu.Root>
-				) : (
-					<SidebarButton
-						className={ styles.loginButton }
-						disabled={ isOffline }
-						onClick={ () => login.mutate() }
-					>
-						{ __( 'Log in with WordPress.com' ) }
-					</SidebarButton>
-				) }
-				{ ! user ? (
-					// Logged in, Settings lives in the user menu; logged out
-					// there is no menu, so keep the page reachable here.
-					<IconButton
-						variant="minimal"
-						tone="neutral"
-						size="small"
-						className={ styles.settingsButton }
-						icon={ cog }
-						label={ __( 'Settings' ) }
-						onClick={ () => void navigate( { to: '/settings' } ) }
-					/>
-				) : null }
+				<SidebarButton
+					className={ styles.userTrigger }
+					onClick={ () => void navigate( { to: '/settings' } ) }
+				>
+					{ user ? (
+						<Gravatar email={ user.email } isDark={ themeIsDark } />
+					) : (
+						<span className={ styles.settingsAvatar } aria-hidden="true">
+							<Icon icon={ settings } size={ 14 } />
+						</span>
+					) }
+					<span className={ styles.userName }>{ __( 'Settings' ) }</span>
+				</SidebarButton>
 				<IconButton
 					variant="minimal"
 					tone="neutral"

--- a/apps/ui/src/components/user-menu/style.module.css
+++ b/apps/ui/src/components/user-menu/style.module.css
@@ -8,7 +8,7 @@
 		var(--wpds-dimension-padding-2xl) - var(--wpds-dimension-padding-xs)
 	);
 
-	/* SidebarButton adds `sm` inline padding; this offset puts the gravatar's
+	/* SidebarButton adds `sm` inline padding; this offset puts the avatar's
 	   left edge on the same column as the site icons. */
 	padding: var(--wpds-dimension-padding-sm) var(--user-menu-trailing-offset)
 		var(--wpds-dimension-padding-xl) var(--user-menu-leading-offset);
@@ -20,22 +20,23 @@
 	gap: var(--wpds-dimension-padding-xs);
 }
 
-.userName,
-.sidebarToggle,
-.settingsButton {
+.userName {
 	color: var(--wpds-color-fg-content-neutral-weak);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
 }
 
 .sidebarToggle {
+	color: var(--wpds-color-fg-content-neutral-weak);
 	margin-inline-end: calc(-1 * var(--wpds-dimension-padding-sm));
 }
 
 .row:hover .userName,
 .row:hover .sidebarToggle,
-.row:hover .settingsButton,
 .row:focus-within .userName,
-.row:focus-within .sidebarToggle,
-.row:focus-within .settingsButton {
+.row:focus-within .sidebarToggle {
 	color: var(--wpds-color-fg-content-neutral);
 }
 
@@ -48,27 +49,22 @@
 	padding-inline-start: calc(var(--wpds-dimension-padding-sm) - var(--user-menu-avatar-offset));
 }
 
-.userName {
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	min-width: 0;
-}
-
-.loginButton {
-	flex: 1;
-	text-align: left;
-}
-
-.popup {
-	min-width: 220px;
-}
-
-.email {
-	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
-	font-size: var(--wpds-typography-font-size-xs);
+/* Signed-out avatar: a circle with the settings (sliders) icon, sized/shaped to
+   match the gravatar it stands in for. */
+.settingsAvatar {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	flex-shrink: 0;
+	background-color: var(--wpds-color-bg-surface-neutral);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+}
+
+.settingsAvatar svg {
+	width: 14px;
+	height: 14px;
+	fill: currentColor;
 }

--- a/apps/ui/src/ui-classic/router/route-welcome/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-welcome/index.tsx
@@ -36,7 +36,7 @@ function WelcomePage() {
 		<div className={ styles.root }>
 			<h1 className={ styles.heading }>{ __( 'Welcome to Studio' ) }</h1>
 			<p className={ styles.subtitle }>
-				{ __( 'Sign in with a free WordPress.com account to unlock everything Studio offers.' ) }
+				{ __( 'Log in with a free WordPress.com account to unlock everything Studio offers.' ) }
 			</p>
 			<ul className={ styles.features }>
 				<li>{ __( 'Chat with a WordPress expert that builds and edits your site' ) }</li>


### PR DESCRIPTION
## Related issues

- Related to # <!-- link the signed-out agentic UI issue -->

## How AI was used in this PR

AI (Claude) built the sign-in band's responsive CSS and its collapse / rotating-tagline behavior, rewrote the sidebar's bottom entry into a direct Settings link, added the Settings tooltips, and standardized the user-facing auth copy on "Log in."

One notable fix worth a close look: the particle-"W" squished and mispositioned at narrow (preview-open) widths because the stacked breakpoint set `.mark { position: static }`, which detached `EmptyBackground`'s `position: absolute; inset: 0` canvas from its container so it filled the whole band. Restoring the positioning context (`relative`) fixed it. The layout was verified by measuring the real component's computed geometry across breakpoints in a throwaway Electron instance.

## Proposed Changes

When you're signed out of WordPress.com, the agentic UI now guides you toward logging in and adapts the surrounding UI to the signed-out state:

- The site **Overview** shows a sign-in band ("Let Studio code it for you") with a responsive particle-"W" illustration — it scales and bleeds off the leading edge on wider panels, hangs off the bottom, and collapses to a small stacked mark when narrow. The "W" always stays a perfect circle.
- That band can be **collapsed** (Hide) to a compact **Log in** button with a short **rotating tagline** beside it. The collapsed control stays clear of the preview toggle and sits above the footer blur. It shows the tagline until the panel gets genuinely tiny.
- The **sidebar's bottom entry** is now a single **Settings** button — your gravatar when signed in, a sliders icon when signed out — that opens Settings directly. Logging in/out, Documentation, and Report an issue live in **Settings → Account** (Docs / Report now have tooltips).
- The **sidebar site rows** reflect the signed-out state (a selected site's Overview is its home).
- User-facing auth copy is standardized on **"Log in"** (previously a mix of "Sign in" / "Log in").

Logging in unlocks the AI "let Studio code it for you" capabilities; nothing here blocks local-site work.

> ⚠️ Visual change: needs human review in light + dark mode.

## Testing Instructions

1. Run the agentic UI **signed out** (no WordPress.com auth).
2. **Overview band:** open a site's Overview.
   - Resize the panel / toggle the preview: the "W" bleeds + scales in the row layout, stacks small when narrow, drops away when tiny — and stays a **perfect circle** at every width.
   - Hit **Hide** → it collapses to a **Log in** button with a rotating tagline; the button is crisp (not blurred) and clears the preview toggle. Reload to bring the full band back.
3. **Sidebar bottom:** shows a **Settings** button (sliders icon signed-out, gravatar signed-in) that opens Settings. Check the signed-out site rows too.
4. **Settings → Account:** Log in / Log out, plus **Docs** and **Report an issue** with tooltips.
5. Verify in **both light and dark** color schemes.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors? <!-- typecheck + affected unit tests pass; needs a manual console pass -->
