### PR TITLE
Agentic UI: Use danger styling for site delete actions

### DIFF
--- a/apps/ui/src/components/delete-site-dialog/index.test.tsx
+++ b/apps/ui/src/components/delete-site-dialog/index.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDeleteSite } from '@/data/queries/use-sites';
+import { DeleteSiteDialog } from './index';
+import type { SiteDetails } from '@/data/core';
+
+vi.mock( '@/data/queries/use-sites', () => ( {
+	useDeleteSite: vi.fn(),
+} ) );
+
+const SITE = { id: 'site-1', name: 'My Site' } as SiteDetails;
+const mutateAsync = vi.fn();
+
+beforeEach( () => {
+	vi.clearAllMocks();
+	vi.mocked( useDeleteSite ).mockReturnValue( { mutateAsync } as unknown as ReturnType<
+		typeof useDeleteSite
+	> );
+} );
+
+function renderDialog( onDeleted?: () => void ) {
+	return render(
+		<DeleteSiteDialog site={ SITE } open onOpenChange={ vi.fn() } onDeleted={ onDeleted } />
+	);
+}
+
+describe( 'DeleteSiteDialog', () => {
+	it( 'deletes the site and its files on confirm', async () => {
+		mutateAsync.mockResolvedValue( undefined );
+		const onDeleted = vi.fn();
+		renderDialog( onDeleted );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Delete site' } ) );
+
+		await waitFor( () =>
+			expect( mutateAsync ).toHaveBeenCalledWith( { id: 'site-1', deleteFiles: true } )
+		);
+		expect( onDeleted ).toHaveBeenCalled();
+	} );
+
+	it( 'keeps the files when the checkbox is unchecked', async () => {
+		mutateAsync.mockResolvedValue( undefined );
+		renderDialog();
+
+		await userEvent.click( screen.getByRole( 'checkbox' ) );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Delete site' } ) );
+
+		await waitFor( () =>
+			expect( mutateAsync ).toHaveBeenCalledWith( { id: 'site-1', deleteFiles: false } )
+		);
+	} );
+
+	it( 'stays open and shows the failure reason when deleting fails', async () => {
+		mutateAsync.mockRejectedValue( new Error( 'Site is running' ) );
+		const onDeleted = vi.fn();
+		renderDialog( onDeleted );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Delete site' } ) );
+
+		// Scoped to the dialog: the error is also announced in an aria-live region.
+		const dialog = await screen.findByRole( 'alertdialog' );
+		expect( await within( dialog ).findByText( 'Site is running' ) ).toBeVisible();
+		expect( onDeleted ).not.toHaveBeenCalled();
+	} );
+} );

--- a/apps/ui/src/components/delete-site-dialog/index.tsx
+++ b/apps/ui/src/components/delete-site-dialog/index.tsx
@@ -1,5 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Dialog } from '@wordpress/ui';
+import { AlertDialog } from '@wordpress/ui';
 import { useState } from 'react';
 import { useDeleteSite } from '@/data/queries/use-sites';
 import styles from './style.module.css';
