### PR TITLE
Tracks: add studio_site_created event

### DIFF
--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -15,6 +15,7 @@ import {
 	pathExists,
 	recursiveCopyDirectory,
 } from '@studio/common/lib/fs-utils';
+import { getWordPressVersion } from '@studio/common/lib/get-wordpress-version';
 import { normalizeLandingPage } from '@studio/common/lib/landing-page';
 import { DEFAULT_LOCALE } from '@studio/common/lib/locale';
 import { isOnline } from '@studio/common/lib/network-utils';
@@ -25,6 +26,7 @@ import {
 	validateAdminUsername,
 } from '@studio/common/lib/passwords';
 import { portFinder } from '@studio/common/lib/port-finder';
+import { type TracksSiteCreateFlowType } from '@studio/common/lib/record-tracks-event';
 import {
 	hasDefaultDbBlock,
 	removeDbConstants,
@@ -81,6 +83,7 @@ import { generateSiteName } from 'cli/lib/site-name';
 import { getDefaultSitePath } from 'cli/lib/site-paths';
 import { logSiteDetails, openSiteInBrowser, setupCustomDomain } from 'cli/lib/site-utils';
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
+import { getTracksOrigin, recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { StatsGroup } from 'cli/lib/types/bump-stats';
 import { untildify } from 'cli/lib/utils';
 import { ValidationError } from 'cli/lib/validation-error';
@@ -109,7 +112,20 @@ export type CreateCommandOptions = {
 	noStart: boolean;
 	skipBrowser: boolean;
 	skipLogDetails: boolean;
+	flowType?: TracksSiteCreateFlowType;
 };
+
+const SITE_CREATE_FLOW_TYPES: readonly TracksSiteCreateFlowType[] = [
+	'new',
+	'blueprint',
+	'import',
+	'sync',
+	'duplicate',
+];
+
+function parseFlowType( value: string | undefined ): TracksSiteCreateFlowType | undefined {
+	return SITE_CREATE_FLOW_TYPES.find( ( flowType ) => flowType === value );
+}
 
 export async function runCommand(
 	sitePath: string,
@@ -141,6 +157,8 @@ export async function runCommand(
 			logger.reportError( loggerError, false );
 		}
 	}
+
+	const createStartedAt = Date.now();
 
 	try {
 		logger.reportStart( LoggerAction.VALIDATE, __( 'Validating site configuration…' ) );
@@ -431,6 +449,24 @@ export async function runCommand(
 		logger.reportKeyValuePair( 'id', siteDetails.id );
 		logger.reportKeyValuePair( 'port', String( siteDetails.port ) );
 		logger.reportKeyValuePair( 'running', String( siteDetails.running ) );
+
+		// Tracks: the CLI is the sole emitter of site-creation, so every path a site comes into
+		// existence (new/blueprint/import/sync/duplicate, app-spawned or standalone) is counted once.
+		// Fires only on success; wrapped so best-effort telemetry can never fail a site creation.
+		try {
+			await recordTracksEvent( TRACKS_EVENTS.SITE_CREATE, {
+				flow_type: options.flowType ?? ( blueprint ? 'blueprint' : 'new' ),
+				php_version: siteDetails.phpVersion,
+				wp_version: getWordPressVersion( sitePath ),
+				custom_domain: !! options.customDomain,
+				ssl_enabled: !! options.enableHttps,
+				time_ms: Date.now() - createStartedAt,
+				...getTracksOrigin(),
+			} );
+		} catch {
+			// Best-effort telemetry — never block or fail a site creation.
+		}
+
 		await emitCliEvent( { event: SITE_EVENTS.CREATED, data: { siteId: siteDetails.id } } );
 	} finally {
 		await disconnectFromDaemon();
@@ -598,6 +634,12 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					type: 'boolean',
 					describe: __( 'Skip printing site URL and admin credentials after creating' ),
 					default: false,
+				} )
+				.option( 'flow-type', {
+					// Internal telemetry hint for the `studio_site_created` Tracks event, set by the
+					// desktop app when it spawns the CLI. Hidden from `--help`.
+					type: 'string',
+					hidden: true,
 				} );
 		},
 		handler: async ( argv ) => {
@@ -797,6 +839,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				noStart: ! argv.start,
 				skipBrowser: !! argv.skipBrowser,
 				skipLogDetails: !! argv.skipLogDetails,
+				flowType: parseFlowType( argv.flowType ),
 			};
 
 			if ( argv.blueprint ) {

--- a/apps/cli/commands/site/tests/create.test.ts
+++ b/apps/cli/commands/site/tests/create.test.ts
@@ -8,6 +8,7 @@ import {
 	arePathsEqual,
 	recursiveCopyDirectory,
 } from '@studio/common/lib/fs-utils';
+import { getWordPressVersion } from '@studio/common/lib/get-wordpress-version';
 import { isOnline } from '@studio/common/lib/network-utils';
 import { portFinder } from '@studio/common/lib/port-finder';
 import { normalizeLineEndings } from '@studio/common/lib/remove-default-db-constants';
@@ -39,6 +40,7 @@ import { copyLanguagePackToSite } from 'cli/lib/language-packs';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
 import { logSiteDetails, openSiteInBrowser, setupCustomDomain } from 'cli/lib/site-utils';
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
+import { recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { ProcessDescription } from 'cli/lib/types/process-manager-ipc';
 import { runBlueprint, startWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger } from 'cli/logger';
@@ -91,6 +93,11 @@ vi.mock( 'cli/lib/site-utils' );
 vi.mock( '@studio/common/lib/agent-skills' );
 vi.mock( 'cli/lib/sqlite-integration' );
 vi.mock( 'cli/lib/wordpress-server-manager' );
+vi.mock( 'cli/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('cli/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
+vi.mock( '@studio/common/lib/get-wordpress-version' );
 
 describe( 'CLI: studio site create', () => {
 	const mockSitePath = '/test/site/new-site';
@@ -184,6 +191,7 @@ describe( 'CLI: studio site create', () => {
 		vi.mocked( isOnline ).mockResolvedValue( true );
 		vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'en' );
 		vi.mocked( copyLanguagePackToSite ).mockResolvedValue( false );
+		vi.mocked( getWordPressVersion ).mockReturnValue( '6.5' );
 	} );
 
 	afterEach( () => {
@@ -1025,6 +1033,104 @@ $table_prefix = 'wp_';
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
 			expect( updateServerFiles ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Tracks: studio_site_created', () => {
+		const mockRecord = vi.mocked( recordTracksEvent );
+
+		const testBlueprint: Blueprint = { steps: [] };
+
+		it( 'emits flow_type "new" with config + timing for a plain create', async () => {
+			await runCommand( mockSitePath, { ...defaultTestOptions } );
+
+			expect( mockRecord ).toHaveBeenCalledTimes( 1 );
+			expect( mockRecord ).toHaveBeenCalledWith(
+				TRACKS_EVENTS.SITE_CREATE,
+				expect.objectContaining( {
+					flow_type: 'new',
+					php_version: '8.3',
+					wp_version: '6.5',
+					custom_domain: false,
+					ssl_enabled: false,
+					channel: 'studio-cli',
+				} )
+			);
+			const props = mockRecord.mock.calls[ 0 ][ 1 ] as Record< string, unknown >;
+			expect( typeof props.time_ms ).toBe( 'number' );
+			expect( props.time_ms as number ).toBeGreaterThanOrEqual( 0 );
+		} );
+
+		it( 'derives flow_type "blueprint" from a blueprint when no flowType is given', async () => {
+			await runCommand( mockSitePath, {
+				...defaultTestOptions,
+				blueprint: { uri: '/home/test/blueprint.json', contents: testBlueprint },
+			} );
+
+			expect( mockRecord ).toHaveBeenCalledWith(
+				TRACKS_EVENTS.SITE_CREATE,
+				expect.objectContaining( { flow_type: 'blueprint' } )
+			);
+		} );
+
+		it.each( [ 'import', 'sync', 'duplicate' ] as const )(
+			'passes through flow_type "%s"',
+			async ( flowType ) => {
+				await runCommand( mockSitePath, { ...defaultTestOptions, flowType } );
+
+				expect( mockRecord ).toHaveBeenCalledWith(
+					TRACKS_EVENTS.SITE_CREATE,
+					expect.objectContaining( { flow_type: flowType } )
+				);
+			}
+		);
+
+		it( 'an explicit flowType wins over blueprint inference', async () => {
+			await runCommand( mockSitePath, {
+				...defaultTestOptions,
+				flowType: 'duplicate',
+				blueprint: { uri: '/home/test/blueprint.json', contents: testBlueprint },
+			} );
+
+			expect( mockRecord ).toHaveBeenCalledWith(
+				TRACKS_EVENTS.SITE_CREATE,
+				expect.objectContaining( { flow_type: 'duplicate' } )
+			);
+		} );
+
+		it( 'reports custom_domain/ssl_enabled as booleans and never sends the domain string', async () => {
+			await runCommand( mockSitePath, {
+				...defaultTestOptions,
+				customDomain: 'mysite.local',
+				enableHttps: true,
+			} );
+
+			expect( mockRecord ).toHaveBeenCalledWith(
+				TRACKS_EVENTS.SITE_CREATE,
+				expect.objectContaining( { custom_domain: true, ssl_enabled: true } )
+			);
+			const props = mockRecord.mock.calls[ 0 ][ 1 ];
+			expect( JSON.stringify( props ) ).not.toContain( 'mysite.local' );
+		} );
+
+		it( 'reports wp_version resolved from disk', async () => {
+			vi.mocked( getWordPressVersion ).mockReturnValue( '6.7.1' );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions } );
+
+			expect( getWordPressVersion ).toHaveBeenCalledWith( mockSitePath );
+			expect( mockRecord ).toHaveBeenCalledWith(
+				TRACKS_EVENTS.SITE_CREATE,
+				expect.objectContaining( { wp_version: '6.7.1' } )
+			);
+		} );
+
+		it( 'does not emit when creation fails before completion', async () => {
+			vi.mocked( startWordPressServer ).mockRejectedValue( new Error( 'Server start failed' ) );
+
+			await expect( runCommand( mockSitePath, { ...defaultTestOptions } ) ).rejects.toThrow();
+
+			expect( mockRecord ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/apps/studio/src/hooks/tests/use-add-site.test.tsx
+++ b/apps/studio/src/hooks/tests/use-add-site.test.tsx
@@ -175,7 +175,8 @@ describe( 'useAddSite', () => {
 			undefined, // adminPassword
 			undefined, // adminEmail
 			undefined, // runtime
-			undefined // fileAccess
+			undefined, // fileAccess
+			undefined // flowType
 		);
 	} );
 

--- a/apps/studio/src/hooks/use-add-site.ts
+++ b/apps/studio/src/hooks/use-add-site.ts
@@ -181,6 +181,9 @@ export function useAddSite() {
 				const shouldSkipStart = ( !! fileForImport && ! isWxrImport ) || !! selectedRemoteSite;
 
 				const enableHttps = formValues.useCustomDomain ? formValues.enableHttps : false;
+				// Blueprint is inferred by the CLI from the blueprint arg; only tag the paths it can't
+				// see. A pull from a remote WordPress.com site rides the same create-then-populate path.
+				const flowType = fileForImport ? 'import' : selectedRemoteSite ? 'sync' : undefined;
 				let updatedBlueprint: Blueprint | undefined;
 				if ( selectedBlueprint?.blueprint ) {
 					const updatedJson = updateBlueprintWithFormValues( selectedBlueprint.blueprint, {
@@ -237,7 +240,8 @@ export function useAddSite() {
 					formValues.adminPassword,
 					formValues.adminEmail,
 					formValues.runtime,
-					formValues.fileAccess
+					formValues.fileAccess,
+					flowType
 				);
 			} catch ( e ) {
 				Sentry.captureException( e );

--- a/apps/studio/src/hooks/use-site-details.tsx
+++ b/apps/studio/src/hooks/use-site-details.tsx
@@ -15,6 +15,7 @@ import { useContentTabs } from 'src/hooks/use-content-tabs';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { simplifyErrorForDisplay, simplifyErrorToFirstSentence } from 'src/lib/error-formatting';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import type { TracksSiteCreateFlowType } from 'src/lib/tracks';
 import type { Blueprint } from 'src/stores/wpcom-api';
 
 // Safety-net poll interval; `site-event`s are the primary signal for running state.
@@ -40,7 +41,8 @@ interface SiteDetailsContext {
 		adminPassword?: string,
 		adminEmail?: string,
 		runtime?: SiteRuntime,
-		fileAccess?: SiteFileAccess
+		fileAccess?: SiteFileAccess,
+		flowType?: TracksSiteCreateFlowType
 	) => Promise< SiteDetails | void >;
 	copySite: ( sourceSiteId: string ) => Promise< SiteDetails | void >;
 	startServer: (
@@ -303,7 +305,8 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			adminPassword?: string,
 			adminEmail?: string,
 			runtime?: SiteRuntime,
-			fileAccess?: SiteFileAccess
+			fileAccess?: SiteFileAccess,
+			flowType?: TracksSiteCreateFlowType
 		) => {
 			// Function to handle error messages and cleanup
 			const showError = ( error?: unknown, hasBlueprint?: boolean ) => {
@@ -383,6 +386,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					adminPassword,
 					adminEmail,
 					noStart,
+					flowType,
 				} );
 				if ( ! newSite ) {
 					showError( undefined, !! blueprint );

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -132,7 +132,12 @@ import * as oauthClient from 'src/lib/oauth';
 import { getAiInstructionsPath } from 'src/lib/server-files-paths';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 import { setAgenticUiEnabled } from 'src/lib/studio-ui-mode';
-import { recordTracksEvent, type TracksChannel, type TracksUiVersion } from 'src/lib/tracks';
+import {
+	recordTracksEvent,
+	type TracksChannel,
+	type TracksSiteCreateFlowType,
+	type TracksUiVersion,
+} from 'src/lib/tracks';
 import { updateSiteUrl } from 'src/lib/update-site-url';
 import * as windowsHelpers from 'src/lib/windows-helpers';
 import { getLogsFilePath, writeLogToFile, type LogLevel } from 'src/logging';
@@ -783,6 +788,7 @@ export async function createSite(
 		adminPassword?: string;
 		adminEmail?: string;
 		noStart?: boolean;
+		flowType?: TracksSiteCreateFlowType;
 	} = {}
 ): Promise< SiteDetails > {
 	const {
@@ -799,6 +805,7 @@ export async function createSite(
 		adminPassword,
 		adminEmail,
 		noStart = false,
+		flowType,
 	} = config;
 
 	const siteId = providedSiteId || crypto.randomUUID();
@@ -834,6 +841,7 @@ export async function createSite(
 				adminPassword,
 				adminEmail,
 				noStart,
+				flowType,
 			},
 			{ wpVersion, blueprint: blueprint?.blueprint }
 		);
@@ -1226,6 +1234,7 @@ export async function copySite(
 			: undefined,
 		adminEmail: sourceSite.adminEmail,
 		noStart: true,
+		flowType: 'duplicate',
 	} );
 
 	// Playground sets the correct siteurl internally, but for the native-php runtime, we need to

--- a/apps/studio/src/lib/tracks.ts
+++ b/apps/studio/src/lib/tracks.ts
@@ -16,6 +16,7 @@ export {
 	type TracksEventName,
 	type TracksChannel,
 	type TracksUiVersion,
+	type TracksSiteCreateFlowType,
 } from '@studio/common/lib/record-tracks-event';
 
 async function commonProps(): Promise< TracksProps > {

--- a/apps/studio/src/modules/add-site/tests/add-site.test.tsx
+++ b/apps/studio/src/modules/add-site/tests/add-site.test.tsx
@@ -217,7 +217,8 @@ describe( 'AddSite', () => {
 			expect.any( String ),
 			'admin@localhost.com',
 			'native-php',
-			'site-directory'
+			'site-directory',
+			undefined // flowType
 		);
 	} );
 
@@ -437,7 +438,8 @@ describe( 'AddSite', () => {
 			expect.any( String ),
 			'admin@localhost.com',
 			'native-php',
-			'site-directory'
+			'site-directory',
+			undefined // flowType
 		);
 	} );
 
@@ -491,7 +493,8 @@ describe( 'AddSite', () => {
 				expect.any( String ),
 				'admin@localhost.com',
 				'native-php',
-				'all-files'
+				'all-files',
+				undefined // flowType
 			);
 		} );
 	} );

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -274,6 +274,7 @@ export function createIpcConnector(): Connector {
 				adminEmail,
 				skipStart,
 				blueprint,
+				flowType,
 			} = params;
 			return ( await ipcApi.createSite( path, {
 				siteName: name,
@@ -286,6 +287,7 @@ export function createIpcConnector(): Connector {
 				adminEmail,
 				noStart: skipStart,
 				blueprint,
+				flowType,
 			} ) ) as SiteDetails;
 		},
 

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -6,7 +6,11 @@ import type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessio
 import type { SiteEvent } from '@studio/common/lib/cli-events';
 import type { ImportEventTuple } from '@studio/common/lib/import-export-events';
 import type { SupportedLocale } from '@studio/common/lib/locale';
-import type { TracksEventName, TracksProps } from '@studio/common/lib/record-tracks-event';
+import type {
+	TracksEventName,
+	TracksProps,
+	TracksSiteCreateFlowType,
+} from '@studio/common/lib/record-tracks-event';
 import type { StudioAssistantQuota } from '@studio/common/lib/studio-assistant-quota';
 import type { SupportedEditor } from '@studio/common/lib/user-settings/editor';
 import type { SupportedTerminal } from '@studio/common/lib/user-settings/terminal';
@@ -539,6 +543,9 @@ export interface CreateSiteParams {
 		blueprint: BlueprintV1Declaration;
 		filePath?: string;
 	};
+	// Telemetry hint for the `studio_site_created` Tracks event. `import`/`sync` are set by the
+	// onboarding flows that create a blank site before populating it.
+	flowType?: TracksSiteCreateFlowType;
 }
 
 export interface ExtractedBlueprintBundle {

--- a/apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx
@@ -280,6 +280,7 @@ export function OnboardingConnectPage() {
 						name,
 						path,
 						skipStart: true,
+						flowType: 'sync',
 					} ),
 				persistConnection: async ( localSiteId ) => {
 					await connector.connectWpcomSite( localSiteId, {

--- a/apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx
@@ -105,6 +105,7 @@ export function OnboardingImportPage() {
 				adminUsername: values.adminUsername || undefined,
 				adminPassword: values.adminPassword || undefined,
 				adminEmail: values.adminEmail || undefined,
+				flowType: 'import',
 			} );
 			createdSiteId = site.id;
 			phase = 'importing';

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -110,6 +110,14 @@ where the sender actually runs — see Testing below for what fires in which bui
   counted exactly once whether it originated in a UI or standalone. The desktop passes its origin to the
   spawned CLI via the `STUDIO_TRACKS_ORIGIN` env var (`studio-ui:v1` / `studio-ui:v2`), injected in
   `apps/studio/src/modules/cli/lib/execute-command.ts`.
+- **`studio_site_created`** is likewise emitted **only** by the CLI, from the `site create` command
+  (`apps/cli/commands/site/create.ts`) on successful creation. Every path a site comes into existence
+  routes through it — new/blueprint (`createSite`), import and sync-pull (a blank site created via
+  `createSite`, then populated), and duplicate (`copySite` copies the files, then also creates via the
+  CLI). The CLI infers `flow_type=blueprint` from the blueprint arg; the callers thread the other
+  non-`new` values down as a `--flow-type` hint (built into the CLI args by `buildSiteCreateArgs` in
+  `packages/common/sites/create.ts`). `channel`/`ui_version` resolve from `STUDIO_TRACKS_ORIGIN` exactly
+  as for `studio_site_start`.
 - **Renderer-originated events** (future) go through the `recordAnalyticsEvent` IPC handler
   (`apps/studio/src/ipc-handlers.ts`). Both renderers share the same Main single entry point, and the
   desktop wrapper's `commonProps()` attaches `channel`/`ui_version` centrally — the `ui_version` is
@@ -155,6 +163,7 @@ events). The table lists the event-specific props.
 |---|---|---|
 | `studio_app_launch` | Desktop Main (`appBoot`) | `is_first_launch` |
 | `studio_site_start` | CLI site-start funnel | (none — `ui_version` comes from the wrapper via `STUDIO_TRACKS_ORIGIN`, only when `channel=studio-ui`) |
+| `studio_site_created` | CLI site-create funnel | `flow_type` (`new`/`blueprint`/`import`/`sync`/`duplicate`), `php_version`, `wp_version` (resolved from disk; `-` if unknown), `custom_domain` (boolean — the domain string is **never** sent), `ssl_enabled` (boolean), `time_ms` (creation duration). Emitted once per **successful** creation from the CLI, so app-spawned and standalone creates are counted once; filter by `channel` to separate UI from CLI. |
 | `studio_setting_telemetry_change` | Desktop Main (`saveAnalyticsEnabled`) | `status` (`on`/`off`), `surface` (`onboarding`/`settings`) — recorded while analytics is still ON (before the write when turning off, after it when turning on) so the opt-out gate never self-suppresses it. |
 | `studio_setting_appearance_change` | Desktop Main (`saveColorScheme`) | `mode` (`light`/`dark`/`system`), `surface` (`settings`) |
 | `studio_setting_language_change` | Desktop Main (`saveUserLocale`) | `locale`, `surface` (`settings`) |

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -157,23 +157,38 @@ AI-event vocabulary: `ai_session_id`, `agent_name`, `agent_version`, `ability_na
 
 Every event also carries the common props `channel`, `ui_version`, `is_a11n`, `platform`, `arch`,
 `app_version` (attached by the wrappers; `ui_version` is absent for pure-CLI `channel=studio-cli`
-events). The table lists the event-specific props.
+events). The tables below list the event-specific props, grouped by kind.
+
+#### Lifecycle events
+
+App and site lifecycle. The two site events are emitted by the CLI (the sole emitter for each), so a
+start / creation is counted once whether it originated in a UI or the standalone CLI — filter by
+`channel` to separate them.
 
 | Event | Emitted from | Event-specific props |
 |---|---|---|
 | `studio_app_launch` | Desktop Main (`appBoot`) | `is_first_launch` |
 | `studio_site_start` | CLI site-start funnel | (none — `ui_version` comes from the wrapper via `STUDIO_TRACKS_ORIGIN`, only when `channel=studio-ui`) |
-| `studio_site_created` | CLI site-create funnel | `flow_type` (`new`/`blueprint`/`import`/`sync`/`duplicate`), `php_version`, `wp_version` (resolved from disk; `-` if unknown), `custom_domain` (boolean — the domain string is **never** sent), `ssl_enabled` (boolean), `time_ms` (creation duration). Emitted once per **successful** creation from the CLI, so app-spawned and standalone creates are counted once; filter by `channel` to separate UI from CLI. |
-| `studio_setting_telemetry_change` | Desktop Main (`saveAnalyticsEnabled`) | `status` (`on`/`off`), `surface` (`onboarding`/`settings`) — recorded while analytics is still ON (before the write when turning off, after it when turning on) so the opt-out gate never self-suppresses it. |
-| `studio_setting_appearance_change` | Desktop Main (`saveColorScheme`) | `mode` (`light`/`dark`/`system`), `surface` (`settings`) |
-| `studio_setting_language_change` | Desktop Main (`saveUserLocale`) | `locale`, `surface` (`settings`) |
-| `studio_setting_code_editor_change` | Desktop Main (`saveUserEditor`) | `editor`, `surface` (`settings`) |
-| `studio_setting_terminal_change` | Desktop Main (`saveUserTerminal`) | `terminal`, `surface` (`settings`) |
-| `studio_setting_default_directory_change` | Desktop Main (`saveDefaultSiteDirectory`) | `is_default` (boolean), `surface` (`settings`) — the directory path is **never** sent (it contains the user's home path). |
-| `studio_setting_quit_action_change` | Desktop Main (`saveQuitSitesBehavior`) | `behavior` (`stop`/`stop-and-auto-start`/`leave-running`), `surface` (`settings`) |
-| `studio_setting_cli_change` | Desktop Main (`installStudioCli`/`uninstallStudioCli`) | `installed` (boolean), `surface` (`settings`) |
-| `studio_setting_agentic_features_change` | Desktop Main (`saveAgenticFeaturesEnabled`) | `enabled` (boolean), `surface` (`settings`) |
-| `studio_setting_ui_change` | Desktop Main (`updateBetaFeature`, `enableAgenticUi` key) | `type` (`classic`/`agentic`), `surface` (`settings`/`banner`/`menu`) — the switch has several entry points; the caller supplies the surface. Not emitted for the boot-time seeding migration (no surface). |
+| `studio_site_created` | CLI site-create funnel | `flow_type` (`new`/`blueprint`/`import`/`sync`/`duplicate`), `php_version`, `wp_version` (resolved from disk; `-` if unknown), `custom_domain` (boolean — the domain string is **never** sent), `ssl_enabled` (boolean), `time_ms` (creation duration). Emitted once per **successful** creation. |
+
+#### Settings-change events
+
+All fire from Desktop Main **only on a real change** (the handler compares against the persisted value
+first), and all carry a `surface` prop identifying where the change was made — `settings` unless noted.
+Sensitive values are never sent as strings (see `is_default` and the directory note below).
+
+| Event | Emitted from | Event-specific props |
+|---|---|---|
+| `studio_setting_telemetry_change` | `saveAnalyticsEnabled` | `status` (`on`/`off`), `surface` (`onboarding`/`settings`) — recorded while analytics is still ON (before the write when turning off, after it when turning on) so the opt-out gate never self-suppresses it. |
+| `studio_setting_appearance_change` | `saveColorScheme` | `mode` (`light`/`dark`/`system`), `surface` (`settings`) |
+| `studio_setting_language_change` | `saveUserLocale` | `locale`, `surface` (`settings`) |
+| `studio_setting_code_editor_change` | `saveUserEditor` | `editor`, `surface` (`settings`) |
+| `studio_setting_terminal_change` | `saveUserTerminal` | `terminal`, `surface` (`settings`) |
+| `studio_setting_default_directory_change` | `saveDefaultSiteDirectory` | `is_default` (boolean), `surface` (`settings`) — the directory path is **never** sent (it contains the user's home path). |
+| `studio_setting_quit_action_change` | `saveQuitSitesBehavior` | `behavior` (`stop`/`stop-and-auto-start`/`leave-running`), `surface` (`settings`) |
+| `studio_setting_cli_change` | `installStudioCli`/`uninstallStudioCli` | `installed` (boolean), `surface` (`settings`) |
+| `studio_setting_agentic_features_change` | `saveAgenticFeaturesEnabled` | `enabled` (boolean), `surface` (`settings`) |
+| `studio_setting_ui_change` | `updateBetaFeature` (`enableAgenticUi` key) | `type` (`classic`/`agentic`), `surface` (`settings`/`banner`/`menu`) — the switch has several entry points; the caller supplies the surface. Not emitted for the boot-time seeding migration (no surface). |
 
 ### How to add a new event
 

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -10,6 +10,7 @@ const TRACKS_PIXEL_URL = 'https://pixel.wp.com/t.gif';
 export const TRACKS_EVENTS = {
 	APP_LAUNCH: 'studio_app_launch',
 	SITE_START: 'studio_site_start',
+	SITE_CREATE: 'studio_site_created',
 	SETTING_TELEMETRY_CHANGE: 'studio_setting_telemetry_change',
 	SETTING_APPEARANCE_CHANGE: 'studio_setting_appearance_change',
 	SETTING_LANGUAGE_CHANGE: 'studio_setting_language_change',
@@ -44,6 +45,11 @@ export type TracksProps = Record< string, string | number | boolean | undefined 
 // and CLI wrappers stay in sync. See `docs/design-docs/analytics-tracks.md`.
 export type TracksChannel = 'studio-ui' | 'studio-cli';
 export type TracksUiVersion = 'v1' | 'v2';
+
+// The path a site came into existence through, for `studio_site_created`. `blueprint` is inferred by
+// the CLI from the presence of a blueprint; the other non-`new` values are threaded down from the
+// caller (import/sync from a renderer, duplicate from the desktop Main `copySite` handler).
+export type TracksSiteCreateFlowType = 'new' | 'blueprint' | 'import' | 'sync' | 'duplicate';
 
 // Builds the Tracks pixel URL. Isolated so a param-name correction is a one-file change. These are
 // the reserved Tracks pixel params: `_en` event name, `_ut`/`_ui` identity, `_ts` timestamp (ms).

--- a/packages/common/sites/create.test.ts
+++ b/packages/common/sites/create.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { buildSiteCreateArgs } from './create';
+
+// Reads a flag's value out of the built argv (the token right after `--<name>`).
+function argValue( args: string[], flag: string ): string | undefined {
+	const index = args.indexOf( flag );
+	return index === -1 ? undefined : args[ index + 1 ];
+}
+
+describe( 'buildSiteCreateArgs', () => {
+	it( 'appends --flow-type when a flowType is provided', () => {
+		const { args } = buildSiteCreateArgs( { path: '/tmp/site', flowType: 'import' } );
+
+		expect( argValue( args, '--flow-type' ) ).toBe( 'import' );
+	} );
+
+	it( 'omits --flow-type when no flowType is provided', () => {
+		const { args } = buildSiteCreateArgs( { path: '/tmp/site' } );
+
+		expect( args ).not.toContain( '--flow-type' );
+	} );
+} );

--- a/packages/common/sites/create.ts
+++ b/packages/common/sites/create.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { type TracksSiteCreateFlowType } from '@studio/common/lib/record-tracks-event';
 import { type SiteFileAccess } from '@studio/common/lib/site-file-access';
 import { siteModeFromRuntime, type SiteRuntime } from '@studio/common/lib/site-runtime';
 import { isWordPressDevVersion } from '@studio/common/lib/wordpress-version-utils';
@@ -26,6 +27,9 @@ export interface SiteCreateOptions {
 	adminPassword?: string;
 	adminEmail?: string;
 	noStart?: boolean;
+	// Telemetry hint for the `studio_site_created` Tracks event. Not a functional site option — the
+	// CLI infers `blueprint` on its own, so only import/sync/duplicate are threaded through here.
+	flowType?: TracksSiteCreateFlowType;
 }
 
 /**
@@ -76,6 +80,9 @@ export function buildSiteCreateArgs( options: SiteCreateOptions ): {
 	}
 	if ( options.noStart ) {
 		args.push( '--no-start' );
+	}
+	if ( options.flowType ) {
+		args.push( '--flow-type', options.flowType );
 	}
 
 	let blueprintTempPath: string | undefined;


### PR DESCRIPTION
## Related issues

- Fixes [STU-2116](https://linear.app/a8c/issue/STU-2116/tracks-site-creation-event)

## How AI was used in this PR

Explored the Tracks infrastructure and every site-creation flow, drafted the plan, and implemented it with AI assistance. All code was reviewed by me; the event was fired end-to-end in dev mode, for both UI and CLI flows, to confirm the tracking is working.

## Proposed Changes

Studio is adopting Tracks alongside MC Stats. This adds a single structured `studio_site_created` event that replaces the coarse MC Stats `studio-app-site-create` counter with queryable configuration and timing detail, so we can express funnels and cohorts instead of a bare count. It fires once whenever a local site comes into existence, through any path — a blank site, from a Blueprint, from an import (WXR/backup), from a WordPress.com sync-pull, or duplicated — distinguished by a `flow_type` property (plus `php_version`, `wp_version`, `custom_domain`, `ssl_enabled`, `time_ms`).

Following the `studio_site_start` model, the **CLI `site create` command is the sole emitter**: both desktop renderers create sites by delegating to the CLI, so a site is counted exactly once whether it originated in a UI (`channel=studio-ui`) or the standalone CLI (`channel=studio-cli`). The event fires only on **successful** creation. No PII is sent — `custom_domain`/`ssl_enabled` are booleans, never the domain string. MC Stats keeps running in parallel so the numbers can be validated before the counter is retired (Phase 2).

This is Main-process / CLI logic with no UI surface, so there is nothing to review visually.

Note on the duplicate flow: a duplicated site reports `custom_domain:false`/`ssl_enabled:false` because the copy deliberately does not inherit the source's domain/SSL (two sites can't share a domain) — this reflects the new copy's actual config, which is the intended behavior.

**Follow-up (not code):** register `studio_site_created` and all of its eventprops — including the wrapper-attached common props (`channel`, `ui_version`, `is_a11n`, `platform`, `arch`, `app_version`) — via the Tracks Registration tool. Registration is documentation + CI integrity, not a queryability gate.

## Testing Instructions

1. Start the app: `npm start`
2. Create a site via new/blueprint/import/Connect and duplicate an existing one
3. Confirm each logs `Would have recorded Tracks event: studio_site_created { flow_type: … }` in the `npm start` terminal with the matching `flow_type`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?