### PR TITLE
Fail pull with a visible error when a backup is already in progress on the remote site

### DIFF
--- a/apps/studio/src/stores/sync/sync-operations-slice.ts
+++ b/apps/studio/src/stores/sync/sync-operations-slice.ts
@@ -666,6 +666,20 @@ export const pullSiteThunk = createTypedAsyncThunk< PullSiteResult, PullSitePayl
 			} );
 			const response = pullSiteResponseSchema.parse( rawResponse );
 
+			// The backup service dedupes requests: `success: true` with `backup_id: 0`
+			// means a backup is already queued or running for the remote site (STU-2098).
+			if ( response.success && ! response.backup_id ) {
+				console.error(
+					`Pull rejected: a backup is already in progress for remote site ${ remoteSiteId }`
+				);
+				return rejectWithValue( {
+					title: sprintf( __( 'Error pulling from %s' ), connectedSite.name ),
+					message: __(
+						'A backup is already in progress for this site. Please wait a few minutes and try again.'
+					),
+				} );
+			}
+
 			if ( response.success ) {
 				// Creating the remote backup can take a while. If the user logged out (slice
 				// reset) or cancelled the pull while this request was in flight, don't resurrect
@@ -871,7 +885,10 @@ const pollPullBackupThunk = createTypedAsyncThunk(
 		const backupId = currentPullState.backupId;
 		if ( ! backupId ) {
 			console.error( 'No backup ID found' );
-			return;
+			return rejectWithValue( {
+				title: sprintf( __( 'Error pulling from %s' ), currentPullState.selectedSite.name ),
+				message: __( 'An error occurred while checking the backup status. Please try again.' ),
+			} );
 		}
 
 		try {

--- a/apps/studio/src/stores/sync/sync-operations-slice.ts
+++ b/apps/studio/src/stores/sync/sync-operations-slice.ts
@@ -490,6 +490,25 @@ const cancelPullThunk = createTypedAsyncThunk(
 	}
 );
 
+const BACKUP_ALREADY_IN_PROGRESS_CODE = 'backup_already_in_progress';
+
+function isBackupAlreadyInProgressError( error: unknown ): boolean {
+	if ( typeof error !== 'object' || error === null ) {
+		return false;
+	}
+	const { error: errorCode, code } = error as { error?: unknown; code?: unknown };
+	return errorCode === BACKUP_ALREADY_IN_PROGRESS_CODE || code === BACKUP_ALREADY_IN_PROGRESS_CODE;
+}
+
+function getBackupAlreadyInProgressRejection( siteName: string ) {
+	return {
+		title: sprintf( __( 'Error pulling from %s' ), siteName ),
+		message: __(
+			'A backup is already in progress for this site. Please wait a few minutes and try again.'
+		),
+	};
+}
+
 const getErrorFromResponse = ( error: unknown ): string => {
 	if (
 		typeof error === 'object' &&
@@ -666,18 +685,13 @@ export const pullSiteThunk = createTypedAsyncThunk< PullSiteResult, PullSitePayl
 			} );
 			const response = pullSiteResponseSchema.parse( rawResponse );
 
-			// The backup service dedupes requests: `success: true` with `backup_id: 0`
-			// means a backup is already queued or running for the remote site (STU-2098).
+			// Servers predating the `backup_already_in_progress` 409 report a deduped
+			// request as `success: true` with `backup_id: 0` (STU-2098).
 			if ( response.success && ! response.backup_id ) {
 				console.error(
 					`Pull rejected: a backup is already in progress for remote site ${ remoteSiteId }`
 				);
-				return rejectWithValue( {
-					title: sprintf( __( 'Error pulling from %s' ), connectedSite.name ),
-					message: __(
-						'A backup is already in progress for this site. Please wait a few minutes and try again.'
-					),
-				} );
+				return rejectWithValue( getBackupAlreadyInProgressRejection( connectedSite.name ) );
 			}
 
 			if ( response.success ) {
@@ -712,6 +726,12 @@ export const pullSiteThunk = createTypedAsyncThunk< PullSiteResult, PullSitePayl
 				throw new Error( 'Pull request failed' );
 			}
 		} catch ( error ) {
+			if ( isBackupAlreadyInProgressError( error ) ) {
+				console.error(
+					`Pull rejected: a backup is already in progress for remote site ${ remoteSiteId }`
+				);
+				return rejectWithValue( getBackupAlreadyInProgressRejection( connectedSite.name ) );
+			}
 			Sentry.captureException( error );
 			return rejectWithValue( {
 				title: sprintf( __( 'Error pulling from %s' ), connectedSite.name ),

--- a/apps/studio/src/stores/tests/sync-operations-slice.test.ts
+++ b/apps/studio/src/stores/tests/sync-operations-slice.test.ts
@@ -1,0 +1,142 @@
+import { vi } from 'vitest';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { store } from 'src/stores';
+import {
+	syncOperationsActions,
+	syncOperationsSelectors,
+	syncOperationsThunks,
+	getPullStatesProgressInfo,
+} from 'src/stores/sync/sync-operations-slice';
+import { testActions, testReducer } from 'src/stores/tests/utils/test-reducer';
+import type { SyncSite } from '@studio/common/types/sync';
+import type { WPCOM } from 'wpcom/types';
+
+vi.mock( 'src/lib/get-ipc-api', () => ( {
+	getIpcApi: vi.fn().mockReturnValue( {
+		showErrorMessageBox: vi.fn(),
+		showNotification: vi.fn(),
+		fetchSnapshots: vi.fn().mockResolvedValue( [] ),
+		getConnectedWpcomSites: vi.fn().mockResolvedValue( [] ),
+		updateConnectedWpcomSites: vi.fn(),
+		cancelSyncOperation: vi.fn(),
+	} ),
+} ) );
+
+const mockShowErrorMessageBox = vi.mocked( getIpcApi )().showErrorMessageBox as ReturnType<
+	typeof vi.fn
+>;
+
+const selectedSite = { id: 'local-site-1', name: 'My Local Site' } as SiteDetails;
+const connectedSite = {
+	id: 256266481,
+	localSiteId: 'local-site-1',
+	name: 'My Remote Site',
+	url: 'https://example.com',
+} as SyncSite;
+
+function createMockClient( postResponse?: unknown ) {
+	return {
+		req: {
+			post: vi.fn().mockResolvedValue( postResponse ),
+			get: vi.fn(),
+		},
+	} as unknown as WPCOM;
+}
+
+store.replaceReducer( testReducer );
+
+describe( 'syncOperations pull thunks', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		store.dispatch( testActions.resetState() );
+	} );
+
+	describe( 'pullSite', () => {
+		it( 'stores the backup ID and fulfills when the server returns one', async () => {
+			const client = createMockClient( { success: true, backup_id: 12345 } );
+
+			const result = await store.dispatch(
+				syncOperationsThunks.pullSite( {
+					client,
+					connectedSite,
+					selectedSite,
+					options: { optionsToSync: [ 'all' ] },
+				} )
+			);
+
+			expect( result.type ).toBe( 'syncOperations/pullSite/fulfilled' );
+			const pullState = syncOperationsSelectors.selectPullState(
+				selectedSite.id,
+				connectedSite.id
+			)( store.getState() );
+			expect( pullState?.backupId ).toBe( 12345 );
+		} );
+
+		it( 'rejects with a "backup already in progress" error when the server dedupes the request with backup_id 0', async () => {
+			const client = createMockClient( { success: true, backup_id: 0 } );
+
+			const result = await store.dispatch(
+				syncOperationsThunks.pullSite( {
+					client,
+					connectedSite,
+					selectedSite,
+					options: { optionsToSync: [ 'all' ] },
+				} )
+			);
+
+			expect( result.type ).toBe( 'syncOperations/pullSite/rejected' );
+			expect( ( result.payload as { message: string } ).message ).toMatch(
+				/backup is already in progress/i
+			);
+
+			const pullState = syncOperationsSelectors.selectPullState(
+				selectedSite.id,
+				connectedSite.id
+			)( store.getState() );
+			expect( pullState?.status.key ).toBe( 'failed' );
+			expect( mockShowErrorMessageBox ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					message: expect.stringMatching( /backup is already in progress/i ),
+				} )
+			);
+		} );
+	} );
+
+	describe( 'pollPullBackup', () => {
+		it( 'rejects and marks the pull as failed when the state has no backup ID', async () => {
+			const client = createMockClient();
+			store.dispatch(
+				syncOperationsActions.updatePullState( {
+					selectedSiteId: selectedSite.id,
+					remoteSiteId: connectedSite.id,
+					state: {
+						backupId: null,
+						status: getPullStatesProgressInfo()[ 'in-progress' ],
+						downloadUrl: null,
+						remoteSiteUrl: connectedSite.url,
+						selectedSite,
+					},
+				} )
+			);
+
+			const result = await store.dispatch(
+				syncOperationsThunks.pollPullBackup( {
+					client,
+					selectedSiteId: selectedSite.id,
+					remoteSiteId: connectedSite.id,
+					signal: new AbortController().signal,
+				} )
+			);
+
+			expect( result.type ).toBe( 'syncOperations/pollPullBackup/rejected' );
+			expect( client.req.get ).not.toHaveBeenCalled();
+
+			const pullState = syncOperationsSelectors.selectPullState(
+				selectedSite.id,
+				connectedSite.id
+			)( store.getState() );
+			expect( pullState?.status.key ).toBe( 'failed' );
+			expect( mockShowErrorMessageBox ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/apps/studio/src/stores/tests/sync-operations-slice.test.ts
+++ b/apps/studio/src/stores/tests/sync-operations-slice.test.ts
@@ -72,6 +72,40 @@ describe( 'syncOperations pull thunks', () => {
 			expect( pullState?.backupId ).toBe( 12345 );
 		} );
 
+		it( 'rejects with a "backup already in progress" error when the server responds 409 backup_already_in_progress', async () => {
+			const client = createMockClient();
+			( client.req.post as ReturnType< typeof vi.fn > ).mockRejectedValue( {
+				error: 'backup_already_in_progress',
+				message: 'A backup is already in progress for this site.',
+				statusCode: 409,
+			} );
+
+			const result = await store.dispatch(
+				syncOperationsThunks.pullSite( {
+					client,
+					connectedSite,
+					selectedSite,
+					options: { optionsToSync: [ 'all' ] },
+				} )
+			);
+
+			expect( result.type ).toBe( 'syncOperations/pullSite/rejected' );
+			expect( ( result.payload as { message: string } ).message ).toMatch(
+				/backup is already in progress/i
+			);
+
+			const pullState = syncOperationsSelectors.selectPullState(
+				selectedSite.id,
+				connectedSite.id
+			)( store.getState() );
+			expect( pullState?.status.key ).toBe( 'failed' );
+			expect( mockShowErrorMessageBox ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					message: expect.stringMatching( /backup is already in progress/i ),
+				} )
+			);
+		} );
+
 		it( 'rejects with a "backup already in progress" error when the server dedupes the request with backup_id 0', async () => {
 			const client = createMockClient( { success: true, backup_id: 0 } );
 


### PR DESCRIPTION
## Related issues

- Related to STU-2098 (the server-side half — rejecting deduped backup requests with a 409 — ships separately)

## How AI was used in this PR

The investigation and implementation were done with Claude Code: it traced a customer's `No backup ID found` log line through the pull flow to the backup dedupe response, cross-checked the diagnosis against the site's backup history and the server-side findings, and wrote the fix plus tests. The code was reviewed by the PR author.

## Proposed Changes

When a pull is requested while the remote site already has a backup queued or running, the backup service dedupes the request. Studio treated that as a successful start, then silently stopped polling — the pull sat at "in progress" forever with no error, and the only trace was a `No backup ID found` log line. Users hit this by restarting Studio mid-pull (losing the in-memory backup ID) and retrying while the original backup was still running server-side.

With this change the pull fails fast instead of hanging: the user gets a dialog explaining that **a backup is already in progress for the site** and to retry in a few minutes, and the pull enters the normal failed state so it can be retried. Both server response shapes are handled — the current `200` with `backup_id: 0` and the upcoming `409` with `code: backup_already_in_progress` — so behavior is identical across the server rollout. The 409 is an expected transient condition and is not reported to Sentry.

As a defensive measure, the backup-status poller now also surfaces an error and marks the pull failed if it ever finds no backup ID, instead of silently abandoning the operation.

## Testing Instructions

- `npm test -- apps/studio/src/stores/tests/sync-operations-slice.test.ts` — covers the valid-ID happy path, both "backup already in progress" response shapes, and the poller guard.
- Manual reproduction (against current production servers): connect a site and start a pull, quit Studio while "Initializing remote backup…" is shown, reopen it, and immediately pull the same site again.
  - Before: the second pull hangs at "in progress" indefinitely; the log shows `No backup ID found`.
  - After: an error dialog reports that a backup is already in progress and suggests retrying in a few minutes; the pull shows the failed state and can be retried. Retrying after the remote backup finishes (a few minutes; visible in the site's backup activity) succeeds.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
