### PR TITLE
Agentic UI: Fix the preview landing on the home page when opening a URL on a stopped site

### DIFF
--- a/apps/ui/src/hooks/use-open-site-url.test.tsx
+++ b/apps/ui/src/hooks/use-open-site-url.test.tsx
@@ -28,6 +28,9 @@ describe( 'useOpenSiteUrl', () => {
 
 	beforeEach( () => {
 		vi.clearAllMocks();
+		// clearAllMocks leaves implementations in place, so reset the default
+		// each test overrides.
+		startSite.mockResolvedValue( undefined );
 		useConnectorMock.mockReturnValue( { openSiteUrl, getSites, onToggleSitePreview } );
 		useStartSiteMock.mockReturnValue( { isPending: false, mutateAsync: startSite } );
 	} );
@@ -53,44 +56,55 @@ describe( 'useOpenSiteUrl', () => {
 	} );
 
 	it( 'drives the in-app preview through auto-login inside the provider', async () => {
-		const wrapper = ( { children }: { children: ReactNode } ) => (
-			<SessionUIProvider>{ children }</SessionUIProvider>
-		);
-		const { result } = renderHook(
-			() => ( { open: useOpenSiteUrl( site ), preview: useSessionPreviewUI() } ),
-			{ wrapper }
-		);
+		const { result } = renderPreviewHook( site );
 
 		await act( () => result.current.open( '/wp-admin/plugins.php' ) );
 
 		expect( openSiteUrl ).not.toHaveBeenCalled();
 		expect( result.current.preview.open ).toBe( true );
 		expect( result.current.preview.path ).toBe(
-			`/studio-auto-login?redirect_to=${ encodeURIComponent(
-				'http://localhost:8881/wp-admin/plugins.php'
-			) }`
+			`/studio-auto-login?redirect_to=${ encodeURIComponent( '/wp-admin/plugins.php' ) }`
 		);
 	} );
 
-	it( 'reads the restarted site so the redirect uses the fresh port', async () => {
+	// The path has to be set before the start resolves, otherwise the preview
+	// mounts on the old path and the load it reports back overwrites this one.
+	// The redirect stays relative so it survives the port a restart hands out.
+	it( 'points the preview at the destination before the start resolves', async () => {
+		startSite.mockReturnValue( new Promise( () => {} ) );
+		const { result } = renderPreviewHook( createSite( { running: false } ) );
+
+		await act( async () => {
+			void result.current.open( '/wp-admin/' );
+		} );
+
+		expect( startSite ).toHaveBeenCalledWith( 'site-1' );
+		expect( getSites ).not.toHaveBeenCalled();
+		expect( result.current.preview.path ).toBe(
+			`/studio-auto-login?redirect_to=${ encodeURIComponent( '/wp-admin/' ) }`
+		);
+	} );
+
+	it( 'leaves the preview pointed at the destination when the start fails', async () => {
 		const stoppedSite = createSite( { running: false } );
-		getSites.mockResolvedValue( [ createSite( { running: true, port: 9999 } ) ] );
-		const wrapper = ( { children }: { children: ReactNode } ) => (
-			<SessionUIProvider>{ children }</SessionUIProvider>
-		);
-		const { result } = renderHook(
-			() => ( { open: useOpenSiteUrl( stoppedSite ), preview: useSessionPreviewUI() } ),
-			{ wrapper }
-		);
+		startSite.mockRejectedValue( new Error( 'boom' ) );
+		const { result } = renderPreviewHook( stoppedSite );
 
 		await act( () => result.current.open( '/wp-admin/' ) );
 
-		expect( startSite ).toHaveBeenCalledWith( 'site-1' );
 		expect( result.current.preview.path ).toBe(
-			`/studio-auto-login?redirect_to=${ encodeURIComponent( 'http://localhost:9999/wp-admin/' ) }`
+			`/studio-auto-login?redirect_to=${ encodeURIComponent( '/wp-admin/' ) }`
 		);
 	} );
 } );
+
+function renderPreviewHook( site: SiteDetails ) {
+	return renderHook( () => ( { open: useOpenSiteUrl( site ), preview: useSessionPreviewUI() } ), {
+		wrapper: ( { children }: { children: ReactNode } ) => (
+			<SessionUIProvider>{ children }</SessionUIProvider>
+		),
+	} );
+}
 
 function createSite( overrides: Partial< SiteDetails > = {} ): SiteDetails {
 	return {

--- a/apps/ui/src/hooks/use-open-site-url.ts
+++ b/apps/ui/src/hooks/use-open-site-url.ts
@@ -1,7 +1,6 @@
 import { useConnector } from '@/data/core';
 import { useStartSite } from '@/data/queries/use-sites';
 import { useOptionalSessionPreviewUI } from '@/hooks/use-session-ui';
-import { getSiteUrl } from '@/lib/get-site-url';
 import type { SiteDetails } from '@/data/core';
 
 /**
@@ -19,39 +18,38 @@ export function useOpenSiteUrl( site: SiteDetails ) {
 	const startSite = useStartSite();
 
 	return async ( relativeUrl: string ) => {
-		let currentSite = site;
-		if ( ! site.running ) {
-			try {
-				await startSite.mutateAsync( site.id );
-			} catch {
-				return;
-			}
-			// Ports are allocated dynamically on start; re-read the started
-			// site so the auto-login redirect doesn't embed a stale URL.
-			try {
-				const sites = await connector.getSites();
-				currentSite = sites.find( ( candidate ) => candidate.id === site.id ) ?? site;
-			} catch {
-				// Keep the closure's site; worst case the redirect misses and
-				// the preview still shows the site root.
-			}
-		}
 		if ( ! preview ) {
+			if ( ! site.running ) {
+				try {
+					await startSite.mutateAsync( site.id );
+				} catch {
+					return;
+				}
+			}
 			void connector.openSiteUrl( site.id, relativeUrl ).catch( ( error ) => {
 				console.error( 'Failed to open site URL:', error );
 			} );
 			return;
 		}
-		try {
-			const redirectTo = new URL( relativeUrl || '/', getSiteUrl( currentSite ) ).toString();
-			preview.setOpen( true );
-			preview.setSite( site.id );
-			preview.updatePath( `/studio-auto-login?redirect_to=${ encodeURIComponent( redirectTo ) }` );
-		} catch ( error ) {
-			// Malformed URL (shouldn't happen) — fall back to the browser so
-			// the click still does something.
-			console.error( 'Failed to open site URL in preview:', error );
-			void connector.openSiteUrl( site.id, relativeUrl ).catch( () => undefined );
+
+		// Point the panel at the destination *before* starting the site. The
+		// preview only mounts its webview once the site is running, so it then
+		// loads the destination directly. Starting first would mount the
+		// webview on the previous path, and the load it reports back would
+		// overwrite the destination we set afterwards.
+		preview.setOpen( true );
+		preview.setSite( site.id );
+		preview.updatePath(
+			`/studio-auto-login?redirect_to=${ encodeURIComponent( relativeUrl || '/' ) }`
+		);
+
+		if ( ! site.running ) {
+			try {
+				await startSite.mutateAsync( site.id );
+			} catch {
+				// The panel already points at the destination; it loads if and
+				// when the site comes up.
+			}
 		}
 	};
 }


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code traced the race and wrote the fix and tests. I found the bug by hand and verified the fix in the app.

## Proposed Changes

Opening a URL in the preview on a **stopped** site landed on the site's home page instead of the requested page — you had to click a second time. The site was started first and the preview pointed at the destination after, so the preview mounted on the previous path while the start was still in flight, and the load it reported back overwrote the destination. It's now pointed at the destination before the site starts.

## Testing Instructions

Agentic UI, with a **stopped** site.

1. From the site's Overview tab, click a WordPress link (e.g. wp-admin).
2. The site starts and the preview lands on **that page**. Before this PR it landed on the home page and needed a second click.
3. Repeat with the site already running — unchanged.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
