### PR TITLE
Correct Tracks registration vs. queryability in the analytics design doc

### DIFF
--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -131,14 +131,9 @@ none fits, and flag it for registration.
 | `app_version` | Product version | e.g. `1.15.0` |
 | `ui_version` | **Custom (Studio-only):** which desktop renderer | `v1` (legacy), `v2` (agentic). No standard slot — must be registered as a Studio-custom property. |
 
-**Common props are attached by the wrappers — don't pass them per event.** `platform`, `arch`,
-`app_version`, and `is_a11n` come from each wrapper's `commonProps()`. The CLI wrapper also resolves
-`channel` and `ui_version` centrally from `STUDIO_TRACKS_ORIGIN` (`studio-cli`, or `studio-ui` + `ui_version`
-when app-spawned). The convention for `channel`/`ui_version` on the desktop side — desktop wrapper attaches
-`channel: studio-ui`, each renderer attaches its own `ui_version` (`v1` for `apps/studio`, `v2` for
-`apps/ui`) — is being centralized in STU-2122; until that lands, `studio_app_launch` still sets them at the
-call site. New event code should rely on the wrapper/renderer to attach them and pass only
-**event-specific** props.
+Common props (`platform`, `arch`, `app_version`, `is_a11n`, and `channel`/`ui_version`) are attached by the
+wrappers/renderers — pass only event-specific props. (Centralizing `channel`/`ui_version` on the desktop
+side is STU-2122; until it lands, `studio_app_launch` still sets them at the call site.)
 
 Reserved for later phases (documented so future events conform): `surface` (in-app area, e.g.
 `onboarding`/`settings`), `outcome` (`success`/`error`).
@@ -164,15 +159,10 @@ Every event also carries the common props `channel`, `is_a11n`, `platform`, `arc
    `apps/cli/lib/tracks.ts`, or the `recordAnalyticsEvent` IPC handler / `Connector.trackEvent` from a
    renderer). Prefer a standardized property name from the vocabulary above; only add a custom prop when
    none fits, and flag it.
-3. **Register the event and its custom eventprops** via the Tracks Registration tool (the Tracks Events
-   Registration repo on GitHub). Registration is a metadata/documentation layer — it does **not** gate
-   data collection or queryability. An event with a valid name is already recorded and fully queryable in
-   Superset (`tracks.prod_events`) without registration. What registration adds: a description, owner, and
-   code/P2 links; a documented type + description for each custom eventprop; and CI checks that the
-   collected data matches the spec. It also unlocks the Tracks tools — and per the Tracks docs those tools
-   will eventually require registration — so it's worth doing even though raw querying doesn't need it.
-   Register each event together with its own custom eventprops; the default/common props (and the wrapper
-   props) come for free and are not registered per-event.
+3. **Register the event and its custom eventprops** via the Tracks Registration tool. Registration adds
+   documentation and CI integrity checks — it does not gate collection or queryability (a validly-named
+   event is already queryable in Superset without it). Common/default props come for free; register only
+   the event's own custom props.
 4. Add a row to the event catalog above.
 
 ## Testing
@@ -212,8 +202,7 @@ What fires depends on the build, so pick the right method:
     `STUDIO_TRACKS_ORIGIN` is set — as the desktop injects when it spawns the CLI (e.g.
     `STUDIO_TRACKS_ORIGIN=studio-ui:v2`).
 - **Live pixel to `pixel.wp.com`.** Only a shipped npm/prod build sends the real request (dev/E2E always
-  no-ops). Confirm server-side by querying `tracks.prod_events` in Superset — collection doesn't require
-  registration, so a validly-named event shows up there whether or not it's registered.
+  no-ops). Confirm server-side by querying `tracks.prod_events` in Superset.
 
 ## Privacy / GDPR
 

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -131,6 +131,15 @@ none fits, and flag it for registration.
 | `app_version` | Product version | e.g. `1.15.0` |
 | `ui_version` | **Custom (Studio-only):** which desktop renderer | `v1` (legacy), `v2` (agentic). No standard slot — must be registered as a Studio-custom property. |
 
+**Common props are attached by the wrappers — don't pass them per event.** `platform`, `arch`,
+`app_version`, and `is_a11n` come from each wrapper's `commonProps()`. The CLI wrapper also resolves
+`channel` and `ui_version` centrally from `STUDIO_TRACKS_ORIGIN` (`studio-cli`, or `studio-ui` + `ui_version`
+when app-spawned). The convention for `channel`/`ui_version` on the desktop side — desktop wrapper attaches
+`channel: studio-ui`, each renderer attaches its own `ui_version` (`v1` for `apps/studio`, `v2` for
+`apps/ui`) — is being centralized in STU-2122; until that lands, `studio_app_launch` still sets them at the
+call site. New event code should rely on the wrapper/renderer to attach them and pass only
+**event-specific** props.
+
 Reserved for later phases (documented so future events conform): `surface` (in-app area, e.g.
 `onboarding`/`settings`), `outcome` (`success`/`error`).
 

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -159,10 +159,11 @@ Every event also carries the common props `channel`, `is_a11n`, `platform`, `arc
    `apps/cli/lib/tracks.ts`, or the `recordAnalyticsEvent` IPC handler / `Connector.trackEvent` from a
    renderer). Prefer a standardized property name from the vocabulary above; only add a custom prop when
    none fits, and flag it.
