### PR TITLE
Agentic UI: Align site directory input styles with others

### DIFF
--- a/apps/ui/src/components/settings-view/index.tsx
+++ b/apps/ui/src/components/settings-view/index.tsx
@@ -3,7 +3,7 @@ import { SUPPORTED_EDITORS, supportedEditorConfig } from '@studio/common/lib/use
 import { SUPPORTED_TERMINALS, terminalConfig } from '@studio/common/lib/user-settings/terminal';
 import { CheckboxControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { close, file, Icon } from '@wordpress/icons';
+import { close } from '@wordpress/icons';
 import { Button, IconButton, SelectControl } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useCallback, useEffect, useState } from 'react';
@@ -234,7 +234,6 @@ function DefaultSiteDirectoryField( { value, onSelect }: { value: string; onSele
 				<span className={ value ? styles.pathPickerValue : styles.pathPickerPlaceholder }>
 					{ value || __( 'Choose a folder…' ) }
 				</span>
-				<Icon icon={ file } className={ styles.pathPickerIcon } />
 			</button>
 		</PreferenceRow>
 	);

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -381,23 +381,22 @@
 	overflow-wrap: anywhere;
 }
 
+/* Mirror the InputLayout recipe SelectControl triggers use (height, surface,
+   border, inline padding) so the picker reads as one of the standard Settings
+   controls. */
 .pathPickerButton {
 	box-sizing: border-box;
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
-	gap: var( --wpds-dimension-padding-lg );
 	inline-size: 240px;
 	max-inline-size: 100%;
-	min-block-size: 36px;
-	padding: 0 var( --wpds-dimension-padding-lg );
+	block-size: 40px;
+	padding: 0 var( --wpds-dimension-padding-md );
 	border: var( --wpds-border-width-xs ) solid var( --wpds-color-stroke-interactive-neutral );
 	border-radius: var( --wpds-border-radius-sm );
-	background: var( --wpds-color-bg-surface-neutral );
-	color: var( --wpds-color-fg-content-neutral );
+	background: var( --wpds-color-bg-interactive-neutral-weak );
+	color: var( --wpds-color-fg-interactive-neutral );
 	font-family: var( --wpds-typography-font-family-body );
-	/* Match SelectControl's trigger text so all controls in a card read the
-	   same size. */
 	font-size: var( --wpds-typography-font-size-md );
 	line-height: var( --wpds-typography-line-height-sm );
 	text-align: start;
@@ -422,12 +421,7 @@
 }
 
 .pathPickerPlaceholder {
-	color: var( --wpds-color-fg-content-neutral-weak );
-}
-
-.pathPickerIcon {
-	flex-shrink: 0;
-	fill: currentColor;
+	color: var( --wpds-color-fg-interactive-neutral-disabled );
 }
 
 .cliHeader {


### PR DESCRIPTION
## Related issues

- Fixes STU-2103

## How AI was used in this PR

AI assisted

## Proposed Changes

Align height and background for `Default site directory` input with other inputs and remove icon in Settings.
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="264" height="59" alt="Screenshot 2026-07-24 at 16 42 56" src="https://github.com/user-attachments/assets/4d9f3062-55b3-4dec-af97-a1a2e170d3db" />
<td><img width="271" height="68" alt="Screenshot 2026-07-24 at 16 42 39" src="https://github.com/user-attachments/assets/5bfb7b8b-7225-40b5-8e63-15be5b3dbe73" />
</tr>
</table>
## Testing Instructions
1. Run Agentic UI
2. Open Settings
3. Assert that the background and height are aligned with other inputs and there is no more folder icon.