### PR TITLE
Agentic UI: Allow cancelling an in-flight push or pull

### DIFF
--- a/apps/cli/tests/local-server.test.ts
+++ b/apps/cli/tests/local-server.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted( () => ( {
 } ) );
 
 vi.mock( '@studio/common/lib/cli-process', () => ( {
+	killChild: vi.fn(),
 	createCliRunner: vi.fn( () => ( {
 		executeCliCommand: mocks.execute,
 		killAll: mocks.killAll,
@@ -199,10 +200,46 @@ describe( 'local web server Connect contracts', () => {
 		const eventChunk = new TextDecoder().decode( ( await reader.read() ).value );
 		await reader.cancel();
 
-		expect( response.status ).toBe( 204 );
+		expect( response.status ).toBe( 200 );
+		await expect( response.json() ).resolves.toEqual( { cancelled: false } );
 		expect( eventChunk ).toContain( '"channel":"sync-pull"' );
 		expect( eventChunk ).toContain( '"siteId":"local-a"' );
 		expect( eventChunk ).toContain( 'Creating remote backup… (18%)' );
+	} );
+
+	// A user cancel is reported as an outcome, not a 500 — the browser connector
+	// turns it back into a cancelled error.
+	it( 'reports a cancelled pull instead of failing the request', async () => {
+		// The CLI never finishes on its own here, so the request only settles if the
+		// cancel lands — which means we must not race it: wait until the pull has
+		// actually started before asking for it to stop.
+		let pullStarted: () => void = () => undefined;
+		const started = new Promise< void >( ( resolve ) => {
+			pullStarted = resolve;
+		} );
+		mocks.execute.mockImplementationOnce( () => {
+			const emitter = new EventEmitter();
+			queueMicrotask( pullStarted );
+			return [ emitter, { kill: () => undefined } ];
+		} );
+		const baseUrl = server.url.replace( 'localhost', '127.0.0.1' );
+
+		const pulling = fetch( `${ baseUrl }/api/sites/local-a/pull`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify( { remoteSiteId: 42 } ),
+		} );
+		await started;
+		const cancelled = await fetch( `${ baseUrl }/api/sites/local-a/sync/cancel`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify( { remoteSiteId: 42 } ),
+		} );
+
+		expect( cancelled.status ).toBe( 204 );
+		const response = await pulling;
+		expect( response.status ).toBe( 200 );
+		await expect( response.json() ).resolves.toEqual( { cancelled: true } );
 	} );
 
 	it( 'returns a signup URL that comes back through the local callback', async () => {

--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -1289,7 +1289,6 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 					{ sitePath: site.path, remoteSiteId, options, signal: release.signal }
 				);
 			} catch ( error ) {
-				// See the pull route — a cancel is reported, not raised as a 500.
 				if ( ! isSyncCancelledError( error ) ) {
 					throw error;
 				}

--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -53,6 +53,7 @@ import {
 	updateSharedSession,
 } from '@studio/common/lib/shared-config';
 import { fetchStudioAssistantQuota } from '@studio/common/lib/studio-assistant-quota';
+import { isSyncCancelledError } from '@studio/common/lib/sync/cancel';
 import { fetchLatestRewindId, fetchSyncableSites } from '@studio/common/lib/sync/sync-api';
 import { detectInstalledApps } from '@studio/common/lib/user-settings/installed-apps';
 import { isWordPressDevVersion } from '@studio/common/lib/wordpress-version-utils';
@@ -205,6 +206,22 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 		for ( const client of sseClients ) {
 			client.write( `data: ${ data }\n\n` );
 		}
+	}
+
+	// In-flight push/pull, keyed the same way the desktop keys them
+	// (`${siteId}-${remoteSiteId}`), so `/sync/cancel` can abort one.
+	const SYNC_ABORT_CONTROLLERS = new Map< string, AbortController >();
+	function registerSyncAbort( siteId: string, remoteSiteId: number ) {
+		const key = `${ siteId }-${ remoteSiteId }`;
+		const controller = new AbortController();
+		SYNC_ABORT_CONTROLLERS.set( key, controller );
+		const release = () => {
+			if ( SYNC_ABORT_CONTROLLERS.get( key ) === controller ) {
+				SYNC_ABORT_CONTROLLERS.delete( key );
+			}
+		};
+		release.signal = controller.signal;
+		return release;
 	}
 
 	// Background watch for the WordPress.com site the user is about to create via
@@ -1114,18 +1131,48 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 				res.status( 404 ).json( { error: `Site ${ req.params.id } not found` } );
 				return;
 			}
-			await pullSite(
-				execute,
-				site.path,
-				remoteSiteId,
-				( progress ) => {
-					sseSend( {
-						channel: 'sync-pull',
-						payload: { ...progress, siteId: req.params.id, remoteSiteId },
-					} );
-				},
-				options
-			);
+			const release = registerSyncAbort( req.params.id, remoteSiteId );
+			try {
+				await pullSite(
+					execute,
+					site.path,
+					remoteSiteId,
+					( progress ) => {
+						sseSend( {
+							channel: 'sync-pull',
+							payload: { ...progress, siteId: req.params.id, remoteSiteId },
+						} );
+					},
+					options,
+					release.signal
+				);
+			} catch ( error ) {
+				// A user cancel is an intentional stop, not a server error — report it
+				// as a result so it doesn't surface as a 500.
+				if ( ! isSyncCancelledError( error ) ) {
+					throw error;
+				}
+				res.json( { cancelled: true } );
+				return;
+			} finally {
+				release();
+			}
+			res.json( { cancelled: false } );
+		} )
+	);
+
+	// Stop an in-flight push or pull. No-op when nothing is running for the site,
+	// and the operation itself refuses to stop once it has moved past its point
+	// of no return (see `canCancelPush` / `canCancelPull`).
+	api.post(
+		'/sites/:id/sync/cancel',
+		asyncHandler( async ( req: Request, res: Response ) => {
+			const { remoteSiteId } = req.body as { remoteSiteId?: number };
+			if ( ! remoteSiteId ) {
+				res.status( 400 ).json( { error: 'remoteSiteId is required' } );
+				return;
+			}
+			SYNC_ABORT_CONTROLLERS.get( `${ req.params.id }-${ remoteSiteId }` )?.abort();
 			res.sendStatus( 204 );
 		} )
 	);
@@ -1227,19 +1274,31 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 				res.status( 404 ).json( { error: `Site ${ req.params.id } not found` } );
 				return;
 			}
-			await pushSite(
-				{
-					executeCliCommand: execute,
-					accessToken: token.accessToken,
-					emit: ( output ) =>
-						sseSend( {
-							channel: 'sync',
-							payload: { ...output, siteId: req.params.id, remoteSiteId },
-						} ),
-				},
-				{ sitePath: site.path, remoteSiteId, options }
-			);
-			res.sendStatus( 204 );
+			const release = registerSyncAbort( req.params.id, remoteSiteId );
+			try {
+				await pushSite(
+					{
+						executeCliCommand: execute,
+						accessToken: token.accessToken,
+						emit: ( output ) =>
+							sseSend( {
+								channel: 'sync-push',
+								payload: { ...output, siteId: req.params.id, remoteSiteId },
+							} ),
+					},
+					{ sitePath: site.path, remoteSiteId, options, signal: release.signal }
+				);
+			} catch ( error ) {
+				// See the pull route — a cancel is reported, not raised as a 500.
+				if ( ! isSyncCancelledError( error ) ) {
+					throw error;
+				}
+				res.json( { cancelled: true } );
+				return;
+			} finally {
+				release();
+			}
+			res.json( { cancelled: false } );
 		} )
 	);
 

--- a/apps/studio/src/ipc-utils.ts
+++ b/apps/studio/src/ipc-utils.ts
@@ -8,7 +8,7 @@ import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { AiSessionPlacementUpdatedEvent } from '@studio/common/ai/sessions/placement';
 import type { RemoteSessionStatus } from '@studio/common/lib/remote-session';
 import type { StoredAuthToken } from '@studio/common/lib/shared-config';
