### PR TITLE
Trigger CI for #4481 (raise devEngines Node to 24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"devEngines": {
 		"runtime": {
 			"name": "node",
-			"version": ">=22.0.0"
+			"version": ">=24.0.0"
 		},
 		"packageManager": {
 			"name": "npm",


### PR DESCRIPTION
Mirror of #4481 (`t-hamano:raise-devengines-node-to-24`) pushed to an in-repo branch so CI runs on it. Not intended for merge — close once CI results are visible on the original PR.