### PR TITLE
Attempt to fix `ENAMETOOLONG` error by filtering and deduping `open_basedir`

### DIFF
--- a/apps/cli/lib/native-php/open-basedir.ts
+++ b/apps/cli/lib/native-php/open-basedir.ts
@@ -1,0 +1,43 @@
+import path from 'path';
+import { arePathsEqual } from '@studio/common/lib/fs-utils';
+
+// Whether `parent` already grants access to `child`: the same path, or a directory
+// it sits under. Walks the child's ancestors and defers each comparison to
+// arePathsEqual, so the filesystem decides what counts as the same path.
+export function containsPath( parent: string, child: string ): boolean {
+	const target = path.normalize( parent );
+	let ancestor = path.normalize( child );
+
+	while ( true ) {
+		if ( arePathsEqual( target, ancestor ) ) {
+			return true;
+		}
+		// dirname stops making progress at the root, which is where the walk ends.
+		const parentDir = path.dirname( ancestor );
+		if ( parentDir === ancestor ) {
+			return false;
+		}
+		ancestor = parentDir;
+	}
+}
+
+// open_basedir matches by path prefix, so an entry nested inside another grants
+// nothing extra. Dropping the redundant ones keeps the directive short, which
+// matters because it rides on the PHP command line and Windows caps that at 32k.
+export function foldContainedPaths( entries: string[] ): string[] {
+	const normalized = entries
+		.filter( Boolean )
+		.map( ( entry ) => path.normalize( entry ) )
+		// Shortest first, so a parent is always considered before anything nested in it.
+		.sort( ( a, b ) => a.length - b.length );
+
+	const kept: string[] = [];
+	for ( const entry of normalized ) {
+		// containsPath holds for identical paths too, so this also drops duplicates —
+		// including ones that differ only in case on a case-insensitive volume.
+		if ( ! kept.some( ( keptEntry ) => containsPath( keptEntry, entry ) ) ) {
+			kept.push( entry );
+		}
+	}
+	return kept;
+}

