### PR TITLE
Cherry-pick: Fix 400 "thinking.type.enabled" with direct Anthropic API key (1.18.0)

### DIFF
--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -13,6 +13,7 @@ import {
 	type AnthropicOptions,
 } from '@earendil-works/pi-ai/api/anthropic-messages';
 import { streamSimple as streamOpenAiResponses } from '@earendil-works/pi-ai/api/openai-responses';
+import { ANTHROPIC_MODELS } from '@earendil-works/pi-ai/providers/anthropic.models';
 import {
 	createAgentSession,
 	createBashTool,
@@ -398,16 +399,27 @@ function buildModel(
 			maxTokens: 32_000,
 		};
 	}
+	// Without `compat.forceAdaptiveThinking` pi-ai sends the legacy
+	// `thinking: { type: 'enabled', budget_tokens }` shape, which Sonnet 5 /
+	// Opus 5 reject with a 400 — copy the thinking fields from pi's catalog.
+	const catalogModel = (
+		ANTHROPIC_MODELS as Partial< Record< string, Model< 'anthropic-messages' > > >
+	 )[ modelId ];
 	return {
 		...common,
 		api: 'anthropic-messages',
 		provider: creds.useBearerAuth ? STUDIO_WPCOM_ANTHROPIC_PROVIDER : 'anthropic',
 		reasoning: true,
+		// contextWindow/maxTokens intentionally stay below the catalog values.
 		contextWindow: 200_000,
 		// thinkingLevel 'high' reserves ~16384 of this budget for extended thinking
 		// (see adjustMaxTokensForThinking in pi-ai); keep enough headroom for visible
 		// output so single tool calls can emit a full-page HTML payload.
 		maxTokens: 32_000,
+		...( catalogModel?.thinkingLevelMap
+			? { thinkingLevelMap: catalogModel.thinkingLevelMap }
+			: {} ),
+		...( catalogModel?.compat ? { compat: catalogModel.compat } : {} ),
 	};
 }
 
@@ -471,7 +483,9 @@ async function createModelRuntime(
 		return modelRuntime;
 	}
 
-	await modelRuntime.setRuntimeApiKey( family, creds.apiKey );
+	// allowNetwork: false — the default refresh fetches remote model catalogs
+	// (unused here) with no timeout guard, blocking the turn on slow networks.
+	await modelRuntime.setRuntimeApiKey( family, creds.apiKey, { allowNetwork: false } );
 	return modelRuntime;
 }
 
@@ -525,6 +539,7 @@ function createWpcomAnthropicProviderConfig(
 				maxTokens: model.maxTokens,
 				headers: creds.extraHeaders,
 				compat: model.compat,
+				thinkingLevelMap: model.thinkingLevelMap,
 			},
 		],
 	};

--- a/apps/cli/ai/tests/pi-runtime.test.ts
+++ b/apps/cli/ai/tests/pi-runtime.test.ts
@@ -1,4 +1,6 @@
+import { ANTHROPIC_MODELS } from '@earendil-works/pi-ai/providers/anthropic.models';
 import { ModelRegistry, SessionManager } from '@earendil-works/pi-coding-agent';
+import { AI_MODELS } from '@studio/common/ai/models';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { runStudioAgentTurn, type StudioAgentTurnConfig } from 'cli/ai/runtimes/pi';
 import type { AgentSessionEvent, CreateAgentSessionOptions } from '@earendil-works/pi-coding-agent';
