### PR TITLE
Updates max_execution_time (cherry-pick #4274)

### DIFF
--- a/apps/cli/lib/native-php/config.ts
+++ b/apps/cli/lib/native-php/config.ts
@@ -162,6 +162,7 @@ export function getNativePhpIniContents( phpVersion: NativePhpSupportedVersion )
 	);
 	const directives: string[] = [
 		'memory_limit=512M',
+		'max_execution_time=0',
 		'post_max_size=2G',
 		'upload_max_filesize=2G',
 		'display_errors=1',

--- a/apps/cli/lib/native-php/tests/config.test.ts
+++ b/apps/cli/lib/native-php/tests/config.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { getDefaultPhpArgs } from 'cli/lib/native-php/config';
+import { getDefaultPhpArgs, getNativePhpIniContents } from 'cli/lib/native-php/config';
+
+describe( 'getNativePhpIniContents', () => {
+	it( 'disables the request time limit so the cli-server SAPI 30s default does not apply', () => {
+		const contents = getNativePhpIniContents( '8.4' );
+
+		expect( contents.split( /\r?\n/ ) ).toContain( 'max_execution_time=0' );
+	} );
+} );
 
 describe( 'getDefaultPhpArgs', () => {
 	it( 'omits Xdebug directives by default', () => {


### PR DESCRIPTION
## Related issues

* Cherry-pick of Automattic/studio#4274 into `release/1.17.0`
* Fixes Automattic/studio#4269

## How AI was used in this PR

Claude Code was used to cherry-pick the original commit and verify the tests. The original fix was explored and proposed with Claude Code, then manually reviewed and tested by the original author.

## Proposed Changes

* Sets the PHP `max_execution_time` to 0 (unlimited) instead of the 30 second `cli-server` SAPI default, so long-running tasks no longer time out when a site runs in PHP mode.

## Testing Instructions

* Start a new Studio site running PHP mode
* Create a plugin which reports the PHP execution limits (example: [https://github.com/jonathanbossenger/php-execution-limits/releases/tag/1.0.0](<https://github.com/jonathanbossenger/php-execution-limits/releases/tag/1.0.0>))
* Check the `max_execution_time` value
* Apply the fix
* Check the new `max_execution_time` value

## Pre-merge Checklist

- [X] Have you checked for TypeScript, React or other console errors?