### PR TITLE
PoC: Claude Code subscription provider via ACP

### DIFF
--- a/apps/cli/ai/auth.ts
+++ b/apps/cli/ai/auth.ts
@@ -17,7 +17,11 @@ async function getPreferredReadyProvider(
 		}
 
 		const definition = getAiProviderDefinition( provider );
-		if ( ( await definition.isVisible() ) && ( await definition.isReady() ) ) {
+		if (
+			definition.autoSelectable &&
+			( await definition.isVisible() ) &&
+			( await definition.isReady() )
+		) {
 			return provider;
 		}
 	}

--- a/apps/cli/ai/providers.ts
+++ b/apps/cli/ai/providers.ts
@@ -1,3 +1,8 @@
+import { execFile } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
 import { password } from '@inquirer/prompts';
 import {
 	AI_MODELS,
@@ -10,15 +15,18 @@ import { __ } from '@wordpress/i18n';
 import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
 import { LoggerError } from 'cli/logger';
 
+const execFileAsync = promisify( execFile );
+
 export const AI_PROVIDERS = {
 	wpcom: 'WordPress.com',
 	'anthropic-api-key': 'Anthropic · API key',
+	'claude-code': 'Claude Code · subscription',
 } as const;
 
 export type AiProviderId = keyof typeof AI_PROVIDERS;
 
 export const DEFAULT_AI_PROVIDER: AiProviderId = 'wpcom';
-export const AI_PROVIDER_PRIORITY: AiProviderId[] = [ 'wpcom', 'anthropic-api-key' ];
+export const AI_PROVIDER_PRIORITY: AiProviderId[] = [ 'wpcom', 'anthropic-api-key', 'claude-code' ];
 
 const DEFAULT_WPCOM_AI_GATEWAY_BASE_URL = 'https://public-api.wordpress.com/wpcom/v2/ai-api-proxy';
 // The wpcom AI proxy maps feature slugs to upstream providers. Historically
@@ -43,6 +51,13 @@ export interface AiProviderDefinition {
 	 * callers don't have to filter AI_MODELS themselves.
 	 */
 	readonly supportedModelFamilies: readonly AiModelFamily[];
+	/**
+	 * Whether the provider may be picked automatically (first-run scan,
+	 * unavailable-provider fallback). Opt-in-only providers — e.g. billing the
+	 * user's Claude subscription — stay selectable but are never chosen for
+	 * the user.
+	 */
+	readonly autoSelectable: boolean;
 	readonly availableModels: readonly AiModelId[];
 	readonly defaultModel: AiModelId;
 	supportsModel( model: AiModelId ): boolean;
@@ -102,6 +117,29 @@ function buildAnthropicCustomHeaders( headers: Record< string, string > ): strin
 		.join( '\n' );
 }
 
+// Claude Code stores subscription credentials in the macOS keychain, or in
+// ~/.claude/.credentials.json elsewhere. The Agent SDK spawned by the ACP
+// adapter reads them itself; Studio only probes for their presence so the
+// provider can report readiness without touching the secrets.
+async function hasClaudeCodeCredentials(): Promise< boolean > {
+	if ( fs.existsSync( path.join( os.homedir(), '.claude', '.credentials.json' ) ) ) {
+		return true;
+	}
+	if ( process.platform === 'darwin' ) {
+		try {
+			await execFileAsync( 'security', [
+				'find-generic-password',
+				'-s',
+				'Claude Code-credentials',
+			] );
+			return true;
+		} catch {
+			return false;
+		}
+	}
+	return false;
+}
+
 function getWpcomAiGatewayBaseUrl(): string {
 	const customBaseUrl = process.env.WPCOM_AI_PROXY_BASE_URL?.trim();
 	return customBaseUrl || DEFAULT_WPCOM_AI_GATEWAY_BASE_URL;
@@ -138,6 +176,7 @@ const AI_PROVIDER_DEFINITIONS: Record< AiProviderId, AiProviderDefinition > = {
 	wpcom: defineProvider( {
 		id: 'wpcom',
 		autoFallbackWhenUnavailable: true,
+		autoSelectable: true,
 		supportedModelFamilies: [ 'anthropic', 'openai' ],
 		isVisible: async () => true,
 		isReady: async () => hasInlineWpcomAuth() || ( await hasValidWpcomAuth() ),
@@ -189,6 +228,7 @@ const AI_PROVIDER_DEFINITIONS: Record< AiProviderId, AiProviderDefinition > = {
 	'anthropic-api-key': defineProvider( {
 		id: 'anthropic-api-key',
 		autoFallbackWhenUnavailable: false,
+		autoSelectable: true,
 		supportedModelFamilies: [ 'anthropic' ],
 		isVisible: async () => true,
 		isReady: async () => {
@@ -211,6 +251,40 @@ const AI_PROVIDER_DEFINITIONS: Record< AiProviderId, AiProviderDefinition > = {
 			const env = createBaseEnvironment();
 			env.ANTHROPIC_API_KEY = apiKey;
 			return env;
+		},
+	} ),
+	// Turns run through the official Claude Code harness via the ACP adapter
+	// (see cli/ai/runtimes/acp) and bill against the user's Claude Pro/Max
+	// subscription. Studio never handles the credentials — the Agent SDK reads
+	// the user's own Claude Code login.
+	'claude-code': defineProvider( {
+		id: 'claude-code',
+		autoFallbackWhenUnavailable: false,
+		autoSelectable: false,
+		supportedModelFamilies: [ 'anthropic' ],
+		isVisible: async () => true,
+		isReady: async () => hasClaudeCodeCredentials(),
+		prepare: async () => {
+			if ( await hasClaudeCodeCredentials() ) {
+				return;
+			}
+			throw new LoggerError(
+				__(
+					'Claude Code login required. Install Claude Code and run `claude` then `/login` to sign in with your Claude subscription.'
+				)
+			);
+		},
+		resolveEnv: async () => {
+			if ( ! ( await hasClaudeCodeCredentials() ) ) {
+				throw new LoggerError(
+					__(
+						'Claude Code login required. Install Claude Code and run `claude` then `/login` to sign in with your Claude subscription.'
+					)
+				);
+			}
+			// Strip any Studio-managed AI credentials so the Agent SDK falls
+			// back to the user's own Claude Code subscription login.
+			return createBaseEnvironment();
 		},
 	} ),
 };

--- a/apps/cli/ai/runtimes/acp/index.ts
+++ b/apps/cli/ai/runtimes/acp/index.ts
@@ -1,0 +1,332 @@
+import { spawn, type ChildProcess } from 'child_process';
+import { createRequire } from 'node:module';
+import path from 'path';
+import { Readable, Writable } from 'stream';
+import {
+	ClientSideConnection,
+	ndJsonStream,
+	PROTOCOL_VERSION,
+	type Client,
+	type RequestPermissionRequest,
+	type RequestPermissionResponse,
+	type SessionNotification,
+	type StopReason as AcpStopReason,
+	type ToolCallUpdate,
+} from '@agentclientprotocol/sdk';
+import { __ } from '@wordpress/i18n';
+import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
+import type {
+	AssistantMessage,
+	StopReason,
+	TextContent,
+	ThinkingContent,
+	Usage,
+	UserMessage,
+} from '@earendil-works/pi-ai';
+import type { AgentSessionEvent } from '@earendil-works/pi-coding-agent';
+import type { StudioAgentTurnConfig, StudioAgentTurnHandle } from 'cli/ai/runtimes/pi';
+
+// The ACP engine runs the official Claude Code harness (via the
+// @agentclientprotocol/claude-agent-acp adapter, which wraps
+// @anthropic-ai/claude-agent-sdk) so turns bill against the user's Claude
+// Pro/Max subscription — the sanctioned path; raw subscription OAuth in a
+// third-party harness is rejected server-side by Anthropic.
+const ACP_ADAPTER_PACKAGE = '@agentclientprotocol/claude-agent-acp';
+const ACP_PROVIDER_NAME = 'claude-code-acp';
+
+const ZERO_USAGE: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function resolveAdapterEntry(): string {
+	const require = createRequire( import.meta.url );
+	const packageJsonPath = require.resolve( `${ ACP_ADAPTER_PACKAGE }/package.json` );
+	// Path mirrors the package's `bin` entry; the subpath itself isn't exported.
+
+	const binEntry = ( require( packageJsonPath ) as { bin?: Record< string, string > } ).bin?.[
+		'claude-agent-acp'
+	];
+	if ( ! binEntry ) {
+		throw new Error( `${ ACP_ADAPTER_PACKAGE } does not expose the claude-agent-acp binary` );
+	}
+	return path.join( path.dirname( packageJsonPath ), binEntry );
+}
+
+function mapAcpStopReason( stopReason: AcpStopReason, interrupted: boolean ): StopReason {
+	if ( interrupted || stopReason === 'cancelled' ) {
+		return 'aborted';
+	}
+	if ( stopReason === 'refusal' ) {
+		return 'error';
+	}
+	if ( stopReason === 'max_tokens' ) {
+		return 'length';
+	}
+	return 'stop';
+}
+
+interface AcpTurnState {
+	interrupted: boolean;
+	child?: ChildProcess;
+	connection?: ClientSideConnection;
+	acpSessionId?: string;
+}
+
+export function runAcpAgentTurn( config: StudioAgentTurnConfig ): StudioAgentTurnHandle {
+	const state: AcpTurnState = { interrupted: false };
+
+	return {
+		result: runTurn( config, state ),
+		async interrupt() {
+			state.interrupted = true;
+			try {
+				if ( state.connection && state.acpSessionId ) {
+					await state.connection.cancel( { sessionId: state.acpSessionId } );
+					return;
+				}
+			} catch {
+				// Fall through to killing the adapter below.
+			}
+			state.child?.kill( 'SIGTERM' );
+		},
+	};
+}
+
+async function runTurn( config: StudioAgentTurnConfig, state: AcpTurnState ): Promise< void > {
+	const { session: sm, onEvent } = config;
+	const env = config.env ?? { ...( process.env as Record< string, string > ) };
+	const site = config.activeSite;
+	const cwd = site && ! site.remote && site.path ? site.path : STUDIO_SITES_ROOT;
+
+	const emit = ( event: AgentSessionEvent ) => onEvent( event );
+
+	const now = () => Date.now();
+	const userMessage: UserMessage = {
+		role: 'user',
+		content: config.prompt,
+		timestamp: now(),
+	};
+
+	// Streaming accumulation state for the assistant message.
+	const content: ( TextContent | ThinkingContent )[] = [];
+	const partialAssistant = (): AssistantMessage => ( {
+		role: 'assistant',
+		content: [ ...content ],
+		api: 'anthropic-messages',
+		provider: ACP_PROVIDER_NAME,
+		model: 'claude-code',
+		usage: ZERO_USAGE,
+		stopReason: 'stop',
+		timestamp: now(),
+	} );
+	const runningToolCalls = new Set< string >();
+
+	const appendChunk = ( kind: 'text' | 'thinking', delta: string ) => {
+		const last = content[ content.length - 1 ];
+		let contentIndex = content.length - 1;
+		if ( ! last || last.type !== kind ) {
+			content.push(
+				kind === 'text' ? { type: 'text', text: '' } : { type: 'thinking', thinking: '' }
+			);
+			contentIndex = content.length - 1;
+			emit( {
+				type: 'message_update',
+				message: partialAssistant(),
+				assistantMessageEvent:
+					kind === 'text'
+						? { type: 'text_start', contentIndex, partial: partialAssistant() }
+						: { type: 'thinking_start', contentIndex, partial: partialAssistant() },
+			} );
+		}
+		const block = content[ contentIndex ];
+		if ( block.type === 'text' ) {
+			block.text += delta;
+		} else {
+			block.thinking += delta;
+		}
+		emit( {
+			type: 'message_update',
+			message: partialAssistant(),
+			assistantMessageEvent:
+				kind === 'text'
+					? { type: 'text_delta', contentIndex, delta, partial: partialAssistant() }
+					: { type: 'thinking_delta', contentIndex, delta, partial: partialAssistant() },
+		} );
+	};
+
+	const handleToolCallUpdate = ( update: ToolCallUpdate & { sessionUpdate?: string } ) => {
+		const toolCallId = update.toolCallId;
+		const toolName = update.title ?? update.kind ?? 'tool';
+		// The initial `tool_call` notification may omit `status`; treat it as
+		// pending so the start of the call is still surfaced.
+		const status = update.status ?? 'pending';
+		if ( status === 'pending' || status === 'in_progress' ) {
+			if ( ! runningToolCalls.has( toolCallId ) ) {
+				runningToolCalls.add( toolCallId );
+				emit( {
+					type: 'tool_execution_start',
+					toolCallId,
+					toolName,
+					args: update.rawInput ?? {},
+				} );
+			}
+			return;
+		}
+		if ( status === 'completed' || status === 'failed' ) {
+			runningToolCalls.delete( toolCallId );
+			emit( {
+				type: 'tool_execution_end',
+				toolCallId,
+				toolName,
+				result: update.rawOutput ?? update.content ?? null,
+				isError: status === 'failed',
+			} );
+		}
+	};
+
+	const client: Client = {
+		// Tool use is auto-approved for the PoC, scoped by the session cwd —
+		// same trust level as the pi tools, which don't prompt either.
+		requestPermission( params: RequestPermissionRequest ): RequestPermissionResponse {
+			const options = params.options ?? [];
+			const preferred =
+				options.find( ( option ) => option.kind === 'allow_always' ) ??
+				options.find( ( option ) => option.kind === 'allow_once' ) ??
+				options[ 0 ];
+			if ( ! preferred ) {
+				return { outcome: { outcome: 'cancelled' } };
+			}
+			return { outcome: { outcome: 'selected', optionId: preferred.optionId } };
+		},
+		sessionUpdate( params: SessionNotification ): void {
+			const update = params.update;
+			switch ( update.sessionUpdate ) {
+				case 'agent_message_chunk':
+					if ( update.content.type === 'text' ) {
+						appendChunk( 'text', update.content.text );
+					}
+					break;
+				case 'agent_thought_chunk':
+					if ( update.content.type === 'text' ) {
+						appendChunk( 'thinking', update.content.text );
+					}
+					break;
+				case 'tool_call':
+				case 'tool_call_update':
+					handleToolCallUpdate( update );
+					break;
+				default:
+					break;
+			}
+		},
+	};
+
+	const adapterEntry = resolveAdapterEntry();
+	const child = spawn( process.execPath, [ adapterEntry ], {
+		env,
+		cwd,
+		stdio: [ 'pipe', 'pipe', 'pipe' ],
+	} );
+	state.child = child;
+
+	let stderrTail = '';
+	child.stderr?.on( 'data', ( chunk: Buffer ) => {
+		stderrTail = ( stderrTail + chunk.toString() ).slice( -2000 );
+	} );
+
+	const spawnFailure = new Promise< never >( ( _resolve, reject ) => {
+		child.once( 'error', ( error ) =>
+			reject(
+				new Error( `${ __( 'Failed to start the Claude Code ACP adapter.' ) } ${ error.message }` )
+			)
+		);
+	} );
+
+	try {
+		const stream = ndJsonStream(
+			Writable.toWeb( child.stdin! ) as WritableStream< Uint8Array >,
+			Readable.toWeb( child.stdout! ) as ReadableStream< Uint8Array >
+		);
+		const connection = new ClientSideConnection( () => client, stream );
+		state.connection = connection;
+
+		await Promise.race( [
+			( async () => {
+				await connection.initialize( {
+					protocolVersion: PROTOCOL_VERSION,
+					clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } },
+					clientInfo: { name: 'wordpress-studio', version: __STUDIO_CLI_VERSION__ },
+				} );
+
+				const newSession = await connection.newSession( {
+					cwd,
+					mcpServers: [
+						{
+							name: 'wordpress-studio',
+							command: process.execPath,
+							args: [ process.argv[ 1 ], 'mcp' ],
+							env: [],
+						},
+					],
+				} );
+				state.acpSessionId = newSession.sessionId;
+
+				emit( { type: 'agent_start' } );
+				emit( { type: 'turn_start' } );
+				sm.appendMessage( userMessage );
+				emit( { type: 'message_start', message: userMessage } );
+				emit( { type: 'message_end', message: userMessage } );
+				emit( { type: 'message_start', message: partialAssistant() } );
+
+				const promptResponse = await connection.prompt( {
+					sessionId: newSession.sessionId,
+					prompt: [ { type: 'text', text: config.prompt } ],
+				} );
+
+				const stopReason = mapAcpStopReason( promptResponse.stopReason, state.interrupted );
+				const assistantMessage: AssistantMessage = {
+					...partialAssistant(),
+					stopReason,
+					...( stopReason === 'error'
+						? { errorMessage: __( 'Claude declined to answer this request.' ) }
+						: {} ),
+				};
+
+				sm.appendMessage( assistantMessage );
+				emit( { type: 'message_end', message: assistantMessage } );
+				emit( { type: 'turn_end', message: assistantMessage, toolResults: [] } );
+				emit( {
+					type: 'agent_end',
+					messages: [ userMessage, assistantMessage ],
+					willRetry: false,
+				} );
+			} )(),
+			spawnFailure,
+		] );
+	} catch ( error ) {
+		if ( state.interrupted ) {
+			const abortedMessage: AssistantMessage = { ...partialAssistant(), stopReason: 'aborted' };
+			sm.appendMessage( abortedMessage );
+			emit( { type: 'message_end', message: abortedMessage } );
+			emit( {
+				type: 'agent_end',
+				messages: [ userMessage, abortedMessage ],
+				willRetry: false,
+			} );
+			return;
+		}
+		const details = stderrTail.trim();
+		throw error instanceof Error && details
+			? new Error( `${ error.message }\n${ details }` )
+			: error;
+	} finally {
+		if ( ! child.killed ) {
+			child.kill( 'SIGTERM' );
+		}
+	}
+}

--- a/apps/cli/ai/tests/auth.test.ts
+++ b/apps/cli/ai/tests/auth.test.ts
@@ -85,7 +85,20 @@ describe( 'AI auth helpers', () => {
 	} );
 
 	it( 'lists available providers', async () => {
-		await expect( getAvailableAiProviders() ).resolves.toEqual( [ 'wpcom', 'anthropic-api-key' ] );
+		await expect( getAvailableAiProviders() ).resolves.toEqual( [
+			'wpcom',
+			'anthropic-api-key',
+			'claude-code',
+		] );
+	} );
+
+	it( 'never auto-selects the claude-code provider', async () => {
+		// No wpcom token and no API key: even if Claude Code credentials exist
+		// on the machine, the opt-in-only claude-code provider must not be
+		// picked for the user — the scan falls back to the default.
+		vi.mocked( readAuthToken ).mockResolvedValue( null );
+
+		await expect( resolveInitialAiProvider() ).resolves.toBe( 'wpcom' );
 	} );
 
 	it( 'configures the WP.com gateway environment', async () => {

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -25,6 +25,7 @@ import { setChatArtifactCallback } from 'cli/ai/chat-artifacts';
 import { startDaemonStatusPolling } from 'cli/ai/daemon-status-poll';
 import { type AiOutputAdapter, JsonAdapter } from 'cli/ai/output-adapter';
 import { AI_PROVIDERS, getAiProviderDefinition, type AiProviderId } from 'cli/ai/providers';
+import { runAcpAgentTurn } from 'cli/ai/runtimes/acp';
 import { runStudioAgentTurn } from 'cli/ai/runtimes/pi';
 import { setScreenshotDirectoryProvider } from 'cli/ai/screenshot-storage';
 import { resolveResumeSessionContext } from 'cli/ai/sessions/context';
@@ -540,7 +541,12 @@ export async function runCommand( options: {
 
 		const turnState: { status: TurnStatus; errorMessage?: string } = { status: 'interrupted' };
 
-		const agentQuery = runStudioAgentTurn( {
+		// The claude-code provider runs the turn through the official Claude
+		// Code harness (ACP adapter) so it can bill the user's subscription;
+		// every other provider keeps using the pi runtime.
+		const runAgentTurnForProvider =
+			currentProvider === 'claude-code' ? runAcpAgentTurn : runStudioAgentTurn;
+		const agentQuery = runAgentTurnForProvider( {
 			prompt: enrichedPrompt,
 			images,
 			env,

--- a/apps/cli/lib/cli-config/core.ts
+++ b/apps/cli/lib/cli-config/core.ts
@@ -64,7 +64,7 @@ const CLI_CONFIG_VERSION = 1;
 
 // IMPORTANT: Always consider that independently installed versions of the CLI (from npm) may also
 // read this file, and any updates to this schema may require updating the `version` field.
-export const aiProviderSchema = z.enum( [ 'wpcom', 'anthropic-api-key' ] );
+export const aiProviderSchema = z.enum( [ 'wpcom', 'anthropic-api-key', 'claude-code' ] );
 
 export const updateCheckSchema = z.object( {
 	lastChecked: z.number(),

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -22,6 +22,8 @@
 		"directory": "apps/cli"
 	},
 	"dependencies": {
+		"@agentclientprotocol/claude-agent-acp": "^0.63.0",
+		"@agentclientprotocol/sdk": "^1.3.0",
 		"@anthropic-ai/sdk": "^0.91.1",
 		"@earendil-works/pi-agent-core": "0.81.0",
 		"@earendil-works/pi-ai": "0.82.1",

--- a/docs/design-docs/acp-claude-code-engine.md
+++ b/docs/design-docs/acp-claude-code-engine.md
@@ -1,0 +1,79 @@
+# ACP engine for Studio Code — Claude Pro/Max subscription provider
+
+Date: 2026-07-30 · Worktree: `~/worktrees.nosync/acp-claude-code-engine-073011` (branch `acp-claude-code-engine-073011`)
+Status: PoC (draft-PR scope per AGENTS.md "Large & Exploratory Contributions")
+
+## Goal
+
+Let Studio Code (Agentic UI, `apps/ui` served by `studio ui` on :8081) run agent turns on a user's **Claude Pro/Max subscription** instead of the WPcom AI proxy — compliantly. Direct subscription-OAuth in a third-party harness is banned by Anthropic (Jan–Apr 2026 enforcement); the sanctioned path is the one Zed uses: **ACP (Agent Client Protocol)** fronting the official Claude Code / Agent SDK harness. Anthropic confirmed ACP/Agent-SDK usage keeps drawing from Pro/Max subscriptions (Zed blog, June 2026).
+
+## Decisions (confirmed with Antonio)
+
+1. **New provider, keep pi.** `claude-code` becomes a third provider next to `wpcom` and `anthropic-api-key`. pi runtime untouched for the other two. No regression risk; A/B-able.
+2. **Auto-approve tools scoped to the site dir.** ACP `session/request_permission` auto-answered "allow"; session `cwd` = site path (`~/Studio/<site>`). Matches current Studio behavior (pi tools don't prompt either).
+3. **Studio tools via existing MCP.** `studio mcp` already exposes Studio tools; passed to the ACP session as an MCP server (`{ command: <cli>, args: ['mcp'] }`). No new bridge code.
+
+## Architecture (as found)
+
+- UI → `Connector` (SSE) → `apps/local` Express :8081 → `RunManager.startAgentRun` forks `studio code sessions resume <id> <prompt> --json` → CLI turn loop → **`runStudioAgentTurn`** (`apps/cli/ai/runtimes/pi/index.ts:107`; sole call site `apps/cli/commands/ai/index.ts:543`) → `JsonEvent`s over Node IPC → SSE → UI reducer.
+- **No runtime abstraction exists** (`pickRuntime` in models.ts:11 comment is stale — symbol doesn't exist). The seam must be created at the turn-dispatch call site.
+- Sessions: pi-format JSONL (`packages/common/ai/sessions/store.ts`), `SessionManager.appendMessage` is public → a non-pi engine can append pi-format entries and the whole transcript/replay/UI keeps working.
+- `--json` (GUI-spawned) mode **hardcodes `wpcom`** at `apps/cli/commands/ai/index.ts:344-347` — must honor the saved provider when it's `claude-code`, otherwise the UI can never reach the new engine.
+- Provider choice persisted as `aiProvider` in `~/.studio/cli.json` (`aiProviderSchema` enum, `apps/cli/lib/cli-config/core.ts:67`). No provider picker exists in any GUI — CLI `/provider` only.
+
+## Design
+
+New runtime `apps/cli/ai/runtimes/acp/`:
+
+- Spawn `@agentclientprotocol/claude-agent-acp` (v0.63.x, Apache-2.0; wraps `@anthropic-ai/claude-agent-sdk@0.3.220`) as a stdio child.
+- Speak ACP via `@agentclientprotocol/sdk` `ClientSideConnection`: `initialize` → `session/new` (cwd = site dir, mcpServers = studio mcp) → `session/prompt`; map `session/update` notifications (agent_message_chunk, tool_call, tool_call_update, plan) onto Studio's `JsonAdapter` events and pi-format session entries.
+- Client callbacks: `requestPermission` → auto-allow (decision 2); `fs` read/write → deny (adapter uses its own tools); terminal — not implemented in PoC.
+- Auth: reuse the user's existing Claude Code login (keychain, `claude /login`). Provider `isReady()` = `claude-agent-acp` resolvable + Claude Code credentials present. No tokens stored by Studio; nothing to leak.
+
+Touched files:
+
+| File | Change |
+|---|---|
+| `apps/cli/ai/providers.ts` | add `claude-code` to `AI_PROVIDERS`, priority list, definition (anthropic family only) |
+| `apps/cli/lib/cli-config/core.ts` | add `claude-code` to `aiProviderSchema` |
+| `apps/cli/commands/ai/index.ts` | JSON mode honors saved `claude-code` provider; turn dispatch branches pi vs ACP |
+| `apps/cli/ai/runtimes/acp/index.ts` | new engine (`runAcpAgentTurn`) |
+| `apps/cli/package.json` | deps `@agentclientprotocol/sdk`, `@agentclientprotocol/claude-agent-acp` |
+
+## Trade-offs
+
+| Decision | Chosen | Cost |
+|---|---|---|
+| ACP vs Agent SDK direct | ACP | One extra process + protocol hop. Buys: ToS-safe seam identical to Zed's, and the same client later plugs Gemini CLI / Codex adapters (one integration, many engines). |
+| New provider vs replace pi | Add provider | Two engines to maintain; model picker semantics differ per provider (GUI picker lists all `AI_MODELS` unfiltered — divergence becomes visible once a family-restricted provider is GUI-reachable). |
+| Auto-allow permissions | Yes (PoC) | Claude Code can edit/run anything under the site dir without confirmation. Same trust level as current pi tools, but Bash is broader. Production wants `session/request_permission` → Studio's `question.asked` UI flow. |
+| Session persistence | Append pi-format entries | ACP-side session state (Claude Code's own session) not resumable across turns unless we keep `session/load` / adapter alive; PoC creates a fresh ACP session per turn and replays context via prompt. Costs context fidelity on long sessions. |
+| Model picker | Ignored by ACP engine (Claude Code default model) | `/model` + GUI picker have no effect on ACP turns in PoC. Mapping `AiModelId` → Agent SDK model ids is straightforward follow-up. |
+| Packaging | npm dep, spawned via `require.resolve` | Fine for CLI/`studio ui`. Electron-packaged app needs the adapter shipped in ASAR/resources — out of PoC scope. |
+| Subscription economics | Rides Pro/Max pool today | Anthropic's paused "Agent SDK credits" plan ($20/$100/$200 monthly) may cap this later. Don't market as unlimited. |
+
+## Known gaps (PoC)
+
+- No streaming-token-level parity: ACP `agent_message_chunk` mapped to Studio message events; thinking blocks summarized/omitted per Claude Code defaults.
+- Interrupt (`POST /runs/:id/interrupt`) → `session/cancel` wired best-effort.
+- Usage caps / 429 UX (wpcom-specific in `ui.ts:2100`) doesn't apply; subscription limit errors surface as plain errors.
+- e2e not covered; verified manually via `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`.
+
+## How to run
+
+1. `cd ~/worktrees.nosync/acp-claude-code-engine-073011 && npm run cli:build:ui`
+2. `node apps/cli/dist/cli/main.mjs ui --no-open` → http://localhost:8081
+3. Set provider: `node apps/cli/dist/cli/main.mjs code` → `/provider` → Claude Code (or `aiProvider: "claude-code"` in `~/.studio/cli.json`).
+4. Send prompt in Agentic UI; confirm turn runs without WPcom/Anthropic key, transcript renders, entries persist across reload.
+
+## Implementation notes (post-build findings)
+
+- Bare `'module'` import got stubbed by the CLI bundler (`vite.config.base.ts` externals regex covers `node:*` + a fixed builtin list only) — use `node:module` for `createRequire` in bundled CLI code.
+- Added `autoSelectable: false` to `AiProviderDefinition`: `claude-code` shows in `/provider` but is never auto-picked by the first-run scan or fallback logic — opting a user's subscription in silently would be wrong. Guarded by a unit test in `apps/cli/ai/tests/auth.test.ts`.
+- `--json` (UI-spawned) mode needed no change: it only forces `wpcom` when no provider is saved; a saved `claude-code` flows through.
+
+## Verified (2026-07-30)
+
+- `npm run typecheck`, `npx eslint --fix` on touched files, `npm test -- apps/cli/...` — all green (13/13 auth tests).
+- Headless: `node apps/cli/dist/cli/main.mjs code "…" --json` → full pi-shaped event stream (message_start/update/end, turn_end, agent_end), `turn.completed status:success`, streamed via Claude subscription. No WPcom/Anthropic key in env.
+- Agentic UI on :8081 (`npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`): prompt sent from composer answered "Claude Code harness. Fable 5 model."; live streaming spinner worked; transcript survived a full page reload (JSONL replay).

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,8 @@
 			"version": "1.17.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@agentclientprotocol/claude-agent-acp": "^0.63.0",
+				"@agentclientprotocol/sdk": "^1.3.0",
 				"@anthropic-ai/sdk": "^0.91.1",
 				"@earendil-works/pi-agent-core": "0.81.0",
 				"@earendil-works/pi-ai": "0.82.1",
@@ -1123,6 +1125,78 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@agentclientprotocol/claude-agent-acp": {
+			"version": "0.63.0",
+			"resolved": "https://registry.npmjs.org/@agentclientprotocol/claude-agent-acp/-/claude-agent-acp-0.63.0.tgz",
+			"integrity": "sha512-/Ylytz6KPGkih1sZd2sJAmWIGMh59T+FCJhlsfW9zpB1Lrg0/Njgk/7TplRfX2f7dELx0FeN+SBG+Uju12XwlA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@agentclientprotocol/sdk": "1.3.0",
+				"@anthropic-ai/claude-agent-sdk": "0.3.220",
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"bin": {
+				"claude-agent-acp": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=22"
+			}
+		},
+		"node_modules/@agentclientprotocol/claude-agent-acp/node_modules/@anthropic-ai/claude-agent-sdk": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+			"integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
+			"license": "SEE LICENSE IN README.md",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
+			},
+			"peerDependencies": {
+				"@anthropic-ai/sdk": ">=0.93.0",
+				"@modelcontextprotocol/sdk": "^1.29.0",
+				"zod": "^4.0.0"
+			}
+		},
+		"node_modules/@agentclientprotocol/claude-agent-acp/node_modules/@anthropic-ai/sdk": {
+			"version": "0.115.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+			"integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@agentclientprotocol/sdk": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+			"integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			}
+		},
 		"node_modules/@alcalzone/ansi-tokenize": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.5.tgz",
@@ -1173,6 +1247,122 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+			"integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+			"integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+			"integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+			"integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+			"integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+			"integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+			"integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+			"integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@anthropic-ai/sdk": {
 			"version": "0.91.1",
@@ -12450,6 +12640,13 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@stablelib/base64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
 			"dev": true,
@@ -19443,6 +19640,13 @@
 		"node_modules/fast-safe-stringify": {
 			"version": "2.1.1",
 			"license": "MIT"
+		},
+		"node_modules/fast-sha256": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+			"license": "Unlicense",
+			"peer": true
 		},
 		"node_modules/fast-string-truncated-width": {
 			"version": "3.0.3",
@@ -28576,6 +28780,17 @@
 			"peer": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/standardwebhooks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+			"integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@stablelib/base64": "^1.0.0",
+				"fast-sha256": "^1.3.0"
 			}
 		},
 		"node_modules/statuses": {


### PR DESCRIPTION
## Related issues

- Related to the ongoing effort to reduce WPcom AI proxy costs by letting users bring their own plan.

## How AI was used in this PR

Research (Anthropic's 2026 third-party OAuth policy, ACP protocol surface), architecture mapping, and drafting the design doc and implementation; all code was reviewed, typechecked, linted, unit-tested, and verified manually end-to-end.

## Proposed Changes

> ⚠️ Draft **Proof of Concept** — directional guidance, not merge-ready. See `docs/design-docs/acp-claude-code-engine.md` (in this PR) for the full design, trade-offs, and verification log.

Adds an **opt-in third AI provider, "Claude Code · subscription"**, that runs Studio Code agent turns on the user's own Claude Pro/Max plan instead of the WPcom AI proxy — cutting proxy cost for users who already pay Anthropic.

Why this shape: since Jan–Apr 2026 Anthropic rejects subscription OAuth tokens in third-party harnesses, so Studio can't just point the existing pi runtime at a subscription token. The sanctioned path (the one Zed uses) is ACP — the **Agent Client Protocol** — fronting the official Claude Code / Agent SDK harness. Studio spawns the `@agentclientprotocol/claude-agent-acp` adapter per turn, speaks ACP to it, and translates the stream back into Studio's existing event/session format, so the transcript UI, session persistence, and replay work unchanged. Studio never sees or stores the user's Claude credentials.

User impact:

- New `/provider` option "Claude Code · subscription" (CLI). Once selected, Agentic UI (`studio ui`) and headless turns run on the subscription.
- **Never auto-selected** — a user's subscription is only used after they explicitly opt in (`autoSelectable: false`, unit-tested).
- Studio's own tools reach the new engine through the existing `studio mcp` server.

Known trade-offs (details in the design doc): fresh ACP session per turn (long-conversation context fidelity), model picker ignored for ACP turns, tool calls auto-approved within the site directory, Electron packaging of the adapter out of scope.

## Testing Instructions

1. Prereq: Claude Code installed and logged in with a Pro/Max plan (`claude` → `/login`).
2. `npm install && npm run cli:build:ui`
3. Select the provider: `node apps/cli/dist/cli/main.mjs code` → `/provider` → "Claude Code · subscription" (or set `"aiProvider": "claude-code"` in `~/.studio/cli.json`).
4. `node apps/cli/dist/cli/main.mjs ui --no-open` → http://localhost:8081 → new chat → send a prompt.
5. Verify: response streams and renders, transcript survives a page reload, and no WPcom login or Anthropic API key is configured.
6. Headless check: `node apps/cli/dist/cli/main.mjs code "Say OK" --json` emits the standard event stream ending in `turn.completed` with `status: "success"`.
7. `npm run typecheck` and `npm test -- apps/cli/ai` pass.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
