### PR TITLE
Agentic UI: Add Connections to site overview

### DIFF
--- a/apps/ui/src/components/site-overview-view/cards.module.css
+++ b/apps/ui/src/components/site-overview-view/cards.module.css
@@ -16,6 +16,134 @@
 	min-width: 0;
 }
 
+.sectionDivider {
+	height: var(--wpds-border-width-xs);
+	background: var(--wpds-color-stroke-surface-neutral);
+}
+
+.cardHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-padding-sm);
+	min-height: 24px;
+}
+
+.cardTitle {
+	margin: 0;
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+	font-weight: var(--wpds-typography-font-weight-medium);
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.empty {
+	margin: 0;
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.rowList {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-md);
+	min-width: 0;
+}
+
+.row {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+	min-width: 0;
+}
+
+.rowText {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.rowMeta {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.rowActions {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-xs);
+	flex: 0 0 auto;
+}
+
+.rowDivider {
+	height: var(--wpds-border-width-xs);
+	background: var(--wpds-color-stroke-surface-neutral-weak);
+}
+
+.rowLink {
+	appearance: none;
+	margin: 0;
+	padding: 0;
+	border: 0;
+	background: none;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	text-align: start;
+	font-family: inherit;
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+	color: var(--wpds-color-fg-content-neutral);
+	cursor: var(--wpds-cursor-control);
+}
+
+.rowLink:hover,
+.rowLink:focus-visible {
+	color: var(--wpds-color-fg-interactive-brand);
+	text-decoration: underline;
+}
+
+.stale {
+	color: var(--wpds-color-fg-content-warning);
+}
+
+.itemIcon {
+	display: grid;
+	place-items: center;
+	flex: 0 0 18px;
+	width: 18px;
+	height: 18px;
+}
+
+.itemIcon svg {
+	fill: currentColor;
+}
+
+.connectionSkeleton {
+	height: 10px;
+	border-radius: var(--wpds-border-radius-sm);
+	background: var(--wpds-color-bg-surface-neutral-weak);
+	animation: connection-loading 1.4s ease-in-out infinite alternate;
+}
+
+@keyframes connection-loading {
+	to {
+		opacity: 0.55;
+	}
+}
+
+.pickerPopup {
+	width: 320px;
+	padding: 0;
+}
+
 .themeSummary {
 	display: flex;
 	align-items: center;
@@ -264,7 +392,8 @@
 
 @media (prefers-reduced-motion: reduce) {
 	.storageSkeleton,
-	.storageLegend {
+	.storageLegend,
+	.connectionSkeleton {
 		animation: none;
 		transition: none;
 	}

--- a/apps/ui/src/components/site-overview-view/cards.module.css
+++ b/apps/ui/src/components/site-overview-view/cards.module.css
@@ -16,6 +16,138 @@
 	min-width: 0;
 }
 
+.sectionDivider {
+	height: var(--wpds-border-width-xs);
+	background: var(--wpds-color-stroke-surface-neutral);
+}
+
+.cardHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-padding-sm);
+	min-height: 24px;
+}
+
+.cardHeaderActionOnly {
+	justify-content: flex-end;
+}
+
+.cardTitle {
+	margin: 0;
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+	font-weight: var(--wpds-typography-font-weight-emphasis);
+	color: var(--wpds-color-foreground-content-neutral);
+}
+
+.empty {
+	margin: 0;
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+.rowList {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-md);
+	min-width: 0;
+}
+
+.row {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+	min-width: 0;
+}
+
+.rowText {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.rowMeta {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+.rowActions {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-xs);
+	flex: 0 0 auto;
+}
+
+.rowDivider {
+	height: var(--wpds-border-width-xs);
+	background: var(--wpds-color-stroke-surface-neutral-weak);
+}
+
+.rowLink {
+	appearance: none;
+	margin: 0;
+	padding: 0;
+	border: 0;
+	background: none;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	text-align: start;
+	font-family: inherit;
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+	color: var(--wpds-color-foreground-content-neutral);
+	cursor: var(--wpds-cursor-control);
+}
+
+.rowLink:hover,
+.rowLink:focus-visible {
+	color: var(--wpds-color-foreground-interactive-brand);
+	text-decoration: underline;
+}
+
+.stale {
+	color: var(--wpds-color-foreground-content-warning);
+}
+
+.itemIcon {
+	display: grid;
+	place-items: center;
+	flex: 0 0 18px;
+	width: 18px;
+	height: 18px;
+}
+
+.itemIcon svg {
+	fill: currentColor;
+}
+
+.connectionSkeleton {
+	height: 10px;
+	border-radius: var(--wpds-border-radius-sm);
+	background: var(--wpds-color-background-surface-neutral-weak);
+	animation: connection-loading 1.4s ease-in-out infinite alternate;
+}
+
+@keyframes connection-loading {
+	to {
+		opacity: 0.55;
+	}
+}
+
+.pickerPopup {
+	width: 320px;
+	padding: 0;
+}
+
 .themeSummary {
 	display: flex;
 	align-items: center;
@@ -288,7 +420,8 @@
 
 @media (prefers-reduced-motion: reduce) {
 	.storageSkeleton,
-	.storageLegend {
+	.storageLegend,
+	.connectionSkeleton {
 		animation: none;
 		transition: none;
 	}

--- a/apps/ui/src/components/site-overview-view/connections-section.tsx
+++ b/apps/ui/src/components/site-overview-view/connections-section.tsx
@@ -1,0 +1,215 @@
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	arrowDown,
+	arrowUp,
+	copy,
+	external,
+	Icon,
+	moreVertical,
+	plus,
+	reusableBlock,
+} from '@wordpress/icons';
+import { Button, IconButton } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import { Fragment, useState } from 'react';
+import * as Menu from '@/components/menu';
+import { PublishPickerView } from '@/components/site-dropdown/publish-picker-view';
+import { ensureProtocol, stripProtocol } from '@/components/site-dropdown/utils';
+import { useConnector } from '@/data/core';
+import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
+import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
+import { usePullSiteFromLive, usePushSiteToLive } from '@/data/queries/use-sync-site';
+import { useIsSiteSyncing } from '@/hooks/use-is-site-syncing';
+import { useOffline } from '@/hooks/use-offline';
+import { formatRelativeTime } from '@/lib/format-relative-time';
+import styles from './cards.module.css';
+import { CardEmptyState, CardRows, CardSection, RowDivider } from './overview-card';
+import { RowLink } from './row-link';
+import type { SiteDetails, SyncSite } from '@/data/core';
+
+const STALE_SYNC_MS = 14 * 24 * 60 * 60 * 1000;
+
+export function ConnectionsSection( { site, busy }: { site: SiteDetails; busy: boolean } ) {
+	const { data: authUser } = useAuthUser();
+	const login = useLogin( { source: 'overview_tab' } );
+	const isOffline = useOffline();
+	const [ pickerOpen, setPickerOpen ] = useState( false );
+	const { data: connections, isLoading } = useConnectedWpcomSites( site.id );
+
+	const connectAction = authUser ? (
+		<Menu.Root open={ pickerOpen } onOpenChange={ setPickerOpen }>
+			<Menu.Trigger
+				render={
+					<IconButton
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						icon={ plus }
+						label={ __( 'Connect a WordPress.com site' ) }
+					/>
+				}
+			/>
+			<Menu.Popup side="bottom" align="end" className={ styles.pickerPopup }>
+				<PublishPickerView site={ site } onClose={ () => setPickerOpen( false ) } />
+			</Menu.Popup>
+		</Menu.Root>
+	) : null;
+
+	return (
+		<CardSection action={ connectAction }>
+			{ ! authUser ? (
+				<>
+					<CardEmptyState>
+						{ __( 'Sign in to connect this site to WordPress.com and sync it.' ) }
+					</CardEmptyState>
+					<div>
+						<Button
+							variant="outline"
+							tone="neutral"
+							size="small"
+							disabled={ login.isPending || isOffline }
+							onClick={ () => login.mutate() }
+						>
+							{ __( 'Log in with WordPress.com' ) }
+						</Button>
+					</div>
+				</>
+			) : isLoading && ! connections ? (
+				<div className={ styles.connectionSkeleton } />
+			) : ! connections?.length ? (
+				<CardEmptyState>
+					{ __( 'Not connected to a live site yet. Connect one to pull or push changes.' ) }
+				</CardEmptyState>
+			) : (
+				<CardRows>
+					{ connections.map( ( connection, index ) => (
+						<Fragment key={ connection.id }>
+							{ index > 0 && <RowDivider /> }
+							<ConnectionRow site={ site } connection={ connection } busy={ busy } />
+						</Fragment>
+					) ) }
+				</CardRows>
+			) }
+		</CardSection>
+	);
+}
+
+function ConnectionRow( {
+	site,
+	connection,
+	busy,
+}: {
+	site: SiteDetails;
+	connection: SyncSite;
+	busy: boolean;
+} ) {
+	const connector = useConnector();
+	const isOffline = useOffline();
+	const pushSiteToLive = usePushSiteToLive();
+	const pullSiteFromLive = usePullSiteFromLive();
+	const { push: isPushing, pull: isPulling } = useIsSiteSyncing( site.id );
+	const syncing = isPushing || isPulling;
+	const disabled = syncing || busy || isOffline;
+	const sync = describeLastSync( connection );
+	const url = ensureProtocol( connection.url );
+
+	return (
+		<div className={ styles.row }>
+			<div className={ styles.rowText }>
+				<RowLink
+					label={ stripProtocol( connection.url ) }
+					tooltip={ connection.name }
+					url={ url }
+				/>
+				<span className={ clsx( styles.rowMeta, sync.stale && styles.stale ) }>{ sync.label }</span>
+			</div>
+			<div className={ styles.rowActions }>
+				<Menu.Root>
+					<Menu.Trigger
+						render={
+							<IconButton
+								variant="minimal"
+								tone="neutral"
+								size="small"
+								icon={ reusableBlock }
+								label={ isPulling ? __( 'Pulling…' ) : isPushing ? __( 'Pushing…' ) : __( 'Sync' ) }
+								disabled={ disabled }
+								loading={ syncing }
+							/>
+						}
+					/>
+					<Menu.Popup side="bottom" align="end">
+						<Menu.Item
+							onClick={ () =>
+								pullSiteFromLive.mutate( { siteId: site.id, remoteSiteId: connection.id } )
+							}
+						>
+							<span className={ styles.itemIcon } aria-hidden="true">
+								<Icon icon={ arrowDown } size={ 18 } />
+							</span>
+							{ __( 'Pull from live' ) }
+						</Menu.Item>
+						<Menu.Item
+							onClick={ () =>
+								pushSiteToLive.mutate( { siteId: site.id, remoteSiteId: connection.id } )
+							}
+						>
+							<span className={ styles.itemIcon } aria-hidden="true">
+								<Icon icon={ arrowUp } size={ 18 } />
+							</span>
+							{ __( 'Push to live' ) }
+						</Menu.Item>
+					</Menu.Popup>
+				</Menu.Root>
+				<Menu.Root>
+					<Menu.Trigger
+						render={
+							<IconButton
+								variant="minimal"
+								tone="neutral"
+								size="small"
+								icon={ moreVertical }
+								label={ __( 'More options' ) }
+							/>
+						}
+					/>
+					<Menu.Popup side="bottom" align="end">
+						<Menu.Item onClick={ () => void connector.openExternalUrl( url ) }>
+							<span className={ styles.itemIcon } aria-hidden="true">
+								<Icon icon={ external } size={ 18 } />
+							</span>
+							{ __( 'Open live site' ) }
+						</Menu.Item>
+						<Menu.Item onClick={ () => void connector.copyText( url ) }>
+							<span className={ styles.itemIcon } aria-hidden="true">
+								<Icon icon={ copy } size={ 18 } />
+							</span>
+							{ __( 'Copy URL' ) }
+						</Menu.Item>
+					</Menu.Popup>
+				</Menu.Root>
+			</div>
+		</div>
+	);
+}
+
+export function describeLastSync( connection: SyncSite ): { label: string; stale: boolean } {
+	const pulled = connection.lastPullTimestamp ? Date.parse( connection.lastPullTimestamp ) : NaN;
+	const pushed = connection.lastPushTimestamp ? Date.parse( connection.lastPushTimestamp ) : NaN;
+	const hasPulled = ! Number.isNaN( pulled );
+	const hasPushed = ! Number.isNaN( pushed );
+
+	if ( ! hasPulled && ! hasPushed ) {
+		return { label: __( 'Never synced' ), stale: true };
+	}
+
+	const pulledLast = hasPulled && ( ! hasPushed || pulled >= pushed );
+	const timestamp = ( pulledLast ? connection.lastPullTimestamp : connection.lastPushTimestamp )!;
+	const relative = formatRelativeTime( timestamp );
+	return {
+		label: pulledLast
+			? sprintf( __( 'Pulled %s ago' ), relative )
+			: sprintf( __( 'Pushed %s ago' ), relative ),
+		stale: Date.now() - Math.max( hasPulled ? pulled : 0, hasPushed ? pushed : 0 ) > STALE_SYNC_MS,
+	};
+}

--- a/apps/ui/src/components/site-overview-view/connections-section.tsx
+++ b/apps/ui/src/components/site-overview-view/connections-section.tsx
@@ -1,0 +1,215 @@
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	arrowDown,
+	arrowUp,
+	copy,
+	external,
+	Icon,
+	moreVertical,
+	plus,
+	reusableBlock,
+} from '@wordpress/icons';
+import { Button, IconButton } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import { Fragment, useState } from 'react';
+import * as Menu from '@/components/menu';
+import { PublishPickerView } from '@/components/site-dropdown/publish-picker-view';
+import { ensureProtocol, stripProtocol } from '@/components/site-dropdown/utils';
+import { useConnector } from '@/data/core';
+import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
+import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
+import { usePullSiteFromLive, usePushSiteToLive } from '@/data/queries/use-sync-site';
+import { useIsSiteSyncing } from '@/hooks/use-is-site-syncing';
+import { useOffline } from '@/hooks/use-offline';
+import { formatRelativeTime } from '@/lib/format-relative-time';
+import styles from './cards.module.css';
+import { CardEmptyState, CardRows, CardSection, RowDivider } from './overview-card';
+import { RowLink } from './row-link';
+import type { SiteDetails, SyncSite } from '@/data/core';
+
+const STALE_SYNC_MS = 14 * 24 * 60 * 60 * 1000;
+
+export function ConnectionsSection( { site, busy }: { site: SiteDetails; busy: boolean } ) {
+	const { data: authUser } = useAuthUser();
+	const login = useLogin();
+	const isOffline = useOffline();
+	const [ pickerOpen, setPickerOpen ] = useState( false );
+	const { data: connections, isLoading } = useConnectedWpcomSites( site.id );
+
+	const connectAction = authUser ? (
+		<Menu.Root open={ pickerOpen } onOpenChange={ setPickerOpen }>
+			<Menu.Trigger
+				render={
+					<IconButton
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						icon={ plus }
+						label={ __( 'Connect a WordPress.com site' ) }
+					/>
+				}
+			/>
+			<Menu.Popup side="bottom" align="end" className={ styles.pickerPopup }>
+				<PublishPickerView site={ site } onClose={ () => setPickerOpen( false ) } />
+			</Menu.Popup>
+		</Menu.Root>
+	) : null;
+
+	return (
+		<CardSection title={ __( 'Connections' ) } action={ connectAction }>
+			{ ! authUser ? (
+				<>
+					<CardEmptyState>
+						{ __( 'Sign in to connect this site to WordPress.com and sync it.' ) }
+					</CardEmptyState>
+					<div>
+						<Button
+							variant="outline"
+							tone="neutral"
+							size="small"
+							disabled={ login.isPending || isOffline }
+							onClick={ () => login.mutate() }
+						>
+							{ __( 'Log in with WordPress.com' ) }
+						</Button>
+					</div>
+				</>
+			) : isLoading && ! connections ? (
+				<div className={ styles.connectionSkeleton } />
+			) : ! connections?.length ? (
+				<CardEmptyState>
+					{ __( 'Not connected to a live site yet. Connect one to pull or push changes.' ) }
+				</CardEmptyState>
+			) : (
+				<CardRows>
+					{ connections.map( ( connection, index ) => (
+						<Fragment key={ connection.id }>
+							{ index > 0 && <RowDivider /> }
+							<ConnectionRow site={ site } connection={ connection } busy={ busy } />
+						</Fragment>
+					) ) }
+				</CardRows>
+			) }
+		</CardSection>
+	);
+}
+
+function ConnectionRow( {
+	site,
+	connection,
+	busy,
+}: {
+	site: SiteDetails;
+	connection: SyncSite;
+	busy: boolean;
+} ) {
+	const connector = useConnector();
+	const isOffline = useOffline();
+	const pushSiteToLive = usePushSiteToLive();
+	const pullSiteFromLive = usePullSiteFromLive();
+	const { push: isPushing, pull: isPulling } = useIsSiteSyncing( site.id );
+	const syncing = isPushing || isPulling;
+	const disabled = syncing || busy || isOffline;
+	const sync = describeLastSync( connection );
+	const url = ensureProtocol( connection.url );
+
+	return (
+		<div className={ styles.row }>
+			<div className={ styles.rowText }>
+				<RowLink
+					label={ stripProtocol( connection.url ) }
+					tooltip={ connection.name }
+					url={ url }
+				/>
+				<span className={ clsx( styles.rowMeta, sync.stale && styles.stale ) }>{ sync.label }</span>
+			</div>
+			<div className={ styles.rowActions }>
+				<Menu.Root>
+					<Menu.Trigger
+						render={
+							<IconButton
+								variant="minimal"
+								tone="neutral"
+								size="small"
+								icon={ reusableBlock }
+								label={ isPulling ? __( 'Pulling…' ) : isPushing ? __( 'Pushing…' ) : __( 'Sync' ) }
+								disabled={ disabled }
+								loading={ syncing }
+							/>
+						}
+					/>
+					<Menu.Popup side="bottom" align="end">
+						<Menu.Item
+							onClick={ () =>
+								pullSiteFromLive.mutate( { siteId: site.id, remoteSiteId: connection.id } )
+							}
+						>
+							<span className={ styles.itemIcon } aria-hidden="true">
+								<Icon icon={ arrowDown } size={ 18 } />
+							</span>
+							{ __( 'Pull from live' ) }
+						</Menu.Item>
+						<Menu.Item
+							onClick={ () =>
+								pushSiteToLive.mutate( { siteId: site.id, remoteSiteId: connection.id } )
+							}
+						>
+							<span className={ styles.itemIcon } aria-hidden="true">
+								<Icon icon={ arrowUp } size={ 18 } />
+							</span>
+							{ __( 'Push to live' ) }
+						</Menu.Item>
+					</Menu.Popup>
+				</Menu.Root>
+				<Menu.Root>
+					<Menu.Trigger
+						render={
+							<IconButton
+								variant="minimal"
+								tone="neutral"
+								size="small"
+								icon={ moreVertical }
+								label={ __( 'More options' ) }
+							/>
+						}
+					/>
+					<Menu.Popup side="bottom" align="end">
+						<Menu.Item onClick={ () => void connector.openExternalUrl( url ) }>
+							<span className={ styles.itemIcon } aria-hidden="true">
+								<Icon icon={ external } size={ 18 } />
+							</span>
+							{ __( 'Open live site' ) }
+						</Menu.Item>
+						<Menu.Item onClick={ () => void connector.copyText( url ) }>
+							<span className={ styles.itemIcon } aria-hidden="true">
+								<Icon icon={ copy } size={ 18 } />
+							</span>
+							{ __( 'Copy URL' ) }
+						</Menu.Item>
+					</Menu.Popup>
+				</Menu.Root>
+			</div>
+		</div>
+	);
+}
+
+export function describeLastSync( connection: SyncSite ): { label: string; stale: boolean } {
+	const pulled = connection.lastPullTimestamp ? Date.parse( connection.lastPullTimestamp ) : NaN;
+	const pushed = connection.lastPushTimestamp ? Date.parse( connection.lastPushTimestamp ) : NaN;
+	const hasPulled = ! Number.isNaN( pulled );
+	const hasPushed = ! Number.isNaN( pushed );
+
+	if ( ! hasPulled && ! hasPushed ) {
+		return { label: __( 'Never synced' ), stale: true };
+	}
+
+	const pulledLast = hasPulled && ( ! hasPushed || pulled >= pushed );
+	const timestamp = ( pulledLast ? connection.lastPullTimestamp : connection.lastPushTimestamp )!;
+	const relative = formatRelativeTime( timestamp );
+	return {
+		label: pulledLast
+			? sprintf( __( 'Pulled %s ago' ), relative )
+			: sprintf( __( 'Pushed %s ago' ), relative ),
+		stale: Date.now() - Math.max( hasPulled ? pulled : 0, hasPushed ? pushed : 0 ) > STALE_SYNC_MS,
+	};
+}

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -6,7 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import settingsStyles from '@/components/site-settings-view/style.module.css';
 import { useConnector } from '@/data/core';
 import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
-import { useLogin } from '@/data/queries/use-auth-user';
+import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
+import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
 import { useDebugLogExists } from '@/data/queries/use-debug-log';
 import { useSiteStorageUsage } from '@/data/queries/use-site-storage-usage';
@@ -23,8 +24,10 @@ import {
 	useUpdateSite,
 	useXdebugEnabledSite,
 } from '@/data/queries/use-sites';
+import { usePullSiteFromLive, usePushSiteToLive } from '@/data/queries/use-sync-site';
 import { useUserPreferences } from '@/data/queries/use-user-preferences';
 import { useWordPressVersions, useWpVersion } from '@/data/queries/use-wordpress-versions';
+import { useIsSiteSyncing } from '@/hooks/use-is-site-syncing';
 import { useOffline } from '@/hooks/use-offline';
 import { useThemeDetails } from '@/hooks/use-theme-details';
 import styles from './style.module.css';
@@ -33,6 +36,7 @@ import type {
 	ConnectorCapabilities,
 	SiteDetails,
 	SupportedEditor,
+	SyncSite,
 	UserPreferences,
 } from '@/data/core';
 import type { ImportEventTuple } from '@studio/common/lib/import-export-events';
@@ -49,6 +53,18 @@ const WP_VERSIONS = [
 	{ label: '6.8', value: '6.8', isBeta: false, isDevelopment: false },
 	{ label: '6.7.2', value: '6.7.2', isBeta: false, isDevelopment: false },
 ];
+
+const CONNECTED_SITE: SyncSite = {
+	id: 42,
+	localSiteId: 'site-1',
+	name: 'Demo Live',
+	url: 'demo.example.com',
+	isStaging: false,
+	isPressable: false,
+	syncSupport: 'syncable',
+	lastPullTimestamp: null,
+	lastPushTimestamp: null,
+};
 
 class ResizeObserverMock {
 	observe = vi.fn();
@@ -77,6 +93,10 @@ vi.mock( '@/components/site-dropdown', () => ( {
 	},
 } ) );
 
+vi.mock( '@/components/site-dropdown/publish-picker-view', () => ( {
+	PublishPickerView: () => <div>Connection picker</div>,
+} ) );
+
 vi.mock( '@/data/core', () => ( {
 	useConnector: vi.fn(),
 } ) );
@@ -86,7 +106,12 @@ vi.mock( '@/data/queries/use-agentic-features', () => ( {
 } ) );
 
 vi.mock( '@/data/queries/use-auth-user', () => ( {
+	useAuthUser: vi.fn(),
 	useLogin: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-connected-wpcom-sites', () => ( {
+	useConnectedWpcomSites: vi.fn(),
 } ) );
 
 vi.mock( '@/data/queries/use-create-site-helpers', () => ( {
@@ -130,6 +155,11 @@ vi.mock( '@/data/queries/use-user-preferences', () => ( {
 	useUserPreferences: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-sync-site', () => ( {
+	usePullSiteFromLive: vi.fn(),
+	usePushSiteToLive: vi.fn(),
+} ) );
+
 vi.mock( '@/data/queries/use-wordpress-versions', () => ( {
 	WP_VERSION_QUERY_KEY: [ 'wp-version' ],
 	useWordPressVersions: vi.fn(),
@@ -153,12 +183,18 @@ vi.mock( '@/hooks/use-sidebar-collapsed', () => ( {
 	useSidebarCollapsed: useSidebarCollapsedMock,
 } ) );
 
+vi.mock( '@/hooks/use-is-site-syncing', () => ( {
+	useIsSiteSyncing: vi.fn(),
+} ) );
+
 vi.mock( '@/hooks/use-traffic-light-space', () => ( {
 	useTrafficLightSpace: useTrafficLightSpaceMock,
 } ) );
 
 const useConnectorMock = vi.mocked( useConnector, { partial: true } );
 const useAgenticFeaturesMock = vi.mocked( useAgenticFeatures );
+const useAuthUserMock = vi.mocked( useAuthUser, { partial: true } );
+const useConnectedWpcomSitesMock = vi.mocked( useConnectedWpcomSites, { partial: true } );
 const useLoginMock = vi.mocked( useLogin, { partial: true } );
 const useExistingCustomDomainsMock = vi.mocked( useExistingCustomDomains, { partial: true } );
 const useCopySiteMock = vi.mocked( useCopySite, { partial: true } );
@@ -175,10 +211,13 @@ const useStartSiteMock = vi.mocked( useStartSite, { partial: true } );
 const useUpdateSiteMock = vi.mocked( useUpdateSite, { partial: true } );
 const useOfflineMock = vi.mocked( useOffline );
 const useThemeDetailsMock = vi.mocked( useThemeDetails );
+const usePullSiteFromLiveMock = vi.mocked( usePullSiteFromLive, { partial: true } );
+const usePushSiteToLiveMock = vi.mocked( usePushSiteToLive, { partial: true } );
 const useUserPreferencesMock = vi.mocked( useUserPreferences, { partial: true } );
 const useWordPressVersionsMock = vi.mocked( useWordPressVersions, { partial: true } );
 const useWpVersionMock = vi.mocked( useWpVersion, { partial: true } );
 const useXdebugEnabledSiteMock = vi.mocked( useXdebugEnabledSite, { partial: true } );
+const useIsSiteSyncingMock = vi.mocked( useIsSiteSyncing );
 
 describe( 'SiteOverviewView', () => {
 	const openSiteUrl = vi.fn().mockResolvedValue( undefined );
@@ -192,6 +231,9 @@ describe( 'SiteOverviewView', () => {
 	const copySite = vi.fn();
 	const exportFullSite = vi.fn();
 	const exportDatabase = vi.fn();
+	const openExternalUrl = vi.fn().mockResolvedValue( undefined );
+	const pullSiteFromLive = vi.fn();
+	const pushSiteToLive = vi.fn();
 	const onTabChange = vi.fn();
 
 	const getFilePath = vi.fn().mockResolvedValue( '/tmp/backup.tar.gz' );
@@ -206,6 +248,7 @@ describe( 'SiteOverviewView', () => {
 		copyText,
 		getFilePath,
 		importSiteFromBackup,
+		openExternalUrl,
 		capabilities: { openInOS } as ConnectorCapabilities,
 	} );
 
@@ -247,7 +290,14 @@ describe( 'SiteOverviewView', () => {
 			reason: null,
 			isReady: true,
 		} );
+		useAuthUserMock.mockReturnValue( {
+			data: { id: 1, email: 'person@example.com', displayName: 'Person' },
+		} );
 		useLoginMock.mockReturnValue( { isPending: false, mutate: vi.fn() } );
+		useConnectedWpcomSitesMock.mockReturnValue( { data: [], isLoading: false } );
+		usePullSiteFromLiveMock.mockReturnValue( { mutate: pullSiteFromLive } );
+		usePushSiteToLiveMock.mockReturnValue( { mutate: pushSiteToLive } );
+		useIsSiteSyncingMock.mockReturnValue( { push: false, pull: false } );
 		useExistingCustomDomainsMock.mockReturnValue( [] );
 		useSitesMock.mockReturnValue( {
 			data: [ createSite( { running: true } ) ],
@@ -388,6 +438,65 @@ describe( 'SiteOverviewView', () => {
 		renderView();
 
 		expect( screen.getByText( 'Measuring…' ) ).toBeVisible();
+	} );
+
+	it( 'offers a complete empty state for connecting a live site', () => {
+		renderView();
+
+		expect( screen.getByRole( 'heading', { name: 'Connections' } ) ).toBeVisible();
+		expect(
+			screen.getByText( 'Not connected to a live site yet. Connect one to pull or push changes.' )
+		).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Connect a WordPress.com site' } ) ).toBeVisible();
+	} );
+
+	it( 'offers login from Connections when signed out', () => {
+		const login = vi.fn();
+		useAuthUserMock.mockReturnValue( { data: null } );
+		useLoginMock.mockReturnValue( { isPending: false, mutate: login } );
+
+		renderView();
+
+		expect(
+			screen.getByText( 'Sign in to connect this site to WordPress.com and sync it.' )
+		).toBeVisible();
+		fireEvent.click( screen.getByRole( 'button', { name: 'Log in with WordPress.com' } ) );
+		expect( login ).toHaveBeenCalled();
+	} );
+
+	it( 'shows a connected site and exposes pull and push actions', async () => {
+		useConnectedWpcomSitesMock.mockReturnValue( {
+			data: [ CONNECTED_SITE ],
+			isLoading: false,
+		} );
+
+		renderView();
+
+		expect( screen.getByText( 'demo.example.com' ) ).toBeVisible();
+		expect( screen.getByText( 'Never synced' ) ).toBeVisible();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Sync' } ) );
+		fireEvent.click( await screen.findByText( 'Pull from live' ) );
+		expect( pullSiteFromLive ).toHaveBeenCalledWith( { siteId: 'site-1', remoteSiteId: 42 } );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Sync' } ) );
+		fireEvent.click( await screen.findByText( 'Push to live' ) );
+		expect( pushSiteToLive ).toHaveBeenCalledWith( { siteId: 'site-1', remoteSiteId: 42 } );
+	} );
+
+	it( 'reflects sync work started from another surface', () => {
+		useConnectedWpcomSitesMock.mockReturnValue( {
+			data: [ CONNECTED_SITE ],
+			isLoading: false,
+		} );
+		useIsSiteSyncingMock.mockReturnValue( { push: true, pull: false } );
+
+		renderView();
+
+		expect( screen.getByRole( 'button', { name: 'Pushing…' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
 	} );
 
 	it( 'keeps the browser action available without a cached thumbnail', () => {

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -3,7 +3,8 @@ import { Tooltip } from '@wordpress/ui';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
 import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
-import { useLogin } from '@/data/queries/use-auth-user';
+import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
+import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
 import { useSiteStorageUsage } from '@/data/queries/use-site-storage-usage';
 import { useSiteThumbnail } from '@/data/queries/use-site-thumbnail';
@@ -18,8 +19,10 @@ import {
 	useUpdateSite,
 	useXdebugEnabledSite,
 } from '@/data/queries/use-sites';
+import { usePullSiteFromLive, usePushSiteToLive } from '@/data/queries/use-sync-site';
 import { useUserPreferences } from '@/data/queries/use-user-preferences';
 import { useWordPressVersions, useWpVersion } from '@/data/queries/use-wordpress-versions';
+import { useIsSiteSyncing } from '@/hooks/use-is-site-syncing';
 import { useOffline } from '@/hooks/use-offline';
 import styles from './style.module.css';
 import { SiteOverviewView } from './index';
@@ -27,6 +30,7 @@ import type {
 	ConnectorCapabilities,
 	SiteDetails,
 	SupportedEditor,
+	SyncSite,
 	UserPreferences,
 } from '@/data/core';
 
@@ -40,6 +44,18 @@ const WP_VERSIONS = [
 	{ label: '6.8', value: '6.8', isBeta: false, isDevelopment: false },
 	{ label: '6.7.2', value: '6.7.2', isBeta: false, isDevelopment: false },
 ];
+
+const CONNECTED_SITE: SyncSite = {
+	id: 42,
+	localSiteId: 'site-1',
+	name: 'Demo Live',
+	url: 'demo.example.com',
+	isStaging: false,
+	isPressable: false,
+	syncSupport: 'syncable',
+	lastPullTimestamp: null,
+	lastPushTimestamp: null,
+};
 
 class ResizeObserverMock {
 	observe = vi.fn();
@@ -68,6 +84,10 @@ vi.mock( '@/components/site-dropdown', () => ( {
 	},
 } ) );
 
+vi.mock( '@/components/site-dropdown/publish-picker-view', () => ( {
+	PublishPickerView: () => <div>Connection picker</div>,
+} ) );
+
 vi.mock( '@/data/core', () => ( {
 	useConnector: vi.fn(),
 } ) );
@@ -77,7 +97,12 @@ vi.mock( '@/data/queries/use-agentic-features', () => ( {
 } ) );
 
 vi.mock( '@/data/queries/use-auth-user', () => ( {
+	useAuthUser: vi.fn(),
 	useLogin: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-connected-wpcom-sites', () => ( {
+	useConnectedWpcomSites: vi.fn(),
 } ) );
 
 vi.mock( '@/data/queries/use-create-site-helpers', () => ( {
@@ -108,6 +133,11 @@ vi.mock( '@/data/queries/use-user-preferences', () => ( {
 	useUserPreferences: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-sync-site', () => ( {
+	usePullSiteFromLive: vi.fn(),
+	usePushSiteToLive: vi.fn(),
+} ) );
+
 vi.mock( '@/data/queries/use-wordpress-versions', () => ( {
 	useWordPressVersions: vi.fn(),
 	useWpVersion: vi.fn(),
@@ -121,12 +151,18 @@ vi.mock( '@/hooks/use-sidebar-collapsed', () => ( {
 	useSidebarCollapsed: useSidebarCollapsedMock,
 } ) );
 
+vi.mock( '@/hooks/use-is-site-syncing', () => ( {
+	useIsSiteSyncing: vi.fn(),
+} ) );
+
 vi.mock( '@/hooks/use-traffic-light-space', () => ( {
 	useTrafficLightSpace: useTrafficLightSpaceMock,
 } ) );
 
 const useConnectorMock = vi.mocked( useConnector, { partial: true } );
 const useAgenticFeaturesMock = vi.mocked( useAgenticFeatures );
+const useAuthUserMock = vi.mocked( useAuthUser, { partial: true } );
+const useConnectedWpcomSitesMock = vi.mocked( useConnectedWpcomSites, { partial: true } );
 const useLoginMock = vi.mocked( useLogin, { partial: true } );
 const useExistingCustomDomainsMock = vi.mocked( useExistingCustomDomains, { partial: true } );
 const useCopySiteMock = vi.mocked( useCopySite, { partial: true } );
@@ -140,10 +176,13 @@ const useSitesMock = vi.mocked( useSites, { partial: true } );
 const useStartSiteMock = vi.mocked( useStartSite, { partial: true } );
 const useUpdateSiteMock = vi.mocked( useUpdateSite, { partial: true } );
 const useOfflineMock = vi.mocked( useOffline );
+const usePullSiteFromLiveMock = vi.mocked( usePullSiteFromLive, { partial: true } );
+const usePushSiteToLiveMock = vi.mocked( usePushSiteToLive, { partial: true } );
 const useUserPreferencesMock = vi.mocked( useUserPreferences, { partial: true } );
 const useWordPressVersionsMock = vi.mocked( useWordPressVersions, { partial: true } );
 const useWpVersionMock = vi.mocked( useWpVersion, { partial: true } );
 const useXdebugEnabledSiteMock = vi.mocked( useXdebugEnabledSite, { partial: true } );
+const useIsSiteSyncingMock = vi.mocked( useIsSiteSyncing );
 
 describe( 'SiteOverviewView', () => {
 	const openSiteUrl = vi.fn().mockResolvedValue( undefined );
@@ -154,6 +193,10 @@ describe( 'SiteOverviewView', () => {
 	const copySite = vi.fn();
 	const exportFullSite = vi.fn();
 	const exportDatabase = vi.fn();
+	const openExternalUrl = vi.fn().mockResolvedValue( undefined );
+	const copyText = vi.fn().mockResolvedValue( undefined );
+	const pullSiteFromLive = vi.fn();
+	const pushSiteToLive = vi.fn();
 	const onTabChange = vi.fn();
 
 	const connectorStub = ( openInOS = true ) => ( {
@@ -161,6 +204,8 @@ describe( 'SiteOverviewView', () => {
 		openSiteFolder,
 		openSiteInEditor,
 		openSiteInTerminal,
+		openExternalUrl,
+		copyText,
 		capabilities: { openInOS } as ConnectorCapabilities,
 	} );
 
@@ -194,7 +239,14 @@ describe( 'SiteOverviewView', () => {
 			reason: null,
 			isReady: true,
 		} );
+		useAuthUserMock.mockReturnValue( {
+			data: { id: 1, email: 'person@example.com', displayName: 'Person' },
+		} );
 		useLoginMock.mockReturnValue( { isPending: false, mutate: vi.fn() } );
+		useConnectedWpcomSitesMock.mockReturnValue( { data: [], isLoading: false } );
+		usePullSiteFromLiveMock.mockReturnValue( { mutate: pullSiteFromLive } );
+		usePushSiteToLiveMock.mockReturnValue( { mutate: pushSiteToLive } );
+		useIsSiteSyncingMock.mockReturnValue( { push: false, pull: false } );
 		useExistingCustomDomainsMock.mockReturnValue( [] );
 		useSitesMock.mockReturnValue( {
 			data: [ createSite( { running: true } ) ],
@@ -310,6 +362,65 @@ describe( 'SiteOverviewView', () => {
 		renderView();
 
 		expect( screen.getByText( 'Measuring…' ) ).toBeVisible();
+	} );
+
+	it( 'offers a complete empty state for connecting a live site', () => {
+		renderView();
+
+		expect( screen.getByRole( 'heading', { name: 'Connections' } ) ).toBeVisible();
+		expect(
+			screen.getByText( 'Not connected to a live site yet. Connect one to pull or push changes.' )
+		).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Connect a WordPress.com site' } ) ).toBeVisible();
+	} );
+
+	it( 'offers login from Connections when signed out', () => {
+		const login = vi.fn();
+		useAuthUserMock.mockReturnValue( { data: null } );
+		useLoginMock.mockReturnValue( { isPending: false, mutate: login } );
+
+		renderView();
+
+		expect(
+			screen.getByText( 'Sign in to connect this site to WordPress.com and sync it.' )
+		).toBeVisible();
+		fireEvent.click( screen.getByRole( 'button', { name: 'Log in with WordPress.com' } ) );
+		expect( login ).toHaveBeenCalled();
+	} );
+
+	it( 'shows a connected site and exposes pull and push actions', async () => {
+		useConnectedWpcomSitesMock.mockReturnValue( {
+			data: [ CONNECTED_SITE ],
+			isLoading: false,
+		} );
+
+		renderView();
+
+		expect( screen.getByText( 'demo.example.com' ) ).toBeVisible();
+		expect( screen.getByText( 'Never synced' ) ).toBeVisible();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Sync' } ) );
+		fireEvent.click( await screen.findByText( 'Pull from live' ) );
+		expect( pullSiteFromLive ).toHaveBeenCalledWith( { siteId: 'site-1', remoteSiteId: 42 } );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Sync' } ) );
+		fireEvent.click( await screen.findByText( 'Push to live' ) );
+		expect( pushSiteToLive ).toHaveBeenCalledWith( { siteId: 'site-1', remoteSiteId: 42 } );
+	} );
+
+	it( 'reflects sync work started from another surface', () => {
+		useConnectedWpcomSitesMock.mockReturnValue( {
+			data: [ CONNECTED_SITE ],
+			isLoading: false,
+		} );
+		useIsSiteSyncingMock.mockReturnValue( { push: true, pull: false } );
+
+		renderView();
+
+		expect( screen.getByRole( 'button', { name: 'Pushing…' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
 	} );
 
 	it( 'keeps the browser action available without a cached thumbnail', () => {

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -34,7 +34,8 @@ import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
 import { useSiteManagementActions } from '@/hooks/use-site-management-actions';
 import { useTrafficLightSpace } from '@/hooks/use-traffic-light-space';
 import { AboutSection } from './about-section';
-import { OverviewCard } from './overview-card';
+import { ConnectionsSection } from './connections-section';
+import { CardSectionDivider, OverviewCard } from './overview-card';
 import styles from './style.module.css';
 import type { SiteSettingsTabId } from '@/components/site-settings-view';
 import type { SiteDetails } from '@/data/core';
@@ -269,6 +270,8 @@ function SiteOverviewBody( {
 									<h2 className={ styles.columnHeading }>{ __( 'About' ) }</h2>
 									<OverviewCard>
 										<AboutSection site={ site } wpVersion={ wpVersion } />
+										<CardSectionDivider />
+										<ConnectionsSection site={ site } busy={ busy } />
 									</OverviewCard>
 								</div>
 								<div className={ styles.actionsColumn }>

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -46,6 +46,7 @@ import { useTrafficLightSpace } from '@/hooks/use-traffic-light-space';
 import { databaseLogo } from '@/lib/logos';
 import { AboutSection } from './about-section';
 import { AdminSection } from './admin-section';
+import { ConnectionsSection } from './connections-section';
 import { OverviewCard } from './overview-card';
 import styles from './style.module.css';
 import type { SiteSettingsTabId } from '@/components/site-settings-view';
@@ -324,6 +325,10 @@ function SiteOverviewBody( {
 											wpVersion={ wpVersion }
 											themeDetails={ themeDetails }
 										/>
+									</OverviewCard>
+									<h2 className={ styles.columnHeading }>{ __( 'Connections' ) }</h2>
+									<OverviewCard>
+										<ConnectionsSection site={ site } busy={ busy } />
 									</OverviewCard>
 									<h2 className={ styles.columnHeading }>{ __( 'WP Admin' ) }</h2>
 									<OverviewCard>

--- a/apps/ui/src/components/site-overview-view/overview-card.tsx
+++ b/apps/ui/src/components/site-overview-view/overview-card.tsx
@@ -2,9 +2,43 @@ import styles from './cards.module.css';
 import type { ReactNode } from 'react';
 
 export function OverviewCard( { children }: { children: ReactNode } ) {
-	return <div className={ styles.card }>{ children }</div>;
+	return <section className={ styles.card }>{ children }</section>;
 }
 
-export function CardSection( { children }: { children: ReactNode } ) {
-	return <section className={ styles.cardSection }>{ children }</section>;
+export function CardSection( {
+	title,
+	action,
+	children,
+}: {
+	title?: string;
+	action?: ReactNode;
+	children: ReactNode;
+} ) {
+	return (
+		<div className={ styles.cardSection }>
+			{ ( title || action ) && (
+				<div className={ styles.cardHeader }>
+					{ title && <h3 className={ styles.cardTitle }>{ title }</h3> }
+					{ action }
+				</div>
+			) }
+			{ children }
+		</div>
+	);
+}
+
+export function CardSectionDivider() {
+	return <div className={ styles.sectionDivider } />;
+}
+
+export function CardEmptyState( { children }: { children: ReactNode } ) {
+	return <p className={ styles.empty }>{ children }</p>;
+}
+
+export function CardRows( { children }: { children: ReactNode } ) {
+	return <div className={ styles.rowList }>{ children }</div>;
+}
+
+export function RowDivider() {
+	return <div className={ styles.rowDivider } />;
 }

--- a/apps/ui/src/components/site-overview-view/overview-card.tsx
+++ b/apps/ui/src/components/site-overview-view/overview-card.tsx
@@ -1,10 +1,45 @@
+import { clsx } from 'clsx';
 import styles from './cards.module.css';
 import type { ReactNode } from 'react';
 
 export function OverviewCard( { children }: { children: ReactNode } ) {
-	return <div className={ styles.card }>{ children }</div>;
+	return <section className={ styles.card }>{ children }</section>;
 }
 
-export function CardSection( { children }: { children: ReactNode } ) {
-	return <section className={ styles.cardSection }>{ children }</section>;
+export function CardSection( {
+	title,
+	action,
+	children,
+}: {
+	title?: string;
+	action?: ReactNode;
+	children: ReactNode;
+} ) {
+	return (
+		<div className={ styles.cardSection }>
+			{ ( title || action ) && (
+				<div className={ clsx( styles.cardHeader, ! title && styles.cardHeaderActionOnly ) }>
+					{ title && <h3 className={ styles.cardTitle }>{ title }</h3> }
+					{ action }
+				</div>
+			) }
+			{ children }
+		</div>
+	);
+}
+
+export function CardSectionDivider() {
+	return <div className={ styles.sectionDivider } />;
+}
+
+export function CardEmptyState( { children }: { children: ReactNode } ) {
+	return <p className={ styles.empty }>{ children }</p>;
+}
+
+export function CardRows( { children }: { children: ReactNode } ) {
+	return <div className={ styles.rowList }>{ children }</div>;
+}
+
+export function RowDivider() {
+	return <div className={ styles.rowDivider } />;
 }

--- a/apps/ui/src/components/site-overview-view/row-link.tsx
+++ b/apps/ui/src/components/site-overview-view/row-link.tsx
@@ -1,0 +1,40 @@
+import { sprintf, __ } from '@wordpress/i18n';
+import { Tooltip } from '@wordpress/ui';
+import { useConnector } from '@/data/core';
+import styles from './cards.module.css';
+
+export function RowLink( {
+	label,
+	url,
+	tooltip,
+}: {
+	label: string;
+	url: string;
+	tooltip?: string;
+} ) {
+	const connector = useConnector();
+
+	return (
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<button
+						type="button"
+						className={ styles.rowLink }
+						aria-label={ sprintf(
+							/* translators: %s: a site address */
+							__( 'Open %s in your browser' ),
+							label
+						) }
+						onClick={ () => void connector.openExternalUrl( url ) }
+					>
+						{ label }
+					</button>
+				}
+			/>
+			<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+				{ tooltip || url }
+			</Tooltip.Popup>
+		</Tooltip.Root>
+	);
+}

--- a/apps/ui/src/hooks/use-is-site-syncing.ts
+++ b/apps/ui/src/hooks/use-is-site-syncing.ts
@@ -1,0 +1,21 @@
+import { useIsMutating } from '@tanstack/react-query';
+import {
+	PULL_FROM_LIVE_MUTATION_KEY,
+	PUSH_TO_LIVE_MUTATION_KEY,
+} from '@/data/queries/use-sync-site';
+
+export function useIsSiteSyncing( siteId: string ): { push: boolean; pull: boolean } {
+	const push =
+		useIsMutating( {
+			mutationKey: PUSH_TO_LIVE_MUTATION_KEY,
+			predicate: ( mutation ) =>
+				( mutation.state.variables as { siteId: string } | undefined )?.siteId === siteId,
+		} ) > 0;
+	const pull =
+		useIsMutating( {
+			mutationKey: PULL_FROM_LIVE_MUTATION_KEY,
+			predicate: ( mutation ) =>
+				( mutation.state.variables as { siteId: string } | undefined )?.siteId === siteId,
+		} ) > 0;
+	return { push, pull };
+}


### PR DESCRIPTION
## Related issues

- Related to #4462

## How AI was used in this PR

AI helped extract the Connections slice from the larger overview exploration, adapt it to the current branch stack, and build coverage for its user states and actions. I reviewed the diff and the rendered result.

## Proposed Changes

This is the first PR in the site-management UI stack:

1. **#4474 — Connections on the overview** (this PR)
2. #4483 — Preview sites on the overview
3. #4400 — Persistent site header with Share and Sync dialogs
4. #4601 — Integrated overview polish, reusable sharing controls, and operation progress

The goal of this layer is to make a local site's live-site relationships visible without leaving Overview.

- Show every live site connected to the selected local site.
- Show the most recent push or pull time and distinguish Production from Staging.
- Provide connect, sync, open, and copy entry points.
- Cover signed-out, disconnected, connected, stale, and in-progress states.

The later stack layers refine these actions into the final Push/Pull layout, open the shared Sync dialog, and add inline plus persistent progress feedback.

## Current UI

![Connections card at native Retina resolution](https://github.com/Automattic/studio/blob/cef6ffaf9f668449a8296c58bef7cea4bd71e42c/pr-fullres-connections-light.png?raw=true)

![Connections in the complete site overview](https://github.com/Automattic/studio/blob/cef6ffaf9f668449a8296c58bef7cea4bd71e42c/pr-fullres-overview-light.png?raw=true)

## Testing Instructions

1. Open a local site's **Overview**.
2. Confirm **Connections** appears as its own card below About.
3. Verify a connected site shows its URL, last sync, and environment.
4. Exercise the connect, sync, open, and copy actions.
5. Check signed-out, disconnected, loading, light, and dark states.

Verification used while preparing this stack:

- Built this exact PR head with the local browser UI target.
- Rendered it against the local Studio backend and captured the screenshot above.
- The focused overview tests and full typecheck pass on the integrated stack head.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
