### PR TITLE
Tracks: import & export events (STU-2117)

### DIFF
--- a/apps/cli/commands/export.ts
+++ b/apps/cli/commands/export.ts
@@ -113,12 +113,8 @@ export function handleExportEvents( emitter: ImportExportEventEmitter ): void {
 		logger.reportSuccess( __( 'Site exported successfully' ) );
 	} );
 
-	emitter.on( ExportEvents.EXPORT_ERROR, ( payload ) => {
-		throw new LoggerError(
-			__( 'Export failed' ),
-			payload.message ? new Error( payload.message ) : undefined
-		);
-	} );
+	// No EXPORT_ERROR handler: every emitter rethrows the original error right after emitting, and
+	// that error carries the failure `code` for analytics — a wrap here would discard it.
 }
 
 export async function runCommand(
@@ -170,7 +166,11 @@ export async function runCommand(
 		} );
 
 		if ( ! exporter ) {
-			throw new LoggerError( __( 'No suitable exporter found for the provided backup file' ) );
+			throw new LoggerError(
+				__( 'No suitable exporter found for the provided backup file' ),
+				undefined,
+				'no_exporter_found'
+			);
 		}
 
 		if ( process.send ) {

--- a/apps/cli/commands/export.ts
+++ b/apps/cli/commands/export.ts
@@ -11,7 +11,8 @@ import { ImportExportEventEmitter } from 'cli/lib/import-export/events';
 import { getExporter } from 'cli/lib/import-export/export/export-manager';
 import { ExportOptions } from 'cli/lib/import-export/export/types';
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
-import { untildify } from 'cli/lib/utils';
+import { getTracksOrigin, recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
+import { classifyExportFailure, untildify } from 'cli/lib/utils';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -126,8 +127,10 @@ export async function runCommand(
 	mode: 'full' | 'content' | 'db' = 'full',
 	splitDbDumpByTable = false,
 	includeOnlyPaths?: string[],
-	applyDeployIgnore = false
+	applyDeployIgnore = false,
+	suppressTracksEvent = false
 ): Promise< void > {
+	const startedAt = Date.now();
 	try {
 		logger.reportStart( LoggerAction.START_DAEMON, __( 'Starting process daemon…' ) );
 		await connectToDaemon();
@@ -178,8 +181,42 @@ export async function runCommand(
 		await exporter.export();
 
 		logger.reportSuccess( sprintf( __( '%s successfully exported' ), exportPath ) );
+
+		if ( ! suppressTracksEvent ) {
+			await recordSiteExportEvent( {
+				success: true,
+				export_type: mode,
+				time_ms: Date.now() - startedAt,
+			} );
+		}
+	} catch ( error ) {
+		if ( ! suppressTracksEvent ) {
+			await recordSiteExportEvent( {
+				success: false,
+				export_type: mode,
+				failure_reason: classifyExportFailure( error ),
+				time_ms: Date.now() - startedAt,
+			} );
+		}
+		throw error;
 	} finally {
 		await disconnectFromDaemon();
+	}
+}
+
+async function recordSiteExportEvent( props: {
+	success: boolean;
+	export_type: string;
+	failure_reason?: string;
+	time_ms: number;
+} ): Promise< void > {
+	try {
+		await recordTracksEvent( TRACKS_EVENTS.SITE_EXPORT, {
+			...props,
+			...getTracksOrigin(),
+		} );
+	} catch {
+		// Best-effort telemetry — never block or fail the export.
 	}
 }
 
@@ -243,6 +280,11 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					default: false,
 					description: __( 'Apply .deployignore patterns when exporting' ),
 					hidden: true,
+				} )
+				.option( 'suppress-tracks-event', {
+					type: 'boolean',
+					default: false,
+					hidden: true,
 				} );
 		},
 		handler: async ( argv ) => {
@@ -276,7 +318,8 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					argv.mode,
 					argv.splitDbDumpByTable,
 					argv.includeOnly,
-					argv.applyDeployIgnore
+					argv.applyDeployIgnore,
+					argv.suppressTracksEvent
 				);
 			} catch ( error ) {
 				if ( error instanceof LoggerError ) {

--- a/apps/cli/commands/export.ts
+++ b/apps/cli/commands/export.ts
@@ -206,7 +206,7 @@ export async function runCommand(
 
 async function recordSiteExportEvent( props: {
 	success: boolean;
-	export_type: string;
+	export_type: 'full' | 'content' | 'db';
 	failure_reason?: string;
 	time_ms: number;
 } ): Promise< void > {

--- a/apps/cli/commands/import.ts
+++ b/apps/cli/commands/import.ts
@@ -382,7 +382,7 @@ export async function runCommand(
 
 async function recordSiteImportEvent( props: {
 	success: boolean;
-	importer_type: string;
+	importer_type: ImporterType | 'unknown';
 	failure_reason?: string;
 	time_ms: number;
 } ): Promise< void > {

--- a/apps/cli/commands/import.ts
+++ b/apps/cli/commands/import.ts
@@ -368,7 +368,13 @@ export async function runCommand(
 		);
 	}
 
-	if ( importError instanceof LoggerError && restartSiteError instanceof Error ) {
+	// Attach the restart error only when the import error has no cause of its own — overwriting an
+	// existing `previousError` would hide the root cause behind the (secondary) restart failure.
+	if (
+		importError instanceof LoggerError &&
+		restartSiteError instanceof Error &&
+		! importError.previousError
+	) {
 		importError.previousError = restartSiteError;
 	}
 

--- a/apps/cli/commands/import.ts
+++ b/apps/cli/commands/import.ts
@@ -138,8 +138,7 @@ export function handleImportEvents( emitter: ImportExportEventEmitter ): void {
 	emitter.on( ValidatorEvents.IMPORT_VALIDATION_ERROR, ( error ) => {
 		throw new LoggerError(
 			__( 'Backup validation failed' ),
-			error instanceof Error ? error : undefined,
-			'validation'
+			error instanceof Error ? error : undefined
 		);
 	} );
 

--- a/apps/cli/commands/import.ts
+++ b/apps/cli/commands/import.ts
@@ -174,13 +174,8 @@ export function handleImportEvents( emitter: ImportExportEventEmitter ): void {
 		logger.reportWarning( warningMessage || __( 'A warning occurred while extracting backup' ) );
 	} );
 
-	emitter.on( BackupExtractEvents.BACKUP_EXTRACT_ERROR, ( error ) => {
-		throw new LoggerError(
-			__( 'Failed to extract backup' ),
-			error instanceof Error ? error : undefined,
-			'extract'
-		);
-	} );
+	// No BACKUP_EXTRACT_ERROR handler: every extraction failure rejects `extractFiles`, which the
+	// import manager wraps in a LoggerError coded `extract` — a wrap here would double-wrap it.
 
 	emitter.on( ImporterEvents.IMPORT_START, () => {
 		logger.reportStart( LoggerAction.IMPORT_SITE, __( 'Importing backup…' ) );

--- a/apps/cli/commands/import.ts
+++ b/apps/cli/commands/import.ts
@@ -5,6 +5,7 @@ import { isWordPressDirectory, recursiveCopyDirectory } from '@studio/common/lib
 import {
 	BackupExtractEvents,
 	ImporterEvents,
+	ImporterType,
 	ImportEventTuple,
 	ImportIpcEvent,
 	ValidatorEvents,
@@ -24,7 +25,8 @@ import { ImportExportEventEmitter } from 'cli/lib/import-export/events';
 import { DEFAULT_IMPORTER_OPTIONS, getImporter } from 'cli/lib/import-export/import/import-manager';
 import { getBackupFileType } from 'cli/lib/import-export/utils';
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
-import { untildify } from 'cli/lib/utils';
+import { getTracksOrigin, recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
+import { classifyImportFailure, untildify } from 'cli/lib/utils';
 import {
 	isServerRunning,
 	startWordPressServer,
@@ -258,12 +260,15 @@ export function handleImportEvents( emitter: ImportExportEventEmitter ): void {
 export async function runCommand(
 	siteFolder: string,
 	importFile: string,
-	alwaysStartServer = false
+	alwaysStartServer = false,
+	suppressTracksEvent = false
 ): Promise< void > {
+	const startedAt = Date.now();
 	let site: SiteData | undefined;
 	let wasServerRunning = false;
 	let importError: unknown;
 	let restartSiteError: unknown;
+	let importerType: ImporterType | undefined;
 
 	try {
 		logger.reportStart( LoggerAction.START_DAEMON, __( 'Starting process daemon…' ) );
@@ -299,6 +304,9 @@ export async function runCommand(
 			{ path: importFile, type: getBackupFileType( importFile ) },
 			DEFAULT_IMPORTER_OPTIONS
 		);
+		importer.on( ImporterEvents.IMPORT_START, ( type ) => {
+			importerType = type;
+		} );
 		if ( process.send ) {
 			handleImportIpc( importer );
 		} else {
@@ -340,6 +348,25 @@ export async function runCommand(
 		}
 	}
 
+	// Record before the LoggerError merge below — merging the restart error into `previousError`
+	// would corrupt the failure classification, which reads the import error's message.
+	if ( ! suppressTracksEvent ) {
+		await recordSiteImportEvent(
+			importError === undefined
+				? {
+						success: true,
+						importer_type: importerType ?? 'unknown',
+						time_ms: Date.now() - startedAt,
+				  }
+				: {
+						success: false,
+						importer_type: importerType ?? 'unknown',
+						failure_reason: classifyImportFailure( importError ),
+						time_ms: Date.now() - startedAt,
+				  }
+		);
+	}
+
 	if ( importError instanceof LoggerError && restartSiteError instanceof Error ) {
 		importError.previousError = restartSiteError;
 	}
@@ -350,6 +377,22 @@ export async function runCommand(
 
 	if ( restartSiteError instanceof Error ) {
 		throw restartSiteError;
+	}
+}
+
+async function recordSiteImportEvent( props: {
+	success: boolean;
+	importer_type: string;
+	failure_reason?: string;
+	time_ms: number;
+} ): Promise< void > {
+	try {
+		await recordTracksEvent( TRACKS_EVENTS.SITE_IMPORT, {
+			...props,
+			...getTracksOrigin(),
+		} );
+	} catch {
+		// Best-effort telemetry — never block or fail the import.
 	}
 }
 
@@ -372,11 +415,16 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					type: 'boolean',
 					default: false,
 					hidden: true,
+				} )
+				.option( 'suppress-tracks-event', {
+					type: 'boolean',
+					default: false,
+					hidden: true,
 				} );
 		},
 		handler: async ( argv ) => {
 			try {
-				await runCommand( argv.path, argv.importFile, argv.startServer );
+				await runCommand( argv.path, argv.importFile, argv.startServer, argv.suppressTracksEvent );
 			} catch ( error ) {
 				if ( error instanceof LoggerError ) {
 					logger.reportError( error );

--- a/apps/cli/commands/import.ts
+++ b/apps/cli/commands/import.ts
@@ -51,7 +51,9 @@ async function setupWordPressFilesOnly( sitePath: string ): Promise< void > {
 		throw new LoggerError(
 			__(
 				'Cannot set up WordPress. Bundled WordPress files not found. Please connect to the internet or reinstall Studio.'
-			)
+			),
+			undefined,
+			'bundled_wp_missing'
 		);
 	}
 
@@ -136,7 +138,8 @@ export function handleImportEvents( emitter: ImportExportEventEmitter ): void {
 	emitter.on( ValidatorEvents.IMPORT_VALIDATION_ERROR, ( error ) => {
 		throw new LoggerError(
 			__( 'Backup validation failed' ),
-			error instanceof Error ? error : undefined
+			error instanceof Error ? error : undefined,
+			'validation'
 		);
 	} );
 
@@ -175,7 +178,8 @@ export function handleImportEvents( emitter: ImportExportEventEmitter ): void {
 	emitter.on( BackupExtractEvents.BACKUP_EXTRACT_ERROR, ( error ) => {
 		throw new LoggerError(
 			__( 'Failed to extract backup' ),
-			error instanceof Error ? error : undefined
+			error instanceof Error ? error : undefined,
+			'extract'
 		);
 	} );
 
@@ -252,9 +256,8 @@ export function handleImportEvents( emitter: ImportExportEventEmitter ): void {
 		logger.reportSuccess( __( 'Site imported successfully' ) );
 	} );
 
-	emitter.on( ImporterEvents.IMPORT_ERROR, ( error ) => {
-		throw new LoggerError( __( 'Import failed' ), new Error( error ) );
-	} );
+	// No IMPORT_ERROR handler: every emitter rethrows the original error right after emitting, and
+	// that error carries the failure `code` for analytics — a wrap here would discard it.
 }
 
 export async function runCommand(
@@ -280,7 +283,11 @@ export async function runCommand(
 		logger.reportSuccess( __( 'Site loaded' ) );
 
 		if ( ! fs.existsSync( importFile ) ) {
-			throw new LoggerError( sprintf( __( 'Import file not found: %s' ), importFile ) );
+			throw new LoggerError(
+				sprintf( __( 'Import file not found: %s' ), importFile ),
+				undefined,
+				'file_not_found'
+			);
 		}
 
 		wasServerRunning = !! ( await isServerRunning( site.id ) );
@@ -349,7 +356,7 @@ export async function runCommand(
 	}
 
 	// Record before the LoggerError merge below — merging the restart error into `previousError`
-	// would corrupt the failure classification, which reads the import error's message.
+	// would corrupt the failure classification, which walks the import error's chain.
 	if ( ! suppressTracksEvent ) {
 		await recordSiteImportEvent(
 			importError === undefined

--- a/apps/cli/commands/pull.ts
+++ b/apps/cli/commands/pull.ts
@@ -223,7 +223,13 @@ export async function runCommand(
 		}
 	}
 
-	if ( pullError instanceof LoggerError && restartSiteError instanceof Error ) {
+	// Attach the restart error only when the pull error has no cause of its own — overwriting an
+	// existing `previousError` would hide the root cause behind the (secondary) restart failure.
+	if (
+		pullError instanceof LoggerError &&
+		restartSiteError instanceof Error &&
+		! pullError.previousError
+	) {
 		pullError.previousError = restartSiteError;
 	}
 

--- a/apps/cli/commands/tests/export.test.ts
+++ b/apps/cli/commands/tests/export.test.ts
@@ -7,6 +7,7 @@ import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
 import { ImportExportEventEmitter } from 'cli/lib/import-export/events';
 import { getExporter } from 'cli/lib/import-export/export/export-manager';
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
+import { recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { Logger, LoggerError } from 'cli/logger';
 import { registerCommand, runCommand } from '../export';
 import type { SiteData } from 'cli/lib/cli-config/core';
@@ -31,6 +32,10 @@ vi.mock( 'cli/lib/sqlite-integration' );
 vi.mock( import( 'cli/lib/import-export/export/export-manager' ), () => ( {
 	getExporter: vi.fn(),
 } ) );
+vi.mock( 'cli/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('cli/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
 
 describe( 'CLI: studio export', () => {
 	const testSitePath = '/test/site';
@@ -166,6 +171,79 @@ describe( 'CLI: studio export', () => {
 			} )
 		);
 		expect( reportErrorSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'records a success Tracks event with the export mode', async () => {
+		await runCommand( testSitePath, testExportPath );
+
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			TRACKS_EVENTS.SITE_EXPORT,
+			expect.objectContaining( {
+				success: true,
+				export_type: 'full',
+				time_ms: expect.any( Number ),
+				channel: 'studio-cli',
+			} )
+		);
+		expect( vi.mocked( recordTracksEvent ).mock.calls[ 0 ][ 1 ] ).not.toHaveProperty(
+			'failure_reason'
+		);
+	} );
+
+	it( 'reports the requested mode as export_type', async () => {
+		await runCommand( testSitePath, testExportPath, 'db' );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			TRACKS_EVENTS.SITE_EXPORT,
+			expect.objectContaining( { success: true, export_type: 'db' } )
+		);
+	} );
+
+	it( 'records a failure Tracks event when no exporter is found', async () => {
+		vi.mocked( getExporter ).mockResolvedValue( null as never );
+
+		await expect( runCommand( testSitePath, testExportPath ) ).rejects.toThrow(
+			'No suitable exporter'
+		);
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			TRACKS_EVENTS.SITE_EXPORT,
+			expect.objectContaining( {
+				success: false,
+				export_type: 'full',
+				failure_reason: 'no_exporter_found',
+				time_ms: expect.any( Number ),
+			} )
+		);
+	} );
+
+	it( 'records a failure Tracks event when the exporter fails', async () => {
+		vi.mocked( getExporter ).mockResolvedValue(
+			createExporter( async () => {
+				throw new Error( 'Database export failed' );
+			} ) as never
+		);
+
+		await expect( runCommand( testSitePath, testExportPath ) ).rejects.toThrow(
+			'Database export failed'
+		);
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			TRACKS_EVENTS.SITE_EXPORT,
+			expect.objectContaining( { success: false, failure_reason: 'database_export' } )
+		);
+	} );
+
+	it( 'does not record a Tracks event when suppressed', async () => {
+		await runCommand( testSitePath, testExportPath, 'full', false, undefined, false, true );
+
+		vi.mocked( getExporter ).mockResolvedValue( null as never );
+		await expect(
+			runCommand( testSitePath, testExportPath, 'full', false, undefined, false, true )
+		).rejects.toThrow( 'No suitable exporter' );
+
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'rejects .sql exports with --mode full', async () => {

--- a/apps/cli/commands/tests/export.test.ts
+++ b/apps/cli/commands/tests/export.test.ts
@@ -221,7 +221,7 @@ describe( 'CLI: studio export', () => {
 	it( 'records a failure Tracks event when the exporter fails', async () => {
 		vi.mocked( getExporter ).mockResolvedValue(
 			createExporter( async () => {
-				throw new Error( 'Database export failed' );
+				throw new LoggerError( 'Database export failed', undefined, 'database_export' );
 			} ) as never
 		);
 

--- a/apps/cli/commands/tests/import.test.ts
+++ b/apps/cli/commands/tests/import.test.ts
@@ -10,6 +10,7 @@ import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
 import { ImportExportEventEmitter } from 'cli/lib/import-export/events';
 import { DEFAULT_IMPORTER_OPTIONS, getImporter } from 'cli/lib/import-export/import/import-manager';
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
+import { recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
 import { runCommand } from '../import';
@@ -39,6 +40,10 @@ vi.mock( '@studio/common/lib/fs-utils', () => ( {
 	isWordPressDirectory: vi.fn(),
 	recursiveCopyDirectory: vi.fn(),
 } ) );
+vi.mock( 'cli/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('cli/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
 
 describe( 'CLI: studio import', () => {
 	const testSitePath = '/test/site';
@@ -191,5 +196,105 @@ describe( 'CLI: studio import', () => {
 
 		await expect( runCommand( testSitePath, testImportPath ) ).rejects.toThrow( 'import failed' );
 		expect( stopWordPressServer ).toHaveBeenCalledWith( testSite.id );
+	} );
+
+	it( 'records a success Tracks event with the importer type', async () => {
+		const importer = createImporter( async () => {
+			importer.emit( ImporterEvents.IMPORT_START, 'jetpack' );
+			return importResult;
+		} );
+		vi.mocked( getImporter ).mockReturnValue( importer as never );
+
+		await runCommand( testSitePath, testImportPath );
+
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			TRACKS_EVENTS.SITE_IMPORT,
+			expect.objectContaining( {
+				success: true,
+				importer_type: 'jetpack',
+				time_ms: expect.any( Number ),
+				channel: 'studio-cli',
+			} )
+		);
+		expect( vi.mocked( recordTracksEvent ).mock.calls[ 0 ][ 1 ] ).not.toHaveProperty(
+			'failure_reason'
+		);
+	} );
+
+	it( 'records a failure Tracks event when no importer was selected', async () => {
+		vi.mocked( getImporter ).mockImplementation( () => {
+			throw new Error( 'No suitable importer found for the provided backup contents' );
+		} );
+
+		await expect( runCommand( testSitePath, testImportPath ) ).rejects.toThrow(
+			'No suitable importer'
+		);
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			TRACKS_EVENTS.SITE_IMPORT,
+			expect.objectContaining( {
+				success: false,
+				importer_type: 'unknown',
+				failure_reason: 'no_importer_found',
+				time_ms: expect.any( Number ),
+			} )
+		);
+	} );
+
+	it( 'records the importer type on failures after the import started', async () => {
+		const importer = createImporter( async () => {
+			importer.emit( ImporterEvents.IMPORT_START, 'sql' );
+			throw new Error( 'Database import failed: unexpected token' );
+		} );
+		vi.mocked( getImporter ).mockReturnValue( importer as never );
+
+		await expect( runCommand( testSitePath, testImportPath ) ).rejects.toThrow(
+			'Database import failed'
+		);
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			TRACKS_EVENTS.SITE_IMPORT,
+			expect.objectContaining( {
+				success: false,
+				importer_type: 'sql',
+				failure_reason: 'database_import',
+			} )
+		);
+	} );
+
+	it( 'records a single Tracks event classified from the import error when restore steps also fail', async () => {
+		vi.mocked( isServerRunning ).mockResolvedValue( { pid: 1234 } as never );
+		vi.mocked( getImporter ).mockReturnValue(
+			createImporter( async () => {
+				throw new Error( 'Backup validation failed' );
+			} ) as never
+		);
+		vi.mocked( keepSqliteIntegrationUpdated ).mockRejectedValue( new Error( 'restart failed' ) );
+
+		await expect( runCommand( testSitePath, testImportPath ) ).rejects.toThrow(
+			'Backup validation failed'
+		);
+
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			TRACKS_EVENTS.SITE_IMPORT,
+			expect.objectContaining( { success: false, failure_reason: 'validation' } )
+		);
+	} );
+
+	it( 'does not record a Tracks event when suppressed', async () => {
+		await runCommand( testSitePath, testImportPath, false, true );
+
+		vi.mocked( getImporter ).mockReturnValue(
+			createImporter( async () => {
+				throw new Error( 'import failed' );
+			} ) as never
+		);
+		await expect( runCommand( testSitePath, testImportPath, false, true ) ).rejects.toThrow(
+			'import failed'
+		);
+
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
 } );

--- a/apps/cli/commands/tests/import.test.ts
+++ b/apps/cli/commands/tests/import.test.ts
@@ -275,19 +275,19 @@ describe( 'CLI: studio import', () => {
 		vi.mocked( isServerRunning ).mockResolvedValue( { pid: 1234 } as never );
 		vi.mocked( getImporter ).mockReturnValue(
 			createImporter( async () => {
-				throw new LoggerError( 'Backup validation failed', undefined, 'validation' );
+				throw new LoggerError( 'Database import failed: x', undefined, 'database_import' );
 			} ) as never
 		);
 		vi.mocked( keepSqliteIntegrationUpdated ).mockRejectedValue( new Error( 'restart failed' ) );
 
 		await expect( runCommand( testSitePath, testImportPath ) ).rejects.toThrow(
-			'Backup validation failed'
+			'Database import failed'
 		);
 
 		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			TRACKS_EVENTS.SITE_IMPORT,
-			expect.objectContaining( { success: false, failure_reason: 'validation' } )
+			expect.objectContaining( { success: false, failure_reason: 'database_import' } )
 		);
 	} );
 

--- a/apps/cli/commands/tests/import.test.ts
+++ b/apps/cli/commands/tests/import.test.ts
@@ -198,6 +198,24 @@ describe( 'CLI: studio import', () => {
 		expect( stopWordPressServer ).toHaveBeenCalledWith( testSite.id );
 	} );
 
+	it( 'keeps the import error cause when restore steps also fail', async () => {
+		vi.mocked( isServerRunning ).mockResolvedValue( { pid: 1234 } as never );
+		vi.mocked( getImporter ).mockReturnValue(
+			createImporter( async () => {
+				throw new LoggerError(
+					'Failed to extract backup',
+					new Error( 'unexpected end of file' ),
+					'extract'
+				);
+			} ) as never
+		);
+		vi.mocked( keepSqliteIntegrationUpdated ).mockRejectedValue( new Error( 'restart failed' ) );
+
+		await expect( runCommand( testSitePath, testImportPath ) ).rejects.toThrow(
+			'Failed to extract backup: unexpected end of file'
+		);
+	} );
+
 	it( 'records a success Tracks event with the importer type', async () => {
 		const importer = createImporter( async () => {
 			importer.emit( ImporterEvents.IMPORT_START, 'jetpack' );

--- a/apps/cli/commands/tests/import.test.ts
+++ b/apps/cli/commands/tests/import.test.ts
@@ -224,7 +224,11 @@ describe( 'CLI: studio import', () => {
 
 	it( 'records a failure Tracks event when no importer was selected', async () => {
 		vi.mocked( getImporter ).mockImplementation( () => {
-			throw new Error( 'No suitable importer found for the provided backup contents' );
+			throw new LoggerError(
+				'No suitable importer found for the provided backup contents',
+				undefined,
+				'no_importer_found'
+			);
 		} );
 
 		await expect( runCommand( testSitePath, testImportPath ) ).rejects.toThrow(
@@ -245,7 +249,11 @@ describe( 'CLI: studio import', () => {
 	it( 'records the importer type on failures after the import started', async () => {
 		const importer = createImporter( async () => {
 			importer.emit( ImporterEvents.IMPORT_START, 'sql' );
-			throw new Error( 'Database import failed: unexpected token' );
+			throw new LoggerError(
+				'Database import failed: unexpected token',
+				undefined,
+				'database_import'
+			);
 		} );
 		vi.mocked( getImporter ).mockReturnValue( importer as never );
 
@@ -267,7 +275,7 @@ describe( 'CLI: studio import', () => {
 		vi.mocked( isServerRunning ).mockResolvedValue( { pid: 1234 } as never );
 		vi.mocked( getImporter ).mockReturnValue(
 			createImporter( async () => {
-				throw new Error( 'Backup validation failed' );
+				throw new LoggerError( 'Backup validation failed', undefined, 'validation' );
 			} ) as never
 		);
 		vi.mocked( keepSqliteIntegrationUpdated ).mockRejectedValue( new Error( 'restart failed' ) );

--- a/apps/cli/lib/import-export/export/export-database.ts
+++ b/apps/cli/lib/import-export/export/export-database.ts
@@ -5,6 +5,7 @@ import { parseJsonFromPhpOutput } from '@studio/common/lib/php-output-parser';
 import { __, sprintf } from '@wordpress/i18n';
 import { move } from 'fs-extra';
 import { runWpCliCommand } from 'cli/lib/run-wp-cli-command';
+import { LoggerError } from 'cli/logger';
 import type { SiteData } from 'cli/lib/cli-config/core';
 
 export async function exportDatabaseToFile(
@@ -26,7 +27,7 @@ export async function exportDatabaseToFile(
 
 	const exitCode = await command.response.exitCode;
 	if ( exitCode !== 0 ) {
-		throw new Error( __( 'Database export failed' ) );
+		throw new LoggerError( __( 'Database export failed' ), undefined, 'database_export' );
 	}
 
 	// Move the file to its final destination
@@ -57,7 +58,7 @@ export async function exportDatabaseToMultipleFiles(
 	const tablesStdout = await command.response.stdoutText;
 	const exitCode = await command.response.exitCode;
 	if ( exitCode !== 0 ) {
-		throw new Error( __( 'Database export failed' ) );
+		throw new LoggerError( __( 'Database export failed' ), undefined, 'database_export' );
 	}
 
 	let tables;
@@ -68,7 +69,11 @@ export async function exportDatabaseToMultipleFiles(
 		console.error(
 			sprintf( __( 'Could not get list of database tables. The WP CLI output: %s' ), tablesStdout )
 		);
-		throw new Error( __( 'Could not get list of database tables to export.' ) );
+		throw new LoggerError(
+			__( 'Could not get list of database tables to export.' ),
+			undefined,
+			'database_export'
+		);
 	}
 
 	const tmpFiles: string[] = [];
@@ -101,7 +106,11 @@ export async function exportDatabaseToMultipleFiles(
 
 		const exitCode = await command.response.exitCode;
 		if ( exitCode !== 0 ) {
-			throw new Error( sprintf( __( 'Database export failed for table %s' ), table ) );
+			throw new LoggerError(
+				sprintf( __( 'Database export failed for table %s' ), table ),
+				undefined,
+				'database_export'
+			);
 		}
 
 		// Move the file to its final destination

--- a/apps/cli/lib/import-export/export/exporters/default-exporter.ts
+++ b/apps/cli/lib/import-export/export/exporters/default-exporter.ts
@@ -22,6 +22,7 @@ import { getSiteUrl } from 'cli/lib/cli-config/sites';
 import { getWordPressVersionFromInstallation } from 'cli/lib/dependency-management/wordpress';
 import { runWpCliCommand } from 'cli/lib/run-wp-cli-command';
 import { ensureSqliteIntegrationForImportedSite } from 'cli/lib/sqlite-integration';
+import { LoggerError } from 'cli/logger';
 import { ImportExportEventEmitter } from '../../events';
 import { exportDatabaseToFile, exportDatabaseToMultipleFiles } from '../export-database';
 import {
@@ -374,7 +375,11 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 		const stdout = await command.response.stdoutText;
 
 		if ( exitCode !== 0 ) {
-			throw new Error( sprintf( __( 'Failed to get site plugins: %s' ), stderr ) );
+			throw new LoggerError(
+				sprintf( __( 'Failed to get site plugins: %s' ), stderr ),
+				undefined,
+				'site_meta'
+			);
 		}
 
 		try {
@@ -388,8 +393,10 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 				);
 			}
 
-			throw new Error(
-				__( 'Could not parse information about installed plugins to create meta.json file.' )
+			throw new LoggerError(
+				__( 'Could not parse information about installed plugins to create meta.json file.' ),
+				undefined,
+				'site_meta'
 			);
 		}
 	}
@@ -413,7 +420,11 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 		const stdout = await command.response.stdoutText;
 
 		if ( exitCode !== 0 ) {
-			throw new Error( sprintf( __( 'Failed to get site themes: %s' ), stderr ) );
+			throw new LoggerError(
+				sprintf( __( 'Failed to get site themes: %s' ), stderr ),
+				undefined,
+				'site_meta'
+			);
 		}
 
 		try {
@@ -427,8 +438,10 @@ export class DefaultExporter extends ImportExportEventEmitter implements Exporte
 				);
 			}
 
-			throw new Error(
-				__( 'Could not parse information about installed themes to create meta.json file.' )
+			throw new LoggerError(
+				__( 'Could not parse information about installed themes to create meta.json file.' ),
+				undefined,
+				'site_meta'
 			);
 		}
 	}

--- a/apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts
+++ b/apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { ImportEvents } from '@studio/common/lib/import-export-events';
 import { __, sprintf } from '@wordpress/i18n';
 import * as fse from 'fs-extra';
+import { LoggerError } from 'cli/logger';
 import { ImportExportEventEmitter } from '../../events';
 import { BackupArchiveInfo } from '../types';
 import { BackupHandler } from './backup-handler-factory';
@@ -183,8 +184,10 @@ export class BackupHandlerWpress extends ImportExportEventEmitter implements Bac
 		try {
 			await fs.promises.access( file.path, constants.F_OK );
 		} catch ( error ) {
-			throw new Error(
-				sprintf( __( 'Input file at location "%s" could not be found.' ), file.path )
+			throw new LoggerError(
+				sprintf( __( 'Input file at location "%s" could not be found.' ), file.path ),
+				undefined,
+				'file_not_found'
 			);
 		}
 
@@ -221,8 +224,10 @@ export class BackupHandlerWpress extends ImportExportEventEmitter implements Bac
 		try {
 			await fs.promises.access( file.path, constants.F_OK );
 		} catch ( error ) {
-			throw new Error(
-				sprintf( __( 'Input file at location "%s" could not be found.' ), file.path )
+			throw new LoggerError(
+				sprintf( __( 'Input file at location "%s" could not be found.' ), file.path ),
+				undefined,
+				'file_not_found'
 			);
 		}
 

--- a/apps/cli/lib/import-export/import/import-manager.ts
+++ b/apps/cli/lib/import-export/import/import-manager.ts
@@ -8,6 +8,7 @@ import {
 } from '@studio/common/lib/import-export-events';
 import { __ } from '@wordpress/i18n';
 import { SiteData } from 'cli/lib/cli-config/core';
+import { LoggerError } from 'cli/logger';
 import { ImportExportEventEmitter } from '../events';
 import { BackupHandlerFactory } from './handlers/backup-handler-factory';
 import {
@@ -60,7 +61,11 @@ class BackupImporter extends ImportExportEventEmitter implements Importer {
 	async import( site: SiteData ): Promise< ImporterResult > {
 		const backupHandler = BackupHandlerFactory.create( this.backupFile );
 		if ( ! backupHandler ) {
-			throw new Error( __( 'No suitable backup handler found for the provided backup file' ) );
+			throw new LoggerError(
+				__( 'No suitable backup handler found for the provided backup file' ),
+				undefined,
+				'no_backup_handler'
+			);
 		}
 
 		const extractionDirectory = await fs.promises.mkdtemp(
@@ -73,7 +78,11 @@ class BackupImporter extends ImportExportEventEmitter implements Importer {
 			const importer = selectImporter( fileList, extractionDirectory, this.importerOptions );
 
 			if ( ! importer ) {
-				throw new Error( __( 'No suitable importer found for the provided backup contents' ) );
+				throw new LoggerError(
+					__( 'No suitable importer found for the provided backup contents' ),
+					undefined,
+					'no_importer_found'
+				);
 			}
 			this.emit( ValidatorEvents.IMPORT_VALIDATION_COMPLETE );
 

--- a/apps/cli/lib/import-export/import/import-manager.ts
+++ b/apps/cli/lib/import-export/import/import-manager.ts
@@ -94,7 +94,18 @@ class BackupImporter extends ImportExportEventEmitter implements Importer {
 				importer.on( eventName, ( data ) => this.emit( eventName, data ) );
 			}
 
-			await backupHandler.extractFiles( this.backupFile, extractionDirectory );
+			try {
+				await backupHandler.extractFiles( this.backupFile, extractionDirectory );
+			} catch ( error ) {
+				// Tag extraction failures for analytics at the single funnel every backup handler
+				// passes through, so the `extract` code is attached in both IPC and logger modes.
+				// Errors that already carry a code (e.g. the wpress handler's `file_not_found`)
+				// keep their more specific one.
+				if ( error instanceof LoggerError && error.code ) {
+					throw error;
+				}
+				throw new LoggerError( __( 'Failed to extract backup' ), error, 'extract' );
+			}
 
 			const result = await importer.import( site );
 

--- a/apps/cli/lib/import-export/import/importers/importer.ts
+++ b/apps/cli/lib/import-export/import/importers/importer.ts
@@ -20,6 +20,7 @@ import { SiteData } from 'cli/lib/cli-config/core';
 import { ensureWpConfig } from 'cli/lib/native-php/site-setup';
 import { runWpCliCommand } from 'cli/lib/run-wp-cli-command';
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
+import { LoggerError } from 'cli/logger';
 import { ImportExportEventEmitter } from '../../events';
 import { BackupContents, MetaFileData } from '../types';
 import { updateSiteUrl } from '../update-site-url';
@@ -134,7 +135,11 @@ abstract class BaseImporter extends ImportExportEventEmitter implements Importer
 				}
 
 				if ( exitCode !== 0 ) {
-					throw new Error( sprintf( __( 'Database import failed: %s' ), stderr ) );
+					throw new LoggerError(
+						sprintf( __( 'Database import failed: %s' ), stderr ),
+						undefined,
+						'database_import'
+					);
 				}
 			} finally {
 				await this.safelyDeletePath( tmpPath );

--- a/apps/cli/lib/import-export/import/importers/wxr-importer.ts
+++ b/apps/cli/lib/import-export/import/importers/wxr-importer.ts
@@ -9,6 +9,7 @@ import {
 	getBundledWxrImportScriptPath,
 } from 'cli/lib/dependency-management/paths';
 import { runWpCliCommand } from 'cli/lib/run-wp-cli-command';
+import { LoggerError } from 'cli/logger';
 import { ImportExportEventEmitter } from '../../events';
 import { BackupContents } from '../types';
 import { ensureDir, Importer, ImporterResult } from './importer';
@@ -37,7 +38,11 @@ export class WxrImporter extends ImportExportEventEmitter implements Importer {
 
 		const wxrFile = this.backup.wxrFiles?.[ 0 ];
 		if ( ! wxrFile ) {
-			const error = new Error( __( 'No WordPress export (.xml) file found to import.' ) );
+			const error = new LoggerError(
+				__( 'No WordPress export (.xml) file found to import.' ),
+				undefined,
+				'wxr_import'
+			);
 			this.emit( ImportEvents.IMPORT_ERROR, error.message );
 			throw error;
 		}
@@ -82,7 +87,11 @@ export class WxrImporter extends ImportExportEventEmitter implements Importer {
 				console.error( __( 'Error during WordPress export import:' ), stderr );
 			}
 			if ( exitCode !== 0 ) {
-				throw new Error( sprintf( __( 'WordPress export import failed: %s' ), stderr ) );
+				throw new LoggerError(
+					sprintf( __( 'WordPress export import failed: %s' ), stderr ),
+					undefined,
+					'wxr_import'
+				);
 			}
 
 			this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );

--- a/apps/cli/lib/import-export/import/tests/import-manager.test.ts
+++ b/apps/cli/lib/import-export/import/tests/import-manager.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect } from 'vitest';
-import { DEFAULT_IMPORTER_OPTIONS } from '../import-manager';
+import { describe, it, expect, vi } from 'vitest';
+import { LoggerError } from 'cli/logger';
+import { ImportExportEventEmitter } from '../../events';
+import { BackupHandlerFactory } from '../handlers/backup-handler-factory';
+import { DEFAULT_IMPORTER_OPTIONS, getImporter } from '../import-manager';
 import { WxrImporter } from '../importers/wxr-importer';
+import type { SiteData } from 'cli/lib/cli-config/core';
+
+vi.mock( '../handlers/backup-handler-factory', () => ( {
+	BackupHandlerFactory: { create: vi.fn() },
+} ) );
 
 // Mirrors the private `selectImporter` logic: the first validator whose
 // `canHandle` returns true wins.
@@ -20,5 +28,53 @@ describe( 'DEFAULT_IMPORTER_OPTIONS', () => {
 
 	it( 'does not select the WxrImporter for a .sql file', () => {
 		expect( selectImporterClass( [ 'backup.sql' ] ) ).not.toBe( WxrImporter );
+	} );
+} );
+
+describe( 'BackupImporter extraction failures', () => {
+	const site = { id: 'site-1', path: '/test/site' } as SiteData;
+
+	class MockBackupHandler extends ImportExportEventEmitter {
+		constructor( private extractError: Error ) {
+			super();
+		}
+		listFiles = vi.fn( async () => [ 'backup.sql' ] );
+		extractFiles = vi.fn( async () => {
+			throw this.extractError;
+		} );
+	}
+
+	function importerWithExtractError( extractError: Error ) {
+		vi.mocked( BackupHandlerFactory.create ).mockReturnValue(
+			new MockBackupHandler( extractError ) as never
+		);
+		return getImporter(
+			{ path: '/tmp/backup.zip', type: 'application/zip' },
+			DEFAULT_IMPORTER_OPTIONS
+		);
+	}
+
+	it( 'wraps extraction failures in a LoggerError coded extract', async () => {
+		const command = importerWithExtractError( new Error( 'unexpected end of file' ) ).import(
+			site
+		);
+
+		await expect( command ).rejects.toThrow( LoggerError );
+		await expect( command ).rejects.toMatchObject( {
+			code: 'extract',
+			message: 'Failed to extract backup: unexpected end of file',
+		} );
+	} );
+
+	it( 'keeps a more specific code already carried by the extraction error', async () => {
+		const command = importerWithExtractError(
+			new LoggerError(
+				'Input file at location "/tmp/backup.zip" could not be found.',
+				undefined,
+				'file_not_found'
+			)
+		).import( site );
+
+		await expect( command ).rejects.toMatchObject( { code: 'file_not_found' } );
 	} );
 } );

--- a/apps/cli/lib/tests/utils.test.ts
+++ b/apps/cli/lib/tests/utils.test.ts
@@ -7,17 +7,6 @@ import {
 } from 'cli/lib/utils';
 import { LoggerError } from 'cli/logger';
 
-// The failure classifiers translate their known msgids at match time so they work against
-// localized error messages. This map lets individual tests install fake "translations".
-const translations: Record< string, string > = {};
-vi.mock( '@wordpress/i18n', async ( importActual ) => {
-	const actual = await importActual< typeof import('@wordpress/i18n') >();
-	return {
-		...actual,
-		__: ( text: string ) => translations[ text ] ?? text,
-	};
-} );
-
 describe( 'normalizeHostname', () => {
 	it( 'should normalize a basic hostname', () => {
 		expect( normalizeHostname( 'example.com' ) ).toBe( 'example.com' );
@@ -104,86 +93,95 @@ describe( 'getPrettyPath', () => {
 
 describe( 'classifyImportFailure', () => {
 	it.each( [
-		[
-			'Cannot set up WordPress. Bundled WordPress files not found. Please connect to the internet or reinstall Studio.',
-			'bundled_wp_missing',
-		],
-		[ 'Import file not found: /tmp/backup.zip', 'file_not_found' ],
-		[ 'Input file at location "/tmp/backup.wpress" could not be found.', 'file_not_found' ],
-		[ 'No suitable backup handler found for the provided backup file', 'no_backup_handler' ],
-		[ 'No suitable importer found for the provided backup contents', 'no_importer_found' ],
-		[ 'Backup validation failed', 'validation' ],
-		[ 'Error: absolute path: /wp-content/index.php', 'invalid_zip' ],
-		[ 'Failed to extract backup', 'extract' ],
-		[ 'Database import failed: unexpected token', 'database_import' ],
-		[ 'WordPress export import failed: wp-cli stderr output', 'wxr_import' ],
-		[ 'ENOSPC: no space left on device', 'disk_full' ],
-		[ 'Database import failed: ENOSPC: no space left on device', 'disk_full' ],
-		[ 'Something else entirely', 'unknown' ],
-	] )( 'classifies %j as %s', ( message, expected ) => {
-		expect( classifyImportFailure( new Error( message ) ) ).toBe( expected );
+		[ 'bundled_wp_missing' ],
+		[ 'file_not_found' ],
+		[ 'no_backup_handler' ],
+		[ 'no_importer_found' ],
+		[ 'validation' ],
+		[ 'extract' ],
+		[ 'database_import' ],
+		[ 'wxr_import' ],
+	] )( 'returns the %s code carried by a LoggerError', ( code ) => {
+		expect( classifyImportFailure( new LoggerError( 'display text', undefined, code ) ) ).toBe(
+			code
+		);
 	} );
 
-	it( 'classifies the inner error of a LoggerError wrapper', () => {
-		const error = new LoggerError( 'Import failed', new Error( 'Database import failed: x' ) );
+	it( 'is locale-independent — classifies by code, not by the translated message', () => {
+		const error = new LoggerError(
+			'Datenbankimport fehlgeschlagen: FEHLER 123',
+			undefined,
+			'database_import'
+		);
 		expect( classifyImportFailure( error ) ).toBe( 'database_import' );
 	} );
 
-	it( 'classifies localized error messages', () => {
-		translations[ 'Database import failed: %s' ] = 'Datenbankimport fehlgeschlagen: %s';
-		translations[ 'No suitable importer found for the provided backup contents' ] =
-			'Kein passender Importer für die bereitgestellten Backup-Inhalte gefunden';
-		try {
-			expect(
-				classifyImportFailure( new Error( 'Datenbankimport fehlgeschlagen: FEHLER 123' ) )
-			).toBe( 'database_import' );
-			expect(
-				classifyImportFailure(
-					new Error( 'Kein passender Importer für die bereitgestellten Backup-Inhalte gefunden' )
-				)
-			).toBe( 'no_importer_found' );
-			// The English text no longer matches once a translation is active — same as at the
-			// throw site, which produces the translated message.
-			expect( classifyImportFailure( new Error( 'Database import failed: x' ) ) ).toBe( 'unknown' );
-		} finally {
-			delete translations[ 'Database import failed: %s' ];
-			delete translations[ 'No suitable importer found for the provided backup contents' ];
-		}
+	it( 'walks the previousError chain for a code', () => {
+		const error = new LoggerError(
+			'Failed to import site',
+			new LoggerError( 'Database import failed: x', undefined, 'database_import' )
+		);
+		expect( classifyImportFailure( error ) ).toBe( 'database_import' );
 	} );
 
-	it( 'handles non-Error input', () => {
-		expect(
-			classifyImportFailure( 'No suitable importer found for the provided backup contents' )
-		).toBe( 'no_importer_found' );
+	it.each( [
+		[ 'ENOSPC: no space left on device', 'disk_full' ],
+		[ 'Error: absolute path: /wp-content/index.php', 'invalid_zip' ],
+	] )( 'classifies untranslated system error %j as %s', ( message, expected ) => {
+		expect( classifyImportFailure( new Error( message ) ) ).toBe( expected );
+	} );
+
+	it( 'prefers disk_full over a coded wrapper when the chain contains ENOSPC', () => {
+		const error = new LoggerError(
+			'Failed to extract backup',
+			new Error( 'ENOSPC: no space left on device' ),
+			'extract'
+		);
+		expect( classifyImportFailure( error ) ).toBe( 'disk_full' );
+	} );
+
+	it( 'falls back to unknown', () => {
+		expect( classifyImportFailure( new Error( 'Something else entirely' ) ) ).toBe( 'unknown' );
+		expect( classifyImportFailure( new LoggerError( 'Uncoded logger error' ) ) ).toBe( 'unknown' );
 		expect( classifyImportFailure( undefined ) ).toBe( 'unknown' );
 	} );
 } );
 
 describe( 'classifyExportFailure', () => {
-	it.each( [
-		[ 'No suitable exporter found for the provided backup file', 'no_exporter_found' ],
-		[ 'Database export failed', 'database_export' ],
-		[ 'Database export failed for table wp_posts', 'database_export' ],
-		[ 'Could not get list of database tables to export.', 'database_export' ],
-		[ 'Failed to get site plugins: wp-cli stderr output', 'site_meta' ],
-		[ 'Failed to get site themes: wp-cli stderr output', 'site_meta' ],
-		[
-			'Could not parse information about installed plugins to create meta.json file.',
-			'site_meta',
-		],
-		[ 'ENOSPC: no space left on device', 'disk_full' ],
-		[ 'ENOSPC: no space left on device, write meta.json', 'disk_full' ],
-		[ 'Something else entirely', 'unknown' ],
-	] )( 'classifies %j as %s', ( message, expected ) => {
-		expect( classifyExportFailure( new Error( message ) ) ).toBe( expected );
+	it.each( [ [ 'no_exporter_found' ], [ 'database_export' ], [ 'site_meta' ] ] )(
+		'returns the %s code carried by a LoggerError',
+		( code ) => {
+			expect( classifyExportFailure( new LoggerError( 'display text', undefined, code ) ) ).toBe(
+				code
+			);
+		}
+	);
+
+	it( 'classifies untranslated ENOSPC errors as disk_full, winning over a coded wrapper', () => {
+		expect( classifyExportFailure( new Error( 'ENOSPC: no space left on device' ) ) ).toBe(
+			'disk_full'
+		);
+		expect(
+			classifyExportFailure(
+				new LoggerError(
+					'Database export failed',
+					new Error( 'ENOSPC: no space left on device' ),
+					'database_export'
+				)
+			)
+		).toBe( 'disk_full' );
 	} );
 
-	it( 'classifies the inner error of a LoggerError wrapper', () => {
-		const error = new LoggerError( 'Export failed', new Error( 'Database export failed' ) );
-		expect( classifyExportFailure( error ) ).toBe( 'database_export' );
-	} );
-
-	it( 'handles non-Error input', () => {
+	it( 'falls back to unknown', () => {
+		expect( classifyExportFailure( new Error( 'Something else entirely' ) ) ).toBe( 'unknown' );
 		expect( classifyExportFailure( undefined ) ).toBe( 'unknown' );
+	} );
+
+	it( 'walks the previousError chain for a code', () => {
+		const error = new LoggerError(
+			'Failed to export site',
+			new LoggerError( 'Database export failed', undefined, 'database_export' )
+		);
+		expect( classifyExportFailure( error ) ).toBe( 'database_export' );
 	} );
 } );

--- a/apps/cli/lib/tests/utils.test.ts
+++ b/apps/cli/lib/tests/utils.test.ts
@@ -7,6 +7,17 @@ import {
 } from 'cli/lib/utils';
 import { LoggerError } from 'cli/logger';
 
+// The failure classifiers translate their known msgids at match time so they work against
+// localized error messages. This map lets individual tests install fake "translations".
+const translations: Record< string, string > = {};
+vi.mock( '@wordpress/i18n', async ( importActual ) => {
+	const actual = await importActual< typeof import('@wordpress/i18n') >();
+	return {
+		...actual,
+		__: ( text: string ) => translations[ text ] ?? text,
+	};
+} );
+
 describe( 'normalizeHostname', () => {
 	it( 'should normalize a basic hostname', () => {
 		expect( normalizeHostname( 'example.com' ) ).toBe( 'example.com' );
@@ -105,7 +116,7 @@ describe( 'classifyImportFailure', () => {
 		[ 'Error: absolute path: /wp-content/index.php', 'invalid_zip' ],
 		[ 'Failed to extract backup', 'extract' ],
 		[ 'Database import failed: unexpected token', 'database_import' ],
-		[ 'WordPress export import failed', 'wxr_import' ],
+		[ 'WordPress export import failed: wp-cli stderr output', 'wxr_import' ],
 		[ 'ENOSPC: no space left on device', 'disk_full' ],
 		[ 'Database import failed: ENOSPC: no space left on device', 'disk_full' ],
 		[ 'Something else entirely', 'unknown' ],
@@ -118,8 +129,32 @@ describe( 'classifyImportFailure', () => {
 		expect( classifyImportFailure( error ) ).toBe( 'database_import' );
 	} );
 
+	it( 'classifies localized error messages', () => {
+		translations[ 'Database import failed: %s' ] = 'Datenbankimport fehlgeschlagen: %s';
+		translations[ 'No suitable importer found for the provided backup contents' ] =
+			'Kein passender Importer für die bereitgestellten Backup-Inhalte gefunden';
+		try {
+			expect(
+				classifyImportFailure( new Error( 'Datenbankimport fehlgeschlagen: FEHLER 123' ) )
+			).toBe( 'database_import' );
+			expect(
+				classifyImportFailure(
+					new Error( 'Kein passender Importer für die bereitgestellten Backup-Inhalte gefunden' )
+				)
+			).toBe( 'no_importer_found' );
+			// The English text no longer matches once a translation is active — same as at the
+			// throw site, which produces the translated message.
+			expect( classifyImportFailure( new Error( 'Database import failed: x' ) ) ).toBe( 'unknown' );
+		} finally {
+			delete translations[ 'Database import failed: %s' ];
+			delete translations[ 'No suitable importer found for the provided backup contents' ];
+		}
+	} );
+
 	it( 'handles non-Error input', () => {
-		expect( classifyImportFailure( 'no suitable importer available' ) ).toBe( 'no_importer_found' );
+		expect(
+			classifyImportFailure( 'No suitable importer found for the provided backup contents' )
+		).toBe( 'no_importer_found' );
 		expect( classifyImportFailure( undefined ) ).toBe( 'unknown' );
 	} );
 } );
@@ -128,10 +163,14 @@ describe( 'classifyExportFailure', () => {
 	it.each( [
 		[ 'No suitable exporter found for the provided backup file', 'no_exporter_found' ],
 		[ 'Database export failed', 'database_export' ],
-		[ 'Failed to get database tables to export', 'database_export' ],
-		[ 'Failed to get site plugins', 'site_meta' ],
-		[ 'Failed to get site themes', 'site_meta' ],
-		[ 'Could not write meta.json', 'site_meta' ],
+		[ 'Database export failed for table wp_posts', 'database_export' ],
+		[ 'Could not get list of database tables to export.', 'database_export' ],
+		[ 'Failed to get site plugins: wp-cli stderr output', 'site_meta' ],
+		[ 'Failed to get site themes: wp-cli stderr output', 'site_meta' ],
+		[
+			'Could not parse information about installed plugins to create meta.json file.',
+			'site_meta',
+		],
 		[ 'ENOSPC: no space left on device', 'disk_full' ],
 		[ 'ENOSPC: no space left on device, write meta.json', 'disk_full' ],
 		[ 'Something else entirely', 'unknown' ],

--- a/apps/cli/lib/tests/utils.test.ts
+++ b/apps/cli/lib/tests/utils.test.ts
@@ -1,5 +1,11 @@
 import os from 'node:os';
-import { getPrettyPath, normalizeHostname } from 'cli/lib/utils';
+import {
+	classifyExportFailure,
+	classifyImportFailure,
+	getPrettyPath,
+	normalizeHostname,
+} from 'cli/lib/utils';
+import { LoggerError } from 'cli/logger';
 
 describe( 'normalizeHostname', () => {
 	it( 'should normalize a basic hostname', () => {
@@ -82,5 +88,61 @@ describe( 'getPrettyPath', () => {
 		expect( getPrettyPath( 'C:\\Users\\george\\Studio\\index.php' ) ).toBe(
 			'C:\\Users\\george\\Studio\\index.php'
 		);
+	} );
+} );
+
+describe( 'classifyImportFailure', () => {
+	it.each( [
+		[
+			'Cannot set up WordPress. Bundled WordPress files not found. Please connect to the internet or reinstall Studio.',
+			'bundled_wp_missing',
+		],
+		[ 'Import file not found: /tmp/backup.zip', 'file_not_found' ],
+		[ 'Input file at location "/tmp/backup.wpress" could not be found.', 'file_not_found' ],
+		[ 'No suitable backup handler found for the provided backup file', 'no_backup_handler' ],
+		[ 'No suitable importer found for the provided backup contents', 'no_importer_found' ],
+		[ 'Backup validation failed', 'validation' ],
+		[ 'Error: absolute path: /wp-content/index.php', 'invalid_zip' ],
+		[ 'Failed to extract backup', 'extract' ],
+		[ 'Database import failed: unexpected token', 'database_import' ],
+		[ 'WordPress export import failed', 'wxr_import' ],
+		[ 'ENOSPC: no space left on device', 'disk_full' ],
+		[ 'Something else entirely', 'unknown' ],
+	] )( 'classifies %j as %s', ( message, expected ) => {
+		expect( classifyImportFailure( new Error( message ) ) ).toBe( expected );
+	} );
+
+	it( 'classifies the inner error of a LoggerError wrapper', () => {
+		const error = new LoggerError( 'Import failed', new Error( 'Database import failed: x' ) );
+		expect( classifyImportFailure( error ) ).toBe( 'database_import' );
+	} );
+
+	it( 'handles non-Error input', () => {
+		expect( classifyImportFailure( 'no suitable importer available' ) ).toBe( 'no_importer_found' );
+		expect( classifyImportFailure( undefined ) ).toBe( 'unknown' );
+	} );
+} );
+
+describe( 'classifyExportFailure', () => {
+	it.each( [
+		[ 'No suitable exporter found for the provided backup file', 'no_exporter_found' ],
+		[ 'Database export failed', 'database_export' ],
+		[ 'Failed to get database tables to export', 'database_export' ],
+		[ 'Failed to get site plugins', 'site_meta' ],
+		[ 'Failed to get site themes', 'site_meta' ],
+		[ 'Could not write meta.json', 'site_meta' ],
+		[ 'ENOSPC: no space left on device', 'disk_full' ],
+		[ 'Something else entirely', 'unknown' ],
+	] )( 'classifies %j as %s', ( message, expected ) => {
+		expect( classifyExportFailure( new Error( message ) ) ).toBe( expected );
+	} );
+
+	it( 'classifies the inner error of a LoggerError wrapper', () => {
+		const error = new LoggerError( 'Export failed', new Error( 'Database export failed' ) );
+		expect( classifyExportFailure( error ) ).toBe( 'database_export' );
+	} );
+
+	it( 'handles non-Error input', () => {
+		expect( classifyExportFailure( undefined ) ).toBe( 'unknown' );
 	} );
 } );

--- a/apps/cli/lib/tests/utils.test.ts
+++ b/apps/cli/lib/tests/utils.test.ts
@@ -107,6 +107,7 @@ describe( 'classifyImportFailure', () => {
 		[ 'Database import failed: unexpected token', 'database_import' ],
 		[ 'WordPress export import failed', 'wxr_import' ],
 		[ 'ENOSPC: no space left on device', 'disk_full' ],
+		[ 'Database import failed: ENOSPC: no space left on device', 'disk_full' ],
 		[ 'Something else entirely', 'unknown' ],
 	] )( 'classifies %j as %s', ( message, expected ) => {
 		expect( classifyImportFailure( new Error( message ) ) ).toBe( expected );
@@ -132,6 +133,7 @@ describe( 'classifyExportFailure', () => {
 		[ 'Failed to get site themes', 'site_meta' ],
 		[ 'Could not write meta.json', 'site_meta' ],
 		[ 'ENOSPC: no space left on device', 'disk_full' ],
+		[ 'ENOSPC: no space left on device, write meta.json', 'disk_full' ],
 		[ 'Something else entirely', 'unknown' ],
 	] )( 'classifies %j as %s', ( message, expected ) => {
 		expect( classifyExportFailure( new Error( message ) ) ).toBe( expected );

--- a/apps/cli/lib/tests/utils.test.ts
+++ b/apps/cli/lib/tests/utils.test.ts
@@ -97,7 +97,6 @@ describe( 'classifyImportFailure', () => {
 		[ 'file_not_found' ],
 		[ 'no_backup_handler' ],
 		[ 'no_importer_found' ],
-		[ 'validation' ],
 		[ 'extract' ],
 		[ 'database_import' ],
 		[ 'wxr_import' ],

--- a/apps/cli/lib/utils.ts
+++ b/apps/cli/lib/utils.ts
@@ -40,6 +40,10 @@ export function classifyPreviewFailure( error: unknown ): string {
 export function classifyImportFailure( error: unknown ): string {
 	const message = error instanceof Error ? error.message : String( error );
 	const normalized = message.toLowerCase();
+	// Checked first so a disk-full error during any phase wins over the phase's own bucket.
+	if ( normalized.includes( 'enospc' ) || normalized.includes( 'no space left' ) ) {
+		return 'disk_full';
+	}
 	// Must precede the `file_not_found` check — this message also contains "not found".
 	if ( normalized.includes( 'bundled wordpress files not found' ) ) {
 		return 'bundled_wp_missing';
@@ -68,9 +72,6 @@ export function classifyImportFailure( error: unknown ): string {
 	if ( normalized.includes( 'wordpress export import failed' ) ) {
 		return 'wxr_import';
 	}
-	if ( normalized.includes( 'enospc' ) || normalized.includes( 'no space left' ) ) {
-		return 'disk_full';
-	}
 	return 'unknown';
 }
 
@@ -78,6 +79,10 @@ export function classifyImportFailure( error: unknown ): string {
 export function classifyExportFailure( error: unknown ): string {
 	const message = error instanceof Error ? error.message : String( error );
 	const normalized = message.toLowerCase();
+	// Checked first so a disk-full error during any phase wins over the phase's own bucket.
+	if ( normalized.includes( 'enospc' ) || normalized.includes( 'no space left' ) ) {
+		return 'disk_full';
+	}
 	if ( normalized.includes( 'no suitable exporter' ) ) {
 		return 'no_exporter_found';
 	}
@@ -93,9 +98,6 @@ export function classifyExportFailure( error: unknown ): string {
 		normalized.includes( 'meta.json' )
 	) {
 		return 'site_meta';
-	}
-	if ( normalized.includes( 'enospc' ) || normalized.includes( 'no space left' ) ) {
-		return 'disk_full';
 	}
 	return 'unknown';
 }

--- a/apps/cli/lib/utils.ts
+++ b/apps/cli/lib/utils.ts
@@ -33,52 +33,26 @@ export function classifyPreviewFailure( error: unknown ): string {
 	return 'unknown';
 }
 
-// Import/export failure buckets for the `failure_reason` Tracks prop, keyed by the exact msgid used
-// at the throw site. These errors are thrown with `__()`-built messages in this same process, so
-// translating the msgid at classification time reproduces the exact localized string — matching
-// works regardless of the active locale (and falls back to English when no translation is loaded).
-// Ordered: the first matching msgid wins.
-const IMPORT_FAILURE_BUCKETS: Array< [ string, string ] > = [
-	[
-		'Cannot set up WordPress. Bundled WordPress files not found. Please connect to the internet or reinstall Studio.',
-		'bundled_wp_missing',
-	],
-	[ 'Import file not found: %s', 'file_not_found' ],
-	[ 'Input file at location "%s" could not be found.', 'file_not_found' ],
-	[ 'No suitable backup handler found for the provided backup file', 'no_backup_handler' ],
-	[ 'No suitable importer found for the provided backup contents', 'no_importer_found' ],
-	[ 'Backup validation failed', 'validation' ],
-	[ 'Failed to extract backup', 'extract' ],
-	[ 'Database import failed: %s', 'database_import' ],
-	[ 'WordPress export import failed: %s', 'wxr_import' ],
-];
-
-const EXPORT_FAILURE_BUCKETS: Array< [ string, string ] > = [
-	[ 'No suitable exporter found for the provided backup file', 'no_exporter_found' ],
-	[ 'Database export failed', 'database_export' ],
-	[ 'Database export failed for table %s', 'database_export' ],
-	[ 'Could not get list of database tables to export.', 'database_export' ],
-	[ 'Failed to get site plugins: %s', 'site_meta' ],
-	[ 'Failed to get site themes: %s', 'site_meta' ],
-	[ 'Could not parse information about installed plugins to create meta.json file.', 'site_meta' ],
-	[ 'Could not parse information about installed themes to create meta.json file.', 'site_meta' ],
-];
-
-// Translates the msgid, strips sprintf placeholders, and requires every remaining static chunk to
-// appear in the message. Chunk-based matching keeps this order-independent, so translations that
-// move the placeholder around still match.
-function matchesTranslatedMessage( normalizedMessage: string, msgid: string ): boolean {
-	const chunks = __( msgid )
-		.toLowerCase()
-		.split( /%(?:\d+\$)?[sd]/ )
-		.map( ( chunk ) => chunk.trim() )
-		.filter( ( chunk ) => chunk.length > 2 );
-	return chunks.length > 0 && chunks.every( ( chunk ) => normalizedMessage.includes( chunk ) );
+// The known import/export failure points throw `LoggerError`s tagged with a machine-readable
+// `code`, which these classifiers return as the `failure_reason` Tracks prop. Classifying on the
+// code rather than the message keeps this locale-independent — messages are `__()`-translated
+// display text. Walks the `previousError` chain so a code survives generic wrapping.
+function findFailureCode( error: unknown ): string | undefined {
+	let current: unknown = error;
+	while ( current instanceof LoggerError ) {
+		if ( current.code ) {
+			return current.code;
+		}
+		current = current.previousError;
+	}
+	return undefined;
 }
 
-function classifyFailureMessage(
+// System/library errors carry no code and are never translated, so they are matched by substring
+// on the full message chain — checked before the code walk so a disk-full error during any phase
+// wins over the phase's own bucket. Never send the raw message: it carries filesystem paths.
+function classifyFailure(
 	error: unknown,
-	buckets: Array< [ string, string ] >,
 	untranslatedBuckets: Array< [ string[], string ] >
 ): string {
 	const message = error instanceof Error ? error.message : String( error );
@@ -88,22 +62,12 @@ function classifyFailureMessage(
 			return bucket;
 		}
 	}
-	for ( const [ msgid, bucket ] of buckets ) {
-		if ( matchesTranslatedMessage( normalized, msgid ) ) {
-			return bucket;
-		}
-	}
-	return 'unknown';
+	return findFailureCode( error ) ?? 'unknown';
 }
 
-// Coarse classification of a site import failure for the `failure_reason` Tracks prop. Same
-// constraints as `classifyPreviewFailure`: never send the raw message (carries file paths).
-// In standalone-logger mode errors arrive as `LoggerError` wrappers whose `.message` getter
-// appends the inner error's message, so inner-message matching still works. System/library
-// errors (ENOSPC, unzipper) are never translated and are matched first, so a disk-full error
-// during any phase wins over the phase's own bucket.
+// Coarse classification of a site import failure for the `failure_reason` Tracks prop.
 export function classifyImportFailure( error: unknown ): string {
-	return classifyFailureMessage( error, IMPORT_FAILURE_BUCKETS, [
+	return classifyFailure( error, [
 		[ [ 'enospc', 'no space left' ], 'disk_full' ],
 		[ [ 'absolute path' ], 'invalid_zip' ],
 	] );
@@ -111,9 +75,7 @@ export function classifyImportFailure( error: unknown ): string {
 
 // Coarse classification of a site export failure for the `failure_reason` Tracks prop.
 export function classifyExportFailure( error: unknown ): string {
-	return classifyFailureMessage( error, EXPORT_FAILURE_BUCKETS, [
-		[ [ 'enospc', 'no space left' ], 'disk_full' ],
-	] );
+	return classifyFailure( error, [ [ [ 'enospc', 'no space left' ], 'disk_full' ] ] );
 }
 
 export function normalizeHostname( hostname: string ): string {

--- a/apps/cli/lib/utils.ts
+++ b/apps/cli/lib/utils.ts
@@ -33,73 +33,87 @@ export function classifyPreviewFailure( error: unknown ): string {
 	return 'unknown';
 }
 
-// Coarse classification of a site import failure for the `failure_reason` Tracks prop. Same
-// constraints as `classifyPreviewFailure`: never send the raw message (carries file paths).
-// In standalone-logger mode errors arrive as `LoggerError` wrappers whose `.message` getter
-// appends the inner error's message, so inner-message substrings still match.
-export function classifyImportFailure( error: unknown ): string {
+// Import/export failure buckets for the `failure_reason` Tracks prop, keyed by the exact msgid used
+// at the throw site. These errors are thrown with `__()`-built messages in this same process, so
+// translating the msgid at classification time reproduces the exact localized string — matching
+// works regardless of the active locale (and falls back to English when no translation is loaded).
+// Ordered: the first matching msgid wins.
+const IMPORT_FAILURE_BUCKETS: Array< [ string, string ] > = [
+	[
+		'Cannot set up WordPress. Bundled WordPress files not found. Please connect to the internet or reinstall Studio.',
+		'bundled_wp_missing',
+	],
+	[ 'Import file not found: %s', 'file_not_found' ],
+	[ 'Input file at location "%s" could not be found.', 'file_not_found' ],
+	[ 'No suitable backup handler found for the provided backup file', 'no_backup_handler' ],
+	[ 'No suitable importer found for the provided backup contents', 'no_importer_found' ],
+	[ 'Backup validation failed', 'validation' ],
+	[ 'Failed to extract backup', 'extract' ],
+	[ 'Database import failed: %s', 'database_import' ],
+	[ 'WordPress export import failed: %s', 'wxr_import' ],
+];
+
+const EXPORT_FAILURE_BUCKETS: Array< [ string, string ] > = [
+	[ 'No suitable exporter found for the provided backup file', 'no_exporter_found' ],
+	[ 'Database export failed', 'database_export' ],
+	[ 'Database export failed for table %s', 'database_export' ],
+	[ 'Could not get list of database tables to export.', 'database_export' ],
+	[ 'Failed to get site plugins: %s', 'site_meta' ],
+	[ 'Failed to get site themes: %s', 'site_meta' ],
+	[ 'Could not parse information about installed plugins to create meta.json file.', 'site_meta' ],
+	[ 'Could not parse information about installed themes to create meta.json file.', 'site_meta' ],
+];
+
+// Translates the msgid, strips sprintf placeholders, and requires every remaining static chunk to
+// appear in the message. Chunk-based matching keeps this order-independent, so translations that
+// move the placeholder around still match.
+function matchesTranslatedMessage( normalizedMessage: string, msgid: string ): boolean {
+	const chunks = __( msgid )
+		.toLowerCase()
+		.split( /%(?:\d+\$)?[sd]/ )
+		.map( ( chunk ) => chunk.trim() )
+		.filter( ( chunk ) => chunk.length > 2 );
+	return chunks.length > 0 && chunks.every( ( chunk ) => normalizedMessage.includes( chunk ) );
+}
+
+function classifyFailureMessage(
+	error: unknown,
+	buckets: Array< [ string, string ] >,
+	untranslatedBuckets: Array< [ string[], string ] >
+): string {
 	const message = error instanceof Error ? error.message : String( error );
 	const normalized = message.toLowerCase();
-	// Checked first so a disk-full error during any phase wins over the phase's own bucket.
-	if ( normalized.includes( 'enospc' ) || normalized.includes( 'no space left' ) ) {
-		return 'disk_full';
+	for ( const [ substrings, bucket ] of untranslatedBuckets ) {
+		if ( substrings.some( ( substring ) => normalized.includes( substring ) ) ) {
+			return bucket;
+		}
 	}
-	// Must precede the `file_not_found` check — this message also contains "not found".
-	if ( normalized.includes( 'bundled wordpress files not found' ) ) {
-		return 'bundled_wp_missing';
-	}
-	if ( normalized.includes( 'not found' ) || normalized.includes( 'could not be found' ) ) {
-		return 'file_not_found';
-	}
-	if ( normalized.includes( 'no suitable backup handler' ) ) {
-		return 'no_backup_handler';
-	}
-	if ( normalized.includes( 'no suitable importer' ) ) {
-		return 'no_importer_found';
-	}
-	if ( normalized.includes( 'backup validation failed' ) ) {
-		return 'validation';
-	}
-	if ( normalized.includes( 'absolute path' ) ) {
-		return 'invalid_zip';
-	}
-	if ( normalized.includes( 'failed to extract' ) ) {
-		return 'extract';
-	}
-	if ( normalized.includes( 'database import failed' ) ) {
-		return 'database_import';
-	}
-	if ( normalized.includes( 'wordpress export import failed' ) ) {
-		return 'wxr_import';
+	for ( const [ msgid, bucket ] of buckets ) {
+		if ( matchesTranslatedMessage( normalized, msgid ) ) {
+			return bucket;
+		}
 	}
 	return 'unknown';
 }
 
+// Coarse classification of a site import failure for the `failure_reason` Tracks prop. Same
+// constraints as `classifyPreviewFailure`: never send the raw message (carries file paths).
+// In standalone-logger mode errors arrive as `LoggerError` wrappers whose `.message` getter
+// appends the inner error's message, so inner-message matching still works. System/library
+// errors (ENOSPC, unzipper) are never translated and are matched first, so a disk-full error
+// during any phase wins over the phase's own bucket.
+export function classifyImportFailure( error: unknown ): string {
+	return classifyFailureMessage( error, IMPORT_FAILURE_BUCKETS, [
+		[ [ 'enospc', 'no space left' ], 'disk_full' ],
+		[ [ 'absolute path' ], 'invalid_zip' ],
+	] );
+}
+
 // Coarse classification of a site export failure for the `failure_reason` Tracks prop.
 export function classifyExportFailure( error: unknown ): string {
-	const message = error instanceof Error ? error.message : String( error );
-	const normalized = message.toLowerCase();
-	// Checked first so a disk-full error during any phase wins over the phase's own bucket.
-	if ( normalized.includes( 'enospc' ) || normalized.includes( 'no space left' ) ) {
-		return 'disk_full';
-	}
-	if ( normalized.includes( 'no suitable exporter' ) ) {
-		return 'no_exporter_found';
-	}
-	if (
-		normalized.includes( 'database export failed' ) ||
-		normalized.includes( 'database tables to export' )
-	) {
-		return 'database_export';
-	}
-	if (
-		normalized.includes( 'failed to get site plugins' ) ||
-		normalized.includes( 'failed to get site themes' ) ||
-		normalized.includes( 'meta.json' )
-	) {
-		return 'site_meta';
-	}
-	return 'unknown';
+	return classifyFailureMessage( error, EXPORT_FAILURE_BUCKETS, [
+		[ [ 'enospc', 'no space left' ], 'disk_full' ],
+	] );
 }
 
 export function normalizeHostname( hostname: string ): string {

--- a/apps/cli/lib/utils.ts
+++ b/apps/cli/lib/utils.ts
@@ -33,6 +33,73 @@ export function classifyPreviewFailure( error: unknown ): string {
 	return 'unknown';
 }
 
+// Coarse classification of a site import failure for the `failure_reason` Tracks prop. Same
+// constraints as `classifyPreviewFailure`: never send the raw message (carries file paths).
+// In standalone-logger mode errors arrive as `LoggerError` wrappers whose `.message` getter
+// appends the inner error's message, so inner-message substrings still match.
+export function classifyImportFailure( error: unknown ): string {
+	const message = error instanceof Error ? error.message : String( error );
+	const normalized = message.toLowerCase();
+	// Must precede the `file_not_found` check — this message also contains "not found".
+	if ( normalized.includes( 'bundled wordpress files not found' ) ) {
+		return 'bundled_wp_missing';
+	}
+	if ( normalized.includes( 'not found' ) || normalized.includes( 'could not be found' ) ) {
+		return 'file_not_found';
+	}
+	if ( normalized.includes( 'no suitable backup handler' ) ) {
+		return 'no_backup_handler';
+	}
+	if ( normalized.includes( 'no suitable importer' ) ) {
+		return 'no_importer_found';
+	}
+	if ( normalized.includes( 'backup validation failed' ) ) {
+		return 'validation';
+	}
+	if ( normalized.includes( 'absolute path' ) ) {
+		return 'invalid_zip';
+	}
+	if ( normalized.includes( 'failed to extract' ) ) {
+		return 'extract';
+	}
+	if ( normalized.includes( 'database import failed' ) ) {
+		return 'database_import';
+	}
+	if ( normalized.includes( 'wordpress export import failed' ) ) {
+		return 'wxr_import';
+	}
+	if ( normalized.includes( 'enospc' ) || normalized.includes( 'no space left' ) ) {
+		return 'disk_full';
+	}
+	return 'unknown';
+}
+
+// Coarse classification of a site export failure for the `failure_reason` Tracks prop.
+export function classifyExportFailure( error: unknown ): string {
+	const message = error instanceof Error ? error.message : String( error );
+	const normalized = message.toLowerCase();
+	if ( normalized.includes( 'no suitable exporter' ) ) {
+		return 'no_exporter_found';
+	}
+	if (
+		normalized.includes( 'database export failed' ) ||
+		normalized.includes( 'database tables to export' )
+	) {
+		return 'database_export';
+	}
+	if (
+		normalized.includes( 'failed to get site plugins' ) ||
+		normalized.includes( 'failed to get site themes' ) ||
+		normalized.includes( 'meta.json' )
+	) {
+		return 'site_meta';
+	}
+	if ( normalized.includes( 'enospc' ) || normalized.includes( 'no space left' ) ) {
+		return 'disk_full';
+	}
+	return 'unknown';
+}
+
 export function normalizeHostname( hostname: string ): string {
 	return hostname
 		.trim()

--- a/apps/cli/logger.ts
+++ b/apps/cli/logger.ts
@@ -24,12 +24,16 @@ function canSend(): boolean {
 
 export class LoggerError extends Error {
 	previousError?: Error;
+	// Machine-readable failure code for analytics classification (see `classifyImportFailure` /
+	// `classifyExportFailure`). The message is `__()`-translated display text and unsafe to match on.
+	readonly code?: string;
 	private errorMessage: string;
 
-	constructor( message: string, previousError?: unknown ) {
+	constructor( message: string, previousError?: unknown, code?: string ) {
 		super();
 		this.name = 'LoggerError';
 		this.errorMessage = message;
+		this.code = code;
 
 		if ( previousError instanceof Error ) {
 			this.previousError = previousError;

--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -891,7 +891,16 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 			try {
 				await new Promise< void >( ( resolve, reject ) => {
 					const [ emitter ] = execute(
-						[ 'import', '--path', site.path, upload.path, '--start-server' ],
+						// Onboarding imports are part of the add-site flow, which `studio_site_imported`
+						// deliberately does not count.
+						[
+							'import',
+							'--path',
+							site.path,
+							upload.path,
+							'--start-server',
+							'--suppress-tracks-event',
+						],
 						{ output: 'capture' }
 					);
 					emitter.on( 'data', ( { data } ) => {

--- a/apps/studio/src/hooks/use-import-export.tsx
+++ b/apps/studio/src/hooks/use-import-export.tsx
@@ -126,6 +126,9 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				await getIpcApi().importSite( selectedSite.id, filePath, {
 					alwaysStartServer: true,
 					showNotification: showImportNotification,
+					// `studio_site_imported` means a user-initiated import into an existing site —
+					// add-site-flow imports are not counted.
+					suppressTracksEvent: isNewSite,
 				} );
 			} catch ( error ) {
 				// The main process handles displaying the error modal, so we don't need any explicit error

--- a/apps/studio/src/modules/cli/lib/execute-export-command.ts
+++ b/apps/studio/src/modules/cli/lib/execute-export-command.ts
@@ -21,7 +21,10 @@ export function executeExportCliCommand(
 		abortSignal?: AbortSignal;
 	} = {}
 ): ExportCliLifecycleEventEmitter {
-	const [ cliEventEmitter, childProcess ] = executeCliCommand( args, { output: 'capture' } );
+	const [ cliEventEmitter, childProcess ] = executeCliCommand( args, {
+		output: 'capture',
+		logPrefix: siteId,
+	} );
 	const lifecycleEventEmitter = new TypedEventEmitter< ExportCliLifecycleEventMap >();
 	let structuredExportError: unknown;
 	let didEmitFinalLifecycleEvent = false;

--- a/apps/studio/src/modules/cli/lib/execute-import-command.ts
+++ b/apps/studio/src/modules/cli/lib/execute-import-command.ts
@@ -23,7 +23,7 @@ export function executeImportCliCommand(
 	args: string[],
 	parentWindow: Electron.BrowserWindow | null
 ): ImportCliLifecycleEventEmitter {
-	const [ cliEventEmitter ] = executeCliCommand( args, { output: 'capture' } );
+	const [ cliEventEmitter ] = executeCliCommand( args, { output: 'capture', logPrefix: siteId } );
 	const lifecycleEventEmitter = new TypedEventEmitter< ImportCliLifecycleEventMap >();
 	let importerType: ImporterType | undefined;
 	let structuredImportError: unknown;

--- a/apps/studio/src/modules/import-export/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/import-export/lib/ipc-handlers.ts
@@ -108,6 +108,7 @@ type ImportOptions = {
 	removeBackupOnComplete?: boolean;
 	showErrorModal?: boolean;
 	showNotification?: boolean;
+	suppressTracksEvent?: boolean;
 };
 
 export async function importSite(
@@ -126,6 +127,7 @@ export async function importSite(
 		removeBackupOnComplete = false,
 		showErrorModal = true,
 		showNotification = true,
+		suppressTracksEvent = false,
 	} = options;
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
@@ -133,6 +135,10 @@ export async function importSite(
 
 	if ( alwaysStartServer ) {
 		args.push( '--start-server' );
+	}
+
+	if ( suppressTracksEvent ) {
+		args.push( '--suppress-tracks-event' );
 	}
 
 	const eventEmitter = executeImportCliCommand( site.details.id, args, parentWindow );
@@ -201,6 +207,7 @@ type ExportOptions = {
 	specificSelectionPaths?: string[];
 	applyDeployIgnore?: boolean;
 	abortSignal?: AbortSignal;
+	suppressTracksEvent?: boolean;
 };
 
 export async function exportSite(
@@ -223,6 +230,7 @@ export async function exportSite(
 		specificSelectionPaths = [],
 		applyDeployIgnore = false,
 		abortSignal,
+		suppressTracksEvent = false,
 	} = options;
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
@@ -230,6 +238,10 @@ export async function exportSite(
 
 	if ( splitDatabaseDumpByTable ) {
 		args.push( '--split-db-dump-by-table' );
+	}
+
+	if ( suppressTracksEvent ) {
+		args.push( '--suppress-tracks-event' );
 	}
 
 	if ( applyDeployIgnore ) {

--- a/apps/studio/src/modules/sync/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/sync/lib/ipc-handlers.ts
@@ -202,6 +202,8 @@ export async function exportSiteForPush(
 			specificSelectionPaths: configuration?.specificSelectionPaths,
 			applyDeployIgnore: true,
 			abortSignal: abortController.signal,
+			// `studio_site_exported` means a user-initiated backup export — sync pushes are not counted.
+			suppressTracksEvent: true,
 		} );
 
 		if ( abortController.signal.aborted ) {

--- a/apps/studio/src/stores/sync/sync-operations-slice.ts
+++ b/apps/studio/src/stores/sync/sync-operations-slice.ts
@@ -969,6 +969,7 @@ const pollPullBackupThunk = createTypedAsyncThunk(
 					removeBackupOnComplete: true,
 					showErrorModal: false,
 					showNotification: false,
+					suppressTracksEvent: true,
 				} );
 
 				// The import runs locally and is intentionally not aborted on logout, but if the

--- a/apps/ui/src/data/core/connectors/import-contracts.test.ts
+++ b/apps/ui/src/data/core/connectors/import-contracts.test.ts
@@ -23,6 +23,7 @@ describe( 'import connector contracts', () => {
 			alwaysStartServer: true,
 			showErrorModal: false,
 			showNotification: false,
+			suppressTracksEvent: true,
 		} );
 	} );
 

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -397,6 +397,9 @@ export function createIpcConnector(): Connector {
 					alwaysStartServer: true,
 					showErrorModal: false,
 					showNotification: false,
+					// Onboarding imports are part of the add-site flow, which `studio_site_imported`
+					// deliberately does not count.
+					suppressTracksEvent: true,
 				} );
 			} finally {
 				unsubscribe?.();

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -243,8 +243,8 @@ emits what"). No file names or paths are ever sent. `failure_reason` is coarse a
 
 | Event | Emitted from | Event-specific props |
 |---|---|---|
-| `studio_site_imported` | CLI `import` | `success` (boolean), `importer_type` (`jetpack`/`local`/`playground`/`sql`/`wpress`/`xml`, or `unknown` when the failure occurred before an importer started), `time_ms` (total command duration, incl. the server restart). On failure also `failure_reason` (`file_not_found`/`no_backup_handler`/`no_importer_found`/`validation`/`invalid_zip`/`extract`/`database_import`/`wxr_import`/`bundled_wp_missing`/`disk_full`/`unknown`). |
-| `studio_site_exported` | CLI `export` | `success` (boolean), `export_type` (`full`/`db` — the `--mode` flag; the sync-only `content` mode never emits because sync pushes are suppressed), `time_ms` (export duration). On failure also `failure_reason` (`no_exporter_found`/`database_export`/`site_meta`/`disk_full`/`unknown`). |
+| `studio_site_imported` | CLI `import` | `success` (boolean), `importer_type` (`jetpack`/`local`/`playground`/`sql`/`wpress`/`xml`, or `unknown` when the failure occurred before an importer started), `time_ms` (total command duration, incl. the server restart). On failure also `failure_reason` (`disk_full`/`file_not_found`/`no_backup_handler`/`no_importer_found`/`validation`/`invalid_zip`/`extract`/`database_import`/`wxr_import`/`bundled_wp_missing`/`unknown`). |
+| `studio_site_exported` | CLI `export` | `success` (boolean), `export_type` (`full`/`content`/`db` — the `--mode` flag; sync pushes are suppressed, so in practice `content` appears only from standalone `studio export --mode content` runs), `time_ms` (export duration). On failure also `failure_reason` (`disk_full`/`no_exporter_found`/`database_export`/`site_meta`/`unknown`). |
 
 #### Preview site events
 

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -238,8 +238,10 @@ Backup import/export, emitted by the **CLI** `import`/`export` commands (the sol
 and agentic UI delegate to the CLI, so standalone-CLI usage is counted too; filter by `channel`). Both
 events mean a **user-initiated** backup operation: add-site-flow imports, sync-pull imports, and
 sync-push exports suppress the event via a hidden `--suppress-tracks-event` flag (see "Which surface
-emits what"). No file names or paths are ever sent. `failure_reason` is coarse and low-cardinality
-(the raw error is never sent — it can carry filesystem paths).
+emits what"). No file names or paths are ever sent. `failure_reason` is coarse and low-cardinality:
+the known failure points throw `LoggerError`s tagged with a machine-readable `code`, which the
+classifier returns directly — the raw, `__()`-translated error message is never sent or matched on
+(it can carry filesystem paths, and its text varies by locale).
 
 | Event | Emitted from | Event-specific props |
 |---|---|---|

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -126,6 +126,16 @@ where the sender actually runs — see Testing below for what fires in which bui
   standalone — `channel`/`ui_version` resolve from `STUDIO_TRACKS_ORIGIN` exactly as for
   `studio_site_start`. The **`studio_preview_site_open`** event is the exception: opening a preview URL is
   a renderer-only affordance with no CLI equivalent, so it fires from the renderer.
+- **`studio_site_imported`/`studio_site_exported`** are emitted **only** by the CLI, from the `import`
+  and `export` commands (`apps/cli/commands/import.ts`, `apps/cli/commands/export.ts`). The desktop
+  Import/Export tab, the agentic UI's export buttons, and standalone-CLI runs all funnel there —
+  `channel`/`ui_version` resolve from `STUDIO_TRACKS_ORIGIN` exactly as for `studio_site_start`. The
+  events deliberately mean **a user imported/exported a backup**: paths that reuse the same CLI
+  commands as an implementation detail — add-site-flow imports (Classic add-site, agentic onboarding
+  import, browser-UI import route), sync-pull imports, and sync-push exports — pass a hidden
+  `--suppress-tracks-event` flag and emit nothing. An aborted sync export also emits nothing (the CLI
+  process is SIGTERM'd before it can record). Runs in parallel with the MC Stats import/export
+  counters for now.
 - **Renderer-originated events** (future) go through the `recordAnalyticsEvent` IPC handler
   (`apps/studio/src/ipc-handlers.ts`). Both renderers share the same Main single entry point, and the
   desktop wrapper's `commonProps()` attaches `channel`/`ui_version` centrally — the `ui_version` is
@@ -221,6 +231,20 @@ enumerated prop values below.
 | `studio_site_open_phpmyadmin` | Renderer (Classic + agentic) | `browser` (`external`/`internal`) |
 | `studio_site_open_folder` | Renderer (Classic + agentic) | (none — opens the OS file manager) |
 | `studio_panel_opened` | Renderer (Classic tab strip + agentic route navigation) | `panel` — the panel opened. Classic: `overview`/`sync`/`settings`/`assistant`/`import-export`/`previews` (only on a genuine user tab switch, not programmatic changes or re-selecting the current tab). Agentic: `overview`/`settings`/`debugging`/`assistant` (`sync`/`import-export`/`previews` are Classic-only). |
+
+#### Import/export events
+
+Backup import/export, emitted by the **CLI** `import`/`export` commands (the sole funnel — the desktop
+and agentic UI delegate to the CLI, so standalone-CLI usage is counted too; filter by `channel`). Both
+events mean a **user-initiated** backup operation: add-site-flow imports, sync-pull imports, and
+sync-push exports suppress the event via a hidden `--suppress-tracks-event` flag (see "Which surface
+emits what"). No file names or paths are ever sent. `failure_reason` is coarse and low-cardinality
+(the raw error is never sent — it can carry filesystem paths).
+
+| Event | Emitted from | Event-specific props |
+|---|---|---|
+| `studio_site_imported` | CLI `import` | `success` (boolean), `importer_type` (`jetpack`/`local`/`playground`/`sql`/`wpress`/`xml`, or `unknown` when the failure occurred before an importer started), `time_ms` (total command duration, incl. the server restart). On failure also `failure_reason` (`file_not_found`/`no_backup_handler`/`no_importer_found`/`validation`/`invalid_zip`/`extract`/`database_import`/`wxr_import`/`bundled_wp_missing`/`disk_full`/`unknown`). |
+| `studio_site_exported` | CLI `export` | `success` (boolean), `export_type` (`full`/`db` — the `--mode` flag; the sync-only `content` mode never emits because sync pushes are suppressed), `time_ms` (export duration). On failure also `failure_reason` (`no_exporter_found`/`database_export`/`site_meta`/`disk_full`/`unknown`). |
 
 #### Preview site events
 

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -245,7 +245,7 @@ classifier returns directly — the raw, `__()`-translated error message is neve
 
 | Event | Emitted from | Event-specific props |
 |---|---|---|
-| `studio_site_imported` | CLI `import` | `success` (boolean), `importer_type` (`jetpack`/`local`/`playground`/`sql`/`wpress`/`xml`, or `unknown` when the failure occurred before an importer started), `time_ms` (total command duration, incl. the server restart). On failure also `failure_reason` (`disk_full`/`file_not_found`/`no_backup_handler`/`no_importer_found`/`validation`/`invalid_zip`/`extract`/`database_import`/`wxr_import`/`bundled_wp_missing`/`unknown`). |
+| `studio_site_imported` | CLI `import` | `success` (boolean), `importer_type` (`jetpack`/`local`/`playground`/`sql`/`wpress`/`xml`, or `unknown` when the failure occurred before an importer started), `time_ms` (total command duration, incl. the server restart). On failure also `failure_reason` (`disk_full`/`file_not_found`/`no_backup_handler`/`no_importer_found`/`invalid_zip`/`extract`/`database_import`/`wxr_import`/`bundled_wp_missing`/`unknown`). |
 | `studio_site_exported` | CLI `export` | `success` (boolean), `export_type` (`full`/`content`/`db` — the `--mode` flag; sync pushes are suppressed, so in practice `content` appears only from standalone `studio export --mode content` runs), `time_ms` (export duration). On failure also `failure_reason` (`disk_full`/`no_exporter_found`/`database_export`/`site_meta`/`unknown`). |
 
 #### Preview site events

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -20,6 +20,8 @@ export const TRACKS_EVENTS = {
 	SITE_OPEN_CUSTOMIZE: 'studio_site_open_customize',
 	SITE_OPEN_PHPMYADMIN: 'studio_site_open_phpmyadmin',
 	SITE_OPEN_FOLDER: 'studio_site_open_folder',
+	SITE_IMPORT: 'studio_site_imported',
+	SITE_EXPORT: 'studio_site_exported',
 	PREVIEW_SITE_CREATE: 'studio_preview_site_create',
 	PREVIEW_SITE_UPDATE: 'studio_preview_site_update',
 	PREVIEW_SITE_DELETE: 'studio_preview_site_delete',


### PR DESCRIPTION
## Related issues

- Related to [STU-2117](https://linear.app/a8c/issue/STU-2117/tracks-import-and-export-events)

## How AI was used in this PR

Implemented with Claude Code (exploration, implementation, and tests), following the patterns from the earlier Tracks PRs (STU-2115/2116/2119). Reviewed by the author.

## Proposed Changes

Adds two Tracks events replacing the MC Stats import/export counters (which stay in place for the parallel-run phase):

- `studio_site_imported` — `success`, `importer_type` (`jetpack`/`local`/`playground`/`sql`/`wpress`/`xml`/`unknown`), `time_ms`, and a coarse `failure_reason` on failure.
- `studio_site_exported` — `success`, `export_type` (`full`/`db`), `time_ms`, and a coarse `failure_reason` on failure.

Both are emitted only by the CLI `import`/`export` commands (the sole funnel, same as `studio_site_created` and the preview events), so desktop, agentic UI, and standalone CLI usage are all counted once, attributable via `channel`/`ui_version`.

The events deliberately mean **a user imported/exported a backup**. Flows that reuse the same CLI commands as an implementation detail — add-site-flow imports (Classic add-site, agentic onboarding, browser-UI import route), sync-pull imports, and sync-push exports — pass a hidden `--suppress-tracks-event` flag and emit nothing. As a side benefit over the MC Stats counters, this stops sync operations from inflating import/export numbers, and the `importer_type` prop correctly reports `xml` (WXR) imports, which MC Stats counted as "unknown importer".

`failure_reason` is a low-cardinality classification — the raw error message is never sent (it can carry file paths).

Notes for reviewers:

- An import that completes but whose server restart fails reports `success: true` — `success` reflects the import itself; the command still exits non-zero.
- An aborted sync export emits nothing (the CLI process is SIGTERM'd), matching today's MC Stats behavior.
- `importer_type` is `unknown` when the failure occurs before a concrete importer starts; `failure_reason` carries the phase signal there.
- `failure_reason` is derived from machine-readable codes on `LoggerError` (locale-independent), attached at the throw sites. As a side effect, several deep errors were promoted from plain `Error` to `LoggerError`, and the redundant logger-mode `IMPORT_ERROR`/`EXPORT_ERROR`/`BACKUP_EXTRACT_ERROR` wrap-throws were removed — so standalone CLI output for `import`/`export`/`push`/`pull` now shows the specific error (e.g. `Database export failed`) instead of a generic `Import failed:`/`Push failed:` prefix. Nothing parses those prefixes.
- The `previousError` merge in `import`/`pull` no longer overwrites an existing cause when a post-import server restart also fails — the root cause stays in the report.

Follow-up (not code): register both events with **all** eventprops (including the wrapper-attached common props `channel`, `ui_version`, `is_a11n`, `platform`, `arch`, `app_version`) via the Tracks Registration tool.

## Testing Instructions

1. Import a backup into an existing site from the desktop Import/Export tab (dev build)
2. Check the `Would have recorded Tracks event studio_site_imported…` log line
3. Verify the add-site import flow and sync push/pull log no import/export events.
4. Confirm exports triggered through CLI report `Would have recorded Tracks event studio_site_imported…` lines

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

