### PR TITLE
Update release notes for version 1.17.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,72 +3,21 @@ Unreleased
 
 1.17.0
 =====
-<!-- Release notes generated using configuration in .github/release.yml at HEAD -->
-* Update ci toolkit #4248
-* Add WordPress export (WXR/.xml) import support #4046
-* Update @yao-pkg/pkg to 6.21.0 to resolve esbuild security alert #4242
-* Update @sentry/electron to 7.15.0 to resolve Dependabot alert #241 #4241
-* Studio Agentic UI: Define signed-out experience for Agentic UI chat #4183
-* Clarify PHP runtime translator comments for Native/Sandbox labels #4234
-* Agentic UI: Remove unused starred flag from AI chat sessions #4229
-* Agentic UI: Add suggested starter prompts over the empty chat #4225
-* Auto-save agentic UI settings and redesign the preferences layout #4219
-* Handle offline mode in the agentic UI #4232
-* Polish 1.16.0 release notes into concise thematic lines #4259
-* Add MCP tab to Agentic UI settings with copyable server config #4264
-* build(deps): bump tar from 7.5.16 to 7.5.19 #4266
-* Agentic UI: Remove theme toggle from sidebar user menu #4263
-* Scope preview list --format json output to the authenticated user #4252
-* Build the browser UI in release CLI builds so `studio ui` ships working #4257
-* Move Fastlane helper tests to the default queue #4261
-* build(deps): bump shell-quote from 1.8.4 to 1.10.0 #4268
-* Fix flaky Windows CLI e2e crash in port-finder port probe #4273
-* Agentic UI: Remove horizontal scroll in Settings #4278
-* Agentic UI: Add default site directory preference to settings #4275
-* Agentic UI: Add site overview view #4258
-* Agentic UI: Add Account section to settings preferences tab #4270
-* apps/ui: Unify url usage #4282
-* Agentic UI: Add Skills tab to application settings #4271
-* Agentic UI: Return to the last visited site instead of the first site #4130
-* Delete AI chat sessions when a site is deleted #4132
-* Remove dead WordPressDataProvider and site REST proxy scaffolding #4279
-* CLI: Add aliases for help, version and path  #4276
-* Make Studio Code aware of theme asset bundling #4262
-* Add Keyboard shortcuts tab to agentic UI settings #4277
-* Continue chat-session cleanup when one session fails during site delete #4292
-* Add global instructions config for the Studio Code agent #4255
-* Agentic UI: fix preview buttons size #4303
-* Remove blueprint warnings leftovers #4289
-* Agentic UI: Show an Xdebug indicator for the Xdebug-enabled site #4285
-* Agentic UI: Add Usage tab #4286
-* Agentic UI: Add Studio CLI toggle to application settings #4302
-* Agentic UI: Render application settings as a fullscreen overlay #4297
-* Agentic UI: Create site from import #4249
-* Agentic UI: Add AI tab with agentic features toggle to settings #4295
-* Fix path-injection in /paths/compare by confining inputs to the sites root #4267
-* Bump transitive brace-expansion to patched versions (CVE-2026-13149) #4294
-* Fix ReDoS in mu-plugins loader path regex #4254
-* Agentic UI: fix resizer for chat input #4301
-* Agentic UI: fix expired previews #4298
-* ci: pin GitHub Actions to commit SHAs (12) #4304
-* Fix incomplete multi-character HTML sanitization in AI tool result previews #4260
-* Point data-liberation-agent references at the studio repository #4300
-* Fix collapsed sidebar overlapping the chat history icon in Agentic UI #4280
-* Add Knip config and initial dead-code cleanup #4293
-* Fixes for offline mode #4272
-* Agentic UI: Make the site settings WordPress version field a dropdown #4284
-* Restrict local imports to registered uploads #4308
-* Surface monthly AI usage limit errors across Studio Code surfaces #4310
-* Agentic UI: add persistent notifications for updates #4204
-* Agentic UI: separate the agentic features toggle from the classic UI switcher #4312
-* Remember Agentic UI preview path per site when switching sites #4281
-* build(deps): bump ruby/setup-ruby from 1.319.0 to 1.321.0 #4317
-* build(deps): bump anthropics/claude-code-action from 1.0.176 to 1.0.181 #4318
-* Bring the Wapuu World easter egg to the agentic UI #4299
-* build(deps): bump the electron group with 4 updates #4319
-* @wzieba made their first contribution in https://github.com/Automattic/studio/pull/4248
-* @mirkosalvato1-ctrl made their first contribution in https://github.com/Automattic/studio/pull/4304
-**Full Changelog**: https://github.com/Automattic/studio/compare/v1.16.0...v1.17.0
+* Added support for importing WordPress export (WXR/.xml) files #4046
+* Agentic UI: Redesigned application settings as an auto-saving fullscreen overlay with new tabs — Account, AI, MCP, Skills, Usage, Keyboard shortcuts, Studio CLI — plus a default site directory preference #4297, #4219, #4270, #4295, #4264, #4271, #4286, #4277, #4302, #4275, #4278
+* Agentic UI: Added a site overview view, site creation from imports, suggested starter prompts, persistent update notifications, and an Xdebug indicator for Xdebug-enabled sites #4258, #4249, #4225, #4204, #4285
+* Agentic UI: Improved continuity between sessions — returning to the last visited site, remembering the preview path per site — and defined the signed-out and offline experiences #4130, #4281, #4183, #4232, #4272
+* Agentic UI: Separated the agentic features toggle from the classic UI switcher, and removed the theme toggle from the sidebar user menu #4312, #4263
+* Agentic UI: Fixed expired previews, chat input resizing, preview button sizing, the collapsed sidebar overlapping the chat history icon, and made the WordPress version field a dropdown in site settings #4298, #4301, #4303, #4280, #4284
+* Agentic UI: Brought over the Wapuu World easter egg #4299
+* Studio Code: Added a global instructions config for the agent #4255
+* Studio Code: Surfaced monthly AI usage limit errors across all surfaces #4310
+* Studio Code: Made the agent aware of theme asset bundling #4262
+* Deleted AI chat sessions when their site is deleted, continuing cleanup even if one session fails #4132, #4292
+* CLI: Added aliases for the help, version and path commands, and made `studio ui` work in release builds #4276, #4257
+* Hardened security: fixed path injection in path comparison, ReDoS in the mu-plugins loader, and HTML sanitization in AI tool result previews; restricted local imports to registered uploads and scoped CLI preview listings to the authenticated user #4267, #4254, #4260, #4308, #4252
+* Updated multiple dependencies, including Electron, Sentry, tar and shell-quote, resolving security alerts for esbuild and brace-expansion #4319, #4241, #4242, #4266, #4268, #4294
+* Misc and maintenance improvements #4293, #4279, #4289, #4300, #4234, #4282, #4229
 
 1.16.0
 =====

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@ Unreleased
 * Added support for importing WordPress export (WXR/.xml) files #4046
 * Agentic UI: Redesigned application settings as an auto-saving fullscreen overlay with new tabs — Account, AI, MCP, Skills, Usage, Keyboard shortcuts, Studio CLI — plus a default site directory preference #4297, #4219, #4270, #4295, #4264, #4271, #4286, #4277, #4302, #4275, #4278
 * Agentic UI: Added a site overview view, site creation from imports, suggested starter prompts, persistent update notifications, and an Xdebug indicator for Xdebug-enabled sites #4258, #4249, #4225, #4204, #4285
