### PR TITLE
Agentic UI: Remove button for editing WP.com profile

### DIFF
--- a/apps/ui/src/components/settings-view/account-section.test.tsx
+++ b/apps/ui/src/components/settings-view/account-section.test.tsx
@@ -120,22 +120,6 @@ describe( 'AccountSection', () => {
 		expect( loginMutate ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'opens the WordPress.com profile through the connector', () => {
-		render( <AccountSection /> );
-
-		fireEvent.click( screen.getByRole( 'button', { name: 'Edit WordPress.com profile' } ) );
-
-		expect( openExternalUrl ).toHaveBeenCalledWith( 'https://wordpress.com/me' );
-	} );
-
-	it( 'disables the profile link when offline', () => {
-		useOfflineMock.mockReturnValue( true );
-
-		render( <AccountSection /> );
-
-		expect( screen.getByRole( 'button', { name: 'Edit WordPress.com profile' } ) ).toBeDisabled();
-	} );
-
 	it( 'disables the login button when offline', () => {
 		useAuthUserMock.mockReturnValue( { data: null, isLoading: false } as never );
 		useOfflineMock.mockReturnValue( true );

--- a/apps/ui/src/components/settings-view/account-section.tsx
+++ b/apps/ui/src/components/settings-view/account-section.tsx
@@ -10,8 +10,6 @@ import { useOffline } from '@/hooks/use-offline';
 import { getLocalizedLink, REPORT_ISSUE_URL } from '@/lib/docs-links';
 import styles from './style.module.css';
 
-const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
-
 function AccountHelpActions() {
 	const connector = useConnector();
 	const locale = useUserLocale();
@@ -63,7 +61,6 @@ function AccountHelpActions() {
 }
 
 export function AccountSection() {
-	const connector = useConnector();
 	const { data: user, isLoading } = useAuthUser();
 	const login = useLogin();
 	const logout = useLogout();
@@ -98,15 +95,6 @@ export function AccountSection() {
 				</div>
 				{ user ? (
 					<div className={ styles.accountButtons }>
-						<Button
-							type="button"
-							variant="minimal"
-							tone="neutral"
-							disabled={ isOffline }
-							onClick={ () => void connector.openExternalUrl( WPCOM_PROFILE_URL ) }
-						>
-							{ __( 'Edit WordPress.com profile' ) }
-						</Button>
 						<Button
 							type="button"
 							variant="outline"


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-2186

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->
It was used to remove the button


## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

This PR removes the `Edit WordPress.com profile` button from the `Settings` section in the agentic UI.

**Before**

<img width="766" height="193" alt="Screenshot 2026-08-04 at 3 46 32 PM" src="https://github.com/user-attachments/assets/36feaa39-9007-4b6e-8c59-651067621c3c" />

**After**

<img width="786" height="167" alt="Screenshot 2026-08-04 at 3 59 55 PM" src="https://github.com/user-attachments/assets/ee2263c0-3590-4d38-865e-a440fe42debd" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* In the agentic UI, navigate to the `Settings` section
* Observe that there is no `Edit WordPress.com profile` button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
