### PR TITLE
Fix studio_telemetry Tracks event silently rejected by malformed name

### DIFF
--- a/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
@@ -134,7 +134,7 @@ export async function saveAnalyticsEnabled(
 	// `recordTracksEvent` is gated by the current opt-out state, so the event must be recorded while
 	// analytics is ON — before turning it off, after turning it on. Order the write around that.
 	const recordEvent = () =>
-		recordTracksEvent( TRACKS_EVENTS.TELEMETRY, {
+		recordTracksEvent( TRACKS_EVENTS.SETTING_TELEMETRY_CHANGE, {
 			channel: 'studio-ui',
 			ui_version: source.uiVersion,
 			surface: source.surface,

--- a/apps/studio/src/modules/user-settings/lib/tests/analytics-settings.test.ts
+++ b/apps/studio/src/modules/user-settings/lib/tests/analytics-settings.test.ts
@@ -24,10 +24,10 @@ beforeEach( () => {
 	vi.clearAllMocks();
 } );
 
-it( 'emits studio_telemetry with status "on" and the source when enabling analytics', async () => {
+it( 'emits studio_setting_telemetry_change with status "on" and the source when enabling analytics', async () => {
 	await saveAnalyticsEnabled( event, true, { surface: 'settings', uiVersion: 'v2' } );
 
-	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.TELEMETRY, {
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_TELEMETRY_CHANGE, {
 		channel: 'studio-ui',
 		ui_version: 'v2',
 		surface: 'settings',
@@ -36,10 +36,10 @@ it( 'emits studio_telemetry with status "on" and the source when enabling analyt
 	expect( mockUpdate ).toHaveBeenCalledWith( { analyticsOptOut: false } );
 } );
 
-it( 'emits studio_telemetry with status "off" and the source when disabling analytics', async () => {
+it( 'emits studio_setting_telemetry_change with status "off" and the source when disabling analytics', async () => {
 	await saveAnalyticsEnabled( event, false, { surface: 'onboarding', uiVersion: 'v1' } );
 
-	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.TELEMETRY, {
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_TELEMETRY_CHANGE, {
 		channel: 'studio-ui',
 		ui_version: 'v1',
 		surface: 'onboarding',

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -135,7 +135,7 @@ Common props (`platform`, `arch`, `app_version`, `is_a11n`, and `channel`/`ui_ve
 wrappers/renderers — pass only event-specific props. (Centralizing `channel`/`ui_version` on the desktop
 side is STU-2122; until it lands, `studio_app_launch` still sets them at the call site.)
 
-`surface` (in-app area, e.g. `onboarding`/`settings`) is live on `studio_telemetry`; the renderer
+`surface` (in-app area, e.g. `onboarding`/`settings`) is live on `studio_setting_telemetry_change`; the renderer
 supplies it per change (Main can't infer it) and it is meant to generalize to other settings-change
 events. Reserved for later phases (documented so future events conform): `outcome` (`success`/`error`).
 
@@ -152,7 +152,7 @@ Every event also carries the common props `channel`, `is_a11n`, `platform`, `arc
 |---|---|---|
 | `studio_app_launch` | Desktop Main (`appBoot`) | `ui_version`, `is_first_launch` |
 | `studio_site_start` | CLI site-start funnel | `ui_version` (only when `channel=studio-ui`) |
-| `studio_telemetry` | Desktop Main (`saveAnalyticsEnabled`) | `status` (`on`/`off`), `surface` (`onboarding`/`settings`) — recorded while analytics is still ON (before the write when turning off, after it when turning on) so the opt-out gate never self-suppresses it. `ui_version` set at the call site from the originating renderer. |
+| `studio_setting_telemetry_change` | Desktop Main (`saveAnalyticsEnabled`) | `status` (`on`/`off`), `surface` (`onboarding`/`settings`) — recorded while analytics is still ON (before the write when turning off, after it when turning on) so the opt-out gate never self-suppresses it. `ui_version` set at the call site from the originating renderer. |
 
 ### How to add a new event
 
@@ -161,12 +161,19 @@ Every event also carries the common props `channel`, `is_a11n`, `platform`, `arc
    `apps/cli/lib/tracks.ts`, or the `recordAnalyticsEvent` IPC handler / `Connector.trackEvent` from a
    renderer). Prefer a standardized property name from the vocabulary above; only add a custom prop when
    none fits, and flag it.
-3. **Register the event and all its eventprops** via the Tracks Registration tool. Registration adds
+3. **Name it per the Tracks convention** — `<source>_<context>_<optional subcontext>_<action>`, at least
+   three underscore-separated segments, matching `^[a-z_][a-z0-9_]*$` (lowercase, digits, underscores). A
+   name that violates this is silently routed to the `tracks_rejects` table and never appears in the normal
+   Live View — check the "Filter for only rejected events" box to spot it. This is separate from
+   registration below: it is a hard ingestion gate, not documentation. (`studio_telemetry` — source +
+   context with no action — was rejected this way until renamed to `studio_setting_telemetry_change`.) The
+   `TRACKS_EVENTS` naming guard test in `record-tracks-event.test.ts` enforces this at CI time.
+4. **Register the event and all its eventprops** via the Tracks Registration tool. Registration adds
    documentation and CI integrity checks — it does not gate collection or queryability (a validly-named
    event is already queryable in Superset without it). Register every prop the event carries, including the
    wrapper-attached common props (`channel`, `is_a11n`, `platform`, `arch`, `app_version`, `ui_version`);
    only the reserved Tracks defaults (timestamp, etc.) come for free.
-4. Add a row to the event catalog above.
+5. Add a row to the event catalog above.
 
 ## Testing
 

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -10,7 +10,7 @@ const TRACKS_PIXEL_URL = 'https://pixel.wp.com/t.gif';
 export const TRACKS_EVENTS = {
 	APP_LAUNCH: 'studio_app_launch',
 	SITE_START: 'studio_site_start',
-	TELEMETRY: 'studio_telemetry',
+	SETTING_TELEMETRY_CHANGE: 'studio_setting_telemetry_change',
 } as const;
 
 export type TracksEventName = ( typeof TRACKS_EVENTS )[ keyof typeof TRACKS_EVENTS ];

--- a/packages/common/lib/tests/record-tracks-event.test.ts
+++ b/packages/common/lib/tests/record-tracks-event.test.ts
@@ -23,6 +23,25 @@ describe( 'isTracksEventName', () => {
 	} );
 } );
 
+// Tracks rejects malformed names into a `tracks_rejects` table where they are invisible in the normal
+// Live View. Names must match `^[a-z_][a-z0-9_]*$` and follow `<source>_<context>_..._<action>` — at
+// least three underscore-separated segments. `studio_telemetry` (source + context, no action) was
+// silently rejected until renamed. This guard keeps every registered event well-formed.
+describe( 'TRACKS_EVENTS naming conventions', () => {
+	const names = Object.values( TRACKS_EVENTS );
+
+	it.each( names )( '"%s" uses only lowercase, digits, and underscores', ( name ) => {
+		expect( name ).toMatch( /^[a-z_][a-z0-9_]*$/ );
+	} );
+
+	it.each( names )( '"%s" is a studio-sourced <context>_<action> name', ( name ) => {
+		const segments = name.split( '_' );
+		expect( segments[ 0 ] ).toBe( 'studio' );
+		expect( segments.length ).toBeGreaterThanOrEqual( 3 );
+		expect( segments.every( Boolean ) ).toBe( true );
+	} );
+} );
+
 describe( '__buildTracksPixelUrl', () => {
 	it( 'targets the Tracks pixel endpoint with identity and timestamp params', () => {
 		const url = new URL(


### PR DESCRIPTION
## Related issues

- Follow up to https://github.com/Automattic/studio/pull/4395

## How AI was used in this PR

I used Claude Code to investigate why `studio_telemetry` was missing from Tracks Live View while `studio_app_launch` and `studio_site_start` were present, but it couldn't find anything. Then I traced it to the Tracks reject table, and used Claude to perform the rename, guard test, and doc updates. All changes were reviewed by me, and the type checker and unit tests were run locally.

## Proposed Changes

The analytics opt-in/opt-out toggle event was being emitted correctly but never reached Tracks: its name, `studio_telemetry`, has only two segments (`source` + `context`) and violates the Tracks `<source>_<context>_<action>` naming convention, so every occurrence was silently routed to the `tracks_rejects` table and was invisible in the normal Live View. The two existing events happened to be well-formed, which masked the problem.

This renames the event to `studio_setting_telemetry_change`, matching the `studio_<context>_change` family planned for the settings/appearance events in STU-2121. The event now lands in Tracks as expected, so analytics preference changes become queryable.

To prevent the same class of bug, a CI guard asserts every `TRACKS_EVENTS` name follows the convention, and the analytics design doc now documents the naming rule as a hard ingestion gate (distinct from registration, which does not gate ingestion), using this event as the cautionary example.

> ⚠️ **Server-side registration still required.** The rename is what unblocks ingestion, but I till need to adjust registration to account for the name change.

## Testing Instructions

- `npm run typecheck` — passes.
- `npm test -- packages/common/lib/tests/record-tracks-event.test.ts apps/studio/src/modules/user-settings/lib/tests/analytics-settings.test.ts` — passes (includes the new naming-convention guard).
- On a real shipped (non-dev) build, toggle the analytics setting off then on in both the classic (v1) and agentic (v2) UIs, and confirm `studio_setting_telemetry_change` now appears in Tracks Live View (with `status` `off`/`on`) instead of the rejects table.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