-* Agentic UI: Improved continuity between sessions — returning to the last visited site, remembering the preview path per site — and defined the signed-out and offline experiences #4130, #4281, #4183, #4232, #4272
+* Agentic UI: Improved continuity between sessions — returning to the last visited site, remembering the preview path per site — and defined the signed-out and offline experiences #4130, #4281, #4183, #4232
 * Agentic UI: Separated the agentic features toggle from the classic UI switcher, and removed the theme toggle from the sidebar user menu #4312, #4263
 * Agentic UI: Fixed expired previews, chat input resizing, preview button sizing, the collapsed sidebar overlapping the chat history icon, and made the WordPress version field a dropdown in site settings #4298, #4301, #4303, #4280, #4284
 * Agentic UI: Brought over the Wapuu World easter egg #4299
@@ -17,7 +17,7 @@ Unreleased
 * CLI: Added aliases for the help, version and path commands, and made `studio ui` work in release builds #4276, #4257
 * Hardened security: fixed path injection in path comparison, ReDoS in the mu-plugins loader, and HTML sanitization in AI tool result previews; restricted local imports to registered uploads and scoped CLI preview listings to the authenticated user #4267, #4254, #4260, #4308, #4252
 * Updated multiple dependencies, including Electron, Sentry, tar and shell-quote, resolving security alerts for esbuild and brace-expansion #4319, #4241, #4242, #4266, #4268, #4294
-* Misc and maintenance improvements #4293, #4279, #4289, #4300, #4234, #4282, #4229
+* Misc and maintenance improvements #4272, #4293, #4279, #4289, #4300, #4234, #4282, #4229
 
 1.16.0
 =====


### PR DESCRIPTION
## Related issues

- Related to the 1.17.0 release

## How AI was used in this PR

AI reviewed the release-notes conventions from previous versions and folded the auto-generated 1.17.0 PR list into thematic lines; I reviewed ALL the PRs added and approved the final wording. 

## Proposed Changes

- Rewrite the raw auto-generated 1.17.0 changelog into concise, user-facing thematic lines, following the same convention as previous releases.
- Group the Agentic UI work into a few thematic entries, keep security fixes and notable features visible, fold dependency bumps into a single line, and drop CI/test/process-only entries.

## Testing Instructions

- Review `RELEASE-NOTES.txt` and confirm every user-facing PR from the 1.17.0 milestone is represented and the wording reads well.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?