### PR TITLE
Agentic UI: Only confirm suggestion replacement after the user modifies the draft

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
@@ -229,8 +229,10 @@ export interface ComposerHandle {
 		text: string,
 		attachments?: { images?: StudioChatImage[]; files?: StudioChatFileAttachment[] }
 	): void;
-	// True when the composer holds anything replaceDraft would discard.
-	hasDraft(): boolean;
+	// Snapshot of what replaceDraft would discard, so callers can decide
+	// whether a confirmation is warranted (e.g. skip it when the draft still
+	// matches a previously inserted suggestion).
+	getDraft(): { text: string; hasAttachments: boolean };
 }
 
 function shouldShellFocusTextarea( target: EventTarget ) {
@@ -498,8 +500,8 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 					node.setSelectionRange( len, len );
 				} );
 			},
-			hasDraft() {
-				return value.trim().length > 0 || attachments.length > 0;
+			getDraft() {
+				return { text: value, hasAttachments: attachments.length > 0 };
 			},
 		} ),
 		[ restoreAttachments, value, attachments ]

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
@@ -229,9 +229,8 @@ export interface ComposerHandle {
 		text: string,
 		attachments?: { images?: StudioChatImage[]; files?: StudioChatFileAttachment[] }
 	): void;
-	// Snapshot of what replaceDraft would discard, so callers can decide
-	// whether a confirmation is warranted (e.g. skip it when the draft still
-	// matches a previously inserted suggestion).
+	// What replaceDraft would discard — lets callers decide whether the
+	// replacement warrants a confirmation.
 	getDraft(): { text: string; hasAttachments: boolean };
 }
 

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -443,7 +443,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 				<SuggestedPrompts
 					siteName={ ownerSite.name }
 					onPick={ ( prompt ) => composerRef.current?.replaceDraft( prompt ) }
-					hasExistingDraft={ () => composerRef.current?.hasDraft() ?? false }
+					getDraft={ () => composerRef.current?.getDraft() ?? { text: '', hasAttachments: false } }
 				/>
 			) : null }
 			<div

--- a/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.test.tsx
@@ -2,41 +2,85 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { SuggestedPrompts } from '.';
 
