### PR TITLE
Agentic UI: Add an Open Studio Logs action to the pull error toast

### DIFF
--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -56,6 +56,7 @@ export const IPC_VOID_HANDLERS = [
 	'openFileInIDE',
 	'openLocalPath',
 	'openSiteURL',
+	'openStudioLogs',
 	'openURL',
 	'popupAppMenu',
 	'setWindowButtonVisibility',

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -1423,6 +1423,10 @@ export function showItemInFolder( _event: IpcMainInvokeEvent, path: string ) {
 	shell.showItemInFolder( path );
 }
 
+export async function openStudioLogs( _event: IpcMainInvokeEvent ) {
+	await shell.openPath( getLogsFilePath() );
+}
+
 export async function readLocalMediaFile(
 	_event: IpcMainInvokeEvent,
 	path: string

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -107,6 +107,7 @@ const api: IpcApi = {
 	generateNumberedNameFromList: ( baseName, usedSites ) =>
 		ipcRendererInvoke( 'generateNumberedNameFromList', baseName, usedSites ),
 	openLocalPath: ( path ) => ipcRendererSend( 'openLocalPath', path ),
+	openStudioLogs: () => ipcRendererSend( 'openStudioLogs' ),
 	showItemInFolder: ( path ) => ipcRendererSend( 'showItemInFolder', path ),
 	loadThemeDetails: ( id, emitLoadingEvent = true ) =>
 		ipcRendererInvoke( 'loadThemeDetails', id, emitLoadingEvent ),

--- a/apps/ui/src/components/create-site-form/index.test.tsx
+++ b/apps/ui/src/components/create-site-form/index.test.tsx
@@ -114,6 +114,7 @@ describe( 'CreateSiteForm', () => {
 				annotatePreview: false,
 				readLocalMedia: false,
 				agentInstructions: false,
+				studioLogs: false,
 				switchToClassicUi: false,
 			},
 		} );
@@ -387,6 +388,7 @@ describe( 'CreateSiteForm', () => {
 				annotatePreview: false,
 				readLocalMedia: false,
 				agentInstructions: false,
+				studioLogs: false,
 				switchToClassicUi: false,
 			},
 		} );

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -122,6 +122,7 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 			annotatePreview: false,
 			readLocalMedia: false,
 			agentInstructions: false,
+			studioLogs: false,
 			switchToClassicUi: false,
 		},
 
@@ -389,6 +390,9 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		},
 		async openSiteInTerminal() {
 			throw new UnsupportedError( 'openSiteInTerminal' );
+		},
+		async openStudioLogs() {
+			throw new UnsupportedError( 'openStudioLogs' );
 		},
 
 		// Analytics — no-op here. Tracks currently flows through the desktop IPC connector; the

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -213,6 +213,7 @@ export function createIpcConnector(): Connector {
 			annotatePreview: true,
 			readLocalMedia: true,
 			agentInstructions: true,
+			studioLogs: true,
 			switchToClassicUi: true,
 		},
 
@@ -796,6 +797,10 @@ export function createIpcConnector(): Connector {
 		async openSiteInTerminal( siteId ): Promise< void > {
 			const sitePath = await resolveSiteFolder( siteId );
 			await ipcApi.openTerminalAtPath( sitePath );
+		},
+
+		async openStudioLogs(): Promise< void > {
+			ipcApi.openStudioLogs();
 		},
 
 		// Analytics. `channel` and `ui_version` are attached by the desktop Tracks wrapper's

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -244,6 +244,7 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			annotatePreview: false,
 			readLocalMedia: false,
 			agentInstructions: true,
+			studioLogs: false,
 			switchToClassicUi: false,
 		},
 
@@ -774,6 +775,13 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 				method: 'POST',
 				body: JSON.stringify( { terminal } ),
 			} );
