### PR TITLE
Add a scroll-to-latest affordance in chat

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSession } from '@/data/queries/use-sessions';
-import { SessionView } from './index';
+import { isScrolledAwayFromLatest, SessionView } from './index';
+import type { LoadedAiSession } from '@/data/core';
 
 const { navigateMock } = vi.hoisted( () => ( { navigateMock: vi.fn() } ) );
 
@@ -44,7 +45,36 @@ vi.mock( '@/hooks/use-session-ui', () => ( {
 	useSessionPreviewAnnotations: vi.fn(),
 } ) );
 
+vi.mock( '@/hooks/use-traffic-light-space', () => ( { useTrafficLightSpace: () => false } ) );
+
+vi.mock( './composer', () => ( {
+	Composer: () => <div />,
+	ComposerSkeleton: () => <div />,
+} ) );
+
+vi.mock( './conversation', () => ( {
+	Conversation: () => <div />,
+} ) );
+
 const useSessionMock = vi.mocked( useSession, { partial: true } );
+
+const SCROLL_TO_LATEST_LABEL = 'Scroll to latest message';
+
+function makeLoadedSession(): LoadedAiSession {
+	return {
+		summary: { id: 'session-1' },
+		entries: [],
+	} as unknown as LoadedAiSession;
+}
+
+function setScrollMetrics(
+	node: HTMLElement,
+	metrics: { scrollTop: number; scrollHeight: number; clientHeight: number }
+) {
+	for ( const [ key, value ] of Object.entries( metrics ) ) {
+		Object.defineProperty( node, key, { value, writable: true, configurable: true } );
+	}
+}
 
 describe( 'SessionView', () => {
 	beforeEach( () => {
@@ -70,5 +100,64 @@ describe( 'SessionView', () => {
 		render( <SessionView sessionId="loading-session" /> );
 
 		expect( navigateMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows the scroll-to-latest button only while scrolled away and scrolls down on click', async () => {
+		useSessionMock.mockReturnValue( {
+			data: makeLoadedSession(),
+			isLoading: false,
+			error: null,
+		} );
+
+		const { container } = render( <SessionView sessionId="session-1" /> );
+
+		const scroller = container.querySelector( '[class*="classicScroll"]' ) as HTMLDivElement;
+		expect( scroller ).not.toBeNull();
+		expect(
+			screen.queryByRole( 'button', { name: SCROLL_TO_LATEST_LABEL } )
+		).not.toBeInTheDocument();
+
+		setScrollMetrics( scroller, { scrollTop: 100, scrollHeight: 1000, clientHeight: 400 } );
+		fireEvent.scroll( scroller );
+
+		const button = await screen.findByRole( 'button', { name: SCROLL_TO_LATEST_LABEL } );
+
+		scroller.scrollTo = vi.fn();
+		fireEvent.click( button );
+		expect( scroller.scrollTo ).toHaveBeenCalledWith( { top: 1000, behavior: 'smooth' } );
+
+		setScrollMetrics( scroller, { scrollTop: 600, scrollHeight: 1000, clientHeight: 400 } );
+		fireEvent.scroll( scroller );
+		await waitFor( () =>
+			expect(
+				screen.queryByRole( 'button', { name: SCROLL_TO_LATEST_LABEL } )
+			).not.toBeInTheDocument()
+		);
+	} );
+} );
+
+describe( 'isScrolledAwayFromLatest', () => {
+	it( 'is false at the very bottom', () => {
+		expect(
+			isScrolledAwayFromLatest( { scrollTop: 600, scrollHeight: 1000, clientHeight: 400 } )
+		).toBe( false );
+	} );
+
+	it( 'is false within the near-bottom threshold', () => {
+		expect(
+			isScrolledAwayFromLatest( { scrollTop: 560, scrollHeight: 1000, clientHeight: 400 } )
+		).toBe( false );
+	} );
+
+	it( 'is true when scrolled beyond the threshold', () => {
+		expect(
+			isScrolledAwayFromLatest( { scrollTop: 500, scrollHeight: 1000, clientHeight: 400 } )
+		).toBe( true );
+	} );
+
+	it( 'is false when the content fits without scrolling', () => {
+		expect(
+			isScrolledAwayFromLatest( { scrollTop: 0, scrollHeight: 400, clientHeight: 400 } )
+		).toBe( false );
 	} );
 } );

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -2,6 +2,8 @@ import { resolveSessionModel } from '@studio/common/ai/models';
 import { findAiSessionOwnerSite } from '@studio/common/ai/sessions/owner-site';
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
+import { arrowDown } from '@wordpress/icons';
+import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import {
 	useCallback,
@@ -9,6 +11,7 @@ import {
 	useLayoutEffect,
 	useMemo,
 	useRef,
+	useState,
 	type ReactNode,
 	type Ref,
 } from 'react';
@@ -38,6 +41,20 @@ import { getSiteSessionHistory, SessionChatActions } from './session-chat-action
 import styles from './style.module.css';
 import { SuggestedPrompts } from './suggested-prompts';
 import type { AiSessionSummary } from '@/data/core';
+
+// Slack below the bottom edge that still counts as "at the latest message",
+// so sub-pixel rounding or a barely-started scroll doesn't flash the button.
+const SCROLL_AWAY_FROM_LATEST_THRESHOLD_PX = 48;
+
+export function isScrolledAwayFromLatest( node: {
+	scrollTop: number;
+	scrollHeight: number;
+	clientHeight: number;
+} ): boolean {
+	return (
+		node.scrollHeight - node.scrollTop - node.clientHeight > SCROLL_AWAY_FROM_LATEST_THRESHOLD_PX
+	);
+}
 
 interface SessionHeaderProps {
 	summary: AiSessionSummary;
@@ -225,6 +242,43 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 	);
 	const scrollRef = useRef< HTMLDivElement >( null );
 	const composerRef = useRef< ComposerHandle >( null );
+	const [ isScrolledAway, setIsScrolledAway ] = useState( false );
+	const hasSession = !! data;
+
+	const updateIsScrolledAway = useCallback( () => {
+		const node = scrollRef.current;
+		if ( node ) {
+			setIsScrolledAway( isScrolledAwayFromLatest( node ) );
+		}
+	}, [] );
+
+	useEffect( () => {
+		const node = scrollRef.current;
+		if ( ! hasSession || ! node ) {
+			return;
+		}
+		updateIsScrolledAway();
+		node.addEventListener( 'scroll', updateIsScrolledAway, { passive: true } );
+		return () => node.removeEventListener( 'scroll', updateIsScrolledAway );
+	}, [ hasSession, updateIsScrolledAway ] );
+
+	// Content can grow without emitting scroll events (e.g. while the
+	// auto-scroll below is suspended by pending questions), so re-check
+	// whenever the transcript changes.
+	useEffect( () => {
+		updateIsScrolledAway();
+	}, [ data, pendingQuestions.length, queuedPrompts.length, updateIsScrolledAway ] );
+
+	const scrollToLatest = useCallback( () => {
+		const node = scrollRef.current;
+		if ( ! node ) {
+			return;
+		}
+		const prefersReducedMotion =
+			typeof window.matchMedia === 'function' &&
+			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+		node.scrollTo( { top: node.scrollHeight, behavior: prefersReducedMotion ? 'auto' : 'smooth' } );
+	}, [] );
 	useSessionCommands( sessionId );
 	const canTogglePreview = !! ownerSite && effectiveEnvironment === 'local';
 	const siteSessionHistory = data
@@ -338,6 +392,19 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 			header={ <SessionHeader summary={ data.summary } /> }
 			composer={
 				<div className={ clsx( styles.classicColumn, styles.classicComposerColumn ) }>
+					{ isScrolledAway ? (
+						<div className={ styles.scrollToLatestWrap }>
+							<IconButton
+								className={ styles.scrollToLatestButton }
+								icon={ arrowDown }
+								label={ __( 'Scroll to latest message' ) }
+								size="small"
+								variant="minimal"
+								tone="neutral"
+								onClick={ scrollToLatest }
+							/>
+						</div>
+					) : null }
 					<QueuedPrompts
 						prompts={ queuedPrompts }
 						onRemove={ removeQueuedPrompt }

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -274,9 +274,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 		if ( ! node ) {
 			return;
 		}
-		const prefersReducedMotion =
-			typeof window.matchMedia === 'function' &&
-			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+		const prefersReducedMotion = window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches;
 		node.scrollTo( { top: node.scrollHeight, behavior: prefersReducedMotion ? 'auto' : 'smooth' } );
 	}, [] );
 	useSessionCommands( sessionId );

--- a/apps/ui/src/ui-classic/components/session-view/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/style.module.css
@@ -195,6 +195,51 @@
 	right: var(--classic-panel-control-left);
 }
 
+/* Anchors the scroll-to-latest button to the absolutely-positioned
+   .composerOuter, floating it above the composer without contributing to the
+   measured composer height. */
+.scrollToLatestWrap {
+	position: absolute;
+	bottom: calc(100% + var(--wpds-dimension-padding-md));
+	left: 0;
+	right: 0;
+	display: flex;
+	justify-content: center;
+	pointer-events: none;
+	-webkit-app-region: no-drag;
+}
+
+.scrollToLatestButton {
+	--wp-ui-button-aspect-ratio: 1;
+	--wp-ui-button-min-width: unset;
+	--wp-ui-button-padding-inline: 0;
+	--wp-ui-button-background-color: var(--wpds-color-bg-surface-neutral-strong);
+	--wp-ui-button-border-color: var(--wpds-color-stroke-surface-neutral-weak);
+
+	pointer-events: auto;
+	border-radius: 50%;
+	box-shadow: var(--wpds-elevation-md);
+	animation: scroll-to-latest-appear 120ms ease-out;
+}
+
+@keyframes scroll-to-latest-appear {
+	from {
+		opacity: 0;
+		transform: translateY(4px);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.scrollToLatestButton {
+		animation: none;
+	}
+}
+
 .classicComposerFooter {
 	display: flex;
 	justify-content: flex-start;

--- a/apps/ui/src/ui-classic/components/session-view/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/style.module.css
@@ -151,6 +151,7 @@
 }
 
 .classicComposerColumn {
+	position: relative;
 	max-width: var(--classic-composer-column-max-width);
 }
 
@@ -195,21 +196,24 @@
 	right: var(--classic-panel-control-left);
 }
 
-/* Anchors the scroll-to-latest button to the absolutely-positioned
-   .composerOuter, floating it above the composer without contributing to the
-   measured composer height. */
+/* Anchors the scroll-to-latest button to the composer column, floating it
+   above the composer without contributing to the measured composer height. */
 .scrollToLatestWrap {
 	position: absolute;
 	bottom: calc(100% + var(--wpds-dimension-padding-md));
-	left: 0;
-	right: 0;
+	inset-inline-start: 0;
+	/* Inset by the composer shell's inline padding so the button lines up
+	   with the send button inside the shell. */
+	inset-inline-end: var(--classic-composer-shell-inline-padding);
 	display: flex;
-	justify-content: center;
+	justify-content: flex-end;
 	pointer-events: none;
 	-webkit-app-region: no-drag;
 }
 
 .scrollToLatestButton {
+	/* Match the 28px composer send button. */
+	--wp-ui-button-height: 28px;
 	--wp-ui-button-aspect-ratio: 1;
 	--wp-ui-button-min-width: unset;
 	--wp-ui-button-padding-inline: 0;

--- a/apps/ui/src/ui-classic/components/session-view/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/style.module.css
@@ -202,9 +202,11 @@
 	position: absolute;
 	bottom: calc(100% + var(--wpds-dimension-padding-md));
 	inset-inline-start: 0;
-	/* Inset by the composer shell's inline padding so the button lines up
-	   with the send button inside the shell. */
-	inset-inline-end: var(--classic-composer-shell-inline-padding);
+	/* Match the send button's inset: the composer toolbar's inline padding is
+	   the shell inline padding minus padding-xs (see composer .toolbar). */
+	inset-inline-end: calc(
+		var(--classic-composer-shell-inline-padding) - var(--wpds-dimension-padding-xs)
+	);
 	display: flex;
 	justify-content: flex-end;
 	pointer-events: none;


### PR DESCRIPTION
## Related issues

- Fixes STU-1953

## How AI was used in this PR

AI assisted with the implementation and the trunk rebase conflict resolution; all changes were reviewed and visually verified by hand.

## Proposed Changes

When reading older messages in a long Studio Code chat, there was no quick way back to the newest activity — you had to scroll manually, and it was easy to miss new messages arriving below.

- Adds a floating "scroll to latest" button that appears above the composer whenever the conversation is scrolled away from the bottom, and smooth-scrolls back to the newest message on click.

## Testing Instructions

1. Open a Agentic UI chat with enough messages to scroll (or send several messages).
2. Scroll up in the conversation, a round arrow-down button appears above the composer, aligned with the send button.
3. Click it — the view scrolls back to the latest message and the button disappears.
4. Verify in both light and dark mode.
5. Optional: switch the app to an RTL locale and confirm the button appears on the correct side.

| LTR | RTL |
|--------|--------|
| <img width="1560" height="965" alt="Screenshot 2026-07-24 at 13 00 28" src="https://github.com/user-attachments/assets/4fa074f9-8851-4ec7-8ba0-47129c008f6d" /> | <img width="1560" height="965" alt="Screenshot 2026-07-24 at 13 00 11" src="https://github.com/user-attachments/assets/f4b5d8d5-90e0-400f-8109-da33af0d93af" /> |



## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
