### PR TITLE
Report why a Blueprint failed instead of the PHP exit code

### DIFF
--- a/apps/cli/lib/native-php/blueprints.ts
+++ b/apps/cli/lib/native-php/blueprints.ts
@@ -5,13 +5,51 @@ import {
 	removeBlueprintTempDir,
 } from '@studio/common/lib/blueprint-bundle';
 import { getBlueprintsPharPath, getPhpBinaryPath } from 'cli/lib/dependency-management/paths';
-import { runPhpCommand } from './php-process';
+import { PhpCommandError, runPhpCommand } from './php-process';
 import type { NativePhpSupportedVersion } from '@studio/common/lib/php-binary-metadata';
 import type { ServerConfig } from 'cli/lib/types/wordpress-server-ipc';
 
 function isWriteAccessError( error: unknown ): boolean {
 	const code = ( error as NodeJS.ErrnoException )?.code;
 	return code === 'EACCES' || code === 'EPERM' || code === 'EROFS';
+}
+
+// Fits a schema validation report (one line per offending property) without overflowing a toast.
+const MAX_BLUEPRINT_ERROR_LENGTH = 2000;
+
+function truncate( message: string ): string {
+	return message.length > MAX_BLUEPRINT_ERROR_LENGTH
+		? `${ message.slice( 0, MAX_BLUEPRINT_ERROR_LENGTH ) }…`
+		: message;
+}
+
+/**
+ * The runner reports on stdout as JSON lines, progress interleaved with errors. Only `message` is
+ * kept; the `details.trace` on step failures is a phar-internal stack, meaningless to the user.
+ */
+export function formatBlueprintRunnerError( error: PhpCommandError ): string {
+	const reportedErrors: string[] = [];
+	for ( const line of error.stdout.split( /\r?\n/ ) ) {
+		const trimmed = line.trim();
+		if ( ! trimmed.startsWith( '{' ) ) {
+			continue;
+		}
+		try {
+			const parsed = JSON.parse( trimmed );
+			if ( parsed?.type === 'error' && typeof parsed.message === 'string' ) {
+				reportedErrors.push( parsed.message );
+			}
+		} catch {
+			// A partial line from a truncated capture - nothing to report from it.
+		}
+	}
+
+	if ( reportedErrors.length > 0 ) {
+		return truncate( reportedErrors.join( '\n' ) );
+	}
+
+	const stderr = error.stderr.trim();
+	return stderr ? truncate( stderr ) : error.message;
 }
 
 export async function runBlueprint(
@@ -114,6 +152,11 @@ export async function runBlueprint(
 				},
 			}
 		);
