### PR TITLE
Tracks: site lifecycle & open-action events (STU-2115)

### DIFF
--- a/apps/cli/commands/site/delete.ts
+++ b/apps/cli/commands/site/delete.ts
@@ -21,6 +21,7 @@ import { connectToDaemon, disconnectFromDaemon, emitCliEvent } from 'cli/lib/dae
 import { removeDomainFromHosts } from 'cli/lib/hosts-file';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { getSnapshotsFromConfig, deleteSnapshotFromConfig } from 'cli/lib/snapshots';
+import { getTracksOrigin, recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
@@ -161,6 +162,18 @@ export async function runCommand(
 		}
 
 		await emitCliEvent( { event: SITE_EVENTS.DELETED, data: { siteId: site.id } } );
+
+		// Tracks: the CLI is the sole emitter of site-delete, whether deleted standalone or by the
+		// desktop app (which delegates to `site delete` and passes its origin via STUDIO_TRACKS_ORIGIN).
+		// Best-effort — wrapped so telemetry can never fail a delete.
+		try {
+			await recordTracksEvent( TRACKS_EVENTS.SITE_DELETE, {
+				...getTracksOrigin(),
+				delete_files: deleteFiles,
+			} );
+		} catch {
+			// Best-effort telemetry — never block or fail a delete.
+		}
 	} finally {
 		await disconnectFromDaemon();
 	}

--- a/apps/cli/commands/site/stop.ts
+++ b/apps/cli/commands/site/stop.ts
@@ -14,11 +14,30 @@ import {
 	killDaemonAndChildren,
 } from 'cli/lib/daemon-client';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
-import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
+import { getTracksOrigin, recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
+import {
+	getRunningSiteCount,
+	isServerRunning,
+	stopWordPressServer,
+} from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
 const logger = new Logger< LoggerAction >();
+
+// Tracks: the CLI is the sole emitter of site-stop, whether stopped standalone or by the desktop app
+// (which delegates to `site stop` and passes its origin via STUDIO_TRACKS_ORIGIN). Best-effort —
+// wrapped so telemetry can never block or fail a stop.
+async function recordSiteStop( runningSiteCount: number | undefined ): Promise< void > {
+	try {
+		await recordTracksEvent( TRACKS_EVENTS.SITE_STOP, {
+			...getTracksOrigin(),
+			running_site_count: runningSiteCount,
+		} );
+	} catch {
+		// Best-effort telemetry — never block or fail a stop.
+	}
+}
 
 export enum Mode {
 	STOP_SINGLE_SITE,
@@ -53,6 +72,7 @@ export async function runCommand( target: Mode, siteFolder: string | undefined )
 				await clearSiteLatestCliPid( site.id );
 				logger.reportSuccess( __( 'WordPress server stopped' ) );
 				await stopProxyIfNoSitesNeedIt( site.id, logger );
+				await recordSiteStop( await getRunningSiteCount() );
 			} catch ( error ) {
 				throw new LoggerError( __( 'Failed to stop WordPress server' ), error );
 			}
@@ -98,6 +118,12 @@ export async function runCommand( target: Mode, siteFolder: string | undefined )
 						runningSites.length
 					)
 				);
+
+				// One event per stopped site, with the count of sites still running afterwards — the
+				// daemon is down here, so it decrements to 0 across the batch.
+				for ( let index = 0; index < runningSites.length; index++ ) {
+					await recordSiteStop( runningSites.length - 1 - index );
+				}
 			}
 		}
 	} finally {

--- a/apps/cli/commands/site/tests/delete.test.ts
+++ b/apps/cli/commands/site/tests/delete.test.ts
@@ -20,6 +20,7 @@ import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
 import { removeDomainFromHosts } from 'cli/lib/hosts-file';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { getSnapshotsFromConfig, deleteSnapshotFromConfig } from 'cli/lib/snapshots';
+import { recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { ProcessDescription } from 'cli/lib/types/process-manager-ipc';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { runCommand } from '../delete';
@@ -59,6 +60,10 @@ vi.mock( 'cli/lib/snapshots' );
 vi.mock( 'cli/lib/wordpress-server-manager' );
 vi.mock( '@studio/common/lib/fs-utils' );
 vi.mock( 'trash' );
+vi.mock( 'cli/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('cli/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
 
 describe( 'CLI: studio site delete', () => {
 	const testSiteFolder = '/test/site/path';
@@ -390,6 +395,24 @@ describe( 'CLI: studio site delete', () => {
 			expect( removeDomainFromHosts ).not.toHaveBeenCalled();
 			expect( deleteSiteCertificate ).not.toHaveBeenCalled();
 			expect( disconnectFromDaemon ).toHaveBeenCalled();
+		} );
+
+		it( 'records a site-delete Tracks event with delete_files true when trashing files', async () => {
+			await runCommand( testSiteFolder, true );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				TRACKS_EVENTS.SITE_DELETE,
+				expect.objectContaining( { delete_files: true } )
+			);
+		} );
+
+		it( 'records a site-delete Tracks event with delete_files false when keeping files', async () => {
+			await runCommand( testSiteFolder, false );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				TRACKS_EVENTS.SITE_DELETE,
+				expect.objectContaining( { delete_files: false } )
+			);
 		} );
 	} );
 } );

--- a/apps/cli/commands/site/tests/stop.test.ts
+++ b/apps/cli/commands/site/tests/stop.test.ts
@@ -8,8 +8,13 @@ import {
 	killDaemonAndChildren,
 } from 'cli/lib/daemon-client';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
