### PR TITLE
Tracks: add settings & appearance change events

### DIFF
--- a/apps/studio/src/components/agentic-ui-banner/index.tsx
+++ b/apps/studio/src/components/agentic-ui-banner/index.tsx
@@ -90,7 +90,7 @@ export function AgenticUiBanner( { onDismiss }: AgenticUiBannerProps ) {
 					</p>
 					<Button
 						variant="primary"
-						onClick={ () => getIpcApi().enableAgenticUi() }
+						onClick={ () => getIpcApi().enableAgenticUi( 'banner' ) }
 						className="mt-4 justify-center w-full pointer-events-auto"
 					>
 						{ __( 'Try it' ) }

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -104,6 +104,7 @@ import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import {
 	getBetaFeatures as getBetaFeaturesFromLib,
 	updateBetaFeature as updateBetaFeatureInLib,
+	type AgenticUiSurface,
 } from 'src/lib/beta-features';
 import {
 	bumpAggregatedUniqueStat,
@@ -1530,8 +1531,11 @@ export async function getBetaFeatures( _event: IpcMainInvokeEvent ): Promise< Be
 	return await getBetaFeaturesFromLib();
 }
 
-export async function enableAgenticUi( _event: IpcMainInvokeEvent ): Promise< void > {
-	await updateBetaFeatureInLib( 'enableAgenticUi', true );
+export async function enableAgenticUi(
+	_event: IpcMainInvokeEvent,
+	surface: AgenticUiSurface = 'settings'
+): Promise< void > {
+	await updateBetaFeatureInLib( 'enableAgenticUi', true, surface );
 	setAgenticUiEnabled( true );
 	const mainWindow = await getMainWindow();
 	if ( mainWindow && ! mainWindow.isDestroyed() ) {
@@ -1539,8 +1543,11 @@ export async function enableAgenticUi( _event: IpcMainInvokeEvent ): Promise< vo
 	}
 }
 
-export async function disableAgenticUi( _event: IpcMainInvokeEvent ): Promise< void > {
-	await updateBetaFeatureInLib( 'enableAgenticUi', false );
+export async function disableAgenticUi(
+	_event: IpcMainInvokeEvent,
+	surface: AgenticUiSurface = 'settings'
+): Promise< void > {
+	await updateBetaFeatureInLib( 'enableAgenticUi', false, surface );
 	setAgenticUiEnabled( false );
 	const mainWindow = await getMainWindow();
 	if ( mainWindow && ! mainWindow.isDestroyed() ) {

--- a/apps/studio/src/lib/beta-features.ts
+++ b/apps/studio/src/lib/beta-features.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
 import { lockAppdata, unlockAppdata, loadUserData, saveUserData } from 'src/storage/user-data';
 
 export interface BetaFeatureDefinition {
@@ -66,5 +67,12 @@ export async function updateBetaFeature(
 		await saveUserData( userData );
 	} finally {
 		await unlockAppdata();
+	}
+
+	if ( key === 'enableAgenticUi' ) {
+		await recordTracksEvent( TRACKS_EVENTS.SETTING_UI_CHANGE, {
+			type: value ? 'agentic' : 'classic',
+			surface: 'settings',
+		} );
 	}
 }

--- a/apps/studio/src/lib/beta-features.ts
+++ b/apps/studio/src/lib/beta-features.ts
@@ -52,9 +52,15 @@ export async function getBetaFeatures(): Promise< BetaFeatures > {
 	return buildBetaFeatures( userData.betaFeatures );
 }
 
+// Where a UI-mode switch was triggered from. Passed through to the Tracks event so we can tell the
+// Settings toggle from the "Try it" banner and the app menu. Omitted for non-user writes (e.g. the
+// boot-time migration), which must not emit an event.
+export type AgenticUiSurface = 'settings' | 'banner' | 'menu';
+
 export async function updateBetaFeature(
 	key: keyof BetaFeatures,
-	value: boolean
+	value: boolean,
+	surface?: AgenticUiSurface
 ): Promise< void > {
 	try {
 		await lockAppdata();
@@ -69,10 +75,10 @@ export async function updateBetaFeature(
 		await unlockAppdata();
 	}
 
-	if ( key === 'enableAgenticUi' ) {
+	if ( key === 'enableAgenticUi' && surface ) {
 		await recordTracksEvent( TRACKS_EVENTS.SETTING_UI_CHANGE, {
 			type: value ? 'agentic' : 'classic',
-			surface: 'settings',
+			surface,
 		} );
 	}
 }

--- a/apps/studio/src/lib/tests/beta-features.test.ts
+++ b/apps/studio/src/lib/tests/beta-features.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment node
+ */
+import { vi } from 'vitest';
+import { updateBetaFeature } from 'src/lib/beta-features';
+import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
+import { loadUserData } from 'src/storage/user-data';
+
+vi.mock( 'src/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('src/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
+vi.mock( 'src/storage/user-data', () => ( {
+	lockAppdata: vi.fn(),
+	unlockAppdata: vi.fn(),
+	loadUserData: vi.fn( async () => ( {} ) ),
+	saveUserData: vi.fn(),
+} ) );
+
+const mockRecord = vi.mocked( recordTracksEvent );
+const mockLoadUserData = vi.mocked( loadUserData );
+
+beforeEach( () => {
+	vi.clearAllMocks();
+	mockLoadUserData.mockResolvedValue( {} as Awaited< ReturnType< typeof loadUserData > > );
+} );
+
+it( 'emits studio_setting_ui_change with type "agentic" when enabling the agentic UI', async () => {
+	await updateBetaFeature( 'enableAgenticUi', true );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_UI_CHANGE, {
+		type: 'agentic',
+		surface: 'settings',
+	} );
+} );
+
+it( 'emits studio_setting_ui_change with type "classic" when disabling the agentic UI', async () => {
+	await updateBetaFeature( 'enableAgenticUi', false );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_UI_CHANGE, {
+		type: 'classic',
+		surface: 'settings',
+	} );
+} );
+
+it( 'does not emit for other beta feature keys', async () => {
+	await updateBetaFeature( 'remoteSession', true );
+
+	expect( mockRecord ).not.toHaveBeenCalled();
+} );

--- a/apps/studio/src/lib/tests/beta-features.test.ts
+++ b/apps/studio/src/lib/tests/beta-features.test.ts
@@ -25,26 +25,32 @@ beforeEach( () => {
 	mockLoadUserData.mockResolvedValue( {} as Awaited< ReturnType< typeof loadUserData > > );
 } );
 
-it( 'emits studio_setting_ui_change with type "agentic" when enabling the agentic UI', async () => {
-	await updateBetaFeature( 'enableAgenticUi', true );
+it( 'emits studio_setting_ui_change with type "agentic" and the given surface when enabling the agentic UI', async () => {
+	await updateBetaFeature( 'enableAgenticUi', true, 'banner' );
 
 	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_UI_CHANGE, {
 		type: 'agentic',
-		surface: 'settings',
+		surface: 'banner',
 	} );
 } );
 
-it( 'emits studio_setting_ui_change with type "classic" when disabling the agentic UI', async () => {
-	await updateBetaFeature( 'enableAgenticUi', false );
+it( 'emits studio_setting_ui_change with type "classic" and the given surface when disabling the agentic UI', async () => {
+	await updateBetaFeature( 'enableAgenticUi', false, 'menu' );
 
 	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_UI_CHANGE, {
 		type: 'classic',
-		surface: 'settings',
+		surface: 'menu',
 	} );
 } );
 
+it( 'does not emit when no surface is given (e.g. the boot-time migration)', async () => {
+	await updateBetaFeature( 'enableAgenticUi', true );
+
+	expect( mockRecord ).not.toHaveBeenCalled();
+} );
+
 it( 'does not emit for other beta feature keys', async () => {
-	await updateBetaFeature( 'remoteSession', true );
+	await updateBetaFeature( 'remoteSession', true, 'settings' );
 
 	expect( mockRecord ).not.toHaveBeenCalled();
 } );

--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -88,7 +88,11 @@ async function buildBetaFeaturesMenu(): Promise< MenuItemConstructorOptions[] > 
 				// Only use sublabel on macOS where it displays nicely
 				sublabel: process.platform === 'darwin' ? definition.description : undefined,
 				click: async ( menuItem: MenuItem ) => {
-					await updateBetaFeature( key as keyof BetaFeatures, menuItem.checked );
+					await updateBetaFeature(
+						key as keyof BetaFeatures,
+						menuItem.checked,
+						key === 'enableAgenticUi' ? 'menu' : undefined
+					);
 					if ( key === 'remoteSession' ) {
 						bumpStat(
 							menuItem.checked

--- a/apps/studio/src/modules/cli/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/cli/lib/ipc-handlers.ts
@@ -1,5 +1,6 @@
 import { dialog } from 'electron';
 import { __ } from '@wordpress/i18n';
+import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
 import { getMainWindow } from 'src/main-window';
 import { createLinuxCliInstallationManager } from 'src/modules/cli/lib/linux-installation-manager';
 import { createMacOSCliInstallationManager } from 'src/modules/cli/lib/macos-installation-manager';
@@ -56,6 +57,10 @@ export async function installStudioCli(): Promise< void > {
 
 	const manager = getCliInstallationManager();
 	await manager.installCliWithConfirmation();
+	await recordTracksEvent( TRACKS_EVENTS.SETTING_CLI_CHANGE, {
+		installed: true,
+		surface: 'settings',
+	} );
 }
 
 export async function uninstallStudioCli(): Promise< void > {
@@ -76,4 +81,8 @@ export async function uninstallStudioCli(): Promise< void > {
 
 	const manager = getCliInstallationManager();
 	await manager.uninstallCliWithConfirmation();
+	await recordTracksEvent( TRACKS_EVENTS.SETTING_CLI_CHANGE, {
+		installed: false,
+		surface: 'settings',
+	} );
 }

--- a/apps/studio/src/modules/cli/lib/tests/cli-tracks.test.ts
+++ b/apps/studio/src/modules/cli/lib/tests/cli-tracks.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment node
+ */
+import { vi } from 'vitest';
+import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
+
+const installCliWithConfirmation = vi.fn();
+const uninstallCliWithConfirmation = vi.fn();
+
+vi.mock( 'src/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('src/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
+vi.mock( 'src/modules/cli/lib/macos-installation-manager', () => ( {
+	createMacOSCliInstallationManager: () => ( {
+		isCliInstalled: vi.fn(),
+		isCliExternallyManaged: vi.fn(),
+		installCliWithConfirmation,
+		uninstallCliWithConfirmation,
+	} ),
+} ) );
+vi.mock( 'src/modules/cli/lib/linux-installation-manager', () => ( {
+	createLinuxCliInstallationManager: vi.fn(),
+} ) );
+vi.mock( 'src/modules/cli/lib/windows-installation-manager', () => ( {
+	WindowsCliInstallationManager: vi.fn(),
+} ) );
+vi.mock( 'src/main-window', () => ( { getMainWindow: vi.fn() } ) );
+
+const mockRecord = vi.mocked( recordTracksEvent );
+
+let installStudioCli: typeof import('src/modules/cli/lib/ipc-handlers').installStudioCli;
+let uninstallStudioCli: typeof import('src/modules/cli/lib/ipc-handlers').uninstallStudioCli;
+
+beforeEach( async () => {
+	vi.clearAllMocks();
+	// The confirmation dialog is only shown outside production; skip it so the tests exercise
+	// the committed-install path directly.
+	vi.stubEnv( 'NODE_ENV', 'production' );
+	vi.stubGlobal( 'process', { ...process, platform: 'darwin' } );
+	( { installStudioCli, uninstallStudioCli } = await import( 'src/modules/cli/lib/ipc-handlers' ) );
+} );
+
+afterEach( () => {
+	vi.unstubAllEnvs();
+	vi.unstubAllGlobals();
+} );
+
+it( 'emits studio_setting_cli_change with installed true after a confirmed install', async () => {
+	await installStudioCli();
+
+	expect( installCliWithConfirmation ).toHaveBeenCalled();
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_CLI_CHANGE, {
+		installed: true,
+		surface: 'settings',
+	} );
+} );
+
+it( 'emits studio_setting_cli_change with installed false after a confirmed uninstall', async () => {
+	await uninstallStudioCli();
+
+	expect( uninstallCliWithConfirmation ).toHaveBeenCalled();
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_CLI_CHANGE, {
+		installed: false,
+		surface: 'settings',
+	} );
+} );

--- a/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
@@ -64,7 +64,7 @@ function AgenticUiCallout() {
 						) }
 					</p>
 				</div>
-				<Button variant="primary" onClick={ () => getIpcApi().enableAgenticUi() }>
+				<Button variant="primary" onClick={ () => getIpcApi().enableAgenticUi( 'settings' ) }>
 					{ __( 'Try it' ) }
 				</Button>
 			</div>

--- a/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
@@ -45,6 +45,10 @@ export async function saveUserTerminal(
 ) {
 	await sendIpcEventToRenderer( 'user-preference-changed' );
 	await updateAppdata( { preferredTerminal } );
+	await recordTracksEvent( TRACKS_EVENTS.SETTING_TERMINAL_CHANGE, {
+		terminal: preferredTerminal,
+		surface: 'settings',
+	} );
 }
 
 export async function getUserTerminal() {
@@ -54,6 +58,10 @@ export async function getUserTerminal() {
 
 export async function saveUserLocale( event: IpcMainInvokeEvent, locale: string ) {
 	await updateSharedConfig( { locale } );
+	await recordTracksEvent( TRACKS_EVENTS.SETTING_LANGUAGE_CHANGE, {
+		locale,
+		surface: 'settings',
+	} );
 }
 
 export async function saveUserEditor( event: IpcMainInvokeEvent, editor: SupportedEditor ) {
@@ -61,6 +69,10 @@ export async function saveUserEditor( event: IpcMainInvokeEvent, editor: Support
 	sendIpcEventToRendererWithWindow( parentWindow, 'user-preference-changed' );
 
 	await updateAppdata( { preferredEditor: editor } );
+	await recordTracksEvent( TRACKS_EVENTS.SETTING_CODE_EDITOR_CHANGE, {
+		editor,
+		surface: 'settings',
+	} );
 }
 
 export async function getDefaultSiteDirectory(): Promise< string > {
@@ -72,6 +84,10 @@ export async function saveDefaultSiteDirectory( event: IpcMainInvokeEvent, direc
 	await ensureWritableDirectory( directory );
 	await sendIpcEventToRenderer( 'user-preference-changed' );
 	await updateAppdata( { defaultSiteDirectory: directory } );
+	await recordTracksEvent( TRACKS_EVENTS.SETTING_DEFAULT_DIRECTORY_CHANGE, {
+		is_default: directory === defaultSitePath,
+		surface: 'settings',
+	} );
 }
 
 export async function getUserLocale() {
@@ -105,6 +121,10 @@ export async function saveColorScheme(
 ) {
 	nativeTheme.themeSource = colorScheme;
 	await updateAppdata( { colorScheme } );
+	await recordTracksEvent( TRACKS_EVENTS.SETTING_APPEARANCE_CHANGE, {
+		mode: colorScheme,
+		surface: 'settings',
+	} );
 }
 
 export async function getColorScheme(): Promise< 'system' | 'light' | 'dark' > {
@@ -152,6 +172,12 @@ export async function saveQuitSitesBehavior(
 	quitSitesBehavior: QuitSitesBehavior | undefined
 ) {
 	await updateAppdata( { quitSitesBehavior } );
+	if ( quitSitesBehavior ) {
+		await recordTracksEvent( TRACKS_EVENTS.SETTING_QUIT_ACTION_CHANGE, {
+			behavior: quitSitesBehavior,
+			surface: 'settings',
+		} );
+	}
 }
 
 export async function getQuitSitesBehavior(): Promise< QuitSitesBehavior | undefined > {
@@ -164,6 +190,10 @@ export async function saveAgenticFeaturesEnabled(
 	enabled: boolean
 ): Promise< void > {
 	await updateAppdata( { agenticFeaturesEnabled: enabled } );
+	await recordTracksEvent( TRACKS_EVENTS.SETTING_AGENTIC_FEATURES_CHANGE, {
+		enabled,
+		surface: 'settings',
+	} );
 }
 
 export async function getAgenticFeaturesEnabled(): Promise< boolean > {

--- a/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
@@ -3,7 +3,11 @@ import {
 	readGlobalInstructionsFile,
 	writeGlobalInstructions,
 } from '@studio/common/ai/global-instructions';
-import { isAnalyticsOptedOut, updateSharedConfig } from '@studio/common/lib/shared-config';
+import {
+	isAnalyticsOptedOut,
+	readSharedConfig,
+	updateSharedConfig,
+} from '@studio/common/lib/shared-config';
 import { DEFAULT_TERMINAL } from 'src/constants';
 import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { isInstalled } from 'src/lib/is-installed';
@@ -43,12 +47,15 @@ export async function saveUserTerminal(
 	event: IpcMainInvokeEvent,
 	preferredTerminal: SupportedTerminal
 ) {
+	const previous = ( await loadUserData() ).preferredTerminal || DEFAULT_TERMINAL;
 	await sendIpcEventToRenderer( 'user-preference-changed' );
 	await updateAppdata( { preferredTerminal } );
-	await recordTracksEvent( TRACKS_EVENTS.SETTING_TERMINAL_CHANGE, {
-		terminal: preferredTerminal,
-		surface: 'settings',
-	} );
+	if ( preferredTerminal !== previous ) {
+		await recordTracksEvent( TRACKS_EVENTS.SETTING_TERMINAL_CHANGE, {
+			terminal: preferredTerminal,
+			surface: 'settings',
+		} );
+	}
 }
 
 export async function getUserTerminal() {
@@ -57,22 +64,28 @@ export async function getUserTerminal() {
 }
 
 export async function saveUserLocale( event: IpcMainInvokeEvent, locale: string ) {
+	const previous = ( await readSharedConfig() ).locale;
 	await updateSharedConfig( { locale } );
-	await recordTracksEvent( TRACKS_EVENTS.SETTING_LANGUAGE_CHANGE, {
-		locale,
-		surface: 'settings',
-	} );
+	if ( locale !== previous ) {
+		await recordTracksEvent( TRACKS_EVENTS.SETTING_LANGUAGE_CHANGE, {
+			locale,
+			surface: 'settings',
+		} );
+	}
 }
 
 export async function saveUserEditor( event: IpcMainInvokeEvent, editor: SupportedEditor ) {
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	sendIpcEventToRendererWithWindow( parentWindow, 'user-preference-changed' );
 
+	const previous = ( await loadUserData() ).preferredEditor;
 	await updateAppdata( { preferredEditor: editor } );
-	await recordTracksEvent( TRACKS_EVENTS.SETTING_CODE_EDITOR_CHANGE, {
-		editor,
-		surface: 'settings',
-	} );
+	if ( editor !== previous ) {
+		await recordTracksEvent( TRACKS_EVENTS.SETTING_CODE_EDITOR_CHANGE, {
+			editor,
+			surface: 'settings',
+		} );
+	}
 }
 
 export async function getDefaultSiteDirectory(): Promise< string > {
@@ -82,12 +95,15 @@ export async function getDefaultSiteDirectory(): Promise< string > {
 
 export async function saveDefaultSiteDirectory( event: IpcMainInvokeEvent, directory: string ) {
 	await ensureWritableDirectory( directory );
+	const previous = ( await loadUserData() ).defaultSiteDirectory || defaultSitePath;
 	await sendIpcEventToRenderer( 'user-preference-changed' );
 	await updateAppdata( { defaultSiteDirectory: directory } );
-	await recordTracksEvent( TRACKS_EVENTS.SETTING_DEFAULT_DIRECTORY_CHANGE, {
-		is_default: directory === defaultSitePath,
-		surface: 'settings',
-	} );
+	if ( directory !== previous ) {
+		await recordTracksEvent( TRACKS_EVENTS.SETTING_DEFAULT_DIRECTORY_CHANGE, {
+			is_default: directory === defaultSitePath,
+			surface: 'settings',
+		} );
+	}
 }
 
 export async function getUserLocale() {
@@ -119,12 +135,15 @@ export async function saveColorScheme(
 	event: IpcMainInvokeEvent,
 	colorScheme: 'system' | 'light' | 'dark'
 ) {
+	const previous = ( await loadUserData() ).colorScheme ?? 'light';
 	nativeTheme.themeSource = colorScheme;
 	await updateAppdata( { colorScheme } );
-	await recordTracksEvent( TRACKS_EVENTS.SETTING_APPEARANCE_CHANGE, {
-		mode: colorScheme,
-		surface: 'settings',
-	} );
+	if ( colorScheme !== previous ) {
+		await recordTracksEvent( TRACKS_EVENTS.SETTING_APPEARANCE_CHANGE, {
+			mode: colorScheme,
+			surface: 'settings',
+		} );
+	}
 }
 
 export async function getColorScheme(): Promise< 'system' | 'light' | 'dark' > {
@@ -171,8 +190,9 @@ export async function saveQuitSitesBehavior(
 	_event: IpcMainInvokeEvent,
 	quitSitesBehavior: QuitSitesBehavior | undefined
 ) {
+	const previous = ( await loadUserData() ).quitSitesBehavior;
 	await updateAppdata( { quitSitesBehavior } );
-	if ( quitSitesBehavior ) {
+	if ( quitSitesBehavior && quitSitesBehavior !== previous ) {
 		await recordTracksEvent( TRACKS_EVENTS.SETTING_QUIT_ACTION_CHANGE, {
 			behavior: quitSitesBehavior,
 			surface: 'settings',
@@ -189,11 +209,14 @@ export async function saveAgenticFeaturesEnabled(
 	_event: IpcMainInvokeEvent,
 	enabled: boolean
 ): Promise< void > {
+	const previous = ( await loadUserData() ).agenticFeaturesEnabled ?? true;
 	await updateAppdata( { agenticFeaturesEnabled: enabled } );
-	await recordTracksEvent( TRACKS_EVENTS.SETTING_AGENTIC_FEATURES_CHANGE, {
-		enabled,
-		surface: 'settings',
-	} );
+	if ( enabled !== previous ) {
+		await recordTracksEvent( TRACKS_EVENTS.SETTING_AGENTIC_FEATURES_CHANGE, {
+			enabled,
+			surface: 'settings',
+		} );
+	}
 }
 
 export async function getAgenticFeaturesEnabled(): Promise< boolean > {

--- a/apps/studio/src/modules/user-settings/lib/tests/settings-tracks.test.ts
+++ b/apps/studio/src/modules/user-settings/lib/tests/settings-tracks.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @vitest-environment node
+ */
+import { IpcMainInvokeEvent } from 'electron';
+import { updateSharedConfig } from '@studio/common/lib/shared-config';
+import { vi } from 'vitest';
+import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
+import {
+	saveColorScheme,
+	saveUserLocale,
+	saveUserEditor,
+	saveUserTerminal,
+	saveDefaultSiteDirectory,
+	saveQuitSitesBehavior,
+	saveAgenticFeaturesEnabled,
+} from 'src/modules/user-settings/lib/ipc-handlers';
+import { defaultSitePath } from 'src/storage/paths';
+import { updateAppdata } from 'src/storage/user-data';
+
+vi.mock( 'electron', () => ( {
+	BrowserWindow: { fromWebContents: vi.fn() },
+	nativeTheme: {},
+} ) );
+vi.mock( 'src/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('src/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
+vi.mock( '@studio/common/lib/shared-config', () => ( {
+	isAnalyticsOptedOut: vi.fn(),
+	updateSharedConfig: vi.fn(),
+} ) );
+vi.mock( 'src/storage/user-data', () => ( {
+	updateAppdata: vi.fn(),
+} ) );
+vi.mock( 'src/ipc-utils', () => ( {
+	sendIpcEventToRenderer: vi.fn(),
+	sendIpcEventToRendererWithWindow: vi.fn(),
+} ) );
+vi.mock( 'src/storage/paths', () => ( {
+	defaultSitePath: '/home/user/Studio',
+	ensureWritableDirectory: vi.fn(),
+} ) );
+
+const mockRecord = vi.mocked( recordTracksEvent );
+const event = {} as IpcMainInvokeEvent;
+
+beforeEach( () => {
+	vi.clearAllMocks();
+} );
+
+it( 'saveColorScheme emits studio_setting_appearance_change with mode + surface', async () => {
+	await saveColorScheme( event, 'dark' );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_APPEARANCE_CHANGE, {
+		mode: 'dark',
+		surface: 'settings',
+	} );
+	expect( updateAppdata ).toHaveBeenCalledWith( { colorScheme: 'dark' } );
+} );
+
+it( 'saveUserLocale emits studio_setting_language_change with locale + surface', async () => {
+	await saveUserLocale( event, 'fr' );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_LANGUAGE_CHANGE, {
+		locale: 'fr',
+		surface: 'settings',
+	} );
+	expect( updateSharedConfig ).toHaveBeenCalledWith( { locale: 'fr' } );
+} );
+
+it( 'saveUserEditor emits studio_setting_code_editor_change with editor + surface', async () => {
+	await saveUserEditor( event, 'vscode' );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_CODE_EDITOR_CHANGE, {
+		editor: 'vscode',
+		surface: 'settings',
+	} );
+} );
+
+it( 'saveUserTerminal emits studio_setting_terminal_change with terminal + surface', async () => {
+	await saveUserTerminal( event, 'iterm' );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_TERMINAL_CHANGE, {
+		terminal: 'iterm',
+		surface: 'settings',
+	} );
+} );
+
+it( 'saveDefaultSiteDirectory emits is_default true when the directory is the default path, and never the path itself', async () => {
+	await saveDefaultSiteDirectory( event, defaultSitePath );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_DEFAULT_DIRECTORY_CHANGE, {
+		is_default: true,
+		surface: 'settings',
+	} );
+	const props = mockRecord.mock.calls[ 0 ][ 1 ] as Record< string, unknown >;
+	expect( props ).not.toHaveProperty( 'directory' );
+	expect( JSON.stringify( props ) ).not.toContain( defaultSitePath );
+} );
+
+it( 'saveDefaultSiteDirectory emits is_default false for a custom directory', async () => {
+	await saveDefaultSiteDirectory( event, '/home/user/Elsewhere' );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_DEFAULT_DIRECTORY_CHANGE, {
+		is_default: false,
+		surface: 'settings',
+	} );
+} );
+
+it( 'saveQuitSitesBehavior emits studio_setting_quit_action_change with behavior + surface', async () => {
+	await saveQuitSitesBehavior( event, 'leave-running' );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_QUIT_ACTION_CHANGE, {
+		behavior: 'leave-running',
+		surface: 'settings',
+	} );
+} );
+
+it( 'saveQuitSitesBehavior does not emit when the behavior is cleared', async () => {
+	await saveQuitSitesBehavior( event, undefined );
+
+	expect( mockRecord ).not.toHaveBeenCalled();
+	expect( updateAppdata ).toHaveBeenCalledWith( { quitSitesBehavior: undefined } );
+} );
+
+it( 'saveAgenticFeaturesEnabled emits studio_setting_agentic_features_change with enabled + surface', async () => {
+	await saveAgenticFeaturesEnabled( event, false );
+
+	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_AGENTIC_FEATURES_CHANGE, {
+		enabled: false,
+		surface: 'settings',
+	} );
+} );

--- a/apps/studio/src/modules/user-settings/lib/tests/settings-tracks.test.ts
+++ b/apps/studio/src/modules/user-settings/lib/tests/settings-tracks.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 import { IpcMainInvokeEvent } from 'electron';
-import { updateSharedConfig } from '@studio/common/lib/shared-config';
+import { readSharedConfig, updateSharedConfig } from '@studio/common/lib/shared-config';
 import { vi } from 'vitest';
 import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
 import {
@@ -15,7 +15,7 @@ import {
 	saveAgenticFeaturesEnabled,
 } from 'src/modules/user-settings/lib/ipc-handlers';
 import { defaultSitePath } from 'src/storage/paths';
-import { updateAppdata } from 'src/storage/user-data';
+import { loadUserData, updateAppdata } from 'src/storage/user-data';
 
 vi.mock( 'electron', () => ( {
 	BrowserWindow: { fromWebContents: vi.fn() },
@@ -27,9 +27,11 @@ vi.mock( 'src/lib/tracks', async ( importActual ) => {
 } );
 vi.mock( '@studio/common/lib/shared-config', () => ( {
 	isAnalyticsOptedOut: vi.fn(),
+	readSharedConfig: vi.fn(),
 	updateSharedConfig: vi.fn(),
 } ) );
 vi.mock( 'src/storage/user-data', () => ( {
+	loadUserData: vi.fn(),
 	updateAppdata: vi.fn(),
 } ) );
 vi.mock( 'src/ipc-utils', () => ( {
@@ -42,13 +44,31 @@ vi.mock( 'src/storage/paths', () => ( {
 } ) );
 
 const mockRecord = vi.mocked( recordTracksEvent );
+const mockLoadUserData = vi.mocked( loadUserData );
+const mockReadSharedConfig = vi.mocked( readSharedConfig );
 const event = {} as IpcMainInvokeEvent;
+
+// The persisted appdata / shared-config the handler reads to detect a real change.
+function setPersisted( userData: Record< string, unknown > = {} ) {
+	mockLoadUserData.mockResolvedValue(
+		userData as unknown as Awaited< ReturnType< typeof loadUserData > >
+	);
+}
+function setPersistedLocale( locale?: string ) {
+	mockReadSharedConfig.mockResolvedValue( {
+		locale,
+	} as unknown as Awaited< ReturnType< typeof readSharedConfig > > );
+}
 
 beforeEach( () => {
 	vi.clearAllMocks();
+	setPersisted();
+	setPersistedLocale();
 } );
 
-it( 'saveColorScheme emits studio_setting_appearance_change with mode + surface', async () => {
+it( 'saveColorScheme emits studio_setting_appearance_change with mode + surface when the mode changes', async () => {
+	setPersisted( { colorScheme: 'light' } );
+
 	await saveColorScheme( event, 'dark' );
 
 	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_APPEARANCE_CHANGE, {
@@ -58,7 +78,18 @@ it( 'saveColorScheme emits studio_setting_appearance_change with mode + surface'
 	expect( updateAppdata ).toHaveBeenCalledWith( { colorScheme: 'dark' } );
 } );
 
-it( 'saveUserLocale emits studio_setting_language_change with locale + surface', async () => {
+it( 'saveColorScheme does not emit when the mode is unchanged (persisted default is light)', async () => {
+	setPersisted( {} );
+
+	await saveColorScheme( event, 'light' );
+
+	expect( mockRecord ).not.toHaveBeenCalled();
+	expect( updateAppdata ).toHaveBeenCalledWith( { colorScheme: 'light' } );
+} );
+
+it( 'saveUserLocale emits studio_setting_language_change with locale + surface when the locale changes', async () => {
+	setPersistedLocale( 'en' );
+
 	await saveUserLocale( event, 'fr' );
 
 	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_LANGUAGE_CHANGE, {
@@ -68,7 +99,18 @@ it( 'saveUserLocale emits studio_setting_language_change with locale + surface',
 	expect( updateSharedConfig ).toHaveBeenCalledWith( { locale: 'fr' } );
 } );
 
-it( 'saveUserEditor emits studio_setting_code_editor_change with editor + surface', async () => {
+it( 'saveUserLocale does not emit when the locale is unchanged', async () => {
+	setPersistedLocale( 'pl' );
+
+	await saveUserLocale( event, 'pl' );
+
+	expect( mockRecord ).not.toHaveBeenCalled();
+	expect( updateSharedConfig ).toHaveBeenCalledWith( { locale: 'pl' } );
+} );
+
+it( 'saveUserEditor emits studio_setting_code_editor_change with editor + surface when the editor changes', async () => {
+	setPersisted( { preferredEditor: 'cursor' } );
+
 	await saveUserEditor( event, 'vscode' );
 
 	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_CODE_EDITOR_CHANGE, {
@@ -77,7 +119,17 @@ it( 'saveUserEditor emits studio_setting_code_editor_change with editor + surfac
 	} );
 } );
 
-it( 'saveUserTerminal emits studio_setting_terminal_change with terminal + surface', async () => {
+it( 'saveUserEditor does not emit when the editor is unchanged', async () => {
+	setPersisted( { preferredEditor: 'vscode' } );
+
+	await saveUserEditor( event, 'vscode' );
+
+	expect( mockRecord ).not.toHaveBeenCalled();
+} );
+
+it( 'saveUserTerminal emits studio_setting_terminal_change with terminal + surface when the terminal changes', async () => {
+	setPersisted( { preferredTerminal: 'terminal' } );
+
 	await saveUserTerminal( event, 'iterm' );
 
 	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_TERMINAL_CHANGE, {
@@ -86,7 +138,17 @@ it( 'saveUserTerminal emits studio_setting_terminal_change with terminal + surfa
 	} );
 } );
 
-it( 'saveDefaultSiteDirectory emits is_default true when the directory is the default path, and never the path itself', async () => {
+it( 'saveUserTerminal does not emit when the terminal is unchanged', async () => {
+	setPersisted( { preferredTerminal: 'iterm' } );
+
+	await saveUserTerminal( event, 'iterm' );
+
+	expect( mockRecord ).not.toHaveBeenCalled();
+} );
+
+it( 'saveDefaultSiteDirectory emits is_default true when set to the default path, and never the path itself', async () => {
+	setPersisted( { defaultSiteDirectory: '/home/user/Elsewhere' } );
+
 	await saveDefaultSiteDirectory( event, defaultSitePath );
 
 	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_DEFAULT_DIRECTORY_CHANGE, {
@@ -99,6 +161,8 @@ it( 'saveDefaultSiteDirectory emits is_default true when the directory is the de
 } );
 
 it( 'saveDefaultSiteDirectory emits is_default false for a custom directory', async () => {
+	setPersisted( { defaultSiteDirectory: defaultSitePath } );
+
 	await saveDefaultSiteDirectory( event, '/home/user/Elsewhere' );
 
 	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_DEFAULT_DIRECTORY_CHANGE, {
@@ -107,13 +171,31 @@ it( 'saveDefaultSiteDirectory emits is_default false for a custom directory', as
 	} );
 } );
 
-it( 'saveQuitSitesBehavior emits studio_setting_quit_action_change with behavior + surface', async () => {
+it( 'saveDefaultSiteDirectory does not emit when the directory is unchanged', async () => {
+	setPersisted( { defaultSiteDirectory: '/home/user/Elsewhere' } );
+
+	await saveDefaultSiteDirectory( event, '/home/user/Elsewhere' );
+
+	expect( mockRecord ).not.toHaveBeenCalled();
+} );
+
+it( 'saveQuitSitesBehavior emits studio_setting_quit_action_change with behavior + surface when it changes', async () => {
+	setPersisted( { quitSitesBehavior: 'stop' } );
+
 	await saveQuitSitesBehavior( event, 'leave-running' );
 
 	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_QUIT_ACTION_CHANGE, {
 		behavior: 'leave-running',
 		surface: 'settings',
 	} );
+} );
+
+it( 'saveQuitSitesBehavior does not emit when the behavior is unchanged', async () => {
+	setPersisted( { quitSitesBehavior: 'leave-running' } );
+
+	await saveQuitSitesBehavior( event, 'leave-running' );
+
+	expect( mockRecord ).not.toHaveBeenCalled();
 } );
 
 it( 'saveQuitSitesBehavior does not emit when the behavior is cleared', async () => {
@@ -123,11 +205,21 @@ it( 'saveQuitSitesBehavior does not emit when the behavior is cleared', async ()
 	expect( updateAppdata ).toHaveBeenCalledWith( { quitSitesBehavior: undefined } );
 } );
 
-it( 'saveAgenticFeaturesEnabled emits studio_setting_agentic_features_change with enabled + surface', async () => {
+it( 'saveAgenticFeaturesEnabled emits studio_setting_agentic_features_change with enabled + surface when it changes', async () => {
+	setPersisted( { agenticFeaturesEnabled: true } );
+
 	await saveAgenticFeaturesEnabled( event, false );
 
 	expect( mockRecord ).toHaveBeenCalledWith( TRACKS_EVENTS.SETTING_AGENTIC_FEATURES_CHANGE, {
 		enabled: false,
 		surface: 'settings',
 	} );
+} );
+
+it( 'saveAgenticFeaturesEnabled does not emit when unchanged (persisted default is true)', async () => {
+	setPersisted( {} );
+
+	await saveAgenticFeaturesEnabled( event, true );
+
+	expect( mockRecord ).not.toHaveBeenCalled();
 } );

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -4,6 +4,7 @@
 import '@sentry/electron/preload';
 import { IpcRendererEvent, contextBridge, ipcRenderer, webUtils } from 'electron';
 import { IpcEvents } from 'src/ipc-utils';
+import type { AgenticUiSurface } from 'src/lib/beta-features';
 
 function ipcRendererInvoke< T extends keyof IpcHandlers >(
 	channel: T,
@@ -88,8 +89,10 @@ const api: IpcApi = {
 	stopAllServers: () => ipcRendererInvoke( 'stopAllServers' ),
 	copyText: ( text ) => ipcRendererInvoke( 'copyText', text ),
 	getAppGlobals: () => ipcRendererInvoke( 'getAppGlobals' ),
-	enableAgenticUi: () => ipcRendererInvoke( 'enableAgenticUi' ),
-	disableAgenticUi: () => ipcRendererInvoke( 'disableAgenticUi' ),
+	enableAgenticUi: ( surface?: AgenticUiSurface ) =>
+		ipcRendererInvoke( 'enableAgenticUi', surface ),
+	disableAgenticUi: ( surface?: AgenticUiSurface ) =>
+		ipcRendererInvoke( 'disableAgenticUi', surface ),
 	dismissAgenticUiBanner: () => ipcRendererInvoke( 'dismissAgenticUiBanner' ),
 	isAgenticUiBannerDismissed: () => ipcRendererInvoke( 'isAgenticUiBannerDismissed' ),
 	getAppUpdateStatus: () => ipcRendererInvoke( 'getAppUpdateStatus' ),

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -156,6 +156,15 @@ events). The table lists the event-specific props.
 | `studio_app_launch` | Desktop Main (`appBoot`) | `is_first_launch` |
 | `studio_site_start` | CLI site-start funnel | (none — `ui_version` comes from the wrapper via `STUDIO_TRACKS_ORIGIN`, only when `channel=studio-ui`) |
 | `studio_setting_telemetry_change` | Desktop Main (`saveAnalyticsEnabled`) | `status` (`on`/`off`), `surface` (`onboarding`/`settings`) — recorded while analytics is still ON (before the write when turning off, after it when turning on) so the opt-out gate never self-suppresses it. |
+| `studio_setting_appearance_change` | Desktop Main (`saveColorScheme`) | `mode` (`light`/`dark`/`system`), `surface` (`settings`) |
+| `studio_setting_language_change` | Desktop Main (`saveUserLocale`) | `locale`, `surface` (`settings`) |
+| `studio_setting_code_editor_change` | Desktop Main (`saveUserEditor`) | `editor`, `surface` (`settings`) |
+| `studio_setting_terminal_change` | Desktop Main (`saveUserTerminal`) | `terminal`, `surface` (`settings`) |
+| `studio_setting_default_directory_change` | Desktop Main (`saveDefaultSiteDirectory`) | `is_default` (boolean), `surface` (`settings`) — the directory path is **never** sent (it contains the user's home path). |
+| `studio_setting_quit_action_change` | Desktop Main (`saveQuitSitesBehavior`) | `behavior` (`stop`/`stop-and-auto-start`/`leave-running`), `surface` (`settings`) |
+| `studio_setting_cli_change` | Desktop Main (`installStudioCli`/`uninstallStudioCli`) | `installed` (boolean), `surface` (`settings`) |
+| `studio_setting_agentic_features_change` | Desktop Main (`saveAgenticFeaturesEnabled`) | `enabled` (boolean), `surface` (`settings`) |
+| `studio_setting_ui_change` | Desktop Main (`updateBetaFeature`, `enableAgenticUi` key) | `type` (`classic`/`agentic`), `surface` (`settings`) |
 
 ### How to add a new event
 

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -164,7 +164,7 @@ events). The table lists the event-specific props.
 | `studio_setting_quit_action_change` | Desktop Main (`saveQuitSitesBehavior`) | `behavior` (`stop`/`stop-and-auto-start`/`leave-running`), `surface` (`settings`) |
 | `studio_setting_cli_change` | Desktop Main (`installStudioCli`/`uninstallStudioCli`) | `installed` (boolean), `surface` (`settings`) |
 | `studio_setting_agentic_features_change` | Desktop Main (`saveAgenticFeaturesEnabled`) | `enabled` (boolean), `surface` (`settings`) |
-| `studio_setting_ui_change` | Desktop Main (`updateBetaFeature`, `enableAgenticUi` key) | `type` (`classic`/`agentic`), `surface` (`settings`) |
+| `studio_setting_ui_change` | Desktop Main (`updateBetaFeature`, `enableAgenticUi` key) | `type` (`classic`/`agentic`), `surface` (`settings`/`banner`/`menu`) — the switch has several entry points; the caller supplies the surface. Not emitted for the boot-time seeding migration (no surface). |
 
 ### How to add a new event
 

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -11,6 +11,15 @@ export const TRACKS_EVENTS = {
 	APP_LAUNCH: 'studio_app_launch',
 	SITE_START: 'studio_site_start',
 	SETTING_TELEMETRY_CHANGE: 'studio_setting_telemetry_change',
+	SETTING_APPEARANCE_CHANGE: 'studio_setting_appearance_change',
+	SETTING_LANGUAGE_CHANGE: 'studio_setting_language_change',
+	SETTING_CODE_EDITOR_CHANGE: 'studio_setting_code_editor_change',
+	SETTING_TERMINAL_CHANGE: 'studio_setting_terminal_change',
+	SETTING_DEFAULT_DIRECTORY_CHANGE: 'studio_setting_default_directory_change',
+	SETTING_QUIT_ACTION_CHANGE: 'studio_setting_quit_action_change',
+	SETTING_CLI_CHANGE: 'studio_setting_cli_change',
+	SETTING_AGENTIC_FEATURES_CHANGE: 'studio_setting_agentic_features_change',
+	SETTING_UI_CHANGE: 'studio_setting_ui_change',
 } as const;
 
 export type TracksEventName = ( typeof TRACKS_EVENTS )[ keyof typeof TRACKS_EVENTS ];


### PR DESCRIPTION
## Related issues

- Fixes STU-2121

## How AI was used in this PR

Claude Code explored the existing Tracks infrastructure, mapped each setting's Main-process persist point, wrote the emits, unit tests, and docs, and verified every event fires with correct props via a dev run. I reviewed the code and confirmed the runtime output for all nine events myself, and iterated with Claude to fix bugs.

## Proposed Changes

Adds Tracks analytics for user-preference changes in the Settings surfaces, so we can understand which appearance, editor, terminal, language, quit-behavior, CLI, agentic-features, and UI-mode choices users actually make. Each event fires only when a change is committed and is suppressed when the user has opted out of analytics.

Following the naming already established by `studio_setting_telemetry_change`, every event uses the `studio_setting_<x>_change` form (this also satisfies the Tracks ingestion gate, which silently rejects names with fewer than three segments). All events carry a `surface: 'settings'` prop.

Privacy: the default-directory event sends only an `is_default` boolean — the directory path (which contains the user's home path) is never included.

Events added: `studio_setting_appearance_change`, `studio_setting_language_change`, `studio_setting_code_editor_change`, `studio_setting_terminal_change`, `studio_setting_default_directory_change`, `studio_setting_quit_action_change`, `studio_setting_cli_change`, `studio_setting_agentic_features_change`, `studio_setting_ui_change`.

> Note: server-side registration of these events and their eventprops via the Tracks Registration tool is a separate, out-of-band step (per the issue's Definition of Done) and is not part of this PR.

## Testing Instructions

1. Start Studio: `npm start` (dev builds run with `NODE_ENV=development`, which logs events instead of sending them),
2. In the running app change each setting (Appearance, Language, Code editor, Terminal, Default directory, Quit action, Studio CLI toggle, Agentic features toggle, and the Classic/Agentic UI switch from Settings, the "Try it" banner, and the app menu).
3. Each change logs a `Would have recorded Tracks event: studio_setting_*_change …` line in the main-process terminal with the expected props.
4. Confirm the default-directory event shows `is_default` and never the path, and that `studio_setting_ui_change` reports the right `surface` (`settings`/`banner`/`menu`) for each entry point. (Add `STUDIO_DEBUG_TRACKS=1` if you also want the raw `Tracks event URL: …` line printed.)

All nine events were verified this way (`mode`/`locale`/`editor`/`terminal`/`is_default`/`behavior`/`installed`/`enabled`/`type` respectively).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

