### PR TITLE
Update model switch dialog copy in the agentic UI

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
@@ -2,6 +2,7 @@ import { getAiModelLabel } from '@studio/common/ai/models';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Dialog } from '@wordpress/ui';
+import styles from './style.module.css';
 import type { AiModelId } from '@/data/core';
 
 /**
@@ -41,7 +42,7 @@ export function FamilySwitchConfirmDialog( {
 					<Dialog.Title>{ __( 'Start a new chat?' ) }</Dialog.Title>
 				</Dialog.Header>
 				<Dialog.Content>
-					<Dialog.Description>
+					<Dialog.Description className={ styles.dialogDescription }>
 						{ pendingModel
 							? createInterpolateElement(
 									sprintf(

--- a/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
@@ -45,7 +45,7 @@ export function FamilySwitchConfirmDialog( {
 							? sprintf(
 									/* translators: 1: current model name, 2: new model name */
 									__(
-										'Switching from %1$s to %2$s starts a fresh conversation — the two model families don\u2019t share memory. Your current chat stays in the sidebar.'
+										'Switching from %1$s to %2$s starts a fresh conversation — the two model families don\u2019t share memory. Your current chat remains available from the Chat history button below the chat box.'
 									),
 									getAiModelLabel( currentModel ),
 									getAiModelLabel( pendingModel )

