### PR TITLE
Fix `updateSiteUrl()` sometimes not taking effect on `runtime: native-php` imports

### DIFF
--- a/apps/cli/lib/import-export/import/importers/importer.ts
+++ b/apps/cli/lib/import-export/import/importers/importer.ts
@@ -1,11 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import { createInterface } from 'readline';
-import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { generateBackupFilename } from '@studio/common/lib/generate-backup-filename';
 import { ImportEvents } from '@studio/common/lib/import-export-events';
 import { isErrnoException } from '@studio/common/lib/is-errno-exception';
+import { writeStudioMuPluginsForNativePhpRuntime } from '@studio/common/lib/mu-plugins';
 import { serializePlugins } from '@studio/common/lib/serialize-plugins';
+import { getSiteRuntime } from '@studio/common/lib/site-runtime';
 import {
 	RecommendedPHPVersion,
 	SupportedPHPVersions,
@@ -16,7 +17,9 @@ import { move } from 'fs-extra';
 import semver from 'semver';
 import trash from 'trash';
 import { SiteData } from 'cli/lib/cli-config/core';
+import { ensureWpConfig } from 'cli/lib/native-php/site-setup';
 import { runWpCliCommand } from 'cli/lib/run-wp-cli-command';
+import { installSqliteIntegration } from 'cli/lib/sqlite-integration';
 import { ImportExportEventEmitter } from '../../events';
 import { BackupContents, MetaFileData } from '../types';
 import { updateSiteUrl } from '../update-site-url';
@@ -66,6 +69,21 @@ abstract class BaseImporter extends ImportExportEventEmitter implements Importer
 
 	abstract import( site: SiteData ): Promise< ImporterResult >;
 
+	// Get a supported PHP version string based on a specific input string, the
+	// underlying meta.json file or the SiteData object.
+	protected resolvePhpVersion( site: SiteData, rawVersion?: string ): SupportedPHPVersion {
+		const version = semver.coerce( rawVersion ?? this.meta?.phpVersion ?? site.phpVersion );
+		if ( ! version ) {
+			return RecommendedPHPVersion;
+		}
+
+		const parsedVersion = `${ version.major }.${ version.minor }`;
+
+		return SupportedPHPVersions.includes( parsedVersion as SupportedPHPVersion )
+			? ( parsedVersion as SupportedPHPVersion )
+			: RecommendedPHPVersion;
+	}
+
 	protected async importDatabase( site: SiteData, sqlFiles: string[] ): Promise< void > {
 		if ( ! sqlFiles.length ) {
 			return;
@@ -104,7 +122,7 @@ abstract class BaseImporter extends ImportExportEventEmitter implements Importer
 					],
 					{
 						requireSqliteCliCommand: true,
-						phpVersion: DEFAULT_PHP_VERSION,
+						phpVersion: this.resolvePhpVersion( site ),
 					}
 				);
 
@@ -148,11 +166,11 @@ abstract class BaseBackupImporter extends BaseImporter {
 			if ( this.shouldCleanUpBeforeImport ) {
 				await this.moveExistingWpContentToTrash( site.path );
 			}
-			await this.importWpConfig( site.path );
-			await this.importWpContent( site.path );
 			if ( this.backup.metaFile ) {
-				this.meta = await this.parseMetaFile();
+				this.meta = await this.parseMetaFile( site );
 			}
+			await this.importWpConfig( site );
+			await this.importWpContent( site );
 			if ( this.backup.sqlFiles.length ) {
 				const databaseDir = path.join( site.path, 'wp-content', 'database' );
 				const dbPath = path.join( databaseDir, '.ht.sqlite' );
@@ -179,7 +197,7 @@ abstract class BaseBackupImporter extends BaseImporter {
 		}
 	}
 
-	protected abstract parseMetaFile(): Promise< MetaFileData | undefined >;
+	protected abstract parseMetaFile( site: SiteData ): Promise< MetaFileData | undefined >;
 
 	protected async createEmptyDatabase( dbPath: string ): Promise< void > {
 		await fs.promises.writeFile( dbPath, '' );
@@ -220,22 +238,26 @@ abstract class BaseBackupImporter extends BaseImporter {
 		}
 	}
 
-	protected async importWpConfig( rootPath: string ): Promise< void > {
-		const wpConfigPath = path.join( rootPath, 'wp-config.php' );
-		const wpConfigSamplePath = path.join( rootPath, 'wp-config-sample.php' );
+	protected async importWpConfig( site: SiteData ): Promise< void > {
+		const wpConfigPath = path.join( site.path, 'wp-config.php' );
+		const wpConfigSamplePath = path.join( site.path, 'wp-config-sample.php' );
 
 		if ( this.backup.wpConfig ) {
 			await fs.promises.copyFile( this.backup.wpConfig, wpConfigPath );
 		} else if ( ! fs.existsSync( wpConfigPath ) && fs.existsSync( wpConfigSamplePath ) ) {
 			await fs.promises.copyFile( wpConfigSamplePath, wpConfigPath );
 		}
+
+		if ( getSiteRuntime( site ) === 'native-php' && ! site.runtimeBlueprintPath ) {
+			await ensureWpConfig( site.path, this.resolvePhpVersion( site ) );
+		}
 	}
 
-	protected async importWpContent( rootPath: string ): Promise< void > {
+	protected async importWpContent( site: SiteData ): Promise< void > {
 		this.emit( ImportEvents.IMPORT_WP_CONTENT_START );
 		const extractionDirectory = this.backup.extractionDirectory;
 		const wpContentSourceDir = this.backup.wpContentDirectory;
-		const wpContentDestDir = path.join( rootPath, 'wp-content' );
+		const wpContentDestDir = path.join( site.path, 'wp-content' );
 
 		// Group files by type
 		const filesByType = this.categorizeWpContentFiles( this.backup.wpContentFiles );
@@ -279,6 +301,12 @@ abstract class BaseBackupImporter extends BaseImporter {
 				} );
 			}
 		}
+
+		await installSqliteIntegration( site.path );
+		if ( getSiteRuntime( site ) === 'native-php' ) {
+			await writeStudioMuPluginsForNativePhpRuntime( site.path, site.isWpAutoUpdating );
+		}
+
 		this.emit( ImportEvents.IMPORT_WP_CONTENT_COMPLETE );
 	}
 
@@ -306,29 +334,13 @@ abstract class BaseBackupImporter extends BaseImporter {
 
 		return categorized;
 	}
-
-	protected parsePhpVersion( version: string | undefined ): string {
-		if ( ! version ) {
-			return RecommendedPHPVersion;
-		}
-		const phpVersion = semver.coerce( version );
-		if ( ! phpVersion ) {
-			return RecommendedPHPVersion;
-		}
-
-		const parsedVersion = `${ phpVersion.major }.${ phpVersion.minor }`;
-
-		return SupportedPHPVersions.includes( parsedVersion as SupportedPHPVersion )
-			? parsedVersion
-			: RecommendedPHPVersion;
-	}
 }
 
 export class JetpackImporter extends BaseBackupImporter {
 	// Jetpack importer follows merge strategy to support selective sync
 	protected shouldCleanUpBeforeImport = false;
 
-	protected async parseMetaFile(): Promise< MetaFileData | undefined > {
+	protected async parseMetaFile( site: SiteData ): Promise< MetaFileData | undefined > {
 		const metaFilePath = this.backup.metaFile;
 		if ( ! metaFilePath ) {
 			return;
@@ -338,7 +350,7 @@ export class JetpackImporter extends BaseBackupImporter {
 			const metaContent = await fs.promises.readFile( metaFilePath, 'utf-8' );
 			const meta = JSON.parse( metaContent );
 			return {
-				phpVersion: this.parsePhpVersion( meta?.phpVersion ),
+				phpVersion: this.resolvePhpVersion( site, meta?.phpVersion ),
 				wordpressVersion: meta?.wordpressVersion || '',
 			};
 		} catch ( e ) {
@@ -357,7 +369,7 @@ export class JetpackImporter extends BaseBackupImporter {
 }
 
 export class LocalImporter extends BaseBackupImporter {
-	protected async parseMetaFile(): Promise< MetaFileData | undefined > {
+	protected async parseMetaFile( site: SiteData ): Promise< MetaFileData | undefined > {
 		const metaFilePath = this.backup.metaFile;
 		if ( ! metaFilePath ) {
 			return;
@@ -367,7 +379,7 @@ export class LocalImporter extends BaseBackupImporter {
 			const metaContent = await fs.promises.readFile( metaFilePath, 'utf-8' );
 			const meta = JSON.parse( metaContent );
 			return {
-				phpVersion: this.parsePhpVersion( meta?.services?.php?.version ),
+				phpVersion: this.resolvePhpVersion( site, meta?.services?.php?.version ),
 				wordpressVersion: '',
 			};
 		} catch ( e ) {

--- a/apps/cli/lib/import-export/import/importers/importer.ts
+++ b/apps/cli/lib/import-export/import/importers/importer.ts
@@ -19,7 +19,7 @@ import trash from 'trash';
 import { SiteData } from 'cli/lib/cli-config/core';
 import { ensureWpConfig } from 'cli/lib/native-php/site-setup';
 import { runWpCliCommand } from 'cli/lib/run-wp-cli-command';
-import { installSqliteIntegration } from 'cli/lib/sqlite-integration';
+import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
 import { ImportExportEventEmitter } from '../../events';
 import { BackupContents, MetaFileData } from '../types';
 import { updateSiteUrl } from '../update-site-url';
@@ -302,7 +302,7 @@ abstract class BaseBackupImporter extends BaseImporter {
 			}
 		}
 
-		await installSqliteIntegration( site.path );
+		await keepSqliteIntegrationUpdated( site.path );
 		if ( getSiteRuntime( site ) === 'native-php' ) {
 			await writeStudioMuPluginsForNativePhpRuntime( site.path, site.isWpAutoUpdating );
 		}

--- a/apps/cli/lib/native-php/site-setup.ts
+++ b/apps/cli/lib/native-php/site-setup.ts
@@ -3,11 +3,18 @@ import path from 'node:path';
 import { DEFAULT_LOCALE } from '@studio/common/lib/locale';
 import { escapePhpSingleQuotedString } from '@studio/common/lib/mu-plugins';
 import { decodePassword } from '@studio/common/lib/passwords';
+import { type NativePhpSupportedVersion } from '@studio/common/lib/php-binary-metadata';
 import { getWpCliPharPath } from 'cli/lib/dependency-management/paths';
+import { ensurePhpBinaryAvailable } from '../dependency-management/php-binary';
 import { runPhpCommand } from './php-process';
 import { getFullyResolvedTmpDirPath } from './tmp-dir';
-import type { NativePhpSupportedVersion } from '@studio/common/lib/php-binary-metadata';
 import type { ServerConfig } from 'cli/lib/types/wordpress-server-ipc';
+
+const WP_CONFIG_TRANSFORMER_PATH = path.resolve(
+	import.meta.dirname,
+	'php',
+	'wp-config-transformer.php'
+);
 
 const DEFAULT_WP_CONFIG_CONSTANTS = { DB_NAME: 'wordpress' } as const;
 
@@ -16,8 +23,7 @@ type Logger = ( ...args: Parameters< typeof console.log > ) => void;
 export async function ensureWpConfig(
 	siteFolder: string,
 	phpVersion: NativePhpSupportedVersion,
-	signal: AbortSignal,
-	wpConfigTransformerPath: string,
+	signal?: AbortSignal,
 	config?: Pick< ServerConfig, 'enableDebugLog' | 'enableDebugDisplay' >
 ): Promise< void > {
 	const wpConfigPath = path.join( siteFolder, 'wp-config.php' );
@@ -46,13 +52,14 @@ $transformer->to_file( $wp_config_path );
 		WP_DEBUG_LOG: enableDebugLog,
 		WP_DEBUG_DISPLAY: enableDebugDisplay,
 	};
+	await ensurePhpBinaryAvailable( phpVersion );
 
 	try {
 		await runPhpCommand(
 			[
 				'-r',
 				ensureWpConfigScript,
-				wpConfigTransformerPath,
+				WP_CONFIG_TRANSFORMER_PATH,
 				wpConfigPath,
 				JSON.stringify( constants ),
 			],

--- a/apps/cli/php-server-child.ts
+++ b/apps/cli/php-server-child.ts
@@ -52,11 +52,6 @@ const SET_DEFAULT_PERMALINKS_PATH = path.resolve(
 	'php',
 	'set-default-permalinks.php'
 );
-const WP_CONFIG_TRANSFORMER_PATH = path.resolve(
-	import.meta.dirname,
-	'php',
-	'wp-config-transformer.php'
-);
 
 // Tracks how many proxied requests each PHP worker is currently handling.
 // Each `php -S` worker processes one request at a time, so a non-zero count
@@ -465,13 +460,7 @@ async function startServer( config: ServerConfig, signal: AbortSignal ): Promise
 		stopSignal.throwIfAborted();
 
 		if ( ! isImportedSite ) {
-			await ensureWpConfig(
-				config.sitePath,
-				phpVersion,
-				stopSignal,
-				WP_CONFIG_TRANSFORMER_PATH,
-				config
-			);
+			await ensureWpConfig( config.sitePath, phpVersion, stopSignal, config );
 			stopSignal.throwIfAborted();
 		}
 
@@ -762,7 +751,6 @@ async function ipcMessageHandler( packet: unknown ) {
 					blueprintConfig.sitePath,
 					blueprintPhpVersion,
 					abortController.signal,
-					WP_CONFIG_TRANSFORMER_PATH,
 					blueprintConfig
 				);
 				await writeStudioMuPluginsForNativePhpRuntime(


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-2197

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

I used Claude to iteratively reach the desired end state through an update-review-then-update workflow. I then used Codex to review the work.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

STU-2197 revealed an underlying problem in `BaseBackupImporter` when used with `native-php` runtime sites: `updateSiteUrl()` did not work as expected. This was because WP-CLI could not connect to the database to run the `wp option get` and `wp search-replace` commands.

The Linear issue describes how this makes `studio wp option get home` return an unexpected result, but the consequences are actually much wider: all `post_content` URLs remain directed at the production site. This does not happen for all `runtime: native-php` imports, as @bcotrim discovered, but it does affect some (presumably related to the shape of the `wp-config.php` being imported).

This PR fixes the problem by ensuring that `BaseBackupImporter` updates `wp-config.php`, installs the SQLite integration plugin, and installs all the Studio-specific mu-plugins. By the time `updateSiteUrl()` is called in `importDatabase()`, all the prerequisites for WP-CLI to work are now in place.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `npm start`
2. Add a new site
3. Choose `Connect a site` and pull one of your remote sites
4. Wait for the pull to finish
5. Once finished, open the site directory in a terminal
6. Run `studio wp option get home`
7. Ensure that it returns the expected local URL (not the original production URL)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
