### PR TITLE
Honor the dependency cooldown in the apps/cli bundle install

### DIFF
--- a/apps/cli/.npmrc
+++ b/apps/cli/.npmrc
@@ -1,0 +1,5 @@
+; The packaging step (`install:bundle`) runs `npm install --no-workspaces` with this directory as
+; the project root, so it does NOT inherit the repo-root .npmrc. Mirror the dependency cooldown here
+; so bundled dependencies also ignore just-published (day-0) releases, which protects the build from
+; same-day upstream regressions (e.g. a transient bad peer-dependency range in a fresh release).
+min-release-age=2


### PR DESCRIPTION
## Related issues

- Related to #3699

## How AI was used in this PR

AI assisted with tracing the CI failure to the missing cooldown config, confirming the publish-order race against the npm registry, and verifying the fix with a dry run. I reviewed the change.

## Proposed Changes

CI packaging broke on an upstream publish-order race. `@smithy/fetch-http-handler@5.7.0` published before the `@smithy/core@^3.32.0` it requires, so `install:bundle` failed with `ETARGET` and the E2E job never ran a test.

The repo root and `apps/studio` both set `min-release-age=2` for exactly this reason. `apps/cli` did not have it. Because `install:bundle` runs `npm install --no-workspaces`, npm treats `apps/cli` as the project root and does not read the repo-root `.npmrc`, so bundled dependencies resolved against day-0 releases on every packaging run.

This mirrors the fix #3699 made for `apps/studio`. It closes the same gap for the CLI bundle, so a bad upstream release no longer breaks packaging on unrelated branches.

## Testing Instructions

1. Check out this branch.
2. Confirm npm reads the new config:
   ```sh
   cd apps/cli && npm config list --no-workspaces | grep before
   ```
   It prints a `before` date two days in the past. On trunk it prints nothing.
3. Run the packaging resolve that failed in CI:
   ```sh
   npm install --omit=dev --no-audit --no-fund --no-package-lock \
     --no-progress --install-links --no-workspaces --dry-run
   ```
4. It exits `0` and resolves `@smithy/core@3.31.1` with `@smithy/fetch-http-handler@5.6.13`, the compatible pair. Without this change npm picks `5.6.13`'s successor and fails with `No matching version found for @smithy/core@^3.32.0`.
5. Regression: `npm run cli:build` still succeeds.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
