### PR TITLE
Default new users to the Agentic UI and remove its feature flag

### DIFF
--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -48,6 +48,9 @@ export class E2ESession {
 			snapshots: [],
 			betaFeatures: {
 				studioSitesCli: true,
+				// These specs drive the classic renderer. Setting this explicitly opts the run
+				// out of the agentic default that fresh installs otherwise get seeded with.
+				enableAgenticUi: false,
 			},
 		};
 

--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -46,6 +46,10 @@ export class E2ESession {
 			version: 1,
 			sites: [],
 			snapshots: [],
+			// The opt-in banner is a floating card over the bottom-right of the site content, so
+			// leaving it up intercepts clicks on whatever sits underneath (e.g. the overview's
+			// customize shortcuts). Start dismissed so specs see the classic UI unobstructed.
+			agenticUiBannerDismissed: true,
 			betaFeatures: {
 				studioSitesCli: true,
 				// These specs drive the classic renderer. Setting this explicitly opts the run

--- a/apps/studio/src/components/site-content-tabs.tsx
+++ b/apps/studio/src/components/site-content-tabs.tsx
@@ -13,7 +13,6 @@ import { MIN_WIDTH_CLASS_TO_MEASURE } from 'src/constants';
 import { useBetaFeatures } from 'src/hooks/use-beta-features';
 import { TabName } from 'src/hooks/use-content-tabs';
 import { useEffectiveTab } from 'src/hooks/use-effective-tab';
-import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -24,7 +23,6 @@ export function SiteContentTabs() {
 	const { importState } = useImportExport();
 	const { effectiveTab, selectedTab, setSelectedTab, tabs } = useEffectiveTab();
 	const { __ } = useI18n();
-	const { enableAgenticUi } = useFeatureFlags();
 	const betaFeatures = useBetaFeatures();
 	const [ bannerDismissed, setBannerDismissed ] = useState( true );
 
@@ -95,7 +93,7 @@ export function SiteContentTabs() {
 		);
 	}
 
-	const showBanner = enableAgenticUi && ! betaFeatures.enableAgenticUi && ! bannerDismissed;
+	const showBanner = ! betaFeatures.enableAgenticUi && ! bannerDismissed;
 
 	return (
 		<div className="relative w-full h-full">

--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -41,15 +41,10 @@ import { getUserLocaleWithFallback } from 'src/lib/locale-node';
 import { setSentryWpcomUserIdMain } from 'src/lib/main-sentry-utils';
 import { maybePromptNightlySwitch, startNightlyPromptPoller } from 'src/lib/nightly-prompt';
 import { getSentryReleaseInfo } from 'src/lib/sentry-release';
+import { getPreferredStudioUiMode, setAgenticUiEnabled } from 'src/lib/studio-ui-mode';
 import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
 import { setupLogging } from 'src/logging';
-import {
-	createMainWindow,
-	getCurrentRendererUrl,
-	getMainWindow,
-	getPreferredStudioUiMode,
-	setAgenticUiEnabled,
-} from 'src/main-window';
+import { createMainWindow, getCurrentRendererUrl, getMainWindow } from 'src/main-window';
 import { migrations } from 'src/migrations';
 import {
 	startCliEventsSubscriber,

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -128,6 +128,7 @@ import { setSentryWpcomUserIdMain } from 'src/lib/main-sentry-utils';
 import * as oauthClient from 'src/lib/oauth';
 import { getAiInstructionsPath } from 'src/lib/server-files-paths';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
+import { setAgenticUiEnabled } from 'src/lib/studio-ui-mode';
 import { recordTracksEvent, type TracksChannel, type TracksUiVersion } from 'src/lib/tracks';
 import { updateSiteUrl } from 'src/lib/update-site-url';
 import * as windowsHelpers from 'src/lib/windows-helpers';
@@ -137,7 +138,6 @@ import {
 	getMainWindow,
 	getTitleBarOverlayOptions,
 	loadMainWindowRenderer,
-	setAgenticUiEnabled,
 } from 'src/main-window';
 import { popupMenu, setupMenu } from 'src/menu';
 import { type InstructionFileType } from 'src/modules/agent-instructions/constants';

--- a/apps/studio/src/ipc-types.d.ts
+++ b/apps/studio/src/ipc-types.d.ts
@@ -99,9 +99,8 @@ type IpcApi = {
 	getPathForFile: ( file: File ) => string;
 };
 
-interface FeatureFlags {
-	enableAgenticUi: boolean;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- no flags in flight; see `src/lib/feature-flags.ts`
+interface FeatureFlags {}
 
 interface BetaFeatures {
 	remoteSession: boolean;

--- a/apps/studio/src/lib/feature-flags.ts
+++ b/apps/studio/src/lib/feature-flags.ts
@@ -5,14 +5,10 @@ export interface FeatureFlagDefinition {
 	default: boolean;
 }
 
-export const FEATURE_FLAGS: Record< keyof FeatureFlags, FeatureFlagDefinition > = {
-	enableAgenticUi: {
-		label: 'Enable Agentic UI',
-		env: 'ENABLE_AGENTIC_UI',
-		flag: 'enableAgenticUi',
-		default: false,
-	},
-} as const;
+// No flags are in flight right now. Add entries here (and to the `FeatureFlags` interface in
+// `ipc-types.d.ts`) to expose one via `ENABLE_*` env vars, the dev Feature Flags menu, and the
+// wpcom `/studio-app/feature-flags` override.
+export const FEATURE_FLAGS: Record< keyof FeatureFlags, FeatureFlagDefinition > = {} as const;
 
 export function getFeatureFlagFromEnv( flag: keyof FeatureFlags ): boolean {
 	const flagDefinition = FEATURE_FLAGS[ flag ] as FeatureFlagDefinition | undefined;

--- a/apps/studio/src/lib/studio-ui-mode.ts
+++ b/apps/studio/src/lib/studio-ui-mode.ts
@@ -1,0 +1,14 @@
+export type StudioUiMode = 'default' | 'agentic';
+
+// Which renderer the app is currently running, seeded at boot from `betaFeatures.enableAgenticUi`
+// and updated when the user switches. Lives here rather than in `main-window` so that modules
+// `main-window` itself depends on (e.g. the CLI) can read it without an import cycle.
+let agenticUiEnabled = false;
+
+export function setAgenticUiEnabled( enabled: boolean ): void {
+	agenticUiEnabled = enabled;
+}
+
+export function getPreferredStudioUiMode(): StudioUiMode {
+	return agenticUiEnabled ? 'agentic' : 'default';
+}

--- a/apps/studio/src/main-window.ts
+++ b/apps/studio/src/main-window.ts
@@ -18,6 +18,7 @@ import {
 	WINDOWS_TITLEBAR_HEIGHT,
 } from 'src/constants';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
+import { getPreferredStudioUiMode, type StudioUiMode } from 'src/lib/studio-ui-mode';
 import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
 import { removeMenu } from 'src/menu';
 import { SiteServer } from 'src/site-server';
@@ -31,21 +32,10 @@ import type { WindowBounds } from 'src/storage/storage-types';
 
 let mainWindow: BrowserWindow | null;
 let currentRendererUrl: string | undefined;
-type StudioUiMode = 'default' | 'agentic';
 
 interface RendererLocation {
 	url: string;
 	filePath?: string;
-}
-
-let agenticUiEnabled = false;
-
-export function setAgenticUiEnabled( enabled: boolean ): void {
-	agenticUiEnabled = enabled;
-}
-
-export function getPreferredStudioUiMode(): StudioUiMode {
-	return agenticUiEnabled ? 'agentic' : 'default';
 }
 
 function getRendererFilePath( mode: StudioUiMode ) {

--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -36,6 +36,7 @@ import { getPreferredStudioUiMode, setAgenticUiEnabled } from 'src/lib/studio-ui
 import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
 import { getLogsFilePath } from 'src/logging';
 import { getMainWindow, loadMainWindowRenderer } from 'src/main-window';
+import { getAgenticFeaturesEnabled } from 'src/modules/user-settings/lib/ipc-handlers';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from 'src/updates';
 
 export async function setupMenu( config: {
@@ -222,6 +223,12 @@ async function getAppMenu(
 
 	const betaFeaturesMenu = await buildBetaFeaturesMenu();
 
+	// The agentic UI binds Cmd/Ctrl+N to "New chat" in the renderer, so the menu must leave the
+	// key alone there — a menu accelerator would consume it before it reaches the DOM. With chat
+	// switched off nothing binds it, so the shortcut falls back to "Add Site…" as in classic.
+	const rendererOwnsNewShortcut =
+		getPreferredStudioUiMode() === 'agentic' && ( await getAgenticFeaturesEnabled() );
+
 	return Menu.buildFromTemplate( [
 		{
 			label: app.name, // macOS ignores this name and uses the name from the .plist
@@ -316,9 +323,7 @@ async function getAppMenu(
 			submenu: [
 				{
 					label: __( 'Add Site…' ),
-					// The agentic UI binds Cmd/Ctrl+N to "New chat" in the renderer;
-					// a menu accelerator would consume the key before it reaches the DOM.
-					accelerator: getPreferredStudioUiMode() === 'agentic' ? undefined : 'CommandOrControl+N',
+					accelerator: rendererOwnsNewShortcut ? undefined : 'CommandOrControl+N',
 					click: async () => {
 						void sendIpcEventToRenderer( 'add-site' );
 					},

--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -32,14 +32,10 @@ import {
 import { getLocalizedLink } from 'src/lib/get-localized-link';
 import { getUserLocaleWithFallback } from 'src/lib/locale-node';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
+import { getPreferredStudioUiMode, setAgenticUiEnabled } from 'src/lib/studio-ui-mode';
 import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
 import { getLogsFilePath } from 'src/logging';
-import {
-	getMainWindow,
-	getPreferredStudioUiMode,
-	loadMainWindowRenderer,
-	setAgenticUiEnabled,
-} from 'src/main-window';
+import { getMainWindow, loadMainWindowRenderer } from 'src/main-window';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from 'src/updates';
 
 export async function setupMenu( config: {
@@ -76,14 +72,8 @@ export async function popupMenu( position?: { x: number; y: number } ) {
 
 async function buildBetaFeaturesMenu(): Promise< MenuItemConstructorOptions[] > {
 	const currentBetaFeatures = await getBetaFeatures();
-	return Object.entries< BetaFeatureDefinition >( getBetaFeaturesDefinition() )
-		.filter( ( [ key ] ) => {
-			if ( key === 'enableAgenticUi' ) {
-				return getFeatureFlagFromEnv( 'enableAgenticUi' );
-			}
-			return true;
-		} )
-		.map( ( [ key, definition ] ) => {
+	return Object.entries< BetaFeatureDefinition >( getBetaFeaturesDefinition() ).map(
+		( [ key, definition ] ) => {
 			// On Windows, use the description as the label for a more compact display
 			const label =
 				process.platform === 'win32' && definition.description
@@ -121,7 +111,8 @@ async function buildBetaFeaturesMenu(): Promise< MenuItemConstructorOptions[] > 
 					void sendIpcEventToRenderer( 'beta-features-updated' );
 				},
 			};
-		} );
+		}
+	);
 }
 
 export function buildViewMenuItems( {
@@ -311,6 +302,7 @@ async function getAppMenu(
 							{
 								label: __( 'Feature Flags' ),
 								submenu: featureFlagsMenu,
+								enabled: featureFlagsMenu.length > 0,
 							},
 					  ]
 					: [] ),
@@ -326,9 +318,7 @@ async function getAppMenu(
 					label: __( 'Add Site…' ),
 					// The agentic UI binds Cmd/Ctrl+N to "New chat" in the renderer;
 					// a menu accelerator would consume the key before it reaches the DOM.
-					accelerator: getFeatureFlagFromEnv( 'enableAgenticUi' )
-						? undefined
-						: 'CommandOrControl+N',
+					accelerator: getPreferredStudioUiMode() === 'agentic' ? undefined : 'CommandOrControl+N',
 					click: async () => {
 						void sendIpcEventToRenderer( 'add-site' );
 					},

--- a/apps/studio/src/migrations/09-seed-agentic-ui-preference.ts
+++ b/apps/studio/src/migrations/09-seed-agentic-ui-preference.ts
@@ -1,0 +1,27 @@
+/**
+ * Seeds an explicit `betaFeatures.enableAgenticUi` so the agentic UI becomes the default for
+ * fresh installs only — existing users stay on the classic UI until they opt in (STU-2149).
+ *
+ * `lastBumpStats` is the marker for "this install has launched before": migrations run before
+ * the launch stats are bumped, so an absent value here really does mean first launch. It's the
+ * same signal Tracks uses for `is_first_launch` (see `index.ts`).
+ *
+ * Deliberately leaves `BETA_FEATURE_DEFAULTS.enableAgenticUi` as `false`, so if this migration
+ * ever fails the fallback keeps existing users where they are rather than moving them. Delete
+ * this file once the agentic UI becomes the plain default for everyone.
+ */
+
+import { updateBetaFeature } from 'src/lib/beta-features';
+import { loadUserData } from 'src/storage/user-data';
+import type { Migration } from '@studio/common/lib/migration';
+
+export const seedAgenticUiPreference: Migration = {
+	async needsToRun() {
+		const { betaFeatures } = await loadUserData();
+		return betaFeatures?.enableAgenticUi === undefined;
+	},
+	async run() {
+		const { lastBumpStats } = await loadUserData();
+		await updateBetaFeature( 'enableAgenticUi', ! lastBumpStats );
+	},
+};

--- a/apps/studio/src/migrations/index.ts
+++ b/apps/studio/src/migrations/index.ts
@@ -7,6 +7,7 @@ import { removeOldServerFilesAndCertificates } from './05-remove-old-server-file
 import { setCliUserUninstalled } from './06-set-cli-user-uninstalled';
 import { removeDesksConfig } from './07-remove-desks-config';
 import { relocateAutostartToAppJson } from './08-relocate-autostart-to-app-json';
+import { seedAgenticUiPreference } from './09-seed-agentic-ui-preference';
 import type { Migration } from '@studio/common/lib/migration';
 
 export const migrations: Migration[] = [
@@ -18,5 +19,6 @@ export const migrations: Migration[] = [
 	setCliUserUninstalled,
 	removeDesksConfig,
 	relocateAutostartToAppJson,
+	seedAgenticUiPreference,
 	moveAiSessionsToStudioDir,
 ];

--- a/apps/studio/src/modules/cli/lib/execute-command.ts
+++ b/apps/studio/src/modules/cli/lib/execute-command.ts
@@ -2,14 +2,14 @@ import { app } from 'electron';
 import { fork, spawnSync, type ChildProcess, type StdioOptions } from 'node:child_process';
 import * as Sentry from '@sentry/electron/main';
 import { z } from 'zod';
-import { getFeatureFlagFromEnv } from 'src/lib/feature-flags';
+import { getPreferredStudioUiMode } from 'src/lib/studio-ui-mode';
 import { TypedEventEmitter } from 'src/modules/cli/lib/typed-event-emitter';
 import { getBundledNodeBinaryPath, getCliPath } from 'src/storage/paths';
 
 // Origin tag passed to every app-spawned CLI process so its Tracks events are attributed to the
 // active desktop renderer (v1 = legacy, v2 = agentic). Read by the CLI in `apps/cli/lib/tracks.ts`.
 function getTracksOriginEnv(): string {
-	return getFeatureFlagFromEnv( 'enableAgenticUi' ) ? 'studio-ui:v2' : 'studio-ui:v1';
+	return getPreferredStudioUiMode() === 'agentic' ? 'studio-ui:v2' : 'studio-ui:v1';
 }
 
 export type CliCommandResult = {

--- a/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
@@ -5,7 +5,6 @@ import Button from 'src/components/button';
 import { DotGrid } from 'src/components/dot-grid';
 import { FormPathInputComponent } from 'src/components/form-path-input';
 import { useBetaFeatures } from 'src/hooks/use-beta-features';
-import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { isWindowsStore } from 'src/lib/app-globals';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { AnalyticsToggle } from 'src/modules/user-settings/components/analytics-toggle';
@@ -40,10 +39,9 @@ import type { QuitSitesBehavior } from 'src/storage/user-data';
 
 function AgenticUiCallout() {
 	const { __ } = useI18n();
-	const { enableAgenticUi } = useFeatureFlags();
 	const betaFeatures = useBetaFeatures();
 
-	if ( ! enableAgenticUi || betaFeatures.enableAgenticUi ) {
+	if ( betaFeatures.enableAgenticUi ) {
 		return null;
 	}
 

--- a/apps/studio/src/tests/main-window.test.ts
+++ b/apps/studio/src/tests/main-window.test.ts
@@ -6,11 +6,11 @@ import { readFile } from 'atomically';
 import { vol } from 'memfs';
 import { vi } from 'vitest';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
+import { setAgenticUiEnabled } from 'src/lib/studio-ui-mode';
 import {
 	createMainWindow,
 	getMainWindow,
 	isToggleSidebarShortcut,
-	setAgenticUiEnabled,
 	__resetMainWindow,
 } from 'src/main-window';
 

--- a/apps/studio/src/tests/menu.test.ts
+++ b/apps/studio/src/tests/menu.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { setAgenticUiEnabled } from 'src/main-window';
+import { setAgenticUiEnabled } from 'src/lib/studio-ui-mode';
 import { buildViewMenuItems } from 'src/menu';
 
 function buildTestViewMenuItems(

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -734,6 +734,11 @@ export function createIpcConnector(): Connector {
 				writes.push( ipcApi.saveAgenticFeaturesEnabled( partial.agenticFeaturesEnabled ) );
 			}
 			await Promise.all( writes );
+			if ( typeof partial.agenticFeaturesEnabled === 'boolean' ) {
+				// Cmd/Ctrl+N belongs to "New chat" only while chat is on, so the
+				// menu has to be rebuilt for the accelerator to change hands.
+				await ipcApi.setupAppMenu( { needsOnboarding: false } );
+			}
 		},
 
 		async selectDefaultSiteDirectory( defaultPath ): Promise< string | null > {


### PR DESCRIPTION
## Related issues

- Fixes STU-2149

## How AI was used in this PR

Claude (Opus 5) implemented the change and ran typecheck + unit tests. New-user and existing-user scenarios verified by hand.

## Proposed Changes

- New installs open the Agentic UI by default. Existing users stay on classic and opt in via the banner, Settings → Preferences, or the Beta Features menu; everyone can still switch back.
- A one-shot migration decides this per install, keyed on whether the app has launched before. Explicit existing choices (current beta testers included) are left alone, and the persisted default stays `false` so a failed migration leaves users where they are.
- Removes the `enableAgenticUi` env flag, keeping the now-empty registry. CLI Tracks events were labelled from that flag rather than the running UI, so classic users were reported as agentic; fixed.
- <kbd>⌘</kbd>/<kbd>Ctrl</kbd>+<kbd>N</kbd> now falls back to "Add Site…" when agentic chat is off. The menu previously released the key whenever the agentic UI was running, but only the chat composer binds it — so with chat off it did nothing. (Still unbound with chat on while outside a session view; pre-existing and renderer-side.)

## Testing Instructions

Back up `~/.studio/*.json`; quit Studio between steps.

1. Remove `app.json`, `cli.json`, `shared.json` → Agentic UI, `ui_version: 'v2'` in the log.
2. Restore, then delete only `betaFeatures.enableAgenticUi` → classic, with banner + Settings callout.
3. Set it `true` with `lastBumpStats` present → agentic; `false` with `lastBumpStats` removed → classic. Neither should be rewritten.
4. <kbd>⌘</kbd>/<kbd>Ctrl</kbd>+<kbd>N</kbd>: New chat in agentic with chat on; Add Site in classic, and in agentic after switching chat off in Settings → AI (no restart needed).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
