### PR TITLE
Agentic UI: Honor Reduce transparency and paint fallbacks for blurred surfaces

### DIFF
--- a/apps/ui/src/components/copy-button/style.module.css
+++ b/apps/ui/src/components/copy-button/style.module.css
@@ -9,7 +9,11 @@
 	border: 0;
 	border-radius: var(--wpds-border-radius-sm, 4px);
 	background-color: var(--wpds-color-bg-surface-neutral);
-	background-color: color-mix(in srgb, var(--wpds-color-bg-surface-neutral) 82%, transparent);
+	background-color: color-mix(
+		in srgb,
+		var(--wpds-color-bg-surface-neutral) var(--surface-alpha, 82%),
+		transparent
+	);
 	backdrop-filter: blur(4px);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	line-height: 1;

--- a/apps/ui/src/components/create-site-form/style.module.css
+++ b/apps/ui/src/components/create-site-form/style.module.css
@@ -11,7 +11,7 @@
 	border-radius: 12px;
 	background: color-mix(
 		in srgb,
-		var(--wpds-color-bg-surface-neutral-strong) 50%,
+		var(--wpds-color-bg-surface-neutral-strong) var(--surface-alpha, 50%),
 		transparent
 	);
 	backdrop-filter: blur(12px);

--- a/apps/ui/src/components/onboarding-footer/style.module.css
+++ b/apps/ui/src/components/onboarding-footer/style.module.css
@@ -9,7 +9,8 @@
 	background: linear-gradient(
 		to top,
 		var(--wpds-color-bg-surface-neutral) 10%,
-		color-mix(in srgb, var(--wpds-color-bg-surface-neutral) 80%, transparent) 55%,
+		color-mix(in srgb, var(--wpds-color-bg-surface-neutral) var(--surface-alpha, 80%), transparent)
+			55%,
 		transparent
 	);
 	backdrop-filter: blur(10px);

--- a/apps/ui/src/components/progressive-blur/index.test.tsx
+++ b/apps/ui/src/components/progressive-blur/index.test.tsx
@@ -1,0 +1,16 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ProgressiveBlur } from './index';
+
+describe( 'ProgressiveBlur', () => {
+	// The four blur layers paint nothing once `backdrop-filter` is off, leaving the
+	// surface fade as the only thing keeping content from showing through. It has to
+	// be in the DOM even when a caller doesn't opt in — CSS decides whether it is
+	// visible — so making it conditional again would silently drop the fallback.
+	it.each( [ true, false ] )( 'renders the surface fade when fadeToSurface=%s', ( fade ) => {
+		const { container } = render( <ProgressiveBlur direction="down" fadeToSurface={ fade } /> );
+
+		expect( container.querySelectorAll( 'span' ) ).toHaveLength( 5 );
+	} );
+} );

--- a/apps/ui/src/components/progressive-blur/index.tsx
+++ b/apps/ui/src/components/progressive-blur/index.tsx
@@ -13,12 +13,20 @@ export function ProgressiveBlur( {
 	fadeToSurface = false,
 }: ProgressiveBlurProps ) {
 	return (
-		<div className={ clsx( styles.root, styles[ direction ], className ) } aria-hidden="true">
+		<div
+			className={ clsx(
+				styles.root,
+				styles[ direction ],
+				fadeToSurface && styles.fadeToSurface,
+				className
+			) }
+			aria-hidden="true"
+		>
 			<span className={ clsx( styles.layer, styles.layerSoft ) } />
 			<span className={ clsx( styles.layer, styles.layerMedium ) } />
 			<span className={ clsx( styles.layer, styles.layerStrong ) } />
 			<span className={ clsx( styles.layer, styles.layerIntense ) } />
-			{ fadeToSurface ? <span className={ styles.surfaceFade } /> : null }
+			<span className={ styles.surfaceFade } />
 		</div>
 	);
 }

--- a/apps/ui/src/components/progressive-blur/style.module.css
+++ b/apps/ui/src/components/progressive-blur/style.module.css
@@ -4,9 +4,19 @@
 	overflow: hidden;
 	contain: paint;
 	--progressive-blur-surface-color: var(--wpds-color-bg-surface-neutral, Canvas);
