### PR TITLE
Agentic UI: Add the full preview panel and restore the Desktop + Mobile comparison

### DIFF
--- a/apps/ui/src/components/preview-split-frame/index.test.tsx
+++ b/apps/ui/src/components/preview-split-frame/index.test.tsx
@@ -100,6 +100,46 @@ describe( 'PreviewSplitFrame', () => {
 		expect( root ).toHaveStyle( '--preview-frame-content-width: 480px' );
 	} );
 
+	it( 'gives the whole frame to the preview in fullscreen', async () => {
+		const preview = () => <aside aria-label="Site preview" />;
+		const { rerender } = render(
+			<PreviewSplitFrame previewOpen preview={ preview }>
+				<span data-testid="content">Content</span>
+			</PreviewSplitFrame>
+		);
+		const root = getFrameRoot();
+		await waitFor( () => expect( root ).toHaveStyle( '--preview-frame-content-width: 480px' ) );
+
+		rerender(
+			<PreviewSplitFrame previewOpen previewFullscreen preview={ preview }>
+				<span data-testid="content">Content</span>
+			</PreviewSplitFrame>
+		);
+
+		expect( root ).toHaveStyle( '--preview-frame-content-width: 0px' );
+		// Nothing left to drag once the content column is gone.
+		await waitFor( () =>
+			expect(
+				screen.queryByRole( 'separator', { name: 'Resize site preview' } )
+			).not.toBeInTheDocument()
+		);
+		// The chat stays mounted but out of reach until the slide finishes.
+		await waitFor( () =>
+			expect( screen.getByTestId( 'content' ).parentElement ).toHaveAttribute(
+				'aria-hidden',
+				'true'
+			)
+		);
+
+		// Leaving fullscreen restores the split the user had before.
+		rerender(
+			<PreviewSplitFrame previewOpen preview={ preview }>
+				<span data-testid="content">Content</span>
+			</PreviewSplitFrame>
+		);
+		expect( root ).toHaveStyle( '--preview-frame-content-width: 480px' );
+	} );
+
 	it( 'keeps preview space reserved when the first mount measurement is zero', () => {
 		frameWidth = 0;
 

--- a/apps/ui/src/components/preview-split-frame/index.tsx
+++ b/apps/ui/src/components/preview-split-frame/index.tsx
@@ -19,29 +19,44 @@ interface PreviewSplitFrameProps {
 	// handles the open/close slide animation.
 	preview?: ( props: PreviewSplitFramePreviewProps ) => ReactNode;
 	previewOpen?: boolean;
+	// Full preview: the preview takes the whole frame and the content column
+	// collapses to zero width (kept mounted so chat state survives).
+	previewFullscreen?: boolean;
 	children?: ReactNode;
 }
 
 export function PreviewSplitFrame( {
 	preview,
 	previewOpen = false,
+	previewFullscreen = false,
 	children,
 }: PreviewSplitFrameProps ) {
 	const showPreview = previewOpen && preview != null;
+	const showFullscreen = showPreview && previewFullscreen;
 	const { rootRef, contentWidthVar, isResizing, handleProps } = usePreviewSplit( { showPreview } );
 	const isSidebarCollapsed = useSidebarCollapsed();
 
-	// Animate only open/close toggles of an already-mounted preview — never the
-	// initial layout, so a route loading with the preview visible doesn't replay
-	// the slide-in. The render-phase update lands the transition class in the
-	// same commit as the width change; an effect-based update would race it.
+	// Animate only open/close/fullscreen toggles of an already-mounted preview —
+	// never the initial layout, so a route loading with the preview visible
+	// doesn't replay the slide-in. The render-phase update lands the transition
+	// class in the same commit as the width change; an effect-based update would
+	// race it.
 	const [ animatingPreviewToggle, setAnimatingPreviewToggle ] = useState( false );
 	const [ previousPreview, setPreviousPreview ] = useState( {
 		mounted: preview != null,
 		open: showPreview,
+		fullscreen: showFullscreen,
 	} );
-	if ( previousPreview.mounted !== ( preview != null ) || previousPreview.open !== showPreview ) {
-		setPreviousPreview( { mounted: preview != null, open: showPreview } );
+	if (
+		previousPreview.mounted !== ( preview != null ) ||
+		previousPreview.open !== showPreview ||
+		previousPreview.fullscreen !== showFullscreen
+	) {
+		setPreviousPreview( {
+			mounted: preview != null,
+			open: showPreview,
+			fullscreen: showFullscreen,
+		} );
 		if ( previousPreview.mounted && preview != null ) {
 			setAnimatingPreviewToggle( true );
 		}
@@ -56,13 +71,18 @@ export function PreviewSplitFrame( {
 			PREVIEW_TOGGLE_DURATION
 		);
 		return () => window.clearTimeout( timeoutId );
-	}, [ animatingPreviewToggle, showPreview ] );
+	}, [ animatingPreviewToggle, showPreview, showFullscreen ] );
 
 	const previewVisible = showPreview || animatingPreviewToggle;
 	const renderedPreview = preview?.( { collapsed: ! previewVisible } );
 	const rootStyle = {
-		'--preview-frame-content-width': contentWidthVar,
+		// Fullscreen collapses the content column; the split geometry keeps its
+		// last width so leaving fullscreen restores the previous split.
+		'--preview-frame-content-width': showFullscreen ? '0px' : contentWidthVar,
 	} as CSSProperties;
+	// Keep the zero-width column visible while it animates shut, then hide it
+	// so the (still mounted) chat can't be reached by focus or a screen reader.
+	const contentHidden = showFullscreen && ! animatingPreviewToggle;
 
 	return (
 		<div
@@ -76,7 +96,12 @@ export function PreviewSplitFrame( {
 			) }
 			style={ rootStyle }
 		>
-			<div className={ styles.contentColumn }>{ children }</div>
+			<div
+				className={ clsx( styles.contentColumn, contentHidden && styles.contentColumnHidden ) }
+				aria-hidden={ contentHidden || undefined }
+			>
+				{ children }
+			</div>
 			{ preview ? (
 				<div
 					className={ clsx(
@@ -89,7 +114,7 @@ export function PreviewSplitFrame( {
 					{ renderedPreview }
 				</div>
 			) : null }
-			{ showPreview && ! animatingPreviewToggle ? (
+			{ showPreview && ! showFullscreen && ! animatingPreviewToggle ? (
 				<ResizeHandle
 					className={ styles.previewResizeHandle }
 					label={ __( 'Resize site preview' ) }

--- a/apps/ui/src/components/preview-split-frame/style.module.css
+++ b/apps/ui/src/components/preview-split-frame/style.module.css
@@ -66,6 +66,12 @@
 	transition: width 150ms ease;
 }
 
+/* Full preview: the column is width 0 once the slide finishes; visibility
+   keeps the mounted chat out of the focus order and the accessibility tree. */
+.contentColumnHidden {
+	visibility: hidden;
+}
+
 .rootPreviewResizing .contentColumn {
 	user-select: none;
 	transition: none;

--- a/apps/ui/src/components/settings-view/index.test.tsx
+++ b/apps/ui/src/components/settings-view/index.test.tsx
@@ -280,6 +280,10 @@ describe( 'SettingsView', () => {
 		expect( screen.getByText( 'Send message' ) ).toBeInTheDocument();
 		expect( screen.getByLabelText( 'Control + Comma' ) ).toBeInTheDocument();
 		expect( screen.getByLabelText( 'Alt + Left arrow' ) ).toBeInTheDocument();
+		// Keep the listed full-preview chord in step with the one SitePreview
+		// actually handles (Ctrl+Shift+F off Apple platforms).
+		expect( screen.getByText( 'Toggle full preview' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Control + Shift + F' ) ).toBeInTheDocument();
 	} );
 
 	it( 'saves the default site directory as soon as one is picked', async () => {

--- a/apps/ui/src/components/settings-view/keyboard-panel.tsx
+++ b/apps/ui/src/components/settings-view/keyboard-panel.tsx
@@ -49,6 +49,7 @@ function getShortcutSections( isApple: boolean ): ShortcutSection[] {
 			title: __( 'Site preview' ),
 			shortcuts: [
 				{ label: __( 'Toggle site preview' ), keys: [ modifierKey, 'Shift', 'B' ] },
+				{ label: __( 'Toggle full preview' ), keys: [ modifierKey, 'Shift', 'F' ] },
 				{ label: __( 'Reload preview' ), keys: [ modifierKey, 'R' ] },
 				{ label: __( 'Go back in preview' ), keys: [ navModifierKey, '←' ] },
 				{ label: __( 'Go forward in preview' ), keys: [ navModifierKey, '→' ] },

--- a/apps/ui/src/components/sidebar-layout/index.test.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.test.tsx
@@ -83,4 +83,22 @@ describe( 'SidebarLayout', () => {
 
 		expect( screen.queryByRole( 'button', { name: 'Show sidebar' } ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'hands the sidebar shortcut to the forcing feature while force-collapsed', () => {
+		const onForceCollapsedToggle = vi.fn();
+		render(
+			<SidebarLayout forceCollapsed onForceCollapsedToggle={ onForceCollapsedToggle }>
+				<div>Content</div>
+			</SidebarLayout>
+		);
+
+		// Collapsed (no resize handle), but its own floating toggle stays away —
+		// the forcing feature (full preview) owns the exit affordance.
+		expect( screen.queryByRole( 'separator', { name: 'Resize sidebar' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Show sidebar' } ) ).not.toBeInTheDocument();
+
+		act( () => toggleSidebarListener?.() );
+
+		expect( onForceCollapsedToggle ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -29,8 +29,26 @@ const { ThemeProvider } = unlock( privateApis );
 const CHROME_BG_LIGHT = '#1e1e1e';
 const CHROME_BG_DARK = '#161616';
 
-export function SidebarLayout( { children }: { children: ReactNode } ) {
+interface SidebarLayoutProps {
+	children: ReactNode;
+	// Hides the sidebar without touching the user's own collapsed state, so
+	// clearing it restores whatever the sidebar was doing before (e.g. while
+	// the site preview is fullscreen). The floating "Show sidebar" toggle is
+	// suppressed too — the forcing feature owns the exit affordance.
+	forceCollapsed?: boolean;
+	// Called when the user asks to toggle the sidebar while it is force-
+	// collapsed (the app-menu shortcut), so the forcing feature can stand down.
+	// The sidebar expands alongside it.
+	onForceCollapsedToggle?: () => void;
+}
+
+export function SidebarLayout( {
+	children,
+	forceCollapsed = false,
+	onForceCollapsedToggle,
+}: SidebarLayoutProps ) {
 	const [ collapsed, setCollapsed ] = useState( false );
+	const effectiveCollapsed = collapsed || forceCollapsed;
 	const connector = useConnector();
 	const reserveTrafficLightSpace = useTrafficLightSpace().start;
 	const colorScheme = useColorScheme();
@@ -41,21 +59,26 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 		storageKey: SIDEBAR_PANEL_STORAGE_KEY,
 	} );
 	const toggleSidebar = useCallback( () => {
+		if ( forceCollapsed ) {
+			onForceCollapsedToggle?.();
+			setCollapsed( false );
+			return;
+		}
 		setCollapsed( ( value ) => ! value );
-	}, [] );
-	const sidebarStyle = collapsed
+	}, [ forceCollapsed, onForceCollapsedToggle ] );
+	const sidebarStyle = effectiveCollapsed
 		? undefined
 		: ( { '--sidebar-width': `${ sidebarResize.width }px` } as CSSProperties );
 
 	useEffect( () => connector.onToggleSidebar( toggleSidebar ), [ connector, toggleSidebar ] );
 
 	return (
-		<SidebarCollapsedContext.Provider value={ collapsed }>
+		<SidebarCollapsedContext.Provider value={ effectiveCollapsed }>
 			<div className={ styles.root } style={ { '--app-chrome-bg': chromeBg } as CSSProperties }>
 				<aside
 					className={ clsx(
 						styles.sidebar,
-						collapsed && styles.sidebarCollapsed,
+						effectiveCollapsed && styles.sidebarCollapsed,
 						sidebarResize.isResizing && styles.sidebarResizing
 					) }
 					style={ sidebarStyle }
@@ -71,14 +94,16 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 								{ /* Toasts sit above the persistent cards: the footer is
 								     bottom-anchored, so a transient toast arriving below a card
 								     would shove it up and drop it back on expiry. */ }
-								{ ! collapsed ? <AppToasts className={ styles.sidebarToasts } /> : null }
-								{ ! collapsed ? <AppMessageCards className={ styles.sidebarCards } /> : null }
+								{ ! effectiveCollapsed ? <AppToasts className={ styles.sidebarToasts } /> : null }
+								{ ! effectiveCollapsed ? (
+									<AppMessageCards className={ styles.sidebarCards } />
+								) : null }
 								<UserMenu onToggleSidebar={ toggleSidebar } />
 							</div>
 						</div>
 					</ThemeProvider>
 				</aside>
-				{ ! collapsed ? (
+				{ ! effectiveCollapsed ? (
 					// Same dark theme scope as the sidebar so the indicator's
 					// brand token resolves against the dark ramp.
 					<ThemeProvider color={ { bg: chromeBg } }>
@@ -95,7 +120,7 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 					</ThemeProvider>
 				) : null }
 				<main className={ styles.main }>
-					{ collapsed ? (
+					{ effectiveCollapsed && ! forceCollapsed ? (
 						<div
 							className={ clsx(
 								styles.floatingToggle,
@@ -116,7 +141,9 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 						</div>
 					) : null }
 					{ children }
-					{ collapsed ? <AppToasts className={ styles.floatingToasts } fit="content" /> : null }
+					{ effectiveCollapsed ? (
+						<AppToasts className={ styles.floatingToasts } fit="content" />
+					) : null }
 				</main>
 				{ sidebarResize.isResizing ? <ResizeOverlay /> : null }
 			</div>

--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -326,6 +326,115 @@ describe( 'SitePreview', () => {
 		);
 	} );
 
+	it( 'toggles full preview from the More options menu', async () => {
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			capabilities: CAPABILITIES,
+		} as never );
+		const onFullscreenChange = vi.fn();
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		} );
+		const ui = ( fullscreen: boolean ) => (
+			<QueryClientProvider client={ queryClient }>
+				<Tooltip.Provider>
+					<SitePreview
+						site={ createSite( { running: true } ) }
+						path="/"
+						reloadNonce={ 0 }
+						fullscreen={ fullscreen }
+						onFullscreenChange={ onFullscreenChange }
+					/>
+				</Tooltip.Provider>
+			</QueryClientProvider>
+		);
+
+		const { rerender } = render( ui( false ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'More options' } ) );
+		fireEvent.click( await screen.findByRole( 'menuitem', { name: 'Full preview' } ) );
+
+		expect( onFullscreenChange ).toHaveBeenCalledWith( true );
+
+		// While full, the same item offers the way back out.
+		rerender( ui( true ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'More options' } ) );
+		fireEvent.click( await screen.findByRole( 'menuitem', { name: 'Exit full preview' } ) );
+
+		expect( onFullscreenChange ).toHaveBeenLastCalledWith( false );
+	} );
+
+	it( 'omits full preview when the host provides no toggle', async () => {
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			capabilities: CAPABILITIES,
+		} as never );
+
+		renderPreview(
+			<SitePreview site={ createSite( { running: true } ) } path="/" reloadNonce={ 0 } />
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'More options' } ) );
+
+		expect( await screen.findByText( 'Responsive mode' ) ).toBeVisible();
+		expect( screen.queryByRole( 'menuitem', { name: 'Full preview' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'asks for full preview when the Desktop + Mobile comparison is picked', async () => {
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			capabilities: CAPABILITIES,
+		} as never );
+		const onFullscreenChange = vi.fn();
+
+		renderPreview(
+			<SitePreview
+				site={ createSite( { running: true } ) }
+				path="/"
+				reloadNonce={ 0 }
+				onFullscreenChange={ onFullscreenChange }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'More options' } ) );
+		fireEvent.click( await screen.findByRole( 'menuitemradio', { name: 'Desktop + Mobile' } ) );
+
+		expect( onFullscreenChange ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'drops the comparison back to Fit pane when full preview ends', async () => {
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			capabilities: CAPABILITIES,
+		} as never );
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		} );
+		const ui = ( fullscreen: boolean ) => (
+			<QueryClientProvider client={ queryClient }>
+				<Tooltip.Provider>
+					<SitePreview
+						site={ createSite( { running: true } ) }
+						path="/"
+						reloadNonce={ 0 }
+						fullscreen={ fullscreen }
+						onFullscreenChange={ vi.fn() }
+					/>
+				</Tooltip.Provider>
+			</QueryClientProvider>
+		);
+
+		const { rerender } = render( ui( true ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'More options' } ) );
+		fireEvent.click( await screen.findByRole( 'menuitemradio', { name: 'Desktop + Mobile' } ) );
+		expect( screen.getByRole( 'menuitemradio', { name: 'Desktop + Mobile' } ) ).toBeChecked();
+
+		// Two frames don't fit the panel, so the comparison doesn't survive the
+		// return to the split layout.
+		rerender( ui( false ) );
+
+		expect( await screen.findByRole( 'menuitemradio', { name: 'Fit pane' } ) ).toBeChecked();
+	} );
+
 	it( 'hides the More options menu when the site is not running', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),

--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -11,7 +11,7 @@ import {
 	SitePreview,
 } from './index';
 import type { SiteDetails } from '@/data/core';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 vi.mock( '@/data/core', () => ( {
 	useConnector: vi.fn(),
@@ -433,6 +433,48 @@ describe( 'SitePreview', () => {
 		rerender( ui( false ) );
 
 		expect( await screen.findByRole( 'menuitemradio', { name: 'Fit pane' } ) ).toBeChecked();
+	} );
+
+	it( 'toggles full preview with the keyboard shortcut', () => {
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			capabilities: CAPABILITIES,
+		} as never );
+		const onFullscreenChange = vi.fn();
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		} );
+		const ui = ( props: Partial< ComponentProps< typeof SitePreview > > ) => (
+			<QueryClientProvider client={ queryClient }>
+				<Tooltip.Provider>
+					<SitePreview
+						site={ createSite( { running: true } ) }
+						path="/"
+						reloadNonce={ 0 }
+						{ ...props }
+					/>
+				</Tooltip.Provider>
+			</QueryClientProvider>
+		);
+		// jsdom reports a non-Apple platform, so the chord is Ctrl+Shift+F.
+		const pressShortcut = () =>
+			fireEvent.keyDown( document, { key: 'f', ctrlKey: true, shiftKey: true } );
+
+		const { rerender, unmount } = render( ui( { onFullscreenChange } ) );
+		pressShortcut();
+		expect( onFullscreenChange ).toHaveBeenLastCalledWith( true );
+
+		// It's a toggle, so it reads the current state on the way back out.
+		rerender( ui( { fullscreen: true, onFullscreenChange } ) );
+		pressShortcut();
+		expect( onFullscreenChange ).toHaveBeenLastCalledWith( false );
+
+		// Without a host toggle the chord stays with the page.
+		unmount();
+		render( ui( {} ) );
+		onFullscreenChange.mockClear();
+		pressShortcut();
+		expect( onFullscreenChange ).not.toHaveBeenCalled();
 	} );
 
 	it( 'hides the More options menu when the site is not running', () => {

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -55,6 +55,10 @@ interface SitePreviewProps {
 	// True while the panel is toggled off but kept mounted (so the webview
 	// stays warm). Disables the global browser shortcuts in that state.
 	collapsed?: boolean;
+	// True while the preview fills the whole window (sidebar and chat hidden).
+	fullscreen?: boolean;
+	// Enters/leaves full preview. The "•••" menu only offers it when provided.
+	onFullscreenChange?: ( value: boolean ) => void;
 }
 
 interface InspectorEvent {
@@ -141,13 +145,16 @@ const VIEWPORT_PRESETS: readonly ViewportPreset[] = [
 	{ id: 'desktop', width: 1440, height: 900 },
 ];
 
-// The preview's viewport mode: natural pane size or one simulated preset.
-type ViewportMode = 'fit' | ViewportPreset[ 'id' ];
+// The preview's viewport mode: natural pane size, one simulated preset, or
+// the side-by-side comparison of the desktop and mobile presets.
+type ViewportMode = 'fit' | ViewportPreset[ 'id' ] | 'split';
 
+// The split view reuses the desktop and mobile presets for its two panes.
 const MOBILE_PRESET = VIEWPORT_PRESETS[ 0 ];
+const DESKTOP_PRESET = VIEWPORT_PRESETS[ 2 ];
 
-// The phone frame's orientation. Landscape rotates the frame a quarter
-// turn (844×390).
+// The phone frame's orientation, shared by the mobile preset and the split
+// view. Landscape rotates the frame a quarter turn (844×390).
 type MobileOrientation = 'portrait' | 'landscape';
 
 const MOBILE_PRESET_LANDSCAPE: ViewportPreset = {
@@ -159,6 +166,10 @@ const MOBILE_PRESET_LANDSCAPE: ViewportPreset = {
 function getMobilePreset( orientation: MobileOrientation ): ViewportPreset {
 	return orientation === 'landscape' ? MOBILE_PRESET_LANDSCAPE : MOBILE_PRESET;
 }
+
+// Breathing room around the split view's phone frame (matches the pane's
+// CSS padding, subtracted before computing the frame's fit-to-height scale).
+const SPLIT_MOBILE_PANE_PADDING = 16;
 
 // A simulated guest viewport: the page lays out at `width`×`height` CSS px
 // and its rendering is scaled by `scale` to fit the preview pane. `mobile`
@@ -346,19 +357,23 @@ function isBrowserShortcutCommand( command: unknown ): command is BrowserShortcu
 	return command === 'back' || command === 'forward' || command === 'reload';
 }
 
-// Trailing "•••" menu holding the preview's environment controls. For now
-// that's the responsive viewport controls; other view options join it as
-// they land.
+// Trailing "•••" menu holding the preview's environment controls: the
+// responsive viewport controls and full preview. Other view options join it
+// as they land.
 function PreviewOverflowMenu( {
 	viewportMode,
 	onViewportModeChange,
 	mobileOrientation,
 	onMobileOrientationChange,
+	fullscreen,
+	onFullscreenChange,
 }: {
 	viewportMode: ViewportMode;
 	onViewportModeChange: ( mode: ViewportMode ) => void;
 	mobileOrientation: MobileOrientation;
 	onMobileOrientationChange: ( orientation: MobileOrientation ) => void;
+	fullscreen: boolean;
+	onFullscreenChange?: ( value: boolean ) => void;
 } ) {
 	const viewportLabels: Record< ViewportPreset[ 'id' ], string > = {
 		mobile: __( 'Mobile' ),
@@ -406,9 +421,10 @@ function PreviewOverflowMenu( {
 								) }
 							</Menu.RadioItem>
 						) ) }
+						<Menu.RadioItem value="split">{ __( 'Desktop + Mobile' ) }</Menu.RadioItem>
 					</Menu.RadioGroup>
 				</Menu.Group>
-				{ viewportMode === 'mobile' ? (
+				{ viewportMode === 'mobile' || viewportMode === 'split' ? (
 					<>
 						<Menu.Separator />
 						<Menu.Group>
@@ -421,6 +437,14 @@ function PreviewOverflowMenu( {
 								<Menu.RadioItem value="landscape">{ __( 'Landscape' ) }</Menu.RadioItem>
 							</Menu.RadioGroup>
 						</Menu.Group>
+					</>
+				) : null }
+				{ onFullscreenChange ? (
+					<>
+						<Menu.Separator />
+						<Menu.Item onClick={ () => onFullscreenChange( ! fullscreen ) }>
+							{ fullscreen ? __( 'Exit full preview' ) : __( 'Full preview' ) }
+						</Menu.Item>
 					</>
 				) : null }
 			</Menu.Popup>
@@ -445,6 +469,8 @@ export function SitePreview( {
 	onAnnotationsDone,
 	onPathChange,
 	collapsed = false,
+	fullscreen = false,
+	onFullscreenChange,
 }: SitePreviewProps ) {
 	const connector = useConnector();
 	const startSite = useStartSite();
@@ -467,9 +493,10 @@ export function SitePreview( {
 	const [ inspectorState, setInspectorState ] = useState< InspectorState >( EMPTY_INSPECTOR_STATE );
 	const [ inspectorCommand, setInspectorCommand ] = useState< InspectorCommand | null >( null );
 	// 'fit' renders at the pane's natural size; a preset id simulates that
-	// viewport.
+	// viewport; 'split' shows the desktop and mobile presets together.
 	const [ viewportMode, setViewportMode ] = useState< ViewportMode >( 'fit' );
-	// Orientation of the phone frame while the mobile preset is active.
+	// Orientation of the phone frame, wherever it shows (mobile preset and
+	// the split view's phone pane).
 	const [ mobileOrientation, setMobileOrientation ] = useState< MobileOrientation >( 'portrait' );
 	const [ paneSize, setPaneSize ] = useState< { width: number; height: number } | null >( null );
 	const rootRef = useRef< HTMLElement | null >( null );
@@ -486,12 +513,42 @@ export function SitePreview( {
 	const activePreset =
 		viewportMode === 'mobile'
 			? getMobilePreset( mobileOrientation )
+			: viewportMode === 'split'
+			? DESKTOP_PRESET
 			: VIEWPORT_PRESETS.find( ( preset ) => preset.id === viewportMode ) ?? null;
+	const splitPreview = viewportMode === 'split';
+	// The split view's phone pane: the mobile preset (in its current
+	// orientation) scaled to fit the pane height, and capped at half the
+	// pane's width so a landscape frame can't crowd out the primary view.
+	const splitMobileViewport = useMemo( () => {
+		if ( ! splitPreview || ! paneSize ) {
+			return null;
+		}
+		const preset = getMobilePreset( mobileOrientation );
+		return getSimulatedViewport( preset, {
+			width: Math.max( 160, Math.min( preset.width, Math.round( paneSize.width / 2 ) ) ),
+			height: Math.max( 120, paneSize.height - SPLIT_MOBILE_PANE_PADDING * 2 ),
+		} );
+	}, [ mobileOrientation, paneSize, splitPreview ] );
+	// In split mode the desktop simulation fits the space left beside the
+	// rendered mobile frame, including its pane padding. This keeps the page
+	// at the desktop breakpoint even when the comparison itself is narrow.
+	const primaryPaneSize = useMemo( () => {
+		if ( ! splitPreview || ! paneSize || ! splitMobileViewport ) {
+			return paneSize;
+		}
+		const mobilePaneWidth =
+			splitMobileViewport.width * splitMobileViewport.scale + SPLIT_MOBILE_PANE_PADDING * 2;
+		return {
+			width: Math.max( 1, paneSize.width - mobilePaneWidth ),
+			height: paneSize.height,
+		};
+	}, [ paneSize, splitMobileViewport, splitPreview ] );
 	// No emulation while the site is stopped: the empty state renders in the
 	// plain pane, and the chosen mode re-applies on start.
 	const previewViewport = useMemo(
-		() => ( canPreview ? getSimulatedViewport( activePreset, paneSize ) : null ),
-		[ activePreset, canPreview, paneSize ]
+		() => ( canPreview ? getSimulatedViewport( activePreset, primaryPaneSize ) : null ),
+		[ activePreset, canPreview, primaryPaneSize ]
 	);
 	// Sizing for the frame around the primary surface: the preset's exact
 	// scaled box (the emulation paints it edge to edge).
@@ -594,8 +651,13 @@ export function SitePreview( {
 		( mode: ViewportMode ) => {
 			setViewportMode( mode );
 			viewportBySiteRef.current[ site.id ] = { ...viewportBySiteRef.current[ site.id ], mode };
+			// Two frames side by side need the room — a desktop page beside a
+			// phone is unreadable in the narrow panel.
+			if ( mode === 'split' ) {
+				onFullscreenChange?.( true );
+			}
 		},
-		[ site.id ]
+		[ onFullscreenChange, site.id ]
 	);
 	const handleMobileOrientationChange = useCallback(
 		( orientation: MobileOrientation ) => {
@@ -607,6 +669,16 @@ export function SitePreview( {
 		},
 		[ site.id ]
 	);
+
+	// The comparison is a full-preview mode: leaving full preview (or landing
+	// on a site that remembered it) falls back to the single fit-to-pane view
+	// rather than squeezing both frames into the panel. Only when the host
+	// offers full preview at all — otherwise the mode could never be picked.
+	useEffect( () => {
+		if ( onFullscreenChange && ! fullscreen && viewportMode === 'split' ) {
+			handleViewportModeChange( 'fit' );
+		}
+	}, [ fullscreen, handleViewportModeChange, onFullscreenChange, viewportMode ] );
 
 	useEffect( () => {
 		setBrowserState( EMPTY_BROWSER_STATE );
@@ -675,9 +747,18 @@ export function SitePreview( {
 	}, [ canPreview, collapsed, handleSwitchRealm, sendBrowserCommand ] );
 
 	return (
-		<aside ref={ rootRef } className={ styles.root } aria-label={ __( 'Site preview' ) }>
+		<aside
+			ref={ rootRef }
+			className={ clsx( styles.root, fullscreen && styles.rootFullscreen ) }
+			aria-label={ __( 'Site preview' ) }
+		>
 			<div
-				className={ styles.header }
+				// In full preview the toolbar reaches the window's physical left
+				// edge, where the macOS traffic lights sit.
+				className={ clsx(
+					styles.header,
+					fullscreen && trafficLightSpace.start && styles.headerTrafficLights
+				) }
 				style={
 					windowControls
 						? {
@@ -779,6 +860,8 @@ export function SitePreview( {
 							onViewportModeChange={ handleViewportModeChange }
 							mobileOrientation={ mobileOrientation }
 							onMobileOrientationChange={ handleMobileOrientationChange }
+							fullscreen={ fullscreen }
+							onFullscreenChange={ onFullscreenChange }
 						/>
 					) : null }
 				</div>
@@ -853,6 +936,54 @@ export function SitePreview( {
 									/>
 								) }
 							</div>
+							{ splitPreview && splitMobileViewport ? (
+								// The comparison's phone pane: a lean companion surface that
+								// follows the primary's navigation (shared `path`) but keeps
+								// annotations and history on the primary pane.
+								<div className={ styles.splitMobilePane }>
+									<div
+										className={ clsx( styles.surfaceFrame, styles.deviceFrame ) }
+										style={ {
+											flex: '0 0 auto',
+											width: splitMobileViewport.width * splitMobileViewport.scale,
+											height: splitMobileViewport.height * splitMobileViewport.scale,
+										} }
+									>
+										{ canUseWebview ? (
+											<WebviewSurface
+												key={ `${ site.id }-mobile` }
+												url={ previewUrl }
+												reloadNonce={ reloadNonce }
+												viewport={ splitMobileViewport }
+												browserCommand={ browserCommand?.type === 'reload' ? browserCommand : null }
+												onNavigate={ handlePreviewNavigation }
+											/>
+										) : (
+											<iframe
+												key={ `${ previewUrl }#${ reloadNonce }` }
+												className={ styles.iframe }
+												style={
+													splitMobileViewport.scale !== 1
+														? {
+																flex: '0 0 auto',
+																width: splitMobileViewport.width,
+																height: splitMobileViewport.height,
+																transform: `scale(${ splitMobileViewport.scale })`,
+																transformOrigin: 'top left',
+														  }
+														: undefined
+												}
+												src={ previewUrl }
+												title={ sprintf(
+													/* translators: %s: site name */
+													__( '%s (mobile)' ),
+													site.name
+												) }
+											/>
+										) }
+									</div>
+								</div>
+							) : null }
 						</>
 					) : (
 						<div className={ styles.empty }>

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -167,6 +167,22 @@ function getMobilePreset( orientation: MobileOrientation ): ViewportPreset {
 	return orientation === 'landscape' ? MOBILE_PRESET_LANDSCAPE : MOBILE_PRESET;
 }
 
+// The preset behind the primary preview surface, or null when the pane
+// renders at its natural size. The split view's primary frame is the desktop
+// preset; its phone companion is sized separately.
+function getActivePreset(
+	mode: ViewportMode,
+	orientation: MobileOrientation
+): ViewportPreset | null {
+	if ( mode === 'mobile' ) {
+		return getMobilePreset( orientation );
+	}
+	if ( mode === 'split' ) {
+		return DESKTOP_PRESET;
+	}
+	return VIEWPORT_PRESETS.find( ( preset ) => preset.id === mode ) ?? null;
+}
+
 // Breathing room around the split view's phone frame (matches the pane's
 // CSS padding, subtracted before computing the frame's fit-to-height scale).
 const SPLIT_MOBILE_PANE_PADDING = 16;
@@ -510,12 +526,7 @@ export function SitePreview( {
 	const showLoadingProgress = canPreview && progress > 0;
 	// Presets are module constants, so this stays referentially stable per
 	// mode + orientation.
-	const activePreset =
-		viewportMode === 'mobile'
-			? getMobilePreset( mobileOrientation )
-			: viewportMode === 'split'
-			? DESKTOP_PRESET
-			: VIEWPORT_PRESETS.find( ( preset ) => preset.id === viewportMode ) ?? null;
+	const activePreset = getActivePreset( viewportMode, mobileOrientation );
 	const splitPreview = viewportMode === 'split';
 	// The split view's phone pane: the mobile preset (in its current
 	// orientation) scaled to fit the pane height, and capped at half the

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -66,7 +66,7 @@ interface InspectorEvent {
 	annotations?: Annotation[];
 	isPicking?: boolean;
 	annotationCount?: number;
-	command?: BrowserShortcutCommandType;
+	command?: PreviewShortcutCommandType;
 }
 
 interface InspectorState {
@@ -89,6 +89,11 @@ interface BrowserNavigationState {
 }
 
 type BrowserShortcutCommandType = 'back' | 'forward' | 'reload';
+
+// What the guest page can forward over the console bridge: the browser
+// commands it swallows, plus the full-preview toggle (the webview covers most
+// of the window in full preview, so the host listener alone would miss it).
+type PreviewShortcutCommandType = BrowserShortcutCommandType | 'full-preview';
 
 interface BrowserCommand {
 	id: number;
@@ -369,8 +374,24 @@ function getRealmShortcut( event: globalThis.KeyboardEvent ): PreviewRealm | nul
 	return null;
 }
 
-function isBrowserShortcutCommand( command: unknown ): command is BrowserShortcutCommandType {
-	return command === 'back' || command === 'forward' || command === 'reload';
+// ⇧⌘F (Ctrl+Shift+F elsewhere) toggles full preview. Listed in Settings →
+// Keyboard alongside the other preview shortcuts.
+const FULL_PREVIEW_SHORTCUT_KEY = 'f';
+
+function isFullPreviewShortcut( event: globalThis.KeyboardEvent ): boolean {
+	if ( event.defaultPrevented || event.repeat ) {
+		return false;
+	}
+	return isKeyboardEvent.primaryShift( event, FULL_PREVIEW_SHORTCUT_KEY );
+}
+
+function isPreviewShortcutCommand( command: unknown ): command is PreviewShortcutCommandType {
+	return (
+		command === 'back' ||
+		command === 'forward' ||
+		command === 'reload' ||
+		command === 'full-preview'
+	);
 }
 
 // Trailing "•••" menu holding the preview's environment controls: the
@@ -611,6 +632,18 @@ export function SitePreview( {
 		commandIdRef.current += 1;
 		setInspectorCommand( { id: commandIdRef.current, type } );
 	}, [] );
+	// Shortcuts the guest page swallowed and forwarded back over the console
+	// bridge: browser commands go to the webview, full preview to the host.
+	const handleForwardedShortcut = useCallback(
+		( command: PreviewShortcutCommandType ) => {
+			if ( command === 'full-preview' ) {
+				onFullscreenChange?.( ! fullscreen );
+				return;
+			}
+			sendBrowserCommand( command );
+		},
+		[ fullscreen, onFullscreenChange, sendBrowserCommand ]
+	);
 
 	// Realm segments (front end / WP Admin / database). Each realm remembers
 	// where you last were: flipping to WP Admin and back returns to the exact
@@ -733,7 +766,11 @@ export function SitePreview( {
 		const handleKeyDown = ( event: globalThis.KeyboardEvent ) => {
 			const command = getBrowserShortcutCommand( event );
 			const realm = command ? null : getRealmShortcut( event );
-			if ( ! command && ! realm ) {
+			// Only claim the full-preview chord when the host actually offers
+			// the mode, so it stays available to the page otherwise.
+			const fullPreview =
+				! command && ! realm && !! onFullscreenChange && isFullPreviewShortcut( event );
+			if ( ! command && ! realm && ! fullPreview ) {
 				return;
 			}
 			const activeElement = document.activeElement;
@@ -750,12 +787,21 @@ export function SitePreview( {
 				sendBrowserCommand( command );
 			} else if ( realm ) {
 				handleSwitchRealm( realm );
+			} else {
+				onFullscreenChange?.( ! fullscreen );
 			}
 		};
 
 		document.addEventListener( 'keydown', handleKeyDown, { capture: true } );
 		return () => document.removeEventListener( 'keydown', handleKeyDown, { capture: true } );
-	}, [ canPreview, collapsed, handleSwitchRealm, sendBrowserCommand ] );
+	}, [
+		canPreview,
+		collapsed,
+		fullscreen,
+		handleSwitchRealm,
+		onFullscreenChange,
+		sendBrowserCommand,
+	] );
 
 	return (
 		<aside
@@ -917,7 +963,7 @@ export function SitePreview( {
 										inspectorCommand={ inspectorCommand }
 										browserCommand={ browserCommand }
 										onBrowserStateChange={ handleBrowserStateChange }
-										onBrowserCommand={ sendBrowserCommand }
+										onBrowserCommand={ handleForwardedShortcut }
 										onNavigate={ handlePreviewNavigation }
 										viewport={ previewViewport }
 									/>
@@ -1056,7 +1102,7 @@ interface WebviewSurfaceProps {
 	inspectorCommand?: InspectorCommand | null;
 	browserCommand?: BrowserCommand | null;
 	onBrowserStateChange?: ( state: BrowserNavigationState ) => void;
-	onBrowserCommand?: ( type: BrowserShortcutCommandType ) => void;
+	onBrowserCommand?: ( type: PreviewShortcutCommandType ) => void;
 	onNavigate?: ( url: string ) => void;
 	// Simulated guest viewport, or null for the webview's natural size.
 	viewport?: PreviewViewport | null;
@@ -1229,7 +1275,7 @@ function WebviewSurface( {
 			}
 			if ( ! parsed ) return;
 			if ( parsed.type === 'browser-command' ) {
-				if ( isBrowserShortcutCommand( parsed.command ) ) {
+				if ( isPreviewShortcutCommand( parsed.command ) ) {
 					onBrowserCommandRef.current?.( parsed.command );
 				}
 				return;

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -82,10 +82,13 @@ export const INSPECTOR_PAGE_SCRIPT =
 			if ( ! hasNavModifier || event.shiftKey || isTextEntryTarget( event.target ) ) return null;
 			return event.key === 'ArrowLeft' ? 'back' : 'forward';
 		}
-		if ( event.shiftKey || event.altKey ) return null;
+		if ( event.altKey ) return null;
 		const hasPrimaryModifier = apple ? event.metaKey : event.ctrlKey;
 		if ( ! hasPrimaryModifier ) return null;
 		const key = event.key.toLowerCase();
+		/* The host owns full preview, but in that mode this page covers most of
+		 * the window — so the chord is caught here and forwarded back. */
+		if ( event.shiftKey ) return key === 'f' ? 'full-preview' : null;
 		if ( key === 'r' ) return 'reload';
 		if ( key === '[' ) return 'back';
 		if ( key === ']' ) return 'forward';

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -13,6 +13,12 @@
 	overflow: hidden;
 }
 
+/* Full preview: the panel spans the whole frame, so the content/preview
+   separator would read as a stray line down the window's edge. */
+.rootFullscreen {
+	border-inline-start: none;
+}
+
 .header {
 	position: relative;
 	display: flex;
@@ -27,6 +33,12 @@
 	/* Sizes the address segments' narrow-width behavior (the title collapse
 	   in location-omnibox.module.css queries this container). */
 	container: studio-preview-toolbar / inline-size;
+}
+
+/* Clears the macOS traffic lights, which always sit at the window's physical
+   top-left — hence the physical padding rather than an inline-start one. */
+.headerTrafficLights {
+	padding-left: 94px;
 }
 
 /* The toolbar doubles as a window drag region; the controls (including the
@@ -154,6 +166,19 @@
 		0 0 0 1px var(--wpds-color-stroke-surface-neutral),
 		var(--wpds-elevation-md);
 	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
+}
+
+/* The split view's phone pane, beside the desktop frame on the shared
+   letterbox. Shrinkable so a narrow panel never crushes the primary view. */
+.splitMobilePane {
+	position: relative;
+	display: flex;
+	flex: 0 1 auto;
+	min-width: 0;
+	align-items: safe center;
+	justify-content: safe center;
+	padding: 16px;
+	overflow: hidden;
 }
 
 .spinnerOverlay {

--- a/apps/ui/src/hooks/use-session-ui.tsx
+++ b/apps/ui/src/hooks/use-session-ui.tsx
@@ -27,6 +27,9 @@ import type { Annotation } from '@/components/site-preview/types';
 
 interface PreviewUIState {
 	open: boolean;
+	// Full preview: the preview fills the window (sidebar and chat hidden).
+	// Only meaningful while `open`; closing the panel always clears it.
+	fullscreen: boolean;
 	reloadNonce: number;
 	// Currently previewed site.
 	siteId: string | null;
@@ -49,13 +52,14 @@ export interface SessionUIState {
 export type SessionUIAction =
 	| { type: 'preview/set-open'; value: boolean }
 	| { type: 'preview/toggle' }
+	| { type: 'preview/set-fullscreen'; value: boolean }
 	| { type: 'preview/navigate'; path: string }
 	| { type: 'preview/reload' }
 	| { type: 'preview/update-path'; path: string }
 	| { type: 'preview/set-site'; siteId: string };
 
 const INITIAL_STATE: SessionUIState = {
-	preview: { open: true, reloadNonce: 0, siteId: null, pathsBySiteId: {} },
+	preview: { open: true, fullscreen: false, reloadNonce: 0, siteId: null, pathsBySiteId: {} },
 };
 
 function reducer( state: SessionUIState, action: SessionUIAction ): SessionUIState {
@@ -63,9 +67,32 @@ function reducer( state: SessionUIState, action: SessionUIAction ): SessionUISta
 		case 'preview/set-open':
 			return state.preview.open === action.value
 				? state
-				: { ...state, preview: { ...state.preview, open: action.value } };
+				: {
+						...state,
+						// Closing the panel leaves full preview; reopening starts split.
+						preview: {
+							...state.preview,
+							open: action.value,
+							fullscreen: action.value && state.preview.fullscreen,
+						},
+				  };
 		case 'preview/toggle':
-			return { ...state, preview: { ...state.preview, open: ! state.preview.open } };
+			return {
+				...state,
+				preview: { ...state.preview, open: ! state.preview.open, fullscreen: false },
+			};
+		case 'preview/set-fullscreen':
+			return state.preview.fullscreen === action.value
+				? state
+				: {
+						...state,
+						preview: {
+							...state.preview,
+							fullscreen: action.value,
+							// Entering full preview reveals the panel it expands.
+							open: action.value || state.preview.open,
+						},
+				  };
 		case 'preview/navigate':
 			return {
 				...state,
@@ -161,12 +188,14 @@ export function useSessionUIDispatch(): Dispatch< SessionUIAction > {
 
 export interface SessionPreviewUI {
 	readonly open: boolean;
+	readonly fullscreen: boolean;
 	readonly path: string;
 	readonly reloadNonce: number;
 	readonly siteId: string | null;
 	readonly pathsBySiteId: Record< string, string >;
 	setOpen: ( value: boolean ) => void;
 	toggle: () => void;
+	setFullscreen: ( value: boolean ) => void;
 	updatePath: ( path: string ) => void;
 	setSite: ( siteId: string ) => void;
 }
@@ -182,6 +211,10 @@ export function useOptionalSessionPreviewUI(): SessionPreviewUI | null {
 		[ dispatch ]
 	);
 	const toggle = useCallback( () => dispatch?.( { type: 'preview/toggle' } ), [ dispatch ] );
+	const setFullscreen = useCallback(
+		( value: boolean ) => dispatch?.( { type: 'preview/set-fullscreen', value } ),
+		[ dispatch ]
+	);
 	const updatePath = useCallback(
 		( path: string ) => dispatch?.( { type: 'preview/update-path', path } ),
 		[ dispatch ]
@@ -196,16 +229,18 @@ export function useOptionalSessionPreviewUI(): SessionPreviewUI | null {
 		}
 		return {
 			open: state.preview.open,
+			fullscreen: state.preview.fullscreen,
 			path: pathForSite( state.preview.pathsBySiteId, state.preview.siteId ),
 			reloadNonce: state.preview.reloadNonce,
 			siteId: state.preview.siteId,
 			pathsBySiteId: state.preview.pathsBySiteId,
 			setOpen,
 			toggle,
+			setFullscreen,
 			updatePath,
 			setSite,
 		};
-	}, [ state, dispatch, setOpen, toggle, updatePath, setSite ] );
+	}, [ state, dispatch, setOpen, toggle, setFullscreen, updatePath, setSite ] );
 }
 
 export function useSessionPreviewUI(): SessionPreviewUI {

--- a/apps/ui/src/ui-classic/router/layout-dashboard/index.tsx
+++ b/apps/ui/src/ui-classic/router/layout-dashboard/index.tsx
@@ -116,6 +116,19 @@ function DashboardLayoutContent() {
 	// `setPreviewSite` effect lands.
 	const previewPath = pathForSite( preview.pathsBySiteId, previewSiteId );
 	const showPreview = preview.open && supportsPreview && !! previewSite;
+	const previewFullscreen = preview.fullscreen && showPreview;
+	// Leave full preview when the route stops supporting a preview (settings,
+	// site settings…) so the user is never left staring at a hidden layout.
+	const { setFullscreen: setPreviewFullscreen } = preview;
+	useEffect( () => {
+		if ( ! supportsPreview ) {
+			setPreviewFullscreen( false );
+		}
+	}, [ supportsPreview, setPreviewFullscreen ] );
+	const exitPreviewFullscreen = useCallback(
+		() => setPreviewFullscreen( false ),
+		[ setPreviewFullscreen ]
+	);
 	const renderPreview = useCallback(
 		( { collapsed }: PreviewSplitFramePreviewProps ) =>
 			previewSite ? (
@@ -126,14 +139,31 @@ function DashboardLayoutContent() {
 					onAnnotationsDone={ onAnnotationsDone }
 					onPathChange={ preview.updatePath }
 					collapsed={ collapsed }
+					fullscreen={ previewFullscreen }
+					onFullscreenChange={ setPreviewFullscreen }
 				/>
 			) : null,
-		[ onAnnotationsDone, previewPath, preview.reloadNonce, preview.updatePath, previewSite ]
+		[
+			onAnnotationsDone,
+			previewFullscreen,
+			previewPath,
+			preview.reloadNonce,
+			preview.updatePath,
+			previewSite,
+			setPreviewFullscreen,
+		]
 	);
 
 	return (
-		<SidebarLayout>
-			<PreviewSplitFrame previewOpen={ showPreview } preview={ renderPreview }>
+		<SidebarLayout
+			forceCollapsed={ previewFullscreen }
+			onForceCollapsedToggle={ exitPreviewFullscreen }
+		>
+			<PreviewSplitFrame
+				previewOpen={ showPreview }
+				previewFullscreen={ previewFullscreen }
+				preview={ renderPreview }
+			>
 				<Outlet />
 			</PreviewSplitFrame>
 		</SidebarLayout>


### PR DESCRIPTION
## Related issues

- Related to STU-2089

## How AI was used in this PR

Implemented with Claude Code, ported from the Design Preview exploration (#3975). I reviewed the code and verified manually in the app.

## Proposed Changes

- **Full preview** — a new item in the preview's **•••** menu hands the whole window to the preview, hiding the sidebar and chat. The chat stays mounted, so nothing is lost on the way in or out. Leaving is the same menu item, or the usual sidebar toggle.
- **Desktop + Mobile is back.** It was cut in review because a desktop page beside a phone is unreadable in the narrow panel; it now travels with full preview, where there's room for both. Picking it goes full preview, and leaving full preview drops back to Fit pane rather than squeezing two frames into the panel.

| Full Preview | Desktop + mobile | Shortcuts |
|--------|--------|--------|
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/e890fc64-bac0-4566-a666-94f2120ca68c" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/21ae4aa2-ca24-4860-831d-552588dd85ed" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/462c44b5-ff90-4d51-b981-064d21634f70" /> |
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/95b7f1bb-ea34-4ac0-ab5d-db5a8846694f" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/0b8902a1-3518-4f88-8d98-a6f8124dd21c" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/fd54f83a-4c44-42ee-ad89-999a6f96639e" /> |

## Testing Instructions

Agentic UI, a running site.

1. Preview → **•••** → **Full preview**: sidebar and chat give way to the preview. The same item (now **Exit full preview**) brings them back, as does the sidebar toggle.
2. **•••** → **Desktop + Mobile**: goes full preview and shows both frames, the phone following the desktop pane's navigation. Try **Landscape** in the orientation group.
3. Leave full preview from the comparison → back to Fit pane in the normal split.
4. Resize the window in each: frames re-fit live.
5. Try the preview keyboard shortcuts to confirm they work
6. Check light + dark.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