+		},
+
+		// The CLI has no equivalent of the desktop's log file — site server output
+		// goes to `~/.studio/daemon/logs` and the rest to the terminal that ran
+		// `studio ui` — so there is nothing to open here.
+		async openStudioLogs() {
+			throw new UnsupportedError( 'openStudioLogs' );
 		},
 
 		// Analytics — no-op here. Tracks currently flows through the desktop IPC connector; the

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -131,6 +131,11 @@ export interface ConnectorCapabilities {
 	// (~/.studio/knowledge/instructions.md). False when hosted remotely, which
 	// hides the Studio Code settings tab.
 	agentInstructions: boolean;
+	// The host keeps a Studio log file the user can open (`openStudioLogs`).
+	// Only the desktop app does — the CLI writes site server output to
+	// `~/.studio/daemon/logs` and everything else to the terminal that started
+	// it, so there is no single log to point a browser user at.
+	studioLogs: boolean;
 	// The host can switch this window back to the classic Studio UI
 	// (`disableAgenticUi`). Only the desktop app ships the classic renderer;
 	// in a browser there is nothing to switch to.
@@ -381,6 +386,9 @@ export interface Connector {
 	openSiteFolder( siteId: string ): Promise< void >;
 	openSiteInEditor( siteId: string ): Promise< void >;
 	openSiteInTerminal( siteId: string ): Promise< void >;
+
+	// Open Studio's own log file. Gated by `capabilities.studioLogs`.
+	openStudioLogs(): Promise< void >;
 
 	// Analytics — record a Tracks event. The desktop wrapper attaches the surface
 	// params (channel/ui_version); see `docs/design-docs/analytics-tracks.md`.

--- a/apps/ui/src/data/queries/use-sync-site.test.tsx
+++ b/apps/ui/src/data/queries/use-sync-site.test.tsx
@@ -42,6 +42,7 @@ describe( 'usePullSiteFromLive', () => {
 		vi.clearAllMocks();
 		finishPull = () => {};
 		useConnectorMock.mockReturnValue( {
+			capabilities: { studioLogs: true },
 			pullSiteFromLive: vi.fn( async ( _siteId, _remoteSiteId, onProgress ) => {
 				onProgress?.( { message: 'Creating remote backup… (24%)', progress: 24 } );
 				await new Promise< void >( ( resolve ) => {
@@ -71,7 +72,10 @@ describe( 'usePullSiteFromLive', () => {
 	} );
 
 	it( 'replaces connector details with an actionable pull error', async () => {
+		const openStudioLogs = vi.fn().mockResolvedValue( undefined );
 		useConnectorMock.mockReturnValue( {
+			capabilities: { studioLogs: true },
+			openStudioLogs,
 			pullSiteFromLive: vi
 				.fn()
 				.mockRejectedValue(
@@ -97,6 +101,34 @@ describe( 'usePullSiteFromLive', () => {
 		expect( screen.queryByText( /Error invoking remote method/ ) ).not.toBeInTheDocument();
 		expect( toast.error ).toHaveBeenCalledWith( "Pull didn't complete", {
 			description: message,
+			action: { label: 'Open Studio Logs', onClick: expect.any( Function ) },
 		} );
+
+		vi.mocked( toast.error ).mock.calls[ 0 ][ 1 ]?.action?.onClick();
+		expect( openStudioLogs ).toHaveBeenCalled();
+	} );
+
+	it( 'omits the logs hint when the host has no Studio log file', async () => {
+		useConnectorMock.mockReturnValue( {
+			capabilities: { studioLogs: false },
+			pullSiteFromLive: vi.fn().mockRejectedValue( new Error( 'nope' ) ),
+		} as unknown as Connector );
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		} );
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<Harness />
+			</QueryClientProvider>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Pull' } ) );
+
+		await waitFor( () =>
+			expect( toast.error ).toHaveBeenCalledWith( "Pull didn't complete", {
+				description: "Studio couldn't copy the live site. Try again.",
+				action: undefined,
+			} )
+		);
 	} );
 } );

--- a/apps/ui/src/data/queries/use-sync-site.ts
+++ b/apps/ui/src/data/queries/use-sync-site.ts
@@ -95,11 +95,27 @@ export function usePullSiteFromLive() {
 			toast.success( __( 'Pull complete' ) );
 		},
 		onError: ( _error, { siteId } ) => {
-			const message = __(
-				"Studio couldn't copy the live site. Try again. If the problem continues, check Studio Logs for details."
-			);
+			// Only point at the logs where the user can actually open them.
+			const canOpenLogs = connector.capabilities.studioLogs;
+			const message = canOpenLogs
+				? __(
+						"Studio couldn't copy the live site. Try again. If the problem continues, check Studio Logs for details."
+				  )
+				: __( "Studio couldn't copy the live site. Try again." );
 			reportSyncError( siteId, 'pull', message );
-			toast.error( __( "Pull didn't complete" ), { description: message } );
+			toast.error( __( "Pull didn't complete" ), {
+				description: message,
+				action: canOpenLogs
+					? {
+							label: __( 'Open Studio Logs' ),
+							onClick: () => {
+								void connector.openStudioLogs().catch( ( error ) => {
+									console.error( 'Failed to open Studio logs:', error );
+								} );
+							},
+					  }
+					: undefined,
+			} );
 		},
 	} );
 }


### PR DESCRIPTION
## Related issues

- Fixes STU-2202

## How AI was used in this PR

Claude traced the existing "Open Studio Logs" flow in the classic UI and the connector/capability seam in `apps/ui`, then wrote the change and the tests. I verified the behaviour in the running desktop app (see screenshot below) and reviewed the diff.

## Proposed Changes

When a pull from live fails, the Agentic UI tells you to "check Studio Logs for details" and then leaves you to find them yourself. The classic UI has always offered an **Open Studio Logs** button on its error dialog; this brings that to the Agentic UI's error card.

Where the host has no Studio log file to open — `studio ui` in a browser, and the hosted target — the button is hidden and the "check Studio Logs" sentence is dropped, so we don't point people at logs they can't reach. The CLI's only log directory holds per-site PHP server output, which is not where a sync failure lands, so opening it there would be misleading.

<img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/01b4e4a8-9e3f-4c05-bce0-eb2057d99e35" />

## Testing Instructions

Requires a site connected to a WordPress.com site.

1. `npm start`, then force a pull failure — easiest is to temporarily make `usePullSiteFromLive`'s `mutationFn` reject
2. The error card should show an **Open Studio Logs** button; clicking it opens today's `~/Library/Logs/Studio/studio-*.log`.
3. Check both light and dark.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
