### PR TITLE
Agentic UI: Disclose that the chat is with an AI in the model picker label

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-disclosure.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-disclosure.tsx
@@ -1,0 +1,24 @@
+import { getAiModelShortLabel } from '@studio/common/ai/models';
+import { __, sprintf } from '@wordpress/i18n';
+import styles from './style.module.css';
+import type { AiModelId } from '@/data/core';
+
+/**
+ * Persistent notice that the other side of the chat is an AI. Required at or
+ * before the first interaction by EU AI Act Art. 50(1), and shown to everyone
+ * rather than geo-gated. Doubles as the model picker's label — naming the model
+ * is what lets one line serve both jobs. Referenced by the prompt field's
+ * `aria-describedby` so it is announced on focus rather than relying on visual
+ * proximity alone.
+ */
+export function AiDisclosure( { id, model }: { id: string; model: AiModelId } ) {
+	return (
+		<span className={ styles.aiDisclosure } id={ id }>
+			{ sprintf(
+				/* translators: %s: name of the selected AI model, e.g. "Sonnet". */
+				__( 'Chatting with %s AI' ),
+				getAiModelShortLabel( model )
+			) }
+		</span>
+	);
+}

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
@@ -323,7 +323,7 @@ describe( 'Composer menu', () => {
 		);
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Select model' } ) );
-		fireEvent.click( await screen.findByText( 'GPT 5.6 Sol' ) );
+		fireEvent.click( await screen.findByRole( 'menuitemradio', { name: 'GPT 5.6 Sol' } ) );
 		fireEvent.click( await screen.findByRole( 'button', { name: 'Start new conversation' } ) );
 
 		await waitFor( () => {
@@ -342,6 +342,38 @@ describe( 'Composer menu', () => {
 				modelId: 'gpt-5.6-sol',
 			} ),
 		] );
+	} );
+} );
+
+describe( 'Composer AI disclosure', () => {
+	it( 'renders the disclosure as text and describes the prompt field with it', () => {
+		renderComposer();
+
+		const disclosure = screen.getByText( 'Chatting with Sonnet AI' );
+		const textarea = screen.getByRole( 'textbox' );
+
+		expect( disclosure.id ).toBeTruthy();
+		expect( textarea ).toHaveAttribute( 'aria-describedby', disclosure.id );
+	} );
+
+	it( 'stays visible once the user starts typing', () => {
+		renderComposer();
+
+		fireEvent.change( screen.getByRole( 'textbox' ), { target: { value: 'Hello' } } );
+
+		expect( screen.getByText( 'Chatting with Sonnet AI' ) ).toBeInTheDocument();
+	} );
+
+	it( 'names whichever model the session is on', () => {
+		renderComposer( { model: 'gpt-5.6-sol' } );
+
+		expect( screen.getByText( 'Chatting with Sol AI' ) ).toBeInTheDocument();
+	} );
+
+	it( 'stays visible while a turn is running', () => {
+		renderComposer( { busy: true } );
+
+		expect( screen.getByText( 'Chatting with Sonnet AI' ) ).toBeInTheDocument();
 	} );
 } );
 

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
@@ -10,7 +10,7 @@ import {
 	type ComposerAttachmentHoverPreviewState,
 } from '@studio/common/ai/composer-attachment-preview';
 import { watchComposerFilePaste } from '@studio/common/ai/composer-attachments';
-import { AI_MODELS, getAiModelFamily, getAiModelLabel } from '@studio/common/ai/models';
+import { AI_MODELS, getAiModelFamily } from '@studio/common/ai/models';
 import { isStudioCustomEntryOfType } from '@studio/common/ai/sessions/entry-types';
 import { AI_SKILL_COMMANDS } from '@studio/common/ai/slash-commands';
 import { useQueryClient } from '@tanstack/react-query';
