### PR TITLE
Agentic UI: Add disk usage to site overview

### DIFF
--- a/apps/cli/tests/local-server.test.ts
+++ b/apps/cli/tests/local-server.test.ts
@@ -13,6 +13,7 @@ import type { LocalServer } from '../../local/src/index';
 const mocks = vi.hoisted( () => ( {
 	execute: vi.fn(),
 	killAll: vi.fn(),
+	measureSiteStorage: vi.fn(),
 } ) );
 
 vi.mock( '@studio/common/lib/cli-process', () => ( {
@@ -22,6 +23,9 @@ vi.mock( '@studio/common/lib/cli-process', () => ( {
 	} ) ),
 } ) );
 vi.mock( '@studio/common/sites/list', () => ( { listSites: vi.fn() } ) );
+vi.mock( '@studio/common/sites/storage-usage', () => ( {
+	measureSiteStorage: mocks.measureSiteStorage,
+} ) );
 vi.mock( '@studio/common/ai/run-manager', () => ( {
 	createAgentRunManager: vi.fn( () => ( {
 		startAgentRun: vi.fn(),
@@ -60,6 +64,14 @@ describe( 'local web server Connect contracts', () => {
 				running: false,
 			},
 		] );
+		mocks.measureSiteStorage.mockResolvedValue( {
+			total: 800,
+			uploads: 400,
+			plugins: 200,
+			themes: 100,
+			database: 50,
+			other: 50,
+		} );
 		mocks.execute.mockImplementation( () => {
 			const emitter = new EventEmitter();
 			queueMicrotask( () => emitter.emit( 'success' ) );
@@ -72,6 +84,23 @@ describe( 'local web server Connect contracts', () => {
 			port: 0,
 			host: '127.0.0.1',
 		} );
+	} );
+
+	it( 'reports a local site storage breakdown', async () => {
+		const response = await fetch(
+			`${ server.url.replace( 'localhost', '127.0.0.1' ) }/api/sites/local-a/storage`
+		);
+
+		expect( response.status ).toBe( 200 );
+		await expect( response.json() ).resolves.toEqual( {
+			total: 800,
+			uploads: 400,
+			plugins: 200,
+			themes: 100,
+			database: 50,
+			other: 50,
+		} );
+		expect( mocks.measureSiteStorage ).toHaveBeenCalledWith( '/sites/local-a' );
 	} );
 
 	afterEach( async () => {

--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -65,6 +65,7 @@ import { buildSiteSetArgs } from '@studio/common/sites/edit';
 import { startSite, stopSite } from '@studio/common/sites/lifecycle';
 import { listSites } from '@studio/common/sites/list';
 import { createSnapshotManager, fetchSnapshots } from '@studio/common/sites/snapshots';
+import { measureSiteStorage } from '@studio/common/sites/storage-usage';
 import { pullSite, pushSite } from '@studio/common/sites/sync';
 import express from 'express';
 import { rateLimit } from 'express-rate-limit';
@@ -504,6 +505,19 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 				return;
 			}
 			res.json( { wpVersion: getWordPressVersion( site.path ) } );
+		} )
+	);
+
+	api.get(
+		'/sites/:id/storage',
+		asyncHandler( async ( req: Request, res: Response ) => {
+			const sites = await listSites( execute );
+			const site = sites.find( ( candidate ) => candidate.id === req.params.id );
+			if ( ! site ) {
+				res.status( 404 ).json( { error: `Site ${ req.params.id } not found` } );
+				return;
+			}
+			res.json( await measureSiteStorage( site.path ) );
 		} )
 	);
 

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -100,6 +100,7 @@ import {
 	extractBlueprintBundle as extractBlueprintBundleShared,
 	type ExtractedBlueprintBundle,
 } from '@studio/common/sites/blueprint-extract';
+import { measureSiteStorage, type SiteStorageUsage } from '@studio/common/sites/storage-usage';
 import { __, sprintf, LocaleData, defaultI18n } from '@wordpress/i18n';
 import { MACOS_TRAFFIC_LIGHT_POSITION, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
@@ -1358,6 +1359,14 @@ export function getWpVersion( _event: IpcMainInvokeEvent, id: string ) {
 	}
 	const wordPressPath = server.details.path;
 	return getWordPressVersion( wordPressPath );
+}
+
+export async function getSiteStorageUsage(
+	_event: IpcMainInvokeEvent,
+	id: string
+): Promise< SiteStorageUsage | null > {
+	const server = SiteServer.get( id );
+	return server ? measureSiteStorage( server.details.path ) : null;
 }
 
 export function getIsMultisite( _event: IpcMainInvokeEvent, id: string ) {

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -100,6 +100,7 @@ import {
 	extractBlueprintBundle as extractBlueprintBundleShared,
 	type ExtractedBlueprintBundle,
 } from '@studio/common/sites/blueprint-extract';
+import { measureSiteStorage, type SiteStorageUsage } from '@studio/common/sites/storage-usage';
 import { __, sprintf, LocaleData, defaultI18n } from '@wordpress/i18n';
 import { MACOS_TRAFFIC_LIGHT_POSITION, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
@@ -1354,6 +1355,14 @@ export function getWpVersion( _event: IpcMainInvokeEvent, id: string ) {
 	}
 	const wordPressPath = server.details.path;
 	return getWordPressVersion( wordPressPath );
+}
+
+export async function getSiteStorageUsage(
+	_event: IpcMainInvokeEvent,
+	id: string
+): Promise< SiteStorageUsage | null > {
+	const server = SiteServer.get( id );
+	return server ? measureSiteStorage( server.details.path ) : null;
 }
 
 export function getIsMultisite( _event: IpcMainInvokeEvent, id: string ) {

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -98,6 +98,7 @@ const api: IpcApi = {
 	getAppUpdateStatus: () => ipcRendererInvoke( 'getAppUpdateStatus' ),
 	installAppUpdate: () => ipcRendererInvoke( 'installAppUpdate' ),
 	getWpVersion: ( id ) => ipcRendererInvoke( 'getWpVersion', id ),
+	getSiteStorageUsage: ( id ) => ipcRendererInvoke( 'getSiteStorageUsage', id ),
 	getIsMultisite: ( id ) => ipcRendererInvoke( 'getIsMultisite', id ),
 	fetchSiteRestApi: ( siteId, request ) => ipcRendererInvoke( 'fetchSiteRestApi', siteId, request ),
 	generateProposedSitePath: ( siteName ) =>

--- a/apps/ui/src/components/site-overview-view/about-section.tsx
+++ b/apps/ui/src/components/site-overview-view/about-section.tsx
@@ -1,13 +1,12 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { external, Icon } from '@wordpress/icons';
-import { Tooltip } from '@wordpress/ui';
 import { useConnector } from '@/data/core';
 import { useSiteStorageUsage } from '@/data/queries/use-site-storage-usage';
 import { useSiteThumbnail } from '@/data/queries/use-site-thumbnail';
 import { useIsSiteStarting, useStartSite } from '@/data/queries/use-sites';
 import styles from './cards.module.css';
 import { CardSection } from './overview-card';
-import type { SiteDetails } from '@/data/core';
+import type { SiteDetails, SiteStorageUsage } from '@/data/core';
 
 const STORAGE_PARTS = [
 	{ key: 'uploads', label: __( 'Media' ), className: styles.storageUploads },
@@ -109,42 +108,65 @@ export function AboutSection( { site, wpVersion }: { site: SiteDetails; wpVersio
 				{ storage.isPending ? (
 					<div className={ styles.storageSkeleton } aria-hidden="true" />
 				) : storage.data && storage.data.total > 0 ? (
-					<div className={ styles.storageBar } aria-label={ __( 'Disk usage breakdown' ) }>
-						{ STORAGE_PARTS.map( ( part ) => {
-							const bytes = storage.data?.[ part.key ] ?? 0;
-							if ( bytes === 0 ) {
-								return null;
-							}
-							const percent = ( bytes / ( storage.data?.total ?? bytes ) ) * 100;
-							const label = sprintf(
-								/* translators: 1: storage category, 2: formatted size, 3: percentage */
-								__( '%1$s — %2$s (%3$s%%)' ),
-								part.label,
-								formatBytes( bytes ),
-								percent < 1 ? '<1' : String( Math.round( percent ) )
-							);
-							return (
-								<Tooltip.Root key={ part.key }>
-									<Tooltip.Trigger
-										render={
-											<span
-												role="img"
-												tabIndex={ 0 }
-												aria-label={ label }
-												className={ `${ styles.storageSegment } ${ part.className }` }
-												style={ { flexGrow: bytes } }
-											/>
-										}
-									/>
-									<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
-										{ label }
-									</Tooltip.Popup>
-								</Tooltip.Root>
-							);
-						} ) }
-					</div>
+					<StorageBar usage={ storage.data } />
 				) : null }
 			</div>
 		</CardSection>
+	);
+}
+
+function StorageBar( { usage }: { usage: SiteStorageUsage } ) {
+	const parts = STORAGE_PARTS.map( ( part ) => ( {
+		...part,
+		bytes: usage[ part.key ],
+		percent: ( usage[ part.key ] / usage.total ) * 100,
+	} ) )
+		.filter( ( part ) => part.bytes > 0 )
+		.map( ( part ) => ( {
+			...part,
+			percentLabel: `${ part.percent < 1 ? '<1' : Math.round( part.percent ) }%`,
+		} ) );
+	const descriptions = parts.map( ( part ) =>
+		sprintf(
+			/* translators: 1: storage category, 2: formatted size, 3: percentage */
+			__( '%1$s — %2$s (%3$s)' ),
+			part.label,
+			formatBytes( part.bytes ),
+			part.percentLabel
+		)
+	);
+	const accessibleLabel = sprintf(
+		/* translators: %s: comma-separated disk usage category descriptions */
+		__( 'Disk usage breakdown: %s' ),
+		descriptions.join( ', ' )
+	);
+
+	return (
+		<div
+			className={ styles.storageInteractive }
+			tabIndex={ 0 }
+			role="group"
+			aria-label={ accessibleLabel }
+		>
+			<div className={ styles.storageBar } aria-hidden="true">
+				{ parts.map( ( part ) => (
+					<span
+						key={ part.key }
+						className={ `${ styles.storageSegment } ${ part.className }` }
+						style={ { flexGrow: part.bytes } }
+					/>
+				) ) }
+			</div>
+			<div className={ styles.storageLegend } aria-hidden="true">
+				{ parts.map( ( part ) => (
+					<div className={ styles.storageLegendRow } key={ part.key }>
+						<span className={ `${ styles.storageLegendSwatch } ${ part.className }` } />
+						<span className={ styles.storageLegendLabel }>{ part.label }</span>
+						<span className={ styles.storageLegendValue }>{ formatBytes( part.bytes ) }</span>
+						<span className={ styles.storageLegendPercent }>{ part.percentLabel }</span>
+					</div>
+				) ) }
+			</div>
+		</div>
 	);
 }

--- a/apps/ui/src/components/site-overview-view/about-section.tsx
+++ b/apps/ui/src/components/site-overview-view/about-section.tsx
@@ -1,11 +1,33 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { external, Icon } from '@wordpress/icons';
+import { Tooltip } from '@wordpress/ui';
 import { useConnector } from '@/data/core';
+import { useSiteStorageUsage } from '@/data/queries/use-site-storage-usage';
 import { useSiteThumbnail } from '@/data/queries/use-site-thumbnail';
 import { useIsSiteStarting, useStartSite } from '@/data/queries/use-sites';
 import styles from './cards.module.css';
 import { CardSection } from './overview-card';
 import type { SiteDetails } from '@/data/core';
+
+const STORAGE_PARTS = [
+	{ key: 'uploads', label: __( 'Media' ), className: styles.storageUploads },
+	{ key: 'plugins', label: __( 'Plugins' ), className: styles.storagePlugins },
+	{ key: 'themes', label: __( 'Themes' ), className: styles.storageThemes },
+	{ key: 'database', label: __( 'Database' ), className: styles.storageDatabase },
+	{ key: 'other', label: __( 'Other' ), className: styles.storageOther },
+] as const;
+
+export function formatBytes( bytes: number ): string {
+	if ( bytes === 0 ) {
+		return '0 MB';
+	}
+	const unitIndex = Math.min( Math.floor( Math.log( bytes ) / Math.log( 1024 ) ), 4 );
+	const units = [ 'B', 'KB', 'MB', 'GB', 'TB' ];
+	const value = bytes / 1024 ** unitIndex;
+	return `${ value >= 10 || unitIndex === 0 ? Math.round( value ) : value.toFixed( 1 ) } ${
+		units[ unitIndex ]
+	}`;
+}
 
 export function AboutSection( { site, wpVersion }: { site: SiteDetails; wpVersion?: string } ) {
 	const connector = useConnector();
@@ -13,6 +35,7 @@ export function AboutSection( { site, wpVersion }: { site: SiteDetails; wpVersio
 	const isStarting = useIsSiteStarting( site.id );
 	const themeName = site.themeDetails?.name || site.themeDetails?.slug || '—';
 	const thumbnail = useSiteThumbnail( site.id );
+	const storage = useSiteStorageUsage( site.id );
 	const wpLabel = wpVersion
 		? sprintf(
 				/* translators: %s: WordPress version number */
@@ -71,6 +94,56 @@ export function AboutSection( { site, wpVersion }: { site: SiteDetails; wpVersio
 						<span>{ phpLabel }</span>
 					</span>
 				</div>
+			</div>
+			<div className={ styles.storageSection }>
+				<div className={ styles.storageHeader }>
+					<span className={ styles.tileLabel }>{ __( 'Disk' ) }</span>
+					<span className={ styles.storageTotal }>
+						{ storage.isPending
+							? __( 'Measuring…' )
+							: storage.data
+							? formatBytes( storage.data.total )
+							: '—' }
+					</span>
+				</div>
+				{ storage.isPending ? (
+					<div className={ styles.storageSkeleton } aria-hidden="true" />
+				) : storage.data && storage.data.total > 0 ? (
+					<div className={ styles.storageBar } aria-label={ __( 'Disk usage breakdown' ) }>
+						{ STORAGE_PARTS.map( ( part ) => {
+							const bytes = storage.data?.[ part.key ] ?? 0;
+							if ( bytes === 0 ) {
+								return null;
+							}
+							const percent = ( bytes / ( storage.data?.total ?? bytes ) ) * 100;
+							const label = sprintf(
+								/* translators: 1: storage category, 2: formatted size, 3: percentage */
+								__( '%1$s — %2$s (%3$s%%)' ),
+								part.label,
+								formatBytes( bytes ),
+								percent < 1 ? '<1' : String( Math.round( percent ) )
+							);
+							return (
+								<Tooltip.Root key={ part.key }>
+									<Tooltip.Trigger
+										render={
+											<span
+												role="img"
+												tabIndex={ 0 }
+												aria-label={ label }
+												className={ `${ styles.storageSegment } ${ part.className }` }
+												style={ { flexGrow: bytes } }
+											/>
+										}
+									/>
+									<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+										{ label }
+									</Tooltip.Popup>
+								</Tooltip.Root>
+							);
+						} ) }
+					</div>
+				) : null }
 			</div>
 		</CardSection>
 	);

--- a/apps/ui/src/components/site-overview-view/cards.module.css
+++ b/apps/ui/src/components/site-overview-view/cards.module.css
@@ -124,9 +124,21 @@
 	color: var(--wpds-color-fg-content-neutral);
 }
 
+.storageInteractive {
+	--storage-uploads: light-dark(#3858e9, #6d8bf0);
+	--storage-plugins: light-dark(#c7367f, #d75c90);
+	--storage-themes: light-dark(#b26b00, #d39a38);
+	--storage-database: light-dark(#00918e, #22a79f);
+	--storage-other: var(--wpds-color-fg-content-neutral-weak);
+
+	position: relative;
+	min-width: 0;
+	border-radius: var(--wpds-border-radius-sm);
+}
+
 .storageBar,
 .storageSkeleton {
-	height: 8px;
+	height: 10px;
 	border-radius: var(--wpds-border-radius-sm);
 	overflow: hidden;
 }
@@ -143,29 +155,91 @@
 	height: 100%;
 }
 
-.storageSegment:focus-visible {
+.storageInteractive:focus-visible {
 	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus-brand);
-	outline-offset: -2px;
+	outline-offset: 2px;
 }
 
 .storageUploads {
-	background: var(--wpds-color-fg-interactive-brand);
+	background: var(--storage-uploads);
 }
 
 .storagePlugins {
-	background: var(--wpds-color-fg-content-error);
+	background: var(--storage-plugins);
 }
 
 .storageThemes {
-	background: var(--wpds-color-fg-content-warning);
+	background: var(--storage-themes);
 }
 
 .storageDatabase {
-	background: var(--wpds-color-fg-content-success);
+	background: var(--storage-database);
 }
 
 .storageOther {
-	background: var(--wpds-color-fg-content-neutral-weak);
+	background: var(--storage-other);
+}
+
+.storageLegend {
+	position: absolute;
+	left: 50%;
+	bottom: calc(100% + var(--wpds-dimension-padding-sm));
+	z-index: 2;
+	display: grid;
+	gap: var(--wpds-dimension-padding-xs);
+	box-sizing: border-box;
+	min-width: 240px;
+	max-width: min(320px, calc(100vw - 32px));
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-md);
+	background: var(--wpds-color-bg-surface-neutral-strong);
+	box-shadow: var(--wpds-elevation-sm);
+	color: var(--wpds-color-fg-content-neutral);
+	opacity: 0;
+	visibility: hidden;
+	transform: translate(-50%, 4px);
+	transition: opacity 120ms ease, transform 120ms ease, visibility 120ms;
+	pointer-events: none;
+}
+
+.storageInteractive:hover .storageLegend,
+.storageInteractive:focus-visible .storageLegend {
+	opacity: 1;
+	visibility: visible;
+	transform: translate(-50%, 0);
+}
+
+.storageLegendRow {
+	display: grid;
+	grid-template-columns: 10px minmax(0, 1fr) auto auto;
+	align-items: center;
+	column-gap: var(--wpds-dimension-padding-sm);
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+}
+
+.storageLegendSwatch {
+	width: 10px;
+	height: 10px;
+	border-radius: 2px;
+}
+
+.storageLegendLabel {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.storageLegendValue {
+	white-space: nowrap;
+}
+
+.storageLegendPercent {
+	min-width: 28px;
+	white-space: nowrap;
+	text-align: end;
+	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
 .storageSkeleton {
@@ -189,7 +263,9 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.storageSkeleton {
+	.storageSkeleton,
+	.storageLegend {
 		animation: none;
+		transition: none;
 	}
 }

--- a/apps/ui/src/components/site-overview-view/cards.module.css
+++ b/apps/ui/src/components/site-overview-view/cards.module.css
@@ -104,3 +104,93 @@
 	line-height: var(--wpds-typography-line-height-xs);
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
+
+.storageSection {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-xs);
+	min-width: 0;
+}
+
+.storageHeader {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-padding-sm);
+}
+
+.storageTotal {
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.storageBar,
+.storageSkeleton {
+	height: 8px;
+	border-radius: var(--wpds-border-radius-sm);
+	overflow: hidden;
+}
+
+.storageBar {
+	display: flex;
+	gap: 2px;
+	background: var(--wpds-color-bg-surface-neutral-weak);
+}
+
+.storageSegment {
+	display: block;
+	min-width: 2px;
+	height: 100%;
+}
+
+.storageSegment:focus-visible {
+	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus-brand);
+	outline-offset: -2px;
+}
+
+.storageUploads {
+	background: var(--wpds-color-fg-interactive-brand);
+}
+
+.storagePlugins {
+	background: var(--wpds-color-fg-content-error);
+}
+
+.storageThemes {
+	background: var(--wpds-color-fg-content-warning);
+}
+
+.storageDatabase {
+	background: var(--wpds-color-fg-content-success);
+}
+
+.storageOther {
+	background: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.storageSkeleton {
+	background: linear-gradient(
+		90deg,
+		var(--wpds-color-bg-surface-neutral-weak) 25%,
+		var(--wpds-color-bg-interactive-neutral-weak-active) 50%,
+		var(--wpds-color-bg-surface-neutral-weak) 75%
+	);
+	background-size: 200% 100%;
+	animation: storage-loading 1.4s ease-in-out infinite;
+}
+
+@keyframes storage-loading {
+	from {
+		background-position: 200% 0;
+	}
+	to {
+		background-position: -200% 0;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.storageSkeleton {
+		animation: none;
+	}
+}

--- a/apps/ui/src/components/site-overview-view/cards.module.css
+++ b/apps/ui/src/components/site-overview-view/cards.module.css
@@ -125,9 +125,21 @@
 	color: var(--wpds-color-fg-content-neutral);
 }
 
+.storageInteractive {
+	--storage-uploads: light-dark(#3858e9, #6d8bf0);
+	--storage-plugins: light-dark(#c7367f, #d75c90);
+	--storage-themes: light-dark(#b26b00, #d39a38);
+	--storage-database: light-dark(#00918e, #22a79f);
+	--storage-other: var(--wpds-color-fg-content-neutral-weak);
+
+	position: relative;
+	min-width: 0;
+	border-radius: var(--wpds-border-radius-sm);
+}
+
 .storageBar,
 .storageSkeleton {
-	height: 8px;
+	height: 10px;
 	border-radius: var(--wpds-border-radius-sm);
 	overflow: hidden;
 }
@@ -144,29 +156,91 @@
 	height: 100%;
 }
 
-.storageSegment:focus-visible {
+.storageInteractive:focus-visible {
 	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus-brand);
-	outline-offset: -2px;
+	outline-offset: 2px;
 }
 
 .storageUploads {
-	background: var(--wpds-color-fg-interactive-brand);
+	background: var(--storage-uploads);
 }
 
 .storagePlugins {
-	background: var(--wpds-color-fg-content-error);
+	background: var(--storage-plugins);
 }
 
 .storageThemes {
-	background: var(--wpds-color-fg-content-warning);
+	background: var(--storage-themes);
 }
 
 .storageDatabase {
-	background: var(--wpds-color-fg-content-success);
+	background: var(--storage-database);
 }
 
 .storageOther {
-	background: var(--wpds-color-fg-content-neutral-weak);
+	background: var(--storage-other);
+}
+
+.storageLegend {
+	position: absolute;
+	left: 50%;
+	bottom: calc(100% + var(--wpds-dimension-padding-sm));
+	z-index: 2;
+	display: grid;
+	gap: var(--wpds-dimension-padding-xs);
+	box-sizing: border-box;
+	min-width: 240px;
+	max-width: min(320px, calc(100vw - 32px));
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-md);
+	background: var(--wpds-color-bg-surface-neutral-strong);
+	box-shadow: var(--wpds-elevation-sm);
+	color: var(--wpds-color-fg-content-neutral);
+	opacity: 0;
+	visibility: hidden;
+	transform: translate(-50%, 4px);
+	transition: opacity 120ms ease, transform 120ms ease, visibility 120ms;
+	pointer-events: none;
+}
+
+.storageInteractive:hover .storageLegend,
+.storageInteractive:focus-visible .storageLegend {
+	opacity: 1;
+	visibility: visible;
+	transform: translate(-50%, 0);
+}
+
+.storageLegendRow {
+	display: grid;
+	grid-template-columns: 10px minmax(0, 1fr) auto auto;
+	align-items: center;
+	column-gap: var(--wpds-dimension-padding-sm);
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+}
+
+.storageLegendSwatch {
+	width: 10px;
+	height: 10px;
+	border-radius: 2px;
+}
+
+.storageLegendLabel {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.storageLegendValue {
+	white-space: nowrap;
+}
+
+.storageLegendPercent {
+	min-width: 28px;
+	white-space: nowrap;
+	text-align: end;
+	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
 .storageSkeleton {
@@ -190,7 +264,9 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.storageSkeleton {
+	.storageSkeleton,
+	.storageLegend {
 		animation: none;
+		transition: none;
 	}
 }

--- a/apps/ui/src/components/site-overview-view/cards.module.css
+++ b/apps/ui/src/components/site-overview-view/cards.module.css
@@ -103,3 +103,93 @@
 	line-height: var(--wpds-typography-line-height-xs);
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
+
+.storageSection {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-xs);
+	min-width: 0;
+}
+
+.storageHeader {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-padding-sm);
+}
+
+.storageTotal {
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.storageBar,
+.storageSkeleton {
+	height: 8px;
+	border-radius: var(--wpds-border-radius-sm);
+	overflow: hidden;
+}
+
+.storageBar {
+	display: flex;
+	gap: 2px;
+	background: var(--wpds-color-bg-surface-neutral-weak);
+}
+
+.storageSegment {
+	display: block;
+	min-width: 2px;
+	height: 100%;
+}
+
+.storageSegment:focus-visible {
+	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus-brand);
+	outline-offset: -2px;
+}
+
+.storageUploads {
+	background: var(--wpds-color-fg-interactive-brand);
+}
+
+.storagePlugins {
+	background: var(--wpds-color-fg-content-error);
+}
+
+.storageThemes {
+	background: var(--wpds-color-fg-content-warning);
+}
+
+.storageDatabase {
+	background: var(--wpds-color-fg-content-success);
+}
+
+.storageOther {
+	background: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.storageSkeleton {
+	background: linear-gradient(
+		90deg,
+		var(--wpds-color-bg-surface-neutral-weak) 25%,
+		var(--wpds-color-bg-interactive-neutral-weak-active) 50%,
+		var(--wpds-color-bg-surface-neutral-weak) 75%
+	);
+	background-size: 200% 100%;
+	animation: storage-loading 1.4s ease-in-out infinite;
+}
+
+@keyframes storage-loading {
+	from {
+		background-position: 200% 0;
+	}
+	to {
+		background-position: -200% 0;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.storageSkeleton {
+		animation: none;
+	}
+}

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -5,6 +5,7 @@ import { useConnector } from '@/data/core';
 import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
 import { useLogin } from '@/data/queries/use-auth-user';
 import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
+import { useSiteStorageUsage } from '@/data/queries/use-site-storage-usage';
 import { useSiteThumbnail } from '@/data/queries/use-site-thumbnail';
 import {
 	useCopySite,
@@ -99,6 +100,10 @@ vi.mock( '@/data/queries/use-site-thumbnail', () => ( {
 	useSiteThumbnail: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-site-storage-usage', () => ( {
+	useSiteStorageUsage: vi.fn(),
+} ) );
+
 vi.mock( '@/data/queries/use-user-preferences', () => ( {
 	useUserPreferences: vi.fn(),
 } ) );
@@ -130,6 +135,7 @@ const useExportFullSiteMock = vi.mocked( useExportFullSite, { partial: true } );
 const useIsSiteStartingMock = vi.mocked( useIsSiteStarting );
 const useIsSiteStoppingMock = vi.mocked( useIsSiteStopping );
 const useSiteThumbnailMock = vi.mocked( useSiteThumbnail, { partial: true } );
+const useSiteStorageUsageMock = vi.mocked( useSiteStorageUsage, { partial: true } );
 const useSitesMock = vi.mocked( useSites, { partial: true } );
 const useStartSiteMock = vi.mocked( useStartSite, { partial: true } );
 const useUpdateSiteMock = vi.mocked( useUpdateSite, { partial: true } );
@@ -198,6 +204,17 @@ describe( 'SiteOverviewView', () => {
 		} );
 		useSiteThumbnailMock.mockReturnValue( {
 			data: 'data:image/png;base64,site-thumbnail',
+		} );
+		useSiteStorageUsageMock.mockReturnValue( {
+			data: {
+				total: 800,
+				uploads: 400,
+				plugins: 200,
+				themes: 100,
+				database: 50,
+				other: 50,
+			},
+			isPending: false,
 		} );
 		useIsSiteStartingMock.mockReturnValue( false );
 		useIsSiteStoppingMock.mockReturnValue( false );
@@ -273,6 +290,23 @@ describe( 'SiteOverviewView', () => {
 		await waitFor( () =>
 			expect( openSiteUrl ).toHaveBeenCalledWith( 'site-1', '/', { autoLogin: false } )
 		);
+	} );
+
+	it( 'shows the total disk usage and an accessible category breakdown', () => {
+		renderView();
+
+		expect( screen.getByText( 'Disk' ) ).toBeVisible();
+		expect( screen.getByText( '800 B' ) ).toBeVisible();
+		expect( screen.getByRole( 'img', { name: 'Media — 400 B (50%)' } ) ).toBeVisible();
+		expect( screen.getByRole( 'img', { name: 'Plugins — 200 B (25%)' } ) ).toBeVisible();
+	} );
+
+	it( 'indicates when disk usage is still being measured', () => {
+		useSiteStorageUsageMock.mockReturnValue( { data: undefined, isPending: true } );
+
+		renderView();
+
+		expect( screen.getByText( 'Measuring…' ) ).toBeVisible();
 	} );
 
 	it( 'keeps the browser action available without a cached thumbnail', () => {

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -297,8 +297,13 @@ describe( 'SiteOverviewView', () => {
 
 		expect( screen.getByText( 'Disk' ) ).toBeVisible();
 		expect( screen.getByText( '800 B' ) ).toBeVisible();
-		expect( screen.getByRole( 'img', { name: 'Media — 400 B (50%)' } ) ).toBeVisible();
-		expect( screen.getByRole( 'img', { name: 'Plugins — 200 B (25%)' } ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'group', {
+				name: 'Disk usage breakdown: Media — 400 B (50%), Plugins — 200 B (25%), Themes — 100 B (13%), Database — 50 B (6%), Other — 50 B (6%)',
+			} )
+		).toBeVisible();
+		expect( screen.getByText( 'Media' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Plugins' ) ).toBeInTheDocument();
 	} );
 
 	it( 'indicates when disk usage is still being measured', () => {

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -295,8 +295,13 @@ describe( 'SiteOverviewView', () => {
 
 		expect( screen.getByText( 'Disk' ) ).toBeVisible();
 		expect( screen.getByText( '800 B' ) ).toBeVisible();
-		expect( screen.getByRole( 'img', { name: 'Media — 400 B (50%)' } ) ).toBeVisible();
-		expect( screen.getByRole( 'img', { name: 'Plugins — 200 B (25%)' } ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'group', {
+				name: 'Disk usage breakdown: Media — 400 B (50%), Plugins — 200 B (25%), Themes — 100 B (13%), Database — 50 B (6%), Other — 50 B (6%)',
+			} )
+		).toBeVisible();
+		expect( screen.getByText( 'Media' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Plugins' ) ).toBeInTheDocument();
 	} );
 
 	it( 'indicates when disk usage is still being measured', () => {

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -5,6 +5,7 @@ import { useConnector } from '@/data/core';
 import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
 import { useLogin } from '@/data/queries/use-auth-user';
 import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
+import { useSiteStorageUsage } from '@/data/queries/use-site-storage-usage';
 import { useSiteThumbnail } from '@/data/queries/use-site-thumbnail';
 import {
 	useCopySite,
@@ -99,6 +100,10 @@ vi.mock( '@/data/queries/use-site-thumbnail', () => ( {
 	useSiteThumbnail: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-site-storage-usage', () => ( {
+	useSiteStorageUsage: vi.fn(),
+} ) );
+
 vi.mock( '@/data/queries/use-user-preferences', () => ( {
 	useUserPreferences: vi.fn(),
 } ) );
@@ -130,6 +135,7 @@ const useExportFullSiteMock = vi.mocked( useExportFullSite, { partial: true } );
 const useIsSiteStartingMock = vi.mocked( useIsSiteStarting );
 const useIsSiteStoppingMock = vi.mocked( useIsSiteStopping );
 const useSiteThumbnailMock = vi.mocked( useSiteThumbnail, { partial: true } );
+const useSiteStorageUsageMock = vi.mocked( useSiteStorageUsage, { partial: true } );
 const useSitesMock = vi.mocked( useSites, { partial: true } );
 const useStartSiteMock = vi.mocked( useStartSite, { partial: true } );
 const useUpdateSiteMock = vi.mocked( useUpdateSite, { partial: true } );
@@ -196,6 +202,17 @@ describe( 'SiteOverviewView', () => {
 		} );
 		useSiteThumbnailMock.mockReturnValue( {
 			data: 'data:image/png;base64,site-thumbnail',
+		} );
+		useSiteStorageUsageMock.mockReturnValue( {
+			data: {
+				total: 800,
+				uploads: 400,
+				plugins: 200,
+				themes: 100,
+				database: 50,
+				other: 50,
+			},
+			isPending: false,
 		} );
 		useIsSiteStartingMock.mockReturnValue( false );
 		useIsSiteStoppingMock.mockReturnValue( false );
@@ -271,6 +288,23 @@ describe( 'SiteOverviewView', () => {
 		await waitFor( () =>
 			expect( openSiteUrl ).toHaveBeenCalledWith( 'site-1', '/', { autoLogin: false } )
 		);
+	} );
+
+	it( 'shows the total disk usage and an accessible category breakdown', () => {
+		renderView();
+
+		expect( screen.getByText( 'Disk' ) ).toBeVisible();
+		expect( screen.getByText( '800 B' ) ).toBeVisible();
+		expect( screen.getByRole( 'img', { name: 'Media — 400 B (50%)' } ) ).toBeVisible();
+		expect( screen.getByRole( 'img', { name: 'Plugins — 200 B (25%)' } ) ).toBeVisible();
+	} );
+
+	it( 'indicates when disk usage is still being measured', () => {
+		useSiteStorageUsageMock.mockReturnValue( { data: undefined, isPending: true } );
+
+		renderView();
+
+		expect( screen.getByText( 'Measuring…' ) ).toBeVisible();
 	} );
 
 	it( 'keeps the browser action available without a cached thumbnail', () => {

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -186,6 +186,9 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		async getSiteThumbnail(): Promise< string | null > {
 			return null;
 		},
+		async getSiteStorageUsage(): Promise< null > {
+			return null;
+		},
 		async exportFullSite(): Promise< string | null > {
 			throw new UnsupportedError( 'exportFullSite' );
 		},

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -184,6 +184,9 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		async getSiteThumbnail(): Promise< string | null > {
 			return null;
 		},
+		async getSiteStorageUsage(): Promise< null > {
+			return null;
+		},
 		async exportFullSite(): Promise< string | null > {
 			throw new UnsupportedError( 'exportFullSite' );
 		},

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -426,6 +426,9 @@ export function createIpcConnector(): Connector {
 		async getSiteThumbnail( siteId ): Promise< string | null > {
 			return ( await ipcApi.getThumbnailData( siteId ) ) as string | null;
 		},
+		async getSiteStorageUsage( siteId ) {
+			return ipcApi.getSiteStorageUsage( siteId );
+		},
 
 		async exportFullSite( siteId ): Promise< string | null > {
 			const sites = ( await ipcApi.getSiteDetails() ) as SiteDetails[];

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -425,6 +425,9 @@ export function createIpcConnector(): Connector {
 		async getSiteThumbnail( siteId ): Promise< string | null > {
 			return ( await ipcApi.getThumbnailData( siteId ) ) as string | null;
 		},
+		async getSiteStorageUsage( siteId ) {
+			return ipcApi.getSiteStorageUsage( siteId );
+		},
 
 		async exportFullSite( siteId ): Promise< string | null > {
 			const sites = ( await ipcApi.getSiteDetails() ) as SiteDetails[];

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -366,6 +366,9 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 		async getSiteThumbnail(): Promise< string | null > {
 			return null;
 		},
+		async getSiteStorageUsage( siteId ) {
+			return api( `/sites/${ encodeURIComponent( siteId ) }/storage` );
+		},
 
 		// Site creation — delegated to the CLI `create` on the local machine.
 		async createSite( params ): Promise< SiteDetails > {

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -364,6 +364,9 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 		async getSiteThumbnail(): Promise< string | null > {
 			return null;
 		},
+		async getSiteStorageUsage( siteId ) {
+			return api( `/sites/${ encodeURIComponent( siteId ) }/storage` );
+		},
 
 		// Site creation — delegated to the CLI `create` on the local machine.
 		async createSite( params ): Promise< SiteDetails > {

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -21,6 +21,7 @@ export type {
 	SelectedSiteFolder,
 	SessionEntry,
 	SiteDetails,
+	SiteStorageUsage,
 	SkillStatus,
 	Snapshot,
 	SnapshotUsage,

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -20,6 +20,7 @@ export type {
 	SelectedSiteFolder,
 	SessionEntry,
 	SiteDetails,
+	SiteStorageUsage,
 	SkillStatus,
 	Snapshot,
 	SnapshotUsage,

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -15,6 +15,7 @@ import type { StudioAssistantQuota } from '@studio/common/lib/studio-assistant-q
 import type { SupportedEditor } from '@studio/common/lib/user-settings/editor';
 import type { SupportedTerminal } from '@studio/common/lib/user-settings/terminal';
 import type { WordPressVersion } from '@studio/common/lib/wordpress-versions';
+import type { SiteStorageUsage } from '@studio/common/sites/storage-usage';
 import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
 import type { Snapshot } from '@studio/common/types/snapshot';
 import type { PullSiteProgress, SyncSite } from '@studio/common/types/sync';
@@ -44,6 +45,7 @@ export type { SupportedEditor } from '@studio/common/lib/user-settings/editor';
 export type { SupportedTerminal } from '@studio/common/lib/user-settings/terminal';
 export type { SupportedLocale } from '@studio/common/lib/locale';
 export type { StudioAssistantQuota } from '@studio/common/lib/studio-assistant-quota';
+export type { SiteStorageUsage } from '@studio/common/sites/storage-usage';
 
 export type InstalledApps = Record< SupportedEditor | SupportedTerminal, boolean >;
 
@@ -196,6 +198,9 @@ export interface Connector {
 	// Cached screenshot thumbnail captured by the desktop app while the site
 	// was running. Returns null when the site has not produced a thumbnail yet.
 	getSiteThumbnail( siteId: string ): Promise< string | null >;
+	// Size of the local site's files, grouped for the overview's disk summary.
+	// Hosted sites return null because their storage is not on this machine.
+	getSiteStorageUsage( siteId: string ): Promise< SiteStorageUsage | null >;
 
 	// Exports a site as a full backup archive (files + database). Prompts the
 	// user for a destination via a save-as dialog; resolves with the chosen

--- a/apps/ui/src/data/queries/use-site-storage-usage.ts
+++ b/apps/ui/src/data/queries/use-site-storage-usage.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+import type { SiteStorageUsage } from '@/data/core';
+
+export const siteStorageUsageQueryKey = ( siteId: string ) =>
+	[ 'site-storage-usage', siteId ] as const;
+
+export function useSiteStorageUsage( siteId: string ) {
+	const connector = useConnector();
+
+	return useQuery< SiteStorageUsage | null >( {
+		queryKey: siteStorageUsageQueryKey( siteId ),
+		queryFn: () => connector.getSiteStorageUsage( siteId ),
+		staleTime: 5 * 60 * 1000,
+		retry: false,
+		meta: { persist: false },
+	} );
+}

--- a/packages/common/sites/storage-usage.test.ts
+++ b/packages/common/sites/storage-usage.test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { measureSiteStorage } from './storage-usage';
+
+const temporaryDirectories: string[] = [];
+
+async function createSite(): Promise< string > {
+	const sitePath = await fs.mkdtemp( path.join( os.tmpdir(), 'studio-storage-usage-' ) );
+	temporaryDirectories.push( sitePath );
+	return sitePath;
+}
+
+async function createFile( sitePath: string, relativePath: string, size: number ): Promise< void > {
+	const filePath = path.join( sitePath, relativePath );
+	await fs.mkdir( path.dirname( filePath ), { recursive: true } );
+	await fs.writeFile( filePath, Buffer.alloc( size ) );
+}
+
+afterEach( async () => {
+	await Promise.all(
+		temporaryDirectories.splice( 0 ).map( ( directory ) => fs.rm( directory, { recursive: true } ) )
+	);
+} );
+
+describe( 'measureSiteStorage', () => {
+	it( 'groups files into the storage categories shown in the UI', async () => {
+		const sitePath = await createSite();
+		await Promise.all( [
+			createFile( sitePath, 'wp-content/uploads/image.jpg', 400 ),
+			createFile( sitePath, 'wp-content/plugins/plugin/index.php', 200 ),
+			createFile( sitePath, 'wp-content/themes/theme/style.css', 100 ),
+			createFile( sitePath, 'wp-content/database/.ht.sqlite', 50 ),
+			createFile( sitePath, 'wp-admin/index.php', 25 ),
+			createFile( sitePath, 'wp-config.php', 25 ),
+		] );
+
+		await expect( measureSiteStorage( sitePath ) ).resolves.toEqual( {
+			total: 800,
+			uploads: 400,
+			plugins: 200,
+			themes: 100,
+			database: 50,
+			other: 50,
+		} );
+	} );
+
+	it( 'does not follow symbolic links', async () => {
+		const sitePath = await createSite();
+		const outsidePath = await createSite();
+		await createFile( outsidePath, 'large-file.bin', 1024 );
+		await fs.symlink( outsidePath, path.join( sitePath, 'linked-content' ) );
+
+		await expect( measureSiteStorage( sitePath ) ).resolves.toEqual( {
+			total: 0,
+			uploads: 0,
+			plugins: 0,
+			themes: 0,
+			database: 0,
+			other: 0,
+		} );
+	} );
+
+	it( 'returns zero usage when the site path cannot be read', async () => {
+		await expect( measureSiteStorage( '/path/that/does/not/exist' ) ).resolves.toEqual( {
+			total: 0,
+			uploads: 0,
+			plugins: 0,
+			themes: 0,
+			database: 0,
+			other: 0,
+		} );
+	} );
+} );

--- a/packages/common/sites/storage-usage.ts
+++ b/packages/common/sites/storage-usage.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export interface SiteStorageUsage {
+	total: number;
+	uploads: number;
+	plugins: number;
+	themes: number;
+	database: number;
+	other: number;
+}
+
+type StorageCategory = Exclude< keyof SiteStorageUsage, 'total' >;
+
+const MAX_CONCURRENT_STATS = 32;
+const CATEGORY_DIRECTORIES: Array< [ string, StorageCategory ] > = [
+	[ path.join( 'wp-content', 'uploads' ), 'uploads' ],
+	[ path.join( 'wp-content', 'plugins' ), 'plugins' ],
+	[ path.join( 'wp-content', 'themes' ), 'themes' ],
+	[ path.join( 'wp-content', 'database' ), 'database' ],
+];
+
+function getCategory( relativePath: string ): StorageCategory {
+	const match = CATEGORY_DIRECTORIES.find(
+		( [ directory ] ) =>
+			relativePath === directory || relativePath.startsWith( `${ directory }${ path.sep }` )
+	);
+	return match?.[ 1 ] ?? 'other';
+}
+
+export async function measureSiteStorage( sitePath: string ): Promise< SiteStorageUsage > {
+	const usage: SiteStorageUsage = {
+		total: 0,
+		uploads: 0,
+		plugins: 0,
+		themes: 0,
+		database: 0,
+		other: 0,
+	};
+	const directories = [ sitePath ];
+	const files: Array< { path: string; category: StorageCategory } > = [];
+
+	for ( let index = 0; index < directories.length; index++ ) {
+		const directory = directories[ index ];
+		let entries;
+		try {
+			entries = await fs.readdir( directory, { withFileTypes: true } );
+		} catch {
+			continue;
+		}
+
+		for ( const entry of entries ) {
+			const entryPath = path.join( directory, entry.name );
+			if ( entry.isDirectory() ) {
+				directories.push( entryPath );
+			} else if ( entry.isFile() ) {
+				files.push( {
+					path: entryPath,
+					category: getCategory( path.relative( sitePath, entryPath ) ),
+				} );
+			}
+		}
+	}
+
+	let nextFile = 0;
+	async function measureNextFile(): Promise< void > {
+		while ( nextFile < files.length ) {
+			const file = files[ nextFile++ ];
+			try {
+				const stats = await fs.stat( file.path );
+				usage.total += stats.size;
+				usage[ file.category ] += stats.size;
+			} catch {
+				// Files can disappear or become unreadable while a site is running.
+			}
+		}
+	}
+
+	await Promise.all(
+		Array.from( { length: Math.min( MAX_CONCURRENT_STATS, files.length ) }, () =>
+			measureNextFile()
+		)
+	);
+
+	return usage;
+}


### PR DESCRIPTION
## Related issues

- Related to #4462

## How AI was used in this PR

AI helped extract this focused slice from the larger overview exploration, implement the filesystem measurement and connector plumbing, and add tests. I reviewed the resulting diff and manually verified the rendered overview in both light and dark modes.

## Proposed Changes

<img width="1354" height="912" alt="image" src="https://github.com/user-attachments/assets/5e9b8506-961e-45b8-bf03-8e1ecad8383c" />
<img width="339" height="190" alt="image" src="https://github.com/user-attachments/assets/9d1cc70f-7d9f-4fb9-87cb-4e0ba91e7da2" />


- Show each local site's total disk usage directly in the About card, with an accessible visual breakdown for Media, Plugins, Themes, Database, and Other files.
- Measure storage without following symlinks or issuing unbounded filesystem work, so large local sites do not make the overview unnecessarily disruptive.
- Keep the summary useful across both the desktop app and local browser UI; hosted sites gracefully omit local disk data.

## Testing Instructions

- Open a local site's Overview and confirm the About card shows a Disk total.
- Hover anywhere on the bar, then focus it with the keyboard, and confirm the floating legend shows every category with its color, size, and percentage.
- Check the card in both light and dark appearance modes.
- Verify sites with little or no data render without a broken or empty breakdown.

Automated verification:

- `npx eslint --fix <modified files>`
- `npm run typecheck`
- `npx vitest run packages/common/sites/storage-usage.test.ts --maxWorkers=1`
- `npx vitest run apps/ui/src/components/site-overview-view/index.test.tsx --maxWorkers=1`
- `npx vitest run apps/cli/tests/local-server.test.ts --maxWorkers=1`
- `npm run cli:build:ui`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
