### PR TITLE
Agentic UI: Recover the site preview from cached cross-site redirects

### DIFF
--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -2583,4 +2583,11 @@ export async function setWebviewViewport(
 	} );
 }
 
+export async function clearWebviewCache(
+	event: IpcMainInvokeEvent,
+	webContentsId: number
+): Promise< void > {
+	await getOwnedWebviewContents( event, webContentsId ).session.clearCache();
+}
+
 export { showTextContextMenu } from 'src/text-context-menu';

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -165,6 +165,7 @@ const api: IpcApi = {
 	readLocalMediaFile: ( path ) => ipcRendererInvoke( 'readLocalMediaFile', path ),
 	setWebviewViewport: ( webContentsId, viewport ) =>
 		ipcRendererInvoke( 'setWebviewViewport', webContentsId, viewport ),
+	clearWebviewCache: ( webContentsId ) => ipcRendererInvoke( 'clearWebviewCache', webContentsId ),
 	isFullscreen: () => ipcRendererInvoke( 'isFullscreen' ),
 	getAllCustomDomains: () => ipcRendererInvoke( 'getAllCustomDomains' ),
 	saveUserTerminal: ( preferredTerminal ) =>

--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -7,6 +7,7 @@ import { useConnector } from '@/data/core';
 import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
 import {
 	getBrowserShortcutCommand,
+	isOffOriginRedirect,
 	getPathFromPreviewUrl,
 	getSimulatedViewport,
 	SitePreview,
@@ -224,10 +225,15 @@ describe( 'SitePreview', () => {
 		fireEvent.keyDown( document.body, { key: 'r', ctrlKey: true } );
 		expect( container.querySelector( 'iframe' ) ).not.toBe( initialIframe );
 
-		// Extra modifiers must not trigger the shortcut.
+		// Shift is the hard-reload chord, which reloads the fallback iframe too.
 		const reloadedIframe = container.querySelector( 'iframe' );
 		fireEvent.keyDown( document.body, { key: 'r', ctrlKey: true, shiftKey: true } );
-		expect( container.querySelector( 'iframe' ) ).toBe( reloadedIframe );
+		expect( container.querySelector( 'iframe' ) ).not.toBe( reloadedIframe );
+
+		// Extra modifiers must not trigger either shortcut.
+		const hardReloadedIframe = container.querySelector( 'iframe' );
+		fireEvent.keyDown( document.body, { key: 'r', ctrlKey: true, altKey: true } );
+		expect( container.querySelector( 'iframe' ) ).toBe( hardReloadedIframe );
 	} );
 
 	it( 'switches realms on primary-modifier number shortcuts', () => {
@@ -642,6 +648,10 @@ describe( 'getBrowserShortcutCommand', () => {
 		expect( getBrowserShortcutCommand( makeEvent( { key: 'r', ctrlKey: true } ) ) ).toBe(
 			'reload'
 		);
+		// Cmd+Shift+R reports an uppercase key; the chord must still match.
+		expect(
+			getBrowserShortcutCommand( makeEvent( { key: 'R', ctrlKey: true, shiftKey: true } ) )
+		).toBe( 'hard-reload' );
 		expect( getBrowserShortcutCommand( makeEvent( { key: '[', ctrlKey: true } ) ) ).toBe( 'back' );
 		expect( getBrowserShortcutCommand( makeEvent( { key: ']', ctrlKey: true } ) ) ).toBe(
 			'forward'
@@ -673,6 +683,32 @@ describe( 'getBrowserShortcutCommand', () => {
 				} )
 			)
 		).toBe( null );
+	} );
+} );
+
+describe( 'isOffOriginRedirect', () => {
+	it( 'flags a load that settled on another port', () => {
+		expect( isOffOriginRedirect( 'http://localhost:8931/', 'http://localhost:8932/' ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'allows same-origin paths, including the auto-login hop', () => {
+		expect(
+			isOffOriginRedirect( 'http://localhost:8932/wp-admin/', 'http://localhost:8932/' )
+		).toBe( false );
+		expect(
+			isOffOriginRedirect(
+				'http://localhost:8932/studio-auto-login?redirect_to=%2Fwp-admin%2F',
+				'http://localhost:8932/'
+			)
+		).toBe( false );
+	} );
+
+	it( 'stays quiet on unparseable urls rather than triggering recovery', () => {
+		expect( isOffOriginRedirect( 'about:blank', 'http://localhost:8932/' ) ).toBe( true );
+		expect( isOffOriginRedirect( '', 'http://localhost:8932/' ) ).toBe( false );
+		expect( isOffOriginRedirect( 'http://localhost:8932/', '' ) ).toBe( false );
 	} );
 } );
 

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -90,7 +90,7 @@ interface BrowserNavigationState {
 	title: string | null;
 }
 
-type BrowserShortcutCommandType = 'back' | 'forward' | 'reload';
+type BrowserShortcutCommandType = 'back' | 'forward' | 'reload' | 'hard-reload';
 
 // What the guest page can forward over the console bridge: the browser
 // commands it swallows, plus the full-preview toggle (the webview covers most
@@ -231,6 +231,7 @@ interface PreviewWindow extends Window {
 			webContentsId: number,
 			viewport: PreviewViewport | null
 		) => Promise< void >;
+		clearWebviewCache?: ( webContentsId: number ) => Promise< void >;
 	};
 }
 
@@ -240,6 +241,26 @@ function getWebviewContentsId( webview: WebviewTag ): number {
 		throw new Error( 'Preview webview is not ready.' );
 	}
 	return webContentsId;
+}
+
+// Chrome keeps cached 301s through every reload variant, and a redirect leaves
+// the webview's current entry on the other site — hence clear, then navigate.
+async function hardReload( webview: WebviewTag, url: string ): Promise< void > {
+	const { ipcApi } = window as PreviewWindow;
+	try {
+		await ipcApi?.clearWebviewCache?.( getWebviewContentsId( webview ) );
+	} catch {
+		// No IPC bridge, or the webview isn't ready.
+	}
+	await webview.loadURL( url ).catch( () => undefined );
+}
+
+export function isOffOriginRedirect( settledUrl: string, intendedUrl: string ): boolean {
+	try {
+		return new URL( settledUrl ).origin !== new URL( intendedUrl ).origin;
+	} catch {
+		return false;
+	}
 }
 
 async function applyWebviewViewport(
@@ -338,6 +359,9 @@ export function getBrowserShortcutCommand(
 	if ( event.defaultPrevented || event.repeat ) {
 		return null;
 	}
+	if ( isKeyboardEvent.primaryShift( event, 'r' ) ) {
+		return 'hard-reload';
+	}
 	if ( isKeyboardEvent.primary( event, 'r' ) ) {
 		return 'reload';
 	}
@@ -392,6 +416,7 @@ function isPreviewShortcutCommand( command: unknown ): command is PreviewShortcu
 		command === 'back' ||
 		command === 'forward' ||
 		command === 'reload' ||
+		command === 'hard-reload' ||
 		command === 'full-preview'
 	);
 }
@@ -406,6 +431,7 @@ function PreviewOverflowMenu( {
 	onMobileOrientationChange,
 	fullscreen,
 	onFullscreenChange,
+	onHardReload,
 }: {
 	viewportMode: ViewportMode;
 	onViewportModeChange: ( mode: ViewportMode ) => void;
@@ -413,6 +439,7 @@ function PreviewOverflowMenu( {
 	onMobileOrientationChange: ( orientation: MobileOrientation ) => void;
 	fullscreen: boolean;
 	onFullscreenChange?: ( value: boolean ) => void;
+	onHardReload: () => void;
 } ) {
 	const viewportLabels: Record< ViewportPreset[ 'id' ], string > = {
 		mobile: __( 'Mobile' ),
@@ -486,6 +513,13 @@ function PreviewOverflowMenu( {
 						</Menu.Item>
 					</>
 				) : null }
+				<Menu.Separator />
+				<Menu.Item
+					onClick={ onHardReload }
+					aria-keyshortcuts={ ariaKeyShortcut.primaryShift( 'r' ) }
+				>
+					{ __( 'Hard refresh' ) }
+				</Menu.Item>
 			</Menu.Popup>
 		</Menu.Root>
 	);
@@ -924,6 +958,7 @@ export function SitePreview( {
 							onMobileOrientationChange={ handleMobileOrientationChange }
 							fullscreen={ fullscreen }
 							onFullscreenChange={ onFullscreenChange }
+							onHardReload={ () => sendBrowserCommand( 'hard-reload' ) }
 						/>
 					) : null }
 				</div>
@@ -977,7 +1012,9 @@ export function SitePreview( {
 									// by remounting; back/forward aren't reachable from the host.
 									<iframe
 										key={ `${ previewUrl }#${ reloadNonce }#${
-											browserCommand?.type === 'reload' ? browserCommand.id : 0
+											browserCommand?.type === 'reload' || browserCommand?.type === 'hard-reload'
+												? browserCommand.id
+												: 0
 										}` }
 										className={ styles.iframe }
 										style={ iframeStyle }
@@ -1162,6 +1199,13 @@ function WebviewSurface( {
 	useEffect( () => {
 		onNavigateRef.current = onNavigate;
 	}, [ onNavigate ] );
+	// The url we want shown; `currentUrlRef` is where the webview actually landed.
+	const urlRef = useRef( url );
+	useEffect( () => {
+		urlRef.current = url;
+	}, [ url ] );
+	// Only loads we started (the mount-time `src` counts) are judged for redirects.
+	const pendingLoadRef = useRef( true );
 
 	const publishBrowserState = useCallback( ( patch: Partial< BrowserNavigationState > = {} ) => {
 		const webview = ref.current as WebviewTag | null;
@@ -1318,6 +1362,13 @@ function WebviewSurface( {
 			if ( typeof navigateEvent.url === 'string' ) {
 				currentUrlRef.current = navigateEvent.url;
 				onNavigateRef.current?.( navigateEvent.url );
+				// Once per load, so a site that legitimately redirects can't loop.
+				if ( pendingLoadRef.current ) {
+					pendingLoadRef.current = false;
+					if ( isOffOriginRedirect( navigateEvent.url, urlRef.current ) ) {
+						void hardReload( webview, urlRef.current );
+					}
+				}
 			}
 			didReadTitleAfterLoad = false;
 			publishBrowserState();
@@ -1379,6 +1430,7 @@ function WebviewSurface( {
 		if ( ! webview ) return;
 		currentUrlRef.current = url;
 		lastReloadNonceRef.current = reloadNonce;
+		pendingLoadRef.current = true;
 		webview.loadURL( url ).catch( () => undefined );
 	}, [ url, reloadNonce, ready ] );
 
@@ -1408,6 +1460,8 @@ function WebviewSurface( {
 				webview.goForward?.();
 			} else if ( browserCommand.type === 'reload' ) {
 				webview.reload?.();
+			} else if ( browserCommand.type === 'hard-reload' ) {
+				void hardReload( webview, urlRef.current );
 			}
 		} finally {
 			publishBrowserState();

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -88,7 +88,10 @@ export const INSPECTOR_PAGE_SCRIPT =
 		const key = event.key.toLowerCase();
 		/* The host owns full preview, but in that mode this page covers most of
 		 * the window — so the chord is caught here and forwarded back. */
-		if ( event.shiftKey ) return key === 'f' ? 'full-preview' : null;
+		if ( event.shiftKey ) {
+			if ( key === 'f' ) return 'full-preview';
+			return key === 'r' ? 'hard-reload' : null;
+		}
 		if ( key === 'r' ) return 'reload';
 		if ( key === '[' ) return 'back';
 		if ( key === ']' ) return 'forward';


### PR DESCRIPTION
## Related issues

- Fixes [STU-2217](https://linear.app/a8c/issue/STU-2217/preview-pane-shows-the-previous-sites-port-on-the-frontend-tab-due-to)

## How AI was used in this PR

Claude Code traced the root cause and wrote the change. Diagnosis was driven by a deterministic repro (below) rather than inspection — three plausible causes were ruled out by experiment first.
Manually validated the fix and reviewed the code

## Proposed Changes

Site ports are recycled between sites, and every preview shares one persistent webview session. So a permanent redirect cached while a port belonged to one site later hijacks whichever site inherits that port: the frontend tab renders someone else's site while wp-admin and phpMyAdmin look correct.

Users had no way out. Restarting the site, the reload button, switching sites, and restarting the app all fail — Chrome keeps cached 301s through every reload variant, and the redirect leaves the webview parked on the other site's URL, so reloading just reloads that.

The preview now notices when a load it started settles on a different origin and recovers itself, so this heals without the user knowing a cache exists. A **Hard refresh** item in the ⋮ menu (⌘⇧R) does the same on demand, covering stale caching we can't detect automatically — same-origin cached redirects, stale theme assets. Only the HTTP cache is dropped, so preview logins survive.

## Testing Instructions

1. Create two sites and note their ports (below: A on 8931, B on 8932).
2. Give B a `wp-content/mu-plugins/redirect.php` that 301s the front end to A:
   ```php
   <?php
   add_action( 'template_redirect', function () {
       wp_redirect( 'http://localhost:8931/', 301 );
       exit;
   } );
   ```
3. Open B's preview — it shows A.
4. Delete the mu-plugin. Confirm the server is clean: `curl -sI http://localhost:8932/` returns `200` with no `Location`.
5. Switch to A and back to B. **B recovers on its own** (before this PR it stayed on A permanently).
6. Check ⋮ → **Hard refresh** and ⌘⇧R, with focus both inside the preview and in its chrome.
7. Confirm wp-admin still auto-logs in — the cache clear must not drop cookies.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