-3. **Register the event and its custom eventprops** via the Tracks Registration tool. Registration adds
+3. **Register the event and all its eventprops** via the Tracks Registration tool. Registration adds
    documentation and CI integrity checks — it does not gate collection or queryability (a validly-named
-   event is already queryable in Superset without it). Common/default props come for free; register only
-   the event's own custom props.
+   event is already queryable in Superset without it). Register every prop the event carries, including the
+   wrapper-attached common props (`channel`, `is_a11n`, `platform`, `arch`, `app_version`, `ui_version`);
+   only the reserved Tracks defaults (timestamp, etc.) come for free.
 4. Add a row to the event catalog above.
 
 ## Testing

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -155,9 +155,15 @@ Every event also carries the common props `channel`, `is_a11n`, `platform`, `arc
    `apps/cli/lib/tracks.ts`, or the `recordAnalyticsEvent` IPC handler / `Connector.trackEvent` from a
    renderer). Prefer a standardized property name from the vocabulary above; only add a custom prop when
    none fits, and flag it.
-3. **Register the event and its properties server-side** in the Tracks event schema. Events still flow
-   without this, but registration is what makes them and their props formally defined and reliably
-   queryable in the dashboards.
+3. **Register the event and its custom eventprops** via the Tracks Registration tool (the Tracks Events
+   Registration repo on GitHub). Registration is a metadata/documentation layer — it does **not** gate
+   data collection or queryability. An event with a valid name is already recorded and fully queryable in
+   Superset (`tracks.prod_events`) without registration. What registration adds: a description, owner, and
+   code/P2 links; a documented type + description for each custom eventprop; and CI checks that the
+   collected data matches the spec. It also unlocks the Tracks tools — and per the Tracks docs those tools
+   will eventually require registration — so it's worth doing even though raw querying doesn't need it.
+   Register each event together with its own custom eventprops; the default/common props (and the wrapper
+   props) come for free and are not registered per-event.
 4. Add a row to the event catalog above.
 
 ## Testing
@@ -197,7 +203,8 @@ What fires depends on the build, so pick the right method:
     `STUDIO_TRACKS_ORIGIN` is set — as the desktop injects when it spawns the CLI (e.g.
     `STUDIO_TRACKS_ORIGIN=studio-ui:v2`).
 - **Live pixel to `pixel.wp.com`.** Only a shipped npm/prod build sends the real request (dev/E2E always
-  no-ops). Best confirmed server-side once the events are registered.
+  no-ops). Confirm server-side by querying `tracks.prod_events` in Superset — collection doesn't require
+  registration, so a validly-named event shows up there whether or not it's registered.
 
 ## Privacy / GDPR
 


### PR DESCRIPTION
## Related issues

- Related to STU-2036
- Related to STU-2122

## How AI was used in this PR

Claude drafted these doc corrections after a reviewer pointed out that the original text conflated Tracks *registration* with data *queryability*. I reviewed the wording against the reviewer's explanation and the actual wrapper code before committing.

## Proposed Changes

Corrects two inaccuracies in the Tracks analytics design doc so contributors instrument events correctly.

Documentation only — no code or behavior changes.

## Testing Instructions

- Read `docs/design-docs/analytics-tracks.md` — the "How to add a new event" step 3, the Testing section's live-pixel note, and the new note under "Property vocabulary".
- No build/test impact; this PR touches only the design doc.

## Pre-merge Checklist

- [x] Documentation-only change — no TypeScript/React/console impact.
- [x] Design doc updated (this PR *is* the doc update).
