### PR TITLE
Agentic UI: Always clear the preview cache when reloading

### DIFF
--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -225,15 +225,15 @@ describe( 'SitePreview', () => {
 		fireEvent.keyDown( document.body, { key: 'r', ctrlKey: true } );
 		expect( container.querySelector( 'iframe' ) ).not.toBe( initialIframe );
 
-		// Shift is the hard-reload chord, which reloads the fallback iframe too.
+		// ⌘⇧R is an alias for the same reload.
 		const reloadedIframe = container.querySelector( 'iframe' );
 		fireEvent.keyDown( document.body, { key: 'r', ctrlKey: true, shiftKey: true } );
 		expect( container.querySelector( 'iframe' ) ).not.toBe( reloadedIframe );
 
-		// Extra modifiers must not trigger either shortcut.
-		const hardReloadedIframe = container.querySelector( 'iframe' );
+		// Extra modifiers must not trigger the shortcut.
+		const aliasReloadedIframe = container.querySelector( 'iframe' );
 		fireEvent.keyDown( document.body, { key: 'r', ctrlKey: true, altKey: true } );
-		expect( container.querySelector( 'iframe' ) ).toBe( hardReloadedIframe );
+		expect( container.querySelector( 'iframe' ) ).toBe( aliasReloadedIframe );
 	} );
 
 	it( 'switches realms on primary-modifier number shortcuts', () => {
@@ -648,10 +648,10 @@ describe( 'getBrowserShortcutCommand', () => {
 		expect( getBrowserShortcutCommand( makeEvent( { key: 'r', ctrlKey: true } ) ) ).toBe(
 			'reload'
 		);
-		// Cmd+Shift+R reports an uppercase key; the chord must still match.
+		// The ⌘⇧R alias reports an uppercase key; it must still map to reload.
 		expect(
 			getBrowserShortcutCommand( makeEvent( { key: 'R', ctrlKey: true, shiftKey: true } ) )
-		).toBe( 'hard-reload' );
+		).toBe( 'reload' );
 		expect( getBrowserShortcutCommand( makeEvent( { key: '[', ctrlKey: true } ) ) ).toBe( 'back' );
 		expect( getBrowserShortcutCommand( makeEvent( { key: ']', ctrlKey: true } ) ) ).toBe(
 			'forward'

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -90,7 +90,7 @@ interface BrowserNavigationState {
 	title: string | null;
 }
 
-type BrowserShortcutCommandType = 'back' | 'forward' | 'reload' | 'hard-reload';
+type BrowserShortcutCommandType = 'back' | 'forward' | 'reload';
 
 // What the guest page can forward over the console bridge: the browser
 // commands it swallows, plus the full-preview toggle (the webview covers most
@@ -243,16 +243,26 @@ function getWebviewContentsId( webview: WebviewTag ): number {
 	return webContentsId;
 }
 
-// Chrome keeps cached 301s through every reload variant, and a redirect leaves
-// the webview's current entry on the other site — hence clear, then navigate.
-async function hardReload( webview: WebviewTag, url: string ): Promise< void > {
+// Reloading always drops the HTTP cache: it keeps edited CSS/JS from being
+// served stale, and it's the only way to shake a cached 301 (Chrome keeps those
+// through every reload variant). When such a redirect has already moved the
+// webview onto another origin, reload() would reload *that*, so navigate.
+async function reloadPreview(
+	webview: WebviewTag,
+	intendedUrl: string,
+	currentUrl: string
+): Promise< void > {
 	const { ipcApi } = window as PreviewWindow;
 	try {
 		await ipcApi?.clearWebviewCache?.( getWebviewContentsId( webview ) );
 	} catch {
 		// No IPC bridge, or the webview isn't ready.
 	}
-	await webview.loadURL( url ).catch( () => undefined );
+	if ( isOffOriginRedirect( currentUrl, intendedUrl ) ) {
+		await webview.loadURL( intendedUrl ).catch( () => undefined );
+		return;
+	}
+	webview.reload?.();
 }
 
 export function isOffOriginRedirect( settledUrl: string, intendedUrl: string ): boolean {
@@ -359,10 +369,8 @@ export function getBrowserShortcutCommand(
 	if ( event.defaultPrevented || event.repeat ) {
 		return null;
 	}
-	if ( isKeyboardEvent.primaryShift( event, 'r' ) ) {
-		return 'hard-reload';
-	}
-	if ( isKeyboardEvent.primary( event, 'r' ) ) {
+	// ⌘⇧R is accepted as an alias so the browser habit isn't a dead key.
+	if ( isKeyboardEvent.primary( event, 'r' ) || isKeyboardEvent.primaryShift( event, 'r' ) ) {
 		return 'reload';
 	}
 	if ( isKeyboardEvent.primary( event, '[' ) ) {
@@ -416,7 +424,6 @@ function isPreviewShortcutCommand( command: unknown ): command is PreviewShortcu
 		command === 'back' ||
 		command === 'forward' ||
 		command === 'reload' ||
-		command === 'hard-reload' ||
 		command === 'full-preview'
 	);
 }
@@ -431,7 +438,6 @@ function PreviewOverflowMenu( {
 	onMobileOrientationChange,
 	fullscreen,
 	onFullscreenChange,
-	onHardReload,
 }: {
 	viewportMode: ViewportMode;
 	onViewportModeChange: ( mode: ViewportMode ) => void;
@@ -439,7 +445,6 @@ function PreviewOverflowMenu( {
 	onMobileOrientationChange: ( orientation: MobileOrientation ) => void;
 	fullscreen: boolean;
 	onFullscreenChange?: ( value: boolean ) => void;
-	onHardReload: () => void;
 } ) {
 	const viewportLabels: Record< ViewportPreset[ 'id' ], string > = {
 		mobile: __( 'Mobile' ),
@@ -513,13 +518,6 @@ function PreviewOverflowMenu( {
 						</Menu.Item>
 					</>
 				) : null }
-				<Menu.Separator />
-				<Menu.Item
-					onClick={ onHardReload }
-					aria-keyshortcuts={ ariaKeyShortcut.primaryShift( 'r' ) }
-				>
-					{ __( 'Hard refresh' ) }
-				</Menu.Item>
 			</Menu.Popup>
 		</Menu.Root>
 	);
@@ -958,7 +956,6 @@ export function SitePreview( {
 							onMobileOrientationChange={ handleMobileOrientationChange }
 							fullscreen={ fullscreen }
 							onFullscreenChange={ onFullscreenChange }
-							onHardReload={ () => sendBrowserCommand( 'hard-reload' ) }
 						/>
 					) : null }
 				</div>
@@ -1012,9 +1009,7 @@ export function SitePreview( {
 									// by remounting; back/forward aren't reachable from the host.
 									<iframe
 										key={ `${ previewUrl }#${ reloadNonce }#${
-											browserCommand?.type === 'reload' || browserCommand?.type === 'hard-reload'
-												? browserCommand.id
-												: 0
+											browserCommand?.type === 'reload' ? browserCommand.id : 0
 										}` }
 										className={ styles.iframe }
 										style={ iframeStyle }
@@ -1366,7 +1361,7 @@ function WebviewSurface( {
 				if ( pendingLoadRef.current ) {
 					pendingLoadRef.current = false;
 					if ( isOffOriginRedirect( navigateEvent.url, urlRef.current ) ) {
-						void hardReload( webview, urlRef.current );
+						void reloadPreview( webview, urlRef.current, navigateEvent.url );
 					}
 				}
 			}
@@ -1459,9 +1454,7 @@ function WebviewSurface( {
 			} else if ( browserCommand.type === 'forward' && webview.canGoForward?.() ) {
 				webview.goForward?.();
 			} else if ( browserCommand.type === 'reload' ) {
-				webview.reload?.();
-			} else if ( browserCommand.type === 'hard-reload' ) {
-				void hardReload( webview, urlRef.current );
+				void reloadPreview( webview, urlRef.current, currentUrlRef.current );
 			}
 		} finally {
 			publishBrowserState();

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -90,7 +90,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 		 * the window — so the chord is caught here and forwarded back. */
 		if ( event.shiftKey ) {
 			if ( key === 'f' ) return 'full-preview';
-			return key === 'r' ? 'hard-reload' : null;
+			return key === 'r' ? 'reload' : null;
 		}
 		if ( key === 'r' ) return 'reload';
 		if ( key === '[' ) return 'back';


### PR DESCRIPTION
## Related issues

- Follow-up to #4505 / [STU-2217](https://linear.app/a8c/issue/STU-2217/preview-pane-shows-the-previous-sites-port-on-the-frontend-tab-due-to), implementing @sejas's review suggestion.

## How AI was used in this PR

Claude Code made the change. It's a net deletion of the surface added in #4505.

## Proposed Changes

#4505 added a separate "Hard refresh" option so users could shake loose a stale cached redirect. @sejas pointed out that the regular refresh button could just do this in all cases — then there's nothing extra to discover, and it also fixes the everyday annoyance of edited CSS/JS being served stale during development.

Reloading the preview now always drops the HTTP cache. Cost is limited to an explicit user action, and previews are local, so a refresh is cheap. Cookies live in a separate store, so preview logins are unaffected.

One thing had to come along: clearing the cache isn't enough on its own, because a cached redirect moves the webview's current entry onto the other site and `reload()` would reload *that*. Reload now re-navigates to the site's own URL when it detects it's sitting off-origin, and reloads normally otherwise.

The dedicated menu item is gone, ⌘⇧R stays as an alias for reload so the browser habit isn't a dead key, and the automatic recovery from #4505 is unchanged.

Trade-off: you can no longer reload the preview with a warm cache, so you can't observe how your site behaves for a returning visitor.

## Testing Instructions

1. With a site running, edit a file its theme loads directly (e.g. add `body { background: red }` to the active theme's `style.css`).
2. Press ⟳ in the preview — the change shows without any manual cache clear. Confirm ⌘⇧R does the same.
3. Redirect recovery still works. Create a second site, give the first a `wp-content/mu-plugins/redirect.php` that 301s its front end to the second's port:
   ```php
   <?php
   add_action( 'template_redirect', function () {
       wp_redirect( 'http://localhost:<other-port>/', 301 );
       exit;
   } );
   ```
   Open its preview (shows the other site), delete the mu-plugin, confirm `curl -sI` returns `200` with no `Location`, then press ⟳ — it returns to the right site.
4. Switching away and back should still self-heal without pressing anything.
5. Confirm wp-admin still auto-logs in after a reload — the cache clear must not drop cookies.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
