### PR TITLE
Agentic UI: Point Reload and Toggle DevTools at the app window instead of the focused webview

### DIFF
--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -6,6 +6,7 @@ import {
 	autoUpdater,
 	MenuItem,
 	shell,
+	type WebContents,
 } from 'electron';
 import {
 	getAppConfigPath,
@@ -38,6 +39,14 @@ import { getLogsFilePath } from 'src/logging';
 import { getMainWindow, loadMainWindowRenderer } from 'src/main-window';
 import { getAgenticFeaturesEnabled } from 'src/modules/user-settings/lib/ipc-handlers';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from 'src/updates';
+
+// Runs against the app window's own contents rather than whatever has focus.
+async function withAppWebContents( run: ( contents: WebContents ) => void ) {
+	const window = await getMainWindow();
+	if ( window && ! window.webContents.isDestroyed() ) {
+		run( window.webContents );
+	}
+}
 
 export async function setupMenu( config: {
 	needsOnboarding: boolean;
@@ -202,10 +211,29 @@ async function getAppMenu(
 		},
 	];
 
+	// Cmd/Ctrl+R belongs to the site preview: the agentic renderer binds it in
+	// the DOM to reload the guest page, so the menu must leave the key alone
+	// there — a menu accelerator would consume it first. That leaves the app
+	// itself with no way to reload, so these target the app window explicitly
+	// rather than using `role: 'reload'`, which acts on whatever webContents
+	// has focus (the preview, once clicked into).
+	const previewOwnsReloadShortcut = getPreferredStudioUiMode() === 'agentic';
 	const devTools: MenuItemConstructorOptions[] = [
-		{ label: __( 'Reload' ), role: 'reload' },
-		{ label: __( 'Force Reload' ), role: 'forceReload' },
-		{ label: __( 'Toggle DevTools' ), role: 'toggleDevTools' },
+		{
+			label: __( 'Reload App' ),
+			...( previewOwnsReloadShortcut ? {} : { accelerator: 'CommandOrControl+R' } ),
+			click: () => void withAppWebContents( ( contents ) => contents.reload() ),
+		},
+		{
+			label: __( 'Force Reload App' ),
+			accelerator: 'CommandOrControl+Shift+R',
+			click: () => void withAppWebContents( ( contents ) => contents.reloadIgnoringCache() ),
+		},
+		{
+			label: __( 'Toggle DevTools' ),
+			accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Control+Shift+I',
+			click: () => void withAppWebContents( ( contents ) => contents.toggleDevTools() ),
+		},
 		{ type: 'separator' },
 	];
 

--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -43,7 +43,7 @@ import { isUpdateReadyToInstall, manualCheckForUpdates } from 'src/updates';
 // Runs against the app window's own contents rather than whatever has focus.
 async function withAppWebContents( run: ( contents: WebContents ) => void ) {
 	const window = await getMainWindow();
-	if ( window && ! window.webContents.isDestroyed() ) {
+	if ( window && ! window.isDestroyed() && ! window.webContents.isDestroyed() ) {
 		run( window.webContents );
 	}
 }


### PR DESCRIPTION
## Related issues

None (split out of the `stu-2162-site-header-actions` exploration)

## How AI was used in this PR

Claude Code cherry-picked this change out of a larger exploration branch and verified it (lint, typecheck) in isolation.

## Proposed Changes

View ▸ Reload / Force Reload / Toggle DevTools used Electron's role-based "focused webContents" target. With a site preview visible, clicking into the preview would shift focus to the guest page, so Reload reloaded the site preview instead of the app — leaving no way to reload the Studio renderer itself from the menu.

These menu items now target the app window's webContents explicitly, and are relabelled "Reload App" / "Force Reload App" to make that explicit. In agentic mode, Reload App drops its ⌘R accelerator so ⌘R still reloads the preview (the renderer's own "Reload preview" shortcut); Force Reload App keeps ⌘⇧R.

## Testing Instructions

1. Launch the app with a site preview visible.
2. Click into the preview area to give the guest webview focus.
3. Use View ▸ Reload App and confirm the app renderer reloads (not the site preview/guest page).
4. In agentic mode, press ⌘R and confirm it still reloads the preview, not the app window.
5. Use View ▸ Force Reload App and confirm it force-reloads the app renderer (⌘⇧R still works too).
6. Use View ▸ Toggle DevTools and confirm DevTools opens for the app window, regardless of which webview had focus.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
