### PR TITLE
Bump seroval to 1.5.6 to resolve fromJSON type confusion alert #299

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28040,7 +28040,9 @@
 			}
 		},
 		"node_modules/seroval": {
-			"version": "1.5.2",
+			"version": "1.5.6",
+			"resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
+			"integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"


### PR DESCRIPTION
## Related issues

- Related to Dependabot alert [#299](https://github.com/Automattic/studio/security/dependabot/299)

## How AI was used in this PR

Claude Code inspected the open Dependabot alerts, traced `seroval` through the dependency tree (transitive via `@tanstack/react-router`), confirmed a clean `npm update` resolution with no other subtree churn, and verified every resolved copy landed on the patched version. I reviewed the lockfile diff myself.

## Proposed Changes

Resolves the critical `seroval` advisory (`seroval.fromJSON()` Promise resolver type confusion, which could invoke attacker-controlled methods during deserialization) by bumping `seroval` from 1.5.2 to 1.5.6. This is a lockfile-only change to a transitive dependency; there is no user-visible behavior change.

## Testing Instructions

- `npm ci` resolves cleanly.
- `npm ls seroval` reports 1.5.6 for every copy (no lingering 1.5.2).

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
