### PR TITLE
Agentic UI: separate the agentic features toggle from the classic UI switcher

### DIFF
--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -229,6 +229,7 @@ export {
 } from 'src/modules/preview-site/lib/ipc-handlers';
 
 export {
+	getAgenticFeaturesEnabled,
 	getColorScheme,
 	getGlobalAgentInstructions,
 	getInstalledAppsAndTerminals,
@@ -238,6 +239,7 @@ export {
 	getUserTerminal,
 	getWapuuScore,
 	previewColorScheme,
+	saveAgenticFeaturesEnabled,
 	saveColorScheme,
 	saveGlobalAgentInstructions,
 	saveQuitSitesBehavior,

--- a/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
@@ -125,6 +125,18 @@ export async function getQuitSitesBehavior(): Promise< QuitSitesBehavior | undef
 	return userData.quitSitesBehavior;
 }
 
+export async function saveAgenticFeaturesEnabled(
+	_event: IpcMainInvokeEvent,
+	enabled: boolean
+): Promise< void > {
+	await updateAppdata( { agenticFeaturesEnabled: enabled } );
+}
+
+export async function getAgenticFeaturesEnabled(): Promise< boolean > {
+	const userData = await loadUserData();
+	return userData.agenticFeaturesEnabled ?? true;
+}
+
 export async function saveWapuuScore( _event: IpcMainInvokeEvent, score: number ): Promise< void > {
 	if ( ! Number.isFinite( score ) || score < 0 || score > 100_000 ) {
 		return;

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -168,6 +168,9 @@ const api: IpcApi = {
 	saveQuitSitesBehavior: ( quitSitesBehavior ) =>
 		ipcRendererInvoke( 'saveQuitSitesBehavior', quitSitesBehavior ),
 	getQuitSitesBehavior: () => ipcRendererInvoke( 'getQuitSitesBehavior' ),
+	saveAgenticFeaturesEnabled: ( enabled ) =>
+		ipcRendererInvoke( 'saveAgenticFeaturesEnabled', enabled ),
+	getAgenticFeaturesEnabled: () => ipcRendererInvoke( 'getAgenticFeaturesEnabled' ),
 	saveWapuuScore: ( score ) => ipcRendererInvoke( 'saveWapuuScore', score ),
 	getWapuuScore: () => ipcRendererInvoke( 'getWapuuScore' ),
 	getUserEditor: () => ipcRendererInvoke( 'getUserEditor' ),

--- a/apps/studio/src/storage/storage-types.ts
+++ b/apps/studio/src/storage/storage-types.ts
@@ -54,6 +54,9 @@ export interface UserData {
 	lastNightlyUpdateCheck?: number;
 	nightlyPromptResult?: NightlyPromptResult;
 	agenticUiBannerDismissed?: boolean;
+	// Whether chat/agent features are offered inside the new UI. Distinct from
+	// `betaFeatures.enableAgenticUi`, which picks the renderer (new vs classic).
+	agenticFeaturesEnabled?: boolean;
 }
 
 export interface PromptWindowsSpeedUpResult {

--- a/apps/studio/src/storage/user-data.ts
+++ b/apps/studio/src/storage/user-data.ts
@@ -85,7 +85,8 @@ type UserDataSafeKeys =
 	| 'wapuuScore'
 	| 'lastNightlyUpdateCheck'
 	| 'nightlyPromptResult'
-	| 'agenticUiBannerDismissed';
+	| 'agenticUiBannerDismissed'
+	| 'agenticFeaturesEnabled';
 
 type PartialUserDataWithSafeKeysToUpdate = Partial< Pick< UserData, UserDataSafeKeys > >;
 

--- a/apps/ui/src/components/settings-view/ai-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/ai-panel.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
+import { useSaveUserPreferences, useUserPreferences } from '@/data/queries/use-user-preferences';
 import { AiPanel } from './ai-panel';
 
 vi.mock( '@wordpress/components', () => ( {
@@ -25,28 +26,45 @@ vi.mock( '@/data/core', () => ( {
 	useConnector: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-user-preferences', () => ( {
+	useUserPreferences: vi.fn(),
+	useSaveUserPreferences: vi.fn(),
+} ) );
+
 vi.mock( './studio-code-panel', () => ( {
 	StudioCodePanel: () => <div data-testid="studio-code-panel" />,
 } ) );
 
 const useConnectorMock = vi.mocked( useConnector );
+const useUserPreferencesMock = vi.mocked( useUserPreferences );
+const useSaveUserPreferencesMock = vi.mocked( useSaveUserPreferences );
 
 describe( 'AiPanel', () => {
 	const disableAgenticUi = vi.fn( () => Promise.resolve() );
+	const mutate = vi.fn();
 
-	function mockConnector( switchToClassicUi: boolean, agentInstructions = true ) {
+	function mockConnector( agentInstructions = true ) {
 		useConnectorMock.mockReturnValue( {
-			capabilities: { switchToClassicUi, agentInstructions },
+			capabilities: { agentInstructions },
 			disableAgenticUi,
+		} as never );
+	}
+
+	function mockPreferences( agenticFeaturesEnabled: boolean, isLoading = false ) {
+		useUserPreferencesMock.mockReturnValue( {
+			data: { agenticFeaturesEnabled },
+			isLoading,
 		} as never );
 	}
 
 	beforeEach( () => {
 		vi.clearAllMocks();
+		useSaveUserPreferencesMock.mockReturnValue( { mutate } as never );
+		mockPreferences( true );
 	} );
 
-	it( 'switches back to the classic UI when agentic features are toggled off', () => {
-		mockConnector( true );
+	it( 'turns agentic features off without leaving the new UI', () => {
+		mockConnector();
 		render( <AiPanel /> );
 
 		const toggle = screen.getByRole( 'checkbox', { name: 'Agentic features' } );
@@ -54,21 +72,32 @@ describe( 'AiPanel', () => {
 
 		fireEvent.click( toggle );
 
-		expect( disableAgenticUi ).toHaveBeenCalled();
-		expect( toggle ).not.toBeChecked();
-		expect( toggle ).toBeDisabled();
-	} );
-
-	it( 'hides the agentic features section when the host cannot switch UIs', () => {
-		mockConnector( false );
-		render( <AiPanel /> );
-
-		expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
+		expect( mutate ).toHaveBeenCalledWith( { agenticFeaturesEnabled: false } );
 		expect( disableAgenticUi ).not.toHaveBeenCalled();
 	} );
 
+	it( 'turns agentic features back on', () => {
+		mockConnector();
+		mockPreferences( false );
+		render( <AiPanel /> );
+
+		const toggle = screen.getByRole( 'checkbox', { name: 'Agentic features' } );
+		expect( toggle ).not.toBeChecked();
+
+		fireEvent.click( toggle );
+
+		expect( mutate ).toHaveBeenCalledWith( { agenticFeaturesEnabled: true } );
+	} );
+
+	it( 'shows the toggle even when the host cannot switch back to the classic UI', () => {
+		mockConnector();
+		render( <AiPanel /> );
+
+		expect( screen.getByRole( 'checkbox', { name: 'Agentic features' } ) ).toBeInTheDocument();
+	} );
+
 	it( 'shows the global instructions editor alongside the agentic features toggle', () => {
-		mockConnector( true );
+		mockConnector();
 		render( <AiPanel /> );
 
 		expect( screen.getByRole( 'checkbox', { name: 'Agentic features' } ) ).toBeInTheDocument();
@@ -76,7 +105,7 @@ describe( 'AiPanel', () => {
 	} );
 
 	it( 'hides the global instructions editor when the host cannot reach the instructions file', () => {
-		mockConnector( true, false );
+		mockConnector( false );
 		render( <AiPanel /> );
 
 		expect( screen.queryByTestId( 'studio-code-panel' ) ).not.toBeInTheDocument();

--- a/apps/ui/src/components/settings-view/ai-panel.tsx
+++ b/apps/ui/src/components/settings-view/ai-panel.tsx
@@ -1,25 +1,15 @@
 import { FormToggle } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { clsx } from 'clsx';
-import { useState } from 'react';
 import { useConnector } from '@/data/core';
+import { useSaveUserPreferences, useUserPreferences } from '@/data/queries/use-user-preferences';
 import { StudioCodePanel } from './studio-code-panel';
 import styles from './style.module.css';
 
 function AgenticFeaturesSection() {
-	const connector = useConnector();
-	const [ disabling, setDisabling ] = useState( false );
-
-	if ( ! connector.capabilities.switchToClassicUi ) {
-		return null;
-	}
-
-	// Turning agentic features off reloads the window into the classic UI, so
-	// there is no enable path here — once disabled, this panel no longer exists.
-	const handleDisable = () => {
-		setDisabling( true );
-		connector.disableAgenticUi().catch( () => setDisabling( false ) );
-	};
+	const { data: preferences, isLoading } = useUserPreferences();
+	const savePreferences = useSaveUserPreferences();
+	const enabled = preferences?.agenticFeaturesEnabled ?? true;
 
 	return (
 		<section className={ styles.preferenceSectionGroup }>
@@ -28,16 +18,16 @@ function AgenticFeaturesSection() {
 					<h2>{ __( 'Agentic features' ) }</h2>
 					<p>
 						{ __(
-							'Studio Code brings agentic, AI-powered site building to Studio. Turning it off reloads the app into the classic interface.'
+							'Chat with Studio Code to build and edit your sites. Turning it off hides chat and opens sites on their overview instead.'
 						) }
 					</p>
 				</div>
 				<div className={ clsx( styles.preferenceControl, styles.toggleControl ) }>
 					<FormToggle
-						checked={ ! disabling }
-						disabled={ disabling }
+						checked={ enabled }
+						disabled={ isLoading }
 						aria-label={ __( 'Agentic features' ) }
-						onChange={ handleDisable }
+						onChange={ () => savePreferences.mutate( { agenticFeaturesEnabled: ! enabled } ) }
 					/>
 				</div>
 			</section>
@@ -49,8 +39,8 @@ export function AiPanel() {
 	const connector = useConnector();
 	return (
 		<div className={ styles.preferencesPanel }>
-			{ connector.capabilities.agentInstructions && <StudioCodePanel /> }
 			<AgenticFeaturesSection />
+			{ connector.capabilities.agentInstructions && <StudioCodePanel /> }
 		</div>
 	);
 }

--- a/apps/ui/src/components/settings-view/ai-panel.tsx
+++ b/apps/ui/src/components/settings-view/ai-panel.tsx
@@ -18,7 +18,7 @@ function AgenticFeaturesSection() {
 					<h2>{ __( 'Agentic features' ) }</h2>
 					<p>
 						{ __(
-							'Chat with Studio Code to build and edit your sites. Turning it off hides chat and opens sites on their overview instead.'
+							'Chat with an agent that builds and edits your sites. Turning this off hides chat — your existing conversations are kept.'
 						) }
 					</p>
 				</div>

--- a/apps/ui/src/components/settings-view/index.test.tsx
+++ b/apps/ui/src/components/settings-view/index.test.tsx
@@ -225,7 +225,26 @@ describe( 'SettingsView', () => {
 		expect( screen.getByTestId( 'ai-panel' ) ).toBeInTheDocument();
 	} );
 
-	it( 'hides the AI tab when the host has no AI settings to offer', () => {
+	it( 'offers the AI tab on every host, since chat can be toggled anywhere', () => {
+		useConnectorMock.mockReturnValue( {
+			selectDefaultSiteDirectory,
+			capabilities: { agentInstructions: false, switchToClassicUi: false },
+		} as never );
+
+		render( <SettingsView activeTab="ai" onTabChange={ vi.fn() } /> );
+
+		expect( screen.getByRole( 'button', { name: 'AI' } ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'ai-panel' ) ).toBeInTheDocument();
+	} );
+
+	it( 'offers Switch to classic in the Settings tab when the host ships the classic UI', () => {
+		render( <SettingsView activeTab="preferences" onTabChange={ vi.fn() } /> );
+
+		expect( screen.getByRole( 'heading', { name: 'Studio experience' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Switch to classic' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides Switch to classic when there is no classic UI to switch to', () => {
 		useConnectorMock.mockReturnValue( {
 			selectDefaultSiteDirectory,
 			capabilities: { agentInstructions: false, switchToClassicUi: false },
@@ -233,8 +252,7 @@ describe( 'SettingsView', () => {
 
 		render( <SettingsView activeTab="preferences" onTabChange={ vi.fn() } /> );
 
-		expect( screen.queryByRole( 'button', { name: 'AI' } ) ).not.toBeInTheDocument();
-		expect( screen.queryByTestId( 'ai-panel' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Switch to classic' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'recognizes the keyboard tab id', () => {

--- a/apps/ui/src/components/settings-view/index.tsx
+++ b/apps/ui/src/components/settings-view/index.tsx
@@ -3,7 +3,7 @@ import { SUPPORTED_EDITORS, supportedEditorConfig } from '@studio/common/lib/use
 import { SUPPORTED_TERMINALS, terminalConfig } from '@studio/common/lib/user-settings/terminal';
 import { __, sprintf } from '@wordpress/i18n';
 import { close, file, Icon } from '@wordpress/icons';
-import { IconButton, SelectControl } from '@wordpress/ui';
+import { Button, IconButton, SelectControl } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useCallback, useEffect, useState } from 'react';
 import * as Tabs from '@/components/tabs';
@@ -25,7 +25,6 @@ import { UsagePanel } from './usage-panel';
 import type { PreferencesFormData } from './preferences';
 import type {
 	ColorScheme,
-	Connector,
 	InstalledApps,
 	QuitSitesBehavior,
 	SupportedEditor,
@@ -43,12 +42,6 @@ export function isSettingsTab( value: string ): value is TabId {
 }
 
 export type SettingsTabId = TabId;
-
-// The AI tab holds the agentic-features toggle and the agent's global
-// instructions; hosts that offer neither (the hosted browser) don't get the tab.
-function hasAiSettings( capabilities: Connector[ 'capabilities' ] ): boolean {
-	return capabilities.switchToClassicUi || capabilities.agentInstructions;
-}
 
 // No "unset" option: the main process resolves a fallback for never-chosen
 // editor/terminal prefs (matching the legacy UI), so an explicit clear can't
@@ -98,7 +91,6 @@ const LOCALE_ELEMENTS: { value: SupportedLocale; label: string }[] = Object.entr
 function SettingsHeader() {
 	// Settings renders fullscreen, so the sidebar (and its floating toggle) is
 	// covered — only the macOS traffic lights still need clearing.
-	const connector = useConnector();
 	const reserveTrafficLightSpace = useTrafficLightSpace();
 	const onClose = useSettingsClose();
 	return (
@@ -111,9 +103,7 @@ function SettingsHeader() {
 			<div className={ styles.headerTabs }>
 				<Tabs.List className={ styles.headerTabList }>
 					<Tabs.Tab tabId="preferences">{ __( 'Settings' ) }</Tabs.Tab>
-					{ hasAiSettings( connector.capabilities ) && (
-						<Tabs.Tab tabId="ai">{ __( 'AI' ) }</Tabs.Tab>
-					) }
+					<Tabs.Tab tabId="ai">{ __( 'AI' ) }</Tabs.Tab>
 					<Tabs.Tab tabId="usage">{ __( 'Usage' ) }</Tabs.Tab>
 					<Tabs.Tab tabId="keyboard">{ __( 'Keyboard' ) }</Tabs.Tab>
 					<Tabs.Tab tabId="skills">{ __( 'Skills' ) }</Tabs.Tab>
@@ -248,6 +238,30 @@ function DefaultSiteDirectoryField( { value, onSelect }: { value: string; onSele
 	);
 }
 
+function StudioExperienceSection() {
+	const connector = useConnector();
+	if ( ! connector.capabilities.switchToClassicUi ) {
+		return null;
+	}
+	return (
+		<section className={ styles.preferenceSectionGroup }>
+			<PreferenceRow
+				title={ __( 'Studio experience' ) }
+				description={ __( 'You are using the new Studio experience.' ) }
+			>
+				<Button
+					type="button"
+					variant="outline"
+					tone="neutral"
+					onClick={ () => void connector.disableAgenticUi() }
+				>
+					{ __( 'Switch to classic' ) }
+				</Button>
+			</PreferenceRow>
+		</section>
+	);
+}
+
 function PreferencesPanel( {
 	data,
 	installedApps,
@@ -313,6 +327,7 @@ function PreferencesPanel( {
 			</section>
 			<AccountSection />
 			<StudioCliSection />
+			<StudioExperienceSection />
 		</div>
 	);
 }
@@ -413,11 +428,9 @@ export function SettingsView( {
 								onChange={ handleChange }
 							/>
 						</Tabs.Panel>
-						{ hasAiSettings( connector.capabilities ) && (
-							<Tabs.Panel tabId="ai">
-								<AiPanel />
-							</Tabs.Panel>
-						) }
+						<Tabs.Panel tabId="ai">
+							<AiPanel />
+						</Tabs.Panel>
 						<Tabs.Panel tabId="usage">
 							<UsagePanel />
 						</Tabs.Panel>

--- a/apps/ui/src/components/settings-view/preferences.test.ts
+++ b/apps/ui/src/components/settings-view/preferences.test.ts
@@ -11,6 +11,7 @@ const SAVED_PREFERENCES: UserPreferences = {
 	defaultSiteDirectory: '/Users/example/Studio',
 	studioCliInstalled: false,
 	studioCliExternallyManaged: false,
+	agenticFeaturesEnabled: true,
 };
 
 describe( 'settings preference helpers', () => {

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -177,6 +177,17 @@
 	border-bottom: 0;
 }
 
+/* A lone row (a headingless single-row card) has no divider to space against,
+   so its own block padding just doubles the top gap against the group's. Drop
+   it and square the group's top padding so the card is evenly inset all around. */
+.preferenceRow:only-child {
+	padding-block: 0;
+}
+
+.preferenceSectionGroup:has(> .preferenceRow:only-child) {
+	padding-block-start: var(--wpds-dimension-padding-xl);
+}
+
 .preferenceText {
 	display: flex;
 	flex-direction: column;

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -87,6 +87,13 @@ vi.mock( '@/data/queries/use-user-locale', () => ( {
 	useUserLocale: vi.fn(),
 } ) );
 
+// Reached through `useAgenticFeatures`, which reads the agentic-features
+// preference; this panel has no QueryClientProvider.
+vi.mock( '@/data/queries/use-user-preferences', () => ( {
+	USER_PREFERENCES_QUERY_KEY: [ 'user-preferences' ],
+	useUserPreferences: () => ( { data: { agenticFeaturesEnabled: true }, isLoading: false } ),
+} ) );
+
 const useConnectorMock = vi.mocked( useConnector );
 const useAuthUserMock = vi.mocked( useAuthUser );
 const useLoginMock = vi.mocked( useLogin );

--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -62,7 +62,12 @@ vi.mock( '@/data/queries/use-sites', () => ( {
 } ) );
 
 vi.mock( '@/data/queries/use-agentic-features', () => ( {
-	useAgenticFeatures: vi.fn( () => ( { enabled: true, reason: null, isReady: true } ) ),
+	useAgenticFeatures: vi.fn( () => ( {
+		enabled: true,
+		chatEnabled: true,
+		reason: null,
+		isReady: true,
+	} ) ),
 } ) );
 
 vi.mock( '@/data/queries/use-user-preferences', () => ( {
@@ -100,6 +105,7 @@ describe( 'SiteList', () => {
 
 		vi.mocked( useAgenticFeatures ).mockReturnValue( {
 			enabled: true,
+			chatEnabled: true,
 			reason: null,
 			isReady: true,
 		} );
@@ -133,6 +139,7 @@ describe( 'SiteList', () => {
 				defaultSiteDirectory: '',
 				studioCliInstalled: false,
 				studioCliExternallyManaged: false,
+				agenticFeaturesEnabled: true,
 			},
 		} );
 		useSitesMock.mockReturnValue( {
@@ -217,6 +224,7 @@ describe( 'SiteList', () => {
 	it( 'opens the site overview when clicking a site while agentic features are unavailable', () => {
 		vi.mocked( useAgenticFeatures ).mockReturnValue( {
 			enabled: false,
+			chatEnabled: false,
 			reason: 'signed-out',
 			isReady: true,
 		} );
@@ -747,6 +755,7 @@ describe( 'SiteList', () => {
 				defaultSiteDirectory: '',
 				studioCliInstalled: false,
 				studioCliExternallyManaged: false,
+				agenticFeaturesEnabled: true,
 			},
 		} );
 
@@ -771,6 +780,7 @@ describe( 'SiteList', () => {
 				defaultSiteDirectory: '',
 				studioCliInstalled: false,
 				studioCliExternallyManaged: false,
+				agenticFeaturesEnabled: true,
 			},
 		} );
 

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -493,13 +493,13 @@ function SiteSection( {
 	isChatActive,
 	isContextActive,
 	hasUnreadUpdate,
-	agenticEnabled,
+	chatEnabled,
 }: {
 	row: SiteRow;
 	isChatActive: boolean;
 	isContextActive: boolean;
 	hasUnreadUpdate: boolean;
-	agenticEnabled: boolean;
+	chatEnabled: boolean;
 } ) {
 	const { site, latestSession } = row;
 	const navigate = useNavigate();
@@ -528,9 +528,9 @@ function SiteSection( {
 		? 'new-message'
 		: 'idle';
 	const handleOpenSite = () => {
-		// Without agentic features (e.g. signed out) there's no chat to open;
-		// the site overview is the site's home instead.
-		if ( ! agenticEnabled ) {
+		// Without chat (signed out, offline, or switched off in Settings →
+		// AI) there's no session to open; the overview is the site's home.
+		if ( ! chatEnabled ) {
 			void navigate( {
 				to: '/sites/$siteId/overview',
 				params: { siteId: site.id },
@@ -611,7 +611,7 @@ function findSessionSiteKey(
 export function SiteList() {
 	const { data: sites, isLoading: sitesLoading } = useSites();
 	const { data: sessions, isLoading: sessionsLoading } = useSessions();
-	const { enabled: agenticEnabled } = useAgenticFeatures();
+	const { chatEnabled } = useAgenticFeatures();
 	const params = useParams( { strict: false } ) as { sessionId?: string; siteId?: string };
 	const pathname = useRouterState( { select: ( state ) => state.location.pathname } );
 	const activeSessionId = params.sessionId;
@@ -709,7 +709,7 @@ export function SiteList() {
 			isChatActive={ row.site.id === activeChatSiteKey }
 			isContextActive={ row.site.id === activeContextSiteKey }
 			hasUnreadUpdate={ unreadSiteIds.has( row.site.id ) }
-			agenticEnabled={ agenticEnabled }
+			chatEnabled={ chatEnabled }
 		/>
 	);
 

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -115,7 +115,12 @@ describe( 'SiteOverviewView', () => {
 		} );
 
 		useConnectorMock.mockReturnValue( { openSiteUrl } );
-		useAgenticFeaturesMock.mockReturnValue( { enabled: true, reason: null, isReady: true } );
+		useAgenticFeaturesMock.mockReturnValue( {
+			enabled: true,
+			chatEnabled: true,
+			reason: null,
+			isReady: true,
+		} );
 		useLoginMock.mockReturnValue( { isPending: false, mutate: vi.fn() } );
 		useExistingCustomDomainsMock.mockReturnValue( [] );
 		useSitesMock.mockReturnValue( {
@@ -234,6 +239,7 @@ describe( 'SiteOverviewView', () => {
 		const loginMutate = vi.fn();
 		useAgenticFeaturesMock.mockReturnValue( {
 			enabled: false,
+			chatEnabled: false,
 			reason: 'signed-out',
 			isReady: true,
 		} );

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -19,6 +19,8 @@ import type {
 } from '../../types';
 import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 
+const AGENTIC_FEATURES_STORAGE_KEY = 'studio-hosted-agentic-features-enabled';
+
 export interface HostedConnectorOptions {
 	// Base URL of the Studio hosted backend (`apps/hosted`), e.g. http://localhost:8088.
 	apiBaseUrl: string;
@@ -328,10 +330,19 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 				defaultSiteDirectory: '',
 				studioCliInstalled: false,
 				studioCliExternallyManaged: false,
+				agenticFeaturesEnabled:
+					window.localStorage.getItem( AGENTIC_FEATURES_STORAGE_KEY ) !== 'false',
 			};
 		},
-		async setUserPreferences() {
-			// No-op: preferences aren't persisted in the browser yet.
+		async setUserPreferences( partial ) {
+			// The rest aren't persisted in the browser yet; this one has to
+			// stick or the AI settings toggle would silently snap back.
+			if ( typeof partial.agenticFeaturesEnabled === 'boolean' ) {
+				window.localStorage.setItem(
+					AGENTIC_FEATURES_STORAGE_KEY,
+					String( partial.agenticFeaturesEnabled )
+				);
+			}
 		},
 		async getAppGlobals(): Promise< AppGlobals > {
 			return { platform: 'browser', isWindowsStore: false };

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -633,6 +633,7 @@ export function createIpcConnector(): Connector {
 				defaultSiteDirectory,
 				studioCliInstalled,
 				studioCliExternallyManaged,
+				agenticFeaturesEnabled,
 			] = ( await Promise.all( [
 				ipcApi.getUserEditor(),
 				ipcApi.getUserTerminal(),
@@ -642,6 +643,7 @@ export function createIpcConnector(): Connector {
 				ipcApi.getDefaultSiteDirectory(),
 				ipcApi.isStudioCliInstalled(),
 				ipcApi.isStudioCliExternallyManaged(),
+				ipcApi.getAgenticFeaturesEnabled(),
 			] ) ) as [
 				SupportedEditor | null,
 				SupportedTerminal | null,
@@ -649,6 +651,7 @@ export function createIpcConnector(): Connector {
 				QuitSitesBehavior | undefined,
 				string | undefined,
 				string,
+				boolean,
 				boolean,
 				boolean,
 			];
@@ -661,6 +664,7 @@ export function createIpcConnector(): Connector {
 				defaultSiteDirectory,
 				studioCliInstalled,
 				studioCliExternallyManaged,
+				agenticFeaturesEnabled,
 			};
 		},
 
@@ -688,6 +692,9 @@ export function createIpcConnector(): Connector {
 				writes.push(
 					partial.studioCliInstalled ? ipcApi.installStudioCli() : ipcApi.uninstallStudioCli()
 				);
+			}
+			if ( typeof partial.agenticFeaturesEnabled === 'boolean' ) {
+				writes.push( ipcApi.saveAgenticFeaturesEnabled( partial.agenticFeaturesEnabled ) );
 			}
 			await Promise.all( writes );
 		},

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -38,6 +38,7 @@ const COLOR_SCHEME_STORAGE_KEY = 'studio-local-color-scheme';
 const EDITOR_STORAGE_KEY = 'studio-local-editor';
 const TERMINAL_STORAGE_KEY = 'studio-local-terminal';
 const QUIT_SITES_BEHAVIOR_STORAGE_KEY = 'studio-local-quit-sites-behavior';
+const AGENTIC_FEATURES_STORAGE_KEY = 'studio-local-agentic-features-enabled';
 
 function parseQuitSitesBehavior( value: string | null ): QuitSitesBehavior | undefined {
 	return value === 'leave-running' || value === 'stop-and-auto-start' || value === 'stop'
@@ -637,6 +638,8 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 				defaultSiteDirectory: '',
 				studioCliInstalled: false,
 				studioCliExternallyManaged: false,
+				agenticFeaturesEnabled:
+					window.localStorage.getItem( AGENTIC_FEATURES_STORAGE_KEY ) !== 'false',
 			};
 		},
 		async setUserPreferences( partial ) {
@@ -663,6 +666,12 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 				} else {
 					window.localStorage.removeItem( QUIT_SITES_BEHAVIOR_STORAGE_KEY );
 				}
+			}
+			if ( typeof partial.agenticFeaturesEnabled === 'boolean' ) {
+				window.localStorage.setItem(
+					AGENTIC_FEATURES_STORAGE_KEY,
+					String( partial.agenticFeaturesEnabled )
+				);
 			}
 		},
 		// Detected on the machine the server runs on (the desktop's installed-app

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -450,6 +450,9 @@ export interface UserPreferences {
 	// app never installs over or uninstalls — the settings toggle disables
 	// itself in that case.
 	studioCliExternallyManaged: boolean;
+	// Whether chat/agent features are offered at all. Unrelated to which
+	// renderer is running — switching to the classic UI is `disableAgenticUi`.
+	agenticFeaturesEnabled: boolean;
 }
 
 export interface AppGlobals {

--- a/apps/ui/src/data/queries/use-agentic-features.test.ts
+++ b/apps/ui/src/data/queries/use-agentic-features.test.ts
@@ -9,15 +9,25 @@ describe( 'deriveAgenticFeatures', () => {
 		const connector = { agenticRequiresAuth: false };
 		expect( deriveAgenticFeatures( connector, undefined ) ).toEqual( {
 			enabled: true,
+			chatEnabled: true,
 			reason: null,
 		} );
-		expect( deriveAgenticFeatures( connector, null ) ).toEqual( { enabled: true, reason: null } );
-		expect( deriveAgenticFeatures( connector, user ) ).toEqual( { enabled: true, reason: null } );
+		expect( deriveAgenticFeatures( connector, null ) ).toEqual( {
+			enabled: true,
+			chatEnabled: true,
+			reason: null,
+		} );
+		expect( deriveAgenticFeatures( connector, user ) ).toEqual( {
+			enabled: true,
+			chatEnabled: true,
+			reason: null,
+		} );
 	} );
 
 	it( 'disables features without a signed-out reason while auth is still loading', () => {
 		expect( deriveAgenticFeatures( { agenticRequiresAuth: true }, undefined ) ).toEqual( {
 			enabled: false,
+			chatEnabled: false,
 			reason: null,
 		} );
 	} );
@@ -25,6 +35,7 @@ describe( 'deriveAgenticFeatures', () => {
 	it( 'disables features with a signed-out reason for signed-out users', () => {
 		expect( deriveAgenticFeatures( { agenticRequiresAuth: true }, null ) ).toEqual( {
 			enabled: false,
+			chatEnabled: false,
 			reason: 'signed-out',
 		} );
 	} );
@@ -32,6 +43,7 @@ describe( 'deriveAgenticFeatures', () => {
 	it( 'enables features for signed-in users', () => {
 		expect( deriveAgenticFeatures( { agenticRequiresAuth: true }, user ) ).toEqual( {
 			enabled: true,
+			chatEnabled: true,
 			reason: null,
 		} );
 	} );
@@ -39,15 +51,35 @@ describe( 'deriveAgenticFeatures', () => {
 	it( 'disables features with an offline reason regardless of auth state', () => {
 		expect( deriveAgenticFeatures( { agenticRequiresAuth: true }, user, true ) ).toEqual( {
 			enabled: false,
+			chatEnabled: false,
 			reason: 'offline',
 		} );
 		expect( deriveAgenticFeatures( { agenticRequiresAuth: false }, undefined, true ) ).toEqual( {
 			enabled: false,
+			chatEnabled: false,
 			reason: 'offline',
 		} );
 		expect( deriveAgenticFeatures( { agenticRequiresAuth: true }, null, true ) ).toEqual( {
 			enabled: false,
+			chatEnabled: false,
 			reason: 'offline',
+		} );
+	} );
+
+	// Turning agentic features off in Settings → AI only takes chat away.
+	// Previews, sync and publishing keep working, so `enabled` stays true.
+	it( 'disables only chat when the user switches agentic features off', () => {
+		expect( deriveAgenticFeatures( { agenticRequiresAuth: true }, user, false, false ) ).toEqual( {
+			enabled: true,
+			chatEnabled: false,
+			reason: null,
+		} );
+		expect(
+			deriveAgenticFeatures( { agenticRequiresAuth: false }, undefined, false, false )
+		).toEqual( {
+			enabled: true,
+			chatEnabled: false,
+			reason: null,
 		} );
 	} );
 } );

--- a/apps/ui/src/data/queries/use-agentic-features.ts
+++ b/apps/ui/src/data/queries/use-agentic-features.ts
@@ -1,5 +1,9 @@
 import { useConnector } from '@/data/core';
 import { useAuthUser, AUTH_USER_QUERY_KEY } from '@/data/queries/use-auth-user';
+import {
+	useUserPreferences,
+	USER_PREFERENCES_QUERY_KEY,
+} from '@/data/queries/use-user-preferences';
 import { useOffline } from '@/hooks/use-offline';
 import type { AuthUser, Connector } from '@/data/core';
 import type { QueryClient } from '@tanstack/react-query';
@@ -7,54 +11,86 @@ import type { QueryClient } from '@tanstack/react-query';
 export type AgenticFeatureReason = 'signed-out' | 'offline' | null;
 
 export interface AgenticFeatures {
+	// Whether the host can reach the agentic backend at all (online + signed
+	// in). Gates everything that needs it, chat included, plus previews,
+	// sync and publishing.
 	enabled: boolean;
+	// Whether chat is on offer: `enabled`, and the user hasn't switched
+	// agentic features off in Settings → AI. Non-chat networked features stay
+	// available when they do, so gate those on `enabled` instead.
+	chatEnabled: boolean;
 	reason: AgenticFeatureReason;
 }
 
 export function deriveAgenticFeatures(
 	connector: Pick< Connector, 'agenticRequiresAuth' >,
 	user: AuthUser | null | undefined,
-	isOffline = false
+	isOffline = false,
+	agenticFeaturesEnabled = true
 ): AgenticFeatures {
+	const withChat = ( features: Omit< AgenticFeatures, 'chatEnabled' > ): AgenticFeatures => ( {
+		...features,
+		chatEnabled: features.enabled && agenticFeaturesEnabled,
+	} );
 	// Agentic features need the network regardless of the connector's auth
 	// requirements, so offline wins over any auth state.
 	if ( isOffline ) {
-		return { enabled: false, reason: 'offline' };
+		return withChat( { enabled: false, reason: 'offline' } );
 	}
 	if ( ! connector.agenticRequiresAuth ) {
-		return { enabled: true, reason: null };
+		return withChat( { enabled: true, reason: null } );
 	}
 	// `undefined` means the auth query hasn't resolved yet — keep features
 	// disabled but without a reason, so signed-out UI (e.g. the sign-in
 	// banner) doesn't flash for signed-in users while auth loads.
 	if ( user === undefined ) {
-		return { enabled: false, reason: null };
+		return withChat( { enabled: false, reason: null } );
 	}
 	if ( ! user ) {
-		return { enabled: false, reason: 'signed-out' };
+		return withChat( { enabled: false, reason: 'signed-out' } );
 	}
-	return { enabled: true, reason: null };
+	return withChat( { enabled: true, reason: null } );
 }
 
 export function useAgenticFeatures(): AgenticFeatures & { isReady: boolean } {
 	const connector = useConnector();
 	const isOffline = useOffline();
 	const { data: user, isLoading } = useAuthUser();
-	const features = deriveAgenticFeatures( connector, user, isOffline );
-	return { ...features, isReady: ! isLoading };
+	const { data: preferences, isLoading: preferencesLoading } = useUserPreferences();
+	const features = deriveAgenticFeatures(
+		connector,
+		user,
+		isOffline,
+		preferences?.agenticFeaturesEnabled ?? true
+	);
+	return { ...features, isReady: ! isLoading && ! preferencesLoading };
 }
 
 export async function resolveAgenticFeatures( context: {
 	queryClient: QueryClient;
 	connector: Connector;
 } ): Promise< AgenticFeatures > {
+	const preferences = await context.queryClient.fetchQuery( {
+		queryKey: USER_PREFERENCES_QUERY_KEY,
+		queryFn: () => context.connector.getUserPreferences(),
+	} );
 	// Skip the auth fetch offline — it could hang without a network.
 	if ( ! navigator.onLine ) {
-		return deriveAgenticFeatures( context.connector, undefined, true );
+		return deriveAgenticFeatures(
+			context.connector,
+			undefined,
+			true,
+			preferences.agenticFeaturesEnabled
+		);
 	}
 	const user = await context.queryClient.fetchQuery( {
 		queryKey: AUTH_USER_QUERY_KEY,
 		queryFn: () => context.connector.getAuthUser(),
 	} );
-	return deriveAgenticFeatures( context.connector, user );
+	return deriveAgenticFeatures(
+		context.connector,
+		user,
+		false,
+		preferences.agenticFeaturesEnabled
+	);
 }

--- a/apps/ui/src/data/queries/use-user-preferences.test.tsx
+++ b/apps/ui/src/data/queries/use-user-preferences.test.tsx
@@ -24,6 +24,7 @@ const PREFERENCES: UserPreferences = {
 	locale: 'en',
 	defaultSiteDirectory: '',
 	studioCliInstalled: true,
+	agenticFeaturesEnabled: true,
 	studioCliExternallyManaged: false,
 };
 

--- a/apps/ui/src/ui-classic/router/route-index/index.test.ts
+++ b/apps/ui/src/ui-classic/router/route-index/index.test.ts
@@ -30,7 +30,11 @@ function createSession( overrides: Partial< AiSessionSummary > = {} ): AiSession
 	};
 }
 
-async function runBeforeLoad( sites: SiteDetails[], sessions: AiSessionSummary[] ) {
+async function runBeforeLoad(
+	sites: SiteDetails[],
+	sessions: AiSessionSummary[],
+	agenticFeaturesEnabled = true
+) {
 	const context = {
 		queryClient: {
 			fetchQuery: ( { queryFn }: { queryFn: () => unknown } ) => queryFn(),
@@ -40,6 +44,7 @@ async function runBeforeLoad( sites: SiteDetails[], sessions: AiSessionSummary[]
 			getSessions: async () => sessions,
 			getAuthUser: async () => null,
 			getOnboardingCompleted: async () => true,
+			getUserPreferences: async () => ( { agenticFeaturesEnabled } ),
 		},
 	};
 	try {
@@ -97,6 +102,17 @@ describe( 'indexRoute.beforeLoad', () => {
 		);
 		expect( redirect.to ).toBe( '/sessions/$sessionId' );
 		expect( redirect.params ).toEqual( { sessionId: 'session-2' } );
+	} );
+
+	it( "opens the target site's overview when agentic features are switched off", async () => {
+		writeLastVisited( { siteId: 'site-2' } );
+		const redirect = await runBeforeLoad(
+			[ createSite(), createSite( { id: 'site-2', path: '/Users/example/Studio/site-two' } ) ],
+			[ createSession(), createSession( { id: 'session-2', ownerSiteId: 'site-2' } ) ],
+			false
+		);
+		expect( redirect.to ).toBe( '/sites/$siteId/overview' );
+		expect( redirect.params ).toEqual( { siteId: 'site-2' } );
 	} );
 
 	it( 'redirects to a new session when the target site has no active sessions', async () => {

--- a/apps/ui/src/ui-classic/router/route-index/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-index/index.tsx
@@ -21,19 +21,6 @@ export const indexRoute = createRoute( {
 			throw redirect( { to: onboardingCompleted ? '/onboarding' : '/welcome' } );
 		}
 
-		const { enabled: agenticEnabled } = await resolveAgenticFeatures( context );
-		if ( ! agenticEnabled ) {
-			throw redirect( {
-				to: '/sites/$siteId/settings',
-				params: { siteId: firstSite.id },
-			} );
-		}
-
-		const sessions = await context.queryClient.fetchQuery( {
-			queryKey: SESSIONS_QUERY_KEY,
-			queryFn: () => context.connector.getSessions(),
-		} );
-
 		// Return the user to their last visited site (recorded by the dashboard
 		// layout), validating against live data so a stale id from a deleted
 		// site falls through to the sidebar's top site — not the raw fetch
@@ -42,6 +29,21 @@ export const indexRoute = createRoute( {
 		const targetSite =
 			( lastVisited.siteId && sites.find( ( site ) => site.id === lastVisited.siteId ) ) ||
 			sortSites( [ ...sites ] )[ 0 ];
+
+		// Without chat there is nothing to open a session for; the site
+		// overview is the site's home instead (matching the sidebar).
+		const { chatEnabled } = await resolveAgenticFeatures( context );
+		if ( ! chatEnabled ) {
+			throw redirect( {
+				to: '/sites/$siteId/overview',
+				params: { siteId: targetSite.id },
+			} );
+		}
+
+		const sessions = await context.queryClient.fetchQuery( {
+			queryKey: SESSIONS_QUERY_KEY,
+			queryFn: () => context.connector.getSessions(),
+		} );
 
 		// Sessions arrive sorted newest-first, so the first session owned by
 		// the site is its most recently updated active one.

--- a/apps/ui/src/ui-classic/router/route-new-session/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-new-session/index.tsx
@@ -17,10 +17,10 @@ export const newSessionRoute = createRoute( {
 	getParentRoute: () => dashboardLayoutRoute,
 	path: '/sites/$siteId/new',
 	beforeLoad: async ( { params, context } ) => {
-		const { enabled } = await resolveAgenticFeatures( context );
-		if ( ! enabled ) {
+		const { chatEnabled } = await resolveAgenticFeatures( context );
+		if ( ! chatEnabled ) {
 			throw redirect( {
-				to: '/sites/$siteId/settings',
+				to: '/sites/$siteId/overview',
 				params: { siteId: params.siteId },
 			} );
 		}

--- a/apps/ui/src/ui-classic/router/route-session-detail/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-session-detail/index.tsx
@@ -7,13 +7,13 @@ import { dashboardLayoutRoute } from '../layout-dashboard';
 function SessionDetail() {
 	const { sessionId } = sessionDetailRoute.useParams();
 	const navigate = useNavigate();
-	const { isReady, enabled } = useAgenticFeatures();
+	const { isReady, chatEnabled } = useAgenticFeatures();
 
 	useEffect( () => {
-		if ( isReady && ! enabled ) {
+		if ( isReady && ! chatEnabled ) {
 			void navigate( { to: '/' } );
 		}
-	}, [ isReady, enabled, navigate ] );
+	}, [ isReady, chatEnabled, navigate ] );
 
 	return <SessionView sessionId={ sessionId } />;
 }
@@ -23,8 +23,8 @@ export const sessionDetailRoute = createRoute( {
 	path: '/sessions/$sessionId',
 	component: SessionDetail,
 	beforeLoad: async ( { context } ) => {
-		const { enabled } = await resolveAgenticFeatures( context );
-		if ( ! enabled ) {
+		const { chatEnabled } = await resolveAgenticFeatures( context );
+		if ( ! chatEnabled ) {
 			throw redirect( { to: '/' } );
 		}
 	},


### PR DESCRIPTION
## Related issues

- Fixes [STU-2097](https://linear.app/a8c/issue/STU-2097/agentic-features-toggle-switches-between-new-and-classic-ui)

## How AI was used in this PR

Implemented with Claude Code, reviewed and verified manually.

## Proposed Changes

The **Agentic features** toggle in Settings → AI now disable AI feature from the Agentic UI
Reintroduces the "switch to classic UI" toggle in Settings.

| Settings | AI Settings |
|--------|--------|
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/9b2e223c-99dd-4ec2-a534-01c76278644c" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/070d7ce2-465e-4f13-83e3-899837eaf4fd" /> | 

## Testing Instructions

1. Enable the new Studio Agentic UI and open **Settings**.
2. In the **Settings** tab, confirm a **Studio experience** section with a **Switch to classic** button. Click it — the window reloads into the classic UI. Switch back to the new UI,.
3. Open the **AI** tab and switch **Agentic features** off. You should stay in the new UI (no reload into classic).
4. Click a site in the sidebar: it opens the **Overview** screen, not a chat. Restart the app — it opens on the overview and the toggle is still off.
5. Open the site dropdown and confirm previews, sync and publishing are still available.
6. Switch **Agentic features** back on and confirm chat returns.
7. Sign out (or go offline) with the toggle on and confirm the existing sign-in / offline behaviour is unchanged.
8. Check both light and dark mode.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
