### PR TITLE
Replace Opus 4.8 with Opus 5 in available AI models (cherry-pick #4342)

### DIFF
--- a/apps/cli/commands/ai/tests/index.test.ts
+++ b/apps/cli/commands/ai/tests/index.test.ts
@@ -142,7 +142,7 @@ describe( 'AI runCommand — resume by id restores session model', () => {
 				id: 'e1',
 				parentId: null,
 				timestamp: '2024-01-01T00:00:00Z',
-				modelId: 'claude-opus-4-8',
+				modelId: 'claude-opus-5',
 			},
 		];
 		const mockSm = {
@@ -162,7 +162,7 @@ describe( 'AI runCommand — resume by id restores session model', () => {
 
 		expect( runStudioAgentTurn ).toHaveBeenCalledTimes( 1 );
 		const callArgs = ( runStudioAgentTurn as Mock ).mock.calls[ 0 ][ 0 ] as { model: string };
-		expect( callArgs.model ).toBe( 'claude-opus-4-8' );
+		expect( callArgs.model ).toBe( 'claude-opus-5' );
 	} );
 } );
 

--- a/packages/common/ai/models.ts
+++ b/packages/common/ai/models.ts
@@ -19,7 +19,7 @@ export interface AiModel {
 // and function tools.)
 export const AI_MODELS = [
 	{ id: 'claude-sonnet-5', label: 'Sonnet 5', family: 'anthropic' },
-	{ id: 'claude-opus-4-8', label: 'Opus 4.8', family: 'anthropic' },
+	{ id: 'claude-opus-5', label: 'Opus 5', family: 'anthropic' },
 	{ id: 'gpt-5.6-sol', label: 'GPT 5.6 Sol', family: 'openai' },
 ] as const satisfies readonly AiModel[];
 


### PR DESCRIPTION
## Related issues

- Cherry-pick of #4342 (merged into `trunk` as `ee45c2e`) onto `release/1.17.0`.

## How AI was used in this PR

Claude Code performed the cherry-pick onto the release branch, verified it applied cleanly with no conflicts, checked the release branch for any remaining references to the removed model ID, and ran the affected test suite plus the full typecheck.

## Proposed Changes

- Users picking a model in Studio Code in the 1.17.0 release now get **Claude Opus 5** instead of Claude Opus 4.8. Opus 5 is a drop-in upgrade at the same pricing, stronger on agentic coding, so the picker's top-tier Anthropic option improves at no cost change.
- Sessions that previously recorded Opus 4.8 fall back to the default model (Sonnet 5) on resume — the existing `resolveSessionModel` fallback covers removed model IDs, so no migration is needed and no session breaks.

## Testing Instructions

- `npm test -- apps/cli/commands/ai/tests/index.test.ts` — passes (8/8) on this branch.
- `npm run typecheck` — passes on this branch.
- In Studio Code, open the model picker: "Opus 5" should be listed (no "Opus 4.8"), and sending a message with it selected should complete a turn against the wpcom provider.
- Resume a session that had Opus 4.8 selected: it should silently switch to the default model.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
