### PR TITLE
Agentic UI: Include apps/ui in translations and adjust some translation strings

### DIFF
--- a/apps/studio/src/components/site-settings-panels.tsx
+++ b/apps/studio/src/components/site-settings-panels.tsx
@@ -393,7 +393,7 @@ export function WordPressSkillsPanel( { siteId }: { siteId: string } ) {
 			) }
 
 			{ statuses.length === 0 && ! error && (
-				<div className="text-sm text-gray-500 text-center py-4">{ __( 'Loading skills...' ) }</div>
+				<div className="text-sm text-gray-500 text-center py-4">{ __( 'Loading skills…' ) }</div>
 			) }
 		</div>
 	);

--- a/apps/studio/src/components/tests/site-content-tabs.test.tsx
+++ b/apps/studio/src/components/tests/site-content-tabs.test.tsx
@@ -87,7 +87,7 @@ describe( 'SiteContentTabs', () => {
 			loadingServer: {},
 		} );
 		await act( async () => renderWithProvider( <SiteContentTabs /> ) );
-		expect( screen.getByRole( 'tab', { name: 'Site Settings' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'tab', { name: 'Site settings' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'tab', { name: 'Sync' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'tab', { name: 'Previews' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'tab', { name: 'Import / Export' } ) ).toBeInTheDocument();
@@ -105,7 +105,7 @@ describe( 'SiteContentTabs', () => {
 		expect( screen.queryByRole( 'tab', { name: 'Overview', selected: true } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Sync', selected: false } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Previews', selected: false } ) ).toBeVisible();
-		expect( screen.queryByRole( 'tab', { name: 'Site Settings', selected: false } ) ).toBeVisible();
+		expect( screen.queryByRole( 'tab', { name: 'Site settings', selected: false } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Studio Code', selected: false } ) ).toBeVisible();
 		expect(
 			screen.queryByRole( 'tab', { name: 'Backup', selected: false } )

--- a/apps/studio/src/hooks/use-content-tabs.tsx
+++ b/apps/studio/src/hooks/use-content-tabs.tsx
@@ -37,7 +37,7 @@ function useTabs() {
 			{
 				order: 5,
 				name: 'settings',
-				title: __( 'Site Settings' ),
+				title: __( 'Site settings' ),
 			}
 		);
 

--- a/apps/studio/src/hooks/use-delete-site.ts
+++ b/apps/studio/src/hooks/use-delete-site.ts
@@ -23,7 +23,7 @@ export function useDeleteSite() {
 			type: 'warning',
 			message: sprintf( __( 'Delete %s' ), trimmedSiteTitle ),
 			detail: __(
-				"The site's database will be lost. Including all posts, pages, comments, and media."
+				"The site's database will be lost, including all posts, pages, comments, and media."
 			),
 			buttons: [ __( 'Delete site' ), __( 'Cancel' ) ],
 			cancelId: CANCEL_BUTTON_INDEX,

--- a/apps/studio/src/modules/add-site/components/options.tsx
+++ b/apps/studio/src/modules/add-site/components/options.tsx
@@ -187,7 +187,7 @@ export default function AddSiteOptions( {
 					illustration={ <BuildNewSiteIllustration /> }
 					title={ __( 'Build a new site' ) }
 					description={ __(
-						'Start from scratch or use a blueprint. Perfect for theme and plugin development.'
+						'Start from scratch or use a Blueprint. Perfect for theme and plugin development.'
 					) }
 					onClick={ () => onOptionSelect( 'new' ) }
 					testId="create-site-option-button"

--- a/apps/studio/src/modules/user-settings/components/skills-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/skills-tab.tsx
@@ -188,7 +188,7 @@ export function SkillsTab() {
 			) }
 
 			{ statuses.length === 0 && ! error && (
-				<div className="text-sm text-gray-500 text-center py-4">{ __( 'Loading skills...' ) }</div>
+				<div className="text-sm text-gray-500 text-center py-4">{ __( 'Loading skills…' ) }</div>
 			) }
 		</div>
 	);

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -232,7 +232,7 @@ describe( 'UsagePanel', () => {
 	it( 'shows a loading row with an empty progress bar in both sections', () => {
 		useStudioAssistantQuotaMock.mockReturnValue( { data: undefined, isLoading: true } as never );
 		// Preview usage is still cached from before the delete, so the bar would
-		// otherwise keep its old fill next to a "Loading..." row.
+		// otherwise keep its old fill next to a "Loading…" row.
 		useDeleteAllSnapshotsMock.mockReturnValue( {
 			mutate: deleteSnapshotsMutate,
 			isPending: true,
@@ -241,7 +241,7 @@ describe( 'UsagePanel', () => {
 
 		render( <UsagePanel /> );
 
-		expect( screen.getAllByText( 'Loading...' ) ).toHaveLength( 2 );
+		expect( screen.getAllByText( 'Loading…' ) ).toHaveLength( 2 );
 		const bars = screen.getAllByTestId( 'usage-progress-bar' );
 		expect( bars ).toHaveLength( 2 );
 		for ( const bar of bars ) {
@@ -279,7 +279,7 @@ describe( 'UsagePanel', () => {
 		render( <UsagePanel /> );
 
 		expect(
-			screen.getByText( 'An error occurred while deleting preview sites. Please try again.' )
+			screen.getByText( 'An error occurred while deleting all preview sites. Please try again.' )
 		).toBeInTheDocument();
 	} );
 

--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -53,7 +53,7 @@ function AiCreditsSummary() {
 	if ( isLoading ) {
 		content = (
 			<>
-				<div className={ styles.previewUsageText }>{ __( 'Loading...' ) }</div>
+				<div className={ styles.previewUsageText }>{ __( 'Loading…' ) }</div>
 				<UsageProgressBar fraction={ 0 } />
 			</>
 		);
@@ -114,10 +114,10 @@ function PreviewSitesSummary( { userId }: { userId: number } ) {
 	const isLoadingPreviewUsage = isLoading || isLoadingSnapshotUsage || deleteAllSnapshots.isPending;
 	const isDisabled = siteCount === 0 || snapshotCreationBlocked || isLoadingPreviewUsage;
 	// Empty while loading: a bar still filled from the previous figure would
-	// contradict the "Loading..." row next to it.
+	// contradict the "Loading…" row next to it.
 	const fraction = isLoadingPreviewUsage ? 0 : clampQuotaFraction( siteCount, siteLimit );
 	const deletePreviewSitesLabel = deleteAllSnapshots.isPending
-		? __( 'Deleting preview sites...' )
+		? __( 'Deleting all preview sites…' )
 		: __( 'Delete all preview sites' );
 
 	const handleDelete = async () => {
@@ -165,7 +165,7 @@ function PreviewSitesSummary( { userId }: { userId: number } ) {
 				<>
 					<div className={ styles.previewUsageText }>
 						{ isLoadingPreviewUsage
-							? __( 'Loading...' )
+							? __( 'Loading…' )
 							: sprintf(
 									/* translators: 1: number of active preview sites, 2: maximum allowed */
 									_n(
@@ -182,7 +182,7 @@ function PreviewSitesSummary( { userId }: { userId: number } ) {
 			) }
 			{ deleteAllSnapshots.error ? (
 				<div className={ styles.errorMessage }>
-					{ __( 'An error occurred while deleting preview sites. Please try again.' ) }
+					{ __( 'An error occurred while deleting all preview sites. Please try again.' ) }
 				</div>
 			) : null }
 		</section>

--- a/apps/ui/src/components/site-dropdown/publish-picker-view.tsx
+++ b/apps/ui/src/components/site-dropdown/publish-picker-view.tsx
@@ -98,7 +98,7 @@ export function PublishPickerView( { site, onClose }: Props ) {
 			) : null }
 			<button type="button" className={ styles.create } onClick={ handleCreateNew }>
 				<Icon icon={ plus } size={ 16 } />
-				<span>{ __( 'Create a new WordPress.com site…' ) }</span>
+				<span>{ __( 'Create a new WordPress.com site' ) }</span>
 			</button>
 		</div>
 	);

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,7 +108,7 @@ lane :generate_pot_file do |commit_message: nil, skip_confirm: false|
   sh('mkdir', '-p', File.dirname(POT_FILE_PATH))
   sh(
     'npx', 'wp-babel-makepot',
-    "#{PROJECT_ROOT_FOLDER}/{apps/studio/src,apps/cli,packages/common}/**/*.{js,jsx,ts,tsx}",
+    "#{PROJECT_ROOT_FOLDER}/{apps/studio/src,apps/cli,apps/ui/src,packages/common}/**/*.{js,jsx,ts,tsx}",
     '--ignore', "#{PROJECT_ROOT_FOLDER}/apps/cli/node_modules/**/*,**/*.d.ts",
     '--base', PROJECT_ROOT_FOLDER,
     '--dir', pot_dir,


### PR DESCRIPTION
## Related issues

- Fixes [STU-2129](https://linear.app/a8c/issue/STU-2129/agentic-ui-strings-are-never-extracted-for-translation)

## How AI was used in this PR

Claude Code diffed `apps/ui`'s extracted strings against the shipped `.pot` and the GlotPress catalogs, then applied the edits. I reviewed them and chose which way each duplicate was unified.

## Proposed Changes

`apps/ui` was missing from the string extraction glob, so its strings never reached GlotPress — **327 of 490 (67%) rendered English in every locale**. Including it adds 565 source references to the next code-freeze `.pot`.

Also de-duplicates strings that existed in both UIs with only cosmetic differences (ellipsis, casing, a sentence fragment), so translators don't get the same sentence twice. Four legacy strings adopted the agentic UI's wording and will be English for one translation round.

macOS menu items (Title Case) and screen-reader announcements (no ellipsis) were deliberately left as separate strings — different surfaces, different conventions.

No catalogs or `.pot` files are touched; `code_freeze` regenerates those.

## Testing Instructions

Extraction — writes only to `/tmp`:

```sh
npx wp-babel-makepot \
  "$PWD/{apps/studio/src,apps/cli,apps/ui/src,packages/common}/**/*.{js,jsx,ts,tsx}" \
  --ignore "$PWD/apps/cli/node_modules/**/*,**/*.d.ts" \
  --base "$PWD" --dir /tmp/pots --output /tmp/check.pot

grep -c "apps/ui" /tmp/check.pot     # 565 here, 0 on trunk
```

Set Settings → Language → **Español** (the window reloads, expected). These should now be translated:

- Settings → Usage, loading: `Loading...` → `cargando…`
- Settings → Usage → *Delete all preview sites*: → `Eliminando todos los sitios de vista previa...`
- Site dropdown → Publish, bottom button: → `Crear un sitio nuevo en WordPress.com`

Expected to still show English until the next GlotPress round — not bugs: legacy **Site settings** tab, **Loading skills…**, delete-site confirmation body, *Build a new site* description.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