+	} catch ( error ) {
+		if ( error instanceof PhpCommandError ) {
+			throw new Error( formatBlueprintRunnerError( error ) );
+		}
+		throw error;
 	} finally {
 		await fs.promises.unlink( tmpPath ).catch( () => {} );
 		if ( fallbackTempDir ) {

--- a/apps/cli/lib/native-php/php-process.ts
+++ b/apps/cli/lib/native-php/php-process.ts
@@ -6,6 +6,30 @@ import type { NativePhpSupportedVersion } from '@studio/common/lib/php-binary-me
 
 type ErrorLogger = ( ...args: Parameters< typeof console.error > ) => void;
 
+// The tail, because PHP reports the fatal last, and capped so a chatty process (the Blueprint
+// runner emits a progress line per step) can't grow the buffer without bound.
+export const MAX_CAPTURED_OUTPUT_CHARS = 64 * 1024;
+
+// Carries the output so callers can report why PHP exited, not just that it did.
+export class PhpCommandError extends Error {
+	constructor(
+		message: string,
+		readonly exitCode: number | null,
+		readonly stdout: string,
+		readonly stderr: string
+	) {
+		super( message );
+		this.name = 'PhpCommandError';
+	}
+}
+
+function appendBounded( buffer: string, chunk: string ): string {
+	const combined = buffer + chunk;
+	return combined.length > MAX_CAPTURED_OUTPUT_CHARS
+		? combined.slice( combined.length - MAX_CAPTURED_OUTPUT_CHARS )
+		: combined;
+}
+
 // Makes a PHP child a process-group leader on POSIX so its subtree can be signalled via the
 // negative PID. On Windows we reap with `taskkill /T` instead, so a new group isn't needed.
 export const DETACH_FOR_GROUP_KILL = process.platform !== 'win32';
@@ -165,20 +189,18 @@ export async function runPhpCommand(
 		} );
 		const reportActivity = () => process.send?.( { topic: 'activity' } );
 
+		// `capture` callers parse the whole stdout; other modes keep a tail only to explain a failure.
+		const capturing = options.mode === 'capture';
 		let stdout = '';
 		phpScriptProcess.stdout?.on( 'data', ( chunk ) => {
 			reportActivity();
-			if ( options.mode === 'capture' ) {
-				stdout += chunk.toString();
-			}
+			stdout = capturing ? stdout + chunk.toString() : appendBounded( stdout, chunk.toString() );
 		} );
 
 		let stderr = '';
 		phpScriptProcess.stderr?.on( 'data', ( chunk ) => {
 			reportActivity();
-			if ( options.mode === 'capture' ) {
-				stderr += chunk.toString();
-			}
+			stderr = capturing ? stderr + chunk.toString() : appendBounded( stderr, chunk.toString() );
 		} );
 
 		phpScriptProcess.once( 'error', ( error: Error ) => {
@@ -190,7 +212,7 @@ export async function runPhpCommand(
 				return;
 			}
 
-			reject( new Error( `PHP command failed (code: ${ code })` ) );
+			reject( new PhpCommandError( `PHP command failed (code: ${ code })`, code, stdout, stderr ) );
 		} );
 	} );
 }

--- a/apps/cli/lib/native-php/tests/blueprints.test.ts
+++ b/apps/cli/lib/native-php/tests/blueprints.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { formatBlueprintRunnerError } from 'cli/lib/native-php/blueprints';
+import { PhpCommandError } from 'cli/lib/native-php/php-process';
+
+function phpError( { stdout = '', stderr = '' }: { stdout?: string; stderr?: string } ) {
+	return new PhpCommandError( 'PHP command failed (code: 1)', 1, stdout, stderr );
+}
+
+describe( 'formatBlueprintRunnerError', () => {
+	it( "reports the runner's schema validation errors", () => {
+		const message = formatBlueprintRunnerError(
+			phpError( {
+				stdout: [
+					'{"type":"progress","progress":0,"caption":"Loading Blueprint data"}',
+					'{"type":"error","message":"Invalid Blueprint v1 provided. See the validation errors below:"}',
+					'{"type":"error","message":"Blueprint root[\\"features\\"][\\"intl\\"]:"}',
+					'{"type":"error","message":"Property \\"intl\\" isn\'t allowed here. Allowed properties are: networking."}',
+				].join( '\n' ),
+			} )
+		);
+
+		expect( message ).toContain( 'Invalid Blueprint v1 provided.' );
+		expect( message ).toContain( 'Property "intl" isn\'t allowed here.' );
+		expect( message ).not.toContain( 'Loading Blueprint data' );
+	} );
+
+	// Step failures carry a `details.trace` that is useless in a toast and dwarfs the message.
+	it( 'keeps the exception message and drops its stack trace', () => {
+		const message = formatBlueprintRunnerError(
+			phpError( {
+				stdout: JSON.stringify( {
+					type: 'error',
+					message: 'Failed to resolve branch file path: dist/main',
+					details: {
+						exception: 'WordPress\\Git\\GitException',
+						trace: '#0 phar:///blueprints.phar/class-gitremote.php(297)',
+					},
+				} ),
+			} )
+		);
+
+		expect( message ).toContain( 'Failed to resolve branch file path: dist/main' );
+		expect( message ).not.toContain( 'class-gitremote.php' );
+	} );
+
+	it( 'falls back to stderr when the runner reported no error lines', () => {
+		const message = formatBlueprintRunnerError(
+			phpError( { stderr: 'PHP Fatal error: Allowed memory size exhausted' } )
+		);
+
+		expect( message ).toContain( 'Allowed memory size exhausted' );
+	} );
+
+	it( 'falls back to the exit code when the process said nothing', () => {
+		expect( formatBlueprintRunnerError( phpError( {} ) ) ).toBe( 'PHP command failed (code: 1)' );
+	} );
+
+	it( 'ignores non-JSON noise on stdout', () => {
+		const message = formatBlueprintRunnerError(
+			phpError( { stdout: 'Warning: something\n{"type":"error","message":"the real problem"}' } )
+		);
+
+		expect( message ).toBe( 'the real problem' );
+	} );
+} );

