### PR TITLE
Pin Reprint to v0.9.2

### DIFF
--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -131,14 +131,7 @@ const FILES_TO_DOWNLOAD: FileToDownload[] = [
 	{
 		name: 'reprint',
 		description: `reprint.phar`,
-		getUrl: async () => {
-			const release = await fetchLatestGithubRelease( 'WordPress/reprint' );
-			const asset = release.assets.find( ( a ) => a.name === 'reprint.phar' );
-			if ( ! asset ) {
-				throw new Error( `No asset found in latest reprint release ${ release.tag_name }` );
-			}
-			return asset.browser_download_url;
-		},
+		getUrl: () => 'https://github.com/WordPress/reprint/releases/download/v0.9.2/reprint.phar',
 		destinationPath: path.join( WP_SERVER_FILES_PATH, 'reprint' ),
 	},
 ];


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Related to STU-2180

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

N/A

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

As things stand, Studio messes directly with Reprint state files to make selective sync work. We want to get rid of this ASAP, but we are fine with putting this on the short-term tech debt account for now to get an initial release of Pressable in Studio out behind a beta flag.

To make this approach safer, we've decided to pin the Reprint version to a known safe release (v0.9.2). This PR does just that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review is sufficient

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