--- a/apps/cli/lib/native-php/open-basedir.ts
+++ b/apps/cli/lib/native-php/open-basedir.ts
@@ -24,7 +24,7 @@ export function containsPath( parent: string, child: string ): boolean {
 // open_basedir matches by path prefix, so an entry nested inside another grants
 // nothing extra. Dropping the redundant ones keeps the directive short, which
 // matters because it rides on the PHP command line and Windows caps that at 32k.
-export function foldContainedPaths( entries: string[] ): string[] {
+export function dropCoveredPaths( entries: string[] ): string[] {
 	const normalized = entries
 		.filter( Boolean )
 		.map( ( entry ) => path.normalize( entry ) )

--- a/apps/cli/lib/symlinks.ts
+++ b/apps/cli/lib/symlinks.ts
@@ -27,9 +27,12 @@ const RESTART_BUDGET_WINDOW_MS = 60_000;
 const IGNORED_SCAN_DIRECTORY_NAMES = new Set( [ 'node_modules', '.git', '.DS_Store' ] );
 
 export function isIgnoredScanPath( entryPath: string ): boolean {
-	return entryPath
-		.split( path.posix.sep )
-		.some( ( segment ) => IGNORED_SCAN_DIRECTORY_NAMES.has( segment ) );
+	return (
+		entryPath
+			// chokidar normalizes all paths to use Posix separators
+			.split( path.posix.sep )
+			.some( ( segment ) => IGNORED_SCAN_DIRECTORY_NAMES.has( segment ) )
+	);
 }
 
 export class SymlinkWatcher extends EventEmitter< SymlinkWatcherEvents > {

--- a/apps/cli/lib/symlinks.ts
+++ b/apps/cli/lib/symlinks.ts
@@ -25,8 +25,12 @@ const RESTART_BUDGET_WINDOW_MS = 60_000;
 // Directories that never host plugin/theme symlinks but can hold thousands of
 // them (npm/pnpm link farms).
 const IGNORED_SCAN_DIRECTORY_NAMES = new Set( [ 'node_modules', '.git', '.DS_Store' ] );
-// chokidar hands `ignored` a full path, so there the same names match per segment.
-const IGNORED_SCAN_PATH = /[\\/](node_modules|\.git|\.DS_Store)([\\/]|$)/;
+
+export function isIgnoredScanPath( entryPath: string ): boolean {
+	return entryPath
+		.split( path.sep )
+		.some( ( segment ) => IGNORED_SCAN_DIRECTORY_NAMES.has( segment ) );
+}
 
 export class SymlinkWatcher extends EventEmitter< SymlinkWatcherEvents > {
 	private watcher: FSWatcher | null = null;
@@ -82,7 +86,7 @@ export class SymlinkWatcher extends EventEmitter< SymlinkWatcherEvents > {
 			ignorePermissionErrors: true,
 			// Skip directories that produce noise and never host plugin/theme symlinks.
 			// chokidar v4+ no longer accepts globs by default — match against the path.
-			ignored: ( entryPath: string ) => IGNORED_SCAN_PATH.test( entryPath ),
+			ignored: isIgnoredScanPath,
 		} );
 
 		const onMaybeSymlink = async ( entryPath: string ) => {

--- a/apps/cli/lib/symlinks.ts
+++ b/apps/cli/lib/symlinks.ts
@@ -1,4 +1,3 @@
-import childProcess from 'child_process';
 import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
@@ -21,6 +20,17 @@ const RESTART_BACKOFF_MS = [ 500, 1000, 2000, 4000, 8000 ];
 // looping forever against a permanently broken watch handle.
 const RESTART_BUDGET = 5;
 const RESTART_BUDGET_WINDOW_MS = 60_000;
+
+// Directories that never host plugin/theme symlinks but can hold thousands of
+// them (npm/pnpm link farms).
+const IGNORED_SCAN_DIRECTORY_NAMES = new Set( [ 'node_modules', '.git', '.DS_Store' ] );
+// chokidar hands `ignored` a full path, so there the same names match per segment.
+const IGNORED_SCAN_PATH = /[\\/](node_modules|\.git|\.DS_Store)([\\/]|$)/;
+
+// Directory levels below the scan root to descend into; an entry sitting directly
+// in the root has depth 1. Equivalent to the watcher's chokidar `depth: 2` rooted
+// at wp-content, i.e. site/wp-content/themes/my-theme/<entry>.
+export const SYMLINK_SCAN_DEPTH = 4;
 
 export class SymlinkWatcher extends EventEmitter< SymlinkWatcherEvents > {
 	private watcher: FSWatcher | null = null;
@@ -76,8 +86,7 @@ export class SymlinkWatcher extends EventEmitter< SymlinkWatcherEvents > {
 			ignorePermissionErrors: true,
 			// Skip directories that produce noise and never host plugin/theme symlinks.
 			// chokidar v4+ no longer accepts globs by default — match against the path.
-			ignored: ( entryPath: string ) =>
-				/[\\/](node_modules|\.git|\.DS_Store)([\\/]|$)/.test( entryPath ),
+			ignored: ( entryPath: string ) => IGNORED_SCAN_PATH.test( entryPath ),
 		} );
 
 		const onMaybeSymlink = async ( entryPath: string ) => {
@@ -182,63 +191,32 @@ export class SymlinkWatcher extends EventEmitter< SymlinkWatcherEvents > {
 	}
 }
 
-function nativeFindSymlinksInDir( dir: string ): Promise< string[] > {
-	return new Promise( ( resolve, reject ) => {
-		const child = childProcess.spawn( 'find', [ dir, '-type', 'l' ] );
-		let output = '';
-		child.stdout.on( 'data', ( data ) => {
-			output += data.toString();
-		} );
-		child.on( 'close', ( code ) => {
-			if ( code !== 0 ) {
-				reject( new Error( `find exited with code ${ code }` ) );
-			} else {
-				const absolutePaths = output
-					.toString()
-					.split( '\n' )
-					.filter( Boolean )
-					.map( ( relative ) => path.resolve( dir, relative ) );
-				resolve( absolutePaths );
-			}
-		} );
-		child.on( 'error', ( error ) => {
-			reject( error );
-		} );
-	} );
-}
-
-async function walkForSymlinks( dir: string, found: string[] ): Promise< void > {
+async function walkForSymlinks(
+	dir: string,
+	found: string[],
+	depth: number,
+	maxDepth: number
+): Promise< void > {
 	let entries: fs.Dirent[];
 	try {
 		entries = await fs.promises.readdir( dir, { withFileTypes: true } );
 	} catch {
-		// Missing dir or denied permissions — match `find`'s behavior of just skipping.
+		// Missing dir or denied permissions — skip it rather than failing the scan.
 		return;
 	}
 	for ( const entry of entries ) {
+		if ( IGNORED_SCAN_DIRECTORY_NAMES.has( entry.name ) ) {
+			continue;
+		}
 		const fullPath = path.join( dir, entry.name );
 		if ( entry.isSymbolicLink() ) {
 			found.push( fullPath );
 			continue;
 		}
-		if ( entry.isDirectory() ) {
-			await walkForSymlinks( fullPath, found );
+		if ( entry.isDirectory() && depth < maxDepth ) {
+			await walkForSymlinks( fullPath, found, depth + 1, maxDepth );
 		}
 	}
-}
-
-async function findSymlinksInDir( dir: string ): Promise< string[] > {
-	if ( process.platform !== 'win32' ) {
-		try {
-			return await nativeFindSymlinksInDir( dir );
-		} catch {
-			// Fall back to the Node implementation if `find` is unavailable or fails.
-		}
-	}
-
-	const found: string[] = [];
-	await walkForSymlinks( dir, found );
-	return found;
 }
 
 // Resolve a symlink to the directory that needs to be granted in open_basedir.
@@ -256,8 +234,12 @@ export async function resolveSymlinkAllowlistEntry( linkPath: string ): Promise<
 	}
 }
 
-export async function collectSymlinkAllowlistEntries( dir: string ): Promise< string[] > {
-	const symlinks = await findSymlinksInDir( dir );
+export async function collectSymlinkAllowlistEntries(
+	dir: string,
+	maxDepth: number = SYMLINK_SCAN_DEPTH
+): Promise< string[] > {
+	const symlinks: string[] = [];
+	await walkForSymlinks( dir, symlinks, 1, maxDepth );
 	const resolved = await Promise.all( symlinks.map( resolveSymlinkAllowlistEntry ) );
 	return Array.from( new Set( resolved.filter( ( entry ): entry is string => entry !== null ) ) );
 }

--- a/apps/cli/lib/symlinks.ts
+++ b/apps/cli/lib/symlinks.ts
@@ -1,3 +1,4 @@
+import childProcess from 'child_process';
 import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
@@ -26,11 +27,6 @@ const RESTART_BUDGET_WINDOW_MS = 60_000;
 const IGNORED_SCAN_DIRECTORY_NAMES = new Set( [ 'node_modules', '.git', '.DS_Store' ] );
 // chokidar hands `ignored` a full path, so there the same names match per segment.
 const IGNORED_SCAN_PATH = /[\\/](node_modules|\.git|\.DS_Store)([\\/]|$)/;
-
-// Directory levels below the scan root to descend into. Six levels cover a
-// Composer path repository within a plugin or theme:
-// wp-content/<type>/<extension>/vendor/<vendor>/<package>.
-export const SYMLINK_SCAN_DEPTH = 6;
 
 export class SymlinkWatcher extends EventEmitter< SymlinkWatcherEvents > {
 	private watcher: FSWatcher | null = null;
@@ -191,17 +187,47 @@ export class SymlinkWatcher extends EventEmitter< SymlinkWatcherEvents > {
 	}
 }
 
-async function walkForSymlinks(
-	dir: string,
-	found: string[],
-	depth: number,
-	maxDepth: number
-): Promise< void > {
+// Builds `find <dir> \( -name a -o -name b \) -prune -o -type l -print0`, so the
+// prune list is generated from IGNORED_SCAN_DIRECTORY_NAMES rather than hand-kept
+// in sync with the walker below. -print0 because newlines are legal in POSIX
+// filenames and would otherwise split one path into two.
+function buildFindArgs( dir: string ): string[] {
+	const nameTests = [ ...IGNORED_SCAN_DIRECTORY_NAMES ].flatMap( ( name, index ) =>
+		index === 0 ? [ '-name', name ] : [ '-o', '-name', name ]
+	);
+	return [ dir, '(', ...nameTests, ')', '-prune', '-o', '-type', 'l', '-print0' ];
+}
+
+function nativeFindSymlinksInDir( dir: string ): Promise< string[] > {
+	return new Promise( ( resolve, reject ) => {
+		const child = childProcess.spawn( 'find', buildFindArgs( dir ) );
+		let output = '';
+		child.stdout.on( 'data', ( data ) => {
+			output += data.toString();
+		} );
+		child.on( 'close', ( code ) => {
+			if ( code !== 0 ) {
+				reject( new Error( `find exited with code ${ code }` ) );
+				return;
+			}
+			const absolutePaths = output
+				.split( '\0' )
+				.filter( Boolean )
+				.map( ( entryPath ) => path.resolve( dir, entryPath ) );
+			resolve( absolutePaths );
+		} );
+		child.on( 'error', ( error ) => {
+			reject( error );
+		} );
+	} );
+}
+
+async function walkForSymlinks( dir: string, found: string[] ): Promise< void > {
 	let entries: fs.Dirent[];
 	try {
 		entries = await fs.promises.readdir( dir, { withFileTypes: true } );
 	} catch {
-		// Missing dir or denied permissions — skip it rather than failing the scan.
+		// Missing dir or denied permissions — match `find`'s behavior of just skipping.
 		return;
 	}
 	for ( const entry of entries ) {
@@ -213,10 +239,24 @@ async function walkForSymlinks(
 			found.push( fullPath );
 			continue;
 		}
-		if ( entry.isDirectory() && depth < maxDepth ) {
-			await walkForSymlinks( fullPath, found, depth + 1, maxDepth );
+		if ( entry.isDirectory() ) {
+			await walkForSymlinks( fullPath, found );
 		}
 	}
+}
+
+async function findSymlinksInDir( dir: string ): Promise< string[] > {
+	if ( process.platform !== 'win32' ) {
+		try {
+			return await nativeFindSymlinksInDir( dir );
+		} catch {
+			// Fall back to the Node implementation if `find` is unavailable or fails.
+		}
+	}
+
+	const found: string[] = [];
+	await walkForSymlinks( dir, found );
+	return found;
 }
 
 // Resolve a symlink to the directory that needs to be granted in open_basedir.
@@ -234,12 +274,8 @@ export async function resolveSymlinkAllowlistEntry( linkPath: string ): Promise<
 	}
 }
 
-export async function collectSymlinkAllowlistEntries(
-	dir: string,
-	maxDepth: number = SYMLINK_SCAN_DEPTH
-): Promise< string[] > {
-	const symlinks: string[] = [];
-	await walkForSymlinks( dir, symlinks, 1, maxDepth );
+export async function collectSymlinkAllowlistEntries( dir: string ): Promise< string[] > {
+	const symlinks = await findSymlinksInDir( dir );
 	const resolved = await Promise.all( symlinks.map( resolveSymlinkAllowlistEntry ) );
 	return Array.from( new Set( resolved.filter( ( entry ): entry is string => entry !== null ) ) );
 }

--- a/apps/cli/lib/symlinks.ts
+++ b/apps/cli/lib/symlinks.ts
@@ -27,10 +27,10 @@ const IGNORED_SCAN_DIRECTORY_NAMES = new Set( [ 'node_modules', '.git', '.DS_Sto
 // chokidar hands `ignored` a full path, so there the same names match per segment.
 const IGNORED_SCAN_PATH = /[\\/](node_modules|\.git|\.DS_Store)([\\/]|$)/;
 
-// Directory levels below the scan root to descend into; an entry sitting directly
-// in the root has depth 1. Equivalent to the watcher's chokidar `depth: 2` rooted
-// at wp-content, i.e. site/wp-content/themes/my-theme/<entry>.
-export const SYMLINK_SCAN_DEPTH = 4;
+// Directory levels below the scan root to descend into. Six levels cover a
+// Composer path repository within a plugin or theme:
+// wp-content/<type>/<extension>/vendor/<vendor>/<package>.
+export const SYMLINK_SCAN_DEPTH = 6;
 
 export class SymlinkWatcher extends EventEmitter< SymlinkWatcherEvents > {
 	private watcher: FSWatcher | null = null;

--- a/apps/cli/lib/symlinks.ts
+++ b/apps/cli/lib/symlinks.ts
@@ -28,7 +28,7 @@ const IGNORED_SCAN_DIRECTORY_NAMES = new Set( [ 'node_modules', '.git', '.DS_Sto
 
 export function isIgnoredScanPath( entryPath: string ): boolean {
 	return entryPath
-		.split( path.sep )
+		.split( path.posix.sep )
 		.some( ( segment ) => IGNORED_SCAN_DIRECTORY_NAMES.has( segment ) );
 }
 

--- a/apps/cli/lib/tests/open-basedir.test.ts
+++ b/apps/cli/lib/tests/open-basedir.test.ts
@@ -1,0 +1,122 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { containsPath, foldContainedPaths } from '../native-php/open-basedir';
+
+const p = ( ...segments: string[] ) => path.join( path.sep, ...segments );
+
+describe( 'containsPath', () => {
+	it( 'treats a path as containing itself', () => {
+		expect( containsPath( p( 'site' ), p( 'site' ) ) ).toBe( true );
+	} );
+
+	it( 'matches a nested path', () => {
+		expect( containsPath( p( 'site' ), p( 'site', 'wp-content', 'plugins' ) ) ).toBe( true );
+	} );
+
+	it( 'does not match a sibling that shares a prefix', () => {
+		expect( containsPath( p( 'site' ), p( 'site-backup' ) ) ).toBe( false );
+	} );
+
+	it( 'does not match upwards', () => {
+		expect( containsPath( p( 'site', 'wp-content' ), p( 'site' ) ) ).toBe( false );
+	} );
+
+	it( 'ignores a trailing separator on the parent', () => {
+		expect( containsPath( `${ p( 'site' ) }${ path.sep }`, p( 'site', 'wp-content' ) ) ).toBe(
+			true
+		);
+	} );
+} );
+
+describe( 'foldContainedPaths', () => {
+	it( 'drops entries nested inside another entry', () => {
+		expect(
+			foldContainedPaths( [
+				p( 'site' ),
+				p( 'site', 'wp-content', 'plugins', 'foo' ),
+				p( 'site', 'wp-content', 'themes', 'bar' ),
+			] )
+		).toEqual( [ p( 'site' ) ] );
+	} );
+
+	it( 'keeps entries outside the site directory', () => {
+		expect(
+			foldContainedPaths( [ p( 'site' ), p( 'site', 'wp-content' ), p( 'shared', 'plugin' ) ] )
+		).toEqual( [ p( 'site' ), p( 'shared', 'plugin' ) ] );
+	} );
+
+	it( 'deduplicates entries that differ only by trailing separator', () => {
+		expect( foldContainedPaths( [ p( 'tmp' ), `${ p( 'tmp' ) }${ path.sep }` ] ) ).toEqual( [
+			p( 'tmp' ),
+		] );
+	} );
+
+	it( 'folds a deep link farm down to the site directory', () => {
+		const nested = Array.from( { length: 500 }, ( _, index ) =>
+			p( 'site', 'wp-content', 'themes', 'x', 'node_modules', '.pnpm', `pkg-${ index }` )
+		);
+		expect( foldContainedPaths( [ p( 'site' ), ...nested ] ) ).toEqual( [ p( 'site' ) ] );
+	} );
+
+	it( 'collapses redundant segments in the entries it emits', () => {
+		expect( foldContainedPaths( [ p( 'site', 'wp-content', '..', 'other' ) ] ) ).toEqual( [
+			p( 'site', 'other' ),
+		] );
+	} );
+
+	it( 'ignores empty entries', () => {
+		expect( foldContainedPaths( [ '', p( 'site' ) ] ) ).toEqual( [ p( 'site' ) ] );
+	} );
+
+	it( 'is order independent', () => {
+		const entries = [ p( 'site', 'wp-content' ), p( 'shared' ), p( 'site' ) ];
+		expect( foldContainedPaths( entries ).sort() ).toEqual(
+			foldContainedPaths( [ ...entries ].reverse() ).sort()
+		);
+	} );
+} );
+
+// The cases above use paths that do not exist, so arePathsEqual falls back to
+// string comparison. These exercise the on-disk comparison it prefers.
+describe( 'containsPath against a real filesystem', () => {
+	let root: string;
+	let site: string;
+
+	beforeAll( () => {
+		root = fs.realpathSync( fs.mkdtempSync( path.join( os.tmpdir(), 'studio-open-basedir-' ) ) );
+		site = path.join( root, 'Site' );
+		fs.mkdirSync( path.join( site, 'wp-content', 'plugins' ), { recursive: true } );
+	} );
+
+	afterAll( () => {
+		fs.rmSync( root, { recursive: true, force: true } );
+	} );
+
+	it( 'sees through a symlinked ancestor', () => {
+		const link = path.join( root, 'linked-site' );
+		fs.symlinkSync( site, link, 'junction' );
+
+		expect( containsPath( site, path.join( link, 'wp-content', 'plugins' ) ) ).toBe( true );
+	} );
+
+	it( 'follows the volume on casing rather than the platform', () => {
+		const differentCase = path.join( root, 'site' );
+		// Ask the filesystem directly instead of inferring from process.platform:
+		// macOS is usually case-insensitive and Linux usually is not, but either can
+		// be mounted the other way.
+		const volumeIsCaseInsensitive = fs.existsSync( differentCase );
+
+		expect( containsPath( differentCase, path.join( site, 'wp-content' ) ) ).toBe(
+			volumeIsCaseInsensitive
+		);
+	} );
+
+	it( 'still rejects a sibling that shares a prefix', () => {
+		const sibling = path.join( root, 'Site-backup' );
+		fs.mkdirSync( sibling, { recursive: true } );
+
+		expect( containsPath( site, sibling ) ).toBe( false );
+	} );
+} );

--- a/apps/cli/lib/tests/open-basedir.test.ts
+++ b/apps/cli/lib/tests/open-basedir.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { containsPath, foldContainedPaths } from '../native-php/open-basedir';
+import { containsPath, dropCoveredPaths } from '../native-php/open-basedir';
 
 const p = ( ...segments: string[] ) => path.join( path.sep, ...segments );
 
@@ -30,10 +30,10 @@ describe( 'containsPath', () => {
 	} );
 } );
 
-describe( 'foldContainedPaths', () => {
+describe( 'dropCoveredPaths', () => {
 	it( 'drops entries nested inside another entry', () => {
 		expect(
-			foldContainedPaths( [
+			dropCoveredPaths( [
 				p( 'site' ),
 				p( 'site', 'wp-content', 'plugins', 'foo' ),
 				p( 'site', 'wp-content', 'themes', 'bar' ),
@@ -43,37 +43,37 @@ describe( 'foldContainedPaths', () => {
 
 	it( 'keeps entries outside the site directory', () => {
 		expect(
-			foldContainedPaths( [ p( 'site' ), p( 'site', 'wp-content' ), p( 'shared', 'plugin' ) ] )
+			dropCoveredPaths( [ p( 'site' ), p( 'site', 'wp-content' ), p( 'shared', 'plugin' ) ] )
 		).toEqual( [ p( 'site' ), p( 'shared', 'plugin' ) ] );
 	} );
 
 	it( 'deduplicates entries that differ only by trailing separator', () => {
-		expect( foldContainedPaths( [ p( 'tmp' ), `${ p( 'tmp' ) }${ path.sep }` ] ) ).toEqual( [
+		expect( dropCoveredPaths( [ p( 'tmp' ), `${ p( 'tmp' ) }${ path.sep }` ] ) ).toEqual( [
 			p( 'tmp' ),
 		] );
 	} );
 
-	it( 'folds a deep link farm down to the site directory', () => {
+	it( 'drops a deep link farm in favour of the site directory', () => {
 		const nested = Array.from( { length: 500 }, ( _, index ) =>
 			p( 'site', 'wp-content', 'themes', 'x', 'node_modules', '.pnpm', `pkg-${ index }` )
 		);
-		expect( foldContainedPaths( [ p( 'site' ), ...nested ] ) ).toEqual( [ p( 'site' ) ] );
+		expect( dropCoveredPaths( [ p( 'site' ), ...nested ] ) ).toEqual( [ p( 'site' ) ] );
 	} );
 
 	it( 'collapses redundant segments in the entries it emits', () => {
-		expect( foldContainedPaths( [ p( 'site', 'wp-content', '..', 'other' ) ] ) ).toEqual( [
+		expect( dropCoveredPaths( [ p( 'site', 'wp-content', '..', 'other' ) ] ) ).toEqual( [
 			p( 'site', 'other' ),
 		] );
 	} );
 
 	it( 'ignores empty entries', () => {
-		expect( foldContainedPaths( [ '', p( 'site' ) ] ) ).toEqual( [ p( 'site' ) ] );
+		expect( dropCoveredPaths( [ '', p( 'site' ) ] ) ).toEqual( [ p( 'site' ) ] );
 	} );
 
 	it( 'is order independent', () => {
 		const entries = [ p( 'site', 'wp-content' ), p( 'shared' ), p( 'site' ) ];
-		expect( foldContainedPaths( entries ).sort() ).toEqual(
-			foldContainedPaths( [ ...entries ].reverse() ).sort()
+		expect( dropCoveredPaths( entries ).sort() ).toEqual(
+			dropCoveredPaths( [ ...entries ].reverse() ).sort()
 		);
 	} );
 } );

--- a/apps/cli/lib/tests/symlinks.test.ts
+++ b/apps/cli/lib/tests/symlinks.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { collectSymlinkAllowlistEntries } from '../symlinks';
 
 let root: string;
@@ -72,20 +72,13 @@ describe( 'collectSymlinkAllowlistEntries', () => {
 		] );
 	} );
 
-	it( 'finds symlinks nested deeper than four directory levels', () => {
-		const deep = makeDir( 'a', 'b', 'c', 'd' );
+	it( 'descends to any depth', () => {
+		const deep = makeDir( 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' );
 		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( deep, 'link' ) );
 
 		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [
 			path.join( outside, 'shared-plugin' ),
 		] );
-	} );
-
-	it( 'stops descending past the default depth limit', () => {
-		const deep = makeDir( 'a', 'b', 'c', 'd', 'e', 'f' );
-		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( deep, 'link' ) );
-
-		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [] );
 	} );
 
 	it( 'finds symlinked Composer dependencies within a plugin', () => {
@@ -100,13 +93,6 @@ describe( 'collectSymlinkAllowlistEntries', () => {
 		] );
 	} );
 
-	it( 'honours an explicit depth limit', () => {
-		const nested = makeDir( 'wp-content', 'plugins' );
-		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( nested, 'shared-plugin' ) );
-
-		return expect( collectSymlinkAllowlistEntries( sitePath, 2 ) ).resolves.toEqual( [] );
-	} );
-
 	it( 'ignores dangling symlinks', () => {
 		const plugins = makeDir( 'wp-content', 'plugins' );
 		fs.symlinkSync( path.join( outside, 'missing' ), path.join( plugins, 'gone' ) );
@@ -118,6 +104,55 @@ describe( 'collectSymlinkAllowlistEntries', () => {
 		const plugins = makeDir( 'wp-content', 'plugins' );
 		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( plugins, 'one' ) );
 		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( plugins, 'two' ) );
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [
+			path.join( outside, 'shared-plugin' ),
+		] );
+	} );
+
+	it( 'returns an empty list for a missing directory', () => {
+		return expect(
+			collectSymlinkAllowlistEntries( path.join( root, 'does-not-exist' ) )
+		).resolves.toEqual( [] );
+	} );
+} );
+
+// The cases above run through `find` on macOS and Linux, so the Node walker would
+// otherwise only ever be exercised on Windows. Force that branch to keep the two
+// implementations in agreement.
+describe( 'collectSymlinkAllowlistEntries via the Node walker', () => {
+	const originalPlatform = process.platform;
+
+	beforeAll( () => {
+		Object.defineProperty( process, 'platform', { value: 'win32', configurable: true } );
+	} );
+
+	afterAll( () => {
+		Object.defineProperty( process, 'platform', {
+			value: originalPlatform,
+			configurable: true,
+		} );
+	} );
+
+	it( 'resolves a symlinked directory to its target', () => {
+		const plugins = makeDir( 'wp-content', 'plugins' );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( plugins, 'shared-plugin' ) );
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [
+			path.join( outside, 'shared-plugin' ),
+		] );
+	} );
+
+	it( 'skips symlinks inside node_modules', () => {
+		const linkFarm = makeDir( 'wp-content', 'themes', 'node_modules' );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( linkFarm, 'dep' ) );
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [] );
+	} );
+
+	it( 'descends to any depth', () => {
+		const deep = makeDir( 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( deep, 'link' ) );
 
 		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [
 			path.join( outside, 'shared-plugin' ),

--- a/apps/cli/lib/tests/symlinks.test.ts
+++ b/apps/cli/lib/tests/symlinks.test.ts
@@ -15,7 +15,7 @@ const makeDir = ( ...segments: string[] ) => {
 };
 
 beforeEach( () => {
-	root = fs.realpathSync( fs.mkdtempSync( path.join( os.tmpdir(), 'studio-symlinks-' ) ) );
+	root = fs.realpathSync.native( fs.mkdtempSync( path.join( os.tmpdir(), 'studio-symlinks-' ) ) );
 	sitePath = path.join( root, 'site' );
 	outside = path.join( root, 'outside' );
 	fs.mkdirSync( sitePath, { recursive: true } );

--- a/apps/cli/lib/tests/symlinks.test.ts
+++ b/apps/cli/lib/tests/symlinks.test.ts
@@ -72,11 +72,32 @@ describe( 'collectSymlinkAllowlistEntries', () => {
 		] );
 	} );
 
-	it( 'stops descending past the depth limit', () => {
+	it( 'finds symlinks nested deeper than four directory levels', () => {
 		const deep = makeDir( 'a', 'b', 'c', 'd' );
 		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( deep, 'link' ) );
 
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [
+			path.join( outside, 'shared-plugin' ),
+		] );
+	} );
+
+	it( 'stops descending past the default depth limit', () => {
+		const deep = makeDir( 'a', 'b', 'c', 'd', 'e', 'f' );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( deep, 'link' ) );
+
 		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [] );
+	} );
+
+	it( 'finds symlinked Composer dependencies within a plugin', () => {
+		const composerVendor = makeDir( 'wp-content', 'plugins', 'my-plugin', 'vendor', 'acme' );
+		fs.symlinkSync(
+			path.join( outside, 'shared-plugin' ),
+			path.join( composerVendor, 'dependency' )
+		);
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [
+			path.join( outside, 'shared-plugin' ),
+		] );
 	} );
 
 	it( 'honours an explicit depth limit', () => {

--- a/apps/cli/lib/tests/symlinks.test.ts
+++ b/apps/cli/lib/tests/symlinks.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { collectSymlinkAllowlistEntries } from '../symlinks';
+import { collectSymlinkAllowlistEntries, isIgnoredScanPath } from '../symlinks';
 
 let root: string;
 let sitePath: string;
@@ -24,6 +24,40 @@ beforeEach( () => {
 
 afterEach( () => {
 	fs.rmSync( root, { recursive: true, force: true } );
+} );
+
+// Guards the rule the watcher and the scan share. Paths are built with path.join
+// so the assertions run against the platform's own separator.
+describe( 'isIgnoredScanPath', () => {
+	it( 'ignores a path ending in an ignored directory', () => {
+		expect( isIgnoredScanPath( path.join( 'site', 'wp-content', 'node_modules' ) ) ).toBe( true );
+	} );
+
+	it( 'ignores anything nested inside an ignored directory', () => {
+		expect(
+			isIgnoredScanPath( path.join( 'site', 'wp-content', 'node_modules', 'pkg', 'index.js' ) )
+		).toBe( true );
+	} );
+
+	it( 'ignores dot-prefixed names', () => {
+		expect( isIgnoredScanPath( path.join( 'site', '.git', 'HEAD' ) ) ).toBe( true );
+		expect( isIgnoredScanPath( path.join( 'site', '.DS_Store' ) ) ).toBe( true );
+	} );
+
+	it( 'keeps ordinary paths', () => {
+		expect( isIgnoredScanPath( path.join( 'site', 'wp-content', 'plugins', 'my-plugin' ) ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'matches whole segments only', () => {
+		expect( isIgnoredScanPath( path.join( 'site', 'my-node_modules-backup' ) ) ).toBe( false );
+		expect( isIgnoredScanPath( path.join( 'site', 'node_modules-old' ) ) ).toBe( false );
+	} );
+
+	it( 'handles an absolute path', () => {
+		expect( isIgnoredScanPath( path.join( root, 'site', 'node_modules' ) ) ).toBe( true );
+	} );
 } );
 
 describe( 'collectSymlinkAllowlistEntries', () => {

--- a/apps/cli/lib/tests/symlinks.test.ts
+++ b/apps/cli/lib/tests/symlinks.test.ts
@@ -26,37 +26,43 @@ afterEach( () => {
 	fs.rmSync( root, { recursive: true, force: true } );
 } );
 
-// Guards the rule the watcher and the scan share. Paths are built with path.join
-// so the assertions run against the platform's own separator.
+// Guards the rule the watcher and the scan share. Paths are built with
+// path.posix.join to match the paths produced by chokidar.
 describe( 'isIgnoredScanPath', () => {
 	it( 'ignores a path ending in an ignored directory', () => {
-		expect( isIgnoredScanPath( path.join( 'site', 'wp-content', 'node_modules' ) ) ).toBe( true );
+		expect( isIgnoredScanPath( path.posix.join( 'site', 'wp-content', 'node_modules' ) ) ).toBe(
+			true
+		);
 	} );
 
 	it( 'ignores anything nested inside an ignored directory', () => {
 		expect(
-			isIgnoredScanPath( path.join( 'site', 'wp-content', 'node_modules', 'pkg', 'index.js' ) )
+			isIgnoredScanPath(
+				path.posix.join( 'site', 'wp-content', 'node_modules', 'pkg', 'index.js' )
+			)
 		).toBe( true );
 	} );
 
 	it( 'ignores dot-prefixed names', () => {
-		expect( isIgnoredScanPath( path.join( 'site', '.git', 'HEAD' ) ) ).toBe( true );
-		expect( isIgnoredScanPath( path.join( 'site', '.DS_Store' ) ) ).toBe( true );
+		expect( isIgnoredScanPath( path.posix.join( 'site', '.git', 'HEAD' ) ) ).toBe( true );
+		expect( isIgnoredScanPath( path.posix.join( 'site', '.DS_Store' ) ) ).toBe( true );
 	} );
 
 	it( 'keeps ordinary paths', () => {
-		expect( isIgnoredScanPath( path.join( 'site', 'wp-content', 'plugins', 'my-plugin' ) ) ).toBe(
-			false
-		);
+		expect(
+			isIgnoredScanPath( path.posix.join( 'site', 'wp-content', 'plugins', 'my-plugin' ) )
+		).toBe( false );
 	} );
 
 	it( 'matches whole segments only', () => {
-		expect( isIgnoredScanPath( path.join( 'site', 'my-node_modules-backup' ) ) ).toBe( false );
-		expect( isIgnoredScanPath( path.join( 'site', 'node_modules-old' ) ) ).toBe( false );
+		expect( isIgnoredScanPath( path.posix.join( 'site', 'my-node_modules-backup' ) ) ).toBe(
+			false
+		);
+		expect( isIgnoredScanPath( path.posix.join( 'site', 'node_modules-old' ) ) ).toBe( false );
 	} );
 
 	it( 'handles an absolute path', () => {
-		expect( isIgnoredScanPath( path.join( root, 'site', 'node_modules' ) ) ).toBe( true );
+		expect( isIgnoredScanPath( path.posix.join( root, 'site', 'node_modules' ) ) ).toBe( true );
 	} );
 } );
 

--- a/apps/cli/lib/tests/symlinks.test.ts
+++ b/apps/cli/lib/tests/symlinks.test.ts
@@ -1,0 +1,111 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { collectSymlinkAllowlistEntries } from '../symlinks';
+
+let root: string;
+let sitePath: string;
+let outside: string;
+
+const makeDir = ( ...segments: string[] ) => {
+	const dir = path.join( sitePath, ...segments );
+	fs.mkdirSync( dir, { recursive: true } );
+	return dir;
+};
+
+beforeEach( () => {
+	root = fs.realpathSync( fs.mkdtempSync( path.join( os.tmpdir(), 'studio-symlinks-' ) ) );
+	sitePath = path.join( root, 'site' );
+	outside = path.join( root, 'outside' );
+	fs.mkdirSync( sitePath, { recursive: true } );
+	fs.mkdirSync( path.join( outside, 'shared-plugin' ), { recursive: true } );
+} );
+
+afterEach( () => {
+	fs.rmSync( root, { recursive: true, force: true } );
+} );
+
+describe( 'collectSymlinkAllowlistEntries', () => {
+	it( 'resolves a symlinked directory to its target', () => {
+		const plugins = makeDir( 'wp-content', 'plugins' );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( plugins, 'shared-plugin' ) );
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [
+			path.join( outside, 'shared-plugin' ),
+		] );
+	} );
+
+	it( 'resolves a symlinked file to its containing directory', () => {
+		const plugins = makeDir( 'wp-content', 'plugins' );
+		fs.writeFileSync( path.join( outside, 'shared-plugin', 'plugin.php' ), '<?php' );
+		fs.symlinkSync(
+			path.join( outside, 'shared-plugin', 'plugin.php' ),
+			path.join( plugins, 'plugin.php' )
+		);
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [
+			path.join( outside, 'shared-plugin' ),
+		] );
+	} );
+
+	it( 'skips symlinks inside node_modules', () => {
+		const linkFarm = makeDir( 'wp-content', 'themes', 'node_modules' );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( linkFarm, 'dep' ) );
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [] );
+	} );
+
+	it( 'skips symlinks inside .git', () => {
+		const gitDir = makeDir( '.git' );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( gitDir, 'link' ) );
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [] );
+	} );
+
+	it( 'descends far enough to cover wp-content/<type>/<extension>', () => {
+		const theme = makeDir( 'wp-content', 'themes', 'my-theme' );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( theme, 'src' ) );
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [
+			path.join( outside, 'shared-plugin' ),
+		] );
+	} );
+
+	it( 'stops descending past the depth limit', () => {
+		const deep = makeDir( 'a', 'b', 'c', 'd' );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( deep, 'link' ) );
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [] );
+	} );
+
+	it( 'honours an explicit depth limit', () => {
+		const nested = makeDir( 'wp-content', 'plugins' );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( nested, 'shared-plugin' ) );
+
+		return expect( collectSymlinkAllowlistEntries( sitePath, 2 ) ).resolves.toEqual( [] );
+	} );
+
+	it( 'ignores dangling symlinks', () => {
+		const plugins = makeDir( 'wp-content', 'plugins' );
+		fs.symlinkSync( path.join( outside, 'missing' ), path.join( plugins, 'gone' ) );
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [] );
+	} );
+
+	it( 'deduplicates symlinks that resolve to the same target', () => {
+		const plugins = makeDir( 'wp-content', 'plugins' );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( plugins, 'one' ) );
+		fs.symlinkSync( path.join( outside, 'shared-plugin' ), path.join( plugins, 'two' ) );
+
+		return expect( collectSymlinkAllowlistEntries( sitePath ) ).resolves.toEqual( [
+			path.join( outside, 'shared-plugin' ),
+		] );
+	} );
+
+	it( 'returns an empty list for a missing directory', () => {
+		return expect(
+			collectSymlinkAllowlistEntries( path.join( root, 'does-not-exist' ) )
+		).resolves.toEqual( [] );
+	} );
+} );

--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -27,7 +27,7 @@ import {
 import { requestSetAdminCredentials, toUrlSearchParams } from './lib/admin-credentials';
 import { getPhpMyAdminPath } from './lib/dependency-management/paths';
 import { runBlueprint } from './lib/native-php/blueprints';
-import { containsPath, foldContainedPaths } from './lib/native-php/open-basedir';
+import { containsPath, dropCoveredPaths } from './lib/native-php/open-basedir';
 import {
 	killAllLivePhpProcesses,
 	spawnPhpProcess,
@@ -129,7 +129,7 @@ function isFileAccessRestricted( config: ServerConfig ): boolean {
 }
 
 function getEffectiveOpenBasedirAllowlist(): string[] {
-	return foldContainedPaths( [ ...staticOpenBasedirAllowlist, ...symlinkOpenBasedirAllowlist ] );
+	return dropCoveredPaths( [ ...staticOpenBasedirAllowlist, ...symlinkOpenBasedirAllowlist ] );
 }
 
 function isCoveredByOpenBasedirAllowlist( target: string ): boolean {

--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -133,7 +133,9 @@ function getEffectiveOpenBasedirAllowlist(): string[] {
 }
 
 function isCoveredByOpenBasedirAllowlist( target: string ): boolean {
-	return getEffectiveOpenBasedirAllowlist().some( ( entry ) => containsPath( entry, target ) );
+	return [ ...staticOpenBasedirAllowlist, ...symlinkOpenBasedirAllowlist ].some( ( entry ) =>
+		containsPath( entry, target )
+	);
 }
 
 function clearOpenBasedirAllowlist(): void {

--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -27,6 +27,7 @@ import {
 import { requestSetAdminCredentials, toUrlSearchParams } from './lib/admin-credentials';
 import { getPhpMyAdminPath } from './lib/dependency-management/paths';
 import { runBlueprint } from './lib/native-php/blueprints';
+import { containsPath, foldContainedPaths } from './lib/native-php/open-basedir';
 import {
 	killAllLivePhpProcesses,
 	spawnPhpProcess,
@@ -104,7 +105,15 @@ let blueprintQueue: Promise< unknown > = Promise.resolve();
 // Symlink-aware open_basedir state. PHP's open_basedir cannot be extended at
 // runtime, so when a new symlink appears under the site directory we have to
 // restart the PHP server with an updated allowlist.
-const currentOpenBasedirAllowlist: Set< string > = new Set();
+//
+// Held as two sets so a rescan can replace the scanned half wholesale: static
+// entries are fixed for the life of the server, while symlink targets come and go
+// as plugins and themes are linked and unlinked.
+const staticOpenBasedirAllowlist: Set< string > = new Set();
+let symlinkOpenBasedirAllowlist: Set< string > = new Set();
+// The list the running workers were started with. A rescan diffs against it:
+// added entries need a restart, removed ones can wait.
+let appliedOpenBasedirAllowlist: string[] = [];
 let symlinkWatcher: SymlinkWatcher | null = null;
 let symlinkRestartTimer: NodeJS.Timeout | null = null;
 let runningConfig: ServerConfig | null = null;
@@ -117,6 +126,20 @@ const NATIVE_PHP_WORKER_POOL_SIZE = 4;
 // disable_functions list; "all files" runs PHP unrestricted.
 function isFileAccessRestricted( config: ServerConfig ): boolean {
 	return getSiteFileAccess( config ) === SITE_FILE_ACCESS_SITE_DIRECTORY;
+}
+
+function getEffectiveOpenBasedirAllowlist(): string[] {
+	return foldContainedPaths( [ ...staticOpenBasedirAllowlist, ...symlinkOpenBasedirAllowlist ] );
+}
+
+function isCoveredByOpenBasedirAllowlist( target: string ): boolean {
+	return getEffectiveOpenBasedirAllowlist().some( ( entry ) => containsPath( entry, target ) );
+}
+
+function clearOpenBasedirAllowlist(): void {
+	staticOpenBasedirAllowlist.clear();
+	symlinkOpenBasedirAllowlist = new Set();
+	appliedOpenBasedirAllowlist = [];
 }
 
 function logToConsole( ...args: Parameters< typeof console.log > ) {
@@ -232,12 +255,15 @@ function startSymlinkWatcher( sitePath: string ): void {
 	const wpContentPath = path.join( sitePath, 'wp-content' );
 	const watcher = new SymlinkWatcher();
 	watcher.on( 'symlink', ( target, symlinkPath ) => {
-		if ( currentOpenBasedirAllowlist.has( target ) ) {
+		// Covered means an existing entry already grants the target — usually the
+		// site directory itself, since a site's own symlinks resolve back inside it.
+		// Restarting for those would cost a request drop and buy nothing.
+		if ( isCoveredByOpenBasedirAllowlist( target ) ) {
 			return;
 		}
 
 		logToConsole( `Detected new symlink at ${ symlinkPath } -> ${ target }` );
-		currentOpenBasedirAllowlist.add( target );
+		symlinkOpenBasedirAllowlist.add( target );
 		scheduleAllowlistRestart();
 	} );
 
@@ -253,9 +279,9 @@ function startSymlinkWatcher( sitePath: string ): void {
 	} );
 
 	watcher.on( 'restart', () => {
-		// Events fired while the watcher was dead are lost. Re-scan wp-content and
-		// fold any newly discovered symlink targets into the allowlist.
-		void reconcileSymlinkAllowlist( wpContentPath );
+		// Events fired while the watcher was dead are lost. Re-scan the site and
+		// rebuild the scanned half of the allowlist from what is actually on disk.
+		void reconcileSymlinkAllowlist( sitePath );
 	} );
 
 	// Watch wp-content and its subdirectories for symlinks
@@ -263,25 +289,31 @@ function startSymlinkWatcher( sitePath: string ): void {
 	symlinkWatcher = watcher;
 }
 
-async function reconcileSymlinkAllowlist( wpContentPath: string ): Promise< void > {
+// Rescans the site and replaces the scanned half of the allowlist, so targets that
+// disappeared while the watcher was dead drop out instead of accumulating for the
+// life of the server. Safe as a wholesale replacement because the scan covers a
+// superset of what the watcher reports (see SYMLINK_SCAN_DEPTH).
+//
+// Only new grants justify a restart: without them PHP is being denied access it
+// should have. A list that merely shrank is an over-grant, and restarting to
+// narrow it would drop in-flight requests and reset opcache for nothing the user
+// can see — the narrower list lands on the next restart that happens anyway.
+async function reconcileSymlinkAllowlist( sitePath: string ): Promise< void > {
 	let entries: string[];
 	try {
-		entries = await collectSymlinkAllowlistEntries( wpContentPath );
+		entries = await collectSymlinkAllowlistEntries( sitePath );
 	} catch ( error ) {
 		errorToConsole( 'Failed to reconcile symlink allowlist after watcher restart:', error );
 		return;
 	}
 
-	let added = false;
-	for ( const target of entries ) {
-		if ( ! currentOpenBasedirAllowlist.has( target ) ) {
-			logToConsole( `Discovered symlink target after watcher restart: ${ target }` );
-			currentOpenBasedirAllowlist.add( target );
-			added = true;
-		}
-	}
+	symlinkOpenBasedirAllowlist = new Set( entries );
 
-	if ( added ) {
+	const added = getEffectiveOpenBasedirAllowlist().filter(
+		( entry ) => ! appliedOpenBasedirAllowlist.some( ( applied ) => containsPath( applied, entry ) )
+	);
+	if ( added.length ) {
+		logToConsole( `Discovered symlink target(s) after watcher restart: ${ added.join( ', ' ) }` );
 		scheduleAllowlistRestart();
 	}
 }
@@ -322,7 +354,7 @@ async function restartPhpServer(): Promise< void > {
 	await stopCurrentPhpServer();
 
 	try {
-		phpProcess = await doStartServer( runningConfig, currentOpenBasedirAllowlist );
+		phpProcess = await doStartServer( runningConfig );
 	} catch ( error ) {
 		errorToConsole( `Failed to restart PHP server:`, error );
 		process.exit( 1 );
@@ -500,29 +532,30 @@ async function startServer( config: ServerConfig, signal: AbortSignal ): Promise
 		// With "all files" access the allowlist stays empty, which disables
 		// open_basedir entirely (see getDefaultPhpArgs).
 		if ( isFileAccessRestricted( config ) ) {
+			staticOpenBasedirAllowlist.add( config.sitePath );
+			staticOpenBasedirAllowlist.add( ROUTER_PATH );
+			staticOpenBasedirAllowlist.add( getPhpMyAdminPath() );
+			staticOpenBasedirAllowlist.add( getNativePhpMyAdminWpEnvPath( config ) );
+			staticOpenBasedirAllowlist.add( getPhpMyAdminSessionPath( config ) );
+			staticOpenBasedirAllowlist.add( muPluginsPath );
+			staticOpenBasedirAllowlist.add( os.tmpdir() );
+			if ( config.autoPrependFile ) {
+				staticOpenBasedirAllowlist.add( path.dirname( config.autoPrependFile ) );
+			}
+			config.openBasedirAllowList?.forEach( ( entry ) => staticOpenBasedirAllowlist.add( entry ) );
+
 			// Snapshot existing symlink targets so open_basedir grants them upfront. New
 			// symlinks added while the server runs are picked up by startSymlinkWatcher
 			// below and trigger a debounced restart with an extended allowlist.
-			const symlinkAllowlistEntries = await collectSymlinkAllowlistEntries( config.sitePath );
+			symlinkOpenBasedirAllowlist = new Set(
+				await collectSymlinkAllowlistEntries( config.sitePath )
+			);
 			stopSignal.throwIfAborted();
-
-			currentOpenBasedirAllowlist.add( config.sitePath );
-			currentOpenBasedirAllowlist.add( ROUTER_PATH );
-			currentOpenBasedirAllowlist.add( getPhpMyAdminPath() );
-			currentOpenBasedirAllowlist.add( getNativePhpMyAdminWpEnvPath( config ) );
-			currentOpenBasedirAllowlist.add( getPhpMyAdminSessionPath( config ) );
-			currentOpenBasedirAllowlist.add( muPluginsPath );
-			currentOpenBasedirAllowlist.add( os.tmpdir() );
-			if ( config.autoPrependFile ) {
-				currentOpenBasedirAllowlist.add( path.dirname( config.autoPrependFile ) );
-			}
-			symlinkAllowlistEntries.forEach( ( entry ) => currentOpenBasedirAllowlist.add( entry ) );
-			config.openBasedirAllowList?.forEach( ( entry ) => currentOpenBasedirAllowlist.add( entry ) );
 		}
 
 		runningConfig = config;
 
-		phpProcess = await doStartServer( config, currentOpenBasedirAllowlist, stopSignal );
+		phpProcess = await doStartServer( config, stopSignal );
 		stopSignal.throwIfAborted();
 		await setAdminCredentials( config, stopSignal );
 		stopSignal.throwIfAborted();
@@ -531,7 +564,7 @@ async function startServer( config: ServerConfig, signal: AbortSignal ): Promise
 		phpProcess = null;
 		await stopSymlinkWatcher();
 		runningConfig = null;
-		currentOpenBasedirAllowlist.clear();
+		clearOpenBasedirAllowlist();
 
 		if ( stopSignal.aborted ) {
 			logToConsole( `Aborted start server operation:`, error );
@@ -547,12 +580,15 @@ async function startServer( config: ServerConfig, signal: AbortSignal ): Promise
 
 async function doStartServer(
 	config: ServerConfig,
-	openBasedirAllowlist: Set< string >,
 	stopSignal?: AbortSignal
 ): Promise< ChildProcess > {
 	const phpVersion = resolveNativePhpVersion( config.phpVersion ?? '' );
 	const spawnedChildren: ChildProcess[] = [];
 	let proxyServer: http.Server | null = null;
+	// Recorded before spawning so a later rescan can diff against what the workers
+	// were actually given, including on the failure paths that tear the pool down.
+	const openBasedirAllowlist = getEffectiveOpenBasedirAllowlist();
+	appliedOpenBasedirAllowlist = openBasedirAllowlist;
 
 	logToConsole(
 		`Spawning native PHP worker pool with ${ NATIVE_PHP_WORKER_POOL_SIZE } workers on public port ${ config.port }`
@@ -585,7 +621,7 @@ async function doStartServer(
 					STUDIO_NATIVE_PHPMYADMIN_WP_ENV_PATH: phpMyAdminWpEnvPath,
 					STUDIO_PHPMYADMIN_SESSION_PATH: getPhpMyAdminSessionPath( config ),
 				},
-				onlyPathsThatPhpCanAccess: Array.from( openBasedirAllowlist ),
+				onlyPathsThatPhpCanAccess: openBasedirAllowlist,
 				disallowRiskyFunctions: isFileAccessRestricted( config ),
 				enableXdebug: config.enableXdebug,
 				autoPrependFile,
@@ -673,7 +709,7 @@ async function stopServer(): Promise< StopServerResult > {
 
 	await stopSymlinkWatcher();
 	runningConfig = null;
-	currentOpenBasedirAllowlist.clear();
+	clearOpenBasedirAllowlist();
 
 	const children = getCurrentPhpProcesses();
 	if ( children.length === 0 && ! phpProxyServer ) {

--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -292,7 +292,7 @@ function startSymlinkWatcher( sitePath: string ): void {
 // Rescans the site and replaces the scanned half of the allowlist, so targets that
 // disappeared while the watcher was dead drop out instead of accumulating for the
 // life of the server. Safe as a wholesale replacement because the scan covers a
-// superset of what the watcher reports (see SYMLINK_SCAN_DEPTH).
+// superset of what the watcher reports.
 //
 // Only new grants justify a restart: without them PHP is being denied access it
 // should have. A list that merely shrank is an over-grant, and restarting to


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-2038

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

I used Claude to iterate in relatively small chunks towards a result I liked. I used Codex to review the result.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

In https://github.com/Automattic/studio/issues/4173, @Tropicalista reported an issue where native PHP sites with "site directory" file access would fail to start and report an `ENAMETOOLONG` error.

`ENAMETOOLONG` errors indicate that the CLI command was too long for the OS to handle (there is such a limit). We don't know what exactly made the command so long, but our best theory is that it's the `open_basedir` directive, which is passed as a CLI option. It could have happened if there was a pnpm-style `node_modules` directory anywhere in the site directory, for example (since this means there can be hundreds of symlink paths in the `open_basedir` directive). 

This PR fixes the problem by applying the following changes:

1. Ignore `node_modules`, `.git`, and `.DS_Store` paths in `findSymlinksInDir()`. Previously, we only ignored those paths when watching for new symlinks. If a pnpm-style `node_modules` dir is the source of the problem, then this is the key fix.
2. If the `open_basedir` list contains `/lorem/ipsum` and `/lorem/ipsum/dolor`, `/lorem/ipsum/dolor` is now dropped before passing the list to PHP (because it is redundant). This change also ensures that newly added symlinks pointing to an already allowed directory don't trigger a process restart.

The next logical step would be to put the `open_basedir` directive in a site-specific `php.ini` file. I'll leave that for another PR, though.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Download a WordPress plugin like [performance-lab](https://wordpress.org/plugins/performance-lab/) and unzip it
2. Have a Studio site
3. Start that site
4. `cd` into `wp-content/plugins` for that site
5. `ln -s PATH_TO_DOWNLOADED_EXTRACTED_PLUGIN_DIR`
6. Open wp-admin
7. Click `Plugins` in the sidebar
8. Ensure that the plugin (Performance Lab in my example) is available to activate

This routine ensures that basic symlink watcher functionality and `open_basedir` compilation still work as expected. It does not test the `ENAMETOOLONG` error specifically, as we don't know exactly how to reproduce that.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
