### PR TITLE
Fix inverted play/pause glyphs on the site status toggle and add a status tooltip

### DIFF
--- a/apps/ui/src/components/site-dropdown/main-view.module.css
+++ b/apps/ui/src/components/site-dropdown/main-view.module.css
@@ -130,7 +130,7 @@
 	--local-server-thumb-shadow: color-mix(in srgb, #0d5f2c 22%, transparent);
 }
 
-.localServerControl:not(:disabled):hover {
+.localServerControl:not([aria-disabled='true']):hover {
 	background-color: var(--local-server-track-bg-hover);
 	box-shadow:
 		inset 0 0 0 var(--wpds-border-width-xs) var(--local-server-track-border-hover),
@@ -147,7 +147,7 @@
 	outline-offset: 2px;
 }
 
-.localServerControl:disabled {
+.localServerControl[aria-disabled='true'] {
 	cursor: not-allowed;
 	opacity: 0.72;
 }

--- a/apps/ui/src/components/site-dropdown/main-view.test.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.test.tsx
@@ -5,7 +5,15 @@ import * as Menu from '@/components/menu';
 import { MainView } from './main-view';
 import type { SiteDetails, Snapshot, SyncSite } from '@/data/core';
 
-const { connector, snapshots, connectedSites, publishPreviewMutate } = vi.hoisted( () => ( {
+const {
+	connector,
+	snapshots,
+	connectedSites,
+	publishPreviewMutate,
+	transitions,
+	startSiteMutate,
+	stopSiteMutate,
+} = vi.hoisted( () => ( {
 	connector: {
 		copyText: vi.fn(),
 		openExternalUrl: vi.fn(),
@@ -13,6 +21,9 @@ const { connector, snapshots, connectedSites, publishPreviewMutate } = vi.hoiste
 	snapshots: [] as Snapshot[],
 	connectedSites: [] as SyncSite[],
 	publishPreviewMutate: vi.fn(),
+	transitions: { starting: false, stopping: false },
+	startSiteMutate: vi.fn(),
+	stopSiteMutate: vi.fn(),
 } ) );
 
 vi.mock( '@tanstack/react-query', async ( importOriginal ) => {
@@ -44,10 +55,10 @@ vi.mock( '@/data/queries/use-preview-site', () => ( {
 } ) );
 
 vi.mock( '@/data/queries/use-sites', () => ( {
-	useIsSiteStarting: () => false,
-	useIsSiteStopping: () => false,
-	useStartSite: () => ( { mutate: vi.fn() } ),
-	useStopSite: () => ( { mutate: vi.fn() } ),
+	useIsSiteStarting: () => transitions.starting,
+	useIsSiteStopping: () => transitions.stopping,
+	useStartSite: () => ( { mutate: startSiteMutate } ),
+	useStopSite: () => ( { mutate: stopSiteMutate } ),
 } ) );
 
 vi.mock( '@/data/queries/use-snapshots', () => ( {
@@ -105,6 +116,10 @@ describe( 'MainView', () => {
 		connector.copyText.mockReset();
 		connector.openExternalUrl.mockReset();
 		publishPreviewMutate.mockReset();
+		startSiteMutate.mockReset();
+		stopSiteMutate.mockReset();
+		transitions.starting = false;
+		transitions.stopping = false;
 		snapshots.splice( 0, snapshots.length, {
 			url: 'preview.example.com',
 			atomicSiteId: 123,
@@ -123,6 +138,45 @@ describe( 'MainView', () => {
 		renderMainView();
 
 		expect( screen.queryByRole( 'img', { name: 'Xdebug enabled' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'labels the site status toggle with the status and the action it performs', () => {
+		const { unmount } = renderMainView();
+
+		const running = screen.getByRole( 'switch', { name: 'Site status: Running. Stop site' } );
+		expect( running ).toBeChecked();
+		fireEvent.click( running );
+		expect( stopSiteMutate ).toHaveBeenCalledWith( site.id );
+
+		unmount();
+		renderMainView( { running: false } );
+
+		const stopped = screen.getByRole( 'switch', { name: 'Site status: Stopped. Start site' } );
+		expect( stopped ).not.toBeChecked();
+		fireEvent.click( stopped );
+		expect( startSiteMutate ).toHaveBeenCalledWith( site.id );
+	} );
+
+	it( 'reports the pending status on the site status toggle without acting on clicks', () => {
+		transitions.starting = true;
+
+		const { unmount } = renderMainView( { running: false } );
+
+		const starting = screen.getByRole( 'switch', { name: 'Site status: Starting' } );
+		expect( starting ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( starting ).toBeChecked();
+		fireEvent.click( starting );
+		expect( startSiteMutate ).not.toHaveBeenCalled();
+
+		unmount();
+		transitions.starting = false;
+		transitions.stopping = true;
+		renderMainView();
+
+		const stopping = screen.getByRole( 'switch', { name: 'Site status: Stopping' } );
+		expect( stopping ).not.toBeChecked();
+		fireEvent.click( stopping );
+		expect( stopSiteMutate ).not.toHaveBeenCalled();
 	} );
 
 	it( 'handles preview URL copy failures', async () => {

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -485,7 +485,7 @@ function LocalServerControl( {
 				<span
 					className={ clsx(
 						styles.localServerGlyph,
-						targetRunning ? styles.playIcon : styles.pauseIcon
+						targetRunning ? styles.pauseIcon : styles.playIcon
 					) }
 				/>
 			</span>

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -260,13 +260,6 @@ export function MainView( { site, activity, onSetupClick, onDisconnectClick }: P
 						starting={ isStarting }
 						stopping={ isStopping }
 						disabled={ isSyncing }
-						busyLabel={
-							isLocalTransitioning
-								? isStopping
-									? __( 'Stopping Studio site' )
-									: __( 'Starting Studio site' )
-								: undefined
-						}
 						onStart={ handleStartLocalClick }
 						onStop={ handleStopLocalClick }
 					/>
@@ -451,7 +444,6 @@ function LocalServerControl( {
 	starting,
 	stopping,
 	disabled,
-	busyLabel,
 	onStart,
 	onStop,
 }: {
@@ -459,37 +451,69 @@ function LocalServerControl( {
 	starting: boolean;
 	stopping: boolean;
 	disabled: boolean;
-	busyLabel?: string;
 	onStart: () => void;
 	onStop: () => void;
 } ) {
 	const pending = starting || stopping;
 	const targetRunning = starting ? true : stopping ? false : running;
+	// aria-disabled rather than disabled: a natively disabled button suppresses
+	// the pointer events the tooltip listens for, hiding the status exactly
+	// while the site is transitioning.
+	const inert = disabled || pending;
+	const statusName = pending
+		? stopping
+			? __( 'Stopping' )
+			: __( 'Starting' )
+		: running
+		? __( 'Running' )
+		: __( 'Stopped' );
+	const statusLabel = sprintf( __( 'Site status: %s' ), statusName );
+	const actionLabel = running ? __( 'Stop site' ) : __( 'Start site' );
 
 	return (
-		<button
-			type="button"
-			className={ clsx(
-				styles.localServerControl,
-				targetRunning && styles.localServerControl_running,
-				pending && styles.localServerControl_pending
-			) }
-			aria-label={ busyLabel ?? __( 'Studio site status' ) }
-			role="switch"
-			aria-checked={ targetRunning }
-			aria-busy={ pending || undefined }
-			disabled={ disabled || pending }
-			onClick={ targetRunning ? onStop : onStart }
-		>
-			<span className={ styles.localServerThumb } aria-hidden="true">
-				<span
-					className={ clsx(
-						styles.localServerGlyph,
-						targetRunning ? styles.pauseIcon : styles.playIcon
-					) }
-				/>
-			</span>
-		</button>
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<button
+						type="button"
+						className={ clsx(
+							styles.localServerControl,
+							targetRunning && styles.localServerControl_running,
+							pending && styles.localServerControl_pending
+						) }
+						aria-label={
+							inert ? statusLabel : sprintf( __( '%1$s. %2$s' ), statusLabel, actionLabel )
+						}
+						role="switch"
+						aria-checked={ targetRunning }
+						aria-busy={ pending || undefined }
+						aria-disabled={ inert || undefined }
+						onClick={ () => {
+							if ( inert ) {
+								return;
+							}
+							if ( targetRunning ) {
+								onStop();
+							} else {
+								onStart();
+							}
+						} }
+					>
+						<span className={ styles.localServerThumb } aria-hidden="true">
+							<span
+								className={ clsx(
+									styles.localServerGlyph,
+									targetRunning ? styles.pauseIcon : styles.playIcon
+								) }
+							/>
+						</span>
+					</button>
+				}
+			/>
+			<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+				{ statusLabel }
+			</Tooltip.Popup>
+		</Tooltip.Root>
 	);
 }
 

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -439,6 +439,24 @@ function SyncActivityError( {
 	);
 }
 
+function getLocalServerStatusName( {
+	running,
+	starting,
+	stopping,
+}: {
+	running: boolean;
+	starting: boolean;
+	stopping: boolean;
+} ) {
+	if ( stopping ) {
+		return __( 'Stopping' );
+	}
+	if ( starting ) {
+		return __( 'Starting' );
+	}
+	return running ? __( 'Running' ) : __( 'Stopped' );
+}
+
 function LocalServerControl( {
 	running,
 	starting,
@@ -460,14 +478,10 @@ function LocalServerControl( {
 	// the pointer events the tooltip listens for, hiding the status exactly
 	// while the site is transitioning.
 	const inert = disabled || pending;
-	const statusName = pending
-		? stopping
-			? __( 'Stopping' )
-			: __( 'Starting' )
-		: running
-		? __( 'Running' )
-		: __( 'Stopped' );
-	const statusLabel = sprintf( __( 'Site status: %s' ), statusName );
+	const statusLabel = sprintf(
+		__( 'Site status: %s' ),
+		getLocalServerStatusName( { running, starting, stopping } )
+	);
 	const actionLabel = running ? __( 'Stop site' ) : __( 'Start site' );
 
 	return (


### PR DESCRIPTION
## Related issues

- Fixes [STU-2153](https://linear.app/a8c/issue/STU-2153/playpause-icons-are-inverted-on-the-site-status-toggle)

## How AI was used in this PR

Claude located the inverted ternary, confirmed the glyph semantics against the CSS module (`.pauseIcon` renders two bars, `.playIcon` renders a triangle), and applied the one-line swap. It then mirrored the sidebar's `SiteStatusButton` tooltip pattern onto the dropdown toggle and added the test coverage. Reviewed by me.

## Proposed Changes

<img width="448" height="273" alt="image" src="https://github.com/user-attachments/assets/c81ef13f-6ca0-4c6a-a27d-32b3b0fe2465" />
<img width="365" height="245" alt="image" src="https://github.com/user-attachments/assets/8c041601-6a04-45de-bc18-e5ca1f87a557" />


The icons for the play/pause toggle in the Site Menu were reversed; you clicked play to stop, and pause to start.  The PR changes that so you click pause to stop, and play to start. I also added a tooltip, and generally matched the behavior of the toggle buttons in the sidebar.

## Testing Instructions

1. Run the agentic UI and open the site dropdown for a stopped site.
2. The status toggle should show a **play** triangle, and hovering it should read "Site status: Stopped". Click it — the site starts.
3. While it starts, the tooltip should read "Site status: Starting" and the glyph should already show pause (the target state). Clicking during this window should do nothing.
4. Once running, the toggle should show **pause** bars and read "Site status: Running". Click it — the site stops, and the tooltip reads "Site status: Stopping" on the way down.
5. Start a sync (push or pull) and confirm the toggle dims, still shows its tooltip, and ignores clicks.
6. Confirm the dimmed/inert styling still looks right — the CSS moved from `:disabled` to `[aria-disabled='true']`.
7. Confirm all of the above in both light and dark mode.