### PR TITLE
Agentic UI: Keep app-wide toasts above the composer when the sidebar is closed

### DIFF
--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -146,7 +146,13 @@ export function SidebarLayout( {
 					) : null }
 					{ children }
 					{ effectiveCollapsed ? (
-						<AppToasts className={ styles.floatingToasts } fit="content" />
+						<AppToasts
+							className={ clsx(
+								styles.floatingToasts,
+								forceCollapsed && styles.floatingToastsOverPreview
+							) }
+							fit="content"
+						/>
 					) : null }
 				</main>
 				{ sidebarResize.isResizing ? <ResizeOverlay /> : null }

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -147,6 +147,10 @@
 	padding: var(--wpds-dimension-padding-sm) calc(var(--wpds-dimension-padding-lg) - var(--wpds-dimension-padding-sm)) 0;
 }
 
+/* --app-main-composer-height is published on the document by the session
+   view's chrome observer, so the shelf rides above the composer as it grows.
+   Views without a composer leave it unset and the shelf sits on the panel's
+   own footer band. */
 .floatingToasts {
 	position: absolute;
 	bottom: calc(52px + var(--app-main-composer-height, 0px));
@@ -155,4 +159,10 @@
 	z-index: 110;
 	pointer-events: auto;
 	-webkit-app-region: no-drag;
+}
+
+/* Fullscreen preview hides the chat column but leaves its composer measured,
+   so ignore that height and sit on the footer band like any composer-less view. */
+.floatingToastsOverPreview {
+	--app-main-composer-height: 0px;
 }

--- a/apps/ui/src/ui-classic/components/session-view/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.test.tsx
@@ -279,6 +279,31 @@ describe( 'SessionView', () => {
 
 		expect( screen.queryByText( 'Studio Code Beta' ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'publishes the composer height for the collapsed-sidebar toast shelf', () => {
+		useSessionMock.mockReturnValue( {
+			data: makeLoadedSession(),
+			isLoading: false,
+			error: null,
+		} );
+
+		const { container, unmount } = render( <SessionView sessionId="session-1" /> );
+
+		const composer = container.querySelector( '[class*="composerOuter"]' ) as HTMLDivElement;
+		expect( composer ).not.toBeNull();
+		Object.defineProperty( composer, 'offsetHeight', { value: 120, configurable: true } );
+		fireEvent( window, new Event( 'resize' ) );
+
+		expect( document.documentElement.style.getPropertyValue( '--app-main-composer-height' ) ).toBe(
+			'120px'
+		);
+
+		unmount();
+
+		expect( document.documentElement.style.getPropertyValue( '--app-main-composer-height' ) ).toBe(
+			''
+		);
+	} );
 } );
 
 describe( 'isScrolledAwayFromLatest', () => {

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -140,17 +140,30 @@ function SessionFrame( {
 				'--classic-header-height',
 				`${ headerRef.current?.offsetHeight ?? 0 }px`
 			);
-			root.style.setProperty(
-				'--classic-composer-height',
-				`${ composerRef.current?.offsetHeight ?? 0 }px`
+			const composerHeight = composerRef.current?.offsetHeight ?? 0;
+			root.style.setProperty( '--classic-composer-height', `${ composerHeight }px` );
+			// The collapsed-sidebar toast shelf lives in the layout's <main>, an
+			// ancestor of this root, so it can't inherit the value from here.
+			// Publishing it on the document lets the shelf ride above the composer
+			// however it grows — wrapped text, attachments, or the resize handle.
+			document.documentElement.style.setProperty(
+				'--app-main-composer-height',
+				`${ composerHeight }px`
 			);
 		};
 
 		updateChromeSize();
 
+		// Views without a composer must fall back to the shelf's 0px default.
+		const clearComposerHeight = () =>
+			document.documentElement.style.removeProperty( '--app-main-composer-height' );
+
 		if ( typeof ResizeObserver === 'undefined' ) {
 			window.addEventListener( 'resize', updateChromeSize );
-			return () => window.removeEventListener( 'resize', updateChromeSize );
+			return () => {
+				window.removeEventListener( 'resize', updateChromeSize );
+				clearComposerHeight();
+			};
 		}
 
 		const resizeObserver = new ResizeObserver( updateChromeSize );
@@ -161,7 +174,10 @@ function SessionFrame( {
 			resizeObserver.observe( composerRef.current );
 		}
 
-		return () => resizeObserver.disconnect();
+		return () => {
+			resizeObserver.disconnect();
+			clearComposerHeight();
+		};
 	}, [] );
 
 	return (


### PR DESCRIPTION
## Related issues

- Fixes [STU-2173](https://linear.app/a8c/issue/STU-2173/app-wide-messages-obscure-the-composer-when-sidebar-is-closed)

## How AI was used in this PR

AI traced the root cause, wrote the fix and the test, and verified the resulting geometry live in `studio ui` (light + dark). I reviewed the diff.

## Proposed Changes

- With the sidebar closed, app-wide toasts covered the chat composer instead of stacking above it. They now sit just above the composer and ride up with it as it grows — wrapped text, attachments, or the drag handle.
- Fullscreen preview keeps toasts on the panel's footer band, since no composer is visible there.

| Light | Dark |
|--------|--------|
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/9775f3d8-203b-4405-9c33-cfff2ff6ad61" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/a8a9df6e-9545-4a93-9e78-1a8bfd53307d" /> | 

## Testing Instructions

- Close the sidebar in a chat session and trigger a toast (start or stop a site). It should sit above the composer, with the input fully usable.
- Type a multi-line draft, then drag the composer's resize handle. The toast should track the composer's top edge in both directions.
- Repeat in fullscreen preview (⋮ → Full preview). Toasts should sit at the bottom-left of the panel.
- Check both light and dark.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
