### PR TITLE
Agentic UI: Fix border for Theme selector

### DIFF
--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -244,18 +244,26 @@
 	border-radius: var( --wpds-border-radius-sm );
 	background: var( --wpds-color-bg-interactive-neutral-weak );
 	pointer-events: none;
-	transform: translateX( calc( var( --appearance-active-index, 0 ) * 100% ) );
+	transform: translateX(
+		calc( var( --appearance-active-index, 0 ) * 100% + var( --appearance-edge-shift, 0px ) )
+	);
 }
 
 /* The indicator is positioned with a logical inset but animated with a
    physical translateX, so RTL needs the sign flipped to slide toward the
    selected option instead of away from it. */
 .appearancePicker:dir( rtl )::before {
-	transform: translateX( calc( var( --appearance-active-index, 0 ) * -100% ) );
+	transform: translateX(
+		calc( var( --appearance-active-index, 0 ) * -100% - var( --appearance-edge-shift, 0px ) )
+	);
 }
 
+/* At the first/last segment, slide the indicator one border-width outward so
+   its border overlays the container's, leaving a single continuous edge
+   instead of a double border. */
 .appearancePicker[data-active-index='0'] {
 	--appearance-active-index: 0;
+	--appearance-edge-shift: calc( var( --wpds-border-width-xs ) * -1 );
 }
 
 .appearancePicker[data-active-index='1'] {
@@ -264,6 +272,7 @@
 
 .appearancePicker[data-active-index='2'] {
 	--appearance-active-index: 2;
+	--appearance-edge-shift: var( --wpds-border-width-xs );
 }
 
 @media not ( prefers-reduced-motion ) {


### PR DESCRIPTION
## Related issues

- Fixes STU-2104

## How AI was used in this PR

AI assisted. I was thinking about something simpler, but ultimately decided to go with AI's proposition.



## Proposed Changes
1. Run Agentic UI
2. Open Settings
3. Assert that there is no double border when the first or last item is selected (I added a red border via dev tools to easy testing):<br />
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="63" height="56" alt="Screenshot 2026-07-24 at 16 23 46" src="https://github.com/user-attachments/assets/ede8720b-1c1c-4897-86f0-94252da93ac6" />
<td><img width="275" height="69" alt="Screenshot 2026-07-24 at 16 23 22" src="https://github.com/user-attachments/assets/7d2ec3ea-1c44-4793-82bd-b6b8bd99b9e0" />
</tr>
</table>