@@ -15,72 +15,37 @@ interface DeleteSiteDialogProps {
 export function DeleteSiteDialog( { site, open, onOpenChange, onDeleted }: DeleteSiteDialogProps ) {
 	const deleteSite = useDeleteSite();
 	const [ deleteFiles, setDeleteFiles ] = useState( true );
-	const [ error, setError ] = useState< string | null >( null );
 
-	const handleConfirm = () => {
-		setError( null );
-		deleteSite.mutate(
-			{ id: site.id, deleteFiles },
-			{
-				onSuccess: () => {
-					onOpenChange( false );
-					onDeleted?.();
-				},
-				onError: ( err: Error ) => {
-					setError( err.message ?? __( 'Unable to delete the site. Please try again.' ) );
-				},
-			}
-		);
+	const handleConfirm = async () => {
+		try {
+			await deleteSite.mutateAsync( { id: site.id, deleteFiles } );
+			onDeleted?.();
+		} catch ( err ) {
+			return {
+				error: ( err as Error )?.message || __( 'Unable to delete the site. Please try again.' ),
+			};
+		}
 	};
 
 	return (
-		<Dialog.Root
-			open={ open }
-			onOpenChange={ ( next ) => {
-				if ( deleteSite.isPending ) {
-					return;
-				}
-				onOpenChange( next );
-				if ( ! next ) {
-					setError( null );
-				}
-			} }
-		>
-			<Dialog.Popup size="small">
-				<Dialog.Header>
-					<Dialog.Title>{ sprintf( __( 'Delete %s' ), site.name ) }</Dialog.Title>
-				</Dialog.Header>
-				<Dialog.Content>
-					<p className={ styles.dialogText }>
-						{ __(
-							"The site's database will be lost, including all posts, pages, comments, and media."
-						) }
-					</p>
-					<label className={ styles.dialogCheckbox }>
-						<input
-							type="checkbox"
-							checked={ deleteFiles }
-							onChange={ ( event ) => setDeleteFiles( event.target.checked ) }
-						/>
-						<span>{ __( 'Delete site files from my computer' ) }</span>
-					</label>
-					{ error ? <div className={ styles.dialogError }>{ error }</div> : null }
-				</Dialog.Content>
-				<Dialog.Footer>
-					<Dialog.Action variant="minimal" tone="neutral" disabled={ deleteSite.isPending }>
-						{ __( 'Cancel' ) }
-					</Dialog.Action>
-					<Button
-						variant="solid"
-						tone="brand"
-						loading={ deleteSite.isPending }
-						loadingAnnouncement={ __( 'Deleting site' ) }
-						onClick={ handleConfirm }
-					>
-						{ __( 'Delete site' ) }
-					</Button>
-				</Dialog.Footer>
-			</Dialog.Popup>
-		</Dialog.Root>
+		<AlertDialog.Root open={ open } onOpenChange={ onOpenChange } onConfirm={ handleConfirm }>
+			<AlertDialog.Popup
+				intent="irreversible"
+				title={ sprintf( __( 'Delete %s' ), site.name ) }
+				description={ __(
+					"The site's database will be lost, including all posts, pages, comments, and media."
+				) }
+				confirmButtonText={ __( 'Delete site' ) }
+			>
+				<label className={ styles.dialogCheckbox }>
+					<input
+						type="checkbox"
+						checked={ deleteFiles }
+						onChange={ ( event ) => setDeleteFiles( event.target.checked ) }
+					/>
+					<span>{ __( 'Delete site files from my computer' ) }</span>
+				</label>
+			</AlertDialog.Popup>
+		</AlertDialog.Root>
 	);
 }

--- a/apps/ui/src/components/delete-site-dialog/style.module.css
+++ b/apps/ui/src/components/delete-site-dialog/style.module.css
@@ -1,10 +1,3 @@
-.dialogText {
-	margin: 0;
-	font-size: var(--wpds-typography-font-size-sm);
-	line-height: var(--wpds-typography-line-height-sm);
-	color: var(--wpds-color-fg-content-neutral-weak);
-}
-
 .dialogCheckbox {
 	display: flex;
 	align-items: center;
@@ -14,11 +7,4 @@
 	line-height: var(--wpds-typography-line-height-sm);
 	color: var(--wpds-color-fg-content-neutral);
 	cursor: var(--wpds-cursor-control);
-}
-
-.dialogError {
-	margin-top: var(--wpds-dimension-padding-sm);
-	font-size: var(--wpds-typography-font-size-sm);
-	line-height: var(--wpds-typography-line-height-sm);
-	color: var(--wpds-color-fg-content-error, var(--wpds-color-fg-content-neutral));
 }

--- a/apps/ui/src/components/menu/index.tsx
+++ b/apps/ui/src/components/menu/index.tsx
@@ -1,6 +1,7 @@
 import { ContextMenu as BaseContextMenu } from '@base-ui/react/context-menu';
 import { Menu as BaseMenu } from '@base-ui/react/menu';
 import { privateApis } from '@wordpress/theme';
+import { clsx } from 'clsx';
 import { forwardRef } from 'react';
 import motionStyles from '@/components/floating-surface-motion/style.module.css';
 import { unlock } from '@/lock-unlock';
@@ -113,14 +114,21 @@ export function ContextPopup( {
 	);
 }
 
-type ItemProps = ComponentPropsWithoutRef< typeof BaseMenu.Item >;
+type ItemProps = ComponentPropsWithoutRef< typeof BaseMenu.Item > & {
+	/** Renders the item in error colors, for actions that destroy data. */
+	destructive?: boolean;
+};
 
 export const Item = forwardRef< ElementRef< typeof BaseMenu.Item >, ItemProps >( function Item(
-	{ className, children, ...props },
+	{ className, children, destructive, ...props },
 	ref
 ) {
 	return (
-		<BaseMenu.Item ref={ ref } className={ `${ styles.item } ${ className ?? '' }` } { ...props }>
+		<BaseMenu.Item
+			ref={ ref }
+			className={ clsx( styles.item, destructive && styles.itemDestructive, className ) }
+			{ ...props }
+		>
 			{ children }
 		</BaseMenu.Item>
 	);

--- a/apps/ui/src/components/menu/style.module.css
+++ b/apps/ui/src/components/menu/style.module.css
@@ -42,6 +42,16 @@
 	background: var(--wpds-color-bg-surface-neutral);
 }
 
+.itemDestructive {
+	color: var(--wpds-color-fg-interactive-error);
+}
+
+.itemDestructive[data-highlighted],
+.itemDestructive:hover {
+	background: var(--wpds-color-bg-interactive-error-active);
+	color: var(--wpds-color-fg-interactive-error-active);
+}
+
 .item[data-disabled] {
 	color: var(--wpds-color-fg-interactive-neutral-disabled);
 	cursor: not-allowed;

--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -163,7 +163,7 @@ function PreviewSitesSummary( { userId }: { userId: number } ) {
 							}
 						/>
 						<Menu.Popup side="bottom" align="end">
-							<Menu.Item disabled={ isDisabled } onClick={ () => void handleDelete() }>
+							<Menu.Item destructive disabled={ isDisabled } onClick={ () => void handleDelete() }>
 								{ deletePreviewSitesLabel }
 							</Menu.Item>
 						</Menu.Popup>

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -478,6 +478,7 @@ function SiteActionsMenu( {
 					</Menu.Item>
 					<Menu.Separator />
 					<Menu.Item
+						destructive
 						onClick={ () => setDeleteOpen( true ) }
 						disabled={ busy || copySite.isPending || isExporting }
 					>


### PR DESCRIPTION
## Related issues

- Fixes [STU-2164](https://linear.app/a8c/issue/STU-2164/use-danger-styling-for-site-delete-actions)

## How AI was used in this PR

Claude Code wrote the change and the dialog tests. Reviewed and verified manually.

## Proposed Changes

Deleting a site is irreversible, but neither entry point looked it. The sidebar site context menu's "Delete site" now reads red, and its confirmation now uses the design system's destructive-confirm pattern (`AlertDialog` + `intent="irreversible"`), so the confirm button is red and the dialog announces itself as an alert, blocks dismissal mid-delete, and surfaces failures inline. "Delete all preview sites" in Settings → Usage gets the same red treatment.

| Delete Site | Delete Preview |
|--------|--------|
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/baa03117-11a0-46d4-9272-9b94020372cd" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/6020dc64-f54c-4be0-a010-e64968e6c5a4" /> | 

## Testing Instructions

1. Right-click a site in the sidebar → "Delete site" is red; the rest of the menu is not.
2. Click it → confirmation modal's "Delete site" button is red. Cancel.
3. Repeat in the other color scheme (Settings → Appearance).
4. Settings → Usage → Preview sites ⋮ → "Delete all preview sites" is red (needs an account with preview sites).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