-	--progressive-blur-surface-strength: 78%;
 	--progressive-blur-surface-hold-stop: 58%;
 	--progressive-blur-surface-fade-stop: 100%;
+
+	/* The blur layers paint nothing once `backdrop-filter` is off, and this
+	   scrim is all that keeps the content scrolling underneath from colliding
+	   with the text on top. It stays invisible (0%) for callers that don't ask
+	   for it, but `--surface-alpha` forces it opaque under reduced
+	   transparency — so every caller gets a readable surface, opted in or not. */
+	--progressive-blur-surface-strength: var(--surface-alpha, 0%);
+}
+
+.fadeToSurface {
+	--progressive-blur-surface-strength: var(--surface-alpha, 78%);
 }
 
 .down {

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -233,3 +233,36 @@ select option {
 		scroll-behavior: auto !important;
 	}
 }
+
+/* Honor the user's reduced-transparency preference (macOS: Accessibility →
+   Display → Reduce transparency), and degrade the same way where
+   `backdrop-filter` isn't supported at all.
+
+   Blur is structural in this app, not decoration: headers, footers, scrims
+   and the composer rely on it to obscure the content scrolling underneath
+   them. Dropping the blur without painting the surface would leave text
+   stacked on text, so both are handled together — `--surface-alpha` is the
+   lever. Translucent surfaces mix their fill with
+   `var( --surface-alpha, <their own resting alpha> )`, so forcing it to 100%
+   here turns every one of them opaque while leaving the resting design
+   untouched everywhere else. */
+@media ( prefers-reduced-transparency: reduce ) {
+	:root {
+		--surface-alpha: 100%;
+	}
+
+	/* Class-scoped rules out-specify a `*`-targeted rule, hence `!important`
+	   — same reasoning as the reduced-motion block above. */
+	*,
+	*::before,
+	*::after {
+		-webkit-backdrop-filter: none !important;
+		backdrop-filter: none !important;
+	}
+}
+
+@supports not ( backdrop-filter: blur( 1px ) ) {
+	:root {
+		--surface-alpha: 100%;
+	}
+}

