### PR TITLE
Add hosted AI models (Kimi, GLM, DeepSeek) via the WordPress.com proxy

### DIFF
--- a/apps/cli/ai/providers.ts
+++ b/apps/cli/ai/providers.ts
@@ -30,6 +30,7 @@ const DEFAULT_WPCOM_AI_GATEWAY_BASE_URL = 'https://public-api.wordpress.com/wpco
 // the existing slugs so no server-side allowlist change is required.
 const WPCOM_AI_FEATURE_HEADER_ANTHROPIC = 'studio-assistant-anthropic';
 const WPCOM_AI_FEATURE_HEADER_OPENAI = 'studio-assistant';
+const WPCOM_AI_FEATURE_HEADER_HOSTED = 'studio-assistant-hosted';
 
 export interface ResolveAiEnvironmentOptions {
 	sessionId?: string;
@@ -136,6 +137,9 @@ function createBaseEnvironment(): Record< string, string > {
 	delete env.OPENAI_API_KEY;
 	delete env.OPENAI_BASE_URL;
 	delete env.STUDIO_OPENAI_DEFAULT_HEADERS;
+	delete env.STUDIO_HOSTED_API_KEY;
+	delete env.STUDIO_HOSTED_BASE_URL;
+	delete env.STUDIO_HOSTED_DEFAULT_HEADERS;
 
 	return env;
 }
@@ -189,6 +193,23 @@ const AI_PROVIDER_DEFINITIONS: Record< AiProviderId, AiProviderDefinition > = {
 				openaiHeaders[ 'X-WPCOM-Session-ID' ] = options.sessionId;
 			}
 			env.STUDIO_OPENAI_DEFAULT_HEADERS = JSON.stringify( openaiHeaders );
+
+			// Hosted third-party models (Kimi, GLM, DeepSeek) speak the OpenAI
+			// Chat Completions dialect, so they share the /v1 prefix with the
+			// OpenAI path and are told apart by the feature header. The vars are
+			// Studio-namespaced because, unlike Anthropic and OpenAI, this family
+			// has no direct-API provider — nothing but this function should be
+			// able to satisfy it.
+			env.STUDIO_HOSTED_BASE_URL = env.OPENAI_BASE_URL;
+			env.STUDIO_HOSTED_API_KEY = accessToken;
+			const hostedHeaders: Record< string, string > = {
+				'User-Agent': getStudioUserAgent(),
+				'X-WPCOM-AI-Feature': WPCOM_AI_FEATURE_HEADER_HOSTED,
+			};
+			if ( options?.sessionId ) {
+				hostedHeaders[ 'X-WPCOM-Session-ID' ] = options.sessionId;
+			}
+			env.STUDIO_HOSTED_DEFAULT_HEADERS = JSON.stringify( hostedHeaders );
 
 			return env;
 		},

--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -12,6 +12,7 @@ import {
 	stream as streamAnthropic,
 	type AnthropicOptions,
 } from '@earendil-works/pi-ai/api/anthropic-messages';
