### PR TITLE
Agentic UI: Fix outer frame scrolling

### DIFF
--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -58,7 +58,10 @@
 .main {
 	flex: 1;
 	min-width: 0;
-	overflow: auto;
+	/* Route panels own their scrolling. Keep this frame fixed so positioned
+	   chrome, such as the collapsed-sidebar toggle, cannot create an outer
+	   scroll range. */
+	overflow: hidden;
 	position: relative;
 	isolation: isolate;
 	background-color: var(--app-chrome-bg);


### PR DESCRIPTION
In the Agentic UI, if you hide the sidebar, you can sometimes scroll the container element unintentionally; usually by scrolling around the preview toggle button.

## How AI was used in this PR

AI was used to trace scroll ownership across the Agentic UI route shells, inspect the history of the sidebar frame and floating toggle, and implement the focused CSS fix. The resulting diff was reviewed locally.

## Proposed Changes

- Keep the Agentic UI dashboard frame fixed so hiding the sidebar cannot introduce an outer scrollbar or move the entire app frame.
- Preserve route-owned scrolling for chat, site overview, settings, and onboarding content.

## Testing Instructions

1. Run `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`.
2. Open a chat route, hide the sidebar, and verify scrolling remains confined to the conversation.
3. Open a site overview, hide the sidebar, and verify scrolling remains confined to the overview content.
4. Check settings and onboarding to confirm their existing scroll containers still work.
5. Repeat the route checks in light and dark themes.

Automated checks:

- `npm run typecheck`
- `npm test -- apps/ui/src/components/sidebar-layout/index.test.tsx apps/ui/src/ui-classic/components/session-view/index.test.tsx apps/ui/src/components/site-overview-view/index.test.tsx apps/ui/src/components/settings-view/index.test.tsx apps/ui/src/ui-classic/router/layout-onboarding/index.test.tsx` (62 tests)
- `npm run cli:build:ui`

> Live light/dark browser verification could not be completed in the agent environment because localhost navigation was blocked; please perform the manual route checks above.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