--- a/apps/cli/lib/native-php/tests/php-process.test.ts
+++ b/apps/cli/lib/native-php/tests/php-process.test.ts
@@ -1,0 +1,115 @@
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const spawnMock = vi.fn();
+
+vi.mock( 'node:child_process', () => {
+	const mockedModule = { spawn: spawnMock, spawnSync: vi.fn() };
+	return { ...mockedModule, default: mockedModule };
+} );
+
+vi.mock( 'cli/lib/dependency-management/paths', () => ( {
+	getPhpBinaryPath: () => '/fake/php',
+} ) );
+
+type FakeChild = EventEmitter & { stdout: PassThrough; stderr: PassThrough };
+
+function createFakeChild(): FakeChild {
+	const child = new EventEmitter() as FakeChild;
+	child.stdout = new PassThrough();
+	child.stderr = new PassThrough();
+	return child;
+}
+
+/**
+ * Drives a fake PHP child: emits the given output, then closes with `code`.
+ * Deferred so the caller can await `runPhpCommand`'s promise while this runs.
+ */
+function respondWith( {
+	stdout = '',
+	stderr = '',
+	code = 0,
+}: {
+	stdout?: string;
+	stderr?: string;
+	code?: number;
+} ) {
+	const child = createFakeChild();
+	spawnMock.mockReturnValue( child );
+	queueMicrotask( () => {
+		if ( stdout ) {
+			child.stdout.write( stdout );
+		}
+		if ( stderr ) {
+			child.stderr.write( stderr );
+		}
+		queueMicrotask( () => child.emit( 'close', code ) );
+	} );
+	return child;
+}
+
+describe( 'runPhpCommand', () => {
+	beforeEach( () => {
+		vi.resetModules();
+		spawnMock.mockReset();
+	} );
+
+	it( 'rejects with a PhpCommandError carrying the failed process output', async () => {
+		const { runPhpCommand, PhpCommandError } = await import( 'cli/lib/native-php/php-process' );
+		respondWith( {
+			stdout: '{"type":"error","message":"Invalid Blueprint v1 provided."}\n',
+			stderr: 'PHP Fatal error: boom\n',
+			code: 1,
+		} );
+
+		const error = await runPhpCommand( [ 'script.php' ], { phpVersion: '8.4' } ).catch(
+			( caught ) => caught
+		);
+
+		expect( error ).toBeInstanceOf( PhpCommandError );
+		expect( error.exitCode ).toBe( 1 );
+		expect( error.stdout ).toContain( 'Invalid Blueprint v1 provided.' );
+		expect( error.stderr ).toContain( 'PHP Fatal error: boom' );
+	} );
+
+	// The Blueprint runner streams through `pipe`, so diagnostics must survive outside `capture`.
+	it( 'captures failure output in pipe mode', async () => {
+		const { runPhpCommand } = await import( 'cli/lib/native-php/php-process' );
+		respondWith( { stderr: 'Could not open input file\n', code: 1 } );
+
+		const error = await runPhpCommand( [ 'missing.php' ], {
+			phpVersion: '8.4',
+			mode: 'pipe',
+		} ).catch( ( caught ) => caught );
+
+		expect( error.stderr ).toContain( 'Could not open input file' );
+	} );
+
+	it( 'keeps the tail when a failing process writes more than the capture limit', async () => {
+		const { runPhpCommand, MAX_CAPTURED_OUTPUT_CHARS } = await import(
+			'cli/lib/native-php/php-process'
+		);
+		const noise = 'x'.repeat( MAX_CAPTURED_OUTPUT_CHARS );
+		respondWith( { stdout: `${ noise }THE-REAL-ERROR`, code: 1 } );
+
+		const error = await runPhpCommand( [ 'chatty.php' ], { phpVersion: '8.4' } ).catch(
+			( caught ) => caught
+		);
+
+		expect( error.stdout ).toContain( 'THE-REAL-ERROR' );
+		expect( error.stdout.length ).toBeLessThanOrEqual( MAX_CAPTURED_OUTPUT_CHARS );
+	} );
+
+	it( 'still resolves capture mode with the full stdout', async () => {
+		const { runPhpCommand } = await import( 'cli/lib/native-php/php-process' );
+		respondWith( { stdout: 'wordpress installed', code: 0 } );
+
+		const result = await runPhpCommand( [ '-r', 'echo 1;' ], {
+			phpVersion: '8.4',
+			mode: 'capture',
+		} );
+
+		expect( result.stdout ).toBe( 'wordpress installed' );
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Part of STU-2124

## How AI was used in this PR

AI assisted with reproducing the failure, tracing it to the swallowed phar output, and drafting the fix and tests. I reviewed the change and verified it locally against the failing Blueprints.

## Proposed Changes

`runPhpCommand` discarded the child's output outside of `capture` mode, so a failed `blueprints.phar` run surfaced only as `PHP command failed (code: 1)`. The runner's actual reason reached nothing but the daemon site log.

- `PhpCommandError` now carries the failed process's `stdout` and `stderr`, bounded to a 64K tail so the Blueprint runner's per-step progress lines cannot grow the buffer without bound.
- `runBlueprint` parses the runner's JSON error lines out of that output and throws them as the message. The `details.trace` that comes with step failures is dropped, since a phar-internal stack means nothing to the user.
- `capture` mode still resolves with the full stdout, so the existing callers that parse it are unaffected.

This does not make any Blueprint work that did not work before. It only reports the reason. The `features.intl` fix that makes Stylish Press create successfully is a follow-up PR.

## Testing Instructions

The failing Blueprints are gallery ones, so no fixture is needed.

1. Check out this branch and run `npm run cli:build`.
2. Save the Stylish Press Blueprint to a file:
   ```sh
   curl -s "https://public-api.wordpress.com/wpcom/v2/studio-app/blueprints" \
     | python3 -c "import json,sys; print(json.dumps([b for b in json.load(sys.stdin)['blueprints'] if b['slug']=='stylish-press-2'][0]['blueprint']))" \
     > /tmp/stylish-press.json
   ```
3. Create a site from it under the native runtime:
   ```sh
   node apps/cli/dist/cli/main.mjs site create --name repro --path /tmp/repro-site \
     --wp latest --runtime native --blueprint /tmp/stylish-press.json --no-start --skip-browser
   ```
4. Before this change, step 3 ends in `Failed to apply Blueprint: PHP command failed (code: 1)`. On this branch it ends in:
   ```
   Failed to apply Blueprint: Invalid Blueprint v1 provided. See the validation errors below:
   Blueprint root["features"]["intl"]:
   Property "intl" isn't allowed here. Allowed properties are: networking.
   ```
5. Step failures report too, not just schema ones. Repeat with the Personal CRM Blueprint from STU-2203 and the message is `Failed to resolve branch file path: dist/main`, with no stack trace attached.
6. Regression: a Blueprint that succeeds still succeeds. Create a site from any working Blueprint and confirm `Blueprint applied successfully`.
7. Now switch to Old UI by disabling the Beta feature (Menu -> Electron -> Beta Features)
8. Create site using Stylish press blueprint
9. You get exact error why create site failed with exact blueprint related error.  


<img width="646" height="976" alt="CleanShot 2026-08-10 at 14 16 37@2x" src="https://github.com/user-attachments/assets/a03ea5eb-9941-4a77-a5ca-868cf7b7e2a4" />

**Tests:** `npm test -- apps/cli/lib/native-php/tests/` → all 12 pass.

**Reset (to re-test):**
```sh
node apps/cli/dist/cli/main.mjs site delete repro --delete-files
rm -rf /tmp/repro-site /tmp/stylish-press.json
```

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
