### PR TITLE
Agentic UI: Drop the restart popup when an update is ready

### DIFF
--- a/apps/studio/src/tests/updates.test.ts
+++ b/apps/studio/src/tests/updates.test.ts
@@ -1,10 +1,11 @@
 /**
  * @vitest-environment node
  */
-import { app, clipboard, dialog, shell, type MessageBoxOptions } from 'electron';
+import { app, autoUpdater, clipboard, dialog, shell, type MessageBoxOptions } from 'electron';
 import * as Sentry from '@sentry/electron/main';
 import { vi } from 'vitest';
-import { manualCheckForUpdates } from 'src/updates';
+import { setAgenticUiEnabled } from 'src/lib/studio-ui-mode';
+import { manualCheckForUpdates, setupUpdates } from 'src/updates';
 
 function getLastDialogOptions(): MessageBoxOptions {
 	const lastCall = vi.mocked( dialog.showMessageBox ).mock.lastCall as unknown as [
@@ -15,7 +16,10 @@ function getLastDialogOptions(): MessageBoxOptions {
 }
 
 vi.mock( 'src/main-window', () => ( {
-	getMainWindow: vi.fn().mockResolvedValue( {} ),
+	getMainWindow: vi.fn().mockResolvedValue( {
+		isDestroyed: () => false,
+		webContents: { isDestroyed: () => false, send: vi.fn() },
+	} ),
 } ) );
 
 const originalFetch = global.fetch;
@@ -152,5 +156,36 @@ describe( 'Linux updater', () => {
 
 		expect( dialog.showMessageBox ).not.toHaveBeenCalled();
 		expect( shell.openExternal ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'update ready to install', () => {
+	async function emitUpdateDownloaded() {
+		Object.defineProperty( process, 'platform', { value: 'darwin', configurable: true } );
+		setupUpdates();
+		const calls = vi.mocked( autoUpdater.on ).mock.calls as unknown as [
+			string,
+			( ...args: unknown[] ) => Promise< void >,
+		][];
+		const handler = calls.find( ( [ event ] ) => event === 'update-downloaded' )?.[ 1 ];
+		await handler?.( {}, 'notes', '1.9.0' );
+	}
+
+	afterEach( () => {
+		setAgenticUiEnabled( false );
+	} );
+
+	it( 'shows the restart dialog in the classic UI', async () => {
+		await emitUpdateDownloaded();
+
+		expect( getLastDialogOptions().message ).toBe( 'Update ready to install' );
+	} );
+
+	it( 'leaves the restart prompt to the sidebar card in the agentic UI', async () => {
+		setAgenticUiEnabled( true );
+
+		await emitUpdateDownloaded();
+
+		expect( dialog.showMessageBox ).not.toHaveBeenCalled();
 	} );
 } );

--- a/apps/studio/src/updates.ts
+++ b/apps/studio/src/updates.ts
@@ -4,6 +4,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { AUTO_UPDATE_INTERVAL_MS, NIGHTLY_UPDATE_TTL_MS } from 'src/constants';
 import { sendIpcEventToRenderer, type AppUpdateStatus } from 'src/ipc-utils';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
+import { getPreferredStudioUiMode } from 'src/lib/studio-ui-mode';
 import { isDevRelease } from 'src/lib/version-utils';
 import { getMainWindow } from 'src/main-window';
 import { loadUserData, updateAppdata } from 'src/storage/user-data';
@@ -140,7 +141,11 @@ export function setupUpdates() {
 		downloadedVersion = typeof releaseName === 'string' ? releaseName : null;
 		console.log( 'Update has been downloaded', { version: downloadedVersion } );
 		void sendIpcEventToRenderer( 'app-update-status', buildAppUpdateStatus() );
-		await showUpdateReadyToInstallNotice();
+		// The agentic UI surfaces this as a dismissable card in the sidebar, so a modal on top of
+		// it would be a duplicate interruption. Classic has no such affordance and still needs it.
+		if ( getPreferredStudioUiMode() !== 'agentic' ) {
+			await showUpdateReadyToInstallNotice();
+		}
 	} );
 
 	if ( ! shouldPoll ) {

--- a/apps/studio/vitest.setup.ts
+++ b/apps/studio/vitest.setup.ts
@@ -144,6 +144,13 @@ vi.mock( 'electron', () => {
 		dialog: {
 			showMessageBox: vi.fn(),
 		},
+		autoUpdater: {
+			setFeedURL: vi.fn(),
+			getFeedURL: vi.fn(),
+			checkForUpdates: vi.fn(),
+			quitAndInstall: vi.fn(),
+			on: vi.fn(),
+		},
 		BrowserWindow: MockBrowserWindow,
 		shell: {
 			openPath: vi.fn( async () => '' ),


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code traced the update flow, wrote the guard and the two unit tests. I verified both UI modes manually by faking a downloaded update locally.

## Proposed Changes

- When an update finishes downloading, the Agentic UI already shows a persistent "ready to install" card in the sidebar. The native modal fired on top of it, so the same prompt arrived twice and a system dialog had to be dismissed before work could continue. The Agentic UI now relies on the card alone.
- Classic UI is unchanged — it has no equivalent affordance, so it keeps the dialog. The manual "Check for Updates" path and the Linux flow are untouched, since those are user-initiated and need a response.

## Testing Instructions

Auto-updates are disabled in dev, so the event has to be faked. In `apps/studio/src/updates.ts`, temporarily add this right after `autoUpdater.setFeedURL( ... )` in `setupUpdates()`:

```ts
setTimeout( () => autoUpdater.emit( 'update-downloaded', {}, '', '1.99.0' ), 8000 );
```

1. `npm start`, wait ~8s → sidebar card "Studio 1.99.0 is ready to install" appears, **no system dialog**.
2. Uncheck Studio → Beta Features → Agentic UI, then fully restart the app (main-process change) → the native "Update ready to install" dialog still appears.

Note: "Restart now" is a no-op on an unpackaged dev build — the card/dialog appearing is what's being verified.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
