### PR TITLE
Agentic UI: Lock the create-site WordPress version field while offline

### DIFF
--- a/apps/ui/src/components/create-site-form/index.test.tsx
+++ b/apps/ui/src/components/create-site-form/index.test.tsx
@@ -6,6 +6,7 @@ import { useConnector } from '@/data/core';
 import { usePathValidator } from '@/data/queries/use-create-site-helpers';
 import { useSites } from '@/data/queries/use-sites';
 import { useWordPressVersions } from '@/data/queries/use-wordpress-versions';
+import { useOffline } from '@/hooks/use-offline';
 import { CreateSiteForm } from './index';
 import type { CreateSiteFormValues } from './index';
 
@@ -31,10 +32,15 @@ vi.mock( '@/data/queries/use-wordpress-versions', () => ( {
 	useWordPressVersions: vi.fn(),
 } ) );
 
+vi.mock( '@/hooks/use-offline', () => ( {
+	useOffline: vi.fn(),
+} ) );
+
 const useConnectorMock = vi.mocked( useConnector, { partial: true } );
 const usePathValidatorMock = vi.mocked( usePathValidator, { partial: true } );
 const useSitesMock = vi.mocked( useSites, { partial: true } );
 const useWordPressVersionsMock = vi.mocked( useWordPressVersions, { partial: true } );
