### PR TITLE
Tracks: emit studio_telemetry when analytics opt-in/opt-out changes

### DIFF
--- a/apps/studio/src/modules/onboarding/index.tsx
+++ b/apps/studio/src/modules/onboarding/index.tsx
@@ -42,7 +42,7 @@ export function Onboarding() {
 	const handleAnalyticsEnabledChange = useCallback(
 		( enabled: boolean ) => {
 			setAnalyticsEnabled( enabled );
-			void saveAnalyticsEnabled( enabled );
+			void saveAnalyticsEnabled( { enabled, surface: 'onboarding' } );
 		},
 		[ saveAnalyticsEnabled ]
 	);

--- a/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
@@ -155,7 +155,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 			await saveDefaultSiteDirectory( dirtyDefaultSiteDirectory );
 		}
 		if ( dirtyAnalyticsEnabled !== undefined ) {
-			await saveAnalyticsEnabled( dirtyAnalyticsEnabled );
+			await saveAnalyticsEnabled( { enabled: dirtyAnalyticsEnabled, surface: 'settings' } );
 		}
 		if ( isQuitSitesBehaviorDirty ) {
 			await saveQuitSitesBehavior( dirtyQuitSitesBehavior );

--- a/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
@@ -8,6 +8,7 @@ import { DEFAULT_TERMINAL } from 'src/constants';
 import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { isInstalled } from 'src/lib/is-installed';
 import { getUserLocaleWithFallback } from 'src/lib/locale-node';
+import { recordTracksEvent, TRACKS_EVENTS, type TracksUiVersion } from 'src/lib/tracks';
 import { SUPPORTED_EDITORS, SupportedEditor } from 'src/modules/user-settings/lib/editor';
 import { SupportedTerminal } from 'src/modules/user-settings/lib/terminal';
 import { UserSettingsTabName } from 'src/modules/user-settings/user-settings-types';
@@ -119,11 +120,34 @@ export async function getAnalyticsEnabled(): Promise< boolean > {
 	return ! ( await isAnalyticsOptedOut() );
 }
 
+// Where the toggle was flipped — the renderer supplies both; Main can't infer them.
+export interface AnalyticsToggleSource {
+	surface: 'onboarding' | 'settings';
+	uiVersion: TracksUiVersion;
+}
+
 export async function saveAnalyticsEnabled(
 	_event: IpcMainInvokeEvent,
-	enabled: boolean
+	enabled: boolean,
+	source: AnalyticsToggleSource
 ): Promise< void > {
-	await updateSharedConfig( { analyticsOptOut: ! enabled } );
+	// `recordTracksEvent` is gated by the current opt-out state, so the event must be recorded while
+	// analytics is ON — before turning it off, after turning it on. Order the write around that.
+	const recordEvent = () =>
+		recordTracksEvent( TRACKS_EVENTS.TELEMETRY, {
+			channel: 'studio-ui',
+			ui_version: source.uiVersion,
+			surface: source.surface,
+			status: enabled ? 'on' : 'off',
+		} );
+
+	if ( enabled ) {
+		await updateSharedConfig( { analyticsOptOut: false } );
+		await recordEvent();
+	} else {
+		await recordEvent();
+		await updateSharedConfig( { analyticsOptOut: true } );
+	}
 }
 
 export async function saveQuitSitesBehavior(

--- a/apps/studio/src/modules/user-settings/lib/tests/analytics-settings.test.ts
+++ b/apps/studio/src/modules/user-settings/lib/tests/analytics-settings.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment node
+ */
+import { IpcMainInvokeEvent } from 'electron';
+import { updateSharedConfig } from '@studio/common/lib/shared-config';
+import { vi } from 'vitest';
+import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
+import { saveAnalyticsEnabled } from 'src/modules/user-settings/lib/ipc-handlers';
+
+vi.mock( 'src/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('src/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
+vi.mock( '@studio/common/lib/shared-config', () => ( {
+	updateSharedConfig: vi.fn(),
+	isAnalyticsOptedOut: vi.fn(),
+} ) );
+
+const mockRecord = vi.mocked( recordTracksEvent );
+const mockUpdate = vi.mocked( updateSharedConfig );
+const event = {} as IpcMainInvokeEvent;
+
+beforeEach( () => {
+	vi.clearAllMocks();
+} );
+
+it( 'emits studio_telemetry with status "on" and the source when enabling analytics', async () => {
+	await saveAnalyticsEnabled( event, true, { surface: 'settings', uiVersion: 'v2' } );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.TELEMETRY, {
+		channel: 'studio-ui',
+		ui_version: 'v2',
+		surface: 'settings',
+		status: 'on',
+	} );
+	expect( mockUpdate ).toHaveBeenCalledWith( { analyticsOptOut: false } );
+} );
+
+it( 'emits studio_telemetry with status "off" and the source when disabling analytics', async () => {
+	await saveAnalyticsEnabled( event, false, { surface: 'onboarding', uiVersion: 'v1' } );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.TELEMETRY, {
+		channel: 'studio-ui',
+		ui_version: 'v1',
+		surface: 'onboarding',
+		status: 'off',
+	} );
+	expect( mockUpdate ).toHaveBeenCalledWith( { analyticsOptOut: true } );
+} );
+
+// `recordTracksEvent` is gated by the opt-out state, so both transitions must be recorded while
+// analytics is still ON: before the write when turning off, after the write when turning on.
+function trackOrder() {
+	const calls: string[] = [];
+	mockRecord.mockImplementation( async () => {
+		calls.push( 'record' );
+	} );
+	mockUpdate.mockImplementation( async () => {
+		calls.push( 'update' );
+	} );
+	return calls;
+}
+
+it( 'records the off-transition before the opt-out gate is written', async () => {
+	const calls = trackOrder();
+
+	await saveAnalyticsEnabled( event, false, { surface: 'settings', uiVersion: 'v1' } );
+
+	expect( calls ).toEqual( [ 'record', 'update' ] );
+} );
+
+it( 'records the on-transition after the opt-out gate is cleared', async () => {
+	const calls = trackOrder();
+
+	await saveAnalyticsEnabled( event, true, { surface: 'settings', uiVersion: 'v1' } );
+
+	expect( calls ).toEqual( [ 'update', 'record' ] );
+} );

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -169,7 +169,8 @@ const api: IpcApi = {
 	saveColorScheme: ( colorScheme ) => ipcRendererInvoke( 'saveColorScheme', colorScheme ),
 	getColorScheme: () => ipcRendererInvoke( 'getColorScheme' ),
 	getAnalyticsEnabled: () => ipcRendererInvoke( 'getAnalyticsEnabled' ),
-	saveAnalyticsEnabled: ( enabled ) => ipcRendererInvoke( 'saveAnalyticsEnabled', enabled ),
+	saveAnalyticsEnabled: ( enabled, source ) =>
+		ipcRendererInvoke( 'saveAnalyticsEnabled', enabled, source ),
 	saveQuitSitesBehavior: ( quitSitesBehavior ) =>
 		ipcRendererInvoke( 'saveQuitSitesBehavior', quitSitesBehavior ),
 	getQuitSitesBehavior: () => ipcRendererInvoke( 'getQuitSitesBehavior' ),

--- a/apps/studio/src/stores/installed-apps-api.ts
+++ b/apps/studio/src/stores/installed-apps-api.ts
@@ -132,9 +132,12 @@ export const installedAppsApi = createApi( {
 			},
 			providesTags: [ 'AnalyticsEnabled' ],
 		} ),
-		saveAnalyticsEnabled: builder.mutation< boolean, boolean >( {
-			queryFn: async ( enabled ) => {
-				await getIpcApi().saveAnalyticsEnabled( enabled );
+		saveAnalyticsEnabled: builder.mutation<
+			boolean,
+			{ enabled: boolean; surface: 'onboarding' | 'settings' }
+		>( {
+			queryFn: async ( { enabled, surface } ) => {
+				await getIpcApi().saveAnalyticsEnabled( enabled, { surface, uiVersion: 'v1' } );
 				return { data: enabled };
 			},
 			invalidatesTags: [ 'AnalyticsEnabled' ],

--- a/apps/ui/src/components/settings-view/index.tsx
+++ b/apps/ui/src/components/settings-view/index.tsx
@@ -375,7 +375,12 @@ export function SettingsView( {
 			if ( Object.keys( patch ).length === 0 ) {
 				return;
 			}
-			savePreferences.mutate( patch, {
+			// Tag only the analytics toggle with its surface for Tracks.
+			const withSource =
+				'analyticsEnabled' in patch
+					? { ...patch, source: { surface: 'settings' } as const }
+					: patch;
+			savePreferences.mutate( withSource, {
 				onSuccess: async () => {
 					if ( 'locale' in patch ) {
 						// Translations are loaded once at bootstrap; the rest of the

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -702,7 +702,7 @@ export function createIpcConnector(): Connector {
 			};
 		},
 
-		async setUserPreferences( partial ): Promise< void > {
+		async setUserPreferences( partial, source ): Promise< void > {
 			const writes: Array< Promise< unknown > > = [];
 			if ( 'editor' in partial ) {
 				writes.push( ipcApi.saveUserEditor( partial.editor ) );
@@ -720,7 +720,12 @@ export function createIpcConnector(): Connector {
 				writes.push( ipcApi.saveUserLocale( partial.locale ) );
 			}
 			if ( 'analyticsEnabled' in partial ) {
-				writes.push( ipcApi.saveAnalyticsEnabled( partial.analyticsEnabled ) );
+				writes.push(
+					ipcApi.saveAnalyticsEnabled( partial.analyticsEnabled, {
+						surface: source?.surface ?? 'settings',
+						uiVersion: 'v2',
+					} )
+				);
 			}
 			if ( 'defaultSiteDirectory' in partial && partial.defaultSiteDirectory ) {
 				writes.push( ipcApi.saveDefaultSiteDirectory( partial.defaultSiteDirectory ) );

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -38,6 +38,7 @@ export type {
 	SupportedLocale,
 	SupportedTerminal,
 	SyncSite,
+	PreferenceChangeSource,
 	UserPreferences,
 	WritableUserPreferences,
 } from './types';

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -341,7 +341,10 @@ export interface Connector {
 	// the granular main-process handlers inside the connector so the UI has a
 	// single query + mutation to work with.
 	getUserPreferences(): Promise< UserPreferences >;
-	setUserPreferences( partial: Partial< WritableUserPreferences > ): Promise< void >;
+	setUserPreferences(
+		partial: Partial< WritableUserPreferences >,
+		source?: PreferenceChangeSource
+	): Promise< void >;
 
 	// Opens a native folder picker for the default-site-directory preference.
 	// Resolves with the chosen path, or `null` when the user cancels (or the
@@ -501,6 +504,12 @@ export type WritableUserPreferences = Omit<
 > & {
 	locale: SupportedLocale;
 };
+
+// Attributes a preference write to an in-app surface for settings-change Tracks
+// events. `ui_version` is fixed per renderer, so connectors set it — not callers.
+export interface PreferenceChangeSource {
+	surface: 'onboarding' | 'settings';
+}
 
 export interface CreateSiteParams {
 	name: string;

--- a/apps/ui/src/data/queries/use-user-preferences.ts
+++ b/apps/ui/src/data/queries/use-user-preferences.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useConnector } from '@/data/core';
-import type { UserPreferences, WritableUserPreferences } from '@/data/core';
+import type { PreferenceChangeSource, UserPreferences, WritableUserPreferences } from '@/data/core';
 
 export const USER_PREFERENCES_QUERY_KEY = [ 'user-preferences' ] as const;
 
@@ -20,8 +20,12 @@ export function useSaveUserPreferences() {
 	const connector = useConnector();
 	const queryClient = useQueryClient();
 	return useMutation( {
-		mutationFn: ( partial: Partial< WritableUserPreferences > ) =>
-			connector.setUserPreferences( partial ).then( () => partial ),
+		// `source` is Tracks-only metadata, split out so it never lands in the patch.
+		mutationFn: ( {
+			source,
+			...partial
+		}: Partial< WritableUserPreferences > & { source?: PreferenceChangeSource } ) =>
+			connector.setUserPreferences( partial, source ).then( () => partial ),
 		onSuccess: ( partial ) => {
 			// Main-process save handlers don't transform the input, so we merge
 			// the submitted partial directly into the cache instead of refetching

--- a/apps/ui/src/ui-classic/router/route-welcome/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-welcome/index.tsx
@@ -81,7 +81,12 @@ function WelcomePage() {
 					__nextHasNoMarginBottom
 					label={ __( 'Help improve Studio by sharing anonymous usage statistics' ) }
 					checked={ preferences?.analyticsEnabled ?? true }
-					onChange={ ( analyticsEnabled ) => saveUserPreferences.mutate( { analyticsEnabled } ) }
+					onChange={ ( analyticsEnabled ) =>
+						saveUserPreferences.mutate( {
+							analyticsEnabled,
+							source: { surface: 'onboarding' },
+						} )
+					}
 				/>
 			</div>
 		</div>

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -135,8 +135,9 @@ Common props (`platform`, `arch`, `app_version`, `is_a11n`, and `channel`/`ui_ve
 wrappers/renderers — pass only event-specific props. (Centralizing `channel`/`ui_version` on the desktop
 side is STU-2122; until it lands, `studio_app_launch` still sets them at the call site.)
 
-Reserved for later phases (documented so future events conform): `surface` (in-app area, e.g.
-`onboarding`/`settings`), `outcome` (`success`/`error`).
+`surface` (in-app area, e.g. `onboarding`/`settings`) is live on `studio_telemetry`; the renderer
+supplies it per change (Main can't infer it) and it is meant to generalize to other settings-change
+events. Reserved for later phases (documented so future events conform): `outcome` (`success`/`error`).
 
 **AI / assistant events (Phase 2+).** Studio Code assistant usage events must use the data team's
 AI-event vocabulary: `ai_session_id`, `agent_name`, `agent_version`, `ability_name`, `outcome`,
@@ -151,6 +152,7 @@ Every event also carries the common props `channel`, `is_a11n`, `platform`, `arc
 |---|---|---|
 | `studio_app_launch` | Desktop Main (`appBoot`) | `ui_version`, `is_first_launch` |
 | `studio_site_start` | CLI site-start funnel | `ui_version` (only when `channel=studio-ui`) |
+| `studio_telemetry` | Desktop Main (`saveAnalyticsEnabled`) | `status` (`on`/`off`), `surface` (`onboarding`/`settings`) — recorded while analytics is still ON (before the write when turning off, after it when turning on) so the opt-out gate never self-suppresses it. `ui_version` set at the call site from the originating renderer. |
 
 ### How to add a new event
 

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -10,6 +10,7 @@ const TRACKS_PIXEL_URL = 'https://pixel.wp.com/t.gif';
 export const TRACKS_EVENTS = {
 	APP_LAUNCH: 'studio_app_launch',
 	SITE_START: 'studio_site_start',
+	TELEMETRY: 'studio_telemetry',
 } as const;
 
 export type TracksEventName = ( typeof TRACKS_EVENTS )[ keyof typeof TRACKS_EVENTS ];


### PR DESCRIPTION
## Related issues

- Fixes [STU-2169](https://linear.app/a8c/issue/STU-2169/tracks-emit-studio-telemetry-on-opt-inopt-out-change)
- Related to [STU-2036](https://linear.app/a8c/issue/STU-2036/add-initial-tracks-analytics)

## How AI was used in this PR

Claude Code implemented the change end-to-end from the Linear issue. It traced all four analytics-toggle call sites across both renderers, designed the source-attribution plumbing, wrote the unit tests, and fixed the on-transition self-suppression bug found by me during manual testing. I reviewed the code, ran the app to verify the emitted events, and confirmed the ordering logic.

## Proposed Changes

The analytics opt-out toggle shipped across onboarding, legacy Settings, and agentic Settings, but flipping it emitted no telemetry — so we had opt-out with no signal on how often users actually opt in or out. This adds a `studio_telemetry` Tracks event that fires whenever the toggle changes.

The event records:
- **`status`** — `on` / `off`
- **`surface`** — where it was flipped (`onboarding` / `settings`)
- **`ui_version`** — which renderer (`v1` legacy / `v2` agentic)

`recordTracksEvent` is gated by the current opt-out state, so a naive "record then write" would silently drop the very off-transition we care about (the gate the write just closed suppresses it), and a naive "write then record" would drop the on-transition. Recording is ordered around the config write per direction so the event is always emitted while analytics is still ON, and neither transition self-suppresses.

The source attribution is built as a reusable `PreferenceChangeSource` channel on the preferences write path (not an analytics-only hack), so tracking future settings changes is a small addition in each Main handler rather than new API.

No user-visible behavior change — this is telemetry only, and respects the existing opt-out (opted-out users still emit nothing).

## Testing Instructions

1. `npm start`, then open Settings (agentic or legacy) or onboarding.
2. Toggle **Usage statistics** off, then on again.
3. In the terminal, confirm two `Would have recorded Tracks event: studio_telemetry` lines appear — one with `status: 'off'`, one with `status: 'on'` — each carrying the correct `surface` and `ui_version` for where you flipped it.
4. `npm test -- apps/studio/src/modules/user-settings/lib/tests/analytics-settings.test.ts` — covers both transitions and the record/write ordering.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

### Remaining before merge

- [ ] Register `studio_telemetry` and its eventprops (`status`, `surface`, plus common props `channel`, `ui_version`, `is_a11n`, `platform`, `arch`, `app_version`) via the Tracks Registration tool — required for the data to be queryable.
