### PR TITLE
Agentic UI: Wait for the remote import before reporting a push complete

### DIFF
--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -1254,7 +1254,7 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 
 	// Push the local site to its connected WordPress.com live site. Long-running
 	// (export → upload → import); progress streams on the SSE `sync` channel.
-	// Resolves once the import is initiated.
+	// Responds once the remote import has finished.
 	api.post(
 		'/sites/:id/push',
 		asyncHandler( async ( req: Request, res: Response ) => {

--- a/apps/studio/src/ipc-utils.ts
+++ b/apps/studio/src/ipc-utils.ts
@@ -40,7 +40,9 @@ export interface IpcEvents {
 	'sync-upload-progress': [ { selectedSiteId: string; remoteSiteId: number; progress: number } ];
 	'sync-upload-manually-paused': [ { selectedSiteId: string; remoteSiteId: number } ];
 	'sync-pull-progress': [ PullSiteProgress & { siteId: string } ];
-	'sync-push-phase': [ { selectedSiteId: string; remoteSiteId: number; phase: PushPhase } ];
+	'sync-push-phase': [
+		{ selectedSiteId: string; remoteSiteId: number; phase: PushPhase; progress?: number },
+	];
 	'snapshot-error': [ { operationId: crypto.UUID; data: SnapshotEventData } ];
 	'snapshot-fatal-error': [ { operationId: crypto.UUID; data: { message: string } } ];
 	'snapshot-output': [ { operationId: crypto.UUID; data: SnapshotEventData } ];

--- a/apps/studio/src/modules/sync/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/sync/lib/ipc-handlers.ts
@@ -612,6 +612,7 @@ export async function pushSiteToLive(
 							selectedSiteId,
 							remoteSiteId,
 							phase: output.phase,
+							progress: output.progress,
 						} );
 					} else if ( output.kind === 'upload-progress' ) {
 						void sendIpcEventToRenderer( 'sync-upload-progress', {

--- a/apps/ui/src/components/site-dropdown/main-view.module.css
+++ b/apps/ui/src/components/site-dropdown/main-view.module.css
@@ -58,6 +58,14 @@
 	fill: currentColor;
 }
 
+/* The popup keeps `overflow: visible`, so this — the only row that fills to the
+   popup edge — has to round its own top corners or it squares off the popup's.
+   Inset by the border width so the curve nests inside it instead of cutting it. */
+.activityStatus:first-child {
+	border-top-left-radius: calc(var(--site-dropdown-radius) - var(--wpds-border-width-xs));
+	border-top-right-radius: calc(var(--site-dropdown-radius) - var(--wpds-border-width-xs));
+}
+
 .activityStatusPending {
 	background: var(--wpds-color-bg-surface-neutral);
 }

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -559,17 +559,22 @@ export function createIpcConnector(): Connector {
 		async pushSiteToLive( siteId, remoteSiteId, options, onPhase ): Promise< void > {
 			// The agentic UI pushes via the shared `pushSite` (export → TUS
 			// upload → import) in both desktop and `studio ui`; the desktop runs
-			// it behind this single IPC handler. Resolves once the import is
-			// initiated (the remote import may still be running).
+			// it behind this single IPC handler. Resolves once the remote import
+			// has finished.
 			const unsubscribe = onPhase
 				? ipcListener.subscribe(
 						'sync-push-phase',
 						(
 							_event: unknown,
-							payload: { selectedSiteId: string; remoteSiteId: number; phase: PushPhase }
+							payload: {
+								selectedSiteId: string;
+								remoteSiteId: number;
+								phase: PushPhase;
+								progress?: number;
+							}
 						) => {
 							if ( payload.selectedSiteId === siteId && payload.remoteSiteId === remoteSiteId ) {
-								onPhase( payload.phase );
+								onPhase( payload.phase, payload.progress );
 							}
 						}
 				  )

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -589,7 +589,7 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 		async pushSiteToLive( siteId, remoteSiteId, options, onPhase ) {
 			const listener = ( output: PushSseOutput ) => {
 				if ( output.siteId === siteId && output.kind === 'phase' ) {
-					onPhase?.( output.phase );
+					onPhase?.( output.phase, output.progress );
 				}
 			};
 			if ( onPhase ) {

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -305,7 +305,7 @@ export interface Connector {
 		siteId: string,
 		remoteSiteId: number,
 		options?: PushSyncOptions,
-		onPhase?: ( phase: PushPhase ) => void
+		onPhase?: ( phase: PushPhase, progress?: number ) => void
 	): Promise< void >;
 	// Pulls the connected WordPress.com site's database + wp-content back
 	// into the local Studio site, or only the selection described by

--- a/apps/ui/src/data/queries/use-sync-site.ts
+++ b/apps/ui/src/data/queries/use-sync-site.ts
@@ -33,8 +33,8 @@ export function usePushSiteToLive() {
 	return useMutation( {
 		mutationKey: PUSH_TO_LIVE_MUTATION_KEY,
 		mutationFn: ( { siteId, remoteSiteId, options }: PushToLiveVariables ) =>
-			connector.pushSiteToLive( siteId, remoteSiteId, options, ( phase ) =>
-				reportPushPhase( siteId, phase )
+			connector.pushSiteToLive( siteId, remoteSiteId, options, ( phase, progress ) =>
+				reportPushPhase( siteId, phase, progress )
 			),
 		onMutate: ( { siteId } ) => {
 			reportSyncPending( siteId, 'push' );

--- a/apps/ui/src/data/sync-activity.test.tsx
+++ b/apps/ui/src/data/sync-activity.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	getSyncCancelLabels,
+	reportPushPhase,
 	reportSyncPending,
 	reportSyncProgress,
 	reportSyncSuccess,
@@ -39,6 +40,22 @@ describe( 'sync activity progress', () => {
 			vi.advanceTimersByTime( 30_000 );
 		} );
 		expect( result.current ).toBeNull();
+	} );
+
+	it( 'describes the phase a push is in, so it never reads as idle', () => {
+		const siteId = 'push-site';
+		const { result } = renderHook( () => useSiteSyncActivity( siteId ) );
+
+		act( () => reportSyncPending( siteId, 'push' ) );
+		act( () => reportPushPhase( siteId, 'creatingRemoteBackup', 40 ) );
+		expect( result.current ).toMatchObject( {
+			phase: 'creatingRemoteBackup',
+			message: 'Backing up remote site… (40%)',
+		} );
+
+		// The remote does not report a percentage for every phase.
+		act( () => reportPushPhase( siteId, 'finishing' ) );
+		expect( result.current ).toMatchObject( { phase: 'finishing', message: 'Almost there…' } );
 	} );
 } );
 

--- a/apps/ui/src/data/sync-activity.ts
+++ b/apps/ui/src/data/sync-activity.ts
@@ -1,5 +1,5 @@
 import { canCancelPull, canCancelPush } from '@studio/common/lib/sync/cancel';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useSyncExternalStore } from 'react';
 import type { PullSiteProgress, PushPhase } from '@/data/core';
 
@@ -92,13 +92,28 @@ export function reportSyncProgress(
 	emit();
 }
 
-export function reportPushPhase( siteId: string, phase: PushPhase ): void {
+// Same wording as the classic renderer's push states, so a user moving between
+// the two UIs reads the same thing. The percentage goes in the message because
+// that is how a pull already reads here — the CLI puts it in its own text.
+function getPushPhaseMessage( phase: PushPhase, progress?: number ): string {
+	const message = {
+		creatingBackup: __( 'Creating backup…' ),
+		uploading: __( 'Uploading site…' ),
+		creatingRemoteBackup: __( 'Backing up remote site…' ),
+		applyingChanges: __( 'Applying changes…' ),
+		finishing: __( 'Almost there…' ),
+	}[ phase ];
+
+	return progress ? sprintf( '%1$s (%2$d%%)', message, Math.round( progress ) ) : message;
+}
+
+export function reportPushPhase( siteId: string, phase: PushPhase, progress?: number ): void {
 	const current = entries.get( siteId );
 	if ( current?.kind !== 'pending' || current.direction !== 'push' ) {
 		return;
 	}
 	clearExpiryTimer( siteId );
-	entries.set( siteId, { ...current, phase } );
+	entries.set( siteId, { ...current, phase, message: getPushPhaseMessage( phase, progress ) } );
 	emit();
 }
 

--- a/packages/common/lib/sync/cancel.ts
+++ b/packages/common/lib/sync/cancel.ts
@@ -23,12 +23,19 @@ export function isSyncCancelledError( error: unknown ): boolean {
 	return message.includes( SYNC_CANCELLED_MESSAGE );
 }
 
+// The phases where the work is still local — the export and the upload. Like
+// `PULL_REMOTE_ACTIONS` below this is an allow-list, so the remote phases added
+// after the import starts stay uncancellable by default. Matches the legacy
+// renderer's `isKeyUploading` set.
+const CANCELLABLE_PUSH_PHASES: PushPhase[] = [ 'creatingBackup', 'uploading' ];
+
 /**
  * A push can be stopped until the remote import is initiated. After that the
  * live site is already being changed and stopping locally would not undo it.
  */
 export function canCancelPush( phase: PushPhase | undefined ): boolean {
-	return phase !== 'applyingChanges';
+	// No phase reported yet: the export has not started.
+	return phase === undefined || CANCELLABLE_PUSH_PHASES.includes( phase );
 }
 
 // Everything the CLI's `pull` reports before it touches the local site. The

--- a/packages/common/sites/sync.test.ts
+++ b/packages/common/sites/sync.test.ts
@@ -2,14 +2,34 @@ import EventEmitter from 'node:events';
 import { describe, expect, it, vi } from 'vitest';
 import { killChild } from '@studio/common/lib/cli-process';
 import { canCancelPull, canCancelPush, isSyncCancelledError } from '@studio/common/lib/sync/cancel';
-import { pullSite } from './sync';
+import { pollImportStatus } from '@studio/common/lib/sync/sync-api';
+import { pullSite, pushSite } from './sync';
 import type { ExecuteCliCommand } from '@studio/common/lib/cli-process';
+import type { ImportResponse } from '@studio/common/types/sync';
 
 // How the child is killed is platform-specific and covered by
 // `lib/tests/cli-process.test.ts`; here we only care that a cancel asks for it.
 vi.mock( '@studio/common/lib/cli-process', async ( importOriginal ) => ( {
 	...( await importOriginal< typeof import('@studio/common/lib/cli-process') >() ),
 	killChild: vi.fn(),
+} ) );
+
+vi.mock( '@studio/common/lib/sync/sync-api', () => ( {
+	initiateImport: vi.fn(),
+	pollImportStatus: vi.fn(),
+} ) );
+
+vi.mock( '@studio/common/lib/sync/tus-upload', () => ( {
+	createTusUpload: vi.fn( () => ( {
+		promise: Promise.resolve( 'attachment-1' ),
+		abort: vi.fn(),
+	} ) ),
+} ) );
+
+// Poll back to back rather than waiting 3s between each status.
+vi.mock( '@studio/common/lib/sync/constants', async ( importOriginal ) => ( {
+	...( await importOriginal< typeof import('@studio/common/lib/sync/constants') >() ),
+	SYNC_POLL_INTERVAL_MS: 0,
 } ) );
 
 describe( 'pullSite', () => {
@@ -104,12 +124,93 @@ describe( 'pullSite', () => {
 	} );
 } );
 
+describe( 'pushSite', () => {
+	function startPush( statuses: ImportResponse[] ) {
+		const emitter = new EventEmitter();
+		const execute = vi.fn( () => {
+			// The handlers are attached right after this returns.
+			queueMicrotask( () => emitter.emit( 'success' ) );
+			return [ emitter, {} ];
+		} ) as unknown as ExecuteCliCommand;
+
+		vi.mocked( pollImportStatus ).mockReset();
+		for ( const status of statuses ) {
+			vi.mocked( pollImportStatus ).mockResolvedValueOnce( status );
+		}
+
+		const emit = vi.fn();
+		const pushing = pushSite(
+			{ executeCliCommand: execute, accessToken: 'token', emit },
+			{ sitePath: '/sites/local', remoteSiteId: 42 }
+		);
+		return { emit, pushing };
+	}
+
+	const working = ( status: string, progress: Partial< ImportResponse > = {} ) =>
+		( {
+			status,
+			success: true,
+			backup_progress: null,
+			import_progress: null,
+			...progress,
+		} ) as ImportResponse;
+
+	it( 'polls the remote import to completion instead of resolving once it starts', async () => {
+		const { emit, pushing } = startPush( [
+			working( 'initial_backup_started', { backup_progress: 40 } ),
+			working( 'archive_import_started', { import_progress: 20 } ),
+			working( 'archive_import_finished' ),
+			working( 'finished' ),
+		] );
+
+		await pushing;
+
+		// Resolving at initiate — the bug — would stop this list at the first
+		// `creatingRemoteBackup`, before any of the polled phases.
+		expect( emit.mock.calls.map( ( [ output ] ) => output ) ).toEqual( [
+			{ kind: 'phase', phase: 'creatingBackup' },
+			{ kind: 'phase', phase: 'uploading' },
+			{ kind: 'phase', phase: 'creatingRemoteBackup' },
+			{ kind: 'phase', phase: 'creatingRemoteBackup', progress: 40 },
+			{ kind: 'phase', phase: 'applyingChanges', progress: 20 },
+			{ kind: 'phase', phase: 'finishing' },
+		] );
+		expect( pollImportStatus ).toHaveBeenCalledTimes( 4 );
+	} );
+
+	it( 'rejects with the reason the remote import failed', async () => {
+		const failure = ( error: string, vp_restore_message: string | null = null ): ImportResponse =>
+			( {
+				status: 'failed',
+				success: false,
+				error,
+				error_data: { vp_restore_status: null, vp_restore_message, vp_rewind_id: null },
+			} ) as ImportResponse;
+
+		await expect(
+			startPush( [ failure( 'Import failed', 'Error importing SQL dump' ) ] ).pushing
+		).rejects.toThrow( /database failed to import/i );
+
+		await expect( startPush( [ failure( 'Import timed out' ) ] ).pushing ).rejects.toThrow(
+			/timed out while importing/i
+		);
+
+		await expect( startPush( [ failure( 'Something else' ) ] ).pushing ).rejects.toThrow(
+			/went wrong while updating the live site/i
+		);
+	} );
+} );
+
 describe( 'cancellable phases', () => {
 	it( 'allows stopping a push until the remote import is initiated', () => {
 		expect( canCancelPush( 'creatingBackup' ) ).toBe( true );
 		expect( canCancelPush( 'uploading' ) ).toBe( true );
 		expect( canCancelPush( undefined ) ).toBe( true );
+
+		// Everything from the import onwards is the live site being rebuilt.
+		expect( canCancelPush( 'creatingRemoteBackup' ) ).toBe( false );
 		expect( canCancelPush( 'applyingChanges' ) ).toBe( false );
+		expect( canCancelPush( 'finishing' ) ).toBe( false );
 	} );
 
 	it( 'allows stopping a pull until the CLI starts writing the local site', () => {

--- a/packages/common/sites/sync.ts
+++ b/packages/common/sites/sync.ts
@@ -2,15 +2,22 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { __ } from '@wordpress/i18n';
 import { killChild } from '@studio/common/lib/cli-process';
 import { SyncCancelledError } from '@studio/common/lib/sync/cancel';
-import { initiateImport } from '@studio/common/lib/sync/sync-api';
+import {
+	SYNC_MAX_STALLED_ATTEMPTS,
+	SYNC_POLL_INTERVAL_MS,
+} from '@studio/common/lib/sync/constants';
+import { initiateImport, pollImportStatus } from '@studio/common/lib/sync/sync-api';
 import { createTusUpload } from '@studio/common/lib/sync/tus-upload';
 import type { ExecuteCliCommand } from '@studio/common/lib/cli-process';
 import type {
+	ImportResponse,
 	PullSiteProgress,
 	PullSyncOptions,
 	PushOutput,
+	PushPhase,
 	PushSyncOptions,
 	SyncOption,
 } from '@studio/common/types/sync';
@@ -36,9 +43,9 @@ function throwIfCancelled( signal: AbortSignal | undefined ): void {
 
 /**
  * Push a local site to its connected WordPress.com live site: export a full
- * archive via the CLI, TUS-upload it (shared {@link createTusUpload}), then
- * initiate the remote import (shared {@link initiateImport}). Resolves once the
- * import is initiated; rejects on any failure.
+ * archive via the CLI, TUS-upload it (shared {@link createTusUpload}), initiate
+ * the remote import (shared {@link initiateImport}), then wait for that import
+ * to finish. Resolves once the live site is updated; rejects on any failure.
  */
 export async function pushSite(
 	ctx: PushSiteContext,
@@ -121,11 +128,86 @@ export async function pushSite(
 		// Point of no return: once the remote import is initiated, cancelling
 		// locally would leave the live site mid-import anyway, so the UI stops
 		// offering it from here on.
-		ctx.emit?.( { kind: 'phase', phase: 'applyingChanges' } );
+		ctx.emit?.( { kind: 'phase', phase: 'creatingRemoteBackup' } );
 		await initiateImport( ctx.accessToken, params.remoteSiteId, attachmentId, params.options );
+		await waitForImport( ctx, params.remoteSiteId );
 	} finally {
 		await fs.promises.rm( dir, { recursive: true, force: true } ).catch( () => undefined );
 	}
+}
+
+/**
+ * Wait for the remote import to finish, reporting the phase it is in.
+ *
+ * WordPress.com takes a safety backup of the live site before importing, which
+ * routinely takes longer than the upload itself. Without this the push would
+ * report success while the live site was still being rebuilt, and a second push
+ * would be rejected with "another import is already in progress". Mirrors the
+ * legacy renderer's `pollPushProgressThunk`.
+ */
+async function waitForImport( ctx: PushSiteContext, remoteSiteId: number ): Promise< void > {
+	let lastReport = '';
+	let stalledPolls = 0;
+
+	while ( stalledPolls < SYNC_MAX_STALLED_ATTEMPTS ) {
+		await new Promise( ( resolve ) => setTimeout( resolve, SYNC_POLL_INTERVAL_MS ) );
+
+		const response = await pollImportStatus( ctx.accessToken, remoteSiteId );
+
+		if ( response.status === 'failed' ) {
+			throw new Error( getImportFailureMessage( response ) );
+		}
+		if ( ! response.success ) {
+			throw new Error( __( 'Something went wrong while updating the live site.' ) );
+		}
+		if ( response.status === 'finished' ) {
+			return;
+		}
+
+		const { phase, progress } = getImportPhase( response );
+		ctx.emit?.( { kind: 'phase', phase, progress } );
+
+		const report = `${ phase }:${ progress ?? '' }`;
+		stalledPolls = report === lastReport ? stalledPolls + 1 : 0;
+		lastReport = report;
+	}
+
+	// The remote reports its own timeouts as a `failed` status, so reaching here
+	// means it went quiet rather than gave up. Bail instead of polling forever.
+	throw new Error(
+		__( 'The live site stopped reporting progress. Check the site and try again.' )
+	);
+}
+
+function getImportPhase(
+	response: Extract< ImportResponse, { status: Exclude< ImportResponse[ 'status' ], 'failed' > } >
+): { phase: PushPhase; progress?: number } {
+	switch ( response.status ) {
+		case 'archive_import_started':
+			return { phase: 'applyingChanges', progress: response.import_progress ?? undefined };
+		case 'archive_import_finished':
+			return { phase: 'finishing' };
+		default:
+			return { phase: 'creatingRemoteBackup', progress: response.backup_progress ?? undefined };
+	}
+}
+
+// Mirrors the legacy renderer's push failure copy (`pollPushProgressThunk`):
+// a failed SQL import and a timeout need different things from the user.
+function getImportFailureMessage(
+	response: Extract< ImportResponse, { status: 'failed' } >
+): string {
+	if ( /importing sql dump/i.test( response.error_data?.vp_restore_message ?? '' ) ) {
+		return __(
+			'The database failed to import on the live site. Review your database and try again.'
+		);
+	}
+	if ( response.error === 'Import timed out' ) {
+		return __(
+			'The live site timed out while importing, likely because the site is too large. Try reducing its content or files.'
+		);
+	}
+	return __( 'Something went wrong while updating the live site.' );
 }
 
 // Mirrors the legacy renderer's export-mode derivation

--- a/packages/common/types/sync.ts
+++ b/packages/common/types/sync.ts
@@ -95,13 +95,20 @@ export const syncSiteSchema = z.object( {
 export type SyncSite = z.infer< typeof syncSiteSchema >;
 
 // Phases a push moves through, named after the legacy renderer's push state
-// keys so both UIs gate cancellation on the same boundary.
-export type PushPhase = 'creatingBackup' | 'uploading' | 'applyingChanges';
+// keys so both UIs gate cancellation on the same boundary. The last three are
+// remote work, reported by polling the import endpoint.
+export type PushPhase =
+	| 'creatingBackup'
+	| 'uploading'
+	| 'creatingRemoteBackup'
+	| 'applyingChanges'
+	| 'finishing';
 
 // Progress a push reports for the UI (the desktop also exposes manual
 // pause/resume; that lives in its own registry on top of these signals).
+// `progress` is how far the current phase has got, when the remote reports it.
 export type PushOutput =
-	| { kind: 'phase'; phase: PushPhase }
+	| { kind: 'phase'; phase: PushPhase; progress?: number }
 	| { kind: 'upload-progress'; progress: number }
 	| { kind: 'network-paused'; error: string }
 	| { kind: 'resumed' };


### PR DESCRIPTION
## Related issues

- Fixes STU-2243
- Stacked on #4510 — review that one first; this PR targets its branch and will retarget to `trunk` once it lands.

## How AI was used in this PR

Written with Claude Code, after tracing how the classic renderer handles the same flow.

## Proposed Changes

A push now stays in progress until the live site has actually been updated. Previously it announced "Push complete" as soon as the archive finished uploading, while WordPress.com was still taking its safety backup and importing — so the app looked done, the live site wasn't, and a second push failed with "another import is already in progress".

The push also stops reading as idle. Instead of showing "Preparing the live site…" for its whole duration, it names the phase it's in and how far along it is: creating the backup, uploading, backing up the remote site, applying changes, almost there — the same wording the classic UI uses. Failures now say what went wrong, distinguishing a failed database import from a timeout on a too-large site.

Cancelling is unaffected: a push is still stoppable until the remote import starts, and refused after.

## Testing Instructions

1. Connect a site to WordPress.com and push it from the site dropdown. Use a site large enough that the remote backup takes a moment.
2. The dropdown should step through the phases with percentages, and **not** toast "Push complete" when the upload finishes.
3. Confirm the live site reflects the change by the time the toast appears.
4. Start a second push immediately after the first completes — it should not fail with "another import is already in progress".
5. Cancel a push during "Creating backup…"/upload — still works; once it reaches "Backing up remote site…" the X is dimmed.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
