### PR TITLE
Agentic UI: Fix site menu alignment

### DIFF
--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -271,6 +271,7 @@
 
 .siteAction {
 	flex-shrink: 0;
+	outline-offset: -2px;
 }
 
 /* Collapsed, only the trailing status button shows; hover/focus/active

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -18,11 +18,14 @@ import {
 } from '@/data/queries/use-sites';
 import { useWordPressVersions, useWpVersion } from '@/data/queries/use-wordpress-versions';
 import { useOffline } from '@/hooks/use-offline';
+import styles from './style.module.css';
 import { SiteOverviewView } from './index';
 import type { SiteDetails } from '@/data/core';
 
 const navigateMock = vi.fn();
 const siteDropdownMock = vi.hoisted( () => vi.fn() );
+const useSidebarCollapsedMock = vi.hoisted( () => vi.fn() );
+const useTrafficLightSpaceMock = vi.hoisted( () => vi.fn() );
 
 const WP_VERSIONS = [
 	{ label: '6.8', value: 'latest', isBeta: false, isDevelopment: false },
@@ -90,7 +93,11 @@ vi.mock( '@/hooks/use-offline', () => ( {
 } ) );
 
 vi.mock( '@/hooks/use-sidebar-collapsed', () => ( {
-	useSidebarCollapsed: () => false,
+	useSidebarCollapsed: useSidebarCollapsedMock,
+} ) );
+
+vi.mock( '@/hooks/use-traffic-light-space', () => ( {
+	useTrafficLightSpace: useTrafficLightSpaceMock,
 } ) );
 
 const useConnectorMock = vi.mocked( useConnector, { partial: true } );
@@ -120,6 +127,8 @@ describe( 'SiteOverviewView', () => {
 
 	beforeEach( () => {
 		vi.clearAllMocks();
+		useSidebarCollapsedMock.mockReturnValue( false );
+		useTrafficLightSpaceMock.mockReturnValue( false );
 		vi.stubGlobal( 'ResizeObserver', ResizeObserverMock );
 		Object.defineProperty( window, 'matchMedia', {
 			writable: true,
@@ -193,6 +202,17 @@ describe( 'SiteOverviewView', () => {
 		expect( screen.getByText( 'Export DB' ) ).toBeVisible();
 		expect( screen.getByText( 'Delete' ) ).toBeVisible();
 		expect( screen.queryByDisplayValue( 'Demo Site' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'offsets the site menu below macOS traffic lights when the sidebar is collapsed', () => {
+		useSidebarCollapsedMock.mockReturnValue( true );
+		useTrafficLightSpaceMock.mockReturnValue( true );
+
+		renderView();
+
+		expect( screen.getByText( 'Demo Site' ).parentElement ).toHaveClass(
+			styles.headerSidebarCollapsed
+		);
 	} );
 
 	it( 'reports tab selection to the route', () => {

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -26,6 +26,7 @@ import { useIsSiteStarting, useIsSiteStopping, useSites } from '@/data/queries/u
 import { useOpenSiteUrl } from '@/hooks/use-open-site-url';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
 import { useSiteManagementActions } from '@/hooks/use-site-management-actions';
+import { useTrafficLightSpace } from '@/hooks/use-traffic-light-space';
 import styles from './style.module.css';
 import type { SiteSettingsTabId } from '@/components/site-settings-view';
 import type { SiteDetails } from '@/data/core';
@@ -49,11 +50,14 @@ interface OverviewButtonProps {
 
 function OverviewHeader( { site }: { site: SiteDetails } ) {
 	const sidebarCollapsed = useSidebarCollapsed();
+	const reserveTrafficLightSpace = useTrafficLightSpace();
 
 	return (
 		<div
 			className={
-				sidebarCollapsed ? `${ styles.header } ${ styles.headerSidebarCollapsed }` : styles.header
+				sidebarCollapsed && reserveTrafficLightSpace
+					? `${ styles.header } ${ styles.headerSidebarCollapsed }`
+					: styles.header
 			}
 		>
 			<SiteDropdown site={ site } showSiteIcon showStatus={ sidebarCollapsed } floating={ false } />

--- a/apps/ui/src/hooks/use-traffic-light-space.ts
+++ b/apps/ui/src/hooks/use-traffic-light-space.ts
@@ -1,3 +1,4 @@
+import { isRTL } from '@wordpress/i18n';
 import { useConnector } from '@/data/core';
 import { useFullscreen } from '@/hooks/use-fullscreen';
 
@@ -7,12 +8,15 @@ import { useFullscreen } from '@/hooks/use-fullscreen';
  *
  * True only when the host overlays them (the macOS desktop app — never the
  * browser) AND the window isn't fullscreen (macOS hides the traffic lights in
- * fullscreen). On Windows/Linux and in `studio ui` / hosted, this is always
- * false, so the sidebar header and the collapsed-sidebar toggle sit flush
- * against the left edge instead of leaving an empty gap.
+ * fullscreen) AND the UI is LTR. The traffic lights are anchored to the
+ * window's left edge (fixed `trafficLightPosition`), while an RTL locale
+ * flips the sidebar to the right — so in RTL nothing sits under the lights
+ * and no gap is needed. On Windows/Linux and in `studio ui` / hosted, this is
+ * always false, so the sidebar header and the collapsed-sidebar toggle sit
+ * flush against the edge instead of leaving an empty gap.
  */
 export function useTrafficLightSpace(): boolean {
 	const connector = useConnector();
 	const isFullscreen = useFullscreen();
-	return connector.reservesTrafficLightSpace && ! isFullscreen;
+	return connector.reservesTrafficLightSpace && ! isFullscreen && ! isRTL();
 }

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -54,12 +54,13 @@ function SessionHeader( { summary }: SessionHeaderProps ) {
 		return null;
 	}
 
