### PR TITLE
Fix site status toggle tests to use the current renderMainView signature

### DIFF
--- a/apps/ui/src/components/site-dropdown/main-view.test.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.test.tsx
@@ -156,7 +156,7 @@ describe( 'MainView', () => {
 		expect( stopSiteMutate ).toHaveBeenCalledWith( site.id );
 
 		unmount();
-		renderMainView( { running: false } );
+		renderMainView( { siteOverrides: { running: false } } );
 
 		const stopped = screen.getByRole( 'switch', { name: 'Site status: Stopped. Start site' } );
 		expect( stopped ).not.toBeChecked();
@@ -167,7 +167,7 @@ describe( 'MainView', () => {
 	it( 'reports the pending status on the site status toggle without acting on clicks', () => {
 		transitions.starting = true;
 
-		const { unmount } = renderMainView( { running: false } );
+		const { unmount } = renderMainView( { siteOverrides: { running: false } } );
 
 		const starting = screen.getByRole( 'switch', { name: 'Site status: Starting' } );
 		expect( starting ).toHaveAttribute( 'aria-disabled', 'true' );


### PR DESCRIPTION
## Related issues

- Related to #4374 and #4307.

## How AI was used in this PR

AI traced the failure to its origin, wrote the fix, and verified it. `npm run typecheck` and the affected suite were run locally and reviewed.

## Proposed Changes

`trunk` is currently red on both **Unit Tests** and **Lint**. This fixes it.

Two PRs landed the same day and conflicted semantically rather than textually, so nothing blocked either one:

- #4307 changed the `renderMainView` test helper to take an options object (`{ siteOverrides, activity }`) instead of a bare site-overrides argument, updating the call sites that existed at the time.
- #4374 was branched before that and added two calls using the previous signature, then merged about seven hours later.

Git merged both cleanly — the two PRs touched different lines of the same file — but the calls no longer match the helper. `{ running: false }` is now swallowed as the options object, `siteOverrides` falls back to `{}`, and the site under test stays *running*. One test then looks for a stopped-site toggle that was never rendered.

The second call site is worth noting: it fails typecheck but still passes, because that test sets `starting` and the pending label wins regardless of `running`. It was quietly asserting against a running site while reading as though it covered a stopped one. Both call sites now pass the override through properly, so that coverage is real again.

No production code changes — this is test-only, and the behavior #4374 shipped is unaffected.

## Testing Instructions

1. `npm test -- apps/ui/src/components/site-dropdown/main-view.test.tsx` — 9 passing.
2. `npm run typecheck` — clean; on `trunk` it reports two `TS2353` errors in this file.
3. Confirm CI is green on both Unit Tests and Lint (the Lint job runs `npm run lint` followed by `npm run typecheck`, which is why one root cause turned two checks red).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