--- a/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
@@ -6,7 +6,7 @@
 .shell {
 	--composer-resting-fill: color-mix(
 		in srgb,
-		var(--wpds-color-bg-surface-neutral-weak, #f4f4f4) 82%,
+		var(--wpds-color-bg-surface-neutral-weak, #f4f4f4) var(--surface-alpha, 82%),
 		transparent
 	);
 	--composer-resting-tint: color-mix(

--- a/apps/ui/src/ui-classic/components/session-view/suggested-prompts/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/suggested-prompts/style.module.css
@@ -105,12 +105,12 @@
 .prompt {
 	--wp-ui-button-background-color: color-mix(
 		in srgb,
-		var(--wpds-color-bg-surface-neutral) 76%,
+		var(--wpds-color-bg-surface-neutral) var(--surface-alpha, 76%),
 		transparent
 	);
 	--wp-ui-button-background-color-active: color-mix(
 		in srgb,
-		var(--wpds-color-bg-surface-neutral-strong) 84%,
+		var(--wpds-color-bg-surface-neutral-strong) var(--surface-alpha, 84%),
 		transparent
 	);
 	--wp-ui-button-border-color: var(--wpds-color-stroke-surface-neutral-weak);
@@ -138,7 +138,7 @@
 	border-radius: 6px 6px 12px 6px;
 	background: color-mix(
 		in srgb,
-		var(--wpds-color-bg-surface-neutral-strong) 88%,
+		var(--wpds-color-bg-surface-neutral-strong) var(--surface-alpha, 88%),
 		transparent
 	);
 	box-shadow: 0 0 16px
@@ -177,21 +177,14 @@
 	}
 }
 
+/* The surfaces above go opaque on their own via `--surface-alpha`; only the
+   effects that have no opaque equivalent need handling here. */
 @media (prefers-reduced-transparency: reduce) {
 	.frost {
 		display: none;
 	}
 
-	.prompt {
-		--wp-ui-button-background-color: var(--wpds-color-bg-surface-neutral);
-		--wp-ui-button-background-color-active: var(--wpds-color-bg-surface-neutral-strong);
-
-		-webkit-backdrop-filter: none;
-		backdrop-filter: none;
-	}
-
 	.transfer {
-		background: var(--wpds-color-bg-surface-neutral-strong);
 		box-shadow: none;
 	}
 }

--- a/apps/ui/src/ui-classic/router/layout-onboarding/style.module.css
+++ b/apps/ui/src/ui-classic/router/layout-onboarding/style.module.css
@@ -54,6 +54,10 @@
 /* Translucent surface that lets the dot grid show through, softened.
    Compose into a rule with `composes: glassSurface from '…'`. */
 .glassSurface {
-	background: color-mix(in srgb, var(--wpds-color-bg-surface-neutral-strong) 50%, transparent);
+	background: color-mix(
+		in srgb,
+		var(--wpds-color-bg-surface-neutral-strong) var(--surface-alpha, 50%),
+		transparent
+	);
 	backdrop-filter: blur(12px);
 }

--- a/apps/ui/src/ui-classic/router/route-onboarding-home/style.module.css
+++ b/apps/ui/src/ui-classic/router/route-onboarding-home/style.module.css
@@ -21,7 +21,7 @@
 	border-radius: 12px;
 	background: color-mix(
 		in srgb,
-		var(--wpds-color-bg-surface-neutral-strong) 50%,
+		var(--wpds-color-bg-surface-neutral-strong) var(--surface-alpha, 50%),
 		transparent
 	);
 	backdrop-filter: blur(12px);

--- a/apps/ui/src/ui-classic/router/route-welcome/style.module.css
+++ b/apps/ui/src/ui-classic/router/route-welcome/style.module.css
@@ -150,7 +150,8 @@
 	background: linear-gradient(
 		to bottom,
 		transparent,
-		color-mix(in srgb, var(--wpds-color-bg-surface-neutral) 55%, transparent) 96px
+		color-mix(in srgb, var(--wpds-color-bg-surface-neutral) var(--surface-alpha, 55%), transparent)
+			96px
 	);
 	-webkit-mask-image: linear-gradient(to bottom, transparent, black 96px);
 	mask-image: linear-gradient(to bottom, transparent, black 96px);


### PR DESCRIPTION
## Related issues

- Fixes [STU-2133](https://linear.app/a8c/issue/STU-2133/ui-has-no-graceful-degradation-for-blur-and-transparent-elements-and)

## How AI was used in this PR

Claude Code mapped every `backdrop-filter` surface, wrote the changes, and drove the browser over CDP to compare each surface with the preference on and off in both color schemes. I reviewed the diff and the rendered result.

## Proposed Changes

Blur is structural in the agentic UI, not decoration — headers, footers, scrims and the composer rely on it to obscure the content scrolling underneath them. macOS's **Reduce transparency** (Accessibility → Display) was ignored, so users who ask for less transparency either kept the blur or, where the OS dropped it, got surfaces that painted nothing at all and let text stack on text.

Every blurred surface now degrades to an opaque fill when the user asks for reduced transparency, or when the platform has no `backdrop-filter` support. Resting appearance is unchanged.

| Off | On |
|--------|--------|
| <img width="3248" height="2120" alt="image" src="https://github.com/user-attachments/assets/e6c09220-7bf5-4971-a09b-e275e979a793" /> | <img width="3248" height="2120" alt="image" src="https://github.com/user-attachments/assets/814e5b6e-9f96-4950-8fc6-8c2c0865d33d" /> | 

## Testing Instructions

1. `npm run start`
2. Toggle System Settings → Accessibility → Display → **Reduce transparency** (applies live)
3. With it on, these should be solid with nothing showing through; with it off, unchanged from trunk:
   - Session view — composer, suggested-prompt pills, logo frost
   - Site overview — footer strip
   - `/onboarding` cards and `/onboarding/create` form + bottom bar
4. Clearest check: on site overview, shrink the window until the list scrolls and scroll to the middle. Before this change, list content bled through the footer strip; now it's painted.
5. Repeat in **dark mode**.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
