### PR TITLE
Agentic UI: Make signed-out site selection read as a normal selection

### DIFF
--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -241,6 +241,28 @@ describe( 'SiteList', () => {
 		} );
 	} );
 
+	it( 'shows the selected site solid without the overview shortcut when signed out', () => {
+		vi.mocked( useAgenticFeatures ).mockReturnValue( {
+			enabled: false,
+			chatEnabled: false,
+			reason: 'signed-out',
+			isReady: true,
+		} );
+		paramsMock = { siteId: 'stopped-site' };
+		pathnameMock = '/sites/stopped-site/overview';
+
+		render( <SiteList /> );
+
+		const stoppedRow = screen.getByText( 'Stopped Site' ).closest( 'section' )!;
+		const className = stoppedRow.getAttribute( 'class' ) ?? '';
+		const siteButton = within( stoppedRow ).getByRole( 'button', { name: 'Stopped Site' } );
+
+		expect( className ).toContain( 'siteActive' );
+		expect( className ).not.toContain( 'siteContextActive' );
+		expect( siteButton ).toHaveAttribute( 'aria-current', 'page' );
+		expect( screen.queryByRole( 'button', { name: 'Site overview' } ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'opens the site overview from the row gear without opening the latest chat', () => {
 		render( <SiteList /> );
 

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -505,6 +505,11 @@ function SiteSection( {
 	const navigate = useNavigate();
 	const sectionRef = useRef< HTMLElement >( null );
 	const isActive = isChatActive || isContextActive;
+	// Without chat, a site's home is its overview, so the context-active row
+	// is simply "the selected site" — show it solid-selected (no dashed
+	// outline, no overview shortcut), matching how chat-active looks.
+	const isSelected = isChatActive || ( isContextActive && ! chatEnabled );
+	const showContextOutline = isContextActive && chatEnabled;
 	// Keep the active site visible — e.g. when launch restores a site that
 	// sits below the sidebar's fold. `nearest` no-ops when already visible.
 	useEffect( () => {
@@ -555,8 +560,8 @@ function SiteSection( {
 			ref={ sectionRef }
 			className={ clsx(
 				styles.site,
-				isChatActive && styles.siteActive,
-				isContextActive && styles.siteContextActive
+				isSelected && styles.siteActive,
+				showContextOutline && styles.siteContextActive
 			) }
 		>
 			<SiteActionsMenu
@@ -574,7 +579,7 @@ function SiteSection( {
 									event.stopPropagation();
 									handleOpenSite();
 								} }
-								aria-current={ isChatActive ? 'page' : undefined }
+								aria-current={ isSelected ? 'page' : undefined }
 							>
 								<span
 									className={ clsx(
@@ -588,7 +593,7 @@ function SiteSection( {
 							</SidebarButton>
 						</div>
 						<div className={ styles.siteActions } data-reorder-exclude>
-							<SiteOverviewButton site={ site } />
+							{ chatEnabled ? <SiteOverviewButton site={ site } /> : null }
 							<SiteStatusButton site={ site } isStarting={ isStarting } isStopping={ isStopping } />
 						</div>
 					</header>


### PR DESCRIPTION
## Related issues

- Fixes STU-2100

## How AI was used in this PR

AI assisted with the implementation, I reviewed and tested



## Proposed Changes

See testing instructions

## Testing Instructions
1. Run Agentic UI
2. Sign out
4. Assert that you don't see redundant Overview shortcut button anymore; Assert that you don't see a dashed border for the selected site; Assert that you see a background for the selected site.
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="303" height="106" alt="Screenshot 2026-07-27 at 17 30 07" src="https://github.com/user-attachments/assets/416a287e-9aa9-45f4-b453-6a61f28ea6e6" />
<td><img width="306" height="97" alt="Screenshot 2026-07-27 at 17 24 38" src="https://github.com/user-attachments/assets/6969e248-19c8-4e25-badf-b38e826c380f" />
</tr>
</table>
5. Sign in
6. Assert that no regressions - by default, we don't have a dashed border; we have a background, and the Overview shortcut button is available<br /><img width="301" height="120" alt="Screenshot 2026-07-27 at 17 24 55" src="https://github.com/user-attachments/assets/4394e158-fd03-4e30-bb9e-f1bab179b936" />
7. Click on Overview shortcut
8. Assert that only in this case you see dashed border and no background<br /><img width="305" height="110" alt="Screenshot 2026-07-27 at 17 33 00" src="https://github.com/user-attachments/assets/9810af2e-e41e-4b81-8027-7f44b886408c" />


