### PR TITLE
Agentic UI: Show the preview URL in the site dropdown

### DIFF
--- a/apps/ui/src/components/site-dropdown/main-view.module.css
+++ b/apps/ui/src/components/site-dropdown/main-view.module.css
@@ -295,21 +295,12 @@
 }
 
 .rowActionButton,
-.rowViewButton,
 .environmentActionButton_outline {
 	border-radius: var(--wpds-border-radius-md);
 }
 
-.rowActionButton,
-.rowViewButton {
-	height: 28px;
-}
-
-.rowViewButton {
-	color: var(--wpds-color-fg-interactive-neutral);
-}
-
 .rowActionButton {
+	height: 28px;
 	width: 28px;
 	padding: 0;
 }

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -223,17 +223,6 @@ export function MainView( {
 		onPushClick();
 	};
 
-	const renderTooltipButton = ( {
-		tooltip,
-		children,
-		...props
-	}: ButtonProps & { tooltip: string } ) => (
-		<Tooltip.Root>
-			<Tooltip.Trigger render={ <Button { ...props }>{ children }</Button> } />
-			<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>{ tooltip }</Tooltip.Popup>
-		</Tooltip.Root>
-	);
-
 	const renderUrlLink = ( {
 		text,
 		url,
@@ -312,18 +301,13 @@ export function MainView( {
 			{ previewSnapshot && ! isPreviewExpired ? (
 				<PopoverRow
 					label={ __( 'Preview' ) }
-					sublabel={ __( 'Ready to share for feedback.' ) }
+					sublabel={ renderUrlLink( {
+						text: stripProtocol( previewSnapshot.url ),
+						url: ensureProtocol( previewSnapshot.url ),
+						label: __( 'Open preview site in your browser' ),
+					} ) }
 					action={
 						<div className={ styles.rowActions }>
-							{ renderTooltipButton( {
-								tooltip: __( 'Open preview site in your browser' ),
-								variant: 'minimal',
-								tone: 'neutral',
-								size: 'small',
-								className: styles.rowViewButton,
-								onClick: () => openExternal( ensureProtocol( previewSnapshot.url ) ),
-								children: __( 'View' ),
-							} ) }
 							<IconButton
 								variant="minimal"
 								tone="neutral"


### PR DESCRIPTION
## Related issues

- Fixes [STU-2136](https://linear.app/a8c/issue/STU-2136)

## How AI was used in this PR

Claude Code applied the change proposed in the issue, spotted the helper and CSS it left dead, and drove the browser check. I reviewed the diff.

## Proposed Changes

- The Preview row in the site dropdown now shows its URL as a link, the same as the Studio and Live rows, so you can see where a preview lives without copying it first.
- Removes the **View** button. It read as "open the preview inside Studio" — that's what View means elsewhere in the app — but it opened an external browser. The URL link does the same thing without the ambiguity. Copy and Update are unchanged.

| Light | Dark |
|--------|--------|
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/fd2a3842-437d-4d91-94c1-980fecb29a4b" /> | <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/1e02155c-41ce-49ec-8574-415d6f806882" /> | 

## Testing Instructions

1. Open a site with an active preview, then open the site dropdown.
2. The Preview row shows the preview URL with an external-link icon; clicking it opens the preview in your browser, and the tooltip/aria-label reads "Open preview site in your browser".
3. Copy and Update still work.
4. Check light and dark.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
