### PR TITLE
Agentic UI: Add multi-note annotation sessions

### DIFF
--- a/apps/ui/src/components/open-in-menu/index.tsx
+++ b/apps/ui/src/components/open-in-menu/index.tsx
@@ -3,6 +3,7 @@ import { chevronDown, Icon } from '@wordpress/icons';
 import { Button, Tooltip } from '@wordpress/ui';
 import { useState } from 'react';
 import * as Menu from '@/components/menu';
+import splitStyles from '@/components/split-button/style.module.css';
 import styles from './style.module.css';
 import { useOpenInDestinations } from './use-open-in-destinations';
 import type { OpenInDestination } from './use-open-in-destinations';
@@ -71,7 +72,7 @@ export function OpenInMenu( {
 
 	return (
 		<Menu.Root>
-			<div className={ styles.splitTrigger }>
+			<div className={ splitStyles.splitTrigger }>
 				<Tooltip.Root>
 					<Tooltip.Trigger
 						render={
@@ -79,7 +80,7 @@ export function OpenInMenu( {
 								variant="minimal"
 								tone="neutral"
 								size="small"
-								className={ styles.splitAction }
+								className={ splitStyles.splitAction }
 								aria-label={ actionLabel }
 								disabled={ lastUsedDestination.disabled }
 								onClick={ () => lastUsedDestination.open() }
@@ -101,7 +102,7 @@ export function OpenInMenu( {
 										variant="minimal"
 										tone="neutral"
 										size="small"
-										className={ styles.splitMenuButton }
+										className={ splitStyles.splitMenuButton }
 										aria-label={ __( 'Open in…' ) }
 									/>
 								}
@@ -112,7 +113,7 @@ export function OpenInMenu( {
 								<Icon
 									icon={ chevronDown }
 									size={ 12 }
-									className={ styles.chevron }
+									className={ splitStyles.chevron }
 									data-keep-size
 								/>
 							</Tooltip.Trigger>

--- a/apps/ui/src/components/open-in-menu/style.module.css
+++ b/apps/ui/src/components/open-in-menu/style.module.css
@@ -1,40 +1,3 @@
-.splitTrigger {
-	display: inline-flex;
-	align-items: center;
-	gap: 1px;
-	flex: 0 0 auto;
-	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
-	/* The buttons' own radius plus the border width, so the halves' rounded
-	   outer corners nest flush against the frame. */
-	border-radius: calc(var(--wpds-border-radius-sm) + var(--wpds-border-width-xs));
-	-webkit-app-region: no-drag;
-}
-
-/* Size the halves so the pair reads as one compact button: normal padding
-   on the outer edges, almost none along the shared seam, and a very narrow
-   chevron tab. Squaring off the shared corners makes the hover fills read
-   as one control split in two. */
-.splitAction {
-	--wp-ui-button-min-width: unset;
-
-	padding-inline: var(--wpds-dimension-padding-xs) 1px;
-	border-start-end-radius: 0;
-	border-end-end-radius: 0;
-}
-
-.splitMenuButton {
-	--wp-ui-button-min-width: unset;
-
-	padding-inline: 1px 3px;
-	border-start-start-radius: 0;
-	border-end-start-radius: 0;
-}
-
-.chevron {
-	color: var(--wpds-color-fg-content-neutral-weak);
-	fill: currentColor;
-}
-
 .popup {
 	min-width: 180px;
 }
@@ -52,7 +15,6 @@
    fill attribute and would otherwise render with the black SVG default. The
    brand logos declare their own fill (`currentColor` or `none` for the
    stroke-drawn ones), so scope the rule to leave them alone. */
-.splitAction svg:not([fill]),
 .itemIcon svg:not([fill]) {
 	fill: currentColor;
 }

--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -362,6 +362,25 @@ describe( 'SitePreview', () => {
 		expect( screen.getByRole( 'button', { name: 'Annotate' } ) ).toBeInTheDocument();
 	} );
 
+	it( 'shows a single annotate toggle while no notes are pending', () => {
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			capabilities: { ...CAPABILITIES, annotatePreview: true },
+		} as never );
+
+		renderPreview(
+			<SitePreview site={ createSite( { running: true } ) } path="/" reloadNonce={ 0 } />
+		);
+
+		// One command means no collapsed variant: a second control would be a
+		// duplicate of this one at every width, and a menu wrapping it would be
+		// a single-item dropdown.
+		expect( screen.getAllByRole( 'button', { name: 'Annotate' } ) ).toHaveLength( 1 );
+		expect(
+			screen.queryByRole( 'button', { name: 'Annotation options' } )
+		).not.toBeInTheDocument();
+	} );
+
 	it( 'hides the Annotate control when agentic features are off', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -79,7 +79,7 @@ interface InspectorState {
 
 interface InspectorCommand {
 	id: number;
-	type: 'toggle-picking' | 'submit';
+	type: 'toggle-picking' | 'cancel' | 'submit';
 }
 
 interface BrowserNavigationState {
@@ -925,26 +925,37 @@ export function SitePreview( {
 				<div className={ clsx( styles.headerSide, styles.headerSideEnd ) }>
 					{ canPreview && chatEnabled && connector.capabilities.annotatePreview ? (
 						<div className={ styles.annotationControls }>
-							<IconButton
-								variant="minimal"
-								tone="neutral"
-								size="small"
-								icon={ pencil }
-								label={ inspectorState.isPicking ? __( 'Stop annotating' ) : __( 'Annotate' ) }
-								disabled={ ! canAnnotate }
-								aria-pressed={ inspectorState.isPicking }
-								onClick={ () => sendInspectorCommand( 'toggle-picking' ) }
-							/>
-							{ inspectorState.annotationCount > 0 ? (
+							{ inspectorState.isPicking ? (
+								<Button
+									variant="minimal"
+									tone="neutral"
+									size="small"
+									disabled={ ! canAnnotate }
+									onClick={ () => sendInspectorCommand( 'cancel' ) }
+								>
+									{ __( 'Cancel' ) }
+								</Button>
+							) : (
+								<IconButton
+									variant="minimal"
+									tone="neutral"
+									size="small"
+									icon={ pencil }
+									label={ __( 'Annotate' ) }
+									disabled={ ! canAnnotate }
+									onClick={ () => sendInspectorCommand( 'toggle-picking' ) }
+								/>
+							) }
+							{ inspectorState.isPicking && inspectorState.annotationCount > 0 ? (
 								<Button
 									variant="solid"
 									tone="brand"
 									size="small"
 									disabled={ ! canAnnotate }
-									aria-label={ __( 'Submit annotations' ) }
+									aria-label={ __( 'Send annotations to chat' ) }
 									onClick={ () => sendInspectorCommand( 'submit' ) }
 								>
-									{ __( 'Submit' ) }
+									{ __( 'Send to chat' ) }
 								</Button>
 							) : null }
 						</div>

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -1,13 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
-import { chevronLeft, chevronRight, moreVertical, pencil } from '@wordpress/icons';
+import {
+	chevronDown,
+	chevronLeft,
+	chevronRight,
+	Icon,
+	moreVertical,
+	pencil,
+} from '@wordpress/icons';
 import { ariaKeyShortcut, displayShortcut, isAppleOS, isKeyboardEvent } from '@wordpress/keycodes';
-import { Button, IconButton } from '@wordpress/ui';
+import { Button, IconButton, Tooltip } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DotGrid } from '@/components/dot-grid';
 import * as Menu from '@/components/menu';
 import { OpenInMenu } from '@/components/open-in-menu';
+import splitStyles from '@/components/split-button/style.module.css';
 import { useConnector } from '@/data/core';
 import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
 import { useIsSiteStarting, useStartSite } from '@/data/queries/use-sites';
@@ -79,7 +87,7 @@ interface InspectorState {
 
 interface InspectorCommand {
 	id: number;
-	type: 'toggle-picking' | 'cancel' | 'submit';
+	type: 'toggle-picking' | 'submit';
 }
 
 interface BrowserNavigationState {
@@ -525,6 +533,123 @@ function PreviewOverflowMenu( {
 	);
 }
 
+// Annotation commands. With nothing pending there's only one command, so the
+// toolbar shows a bare toggle at every width. Once notes are waiting there are
+// two, and a narrow toolbar can't fit them inline — `style.module.css` swaps
+// the inline pair for a split button, so only one layout is ever in the a11y
+// tree.
+function PreviewAnnotationControls( {
+	isPicking,
+	annotationCount,
+	disabled,
+	onCommand,
+}: {
+	isPicking: boolean;
+	annotationCount: number;
+	disabled: boolean;
+	onCommand: ( type: InspectorCommand[ 'type' ] ) => void;
+} ) {
+	const toggleLabel = isPicking ? __( 'Stop annotating' ) : __( 'Annotate' );
+	const submitLabel = __( 'Send annotations to chat' );
+	const hasPending = annotationCount > 0;
+	return (
+		<>
+			<div
+				className={ clsx( styles.annotationControls, hasPending && styles.annotationControlsWide ) }
+			>
+				<IconButton
+					variant="minimal"
+					tone="neutral"
+					size="small"
+					icon={ pencil }
+					label={ toggleLabel }
+					disabled={ disabled }
+					aria-pressed={ isPicking }
+					onClick={ () => onCommand( 'toggle-picking' ) }
+				/>
+				{ hasPending ? (
+					<Button
+						variant="solid"
+						tone="brand"
+						size="small"
+						disabled={ disabled }
+						aria-label={ submitLabel }
+						onClick={ () => onCommand( 'submit' ) }
+					>
+						{ __( 'Send to chat' ) }
+					</Button>
+				) : null }
+			</div>
+			{ hasPending ? (
+				<div className={ styles.annotationMenu }>
+					{ /* Two commands to offer, so it becomes a split button matching the
+						"Open in…" control beside it: the pencil still toggles directly,
+						the chevron opens the pair. Modal for the same reason as the
+						overflow menu — the webview swallows outside clicks, so the
+						backdrop is what dismisses it. */ }
+					<Menu.Root>
+						<div className={ splitStyles.splitTrigger }>
+							<Tooltip.Root>
+								<Tooltip.Trigger
+									render={
+										<Button
+											variant="minimal"
+											tone="neutral"
+											size="small"
+											className={ splitStyles.splitAction }
+											aria-label={ toggleLabel }
+											aria-pressed={ isPicking }
+											disabled={ disabled }
+											onClick={ () => onCommand( 'toggle-picking' ) }
+										/>
+									}
+								>
+									<Icon icon={ pencil } size={ 18 } />
+								</Tooltip.Trigger>
+								<Tooltip.Popup positioner={ <Tooltip.Positioner side="bottom" /> }>
+									{ toggleLabel }
+								</Tooltip.Popup>
+							</Tooltip.Root>
+							<Tooltip.Root>
+								<Menu.Trigger
+									render={
+										<Tooltip.Trigger
+											render={
+												<Button
+													variant="minimal"
+													tone="neutral"
+													size="small"
+													className={ splitStyles.splitMenuButton }
+													aria-label={ __( 'Annotation options' ) }
+													disabled={ disabled }
+												/>
+											}
+										>
+											<Icon
+												icon={ chevronDown }
+												size={ 12 }
+												className={ splitStyles.chevron }
+												data-keep-size
+											/>
+										</Tooltip.Trigger>
+									}
+								/>
+								<Tooltip.Popup positioner={ <Tooltip.Positioner side="bottom" /> }>
+									{ __( 'Annotation options' ) }
+								</Tooltip.Popup>
+							</Tooltip.Root>
+						</div>
+						<Menu.Popup side="bottom" align="end">
+							<Menu.Item onClick={ () => onCommand( 'toggle-picking' ) }>{ toggleLabel }</Menu.Item>
+							<Menu.Item onClick={ () => onCommand( 'submit' ) }>{ submitLabel }</Menu.Item>
+						</Menu.Popup>
+					</Menu.Root>
+				</div>
+			) : null }
+		</>
+	);
+}
+
 function areBrowserStatesEqual( a: BrowserNavigationState, b: BrowserNavigationState ) {
 	return (
 		a.canGoBack === b.canGoBack &&
@@ -924,41 +1049,12 @@ export function SitePreview( {
 				</div>
 				<div className={ clsx( styles.headerSide, styles.headerSideEnd ) }>
 					{ canPreview && chatEnabled && connector.capabilities.annotatePreview ? (
-						<div className={ styles.annotationControls }>
-							{ inspectorState.isPicking ? (
-								<Button
-									variant="minimal"
-									tone="neutral"
-									size="small"
-									disabled={ ! canAnnotate }
-									onClick={ () => sendInspectorCommand( 'cancel' ) }
-								>
-									{ __( 'Cancel' ) }
-								</Button>
-							) : (
-								<IconButton
-									variant="minimal"
-									tone="neutral"
-									size="small"
-									icon={ pencil }
-									label={ __( 'Annotate' ) }
-									disabled={ ! canAnnotate }
-									onClick={ () => sendInspectorCommand( 'toggle-picking' ) }
-								/>
-							) }
-							{ inspectorState.isPicking && inspectorState.annotationCount > 0 ? (
-								<Button
-									variant="solid"
-									tone="brand"
-									size="small"
-									disabled={ ! canAnnotate }
-									aria-label={ __( 'Send annotations to chat' ) }
-									onClick={ () => sendInspectorCommand( 'submit' ) }
-								>
-									{ __( 'Send to chat' ) }
-								</Button>
-							) : null }
-						</div>
+						<PreviewAnnotationControls
+							isPicking={ inspectorState.isPicking }
+							annotationCount={ inspectorState.annotationCount }
+							disabled={ ! canAnnotate }
+							onCommand={ sendInspectorCommand }
+						/>
 					) : null }
 					<OpenInMenu key={ site.id } site={ site } browserPath={ getSafePath( path ) } />
 					{ canPreview ? (

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -1192,7 +1192,6 @@ function WebviewSurface( {
 	const domReadyRef = useRef( false );
 	const currentUrlRef = useRef( url );
 	const storedAnnotationsRef = useRef< Annotation[] >( [] );
-	const storedIsPickingRef = useRef( false );
 	const lastReloadNonceRef = useRef( reloadNonce );
 	const progressTimerRef = useRef< ReturnType< typeof setInterval > | null >( null );
 	const progressResetTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
@@ -1311,16 +1310,14 @@ function WebviewSurface( {
 			// window.__studioInspectorState before the IIFE runs so the
 			// freshly-injected inspector picks them up on init.
 			const stored = storedAnnotationsRef.current;
-			const preload = [
-				stored.length > 0 ? `window.__studioInspectorState=${ JSON.stringify( stored ) };` : '',
-				`window.__studioInspectorPicking=${ JSON.stringify( storedIsPickingRef.current ) };`,
-			].join( '' );
+			const preload =
+				stored.length > 0 ? `window.__studioInspectorState=${ JSON.stringify( stored ) };` : '';
 			webview
 				.executeJavaScript( preload + INSPECTOR_PAGE_SCRIPT, false )
 				.then( () => {
 					onInspectorStateRef.current?.( {
 						ready: true,
-						isPicking: storedIsPickingRef.current,
+						isPicking: false,
 						annotationCount: stored.length,
 					} );
 				} )
@@ -1348,7 +1345,6 @@ function WebviewSurface( {
 				return;
 			}
 			if ( parsed.type === 'state' ) {
-				storedIsPickingRef.current = Boolean( parsed.isPicking );
 				onInspectorStateRef.current?.( {
 					ready: true,
 					isPicking: Boolean( parsed.isPicking ),

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -1192,6 +1192,7 @@ function WebviewSurface( {
 	const domReadyRef = useRef( false );
 	const currentUrlRef = useRef( url );
 	const storedAnnotationsRef = useRef< Annotation[] >( [] );
+	const storedIsPickingRef = useRef( false );
 	const lastReloadNonceRef = useRef( reloadNonce );
 	const progressTimerRef = useRef< ReturnType< typeof setInterval > | null >( null );
 	const progressResetTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
@@ -1310,14 +1311,16 @@ function WebviewSurface( {
 			// window.__studioInspectorState before the IIFE runs so the
 			// freshly-injected inspector picks them up on init.
 			const stored = storedAnnotationsRef.current;
-			const preload =
-				stored.length > 0 ? `window.__studioInspectorState=${ JSON.stringify( stored ) };` : '';
+			const preload = [
+				stored.length > 0 ? `window.__studioInspectorState=${ JSON.stringify( stored ) };` : '',
+				`window.__studioInspectorPicking=${ JSON.stringify( storedIsPickingRef.current ) };`,
+			].join( '' );
 			webview
 				.executeJavaScript( preload + INSPECTOR_PAGE_SCRIPT, false )
 				.then( () => {
 					onInspectorStateRef.current?.( {
 						ready: true,
-						isPicking: false,
+						isPicking: storedIsPickingRef.current,
 						annotationCount: stored.length,
 					} );
 				} )
@@ -1345,6 +1348,7 @@ function WebviewSurface( {
 				return;
 			}
 			if ( parsed.type === 'state' ) {
+				storedIsPickingRef.current = Boolean( parsed.isPicking );
 				onInspectorStateRef.current?.( {
 					ready: true,
 					isPicking: Boolean( parsed.isPicking ),

--- a/apps/ui/src/components/site-preview/inspector-script.test.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.test.ts
@@ -7,9 +7,11 @@ import {
 
 describe( 'site preview inspector sessions', () => {
 	afterEach( () => {
+		// Without this the previous inspector's document listeners stay live and
+		// answer the next test's commands alongside the instance under test.
+		( window as Window & { __studioInspectorDispose?: () => void } ).__studioInspectorDispose?.();
 		vi.restoreAllMocks();
 		document.body.replaceChildren();
-		delete ( window as Window & { __studioInspectorMounted?: boolean } ).__studioInspectorMounted;
 		delete ( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState;
 	} );
 
@@ -66,25 +68,34 @@ describe( 'site preview inspector sessions', () => {
 		expect( latestState( log ) ).toMatchObject( { isPicking: false, annotationCount: 0 } );
 	} );
 
-	it( 'clears the pending batch when annotation mode is cancelled', () => {
+	it( 'keeps saved notes when annotation mode is switched off', () => {
 		const log = vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
-		( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState = [
-			{
-				id: 'saved',
-				comment: 'Saved note',
-				path: window.location.pathname + window.location.search,
-				documentRect: { left: 10, top: 10, width: 100, height: 40 },
-			},
-		];
+		seedSavedNote();
 
 		new Function( INSPECTOR_PAGE_SCRIPT )();
 		command( 'toggle-picking' );
-		command( 'cancel' );
+		document.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true, cancelable: true } )
+		);
 
-		expect( latestState( log ) ).toMatchObject( { isPicking: false, annotationCount: 0 } );
+		expect( latestState( log ) ).toMatchObject( { isPicking: false, annotationCount: 1 } );
 		expect(
 			( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState
-		).toEqual( [] );
+		).toHaveLength( 1 );
+	} );
+
+	it( 'reopens an existing note without turning picking back on', () => {
+		const log = vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		seedSavedNote();
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+		const root = ( document.querySelector( '#__studio-inspector-host' ) as HTMLElement )
+			.shadowRoot as ShadowRoot;
+		const marker = root.querySelector( '.marker' ) as HTMLElement;
+		marker.dispatchEvent( new MouseEvent( 'click', { bubbles: true, cancelable: true } ) );
+
+		expect( root.querySelector( '.popup' ) ).toBeInTheDocument();
+		expect( latestState( log ) ).toMatchObject( { isPicking: false, annotationCount: 1 } );
 	} );
 
 	it( 'submits saved notes when an empty draft popup is open', () => {
@@ -92,14 +103,7 @@ describe( 'site preview inspector sessions', () => {
 		document.body.innerHTML = '<h1 id="draft">Draft</h1>';
 		const draft = document.querySelector( '#draft' ) as HTMLElement;
 		vi.spyOn( draft, 'getBoundingClientRect' ).mockReturnValue( rect( 10, 10 ) );
-		( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState = [
-			{
-				id: 'saved',
-				comment: 'Saved note',
-				path: window.location.pathname + window.location.search,
-				documentRect: { left: 10, top: 10, width: 100, height: 40 },
-			},
-		];
+		seedSavedNote();
 
 		new Function( INSPECTOR_PAGE_SCRIPT )();
 		command( 'toggle-picking' );
@@ -139,6 +143,18 @@ describe( 'site preview inspector sessions', () => {
 		expect( root.querySelectorAll( '.marker' ) ).toHaveLength( 0 );
 	} );
 } );
+
+function seedSavedNote() {
+	( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState = [
+		{
+			id: 'saved',
+			comment: 'Saved note',
+			tag: 'h1',
+			path: window.location.pathname + window.location.search,
+			documentRect: { left: 10, top: 10, width: 100, height: 40 },
+		},
+	];
+}
 
 function command( type: string ) {
 	window.dispatchEvent( new CustomEvent( INSPECTOR_COMMAND_EVENT, { detail: { type } } ) );

--- a/apps/ui/src/components/site-preview/inspector-script.test.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	INSPECTOR_BRIDGE_PREFIX,
+	INSPECTOR_COMMAND_EVENT,
+	INSPECTOR_PAGE_SCRIPT,
+} from './inspector-script';
+
+describe( 'site preview inspector sessions', () => {
+	afterEach( () => {
+		vi.restoreAllMocks();
+		document.body.replaceChildren();
+		delete ( window as Window & { __studioInspectorMounted?: boolean } ).__studioInspectorMounted;
+		delete ( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState;
+	} );
+
+	it( 'saves several notes without leaving annotation mode', () => {
+		const log = vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		document.body.innerHTML = '<h1 id="first">First</h1><p id="second">Second</p>';
+		const first = document.querySelector( '#first' ) as HTMLElement;
+		const second = document.querySelector( '#second' ) as HTMLElement;
+		vi.spyOn( first, 'getBoundingClientRect' ).mockReturnValue( rect( 10, 10 ) );
+		vi.spyOn( second, 'getBoundingClientRect' ).mockReturnValue( rect( 10, 80 ) );
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+		const root = ( document.querySelector( '#__studio-inspector-host' ) as HTMLElement )
+			.shadowRoot as ShadowRoot;
+		command( 'toggle-picking' );
+		first.dispatchEvent( new MouseEvent( 'click', { bubbles: true, cancelable: true } ) );
+
+		const firstTextarea = root.querySelector( 'textarea' ) as HTMLTextAreaElement;
+		firstTextarea.value = 'First note';
+		firstTextarea.dispatchEvent( new InputEvent( 'input', { bubbles: true } ) );
+		firstTextarea.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true, cancelable: true } )
+		);
+
+		expect( root.querySelector( '.popup' ) ).toBeNull();
+		expect( root.querySelectorAll( '.marker' ) ).toHaveLength( 1 );
+		expect( latestState( log ) ).toMatchObject( { isPicking: true, annotationCount: 1 } );
+
+		second.dispatchEvent( new MouseEvent( 'click', { bubbles: true, cancelable: true } ) );
+		const secondTextarea = root.querySelector( 'textarea' ) as HTMLTextAreaElement;
+		secondTextarea.value = 'First line';
+		secondTextarea.dispatchEvent( new InputEvent( 'input', { bubbles: true } ) );
+		secondTextarea.setSelectionRange( secondTextarea.value.length, secondTextarea.value.length );
+		secondTextarea.dispatchEvent(
+			new KeyboardEvent( 'keydown', {
+				key: 'Enter',
+				metaKey: true,
+				bubbles: true,
+				cancelable: true,
+			} )
+		);
+		expect( secondTextarea.value ).toBe( 'First line\n' );
+		secondTextarea.value += 'Second line';
+		secondTextarea.dispatchEvent( new InputEvent( 'input', { bubbles: true } ) );
+		command( 'submit' );
+
+		const done = bridgeMessages( log ).find( ( message ) => message.type === 'done' );
+		expect( done?.annotations ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( { comment: 'First note' } ),
+				expect.objectContaining( { comment: 'First line\nSecond line' } ),
+			] )
+		);
+		expect( latestState( log ) ).toMatchObject( { isPicking: false, annotationCount: 0 } );
+	} );
+
+	it( 'keeps saved notes while only showing markers for the current page', () => {
+		vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		const currentPath = window.location.pathname + window.location.search;
+		( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState = [
+			{
+				id: 'current',
+				comment: 'Current page',
+				path: currentPath,
+				documentRect: { left: 10, top: 10, width: 100, height: 40 },
+			},
+			{
+				id: 'other',
+				comment: 'Another page',
+				path: '/another-page/',
+				documentRect: { left: 10, top: 10, width: 100, height: 40 },
+			},
+		];
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+		const root = ( document.querySelector( '#__studio-inspector-host' ) as HTMLElement )
+			.shadowRoot as ShadowRoot;
+
+		expect( root.querySelectorAll( '.marker' ) ).toHaveLength( 1 );
+		expect( root.querySelector( '.marker' ) ).toHaveTextContent( '1' );
+		expect(
+			( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState
+		).toHaveLength( 2 );
+	} );
+
+	it( 'clears the pending batch when annotation mode is cancelled', () => {
+		const log = vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState = [
+			{
+				id: 'saved',
+				comment: 'Saved note',
+				path: window.location.pathname + window.location.search,
+				documentRect: { left: 10, top: 10, width: 100, height: 40 },
+			},
+		];
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+		command( 'toggle-picking' );
+		command( 'cancel' );
+
+		expect( latestState( log ) ).toMatchObject( { isPicking: false, annotationCount: 0 } );
+		expect(
+			( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState
+		).toEqual( [] );
+	} );
+} );
+
+function command( type: string ) {
+	window.dispatchEvent( new CustomEvent( INSPECTOR_COMMAND_EVENT, { detail: { type } } ) );
+}
+
+function rect( left: number, top: number ): DOMRect {
+	return {
+		x: left,
+		y: top,
+		left,
+		top,
+		right: left + 100,
+		bottom: top + 40,
+		width: 100,
+		height: 40,
+		toJSON: () => ( {} ),
+	} as DOMRect;
+}
+
+interface ConsoleLogSpy {
+	mock: { calls: unknown[][] };
+}
+
+function bridgeMessages( log: ConsoleLogSpy ): Array< Record< string, unknown > > {
+	return log.mock.calls
+		.map( ( call ) => call[ 0 ] )
+		.filter(
+			( message ): message is string =>
+				typeof message === 'string' && message.startsWith( INSPECTOR_BRIDGE_PREFIX )
+		)
+		.map( ( message ) => JSON.parse( message.slice( INSPECTOR_BRIDGE_PREFIX.length ) ) );
+}
+
+function latestState( log: ConsoleLogSpy ) {
+	return bridgeMessages( log )
+		.filter( ( message ) => message.type === 'state' )
+		.at( -1 );
+}

--- a/apps/ui/src/components/site-preview/inspector-script.test.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.test.ts
@@ -11,7 +11,6 @@ describe( 'site preview inspector sessions', () => {
 		document.body.replaceChildren();
 		delete ( window as Window & { __studioInspectorMounted?: boolean } ).__studioInspectorMounted;
 		delete ( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState;
-		delete ( window as Window & { __studioInspectorPicking?: boolean } ).__studioInspectorPicking;
 	} );
 
 	it( 'saves several notes without leaving annotation mode', () => {
@@ -67,35 +66,6 @@ describe( 'site preview inspector sessions', () => {
 		expect( latestState( log ) ).toMatchObject( { isPicking: false, annotationCount: 0 } );
 	} );
 
-	it( 'keeps saved notes while only showing markers for the current page', () => {
-		vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
-		const currentPath = window.location.pathname + window.location.search;
-		( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState = [
-			{
-				id: 'current',
-				comment: 'Current page',
-				path: currentPath,
-				documentRect: { left: 10, top: 10, width: 100, height: 40 },
-			},
-			{
-				id: 'other',
-				comment: 'Another page',
-				path: '/another-page/',
-				documentRect: { left: 10, top: 10, width: 100, height: 40 },
-			},
-		];
-
-		new Function( INSPECTOR_PAGE_SCRIPT )();
-		const root = ( document.querySelector( '#__studio-inspector-host' ) as HTMLElement )
-			.shadowRoot as ShadowRoot;
-
-		expect( root.querySelectorAll( '.marker' ) ).toHaveLength( 1 );
-		expect( root.querySelector( '.marker' ) ).toHaveTextContent( '1' );
-		expect(
-			( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState
-		).toHaveLength( 2 );
-	} );
-
 	it( 'clears the pending batch when annotation mode is cancelled', () => {
 		const log = vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
 		( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState = [
@@ -115,15 +85,6 @@ describe( 'site preview inspector sessions', () => {
 		expect(
 			( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState
 		).toEqual( [] );
-	} );
-
-	it( 'restores active annotation mode after navigation', () => {
-		const log = vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
-		( window as Window & { __studioInspectorPicking?: boolean } ).__studioInspectorPicking = true;
-
-		new Function( INSPECTOR_PAGE_SCRIPT )();
-
-		expect( latestState( log ) ).toMatchObject( { isPicking: true } );
 	} );
 
 	it( 'submits saved notes when an empty draft popup is open', () => {

--- a/apps/ui/src/components/site-preview/inspector-script.test.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.test.ts
@@ -11,6 +11,7 @@ describe( 'site preview inspector sessions', () => {
 		document.body.replaceChildren();
 		delete ( window as Window & { __studioInspectorMounted?: boolean } ).__studioInspectorMounted;
 		delete ( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState;
+		delete ( window as Window & { __studioInspectorPicking?: boolean } ).__studioInspectorPicking;
 	} );
 
 	it( 'saves several notes without leaving annotation mode', () => {
@@ -114,6 +115,39 @@ describe( 'site preview inspector sessions', () => {
 		expect(
 			( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState
 		).toEqual( [] );
+	} );
+
+	it( 'restores active annotation mode after navigation', () => {
+		const log = vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		( window as Window & { __studioInspectorPicking?: boolean } ).__studioInspectorPicking = true;
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+
+		expect( latestState( log ) ).toMatchObject( { isPicking: true } );
+	} );
+
+	it( 'submits saved notes when an empty draft popup is open', () => {
+		const log = vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		document.body.innerHTML = '<h1 id="draft">Draft</h1>';
+		const draft = document.querySelector( '#draft' ) as HTMLElement;
+		vi.spyOn( draft, 'getBoundingClientRect' ).mockReturnValue( rect( 10, 10 ) );
+		( window as Window & { __studioInspectorState?: unknown[] } ).__studioInspectorState = [
+			{
+				id: 'saved',
+				comment: 'Saved note',
+				path: window.location.pathname + window.location.search,
+				documentRect: { left: 10, top: 10, width: 100, height: 40 },
+			},
+		];
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+		command( 'toggle-picking' );
+		draft.dispatchEvent( new MouseEvent( 'click', { bubbles: true, cancelable: true } ) );
+		command( 'submit' );
+
+		const done = bridgeMessages( log ).find( ( message ) => message.type === 'done' );
+		expect( done?.annotations ).toEqual( [ expect.objectContaining( { comment: 'Saved note' } ) ] );
+		expect( latestState( log ) ).toMatchObject( { isPicking: false, annotationCount: 0 } );
 	} );
 } );
 

--- a/apps/ui/src/components/site-preview/inspector-script.test.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.test.ts
@@ -149,6 +149,34 @@ describe( 'site preview inspector sessions', () => {
 		expect( done?.annotations ).toEqual( [ expect.objectContaining( { comment: 'Saved note' } ) ] );
 		expect( latestState( log ) ).toMatchObject( { isPicking: false, annotationCount: 0 } );
 	} );
+
+	it( 'does not save while text input is being composed', () => {
+		vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		document.body.innerHTML = '<h1 id="composing">Composing</h1>';
+		const target = document.querySelector( '#composing' ) as HTMLElement;
+		vi.spyOn( target, 'getBoundingClientRect' ).mockReturnValue( rect( 10, 10 ) );
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+		const root = ( document.querySelector( '#__studio-inspector-host' ) as HTMLElement )
+			.shadowRoot as ShadowRoot;
+		command( 'toggle-picking' );
+		target.dispatchEvent( new MouseEvent( 'click', { bubbles: true, cancelable: true } ) );
+
+		const textarea = root.querySelector( 'textarea' ) as HTMLTextAreaElement;
+		textarea.value = '入力中';
+		textarea.dispatchEvent( new InputEvent( 'input', { bubbles: true } ) );
+		textarea.dispatchEvent(
+			new KeyboardEvent( 'keydown', {
+				key: 'Enter',
+				isComposing: true,
+				bubbles: true,
+				cancelable: true,
+			} )
+		);
+
+		expect( root.querySelector( '.popup' ) ).toBeInTheDocument();
+		expect( root.querySelectorAll( '.marker' ) ).toHaveLength( 0 );
+	} );
 } );
 
 function command( type: string ) {

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -17,7 +17,7 @@
  * The annotation controls live in the host toolbar (not in the page), and
  * drive the inspector by dispatching `INSPECTOR_COMMAND_EVENT` custom events
  * on the guest `window` via `webview.executeJavaScript()`:
- *   host -> guest: `{ "type": "toggle-picking" | "submit" | "report-state" }`
+ *   host -> guest: `{ "type": "toggle-picking" | "cancel" | "submit" | "report-state" }`
  *
  * Layout strategy: markers and the picking highlight use `position: absolute`
  * anchored at *document* coordinates (viewport rect + scroll offset). They
@@ -233,6 +233,8 @@ export const INSPECTOR_PAGE_SCRIPT =
 		.popup .cancel:hover { background: rgba(255,255,255,0.08); }
 		.popup .save { background: #fff; color: #1a1a1a; }
 		.popup .save[disabled] { opacity: 0.4; cursor: default; }
+		.popup .submit { background: rgba(255,255,255,0.12); color: #fff; }
+		.popup .submit[disabled] { opacity: 0.4; cursor: default; }
 	` +
 	'`' +
 	String.raw`;
@@ -351,13 +353,58 @@ export const INSPECTOR_PAGE_SCRIPT =
 		render();
 	}
 
+	function commitActivePopup() {
+		if ( ! activePopup ) return true;
+		const state = activePopup;
+		const trimmed = ( state.comment || '' ).trim();
+		if ( ! trimmed ) return false;
+		if ( state.id ) {
+			annotations = annotations.map( ( annotation ) =>
+				annotation.id === state.id
+					? Object.assign( {}, annotation, { comment: trimmed, updatedAt: Date.now() } )
+					: annotation
+			);
+		} else {
+			annotations = annotations.concat( [
+				{
+					id: uid(),
+					comment: trimmed,
+					selector: state.target.selector,
+					tag: state.target.tag,
+					nearbyText: state.target.nearbyText,
+					boundingBox: state.target.boundingBox,
+					documentRect: state.target.documentRect,
+					computedStyles: state.target.computedStyles,
+					path: window.location.pathname + window.location.search,
+					url: window.location.href,
+					timestamp: Date.now(),
+				},
+			] );
+		}
+		persistAnnotations();
+		return true;
+	}
+
 	function submitAnnotations() {
+		if ( ! commitActivePopup() ) {
+			sendState();
+			return;
+		}
 		if ( annotations.length === 0 ) {
 			sendState();
 			return;
 		}
 		const sent = annotations.slice();
 		send( { type: 'done', annotations: sent } );
+		annotations = [];
+		activePopup = null;
+		isPicking = false;
+		hoveredEl = null;
+		persistAnnotations();
+		render();
+	}
+
+	function cancelAnnotations() {
 		annotations = [];
 		activePopup = null;
 		isPicking = false;
@@ -374,6 +421,10 @@ export const INSPECTOR_PAGE_SCRIPT =
 		}
 		if ( command.type === 'submit' ) {
 			submitAnnotations();
+			return;
+		}
+		if ( command.type === 'cancel' ) {
+			cancelAnnotations();
 			return;
 		}
 		if ( command.type === 'report-state' ) {
@@ -447,12 +498,6 @@ export const INSPECTOR_PAGE_SCRIPT =
 
 		const closePopup = () => {
 			activePopup = null;
-			/* Picking does NOT auto-resume after save/cancel. Auto-resume was
-			 * convenient for chaining annotations but it silently blocks every
-			 * link click in the page (the picking handler calls
-			 * preventDefault), making the preview feel broken. The user
-			 * re-enters picking mode via the Annotate button. */
-			isPicking = false;
 			hoveredEl = null;
 			persistAnnotations();
 			render();
@@ -469,34 +514,38 @@ export const INSPECTOR_PAGE_SCRIPT =
 		save.textContent = state.id ? 'Update' : 'Save';
 		save.disabled = ! ( state.comment && state.comment.trim() );
 		save.addEventListener( 'click', () => {
-			const trimmed = ( state.comment || '' ).trim();
-			if ( ! trimmed ) return;
-			if ( state.id ) {
-				annotations = annotations.map( ( a ) =>
-					a.id === state.id
-						? Object.assign( {}, a, { comment: trimmed, updatedAt: Date.now() } )
-						: a
-				);
-			} else {
-				annotations = annotations.concat( [
-					{
-						id: uid(),
-						comment: trimmed,
-						selector: state.target.selector,
-						tag: state.target.tag,
-						nearbyText: state.target.nearbyText,
-						boundingBox: state.target.boundingBox,
-						documentRect: state.target.documentRect,
-						computedStyles: state.target.computedStyles,
-						path: window.location.pathname + window.location.search,
-						url: window.location.href,
-						timestamp: Date.now(),
-					},
-				] );
-			}
+			if ( ! commitActivePopup() ) return;
 			closePopup();
 		} );
 		actions.appendChild( save );
+
+		const submit = document.createElement( 'button' );
+		submit.className = 'submit';
+		submit.textContent = 'Send to chat';
+		submit.disabled = ! ( state.comment && state.comment.trim() );
+		submit.addEventListener( 'click', submitAnnotations );
+		actions.appendChild( submit );
+
+		ta.addEventListener( 'input', () => {
+			submit.disabled = ! state.comment.trim();
+		} );
+		ta.addEventListener( 'keydown', ( event ) => {
+			if ( event.key !== 'Enter' ) return;
+			if ( event.metaKey || event.ctrlKey ) {
+				event.preventDefault();
+				const start = ta.selectionStart;
+				const end = ta.selectionEnd;
+				ta.value = ta.value.slice( 0, start ) + '\n' + ta.value.slice( end );
+				state.comment = ta.value;
+				ta.setSelectionRange( start + 1, start + 1 );
+				save.disabled = ! state.comment.trim();
+				submit.disabled = save.disabled;
+				return;
+			}
+			if ( event.shiftKey ) return;
+			event.preventDefault();
+			save.click();
+		} );
 
 		popup.appendChild( actions );
 
@@ -507,7 +556,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 	}
 
 	function openPopupForAnnotation( ann ) {
-		isPicking = false;
+		isPicking = true;
 		hoveredEl = null;
 		activePopup = {
 			id: ann.id,
@@ -527,7 +576,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 
 	function openPopupForElement( el ) {
 		const viewport = el.getBoundingClientRect();
-		isPicking = false;
+		isPicking = true;
 		activePopup = {
 			fromPicker: true,
 			comment: '',
@@ -557,7 +606,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 	document.addEventListener(
 		'mousemove',
 		( e ) => {
-			if ( ! isPicking ) return;
+			if ( ! isPicking || activePopup ) return;
 			if ( isOurElement( e.target ) ) {
 				if ( hoveredEl !== null ) {
 					hoveredEl = null;
@@ -576,7 +625,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 	document.addEventListener(
 		'click',
 		( e ) => {
-			if ( ! isPicking ) return;
+			if ( ! isPicking || activePopup ) return;
 			if ( isOurElement( e.target ) ) return;
 			e.preventDefault();
 			e.stopPropagation();

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -17,7 +17,7 @@
  * The annotation controls live in the host toolbar (not in the page), and
  * drive the inspector by dispatching `INSPECTOR_COMMAND_EVENT` custom events
  * on the guest `window` via `webview.executeJavaScript()`:
- *   host -> guest: `{ "type": "toggle-picking" | "cancel" | "submit" | "report-state" }`
+ *   host -> guest: `{ "type": "toggle-picking" | "submit" | "report-state" }`
  *
  * Layout strategy: markers and the picking highlight use `position: absolute`
  * anchored at *document* coordinates (viewport rect + scroll offset). They
@@ -39,7 +39,13 @@ export const INSPECTOR_PAGE_SCRIPT =
 		);
 		return;
 	}
+	/* A stale instance can outlive its host element (the mount flag is per
+	 * document, its listeners are not), so retire it before taking over. */
+	if ( typeof window.__studioInspectorDispose === 'function' ) {
+		window.__studioInspectorDispose();
+	}
 	window.__studioInspectorMounted = true;
+	const teardown = new AbortController();
 
 	const BRIDGE_PREFIX = '` +
 	INSPECTOR_BRIDGE_PREFIX +
@@ -179,6 +185,13 @@ export const INSPECTOR_PAGE_SCRIPT =
 	document.body.appendChild( host );
 	const root = host.attachShadow( { mode: 'open' } );
 
+	window.__studioInspectorDispose = () => {
+		teardown.abort();
+		host.remove();
+		delete window.__studioInspectorMounted;
+		delete window.__studioInspectorDispose;
+	};
+
 	const style = document.createElement( 'style' );
 	style.textContent = ` +
 	'`' +
@@ -222,10 +235,13 @@ export const INSPECTOR_PAGE_SCRIPT =
 			padding: 8px; font: 13px/1.4 inherit; outline: none;
 		}
 		.popup textarea:focus { border-color: #2563eb; }
-		.popup .actions { display: flex; justify-content: flex-end; gap: 6px; }
+		.popup .actions { display: flex; justify-content: flex-end; gap: 4px; }
+		/* Sized so Delete/Cancel/Update/Send to chat all fit one row of the
+		   320px popup; nowrap keeps a tight fit from wrapping a label onto a
+		   second line instead of the row overflowing visibly. */
 		.popup button {
-			padding: 6px 12px; border-radius: 16px; border: none;
-			font: 600 12px/1 inherit; cursor: pointer;
+			padding: 6px 8px; border-radius: 16px; border: none;
+			font: 600 11px/1 inherit; white-space: nowrap; cursor: pointer;
 		}
 		.popup .delete { background: transparent; color: rgba(255,255,255,0.5); margin-right: auto; }
 		.popup .delete:hover { color: #ef4444; }
@@ -385,57 +401,49 @@ export const INSPECTOR_PAGE_SCRIPT =
 		return true;
 	}
 
+	function hasDraft() {
+		return !! ( activePopup && ( activePopup.comment || '' ).trim() );
+	}
+
 	function submitAnnotations() {
-		if ( activePopup && ! ( activePopup.comment || '' ).trim() ) {
-			if ( annotations.length === 0 ) {
-				sendState();
+		if ( annotations.length === 0 && ! hasDraft() ) {
+			sendState();
+			return;
+		}
+		/* An untouched popup is a draft the user never filled in — drop it
+		 * rather than blocking the notes they did save. */
+		if ( hasDraft() ) {
+			commitActivePopup();
+		} else {
+			activePopup = null;
+		}
+		send( { type: 'done', annotations: annotations.slice() } );
+		annotations = [];
+		activePopup = null;
+		isPicking = false;
+		hoveredEl = null;
+		persistAnnotations();
+		render();
+	}
+
+	window.addEventListener(
+		COMMAND_EVENT,
+		( event ) => {
+			const command = event.detail || {};
+			if ( command.type === 'toggle-picking' ) {
+				togglePicking();
 				return;
 			}
-			activePopup = null;
-		} else if ( ! commitActivePopup() ) {
-			return;
-		}
-		if ( annotations.length === 0 ) {
-			sendState();
-			return;
-		}
-		const sent = annotations.slice();
-		send( { type: 'done', annotations: sent } );
-		annotations = [];
-		activePopup = null;
-		isPicking = false;
-		hoveredEl = null;
-		persistAnnotations();
-		render();
-	}
-
-	function cancelAnnotations() {
-		annotations = [];
-		activePopup = null;
-		isPicking = false;
-		hoveredEl = null;
-		persistAnnotations();
-		render();
-	}
-
-	window.addEventListener( COMMAND_EVENT, ( event ) => {
-		const command = event.detail || {};
-		if ( command.type === 'toggle-picking' ) {
-			togglePicking();
-			return;
-		}
-		if ( command.type === 'submit' ) {
-			submitAnnotations();
-			return;
-		}
-		if ( command.type === 'cancel' ) {
-			cancelAnnotations();
-			return;
-		}
-		if ( command.type === 'report-state' ) {
-			sendState();
-		}
-	} );
+			if ( command.type === 'submit' ) {
+				submitAnnotations();
+				return;
+			}
+			if ( command.type === 'report-state' ) {
+				sendState();
+			}
+		},
+		{ signal: teardown.signal }
+	);
 
 	function buildPopup( state ) {
 		const popup = document.createElement( 'div' );
@@ -475,13 +483,10 @@ export const INSPECTOR_PAGE_SCRIPT =
 			( state.target.nearbyText ? ' — ' + state.target.nearbyText : '' );
 		popup.appendChild( target );
 
+		state.comment = state.comment || '';
 		const ta = document.createElement( 'textarea' );
 		ta.placeholder = 'What should change about this element?';
-		ta.value = state.comment || '';
-		ta.addEventListener( 'input', () => {
-			state.comment = ta.value;
-			save.disabled = ! state.comment.trim();
-		} );
+		ta.value = state.comment;
 		popup.appendChild( ta );
 		setTimeout( () => ta.focus(), 0 );
 
@@ -517,7 +522,6 @@ export const INSPECTOR_PAGE_SCRIPT =
 		const save = document.createElement( 'button' );
 		save.className = 'save';
 		save.textContent = state.id ? 'Update' : 'Save';
-		save.disabled = ! ( state.comment && state.comment.trim() );
 		save.addEventListener( 'click', () => {
 			if ( ! commitActivePopup() ) return;
 			closePopup();
@@ -527,12 +531,20 @@ export const INSPECTOR_PAGE_SCRIPT =
 		const submit = document.createElement( 'button' );
 		submit.className = 'submit';
 		submit.textContent = 'Send to chat';
-		submit.disabled = ! ( state.comment && state.comment.trim() );
 		submit.addEventListener( 'click', submitAnnotations );
 		actions.appendChild( submit );
 
+		function syncActions() {
+			save.disabled = ! state.comment.trim();
+			/* Sending stays available while notes are already saved, even if
+			 * this popup is an untouched draft — submit discards it. */
+			submit.disabled = save.disabled && annotations.length === 0;
+		}
+		syncActions();
+
 		ta.addEventListener( 'input', () => {
-			submit.disabled = ! state.comment.trim();
+			state.comment = ta.value;
+			syncActions();
 		} );
 		ta.addEventListener( 'keydown', ( event ) => {
 			if ( event.key !== 'Enter' || event.isComposing || event.keyCode === 229 ) return;
@@ -543,8 +555,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 				ta.value = ta.value.slice( 0, start ) + '\n' + ta.value.slice( end );
 				state.comment = ta.value;
 				ta.setSelectionRange( start + 1, start + 1 );
-				save.disabled = ! state.comment.trim();
-				submit.disabled = save.disabled;
+				syncActions();
 				return;
 			}
 			if ( event.shiftKey ) return;
@@ -560,8 +571,10 @@ export const INSPECTOR_PAGE_SCRIPT =
 		return popup;
 	}
 
+	/* Editing an existing note leaves picking mode alone: markers stay
+	 * clickable when picking is off, and silently switching it on would
+	 * swallow every subsequent link click in the page. */
 	function openPopupForAnnotation( ann ) {
-		isPicking = true;
 		hoveredEl = null;
 		activePopup = {
 			id: ann.id,
@@ -581,7 +594,6 @@ export const INSPECTOR_PAGE_SCRIPT =
 
 	function openPopupForElement( el ) {
 		const viewport = el.getBoundingClientRect();
-		isPicking = true;
 		activePopup = {
 			fromPicker: true,
 			comment: '',
@@ -624,7 +636,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 				showHighlight( hoveredEl );
 			}
 		},
-		true
+		{ capture: true, signal: teardown.signal }
 	);
 
 	document.addEventListener(
@@ -636,7 +648,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 			e.stopPropagation();
 			openPopupForElement( e.target );
 		},
-		true
+		{ capture: true, signal: teardown.signal }
 	);
 
 	document.addEventListener(
@@ -661,7 +673,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 				render();
 			}
 		},
-		true
+		{ capture: true, signal: teardown.signal }
 	);
 
 	render();

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -243,7 +243,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 	/* ------------------------------------------------------------------
 	 * State + DOM
 	 * ---------------------------------------------------------------- */
-	let isPicking = Boolean( window.__studioInspectorPicking );
+	let isPicking = false;
 	let hoveredEl = null;
 	let activePopup = null; /* { id?, target, comment, fromPicker? } */
 	let annotations = Array.isArray( window.__studioInspectorState )
@@ -260,7 +260,6 @@ export const INSPECTOR_PAGE_SCRIPT =
 	}
 
 	function sendState() {
-		window.__studioInspectorPicking = isPicking;
 		send( {
 			type: 'state',
 			isPicking,

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -243,7 +243,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 	/* ------------------------------------------------------------------
 	 * State + DOM
 	 * ---------------------------------------------------------------- */
-	let isPicking = false;
+	let isPicking = Boolean( window.__studioInspectorPicking );
 	let hoveredEl = null;
 	let activePopup = null; /* { id?, target, comment, fromPicker? } */
 	let annotations = Array.isArray( window.__studioInspectorState )
@@ -260,6 +260,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 	}
 
 	function sendState() {
+		window.__studioInspectorPicking = isPicking;
 		send( {
 			type: 'state',
 			isPicking,
@@ -386,8 +387,13 @@ export const INSPECTOR_PAGE_SCRIPT =
 	}
 
 	function submitAnnotations() {
-		if ( ! commitActivePopup() ) {
-			sendState();
+		if ( activePopup && ! ( activePopup.comment || '' ).trim() ) {
+			if ( annotations.length === 0 ) {
+				sendState();
+				return;
+			}
+			activePopup = null;
+		} else if ( ! commitActivePopup() ) {
 			return;
 		}
 		if ( annotations.length === 0 ) {
@@ -530,7 +536,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 			submit.disabled = ! state.comment.trim();
 		} );
 		ta.addEventListener( 'keydown', ( event ) => {
-			if ( event.key !== 'Enter' ) return;
+			if ( event.key !== 'Enter' || event.isComposing || event.keyCode === 229 ) return;
 			if ( event.metaKey || event.ctrlKey ) {
 				event.preventDefault();
 				const start = ta.selectionStart;

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -49,11 +49,13 @@
 
 /* Matching flexible side tracks: because both flex from the same 0 basis,
    the address control between them sits at the toolbar's true center no
-   matter how many controls each side holds. */
+   matter how many controls each side holds. They keep their automatic
+   min-content floor, so a narrow toolbar shrinks the address segments
+   between them rather than letting the (non-shrinking) button groups
+   spill out of their track and over the address bar. */
 .headerSide {
 	display: flex;
 	flex: 1 1 0;
-	min-width: 0;
 	align-items: center;
 	gap: var(--wpds-dimension-padding-md);
 }
@@ -76,6 +78,27 @@
 	align-items: center;
 	gap: var(--wpds-dimension-padding-xs);
 	flex-shrink: 0;
+}
+
+.annotationMenu {
+	display: none;
+	align-items: center;
+	flex-shrink: 0;
+}
+
+/* Below this width the inline "Send to chat" button starts eating into the
+   address segments, so the pair folds into a split button. Only applies to
+   the pending-notes layout: a lone annotate toggle always fits. The query
+   measures the header's content box, so this trips at a ~532px pane — just
+   above the width where the segments begin to erode. */
+@container studio-preview-toolbar (max-width: 500px) {
+	.annotationControlsWide {
+		display: none;
+	}
+
+	.annotationMenu {
+		display: flex;
+	}
 }
 
 /* 2px bar overlapping the header's bottom border, like a browser's page-load

--- a/apps/ui/src/components/split-button/style.module.css
+++ b/apps/ui/src/components/split-button/style.module.css
@@ -1,0 +1,48 @@
+/* Shared chrome for the preview toolbar's split buttons: a primary action
+   fused to a narrow chevron tab that opens the full menu. Used by the
+   "Open in…" control and the collapsed annotation control, which sit next
+   to each other and have to read as the same kind of thing. */
+.splitTrigger {
+	display: inline-flex;
+	align-items: center;
+	gap: 1px;
+	flex: 0 0 auto;
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+	/* The buttons' own radius plus the border width, so the halves' rounded
+	   outer corners nest flush against the frame. */
+	border-radius: calc(var(--wpds-border-radius-sm) + var(--wpds-border-width-xs));
+	-webkit-app-region: no-drag;
+}
+
+/* Size the halves so the pair reads as one compact button: normal padding
+   on the outer edges, almost none along the shared seam, and a very narrow
+   chevron tab. Squaring off the shared corners makes the hover fills read
+   as one control split in two. */
+.splitAction {
+	--wp-ui-button-min-width: unset;
+
+	padding-inline: var(--wpds-dimension-padding-xs) 1px;
+	border-start-end-radius: 0;
+	border-end-end-radius: 0;
+}
+
+.splitMenuButton {
+	--wp-ui-button-min-width: unset;
+
+	padding-inline: 1px 3px;
+	border-start-start-radius: 0;
+	border-end-start-radius: 0;
+}
+
+.chevron {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	fill: currentColor;
+}
+
+/* Map the foreground color onto @wordpress/icons SVGs, which ship without a
+   fill attribute and would otherwise render with the black SVG default. The
+   brand logos declare their own fill (`currentColor` or `none` for the
+   stroke-drawn ones), so scope the rule to leave them alone. */
+.splitAction svg:not([fill]) {
+	fill: currentColor;
+}


### PR DESCRIPTION
## Related issues

- Related to [STU-2183](https://linear.app/a8c/issue/STU-2183/design-spec-focused-element-annotations-for-studio-preview-and-cli)

## How AI was used in this PR

Codex extracted this focused change from the larger annotation workflow exploration. The interaction model was directed and reviewed manually.

## Proposed Changes

<img width="757" height="349" alt="image" src="https://github.com/user-attachments/assets/92c9b9df-d903-420e-8ff7-f000fb8dc27b" />
<img width="256" height="56" alt="image" src="https://github.com/user-attachments/assets/ec2c2b65-ef1a-42d7-b3ec-2441995725f8" />

- Keeps annotation mode active after saving so users can add several notes on the current page.
- Separates saving a note from sending the full batch to chat.
- Replaces the active Annotate control with clear Cancel and Send to chat actions.
- Uses Return to save a note and Cmd/Ctrl+Return to insert a newline.
- Ends annotation mode after a page load instead of trapping the user in selection mode.

> ⚠️ Visual change: needs human review in light + dark mode.

## Testing Instructions

1. Open a running site and enter annotation mode.
2. Save multiple notes on the current page and confirm annotation mode remains active.
3. Confirm Return saves and Cmd/Ctrl+Return inserts a newline.
4. Confirm Cancel clears the batch and Send to chat submits it.
5. Run:
   - `npm run typecheck`
   - `npm test -- apps/ui/src/components/site-preview/inspector-script.test.ts apps/ui/src/components/site-preview/index.test.tsx`

## Pre-merge Checklist

- [x] Focused tests pass
- [x] Typecheck passes
- [ ] Human visual review in light and dark mode
- [ ] Full CI passes