@@ -29,6 +29,7 @@ import {
 	forwardRef,
 	useCallback,
 	useEffect,
+	useId,
 	useImperativeHandle,
 	useLayoutEffect,
 	useRef,
@@ -46,6 +47,7 @@ import {
 	reconcilePrimedSessionQueryData,
 	SESSIONS_QUERY_KEY,
 } from '@/data/queries/use-sessions';
+import { AiDisclosure } from './ai-disclosure';
 import { FamilySwitchConfirmDialog } from './family-switch-confirm-dialog';
 import styles from './style.module.css';
 import {
@@ -192,7 +194,7 @@ export function ComposerSkeleton() {
 			<div className={ styles.shell }>
 				<textarea className={ styles.input } rows={ 2 } disabled tabIndex={ -1 } />
 				<div className={ styles.toolbar }>
-					<span className={ styles.pill } />
+					<span className={ styles.iconButton } />
 				</div>
 			</div>
 		</div>
@@ -387,6 +389,7 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 	const [ isResizingComposer, setIsResizingComposer ] = useState( false );
 	const textareaRef = useRef< HTMLTextAreaElement | null >( null );
 	const fileInputRef = useRef< HTMLInputElement | null >( null );
+	const aiDisclosureId = useId();
 	const manualTextareaHeightRef = useRef< number | null >( null );
 	const resizeDragRef = useRef< { startY: number; startHeight: number } | null >( null );
 	const connector = useConnector();
@@ -946,6 +949,7 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 							ref={ textareaRef }
 							className={ styles.input }
 							placeholder={ placeholder }
+							aria-describedby={ aiDisclosureId }
 							value={ value }
 							onChange={ ( event ) => setValue( event.target.value ) }
 							onPaste={ pasteHandlers.onPaste }
@@ -1057,7 +1061,7 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 													/>
 												}
 											>
-												<span>{ getAiModelLabel( model ) }</span>
+												<AiDisclosure id={ aiDisclosureId } model={ model } />
 												<Icon icon={ chevronDownSmall } size={ 16 } />
 											</Tooltip.Trigger>
 										}

--- a/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
@@ -388,6 +388,9 @@
 	display: flex;
 	align-items: flex-end;
 	justify-content: space-between;
+	/* Release valve for the narrowest panel width: wrap rather than push the send
+	   button out of the shell or clip the AI disclosure. */
+	flex-wrap: wrap;
 	gap: var(--wpds-dimension-padding-sm);
 	min-width: 0;
 	padding: 0 calc(var(--composer-inline-padding) - var(--wpds-dimension-padding-xs))
@@ -402,12 +405,15 @@
 }
 
 .leftActions {
-	flex: 1 1 auto;
-	min-width: 0;
+	flex: 0 0 auto;
 }
 
