### PR TITLE
Send custom user agent header on Studio Code AI requests

### DIFF
--- a/apps/cli/ai/providers.ts
+++ b/apps/cli/ai/providers.ts
@@ -96,6 +96,11 @@ async function resolveAnthropicApiKey( options?: {
 	return apiKey;
 }
 
+function getStudioUserAgent(): string {
+	const version = typeof __STUDIO_CLI_VERSION__ === 'string' ? __STUDIO_CLI_VERSION__ : '';
+	return version ? `WordPressStudio/${ version }` : 'WordPressStudio';
+}
+
 function buildAnthropicCustomHeaders( headers: Record< string, string > ): string {
 	return Object.entries( headers )
 		.map( ( [ name, value ] ) => `${ name }: ${ value }` )
@@ -161,6 +166,7 @@ const AI_PROVIDER_DEFINITIONS: Record< AiProviderId, AiProviderDefinition > = {
 			env.ANTHROPIC_BASE_URL = gatewayBaseUrl;
 			env.ANTHROPIC_AUTH_TOKEN = accessToken;
 			const anthropicHeaders: Record< string, string > = {
+				'User-Agent': getStudioUserAgent(),
 				'X-WPCOM-AI-Feature': WPCOM_AI_FEATURE_HEADER_ANTHROPIC,
 			};
 			if ( options?.sessionId ) {
@@ -176,6 +182,7 @@ const AI_PROVIDER_DEFINITIONS: Record< AiProviderId, AiProviderDefinition > = {
 			env.OPENAI_BASE_URL = `${ gatewayBaseUrl.replace( /\/+$/, '' ) }/v1`;
 			env.OPENAI_API_KEY = accessToken;
 			const openaiHeaders: Record< string, string > = {
+				'User-Agent': getStudioUserAgent(),
 				'X-WPCOM-AI-Feature': WPCOM_AI_FEATURE_HEADER_OPENAI,
 			};
 			if ( options?.sessionId ) {

--- a/apps/cli/ai/tests/auth.test.ts
+++ b/apps/cli/ai/tests/auth.test.ts
@@ -28,8 +28,13 @@ vi.mock( 'cli/lib/cli-config/core', () => ( {
 describe( 'AI auth helpers', () => {
 	beforeEach( () => {
 		vi.resetAllMocks();
+		vi.stubGlobal( '__STUDIO_CLI_VERSION__', '1.2.3' );
 		vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
 		delete process.env.WPCOM_AI_PROXY_BASE_URL;
+	} );
+
+	afterEach( () => {
+		vi.unstubAllGlobals();
 	} );
 
 	it( 'uses the saved Anthropic API key when provider is Anthropic API key', async () => {
@@ -104,7 +109,9 @@ describe( 'AI auth helpers', () => {
 			'https://public-api.wordpress.com/wpcom/v2/ai-api-proxy'
 		);
 		expect( env.ANTHROPIC_AUTH_TOKEN ).toBe( 'wpcom-token' );
-		expect( env.ANTHROPIC_CUSTOM_HEADERS ).toBe( 'X-WPCOM-AI-Feature: studio-assistant-anthropic' );
+		expect( env.ANTHROPIC_CUSTOM_HEADERS ).toBe(
+			'User-Agent: WordPressStudio/1.2.3\nX-WPCOM-AI-Feature: studio-assistant-anthropic'
+		);
 		expect( env.ANTHROPIC_API_KEY ).toBeUndefined();
 	} );
 
@@ -121,7 +128,7 @@ describe( 'AI auth helpers', () => {
 		const env = await resolveAiEnvironment( 'wpcom', { sessionId: 'session-abc' } );
 
 		expect( env.ANTHROPIC_CUSTOM_HEADERS ).toBe(
-			'X-WPCOM-AI-Feature: studio-assistant-anthropic\nX-WPCOM-Session-ID: session-abc'
+			'User-Agent: WordPressStudio/1.2.3\nX-WPCOM-AI-Feature: studio-assistant-anthropic\nX-WPCOM-Session-ID: session-abc'
 		);
 	} );
 


### PR DESCRIPTION
## How AI was used in this PR

AI was used to investigate where Studio Code's AI requests originate, implement the header change, and update the affected tests. The change was reviewed and verified locally.

## Proposed Changes

- Use custom user agent instead of default one.

## Testing Instructions

1. Run `npm run cli:build && node apps/cli/dist/cli/main.mjs code` and start a Studio Code chat on the WordPress.com provider.
2. Confirm you get a 403 error. I'll whitelist the new UA before merging this PR.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