-function renderPrompts( hasExistingDraft: () => boolean ) {
-	const onPick = vi.fn();
-	render(
-		<SuggestedPrompts
-			siteName="Test Site"
-			onPick={ onPick }
-			hasExistingDraft={ hasExistingDraft }
-		/>
-	);
-	return { onPick };
+function renderPrompts( initialDraft = { text: '', hasAttachments: false } ) {
+	// Mirrors the composer: onPick replaces the draft with the picked prompt.
+	const draft = { ...initialDraft };
+	const onPick = vi.fn( ( prompt: string ) => {
+		draft.text = prompt;
+		draft.hasAttachments = false;
+	} );
+	render( <SuggestedPrompts siteName="Test Site" onPick={ onPick } getDraft={ () => draft } /> );
+	return { onPick, draft };
+}
+
+function pickSuggestion( index: number ) {
+	fireEvent.click( screen.getAllByRole( 'listitem' )[ index ].querySelector( 'button' )! );
 }
 
 describe( 'SuggestedPrompts', () => {
 	it( 'picks straight through when the composer is empty', () => {
-		const { onPick } = renderPrompts( () => false );
-		fireEvent.click( screen.getAllByRole( 'button' )[ 0 ] );
+		const { onPick } = renderPrompts();
+		pickSuggestion( 0 );
 		expect( onPick ).toHaveBeenCalledTimes( 1 );
 		expect( onPick.mock.calls[ 0 ][ 0 ] ).toBeTruthy();
 		expect( screen.queryByText( 'Replace your draft?' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'asks before replacing an existing draft', () => {
-		const { onPick } = renderPrompts( () => true );
-		fireEvent.click( screen.getAllByRole( 'button' )[ 0 ] );
+	it( 'replaces an untouched suggestion without asking', () => {
+		const { onPick } = renderPrompts();
+		pickSuggestion( 0 );
+		pickSuggestion( 1 );
+		expect( onPick ).toHaveBeenCalledTimes( 2 );
+		expect( screen.queryByText( 'Replace your draft?' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'asks before replacing a user-written draft', () => {
+		const { onPick } = renderPrompts( { text: 'my own words', hasAttachments: false } );
+		pickSuggestion( 0 );
 		expect( onPick ).not.toHaveBeenCalled();
 		expect( screen.getByText( 'Replace your draft?' ) ).toBeInTheDocument();
 
-		fireEvent.click( screen.getByRole( 'button', { name: 'Use suggestion' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Replace draft' } ) );
 		expect( onPick ).toHaveBeenCalledTimes( 1 );
 		expect( screen.queryByText( 'Replace your draft?' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'asks again once the user edits the inserted suggestion', () => {
+		const { onPick, draft } = renderPrompts();
+		pickSuggestion( 0 );
+		draft.text += ' plus my edits';
+		pickSuggestion( 1 );
+		expect( onPick ).toHaveBeenCalledTimes( 1 );
+		expect( screen.getByText( 'Replace your draft?' ) ).toBeInTheDocument();
+	} );
+
+	it( 'asks when attachments were added after inserting a suggestion', () => {
+		const { onPick, draft } = renderPrompts();
+		pickSuggestion( 0 );
+		draft.hasAttachments = true;
+		pickSuggestion( 1 );
+		expect( onPick ).toHaveBeenCalledTimes( 1 );
+		expect( screen.getByText( 'Replace your draft?' ) ).toBeInTheDocument();
+	} );
+
+	it( 'resets the baseline after a confirmed replacement', () => {
+		const { onPick, draft } = renderPrompts();
+		pickSuggestion( 0 );
+		draft.text = 'edited by hand';
+		pickSuggestion( 1 );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Replace draft' } ) );
+		expect( onPick ).toHaveBeenCalledTimes( 2 );
+
+		// The confirmed suggestion is the new baseline: picking another one
+		// goes straight through again.
+		pickSuggestion( 2 );
+		expect( onPick ).toHaveBeenCalledTimes( 3 );
+		expect( screen.queryByText( 'Replace your draft?' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'keeps the draft on cancel', () => {
-		const { onPick } = renderPrompts( () => true );
-		fireEvent.click( screen.getAllByRole( 'button' )[ 0 ] );
+		const { onPick } = renderPrompts( { text: 'my own words', hasAttachments: false } );
+		pickSuggestion( 0 );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 		expect( onPick ).not.toHaveBeenCalled();
 		expect( screen.queryByText( 'Replace your draft?' ) ).not.toBeInTheDocument();

--- a/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button, Dialog } from '@wordpress/ui';
 import { clsx } from 'clsx';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { getSuggestedPrompts } from './prompts';
 import styles from './style.module.css';
 
@@ -9,24 +9,37 @@ interface SuggestedPromptsProps {
 	siteName: string;
 	// Drops the prompt into the composer (focused) — the user sends it.
 	onPick: ( prompt: string ) => void;
-	// Checked at click time; a truthy draft asks for confirmation before
-	// onPick overwrites it.
-	hasExistingDraft: () => boolean;
+	// Checked at click time; confirmation is only asked when the draft
+	// diverged from the last suggestion we inserted (user edits count,
+	// switching between untouched suggestions does not).
+	getDraft: () => { text: string; hasAttachments: boolean };
 }
 
 // Plain-text starter prompts floating under the empty-state logo. One action:
 // click to load the prompt into the composer, ready to tweak or send. A fresh
 // sample rotates in per mount (memo keeps it stable across re-renders).
-export function SuggestedPrompts( { siteName, onPick, hasExistingDraft }: SuggestedPromptsProps ) {
+export function SuggestedPrompts( { siteName, onPick, getDraft }: SuggestedPromptsProps ) {
 	const prompts = useMemo( () => getSuggestedPrompts( siteName ), [ siteName ] );
 	const [ pendingPrompt, setPendingPrompt ] = useState< string | null >( null );
+	// Text of the last suggestion we inserted. While the draft still equals it
+	// (and no attachments were added), another suggestion may replace it freely.
+	const baselineRef = useRef< string | null >( null );
+
+	const apply = ( prompt: string ) => {
+		baselineRef.current = prompt;
+		onPick( prompt );
+	};
 
 	const pick = ( prompt: string ) => {
-		if ( hasExistingDraft() ) {
-			setPendingPrompt( prompt );
+		const draft = getDraft();
+		const isEmpty = draft.text.trim().length === 0 && ! draft.hasAttachments;
+		const matchesBaseline =
+			baselineRef.current !== null && draft.text === baselineRef.current && ! draft.hasAttachments;
+		if ( isEmpty || matchesBaseline ) {
+			apply( prompt );
 			return;
 		}
-		onPick( prompt );
+		setPendingPrompt( prompt );
 	};
 
 	return (
@@ -67,9 +80,7 @@ export function SuggestedPrompts( { siteName, onPick, hasExistingDraft }: Sugges
 					</Dialog.Header>
 					<Dialog.Content>
 						<Dialog.Description>
-							{ __(
-								'Using this suggestion will replace the message and attachments you’ve already added.'
-							) }
+							{ __( 'Your current draft and attachments will be discarded.' ) }
 						</Dialog.Description>
 					</Dialog.Content>
 					<Dialog.Footer>
@@ -78,15 +89,15 @@ export function SuggestedPrompts( { siteName, onPick, hasExistingDraft }: Sugges
 						</Dialog.Action>
 						<Button
 							variant="solid"
-							tone="brand"
+							className={ styles.replaceAction }
 							onClick={ () => {
 								if ( pendingPrompt ) {
-									onPick( pendingPrompt );
+									apply( pendingPrompt );
 								}
 								setPendingPrompt( null );
 							} }
 						>
-							{ __( 'Use suggestion' ) }
+							{ __( 'Replace draft' ) }
 						</Button>
 					</Dialog.Footer>
 				</Dialog.Popup>

--- a/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.tsx
@@ -32,14 +32,14 @@ export function SuggestedPrompts( { siteName, onPick, getDraft }: SuggestedPromp
 
 	const pick = ( prompt: string ) => {
 		const draft = getDraft();
-		const isEmpty = draft.text.trim().length === 0 && ! draft.hasAttachments;
-		const matchesBaseline =
-			baselineRef.current !== null && draft.text === baselineRef.current && ! draft.hasAttachments;
-		if ( isEmpty || matchesBaseline ) {
+		const isUntouched =
+			! draft.hasAttachments &&
+			( draft.text.trim().length === 0 || draft.text === baselineRef.current );
+		if ( isUntouched ) {
 			apply( prompt );
-			return;
+		} else {
+			setPendingPrompt( prompt );
 		}
-		setPendingPrompt( prompt );
 	};
 
 	return (

--- a/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.tsx
@@ -89,7 +89,7 @@ export function SuggestedPrompts( { siteName, onPick, getDraft }: SuggestedPromp
 						</Dialog.Action>
 						<Button
 							variant="solid"
-							className={ styles.replaceAction }
+							tone="brand"
 							onClick={ () => {
 								if ( pendingPrompt ) {
 									apply( pendingPrompt );

--- a/apps/ui/src/ui-classic/components/session-view/suggested-prompts/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/suggested-prompts/style.module.css
@@ -103,13 +103,3 @@
 	outline-offset: 2px;
 	border-radius: var(--wpds-border-radius-xs);
 }
-
-/* Destructive confirm action: repaint the solid Button with the error
-   palette (same override pattern as @wordpress/ui AlertDialog's
-   irreversible intent) — replacing a draft discards user content. */
-.replaceAction {
-	--wp-ui-button-background-color: var(--wpds-color-bg-interactive-error-strong);
-	--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-error-strong-active);
-	--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-error-strong);
-	--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-error-strong-active);
-}

--- a/apps/ui/src/ui-classic/components/session-view/suggested-prompts/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/suggested-prompts/style.module.css
@@ -103,3 +103,13 @@
 	outline-offset: 2px;
 	border-radius: var(--wpds-border-radius-xs);
 }
+
+/* Destructive confirm action: repaint the solid Button with the error
+   palette (same override pattern as @wordpress/ui AlertDialog's
+   irreversible intent) — replacing a draft discards user content. */
+.replaceAction {
+	--wp-ui-button-background-color: var(--wpds-color-bg-interactive-error-strong);
+	--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-error-strong-active);
+	--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-error-strong);
+	--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-error-strong-active);
+}


### PR DESCRIPTION
## Related issues

- Fixes STU-2090

Clicking a suggested prompt currently asks for confirmation whenever the composer holds any text — including the text of another suggestion the user just clicked and hasn't touched. That makes browsing suggestions feel naggy: switching between them shouldn't require confirming each time.

## How AI was used in this PR

AI assisted with the implementation and tests; all changes were reviewed manually.

## Proposed Changes

- Suggestions now replace each other freely while the draft is untouched. The confirmation dialog only appears when the draft diverged from the last inserted suggestion — i.e. the user typed something or added attachments, so replacing it would actually discard their work.
- The confirmation is clearer about consequence: the description now reads "Your current draft and attachments will be discarded." and the confirm button is labeled "Replace draft" with destructive (error) styling, matching the irreversible-action pattern used elsewhere.

## Testing Instructions

1. `npm run start`
2. Start a new chat (empty session shows suggested prompts).
3. Click a suggestion, then click a different one — it should replace the draft immediately, no dialog.
4. Click a suggestion, edit the inserted text (or add an attachment), then click another suggestion — the confirmation dialog should appear with the "Replace draft" destructive button.
5. Confirm the dialog — the draft is replaced; after that, switching suggestions again works without a dialog until you edit once more.
6. Type your own message from scratch, then click a suggestion — dialog appears.
7. Check the dialog in both light and dark themes.


https://github.com/user-attachments/assets/ca23666c-3821-43ec-8712-3b192347a260



## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
