### PR TITLE
Agentic UI: Fix crash when a toast is replaced in place with a different shape

### DIFF
--- a/apps/ui/src/components/app-toasts/index.test.tsx
+++ b/apps/ui/src/components/app-toasts/index.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { showToast, resetAppMessagesForTests } from '@/data/app-messages';
+import { AppToasts } from './index';
+
+describe( 'AppToasts', () => {
+	afterEach( () => {
+		resetAppMessagesForTests();
+	} );
+
+	it( 'replaces a toast in place when the same id is shown again', () => {
+		render( <AppToasts /> );
+
+		act( () => {
+			showToast( { id: 'sync-1', intent: 'info', title: 'Pushing to live', durationMs: 0 } );
+		} );
+		expect( screen.getByText( 'Pushing to live' ) ).toBeVisible();
+
+		act( () => {
+			showToast( { id: 'sync-1', intent: 'success', title: 'Push complete' } );
+		} );
+		expect( screen.getByText( 'Push complete' ) ).toBeVisible();
+		expect( screen.queryByText( 'Pushing to live' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'survives a replacement that drops the description', () => {
+		render( <AppToasts /> );
+
+		// A running sync carries phase detail; its result usually doesn't. The
+		// shared Notice cannot be reused across that change.
+		act( () => {
+			showToast( {
+				id: 'sync-1',
+				intent: 'info',
+				title: 'Pushing to live',
+				description: 'Uploading… 62%',
+				durationMs: 0,
+			} );
+		} );
+		expect( screen.getByText( 'Uploading… 62%' ) ).toBeVisible();
+
+		act( () => {
+			showToast( { id: 'sync-1', intent: 'success', title: 'Push complete' } );
+		} );
+
+		expect( screen.getByText( 'Push complete' ) ).toBeVisible();
+		expect( screen.queryByText( 'Uploading… 62%' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps a pinned toast open with no expiry timer', () => {
+		render( <AppToasts /> );
+
+		act( () => {
+			showToast( { id: 'sync-1', intent: 'info', title: 'Pulling from live', durationMs: 0 } );
+		} );
+
+		expect( screen.getByText( 'Pulling from live' ) ).toBeVisible();
+	} );
+} );

--- a/apps/ui/src/components/app-toasts/index.tsx
+++ b/apps/ui/src/components/app-toasts/index.tsx
@@ -50,7 +50,15 @@ export function AppToasts( {
 								onMouseEnter={ () => pauseToastExpiry( item.id ) }
 								onMouseLeave={ () => resumeToastExpiry( item.id ) }
 							>
-								<Notice.Root intent={ item.intent } className={ styles.notice }>
+								{ /* Keyed on the notice's shape, not just its id: a toast that is
+							     replaced in place — a running sync becoming its result —
+							     can gain or lose a description, and reusing the same Notice
+							     across that change misaligns its internal hooks. */ }
+								<Notice.Root
+									key={ `${ item.intent }:${ !! item.description }:${ !! item.action }` }
+									intent={ item.intent }
+									className={ styles.notice }
+								>
 									<Notice.Title>{ item.title }</Notice.Title>
 									{ item.description ? (
 										<Notice.Description>{ item.description }</Notice.Description>


### PR DESCRIPTION
## Related issues

- None (split out of the `stu-2162-site-header-actions` exploration)

## How AI was used in this PR

Claude Code cherry-picked this fix out of a larger exploration branch and verified it (the regression test, lint, typecheck) in isolation.

## Proposed Changes

Fixes a crash that occurred when an app toast was updated in place and its content shape changed — for example, a running-sync toast transitioning into its success or failure result, where the result gains or loses a description. Previously React tried to update the existing `Notice` across that shape change and crashed; now the `Notice` re-mounts cleanly instead, so the toast transitions smoothly with no crash.

## Testing Instructions

1. Run the included regression test: `npm test -- apps/ui/src/components/app-toasts/index.test.tsx` — it exercises the toast-shape transition directly and must pass.
2. Manual repro (optional): trigger a toast that starts in a running state with a description (e.g. a sync in progress), then let it transition to a result state without a description (e.g. success/failure), and confirm the toast updates cleanly with no crash.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
