### PR TITLE
Fix `Build PHP CLI Binaries` GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-php-cli-binaries.yml
+++ b/.github/workflows/build-php-cli-binaries.yml
@@ -15,7 +15,7 @@ on:
       xdebug_version:
         description: Xdebug version to package
         required: true
-        default: 3.5.1
+        default: 3.5.3
       spc_ref:
         # Pinned to PR #1204, which enables SQLITE_ENABLE_COLUMN_METADATA on
         # Unix builds so PDO populates getColumnMeta()['table'] (fixes

--- a/.github/workflows/build-php-cli-binaries.yml
+++ b/.github/workflows/build-php-cli-binaries.yml
@@ -608,6 +608,18 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        # The metadata script and the formatting it runs afterwards need the repo's dev dependencies.
+        # `--ignore-scripts` skips the postinstall downloads (WordPress files, PHP binaries), which
+        # this job never uses.
+        run: npm ci --ignore-scripts
+
       - name: Download PHP CLI artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-2188

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Claude was used to investigate and implement the solution, which iterative directions from me on the desired end state.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

https://github.com/Automattic/studio/pull/4021 introduced a regression where the `Build PHP CLI Binaries` GitHub Actions workflow started [failing](https://github.com/Automattic/studio/actions/runs/30805172030/job/91665322387#step:6:39) because there are no `node_modules` available in the CI runner context. This PR fixes the problem by:

- Setting up the correct Node version
- Running `npm ci`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review is sufficient

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
