### PR TITLE
Agentic UI: Scroll agent questions clear of the composer

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
@@ -632,8 +632,10 @@ describe( 'Conversation turn-closed markers', () => {
 
 describe( 'getQuestionScrollDelta', () => {
 	// The scroller spans the full column, so its bottom sits *under* the
-	// floating composer; `reservedBottomSpace` is the padding holding content
-	// clear of it. Column runs 0-800 with a 140px-tall composer.
+	// floating composer. `reservedBottomSpace` is the scroller padding holding
+	// content clear of the composer plus the column's own trailing space, so a
+	// card settles where scrolling to the bottom would put it rather than flush.
+	// Column runs 0-800 with a 120px composer and 20px of trailing space.
 	const container = { containerTop: 0, containerBottom: 800, reservedBottomSpace: 140 };
 
 	it( 'scrolls a question hidden behind the composer fully clear of it', () => {

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { createElement, useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Conversation, entriesToRenderItems } from './index';
+import { Conversation, entriesToRenderItems, getQuestionScrollDelta } from './index';
 import type { LoadedAiSession, SessionEntry } from '@/data/core';
 import type { StudioChatArtifactWidgetDraft } from '@studio/common/ai/chat-artifacts';
 
@@ -627,6 +627,37 @@ describe( 'Conversation turn-closed markers', () => {
 
 	it( 'renders no marker for successful turns', () => {
 		expect( entriesToRenderItems( [ turnClosedEntry( 'success' ) ] ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'getQuestionScrollDelta', () => {
+	// The scroller spans the full column, so its bottom sits *under* the
+	// floating composer; `reservedBottomSpace` is the padding holding content
+	// clear of it. Column runs 0-800 with a 140px-tall composer.
+	const container = { containerTop: 0, containerBottom: 800, reservedBottomSpace: 140 };
+
+	it( 'scrolls a question hidden behind the composer fully clear of it', () => {
+		// Card ends at 700, i.e. 40px below the composer's top edge at 660.
+		const delta = getQuestionScrollDelta( {
+			...container,
+			elementTop: 500,
+			elementBottom: 700,
+		} );
+
+		expect( delta ).toBe( 40 );
+		expect( 700 - delta ).toBeLessThanOrEqual( 800 - 140 );
+	} );
+
+	it( 'leaves a question that already clears the composer alone', () => {
+		expect( getQuestionScrollDelta( { ...container, elementTop: 400, elementBottom: 600 } ) ).toBe(
+			0
+		);
+	} );
+
+	it( 'scrolls up to a question cut off at the top, ignoring the bottom clearance', () => {
+		expect( getQuestionScrollDelta( { ...container, elementTop: 4, elementBottom: 300 } ) ).toBe(
+			-8
+		);
 	} );
 } );
 

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -150,6 +150,9 @@ interface PiToolResultLike {
 const HIDDEN_TOOL_ROWS = new Set( [ 'studio_present', 'AskUserQuestion' ] );
 const QUESTION_COLLAPSE_DELAY_MS = 650;
 const QUESTION_SCROLL_TOP_MARGIN_PX = 12;
+// Only a pre-layout fallback. The scroller spans the full column with the
+// composer floating over it, so the space to actually keep clear is the
+// scroller's reserved bottom padding, which tracks the live composer height.
 const QUESTION_SCROLL_BOTTOM_CLEARANCE_PX = 96;
 
 function usePrefersReducedMotion(): boolean {
@@ -957,6 +960,32 @@ function getNearestScrollContainer( element: HTMLElement ): HTMLElement | null {
 	return null;
 }
 
+function getReservedBottomSpace( container: HTMLElement | null ): number {
+	if ( ! container ) {
+		return QUESTION_SCROLL_BOTTOM_CLEARANCE_PX;
+	}
+	const paddingBottom = parseFloat( window.getComputedStyle( container ).paddingBottom );
+	return Number.isFinite( paddingBottom ) ? paddingBottom : QUESTION_SCROLL_BOTTOM_CLEARANCE_PX;
+}
+
+export function getQuestionScrollDelta( {
+	elementTop,
+	elementBottom,
+	containerTop,
+	containerBottom,
+	reservedBottomSpace,
+}: {
+	elementTop: number;
+	elementBottom: number;
+	containerTop: number;
+	containerBottom: number;
+	reservedBottomSpace: number;
+} ): number {
+	const topOverflow = elementTop - ( containerTop + QUESTION_SCROLL_TOP_MARGIN_PX );
+	const bottomOverflow = elementBottom - ( containerBottom - reservedBottomSpace );
+	return topOverflow < 0 ? topOverflow : Math.max( bottomOverflow, 0 );
+}
+
 function scrollElementIntoViewIfNeeded( element: HTMLElement, prefersReducedMotion: boolean ) {
 	const container = getNearestScrollContainer( element );
 	const elementRect = element.getBoundingClientRect();
@@ -968,10 +997,13 @@ function scrollElementIntoViewIfNeeded( element: HTMLElement, prefersReducedMoti
 				bottom: window.innerHeight || document.documentElement.clientHeight,
 				left: 0,
 		  };
-	const topOverflow = elementRect.top - ( containerRect.top + QUESTION_SCROLL_TOP_MARGIN_PX );
-	const bottomOverflow =
-		elementRect.bottom - ( containerRect.bottom - QUESTION_SCROLL_BOTTOM_CLEARANCE_PX );
-	const scrollDelta = topOverflow < 0 ? topOverflow : Math.max( bottomOverflow, 0 );
+	const scrollDelta = getQuestionScrollDelta( {
+		elementTop: elementRect.top,
+		elementBottom: elementRect.bottom,
+		containerTop: containerRect.top,
+		containerBottom: containerRect.bottom,
+		reservedBottomSpace: getReservedBottomSpace( container ),
+	} );
 
 	if ( scrollDelta !== 0 ) {
 		const behavior: ScrollBehavior = prefersReducedMotion ? 'auto' : 'smooth';

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -960,12 +960,22 @@ function getNearestScrollContainer( element: HTMLElement ): HTMLElement | null {
 	return null;
 }
 
-function getReservedBottomSpace( container: HTMLElement | null ): number {
+function getPaddingBottom( element: HTMLElement ): number {
+	const paddingBottom = parseFloat( window.getComputedStyle( element ).paddingBottom );
+	return Number.isFinite( paddingBottom ) ? paddingBottom : 0;
+}
+
+function getReservedBottomSpace( element: HTMLElement, container: HTMLElement | null ): number {
 	if ( ! container ) {
 		return QUESTION_SCROLL_BOTTOM_CLEARANCE_PX;
 	}
-	const paddingBottom = parseFloat( window.getComputedStyle( container ).paddingBottom );
-	return Number.isFinite( paddingBottom ) ? paddingBottom : QUESTION_SCROLL_BOTTOM_CLEARANCE_PX;
+	// The scroller's padding holds content clear of the floating composer; the
+	// column's own trailing space keeps the card from settling flush against it.
+	let column = element;
+	while ( column.parentElement && column.parentElement !== container ) {
+		column = column.parentElement;
+	}
+	return getPaddingBottom( container ) + getPaddingBottom( column );
 }
 
 export function getQuestionScrollDelta( {
@@ -1002,7 +1012,7 @@ function scrollElementIntoViewIfNeeded( element: HTMLElement, prefersReducedMoti
 		elementBottom: elementRect.bottom,
 		containerTop: containerRect.top,
 		containerBottom: containerRect.bottom,
-		reservedBottomSpace: getReservedBottomSpace( container ),
+		reservedBottomSpace: getReservedBottomSpace( element, container ),
 	} );
 
 	if ( scrollDelta !== 0 ) {

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -528,13 +528,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 					getDraft={ () => composerRef.current?.getDraft() ?? { text: '', hasAttachments: false } }
 				/>
 			) : null }
-			<div
-				className={ clsx(
-					styles.classicColumn,
-					styles.classicConversationSpacing,
-					pendingQuestions.length > 0 && styles.classicConversationWithQuestions
-				) }
-			>
+			<div className={ clsx( styles.classicColumn, styles.classicConversationSpacing ) }>
 				<Conversation
 					data={ data }
 					isRunning={ isRunning }

--- a/apps/ui/src/ui-classic/components/session-view/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/style.module.css
@@ -158,10 +158,6 @@
 	padding-bottom: var(--wpds-dimension-padding-2xl);
 }
 
-.classicConversationWithQuestions {
-	padding-bottom: calc(var(--wpds-dimension-padding-2xl) + 96px);
-}
-
 .classicComposerOuter {
 	padding: 0 var(--classic-composer-outer-inline-padding) 0;
 }


### PR DESCRIPTION
## Related issues

- Fixes STU-2157

## How AI was used in this PR

Tested manually first to confirm the issue. Fix was implemented with Claude. Manually reviewed and confirmed the fix

## Proposed Changes

When the agent asks a question, the bottom of the question card could end up hidden underneath the composer, so the last option wasn't visible or clickable — leaving the run blocked on a choice the user couldn't see.

<img width="3248" height="2120" alt="image" src="https://github.com/user-attachments/assets/325ef4a4-ecac-48f5-b333-05a1ed087c48" />

## Testing Instructions

1. Open a chat and get the agent to ask a question — e.g. *"Use the AskUserQuestion tool to ask me 2 questions about how I'd like this site styled, with 3 options each."*
2. Before it answers, grow the composer past ~96px: type several lines of text, or drag the composer's resize handle up.
3. When the question appears, all of its options should be visible above the composer.

On trunk the last option is cut off; the taller the composer, the more is hidden.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
