### PR TITLE
Simplify and align the analytics toggle in legacy settings

### DIFF
--- a/apps/studio/src/modules/user-settings/components/analytics-toggle.tsx
+++ b/apps/studio/src/modules/user-settings/components/analytics-toggle.tsx
@@ -10,20 +10,13 @@ export function AnalyticsToggle( { value, onChange }: AnalyticsToggleProps ) {
 	const { __ } = useI18n();
 
 	return (
-		<div className="flex flex-col gap-1">
-			<CheckboxControl
-				__nextHasNoMarginBottom
-				id="analytics-toggle"
-				className="[&_.components-checkbox-control__label]:font-semibold [&_.components-checkbox-control__label]:text-frame-text"
-				label={ __( 'Help improve Studio by sharing anonymous usage statistics' ) }
-				checked={ value }
-				onChange={ onChange }
-			/>
-			<div className="a8c-body-small text-frame-text-secondary ml-7">
-				{ __(
-					'Anonymous usage data helps us understand how Studio is used so we can improve it. No personally identifiable information is collected.'
-				) }
-			</div>
-		</div>
+		<CheckboxControl
+			__nextHasNoMarginBottom
+			id="analytics-toggle"
+			className="pl-4 [&_.components-checkbox-control__label]:font-semibold [&_.components-checkbox-control__label]:text-frame-text"
+			label={ __( 'Help improve Studio by sharing anonymous usage statistics' ) }
+			checked={ value }
+			onChange={ onChange }
+		/>
 	);
 }


### PR DESCRIPTION
## Related issues

- Follow up to #4162

## How AI was used in this PR

Claude Code applied a designer's feedback: removed the redundant description line and computed the left padding needed to align the checkbox with the CLI toggle (based on the rendered `@wordpress/components` control dimensions).

## Proposed Changes

The analytics opt-out checkbox in the legacy (`apps/studio`) Settings screen previously rendered a second line of descriptive text and sat with its own indentation.

Per design feedback:

- Removed the secondary description line, so the setting is now a single, cleaner label — consistent with how this screen is being wound down.
- Added left padding so the checkbox's right edge lines up with the right edge of the "Studio CLI for terminal" switch above it, and both settings' labels line up on the left. This makes the two adjacent controls read as a coherent group.

## Testing Instructions

1. Open **Settings** (General tab) in Studio.
2. Confirm the "Help improve Studio by sharing anonymous usage statistics" checkbox no longer shows a second line of description text.
3. Confirm the checkbox's right edge aligns with the right edge of the "Studio CLI for terminal" switch, and both labels start at the same left position.
4. Verify in **both light and dark** color schemes.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