--- a/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
@@ -47,7 +47,7 @@ export function FamilySwitchConfirmDialog( {
 									sprintf(
 										/* translators: 1: current model name, 2: new model name */
 										__(
-											'Switching from %1$s to %2$s starts a fresh chat; the two models don\u2019t share memory. You can always find previous chats in the <history>Chat history</history> button below the chat box.'
+											'Switching from %1$s to %2$s starts a fresh chat because the models don\u2019t share memory. You can find previous chats using <history>Chat history</history> below the chat box.'
 										),
 										getAiModelLabel( currentModel ),
 										getAiModelLabel( pendingModel )
@@ -68,7 +68,7 @@ export function FamilySwitchConfirmDialog( {
 						loadingAnnouncement={ __( 'Starting new chat' ) }
 						onClick={ onConfirm }
 					>
-						{ __( 'Start a new chat' ) }
+						{ __( 'Yes, new chat' ) }
 					</Button>
 				</Dialog.Footer>
 			</Dialog.Popup>

--- a/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
@@ -65,10 +65,10 @@ export function FamilySwitchConfirmDialog( {
 						variant="solid"
 						tone="brand"
 						loading={ inFlight }
-						loadingAnnouncement={ __( 'Starting new conversation' ) }
+						loadingAnnouncement={ __( 'Starting new chat' ) }
 						onClick={ onConfirm }
 					>
-						{ __( 'Start new conversation' ) }
+						{ __( 'Start a new chat' ) }
 					</Button>
 				</Dialog.Footer>
 			</Dialog.Popup>

--- a/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
@@ -37,7 +37,7 @@ export function FamilySwitchConfirmDialog( {
 		>
 			<Dialog.Popup size="small">
 				<Dialog.Header>
-					<Dialog.Title>{ __( 'Start a new conversation?' ) }</Dialog.Title>
+					<Dialog.Title>{ __( 'Start a new chat?' ) }</Dialog.Title>
 				</Dialog.Header>
 				<Dialog.Content>
 					<Dialog.Description>
@@ -45,7 +45,7 @@ export function FamilySwitchConfirmDialog( {
 							? sprintf(
 									/* translators: 1: current model name, 2: new model name */
 									__(
-										'Switching from %1$s to %2$s starts a fresh conversation — the two model families don\u2019t share memory. Your current chat remains available from the Chat history button below the chat box.'
+										'Switching from %1$s to %2$s starts a fresh chat; the two models don\u2019t share memory. You can always find previous chats in the Chat history button below the chat box.'
 									),
 									getAiModelLabel( currentModel ),
 									getAiModelLabel( pendingModel )

--- a/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx
@@ -1,4 +1,5 @@
 import { getAiModelLabel } from '@studio/common/ai/models';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Dialog } from '@wordpress/ui';
 import type { AiModelId } from '@/data/core';
@@ -42,13 +43,16 @@ export function FamilySwitchConfirmDialog( {
 				<Dialog.Content>
 					<Dialog.Description>
 						{ pendingModel
-							? sprintf(
-									/* translators: 1: current model name, 2: new model name */
-									__(
-										'Switching from %1$s to %2$s starts a fresh chat; the two models don\u2019t share memory. You can always find previous chats in the Chat history button below the chat box.'
+							? createInterpolateElement(
+									sprintf(
+										/* translators: 1: current model name, 2: new model name */
+										__(
+											'Switching from %1$s to %2$s starts a fresh chat; the two models don\u2019t share memory. You can always find previous chats in the <history>Chat history</history> button below the chat box.'
+										),
+										getAiModelLabel( currentModel ),
+										getAiModelLabel( pendingModel )
 									),
-									getAiModelLabel( currentModel ),
-									getAiModelLabel( pendingModel )
+									{ history: <strong /> }
 							  )
 							: '' }
 					</Dialog.Description>

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
@@ -331,7 +331,7 @@ describe( 'Composer menu', () => {
 		);
 		expect( within( dialog ).getByText( 'Chat history' ).tagName ).toBe( 'STRONG' );
 		expect( dialog ).not.toHaveTextContent( 'sidebar' );
-		fireEvent.click( await screen.findByRole( 'button', { name: 'Start new conversation' } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Start a new chat' } ) );
 
 		await waitFor( () => {
 			expect( onSwitchSession ).toHaveBeenCalledWith( 'fresh-session' );

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
@@ -324,6 +324,11 @@ describe( 'Composer menu', () => {
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Select model' } ) );
 		fireEvent.click( await screen.findByText( 'GPT 5.6 Sol' ) );
+		const dialog = await screen.findByRole( 'dialog' );
+		expect( dialog ).toHaveTextContent(
+			'Your current chat remains available from the Chat history button below the chat box.'
+		);
+		expect( dialog ).not.toHaveTextContent( 'sidebar' );
 		fireEvent.click( await screen.findByRole( 'button', { name: 'Start new conversation' } ) );
 
 		await waitFor( () => {

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
@@ -327,11 +327,11 @@ describe( 'Composer menu', () => {
 		const dialog = await screen.findByRole( 'dialog' );
 		expect( dialog ).toHaveTextContent( 'Start a new chat?' );
 		expect( dialog ).toHaveTextContent(
-			'Switching from Sonnet 5 to GPT 5.6 Sol starts a fresh chat; the two models don’t share memory. You can always find previous chats in the Chat history button below the chat box.'
+			'Switching from Sonnet 5 to GPT 5.6 Sol starts a fresh chat because the models don\u2019t share memory. You can find previous chats using Chat history below the chat box.'
 		);
 		expect( within( dialog ).getByText( 'Chat history' ).tagName ).toBe( 'STRONG' );
 		expect( dialog ).not.toHaveTextContent( 'sidebar' );
-		fireEvent.click( await screen.findByRole( 'button', { name: 'Start a new chat' } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Yes, new chat' } ) );
 
 		await waitFor( () => {
 			expect( onSwitchSession ).toHaveBeenCalledWith( 'fresh-session' );

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
@@ -325,8 +325,9 @@ describe( 'Composer menu', () => {
 		fireEvent.click( screen.getByRole( 'button', { name: 'Select model' } ) );
 		fireEvent.click( await screen.findByText( 'GPT 5.6 Sol' ) );
 		const dialog = await screen.findByRole( 'dialog' );
+		expect( dialog ).toHaveTextContent( 'Start a new chat?' );
 		expect( dialog ).toHaveTextContent(
-			'Your current chat remains available from the Chat history button below the chat box.'
+			'Switching from Sonnet 5 to GPT 5.6 Sol starts a fresh chat; the two models don’t share memory. You can always find previous chats in the Chat history button below the chat box.'
 		);
 		expect( dialog ).not.toHaveTextContent( 'sidebar' );
 		fireEvent.click( await screen.findByRole( 'button', { name: 'Start new conversation' } ) );

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
@@ -329,6 +329,7 @@ describe( 'Composer menu', () => {
 		expect( dialog ).toHaveTextContent(
 			'Switching from Sonnet 5 to GPT 5.6 Sol starts a fresh chat; the two models don’t share memory. You can always find previous chats in the Chat history button below the chat box.'
 		);
+		expect( within( dialog ).getByText( 'Chat history' ).tagName ).toBe( 'STRONG' );
 		expect( dialog ).not.toHaveTextContent( 'sidebar' );
 		fireEvent.click( await screen.findByRole( 'button', { name: 'Start new conversation' } ) );
 

--- a/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
@@ -598,3 +598,7 @@
 	color: var(--wpds-color-fg-content-error, #dc2626);
 	font-size: var(--wpds-typography-font-size-xs);
 }
+
+.dialogDescription {
+	text-wrap: pretty;
+}


### PR DESCRIPTION
## How AI was used in this PR

AI located the model-switch confirmation flow, updated the user-facing copy, added regression coverage, and ran the required validation. The resulting diff was reviewed for scope and correctness.

## Proposed Changes

<img width="482" height="351" alt="image" src="https://github.com/user-attachments/assets/76effff3-8dae-4533-b13e-904efad93693" />

- Clarify that switching models starts a fresh chat while previous chats remain available from the Chat history button below the chat box. This replaces the incorrect sidebar reference and reassures users that their previous chats were not lost.

## Testing Instructions

1. Open an existing agentic UI conversation.
2. Switch to a model in a different family, such as GPT 5.6 Sol.
3. Confirm the dialog title reads “Start a new chat?”
4. Confirm the dialog explains that previous chats are available from the Chat history button below the chat box and does not mention a sidebar.
5. Confirm that starting the new conversation still switches to the selected model.

Automated validation:

- `npx eslint --fix apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx`
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx` (11 tests passed)

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