+import { streamSimple as streamOpenAiCompletions } from '@earendil-works/pi-ai/api/openai-completions';
 import { streamSimple as streamOpenAiResponses } from '@earendil-works/pi-ai/api/openai-responses';
 import { ANTHROPIC_MODELS } from '@earendil-works/pi-ai/providers/anthropic.models';
 import {
@@ -33,6 +34,7 @@ import {
 } from '@earendil-works/pi-coding-agent';
 import { readGlobalInstructions } from '@studio/common/ai/global-instructions';
 import {
+	aiModelSupportsImages,
 	DEFAULT_MODEL,
 	getAiModelFamily,
 	type AiModelFamily,
@@ -70,11 +72,13 @@ import type { AskUserHandler, SiteInfo } from 'cli/ai/types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AgentToolAny = AgentTool< any >;
-type StudioModel = Model< 'openai-responses' > | Model< 'anthropic-messages' >;
+type StudioOpenAiCompatibleModel = Model< 'openai-responses' > | Model< 'openai-completions' >;
+type StudioModel = StudioOpenAiCompatibleModel | Model< 'anthropic-messages' >;
 type ProviderConfigInput = Parameters< ModelRuntime[ 'registerProvider' ] >[ 1 ];
 
 const STUDIO_WPCOM_ANTHROPIC_PROVIDER = 'studio-wpcom-anthropic';
 const STUDIO_WPCOM_OPENAI_PROVIDER = 'studio-wpcom-openai';
+const STUDIO_WPCOM_HOSTED_PROVIDER = 'studio-wpcom-hosted';
 const STUDIO_AGENT_DIR = STUDIO_SITES_ROOT;
 const STUDIO_WPCOM_BODY_FILES_ROOT = getConfigDirectory();
 const STUDIO_WPCOM_BODY_FILES_DIR = getAiPayloadsPath();
@@ -142,29 +146,47 @@ interface ResolvedCredentials {
 	useBearerAuth: boolean;
 }
 
+// Families that speak an OpenAI dialect each get their own env namespace so a
+// single resolved environment can carry all of them and the user can swap
+// models mid-session.
+const OPENAI_DIALECT_ENV_VARS = {
+	openai: {
+		label: 'OpenAI',
+		apiKey: 'OPENAI_API_KEY',
+		baseUrl: 'OPENAI_BASE_URL',
+		headers: 'STUDIO_OPENAI_DEFAULT_HEADERS',
+	},
+	hosted: {
+		label: 'Hosted',
+		apiKey: 'STUDIO_HOSTED_API_KEY',
+		baseUrl: 'STUDIO_HOSTED_BASE_URL',
+		headers: 'STUDIO_HOSTED_DEFAULT_HEADERS',
+	},
+} as const;
+
 function resolveCredentials(
 	family: AiModelFamily,
 	env: Record< string, string >
 ): { ok: true; creds: ResolvedCredentials } | { ok: false; reason: string } {
-	if ( family === 'openai' ) {
-		const apiKey = env.OPENAI_API_KEY?.trim();
+	if ( family === 'openai' || family === 'hosted' ) {
+		const vars = OPENAI_DIALECT_ENV_VARS[ family ];
+		const apiKey = env[ vars.apiKey ]?.trim();
 		if ( ! apiKey ) {
 			return {
 				ok: false,
-				reason:
-					'OpenAI provider selected but OPENAI_API_KEY is not set. On the WordPress.com provider this means the wpcom access token is missing — run /login to authenticate.',
+				reason: `${ vars.label } models are only available through the WordPress.com provider, and ${ vars.apiKey } is not set — run /login to authenticate.`,
 			};
 		}
-		const baseURL = env.OPENAI_BASE_URL?.trim();
+		const baseURL = env[ vars.baseUrl ]?.trim();
 		if ( ! baseURL ) {
-			return { ok: false, reason: 'OPENAI_BASE_URL not set — cannot route to wpcom proxy.' };
+			return { ok: false, reason: `${ vars.baseUrl } not set — cannot route to wpcom proxy.` };
 		}
 		return {
 			ok: true,
 			creds: {
 				apiKey,
 				baseURL,
-				extraHeaders: parseJsonHeaderEnv( env.STUDIO_OPENAI_DEFAULT_HEADERS ),
+				extraHeaders: parseJsonHeaderEnv( vars.headers, env[ vars.headers ] ),
 				useBearerAuth: false,
 			},
 		};
@@ -374,10 +396,36 @@ function buildModel(
 		id: modelId,
 		name: modelId,
 		baseUrl,
-		input: [ 'text' as const, 'image' as const ],
+		input: aiModelSupportsImages( modelId )
+			? [ 'text' as const, 'image' as const ]
+			: [ 'text' as const ],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		...( creds.extraHeaders ? { headers: creds.extraHeaders } : {} ),
 	};
+
+	if ( family === 'hosted' ) {
+		// pi infers `compat` from the base URL, and the wpcom proxy URL reads as
+		// plain OpenAI — so spell out the shape or requests carry OpenAI-only
+		// fields these upstreams reject. With `supportsReasoningEffort` false and
+		// the default `thinkingFormat`, no thinking switch is sent at all and
+		// each model uses its own default — the portable choice across vendors
+		// that spell that parameter differently. Reasoning still streams back.
+		return {
+			...common,
+			api: 'openai-completions',
+			provider: STUDIO_WPCOM_HOSTED_PROVIDER,
+			reasoning: true,
+			contextWindow: 262_144,
+			maxTokens: 32_000,
+			compat: {
+				supportsStore: false,
+				supportsDeveloperRole: false,
+				supportsReasoningEffort: false,
+				supportsStrictMode: false,
+				maxTokensField: 'max_tokens',
+			},
+		};
+	}
 
 	if ( family === 'openai' ) {
 		// GPT-5.6 models reject function tools on /v1/chat/completions unless
@@ -476,10 +524,12 @@ async function createModelRuntime(
 		return modelRuntime;
 	}
 
-	if ( family === 'openai' ) {
+	if ( family === 'openai' || family === 'hosted' ) {
+		// `buildModel` already resolved the provider and wire API for this
+		// family; read them off the model rather than deriving them again.
 		modelRuntime.registerProvider(
-			STUDIO_WPCOM_OPENAI_PROVIDER,
-			createWpcomOpenAiProviderConfig( model as Model< 'openai-responses' >, creds )
+			model.provider,
+			createWpcomOpenAiCompatibleProviderConfig( model as StudioOpenAiCompatibleModel, creds )
 		);
 		return modelRuntime;
 	}
@@ -546,26 +596,29 @@ function createWpcomAnthropicProviderConfig(
 	};
 }
 
-// The wpcom OpenAI path only needs pi's stock Responses streaming; the custom
-// provider exists to wrap the stream with the usage-cap 429 rewrite.
-function createWpcomOpenAiProviderConfig(
-	model: Model< 'openai-responses' >,
+// The wpcom OpenAI-dialect paths only need pi's stock streaming for their API;
+// the custom provider exists to wrap the stream with the usage-cap 429 rewrite.
+function createWpcomOpenAiCompatibleProviderConfig(
+	model: StudioOpenAiCompatibleModel,
 	creds: ResolvedCredentials
 ): ProviderConfigInput {
+	// pi types `streamSimple` against `Model<Api>`; each API's stream function
+	// is narrower, and the model registered below is the one passed in.
+	const stream = (
+		model.api === 'openai-completions' ? streamOpenAiCompletions : streamOpenAiResponses
+	) as NonNullable< ProviderConfigInput[ 'streamSimple' ] >;
 	return {
 		baseUrl: creds.baseURL,
 		apiKey: escapePiConfigValue( creds.apiKey ),
-		api: 'openai-responses',
+		api: model.api,
 		headers: creds.extraHeaders,
 		streamSimple: ( m, ctx, options?: SimpleStreamOptions ) =>
-			withUsageCapErrorRewrite(
-				streamOpenAiResponses( m as Model< 'openai-responses' >, ctx, options )
-			),
+			withUsageCapErrorRewrite( stream( m, ctx, options ) ),
 		models: [
 			{
 				id: model.id,
 				name: model.name,
-				api: 'openai-responses',
+				api: model.api,
 				baseUrl: model.baseUrl,
 				reasoning: model.reasoning,
 				input: model.input,
@@ -646,17 +699,24 @@ function buildAgentTools(
 		renameTool( createLsTool( STUDIO_WPCOM_BODY_FILES_ROOT ), 'Ls' ),
 	];
 
+	// A text-only model drops image blocks from tool results while still
+	// receiving their text, so it would report on a screenshot it never saw.
+	const withoutUnusableTools = ( tools: AgentToolAny[] ): AgentToolAny[] =>
+		aiModelSupportsImages( config.model )
+			? tools
+			: tools.filter( ( tool ) => tool.name !== takeScreenshotTool.name );
+
 	if ( isRemoteSite ) {
 		const remoteStudioTools = [ takeScreenshotTool, createSiteTool, pullSiteTool ].map( ( tool ) =>
 			withChatArtifactEmission( tool, chatArtifactsEnabled )
 		);
-		return [
+		return withoutUnusableTools( [
 			createWpcomRequestTool( config.wpcomAccessToken!, config.activeSite!.wpcomSiteId! ),
 			...remoteStudioTools,
 			...remoteScratchTools,
 			...askUserTool,
 			...skillTool,
-		];
+		] );
 	}
 
 	const piTools: AgentToolAny[] = [
@@ -675,7 +735,7 @@ function buildAgentTools(
 			? buildSiteDeletionConfirm( config.onAskUser )
 			: undefined,
 	} ) as unknown as AgentToolAny[];
-	return [ ...studioTools, ...askUserTool, ...skillTool, ...piTools ];
+	return withoutUnusableTools( [ ...studioTools, ...askUserTool, ...skillTool, ...piTools ] );
 }
 
 // Two-step confirmation for site deletion:
@@ -748,7 +808,10 @@ function buildSiteDeletionConfirm( onAskUser: AskUserHandler ): ConfirmSiteDelet
 	};
 }
 
-function parseJsonHeaderEnv( value: string | undefined ): Record< string, string > | undefined {
+function parseJsonHeaderEnv(
+	name: string,
+	value: string | undefined
+): Record< string, string > | undefined {
 	if ( ! value ) return undefined;
 	try {
 		const parsed: unknown = JSON.parse( value );
@@ -759,12 +822,10 @@ function parseJsonHeaderEnv( value: string | undefined ): Record< string, string
 			return entries.length ? Object.fromEntries( entries ) : undefined;
 		}
 		console.warn(
-			'STUDIO_OPENAI_DEFAULT_HEADERS must be a JSON object of string→string pairs; ignoring custom headers.'
+			`${ name } must be a JSON object of string→string pairs; ignoring custom headers.`
 		);
 	} catch {
-		console.warn(
-			'STUDIO_OPENAI_DEFAULT_HEADERS contained malformed JSON; ignoring custom headers.'
-		);
+		console.warn( `${ name } contained malformed JSON; ignoring custom headers.` );
 	}
 	return undefined;
 }

--- a/apps/cli/ai/runtimes/pi/tests/usage-cap.test.ts
+++ b/apps/cli/ai/runtimes/pi/tests/usage-cap.test.ts
@@ -26,7 +26,25 @@ function errorMessageWith( errorMessage: string ): AssistantMessage {
 }
 
 describe( 'withUsageCapErrorRewrite', () => {
-	it( 'stamps the usage-cap prefix on 429 error events', async () => {
+	it( 'stamps the usage-cap prefix on cost-cap 429 error events', async () => {
+		const source = createAssistantMessageEventStream();
+		const wrapped = withUsageCapErrorRewrite( source );
+		source.push( {
+			type: 'error',
+			reason: 'error',
+			error: errorMessageWith( '429 {"error":{"code":"cost_cap_exceeded"}}' ),
+		} );
+		source.end();
+
+		const result = await wrapped.result();
+		expect( result.errorMessage ).toBe(
+			`${ USAGE_CAP_ERROR_PREFIX }: 429 {"error":{"code":"cost_cap_exceeded"}}`
+		);
+	} );
+
+	// Hosted upstreams 429 for their own rate limits. Stamping the prefix would
+	// make pi treat those as non-retryable, killing a retry that would succeed.
+	it( 'leaves a 429 without the cost-cap code retryable', async () => {
 		const source = createAssistantMessageEventStream();
 		const wrapped = withUsageCapErrorRewrite( source );
 		source.push( {
@@ -37,9 +55,7 @@ describe( 'withUsageCapErrorRewrite', () => {
 		source.end();
 
 		const result = await wrapped.result();
-		expect( result.errorMessage ).toBe(
-			`${ USAGE_CAP_ERROR_PREFIX }: 429 {"error":{"type":"rate_limit_error"}}`
-		);
+		expect( result.errorMessage ).toBe( '429 {"error":{"type":"rate_limit_error"}}' );
 	} );
 
 	it( 'leaves non-429 errors untouched', async () => {

--- a/apps/cli/ai/runtimes/pi/usage-cap.ts
+++ b/apps/cli/ai/runtimes/pi/usage-cap.ts
@@ -1,15 +1,17 @@
 import { createAssistantMessageEventStream } from '@earendil-works/pi-ai';
-import { buildUsageCapErrorMessage, isHttp429ErrorMessage } from '@studio/common/ai/json-events';
+import { buildUsageCapErrorMessage, isCostCapErrorMessage } from '@studio/common/ai/json-events';
 import type { AssistantMessageEventStream } from '@earendil-works/pi-ai';
 
 /**
- * On the WordPress.com AI proxy a 429 always means the account's monthly
- * usage cap (see #3102), which retrying can't recover — but pi treats any
- * bare 429 as a transient throttle and retries it with backoff. Rewriting
- * the error with the canonical prefix makes pi classify it as a
- * non-retryable provider limit and gives every surface a stable marker for
- * the cap UI. Only wire this into wpcom-backed providers: on a user-supplied
- * API key a 429 is a genuine rate limit and should keep retrying.
+ * The WordPress.com AI proxy reports the account's monthly cost cap as a 429
+ * carrying `cost_cap_exceeded` (see #3102). Retrying can't recover it, but pi
+ * treats a bare 429 as a transient throttle and retries with backoff, so the
+ * error is rewritten with the canonical prefix — that makes pi classify it as
+ * a non-retryable provider limit and gives every surface a stable marker for
+ * the cap UI.
+ *
+ * The code, not the status, is the gate: hosted upstreams behind the proxy
+ * return their own 429s for rate limits, and those *should* keep retrying.
  */
 export function withUsageCapErrorRewrite(
 	source: AssistantMessageEventStream
@@ -17,7 +19,7 @@ export function withUsageCapErrorRewrite(
 	const rewritten = createAssistantMessageEventStream();
 	void ( async () => {
 		for await ( const event of source ) {
-			if ( event.type === 'error' && isHttp429ErrorMessage( event.error.errorMessage ) ) {
+			if ( event.type === 'error' && isCostCapErrorMessage( event.error.errorMessage ) ) {
 				event.error.errorMessage = buildUsageCapErrorMessage( event.error.errorMessage ?? '' );
 			}
 			rewritten.push( event );

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -1,7 +1,7 @@
-import { getAiModelFamily } from '@studio/common/ai/models';
+import { getAiModelFamily, getVisibleAiModels } from '@studio/common/ai/models';
 import { getAiModelLabel, type AiModelId } from '@studio/common/ai/models';
 import { getAiSkillCommands } from '@studio/common/ai/slash-commands';
-import { readAuthToken } from '@studio/common/lib/shared-config';
+import { isAutomatticianFromToken, readAuthToken } from '@studio/common/lib/shared-config';
 import { __, sprintf } from '@wordpress/i18n';
 import { getAvailableAiProviders, isAiProviderReady } from 'cli/ai/auth';
 import { AI_PROVIDERS, getAiProviderDefinition, type AiProviderId } from 'cli/ai/providers';
@@ -334,6 +334,12 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 		description: __( 'Switch the AI model' ),
 		handler: async ( _prompt, ctx ) => {
 			const { availableModels } = getAiProviderDefinition( ctx.currentProvider );
+			const visible = new Set(
+				getVisibleAiModels( await isAutomatticianFromToken(), ctx.currentModel ).map(
+					( model ) => model.id
+				)
+			);
+			const offeredModels = availableModels.filter( ( id ) => visible.has( id ) );
 			// Build options and a reverse lookup at the same time so we never
 			// have to recover the model id from the label. A startsWith-based
 			// match is buggy when one model's label is a prefix of another's
@@ -341,7 +347,7 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 			// returns the other id), so we keep the label → id mapping
 			// explicit here and look up by exact match below.
 			const labelToId = new Map< string, AiModelId >();
-			const modelOptions = availableModels.map( ( id ) => {
+			const modelOptions = offeredModels.map( ( id ) => {
 				const label =
 					id === ctx.currentModel
 						? sprintf(

--- a/apps/cli/ai/tests/pi-runtime.test.ts
+++ b/apps/cli/ai/tests/pi-runtime.test.ts
@@ -274,6 +274,92 @@ describe( 'pi runtime', () => {
 		expect( mocks.createdSessions[ 0 ].options.model?.input ).toEqual( [ 'text', 'image' ] );
 	} );
 
+	const HOSTED_ENV = {
+		STUDIO_HOSTED_API_KEY: 'wpcom-token',
+		STUDIO_HOSTED_BASE_URL: 'https://proxy.example.com/v1',
+	};
+
+	it( 'routes hosted models to the wpcom Chat Completions path', async () => {
+		await runRuntime( {
+			prompt: 'hello',
+			env: {
+				...HOSTED_ENV,
+				STUDIO_HOSTED_DEFAULT_HEADERS: JSON.stringify( {
+					'X-WPCOM-AI-Feature': 'studio-assistant-hosted',
+					'X-WPCOM-Session-ID': 'session-2',
+				} ),
+			},
+			model: 'moonshotai/Kimi-K2.6',
+			session: newSession(),
+		} );
+
+		const options = mocks.createdSessions[ 0 ].options;
+		expect( options.model?.id ).toBe( 'moonshotai/Kimi-K2.6' );
+		expect( options.model?.provider ).toBe( 'studio-wpcom-hosted' );
+		expect( options.model?.api ).toBe( 'openai-completions' );
+	} );
+
+	// Without these the request carries OpenAI-only fields these upstreams
+	// reject: pi infers them from the base URL, which for us reads as OpenAI.
+	it( 'declares hosted compat overrides the proxy URL cannot be detected from', async () => {
+		await runRuntime( {
+			prompt: 'hello',
+			env: HOSTED_ENV,
+			model: 'moonshotai/Kimi-K3',
+			session: newSession(),
+		} );
+
+		expect( mocks.createdSessions[ 0 ].options.model?.compat ).toMatchObject( {
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: false,
+			supportsStrictMode: false,
+			maxTokensField: 'max_tokens',
+		} );
+	} );
+
+	it( 'advertises image input per model rather than per family', async () => {
+		await runRuntime( {
+			prompt: 'hello',
+			env: HOSTED_ENV,
+			model: 'moonshotai/Kimi-K2.6',
+			session: newSession(),
+		} );
+		await runRuntime( {
+			prompt: 'hello',
+			env: HOSTED_ENV,
+			model: 'zai-org/GLM-5.2',
+			session: newSession(),
+		} );
+
+		expect( mocks.createdSessions[ 0 ].options.model?.input ).toEqual( [ 'text', 'image' ] );
+		expect( mocks.createdSessions[ 1 ].options.model?.input ).toEqual( [ 'text' ] );
+	} );
+
+	// pi drops image blocks from tool results on a text-only model but still
+	// delivers the result text, so the model would describe a capture it never saw.
+	it( 'withholds take_screenshot from models that cannot see images', async () => {
+		await runRuntime( {
+			prompt: 'hello',
+			env: HOSTED_ENV,
+			model: 'moonshotai/Kimi-K2.6',
+			session: newSession(),
+		} );
+		await runRuntime( {
+			prompt: 'hello',
+			env: HOSTED_ENV,
+			model: 'zai-org/GLM-5.2',
+			session: newSession(),
+		} );
+
+		const toolNames = ( index: number ) =>
+			( ( mocks.createdSessions[ index ].options.customTools ?? [] ) as { name: string }[] ).map(
+				( tool ) => tool.name
+			);
+		expect( toolNames( 0 ) ).toContain( 'take_screenshot' );
+		expect( toolNames( 1 ) ).not.toContain( 'take_screenshot' );
+	} );
+
 	it( 'rejects oversized direct Write, Edit, and Bash payloads', async () => {
 		await runRuntime( {
 			prompt: 'hello',

--- a/apps/cli/ai/tests/slash-commands.test.ts
+++ b/apps/cli/ai/tests/slash-commands.test.ts
@@ -37,7 +37,10 @@ vi.mock( 'cli/commands/auth/login', () => ( { runCommand: vi.fn() } ) );
 vi.mock( 'cli/commands/auth/logout', () => ( { runCommand: vi.fn() } ) );
 vi.mock( 'cli/commands/preview/create', () => ( { runCommand: vi.fn() } ) );
 vi.mock( 'cli/commands/preview/update', () => ( { runCommand: vi.fn() } ) );
-vi.mock( '@studio/common/lib/shared-config', () => ( { readAuthToken: vi.fn() } ) );
+vi.mock( '@studio/common/lib/shared-config', () => ( {
+	readAuthToken: vi.fn(),
+	isAutomatticianFromToken: vi.fn().mockResolvedValue( true ),
+} ) );
 
 vi.mock( 'cli/remote-session/daemon', () => {
 	return {

--- a/apps/studio/src/components/studio-code-session/composer/index.tsx
+++ b/apps/studio/src/components/studio-code-session/composer/index.tsx
@@ -10,8 +10,9 @@ import {
 	type ComposerAttachmentHoverPreviewState,
 } from '@studio/common/ai/composer-attachment-preview';
 import { watchComposerFilePaste } from '@studio/common/ai/composer-attachments';
-import { AI_MODELS, getAiModelFamily, getAiModelLabel } from '@studio/common/ai/models';
+import { getAiModelFamily, getAiModelLabel, getVisibleAiModels } from '@studio/common/ai/models';
 import { isStudioCustomEntryOfType } from '@studio/common/ai/sessions/entry-types';
+import { isAutomatticianEmail } from '@studio/common/lib/automattician';
 import { useQueryClient } from '@tanstack/react-query';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -25,6 +26,7 @@ import {
 	useState,
 	type SetStateAction,
 } from 'react';
+import { useAuth } from 'src/hooks/use-auth';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import * as Menu from '../menu';
@@ -308,6 +310,8 @@ export function Composer( {
 	// Cross-family swap state. We hold the picked model here while the
 	// confirmation dialog is open; nothing is persisted until the user
 	// confirms.
+	const { user } = useAuth();
+	const visibleModels = getVisibleAiModels( isAutomatticianEmail( user?.email ), model );
 	const [ pendingFamilyChange, setPendingFamilyChange ] = useState< AiModelId | null >( null );
 	const [ familySwitchInFlight, setFamilySwitchInFlight ] = useState( false );
 
@@ -687,7 +691,7 @@ export function Composer( {
 										value={ model }
 										onValueChange={ ( value ) => handleModelChange( value as AiModelId ) }
 									>
-										{ AI_MODELS.map( ( { id, label } ) => (
+										{ visibleModels.map( ( { id, label } ) => (
 											<Menu.RadioItem key={ id } value={ id }>
 												{ label }
 											</Menu.RadioItem>

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
@@ -10,7 +10,12 @@ import {
 	type ComposerAttachmentHoverPreviewState,
 } from '@studio/common/ai/composer-attachment-preview';
 import { watchComposerFilePaste } from '@studio/common/ai/composer-attachments';
-import { AI_MODELS, getAiModelFamily, getAiModelLabel } from '@studio/common/ai/models';
+import {
+	AI_MODELS,
+	getAiModelFamily,
+	getAiModelLabel,
+	getVisibleAiModels,
+} from '@studio/common/ai/models';
 import {
 	AI_PROVIDER_IDS,
 	AI_PROVIDER_LABELS,
@@ -23,6 +28,7 @@ import {
 } from '@studio/common/ai/providers';
 import { isStudioCustomEntryOfType } from '@studio/common/ai/sessions/entry-types';
 import { getAiSkillCommands } from '@studio/common/ai/slash-commands';
+import { isAutomatticianEmail } from '@studio/common/lib/automattician';
 import { useQueryClient } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
 import {
@@ -53,6 +59,7 @@ import { createPortal } from 'react-dom';
 import * as Menu from '@/components/menu';
 import { useConnector } from '@/data/core';
 import { useAiSettings } from '@/data/queries/use-ai-settings';
+import { useAuthUser } from '@/data/queries/use-auth-user';
 import {
 	primeSessionQueryData,
 	reconcilePrimedSessionQueryData,
@@ -356,6 +363,13 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 	// Only offer models the conversation's provider can serve. Hosts without AI
 	// settings (capabilities.aiSettings false) keep the full list.
 	const availableModels = aiSettings ? getAiProviderModels( sessionProvider ) : AI_MODELS;
+	const { data: authUser } = useAuthUser();
+	const visibleModelIds = new Set(
+		getVisibleAiModels( isAutomatticianEmail( authUser?.email ), model ).map(
+			( entry ) => entry.id
+		)
+	);
+	const offeredModels = availableModels.filter( ( entry ) => visibleModelIds.has( entry.id ) );
 
 	const slash = useSlashCommands( {
 		value,
@@ -1083,7 +1097,7 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 										value={ model }
 										onValueChange={ ( value ) => handleModelChange( value as AiModelId ) }
 									>
-										{ availableModels.map( ( { id, label } ) => (
+										{ offeredModels.map( ( { id, label } ) => (
 											<Menu.RadioItem key={ id } value={ id }>
 												{ label }
 											</Menu.RadioItem>

--- a/packages/common/ai/json-events.ts
+++ b/packages/common/ai/json-events.ts
@@ -58,34 +58,27 @@ export function buildUsageCapErrorMessage( originalMessage: string ): string {
 	return `${ USAGE_CAP_ERROR_PREFIX }: ${ originalMessage }`;
 }
 
-// Raw HTTP 429 shapes as the SDKs format them: the Anthropic SDK produces
-// "429 <body>", pi-ai's OpenAI path "OpenAI API error (429): <body>", plus
-// legacy Claude Code SDK forms.
-const HTTP_429_ERROR_PATTERN =
-	/(?:^429\b|\(429\)|API Error:\s*429\b|status code\s+429\b|"status"\s*:\s*429\b)/i;
+const USAGE_CAP_PATTERN = new RegExp( `(?:${ USAGE_CAP_ERROR_PREFIX }|cost_cap_exceeded)`, 'i' );
 
 /**
- * Returns true when an error message reports an HTTP 429, whatever SDK
- * formatted it. Callers are responsible for provider gating: only on the
- * WordPress.com proxy does a 429 mean the usage cap.
- */
-export function isHttp429ErrorMessage( message: string | undefined | null ): boolean {
-	return HTTP_429_ERROR_PATTERN.test( message ?? '' );
-}
-
-const USAGE_CAP_PATTERN = new RegExp(
-	`(?:${ USAGE_CAP_ERROR_PREFIX }|API Error:\\s*429\\b|status code\\s+429\\b|"status"\\s*:\\s*429\\b)`,
-	'i'
-);
-
-/**
- * Returns true when an error message indicates the user hit the AI usage cap
- * (HTTP 429 from the WordPress.com proxy). Raw, un-rewritten 429 messages
- * (e.g. from a user-supplied Anthropic API key, where a 429 is a transient
- * rate limit rather than a monthly cap) intentionally don't match.
+ * Returns true when an error message indicates the user hit the AI usage cap:
+ * either the runtime stamped the canonical prefix, or the proxy's
+ * `cost_cap_exceeded` code survived verbatim. A bare 429 deliberately doesn't
+ * match — it may be a hosted upstream's rate limit, or a user-supplied API key
+ * being throttled, and both of those are retryable.
  */
 export function isUsageCapError( message: string | undefined | null ): boolean {
 	return USAGE_CAP_PATTERN.test( message ?? '' );
+}
+
+/**
+ * Returns true when a proxy error is the account's monthly cost cap rather than
+ * a transient rate limit. Hosted upstreams behind the proxy return their own
+ * 429s for token-per-minute limits, which retrying does clear, so the status
+ * alone can't tell the two apart — the `cost_cap_exceeded` code can.
+ */
+export function isCostCapErrorMessage( message: string | undefined | null ): boolean {
+	return /\bcost_cap_exceeded\b/i.test( message ?? '' );
 }
 
 /**

--- a/packages/common/ai/models.ts
+++ b/packages/common/ai/models.ts
@@ -1,7 +1,7 @@
 import { isStudioCustomEntryOfType } from './sessions/entry-types';
 import type { SessionEntry } from '@earendil-works/pi-coding-agent';
 
-export type AiModelFamily = 'anthropic' | 'openai';
+export type AiModelFamily = 'anthropic' | 'openai' | 'hosted';
 
 export interface AiModel {
 	/** Stable model id sent to the upstream provider. */
@@ -10,6 +10,19 @@ export interface AiModel {
 	label: string;
 	/** Which runtime serves this model. Drives `pickRuntime` in agent.ts. */
 	family: AiModelFamily;
+	/**
+	 * Whether the model accepts image input. Defaults to true. Set false for
+	 * text-only models so the runtime doesn't advertise vision they lack —
+	 * screenshot tool results are images.
+	 */
+	supportsImages?: boolean;
+	/**
+	 * Hide the model from pickers for non-Automatticians. Visibility only —
+	 * the wpcom proxy is what actually refuses these upstreams, so this never
+	 * gates `isAiModelId`: a session that already recorded one must still
+	 * resolve rather than silently snap back to the default.
+	 */
+	requiresAutomattician?: boolean;
 }
 
 // Pro / o-series OpenAI variants (`gpt-*-pro`, `o[1-9]*`) are intentionally
@@ -21,6 +34,43 @@ export const AI_MODELS = [
 	{ id: 'claude-sonnet-5', label: 'Sonnet 5', family: 'anthropic' },
 	{ id: 'claude-opus-5', label: 'Opus 5', family: 'anthropic' },
 	{ id: 'gpt-5.6-sol', label: 'GPT 5.6 Sol', family: 'openai' },
+	// Hosted models keep their vendor-prefixed ids — the proxy passes them
+	// upstream verbatim.
+	{ id: 'moonshotai/Kimi-K3', label: 'Kimi K3', family: 'hosted', requiresAutomattician: true },
+	{
+		id: 'moonshotai/Kimi-K2.6',
+		label: 'Kimi K2.6',
+		family: 'hosted',
+		requiresAutomattician: true,
+	},
+	{
+		id: 'zai-org/GLM-5.2',
+		label: 'GLM 5.2',
+		family: 'hosted',
+		supportsImages: false,
+		requiresAutomattician: true,
+	},
+	{
+		id: 'zai-org/GLM-5.2-Fast',
+		label: 'GLM 5.2 Fast',
+		family: 'hosted',
+		supportsImages: false,
+		requiresAutomattician: true,
+	},
+	{
+		id: 'deepseek-ai/DeepSeek-V4-Pro',
+		label: 'DeepSeek V4 Pro',
+		family: 'hosted',
+		supportsImages: false,
+		requiresAutomattician: true,
+	},
+	{
+		id: 'deepseek-ai/DeepSeek-V4-Flash-0731',
+		label: 'DeepSeek V4 Flash',
+		family: 'hosted',
+		supportsImages: false,
+		requiresAutomattician: true,
+	},
 ] as const satisfies readonly AiModel[];
 
 export type AiModelId = ( typeof AI_MODELS )[ number ][ 'id' ];
@@ -54,6 +104,35 @@ export function getAiModelFamily( id: AiModelId ): AiModelFamily {
 
 export function getAiModelLabel( id: AiModelId ): string {
 	return getAiModel( id ).label;
+}
+
+// Widened to AiModel: `as const satisfies` narrows each entry to its own
+// literal type, so the optional flags aren't on the union.
+const ALL_MODELS = AI_MODELS as readonly AiModel[];
+const UNRESTRICTED_MODELS = ALL_MODELS.filter( ( model ) => ! model.requiresAutomattician );
+
+/**
+ * The models to offer in a picker. Restricted models stay in `AI_MODELS` (so
+ * ids keep validating) but are withheld from anyone who isn't an Automattician.
+ *
+ * `keepId` is always offered even when restricted, so a picker never hides the
+ * value it is currently displaying.
+ */
+export function getVisibleAiModels(
+	isAutomattician: boolean,
+	keepId?: AiModelId
+): readonly AiModel[] {
+	const visible = isAutomattician ? ALL_MODELS : UNRESTRICTED_MODELS;
+	if ( ! keepId || visible.some( ( model ) => model.id === keepId ) ) {
+		return visible;
+	}
+	return [ ...visible, getAiModel( keepId ) ];
+}
+
+// Tolerates ids outside AI_MODELS — callers can reach here with a cast, and
+// image support is the safe default.
+export function aiModelSupportsImages( id: AiModelId ): boolean {
+	return MODEL_BY_ID.get( id )?.supportsImages ?? true;
 }
 
 /**

--- a/packages/common/ai/providers.ts
+++ b/packages/common/ai/providers.ts
@@ -21,11 +21,11 @@ export const AI_PROVIDER_LABELS: Record< AiProviderId, string > = {
 	'anthropic-api-key': 'Anthropic API',
 };
 
-// Which model families each provider can service. `wpcom` relays both
-// Anthropic and OpenAI wire formats through the same proxy; direct-API
-// providers are restricted to their own family.
+// Which model families each provider can service. `wpcom` relays the
+// Anthropic, OpenAI, and hosted wire formats through the same proxy;
+// direct-API providers are restricted to their own family.
 const PROVIDER_MODEL_FAMILIES: Record< AiProviderId, readonly AiModelFamily[] > = {
-	wpcom: [ 'anthropic', 'openai' ],
+	wpcom: [ 'anthropic', 'openai', 'hosted' ],
 	'anthropic-api-key': [ 'anthropic' ],
 };
 

--- a/packages/common/ai/tests/json-events.test.ts
+++ b/packages/common/ai/tests/json-events.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import {
 	buildUsageCapErrorMessage,
 	getAgentEndFailure,
-	isHttp429ErrorMessage,
 	isAiAccessRequiredError,
 	isAiBlockedError,
 	isUsageCapError,
@@ -44,32 +43,6 @@ function agentEnd(
 	return { type: 'agent_end', willRetry, messages } as unknown as AgentSessionEvent;
 }
 
-describe( 'isHttp429ErrorMessage', () => {
-	it.each( [
-		// Anthropic SDK: "<status> <message or JSON body>".
-		'429 {"type":"error","error":{"type":"rate_limit_error","message":"exceeded"}}',
-		'429 Number of requests has exceeded your monthly limit',
-		'429 status code (no body)',
-		// pi-ai OpenAI Responses formatting.
-		'OpenAI API error (429): {"error":{"message":"exceeded"}}',
-		// Legacy Claude Code SDK formatting.
-		'API Error: 429 {"error":"exceeded"}',
-	] )( 'matches %s', ( message ) => {
-		expect( isHttp429ErrorMessage( message ) ).toBe( true );
-	} );
-
-	it.each( [
-		'500 internal server error',
-		'Request took 429 ms',
-		'API Error: 500 upstream failure',
-		undefined,
-		null,
-		'',
-	] )( 'does not match %s', ( message ) => {
-		expect( isHttp429ErrorMessage( message ) ).toBe( false );
-	} );
-} );
-
 describe( 'isUsageCapError', () => {
 	it( 'matches the canonical runtime-stamped prefix', () => {
 		expect( isUsageCapError( buildUsageCapErrorMessage( '429 exceeded' ) ) ).toBe( true );
@@ -78,10 +51,18 @@ describe( 'isUsageCapError', () => {
 		);
 	} );
 
-	it( 'matches legacy Claude Code SDK formats', () => {
-		expect( isUsageCapError( 'API Error: 429 {"error":"x"}' ) ).toBe( true );
-		expect( isUsageCapError( 'Request failed with status code 429' ) ).toBe( true );
-		expect( isUsageCapError( '{"status": 429}' ) ).toBe( true );
+	it( 'matches an un-rewritten proxy cost-cap code', () => {
+		expect(
+			isUsageCapError( 'OpenAI API error (429): {"error":{"code":"cost_cap_exceeded"}}' )
+		).toBe( true );
+	} );
+
+	// A hosted upstream 429s for its own token-per-minute limits, which
+	// retrying clears — those must not read as the monthly cap.
+	it( 'does not match a 429 without the cost-cap code', () => {
+		expect( isUsageCapError( 'API Error: 429 {"error":"x"}' ) ).toBe( false );
+		expect( isUsageCapError( 'Request failed with status code 429' ) ).toBe( false );
+		expect( isUsageCapError( '{"status": 429}' ) ).toBe( false );
 	} );
 
 	it( 'does not match raw un-rewritten 429s (non-wpcom rate limits)', () => {

--- a/packages/common/lib/automattician.ts
+++ b/packages/common/lib/automattician.ts
@@ -1,0 +1,15 @@
+/**
+ * Automattician detection from a WordPress.com account email.
+ *
+ * Kept in its own leaf module — with no Node imports — so sandboxed renderers
+ * can share it with `shared-config.ts`, which reads the token off disk and
+ * therefore can't be imported from the renderer.
+ *
+ * This is a heuristic: an Automattician whose WordPress.com account uses a
+ * personal address reads as false. Use it to decide what to *show*, never as
+ * an access control — that has to live server-side, where the real identity is.
+ */
+export function isAutomatticianEmail( email: string | undefined | null ): boolean {
+	const normalized = email?.toLowerCase() ?? '';
+	return normalized.endsWith( '@a8c.com' ) || normalized.endsWith( '@automattic.com' );
+}

--- a/packages/common/lib/shared-config.ts
+++ b/packages/common/lib/shared-config.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { LOCKFILE_STALE_TIME, LOCKFILE_WAIT_TIME, SHARED_CONFIG_LOCKFILE_NAME } from '../constants';
 import { syncSiteSchema } from '../types/sync';
 import { authTokenSchema, type StoredAuthToken } from './auth-token-schema';
+import { isAutomatticianEmail } from './automattician';
 import { hideDirectoryOnWindows } from './hide-dir-windows';
 import { lockFileAsync, unlockFileAsync } from './lockfile';
 import { getConfigDirectory, getSharedConfigPath } from './well-known-paths';
@@ -257,7 +258,5 @@ export async function isAnalyticsOptedOut(): Promise< boolean > {
 // auth token's email domain. Returns false when logged out. Kept synchronous-friendly (no network
 // call) so it can run on every event; the authoritative team-membership check lives elsewhere.
 export async function isAutomatticianFromToken(): Promise< boolean > {
-	const token = await readAuthToken();
-	const email = token?.email?.toLowerCase() ?? '';
-	return email.endsWith( '@a8c.com' ) || email.endsWith( '@automattic.com' );
+	return isAutomatticianEmail( ( await readAuthToken() )?.email );
 }


### PR DESCRIPTION
## Related issues

- Related to the WordPress.com AI proxy work that adds the `studio-assistant-hosted` feature slug 

## How AI was used in this PR

Written end-to-end in a Claude Code session, then reviewed by me. The parts worth a careful human read.

## Proposed Changes

Studio Code has only ever offered Anthropic and OpenAI models. This adds a third family of third-party models relayed through the WordPress.com AI proxy — Kimi K3 and K2.6, GLM 5.2 and 5.2 Fast, DeepSeek V4 Pro and V4 Flash — so we can evaluate them against real Studio work.

They are **visible to Automatticians only** while we assess cost and quality. That is deliberately a visibility filter, the proxy is what actually refuses these upstreams.

Two behaviour changes fall out of supporting models that aren't Claude or GPT:

**Text-only models no longer pretend to see.** GLM and DeepSeek don't accept images. Those models simply don't get the screenshot tool now, so they say they can't verify visually instead of inventing a verdict.

**Rate limits are no longer mislabelled as your monthly cap.** The client treated any HTTP 429 from the proxy as the account cost cap, which was true when only first-party slugs existed. Hosted upstreams return their own 429s for token-per-minute limits, which retrying does clear.

## Testing Instructions

Requires a WordPress.com login and a proxy that serves the `studio-assistant-hosted` slug. Point Studio at a sandbox with the proxy changes.
