### PR TITLE
Log CLI Tracks events in the terminal during npm start

### DIFF
--- a/apps/cli/lib/tests/tracks.test.ts
+++ b/apps/cli/lib/tests/tracks.test.ts
@@ -63,6 +63,7 @@ describe( 'recordTracksEvent', () => {
 	it( 'does not send when the build-time telemetry flag is off', async () => {
 		vi.stubGlobal( '__ENABLE_CLI_TELEMETRY__', false );
 		delete process.env.STUDIO_FORCE_CLI_TELEMETRY;
+		process.env.NODE_ENV = 'production';
 
 		await recordTracksEvent( TRACKS_EVENTS.SITE_START, { channel: 'studio-cli' } );
 
@@ -77,6 +78,27 @@ describe( 'recordTracksEvent', () => {
 		await recordTracksEvent( TRACKS_EVENTS.SITE_START, { channel: 'studio-cli' } );
 
 		expect( mockRecord ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'proceeds in development so CLI events log during npm start', async () => {
+		vi.stubGlobal( '__ENABLE_CLI_TELEMETRY__', false );
+		delete process.env.STUDIO_FORCE_CLI_TELEMETRY;
+		process.env.NODE_ENV = 'development';
+
+		await recordTracksEvent( TRACKS_EVENTS.SITE_START, { channel: 'studio-cli' } );
+
+		expect( mockRecord ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'opt-out still wins in development', async () => {
+		vi.stubGlobal( '__ENABLE_CLI_TELEMETRY__', false );
+		delete process.env.STUDIO_FORCE_CLI_TELEMETRY;
+		process.env.NODE_ENV = 'development';
+		mockOptedOut.mockResolvedValue( true );
+
+		await recordTracksEvent( TRACKS_EVENTS.SITE_START, { channel: 'studio-cli' } );
+
+		expect( mockRecord ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does not send when opted out', async () => {

--- a/apps/cli/lib/tracks.ts
+++ b/apps/cli/lib/tracks.ts
@@ -59,15 +59,24 @@ async function commonProps(): Promise< TracksProps > {
 //      is partly belt-and-suspenders, but it keeps a non-dev build with the flag off silent too, and
 //      matches how the sibling MC-Stats CLI code gates — see `recordSiteRuntimeUsage`.)
 //
-// Consequence for local runs: in a dev build this returns early, so you will NOT see a "Would have
-// recorded studio_site_start" log — that's expected, not a bug. To exercise Tracks against a dev
-// build without rebuilding, set `STUDIO_FORCE_CLI_TELEMETRY=1` at runtime (the shared core still
-// no-ops the network send in dev/E2E, so this only enables the code path + logging).
+// Consequence for local runs: a dev build has the build-time flag off, so telemetry is enabled here
+// only via one of the two runtime escape hatches below. In both cases the shared core still no-ops the
+// network send in dev/E2E, so nothing is actually sent — they only enable the code path + the "Would
+// have recorded…" log:
+//   - `NODE_ENV === 'development'` — inherited from the desktop during `npm start`, so CLI events log
+//     the same "Would have recorded… studio_site_start" line the desktop already logs for
+//     `studio_app_launch`, giving both surfaces the same `npm start` visibility with no extra setup.
+//   - `STUDIO_FORCE_CLI_TELEMETRY=1` — exercise Tracks against a dev build outside a dev run (e.g. a
+//     standalone CLI invocation), typically paired with `STUDIO_DEBUG_TRACKS=1` to log the pixel URL.
 export async function recordTracksEvent(
 	event: TracksEventName,
 	props: TracksProps = {}
 ): Promise< void > {
-	if ( ! __ENABLE_CLI_TELEMETRY__ && ! process.env.STUDIO_FORCE_CLI_TELEMETRY ) {
+	const telemetryAllowed =
+		__ENABLE_CLI_TELEMETRY__ ||
+		process.env.STUDIO_FORCE_CLI_TELEMETRY ||
+		process.env.NODE_ENV === 'development';
+	if ( ! telemetryAllowed ) {
 		return;
 	}
 	if ( await isAnalyticsOptedOut() ) {

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -179,10 +179,14 @@ What fires depends on the build, so pick the right method:
   `__ENABLE_CLI_TELEMETRY__` gate, so a plain `npm start` logs `Would have recorded… studio_app_launch`
   in the **Main-process terminal** (the shared core no-ops the network send in dev/E2E). Add
   `enableAgenticUi` to see `ui_version: v2`.
-- **`studio_site_start` — NOT emitted in a plain dev run.** It fires from the CLI, gated by
-  `__ENABLE_CLI_TELEMETRY__`, which is compiled to `false` in dev builds — so `npm start` and a normal
-  `npm run cli:build` emit nothing, by design. To exercise it against a dev build **without** rebuilding,
-  set the runtime override `STUDIO_FORCE_CLI_TELEMETRY=1`, and run the CLI directly in a terminal:
+- **`studio_site_start` in a dev run.** It fires from the CLI, whose build-time
+  `__ENABLE_CLI_TELEMETRY__` gate is compiled to `false` in dev builds. The CLI wrapper treats
+  `NODE_ENV === 'development'` as an escape hatch, though, so during a plain `npm start` a UI-triggered
+  site start logs `Would have recorded… studio_site_start` in the **`npm start` terminal** (echoed as
+  `[CLI - <siteId>] …`), the same way the desktop logs `studio_app_launch` — the shared core still
+  no-ops the network send. To exercise it against a dev build **outside** a dev run (e.g. a standalone
+  CLI invocation) **without** rebuilding, set the runtime override `STUDIO_FORCE_CLI_TELEMETRY=1`, and
+  run the CLI directly in a terminal:
 
   ```
   # pick a site that is OFFLINE in `studio list` — `start` no-ops on an already-running site


### PR DESCRIPTION
## Related issues

- Related to STU-2170

## How AI was used in this PR

Claude Code investigated why CLI Tracks events were invisible in dev, proposed and implemented the fix, added tests, and updated the design doc. I reviewed the reasoning — in particular confirming the new `NODE_ENV === 'development'` condition is a strict subset of the shared core's dev/E2E no-op, so it cannot cause a real pixel to fire in any shipped or CI build.

## Proposed Changes

When running Studio locally with `npm start`, the desktop Main process already logs a `Would have recorded Tracks event: studio_app_launch { … }` line for each event — useful when debugging analytics or reviewing a Tracks PR. CLI-emitted events (notably `studio_site_start`) printed **nothing** in a plain dev run, so there was no parity: you couldn't see a CLI event fire without a manual multi-env-var incantation.

This makes CLI Tracks events log the same `Would have recorded…` line automatically during `npm start`, matching the desktop behavior with no extra setup. The CLI wrapper now treats `NODE_ENV === 'development'` (inherited by the forked CLI child from the desktop) as an escape hatch, letting the call reach the shared core — which logs the line and no-ops the network in dev.

This is a **debug-visibility change only**. The shared core remains the single guardian that no real pixel fires in dev/E2E, and the new condition is a strict subset of that no-op condition, so it cannot leak analytics. The build-time `__ENABLE_CLI_TELEMETRY__` gate still fully protects standalone dev CLI builds and all shipped/CI builds (verified nothing outside test files sets `NODE_ENV=development`). It also fixes a small asymmetry: the desktop already fell through to the shared core in dev while the CLI's stricter gate did not.

## Testing Instructions

Automated:
- `npm test -- apps/cli/lib/tests/tracks.test.ts` — includes new cases for the dev pass-through and that opt-out still wins in dev.
- `npm run typecheck`

End-to-end (manual):
1. `npm run cli:build`
2. `npm start`
3. Start a site from the UI and watch the `npm start` terminal. You should see, alongside the existing `studio_app_launch` line:

```
[CLI - <siteId>] Would have recorded Tracks event: studio_site_start {
  platform: 'darwin', arch: 'arm64', app_version: '1.17.0',
  is_a11n: true, channel: 'studio-ui', ui_version: 'v1'
}
```

Confirmed working locally. No real network request is made (shared core no-ops in dev).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?