-import type { PullSiteProgress } from '@studio/common/types/sync';
+import type { PullSiteProgress, PushPhase } from '@studio/common/types/sync';
 
 type SnapshotEventData = {
 	action: PreviewCommandLoggerAction;
@@ -40,6 +40,7 @@ export interface IpcEvents {
 	'sync-upload-progress': [ { selectedSiteId: string; remoteSiteId: number; progress: number } ];
 	'sync-upload-manually-paused': [ { selectedSiteId: string; remoteSiteId: number } ];
 	'sync-pull-progress': [ PullSiteProgress & { siteId: string } ];
+	'sync-push-phase': [ { selectedSiteId: string; remoteSiteId: number; phase: PushPhase } ];
 	'snapshot-error': [ { operationId: crypto.UUID; data: SnapshotEventData } ];
 	'snapshot-fatal-error': [ { operationId: crypto.UUID; data: { message: string } } ];
 	'snapshot-output': [ { operationId: crypto.UUID; data: SnapshotEventData } ];

--- a/apps/studio/src/modules/sync/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/sync/lib/ipc-handlers.ts
@@ -12,6 +12,7 @@ import {
 } from '@studio/common/lib/connected-sites';
 import { isErrnoException } from '@studio/common/lib/is-errno-exception';
 import { getCurrentUserId } from '@studio/common/lib/shared-config';
+import { isSyncCancelledError } from '@studio/common/lib/sync/cancel';
 import { fetchLatestRewindId, fetchSyncableSites } from '@studio/common/lib/sync/sync-api';
 import { shouldRetryTusStatus } from '@studio/common/lib/sync/tus-upload';
 import wpcomFactory from '@studio/common/lib/wpcom-factory';
@@ -40,6 +41,9 @@ import { SyncOption } from 'src/types';
  * Key format: `${selectedSiteId}-${remoteSiteId}`
  */
 const SYNC_ABORT_CONTROLLERS = new Map< string, AbortController >();
+
+// Agentic push/pull resolve with this instead of rejecting when the user cancels.
+type SyncOperationResult = { cancelled: boolean };
 
 /**
  * Registry to store TUS upload instances and their pause state for ongoing uploads.
@@ -533,24 +537,47 @@ export async function pullSiteFromLive(
 	siteId: string,
 	remoteSiteId: number,
 	options?: PullSyncOptions
-): Promise< void > {
+): Promise< SyncOperationResult > {
 	const site = SiteServer.get( siteId );
 	if ( ! site ) {
 		throw new Error( 'Site not found.' );
 	}
 	const window = BrowserWindow.fromWebContents( event.sender );
-	return pullSite(
-		executeCliCommand,
-		site.details.path,
-		remoteSiteId,
-		( progress ) => {
-			sendIpcEventToRendererWithWindow( window, 'sync-pull-progress', {
-				siteId,
-				...progress,
-			} );
-		},
-		options
-	);
+	// Registered under the same key the legacy renderer uses, so `cancelSyncOperation`
+	// stops an agentic pull too.
+	const operationId = `${ siteId }-${ remoteSiteId }`;
+	const abortController = new AbortController();
+	SYNC_ABORT_CONTROLLERS.set( operationId, abortController );
+	try {
+		await pullSite(
+			executeCliCommand,
+			site.details.path,
+			remoteSiteId,
+			( progress ) => {
+				sendIpcEventToRendererWithWindow( window, 'sync-pull-progress', {
+					siteId,
+					...progress,
+				} );
+			},
+			options,
+			abortController.signal
+		);
+		return { cancelled: false };
+	} catch ( error ) {
+		// A user cancel is an intentional stop, not a failure. Rejecting here would
+		// make Electron log it as a handler error in the very log we point users at
+		// when a pull fails, so report it as a result instead — the renderer turns it
+		// back into a cancelled operation. Same reasoning as `downloadSyncBackup`.
+		if ( isSyncCancelledError( error ) ) {
+			console.log( `[Sync] Pull cancelled by user for operation: ${ operationId }` );
+			return { cancelled: true };
+		}
+		throw error;
+	} finally {
+		if ( SYNC_ABORT_CONTROLLERS.get( operationId ) === abortController ) {
+			SYNC_ABORT_CONTROLLERS.delete( operationId );
+		}
+	}
 }
 
 // Push for the agentic UI (apps/ui): the same shared `pushSite` the `studio ui`
@@ -563,7 +590,7 @@ export async function pushSiteToLive(
 	selectedSiteId: string,
 	remoteSiteId: number,
 	options?: PushSyncOptions
-): Promise< void > {
+): Promise< SyncOperationResult > {
 	const site = SiteServer.get( selectedSiteId );
 	if ( ! site ) {
 		throw new Error( 'Site not found.' );
@@ -572,33 +599,57 @@ export async function pushSiteToLive(
 	if ( ! token?.accessToken ) {
 		throw new Error( 'No token found' );
 	}
-	await pushSite(
-		{
-			executeCliCommand,
-			accessToken: token.accessToken,
-			emit: ( output ) => {
-				if ( output.kind === 'upload-progress' ) {
-					void sendIpcEventToRenderer( 'sync-upload-progress', {
-						selectedSiteId,
-						remoteSiteId,
-						progress: output.progress,
-					} );
-				} else if ( output.kind === 'network-paused' ) {
-					void sendIpcEventToRenderer( 'sync-upload-network-paused', {
-						selectedSiteId,
-						remoteSiteId,
-						error: output.error,
-					} );
-				} else if ( output.kind === 'resumed' ) {
-					void sendIpcEventToRenderer( 'sync-upload-resumed', {
-						selectedSiteId,
-						remoteSiteId,
-					} );
-				}
+	// See `pullSiteFromLive` — same registry, so `cancelSyncOperation` covers both UIs.
+	const operationId = `${ selectedSiteId }-${ remoteSiteId }`;
+	const abortController = new AbortController();
+	SYNC_ABORT_CONTROLLERS.set( operationId, abortController );
+	try {
+		await pushSite(
+			{
+				executeCliCommand,
+				accessToken: token.accessToken,
+				emit: ( output ) => {
+					if ( output.kind === 'phase' ) {
+						void sendIpcEventToRenderer( 'sync-push-phase', {
+							selectedSiteId,
+							remoteSiteId,
+							phase: output.phase,
+						} );
+					} else if ( output.kind === 'upload-progress' ) {
+						void sendIpcEventToRenderer( 'sync-upload-progress', {
+							selectedSiteId,
+							remoteSiteId,
+							progress: output.progress,
+						} );
+					} else if ( output.kind === 'network-paused' ) {
+						void sendIpcEventToRenderer( 'sync-upload-network-paused', {
+							selectedSiteId,
+							remoteSiteId,
+							error: output.error,
+						} );
+					} else if ( output.kind === 'resumed' ) {
+						void sendIpcEventToRenderer( 'sync-upload-resumed', {
+							selectedSiteId,
+							remoteSiteId,
+						} );
+					}
+				},
 			},
-		},
-		{ sitePath: site.details.path, remoteSiteId, options }
-	);
+			{ sitePath: site.details.path, remoteSiteId, options, signal: abortController.signal }
+		);
+		return { cancelled: false };
+	} catch ( error ) {
+		// See `pullSiteFromLive` — a cancel is reported, not thrown.
+		if ( isSyncCancelledError( error ) ) {
+			console.log( `[Sync] Push cancelled by user for operation: ${ operationId }` );
+			return { cancelled: true };
+		}
+		throw error;
+	} finally {
+		if ( SYNC_ABORT_CONTROLLERS.get( operationId ) === abortController ) {
+			SYNC_ABORT_CONTROLLERS.delete( operationId );
+		}
+	}
 }
 
 // Fetches every WordPress.com site the authenticated user can sync to.

--- a/apps/studio/src/modules/sync/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/sync/lib/ipc-handlers.ts
@@ -42,7 +42,6 @@ import { SyncOption } from 'src/types';
  */
 const SYNC_ABORT_CONTROLLERS = new Map< string, AbortController >();
 
-// Agentic push/pull resolve with this instead of rejecting when the user cancels.
 type SyncOperationResult = { cancelled: boolean };
 
 /**
@@ -599,7 +598,6 @@ export async function pushSiteToLive(
 	if ( ! token?.accessToken ) {
 		throw new Error( 'No token found' );
 	}
-	// See `pullSiteFromLive` — same registry, so `cancelSyncOperation` covers both UIs.
 	const operationId = `${ selectedSiteId }-${ remoteSiteId }`;
 	const abortController = new AbortController();
 	SYNC_ABORT_CONTROLLERS.set( operationId, abortController );

--- a/apps/ui/src/components/site-dropdown/index.test.tsx
+++ b/apps/ui/src/components/site-dropdown/index.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SiteDropdown } from './index';
+import type { SiteDetails, SyncSite } from '@/data/core';
+
+// Drives the real wiring behind "confirming the sync dialog reopens the
+// dropdown": the dialog closes, an effect fires, and it clicks the trigger.
+// Clicking (rather than setting state) is what keeps Base UI from re-arming its
+// hover-close, so this asserts the click actually happens.
+
+const { connectedSites, pullMutate } = vi.hoisted( () => ( {
+	connectedSites: [] as SyncSite[],
+	pullMutate: vi.fn(),
+} ) );
+
+vi.mock( '@/data/core', () => ( { useConnector: () => ( {} ) } ) );
+vi.mock( '@/data/queries/use-connected-wpcom-sites', () => ( {
+	useConnectedWpcomSites: () => ( { data: connectedSites } ),
+} ) );
+vi.mock( '@/data/queries/use-snapshots', () => ( { useSnapshots: () => ( { data: [] } ) } ) );
+vi.mock( '@/data/queries/use-sites', () => ( {
+	useIsSiteStarting: () => false,
+	useIsSiteStopping: () => false,
+} ) );
+vi.mock( '@/data/queries/use-sync-site', () => ( {
+	usePullSiteFromLive: () => ( { mutate: pullMutate } ),
+	usePushSiteToLive: () => ( { mutate: vi.fn() } ),
+} ) );
+vi.mock( '@/data/sync-activity', () => ( { useSiteSyncActivity: () => null } ) );
+vi.mock( '@/components/selective-sync/lib/get-ipc-api', () => ( {
+	registerSelectiveSyncConnector: vi.fn(),
+} ) );
+vi.mock( './disconnect-site-dialog', () => ( { DisconnectSiteDialog: () => null } ) );
+vi.mock( '@/components/selective-sync/lib/convert-tree-to-sync-options', () => ( {
+	convertTreeToPullOptions: () => ( { optionsToSync: [ 'all' ], include_path_list: [] } ),
+	convertTreeToPushOptions: () => ( { optionsToSync: [ 'all' ] } ),
+} ) );
+vi.mock( './publish-picker-view', () => ( { PublishPickerView: () => null } ) );
+
+// Stand-ins for the popup contents and the dialog, so the test can drive
+// "open the dialog" and "confirm it" without their real dependencies.
+vi.mock( './main-view', () => ( {
+	MainView: ( { onPullClick }: { onPullClick: () => void } ) => (
+		<button onClick={ onPullClick }>Pull from live</button>
+	),
+} ) );
+vi.mock( '@/components/selective-sync/sync-dialog', () => ( {
+	SyncDialog: ( { onPull }: { onPull: ( tree: unknown[] ) => void } ) => (
+		<button onClick={ () => onPull( [] ) }>Confirm pull</button>
+	),
+} ) );
+
+const site: SiteDetails = {
+	id: 'site-1',
+	name: 'Demo Site',
+	path: '/tmp/demo-site',
+	port: 8881,
+	running: true,
+	phpVersion: '8.3',
+};
+
+const liveSite: SyncSite = {
+	id: 123,
+	localSiteId: 'site-1',
+	name: 'Live Site',
+	url: 'example.com',
+	isStaging: false,
+	isPressable: false,
+	syncSupport: 'already-connected',
+	lastPullTimestamp: null,
+	lastPushTimestamp: null,
+};
+
+describe( 'SiteDropdown sync dialog', () => {
+	beforeEach( () => {
+		pullMutate.mockReset();
+		connectedSites.splice( 0, connectedSites.length, liveSite );
+	} );
+
+	it( 'reopens the dropdown after the pull is confirmed', async () => {
+		render( <SiteDropdown site={ site } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: /Demo Site/ } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Pull from live' } ) );
+
+		// The dialog replaces the dropdown, matching the disconnect dialog's rule.
+		expect( screen.queryByRole( 'button', { name: 'Pull from live' } ) ).not.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Confirm pull' } ) );
+
+		expect( pullMutate ).toHaveBeenCalledWith(
+			expect.objectContaining( { siteId: site.id, remoteSiteId: liveSite.id } )
+		);
+		await waitFor( () =>
+			expect( screen.getByRole( 'button', { name: 'Pull from live' } ) ).toBeInTheDocument()
+		);
+	} );
+
+	it( 'leaves the dropdown closed when the dialog is dismissed without syncing', async () => {
+		render( <SiteDropdown site={ site } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: /Demo Site/ } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Pull from live' } ) );
+
+		expect( screen.queryByRole( 'button', { name: 'Pull from live' } ) ).not.toBeInTheDocument();
+		expect( pullMutate ).not.toHaveBeenCalled();
+	} );
+} );

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as Menu from '@/components/menu';
 import {
 	convertTreeToPullOptions,
@@ -48,6 +48,8 @@ export function SiteDropdown( {
 }: Props ) {
 	const [ view, setView ] = useState< 'main' | 'picker' >( 'main' );
 	const [ menuOpen, setMenuOpen ] = useState( defaultOpen );
+	const rootRef = useRef< HTMLDivElement >( null );
+	const reopenAfterDialogRef = useRef( false );
 	const [ disconnectOpen, setDisconnectOpen ] = useState( false );
 	const [ syncDialogType, setSyncDialogType ] = useState< 'push' | 'pull' | null >( null );
 
@@ -101,29 +103,51 @@ export function SiteDropdown( {
 		setSyncDialogType( type );
 	};
 
+	const startSyncFromDialog = ( start: () => void ) => {
+		start();
+		reopenAfterDialogRef.current = true;
+		setSyncDialogType( null );
+	};
+
+	// Reopen the dropdown once the dialog is gone, so the sync progress and its
+	// cancel are in view. It clicks the trigger rather than setting state: Base UI
+	// only clears its hover-close interaction on a real interaction, so a menu
+	// opened via `setMenuOpen` dismisses itself the moment the pointer moves
+	// outside it. Running in an effect (rather than a timer) guarantees the modal
+	// has unmounted and returned focus first — cleanups run before this.
+	useEffect( () => {
+		if ( syncDialogType !== null || ! reopenAfterDialogRef.current ) {
+			return;
+		}
+		reopenAfterDialogRef.current = false;
+		rootRef.current?.querySelector< HTMLElement >( '[aria-haspopup="menu"]' )?.click();
+	}, [ syncDialogType ] );
+
 	const handleDialogPush = ( tree: TreeNode[] ) => {
 		if ( ! liveSite ) return;
 		const options = convertTreeToPushOptions( tree );
-		pushSiteToLive.mutate(
-			{ siteId: site.id, remoteSiteId: liveSite.id, options },
-			{ onSuccess: () => void connector.openExternalUrl( ensureProtocol( liveSite.url ) ) }
+		startSyncFromDialog( () =>
+			pushSiteToLive.mutate(
+				{ siteId: site.id, remoteSiteId: liveSite.id, options },
+				{ onSuccess: () => void connector.openExternalUrl( ensureProtocol( liveSite.url ) ) }
+			)
 		);
-		setSyncDialogType( null );
 	};
 
 	const handleDialogPull = ( tree: TreeNode[] ) => {
 		if ( ! liveSite ) return;
 		const { optionsToSync, include_path_list: includePathList } = convertTreeToPullOptions( tree );
-		pullSiteFromLive.mutate( {
-			siteId: site.id,
-			remoteSiteId: liveSite.id,
-			options: { optionsToSync, includePathList },
-		} );
-		setSyncDialogType( null );
+		startSyncFromDialog( () =>
+			pullSiteFromLive.mutate( {
+				siteId: site.id,
+				remoteSiteId: liveSite.id,
+				options: { optionsToSync, includePathList },
+			} )
+		);
 	};
 
 	return (
-		<div className={ styles.root }>
+		<div className={ styles.root } ref={ rootRef }>
 			<Menu.Root
 				modal={ false }
 				open={ menuOpen }

--- a/apps/ui/src/components/site-dropdown/main-view.module.css
+++ b/apps/ui/src/components/site-dropdown/main-view.module.css
@@ -30,6 +30,9 @@
 .activityStatusNote {
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font-size: var(--wpds-typography-font-size-xs);
+	/* Matches the smaller font size — inheriting the row's `sm` line height
+	   leaves this sentence too airy once it wraps onto a second line. */
+	line-height: var(--wpds-typography-line-height-xs);
 	text-wrap: pretty;
 }
 

--- a/apps/ui/src/components/site-dropdown/main-view.module.css
+++ b/apps/ui/src/components/site-dropdown/main-view.module.css
@@ -9,12 +9,50 @@
 
 .activityStatus {
 	display: flex;
-	flex-direction: column;
-	gap: 4px;
+	/* Pin the cancel button to the top: centring drifts it down the block as the
+	   progress message and the "can't cancel" reason wrap. */
+	align-items: flex-start;
+	gap: var(--wpds-dimension-padding-md);
 	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
 	color: var(--wpds-color-fg-content-neutral);
 	font-size: var(--wpds-typography-font-size-sm);
 	line-height: var(--wpds-typography-line-height-sm);
+}
+
+.activityStatusText {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-width: 0;
+	flex: 1;
+}
+
+.activityStatusNote {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-xs);
+	text-wrap: pretty;
+}
+
+/* Matches .moreMenuTrigger: the popup is an inverted surface, so the design
+   system's own disabled colour lands on the wrong background and the button
+   reads as enabled. */
+.cancelSyncButton {
+	flex: 0 0 auto;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	justify-content: center;
+	color: var(--wpds-color-fg-interactive-neutral);
+}
+
+.cancelSyncButton:is([data-disabled], :disabled) {
+	color: var(--wpds-color-fg-interactive-neutral-disabled);
+}
+
+.cancelSyncButton svg {
+	width: 14px;
+	height: 14px;
+	fill: currentColor;
 }
 
 .activityStatusPending {

--- a/apps/ui/src/components/site-dropdown/main-view.test.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.test.tsx
@@ -66,11 +66,14 @@ vi.mock( '@/data/queries/use-snapshots', () => ( {
 	useSnapshots: () => ( { data: snapshots } ),
 } ) );
 
+const cancelSyncMutate = vi.fn();
+
 vi.mock( '@/data/queries/use-sync-site', () => ( {
 	PULL_FROM_LIVE_MUTATION_KEY: [ 'pull-site-from-live' ],
 	PUSH_TO_LIVE_MUTATION_KEY: [ 'push-site-to-live' ],
 	usePullSiteFromLive: () => ( { mutate: vi.fn() } ),
 	usePushSiteToLive: () => ( { mutate: vi.fn() } ),
+	useCancelSync: () => ( { mutate: cancelSyncMutate } ),
 } ) );
 
 const liveSite: SyncSite = {
@@ -124,6 +127,7 @@ describe( 'MainView', () => {
 		vi.mocked( useIsMutating ).mockImplementation( () => 0 );
 		connector.copyText.mockReset();
 		connector.openExternalUrl.mockReset();
+		cancelSyncMutate.mockReset();
 		publishPreviewMutate.mockReset();
 		startSiteMutate.mockReset();
 		stopSiteMutate.mockReset();
@@ -260,6 +264,65 @@ describe( 'MainView', () => {
 		const pullButton = screen.getByRole( 'button', { name: 'Pull from live' } );
 		expect( pullButton.getAttribute( 'aria-disabled' ) ).not.toBe( 'true' );
 		expect( screen.getByRole( 'button', { name: 'Push to live' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'offers to stop an in-flight push and reports the site being stopped', () => {
+		connectedSites.splice( 0, connectedSites.length, liveSite );
+
+		renderMainView( {
+			activity: { kind: 'pending', direction: 'push', phase: 'uploading' },
+		} );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel push' } ) );
+
+		expect( cancelSyncMutate ).toHaveBeenCalledWith( {
+			siteId: site.id,
+			remoteSiteId: liveSite.id,
+		} );
+		expect( screen.getByRole( 'status' ) ).not.toHaveTextContent( 'can not be cancelled' );
+	} );
+
+	it( 'stops offering to cancel a push once the remote import has started', () => {
+		connectedSites.splice( 0, connectedSites.length, liveSite );
+
+		renderMainView( {
+			activity: { kind: 'pending', direction: 'push', phase: 'applyingChanges' },
+		} );
+
+		const blocked = screen.getByRole( 'button', {
+			name: 'Push can not be cancelled while applying changes to the remote site',
+		} );
+		fireEvent.click( blocked );
+
+		expect( blocked ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( cancelSyncMutate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stops offering to cancel a pull once the local import has started', () => {
+		connectedSites.splice( 0, connectedSites.length, liveSite );
+
+		renderMainView( {
+			activity: {
+				kind: 'pending',
+				direction: 'pull',
+				action: 'import',
+				message: 'Importing backup…',
+			},
+		} );
+
+		// The reason doubles as the accessible name, so it reaches the tooltip and
+		// screen readers instead of a bare "Cancel pull" that then does nothing.
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Pull can not be cancelled while importing changes to your local site',
+			} )
+		).toHaveAttribute( 'aria-disabled', 'true' );
+
+		// And stated in the panel itself — a tooltip on a disabled control is a
+		// dead end, since nothing invites you to hover it.
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent(
+			'Pull can not be cancelled while importing changes to your local site'
+		);
 	} );
 
 	it( 'reflects an in-flight pull on both live sync controls', () => {

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -2,7 +2,7 @@ import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
 import { isSnapshotExpired } from '@studio/common/lib/snapshots';
 import { useIsMutating } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
-import { arrowDown, arrowUp, copy, external, Icon, moreHorizontal } from '@wordpress/icons';
+import { arrowDown, arrowUp, close, copy, external, Icon, moreHorizontal } from '@wordpress/icons';
 import { Button, IconButton, Tooltip } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useMemo } from 'react';
@@ -23,7 +23,9 @@ import { useSnapshots } from '@/data/queries/use-snapshots';
 import {
 	PULL_FROM_LIVE_MUTATION_KEY,
 	PUSH_TO_LIVE_MUTATION_KEY,
+	useCancelSync,
 } from '@/data/queries/use-sync-site';
+import { canCancelSyncActivity, getSyncCancelLabels } from '@/data/sync-activity';
 import { getSiteUrl } from '@/lib/get-site-url';
 import styles from './main-view.module.css';
 import { PopoverRow } from './popover-row';
@@ -128,6 +130,7 @@ export function MainView( {
 	const startSite = useStartSite();
 	const stopSite = useStopSite();
 	const publishPreviewSite = usePublishPreviewSite();
+	const cancelSync = useCancelSync();
 
 	const isStarting = useIsSiteStarting( site.id );
 	const isStopping = useIsSiteStopping( site.id );
@@ -251,7 +254,15 @@ export function MainView( {
 	return (
 		<div className={ styles.rows }>
 			{ activity?.kind === 'pending' || activity?.kind === 'error' ? (
-				<SyncActivityDetails activity={ activity } />
+				<SyncActivityDetails
+					activity={ activity }
+					onCancel={
+						liveSite && canCancelSyncActivity( activity )
+							? () => cancelSync.mutate( { siteId: site.id, remoteSiteId: liveSite.id } )
+							: undefined
+					}
+					canCancel={ canCancelSyncActivity( activity ) }
+				/>
 			) : null }
 
 			<PopoverRow
@@ -452,22 +463,52 @@ function XdebugBadge( { running }: { running: boolean } ) {
 
 function SyncActivityDetails( {
 	activity,
+	onCancel,
+	canCancel,
 }: {
 	activity: Extract< SyncActivity, { kind: 'pending' | 'error' } >;
+	onCancel?: () => void;
+	canCancel: boolean;
 } ) {
+	// Same wording as the classic renderer, and the same source the trigger's
+	// always-visible cancel uses, so the two never disagree.
+	const cancel = getSyncCancelLabels( activity );
+	const blockedLabel = cancel && ! cancel.enabled ? cancel.label : null;
+
 	return (
 		<div
 			className={ clsx(
 				styles.activityStatus,
 				activity.kind === 'error' ? styles.activityStatusError : styles.activityStatusPending
 			) }
-			role="status"
-			aria-live="polite"
 		>
-			<div className={ styles.activityStatusTitle }>{ getSyncActivityLabel( activity ) }</div>
-			<div className={ styles.activityStatusMessage }>
-				{ activity.message ?? __( 'Preparing the live site…' ) }
+			<div className={ styles.activityStatusText } role="status" aria-live="polite">
+				<div className={ styles.activityStatusTitle }>{ getSyncActivityLabel( activity ) }</div>
+				<div className={ styles.activityStatusMessage }>
+					{ activity.message ?? __( 'Preparing the live site…' ) }
+				</div>
+				{ blockedLabel ? (
+					// Stating this inline rather than leaving it to the disabled
+					// button's tooltip: nobody hovers a control that looks inert.
+					<div className={ styles.activityStatusNote }>{ blockedLabel }</div>
+				) : null }
 			</div>
+			{ cancel ? (
+				// A plain Button, not an IconButton: IconButton always wraps itself in
+				// a Tooltip, and tooltips never render inside this menu anyway.
+				<Button
+					className={ styles.cancelSyncButton }
+					variant="minimal"
+					tone="neutral"
+					size="small"
+					aria-label={ cancel.label }
+					disabled={ ! cancel.enabled }
+					focusableWhenDisabled
+					onClick={ () => onCancel?.() }
+				>
+					<Icon icon={ close } size={ 20 } />
+				</Button>
+			) : null }
 		</div>
 	);
 }

--- a/apps/ui/src/components/site-dropdown/trigger-secondary.ts
+++ b/apps/ui/src/components/site-dropdown/trigger-secondary.ts
@@ -35,6 +35,13 @@ export function getSyncActivityLabel( activity: SyncActivity ): string {
 		return activity.direction === 'push' ? __( 'Pushed to live' ) : __( 'Pulled from live' );
 	}
 
+	if ( activity.kind === 'cancelled' ) {
+		if ( activity.direction === 'preview' ) {
+			return __( 'Preview publishing cancelled' );
+		}
+		return activity.direction === 'push' ? __( 'Push cancelled' ) : __( 'Pull cancelled' );
+	}
+
 	if ( activity.direction === 'preview' ) {
 		return __( 'Publishing preview failed' );
 	}
@@ -47,7 +54,12 @@ function getSyncActivityTone( activity: SyncActivity ): TriggerSecondaryTone {
 	if ( activity.kind === 'pending' ) {
 		return 'pending';
 	}
-	return activity.kind === 'success' ? 'success' : 'error';
+	if ( activity.kind === 'success' ) {
+		return 'success';
+	}
+	// A cancel is the user's own doing, not a failure — the legacy renderer
+	// likewise shows it without error styling.
+	return activity.kind === 'cancelled' ? 'neutral' : 'error';
 }
 
 function formatTimestampPhrase(

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -271,6 +271,9 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		async pushSiteToLive() {
 			throw new UnsupportedError( 'pushSiteToLive' );
 		},
+		async cancelSync() {
+			throw new UnsupportedError( 'cancelSync' );
+		},
 		async pullSiteFromLive() {
 			throw new UnsupportedError( 'pullSiteFromLive' );
 		},

--- a/apps/ui/src/data/core/connectors/ipc/index.test.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.test.ts
@@ -1,3 +1,4 @@
+import { isSyncCancelledError } from '@studio/common/lib/sync/cancel';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createIpcConnector } from './index';
 import type { SiteDetails } from '@/data/core';
@@ -178,7 +179,15 @@ describe( 'createIpcConnector Connect contracts', () => {
 		} );
 		pullSiteFromLive.mockImplementation( async ( siteId ) => {
 			progressListener( {}, { siteId: 'other', message: 'Ignore me' } );
-			progressListener( {}, { siteId, message: 'Downloading backup… (50%)', progress: 50 } );
+			progressListener(
+				{},
+				{
+					siteId,
+					message: 'Downloading backup… (50%)',
+					progress: 50,
+					action: 'initiateBackup',
+				}
+			);
 		} );
 		const onProgress = vi.fn();
 
@@ -189,7 +198,54 @@ describe( 'createIpcConnector Connect contracts', () => {
 		expect( onProgress ).toHaveBeenCalledWith( {
 			message: 'Downloading backup… (50%)',
 			progress: 50,
+			action: 'initiateBackup',
 		} );
 		expect( unsubscribe ).toHaveBeenCalledOnce();
+	} );
+
+	// The main process reports a user cancel as a result rather than rejecting, so
+	// Electron doesn't log it as a handler error in the log we point users at when
+	// a pull fails. The connector turns it back into an error for the caller.
+	it( 'raises a reported cancel as a cancelled error', async () => {
+		getConnectedWpcomSites.mockResolvedValue( [] );
+		subscribe.mockImplementation( () => unsubscribe );
+		pullSiteFromLive.mockResolvedValue( { cancelled: true } );
+
+		await expect( createIpcConnector().pullSiteFromLive( 'site-1', 42 ) ).rejects.toSatisfy(
+			isSyncCancelledError
+		);
+	} );
+
+	it( 'completes normally when nothing was cancelled', async () => {
+		getConnectedWpcomSites.mockResolvedValue( [] );
+		subscribe.mockImplementation( () => unsubscribe );
+		pullSiteFromLive.mockResolvedValue( { cancelled: false } );
+
+		await expect( createIpcConnector().pullSiteFromLive( 'site-1', 42 ) ).resolves.toBeUndefined();
+	} );
+
+	// Without the CLI action the cancel gate can't tell the remote phases from
+	// the local import, so every pull looks cancellable right through the import.
+	it( 'forwards the CLI action that drives the cancel gate', async () => {
+		getConnectedWpcomSites.mockResolvedValue( [] );
+		let progressListener: ( event: unknown, payload: unknown ) => void = () => {};
+		subscribe.mockImplementation( ( _channel, listener ) => {
+			progressListener = listener;
+			return unsubscribe;
+		} );
+		pullSiteFromLive.mockImplementation( async ( siteId ) => {
+			progressListener(
+				{},
+				{ siteId, message: 'Importing plugins… (3406/9394)', action: 'import' }
+			);
+		} );
+		const onProgress = vi.fn();
+
+		await createIpcConnector().pullSiteFromLive( 'site-1', 42, onProgress );
+
+		expect( onProgress ).toHaveBeenCalledWith( {
+			message: 'Importing plugins… (3406/9394)',
+			action: 'import',
+		} );
 	} );
 } );

--- a/apps/ui/src/data/core/connectors/ipc/index.test.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.test.ts
@@ -108,6 +108,8 @@ describe( 'createIpcConnector Connect contracts', () => {
 	const getSiteDetails = vi.fn();
 	const getConnectedWpcomSites = vi.fn();
 	const pullSiteFromLive = vi.fn();
+	const pushSiteToLive = vi.fn();
+	const updateConnectedWpcomSites = vi.fn();
 	const subscribe = vi.fn();
 	const unsubscribe = vi.fn();
 
@@ -120,6 +122,8 @@ describe( 'createIpcConnector Connect contracts', () => {
 			getSiteDetails,
 			getConnectedWpcomSites,
 			pullSiteFromLive,
+			pushSiteToLive,
+			updateConnectedWpcomSites,
 		} );
 		vi.stubGlobal( 'ipcListener', { subscribe } );
 	} );
@@ -201,6 +205,37 @@ describe( 'createIpcConnector Connect contracts', () => {
 			action: 'initiateBackup',
 		} );
 		expect( unsubscribe ).toHaveBeenCalledOnce();
+	} );
+
+	// A cancelled sync never happened, so it must not stamp the connection's
+	// last-synced time — otherwise the site header would later read "Pushed 2
+	// minutes ago" for a push the user stopped.
+	it( 'does not record a sync time when the push is cancelled', async () => {
+		getConnectedWpcomSites.mockResolvedValue( [
+			{ id: 42, localSiteId: 'site-1', lastPushTimestamp: null },
+		] );
+		subscribe.mockImplementation( () => unsubscribe );
+		pushSiteToLive.mockResolvedValue( { cancelled: true } );
+
+		await expect( createIpcConnector().pushSiteToLive( 'site-1', 42 ) ).rejects.toSatisfy(
+			isSyncCancelledError
+		);
+
+		expect( updateConnectedWpcomSites ).not.toHaveBeenCalled();
+	} );
+
+	it( 'records the sync time once the push completes', async () => {
+		getConnectedWpcomSites.mockResolvedValue( [
+			{ id: 42, localSiteId: 'site-1', lastPushTimestamp: null },
+		] );
+		subscribe.mockImplementation( () => unsubscribe );
+		pushSiteToLive.mockResolvedValue( { cancelled: false } );
+
+		await createIpcConnector().pushSiteToLive( 'site-1', 42 );
+
+		expect( updateConnectedWpcomSites ).toHaveBeenCalledWith( [
+			expect.objectContaining( { id: 42, lastPushTimestamp: expect.any( String ) } ),
+		] );
 	} );
 
 	// The main process reports a user cancel as a result rather than rejecting, so

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -4,6 +4,7 @@ import {
 	STUDIO_ASSISTANT_QUOTA_URL,
 	studioAssistantQuotaSchema,
 } from '@studio/common/lib/studio-assistant-quota';
+import { SyncCancelledError } from '@studio/common/lib/sync/cancel';
 import { fetchWordPressVersions } from '@studio/common/lib/wordpress-versions';
 import { __ } from '@wordpress/i18n';
 import { buildPublishCheckoutUrl } from '../publish-checkout-url';
@@ -21,6 +22,7 @@ import type {
 	LoadedAiSession,
 	AppUpdateStatus,
 	ProposedSitePath,
+	PushPhase,
 	QuitSitesBehavior,
 	SelectedSiteFolder,
 	SiteDetails,
@@ -554,13 +556,42 @@ export function createIpcConnector(): Connector {
 			);
 		},
 
-		async pushSiteToLive( siteId, remoteSiteId, options ): Promise< void > {
+		async pushSiteToLive( siteId, remoteSiteId, options, onPhase ): Promise< void > {
 			// The agentic UI pushes via the shared `pushSite` (export → TUS
 			// upload → import) in both desktop and `studio ui`; the desktop runs
 			// it behind this single IPC handler. Resolves once the import is
 			// initiated (the remote import may still be running).
-			await ipcApi.pushSiteToLive( siteId, remoteSiteId, options );
+			const unsubscribe = onPhase
+				? ipcListener.subscribe(
+						'sync-push-phase',
+						(
+							_event: unknown,
+							payload: { selectedSiteId: string; remoteSiteId: number; phase: PushPhase }
+						) => {
+							if ( payload.selectedSiteId === siteId && payload.remoteSiteId === remoteSiteId ) {
+								onPhase( payload.phase );
+							}
+						}
+				  )
+				: undefined;
+			let result: { cancelled?: boolean } | undefined;
+			try {
+				result = await ipcApi.pushSiteToLive( siteId, remoteSiteId, options );
+			} finally {
+				unsubscribe?.();
+			}
+			// The main process reports a cancel instead of rejecting, to keep it out
+			// of the logs as an error; turn it back into one for the caller.
+			if ( result?.cancelled ) {
+				throw new SyncCancelledError();
+			}
 			await markConnectedWpcomSiteSynced( siteId, remoteSiteId, 'push' );
+		},
+
+		async cancelSync( siteId, remoteSiteId ): Promise< void > {
+			// Same registry the classic renderer cancels through — the operation id
+			// is `${siteId}-${remoteSiteId}`.
+			ipcApi.cancelSyncOperation( `${ siteId }-${ remoteSiteId }` );
 		},
 
 		async pullSiteFromLive( siteId, remoteSiteId, onProgress, options ): Promise< void > {
@@ -569,21 +600,27 @@ export function createIpcConnector(): Connector {
 						'sync-pull-progress',
 						(
 							_event: unknown,
-							payload: { siteId: string; message: string; progress?: number }
+							payload: { siteId: string; message: string; progress?: number; action?: string }
 						) => {
 							if ( payload.siteId === siteId ) {
 								onProgress( {
 									message: payload.message,
 									...( payload.progress === undefined ? {} : { progress: payload.progress } ),
+									// Drives the cancel gate — without it every pull looks cancellable.
+									...( payload.action === undefined ? {} : { action: payload.action } ),
 								} );
 							}
 						}
 				  )
 				: undefined;
+			let result: { cancelled?: boolean } | undefined;
 			try {
-				await ipcApi.pullSiteFromLive( siteId, remoteSiteId, options );
+				result = await ipcApi.pullSiteFromLive( siteId, remoteSiteId, options );
 			} finally {
 				unsubscribe?.();
+			}
+			if ( result?.cancelled ) {
+				throw new SyncCancelledError();
 			}
 			await markConnectedWpcomSiteSynced( siteId, remoteSiteId, 'pull' );
 		},

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -1,4 +1,5 @@
 import { getAuthenticationUrl, getSignUpUrl } from '@studio/common/lib/oauth';
+import { SyncCancelledError } from '@studio/common/lib/sync/cancel';
 import { fetchWordPressVersions } from '@studio/common/lib/wordpress-versions';
 import { __ } from '@wordpress/i18n';
 import { readOnboardingHints, writeOnboardingHints } from '../browser-onboarding-hints';
@@ -34,6 +35,7 @@ import type {
 } from '../../types';
 import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { ImportEventTuple } from '@studio/common/lib/import-export-events';
+import type { PushOutput } from '@studio/common/types/sync';
 
 // The in-app dark/light/system choice, persisted in the browser (there's no
 // Electron `nativeTheme` to mirror it) so it sticks across reloads.
@@ -72,6 +74,7 @@ type PullProgressSseOutput = PullSiteProgress & {
 	remoteSiteId: number;
 };
 type ImportSseOutput = { siteId: string; event: ImportEventTuple };
+type PushSseOutput = PushOutput & { siteId: string; remoteSiteId: number };
 
 // Envelope used by the backend's `/events` SSE stream so a single connection
 // can carry every live update consumed by the browser UI.
@@ -80,6 +83,7 @@ type ServerEvent =
 	| { channel: 'placement'; payload: AiSessionPlacementUpdatedEvent }
 	| { channel: 'snapshot'; payload: SnapshotSseOutput }
 	| { channel: 'sync-pull'; payload: PullProgressSseOutput }
+	| { channel: 'sync-push'; payload: PushSseOutput }
 	| { channel: 'import'; payload: ImportSseOutput }
 	| { channel: 'sync-connect'; payload: { remoteSiteId: number; studioSiteId: string } };
 
@@ -104,6 +108,7 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 	const placementListeners = new Set< ( event: AiSessionPlacementUpdatedEvent ) => void >();
 	const snapshotListeners = new Set< ( output: SnapshotSseOutput ) => void >();
 	const pullProgressListeners = new Set< ( output: PullProgressSseOutput ) => void >();
+	const pushOutputListeners = new Set< ( output: PushSseOutput ) => void >();
 	const importListeners = new Set< ( output: ImportSseOutput ) => void >();
 	const syncConnectListeners = new Set<
 		( event: { remoteSiteId: number; studioSiteId: string } ) => void
@@ -228,6 +233,8 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 					snapshotListeners.forEach( ( listener ) => listener( parsed.payload ) );
 				} else if ( parsed.channel === 'sync-pull' ) {
 					pullProgressListeners.forEach( ( listener ) => listener( parsed.payload ) );
+				} else if ( parsed.channel === 'sync-push' ) {
+					pushOutputListeners.forEach( ( listener ) => listener( parsed.payload ) );
 				} else if ( parsed.channel === 'import' ) {
 					importListeners.forEach( ( listener ) => listener( parsed.payload ) );
 				} else if ( parsed.channel === 'sync-connect' ) {
@@ -579,10 +586,35 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 				method: 'POST',
 			} );
 		},
-		async pushSiteToLive( siteId, remoteSiteId, options ) {
-			await api( `/sites/${ encodeURIComponent( siteId ) }/push`, {
+		async pushSiteToLive( siteId, remoteSiteId, options, onPhase ) {
+			const listener = ( output: PushSseOutput ) => {
+				if ( output.siteId === siteId && output.kind === 'phase' ) {
+					onPhase?.( output.phase );
+				}
+			};
+			if ( onPhase ) {
+				pushOutputListeners.add( listener );
+			}
+			let result: { cancelled?: boolean } | undefined;
+			try {
+				result = await api( `/sites/${ encodeURIComponent( siteId ) }/push`, {
+					method: 'POST',
+					body: JSON.stringify( { remoteSiteId, options } ),
+				} );
+			} finally {
+				pushOutputListeners.delete( listener );
+			}
+			// The server reports a cancel instead of failing the request; turn it
+			// back into an error for the caller.
+			if ( result?.cancelled ) {
+				throw new SyncCancelledError();
+			}
+		},
+
+		async cancelSync( siteId, remoteSiteId ) {
+			await api( `/sites/${ encodeURIComponent( siteId ) }/sync/cancel`, {
 				method: 'POST',
-				body: JSON.stringify( { remoteSiteId, options } ),
+				body: JSON.stringify( { remoteSiteId } ),
 			} );
 		},
 		async pullSiteFromLive( siteId, remoteSiteId, onProgress, options ) {
@@ -591,19 +623,25 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 					onProgress?.( {
 						message: output.message,
 						...( output.progress === undefined ? {} : { progress: output.progress } ),
+						// Drives the cancel gate — without it every pull looks cancellable.
+						...( output.action === undefined ? {} : { action: output.action } ),
 					} );
 				}
 			};
 			if ( onProgress ) {
 				pullProgressListeners.add( listener );
 			}
+			let result: { cancelled?: boolean } | undefined;
 			try {
-				await api( `/sites/${ encodeURIComponent( siteId ) }/pull`, {
+				result = await api( `/sites/${ encodeURIComponent( siteId ) }/pull`, {
 					method: 'POST',
 					body: JSON.stringify( { remoteSiteId, options } ),
 				} );
 			} finally {
 				pullProgressListeners.delete( listener );
+			}
+			if ( result?.cancelled ) {
+				throw new SyncCancelledError();
 			}
 		},
 		async getLatestRewindId( remoteSiteId ) {

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -18,6 +18,7 @@ export type {
 	ProposedSitePath,
 	PullSiteProgress,
 	PullSyncOptions,
+	PushPhase,
 	PushSyncOptions,
 	QuitSitesBehavior,
 	SelectedSiteFolder,

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -21,6 +21,7 @@ import type { Snapshot } from '@studio/common/types/snapshot';
 import type {
 	PullSiteProgress,
 	PullSyncOptions,
+	PushPhase,
 	PushSyncOptions,
 	SyncSite,
 } from '@studio/common/types/sync';
@@ -49,6 +50,7 @@ export type { Snapshot } from '@studio/common/types/snapshot';
 export type {
 	PullSiteProgress,
 	PullSyncOptions,
+	PushPhase,
 	PushSyncOptions,
 	SyncSite,
 } from '@studio/common/types/sync';
@@ -298,7 +300,8 @@ export interface Connector {
 	pushSiteToLive(
 		siteId: string,
 		remoteSiteId: number,
-		options?: PushSyncOptions
+		options?: PushSyncOptions,
+		onPhase?: ( phase: PushPhase ) => void
 	): Promise< void >;
 	// Pulls the connected WordPress.com site's database + wp-content back
 	// into the local Studio site, or only the selection described by
@@ -310,6 +313,10 @@ export interface Connector {
 		onProgress?: ( progress: PullSiteProgress ) => void,
 		options?: PullSyncOptions
 	): Promise< void >;
+	// Stops an in-flight push or pull, rejecting the operation with a cancelled
+	// error. A no-op once the operation is past the point where stopping is safe
+	// (`canCancelPush` / `canCancelPull`), and when nothing is running.
+	cancelSync( siteId: string, remoteSiteId: number ): Promise< void >;
 	// Latest rewind (backup) id of the connected live site, or `null` when no
 	// backup exists yet. Selective pull browses the backup tree under this id.
 	getLatestRewindId( remoteSiteId: number ): Promise< string | null >;

--- a/apps/ui/src/data/queries/use-sync-site.ts
+++ b/apps/ui/src/data/queries/use-sync-site.ts
@@ -83,8 +83,6 @@ type CancelSyncVariables = {
 	remoteSiteId: number;
 };
 
-// Stopping is best-effort: the push/pull mutation itself rejects with a
-// cancelled error and reports the outcome, so nothing is reported here.
 export function useCancelSync() {
 	const connector = useConnector();
 	return useMutation( {

--- a/apps/ui/src/data/queries/use-sync-site.ts
+++ b/apps/ui/src/data/queries/use-sync-site.ts
@@ -1,3 +1,4 @@
+import { isSyncCancelledError } from '@studio/common/lib/sync/cancel';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { toast } from '@/data/app-messages';
@@ -5,6 +6,8 @@ import { useConnector } from '@/data/core';
 import { connectedWpcomSitesQueryKey } from '@/data/queries/use-connected-wpcom-sites';
 import { SITES_QUERY_KEY } from '@/data/queries/use-sites';
 import {
+	reportPushPhase,
+	reportSyncCancelled,
 	reportSyncError,
 	reportSyncPending,
 	reportSyncProgress,
@@ -30,7 +33,9 @@ export function usePushSiteToLive() {
 	return useMutation( {
 		mutationKey: PUSH_TO_LIVE_MUTATION_KEY,
 		mutationFn: ( { siteId, remoteSiteId, options }: PushToLiveVariables ) =>
-			connector.pushSiteToLive( siteId, remoteSiteId, options ),
+			connector.pushSiteToLive( siteId, remoteSiteId, options, ( phase ) =>
+				reportPushPhase( siteId, phase )
+			),
 		onMutate: ( { siteId } ) => {
 			reportSyncPending( siteId, 'push' );
 		},
@@ -42,6 +47,11 @@ export function usePushSiteToLive() {
 			toast.success( __( 'Push complete' ) );
 		},
 		onError: ( error, { siteId } ) => {
+			if ( isSyncCancelledError( error ) ) {
+				reportSyncCancelled( siteId, 'push' );
+				toast.success( __( 'Push cancelled' ) );
+				return;
+			}
 			const message = error instanceof Error ? error.message : String( error );
 			reportSyncError( siteId, 'push', message );
 			toast.error( __( "Push didn't complete" ) );
@@ -64,6 +74,24 @@ export function useDisconnectWpcomSite() {
 			void queryClient.invalidateQueries( {
 				queryKey: connectedWpcomSitesQueryKey( siteId ),
 			} );
+		},
+	} );
+}
+
+type CancelSyncVariables = {
+	siteId: string;
+	remoteSiteId: number;
+};
+
+// Stopping is best-effort: the push/pull mutation itself rejects with a
+// cancelled error and reports the outcome, so nothing is reported here.
+export function useCancelSync() {
+	const connector = useConnector();
+	return useMutation( {
+		mutationFn: ( { siteId, remoteSiteId }: CancelSyncVariables ) =>
+			connector.cancelSync( siteId, remoteSiteId ),
+		onError: ( error ) => {
+			console.error( 'Failed to cancel sync:', error );
 		},
 	} );
 }
@@ -102,6 +130,14 @@ export function usePullSiteFromLive() {
 			toast.success( __( 'Pull complete' ) );
 		},
 		onError: ( _error, { siteId } ) => {
+			if ( isSyncCancelledError( _error ) ) {
+				reportSyncCancelled( siteId, 'pull' );
+				// The CLI restarts the site server on its way out, so the local
+				// site may have been stopped and started again.
+				void queryClient.invalidateQueries( { queryKey: SITES_QUERY_KEY } );
+				toast.success( __( 'Pull cancelled' ) );
+				return;
+			}
 			// Only point at the logs where the user can actually open them.
 			const canOpenLogs = connector.capabilities.studioLogs;
 			const message = canOpenLogs

--- a/apps/ui/src/data/sync-activity.test.tsx
+++ b/apps/ui/src/data/sync-activity.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+	getSyncCancelLabels,
 	reportSyncPending,
 	reportSyncProgress,
 	reportSyncSuccess,
@@ -38,5 +39,39 @@ describe( 'sync activity progress', () => {
 			vi.advanceTimersByTime( 30_000 );
 		} );
 		expect( result.current ).toBeNull();
+	} );
+} );
+
+describe( 'getSyncCancelLabels', () => {
+	it( 'offers the cancel while the work can still be stopped', () => {
+		expect(
+			getSyncCancelLabels( { kind: 'pending', direction: 'push', phase: 'uploading' } )
+		).toEqual( { enabled: true, label: 'Cancel push' } );
+		expect(
+			getSyncCancelLabels( { kind: 'pending', direction: 'pull', action: 'initiateBackup' } )
+		).toEqual( { enabled: true, label: 'Cancel pull' } );
+	} );
+
+	// Kept visible but disabled, so the affordance does not vanish mid-sync — the
+	// label carries the reason instead.
+	it( 'keeps the cancel but explains why it is refused past the point of no return', () => {
+		expect(
+			getSyncCancelLabels( { kind: 'pending', direction: 'push', phase: 'applyingChanges' } )
+		).toEqual( {
+			enabled: false,
+			label: 'Push can not be cancelled while applying changes to the remote site',
+		} );
+		expect(
+			getSyncCancelLabels( { kind: 'pending', direction: 'pull', action: 'import' } )
+		).toEqual( {
+			enabled: false,
+			label: 'Pull can not be cancelled while importing changes to your local site',
+		} );
+	} );
+
+	it( 'offers nothing when no push or pull is running', () => {
+		expect( getSyncCancelLabels( null ) ).toBeNull();
+		expect( getSyncCancelLabels( { kind: 'success', direction: 'pull' } ) ).toBeNull();
+		expect( getSyncCancelLabels( { kind: 'pending', direction: 'preview' } ) ).toBeNull();
 	} );
 } );

--- a/apps/ui/src/data/sync-activity.ts
+++ b/apps/ui/src/data/sync-activity.ts
@@ -1,5 +1,7 @@
+import { canCancelPull, canCancelPush } from '@studio/common/lib/sync/cancel';
+import { __ } from '@wordpress/i18n';
 import { useSyncExternalStore } from 'react';
-import type { PullSiteProgress } from '@/data/core';
+import type { PullSiteProgress, PushPhase } from '@/data/core';
 
 // Tracks in-flight and recently completed live-site sync operations so the
 // Site Details header can surface a cross-page indicator. Uses a module-
@@ -13,8 +15,18 @@ import type { PullSiteProgress } from '@/data/core';
 export type SyncDirection = 'push' | 'pull' | 'preview';
 
 export type SyncActivity =
-	| { kind: 'pending'; direction: SyncDirection; message?: string; progress?: number }
+	| {
+			kind: 'pending';
+			direction: SyncDirection;
+			message?: string;
+			progress?: number;
+			// How far a push has got; drives the cancel gate. Pull reports the
+			// equivalent through the CLI `action` behind its progress message.
+			phase?: PushPhase;
+			action?: string;
+	  }
 	| { kind: 'success'; direction: SyncDirection }
+	| { kind: 'cancelled'; direction: SyncDirection }
 	| { kind: 'error'; direction: SyncDirection; message: string };
 
 // How long success/error stay visible before the indicator vanishes.
@@ -70,6 +82,40 @@ export function reportSyncProgress(
 	emit();
 }
 
+export function reportPushPhase( siteId: string, phase: PushPhase ): void {
+	const current = entries.get( siteId );
+	if ( current?.kind !== 'pending' || current.direction !== 'push' ) {
+		return;
+	}
+	clearExpiryTimer( siteId );
+	entries.set( siteId, { ...current, phase } );
+	emit();
+}
+
+export function reportSyncCancelled( siteId: string, direction: SyncDirection ): void {
+	entries.set( siteId, { kind: 'cancelled', direction } );
+	scheduleExpiry( siteId );
+	emit();
+}
+
+/**
+ * Whether the in-flight operation can still be stopped. Mirrors the legacy
+ * renderer: a push is cancellable until the remote import is initiated, a pull
+ * until the CLI starts writing the local site.
+ */
+export function canCancelSyncActivity( activity: SyncActivity | null ): boolean {
+	if ( activity?.kind !== 'pending' ) {
+		return false;
+	}
+	if ( activity.direction === 'push' ) {
+		return canCancelPush( activity.phase );
+	}
+	if ( activity.direction === 'pull' ) {
+		return canCancelPull( activity.action );
+	}
+	return false;
+}
+
 export function reportSyncSuccess( siteId: string, direction: SyncDirection ): void {
 	entries.set( siteId, { kind: 'success', direction } );
 	scheduleExpiry( siteId );
@@ -95,4 +141,33 @@ export function useSiteSyncActivity( siteId: string | undefined ): SyncActivity 
 		() => ( siteId ? snapshot.get( siteId ) ?? null : null ),
 		() => null
 	);
+}
+
+/**
+ * Wording for the cancel affordance, or null when there is nothing to cancel.
+ * Shared by the dropdown trigger (always visible while a sync runs) and the
+ * progress panel inside the dropdown, so both read identically.
+ */
+export function getSyncCancelLabels(
+	activity: SyncActivity | null
+): { label: string; enabled: boolean } | null {
+	if ( activity?.kind !== 'pending' || activity.direction === 'preview' ) {
+		return null;
+	}
+
+	const enabled = canCancelSyncActivity( activity );
+	if ( activity.direction === 'push' ) {
+		return {
+			enabled,
+			label: enabled
+				? __( 'Cancel push' )
+				: __( 'Push can not be cancelled while applying changes to the remote site' ),
+		};
+	}
+	return {
+		enabled,
+		label: enabled
+			? __( 'Cancel pull' )
+			: __( 'Pull can not be cancelled while importing changes to your local site' ),
+	};
 }

--- a/packages/common/lib/cli-process.ts
+++ b/packages/common/lib/cli-process.ts
@@ -135,28 +135,45 @@ export interface CliRunner {
 	killAll(): void;
 }
 
+// How long a child gets to exit on SIGTERM before it is killed outright.
+const SIGKILL_GRACE_MS = 2000;
+
+// Only kills the child; its `close` handler still runs so awaiting callers
+// see a failure instead of hanging forever.
+export function killChild( child: ChildProcess ): void {
+	const pid = child.pid;
+
+	// `child.kill()` only terminates the forked CLI process; on Windows its
+	// php.exe descendants would orphan and keep their DLLs locked. `taskkill
+	// /T` walks the whole tree instead.
+	if ( process.platform === 'win32' && pid ) {
+		spawnSync( 'taskkill', [ '/F', '/T', '/PID', String( pid ) ], {
+			windowsHide: true,
+			stdio: 'ignore',
+		} );
+		return;
+	}
+
+	child.kill();
+
+	// SIGTERM is only a request, and the CLI ignores it: importing
+	// `wordpress-server-manager` registers a handler that aborts a controller
+	// without ever exiting, which replaces Node's default terminate. A child
+	// busy importing a site therefore survives `kill()` indefinitely — a
+	// cancelled sync would report "stopped" while still writing to the site.
+	// SIGKILL cannot be caught or ignored.
+	const forceKill = setTimeout( () => {
+		if ( child.exitCode === null && child.signalCode === null ) {
+			child.kill( 'SIGKILL' );
+		}
+	}, SIGKILL_GRACE_MS );
+	forceKill.unref?.();
+	child.once( 'exit', () => clearTimeout( forceKill ) );
+}
+
 export function createCliRunner( config: CliRunnerConfig ): CliRunner {
 	const { cliBinary, nodeBinary, execArgv = [ '--experimental-wasm-jspi' ], onError } = config;
 	const liveChildren = new Set< ChildProcess >();
-
-	// Only kills the child; its `close` handler still runs so awaiting callers
-	// see a failure instead of hanging forever.
-	function killChild( child: ChildProcess ): void {
-		const pid = child.pid;
-
-		// `child.kill()` only terminates the forked CLI process; on Windows its
-		// php.exe descendants would orphan and keep their DLLs locked. `taskkill
-		// /T` walks the whole tree instead.
-		if ( process.platform === 'win32' && pid ) {
-			spawnSync( 'taskkill', [ '/F', '/T', '/PID', String( pid ) ], {
-				windowsHide: true,
-				stdio: 'ignore',
-			} );
-			return;
-		}
-
-		child.kill();
-	}
 
 	function executeCliCommand(
 		args: string[],

--- a/packages/common/lib/sync/cancel.ts
+++ b/packages/common/lib/sync/cancel.ts
@@ -1,0 +1,56 @@
+import { SyncCommandLoggerAction } from '@studio/common/logger-actions';
+import type { PushPhase } from '@studio/common/types/sync';
+
+// Kept free of Node imports so the renderers can share these helpers with the
+// main process and the `studio ui` server.
+
+// A cancelled sync rejects with this message. Class identity is lost crossing
+// IPC and HTTP, so the message is the wire format — see `isSyncCancelledError`.
+export const SYNC_CANCELLED_MESSAGE = 'STUDIO_SYNC_CANCELLED';
+
+export class SyncCancelledError extends Error {
+	constructor() {
+		super( SYNC_CANCELLED_MESSAGE );
+		this.name = 'SyncCancelledError';
+	}
+}
+
+export function isSyncCancelledError( error: unknown ): boolean {
+	const message =
+		error instanceof Error ? error.message : typeof error === 'string' ? error : String( error );
+	// Electron prefixes IPC rejections ("Error invoking remote method …"), and the
+	// `studio ui` server relays the message inside a JSON body, so match loosely.
+	return message.includes( SYNC_CANCELLED_MESSAGE );
+}
+
+/**
+ * A push can be stopped until the remote import is initiated. After that the
+ * live site is already being changed and stopping locally would not undo it.
+ */
+export function canCancelPush( phase: PushPhase | undefined ): boolean {
+	return phase !== 'applyingChanges';
+}
+
+// Everything the CLI's `pull` reports before it touches the local site. The
+// first local write is `stopSite`, and the import actions that follow come from
+// a different logger enum — so this is an allow-list rather than a deny-list:
+// an action we don't recognise is treated as local work in progress.
+const PULL_REMOTE_ACTIONS: string[] = [
+	SyncCommandLoggerAction.START_DAEMON,
+	SyncCommandLoggerAction.LOAD_SITES,
+	SyncCommandLoggerAction.FETCH_REMOTE_SITES,
+	SyncCommandLoggerAction.INITIATE_BACKUP,
+	SyncCommandLoggerAction.POLL_BACKUP,
+	SyncCommandLoggerAction.DOWNLOAD,
+];
+
+/**
+ * A pull can be stopped while the work is still remote (creating the backup,
+ * downloading it). Once the CLI moves on to writing the local site, killing it
+ * would leave a half-imported site behind, so cancelling is refused — matching
+ * the legacy renderer's `importing` state.
+ */
+export function canCancelPull( action: string | undefined ): boolean {
+	// No progress reported yet: the CLI has not started doing anything local.
+	return action === undefined || PULL_REMOTE_ACTIONS.includes( action );
+}

--- a/packages/common/lib/tests/cli-process.test.ts
+++ b/packages/common/lib/tests/cli-process.test.ts
@@ -3,6 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { killChild } from '@studio/common/lib/cli-process';
 import type { ChildProcess } from 'node:child_process';
 
+// `killChild` branches on the platform: signals on POSIX, `taskkill /F /T` on
+// Windows. Pin it to POSIX so these run the same everywhere — on a Windows host
+// they would otherwise fire a real `taskkill` at whatever holds this pid.
+const originalPlatform = process.platform;
+function setPlatform( platform: NodeJS.Platform ) {
+	Object.defineProperty( process, 'platform', { value: platform, configurable: true } );
+}
+
 // A child that is still running: `kill()` records the signal but, like the real
 // CLI (which registers a SIGTERM handler that never exits), it does not die.
 function createStubbornChild() {
@@ -24,10 +32,12 @@ function createStubbornChild() {
 describe( 'killChild', () => {
 	beforeEach( () => {
 		vi.useFakeTimers();
+		setPlatform( 'darwin' );
 	} );
 
 	afterEach( () => {
 		vi.useRealTimers();
+		setPlatform( originalPlatform );
 	} );
 
 	it( 'escalates to SIGKILL when the child ignores SIGTERM', () => {

--- a/packages/common/lib/tests/cli-process.test.ts
+++ b/packages/common/lib/tests/cli-process.test.ts
@@ -1,0 +1,56 @@
+import EventEmitter from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { killChild } from '@studio/common/lib/cli-process';
+import type { ChildProcess } from 'node:child_process';
+
+// A child that is still running: `kill()` records the signal but, like the real
+// CLI (which registers a SIGTERM handler that never exits), it does not die.
+function createStubbornChild() {
+	const child = new EventEmitter() as unknown as ChildProcess & { signals: string[] };
+	const signals: string[] = [];
+	Object.assign( child, {
+		pid: 1234,
+		exitCode: null,
+		signalCode: null,
+		signals,
+		kill: ( signal?: string ) => {
+			signals.push( signal ?? 'SIGTERM' );
+			return true;
+		},
+	} );
+	return child as ChildProcess & { signals: string[] };
+}
+
+describe( 'killChild', () => {
+	beforeEach( () => {
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+	} );
+
+	it( 'escalates to SIGKILL when the child ignores SIGTERM', () => {
+		const child = createStubbornChild();
+
+		killChild( child );
+		expect( child.signals ).toEqual( [ 'SIGTERM' ] );
+
+		vi.advanceTimersByTime( 5000 );
+
+		// Without this a cancelled sync reports "stopped" while the CLI keeps
+		// importing into the site.
+		expect( child.signals ).toEqual( [ 'SIGTERM', 'SIGKILL' ] );
+	} );
+
+	it( 'leaves a child that exits on SIGTERM alone', () => {
+		const child = createStubbornChild();
+
+		killChild( child );
+		Object.assign( child, { exitCode: 0 } );
+		child.emit( 'exit', 0, null );
+		vi.advanceTimersByTime( 5000 );
+
+		expect( child.signals ).toEqual( [ 'SIGTERM' ] );
+	} );
+} );

--- a/packages/common/sites/sync.test.ts
+++ b/packages/common/sites/sync.test.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'node:events';
 import { describe, expect, it, vi } from 'vitest';
+import { canCancelPull, canCancelPush, isSyncCancelledError } from '@studio/common/lib/sync/cancel';
 import { pullSite } from './sync';
 import type { ExecuteCliCommand } from '@studio/common/lib/cli-process';
 
@@ -30,10 +31,40 @@ describe( 'pullSite', () => {
 		expect( onProgress ).toHaveBeenNthCalledWith( 1, {
 			message: 'Creating remote backup… (24%)',
 			progress: 24,
+			action: 'initiateBackup',
 		} );
 		expect( onProgress ).toHaveBeenNthCalledWith( 2, {
 			message: 'Importing media uploads… (3/10)',
+			action: 'importWpContent',
 		} );
+	} );
+
+	it( 'kills the CLI and rejects as cancelled when the signal aborts', async () => {
+		const emitter = new EventEmitter();
+		const child = { kill: vi.fn(), pid: 4242 };
+		const execute = vi.fn( () => [ emitter, child ] ) as unknown as ExecuteCliCommand;
+		const controller = new AbortController();
+		const pulling = pullSite(
+			execute,
+			'/sites/local',
+			42,
+			undefined,
+			undefined,
+			controller.signal
+		);
+
+		controller.abort();
+
+		await expect( pulling ).rejects.toSatisfy( isSyncCancelledError );
+		expect( child.kill ).toHaveBeenCalled();
+	} );
+
+	it( 'rejects immediately when the signal is already aborted', async () => {
+		const execute = vi.fn() as unknown as ExecuteCliCommand;
+		await expect(
+			pullSite( execute, '/sites/local', 42, undefined, undefined, AbortSignal.abort() )
+		).rejects.toSatisfy( isSyncCancelledError );
+		expect( execute ).not.toHaveBeenCalled();
 	} );
 
 	it( 'passes backup node ids with commas as separate argv values', async () => {
@@ -62,5 +93,42 @@ describe( 'pullSite', () => {
 			],
 			{ output: 'capture' }
 		);
+	} );
+} );
+
+describe( 'cancellable phases', () => {
+	it( 'allows stopping a push until the remote import is initiated', () => {
+		expect( canCancelPush( 'creatingBackup' ) ).toBe( true );
+		expect( canCancelPush( 'uploading' ) ).toBe( true );
+		expect( canCancelPush( undefined ) ).toBe( true );
+		expect( canCancelPush( 'applyingChanges' ) ).toBe( false );
+	} );
+
+	it( 'allows stopping a pull until the CLI starts writing the local site', () => {
+		// Everything the CLI does before the first local write, in the order it
+		// reports it — a pull is cancellable throughout.
+		expect( canCancelPull( undefined ) ).toBe( true );
+		expect( canCancelPull( 'startDaemon' ) ).toBe( true );
+		expect( canCancelPull( 'loadSites' ) ).toBe( true );
+		expect( canCancelPull( 'fetchRemoteSites' ) ).toBe( true );
+		expect( canCancelPull( 'initiateBackup' ) ).toBe( true );
+		expect( canCancelPull( 'download' ) ).toBe( true );
+
+		// `stopSite` is the first local write; the import actions after it come
+		// from another logger enum, so anything unrecognised is refused too.
+		expect( canCancelPull( 'stopSite' ) ).toBe( false );
+		expect( canCancelPull( 'extractBackup' ) ).toBe( false );
+		expect( canCancelPull( 'importDatabase' ) ).toBe( false );
+		expect( canCancelPull( 'startSite' ) ).toBe( false );
+	} );
+
+	it( 'recognises a cancelled sync through IPC and HTTP error wrapping', () => {
+		expect( isSyncCancelledError( new Error( 'STUDIO_SYNC_CANCELLED' ) ) ).toBe( true );
+		expect(
+			isSyncCancelledError(
+				new Error( "Error invoking remote method 'pushSiteToLive': Error: STUDIO_SYNC_CANCELLED" )
+			)
+		).toBe( true );
+		expect( isSyncCancelledError( new Error( 'Remote backup failed' ) ) ).toBe( false );
 	} );
 } );

--- a/packages/common/sites/sync.test.ts
+++ b/packages/common/sites/sync.test.ts
@@ -1,8 +1,16 @@
 import EventEmitter from 'node:events';
 import { describe, expect, it, vi } from 'vitest';
+import { killChild } from '@studio/common/lib/cli-process';
 import { canCancelPull, canCancelPush, isSyncCancelledError } from '@studio/common/lib/sync/cancel';
 import { pullSite } from './sync';
 import type { ExecuteCliCommand } from '@studio/common/lib/cli-process';
+
+// How the child is killed is platform-specific and covered by
+// `lib/tests/cli-process.test.ts`; here we only care that a cancel asks for it.
+vi.mock( '@studio/common/lib/cli-process', async ( importOriginal ) => ( {
+	...( await importOriginal< typeof import('@studio/common/lib/cli-process') >() ),
+	killChild: vi.fn(),
+} ) );
 
 describe( 'pullSite', () => {
 	it( 'forwards live CLI messages and their percentage', async () => {
@@ -41,7 +49,7 @@ describe( 'pullSite', () => {
 
 	it( 'kills the CLI and rejects as cancelled when the signal aborts', async () => {
 		const emitter = new EventEmitter();
-		const child = { kill: vi.fn(), pid: 4242 };
+		const child = { pid: 4242 };
 		const execute = vi.fn( () => [ emitter, child ] ) as unknown as ExecuteCliCommand;
 		const controller = new AbortController();
 		const pulling = pullSite(
@@ -56,7 +64,7 @@ describe( 'pullSite', () => {
 		controller.abort();
 
 		await expect( pulling ).rejects.toSatisfy( isSyncCancelledError );
-		expect( child.kill ).toHaveBeenCalled();
+		expect( killChild ).toHaveBeenCalledWith( child );
 	} );
 
 	it( 'rejects immediately when the signal is already aborted', async () => {

--- a/packages/common/sites/sync.ts
+++ b/packages/common/sites/sync.ts
@@ -2,32 +2,36 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { killChild } from '@studio/common/lib/cli-process';
+import { SyncCancelledError } from '@studio/common/lib/sync/cancel';
 import { initiateImport } from '@studio/common/lib/sync/sync-api';
 import { createTusUpload } from '@studio/common/lib/sync/tus-upload';
 import type { ExecuteCliCommand } from '@studio/common/lib/cli-process';
 import type {
 	PullSiteProgress,
 	PullSyncOptions,
+	PushOutput,
 	PushSyncOptions,
 	SyncOption,
 } from '@studio/common/types/sync';
+
+export type { PushOutput, PushPhase } from '@studio/common/types/sync';
 
 /**
  * WordPress.com sync operations. Pull is delegated to the Studio CLI; push uses
  * the shared upload/import primitives.
  */
 
-// Progress a push reports for the UI (the desktop also exposes manual
-// pause/resume; that lives in its own registry on top of these signals).
-export type PushOutput =
-	| { kind: 'upload-progress'; progress: number }
-	| { kind: 'network-paused'; error: string }
-	| { kind: 'resumed' };
-
 export interface PushSiteContext {
 	executeCliCommand: ExecuteCliCommand;
 	accessToken: string;
 	emit?: ( output: PushOutput ) => void;
+}
+
+function throwIfCancelled( signal: AbortSignal | undefined ): void {
+	if ( signal?.aborted ) {
+		throw new SyncCancelledError();
+	}
 }
 
 /**
@@ -38,14 +42,23 @@ export interface PushSiteContext {
  */
 export async function pushSite(
 	ctx: PushSiteContext,
-	params: { sitePath: string; remoteSiteId: number; options?: PushSyncOptions }
+	params: {
+		sitePath: string;
+		remoteSiteId: number;
+		options?: PushSyncOptions;
+		signal?: AbortSignal;
+	}
 ): Promise< void > {
+	const { signal } = params;
 	const dir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-push-' ) );
 	const archivePath = path.join( dir, `site_${ crypto.randomUUID() }.tar.gz` );
 
 	try {
+		throwIfCancelled( signal );
+
+		ctx.emit?.( { kind: 'phase', phase: 'creatingBackup' } );
 		await new Promise< void >( ( resolve, reject ) => {
-			const [ emitter ] = ctx.executeCliCommand(
+			const [ emitter, child ] = ctx.executeCliCommand(
 				[
 					'export',
 					'--path',
@@ -61,12 +74,30 @@ export async function pushSite(
 				],
 				{ output: 'capture' }
 			);
-			emitter.on( 'success', () => resolve() );
-			emitter.on( 'failure', ( { error } ) => reject( error ) );
-			emitter.on( 'error', ( { error } ) => reject( error ) );
+			const stopExport = () => {
+				// See `pullSite` — the cancel must settle even if the kill fails.
+				try {
+					killChild( child );
+					console.log( `[push] Stopped CLI process ${ child.pid ?? '(no pid)' }` );
+				} catch ( error ) {
+					console.error( '[push] Failed to stop the CLI process', error );
+				}
+				reject( new SyncCancelledError() );
+			};
+			signal?.addEventListener( 'abort', stopExport, { once: true } );
+			const done = ( settle: () => void ) => () => {
+				signal?.removeEventListener( 'abort', stopExport );
+				settle();
+			};
+			emitter.on( 'success', done( resolve ) );
+			emitter.on( 'failure', ( { error } ) => done( () => reject( error ) )() );
+			emitter.on( 'error', ( { error } ) => done( () => reject( error ) )() );
 		} );
 
-		const { promise } = createTusUpload( {
+		throwIfCancelled( signal );
+
+		ctx.emit?.( { kind: 'phase', phase: 'uploading' } );
+		const { promise, abort } = createTusUpload( {
 			token: ctx.accessToken,
 			remoteSiteId: params.remoteSiteId,
 			archivePath,
@@ -74,8 +105,23 @@ export async function pushSite(
 			onNetworkPause: ( error ) => ctx.emit?.( { kind: 'network-paused', error } ),
 			onResume: () => ctx.emit?.( { kind: 'resumed' } ),
 		} );
-		const attachmentId = await promise;
+		signal?.addEventListener( 'abort', abort, { once: true } );
+		let attachmentId: string;
+		try {
+			attachmentId = await promise;
+		} catch ( error ) {
+			throwIfCancelled( signal );
+			throw error;
+		} finally {
+			signal?.removeEventListener( 'abort', abort );
+		}
 
+		throwIfCancelled( signal );
+
+		// Point of no return: once the remote import is initiated, cancelling
+		// locally would leave the live site mid-import anyway, so the UI stops
+		// offering it from here on.
+		ctx.emit?.( { kind: 'phase', phase: 'applyingChanges' } );
 		await initiateImport( ctx.accessToken, params.remoteSiteId, attachmentId, params.options );
 	} finally {
 		await fs.promises.rm( dir, { recursive: true, force: true } ).catch( () => undefined );
@@ -110,10 +156,16 @@ export function pullSite(
 	siteFolder: string,
 	remoteSiteId: number,
 	emit?: ( output: PullSiteProgress ) => void,
-	options?: PullSyncOptions
+	options?: PullSyncOptions,
+	signal?: AbortSignal
 ): Promise< void > {
 	return new Promise( ( resolve, reject ) => {
-		const [ emitter ] = executeCliCommand(
+		if ( signal?.aborted ) {
+			reject( new SyncCancelledError() );
+			return;
+		}
+
+		const [ emitter, child ] = executeCliCommand(
 			[
 				'pull',
 				'--path',
@@ -130,8 +182,26 @@ export function pullSite(
 			],
 			{ output: 'capture' }
 		);
+
+		const stopPull = () => {
+			// Reject even if the kill fails — otherwise a cancel would hang the
+			// caller forever instead of stopping.
+			try {
+				killChild( child );
+				console.log( `[pull] Stopped CLI process ${ child.pid ?? '(no pid)' }` );
+			} catch ( error ) {
+				console.error( '[pull] Failed to stop the CLI process', error );
+			}
+			reject( new SyncCancelledError() );
+		};
+		signal?.addEventListener( 'abort', stopPull, { once: true } );
+		const settle = ( run: () => void ) => {
+			signal?.removeEventListener( 'abort', stopPull );
+			run();
+		};
+
 		emitter.on( 'data', ( { data } ) => {
-			const progress = data as { status?: unknown; message?: unknown } | null;
+			const progress = data as { status?: unknown; message?: unknown; action?: unknown } | null;
 			if ( progress?.status !== 'inprogress' || typeof progress.message !== 'string' ) {
 				return;
 			}
@@ -140,10 +210,11 @@ export function pullSite(
 			emit?.( {
 				message: progress.message,
 				...( percent ? { progress: Math.min( 100, Number( percent ) ) } : {} ),
+				...( typeof progress.action === 'string' ? { action: progress.action } : {} ),
 			} );
 		} );
-		emitter.on( 'success', () => resolve() );
-		emitter.on( 'failure', ( { error } ) => reject( error ) );
-		emitter.on( 'error', ( { error } ) => reject( error ) );
+		emitter.on( 'success', () => settle( resolve ) );
+		emitter.on( 'failure', ( { error } ) => settle( () => reject( error ) ) );
+		emitter.on( 'error', ( { error } ) => settle( () => reject( error ) ) );
 	} );
 }

--- a/packages/common/types/sync.ts
+++ b/packages/common/types/sync.ts
@@ -94,9 +94,25 @@ export const syncSiteSchema = z.object( {
 
 export type SyncSite = z.infer< typeof syncSiteSchema >;
 
+// Phases a push moves through, named after the legacy renderer's push state
+// keys so both UIs gate cancellation on the same boundary.
+export type PushPhase = 'creatingBackup' | 'uploading' | 'applyingChanges';
+
+// Progress a push reports for the UI (the desktop also exposes manual
+// pause/resume; that lives in its own registry on top of these signals).
+export type PushOutput =
+	| { kind: 'phase'; phase: PushPhase }
+	| { kind: 'upload-progress'; progress: number }
+	| { kind: 'network-paused'; error: string }
+	| { kind: 'resumed' };
+
 export type PullSiteProgress = {
 	message: string;
 	progress?: number;
+	// The CLI `LoggerAction` behind this message. Used to tell the remote-side
+	// phases (backup, download) from the local import, which must not be
+	// cancelled midway — see `canCancelPull`.
+	action?: string;
 };
 
 // Pull backup API schemas


### PR DESCRIPTION
## Related issues

- Fixes STU-2222

## How AI was used in this PR

Written with Claude Code, then verified end to end against real pushes and pulls

## Proposed Changes

You can now stop an in-flight sync from the site dropdown, with the same boundary Classic uses: a push can be cancelled until the remote import is initiated, a pull until the CLI starts writing your local site. Past that point the button is disabled and the panel says why, because stopping there would leave a half-imported site. Cancelling reports "Push/Pull cancelled" rather than an error, and is logged as such.

| Pull Started | Pull Cancelled | Push Started | Push Cancelled |
|--------|--------|--------|--------|
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/0e42b908-3d45-4e51-8165-7f151f21a2d0" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/c1b8fff0-1de0-4592-b344-41d723a0c0dd" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/4b49ec16-f012-4fb0-ad2b-5c030d026b59" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/b64f87bd-4ea0-4dea-a8c3-ec7e55db65b2" /> |

## Testing Instructions

1. Connect a site to WordPress.com and start a **pull** from the site dropdown.
2. While it reads "Creating remote backup…" or "Downloading backup…", hit the X. The pull stops, you get "Pull cancelled", and Studio Logs shows `[Sync] Pull cancelled by user` with no error.
3. Start another pull and wait for "Importing…". The X is now dimmed and the panel explains why; clicking does nothing.
4. Repeat with a **push**: cancellable during "Creating backup…"/upload, refused once the remote import starts.
5. Confirm no `studio` CLI process survives a cancel (`ps aux | grep "main.mjs pull"`).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