+const useOfflineMock = vi.mocked( useOffline );
 
 function deferred< T >() {
 	let resolve!: ( value: T ) => void;
@@ -113,6 +119,7 @@ describe( 'CreateSiteForm', () => {
 		} );
 		useSitesMock.mockReturnValue( { data: [] } );
 		useWordPressVersionsMock.mockReturnValue( { data: undefined } );
+		useOfflineMock.mockReturnValue( false );
 		usePathValidatorMock.mockReturnValue( {
 			generateProposedPath: vi.fn( async ( name: string ) => ( {
 				path: `/sites/${ name }`,
@@ -435,6 +442,29 @@ describe( 'CreateSiteForm', () => {
 		openAdvancedSettings();
 
 		expect( screen.getByLabelText( 'WordPress version' ).tagName ).toBe( 'SELECT' );
+	} );
+
+	it( 'locks the WordPress version to a disabled "latest" select while offline', async () => {
+		useOfflineMock.mockReturnValue( true );
+		renderForm( { name: 'Offline site', wpVersion: '6.7' } );
+		openAdvancedSettings();
+
+		const select = screen.getByLabelText( 'WordPress version' );
+		expect( select.tagName ).toBe( 'SELECT' );
+		expect( select ).toBeDisabled();
+		await waitFor( () => expect( select ).toHaveValue( DEFAULT_WORDPRESS_VERSION ) );
+
+		const trigger = select.closest( 'div[style*="pointer-events"]' )?.parentElement as HTMLElement;
+		fireEvent.mouseEnter( trigger );
+		fireEvent.mouseMove( trigger, { movementX: 1, movementY: 1 } );
+		// Tooltips use Base UI's default open delay, so wait long enough for the popup.
+		expect(
+			await screen.findByText(
+				'Changing WordPress version requires an internet connection.',
+				{},
+				{ timeout: 2000 }
+			)
+		).toBeVisible();
 	} );
 
 	it( 'supports an external submission gate', async () => {

--- a/apps/ui/src/components/create-site-form/index.tsx
+++ b/apps/ui/src/components/create-site-form/index.tsx
@@ -24,6 +24,7 @@ import { useConnector } from '@/data/core';
 import { usePathValidator } from '@/data/queries/use-create-site-helpers';
 import { useSites } from '@/data/queries/use-sites';
 import { useWordPressVersions } from '@/data/queries/use-wordpress-versions';
+import { useOffline } from '@/hooks/use-offline';
 import styles from './style.module.css';
 import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
 import type {
@@ -433,14 +434,18 @@ export function CreateSiteForm( {
 	}, [ defaults, initialValues ] );
 
 	const { data: wpVersions } = useWordPressVersions();
+	const isOffline = useOffline();
+	// While offline, "latest" is the only version installable without a
+	// download, so it's forced — same as the legacy version selector.
 	useEffect( () => {
-		if ( ! wpVersions?.length ) return;
-		setData( ( prev ) =>
-			wpVersions.some( ( version ) => version.value === prev.wpVersion )
-				? prev
-				: { ...prev, wpVersion: DEFAULT_WORDPRESS_VERSION }
-		);
-	}, [ wpVersions, data.wpVersion ] );
+		if ( ! isOffline && ! wpVersions?.length ) return;
+		setData( ( prev ) => {
+			const keep =
+				prev.wpVersion === DEFAULT_WORDPRESS_VERSION ||
+				( ! isOffline && !! wpVersions?.some( ( version ) => version.value === prev.wpVersion ) );
+			return keep ? prev : { ...prev, wpVersion: DEFAULT_WORDPRESS_VERSION };
+		} );
+	}, [ wpVersions, isOffline, data.wpVersion ] );
 
 	const fields = useMemo< Field< FormData >[] >(
 		() => [
@@ -461,7 +466,9 @@ export function CreateSiteForm( {
 				},
 			},
 			phpVersionField< FormData >(),
-			wpVersionField< FormData >( DEFAULT_WORDPRESS_VERSION, wpVersions ),
+			wpVersionField< FormData >( DEFAULT_WORDPRESS_VERSION, wpVersions, {
+				offline: isOffline,
+			} ),
 			adminUsernameField< FormData >(),
 			adminPasswordField< FormData >(),
 			adminEmailField< FormData >(),
@@ -475,7 +482,7 @@ export function CreateSiteForm( {
 				Edit: EnableHttpsControl,
 			},
 		],
-		[ existingDomainNames, wpVersions ]
+		[ existingDomainNames, isOffline, wpVersions ]
 	);
 
 	const basicForm = useMemo< Form >(


### PR DESCRIPTION
## Related issues

- Related to STU-1927
- Follow-up to #4284, which added this behavior to the site settings form

## How AI was used in this PR

Implemented with Claude: ported the legacy `wp-version-selector` offline semantics onto the create-site form, reusing the `offline` support `wpVersionField` already gained in #4284. Code and tests reviewed by me.

## Proposed Changes

The WordPress version field in the agentic UI **create-site** form didn't account for being offline. Because the version list is fetched over the network, going offline left the field with nothing to offer and it degraded to a free-text input — you could type any version, and only "latest" can actually be installed without a download.

- **Offline, the field now locks to "latest"** and is disabled, with the explanation shown as a hover tooltip — the same behavior Studio Classic's create form has, and the same the settings form got in #4284.
- **The field stays a dropdown while offline** instead of degrading to free text, so there's no way to type a version that can't be installed.
- **A pre-seeded version is forced back to "latest" while offline** — e.g. when a Blueprint suggestion asks for 6.7 — so the form can't submit something that would fail on creation.
- **Online behavior is unchanged**, including the existing free-text fallback when the version list can't be fetched while online.

| Light | Dark |
|--------|--------|
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/a2ff49ab-c03a-4414-8168-e34c9975cb25" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/d8b3a3d6-47fa-4213-95fc-d4caa4c58645" /> | 

## Testing Instructions

1. Launch Studio with the agentic UI and start creating a new site → expand **Advanced settings**.
2. While online, confirm the WordPress version field is unchanged: a dropdown with "latest" plus the available versions, and still editable.
3. Go offline (turn off Wi-Fi), then reopen the create-site form → **Advanced settings**.
4. The WordPress version field should be a **disabled dropdown showing "latest"** — not a text input. Hover it: the tooltip reads "Changing WordPress version requires an internet connection."
5. Still offline, start the flow from a Blueprint that suggests a specific version (e.g. 6.7) — the field should force back to "latest" rather than keeping the suggested version.
6. Create the site while offline and confirm it succeeds on the latest bundled version.
7. Go back online — the field should re-enable and list the fetched versions again.
8. Check the field in **both light and dark** color schemes.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