-	const toggleSpacerClass =
-		sidebarCollapsed && reserveTrafficLightSpace ? styles.toggleSpacer : null;
-
 	return (
-		<div className={ styles.header }>
-			{ toggleSpacerClass ? <span className={ toggleSpacerClass } aria-hidden="true" /> : null }
+		<div
+			className={ clsx(
+				styles.header,
+				sidebarCollapsed && reserveTrafficLightSpace && styles.headerSidebarCollapsed
+			) }
+		>
 			{ site ? (
 				<SiteDropdown
 					site={ site }

--- a/apps/ui/src/ui-classic/components/session-view/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/style.module.css
@@ -41,22 +41,20 @@
 	display: flex;
 	align-items: center;
 	gap: var(--wpds-dimension-padding-sm);
-	padding-block: var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-sm);
-	padding-inline: var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-2xl);
+	padding-block: var(--wpds-dimension-padding-sm);
+	padding-inline: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-2xl);
 	min-height: 46px;
 	font-size: var(--wpds-typography-font-size-sm);
 	color: var(--wpds-color-fg-content-neutral);
 	-webkit-app-region: drag;
 }
 
-/* Clears the macOS traffic lights when the collapsed sidebar puts this
-   header at the window's left edge, matching the sidebar header's
-   reservation. */
-.toggleSpacer {
-	display: block;
-	flex-shrink: 0;
-	width: calc(94px - var(--wpds-dimension-padding-lg) - var(--wpds-dimension-padding-sm));
-	align-self: stretch;
+.headerSidebarCollapsed {
+	padding-top: calc(
+		var(--wpds-dimension-padding-xl) + var(--wpds-dimension-padding-2xl) +
+			var(--wpds-dimension-padding-lg)
+	);
+	padding-inline-start: var(--wpds-dimension-padding-xl);
 }
 
 .headerSite {


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-2083

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Codex helped inspect the layout paths, implement the changes, add regression coverage, and run validation. I reviewed the diff and verified the UI in light and dark modes.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

- Align the site menu consistently across chat and settings while keeping it clear of the macOS traffic lights when the sidebar is collapsed.
- Keep the Site overview keyboard focus ring fully visible instead of clipping it inside the action rail.

| Light | Dark |
|--------|--------|
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/652384e9-8a11-49c9-8f21-12de267bdf8a" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/ddda8e89-7fb4-4914-a2ee-85692c836345" /> |
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/75176ac5-7532-426d-96a4-0bef442b53f9" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/192cd42c-783a-4798-9559-1e729cf6ef36" /> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run Studio on macOS and compare the site menu position in the chat and settings panels.
2. Collapse the sidebar and confirm the site menu sits below the traffic lights.
3. Navigate to the Site overview icon with the keyboard and confirm its focus ring is not clipped.
4. Repeat the visual checks in light and dark modes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
