### PR TITLE
Update SQLite database integration to v3.0.0-rc.8

### DIFF
--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import { extractZip } from '../packages/common/lib/extract-zip.ts';
 import { fetch, sharedDispatcher, throwForHttpStatus, withRetry } from './lib/with-retry.ts';
 
-const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.7';
+const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.8';
 const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/releases/download/${ SQLITE_DATABASE_INTEGRATION_VERSION }/plugin-sqlite-database-integration.zip`;
 
 async function fetchWithRetry( name: string, url: string ): Promise< Buffer > {


### PR DESCRIPTION
## Related issues

- Related to https://github.com/WordPress/sqlite-database-integration/releases/tag/v3.0.0-rc.8

## How AI was used in this PR

Claude Code bumped the pinned SQLite integration version and verified the new GitHub release exposes the expected asset. I reviewed the change and tested it locally via `npm install`.

## Proposed Changes

- Updates the bundled [WordPress SQLite database integration](https://github.com/WordPress/sqlite-database-integration/releases/tag/v3.0.0-rc.8) plugin from `v3.0.0-rc.7` to `v3.0.0-rc.8`, so Studio sites run on the latest SQLite driver with its upstream fixes and improvements.

## Testing Instructions

- Run `npm install` (which triggers the `postinstall` download of `wp-files/`) and confirm `wp-files/sqlite-database-integration` reflects the `v3.0.0-rc.8` release.
- Start a site and verify core operations (site boot, admin, basic DB reads/writes) work as expected.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
