### PR TITLE
Agentic UI: fix copy button space in chat

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -76,6 +76,7 @@ import { refreshIcon } from '@/lib/icons';
 import { ThinkingIndicator } from '../thinking-indicator';
 import styles from './style.module.css';
 import type { SessionEntry } from '@earendil-works/pi-coding-agent';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 
 interface AgentQuestionRenderItem {
 	key: string;
@@ -432,16 +433,50 @@ function UserTurn( {
 	);
 }
 
-function AssistantText( { text, copyText }: { text: string; copyText?: string } ) {
+function AssistantText( {
+	text,
+	copyText,
+	showActions,
+	onToggleSelect,
+}: {
+	text: string;
+	copyText?: string;
+	showActions: boolean;
+	onToggleSelect: () => void;
+} ) {
+	const handleClick = ( event: ReactMouseEvent< HTMLDivElement > ) => {
+		// Links and the buttons inside code blocks or the action row own their
+		// clicks; only bare message content toggles the actions.
+		if ( ( event.target as HTMLElement | null )?.closest( 'a, button' ) ) {
+			return;
+		}
+		// A click that ends a text drag is a selection, not a tap.
+		const selection = window.getSelection();
+		if ( selection && ! selection.isCollapsed && selection.toString().trim() ) {
+			return;
+		}
+		onToggleSelect();
+	};
+
 	return (
-		<div className={ styles.assistantTurn }>
+		// Clicking the message is a mouse convenience for revealing its actions;
+		// keyboard users reach the same buttons by tabbing to them, which opens
+		// the row via :focus-within. Deliberately no button role — the message
+		// holds links, and nesting them inside a control would be invalid.
+		<div
+			className={ styles.assistantTurn }
+			data-actions-open={ showActions ? 'true' : undefined }
+			onClick={ copyText ? handleClick : undefined }
+		>
 			<Markdown>{ text }</Markdown>
 			{ copyText ? (
-				<CopyButton
-					text={ copyText }
-					label={ __( 'Copy message' ) }
-					className={ styles.messageActions }
-				/>
+				<div className={ styles.messageActions }>
+					<div className={ styles.messageActionsClip }>
+						<div className={ styles.messageActionsRow }>
+							<CopyButton text={ copyText } label={ __( 'Copy message' ) } />
+						</div>
+					</div>
+				</div>
 			) : null }
 		</div>
 	);
@@ -1187,6 +1222,30 @@ export function Conversation( {
 		[ entries, isRunning ]
 	);
 
+	// One selected message at a time, so picking a new one closes the last.
+	const [ selectedKey, setSelectedKey ] = useState< string | null >( null );
+	const sessionId = data.summary.id;
+	useEffect( () => {
+		setSelectedKey( null );
+	}, [ sessionId ] );
+
+	// The newest reply keeps its actions open, so copying the answer you just
+	// got never depends on discovering that messages can be clicked. Held back
+	// until the turn settles — mid-run the last text block keeps moving as new
+	// blocks stream in, and the row would hop down the transcript with it.
+	const latestActionableKey = useMemo( () => {
+		if ( isRunning ) {
+			return null;
+		}
+		for ( let index = items.length - 1; index >= 0; index -= 1 ) {
+			const item = items[ index ];
+			if ( item.kind === 'assistant-text' && item.copyText ) {
+				return item.key;
+			}
+		}
+		return null;
+	}, [ isRunning, items ] );
+
 	return (
 		<div className={ styles.root }>
 			{ items.map( ( item ) => {
@@ -1196,7 +1255,17 @@ export function Conversation( {
 							<UserTurn key={ item.key } text={ item.text } attachments={ item.attachments } />
 						);
 					case 'assistant-text':
-						return <AssistantText key={ item.key } text={ item.text } copyText={ item.copyText } />;
+						return (
+							<AssistantText
+								key={ item.key }
+								text={ item.text }
+								copyText={ item.copyText }
+								showActions={ selectedKey === item.key || item.key === latestActionableKey }
+								onToggleSelect={ () =>
+									setSelectedKey( ( current ) => ( current === item.key ? null : item.key ) )
+								}
+							/>
+						);
 					case 'tool-use':
 						return (
 							<ToolUseRow

--- a/apps/ui/src/ui-classic/components/session-view/conversation/selection.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/selection.test.tsx
@@ -1,0 +1,85 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Tooltip } from '@wordpress/ui';
+import { describe, expect, it, vi } from 'vitest';
+import { Conversation } from '.';
+import type { LoadedAiSession, SessionEntry } from '@/data/core';
+
+vi.mock( '@/data/core', () => ( {
+	useConnector: () => ( {
+		capabilities: { readLocalMedia: false },
+		copyText: vi.fn().mockResolvedValue( undefined ),
+	} ),
+} ) );
+
+function assistantReply( text: string ): SessionEntry {
+	return {
+		type: 'message',
+		message: { role: 'assistant', content: [ { type: 'text', text } ] },
+	} as unknown as SessionEntry;
+}
+
+function renderConversation( { isRunning = false }: { isRunning?: boolean } = {} ) {
+	const data = {
+		summary: { id: 'session-1' },
+		entries: [ assistantReply( 'First reply' ), assistantReply( 'Second reply' ) ],
+	} as unknown as LoadedAiSession;
+
+	return render(
+		<QueryClientProvider client={ new QueryClient() }>
+			<Tooltip.Provider delay={ 0 }>
+				<Conversation
+					data={ data }
+					isRunning={ isRunning }
+					startedAt={ null }
+					pendingQuestions={ new Set() }
+					pendingAnswers={ {} }
+					onAnswerQuestion={ vi.fn() }
+				/>
+			</Tooltip.Provider>
+		</QueryClientProvider>
+	);
+}
+
+function openTurnTexts( container: HTMLElement ) {
+	return Array.from( container.querySelectorAll( '[data-actions-open="true"]' ) ).map(
+		( turn ) => turn.textContent
+	);
+}
+
+describe( 'Conversation message actions', () => {
+	it( 'opens the actions on the newest reply without any interaction', () => {
+		const { container } = renderConversation();
+
+		expect( openTurnTexts( container ) ).toEqual( [ 'Second reply' ] );
+	} );
+
+	it( 'holds the actions back while the turn is still running', () => {
+		const { container } = renderConversation( { isRunning: true } );
+
+		expect( openTurnTexts( container ) ).toEqual( [] );
+	} );
+
+	it( 'opens an older reply when clicked and closes it when clicked again', () => {
+		const { container } = renderConversation();
+
+		fireEvent.click( screen.getByText( 'First reply' ) );
+		expect( openTurnTexts( container ) ).toEqual( [ 'First reply', 'Second reply' ] );
+
+		fireEvent.click( screen.getByText( 'First reply' ) );
+		expect( openTurnTexts( container ) ).toEqual( [ 'Second reply' ] );
+	} );
+
+	it( 'ignores a click that ends a text selection', () => {
+		const { container } = renderConversation();
+		vi.spyOn( window, 'getSelection' ).mockReturnValue( {
+			isCollapsed: false,
+			toString: () => 'First',
+		} as unknown as Selection );
+
+		fireEvent.click( screen.getByText( 'First reply' ) );
+
+		expect( openTurnTexts( container ) ).toEqual( [ 'Second reply' ] );
+		vi.restoreAllMocks();
+	} );
+} );

--- a/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
@@ -4,16 +4,17 @@
 	gap: var(--wpds-dimension-padding-lg);
 }
 
-/* User bubbles act as turn anchors. No top padding — the space above comes
-   from the preceding turn's in-flow copy-button line plus the root gap. The
-   bottom padding mirrors that copy line's height (1.75rem, keep in sync with
-   the copy-button size) so every turn is followed by the same amount of
-   space. */
+/* User bubbles act as turn anchors; give them generous breathing room above
+   and below so the user's prompt stands apart from the assistant response. */
 .userTurn {
 	display: flex;
 	flex-direction: column;
 	margin-right: calc(-1 * var(--classic-composer-shell-inline-padding));
-	padding: 0 0 1.75rem;
+	padding: var(--wpds-dimension-padding-xl) 0;
+}
+
+.userTurn:first-child {
+	padding-top: 0;
 }
 
 .userAttachments {
@@ -684,23 +685,47 @@
 	overflow-wrap: anywhere;
 }
 
-/* Assistant response wrapper: the copy button stays hidden until the turn is
-   hovered (or a control inside it is focused). */
-.assistantTurn {
-	display: flex;
-	flex-direction: column;
-	gap: var(--wpds-dimension-padding-xs);
+/* Action footer for an assistant message: open on the newest reply, and on any
+   older one the reader clicks. A closed turn reserves no space for it. */
+.messageActions {
+	display: grid;
+	grid-template-rows: 0fr;
+	/* Optical alignment of the 16px glyph with the text column. It lives out
+	   here rather than on the row so the negative offset doesn't drag the
+	   button past the clip's edge; the row's inline padding cancels the extra
+	   -sm so the net shift is still (16px - button) / 2. */
+	margin-inline-start: calc((16px - 1.75rem) / 2 - var(--wpds-dimension-padding-sm));
+	opacity: 0;
+	transition:
+		grid-template-rows 180ms cubic-bezier(0.2, 0, 0, 1),
+		opacity 120ms ease;
 }
 
-.messageActions {
+/* :focus-within keeps the row reachable by keyboard — tabbing to the copy
+   button opens it without a click. */
+.assistantTurn[data-actions-open='true'] .messageActions,
+.assistantTurn:focus-within .messageActions {
+	grid-template-rows: 1fr;
+	opacity: 1;
+}
+
+.messageActionsClip {
+	min-height: 0;
+	overflow: hidden;
+}
+
+/* The clip cuts on every side, so the row carries enough padding for the
+   buttons' hover backgrounds and focus rings to sit fully inside it. */
+.messageActionsRow {
 	display: flex;
 	align-items: center;
-	margin-inline-start: calc((16px - 1.75rem) / 2);
-	opacity: 0;
-	transition: opacity 0.12s ease;
+	gap: var(--wpds-dimension-padding-xs);
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm)
+		var(--wpds-dimension-padding-sm);
 }
 
-.assistantTurn:hover .messageActions,
-.assistantTurn:focus-within .messageActions {
-	opacity: 1;
+@media (prefers-reduced-motion: reduce) {
+	.messageActions {
+		transition: none;
+	}
 }

--- a/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
@@ -686,22 +686,33 @@
 }
 
 /* Assistant response wrapper: the copy button stays hidden until the turn is
-   hovered (or a control inside it is focused). */
+   hovered (or a control inside it is focused). It is absolutely positioned in
+   the spacing below the message so it takes no layout space and leaves no gap
+   between conversation blocks. */
 .assistantTurn {
+	position: relative;
 	display: flex;
 	flex-direction: column;
-	gap: var(--wpds-dimension-padding-xs);
 }
 
 .messageActions {
+	position: absolute;
+	/* Flush with the turn's bottom edge, with the visual offset as padding so
+	   the pointer never crosses a dead zone that would drop :hover en route to
+	   the button. */
+	inset-block-start: 100%;
+	padding-block-start: var(--wpds-dimension-padding-xs);
+	inset-inline-start: calc((16px - 1.75rem) / 2);
+	inset-inline-end: 0;
 	display: flex;
 	align-items: center;
-	margin-inline-start: calc((16px - 1.75rem) / 2);
 	opacity: 0;
+	pointer-events: none;
 	transition: opacity 0.12s ease;
 }
 
 .assistantTurn:hover .messageActions,
 .assistantTurn:focus-within .messageActions {
 	opacity: 1;
+	pointer-events: auto;
 }

--- a/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
@@ -4,17 +4,16 @@
 	gap: var(--wpds-dimension-padding-lg);
 }
 
-/* User bubbles act as turn anchors; give them generous breathing room above
-   and below so the user's prompt stands apart from the assistant response. */
+/* User bubbles act as turn anchors. No top padding — the space above comes
+   from the preceding turn's in-flow copy-button line plus the root gap. The
+   bottom padding mirrors that copy line's height (1.75rem, keep in sync with
+   the copy-button size) so every turn is followed by the same amount of
+   space. */
 .userTurn {
 	display: flex;
 	flex-direction: column;
 	margin-right: calc(-1 * var(--classic-composer-shell-inline-padding));
-	padding: var(--wpds-dimension-padding-xl) 0;
-}
-
-.userTurn:first-child {
-	padding-top: 0;
+	padding: 0 0 1.75rem;
 }
 
 .userAttachments {
@@ -686,33 +685,22 @@
 }
 
 /* Assistant response wrapper: the copy button stays hidden until the turn is
-   hovered (or a control inside it is focused). It is absolutely positioned in
-   the spacing below the message so it takes no layout space and leaves no gap
-   between conversation blocks. */
+   hovered (or a control inside it is focused). */
 .assistantTurn {
-	position: relative;
 	display: flex;
 	flex-direction: column;
+	gap: var(--wpds-dimension-padding-xs);
 }
 
 .messageActions {
-	position: absolute;
-	/* Flush with the turn's bottom edge, with the visual offset as padding so
-	   the pointer never crosses a dead zone that would drop :hover en route to
-	   the button. */
-	inset-block-start: 100%;
-	padding-block-start: var(--wpds-dimension-padding-xs);
-	inset-inline-start: calc((16px - 1.75rem) / 2);
-	inset-inline-end: 0;
 	display: flex;
 	align-items: center;
+	margin-inline-start: calc((16px - 1.75rem) / 2);
 	opacity: 0;
-	pointer-events: none;
 	transition: opacity 0.12s ease;
 }
 
 .assistantTurn:hover .messageActions,
 .assistantTurn:focus-within .messageActions {
 	opacity: 1;
-	pointer-events: auto;
 }


### PR DESCRIPTION
## Related issues

- Fixes STU-2082

## How AI was used in this PR

AI assisted with the fix, I reviewed and tested

## Proposed Changes
We have a huge space after messages in chat due to the hidden Copy button. This PR fixes it to have a rational space
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="1141" height="352" alt="Screenshot 2026-07-24 at 15 58 22" src="https://github.com/user-attachments/assets/17de1227-9689-4dbc-bb12-72f3e4f7d970" />
<td><img width="1093" height="318" alt="Screenshot 2026-07-24 at 15 57 36" src="https://github.com/user-attachments/assets/da144413-a850-4cb9-ba84-4a4ec89a10d5" />
</tr>
</table>

## Testing Instructions
1. Open new Agentic UI
2. Send any massege
3. Mouse over that message
4. Assert that the copy button appeared and the UX is good - it's easily achievable and clickable
