### PR TITLE
Do not build data-liberation during building CLI

### DIFF
--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -74,12 +74,7 @@ export function buildLocalUiPlugin() {
 	};
 }
 
-// Ship only the self-contained engine bundle — its deps are inlined. Shipping
-// the tsc output + node_modules instead added ~10k files to the installer and
-// ~8 min to the Windows CI build (STU-2027). Bundles are committed under
-// packages/data-liberation-agent/dist/; regenerate with
-// `npm -w data-liberation run build:mcp-bundle` when DLA source or deps change
-// (CI fails on drift).
+// Copy the committed data-liberation-agent/dist into the dist/cli/data-liberation-agent.
 function copyDataLiberationEngine( outDir: string ) {
 	const serverBundlePath = resolve( dataLiberationSourcePath, 'dist', 'mcp-server.bundle.mjs' );
 	const scriptsDistPath = resolve( dataLiberationSourcePath, 'dist', 'scripts' );

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -40,7 +40,6 @@ const dataLiberationSourcePath = resolve(
 	'packages',
 	'data-liberation-agent'
 );
-const repoRoot = resolve( __dirname, '..', '..' );
 
 // The `studio ui` command serves the built browser UI (apps/ui `dist-local`)
 // from `<chunk dir>/ui`, so it must sit next to the built chunks too. Built
@@ -77,31 +76,33 @@ export function buildLocalUiPlugin() {
 
 // Ship only the self-contained engine bundle — its deps are inlined. Shipping
 // the tsc output + node_modules instead added ~10k files to the installer and
-// ~8 min to the Windows CI build (STU-2027).
+// ~8 min to the Windows CI build (STU-2027). Bundles are committed under
+// packages/data-liberation-agent/dist/; regenerate with
+// `npm -w data-liberation run build:mcp-bundle` when DLA source or deps change
+// (CI fails on drift).
 function copyDataLiberationEngine( outDir: string ) {
-	execSync( 'npm -w data-liberation run build:mcp-bundle', {
-		cwd: repoRoot,
-		stdio: 'inherit',
-	} );
+	const serverBundlePath = resolve( dataLiberationSourcePath, 'dist', 'mcp-server.bundle.mjs' );
+	const scriptsDistPath = resolve( dataLiberationSourcePath, 'dist', 'scripts' );
+	if ( ! existsSync( serverBundlePath ) || ! existsSync( scriptsDistPath ) ) {
+		throw new Error(
+			'Data Liberation engine bundles are missing under packages/data-liberation-agent/dist/. ' +
+				'Run `npm -w data-liberation run build:mcp-bundle` and commit the updated artifacts.'
+		);
+	}
+
 	const engineOutDir = resolve( outDir, 'data-liberation-agent' );
 	mkdirSync( resolve( engineOutDir, 'dist' ), { recursive: true } );
-	copyFileSync(
-		resolve( dataLiberationSourcePath, 'dist', 'mcp-server.bundle.mjs' ),
-		resolve( engineOutDir, 'dist', 'mcp-server.bundle.mjs' )
-	);
+	copyFileSync( serverBundlePath, resolve( engineOutDir, 'dist', 'mcp-server.bundle.mjs' ) );
 	cpSync( resolve( dataLiberationSourcePath, 'skills' ), resolve( engineOutDir, 'skills' ), {
 		recursive: true,
 	} );
 
 	// The skills also invoke pipeline drivers via `node scripts/run.mjs <name>`.
 	// Ship the launcher plus the self-contained driver bundles it falls back to
-	// when no dev dependencies resolve next to it (dist/scripts/, emitted by the
-	// same build:mcp-bundle run as the server bundle).
-	cpSync(
-		resolve( dataLiberationSourcePath, 'dist', 'scripts' ),
-		resolve( engineOutDir, 'dist', 'scripts' ),
-		{ recursive: true }
-	);
+	// when no dev dependencies resolve next to it (dist/scripts/).
+	cpSync( scriptsDistPath, resolve( engineOutDir, 'dist', 'scripts' ), {
+		recursive: true,
+	} );
 	mkdirSync( resolve( engineOutDir, 'scripts' ), { recursive: true } );
 	copyFileSync(
 		resolve( dataLiberationSourcePath, 'scripts', 'run.mjs' ),


### PR DESCRIPTION
## Related issues

- Related STU-2208

## How AI was used in this PR

AI assisted

## Proposed Changes
`cli:build` no longer rebuilds the Data Liberation MCP bundles on every run.

Those bundles are committed artifacts (used by `/liberate` in Studio Code and by the Claude/Codex plugin). Rebuilding them during CLI packaging was only a convenience, and it caused confusion and extra build time — especially when unrelated root dependency changes.

The CLI build now copies the committed bundles and fails with a clear error only if they’re missing.

1. CI: Unchanged in practice — Buildkite already keeps dist/ fresh via the drift check.
2. Local work: if someone works with data-liberation, they will rebuild it explicitly, so no problems with it.

## Testing Instructions

Visual review should suffice