### PR TITLE
Agentic UI: Make the sidebar footer a direct Settings entry

### DIFF
--- a/apps/ui/src/components/settings-view/account-section.test.tsx
+++ b/apps/ui/src/components/settings-view/account-section.test.tsx
@@ -29,6 +29,12 @@ vi.mock( '@wordpress/ui', () => ( {
 		void size;
 		return <button { ...props }>{ loading ? loadingAnnouncement : children }</button>;
 	},
+	Tooltip: {
+		Root: ( { children }: { children?: ReactNode } ) => <>{ children }</>,
+		Trigger: ( { render }: { render?: ReactNode } ) => <>{ render }</>,
+		Popup: () => null,
+		Positioner: () => null,
+	},
 } ) );
 
 vi.mock( '@/components/gravatar', () => ( {

--- a/apps/ui/src/components/settings-view/account-section.test.tsx
+++ b/apps/ui/src/components/settings-view/account-section.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
 import { useAuthUser, useLogin, useLogout } from '@/data/queries/use-auth-user';
 import { useUserLocale } from '@/data/queries/use-user-locale';
+import { useOffline } from '@/hooks/use-offline';
 import { AccountSection } from './account-section';
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
@@ -59,11 +60,16 @@ vi.mock( '@/hooks/use-color-scheme', () => ( {
 	useColorScheme: () => 'light',
 } ) );
 
+vi.mock( '@/hooks/use-offline', () => ( {
+	useOffline: vi.fn(),
+} ) );
+
 const useConnectorMock = vi.mocked( useConnector );
 const useAuthUserMock = vi.mocked( useAuthUser );
 const useLoginMock = vi.mocked( useLogin );
 const useLogoutMock = vi.mocked( useLogout );
 const useUserLocaleMock = vi.mocked( useUserLocale );
+const useOfflineMock = vi.mocked( useOffline );
 
 describe( 'AccountSection', () => {
 	const loginMutate = vi.fn();
@@ -75,6 +81,7 @@ describe( 'AccountSection', () => {
 
 		useConnectorMock.mockReturnValue( { openExternalUrl } as never );
 		useUserLocaleMock.mockReturnValue( undefined );
+		useOfflineMock.mockReturnValue( false );
 		useAuthUserMock.mockReturnValue( {
 			data: { id: 1, displayName: 'Ada Lovelace', email: 'ada@example.com' },
 			isLoading: false,
@@ -111,6 +118,31 @@ describe( 'AccountSection', () => {
 		fireEvent.click( screen.getByRole( 'button', { name: 'Log in' } ) );
 
 		expect( loginMutate ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'opens the WordPress.com profile through the connector', () => {
+		render( <AccountSection /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Edit WordPress.com profile' } ) );
+
+		expect( openExternalUrl ).toHaveBeenCalledWith( 'https://wordpress.com/me' );
+	} );
+
+	it( 'disables the profile link when offline', () => {
+		useOfflineMock.mockReturnValue( true );
+
+		render( <AccountSection /> );
+
+		expect( screen.getByRole( 'button', { name: 'Edit WordPress.com profile' } ) ).toBeDisabled();
+	} );
+
+	it( 'disables the login button when offline', () => {
+		useAuthUserMock.mockReturnValue( { data: null, isLoading: false } as never );
+		useOfflineMock.mockReturnValue( true );
+
+		render( <AccountSection /> );
+
+		expect( screen.getByRole( 'button', { name: 'Log in' } ) ).toBeDisabled();
 	} );
 
 	it( 'opens docs and issue links through the connector', () => {

--- a/apps/ui/src/components/settings-view/account-section.tsx
+++ b/apps/ui/src/components/settings-view/account-section.tsx
@@ -6,8 +6,11 @@ import { useConnector } from '@/data/core';
 import { useAuthUser, useLogin, useLogout } from '@/data/queries/use-auth-user';
 import { useUserLocale } from '@/data/queries/use-user-locale';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useOffline } from '@/hooks/use-offline';
 import { getLocalizedLink, REPORT_ISSUE_URL } from '@/lib/docs-links';
 import styles from './style.module.css';
+
+const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
 
 function AccountHelpActions() {
 	const connector = useConnector();
@@ -60,10 +63,12 @@ function AccountHelpActions() {
 }
 
 export function AccountSection() {
+	const connector = useConnector();
 	const { data: user, isLoading } = useAuthUser();
 	const login = useLogin();
 	const logout = useLogout();
 	const themeIsDark = useColorScheme() === 'dark';
+	const isOffline = useOffline();
 
 	return (
 		<section className={ styles.preferenceSectionGroup }>
@@ -92,22 +97,33 @@ export function AccountSection() {
 					</div>
 				</div>
 				{ user ? (
-					<Button
-						type="button"
-						variant="outline"
-						tone="neutral"
-						loading={ logout.isPending }
-						loadingAnnouncement={ __( 'Logging out' ) }
-						onClick={ () => logout.mutate() }
-					>
-						{ __( 'Log out' ) }
-					</Button>
+					<div className={ styles.accountButtons }>
+						<Button
+							type="button"
+							variant="minimal"
+							tone="neutral"
+							disabled={ isOffline }
+							onClick={ () => void connector.openExternalUrl( WPCOM_PROFILE_URL ) }
+						>
+							{ __( 'Edit WordPress.com profile' ) }
+						</Button>
+						<Button
+							type="button"
+							variant="outline"
+							tone="neutral"
+							loading={ logout.isPending }
+							loadingAnnouncement={ __( 'Logging out' ) }
+							onClick={ () => logout.mutate() }
+						>
+							{ __( 'Log out' ) }
+						</Button>
+					</div>
 				) : (
 					<Button
 						type="button"
 						variant="outline"
 						tone="neutral"
-						disabled={ isLoading }
+						disabled={ isLoading || isOffline }
 						loading={ login.isPending }
 						loadingAnnouncement={ __( 'Logging in' ) }
 						onClick={ () => login.mutate() }

--- a/apps/ui/src/components/settings-view/account-section.tsx
+++ b/apps/ui/src/components/settings-view/account-section.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
+import { Button, Tooltip } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { Gravatar } from '@/components/gravatar';
 import { useConnector } from '@/data/core';
@@ -19,24 +19,42 @@ function AccountHelpActions() {
 
 	return (
 		<div className={ styles.accountActions }>
-			<Button
-				type="button"
-				variant="minimal"
-				tone="neutral"
-				size="small"
-				onClick={ () => openLink( getLocalizedLink( locale, 'docsStudio' ) ) }
-			>
-				{ __( 'Docs' ) }
-			</Button>
-			<Button
-				type="button"
-				variant="minimal"
-				tone="neutral"
-				size="small"
-				onClick={ () => openLink( REPORT_ISSUE_URL ) }
-			>
-				{ __( 'Report an issue' ) }
-			</Button>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					render={
+						<Button
+							type="button"
+							variant="minimal"
+							tone="neutral"
+							size="small"
+							onClick={ () => openLink( getLocalizedLink( locale, 'docsStudio' ) ) }
+						>
+							{ __( 'Docs' ) }
+						</Button>
+					}
+				/>
+				<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+					{ __( 'Documentation' ) }
+				</Tooltip.Popup>
+			</Tooltip.Root>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					render={
+						<Button
+							type="button"
+							variant="minimal"
+							tone="neutral"
+							size="small"
+							onClick={ () => openLink( REPORT_ISSUE_URL ) }
+						>
+							{ __( 'Report an issue' ) }
+						</Button>
+					}
+				/>
+				<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+					{ __( 'Report an issue or request a feature' ) }
+				</Tooltip.Popup>
+			</Tooltip.Root>
 		</div>
 	);
 }

--- a/apps/ui/src/components/settings-view/index.test.tsx
+++ b/apps/ui/src/components/settings-view/index.test.tsx
@@ -61,6 +61,12 @@ vi.mock( '@wordpress/ui', () => ( {
 			</select>
 		</label>
 	),
+	Tooltip: {
+		Root: ( { children }: { children?: ReactNode } ) => <>{ children }</>,
+		Trigger: ( { render }: { render?: ReactNode } ) => <>{ render }</>,
+		Popup: () => null,
+		Positioner: () => null,
+	},
 } ) );
 
 vi.mock( '@/components/tabs', () => ( {

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -343,6 +343,15 @@
 	min-width: 0;
 }
 
+.accountButtons {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: var( --wpds-dimension-padding-sm );
+	flex-wrap: wrap;
+	flex-shrink: 0;
+}
+
 .accountIdentity {
 	display: flex;
 	align-items: center;

--- a/apps/ui/src/components/user-menu/index.test.tsx
+++ b/apps/ui/src/components/user-menu/index.test.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuthUser } from '@/data/queries/use-auth-user';
+import { UserMenu } from './index';
+
+const navigateMock = vi.fn();
+
+vi.mock( '@tanstack/react-router', () => ( {
+	useNavigate: () => navigateMock,
+} ) );
+
+vi.mock( '@/components/gravatar', () => ( {
+	Gravatar: () => <span data-testid="gravatar" />,
+} ) );
+
+vi.mock( '@/data/queries/use-auth-user', () => ( {
+	useAuthUser: vi.fn(),
+} ) );
+
+vi.mock( '@/hooks/use-color-scheme', () => ( {
+	useColorScheme: () => 'light',
+} ) );
+
+const useAuthUserMock = vi.mocked( useAuthUser );
+
+describe( 'UserMenu', () => {
+	const onToggleSidebar = vi.fn();
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+
+		useAuthUserMock.mockReturnValue( {
+			data: { id: 1, displayName: 'Ada Lovelace', email: 'ada@example.com' },
+		} as never );
+	} );
+
+	it( 'opens Settings directly and shows the gravatar when signed in', () => {
+		render( <UserMenu onToggleSidebar={ onToggleSidebar } /> );
+
+		expect( screen.getByTestId( 'gravatar' ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Settings' } ) );
+
+		expect( navigateMock ).toHaveBeenCalledWith( { to: '/settings' } );
+	} );
+
+	it( 'opens Settings directly with a placeholder icon when signed out', () => {
+		useAuthUserMock.mockReturnValue( { data: null } as never );
+
+		render( <UserMenu onToggleSidebar={ onToggleSidebar } /> );
+
+		expect( screen.queryByTestId( 'gravatar' ) ).not.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Settings' } ) );
+
+		expect( navigateMock ).toHaveBeenCalledWith( { to: '/settings' } );
+	} );
+
+	it( 'toggles the sidebar from the hide control', () => {
+		render( <UserMenu onToggleSidebar={ onToggleSidebar } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Hide sidebar' } ) );
+
+		expect( onToggleSidebar ).toHaveBeenCalledTimes( 1 );
+		expect( navigateMock ).not.toHaveBeenCalled();
+	} );
+} );

--- a/apps/ui/src/components/user-menu/index.tsx
+++ b/apps/ui/src/components/user-menu/index.tsx
@@ -1,98 +1,39 @@
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { cog } from '@wordpress/icons';
+import { Icon, settings } from '@wordpress/icons';
 import { IconButton } from '@wordpress/ui';
 import { Gravatar } from '@/components/gravatar';
-import * as Menu from '@/components/menu';
 import { SidebarButton } from '@/components/sidebar-button';
-import { useConnector } from '@/data/core';
-import { useAuthUser, useLogin, useLogout } from '@/data/queries/use-auth-user';
-import { useUserLocale } from '@/data/queries/use-user-locale';
+import { useAuthUser } from '@/data/queries/use-auth-user';
 import { useColorScheme } from '@/hooks/use-color-scheme';
-import { useOffline } from '@/hooks/use-offline';
-import { getLocalizedLink, REPORT_ISSUE_URL } from '@/lib/docs-links';
 import { drawerIcon } from '@/lib/icons';
 import styles from './style.module.css';
-
-const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
 
 type Props = {
 	onToggleSidebar: () => void;
 };
 
 export function UserMenu( { onToggleSidebar }: Props ) {
-	const connector = useConnector();
 	const { data: user } = useAuthUser();
-	const login = useLogin();
-	const logout = useLogout();
 	const navigate = useNavigate();
-
-	const isOffline = useOffline();
-	const locale = useUserLocale();
 	const themeIsDark = useColorScheme() === 'dark';
-
-	const openLink = ( url: string ) => {
-		void connector.openExternalUrl( url );
-	};
 
 	return (
 		<div className={ styles.root }>
 			<div className={ styles.row }>
-				{ user ? (
-					<Menu.Root modal={ false }>
-						<Menu.Trigger
-							render={
-								<SidebarButton className={ styles.userTrigger }>
-									<Gravatar email={ user.email } isDark={ themeIsDark } />
-									<span className={ styles.userName }>{ user.displayName }</span>
-								</SidebarButton>
-							}
-						/>
-						<Menu.Popup side="top" align="start" className={ styles.popup }>
-							<div className={ styles.email } title={ user.email }>
-								{ user.email }
-							</div>
-							<Menu.Item onClick={ () => void navigate( { to: '/settings' } ) }>
-								{ __( 'Settings' ) }
-							</Menu.Item>
-							<Menu.Item disabled={ isOffline } onClick={ () => openLink( WPCOM_PROFILE_URL ) }>
-								{ __( 'Edit WordPress.com profile' ) }
-							</Menu.Item>
-							<Menu.Item
-								disabled={ isOffline }
-								onClick={ () => openLink( getLocalizedLink( locale, 'docsStudio' ) ) }
-							>
-								{ __( 'Documentation' ) }
-							</Menu.Item>
-							<Menu.Item disabled={ isOffline } onClick={ () => openLink( REPORT_ISSUE_URL ) }>
-								{ __( 'Report an issue' ) }
-							</Menu.Item>
-							<Menu.Separator />
-							<Menu.Item onClick={ () => logout.mutate() }>{ __( 'Log out' ) }</Menu.Item>
-						</Menu.Popup>
-					</Menu.Root>
-				) : (
-					<SidebarButton
-						className={ styles.loginButton }
-						disabled={ isOffline }
-						onClick={ () => login.mutate() }
-					>
-						{ __( 'Log in with WordPress.com' ) }
-					</SidebarButton>
-				) }
-				{ ! user ? (
-					// Logged in, Settings lives in the user menu; logged out
-					// there is no menu, so keep the page reachable here.
-					<IconButton
-						variant="minimal"
-						tone="neutral"
-						size="small"
-						className={ styles.settingsButton }
-						icon={ cog }
-						label={ __( 'Settings' ) }
-						onClick={ () => void navigate( { to: '/settings' } ) }
-					/>
-				) : null }
+				<SidebarButton
+					className={ styles.userTrigger }
+					onClick={ () => void navigate( { to: '/settings' } ) }
+				>
+					{ user ? (
+						<Gravatar email={ user.email } isDark={ themeIsDark } />
+					) : (
+						<span className={ styles.settingsAvatar } aria-hidden="true">
+							<Icon icon={ settings } size={ 14 } />
+						</span>
+					) }
+					<span className={ styles.userName }>{ __( 'Settings' ) }</span>
+				</SidebarButton>
 				<IconButton
 					variant="minimal"
 					tone="neutral"

--- a/apps/ui/src/components/user-menu/style.module.css
+++ b/apps/ui/src/components/user-menu/style.module.css
@@ -8,7 +8,7 @@
 		var(--wpds-dimension-padding-2xl) - var(--wpds-dimension-padding-xs)
 	);
 
-	/* SidebarButton adds `sm` inline padding; this offset puts the gravatar's
+	/* SidebarButton adds `sm` inline padding; this offset puts the avatar's
 	   left edge on the same column as the site icons. */
 	padding: var(--wpds-dimension-padding-sm) var(--user-menu-trailing-offset)
 		var(--wpds-dimension-padding-xl) var(--user-menu-leading-offset);
@@ -20,22 +20,23 @@
 	gap: var(--wpds-dimension-padding-xs);
 }
 
-.userName,
-.sidebarToggle,
-.settingsButton {
+.userName {
 	color: var(--wpds-color-fg-content-neutral-weak);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
 }
 
 .sidebarToggle {
+	color: var(--wpds-color-fg-content-neutral-weak);
 	margin-inline-end: calc(-1 * var(--wpds-dimension-padding-sm));
 }
 
 .row:hover .userName,
 .row:hover .sidebarToggle,
-.row:hover .settingsButton,
 .row:focus-within .userName,
-.row:focus-within .sidebarToggle,
-.row:focus-within .settingsButton {
+.row:focus-within .sidebarToggle {
 	color: var(--wpds-color-fg-content-neutral);
 }
 
@@ -48,27 +49,22 @@
 	padding-inline-start: calc(var(--wpds-dimension-padding-sm) - var(--user-menu-avatar-offset));
 }
 
-.userName {
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	min-width: 0;
-}
-
-.loginButton {
-	flex: 1;
-	text-align: left;
-}
-
-.popup {
-	min-width: 220px;
-}
-
-.email {
-	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
-	font-size: var(--wpds-typography-font-size-xs);
+/* Signed-out avatar: a circle with the settings (sliders) icon, sized/shaped to
+   match the gravatar it stands in for. */
+.settingsAvatar {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	flex-shrink: 0;
+	background-color: var(--wpds-color-bg-surface-neutral);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+}
+
+.settingsAvatar svg {
+	width: 14px;
+	height: 14px;
+	fill: currentColor;
 }


### PR DESCRIPTION
## Related issues
- Fixes STU-2102

## How AI was used in this PR

AI implemented the change following the direction of #4311, I reviewed and tested

## Proposed Changes
When you click on Avatar in left bottom corner we should land users on Settigns page instead of dropdown.
We do it to unify behavior for logged-in and logged-out users, and all links in the dropdown are already available on the Settings page.
See testing instructions.

## Testing Instructions
1. Run Agentic UI
2. Sign in - assert that you see your avatar and Settings label. Clicking on it should lead you directly to the settings page
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>

<tr>
<td><img width="313" height="262" alt="Screenshot 2026-07-27 at 12 40 36" src="https://github.com/user-attachments/assets/43c3d3ff-3472-46d8-8263-c70e7ea2bfe3" />
<td><img width="307" height="54" alt="Screenshot 2026-07-27 at 12 37 48" src="https://github.com/user-attachments/assets/6e4bfd32-f714-4734-9a65-2aa8481a8cb4" />
</tr>
</table>
3. Log out
4. Assert that now you see the Settings icon insteadof avatar and click on it still leads you to settings page
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>

<tr>
<td><img width="310" height="52" alt="Screenshot 2026-07-27 at 12 40 14" src="https://github.com/user-attachments/assets/d5e55276-edff-4f42-8103-07f1111ab836" />
<td><img width="307" height="49" alt="Screenshot 2026-07-27 at 12 38 06" src="https://github.com/user-attachments/assets/e9cbc9c3-d6fa-4658-8d52-2057072bf154" />
</tr>

<tr>
<td>
<td>
</tr>
</table>
5. Open Settings page and assert that you see tooltips for "Docs" and for "Report an issue"<br /><img width="261" height="74" alt="Screenshot 2026-07-27 at 14 47 37" src="https://github.com/user-attachments/assets/7a929fe8-bb10-43d4-b0a8-15dba0ea6037" />