+/* Holds the AI disclosure, which must stay whole — see .aiDisclosure. */
 .rightActions {
 	flex: 0 0 auto;
+	/* Keeps these anchored to the inline end on their own line once the toolbar
+	   wraps, where `space-between` no longer applies. */
+	margin-inline-start: auto;
 }
 
 .iconButton {
@@ -442,12 +448,13 @@
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
+/* Model picker. Its label is also the AI disclosure, so it is sized to show
+   that line whole rather than clipped to the model name's width. */
 .pill {
 	display: inline-flex;
 	flex: 0 0 auto;
 	align-items: center;
 	gap: 6px;
-	max-width: min(42vw, 160px);
 	height: 28px;
 	padding: 0 var(--wpds-dimension-padding-sm);
 	border: 0;
@@ -455,15 +462,8 @@
 	background-color: transparent;
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font: inherit;
-	font-size: var(--wpds-typography-font-size-sm);
+	font-size: var(--wpds-typography-font-size-xs);
 	cursor: pointer;
-	white-space: nowrap;
-}
-
-.pill span {
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
@@ -597,4 +597,13 @@
 .error {
 	color: var(--wpds-color-fg-content-error, #dc2626);
 	font-size: var(--wpds-typography-font-size-xs);
+}
+
+/* Label of the model picker (.pill). Never shrinks: a half-rendered disclosure
+   ("Chatting with Sonn…") would not be the clear notice it exists to be, so the
+   toolbar wraps instead. */
+.aiDisclosure {
+	flex: 0 0 auto;
+	line-height: var(--wpds-typography-line-height-xs);
+	white-space: nowrap;
 }

--- a/packages/common/ai/models.ts
+++ b/packages/common/ai/models.ts
@@ -8,6 +8,13 @@ export interface AiModel {
 	id: string;
 	/** Human-readable label shown in the model picker. */
 	label: string;
+	/**
+	 * Bare model name, for prose that already supplies the context — e.g. the
+	 * composer's "Chatting with Sonnet AI". Not derivable from `label`: the
+	 * distinguishing word is the last one for OpenAI and the first for
+	 * Anthropic.
+	 */
+	shortLabel: string;
 	/** Which runtime serves this model. Drives `pickRuntime` in agent.ts. */
 	family: AiModelFamily;
 }
@@ -18,9 +25,9 @@ export interface AiModel {
 // through the proxy's `/v1/responses` path, which supports reasoning models
 // and function tools.)
 export const AI_MODELS = [
-	{ id: 'claude-sonnet-5', label: 'Sonnet 5', family: 'anthropic' },
-	{ id: 'claude-opus-5', label: 'Opus 5', family: 'anthropic' },
-	{ id: 'gpt-5.6-sol', label: 'GPT 5.6 Sol', family: 'openai' },
+	{ id: 'claude-sonnet-5', label: 'Sonnet 5', shortLabel: 'Sonnet', family: 'anthropic' },
+	{ id: 'claude-opus-5', label: 'Opus 5', shortLabel: 'Opus', family: 'anthropic' },
+	{ id: 'gpt-5.6-sol', label: 'GPT 5.6 Sol', shortLabel: 'Sol', family: 'openai' },
 ] as const satisfies readonly AiModel[];
 
 export type AiModelId = ( typeof AI_MODELS )[ number ][ 'id' ];
@@ -54,6 +61,10 @@ export function getAiModelFamily( id: AiModelId ): AiModelFamily {
 
 export function getAiModelLabel( id: AiModelId ): string {
 	return getAiModel( id ).label;
+}
+
+export function getAiModelShortLabel( id: AiModelId ): string {
+	return getAiModel( id ).shortLabel;
 }
 
 /**


### PR DESCRIPTION
## Related issues

- Related to STU-2134

## How AI was used in this PR

Claude Code wrote the implementation and tests, and researched the copy precedent. Placement went through several rounds with a human designer driving; the visual result has not been verified by AI. Reviewers should look at the composer toolbar in both color schemes.

## Proposed Changes

<img width="466" height="147" alt="image" src="https://github.com/user-attachments/assets/2f1e7a9b-2ac3-46d0-b4e4-3023e15eef7e" />
<img width="460" height="147" alt="image" src="https://github.com/user-attachments/assets/17202996-cc16-43d8-abad-0b2fcc49a400" />


EU AI Act §50(1) requires that anyone interacting with an AI system be told so, by a clear notice present at or before the first interaction and kept visible throughout. The Agentic UI chat had no such disclosure anywhere. The obligation applies from 2 August 2026.

The composer's model picker now says **Chatting with Sonnet AI** instead of **Sonnet 5**, and switches to *Opus* or *Sol* with the selected model. Folding the model name into the sentence lets one control do both jobs, so the disclosure is permanently on screen. It is real text in the accessibility tree, and the prompt field is `aria-describedby` it, so screen readers announce it when focus lands in the composer rather than leaving it to visual proximity.

The picker's full labels are unchanged inside the menu — you still pick between *Sonnet 5*, *Opus 5*, and *GPT 5.6 Sol*. Only the button shortens, and it drops a size to sit quieter next to send. Adding a model to the catalog now means giving it a short name as well; the type enforces it.

Notable trade-off: the disclosure is never allowed to ellipsise, since a clipped notice ("Chatting with Sonn…") stops being the clear disclosure it exists to be. At the narrowest the chat panel can be dragged (280px, with the stop button showing), the toolbar wraps to a second row instead.

## Testing Instructions

1. Open a chat on any site. The composer toolbar reads **Chatting with Sonnet AI** where it used to read **Sonnet 5**.
2. Type into the composer — the notice stays put. It is not a placeholder.
3. Click it, pick **GPT 5.6 Sol**. The label becomes **Chatting with Sol AI**. Pick **Opus 5** → **Chatting with Opus AI**. The menu itself still shows full model names.
4. Send a message. The notice stays visible while the turn runs, alongside the stop button.
5. With VoiceOver on, focus the prompt field — it should announce the disclosure as the field's description.
6. Check both light and dark mode, and drag the preview panel splitter to squeeze the chat column: the notice should stay whole at every width, with the toolbar wrapping rather than clipping it at the extreme.