@@ -422,6 +424,7 @@ describe( 'pi runtime', () => {
 		expect( options.model?.api ).toBe( 'anthropic-messages' );
 		expect( options.model?.maxTokens ).toBe( 32_000 );
 		expect( options.model?.input ).toEqual( [ 'text', 'image' ] );
+		expect( options.model?.compat ).toMatchObject( { forceAdaptiveThinking: true } );
 		const modelRegistry = new ModelRegistry( options.modelRuntime! );
 		const auth = await modelRegistry.getApiKeyAndHeaders( options.model! );
 		expect( auth ).toMatchObject( {
@@ -432,6 +435,54 @@ describe( 'pi runtime', () => {
 				'X-WPCOM-Session-ID': 'session-1',
 			},
 		} );
+	} );
+
+	// Without `compat.forceAdaptiveThinking`, pi-ai sends a thinking shape that
+	// Sonnet 5 / Opus 5 reject with a 400.
+	it( 'marks direct-key Anthropic models as adaptive-thinking', async () => {
+		await runRuntime( {
+			prompt: 'hello',
+			env: { ANTHROPIC_API_KEY: 'sk-ant-test' },
+			model: 'claude-sonnet-5',
+			session: newSession(),
+		} );
+
+		const model = mocks.createdSessions[ 0 ].options.model!;
+		expect( model.provider ).toBe( 'anthropic' );
+		expect( model.compat ).toMatchObject( { forceAdaptiveThinking: true } );
+		expect( model.thinkingLevelMap ).toEqual( { xhigh: 'xhigh', max: 'max' } );
+		// Studio's conservative limits are intentionally not taken from pi's catalog.
+		expect( model.maxTokens ).toBe( 32_000 );
+		expect( model.contextWindow ).toBe( 200_000 );
+	} );
+
+	it( 'copies per-model compat from the pi catalog', async () => {
+		await runRuntime( {
+			prompt: 'hello',
+			env: { ANTHROPIC_API_KEY: 'sk-ant-test' },
+			model: 'claude-opus-5',
+			session: newSession(),
+		} );
+
+		const model = mocks.createdSessions[ 0 ].options.model!;
+		expect( model.compat ).toMatchObject( {
+			forceAdaptiveThinking: true,
+			supportsTemperature: false,
+		} );
+	} );
+
+	// A Studio model missing from the pinned pi-ai catalog would silently fall
+	// back to the rejected thinking shape.
+	it( 'has a pi catalog entry with adaptive-thinking compat for every Anthropic model', () => {
+		const anthropicIds = AI_MODELS.filter( ( m ) => m.family === 'anthropic' ).map( ( m ) => m.id );
+		expect( anthropicIds.length ).toBeGreaterThan( 0 );
+		for ( const id of anthropicIds ) {
+			const catalogModel = ( ANTHROPIC_MODELS as Record< string, { compat?: object } > )[ id ];
+			expect( catalogModel, `missing pi catalog entry for ${ id }` ).toBeDefined();
+			expect( catalogModel.compat, `missing compat for ${ id }` ).toMatchObject( {
+				forceAdaptiveThinking: true,
+			} );
+		}
 	} );
 
 	// pi parses registerProvider config values as templates, so a wpcom token


### PR DESCRIPTION
## Related issues

- Cherry-pick of #4480 into `release/1.18.0`. Related to STU-2205.

## How AI was used in this PR

Cherry-pick of an already-reviewed trunk commit; tests re-run on the release branch.

## Proposed Changes

Cherry-picks 97a5a94e6 from trunk: chatting with a direct Anthropic API key always failed with `400 "thinking.type.enabled" is not supported for this model`. See #4480 for full details.

- Copies thinking metadata (`compat`, `thinkingLevelMap`) from pi-ai's bundled catalog so requests use `thinking: { type: "adaptive" }`.
- Passes `allowNetwork: false` when setting the runtime API key, removing an unguarded per-turn network fetch.

## Testing Instructions

Same as #4480:

1. `npm run cli:build && node apps/cli/dist/cli/main.mjs ai`
2. `/provider` → "Anthropic · API key", enter a valid key, send a prompt on Sonnet 5 — streams instead of the 400. Repeat on Opus 5.
3. `npm test -- apps/cli/ai/tests/pi-runtime.test.ts` — 13 tests pass (verified on this branch).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
