### PR TITLE
Agentic UI: Lower the session composer footer controls to hug the panel's bottom edge

### DIFF
--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -95,12 +95,13 @@
 	background-color: var(--wpds-color-fg-interactive-brand);
 }
 
-/* Bottom-left of the main area. The 46px min-height matches the session
-   view's `panelFooterControls` so the toggle lines up vertically with the
-   chat-history/new-chat buttons. */
+/* Bottom-left of the main area. The 46px min-height and the negative bottom
+   offset both match the session view's `panelFooterControls` so the toggle
+   lines up vertically with the chat-history/new-chat buttons — keep the two
+   in sync. */
 .floatingToggle {
 	position: absolute;
-	bottom: 0;
+	bottom: calc(-1 * var(--wpds-dimension-padding-sm));
 	inset-inline-start: var(--wpds-dimension-padding-xl);
 	display: flex;
 	align-items: center;

--- a/apps/ui/src/ui-classic/components/session-view/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/style.module.css
@@ -169,9 +169,11 @@
 .panelFooterControls {
 	position: absolute;
 	inset-inline-start: var(--classic-panel-footer-left);
-	/* Keep the controls fully inside .root (overflow: hidden) so focus
-	   rings aren't clipped at the window edge. */
-	bottom: 0;
+	/* Sit the strip low in its reserved band so the controls read as anchored
+	   to the panel's bottom edge rather than floating under the composer. The
+	   strip's own bottom padding keeps the buttons and their focus rings clear
+	   of .root's overflow: hidden edge. */
+	bottom: calc(-1 * var(--wpds-dimension-padding-sm));
 	z-index: 3;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
## Proposed Changes

<img width="1600" height="486" alt="image" src="https://github.com/user-attachments/assets/5f02d81d-efb7-4a9c-9af3-653bf42febb5" />

The actions below the chat composer (including the sidebar toggle) are unevently spaced, with more space below than above. To help visual balance, this PR moves them down a bit.

## Testing Instructions

1. Run the app and open any site's chat session.
2. Look at the controls below the composer (chat history icon + **New chat**).
3. They should sit closer to the bottom edge of the chat panel than before, with a slightly larger gap between them and the composer card.
4. Tab to both controls and confirm the focus ring renders fully — the strip's own bottom padding keeps it clear of the panel's `overflow: hidden` edge.
5. Check in **both light and dark** color schemes, and at both narrow and wide panel widths (the preview panel open and closed).

## How AI was used in this PR

Claude Code compared the composer footer's positioning between `trunk` and the `explore-site-centric-conversation-chrome` design-preview branch, identified the single declaration responsible for the difference, and ported it. The change was reviewed by hand.