### PR TITLE
Agentic UI: Add preview sites to site overview

### DIFF
--- a/apps/ui/src/components/site-overview-view/cards.module.css
+++ b/apps/ui/src/components/site-overview-view/cards.module.css
@@ -41,6 +41,20 @@
 	color: var(--wpds-color-foreground-content-neutral);
 }
 
+.headerActions {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+}
+
+.headerMeta {
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	white-space: nowrap;
+	cursor: default;
+}
+
 .empty {
 	margin: 0;
 	font-size: var(--wpds-typography-font-size-sm);
@@ -68,6 +82,20 @@
 	flex-direction: column;
 	gap: 2px;
 	min-width: 0;
+}
+
+.rowTitle {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+	color: var(--wpds-color-foreground-content-neutral);
+}
+
+.rowTitleExpired {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	text-decoration: line-through;
 }
 
 .rowMeta {
@@ -116,6 +144,10 @@
 
 .stale {
 	color: var(--wpds-color-foreground-content-warning);
+}
+
+.expired {
+	color: var(--wpds-color-foreground-content-error);
 }
 
 .itemIcon {

--- a/apps/ui/src/components/site-overview-view/cards.module.css
+++ b/apps/ui/src/components/site-overview-view/cards.module.css
@@ -37,6 +37,20 @@
 	color: var(--wpds-color-fg-content-neutral);
 }
 
+.headerActions {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+}
+
+.headerMeta {
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	white-space: nowrap;
+	cursor: default;
+}
+
 .empty {
 	margin: 0;
 	font-size: var(--wpds-typography-font-size-sm);
@@ -64,6 +78,20 @@
 	flex-direction: column;
 	gap: 2px;
 	min-width: 0;
+}
+
+.rowTitle {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.rowTitleExpired {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	text-decoration: line-through;
 }
 
 .rowMeta {
@@ -112,6 +140,10 @@
 
 .stale {
 	color: var(--wpds-color-fg-content-warning);
+}
+
+.expired {
+	color: var(--wpds-color-fg-content-error);
 }
 
 .itemIcon {

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -6,6 +6,7 @@ import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
 import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
+import { usePublishPreviewSite } from '@/data/queries/use-preview-site';
 import { useSiteStorageUsage } from '@/data/queries/use-site-storage-usage';
 import { useSiteThumbnail } from '@/data/queries/use-site-thumbnail';
 import {
@@ -19,6 +20,7 @@ import {
 	useUpdateSite,
 	useXdebugEnabledSite,
 } from '@/data/queries/use-sites';
+import { useSnapshots, useSnapshotUsage } from '@/data/queries/use-snapshots';
 import { usePullSiteFromLive, usePushSiteToLive } from '@/data/queries/use-sync-site';
 import { useUserPreferences } from '@/data/queries/use-user-preferences';
 import { useWordPressVersions, useWpVersion } from '@/data/queries/use-wordpress-versions';
@@ -105,6 +107,15 @@ vi.mock( '@/data/queries/use-connected-wpcom-sites', () => ( {
 	useConnectedWpcomSites: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-preview-site', () => ( {
+	usePublishPreviewSite: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-snapshots', () => ( {
+	useSnapshots: vi.fn(),
+	useSnapshotUsage: vi.fn(),
+} ) );
+
 vi.mock( '@/data/queries/use-create-site-helpers', () => ( {
 	useExistingCustomDomains: vi.fn(),
 } ) );
@@ -163,6 +174,9 @@ const useConnectorMock = vi.mocked( useConnector, { partial: true } );
 const useAgenticFeaturesMock = vi.mocked( useAgenticFeatures );
 const useAuthUserMock = vi.mocked( useAuthUser, { partial: true } );
 const useConnectedWpcomSitesMock = vi.mocked( useConnectedWpcomSites, { partial: true } );
+const usePublishPreviewSiteMock = vi.mocked( usePublishPreviewSite, { partial: true } );
+const useSnapshotsMock = vi.mocked( useSnapshots, { partial: true } );
+const useSnapshotUsageMock = vi.mocked( useSnapshotUsage, { partial: true } );
 const useLoginMock = vi.mocked( useLogin, { partial: true } );
 const useExistingCustomDomainsMock = vi.mocked( useExistingCustomDomains, { partial: true } );
 const useCopySiteMock = vi.mocked( useCopySite, { partial: true } );
@@ -197,6 +211,7 @@ describe( 'SiteOverviewView', () => {
 	const copyText = vi.fn().mockResolvedValue( undefined );
 	const pullSiteFromLive = vi.fn();
 	const pushSiteToLive = vi.fn();
+	const publishPreviewSite = vi.fn();
 	const onTabChange = vi.fn();
 
 	const connectorStub = ( openInOS = true ) => ( {
@@ -244,6 +259,12 @@ describe( 'SiteOverviewView', () => {
 		} );
 		useLoginMock.mockReturnValue( { isPending: false, mutate: vi.fn() } );
 		useConnectedWpcomSitesMock.mockReturnValue( { data: [], isLoading: false } );
+		useSnapshotsMock.mockReturnValue( { data: [] } );
+		useSnapshotUsageMock.mockReturnValue( { data: undefined } );
+		usePublishPreviewSiteMock.mockReturnValue( {
+			isPending: false,
+			mutate: publishPreviewSite,
+		} );
 		usePullSiteFromLiveMock.mockReturnValue( { mutate: pullSiteFromLive } );
 		usePushSiteToLiveMock.mockReturnValue( { mutate: pushSiteToLive } );
 		useIsSiteSyncingMock.mockReturnValue( { push: false, pull: false } );
@@ -421,6 +442,49 @@ describe( 'SiteOverviewView', () => {
 			'aria-disabled',
 			'true'
 		);
+	} );
+
+	it( 'shows preview expiry and account usage', () => {
+		useSnapshotsMock.mockReturnValue( {
+			data: [
+				{
+					url: 'demo-preview.wp.build',
+					atomicSiteId: 1,
+					localSiteId: 'site-1',
+					date: Date.now() - 5 * 24 * 60 * 60 * 1000,
+				},
+			],
+		} );
+		useSnapshotUsageMock.mockReturnValue( {
+			data: { siteCount: 2, siteLimit: 10, siteCreationBlocked: false },
+		} );
+
+		renderView();
+
+		expect( screen.getByText( 'demo-preview.wp.build' ) ).toBeVisible();
+		expect( screen.getByText( 'Expires in 2 days' ) ).toBeVisible();
+		expect( screen.getByText( '2 of 10' ) ).toBeVisible();
+	} );
+
+	it( 'publishes a preview site from its empty state', () => {
+		renderView();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Publish a preview site' } ) );
+
+		expect( publishPreviewSite ).toHaveBeenCalledWith( { siteId: 'site-1' } );
+	} );
+
+	it( 'explains that preview publishing requires sign-in', () => {
+		useAuthUserMock.mockReturnValue( { data: null } );
+
+		renderView();
+
+		expect(
+			screen.getByText( 'Sign in to publish a preview site and share your work.' )
+		).toBeVisible();
+		expect(
+			screen.queryByRole( 'button', { name: 'Publish a preview site' } )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'keeps the browser action available without a cached thumbnail', () => {

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -10,6 +10,7 @@ import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
 import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
 import { useDebugLogExists } from '@/data/queries/use-debug-log';
+import { usePublishPreviewSite } from '@/data/queries/use-preview-site';
 import { useSiteStorageUsage } from '@/data/queries/use-site-storage-usage';
 import { useSiteThumbnail } from '@/data/queries/use-site-thumbnail';
 import {
@@ -24,6 +25,7 @@ import {
 	useUpdateSite,
 	useXdebugEnabledSite,
 } from '@/data/queries/use-sites';
+import { useSnapshots, useSnapshotUsage } from '@/data/queries/use-snapshots';
 import { usePullSiteFromLive, usePushSiteToLive } from '@/data/queries/use-sync-site';
 import { useUserPreferences } from '@/data/queries/use-user-preferences';
 import { useWordPressVersions, useWpVersion } from '@/data/queries/use-wordpress-versions';
@@ -114,6 +116,15 @@ vi.mock( '@/data/queries/use-connected-wpcom-sites', () => ( {
 	useConnectedWpcomSites: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-preview-site', () => ( {
+	usePublishPreviewSite: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-snapshots', () => ( {
+	useSnapshots: vi.fn(),
+	useSnapshotUsage: vi.fn(),
+} ) );
+
 vi.mock( '@/data/queries/use-create-site-helpers', () => ( {
 	useExistingCustomDomains: vi.fn(),
 } ) );
@@ -195,6 +206,9 @@ const useConnectorMock = vi.mocked( useConnector, { partial: true } );
 const useAgenticFeaturesMock = vi.mocked( useAgenticFeatures );
 const useAuthUserMock = vi.mocked( useAuthUser, { partial: true } );
 const useConnectedWpcomSitesMock = vi.mocked( useConnectedWpcomSites, { partial: true } );
+const usePublishPreviewSiteMock = vi.mocked( usePublishPreviewSite, { partial: true } );
+const useSnapshotsMock = vi.mocked( useSnapshots, { partial: true } );
+const useSnapshotUsageMock = vi.mocked( useSnapshotUsage, { partial: true } );
 const useLoginMock = vi.mocked( useLogin, { partial: true } );
 const useExistingCustomDomainsMock = vi.mocked( useExistingCustomDomains, { partial: true } );
 const useCopySiteMock = vi.mocked( useCopySite, { partial: true } );
@@ -234,6 +248,7 @@ describe( 'SiteOverviewView', () => {
 	const openExternalUrl = vi.fn().mockResolvedValue( undefined );
 	const pullSiteFromLive = vi.fn();
 	const pushSiteToLive = vi.fn();
+	const publishPreviewSite = vi.fn();
 	const onTabChange = vi.fn();
 
 	const getFilePath = vi.fn().mockResolvedValue( '/tmp/backup.tar.gz' );
@@ -295,6 +310,12 @@ describe( 'SiteOverviewView', () => {
 		} );
 		useLoginMock.mockReturnValue( { isPending: false, mutate: vi.fn() } );
 		useConnectedWpcomSitesMock.mockReturnValue( { data: [], isLoading: false } );
+		useSnapshotsMock.mockReturnValue( { data: [] } );
+		useSnapshotUsageMock.mockReturnValue( { data: undefined } );
+		usePublishPreviewSiteMock.mockReturnValue( {
+			isPending: false,
+			mutate: publishPreviewSite,
+		} );
 		usePullSiteFromLiveMock.mockReturnValue( { mutate: pullSiteFromLive } );
 		usePushSiteToLiveMock.mockReturnValue( { mutate: pushSiteToLive } );
 		useIsSiteSyncingMock.mockReturnValue( { push: false, pull: false } );
@@ -497,6 +518,49 @@ describe( 'SiteOverviewView', () => {
 			'aria-disabled',
 			'true'
 		);
+	} );
+
+	it( 'shows preview expiry and account usage', () => {
+		useSnapshotsMock.mockReturnValue( {
+			data: [
+				{
+					url: 'demo-preview.wp.build',
+					atomicSiteId: 1,
+					localSiteId: 'site-1',
+					date: Date.now() - 5 * 24 * 60 * 60 * 1000,
+				},
+			],
+		} );
+		useSnapshotUsageMock.mockReturnValue( {
+			data: { siteCount: 2, siteLimit: 10, siteCreationBlocked: false },
+		} );
+
+		renderView();
+
+		expect( screen.getByText( 'demo-preview.wp.build' ) ).toBeVisible();
+		expect( screen.getByText( 'Expires in 2 days' ) ).toBeVisible();
+		expect( screen.getByText( '2 of 10' ) ).toBeVisible();
+	} );
+
+	it( 'publishes a preview site from its empty state', () => {
+		renderView();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Publish a preview site' } ) );
+
+		expect( publishPreviewSite ).toHaveBeenCalledWith( { siteId: 'site-1' } );
+	} );
+
+	it( 'explains that preview publishing requires sign-in', () => {
+		useAuthUserMock.mockReturnValue( { data: null } );
+
+		renderView();
+
+		expect(
+			screen.getByText( 'Sign in to publish a preview site and share your work.' )
+		).toBeVisible();
+		expect(
+			screen.queryByRole( 'button', { name: 'Publish a preview site' } )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'keeps the browser action available without a cached thumbnail', () => {

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -36,6 +36,7 @@ import { useTrafficLightSpace } from '@/hooks/use-traffic-light-space';
 import { AboutSection } from './about-section';
 import { ConnectionsSection } from './connections-section';
 import { CardSectionDivider, OverviewCard } from './overview-card';
+import { PreviewSitesSection } from './preview-sites-section';
 import styles from './style.module.css';
 import type { SiteSettingsTabId } from '@/components/site-settings-view';
 import type { SiteDetails } from '@/data/core';
@@ -272,6 +273,8 @@ function SiteOverviewBody( {
 										<AboutSection site={ site } wpVersion={ wpVersion } />
 										<CardSectionDivider />
 										<ConnectionsSection site={ site } busy={ busy } />
+										<CardSectionDivider />
+										<PreviewSitesSection site={ site } />
 									</OverviewCard>
 								</div>
 								<div className={ styles.actionsColumn }>

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -48,6 +48,7 @@ import { AboutSection } from './about-section';
 import { AdminSection } from './admin-section';
 import { ConnectionsSection } from './connections-section';
 import { OverviewCard } from './overview-card';
+import { PreviewSitesSection } from './preview-sites-section';
 import styles from './style.module.css';
 import type { SiteSettingsTabId } from '@/components/site-settings-view';
 import type { SiteDetails } from '@/data/core';
@@ -329,6 +330,10 @@ function SiteOverviewBody( {
 									<h2 className={ styles.columnHeading }>{ __( 'Connections' ) }</h2>
 									<OverviewCard>
 										<ConnectionsSection site={ site } busy={ busy } />
+									</OverviewCard>
+									<h2 className={ styles.columnHeading }>{ __( 'Preview sites' ) }</h2>
+									<OverviewCard>
+										<PreviewSitesSection site={ site } />
 									</OverviewCard>
 									<h2 className={ styles.columnHeading }>{ __( 'WP Admin' ) }</h2>
 									<OverviewCard>

--- a/apps/ui/src/components/site-overview-view/preview-sites-section.tsx
+++ b/apps/ui/src/components/site-overview-view/preview-sites-section.tsx
@@ -1,0 +1,220 @@
+import { DAY_MS, DEMO_SITE_EXPIRATION_DAYS } from '@studio/common/constants';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { copy, external, Icon, moreVertical, plus, update } from '@wordpress/icons';
+import { IconButton, Tooltip } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import { Fragment, useMemo } from 'react';
+import * as Menu from '@/components/menu';
+import { ensureProtocol, stripProtocol } from '@/components/site-dropdown/utils';
+import { useConnector } from '@/data/core';
+import { useAuthUser } from '@/data/queries/use-auth-user';
+import { usePublishPreviewSite } from '@/data/queries/use-preview-site';
+import { useSnapshots, useSnapshotUsage } from '@/data/queries/use-snapshots';
+import { useOffline } from '@/hooks/use-offline';
+import styles from './cards.module.css';
+import { CardEmptyState, CardRows, CardSection, RowDivider } from './overview-card';
+import { RowLink } from './row-link';
+import type { SiteDetails, Snapshot } from '@/data/core';
+
+const LIFETIME_MS = DEMO_SITE_EXPIRATION_DAYS * DAY_MS;
+
+export function PreviewSitesSection( { site }: { site: SiteDetails } ) {
+	const { data: authUser } = useAuthUser();
+	const isOffline = useOffline();
+	const { data: allSnapshots } = useSnapshots( authUser?.id );
+	const { data: usage } = useSnapshotUsage( authUser?.id );
+	const publishPreviewSite = usePublishPreviewSite();
+
+	const snapshots = useMemo(
+		() =>
+			( allSnapshots ?? [] )
+				.filter( ( snapshot ) => snapshot.localSiteId === site.id )
+				.sort( ( a, b ) => b.date - a.date ),
+		[ allSnapshots, site.id ]
+	);
+
+	const publishAction = authUser ? (
+		<div className={ styles.headerActions }>
+			{ usage && usage.siteLimit > 0 ? (
+				<Tooltip.Root>
+					<Tooltip.Trigger
+						render={
+							<span className={ styles.headerMeta }>
+								{ sprintf(
+									// translators: 1: previews in use, 2: total previews allowed.
+									__( '%1$d of %2$d' ),
+									usage.siteCount,
+									usage.siteLimit
+								) }
+							</span>
+						}
+					/>
+					<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+						{ sprintf(
+							// translators: 1: previews in use, 2: total previews allowed.
+							__( '%1$d of %2$d preview sites used on your account' ),
+							usage.siteCount,
+							usage.siteLimit
+						) }
+					</Tooltip.Popup>
+				</Tooltip.Root>
+			) : null }
+			<IconButton
+				variant="minimal"
+				tone="neutral"
+				size="small"
+				icon={ plus }
+				label={ __( 'Publish a preview site' ) }
+				disabled={ publishPreviewSite.isPending || isOffline }
+				loading={ publishPreviewSite.isPending }
+				loadingAnnouncement={ __( 'Publishing preview site' ) }
+				onClick={ () => publishPreviewSite.mutate( { siteId: site.id } ) }
+			/>
+		</div>
+	) : null;
+
+	return (
+		<CardSection title={ __( 'Preview sites' ) } action={ publishAction }>
+			{ ! authUser ? (
+				<CardEmptyState>
+					{ __( 'Sign in to publish a preview site and share your work.' ) }
+				</CardEmptyState>
+			) : ! snapshots.length ? (
+				<CardEmptyState>
+					{ sprintf(
+						// translators: %d: number of days a preview site stays online.
+						_n(
+							'No preview site yet. Publishing one gives you a shareable link for %d day.',
+							'No preview site yet. Publishing one gives you a shareable link for %d days.',
+							DEMO_SITE_EXPIRATION_DAYS
+						),
+						DEMO_SITE_EXPIRATION_DAYS
+					) }
+				</CardEmptyState>
+			) : (
+				<CardRows>
+					{ snapshots.map( ( snapshot, index ) => (
+						<Fragment key={ snapshot.url }>
+							{ index > 0 && <RowDivider /> }
+							<PreviewRow site={ site } snapshot={ snapshot } />
+						</Fragment>
+					) ) }
+				</CardRows>
+			) }
+		</CardSection>
+	);
+}
+
+function PreviewRow( { site, snapshot }: { site: SiteDetails; snapshot: Snapshot } ) {
+	const connector = useConnector();
+	const isOffline = useOffline();
+	const publishPreviewSite = usePublishPreviewSite();
+	const life = describeLife( snapshot );
+	const url = ensureProtocol( snapshot.url );
+
+	const republish = () =>
+		publishPreviewSite.mutate( {
+			siteId: site.id,
+			existingHostname: life.expired ? undefined : stripProtocol( snapshot.url ),
+		} );
+
+	return (
+		<div className={ styles.row }>
+			<div className={ styles.rowText }>
+				{ life.expired ? (
+					<span className={ clsx( styles.rowTitle, styles.rowTitleExpired ) } title={ url }>
+						{ stripProtocol( snapshot.url ) }
+					</span>
+				) : (
+					<RowLink label={ stripProtocol( snapshot.url ) } url={ url } />
+				) }
+				<span
+					className={ clsx(
+						styles.rowMeta,
+						life.expired ? styles.expired : life.endingSoon && styles.stale
+					) }
+				>
+					{ life.label }
+				</span>
+			</div>
+			<div className={ styles.rowActions }>
+				{ life.expired ? (
+					<IconButton
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						icon={ update }
+						label={ __( 'Republish' ) }
+						disabled={ publishPreviewSite.isPending || isOffline }
+						loading={ publishPreviewSite.isPending }
+						loadingAnnouncement={ __( 'Publishing preview site' ) }
+						onClick={ republish }
+					/>
+				) : (
+					<IconButton
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						icon={ external }
+						label={ __( 'Open preview site' ) }
+						onClick={ () => void connector.openExternalUrl( url ) }
+					/>
+				) }
+				<Menu.Root>
+					<Menu.Trigger
+						render={
+							<IconButton
+								variant="minimal"
+								tone="neutral"
+								size="small"
+								icon={ moreVertical }
+								label={ __( 'More options' ) }
+							/>
+						}
+					/>
+					<Menu.Popup side="bottom" align="end">
+						<Menu.Item onClick={ () => void connector.copyText( url ) }>
+							<span className={ styles.itemIcon } aria-hidden="true">
+								<Icon icon={ copy } size={ 18 } />
+							</span>
+							{ __( 'Copy link' ) }
+						</Menu.Item>
+						{ ! life.expired && (
+							<Menu.Item
+								disabled={ publishPreviewSite.isPending || isOffline }
+								onClick={ republish }
+							>
+								<span className={ styles.itemIcon } aria-hidden="true">
+									<Icon icon={ update } size={ 18 } />
+								</span>
+								{ __( 'Update preview' ) }
+							</Menu.Item>
+						) }
+					</Menu.Popup>
+				</Menu.Root>
+			</div>
+		</div>
+	);
+}
+
+function describeLife( snapshot: Snapshot ): {
+	label: string;
+	endingSoon: boolean;
+	expired: boolean;
+} {
+	const remainingMs = snapshot.date + LIFETIME_MS - Date.now();
+	if ( remainingMs <= 0 ) {
+		return { label: __( 'Expired' ), endingSoon: false, expired: true };
+	}
+
+	const remainingDays = Math.ceil( remainingMs / DAY_MS );
+	return {
+		label: sprintf(
+			// translators: %d: number of days until a preview site expires.
+			_n( 'Expires in %d day', 'Expires in %d days', remainingDays ),
+			remainingDays
+		),
+		endingSoon: remainingMs <= DAY_MS,
+		expired: false,
+	};
+}

--- a/apps/ui/src/components/site-overview-view/preview-sites-section.tsx
+++ b/apps/ui/src/components/site-overview-view/preview-sites-section.tsx
@@ -1,0 +1,220 @@
+import { DAY_MS, DEMO_SITE_EXPIRATION_DAYS } from '@studio/common/constants';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { copy, external, Icon, moreVertical, plus, update } from '@wordpress/icons';
+import { IconButton, Tooltip } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import { Fragment, useMemo } from 'react';
+import * as Menu from '@/components/menu';
+import { ensureProtocol, stripProtocol } from '@/components/site-dropdown/utils';
+import { useConnector } from '@/data/core';
+import { useAuthUser } from '@/data/queries/use-auth-user';
+import { usePublishPreviewSite } from '@/data/queries/use-preview-site';
+import { useSnapshots, useSnapshotUsage } from '@/data/queries/use-snapshots';
+import { useOffline } from '@/hooks/use-offline';
+import styles from './cards.module.css';
+import { CardEmptyState, CardRows, CardSection, RowDivider } from './overview-card';
+import { RowLink } from './row-link';
+import type { SiteDetails, Snapshot } from '@/data/core';
+
+const LIFETIME_MS = DEMO_SITE_EXPIRATION_DAYS * DAY_MS;
+
+export function PreviewSitesSection( { site }: { site: SiteDetails } ) {
+	const { data: authUser } = useAuthUser();
+	const isOffline = useOffline();
+	const { data: allSnapshots } = useSnapshots( authUser?.id );
+	const { data: usage } = useSnapshotUsage( authUser?.id );
+	const publishPreviewSite = usePublishPreviewSite();
+
+	const snapshots = useMemo(
+		() =>
+			( allSnapshots ?? [] )
+				.filter( ( snapshot ) => snapshot.localSiteId === site.id )
+				.sort( ( a, b ) => b.date - a.date ),
+		[ allSnapshots, site.id ]
+	);
+
+	const publishAction = authUser ? (
+		<div className={ styles.headerActions }>
+			{ usage && usage.siteLimit > 0 ? (
+				<Tooltip.Root>
+					<Tooltip.Trigger
+						render={
+							<span className={ styles.headerMeta }>
+								{ sprintf(
+									// translators: 1: previews in use, 2: total previews allowed.
+									__( '%1$d of %2$d' ),
+									usage.siteCount,
+									usage.siteLimit
+								) }
+							</span>
+						}
+					/>
+					<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+						{ sprintf(
+							// translators: 1: previews in use, 2: total previews allowed.
+							__( '%1$d of %2$d preview sites used on your account' ),
+							usage.siteCount,
+							usage.siteLimit
+						) }
+					</Tooltip.Popup>
+				</Tooltip.Root>
+			) : null }
+			<IconButton
+				variant="minimal"
+				tone="neutral"
+				size="small"
+				icon={ plus }
+				label={ __( 'Publish a preview site' ) }
+				disabled={ publishPreviewSite.isPending || isOffline }
+				loading={ publishPreviewSite.isPending }
+				loadingAnnouncement={ __( 'Publishing preview site' ) }
+				onClick={ () => publishPreviewSite.mutate( { siteId: site.id } ) }
+			/>
+		</div>
+	) : null;
+
+	return (
+		<CardSection action={ publishAction }>
+			{ ! authUser ? (
+				<CardEmptyState>
+					{ __( 'Sign in to publish a preview site and share your work.' ) }
+				</CardEmptyState>
+			) : ! snapshots.length ? (
+				<CardEmptyState>
+					{ sprintf(
+						// translators: %d: number of days a preview site stays online.
+						_n(
+							'No preview site yet. Publishing one gives you a shareable link for %d day.',
+							'No preview site yet. Publishing one gives you a shareable link for %d days.',
+							DEMO_SITE_EXPIRATION_DAYS
+						),
+						DEMO_SITE_EXPIRATION_DAYS
+					) }
+				</CardEmptyState>
+			) : (
+				<CardRows>
+					{ snapshots.map( ( snapshot, index ) => (
+						<Fragment key={ snapshot.url }>
+							{ index > 0 && <RowDivider /> }
+							<PreviewRow site={ site } snapshot={ snapshot } />
+						</Fragment>
+					) ) }
+				</CardRows>
+			) }
+		</CardSection>
+	);
+}
+
+function PreviewRow( { site, snapshot }: { site: SiteDetails; snapshot: Snapshot } ) {
+	const connector = useConnector();
+	const isOffline = useOffline();
+	const publishPreviewSite = usePublishPreviewSite();
+	const life = describeLife( snapshot );
+	const url = ensureProtocol( snapshot.url );
+
+	const republish = () =>
+		publishPreviewSite.mutate( {
+			siteId: site.id,
+			existingHostname: life.expired ? undefined : stripProtocol( snapshot.url ),
+		} );
+
+	return (
+		<div className={ styles.row }>
+			<div className={ styles.rowText }>
+				{ life.expired ? (
+					<span className={ clsx( styles.rowTitle, styles.rowTitleExpired ) } title={ url }>
+						{ stripProtocol( snapshot.url ) }
+					</span>
+				) : (
+					<RowLink label={ stripProtocol( snapshot.url ) } url={ url } />
+				) }
+				<span
+					className={ clsx(
+						styles.rowMeta,
+						life.expired ? styles.expired : life.endingSoon && styles.stale
+					) }
+				>
+					{ life.label }
+				</span>
+			</div>
+			<div className={ styles.rowActions }>
+				{ life.expired ? (
+					<IconButton
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						icon={ update }
+						label={ __( 'Republish' ) }
+						disabled={ publishPreviewSite.isPending || isOffline }
+						loading={ publishPreviewSite.isPending }
+						loadingAnnouncement={ __( 'Publishing preview site' ) }
+						onClick={ republish }
+					/>
+				) : (
+					<IconButton
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						icon={ external }
+						label={ __( 'Open preview site' ) }
+						onClick={ () => void connector.openExternalUrl( url ) }
+					/>
+				) }
+				<Menu.Root>
+					<Menu.Trigger
+						render={
+							<IconButton
+								variant="minimal"
+								tone="neutral"
+								size="small"
+								icon={ moreVertical }
+								label={ __( 'More options' ) }
+							/>
+						}
+					/>
+					<Menu.Popup side="bottom" align="end">
+						<Menu.Item onClick={ () => void connector.copyText( url ) }>
+							<span className={ styles.itemIcon } aria-hidden="true">
+								<Icon icon={ copy } size={ 18 } />
+							</span>
+							{ __( 'Copy link' ) }
+						</Menu.Item>
+						{ ! life.expired && (
+							<Menu.Item
+								disabled={ publishPreviewSite.isPending || isOffline }
+								onClick={ republish }
+							>
+								<span className={ styles.itemIcon } aria-hidden="true">
+									<Icon icon={ update } size={ 18 } />
+								</span>
+								{ __( 'Update preview' ) }
+							</Menu.Item>
+						) }
+					</Menu.Popup>
+				</Menu.Root>
+			</div>
+		</div>
+	);
+}
+
+function describeLife( snapshot: Snapshot ): {
+	label: string;
+	endingSoon: boolean;
+	expired: boolean;
+} {
+	const remainingMs = snapshot.date + LIFETIME_MS - Date.now();
+	if ( remainingMs <= 0 ) {
+		return { label: __( 'Expired' ), endingSoon: false, expired: true };
+	}
+
+	const remainingDays = Math.ceil( remainingMs / DAY_MS );
+	return {
+		label: sprintf(
+			// translators: %d: number of days until a preview site expires.
+			_n( 'Expires in %d day', 'Expires in %d days', remainingDays ),
+			remainingDays
+		),
+		endingSoon: remainingMs <= DAY_MS,
+		expired: false,
+	};
+}


### PR DESCRIPTION
## Related issues

- None.

## How AI was used in this PR

Codex helped extract Preview sites from the larger overview exploration into a focused stacked change, then supported the later design iterations represented by the top integration PR. I reviewed the resulting diff and rendered states.

## Proposed Changes

This is the second PR in the site-management UI stack:

1. #4474 — Connections on the overview
2. **#4483 — Preview sites on the overview** (this PR)
3. #4400 — Persistent site header with Share and Sync dialogs
4. #4601 — Integrated overview polish, reusable sharing controls, and operation progress

This layer makes temporary shareable sites visible and manageable from Overview.

- List previews belonging to the current local site.
- Distinguish active and expired previews and show their remaining lifetime.
- Provide direct publish, open, copy, update/republish, and overflow actions.
- Cover empty, loading, signed-out, offline, active, and expired states.

The top stack layer (#4601) carries the final action labels and ordering, deletion and bulk expired cleanup, footer creation action, live publishing progress, and the reusable list shared with the Share dialog.

## Current UI

![Preview sites card at native Retina resolution](https://github.com/Automattic/studio/blob/62acd0f439a80d347e9c5a0096e4280cb58dabc7/pr-fullres-previews-light.png?raw=true)

![The reusable Preview sites list in Share](https://github.com/Automattic/studio/blob/62acd0f439a80d347e9c5a0096e4280cb58dabc7/pr-fullres-share-light.png?raw=true)

## Testing Instructions

1. Open a site's **Overview** while signed in.
2. Confirm **Preview sites** appears after Connections.
3. Check active, expired, empty, and loading states.
4. Exercise publish, open, copy, update/republish, and overflow actions.
5. Verify offline-disabled behavior and both light and dark appearances.

Verification used while preparing this stack:

- Built this exact PR head with the local browser UI target.
- Rendered it against the local Studio backend and captured the screenshot above.
- The focused overview and preview-query tests and full typecheck pass on the integrated stack head.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
