### PR TITLE
Agentic: Studio Code AI semi-open beta

### DIFF
--- a/apps/studio/src/components/ai-access-required-notice.tsx
+++ b/apps/studio/src/components/ai-access-required-notice.tsx
@@ -1,11 +1,22 @@
 import {
 	formatAiAccessRequiredNotice,
+	formatAiBlockedNotice,
 	STUDIO_CODE_AI_BETA_APPLY_URL,
+	WPCOM_SUPPORT_CONTACT_URL,
 	type StudioAssistantQuota,
 } from '@studio/common/lib/studio-assistant-quota';
 import { createInterpolateElement } from '@wordpress/element';
 import Button from 'src/components/button';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import type { ReactNode } from 'react';
+
+function NoticeLink( { url, children }: { url: string; children?: ReactNode } ) {
+	return (
+		<Button variant="link" onClick={ () => getIpcApi().openURL( url ) }>
+			{ children }
+		</Button>
+	);
+}
 
 export function AiAccessRequiredNotice( {
 	quota,
@@ -13,11 +24,12 @@ export function AiAccessRequiredNotice( {
 	quota?: Pick< StudioAssistantQuota, 'costUsage' > | null;
 } ) {
 	return createInterpolateElement( formatAiAccessRequiredNotice( quota ), {
-		applyLink: (
-			<Button
-				variant="link"
-				onClick={ () => getIpcApi().openURL( STUDIO_CODE_AI_BETA_APPLY_URL ) }
-			/>
-		),
+		applyLink: <NoticeLink url={ STUDIO_CODE_AI_BETA_APPLY_URL } />,
+	} );
+}
+
+export function AiBlockedNotice() {
+	return createInterpolateElement( formatAiBlockedNotice(), {
+		supportLink: <NoticeLink url={ WPCOM_SUPPORT_CONTACT_URL } />,
 	} );
 }

--- a/apps/studio/src/components/ai-access-required-notice.tsx
+++ b/apps/studio/src/components/ai-access-required-notice.tsx
@@ -1,0 +1,23 @@
+import {
+	formatAiAccessRequiredNotice,
+	STUDIO_CODE_AI_BETA_APPLY_URL,
+	type StudioAssistantQuota,
+} from '@studio/common/lib/studio-assistant-quota';
+import { createInterpolateElement } from '@wordpress/element';
+import Button from 'src/components/button';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+
+export function AiAccessRequiredNotice( {
+	quota,
+}: {
+	quota?: Pick< StudioAssistantQuota, 'costUsage' > | null;
+} ) {
+	return createInterpolateElement( formatAiAccessRequiredNotice( quota ), {
+		applyLink: (
+			<Button
+				variant="link"
+				onClick={ () => getIpcApi().openURL( STUDIO_CODE_AI_BETA_APPLY_URL ) }
+			/>
+		),
+	} );
+}

--- a/apps/studio/src/components/studio-code-session/access-requirements.tsx
+++ b/apps/studio/src/components/studio-code-session/access-requirements.tsx
@@ -1,4 +1,14 @@
-import { ADD_PAYMENT_METHOD_URL } from '@studio/common/lib/studio-assistant-quota';
+import {
+	ADD_PAYMENT_METHOD_URL,
+	formatAiAccessRequiredHeadline,
+	formatAiBlockedNotice,
+	getStudioCodeAiAccessState,
+	STUDIO_CODE_AI_BETA_APPLY_URL,
+	WPCOM_SUPPORT_CONTACT_URL,
+	type StudioAssistantQuota,
+	type StudioCodeAiAccessState,
+} from '@studio/common/lib/studio-assistant-quota';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
@@ -8,21 +18,42 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 import styles from './access-requirements.module.css';
 import { StudioCodeTabImage } from './studio-code-tab-image';
 
+type AccessQuota = Pick<
+	StudioAssistantQuota,
+	'costUsage' | 'studioCodeAiHasAccess' | 'studioCodeAiAccess'
+>;
+
 // No email-verification case: adding a payment method on WordPress.com
 // already requires a verified email, so a card-holding account can't have an
 // unverified address.
-const requirementCopy = {
-	title: __( 'Studio Code Beta' ),
-	description: __(
-		'To enroll in our free beta you must add a valid payment method to your WordPress.com account.'
-	),
-	button: __( 'Add payment method' ),
-	url: ADD_PAYMENT_METHOD_URL,
-	browserTitle: __( 'Finish adding your payment method' ),
-	browserDescription: __(
-		'Complete the setup in your browser, then come back here. Studio will check your account again.'
-	),
-} as const;
+function getRequirementCopy( accessState: StudioCodeAiAccessState, quota: AccessQuota ) {
+	if ( accessState === 'not-enabled' ) {
+		return {
+			title: __( 'Studio Code Beta' ),
+			description: formatAiAccessRequiredHeadline( quota ),
+			reassurance: null,
+			button: __( 'Apply for access' ),
+			url: STUDIO_CODE_AI_BETA_APPLY_URL,
+			browserTitle: __( 'Finish applying for access' ),
+			browserDescription: __(
+				'Complete your application in your browser, then come back here. Studio will check your account again.'
+			),
+		};
+	}
+	return {
+		title: __( 'Studio Code Beta' ),
+		description: __(
+			'To enroll in our free beta you must add a valid payment method to your WordPress.com account.'
+		),
+		reassurance: __( 'You won’t be charged during the beta.' ),
+		button: __( 'Add payment method' ),
+		url: ADD_PAYMENT_METHOD_URL,
+		browserTitle: __( 'Finish adding your payment method' ),
+		browserDescription: __(
+			'Complete the setup in your browser, then come back here. Studio will check your account again.'
+		),
+	};
+}
 
 function IllustrationRail() {
 	return (
@@ -36,20 +67,52 @@ function IllustrationRail() {
 }
 
 /**
- * Upfront gate for the Studio Code tab (STU-2178). The WordPress.com proxy
- * denies AI requests without a saved payment method or a verified email
- * (STU-2174); this surfaces that requirement before the first prompt instead
- * of as an error after it. The proxy remains the enforcement point.
+ * Upfront gate for the Studio Code tab. The WordPress.com proxy denies AI
+ * requests without a saved payment method or a verified email (STU-2174), and
+ * for accounts without semi-open beta access (STU-2146); this surfaces those
+ * requirements before the first prompt instead of as an error after it. Beta
+ * access outranks the payment requirement — there's no point collecting a
+ * card from an account that can't get in yet. The proxy remains the
+ * enforcement point.
  */
 export function AccessRequirements( {
+	quota,
 	isRechecking,
 	onRecheck,
 }: {
+	quota: AccessQuota;
 	isRechecking: boolean;
 	onRecheck: () => void;
 } ) {
 	const [ isWaitingForBrowser, setIsWaitingForBrowser ] = useState( false );
-	const copy = requirementCopy;
+	const accessState = getStudioCodeAiAccessState( quota );
+
+	if ( accessState === 'blocked' ) {
+		return (
+			<div className={ styles.root }>
+				<div className={ styles.centeredContent }>
+					<div className={ styles.centeredCopy }>
+						<div className="a8c-subtitle mb-1">{ __( 'Studio Code Beta' ) }</div>
+						<div className="max-w-[48ch] text-frame-text-secondary a8c-body">
+							{ createInterpolateElement( formatAiBlockedNotice(), { supportLink: <span /> } ) }
+						</div>
+						<div className="mt-8">
+							<Button
+								variant="primary"
+								onClick={ () => void getIpcApi().openURL( WPCOM_SUPPORT_CONTACT_URL ) }
+							>
+								{ __( 'Contact support' ) }
+								<ArrowIcon />
+							</Button>
+						</div>
+					</div>
+				</div>
+				<IllustrationRail />
+			</div>
+		);
+	}
+
+	const copy = getRequirementCopy( accessState, quota );
 
 	if ( isWaitingForBrowser ) {
 		return (
@@ -83,9 +146,9 @@ export function AccessRequirements( {
 					<div className="a8c-subtitle mb-1">{ copy.title }</div>
 					<div className="max-w-[48ch] text-frame-text-secondary a8c-body">
 						<span>{ copy.description }</span>
-						<span className={ styles.reassuranceLine }>
-							{ __( 'You won’t be charged during the beta.' ) }
-						</span>
+						{ copy.reassurance && (
+							<span className={ styles.reassuranceLine }>{ copy.reassurance }</span>
+						) }
 					</div>
 					<div className="mt-8">
 						<Button

--- a/apps/studio/src/components/studio-code-session/conversation/index.tsx
+++ b/apps/studio/src/components/studio-code-session/conversation/index.tsx
@@ -8,7 +8,11 @@ import {
 	type StudioChatArtifactWidgetDraft,
 } from '@studio/common/ai/chat-artifacts';
 import { readBlobAsDataUrl } from '@studio/common/ai/composer-attachments';
-import { isAiBlockedError, isUsageCapError } from '@studio/common/ai/json-events';
+import {
+	isAiAccessRequiredError,
+	isAiBlockedError,
+	isUsageCapError,
+} from '@studio/common/ai/json-events';
 import {
 	isStudioCustomEntryOfType,
 	type StudioChatAttachmentSummary,
@@ -27,7 +31,8 @@ import {
 import { __ } from '@wordpress/i18n';
 import { image, page } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { AiAccessRequiredNotice } from 'src/components/ai-access-required-notice';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useGetStudioAssistantQuota } from 'src/stores/wpcom-api';
@@ -654,10 +659,15 @@ function AgentQuestion( {
 // instead of the raw provider message.
 function TurnErrorMarker( { message }: { message: string } ) {
 	const isUsageCap = isUsageCapError( message );
-	const { data: quota } = useGetStudioAssistantQuota( undefined, { skip: ! isUsageCap } );
-	let text: string;
+	const isAccessRequired = isAiAccessRequiredError( message );
+	const { data: quota } = useGetStudioAssistantQuota( undefined, {
+		skip: ! isUsageCap && ! isAccessRequired,
+	} );
+	let text: ReactNode;
 	if ( isAiBlockedError( message ) ) {
 		text = formatAiBlockedNotice();
+	} else if ( isAccessRequired ) {
+		text = <AiAccessRequiredNotice quota={ quota } />;
 	} else if ( isUsageCap ) {
 		text = formatUsageCapNotice( quota?.costResetDate );
 	} else {

--- a/apps/studio/src/components/studio-code-session/conversation/index.tsx
+++ b/apps/studio/src/components/studio-code-session/conversation/index.tsx
@@ -24,15 +24,12 @@ import {
 	getToolResultDiff,
 	type NormalizedToolResult,
 } from '@studio/common/ai/tools';
-import {
-	formatAiBlockedNotice,
-	formatUsageCapNotice,
-} from '@studio/common/lib/studio-assistant-quota';
+import { formatUsageCapNotice } from '@studio/common/lib/studio-assistant-quota';
 import { __ } from '@wordpress/i18n';
 import { image, page } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { AiAccessRequiredNotice } from 'src/components/ai-access-required-notice';
+import { AiAccessRequiredNotice, AiBlockedNotice } from 'src/components/ai-access-required-notice';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useGetStudioAssistantQuota } from 'src/stores/wpcom-api';
@@ -665,7 +662,7 @@ function TurnErrorMarker( { message }: { message: string } ) {
 	} );
 	let text: ReactNode;
 	if ( isAiBlockedError( message ) ) {
-		text = formatAiBlockedNotice();
+		text = <AiBlockedNotice />;
 	} else if ( isAccessRequired ) {
 		text = <AiAccessRequiredNotice quota={ quota } />;
 	} else if ( isUsageCap ) {

--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -3,6 +3,7 @@ import {
 	isStudioCustomEntryOfType,
 	type StudioCustomEntry,
 } from '@studio/common/ai/sessions/entry-types';
+import { getStudioCodeAiAccessState } from '@studio/common/lib/studio-assistant-quota';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -490,8 +491,17 @@ function SessionGate( { selectedSite }: { selectedSite: SiteDetails } ) {
 
 	// Fail open when the quota is unavailable (offline, error, older server) —
 	// the WordPress.com proxy enforces the same gate server-side.
-	if ( quota && ! quota.hasPaymentMethod ) {
-		return <AccessRequirements isRechecking={ isQuotaFetching } onRecheck={ refetchQuota } />;
+	if (
+		quota &&
+		( getStudioCodeAiAccessState( quota ) !== 'available' || ! quota.hasPaymentMethod )
+	) {
+		return (
+			<AccessRequirements
+				quota={ quota }
+				isRechecking={ isQuotaFetching }
+				onRecheck={ refetchQuota }
+			/>
+		);
 	}
 
 	return <SessionContent selectedSite={ selectedSite } />;

--- a/apps/studio/src/components/studio-code-session/tests/access-requirements.test.tsx
+++ b/apps/studio/src/components/studio-code-session/tests/access-requirements.test.tsx
@@ -162,4 +162,77 @@ describe( 'StudioCodeSession access requirements gate', () => {
 
 		await screen.findByTestId( 'composer' );
 	} );
+
+	it( 'asks an ungranted account to apply for beta access', async () => {
+		setQuota( {
+			hasPaymentMethod: true,
+			emailVerified: true,
+			costUsage: 0,
+			studioCodeAiHasAccess: false,
+			studioCodeAiAccess: 'default',
+		} );
+
+		render( <StudioCodeSession selectedSite={ selectedSite } /> );
+
+		await screen.findByText( 'Studio Code AI is currently available through limited beta access.' );
+		expect( screen.queryByTestId( 'composer' ) ).not.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'button', { name: /apply for access/i } ) );
+		expect( mockIpc.openURL ).toHaveBeenCalledWith(
+			'https://developer.wordpress.com/studio/studio-code-beta/'
+		);
+		await screen.findByText( 'Finish applying for access' );
+	} );
+
+	it( 'shows the apply gate before the payment gate when both are missing', async () => {
+		setQuota( {
+			hasPaymentMethod: false,
+			emailVerified: true,
+			costUsage: 0,
+			studioCodeAiHasAccess: false,
+			studioCodeAiAccess: 'default',
+		} );
+
+		render( <StudioCodeSession selectedSite={ selectedSite } /> );
+
+		await screen.findByRole( 'button', { name: /apply for access/i } );
+		expect(
+			screen.queryByRole( 'button', { name: /add payment method/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'tells an ungranted account with spend this cycle that access is now limited', async () => {
+		setQuota( {
+			hasPaymentMethod: true,
+			emailVerified: true,
+			costUsage: 3,
+			studioCodeAiHasAccess: false,
+			studioCodeAiAccess: 'default',
+		} );
+
+		render( <StudioCodeSession selectedSite={ selectedSite } /> );
+
+		await screen.findByText(
+			'Thanks for participating in the Studio Code AI beta. Access is now limited.'
+		);
+	} );
+
+	it( 'shows the suspension copy with a support link for a blocked account', async () => {
+		setQuota( {
+			hasPaymentMethod: true,
+			emailVerified: true,
+			costUsage: 0,
+			studioCodeAiHasAccess: false,
+			studioCodeAiAccess: 'blocked',
+		} );
+
+		render( <StudioCodeSession selectedSite={ selectedSite } /> );
+
+		await screen.findByText( /Studio Code AI is blocked for this WordPress.com account/ );
+		expect( screen.queryByTestId( 'composer' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /apply for access/i } ) ).not.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'button', { name: /contact support/i } ) );
+		expect( mockIpc.openURL ).toHaveBeenCalledWith( 'https://wordpress.com/support/contact/' );
+	} );
 } );

--- a/apps/studio/src/modules/user-settings/components/prompt-info.tsx
+++ b/apps/studio/src/modules/user-settings/components/prompt-info.tsx
@@ -1,13 +1,12 @@
 import {
 	clampQuotaFraction,
-	formatAiBlockedNotice,
 	formatQuotaPercentage,
 	formatQuotaResetDate,
 	getStudioCodeAiAccessState,
 } from '@studio/common/lib/studio-assistant-quota';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { AiAccessRequiredNotice } from 'src/components/ai-access-required-notice';
+import { AiAccessRequiredNotice, AiBlockedNotice } from 'src/components/ai-access-required-notice';
 import ProgressBar from 'src/components/progress-bar';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
@@ -44,7 +43,7 @@ export function PromptInfo() {
 						<div className={ cx( 'flex flex-row items-center', ! isDenied && 'text-right' ) }>
 							<span className="text-frame-text-secondary">
 								{ isOffline && __( "You're currently offline" ) }
-								{ accessState === 'blocked' && formatAiBlockedNotice() }
+								{ accessState === 'blocked' && <AiBlockedNotice /> }
 								{ accessState === 'not-enabled' && (
 									<AiAccessRequiredNotice quota={ assistantQuota } />
 								) }

--- a/apps/studio/src/modules/user-settings/components/prompt-info.tsx
+++ b/apps/studio/src/modules/user-settings/components/prompt-info.tsx
@@ -3,9 +3,11 @@ import {
 	formatAiBlockedNotice,
 	formatQuotaPercentage,
 	formatQuotaResetDate,
+	getStudioCodeAiAccessState,
 } from '@studio/common/lib/studio-assistant-quota';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import { AiAccessRequiredNotice } from 'src/components/ai-access-required-notice';
 import ProgressBar from 'src/components/progress-bar';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
@@ -23,9 +25,13 @@ export function PromptInfo() {
 	} = useGetStudioAssistantQuota( undefined, {
 		refetchOnMountOrArgChange: true,
 	} );
-	const isBlocked = Boolean( assistantQuota?.isStudioCodeAiBlocked ) && ! isOffline && ! isError;
+	const accessState =
+		assistantQuota && ! isOffline && ! isError
+			? getStudioCodeAiAccessState( assistantQuota )
+			: 'available';
+	const isDenied = accessState !== 'available';
 	const assistantQuotaWithCostCap =
-		assistantQuota && assistantQuota.costCap > 0 && ! isOffline && ! isError && ! isBlocked
+		assistantQuota && assistantQuota.costCap > 0 && ! isOffline && ! isError && ! isDenied
 			? assistantQuota
 			: undefined;
 
@@ -35,11 +41,14 @@ export function PromptInfo() {
 			<div className="flex gap-3 flex-row items-center w-full">
 				<div className="flex w-full flex-col gap-2">
 					<div className="flex w-full flex-row justify-between gap-8 ">
-						<div className={ cx( 'flex flex-row items-center', ! isBlocked && 'text-right' ) }>
+						<div className={ cx( 'flex flex-row items-center', ! isDenied && 'text-right' ) }>
 							<span className="text-frame-text-secondary">
 								{ isOffline && __( "You're currently offline" ) }
-								{ isBlocked && formatAiBlockedNotice() }
-								{ ! isOffline && ! isBlocked && isLoading && __( 'Loading Studio Code limits…' ) }
+								{ accessState === 'blocked' && formatAiBlockedNotice() }
+								{ accessState === 'not-enabled' && (
+									<AiAccessRequiredNotice quota={ assistantQuota } />
+								) }
+								{ ! isOffline && ! isDenied && isLoading && __( 'Loading Studio Code limits…' ) }
 								{ assistantQuotaWithCostCap &&
 									sprintf(
 										/* translators: %1$s: percentage of monthly limit used (e.g. 7.5%). %2$s: date the limit resets (e.g. July 1, 2026). */
@@ -55,7 +64,7 @@ export function PromptInfo() {
 									) }
 								{ ! isLoading &&
 									! isOffline &&
-									! isBlocked &&
+									! isDenied &&
 									! assistantQuotaWithCostCap &&
 									__( 'Studio Code limits are temporarily unavailable.' ) }
 							</span>

--- a/apps/ui/src/components/ai-access-required-notice/index.tsx
+++ b/apps/ui/src/components/ai-access-required-notice/index.tsx
@@ -1,31 +1,45 @@
 import {
 	formatAiAccessRequiredNotice,
+	formatAiBlockedNotice,
 	STUDIO_CODE_AI_BETA_APPLY_URL,
+	WPCOM_SUPPORT_CONTACT_URL,
 	type StudioAssistantQuota,
 } from '@studio/common/lib/studio-assistant-quota';
 import { createInterpolateElement } from '@wordpress/element';
 import { useConnector } from '@/data/core';
+import type { ReactNode } from 'react';
+
+// Electron swallows plain `target="_blank"` navigations — route clicks
+// through the connector so the link opens in the system browser.
+function NoticeLink( { url, children }: { url: string; children?: ReactNode } ) {
+	const connector = useConnector();
+	return (
+		<a
+			href={ url }
+			target="_blank"
+			rel="noreferrer noopener"
+			onClick={ ( event ) => {
+				event.preventDefault();
+				void connector.openExternalUrl( url );
+			} }
+		>
+			{ children }
+		</a>
+	);
+}
 
 export function AiAccessRequiredNotice( {
 	quota,
 }: {
 	quota?: Pick< StudioAssistantQuota, 'costUsage' > | null;
 } ) {
-	const connector = useConnector();
 	return createInterpolateElement( formatAiAccessRequiredNotice( quota ), {
-		applyLink: (
-			// Electron swallows plain `target="_blank"` navigations — route
-			// clicks through the connector so the link opens in the system
-			// browser.
-			<a
-				href={ STUDIO_CODE_AI_BETA_APPLY_URL }
-				target="_blank"
-				rel="noreferrer noopener"
-				onClick={ ( event ) => {
-					event.preventDefault();
-					void connector.openExternalUrl( STUDIO_CODE_AI_BETA_APPLY_URL );
-				} }
-			/>
-		),
+		applyLink: <NoticeLink url={ STUDIO_CODE_AI_BETA_APPLY_URL } />,
+	} );
+}
+
+export function AiBlockedNotice() {
+	return createInterpolateElement( formatAiBlockedNotice(), {
+		supportLink: <NoticeLink url={ WPCOM_SUPPORT_CONTACT_URL } />,
 	} );
 }

--- a/apps/ui/src/components/ai-access-required-notice/index.tsx
+++ b/apps/ui/src/components/ai-access-required-notice/index.tsx
@@ -1,0 +1,31 @@
+import {
+	formatAiAccessRequiredNotice,
+	STUDIO_CODE_AI_BETA_APPLY_URL,
+	type StudioAssistantQuota,
+} from '@studio/common/lib/studio-assistant-quota';
+import { createInterpolateElement } from '@wordpress/element';
+import { useConnector } from '@/data/core';
+
+export function AiAccessRequiredNotice( {
+	quota,
+}: {
+	quota?: Pick< StudioAssistantQuota, 'costUsage' > | null;
+} ) {
+	const connector = useConnector();
+	return createInterpolateElement( formatAiAccessRequiredNotice( quota ), {
+		applyLink: (
+			// Electron swallows plain `target="_blank"` navigations — route
+			// clicks through the connector so the link opens in the system
+			// browser.
+			<a
+				href={ STUDIO_CODE_AI_BETA_APPLY_URL }
+				target="_blank"
+				rel="noreferrer noopener"
+				onClick={ ( event ) => {
+					event.preventDefault();
+					void connector.openExternalUrl( STUDIO_CODE_AI_BETA_APPLY_URL );
+				} }
+			/>
+		),
+	} );
+}

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -224,10 +224,12 @@ describe( 'UsagePanel', () => {
 		render( <UsagePanel /> );
 
 		expect(
-			screen.getByText(
-				'Studio Code AI is blocked for this WordPress.com account. If you believe this is a mistake, contact WordPress.com support.'
-			)
+			screen.getByText( /Studio Code AI is blocked for this WordPress.com account/ )
 		).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'contact WordPress.com support' } ) ).toHaveAttribute(
+			'href',
+			'https://wordpress.com/support/contact/'
+		);
 	} );
 
 	it( 'shows the request-access copy, not the suspension copy, for an ungranted default account', () => {
@@ -251,9 +253,7 @@ describe( 'UsagePanel', () => {
 			screen.getByRole( 'link', { name: 'developer.wordpress.com/studio/studio-code-beta' } )
 		).toHaveAttribute( 'href', 'https://developer.wordpress.com/studio/studio-code-beta/' );
 		expect(
-			screen.queryByText(
-				'Studio Code AI is blocked for this WordPress.com account. If you believe this is a mistake, contact WordPress.com support.'
-			)
+			screen.queryByText( /Studio Code AI is blocked for this WordPress.com account/ )
 		).not.toBeInTheDocument();
 	} );
 

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -209,6 +209,95 @@ describe( 'UsagePanel', () => {
 		).toBeInTheDocument();
 	} );
 
+	it( 'shows the suspension copy for an explicitly blocked account', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 100,
+				costResetDate: '2026-08-01T12:00:00',
+				studioCodeAiHasAccess: false,
+				studioCodeAiAccess: 'blocked',
+			},
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect(
+			screen.getByText(
+				'Studio Code AI is blocked for this WordPress.com account. If you believe this is a mistake, contact WordPress.com support.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows the request-access copy, not the suspension copy, for an ungranted default account', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 100,
+				costResetDate: '2026-08-01T12:00:00',
+				studioCodeAiHasAccess: false,
+				studioCodeAiAccess: 'default',
+			},
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect(
+			screen.getByText( /Studio Code AI is currently available through limited beta access/ )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'link', { name: 'developer.wordpress.com/studio/studio-code-beta' } )
+		).toHaveAttribute( 'href', 'https://developer.wordpress.com/studio/studio-code-beta/' );
+		expect(
+			screen.queryByText(
+				'Studio Code AI is blocked for this WordPress.com account. If you believe this is a mistake, contact WordPress.com support.'
+			)
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'tells an ungranted account with spend this cycle that beta access is now required', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 3,
+				costCap: 100,
+				costResetDate: '2026-08-01T12:00:00',
+				studioCodeAiHasAccess: false,
+				studioCodeAiAccess: 'default',
+			},
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect(
+			screen.getByText( /Thanks for participating in the Studio Code AI beta/ )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'link', { name: 'developer.wordpress.com/studio/studio-code-beta' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows normal usage when access is granted through a default-allow policy', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 25,
+				costCap: 100,
+				costResetDate: '2026-08-01T12:00:00',
+				studioCodeAiHasAccess: true,
+				studioCodeAiAccess: 'default',
+			},
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect(
+			screen.getByText( '25% of monthly limit used (resets on August 1, 2026)' )
+		).toBeInTheDocument();
+	} );
+
 	it( 'confirms through the connector before deleting all preview sites', async () => {
 		render( <UsagePanel /> );
 

--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -2,7 +2,6 @@ import {
 	clampQuotaFraction,
 	formatQuotaPercentage,
 	formatQuotaResetDate,
-	formatAiBlockedNotice,
 	getStudioCodeAiAccessState,
 } from '@studio/common/lib/studio-assistant-quota';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -10,7 +9,7 @@ import { moreHorizontal } from '@wordpress/icons';
 import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { SigninNotice } from '@/components/agentic-signin-banner';
-import { AiAccessRequiredNotice } from '@/components/ai-access-required-notice';
+import { AiAccessRequiredNotice, AiBlockedNotice } from '@/components/ai-access-required-notice';
 import * as Menu from '@/components/menu';
 import { OfflineNotice } from '@/components/offline-banner';
 import { useConnector } from '@/data/core';
@@ -71,7 +70,7 @@ function AiCreditsSummary() {
 		content = (
 			<div className={ styles.previewUsageText }>
 				{ accessState === 'blocked' ? (
-					formatAiBlockedNotice()
+					<AiBlockedNotice />
 				) : (
 					<AiAccessRequiredNotice quota={ quota } />
 				) }

--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -3,12 +3,14 @@ import {
 	formatQuotaPercentage,
 	formatQuotaResetDate,
 	formatAiBlockedNotice,
+	getStudioCodeAiAccessState,
 } from '@studio/common/lib/studio-assistant-quota';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { moreHorizontal } from '@wordpress/icons';
 import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { SigninNotice } from '@/components/agentic-signin-banner';
+import { AiAccessRequiredNotice } from '@/components/ai-access-required-notice';
 import * as Menu from '@/components/menu';
 import { OfflineNotice } from '@/components/offline-banner';
 import { useConnector } from '@/data/core';
@@ -49,6 +51,7 @@ function UsageProgressBar( { fraction }: { fraction: number } ) {
 function AiCreditsSummary() {
 	const locale = useUserLocale();
 	const { data: quota, isLoading, isError } = useStudioAssistantQuota();
+	const accessState = quota ? getStudioCodeAiAccessState( quota ) : 'available';
 
 	let content;
 	if ( isLoading ) {
@@ -64,8 +67,16 @@ function AiCreditsSummary() {
 				{ __( 'Studio Code limits are temporarily unavailable.' ) }
 			</div>
 		);
-	} else if ( quota?.isStudioCodeAiBlocked ) {
-		content = <div className={ styles.previewUsageText }>{ formatAiBlockedNotice() }</div>;
+	} else if ( accessState !== 'available' ) {
+		content = (
+			<div className={ styles.previewUsageText }>
+				{ accessState === 'blocked' ? (
+					formatAiBlockedNotice()
+				) : (
+					<AiAccessRequiredNotice quota={ quota } />
+				) }
+			</div>
+		);
 	} else if ( quota && quota.costCap > 0 ) {
 		const fraction = clampQuotaFraction( quota.costUsage, quota.costCap );
 		content = (

--- a/apps/ui/src/ui-classic/components/session-view/access-requirements.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/access-requirements.test.tsx
@@ -10,6 +10,18 @@ vi.mock( '@/data/core', () => ( {
 
 const useConnectorMock = vi.mocked( useConnector, { partial: true } );
 
+const grantedQuota = {
+	costUsage: 0,
+	studioCodeAiHasAccess: true,
+	studioCodeAiAccess: 'granted',
+};
+
+const notEnabledQuota = {
+	costUsage: 0,
+	studioCodeAiHasAccess: false,
+	studioCodeAiAccess: 'default',
+};
+
 describe( 'AccessRequirements', () => {
 	const openExternalUrl = vi.fn().mockResolvedValue( undefined );
 
@@ -20,7 +32,9 @@ describe( 'AccessRequirements', () => {
 
 	it( 'shows the payment requirement and hands off to the browser', async () => {
 		const user = userEvent.setup();
-		render( <AccessRequirements isRechecking={ false } onRecheck={ vi.fn() } /> );
+		render(
+			<AccessRequirements quota={ grantedQuota } isRechecking={ false } onRecheck={ vi.fn() } />
+		);
 
 		expect( screen.getByText( 'Studio Code Beta' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'You won’t be charged during the beta.' ) ).toBeInTheDocument();
@@ -37,7 +51,9 @@ describe( 'AccessRequirements', () => {
 	it( 'rechecks from the waiting state and can go back', async () => {
 		const user = userEvent.setup();
 		const onRecheck = vi.fn();
-		render( <AccessRequirements isRechecking={ false } onRecheck={ onRecheck } /> );
+		render(
+			<AccessRequirements quota={ grantedQuota } isRechecking={ false } onRecheck={ onRecheck } />
+		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Add payment method' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Check again' } ) );
@@ -49,9 +65,71 @@ describe( 'AccessRequirements', () => {
 
 	it( 'labels the recheck button while a recheck is in flight', async () => {
 		const user = userEvent.setup();
-		render( <AccessRequirements isRechecking={ true } onRecheck={ vi.fn() } /> );
+		render(
+			<AccessRequirements quota={ grantedQuota } isRechecking={ true } onRecheck={ vi.fn() } />
+		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Add payment method' } ) );
 		expect( screen.getByRole( 'button', { name: 'Checking…' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'asks an ungranted account to apply for beta access, even without a payment method', async () => {
+		const user = userEvent.setup();
+		render(
+			<AccessRequirements quota={ notEnabledQuota } isRechecking={ false } onRecheck={ vi.fn() } />
+		);
+
+		expect(
+			screen.getByText( 'Studio Code AI is currently available through limited beta access.' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Add payment method' } )
+		).not.toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Apply for access' } ) );
+
+		expect( openExternalUrl ).toHaveBeenCalledWith(
+			'https://developer.wordpress.com/studio/studio-code-beta/'
+		);
+		expect( screen.getByText( 'Finish applying for access' ) ).toBeInTheDocument();
+	} );
+
+	it( 'tells an ungranted account with spend this cycle that access is now limited', () => {
+		render(
+			<AccessRequirements
+				quota={ { ...notEnabledQuota, costUsage: 3 } }
+				isRechecking={ false }
+				onRecheck={ vi.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByText(
+				'Thanks for participating in the Studio Code AI beta. Access is now limited.'
+			)
+		).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Apply for access' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the suspension copy with a support link for a blocked account', async () => {
+		const user = userEvent.setup();
+		render(
+			<AccessRequirements
+				quota={ { ...notEnabledQuota, studioCodeAiAccess: 'blocked' } }
+				isRechecking={ false }
+				onRecheck={ vi.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByText( /Studio Code AI is blocked for this WordPress.com account/ )
+		).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Apply for access' } ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Add payment method' } )
+		).not.toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Contact support' } ) );
+		expect( openExternalUrl ).toHaveBeenCalledWith( 'https://wordpress.com/support/contact/' );
 	} );
 } );

--- a/apps/ui/src/ui-classic/components/session-view/access-requirements.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/access-requirements.tsx
@@ -1,4 +1,14 @@
-import { ADD_PAYMENT_METHOD_URL } from '@studio/common/lib/studio-assistant-quota';
+import {
+	ADD_PAYMENT_METHOD_URL,
+	formatAiAccessRequiredHeadline,
+	formatAiBlockedNotice,
+	getStudioCodeAiAccessState,
+	STUDIO_CODE_AI_BETA_APPLY_URL,
+	WPCOM_SUPPORT_CONTACT_URL,
+	type StudioAssistantQuota,
+	type StudioCodeAiAccessState,
+} from '@studio/common/lib/studio-assistant-quota';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import { clsx } from 'clsx';
@@ -6,22 +16,42 @@ import { useState } from 'react';
 import { useConnector } from '@/data/core';
 import styles from './access-requirements.module.css';
 
+type AccessQuota = Pick<
+	StudioAssistantQuota,
+	'costUsage' | 'studioCodeAiHasAccess' | 'studioCodeAiAccess'
+>;
+
 // No email-verification case: adding a payment method on WordPress.com
 // already requires a verified email, so a card-holding account can't have an
 // unverified address.
-const requirementCopy = {
-	title: __( 'Studio Code Beta' ),
-	description: __(
-		'To enroll in our free beta you must add a valid payment method to your WordPress.com account.'
-	),
-	reassurance: __( 'You won’t be charged during the beta.' ),
-	button: __( 'Add payment method' ),
-	url: ADD_PAYMENT_METHOD_URL,
-	browserTitle: __( 'Finish adding your payment method' ),
-	browserDescription: __(
-		'Complete the setup in your browser, then come back here. Studio will check your account again.'
-	),
-} as const;
+function getRequirementCopy( accessState: StudioCodeAiAccessState, quota: AccessQuota ) {
+	if ( accessState === 'not-enabled' ) {
+		return {
+			title: __( 'Studio Code Beta' ),
+			description: formatAiAccessRequiredHeadline( quota ),
+			reassurance: null,
+			button: __( 'Apply for access' ),
+			url: STUDIO_CODE_AI_BETA_APPLY_URL,
+			browserTitle: __( 'Finish applying for access' ),
+			browserDescription: __(
+				'Complete your application in your browser, then come back here. Studio will check your account again.'
+			),
+		};
+	}
+	return {
+		title: __( 'Studio Code Beta' ),
+		description: __(
+			'To enroll in our free beta you must add a valid payment method to your WordPress.com account.'
+		),
+		reassurance: __( 'You won’t be charged during the beta.' ),
+		button: __( 'Add payment method' ),
+		url: ADD_PAYMENT_METHOD_URL,
+		browserTitle: __( 'Finish adding your payment method' ),
+		browserDescription: __(
+			'Complete the setup in your browser, then come back here. Studio will check your account again.'
+		),
+	};
+}
 
 function Frost() {
 	return (
@@ -35,21 +65,51 @@ function Frost() {
 }
 
 /**
- * Upfront gate for the agentic chat (STU-2178). The WordPress.com proxy denies
- * AI requests without a saved payment method (STU-2174); this surfaces that
- * requirement before the first prompt instead of as an error after it. The
- * proxy remains the enforcement point.
+ * Upfront gate for the agentic chat. The WordPress.com proxy denies AI
+ * requests without a saved payment method (STU-2174), and for accounts
+ * without semi-open beta access (STU-2146); this surfaces those requirements
+ * before the first prompt instead of as an error after it. Beta access
+ * outranks the payment requirement — there's no point collecting a card from
+ * an account that can't get in yet. The proxy remains the enforcement point.
  */
 export function AccessRequirements( {
+	quota,
 	isRechecking,
 	onRecheck,
 }: {
+	quota: AccessQuota;
 	isRechecking: boolean;
 	onRecheck: () => void;
 } ) {
 	const connector = useConnector();
 	const [ isWaitingForBrowser, setIsWaitingForBrowser ] = useState( false );
-	const copy = requirementCopy;
+	const accessState = getStudioCodeAiAccessState( quota );
+
+	if ( accessState === 'blocked' ) {
+		return (
+			<div className={ styles.root }>
+				<Frost />
+				<div className={ styles.copy }>
+					<h2 className={ styles.title }>{ __( 'Studio Code Beta' ) }</h2>
+					<p className={ styles.description }>
+						{ createInterpolateElement( formatAiBlockedNotice(), { supportLink: <span /> } ) }
+					</p>
+					<div className={ styles.actions }>
+						<Button
+							type="button"
+							variant="solid"
+							className={ styles.cta }
+							onClick={ () => void connector.openExternalUrl( WPCOM_SUPPORT_CONTACT_URL ) }
+						>
+							{ __( 'Contact support' ) }
+						</Button>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	const copy = getRequirementCopy( accessState, quota );
 
 	if ( isWaitingForBrowser ) {
 		return (
@@ -89,7 +149,7 @@ export function AccessRequirements( {
 			<div className={ styles.copy }>
 				<h2 className={ styles.title }>{ copy.title }</h2>
 				<p className={ styles.description }>{ copy.description }</p>
-				<p className={ styles.description }>{ copy.reassurance }</p>
+				{ copy.reassurance && <p className={ styles.description }>{ copy.reassurance }</p> }
 				<div className={ styles.actions }>
 					<Button
 						type="button"

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -25,10 +25,7 @@ import {
 	splitCommandArgs,
 	type NormalizedToolResult,
 } from '@studio/common/ai/tools';
-import {
-	formatAiBlockedNotice,
-	formatUsageCapNotice,
-} from '@studio/common/lib/studio-assistant-quota';
+import { formatUsageCapNotice } from '@studio/common/lib/studio-assistant-quota';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	blockDefault,
@@ -82,7 +79,7 @@ import {
 	type ReactNode,
 	MouseEvent as ReactMouseEvent,
 } from 'react';
-import { AiAccessRequiredNotice } from '@/components/ai-access-required-notice';
+import { AiAccessRequiredNotice, AiBlockedNotice } from '@/components/ai-access-required-notice';
 import { CopyButton } from '@/components/copy-button';
 import { Markdown } from '@/components/markdown';
 import { useConnector, type LoadedAiSession } from '@/data/core';
@@ -1201,7 +1198,7 @@ function TurnErrorMarker( { message }: { message: string } ) {
 	const { data: quota } = useStudioAssistantQuota( { enabled: isUsageCap || isAccessRequired } );
 	let text: ReactNode;
 	if ( isAiBlockedError( message ) ) {
-		text = formatAiBlockedNotice();
+		text = <AiBlockedNotice />;
 	} else if ( isAccessRequired ) {
 		text = <AiAccessRequiredNotice quota={ quota } />;
 	} else if ( isUsageCap ) {

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -7,7 +7,11 @@ import {
 	stripMediaWidgetPayloadLines,
 	type StudioChatArtifactWidgetDraft,
 } from '@studio/common/ai/chat-artifacts';
-import { isAiBlockedError, isUsageCapError } from '@studio/common/ai/json-events';
+import {
+	isAiAccessRequiredError,
+	isAiBlockedError,
+	isUsageCapError,
+} from '@studio/common/ai/json-events';
 import {
 	isStudioCustomEntryOfType,
 	type StudioChatAttachmentSummary,
@@ -69,7 +73,16 @@ import {
 } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import {
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+	type ReactNode,
+	MouseEvent as ReactMouseEvent,
+} from 'react';
+import { AiAccessRequiredNotice } from '@/components/ai-access-required-notice';
 import { CopyButton } from '@/components/copy-button';
 import { Markdown } from '@/components/markdown';
 import { useConnector, type LoadedAiSession } from '@/data/core';
@@ -79,7 +92,6 @@ import { refreshIcon } from '@/lib/icons';
 import { ThinkingIndicator } from '../thinking-indicator';
 import styles from './style.module.css';
 import type { SessionEntry } from '@earendil-works/pi-coding-agent';
-import type { MouseEvent as ReactMouseEvent } from 'react';
 
 interface AgentQuestionRenderItem {
 	key: string;
@@ -1185,10 +1197,13 @@ function AgentQuestionBatch( {
 // instead of the raw provider message.
 function TurnErrorMarker( { message }: { message: string } ) {
 	const isUsageCap = isUsageCapError( message );
-	const { data: quota } = useStudioAssistantQuota( { enabled: isUsageCap } );
-	let text: string;
+	const isAccessRequired = isAiAccessRequiredError( message );
+	const { data: quota } = useStudioAssistantQuota( { enabled: isUsageCap || isAccessRequired } );
+	let text: ReactNode;
 	if ( isAiBlockedError( message ) ) {
 		text = formatAiBlockedNotice();
+	} else if ( isAccessRequired ) {
+		text = <AiAccessRequiredNotice quota={ quota } />;
 	} else if ( isUsageCap ) {
 		text = formatUsageCapNotice( quota?.costResetDate );
 	} else {

--- a/apps/ui/src/ui-classic/components/session-view/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.test.tsx
@@ -76,9 +76,10 @@ function makeQuota( overrides: Partial< { hasPaymentMethod: boolean; emailVerifi
 		costUsage: 0,
 		costCap: 500000,
 		costResetDate: '2026-09-01T00:00:00+00:00',
-		isStudioCodeAiBlocked: false,
 		emailVerified: true,
 		hasPaymentMethod: true,
+		studioCodeAiHasAccess: true,
+		studioCodeAiAccess: 'granted',
 		...overrides,
 	};
 }

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -1,5 +1,6 @@
 import { resolveSessionModel } from '@studio/common/ai/models';
 import { findAiSessionOwnerSite } from '@studio/common/ai/sessions/owner-site';
+import { getStudioCodeAiAccessState } from '@studio/common/lib/studio-assistant-quota';
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { arrowDown } from '@wordpress/icons';
@@ -421,7 +422,10 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 
 	// Fail open when the quota is unavailable (offline, error, older server) —
 	// the WordPress.com proxy enforces the same gate server-side.
-	if ( quota && ! quota.hasPaymentMethod ) {
+	if (
+		quota &&
+		( getStudioCodeAiAccessState( quota ) !== 'available' || ! quota.hasPaymentMethod )
+	) {
 		return (
 			<SessionFrame
 				header={ <SessionHeader summary={ data.summary } /> }
@@ -429,6 +433,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 			>
 				<EmptyBackground />
 				<AccessRequirements
+					quota={ quota }
 					isRechecking={ isQuotaFetching }
 					onRecheck={ () => void refetchQuota() }
 				/>

--- a/packages/common/ai/json-events.ts
+++ b/packages/common/ai/json-events.ts
@@ -100,6 +100,17 @@ export function isAiBlockedError( message: string | undefined | null ): boolean 
 }
 
 /**
+ * Returns true when an error message reports that Studio Code AI beta access
+ * hasn't been enabled for the account (STU-2146). Same mechanism as
+ * `isAiBlockedError`: the WordPress.com proxy stamps the
+ * `studio_code_ai_access_required` code into the message text, since the AI
+ * SDKs surface only the message string.
+ */
+export function isAiAccessRequiredError( message: string | undefined | null ): boolean {
+	return /studio_code_ai_access_required/i.test( message ?? '' );
+}
+
+/**
  * Extract the failure of a completed turn from its final `agent_end` event.
  * The error text lives on the last assistant message's `errorMessage`
  * (streamed API failures) or its text blocks (synthetic pre-flight errors).

--- a/packages/common/ai/tests/json-events.test.ts
+++ b/packages/common/ai/tests/json-events.test.ts
@@ -3,6 +3,7 @@ import {
 	buildUsageCapErrorMessage,
 	getAgentEndFailure,
 	isHttp429ErrorMessage,
+	isAiAccessRequiredError,
 	isAiBlockedError,
 	isUsageCapError,
 	USAGE_CAP_ERROR_PREFIX,
@@ -106,6 +107,36 @@ describe( 'isAiBlockedError', () => {
 		expect( isAiBlockedError( '403 Studio Code AI is blocked for this account.' ) ).toBe( false );
 		expect( isAiBlockedError( 'Monthly usage limit reached: x' ) ).toBe( false );
 		expect( isAiBlockedError( undefined ) ).toBe( false );
+		expect(
+			isAiBlockedError(
+				'403 studio_code_ai_access_required: Studio Code AI access has not been enabled for this account.'
+			)
+		).toBe( false );
+	} );
+} );
+
+describe( 'isAiAccessRequiredError', () => {
+	it( 'matches the load-bearing code token wherever it appears in the message', () => {
+		expect(
+			isAiAccessRequiredError(
+				'403 studio_code_ai_access_required: Studio Code AI access has not been enabled for this account.'
+			)
+		).toBe( true );
+		expect(
+			isAiAccessRequiredError(
+				'403 {"code":"studio_code_ai_access_required","message":"Studio Code AI access has not been enabled for this account.","data":{"status":403}}'
+			)
+		).toBe( true );
+	} );
+
+	it( 'does not match the blocked code or unrelated errors', () => {
+		expect(
+			isAiAccessRequiredError(
+				'403 studio_code_ai_disabled: Studio Code AI is blocked for this account.'
+			)
+		).toBe( false );
+		expect( isAiAccessRequiredError( '403 model not allowed' ) ).toBe( false );
+		expect( isAiAccessRequiredError( undefined ) ).toBe( false );
 	} );
 } );
 

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -11,23 +11,49 @@ export const studioAssistantQuotaSchema = z
 		cost_usage: z.number(),
 		cost_cap: z.number(),
 		cost_reset_date: z.string(),
-		// Per-user kill switch (STU-2143); older servers omit the field.
-		is_studio_code_ai_blocked: z.boolean().optional(),
 		// Entitlement gates (STU-2174); older servers omit both fields. Default to
 		// true so a stale server never locks the UI — the proxy still enforces.
 		email_verified: z.boolean().optional(),
 		has_payment_method: z.boolean().optional(),
+		// Semi-open beta access (STU-2146); older servers omit the fields.
+		// `studio_code_ai_has_access` is the policy outcome the AI proxy
+		// enforces; `studio_code_ai_access` is the raw per-user decision
+		// ("granted" | "blocked" | "default" — kept as a plain string so new
+		// server-side values never fail the parse).
+		studio_code_ai_has_access: z.boolean().optional(),
+		studio_code_ai_access: z.string().optional(),
 	} )
 	.transform( ( data ) => ( {
 		costUsage: data.cost_usage,
 		costCap: data.cost_cap,
 		costResetDate: data.cost_reset_date,
-		isStudioCodeAiBlocked: data.is_studio_code_ai_blocked ?? false,
 		emailVerified: data.email_verified ?? true,
 		hasPaymentMethod: data.has_payment_method ?? true,
+		studioCodeAiHasAccess: data.studio_code_ai_has_access,
+		studioCodeAiAccess: data.studio_code_ai_access,
 	} ) );
 
 export type StudioAssistantQuota = z.infer< typeof studioAssistantQuotaSchema >;
+
+export type StudioCodeAiAccessState = 'available' | 'blocked' | 'not-enabled';
+
+/**
+ * Collapse the quota's access fields into the three UI states of the
+ * semi-open beta (STU-2146). Gates on `studioCodeAiHasAccess` first — the
+ * policy outcome the AI proxy enforces — and only consults the raw per-user
+ * decision to tell an explicit block apart from a not-yet-enabled default.
+ * Anything but an explicit `false` counts as available (older servers omit
+ * the field, and enforcement lives in the proxy), so a future default-allow
+ * flip needs no client change.
+ */
+export function getStudioCodeAiAccessState(
+	quota: Pick< StudioAssistantQuota, 'studioCodeAiHasAccess' | 'studioCodeAiAccess' >
+): StudioCodeAiAccessState {
+	if ( quota.studioCodeAiHasAccess !== false ) {
+		return 'available';
+	}
+	return quota.studioCodeAiAccess === 'blocked' ? 'blocked' : 'not-enabled';
+}
 
 /**
  * Fetch the account's Studio AI quota from WordPress.com. Resolves `null` on
@@ -70,12 +96,43 @@ export function formatQuotaResetDate( date: string, locale?: string ): string {
 }
 
 /**
- * User-facing copy for the per-account Studio Code AI kill switch (STU-2143).
- * Shared by every surface so the wording stays consistent.
+ * User-facing copy for an account whose Studio Code AI access was explicitly
+ * blocked (access === "blocked", STU-2143/STU-2146). Shared by every surface
+ * so the wording stays consistent.
  */
 export function formatAiBlockedNotice(): string {
 	return __(
-		'Studio Code AI is unavailable for this WordPress.com account. If you believe this is a mistake, contact WordPress.com support.'
+		'Studio Code AI is blocked for this WordPress.com account. If you believe this is a mistake, contact WordPress.com support.'
+	);
+}
+
+export const STUDIO_CODE_AI_BETA_APPLY_URL =
+	'https://developer.wordpress.com/studio/studio-code-beta/';
+
+/**
+ * User-facing copy for an account that hasn't been granted Studio Code AI
+ * beta access yet (STU-2146). Deliberately distinct from the blocked notice:
+ * nothing is wrong with the account — access just hasn't been enabled. Spend
+ * on the quota means the account has demonstrably used Studio Code AI this
+ * billing cycle (the backend keeps reporting the real month total after
+ * access flips off), so those users read that the requirement is new rather
+ * than that the feature never existed for them.
+ *
+ * The returned string wraps the application URL in an `<applyLink>` token:
+ * render it with `createInterpolateElement`, pointing the token at
+ * `STUDIO_CODE_AI_BETA_APPLY_URL`.
+ */
+export function formatAiAccessRequiredNotice(
+	quota?: Pick< StudioAssistantQuota, 'costUsage' > | null
+): string {
+	if ( quota && quota.costUsage > 0 ) {
+		return __(
+			'Thanks for participating in the Studio Code AI beta. Access is now limited. Apply to continue at <applyLink>developer.wordpress.com/studio/studio-code-beta</applyLink>.'
+		);
+	}
+
+	return __(
+		'Studio Code AI is currently available through limited beta access. Apply at <applyLink>developer.wordpress.com/studio/studio-code-beta</applyLink>.'
 	);
 }
 

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -6,6 +6,8 @@ export const STUDIO_ASSISTANT_QUOTA_URL =
 
 export const ADD_PAYMENT_METHOD_URL = 'https://my.wordpress.com/me/billing/payment-methods/add';
 
+export const WPCOM_SUPPORT_CONTACT_URL = 'https://wordpress.com/support/contact/';
+
 export const studioAssistantQuotaSchema = z
 	.object( {
 		cost_usage: z.number(),
@@ -98,11 +100,15 @@ export function formatQuotaResetDate( date: string, locale?: string ): string {
 /**
  * User-facing copy for an account whose Studio Code AI access was explicitly
  * blocked (access === "blocked", STU-2143/STU-2146). Shared by every surface
- * so the wording stays consistent.
+ * so the wording stays consistent. The string wraps the support
+ * call-to-action in a `<supportLink>` token: render it with
+ * `createInterpolateElement`, pointing the token at
+ * `WPCOM_SUPPORT_CONTACT_URL` — or at a plain `<span />` on surfaces that
+ * show their own support button.
  */
 export function formatAiBlockedNotice(): string {
 	return __(
-		'Studio Code AI is blocked for this WordPress.com account. If you believe this is a mistake, contact WordPress.com support.'
+		'Studio Code AI is blocked for this WordPress.com account. If you believe this is a mistake, <supportLink>contact WordPress.com support</supportLink>.'
 	);
 }
 
@@ -110,30 +116,41 @@ export const STUDIO_CODE_AI_BETA_APPLY_URL =
 	'https://developer.wordpress.com/studio/studio-code-beta/';
 
 /**
- * User-facing copy for an account that hasn't been granted Studio Code AI
- * beta access yet (STU-2146). Deliberately distinct from the blocked notice:
- * nothing is wrong with the account — access just hasn't been enabled. Spend
- * on the quota means the account has demonstrably used Studio Code AI this
- * billing cycle (the backend keeps reporting the real month total after
- * access flips off), so those users read that the requirement is new rather
- * than that the feature never existed for them.
- *
- * The returned string wraps the application URL in an `<applyLink>` token:
- * render it with `createInterpolateElement`, pointing the token at
- * `STUDIO_CODE_AI_BETA_APPLY_URL`.
+ * Headline sentence for an account that hasn't been granted Studio Code AI
+ * beta access yet (STU-2146), without an apply CTA — for surfaces that render
+ * their own action button (e.g. the AccessRequirements gate). Spend on the
+ * quota means the account has demonstrably used Studio Code AI this billing
+ * cycle (the backend keeps reporting the real month total after access flips
+ * off), so those users read that the requirement is new rather than that the
+ * feature never existed for them.
+ */
+export function formatAiAccessRequiredHeadline(
+	quota?: Pick< StudioAssistantQuota, 'costUsage' > | null
+): string {
+	if ( quota && quota.costUsage > 0 ) {
+		return __( 'Thanks for participating in the Studio Code AI beta. Access is now limited.' );
+	}
+	return __( 'Studio Code AI is currently available through limited beta access.' );
+}
+
+/**
+ * Full inline notice for an account without Studio Code AI beta access:
+ * the headline above followed by an apply sentence. Deliberately distinct
+ * from the blocked notice — nothing is wrong with the account; access just
+ * hasn't been enabled. The apply sentence wraps the application URL in an
+ * `<applyLink>` token: render it with `createInterpolateElement`, pointing
+ * the token at `STUDIO_CODE_AI_BETA_APPLY_URL`.
  */
 export function formatAiAccessRequiredNotice(
 	quota?: Pick< StudioAssistantQuota, 'costUsage' > | null
 ): string {
-	if ( quota && quota.costUsage > 0 ) {
-		return __(
-			'Thanks for participating in the Studio Code AI beta. Access is now limited. Apply to continue at <applyLink>developer.wordpress.com/studio/studio-code-beta</applyLink>.'
-		);
-	}
-
-	return __(
-		'Studio Code AI is currently available through limited beta access. Apply at <applyLink>developer.wordpress.com/studio/studio-code-beta</applyLink>.'
-	);
+	const applySentence =
+		quota && quota.costUsage > 0
+			? __(
+					'Apply to continue at <applyLink>developer.wordpress.com/studio/studio-code-beta</applyLink>.'
+			  )
+			: __( 'Apply at <applyLink>developer.wordpress.com/studio/studio-code-beta</applyLink>.' );
+	return `${ formatAiAccessRequiredHeadline( quota ) } ${ applySentence }`;
 }
 
 /**

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -108,6 +108,7 @@ export function formatQuotaResetDate( date: string, locale?: string ): string {
  */
 export function formatAiBlockedNotice(): string {
 	return __(
+		/* translators: <supportLink> and </supportLink> wrap the link to WordPress.com support and must be kept as-is. */
 		'Studio Code AI is blocked for this WordPress.com account. If you believe this is a mistake, <supportLink>contact WordPress.com support</supportLink>.'
 	);
 }
@@ -147,9 +148,13 @@ export function formatAiAccessRequiredNotice(
 	const applySentence =
 		quota && quota.costUsage > 0
 			? __(
+					/* translators: <applyLink> and </applyLink> wrap the beta application URL and must be kept as-is. */
 					'Apply to continue at <applyLink>developer.wordpress.com/studio/studio-code-beta</applyLink>.'
 			  )
-			: __( 'Apply at <applyLink>developer.wordpress.com/studio/studio-code-beta</applyLink>.' );
+			: __(
+					/* translators: <applyLink> and </applyLink> wrap the beta application URL and must be kept as-is. */
+					'Apply at <applyLink>developer.wordpress.com/studio/studio-code-beta</applyLink>.'
+			  );
 	return `${ formatAiAccessRequiredHeadline( quota ) } ${ applySentence }`;
 }
 

--- a/packages/common/lib/tests/studio-assistant-quota.test.ts
+++ b/packages/common/lib/tests/studio-assistant-quota.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+	formatAiAccessRequiredNotice,
+	getStudioCodeAiAccessState,
+	studioAssistantQuotaSchema,
+} from '@studio/common/lib/studio-assistant-quota';
+
+const baseResponse = {
+	cost_usage: 10,
+	cost_cap: 100,
+	cost_reset_date: '2026-09-01T00:00:00',
+};
+
+function parseAccessState( response: Record< string, unknown > ) {
+	return getStudioCodeAiAccessState( studioAssistantQuotaSchema.parse( response ) );
+}
+
+describe( 'getStudioCodeAiAccessState', () => {
+	it( 'is available for a granted user', () => {
+		expect(
+			parseAccessState( {
+				...baseResponse,
+				studio_code_ai_has_access: true,
+				studio_code_ai_access: 'granted',
+			} )
+		).toBe( 'available' );
+	} );
+
+	it( 'shows the request-access state, not blocked, for an ungranted default user', () => {
+		expect(
+			parseAccessState( {
+				...baseResponse,
+				studio_code_ai_has_access: false,
+				studio_code_ai_access: 'default',
+			} )
+		).toBe( 'not-enabled' );
+	} );
+
+	it( 'is blocked only for an explicit per-user block', () => {
+		expect(
+			parseAccessState( {
+				...baseResponse,
+				studio_code_ai_has_access: false,
+				studio_code_ai_access: 'blocked',
+			} )
+		).toBe( 'blocked' );
+	} );
+
+	it( 'gates on has_access first: a default user is available after a default-allow flip', () => {
+		expect(
+			parseAccessState( {
+				...baseResponse,
+				studio_code_ai_has_access: true,
+				studio_code_ai_access: 'default',
+			} )
+		).toBe( 'available' );
+	} );
+
+	it( 'treats responses from older servers without the fields as available', () => {
+		expect( parseAccessState( baseResponse ) ).toBe( 'available' );
+	} );
+} );
+
+describe( 'formatAiAccessRequiredNotice', () => {
+	it( 'tells accounts with spend this billing cycle that beta access is now required', () => {
+		expect( formatAiAccessRequiredNotice( { costUsage: 3 } ) ).toBe(
+			'Thanks for participating in the Studio Code AI beta. Access is now limited. Apply to continue at <applyLink>developer.wordpress.com/studio/studio-code-beta</applyLink>.'
+		);
+	} );
+
+	it( 'falls back to the generic beta copy without spend or without a quota', () => {
+		const genericNotice =
+			'Studio Code AI is currently available through limited beta access. Apply at <applyLink>developer.wordpress.com/studio/studio-code-beta</applyLink>.';
+		expect( formatAiAccessRequiredNotice( { costUsage: 0 } ) ).toBe( genericNotice );
+		expect( formatAiAccessRequiredNotice( undefined ) ).toBe( genericNotice );
+		expect( formatAiAccessRequiredNotice( null ) ).toBe( genericNotice );
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Fixes STU-2146

## How AI was used in this PR
AI assisted


## Proposed Changes
This PR is a preparation for switching Studio Code AI to semi-open beta with access-request flow.

### Access blocked by default (existing user)
<table>
<tr>
<td>Classic UI
<td>Agentic UI
</tr>
<tr>
<td><img width="565" height="412" alt="Screenshot 2026-08-05 at 21 55 31" src="https://github.com/user-attachments/assets/ba985787-9398-418a-bb56-7c17f21d341a" />
<td><img width="568" height="329" alt="Screenshot 2026-08-05 at 21 56 30" src="https://github.com/user-attachments/assets/2d8f9e37-03bd-4bfa-810e-ce8c5cf6cd82" />
</tr>
<tr>
<td><img width="837" height="520" alt="Screenshot 2026-08-05 at 22 37 16" src="https://github.com/user-attachments/assets/a00ec671-8c53-4b2b-897a-5e07e032ad9b" />
<td><img width="327" height="410" alt="Screenshot 2026-08-05 at 22 37 34" src="https://github.com/user-attachments/assets/c96fac76-db71-4434-934c-fa97b28e57a1" />
</tr>
</table>

### Access blocked by default (new user)
<table>
<tr>
<td>Classic UI
<td>Agentic UI
</tr>
<tr>
<td><img width="564" height="411" alt="Screenshot 2026-08-05 at 22 36 08" src="https://github.com/user-attachments/assets/2247a20b-2204-4872-9ed3-0bcf193c47cf" />
<td><img width="574" height="331" alt="Screenshot 2026-08-05 at 22 35 14" src="https://github.com/user-attachments/assets/b9408e07-d061-47e0-8765-e290ec30452e" />
</tr>
<tr>
<td><img width="844" height="523" alt="Screenshot 2026-08-05 at 22 36 26" src="https://github.com/user-attachments/assets/11bc7487-c263-41b6-9b2b-3cfffbacf6af" />
<td><img width="395" height="400" alt="Screenshot 2026-08-05 at 22 35 32" src="https://github.com/user-attachments/assets/3c13af6d-33d2-417b-af99-01350daae7d9" />
</tr>
</table>

### Access blocked manually
<table>
<tr>
<td>Classic UI
<td>Agentic UI
</tr>
<tr>
<td><img width="568" height="409" alt="Screenshot 2026-08-05 at 22 39 56" src="https://github.com/user-attachments/assets/52ab5370-ad4c-439c-b3b4-9426e077c06f" />
<td><img width="571" height="330" alt="Screenshot 2026-08-05 at 22 40 49" src="https://github.com/user-attachments/assets/6120bd42-9a09-423f-965d-7f1ed1f70315" />
</tr>
<tr>
<td><img width="852" height="528" alt="Screenshot 2026-08-05 at 22 40 15" src="https://github.com/user-attachments/assets/be2fc488-05bc-4761-8dc7-a14ac1b8f9f8" />
<td><img width="410" height="415" alt="Screenshot 2026-08-05 at 22 40 34" src="https://github.com/user-attachments/assets/b237d69e-1372-4fd7-b10b-643dfea978dd" />
</tr>
</table>

## Testing Instructions
See testing instructions in 163871-ghe-Automattic/missioncontrol