### PR TITLE
Require Node 24 in devEngines so it matches the npm >=11 requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"devEngines": {
 		"runtime": {
 			"name": "node",
-			"version": ">=22.0.0"
+			"version": ">=24.0.0"
 		},
 		"packageManager": {
 			"name": "npm",


### PR DESCRIPTION
## Related issues

- None — found while setting up a local dev environment.

<img width="878" height="289" alt="studio-node" src="https://github.com/user-attachments/assets/3a6e5333-4736-4677-83f2-2923978ccfca" />

## How AI was used in this PR

Claude Code investigated the failing `npm install`, traced it to the contradiction between the two `devEngines` constraints, and made the one-line change. I reviewed the reasoning and confirmed the resulting Node/npm resolution locally.

## Proposed Changes

The two `devEngines` constraints contradict each other: `runtime` allows Node 22, but Node 22 bundles npm 10.9.x, which can never satisfy `packageManager: ">=11.0.0"`. A contributor whose version manager honours the declared runtime floor is blocked from installing at all, with an `EBADDEVENGINES` error that blames npm rather than Node. Meanwhile, `.nvmrc` pins 24.15.0.

## Testing Instructions

1. Check out this branch and make sure your version manager picks up the change.
2. `node -v` should report 24.x, and `npm -v` should report 11.x.
3. `npm install` should complete without `EBADDEVENGINES`.

To see the original failure, switch to `trunk` with a version manager that reads `devEngines` (or run `npm install` under Node 22) — the install aborts with the error above.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