+import { recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { ProcessDescription } from 'cli/lib/types/process-manager-ipc';
-import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
+import {
+	getRunningSiteCount,
+	isServerRunning,
+	stopWordPressServer,
+} from 'cli/lib/wordpress-server-manager';
 import { Mode, runCommand } from '../stop';
 
 vi.mock( 'cli/lib/cli-config/core', async () => {
@@ -31,6 +36,10 @@ vi.mock( 'cli/lib/cli-config/sites', async () => {
 vi.mock( 'cli/lib/daemon-client' );
 vi.mock( 'cli/lib/site-utils' );
 vi.mock( 'cli/lib/wordpress-server-manager' );
+vi.mock( 'cli/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('cli/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
 
 describe( 'CLI: studio site stop', () => {
 	// Simple test data
@@ -63,6 +72,7 @@ describe( 'CLI: studio site stop', () => {
 		vi.mocked( clearSiteLatestCliPid ).mockResolvedValue( undefined );
 		vi.mocked( stopProxyIfNoSitesNeedIt ).mockResolvedValue( undefined );
 		vi.mocked( killDaemonAndChildren ).mockResolvedValue( undefined );
+		vi.mocked( getRunningSiteCount ).mockResolvedValue( 0 );
 	} );
 
 	afterEach( () => {
@@ -123,6 +133,24 @@ describe( 'CLI: studio site stop', () => {
 			expect( clearSiteLatestCliPid ).toHaveBeenCalledWith( testSite.id );
 			expect( stopProxyIfNoSitesNeedIt ).toHaveBeenCalledWith( testSite.id, expect.any( Object ) );
 			expect( disconnectFromDaemon ).toHaveBeenCalled();
+		} );
+
+		it( 'records a site-stop Tracks event with the remaining running-site count', async () => {
+			vi.mocked( isServerRunning ).mockResolvedValue( testProcessDescription );
+			vi.mocked( getRunningSiteCount ).mockResolvedValue( 2 );
+
+			await runCommand( Mode.STOP_SINGLE_SITE, '/test/site' );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				TRACKS_EVENTS.SITE_STOP,
+				expect.objectContaining( { running_site_count: 2 } )
+			);
+		} );
+
+		it( 'does not record a site-stop Tracks event when the site is not running', async () => {
+			await runCommand( Mode.STOP_SINGLE_SITE, '/test/site' );
+
+			expect( recordTracksEvent ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should not call stopProxyIfNoSitesNeedIt if site is not running', async () => {
@@ -207,6 +235,7 @@ describe( 'CLI: studio site stop --all', () => {
 		vi.mocked( isServerRunning ).mockResolvedValue( undefined );
 		vi.mocked( killDaemonAndChildren ).mockResolvedValue( undefined );
 		vi.mocked( clearSiteLatestCliPid ).mockResolvedValue( undefined );
+		vi.mocked( getRunningSiteCount ).mockResolvedValue( 0 );
 	} );
 
 	afterEach( () => {
@@ -321,6 +350,24 @@ describe( 'CLI: studio site stop --all', () => {
 			expect( isServerRunning ).toHaveBeenCalledWith( 'site-1' );
 			expect( isServerRunning ).toHaveBeenCalledWith( 'site-2' );
 			expect( isServerRunning ).toHaveBeenCalledWith( 'site-3' );
+
+			// One event per stopped site, with the remaining count decrementing to 0.
+			expect( recordTracksEvent ).toHaveBeenCalledTimes( 3 );
+			expect( recordTracksEvent ).toHaveBeenNthCalledWith(
+				1,
+				TRACKS_EVENTS.SITE_STOP,
+				expect.objectContaining( { running_site_count: 2 } )
+			);
+			expect( recordTracksEvent ).toHaveBeenNthCalledWith(
+				2,
+				TRACKS_EVENTS.SITE_STOP,
+				expect.objectContaining( { running_site_count: 1 } )
+			);
+			expect( recordTracksEvent ).toHaveBeenNthCalledWith(
+				3,
+				TRACKS_EVENTS.SITE_STOP,
+				expect.objectContaining( { running_site_count: 0 } )
+			);
 
 			expect( killDaemonAndChildren ).toHaveBeenCalledTimes( 1 );
 

--- a/apps/cli/lib/tests/wordpress-server-manager.test.ts
+++ b/apps/cli/lib/tests/wordpress-server-manager.test.ts
@@ -11,6 +11,7 @@ import * as daemonClient from 'cli/lib/daemon-client';
 import { DaemonBus } from 'cli/lib/daemon-client';
 import { ensurePhpBinaryAvailable } from 'cli/lib/dependency-management/php-binary';
 import { recordSiteRuntimeUsage } from 'cli/lib/site-runtime-stats';
+import { recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import {
 	isServerRunning,
 	sendWpCliCommand,
@@ -29,6 +30,10 @@ vi.mock( 'cli/lib/site-runtime-stats', () => ( {
 vi.mock( 'cli/lib/cli-config/sites', () => ( {
 	updateSiteLatestCliPid: vi.fn(),
 } ) );
+vi.mock( 'cli/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('cli/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
 
 describe( 'WordPress Server Manager', () => {
 	const mockLogger = {
@@ -68,6 +73,7 @@ describe( 'WordPress Server Manager', () => {
 		vi.mocked( daemonClient.stopProcess ).mockResolvedValue( undefined );
 		vi.mocked( daemonClient.getDaemonBus ).mockResolvedValue( mockBus as DaemonBus );
 		vi.mocked( daemonClient.sendMessageToProcess ).mockReturnValue( Promise.resolve() );
+		vi.mocked( daemonClient.listProcesses ).mockResolvedValue( [ mockProcessDescription ] );
 	} );
 
 	afterEach( () => {
@@ -297,6 +303,40 @@ describe( 'WordPress Server Manager', () => {
 			await expect( startWordPressServer( mockSiteData, mockLogger ) ).rejects.toThrow();
 
 			expect( vi.mocked( recordSiteRuntimeUsage ) ).not.toHaveBeenCalled();
+		} );
+
+		it( 'records a successful site-start Tracks event with timing and running-site count', async () => {
+			setupIpcMocks();
+			vi.mocked( daemonClient.listProcesses ).mockResolvedValue( [
+				mockProcessDescription,
+				{ ...mockProcessDescription, name: 'studio-site-other', pmId: 6 },
+			] );
+
+			await startWordPressServer( mockSiteData, mockLogger );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				TRACKS_EVENTS.SITE_START,
+				expect.objectContaining( {
+					success: true,
+					running_site_count: 2,
+					time_ms: expect.any( Number ),
+				} )
+			);
+		} );
+
+		it( 'records a failed site-start Tracks event with a classified reason', async () => {
+			vi.mocked( daemonClient.startProcess ).mockRejectedValue( new Error( 'start timed out' ) );
+
+			await expect( startWordPressServer( mockSiteData, mockLogger ) ).rejects.toThrow();
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				TRACKS_EVENTS.SITE_START,
+				expect.objectContaining( {
+					success: false,
+					failure_reason: 'timeout',
+					time_ms: expect.any( Number ),
+				} )
+			);
 		} );
 
 		it( 'should handle start process failure', async () => {

--- a/apps/cli/lib/wordpress-server-manager.ts
+++ b/apps/cli/lib/wordpress-server-manager.ts
@@ -27,6 +27,7 @@ import { SiteData } from 'cli/lib/cli-config/core';
 import { updateSiteLatestCliPid } from 'cli/lib/cli-config/sites';
 import {
 	isProcessRunning,
+	listProcesses,
 	startProcess,
 	stopProcess,
 	getDaemonBus,
@@ -54,6 +55,20 @@ process.on( 'SIGTERM', () => abortController.abort() );
 
 export function getProcessName( siteId: string ): string {
 	return `${ SITE_PROCESS_PREFIX }${ siteId }`;
+}
+
+// Number of Studio site servers currently running, for the `running_site_count` Tracks prop. Queries
+// the daemon for online processes named with the site prefix. Best-effort: returns `undefined` if the
+// daemon can't be reached, so a telemetry read never fails the operation it annotates.
+export async function getRunningSiteCount(): Promise< number | undefined > {
+	try {
+		const processes = await listProcesses();
+		return processes.filter(
+			( proc ) => proc.status === 'online' && proc.name.startsWith( SITE_PROCESS_PREFIX )
+		).length;
+	} catch {
+		return undefined;
+	}
 }
 
 function getChildScriptPath( runtime: SiteRuntime ): string {
@@ -297,6 +312,7 @@ export async function startWordPressServer(
 	const phpErrorLogSizeAtStart = await fileSize( phpErrorLogPath );
 
 	const readyOrExit = await subscribeForReadyOrExit( processName );
+	const startedAt = Date.now();
 	try {
 		const processDesc = await startProcess( processName, wordPressServerChildPath, { runtime } );
 		await readyOrExit.waitFor( processDesc.pmId );
@@ -317,7 +333,12 @@ export async function startWordPressServer(
 		// so a short-lived `studio start` process doesn't exit before the event is sent, but wrapped in
 		// try/catch so best-effort telemetry can never block or fail the site start.
 		try {
-			await recordTracksEvent( TRACKS_EVENTS.SITE_START, { ...getTracksOrigin() } );
+			await recordTracksEvent( TRACKS_EVENTS.SITE_START, {
+				...getTracksOrigin(),
+				success: true,
+				time_ms: Date.now() - startedAt,
+				running_site_count: await getRunningSiteCount(),
+			} );
 		} catch {
 			// Best-effort telemetry — never block or fail a site start.
 		}
@@ -328,10 +349,41 @@ export async function startWordPressServer(
 		}
 		return runningProcess;
 	} catch ( error ) {
+		try {
+			await recordTracksEvent( TRACKS_EVENTS.SITE_START, {
+				...getTracksOrigin(),
+				success: false,
+				failure_reason: classifyStartFailure( error ),
+				time_ms: Date.now() - startedAt,
+			} );
+		} catch {
+			// Best-effort telemetry — never block or fail a site start.
+		}
 		throw await withCapturedPhpErrors( error, phpErrorLogPath, phpErrorLogSizeAtStart );
 	} finally {
 		readyOrExit.dispose();
 	}
+}
+
+// Coarse, low-cardinality classification of a start failure for the `failure_reason` Tracks prop.
+// Never send the raw error message: it can carry captured PHP output and filesystem paths (PII), and
+// its high cardinality would make the prop unqueryable.
+function classifyStartFailure( error: unknown ): string {
+	const message = error instanceof Error ? error.message : String( error );
+	const normalized = message.toLowerCase();
+	if ( normalized.includes( 'timeout' ) || normalized.includes( 'timed out' ) ) {
+		return 'timeout';
+	}
+	if ( normalized.includes( 'port' ) ) {
+		return 'port_unavailable';
+	}
+	if ( normalized.includes( 'php' ) ) {
+		return 'php_error';
+	}
+	if ( normalized.includes( 'exit' ) ) {
+		return 'process_exited';
+	}
+	return 'unknown';
 }
 
 async function clearStudioErrorLog( site: SiteData ): Promise< void > {

--- a/apps/studio/src/components/content-tab-overview.tsx
+++ b/apps/studio/src/components/content-tab-overview.tsx
@@ -20,9 +20,11 @@ import { ArrowIcon } from 'src/components/arrow-icon';
 import { ButtonsSection, ButtonsSectionProps } from 'src/components/buttons-section';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
+import { recordRendererTracksEvent } from 'src/lib/analytics';
 import { cx } from 'src/lib/cx';
 import { getFileManagerLabel } from 'src/lib/file-manager';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { TRACKS_EVENTS, type TracksCustomizeEntryPoint } from 'src/lib/tracks';
 import { supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
 import { getTerminalName } from 'src/modules/user-settings/lib/terminal';
 import { useGetUserEditorQuery, useGetUserTerminalQuery } from 'src/stores/installed-apps-api';
@@ -51,44 +53,58 @@ function CustomizeSection( {
 	const { startServer, loadingServer } = useSiteDetails();
 	const isLoading = selectedSite?.id ? loadingServer[ selectedSite.id ] : false;
 
-	const handleCustomizeClick = ( url: string ) => async () => {
-		if ( isLoading ) return;
-		if ( ! selectedSite.running ) {
-			await startServer( selectedSite );
-		}
-		getIpcApi().openSiteURL( selectedSite.id, url );
-	};
+	const handleCustomizeClick =
+		( url: string, entryPoint: TracksCustomizeEntryPoint ) => async () => {
+			if ( isLoading ) return;
+			recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_CUSTOMIZE, { entry_point: entryPoint } );
+			if ( ! selectedSite.running ) {
+				await startServer( selectedSite );
+			}
+			getIpcApi().openSiteURL( selectedSite.id, url );
+		};
 
 	const blockThemeButtons: ButtonsSectionProps[ 'buttonsArray' ] = [
 		{
 			label: __( 'Site Editor' ),
 			icon: desktop,
-			onClick: handleCustomizeClick( '/wp-admin/site-editor.php' ),
+			onClick: handleCustomizeClick( '/wp-admin/site-editor.php', 'editor' ),
 		},
 		{
 			label: __( 'Styles' ),
 			icon: styles,
-			onClick: handleCustomizeClick( '/wp-admin/site-editor.php?path=%2Fwp_global_styles' ),
+			onClick: handleCustomizeClick(
+				'/wp-admin/site-editor.php?path=%2Fwp_global_styles',
+				'editor_styles'
+			),
 		},
 		{
 			label: __( 'Patterns' ),
 			icon: symbolFilled,
-			onClick: handleCustomizeClick( '/wp-admin/site-editor.php?path=%2Fpatterns' ),
+			onClick: handleCustomizeClick(
+				'/wp-admin/site-editor.php?path=%2Fpatterns',
+				'editor_patterns'
+			),
 		},
 		{
 			label: __( 'Navigation' ),
 			icon: navigation,
-			onClick: handleCustomizeClick( '/wp-admin/site-editor.php?path=%2Fnavigation' ),
+			onClick: handleCustomizeClick(
+				'/wp-admin/site-editor.php?path=%2Fnavigation',
+				'editor_navigation'
+			),
 		},
 		{
 			label: __( 'Templates' ),
 			icon: layout,
-			onClick: handleCustomizeClick( '/wp-admin/site-editor.php?path=%2Fwp_template' ),
+			onClick: handleCustomizeClick(
+				'/wp-admin/site-editor.php?path=%2Fwp_template',
+				'editor_templates'
+			),
 		},
 		{
 			label: __( 'Pages' ),
 			icon: page,
-			onClick: handleCustomizeClick( '/wp-admin/site-editor.php?path=%2Fpage' ),
+			onClick: handleCustomizeClick( '/wp-admin/site-editor.php?path=%2Fpage', 'editor_pages' ),
 		},
 	];
 
@@ -96,7 +112,7 @@ function CustomizeSection( {
 		{
 			label: __( 'Customizer' ),
 			icon: pencil,
-			onClick: handleCustomizeClick( '/wp-admin/customize.php' ),
+			onClick: handleCustomizeClick( '/wp-admin/customize.php', 'customizer' ),
 		},
 	];
 
@@ -104,7 +120,7 @@ function CustomizeSection( {
 		classicThemeButtons.push( {
 			label: __( 'Menus' ),
 			icon: navigation,
-			onClick: handleCustomizeClick( '/wp-admin/nav-menus.php' ),
+			onClick: handleCustomizeClick( '/wp-admin/nav-menus.php', 'menus' ),
 		} );
 	}
 
@@ -112,7 +128,7 @@ function CustomizeSection( {
 		classicThemeButtons.push( {
 			label: __( 'Widgets' ),
 			icon: widget,
-			onClick: handleCustomizeClick( '/wp-admin/widgets.php' ),
+			onClick: handleCustomizeClick( '/wp-admin/widgets.php', 'widgets' ),
 		} );
 	}
 
@@ -144,6 +160,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 			className: 'text-nowrap',
 			icon: archive,
 			onClick: () => {
+				recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_FOLDER );
 				getIpcApi().openLocalPath( selectedSite.path );
 			},
 		},
@@ -182,6 +199,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		icon: grid,
 		disabled: isServerLoading,
 		onClick: async () => {
+			recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_PHPMYADMIN );
 			if ( ! selectedSite.running ) {
 				await startServer( selectedSite );
 			}
@@ -217,6 +235,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	const handleThumbnailClick = async () => {
 		if ( isServerLoading ) return;
 
+		recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER );
 		if ( ! selectedSite.running ) {
 			await startServer( selectedSite );
 		}

--- a/apps/studio/src/components/content-tab-overview.tsx
+++ b/apps/studio/src/components/content-tab-overview.tsx
@@ -1,4 +1,8 @@
 import * as Sentry from '@sentry/electron/renderer';
+import {
+	TRACKS_EVENTS,
+	type TracksCustomizeEntryPoint,
+} from '@studio/common/lib/record-tracks-event';
 import { __ } from '@wordpress/i18n';
 import {
 	archive,
@@ -24,7 +28,6 @@ import { recordRendererTracksEvent } from 'src/lib/analytics';
 import { cx } from 'src/lib/cx';
 import { getFileManagerLabel } from 'src/lib/file-manager';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { TRACKS_EVENTS, type TracksCustomizeEntryPoint } from 'src/lib/tracks';
 import { supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
 import { getTerminalName } from 'src/modules/user-settings/lib/terminal';
 import { useGetUserEditorQuery, useGetUserTerminalQuery } from 'src/stores/installed-apps-api';

--- a/apps/studio/src/components/content-tab-overview.tsx
+++ b/apps/studio/src/components/content-tab-overview.tsx
@@ -59,7 +59,10 @@ function CustomizeSection( {
 	const handleCustomizeClick =
 		( url: string, entryPoint: TracksCustomizeEntryPoint ) => async () => {
 			if ( isLoading ) return;
-			recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_CUSTOMIZE, { entry_point: entryPoint } );
+			recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_CUSTOMIZE, {
+				entry_point: entryPoint,
+				browser: 'external',
+			} );
 			if ( ! selectedSite.running ) {
 				await startServer( selectedSite );
 			}
@@ -202,7 +205,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		icon: grid,
 		disabled: isServerLoading,
 		onClick: async () => {
-			recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_PHPMYADMIN );
+			recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_PHPMYADMIN, { browser: 'external' } );
 			if ( ! selectedSite.running ) {
 				await startServer( selectedSite );
 			}
@@ -238,7 +241,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	const handleThumbnailClick = async () => {
 		if ( isServerLoading ) return;
 
-		recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER );
+		recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER, { browser: 'external' } );
 		if ( ! selectedSite.running ) {
 			await startServer( selectedSite );
 		}

--- a/apps/studio/src/components/content-tab-overview.tsx
+++ b/apps/studio/src/components/content-tab-overview.tsx
@@ -179,6 +179,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 			className: 'text-nowrap',
 			icon: code,
 			onClick: async () => {
+				recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_EDITOR, { editor } );
 				await getIpcApi().openAppAtPath( editor, selectedSite.path );
 			},
 		} );

--- a/apps/studio/src/components/header.tsx
+++ b/apps/studio/src/components/header.tsx
@@ -3,7 +3,9 @@ import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import { SiteManagementActions } from 'src/components/site-management-actions';
 import { useSiteDetails } from 'src/hooks/use-site-details';
+import { recordRendererTracksEvent } from 'src/lib/analytics';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { TRACKS_EVENTS } from 'src/lib/tracks';
 
 export default function Header() {
 	const { __ } = useI18n();
@@ -13,6 +15,7 @@ export default function Header() {
 	const handleWpAdminClick = async () => {
 		if ( ! site || isLoading ) return;
 
+		recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_WP_ADMIN );
 		if ( ! site.running ) {
 			await startServer( site );
 		}
@@ -22,6 +25,7 @@ export default function Header() {
 	const handleOpenSiteClick = async () => {
 		if ( ! site || isLoading ) return;
 
+		recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER );
 		if ( ! site.running ) {
 			await startServer( site );
 		}

--- a/apps/studio/src/components/header.tsx
+++ b/apps/studio/src/components/header.tsx
@@ -15,7 +15,7 @@ export default function Header() {
 	const handleWpAdminClick = async () => {
 		if ( ! site || isLoading ) return;
 
-		recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_WP_ADMIN );
+		recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_WP_ADMIN, { browser: 'external' } );
 		if ( ! site.running ) {
 			await startServer( site );
 		}
@@ -25,7 +25,7 @@ export default function Header() {
 	const handleOpenSiteClick = async () => {
 		if ( ! site || isLoading ) return;
 
-		recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER );
+		recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER, { browser: 'external' } );
 		if ( ! site.running ) {
 			await startServer( site );
 		}

--- a/apps/studio/src/components/header.tsx
+++ b/apps/studio/src/components/header.tsx
@@ -1,3 +1,4 @@
+import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
 import { useI18n } from '@wordpress/react-i18n';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
@@ -5,7 +6,6 @@ import { SiteManagementActions } from 'src/components/site-management-actions';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { recordRendererTracksEvent } from 'src/lib/analytics';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { TRACKS_EVENTS } from 'src/lib/tracks';
 
 export default function Header() {
 	const { __ } = useI18n();

--- a/apps/studio/src/components/site-content-tabs.tsx
+++ b/apps/studio/src/components/site-content-tabs.tsx
@@ -15,7 +15,9 @@ import { TabName } from 'src/hooks/use-content-tabs';
 import { useEffectiveTab } from 'src/hooks/use-effective-tab';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
+import { recordRendererTracksEvent } from 'src/lib/analytics';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { TRACKS_EVENTS } from 'src/lib/tracks';
 import { ContentTabSync } from 'src/modules/sync';
 
 export function SiteContentTabs() {
@@ -108,6 +110,7 @@ export function SiteContentTabs() {
 						// so the useEffect can detect it was user-initiated
 						if ( tabName !== effectiveTab ) {
 							lastChangeWasUser.current = true;
+							recordRendererTracksEvent( TRACKS_EVENTS.PANEL_OPENED, { panel: tabName } );
 						}
 						setSelectedTab( tabName as TabName );
 					} }

--- a/apps/studio/src/components/site-content-tabs.tsx
+++ b/apps/studio/src/components/site-content-tabs.tsx
@@ -1,3 +1,4 @@
+import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -17,7 +18,6 @@ import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { recordRendererTracksEvent } from 'src/lib/analytics';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { TRACKS_EVENTS } from 'src/lib/tracks';
 import { ContentTabSync } from 'src/modules/sync';
 
 export function SiteContentTabs() {

--- a/apps/studio/src/components/site-menu.tsx
+++ b/apps/studio/src/components/site-menu.tsx
@@ -9,10 +9,12 @@ import { useContentTabs } from 'src/hooks/use-content-tabs';
 import { useDeleteSite } from 'src/hooks/use-delete-site';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
+import { recordRendererTracksEvent } from 'src/lib/analytics';
 import { isMac } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { getFileManagerLabel } from 'src/lib/file-manager';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { TRACKS_EVENTS } from 'src/lib/tracks';
 import { supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
 import { getTerminalName } from 'src/modules/user-settings/lib/terminal';
 import { useRootSelector } from 'src/stores';
@@ -313,18 +315,21 @@ export default function SiteMenu( { className }: SiteMenuProps ) {
 						void stopServer( site.id );
 						break;
 					case 'open-site':
+						recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER );
 						if ( ! site.running ) {
 							await startServer( site );
 						}
 						ipcApi.openSiteURL( site.id, '', { autoLogin: false } );
 						break;
 					case 'open-admin':
+						recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_WP_ADMIN );
 						if ( ! site.running ) {
 							await startServer( site );
 						}
 						ipcApi.openSiteURL( site.id, '/wp-admin/' );
 						break;
 					case 'open-finder':
+						recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_FOLDER );
 						ipcApi.openLocalPath( site.path );
 						break;
 					case 'open-editor':

--- a/apps/studio/src/components/site-menu.tsx
+++ b/apps/studio/src/components/site-menu.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/electron/renderer';
+import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
 import { speak } from '@wordpress/a11y';
 import { Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -14,7 +15,6 @@ import { isMac } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { getFileManagerLabel } from 'src/lib/file-manager';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { TRACKS_EVENTS } from 'src/lib/tracks';
 import { supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
 import { getTerminalName } from 'src/modules/user-settings/lib/terminal';
 import { useRootSelector } from 'src/stores';

--- a/apps/studio/src/components/site-menu.tsx
+++ b/apps/studio/src/components/site-menu.tsx
@@ -338,6 +338,7 @@ export default function SiteMenu( { className }: SiteMenuProps ) {
 						break;
 					case 'open-editor':
 						if ( editor ) {
+							recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_EDITOR, { editor } );
 							void ipcApi.openAppAtPath( editor, site.path );
 						}
 						break;

--- a/apps/studio/src/components/site-menu.tsx
+++ b/apps/studio/src/components/site-menu.tsx
@@ -315,14 +315,18 @@ export default function SiteMenu( { className }: SiteMenuProps ) {
 						void stopServer( site.id );
 						break;
 					case 'open-site':
-						recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER );
+						recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER, {
+							browser: 'external',
+						} );
 						if ( ! site.running ) {
 							await startServer( site );
 						}
 						ipcApi.openSiteURL( site.id, '', { autoLogin: false } );
 						break;
 					case 'open-admin':
-						recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_WP_ADMIN );
+						recordRendererTracksEvent( TRACKS_EVENTS.SITE_OPEN_WP_ADMIN, {
+							browser: 'external',
+						} );
 						if ( ! site.running ) {
 							await startServer( site );
 						}

--- a/apps/studio/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/apps/studio/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -177,6 +177,54 @@ describe( 'ShortcutsSection', () => {
 		} );
 	} );
 
+	it( 'records a Tracks event when opening the site folder', async () => {
+		const recordAnalyticsEventMock = vi.fn().mockResolvedValue( undefined );
+		vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+			openLocalPath: vi.fn(),
+			recordAnalyticsEvent: recordAnalyticsEventMock,
+			getUserEditor: vi.fn().mockResolvedValue( null ),
+			getUserTerminal: vi.fn().mockResolvedValue( 'terminal' ),
+		} );
+
+		const { getByLabelText } = renderWithProvider(
+			<ContentTabOverview selectedSite={ selectedSite } />
+		);
+
+		const folderButton = await waitFor( () => getByLabelText( 'Finder' ) );
+		fireEvent.click( folderButton );
+
+		await waitFor( () => {
+			expect( recordAnalyticsEventMock ).toHaveBeenCalledWith(
+				'studio_site_open_folder',
+				expect.anything()
+			);
+		} );
+	} );
+
+	it( 'records a Tracks event when opening phpMyAdmin', async () => {
+		const recordAnalyticsEventMock = vi.fn().mockResolvedValue( undefined );
+		vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+			openSiteURL: vi.fn(),
+			recordAnalyticsEvent: recordAnalyticsEventMock,
+			getUserEditor: vi.fn().mockResolvedValue( null ),
+			getUserTerminal: vi.fn().mockResolvedValue( 'terminal' ),
+		} );
+
+		const { getByLabelText } = renderWithProvider(
+			<ContentTabOverview selectedSite={ selectedSite } />
+		);
+
+		const phpMyAdminButton = await waitFor( () => getByLabelText( 'phpMyAdmin' ) );
+		fireEvent.click( phpMyAdminButton );
+
+		await waitFor( () => {
+			expect( recordAnalyticsEventMock ).toHaveBeenCalledWith(
+				'studio_site_open_phpmyadmin',
+				expect.anything()
+			);
+		} );
+	} );
+
 	it( 'shows users preferred editor', async () => {
 		// Mock the IPC API
 		vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {

--- a/apps/studio/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/apps/studio/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -75,9 +75,11 @@ describe( 'ShortcutsSection', () => {
 		// Mock the IPC API with getInstalledApps returning the installed apps
 		const openURLMock = vi.fn();
 		const openAppAtPathMock = vi.fn();
+		const recordAnalyticsEventMock = vi.fn().mockResolvedValue( undefined );
 		vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
 			openURL: openURLMock,
 			openAppAtPath: openAppAtPathMock,
+			recordAnalyticsEvent: recordAnalyticsEventMock,
 			getUserEditor: vi.fn().mockResolvedValue( 'vscode' ),
 			getUserTerminal: vi.fn().mockResolvedValue( 'terminal' ),
 			getInstalledAppsAndTerminals: vi.fn().mockResolvedValue( {
@@ -106,6 +108,9 @@ describe( 'ShortcutsSection', () => {
 		await waitFor( () => {
 			expect( openAppAtPathMock ).toHaveBeenCalledWith( 'vscode', selectedSite.path );
 		} );
+		expect( recordAnalyticsEventMock ).toHaveBeenCalledWith( 'studio_site_open_in_editor', {
+			editor: 'vscode',
+		} );
 	} );
 
 	it( 'opens site in PhpStorm when PhpStorm is installed and the button is clicked, only available on MacOS', async () => {
@@ -115,6 +120,7 @@ describe( 'ShortcutsSection', () => {
 		const openAppAtPathMock = vi.fn();
 		vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
 			openAppAtPath: openAppAtPathMock,
+			recordAnalyticsEvent: vi.fn().mockResolvedValue( undefined ),
 			getUserEditor: vi.fn().mockResolvedValue( 'phpstorm' ), // User prefers PhpStorm
 			getUserTerminal: vi.fn().mockResolvedValue( 'terminal' ),
 			getInstalledAppsAndTerminals: vi.fn().mockResolvedValue( {

--- a/apps/studio/src/components/tests/content-tab-overview.actions.test.tsx
+++ b/apps/studio/src/components/tests/content-tab-overview.actions.test.tsx
@@ -49,14 +49,31 @@ const site: StartedSiteDetails = {
 	},
 };
 
-// Each block-theme Customize button and the URL it opens (content-tab-overview.tsx).
+// Each block-theme Customize button, the URL it opens, and the entry_point it
+// reports to Tracks (content-tab-overview.tsx).
 const CUSTOMIZE_LINKS = [
-	{ label: 'Site Editor', url: '/wp-admin/site-editor.php' },
-	{ label: 'Styles', url: '/wp-admin/site-editor.php?path=%2Fwp_global_styles' },
-	{ label: 'Patterns', url: '/wp-admin/site-editor.php?path=%2Fpatterns' },
-	{ label: 'Navigation', url: '/wp-admin/site-editor.php?path=%2Fnavigation' },
-	{ label: 'Templates', url: '/wp-admin/site-editor.php?path=%2Fwp_template' },
-	{ label: 'Pages', url: '/wp-admin/site-editor.php?path=%2Fpage' },
+	{ label: 'Site Editor', url: '/wp-admin/site-editor.php', entryPoint: 'editor' },
+	{
+		label: 'Styles',
+		url: '/wp-admin/site-editor.php?path=%2Fwp_global_styles',
+		entryPoint: 'editor_styles',
+	},
+	{
+		label: 'Patterns',
+		url: '/wp-admin/site-editor.php?path=%2Fpatterns',
+		entryPoint: 'editor_patterns',
+	},
+	{
+		label: 'Navigation',
+		url: '/wp-admin/site-editor.php?path=%2Fnavigation',
+		entryPoint: 'editor_navigation',
+	},
+	{
+		label: 'Templates',
+		url: '/wp-admin/site-editor.php?path=%2Fwp_template',
+		entryPoint: 'editor_templates',
+	},
+	{ label: 'Pages', url: '/wp-admin/site-editor.php?path=%2Fpage', entryPoint: 'editor_pages' },
 ];
 
 const wrapper = ( { children }: { children: ReactNode } ) => (
@@ -100,6 +117,7 @@ beforeEach( () => {
 		getUserTerminal: vi.fn().mockResolvedValue( undefined ),
 		startServer: vi.fn().mockResolvedValue( { ...site, running: true } ),
 		openSiteURL: vi.fn(),
+		recordAnalyticsEvent: vi.fn().mockResolvedValue( undefined ),
 	} );
 } );
 
@@ -114,6 +132,23 @@ describe( 'ContentTabOverview — Customize links (IPC command boundary)', () =>
 			expect( getIpcApi().openSiteURL ).toHaveBeenCalledWith( SITE_ID, url );
 		} );
 	} );
+
+	it.each( CUSTOMIZE_LINKS )(
+		'$label records a customize Tracks event with entry_point $entryPoint',
+		async ( { label, entryPoint } ) => {
+			const user = userEvent.setup();
+			renderOverview();
+
+			await user.click( await findEnabledButton( label ) );
+
+			await waitFor( () => {
+				expect( getIpcApi().recordAnalyticsEvent ).toHaveBeenCalledWith(
+					'studio_site_open_customize',
+					{ entry_point: entryPoint }
+				);
+			} );
+		}
+	);
 
 	it( 'starts the server before opening when the site is stopped', async () => {
 		const user = userEvent.setup();

--- a/apps/studio/src/components/tests/content-tab-overview.actions.test.tsx
+++ b/apps/studio/src/components/tests/content-tab-overview.actions.test.tsx
@@ -144,7 +144,7 @@ describe( 'ContentTabOverview — Customize links (IPC command boundary)', () =>
 			await waitFor( () => {
 				expect( getIpcApi().recordAnalyticsEvent ).toHaveBeenCalledWith(
 					'studio_site_open_customize',
-					{ entry_point: entryPoint }
+					{ entry_point: entryPoint, browser: 'external' }
 				);
 			} );
 		}

--- a/apps/studio/src/components/tests/header.test.tsx
+++ b/apps/studio/src/components/tests/header.test.tsx
@@ -37,6 +37,7 @@ function mockGetIpcApi( mocks: Record< string, Mock > ) {
 		setSnapshot: vi.fn(),
 		startServer: vi.fn( () => Promise.resolve() ),
 		showErrorMessageBox: vi.fn(),
+		recordAnalyticsEvent: vi.fn().mockResolvedValue( undefined ),
 		...mocks,
 	} as unknown as IpcApi );
 }
@@ -81,6 +82,10 @@ describe( 'Header', () => {
 			expect( vi.mocked( getIpcApi )().openSiteURL ).toHaveBeenCalledWith( 'mock-id', '', {
 				autoLogin: false,
 			} );
+			expect( vi.mocked( getIpcApi )().recordAnalyticsEvent ).toHaveBeenCalledWith(
+				'studio_site_open_in_browser',
+				expect.anything()
+			);
 		} );
 
 		it( 'opens wp-admin with auto-login', async () => {
@@ -95,6 +100,10 @@ describe( 'Header', () => {
 			expect( vi.mocked( getIpcApi )().openSiteURL ).toHaveBeenCalledWith(
 				'mock-id',
 				'/wp-admin/'
+			);
+			expect( vi.mocked( getIpcApi )().recordAnalyticsEvent ).toHaveBeenCalledWith(
+				'studio_site_open_wp_admin',
+				expect.anything()
 			);
 		} );
 	} );

--- a/apps/studio/src/components/tests/site-content-tabs.test.tsx
+++ b/apps/studio/src/components/tests/site-content-tabs.test.tsx
@@ -1,9 +1,11 @@
 import { act, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { vi } from 'vitest';
 import { SiteContentTabs } from 'src/components/site-content-tabs';
 import { ContentTabsProvider } from 'src/hooks/use-content-tabs';
 import { useSiteDetails } from 'src/hooks/use-site-details';
+import { getIpcApi } from 'src/lib/get-ipc-api';
 import { store } from 'src/stores';
 import { testActions, testReducer } from 'src/stores/tests/utils/test-reducer';
 
@@ -37,6 +39,7 @@ vi.mock( 'src/lib/get-ipc-api', async () => ( {
 		getUserEditor: vi.fn().mockResolvedValue( 'vscode' ),
 		setWindowControlVisibility: vi.fn(),
 		isAgenticUiBannerDismissed: vi.fn().mockResolvedValue( true ),
+		recordAnalyticsEvent: vi.fn().mockResolvedValue( undefined ),
 	} ),
 } ) );
 
@@ -110,5 +113,21 @@ describe( 'SiteContentTabs', () => {
 		expect(
 			screen.queryByRole( 'tab', { name: 'Backup', selected: false } )
 		).not.toBeInTheDocument();
+	} );
+	it( 'records a panel-opened Tracks event when the user switches tabs', async () => {
+		const user = userEvent.setup();
+		vi.mocked( useSiteDetails, { partial: true } ).mockReturnValue( {
+			selectedSite,
+			sites: [ selectedSite ],
+			loadingServer: {},
+		} );
+		await act( async () => renderWithProvider( <SiteContentTabs /> ) );
+
+		await user.click( screen.getByRole( 'tab', { name: 'Sync' } ) );
+
+		expect( vi.mocked( getIpcApi )().recordAnalyticsEvent ).toHaveBeenCalledWith(
+			'studio_panel_opened',
+			{ panel: 'sync' }
+		);
 	} );
 } );

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -134,6 +134,7 @@ import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 import { setAgenticUiEnabled } from 'src/lib/studio-ui-mode';
 import {
 	recordTracksEvent,
+	TRACKS_EVENTS,
 	type TracksChannel,
 	type TracksSiteCreateFlowType,
 	type TracksUiVersion,
@@ -1627,6 +1628,11 @@ export async function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath
 
 	const preferredTerminal = await getUserTerminal();
 
+	// The single funnel for "open in terminal" across both the apps/studio buttons/context-menu and the
+	// apps/ui ipc connector — emitting here counts every path once. Fire-and-forget; the wrapper gates
+	// opt-out and never throws.
+	void recordTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_TERMINAL, { terminal: preferredTerminal } );
+
 	if ( platform === 'darwin' ) {
 		const escapedPath = targetPath.replace( /\\/g, '\\\\' ).replace( /"/g, '\\"' );
 		const bundleIds = {
@@ -1723,6 +1729,11 @@ export async function openAppAtPath(
 	const editor = supportedEditorConfig[ editorKey ];
 	const allPaths = [ filePath, ...otherFiles ];
 	const quotedPaths = allPaths.map( ( p ) => `"${ p }"` ).join( ' ' );
+
+	// The single funnel for "open in editor" across both the apps/studio buttons/context-menu and the
+	// apps/ui ipc connector — emitting here counts every path once. Fire-and-forget; the wrapper gates
+	// opt-out and never throws.
+	void recordTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_EDITOR, { editor: editorKey } );
 
 	if ( platform === 'darwin' ) {
 		const cmd = `open -b ${ editor.macOSBundleId } ${ quotedPaths }`;

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -1730,11 +1730,6 @@ export async function openAppAtPath(
 	const allPaths = [ filePath, ...otherFiles ];
 	const quotedPaths = allPaths.map( ( p ) => `"${ p }"` ).join( ' ' );
 
-	// The single funnel for "open in editor" across both the apps/studio buttons/context-menu and the
-	// apps/ui ipc connector — emitting here counts every path once. Fire-and-forget; the wrapper gates
-	// opt-out and never throws.
-	void recordTracksEvent( TRACKS_EVENTS.SITE_OPEN_IN_EDITOR, { editor: editorKey } );
-
 	if ( platform === 'darwin' ) {
 		const cmd = `open -b ${ editor.macOSBundleId } ${ quotedPaths }`;
 		return promiseExec( cmd );

--- a/apps/studio/src/lib/analytics.ts
+++ b/apps/studio/src/lib/analytics.ts
@@ -1,0 +1,14 @@
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import type { TracksEventName, TracksProps } from 'src/lib/tracks';
+
+// Records a Tracks event from the (legacy) renderer. Routes through the `recordAnalyticsEvent` IPC
+// handler so the desktop Main wrapper attaches the common props (`channel`, `ui_version`, …) and
+// enforces the opt-out in one place. Typed against `TracksEventName` for compile-time name checking;
+// fire-and-forget so a telemetry hiccup never affects the UI action that triggered it.
+export function recordRendererTracksEvent( event: TracksEventName, props: TracksProps = {} ): void {
+	void getIpcApi()
+		.recordAnalyticsEvent( event, props )
+		.catch( () => {
+			// Best-effort telemetry — never surface an error to the UI.
+		} );
+}

--- a/apps/studio/src/lib/analytics.ts
+++ b/apps/studio/src/lib/analytics.ts
@@ -1,5 +1,5 @@
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import type { TracksEventName, TracksProps } from 'src/lib/tracks';
+import type { TracksEventName, TracksProps } from '@studio/common/lib/record-tracks-event';
 
 // Records a Tracks event from the (legacy) renderer. Routes through the `recordAnalyticsEvent` IPC
 // handler so the desktop Main wrapper attaches the common props (`channel`, `ui_version`, …) and

--- a/apps/studio/src/lib/tracks.ts
+++ b/apps/studio/src/lib/tracks.ts
@@ -14,11 +14,9 @@ import { getPreferredUiVersion } from 'src/lib/studio-ui-mode';
 export {
 	TRACKS_EVENTS,
 	type TracksEventName,
-	type TracksProps,
 	type TracksChannel,
 	type TracksUiVersion,
 	type TracksSiteCreateFlowType,
-	type TracksCustomizeEntryPoint,
 } from '@studio/common/lib/record-tracks-event';
 
 async function commonProps(): Promise< TracksProps > {

--- a/apps/studio/src/lib/tracks.ts
+++ b/apps/studio/src/lib/tracks.ts
@@ -14,9 +14,11 @@ import { getPreferredUiVersion } from 'src/lib/studio-ui-mode';
 export {
 	TRACKS_EVENTS,
 	type TracksEventName,
+	type TracksProps,
 	type TracksChannel,
 	type TracksUiVersion,
 	type TracksSiteCreateFlowType,
+	type TracksCustomizeEntryPoint,
 } from '@studio/common/lib/record-tracks-event';
 
 async function commonProps(): Promise< TracksProps > {

--- a/apps/studio/src/tests/open-file-in-ide.test.ts
+++ b/apps/studio/src/tests/open-file-in-ide.test.ts
@@ -7,10 +7,11 @@ import { normalize, join } from 'path';
 import { readFile } from 'atomically';
 import { vol } from 'memfs';
 import { vi } from 'vitest';
-import { openAppAtPath, openFileInIDE } from 'src/ipc-handlers';
+import { openAppAtPath, openFileInIDE, openTerminalAtPath } from 'src/ipc-handlers';
 import { isInstalled } from 'src/lib/is-installed';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
-import { getUserEditor } from 'src/modules/user-settings/lib/ipc-handlers';
+import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
+import { getUserEditor, getUserTerminal } from 'src/modules/user-settings/lib/ipc-handlers';
 import { linuxFindEditorPath } from 'src/modules/user-settings/lib/linux-editor-path';
 import { SiteServer } from 'src/site-server';
 
@@ -49,7 +50,12 @@ vi.mock( 'src/modules/user-settings/lib/linux-editor-path', () => ( {
 } ) );
 vi.mock( 'src/modules/user-settings/lib/ipc-handlers', async () => ( {
 	getUserEditor: vi.fn().mockResolvedValue( null ),
+	getUserTerminal: vi.fn().mockResolvedValue( 'terminal' ),
 } ) );
+vi.mock( 'src/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('src/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
 vi.mock( 'src/main-window' );
 vi.mock( '@studio/common/lib/bump-stat' );
 vi.mock( 'atomically' );
@@ -189,6 +195,16 @@ describe( 'openAppAtPath on Linux', () => {
 		expect( calls[ 0 ] ).toContain( '"/sites/test-site/wp-content/plugins/hello.php"' );
 	} );
 
+	it( 'records an open-in-editor Tracks event with the resolved editor', async () => {
+		vi.mocked( linuxFindEditorPath ).mockResolvedValue( '/usr/bin/code' );
+
+		await openAppAtPath( mockIpcMainInvokeEvent, 'vscode', '/sites/test-site' );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( TRACKS_EVENTS.SITE_OPEN_IN_EDITOR, {
+			editor: 'vscode',
+		} );
+	} );
+
 	it( 'falls back to the editor URL scheme when no binary is found', async () => {
 		vi.mocked( linuxFindEditorPath ).mockResolvedValue( null );
 
@@ -206,5 +222,31 @@ describe( 'openAppAtPath on Linux', () => {
 			2,
 			'vscode://file//sites/test-site/wp-content/plugins/hello.php?windowId=_blank'
 		);
+	} );
+} );
+
+describe( 'openTerminalAtPath on macOS', () => {
+	const originalPlatform = process.platform;
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		Object.defineProperty( process, 'platform', { value: 'darwin', configurable: true } );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( process, 'platform', {
+			value: originalPlatform,
+			configurable: true,
+		} );
+	} );
+
+	it( 'records an open-in-terminal Tracks event with the resolved terminal', async () => {
+		vi.mocked( getUserTerminal ).mockResolvedValue( 'iterm' );
+
+		await openTerminalAtPath( mockIpcMainInvokeEvent, '/sites/test-site' );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( TRACKS_EVENTS.SITE_OPEN_IN_TERMINAL, {
+			terminal: 'iterm',
+		} );
 	} );
 } );

--- a/apps/studio/src/tests/open-file-in-ide.test.ts
+++ b/apps/studio/src/tests/open-file-in-ide.test.ts
@@ -115,6 +115,17 @@ describe( 'openFileInIDE', () => {
 		expect( calls[ 0 ] ).toContain( join( 'wp-content', 'plugins', 'hello.php' ) );
 	} );
 
+	it( 'does not record an open-in-editor Tracks event when opening a single file', async () => {
+		vi.mocked( getUserEditor ).mockResolvedValue( 'cursor' );
+
+		await openFileInIDE( mockIpcMainInvokeEvent, 'wp-content/plugins/hello.php', 'site-1' );
+
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+			TRACKS_EVENTS.SITE_OPEN_IN_EDITOR,
+			expect.anything()
+		);
+	} );
+
 	it( 'should fall back to first installed editor when no preference is set', async () => {
 		vi.mocked( isInstalled ).mockImplementation( ( key ) => key === 'phpstorm' );
 
@@ -195,14 +206,15 @@ describe( 'openAppAtPath on Linux', () => {
 		expect( calls[ 0 ] ).toContain( '"/sites/test-site/wp-content/plugins/hello.php"' );
 	} );
 
-	it( 'records an open-in-editor Tracks event with the resolved editor', async () => {
+	it( 'does not record an open-in-editor Tracks event (it is shared with single-file opens)', async () => {
 		vi.mocked( linuxFindEditorPath ).mockResolvedValue( '/usr/bin/code' );
 
 		await openAppAtPath( mockIpcMainInvokeEvent, 'vscode', '/sites/test-site' );
 
-		expect( recordTracksEvent ).toHaveBeenCalledWith( TRACKS_EVENTS.SITE_OPEN_IN_EDITOR, {
-			editor: 'vscode',
-		} );
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+			TRACKS_EVENTS.SITE_OPEN_IN_EDITOR,
+			expect.anything()
+		);
 	} );
 
 	it( 'falls back to the editor URL scheme when no binary is found', async () => {

--- a/apps/ui/src/components/open-in-menu/index.test.tsx
+++ b/apps/ui/src/components/open-in-menu/index.test.tsx
@@ -152,10 +152,13 @@ describe( 'OpenInMenu', () => {
 		fireEvent.click( destination( 'Zed' ) );
 		fireEvent.click( destination( 'Terminal' ) );
 
-		expect( trackEvent ).toHaveBeenCalledWith( 'studio_site_open_in_browser' );
+		expect( trackEvent ).toHaveBeenCalledWith( 'studio_site_open_in_browser', {
+			browser: 'external',
+		} );
 		expect( trackEvent ).toHaveBeenCalledWith( 'studio_site_open_folder' );
-		expect( trackEvent ).not.toHaveBeenCalledWith( 'studio_site_open_in_editor' );
-		expect( trackEvent ).not.toHaveBeenCalledWith( 'studio_site_open_in_terminal' );
+		const trackedEvents = trackEvent.mock.calls.map( ( call ) => call[ 0 ] );
+		expect( trackedEvents ).not.toContain( 'studio_site_open_in_editor' );
+		expect( trackedEvents ).not.toContain( 'studio_site_open_in_terminal' );
 	} );
 
 	it( 'offers no phpMyAdmin destination', () => {

--- a/apps/ui/src/components/open-in-menu/index.test.tsx
+++ b/apps/ui/src/components/open-in-menu/index.test.tsx
@@ -161,6 +161,16 @@ describe( 'OpenInMenu', () => {
 		expect( trackedEvents ).not.toContain( 'studio_site_open_in_terminal' );
 	} );
 
+	it( 'records the browser event matching the active preview realm', () => {
+		renderMenu( { running: true }, '/wp-admin/plugins.php' );
+
+		fireEvent.click( destination( 'Browser' ) );
+
+		expect( trackEvent ).toHaveBeenCalledWith( 'studio_site_open_wp_admin', {
+			browser: 'external',
+		} );
+	} );
+
 	it( 'offers no phpMyAdmin destination', () => {
 		// The preview's address bar owns the database realm; navigating there
 		// from here strands it with no segment to represent it.
@@ -238,8 +248,8 @@ describe( 'OpenInMenu', () => {
 	} );
 } );
 
-function renderMenu( overrides: Partial< SiteDetails > = {} ) {
-	return render( <OpenInMenu site={ createSite( overrides ) } browserPath={ BROWSER_PATH } /> );
+function renderMenu( overrides: Partial< SiteDetails > = {}, browserPath: string = BROWSER_PATH ) {
+	return render( <OpenInMenu site={ createSite( overrides ) } browserPath={ browserPath } /> );
 }
 
 function destination( label: string | RegExp ): HTMLElement {

--- a/apps/ui/src/components/open-in-menu/index.test.tsx
+++ b/apps/ui/src/components/open-in-menu/index.test.tsx
@@ -92,6 +92,7 @@ describe( 'OpenInMenu', () => {
 	const openSiteFolder = vi.fn().mockResolvedValue( undefined );
 	const openSiteInEditor = vi.fn().mockResolvedValue( undefined );
 	const openSiteInTerminal = vi.fn().mockResolvedValue( undefined );
+	const trackEvent = vi.fn().mockResolvedValue( undefined );
 	const startSite = vi.fn().mockResolvedValue( undefined );
 
 	beforeEach( () => {
@@ -103,6 +104,7 @@ describe( 'OpenInMenu', () => {
 			openSiteFolder,
 			openSiteInEditor,
 			openSiteInTerminal,
+			trackEvent,
 			getSites: vi.fn().mockResolvedValue( [] ),
 		} );
 		useStartSiteMock.mockReturnValue( {
@@ -140,6 +142,20 @@ describe( 'OpenInMenu', () => {
 		expect( openSiteFolder ).toHaveBeenCalledWith( 'site-1' );
 		expect( openSiteInEditor ).toHaveBeenCalledWith( 'site-1' );
 		expect( openSiteInTerminal ).toHaveBeenCalledWith( 'site-1' );
+	} );
+
+	it( 'records Tracks events for browser and folder only (editor and terminal emit in Main)', () => {
+		renderMenu( { running: true } );
+
+		fireEvent.click( destination( 'Browser' ) );
+		fireEvent.click( destination( /^(Finder|File Explorer|File manager)$/ ) );
+		fireEvent.click( destination( 'Zed' ) );
+		fireEvent.click( destination( 'Terminal' ) );
+
+		expect( trackEvent ).toHaveBeenCalledWith( 'studio_site_open_in_browser' );
+		expect( trackEvent ).toHaveBeenCalledWith( 'studio_site_open_folder' );
+		expect( trackEvent ).not.toHaveBeenCalledWith( 'studio_site_open_in_editor' );
+		expect( trackEvent ).not.toHaveBeenCalledWith( 'studio_site_open_in_terminal' );
 	} );
 
 	it( 'offers no phpMyAdmin destination', () => {

--- a/apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx
+++ b/apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx
@@ -1,3 +1,4 @@
+import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
 import { supportedEditorConfig } from '@studio/common/lib/user-settings/editor';
 import { terminalConfig } from '@studio/common/lib/user-settings/terminal';
 import { useNavigate } from '@tanstack/react-router';
@@ -73,6 +74,7 @@ export function useOpenInDestinations(
 			disabled: ! site.running,
 			open: () => {
 				onOpen?.( 'browser' );
+				void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER );
 				// Routed through the host rather than `openExternalUrl` so the
 				// URL goes via /studio-auto-login; opening it raw drops the
 				// session and lands admin screens on the login form.
@@ -88,6 +90,7 @@ export function useOpenInDestinations(
 			disabled: false,
 			open: () => {
 				onOpen?.( 'files' );
+				void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_FOLDER );
 				void connector.openSiteFolder( site.id ).catch( ( error ) => {
 					console.error( 'Failed to open site folder:', error );
 				} );

--- a/apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx
+++ b/apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx
@@ -74,7 +74,8 @@ export function useOpenInDestinations(
 			disabled: ! site.running,
 			open: () => {
 				onOpen?.( 'browser' );
-				void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER );
+				// This destination leaves Studio for the OS browser.
+				void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER, { browser: 'external' } );
 				// Routed through the host rather than `openExternalUrl` so the
 				// URL goes via /studio-auto-login; opening it raw drops the
 				// session and lands admin screens on the login form.

--- a/apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx
+++ b/apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx
@@ -4,6 +4,7 @@ import { terminalConfig } from '@studio/common/lib/user-settings/terminal';
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { code, external } from '@wordpress/icons';
+import { getPreviewRealm, getRealmOpenEvent } from '@/components/site-preview/address-bar';
 import { useConnector } from '@/data/core';
 import { useUserPreferences } from '@/data/queries/use-user-preferences';
 import { editorLogos, finderLogo, folderLogo, terminalLogo, terminalLogos } from '@/lib/logos';
@@ -74,8 +75,12 @@ export function useOpenInDestinations(
 			disabled: ! site.running,
 			open: () => {
 				onOpen?.( 'browser' );
-				// This destination leaves Studio for the OS browser.
-				void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER, { browser: 'external' } );
+				// This destination leaves Studio for the OS browser, carrying whatever the
+				// preview is currently showing — so the event matches the active realm
+				// (front end / WP Admin / phpMyAdmin) rather than always the front end.
+				void connector.trackEvent( getRealmOpenEvent( getPreviewRealm( browserPath ) ), {
+					browser: 'external',
+				} );
 				// Routed through the host rather than `openExternalUrl` so the
 				// URL goes via /studio-auto-login; opening it raw drops the
 				// session and lands admin screens on the login form.

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -1,3 +1,4 @@
+import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
 import { isSnapshotExpired } from '@studio/common/lib/snapshots';
 import { useIsMutating } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
@@ -211,7 +212,17 @@ export function MainView( { site, activity, onSetupClick, onDisconnectClick }: P
 		</Tooltip.Root>
 	);
 
-	const renderUrlLink = ( { text, url, label }: { text: string; url: string; label: string } ) => (
+	const renderUrlLink = ( {
+		text,
+		url,
+		label,
+		onOpen,
+	}: {
+		text: string;
+		url: string;
+		label: string;
+		onOpen?: () => void;
+	} ) => (
 		<Tooltip.Root>
 			<Tooltip.Trigger
 				render={
@@ -219,7 +230,10 @@ export function MainView( { site, activity, onSetupClick, onDisconnectClick }: P
 						type="button"
 						className={ styles.urlLink }
 						aria-label={ label }
-						onClick={ () => openExternal( url ) }
+						onClick={ () => {
+							onOpen?.();
+							openExternal( url );
+						} }
 					>
 						<span>{ text }</span>
 						<Icon icon={ external } size={ 12 } aria-hidden="true" />
@@ -253,6 +267,10 @@ export function MainView( { site, activity, onSetupClick, onDisconnectClick }: P
 								text: localSublabel,
 								url: localSiteUrl,
 								label: __( 'Open Studio site in your browser' ),
+								onOpen: () =>
+									void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_IN_BROWSER, {
+										browser: 'external',
+									} ),
 						  } )
 						: localSublabel
 				}

--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -115,10 +115,11 @@ describe( 'SiteList', () => {
 		useSiteSyncActivityMock.mockReturnValue( null );
 		useSessionsMock.mockReturnValue( { data: [], isLoading: false } );
 		useConnectorMock.mockReturnValue( {
-			openExternalUrl: vi.fn(),
-			openSiteFolder: vi.fn(),
-			openSiteInEditor: vi.fn(),
-			openSiteInTerminal: vi.fn(),
+			openExternalUrl: vi.fn().mockResolvedValue( undefined ),
+			openSiteFolder: vi.fn().mockResolvedValue( undefined ),
+			openSiteInEditor: vi.fn().mockResolvedValue( undefined ),
+			openSiteInTerminal: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 		} as unknown as ReturnType< typeof useConnector > );
 		useCopySiteMock.mockReturnValue( { isPending: false, mutate: vi.fn() } );
 		useDeleteSiteMock.mockReturnValue( { isPending: false, mutate: vi.fn() } );
@@ -206,6 +207,32 @@ describe( 'SiteList', () => {
 		expect( screen.getByText( 'Open folder' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Export entire site' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Delete site' ) ).toBeInTheDocument();
+	} );
+
+	it( 'records a Tracks event when opening the site folder from the menu', async () => {
+		render( <SiteList /> );
+
+		fireEvent.contextMenu( screen.getByText( 'Stopped Site' ) );
+		fireEvent.click( await screen.findByText( 'Open folder' ) );
+
+		expect( useConnectorMock().trackEvent ).toHaveBeenCalledWith( 'studio_site_open_folder' );
+	} );
+
+	it( 'records external-browser Tracks events for phpMyAdmin and WP admin', async () => {
+		render( <SiteList /> );
+
+		fireEvent.contextMenu( screen.getByText( 'Running Site' ) );
+		fireEvent.click( await screen.findByText( 'Open phpMyAdmin' ) );
+
+		fireEvent.contextMenu( screen.getByText( 'Running Site' ) );
+		fireEvent.click( await screen.findByText( 'Open WP admin' ) );
+
+		expect( useConnectorMock().trackEvent ).toHaveBeenCalledWith( 'studio_site_open_phpmyadmin', {
+			browser: 'external',
+		} );
+		expect( useConnectorMock().trackEvent ).toHaveBeenCalledWith( 'studio_site_open_wp_admin', {
+			browser: 'external',
+		} );
 	} );
 
 	it( 'opens site settings from the site actions menu', async () => {

--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -247,6 +247,9 @@ describe( 'SiteList', () => {
 			params: { siteId: 'stopped-site' },
 			search: { tab: 'general' },
 		} );
+		expect( useConnectorMock().trackEvent ).toHaveBeenCalledWith( 'studio_panel_opened', {
+			panel: 'settings',
+		} );
 	} );
 
 	it( 'opens the site overview when clicking a site while agentic features are unavailable', () => {
@@ -265,6 +268,19 @@ describe( 'SiteList', () => {
 		expect( navigateMock ).toHaveBeenLastCalledWith( {
 			to: '/sites/$siteId/overview',
 			params: { siteId: 'stopped-site' },
+		} );
+		expect( useConnectorMock().trackEvent ).toHaveBeenCalledWith( 'studio_panel_opened', {
+			panel: 'overview',
+		} );
+	} );
+
+	it( 'records an assistant panel event when clicking a site name opens chat', () => {
+		render( <SiteList /> );
+
+		fireEvent.click( screen.getByText( 'Stopped Site' ) );
+
+		expect( useConnectorMock().trackEvent ).toHaveBeenCalledWith( 'studio_panel_opened', {
+			panel: 'assistant',
 		} );
 	} );
 
@@ -295,6 +311,9 @@ describe( 'SiteList', () => {
 
 		fireEvent.click( screen.getAllByRole( 'button', { name: 'Site overview' } )[ 0 ] );
 
+		expect( useConnectorMock().trackEvent ).toHaveBeenCalledWith( 'studio_panel_opened', {
+			panel: 'overview',
+		} );
 		expect( navigateMock ).toHaveBeenCalledTimes( 1 );
 		expect( navigateMock ).toHaveBeenLastCalledWith( {
 			to: '/sites/$siteId/overview',

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -1,4 +1,5 @@
 import { findAiSessionOwnerSite } from '@studio/common/ai/sessions/owner-site';
+import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
 import { sortSites } from '@studio/common/lib/sort-sites';
 import { supportedEditorConfig } from '@studio/common/lib/user-settings/editor';
 import { terminalConfig } from '@studio/common/lib/user-settings/terminal';
@@ -359,6 +360,7 @@ function SiteActionsMenu( {
 	};
 
 	const handleOpenFolder = () => {
+		void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_FOLDER );
 		void connector.openSiteFolder( site.id ).catch( ( error ) => {
 			console.error( 'Failed to open site folder:', error );
 		} );
@@ -382,12 +384,14 @@ function SiteActionsMenu( {
 	};
 
 	const handleOpenPhpMyAdmin = () => {
+		void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_PHPMYADMIN, { browser: 'external' } );
 		void connector.openExternalUrl(
 			`${ getSiteUrl( site ) }/phpmyadmin/index.php?route=/database/structure&db=wordpress`
 		);
 	};
 
 	const handleOpenWpAdmin = () => {
+		void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_WP_ADMIN, { browser: 'external' } );
 		const siteUrl = getSiteUrl( site );
 		const redirectTo = new URL( '/wp-admin/', siteUrl ).toString();
 		const autoLoginUrl = new URL( '/studio-auto-login', siteUrl );

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -206,6 +206,7 @@ function sortSitesByManualOrder( sites: SiteDetails[], manualOrder: string[] ): 
 
 function SiteOverviewButton( { site }: { site: SiteDetails } ) {
 	const navigate = useNavigate();
+	const connector = useConnector();
 
 	return (
 		<IconButton
@@ -217,6 +218,7 @@ function SiteOverviewButton( { site }: { site: SiteDetails } ) {
 			className={ styles.siteAction }
 			onClick={ ( event ) => {
 				event.stopPropagation();
+				void connector.trackEvent( TRACKS_EVENTS.PANEL_OPENED, { panel: 'overview' } );
 				void navigate( {
 					to: '/sites/$siteId/overview',
 					params: { siteId: site.id },
@@ -427,13 +429,14 @@ function SiteActionsMenu( {
 					) }
 					<Menu.Separator />
 					<Menu.Item
-						onClick={ () =>
+						onClick={ () => {
+							void connector.trackEvent( TRACKS_EVENTS.PANEL_OPENED, { panel: 'settings' } );
 							void navigate( {
 								to: '/sites/$siteId/overview',
 								params: { siteId: site.id },
 								search: { tab: 'general' },
-							} )
-						}
+							} );
+						} }
 					>
 						{ __( 'Site settings' ) }
 					</Menu.Item>
@@ -507,6 +510,7 @@ function SiteSection( {
 } ) {
 	const { site, latestSession } = row;
 	const navigate = useNavigate();
+	const connector = useConnector();
 	const sectionRef = useRef< HTMLElement >( null );
 	const isActive = isChatActive || isContextActive;
 	// Without chat, a site's home is its overview, so the context-active row
@@ -540,12 +544,14 @@ function SiteSection( {
 		// Without chat (signed out, offline, or switched off in Settings →
 		// AI) there's no session to open; the overview is the site's home.
 		if ( ! chatEnabled ) {
+			void connector.trackEvent( TRACKS_EVENTS.PANEL_OPENED, { panel: 'overview' } );
 			void navigate( {
 				to: '/sites/$siteId/overview',
 				params: { siteId: site.id },
 			} );
 			return;
 		}
+		void connector.trackEvent( TRACKS_EVENTS.PANEL_OPENED, { panel: 'assistant' } );
 		if ( latestSession ) {
 			void navigate( {
 				to: '/sessions/$sessionId',

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -499,9 +499,11 @@ describe( 'SiteOverviewView', () => {
 
 		expect( trackEvent ).toHaveBeenCalledWith( 'studio_site_open_customize', {
 			entry_point: 'editor',
+			browser: 'internal',
 		} );
 		expect( trackEvent ).toHaveBeenCalledWith( 'studio_site_open_customize', {
 			entry_point: 'media_library',
+			browser: 'internal',
 		} );
 	} );
 

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -124,6 +124,7 @@ const useXdebugEnabledSiteMock = vi.mocked( useXdebugEnabledSite, { partial: tru
 
 describe( 'SiteOverviewView', () => {
 	const openSiteUrl = vi.fn().mockResolvedValue( undefined );
+	const trackEvent = vi.fn().mockResolvedValue( undefined );
 	const startSite = vi.fn().mockResolvedValue( undefined );
 	const copySite = vi.fn();
 	const exportFullSite = vi.fn();
@@ -149,7 +150,7 @@ describe( 'SiteOverviewView', () => {
 			} ) ),
 		} );
 
-		useConnectorMock.mockReturnValue( { openSiteUrl } );
+		useConnectorMock.mockReturnValue( { openSiteUrl, trackEvent } );
 		useAgenticFeaturesMock.mockReturnValue( {
 			enabled: true,
 			chatEnabled: true,
@@ -488,6 +489,20 @@ describe( 'SiteOverviewView', () => {
 			expect( openSiteUrl ).toHaveBeenCalledWith( 'site-1', '/wp-admin/site-editor.php' )
 		);
 		expect( openSiteUrl ).toHaveBeenCalledWith( 'site-1', '/wp-admin/upload.php' );
+	} );
+
+	it( 'records a customize Tracks event with the entry_point for each shortcut', () => {
+		renderView();
+
+		fireEvent.click( screen.getByText( 'Site Editor' ).closest( 'button' )! );
+		fireEvent.click( screen.getByText( 'Media Library' ).closest( 'button' )! );
+
+		expect( trackEvent ).toHaveBeenCalledWith( 'studio_site_open_customize', {
+			entry_point: 'editor',
+		} );
+		expect( trackEvent ).toHaveBeenCalledWith( 'studio_site_open_customize', {
+			entry_point: 'media_library',
+		} );
 	} );
 
 	it( 'runs manage actions and confirms deletion in a dialog', () => {

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -1,3 +1,7 @@
+import {
+	TRACKS_EVENTS,
+	type TracksCustomizeEntryPoint,
+} from '@studio/common/lib/record-tracks-event';
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import {
@@ -22,6 +26,7 @@ import { ProgressiveBlur } from '@/components/progressive-blur';
 import { SiteDropdown } from '@/components/site-dropdown';
 import { isSiteSettingsTab, SiteSettingsForm } from '@/components/site-settings-view';
 import * as Tabs from '@/components/tabs';
+import { useConnector } from '@/data/core';
 import { useIsSiteStarting, useIsSiteStopping, useSites } from '@/data/queries/use-sites';
 import { useOpenSiteUrl } from '@/hooks/use-open-site-url';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
@@ -173,6 +178,12 @@ function SiteOverviewBody( {
 	// first when needed) rather than the external browser.
 	const openSiteUrl = useOpenSiteUrl( site );
 
+	const connector = useConnector();
+	const openCustomize = ( url: string, entryPoint: TracksCustomizeEntryPoint ) => {
+		void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_CUSTOMIZE, { entry_point: entryPoint } );
+		void openSiteUrl( url );
+	};
+
 	return (
 		<div className={ styles.root }>
 			<OverviewHeader site={ site } openSiteDropdown={ openSiteDropdown } />
@@ -207,14 +218,17 @@ function SiteOverviewBody( {
 													icon={ <Icon icon={ desktop } size={ 18 } /> }
 													label={ __( 'Site Editor' ) }
 													disabled={ busy }
-													onClick={ () => void openSiteUrl( '/wp-admin/site-editor.php' ) }
+													onClick={ () => openCustomize( '/wp-admin/site-editor.php', 'editor' ) }
 												/>
 												<OverviewButton
 													icon={ <Icon icon={ stylesIcon } size={ 18 } /> }
 													label={ __( 'Styles' ) }
 													disabled={ busy }
 													onClick={ () =>
-														void openSiteUrl( '/wp-admin/site-editor.php?path=%2Fwp_global_styles' )
+														openCustomize(
+															'/wp-admin/site-editor.php?path=%2Fwp_global_styles',
+															'editor_styles'
+														)
 													}
 												/>
 												<OverviewButton
@@ -222,7 +236,10 @@ function SiteOverviewBody( {
 													label={ __( 'Patterns' ) }
 													disabled={ busy }
 													onClick={ () =>
-														void openSiteUrl( '/wp-admin/site-editor.php?path=%2Fpatterns' )
+														openCustomize(
+															'/wp-admin/site-editor.php?path=%2Fpatterns',
+															'editor_patterns'
+														)
 													}
 												/>
 												<OverviewButton
@@ -230,7 +247,10 @@ function SiteOverviewBody( {
 													label={ __( 'Navigation' ) }
 													disabled={ busy }
 													onClick={ () =>
-														void openSiteUrl( '/wp-admin/site-editor.php?path=%2Fnavigation' )
+														openCustomize(
+															'/wp-admin/site-editor.php?path=%2Fnavigation',
+															'editor_navigation'
+														)
 													}
 												/>
 												<OverviewButton
@@ -238,7 +258,10 @@ function SiteOverviewBody( {
 													label={ __( 'Templates' ) }
 													disabled={ busy }
 													onClick={ () =>
-														void openSiteUrl( '/wp-admin/site-editor.php?path=%2Fwp_template' )
+														openCustomize(
+															'/wp-admin/site-editor.php?path=%2Fwp_template',
+															'editor_templates'
+														)
 													}
 												/>
 												<OverviewButton
@@ -246,7 +269,10 @@ function SiteOverviewBody( {
 													label={ __( 'Pages' ) }
 													disabled={ busy }
 													onClick={ () =>
-														void openSiteUrl( '/wp-admin/site-editor.php?path=%2Fpage' )
+														openCustomize(
+															'/wp-admin/site-editor.php?path=%2Fpage',
+															'editor_pages'
+														)
 													}
 												/>
 											</>
@@ -256,14 +282,14 @@ function SiteOverviewBody( {
 													icon={ <Icon icon={ pencil } size={ 18 } /> }
 													label={ __( 'Customizer' ) }
 													disabled={ busy }
-													onClick={ () => void openSiteUrl( '/wp-admin/customize.php' ) }
+													onClick={ () => openCustomize( '/wp-admin/customize.php', 'customizer' ) }
 												/>
 												{ themeDetails?.supportsMenus ? (
 													<OverviewButton
 														icon={ <Icon icon={ navigation } size={ 18 } /> }
 														label={ __( 'Menus' ) }
 														disabled={ busy }
-														onClick={ () => void openSiteUrl( '/wp-admin/nav-menus.php' ) }
+														onClick={ () => openCustomize( '/wp-admin/nav-menus.php', 'menus' ) }
 													/>
 												) : null }
 												{ themeDetails?.supportsWidgets ? (
@@ -271,7 +297,7 @@ function SiteOverviewBody( {
 														icon={ <Icon icon={ widget } size={ 18 } /> }
 														label={ __( 'Widgets' ) }
 														disabled={ busy }
-														onClick={ () => void openSiteUrl( '/wp-admin/widgets.php' ) }
+														onClick={ () => openCustomize( '/wp-admin/widgets.php', 'widgets' ) }
 													/>
 												) : null }
 											</>
@@ -280,7 +306,7 @@ function SiteOverviewBody( {
 											icon={ <Icon icon={ media } size={ 18 } /> }
 											label={ __( 'Media Library' ) }
 											disabled={ busy }
-											onClick={ () => void openSiteUrl( '/wp-admin/upload.php' ) }
+											onClick={ () => openCustomize( '/wp-admin/upload.php', 'media_library' ) }
 										/>
 									</ButtonSection>
 

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -180,7 +180,11 @@ function SiteOverviewBody( {
 
 	const connector = useConnector();
 	const openCustomize = ( url: string, entryPoint: TracksCustomizeEntryPoint ) => {
-		void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_CUSTOMIZE, { entry_point: entryPoint } );
+		// The agentic UI opens customize screens in its in-app preview panel, not the OS browser.
+		void connector.trackEvent( TRACKS_EVENTS.SITE_OPEN_CUSTOMIZE, {
+			entry_point: entryPoint,
+			browser: 'internal',
+		} );
 		void openSiteUrl( url );
 	};
 

--- a/apps/ui/src/components/site-preview/address-bar.test.tsx
+++ b/apps/ui/src/components/site-preview/address-bar.test.tsx
@@ -6,6 +6,7 @@ import { useConnector } from '@/data/core';
 import {
 	getPreviewRealm,
 	getRealmNavigationPath,
+	getRealmOpenEvent,
 	parseOmniboxInput,
 	PreviewAddressBar,
 } from './address-bar';
@@ -155,6 +156,14 @@ describe( 'getPreviewRealm', () => {
 		expect( getPreviewRealm( autoLoginPath( '/wp-admin/plugins.php' ) ) ).toBe( 'admin' );
 		expect( getPreviewRealm( autoLoginPath( '/phpmyadmin/index.php' ) ) ).toBe( 'database' );
 		expect( getPreviewRealm( autoLoginPath( '/about/' ) ) ).toBe( 'frontend' );
+	} );
+} );
+
+describe( 'getRealmOpenEvent', () => {
+	it( 'maps each realm to its site-open Tracks event', () => {
+		expect( getRealmOpenEvent( 'frontend' ) ).toBe( 'studio_site_open_in_browser' );
+		expect( getRealmOpenEvent( 'admin' ) ).toBe( 'studio_site_open_wp_admin' );
+		expect( getRealmOpenEvent( 'database' ) ).toBe( 'studio_site_open_phpmyadmin' );
 	} );
 } );
 

--- a/apps/ui/src/components/site-preview/address-bar.tsx
+++ b/apps/ui/src/components/site-preview/address-bar.tsx
@@ -1,4 +1,5 @@
 import { Autocomplete } from '@base-ui/react/autocomplete';
+import { TRACKS_EVENTS, type TracksEventName } from '@studio/common/lib/record-tracks-event';
 import { __ } from '@wordpress/i18n';
 import { globe, help, home, page as pageIcon, post as postIcon, wordpress } from '@wordpress/icons';
 import { ariaKeyShortcut, displayShortcut } from '@wordpress/keycodes';
@@ -62,6 +63,19 @@ export function getPreviewRealm( path: string ): PreviewRealm {
 		return 'database';
 	}
 	return 'frontend';
+}
+
+// The site-open Tracks event that corresponds to a preview realm. Shared by the preview realm
+// switcher (which sends `browser: 'internal'`) and the "open in browser" button (`external`), so both
+// describe the same destination the same way.
+const REALM_OPEN_EVENTS: Record< PreviewRealm, TracksEventName > = {
+	frontend: TRACKS_EVENTS.SITE_OPEN_IN_BROWSER,
+	admin: TRACKS_EVENTS.SITE_OPEN_WP_ADMIN,
+	database: TRACKS_EVENTS.SITE_OPEN_PHPMYADMIN,
+};
+
+export function getRealmOpenEvent( realm: PreviewRealm ): TracksEventName {
+	return REALM_OPEN_EVENTS[ realm ];
 }
 
 /**

--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -78,6 +78,7 @@ describe( 'SitePreview', () => {
 	it( 'shows the active realm name with the same tooltip as when inactive', async () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 
@@ -105,6 +106,7 @@ describe( 'SitePreview', () => {
 	it( 'shows adjacent toolbar tooltips immediately while the delay group is active', async () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 
@@ -161,6 +163,7 @@ describe( 'SitePreview', () => {
 	it( 'keeps the Open in… control in the toolbar while the site is stopped', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 
@@ -172,6 +175,7 @@ describe( 'SitePreview', () => {
 	it( 'shows a refresh button that reloads the active preview surface', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 
@@ -205,6 +209,7 @@ describe( 'SitePreview', () => {
 	it( 'reloads the preview on the primary-modifier+R shortcut', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 
@@ -228,6 +233,7 @@ describe( 'SitePreview', () => {
 	it( 'switches realms on primary-modifier number shortcuts', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 		const onPathChange = vi.fn();
@@ -253,9 +259,55 @@ describe( 'SitePreview', () => {
 		expect( onPathChange ).not.toHaveBeenCalled();
 	} );
 
+	it( 'records an internal-browser Tracks event when switching realms', () => {
+		const trackEvent = vi.fn().mockResolvedValue( undefined );
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent,
+			capabilities: CAPABILITIES,
+		} as never );
+
+		renderPreview(
+			<SitePreview
+				site={ createSite( { running: true } ) }
+				path="/"
+				reloadNonce={ 0 }
+				onPathChange={ vi.fn() }
+			/>
+		);
+
+		fireEvent.keyDown( document.body, { key: '2', ctrlKey: true } );
+		expect( trackEvent ).toHaveBeenCalledWith( 'studio_site_open_wp_admin', {
+			browser: 'internal',
+		} );
+	} );
+
+	it( 'does not record a realm switch when re-selecting the active realm', () => {
+		const trackEvent = vi.fn().mockResolvedValue( undefined );
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent,
+			capabilities: CAPABILITIES,
+		} as never );
+
+		renderPreview(
+			<SitePreview
+				site={ createSite( { running: true } ) }
+				path="/wp-admin/"
+				reloadNonce={ 0 }
+				onPathChange={ vi.fn() }
+			/>
+		);
+
+		// Already on the admin realm; its shortcut is a no-op.
+		fireEvent.keyDown( document.body, { key: '2', ctrlKey: true } );
+		expect( trackEvent ).not.toHaveBeenCalled();
+	} );
+
 	it( 'switches to the database realm on its shortcut', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 		const onPathChange = vi.fn();
@@ -278,6 +330,7 @@ describe( 'SitePreview', () => {
 	it( 'hides the Annotate control when the host cannot annotate the preview', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 
@@ -333,6 +386,7 @@ describe( 'SitePreview', () => {
 	it( 'offers responsive modes from the More options menu while running', async () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 
@@ -366,6 +420,7 @@ describe( 'SitePreview', () => {
 	it( 'toggles full preview from the More options menu', async () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 		const onFullscreenChange = vi.fn();
@@ -403,6 +458,7 @@ describe( 'SitePreview', () => {
 	it( 'omits full preview when the host provides no toggle', async () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 
@@ -419,6 +475,7 @@ describe( 'SitePreview', () => {
 	it( 'asks for full preview when the Desktop + Mobile comparison is picked', async () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 		const onFullscreenChange = vi.fn();
@@ -441,6 +498,7 @@ describe( 'SitePreview', () => {
 	it( 'drops the comparison back to Fit pane when full preview ends', async () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 		const queryClient = new QueryClient( {
@@ -475,6 +533,7 @@ describe( 'SitePreview', () => {
 	it( 'toggles full preview with the keyboard shortcut', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 		const onFullscreenChange = vi.fn();
@@ -517,6 +576,7 @@ describe( 'SitePreview', () => {
 	it( 'hides the More options menu when the site is not running', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 
@@ -528,6 +588,7 @@ describe( 'SitePreview', () => {
 	it( 'remembers the responsive mode per site during the session', async () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
 			capabilities: CAPABILITIES,
 		} as never );
 

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -20,6 +20,7 @@ import {
 	getPathFromPreviewUrl,
 	getPreviewRealm,
 	getRealmNavigationPath,
+	getRealmOpenEvent,
 	PreviewAddressBar,
 	REALM_SHORTCUT_KEYS,
 	useDebouncedValue,
@@ -673,10 +674,12 @@ export function SitePreview( {
 			if ( getPreviewRealm( getSafePath( path ) ) === realm ) {
 				return;
 			}
+			// The agentic UI opens the realm in its in-app preview panel.
+			void connector.trackEvent( getRealmOpenEvent( realm ), { browser: 'internal' } );
 			const target = lastRealmPathsRef.current[ realm ];
 			onPathChange?.( getRealmNavigationPath( target, siteUrl ) );
 		},
-		[ onPathChange, path, siteUrl ]
+		[ connector, onPathChange, path, siteUrl ]
 	);
 
 	const browserShortcuts = useMemo(

--- a/apps/ui/src/components/site-settings-view/index.test.tsx
+++ b/apps/ui/src/components/site-settings-view/index.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { isSiteSettingsTab, siteSettingsTabToPanel } from './index';
+
+describe( 'isSiteSettingsTab', () => {
+	it( 'accepts the known tab ids', () => {
+		expect( isSiteSettingsTab( 'overview' ) ).toBe( true );
+		expect( isSiteSettingsTab( 'general' ) ).toBe( true );
+		expect( isSiteSettingsTab( 'debugging' ) ).toBe( true );
+	} );
+
+	it( 'rejects anything else', () => {
+		expect( isSiteSettingsTab( 'settings' ) ).toBe( false );
+		expect( isSiteSettingsTab( '' ) ).toBe( false );
+	} );
+} );
+
+describe( 'siteSettingsTabToPanel', () => {
+	it( 'maps the General tab to the shared "settings" panel', () => {
+		expect( siteSettingsTabToPanel( 'general' ) ).toBe( 'settings' );
+	} );
+
+	it( 'keeps overview and debugging as-is', () => {
+		expect( siteSettingsTabToPanel( 'overview' ) ).toBe( 'overview' );
+		expect( siteSettingsTabToPanel( 'debugging' ) ).toBe( 'debugging' );
+	} );
+} );

--- a/apps/ui/src/components/site-settings-view/index.tsx
+++ b/apps/ui/src/components/site-settings-view/index.tsx
@@ -28,6 +28,7 @@ import { useWordPressVersions, useWpVersion } from '@/data/queries/use-wordpress
 import { useOffline } from '@/hooks/use-offline';
 import styles from './style.module.css';
 import type { SiteDetails } from '@/data/core';
+import type { TracksPanel } from '@studio/common/lib/record-tracks-event';
 import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
 import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
 import type { FormEvent } from 'react';
@@ -328,3 +329,9 @@ export function isSiteSettingsTab( value: string ): value is TabId {
 }
 
 export type SiteSettingsTabId = TabId;
+
+// The `studio_panel_opened` value for a tab. The General tab reports `settings` so it lines up with
+// Studio Classic's Settings panel; overview and debugging keep their own names.
+export function siteSettingsTabToPanel( tab: TabId ): TracksPanel {
+	return tab === 'general' ? 'settings' : tab;
+}

--- a/apps/ui/src/data/core/connectors/ipc/index.test.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.test.ts
@@ -58,6 +58,48 @@ describe( 'createIpcConnector exports', () => {
 	} );
 } );
 
+describe( 'createIpcConnector openSiteInEditor', () => {
+	const getSiteDetails = vi
+		.fn()
+		.mockResolvedValue( [ { id: 'site-1', name: 'Demo', path: '/Users/x/Studio/demo' } ] );
+	const getUserEditor = vi.fn().mockResolvedValue( 'vscode' );
+	const openAppAtPath = vi.fn();
+	const recordAnalyticsEvent = vi.fn().mockResolvedValue( undefined );
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.stubGlobal( 'ipcApi', {
+			getSiteDetails,
+			getUserEditor,
+			openAppAtPath,
+			recordAnalyticsEvent,
+		} );
+		vi.stubGlobal( 'ipcListener', { subscribe: vi.fn() } );
+	} );
+
+	afterEach( () => {
+		vi.unstubAllGlobals();
+	} );
+
+	it( 'records an open-in-editor event and launches the editor at the site path', async () => {
+		await createIpcConnector().openSiteInEditor( 'site-1' );
+
+		expect( recordAnalyticsEvent ).toHaveBeenCalledWith( 'studio_site_open_in_editor', {
+			editor: 'vscode',
+		} );
+		expect( openAppAtPath ).toHaveBeenCalledWith( 'vscode', '/Users/x/Studio/demo' );
+	} );
+
+	it( 'does not record or launch when no editor is configured', async () => {
+		getUserEditor.mockResolvedValueOnce( null );
+
+		await expect( createIpcConnector().openSiteInEditor( 'site-1' ) ).rejects.toThrow();
+
+		expect( recordAnalyticsEvent ).not.toHaveBeenCalled();
+		expect( openAppAtPath ).not.toHaveBeenCalled();
+	} );
+} );
+
 describe( 'createIpcConnector Connect contracts', () => {
 	const createSite = vi.fn();
 	const fetchSyncableWpcomSites = vi.fn();

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -1,3 +1,4 @@
+import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
 import {
 	STUDIO_ASSISTANT_QUOTA_URL,
@@ -792,6 +793,8 @@ export function createIpcConnector(): Connector {
 			if ( ! editor ) {
 				throw new Error( 'No preferred editor configured.' );
 			}
+			// Emit here rather than in Main's `openAppAtPath`, which is shared with single-file opens.
+			void ipcApi.recordAnalyticsEvent( TRACKS_EVENTS.SITE_OPEN_IN_EDITOR, { editor } );
 			await ipcApi.openAppAtPath( editor, sitePath );
 		},
 

--- a/apps/ui/src/ui-classic/router/route-site-overview/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-site-overview/index.tsx
@@ -1,7 +1,9 @@
+import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
 import { createRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { useEffect } from 'react';
 import { SiteOverviewView } from '@/components/site-overview-view';
-import { isSiteSettingsTab } from '@/components/site-settings-view';
+import { isSiteSettingsTab, siteSettingsTabToPanel } from '@/components/site-settings-view';
+import { useConnector } from '@/data/core';
 import { useSites, SITES_QUERY_KEY } from '@/data/queries/use-sites';
 import { dashboardLayoutRoute } from '../layout-dashboard';
 import type { SiteSettingsTabId } from '@/components/site-settings-view';
@@ -18,6 +20,7 @@ function SiteOverviewPage() {
 	const { siteId } = siteOverviewRoute.useParams();
 	const { tab, sync } = siteOverviewRoute.useSearch();
 	const navigate = useNavigate();
+	const connector = useConnector();
 	const { data: sites } = useSites();
 	const activeTab: SiteSettingsTabId = tab ?? 'overview';
 
@@ -37,14 +40,17 @@ function SiteOverviewPage() {
 			siteId={ siteId }
 			activeTab={ activeTab }
 			openSiteDropdown={ sync === 'pull' }
-			onTabChange={ ( next ) =>
+			onTabChange={ ( next ) => {
+				void connector.trackEvent( TRACKS_EVENTS.PANEL_OPENED, {
+					panel: siteSettingsTabToPanel( next ),
+				} );
 				void navigate( {
 					to: '/sites/$siteId/overview',
 					params: { siteId },
 					search: { tab: next },
 					replace: true,
-				} )
-			}
+				} );
+			} }
 		/>
 	);
 }

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -175,23 +175,32 @@ start / creation is counted once whether it originated in a UI or the standalone
 
 Day-to-day site actions. **Stop and delete are emitted by the CLI** (the sole funnel — the desktop
 delegates both to the CLI, so standalone-CLI usage is counted too; filter by `channel`). The **open**
-actions are emitted where each affordance lives: `open_in_editor`/`open_in_terminal` from Desktop Main
-(a single funnel that also covers the agentic UI, whose connector routes through the same handlers);
-the rest from the renderer (the underlying `openSiteURL`/`openLocalPath` IPC is generic, so Main can't
-attribute them). `studio_panel_opened` is Desktop-Classic-only — the agentic UI navigates via routes,
-not a tab strip. No site names, paths, or URLs are ever sent — only the enumerated prop values below.
+actions are emitted from the renderer (both Classic and agentic), except `open_in_editor` /
+`open_in_terminal`, which fire from Desktop Main (`openAppAtPath` / `openTerminalAtPath`) — a single
+funnel that also covers the agentic UI, whose connector routes through the same handlers.
+
+The site-content open events (`open_in_browser`, `open_wp_admin`, `open_customize`,
+`open_phpmyadmin`) carry a **`browser`** prop recording where the content opened: `external` (the OS
+browser) or `internal` (the agentic UI's in-app preview panel). Studio Classic always opens the OS
+browser, so it always sends `external`; the agentic UI sends `internal` when it navigates the preview
+panel (e.g. the overview Customize buttons) and `external` when the affordance explicitly leaves
+Studio (e.g. the site-list "Open phpMyAdmin"/"Open WP admin" menu items and the site header's "open in
+your browser" link). Navigation *within* the agentic preview panel (the address bar, switching preview
+tabs) is out of scope here and tracked separately. `studio_panel_opened` is Desktop-Classic-only — the
+agentic UI navigates via routes, not a tab strip. No site names, paths, or URLs are ever sent — only
+the enumerated prop values below.
 
 | Event | Emitted from | Event-specific props |
 |---|---|---|
 | `studio_site_stop` | CLI site-stop funnel | `running_site_count` (running Studio sites remaining after this stop). A "stop all" emits one event per stopped site, counting down to 0. |
 | `studio_site_delete` | CLI site-delete funnel | `delete_files` (boolean — whether the site's files were moved to trash). Emitted once per **successful** delete. |
-| `studio_site_open_in_browser` | Renderer (Classic + agentic) | (none) |
+| `studio_site_open_in_browser` | Renderer (Classic + agentic) | `browser` (`external`/`internal`) |
 | `studio_site_open_in_editor` | Desktop Main (`openAppAtPath`) | `editor` (the resolved editor, e.g. `vscode`/`phpstorm`) |
 | `studio_site_open_in_terminal` | Desktop Main (`openTerminalAtPath`) | `terminal` (the resolved terminal, e.g. `terminal`/`iterm`/`ghostty`/`warp`) |
-| `studio_site_open_wp_admin` | Renderer (Classic) | (none) |
-| `studio_site_open_customize` | Renderer (Classic + agentic) | `entry_point` — the affordance clicked: `editor`, `editor_styles`, `editor_patterns`, `editor_navigation`, `editor_templates`, `editor_pages`, `media_library` (block themes) or `customizer`, `menus`, `widgets` (classic themes). |
-| `studio_site_open_phpmyadmin` | Renderer (Classic) | (none — a native-runtime affordance in practice) |
-| `studio_site_open_folder` | Renderer (Classic + agentic) | (none) |
+| `studio_site_open_wp_admin` | Renderer (Classic + agentic) | `browser` (`external`/`internal`) |
+| `studio_site_open_customize` | Renderer (Classic + agentic) | `entry_point` — the affordance clicked: `editor`, `editor_styles`, `editor_patterns`, `editor_navigation`, `editor_templates`, `editor_pages`, `media_library` (block themes) or `customizer`, `menus`, `widgets` (classic themes). Plus `browser` (`external`/`internal`). |
+| `studio_site_open_phpmyadmin` | Renderer (Classic + agentic) | `browser` (`external`/`internal`) |
+| `studio_site_open_folder` | Renderer (Classic + agentic) | (none — opens the OS file manager) |
 | `studio_panel_opened` | Renderer (Classic tab strip) | `panel` — the tab opened: `overview`/`sync`/`settings`/`assistant`/`import-export`/`previews`. Emitted only on a genuine user tab switch (not programmatic changes or re-selecting the current tab). |
 
 #### Settings-change events

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -168,8 +168,31 @@ start / creation is counted once whether it originated in a UI or the standalone
 | Event | Emitted from | Event-specific props |
 |---|---|---|
 | `studio_app_launch` | Desktop Main (`appBoot`) | `is_first_launch` |
-| `studio_site_start` | CLI site-start funnel | (none — `ui_version` comes from the wrapper via `STUDIO_TRACKS_ORIGIN`, only when `channel=studio-ui`) |
+| `studio_site_start` | CLI site-start funnel | `success` (boolean), `time_ms` (start duration). On success also `running_site_count` (running Studio sites after this one comes up). On failure instead `failure_reason` (coarse, low-cardinality: `timeout`/`port_unavailable`/`php_error`/`process_exited`/`unknown` — the raw error is never sent). |
 | `studio_site_created` | CLI site-create funnel | `flow_type` (`new`/`blueprint`/`import`/`sync`/`duplicate`), `php_version`, `wp_version` (resolved from disk; `-` if unknown), `custom_domain` (boolean — the domain string is **never** sent), `ssl_enabled` (boolean), `time_ms` (creation duration). Emitted once per **successful** creation. |
+
+#### Site operation events
+
+Day-to-day site actions. **Stop and delete are emitted by the CLI** (the sole funnel — the desktop
+delegates both to the CLI, so standalone-CLI usage is counted too; filter by `channel`). The **open**
+actions are emitted where each affordance lives: `open_in_editor`/`open_in_terminal` from Desktop Main
+(a single funnel that also covers the agentic UI, whose connector routes through the same handlers);
+the rest from the renderer (the underlying `openSiteURL`/`openLocalPath` IPC is generic, so Main can't
+attribute them). `studio_panel_opened` is Desktop-Classic-only — the agentic UI navigates via routes,
+not a tab strip. No site names, paths, or URLs are ever sent — only the enumerated prop values below.
+
+| Event | Emitted from | Event-specific props |
+|---|---|---|
+| `studio_site_stop` | CLI site-stop funnel | `running_site_count` (running Studio sites remaining after this stop). A "stop all" emits one event per stopped site, counting down to 0. |
+| `studio_site_delete` | CLI site-delete funnel | `delete_files` (boolean — whether the site's files were moved to trash). Emitted once per **successful** delete. |
+| `studio_site_open_in_browser` | Renderer (Classic + agentic) | (none) |
+| `studio_site_open_in_editor` | Desktop Main (`openAppAtPath`) | `editor` (the resolved editor, e.g. `vscode`/`phpstorm`) |
+| `studio_site_open_in_terminal` | Desktop Main (`openTerminalAtPath`) | `terminal` (the resolved terminal, e.g. `terminal`/`iterm`/`ghostty`/`warp`) |
+| `studio_site_open_wp_admin` | Renderer (Classic) | (none) |
+| `studio_site_open_customize` | Renderer (Classic + agentic) | `entry_point` — the affordance clicked: `editor`, `editor_styles`, `editor_patterns`, `editor_navigation`, `editor_templates`, `editor_pages`, `media_library` (block themes) or `customizer`, `menus`, `widgets` (classic themes). |
+| `studio_site_open_phpmyadmin` | Renderer (Classic) | (none — a native-runtime affordance in practice) |
+| `studio_site_open_folder` | Renderer (Classic + agentic) | (none) |
+| `studio_panel_opened` | Renderer (Classic tab strip) | `panel` — the tab opened: `overview`/`sync`/`settings`/`assistant`/`import-export`/`previews`. Emitted only on a genuine user tab switch (not programmatic changes or re-selecting the current tab). |
 
 #### Settings-change events
 

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -182,13 +182,17 @@ funnel that also covers the agentic UI, whose connector routes through the same 
 The site-content open events (`open_in_browser`, `open_wp_admin`, `open_customize`,
 `open_phpmyadmin`) carry a **`browser`** prop recording where the content opened: `external` (the OS
 browser) or `internal` (the agentic UI's in-app preview panel). Studio Classic always opens the OS
-browser, so it always sends `external`; the agentic UI sends `internal` when it navigates the preview
-panel (e.g. the overview Customize buttons) and `external` when the affordance explicitly leaves
-Studio (e.g. the site-list "Open phpMyAdmin"/"Open WP admin" menu items and the site header's "open in
-your browser" link). Navigation *within* the agentic preview panel (the address bar, switching preview
-tabs) is out of scope here and tracked separately. `studio_panel_opened` is Desktop-Classic-only — the
-agentic UI navigates via routes, not a tab strip. No site names, paths, or URLs are ever sent — only
-the enumerated prop values below.
+browser, so it always sends `external`. The agentic UI sends `internal` when it opens content in the
+preview panel — the overview Customize buttons, and switching the preview's realm tabs (front end →
+`open_in_browser`, WP Admin → `open_wp_admin`, database → `open_phpmyadmin`; re-selecting the active
+tab is a no-op and emits nothing) — and `external` when the affordance leaves Studio: the site-list
+"Open phpMyAdmin"/"Open WP admin" menu items, the site header's "open in your browser" link, and the
+preview's "Open in… → Browser" button. That last button fires the event matching whatever realm the
+preview is currently showing, so opening a WP Admin preview externally is an `open_wp_admin`
+(`external`), not an `open_in_browser`. Free-form navigation *within* the preview panel (typing in the
+address bar) is out of scope here and tracked separately. `studio_panel_opened` is Desktop-Classic-only
+— the agentic UI navigates via routes, not a tab strip. No site names, paths, or URLs are ever sent —
+only the enumerated prop values below.
 
 | Event | Emitted from | Event-specific props |
 |---|---|---|

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -175,9 +175,12 @@ start / creation is counted once whether it originated in a UI or the standalone
 
 Day-to-day site actions. **Stop and delete are emitted by the CLI** (the sole funnel — the desktop
 delegates both to the CLI, so standalone-CLI usage is counted too; filter by `channel`). The **open**
-actions are emitted from the renderer (both Classic and agentic), except `open_in_editor` /
-`open_in_terminal`, which fire from Desktop Main (`openAppAtPath` / `openTerminalAtPath`) — a single
-funnel that also covers the agentic UI, whose connector routes through the same handlers.
+actions are emitted from the renderer (both Classic and agentic). `open_in_terminal` is the exception:
+it fires from Desktop Main (`openTerminalAtPath`) — a single funnel that also covers the agentic UI,
+whose connector routes through it. `open_in_editor` is *not* emitted in Main's `openAppAtPath`, because
+that handler is shared with single-file opens (AI skills, "Open <file>"); it fires at the three "open
+site in editor" affordances instead (Classic overview button + site-menu, and the agentic UI's
+`openSiteInEditor` connector method).
 
 The site-content open events (`open_in_browser`, `open_wp_admin`, `open_customize`,
 `open_phpmyadmin`) carry a **`browser`** prop recording where the content opened: `external` (the OS
@@ -203,7 +206,7 @@ enumerated prop values below.
 | `studio_site_stop` | CLI site-stop funnel | `running_site_count` (running Studio sites remaining after this stop). A "stop all" emits one event per stopped site, counting down to 0. |
 | `studio_site_delete` | CLI site-delete funnel | `delete_files` (boolean — whether the site's files were moved to trash). Emitted once per **successful** delete. |
 | `studio_site_open_in_browser` | Renderer (Classic + agentic) | `browser` (`external`/`internal`) |
-| `studio_site_open_in_editor` | Desktop Main (`openAppAtPath`) | `editor` (the resolved editor, e.g. `vscode`/`phpstorm`) |
+| `studio_site_open_in_editor` | Renderer (Classic + agentic) | `editor` (the resolved editor, e.g. `vscode`/`phpstorm`). Emitted at the "open site in editor" affordances, not in Main's `openAppAtPath` — that handler is shared with single-file opens (AI skills, "Open <file>"), which must not count as opening the site. |
 | `studio_site_open_in_terminal` | Desktop Main (`openTerminalAtPath`) | `terminal` (the resolved terminal, e.g. `terminal`/`iterm`/`ghostty`/`warp`) |
 | `studio_site_open_wp_admin` | Renderer (Classic + agentic) | `browser` (`external`/`internal`) |
 | `studio_site_open_customize` | Renderer (Classic + agentic) | `entry_point` — the affordance clicked: `editor`, `editor_styles`, `editor_patterns`, `editor_navigation`, `editor_templates`, `editor_pages`, `media_library` (block themes) or `customizer`, `menus`, `widgets` (classic themes). Plus `browser` (`external`/`internal`). |

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -190,9 +190,13 @@ tab is a no-op and emits nothing) — and `external` when the affordance leaves 
 preview's "Open in… → Browser" button. That last button fires the event matching whatever realm the
 preview is currently showing, so opening a WP Admin preview externally is an `open_wp_admin`
 (`external`), not an `open_in_browser`. Free-form navigation *within* the preview panel (typing in the
-address bar) is out of scope here and tracked separately. `studio_panel_opened` is Desktop-Classic-only
-— the agentic UI navigates via routes, not a tab strip. No site names, paths, or URLs are ever sent —
-only the enumerated prop values below.
+address bar) is out of scope here and tracked separately. `studio_panel_opened` fires in **both**
+front-ends: Classic from its tab strip, and the agentic UI from its route navigations (the
+overview/settings/debugging tab switches, the site-list gear → overview, a site-name click → assistant
+or, when chat is unavailable, overview, and the context-menu "Site settings" → settings). The agentic
+UI's General settings tab reports `panel: settings` so it lines up with Classic's Settings panel; its
+Debugging tab reports `panel: debugging`. No site names, paths, or URLs are ever sent — only the
+enumerated prop values below.
 
 | Event | Emitted from | Event-specific props |
 |---|---|---|
@@ -205,7 +209,7 @@ only the enumerated prop values below.
 | `studio_site_open_customize` | Renderer (Classic + agentic) | `entry_point` — the affordance clicked: `editor`, `editor_styles`, `editor_patterns`, `editor_navigation`, `editor_templates`, `editor_pages`, `media_library` (block themes) or `customizer`, `menus`, `widgets` (classic themes). Plus `browser` (`external`/`internal`). |
 | `studio_site_open_phpmyadmin` | Renderer (Classic + agentic) | `browser` (`external`/`internal`) |
 | `studio_site_open_folder` | Renderer (Classic + agentic) | (none — opens the OS file manager) |
-| `studio_panel_opened` | Renderer (Classic tab strip) | `panel` — the tab opened: `overview`/`sync`/`settings`/`assistant`/`import-export`/`previews`. Emitted only on a genuine user tab switch (not programmatic changes or re-selecting the current tab). |
+| `studio_panel_opened` | Renderer (Classic tab strip + agentic route navigation) | `panel` — the panel opened. Classic: `overview`/`sync`/`settings`/`assistant`/`import-export`/`previews` (only on a genuine user tab switch, not programmatic changes or re-selecting the current tab). Agentic: `overview`/`settings`/`debugging`/`assistant` (`sync`/`import-export`/`previews` are Classic-only). |
 
 #### Settings-change events
 

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -61,6 +61,11 @@ export type TracksUiVersion = 'v1' | 'v2';
 // caller (import/sync from a renderer, duplicate from the desktop Main `copySite` handler).
 export type TracksSiteCreateFlowType = 'new' | 'blueprint' | 'import' | 'sync' | 'duplicate';
 
+// Where a site "open" action rendered the site content, sent as `browser` on the site-content open
+// events (open_in_browser/wp_admin/customize/phpmyadmin). Studio Classic (v1) always opens the OS
+// browser (`external`); the agentic UI (v2) can open its in-app preview panel (`internal`).
+export type TracksBrowserTarget = 'external' | 'internal';
+
 // The affordance a `studio_site_open_customize` event was launched from, sent as `entry_point`. Block
 // themes expose the site editor and its sub-views plus the media library; classic themes expose the
 // Customizer and (theme-dependent) Menus/Widgets screens.

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -81,6 +81,18 @@ export type TracksCustomizeEntryPoint =
 	| 'menus'
 	| 'widgets';
 
+// The site panel/tab a `studio_panel_opened` event refers to. Studio Classic emits the tab-strip names
+// (`sync`/`import-export`/`previews` are Classic-only); the agentic UI reuses the shared names —
+// `settings` for its General tab and `debugging` for its Debugging tab.
+export type TracksPanel =
+	| 'overview'
+	| 'settings'
+	| 'debugging'
+	| 'assistant'
+	| 'sync'
+	| 'import-export'
+	| 'previews';
+
 // Builds the Tracks pixel URL. Isolated so a param-name correction is a one-file change. These are
 // the reserved Tracks pixel params: `_en` event name, `_ut`/`_ui` identity, `_ts` timestamp (ms).
 // Every event prop is coerced to a string (Tracks stores all values as strings) and appended as its

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -11,6 +11,16 @@ export const TRACKS_EVENTS = {
 	APP_LAUNCH: 'studio_app_launch',
 	SITE_START: 'studio_site_start',
 	SITE_CREATE: 'studio_site_created',
+	SITE_STOP: 'studio_site_stop',
+	SITE_DELETE: 'studio_site_delete',
+	SITE_OPEN_IN_BROWSER: 'studio_site_open_in_browser',
+	SITE_OPEN_IN_EDITOR: 'studio_site_open_in_editor',
+	SITE_OPEN_IN_TERMINAL: 'studio_site_open_in_terminal',
+	SITE_OPEN_WP_ADMIN: 'studio_site_open_wp_admin',
+	SITE_OPEN_CUSTOMIZE: 'studio_site_open_customize',
+	SITE_OPEN_PHPMYADMIN: 'studio_site_open_phpmyadmin',
+	SITE_OPEN_FOLDER: 'studio_site_open_folder',
+	PANEL_OPENED: 'studio_panel_opened',
 	SETTING_TELEMETRY_CHANGE: 'studio_setting_telemetry_change',
 	SETTING_APPEARANCE_CHANGE: 'studio_setting_appearance_change',
 	SETTING_LANGUAGE_CHANGE: 'studio_setting_language_change',
@@ -50,6 +60,21 @@ export type TracksUiVersion = 'v1' | 'v2';
 // the CLI from the presence of a blueprint; the other non-`new` values are threaded down from the
 // caller (import/sync from a renderer, duplicate from the desktop Main `copySite` handler).
 export type TracksSiteCreateFlowType = 'new' | 'blueprint' | 'import' | 'sync' | 'duplicate';
+
+// The affordance a `studio_site_open_customize` event was launched from, sent as `entry_point`. Block
+// themes expose the site editor and its sub-views plus the media library; classic themes expose the
+// Customizer and (theme-dependent) Menus/Widgets screens.
+export type TracksCustomizeEntryPoint =
+	| 'editor'
+	| 'editor_styles'
+	| 'editor_patterns'
+	| 'editor_navigation'
+	| 'editor_templates'
+	| 'editor_pages'
+	| 'media_library'
+	| 'customizer'
+	| 'menus'
+	| 'widgets';
 
 // Builds the Tracks pixel URL. Isolated so a param-name correction is a one-file change. These are
 // the reserved Tracks pixel params: `_en` event name, `_ut`/`_ui` identity, `_ts` timestamp (ms).


### PR DESCRIPTION
## Related issues

- Fixes [STU-2115](https://linear.app/a8c/issue/STU-2115/tracks-site-lifecycle-and-open-actions)
- Part of [STU-2036](https://linear.app/a8c/issue/STU-2036/add-initial-tracks-analytics)

## How AI was used in this PR

Claude Code (Opus 4.8) explored the existing Tracks infrastructure, proposed the emit-locus strategy, wrote the implementation and tests, and ran lint/typecheck/tests plus a CLI dev-smoke.

I reviewed each emit point, the `failure_reason` classifier, and the stop-all counting semantics, and drove the design decisions (CLI vs Main vs renderer placement, classic-theme `entry_point` values, stop-all one-event-per-site). Then tested thoroughly and kept iterating to ensure all events are triggered correctly.

## Proposed Changes

Adds the largest group of Tracks events — day-to-day site operations — so product can see how people actually use their local sites. This runs in parallel with the existing MC Stats, anonymous and opt-out-gated, following the patterns established in the initial Tracks work.

It **extends** the live `studio_site_start` event with `success`, `time_ms`, `running_site_count`, and (on failure) a coarse `failure_reason`, and **adds** ten events: `studio_site_stop`, `studio_site_delete`, the "open in…" affordances (`open_in_browser`/`open_in_editor`/`open_in_terminal`/`open_wp_admin`/`open_customize`/`open_phpmyadmin`/`open_folder`), and `studio_panel_opened`.

Each event is emitted at the single surface that funnels every user path exactly once:
- **Start / stop / delete → the CLI.** The desktop delegates all three to the CLI, so emitting there counts standalone-CLI usage too (mirrors `studio_site_created`).
- **Open in editor / terminal → Desktop Main.** These launch a local app and are the shared funnel for both the classic renderer and the agentic UI.
- **The remaining open actions + panel switches → the renderer**, since they route through generic IPC that Main can't attribute.

No site names, paths, or URLs are ever sent — only enumerated prop values (e.g. `entry_point`, `panel`, resolved `editor`/`terminal`). `failure_reason` is a classified low-cardinality string, never the raw error.

There is **no user-visible behavior change** — the affordances behave exactly as before; they now also record analytics (subject to the existing opt-out).

## Testing Instructions

1. Start Studio: `npm start`
2. Confirm different events surface as `Would have recorded…` in the main-process terminal as you exercise the UI. 

**Follow-up (not in this PR):** register each new event and all its eventprops (incl. the wrapper-attached common props) via the Tracks Registration tool — documentation/CI only; it does not gate ingestion.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?