### PR TITLE
Tracks: onboarding & authentication events (STU-2114)

### DIFF
--- a/apps/cli/commands/auth/login.ts
+++ b/apps/cli/commands/auth/login.ts
@@ -9,6 +9,7 @@ import { getUserInfo } from 'cli/lib/api';
 import { openBrowser } from 'cli/lib/browser';
 import { emitCliEvent } from 'cli/lib/daemon-client';
 import { getAppLocale } from 'cli/lib/i18n';
+import { getTracksOrigin, recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -56,11 +57,19 @@ export async function runCommand(): Promise< void > {
 	let accessToken: Awaited< ReturnType< typeof input > >;
 	let user: Awaited< ReturnType< typeof getUserInfo > >;
 
+	// `account_type` is absent throughout: the CLI has no signup path.
+	const authProps = { ...getTracksOrigin(), source: 'cli' as const };
+
 	try {
 		accessToken = await input( { message: __( 'Authentication token:' ) } );
 		user = await getUserInfo( accessToken );
 		logger.reportSuccess( __( 'Authentication completed successfully!' ) );
 	} catch ( error ) {
+		await recordTracksEvent( TRACKS_EVENTS.WPCOM_AUTH, {
+			...authProps,
+			success: false,
+			failure_reason: 'profile_fetch_failed',
+		} );
 		logger.reportError( new LoggerError( __( 'Authentication failed. Please try again.' ) ) );
 		return;
 	}
@@ -77,6 +86,11 @@ export async function runCommand(): Promise< void > {
 	try {
 		await updateSharedConfig( { authToken } );
 	} catch ( error ) {
+		await recordTracksEvent( TRACKS_EVENTS.WPCOM_AUTH, {
+			...authProps,
+			success: false,
+			failure_reason: 'unknown',
+		} );
 		if ( error instanceof LoggerError ) {
 			logger.reportError( error );
 		} else {
@@ -84,6 +98,9 @@ export async function runCommand(): Promise< void > {
 		}
 		return;
 	}
+
+	// After the token is stored — the wrapper reads it to resolve `is_a11n`.
+	await recordTracksEvent( TRACKS_EVENTS.WPCOM_AUTH, { ...authProps, success: true } );
 
 	try {
 		await emitCliEvent( { event: AUTH_EVENTS.LOGIN, data: { token: authToken } } );

--- a/apps/cli/commands/auth/tests/login.test.ts
+++ b/apps/cli/commands/auth/tests/login.test.ts
@@ -5,6 +5,7 @@ import { vi } from 'vitest';
 import { getUserInfo } from 'cli/lib/api';
 import { openBrowser } from 'cli/lib/browser';
 import { getAppLocale } from 'cli/lib/i18n';
+import { recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { LoggerError } from 'cli/logger';
 import {
 	mockReportStart,
@@ -29,6 +30,11 @@ vi.mock( 'cli/lib/daemon-client', () => ( {
 	emitCliEvent: vi.fn(),
 } ) );
 vi.mock( 'cli/lib/i18n' );
+vi.mock( 'cli/lib/tracks', async ( importOriginal ) => ( {
+	...( await importOriginal< typeof import('cli/lib/tracks') >() ),
+	recordTracksEvent: vi.fn(),
+	getTracksOrigin: () => ( { channel: 'studio-cli' } ),
+} ) );
 vi.mock( 'cli/logger', () => ( {
 	Logger: class {
 		reportStart = mockReportStart;
@@ -167,5 +173,76 @@ describe( 'Auth Login Command', () => {
 			'fr',
 			'https://developer.wordpress.com/copy-oauth-token'
 		);
+	} );
+
+	describe( 'Tracks event', () => {
+		const authEvents = () =>
+			vi
+				.mocked( recordTracksEvent )
+				.mock.calls.filter( ( [ name ] ) => name === TRACKS_EVENTS.WPCOM_AUTH );
+
+		// `account_type` is absent throughout — the CLI has no signup path.
+		it( 'records a successful login', async () => {
+			await runCommand();
+
+			expect( authEvents() ).toEqual( [
+				[ TRACKS_EVENTS.WPCOM_AUTH, { channel: 'studio-cli', source: 'cli', success: true } ],
+			] );
+		} );
+
+		// `is_a11n` is derived from the stored token, so the event must follow the write.
+		it( 'records the success only after the token is stored', async () => {
+			const order: string[] = [];
+			vi.mocked( updateSharedConfig ).mockImplementation( async () => {
+				order.push( 'write' );
+			} );
+			vi.mocked( recordTracksEvent ).mockImplementation( async () => {
+				order.push( 'record' );
+			} );
+
+			await runCommand();
+
+			expect( order ).toEqual( [ 'write', 'record' ] );
+		} );
+
+		it( 'records a failure when the token is rejected', async () => {
+			vi.mocked( getUserInfo ).mockRejectedValue( new LoggerError( 'nope' ) );
+
+			await runCommand();
+
+			expect( authEvents() ).toEqual( [
+				[
+					TRACKS_EVENTS.WPCOM_AUTH,
+					{
+						channel: 'studio-cli',
+						source: 'cli',
+						success: false,
+						failure_reason: 'profile_fetch_failed',
+					},
+				],
+			] );
+		} );
+
+		it( 'records a failure when the token cannot be stored', async () => {
+			vi.mocked( updateSharedConfig ).mockRejectedValue( new LoggerError( 'disk full' ) );
+
+			await runCommand();
+
+			expect( authEvents() ).toEqual( [
+				[
+					TRACKS_EVENTS.WPCOM_AUTH,
+					{ channel: 'studio-cli', source: 'cli', success: false, failure_reason: 'unknown' },
+				],
+			] );
+		} );
+
+		// Nothing was authenticated, so there is no outcome to record.
+		it( 'records nothing when already authenticated', async () => {
+			vi.mocked( readAuthToken ).mockResolvedValue( mockExistingToken );
+
+			await runCommand();
+
+			expect( authEvents() ).toEqual( [] );
+		} );
 	} );
 } );

--- a/apps/studio/src/components/auth-provider.tsx
+++ b/apps/studio/src/components/auth-provider.tsx
@@ -11,12 +11,15 @@ import { setSentryWpcomUserIdRenderer } from 'src/lib/renderer-sentry-utils';
 import { useAppDispatch, useI18nLocale } from 'src/stores';
 import { userLoggedOut } from 'src/stores/auth-actions';
 import { setWpcomClient } from 'src/stores/wpcom-api';
+import type { TracksAuthSource } from '@studio/common/lib/record-tracks-event';
 import type { WPCOM } from 'wpcom/types';
 
 export interface AuthContextType {
 	client: WPCOM | undefined;
 	isAuthenticated: boolean;
-	authenticate: () => void; // Adjust based on the actual implementation
+	// `source` is required so every login affordance has to name itself for `studio_wpcom_auth` — a
+	// missed one becomes a type error rather than a silent `unknown` in the data.
+	authenticate: ( source: TracksAuthSource ) => void;
 	logout: () => Promise< void >; // Adjust based on the actual implementation
 	user?: { id: number; email: string; displayName: string };
 }
@@ -33,7 +36,7 @@ interface WpcomParams extends Record< string, unknown > {
 export const AuthContext = createContext< AuthContextType >( {
 	client: undefined,
 	isAuthenticated: false,
-	authenticate: () => {
+	authenticate: ( _source: TracksAuthSource ) => {
 		// Placeholder for authenticate logic. Just to avoid lint error
 	},
 	logout: () => Promise.resolve(),
@@ -48,7 +51,10 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 	const isOffline = useOffline();
 
 	const dispatch = useAppDispatch();
-	const authenticate = useCallback( () => getIpcApi().authenticate(), [] );
+	const authenticate = useCallback(
+		( source: TracksAuthSource ) => getIpcApi().authenticate( false, source ),
+		[]
+	);
 
 	const handleInvalidToken = useCallback( async () => {
 		try {

--- a/apps/studio/src/components/content-tab-previews.tsx
+++ b/apps/studio/src/components/content-tab-previews.tsx
@@ -100,7 +100,7 @@ function NoAuth( { selectedSite }: React.ComponentProps< typeof EmptyGeneric > )
 							if ( isOffline ) {
 								return;
 							}
-							authenticate();
+							authenticate( 'previews_tab' );
 						} }
 					>
 						{ __( 'Log in to WordPress.com' ) }
@@ -125,7 +125,7 @@ function NoAuth( { selectedSite }: React.ComponentProps< typeof EmptyGeneric > )
 								if ( isOffline ) {
 									return;
 								}
-								getIpcApi().authenticate( true );
+								getIpcApi().authenticate( true, 'previews_tab' );
 							} }
 						>
 							{ __( 'Create a free account' ) }

--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -160,7 +160,7 @@ function NoAuth() {
 								if ( isOffline ) {
 									return;
 								}
-								authenticate();
+								authenticate( 'assistant_tab' );
 							} }
 						>
 							{ __( 'Log in to WordPress.com' ) }
@@ -185,7 +185,7 @@ function NoAuth() {
 									if ( isOffline ) {
 										return;
 									}
-									getIpcApi().authenticate( true );
+									getIpcApi().authenticate( true, 'assistant_tab' );
 								} }
 							>
 								{ __( 'Create a free account' ) }

--- a/apps/studio/src/components/top-bar.tsx
+++ b/apps/studio/src/components/top-bar.tsx
@@ -98,7 +98,7 @@ function Authentication() {
 			placement="bottom-end"
 		>
 			<Button
-				onClick={ () => getIpcApi().authenticate( false ) }
+				onClick={ () => getIpcApi().authenticate( false, 'top_bar' ) }
 				aria-label={ __( 'Log in to Studio with WordPress.com' ) }
 				variant="icon"
 				className="flex gap-x-2 justify-between w-full text-white !rounded-lg !px-2 !py-1.5 h-auto active:!text-white hover:!text-white hover:underline items-center"

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -106,6 +106,7 @@ import { measureSiteStorage, type SiteStorageUsage } from '@studio/common/sites/
 import { __, sprintf, LocaleData, defaultI18n } from '@wordpress/i18n';
 import { MACOS_TRAFFIC_LIGHT_POSITION, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
 import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
+import { setPendingAuthContext } from 'src/lib/auth-tracks-context';
 import {
 	getBetaFeatures as getBetaFeaturesFromLib,
 	updateBetaFeature as updateBetaFeatureInLib,
@@ -144,6 +145,7 @@ import { setAgenticUiEnabled } from 'src/lib/studio-ui-mode';
 import {
 	recordTracksEvent,
 	TRACKS_EVENTS,
+	type TracksAuthSource,
 	type TracksChannel,
 	type TracksSiteCreateFlowType,
 	type TracksUiVersion,
@@ -1312,7 +1314,14 @@ export function logRendererMessage(
 	writeLogToFile( level, processId, ...args );
 }
 
-export async function authenticate( event: IpcMainInvokeEvent, isSignup = false ) {
+export async function authenticate(
+	event: IpcMainInvokeEvent,
+	isSignup = false,
+	source: TracksAuthSource = 'unknown'
+) {
+	// The result arrives later, in a deep link that knows neither of these. Stash them for it.
+	setPendingAuthContext( source, isSignup ? 'new' : 'existing' );
+
 	const locale = await getUserLocaleWithFallback();
 	const authUrl = isSignup ? oauthClient.getSignUpUrl( locale ) : getAuthenticationUrl( locale );
 	void shellOpenExternalWrapper( authUrl );
@@ -1599,7 +1608,18 @@ export async function getOnboardingData( _event: IpcMainInvokeEvent ): Promise< 
 }
 
 export async function saveOnboarding( event: IpcMainInvokeEvent, onboardingCompleted: boolean ) {
+	const { onboardingCompleted: previous = false } = await loadUserData();
 	await updateAppdata( { onboardingCompleted } );
+
+	// Both front-ends funnel through here (Classic on skip/login, the agentic UI when the tour ends), so
+	// this is the one place a completion can be counted. Only on a real transition — a re-save must not
+	// look like a second user finishing onboarding.
+	if ( onboardingCompleted && ! previous ) {
+		await recordTracksEvent( TRACKS_EVENTS.ONBOARDING_COMPLETE, {
+			// Whether they leave onboarding with an account, which is what "skipped" really meant.
+			authenticated: await oauthClient.isAuthenticated(),
+		} );
+	}
 }
 
 export async function getBetaFeatures( _event: IpcMainInvokeEvent ): Promise< BetaFeatures > {

--- a/apps/studio/src/lib/auth-tracks-context.ts
+++ b/apps/studio/src/lib/auth-tracks-context.ts
@@ -1,0 +1,53 @@
+import type {
+	TracksAuthAccountType,
+	TracksAuthSource,
+} from '@studio/common/lib/record-tracks-event';
+
+// `source` and `account_type` for `studio_wpcom_auth` are known only when auth *starts* (the affordance
+// the user clicked, and whether we opened the login or the signup URL), but the outcome arrives much
+// later, in a deep link that carries nothing but a token. This module bridges the two: both ends run in
+// the Main process, so a module-level value is enough — no persistence, and it dies with the process.
+//
+// Deliberately lossy. When the link can't be made (see `takePendingAuthContext`) the event still fires,
+// reporting `source: 'unknown'` rather than guessing.
+
+// Long enough for a slow login (find the browser, sign in, maybe 2FA), short enough that a context
+// abandoned hours ago never attaches itself to an unrelated deep link.
+const PENDING_AUTH_TTL_MS = 15 * 60 * 1000;
+
+interface PendingAuthContext {
+	source: TracksAuthSource;
+	accountType: TracksAuthAccountType;
+	startedAt: number;
+}
+
+let pending: PendingAuthContext | undefined;
+
+// Records where an auth attempt started. Last write wins: if the user opens several login tabs, the one
+// they finish is almost always the most recent, so the newest context is the best guess for the deep
+// link that eventually arrives.
+export function setPendingAuthContext(
+	source: TracksAuthSource,
+	accountType: TracksAuthAccountType
+): void {
+	pending = { source, accountType, startedAt: Date.now() };
+}
+
+// Reads and clears the context. Returns `undefined` when there is nothing to attribute — no initiation
+// seen (the app restarted mid-flow, or the deep link cold-started it), the context expired, or it was
+// already consumed by an earlier deep link. Clearing is what keeps a stale context from being reused.
+export function takePendingAuthContext(): PendingAuthContext | undefined {
+	const context = pending;
+	pending = undefined;
+
+	if ( ! context || Date.now() - context.startedAt > PENDING_AUTH_TTL_MS ) {
+		return undefined;
+	}
+
+	return context;
+}
+
+// Test-only: drop any context left over from a previous case.
+export function __resetPendingAuthContext(): void {
+	pending = undefined;
+}

--- a/apps/studio/src/lib/deeplink/handlers/auth.ts
+++ b/apps/studio/src/lib/deeplink/handlers/auth.ts
@@ -22,14 +22,17 @@ type StoredAuthToken = z.infer< typeof authTokenSchema >;
 class AuthCallbackError extends Error {
 	constructor(
 		message: string,
-		public readonly code: TracksAuthFailureReason
+		public readonly code: TracksAuthFailureReason,
+		public readonly originalError?: unknown
 	) {
 		super( message );
 	}
 }
 
+// Only tagged failures are classified. Anything else is genuinely unexpected — `unknown`, matching what
+// the CLI reports for its own untagged failures, so a reason means the same thing in both channels.
 function classifyAuthFailure( error: unknown ): TracksAuthFailureReason {
-	return error instanceof AuthCallbackError ? error.code : 'profile_fetch_failed';
+	return error instanceof AuthCallbackError ? error.code : 'unknown';
 }
 
 async function handleAuthCallback( hash: string ): Promise< StoredAuthToken > {
@@ -50,11 +53,21 @@ async function handleAuthCallback( hash: string ): Promise< StoredAuthToken > {
 	if ( isNaN( expiresIn ) || expiresIn === 0 || ! accessToken ) {
 		throw new AuthCallbackError( 'Error while getting token', 'token_error' );
 	}
-	const rawResponse = await wpcomFactory( accessToken, wpcomXhrRequest ).req.get(
-		'/me?fields=ID,email,display_name'
-	);
-
-	const response = meResponseSchema.parse( rawResponse );
+	let response;
+	try {
+		const rawResponse = await wpcomFactory( accessToken, wpcomXhrRequest ).req.get(
+			'/me?fields=ID,email,display_name'
+		);
+		response = meResponseSchema.parse( rawResponse );
+	} catch ( error ) {
+		// The request failing and the response not matching the schema are both "we couldn't read the
+		// profile". Rethrow tagged, preserving the original message for the renderer and Sentry.
+		throw new AuthCallbackError(
+			error instanceof Error ? error.message : String( error ),
+			'profile_fetch_failed',
+			error
+		);
+	}
 
 	return authTokenSchema.parse( {
 		expiresIn,
@@ -89,7 +102,12 @@ export async function handleAuthDeeplink( urlObject: URL ): Promise< void > {
 		void recordTracksEvent( TRACKS_EVENTS.WPCOM_AUTH, { ...authProps, success: true } );
 		void sendIpcEventToRenderer( 'auth-updated', { token: authResult } );
 	} catch ( error ) {
-		Sentry.captureException( error );
+		// Report the underlying error where we wrapped one, so Sentry keeps the original stack.
+		Sentry.captureException(
+			error instanceof AuthCallbackError && error.originalError !== undefined
+				? error.originalError
+				: error
+		);
 		void recordTracksEvent( TRACKS_EVENTS.WPCOM_AUTH, {
 			...authProps,
 			success: false,

--- a/apps/studio/src/lib/deeplink/handlers/auth.ts
+++ b/apps/studio/src/lib/deeplink/handlers/auth.ts
@@ -4,7 +4,10 @@ import wpcomFactory from '@studio/common/lib/wpcom-factory';
 import wpcomXhrRequest from '@studio/common/lib/wpcom-xhr-request-factory';
 import { z } from 'zod';
 import { sendIpcEventToRenderer } from 'src/ipc-utils';
+import { takePendingAuthContext } from 'src/lib/auth-tracks-context';
 import { setSentryWpcomUserIdMain } from 'src/lib/main-sentry-utils';
+import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
+import type { TracksAuthFailureReason } from 'src/lib/tracks';
 
 const meResponseSchema = z.object( {
 	ID: z.number(),
@@ -14,20 +17,38 @@ const meResponseSchema = z.object( {
 
 type StoredAuthToken = z.infer< typeof authTokenSchema >;
 
+// Tags the failure so Tracks can classify it without matching on the message text. The messages
+// themselves are unchanged — the renderer still recognises `access_denied` by substring.
+class AuthCallbackError extends Error {
+	constructor(
+		message: string,
+		public readonly code: TracksAuthFailureReason
+	) {
+		super( message );
+	}
+}
+
+function classifyAuthFailure( error: unknown ): TracksAuthFailureReason {
+	return error instanceof AuthCallbackError ? error.code : 'profile_fetch_failed';
+}
+
 async function handleAuthCallback( hash: string ): Promise< StoredAuthToken > {
 	const params = new URLSearchParams( hash.substring( 1 ) );
 	const error = params.get( 'error' );
 
 	if ( error ) {
 		// Close the browser if code found or error
-		throw new Error( error );
+		throw new AuthCallbackError(
+			error,
+			error === 'access_denied' ? 'access_denied' : 'token_error'
+		);
 	}
 
 	const accessToken = params.get( 'access_token' ) ?? '';
 	const expiresIn = parseInt( params.get( 'expires_in' ) ?? '0' );
 
 	if ( isNaN( expiresIn ) || expiresIn === 0 || ! accessToken ) {
-		throw new Error( 'Error while getting token' );
+		throw new AuthCallbackError( 'Error while getting token', 'token_error' );
 	}
 	const rawResponse = await wpcomFactory( accessToken, wpcomXhrRequest ).req.get(
 		'/me?fields=ID,email,display_name'
@@ -52,13 +73,28 @@ async function handleAuthCallback( hash: string ): Promise< StoredAuthToken > {
  */
 export async function handleAuthDeeplink( urlObject: URL ): Promise< void > {
 	const { hash } = urlObject;
+	// Taken once, up front, so both branches see it and it is consumed exactly once.
+	const context = takePendingAuthContext();
+	const authProps = {
+		source: context?.source ?? 'unknown',
+		account_type: context?.accountType,
+	};
+
 	try {
 		const authResult = await handleAuthCallback( hash );
 		await updateSharedConfig( { authToken: authResult } );
 		setSentryWpcomUserIdMain( authResult.id );
+		// After the token is stored: the wrapper derives `is_a11n` from it, so recording earlier would
+		// tag every Automattician's login as `false`.
+		void recordTracksEvent( TRACKS_EVENTS.WPCOM_AUTH, { ...authProps, success: true } );
 		void sendIpcEventToRenderer( 'auth-updated', { token: authResult } );
 	} catch ( error ) {
 		Sentry.captureException( error );
+		void recordTracksEvent( TRACKS_EVENTS.WPCOM_AUTH, {
+			...authProps,
+			success: false,
+			failure_reason: classifyAuthFailure( error ),
+		} );
 		void sendIpcEventToRenderer( 'auth-updated', { error } );
 	}
 }

--- a/apps/studio/src/lib/deeplink/tests/auth.test.ts
+++ b/apps/studio/src/lib/deeplink/tests/auth.test.ts
@@ -4,12 +4,18 @@
 import { readFile, writeFile } from 'atomically';
 import { vi } from 'vitest';
 import { sendIpcEventToRenderer } from 'src/ipc-utils';
+import { __resetPendingAuthContext, setPendingAuthContext } from 'src/lib/auth-tracks-context';
 import { handleAuthDeeplink } from 'src/lib/deeplink/handlers/auth';
+import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
 
 const mockWpcomGet = vi.fn();
 
 vi.mock( 'src/lib/certificate-manager', () => ( {} ) );
 vi.mock( 'src/ipc-utils' );
+vi.mock( 'src/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('src/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
 vi.mock( '@studio/common/lib/wpcom-factory', () => ( {
 	default: () => ( {
 		req: { get: mockWpcomGet },
@@ -52,8 +58,10 @@ describe( 'handleAuthDeeplink', () => {
 		const url = new URL( 'wp-studio://auth#error=access_denied' );
 		await handleAuthDeeplink( url );
 
+		// Matched by message, not identity: the error also carries a `code` for Tracks, and the renderer
+		// keys its "Authorization denied" dialog off the message.
 		expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'auth-updated', {
-			error: new Error( 'access_denied' ),
+			error: expect.objectContaining( { message: 'access_denied' } ),
 		} );
 		expect( writeFile ).not.toHaveBeenCalled();
 	} );
@@ -78,5 +86,106 @@ describe( 'handleAuthDeeplink', () => {
 			error: expect.any( Error ),
 		} );
 		expect( writeFile ).not.toHaveBeenCalled();
+	} );
+
+	describe( 'Tracks event', () => {
+		const successUrl = () => new URL( 'wp-studio://auth#access_token=mock-token&expires_in=3600' );
+
+		const lastAuthEventProps = () => {
+			const calls = vi
+				.mocked( recordTracksEvent )
+				.mock.calls.filter( ( [ event ] ) => event === TRACKS_EVENTS.WPCOM_AUTH );
+			return calls.at( -1 )?.[ 1 ];
+		};
+
+		beforeEach( () => {
+			__resetPendingAuthContext();
+			mockWpcomGet.mockResolvedValue( {
+				ID: 123,
+				email: 'user@example.com',
+				display_name: 'Test User',
+			} );
+		} );
+
+		it( 'records a successful login with the initiating context', async () => {
+			setPendingAuthContext( 'top_bar', 'existing' );
+
+			await handleAuthDeeplink( successUrl() );
+
+			expect( lastAuthEventProps() ).toEqual( {
+				success: true,
+				source: 'top_bar',
+				account_type: 'existing',
+			} );
+		} );
+
+		// `is_a11n` is derived from the stored token, so recording before the write would tag every
+		// Automattician's login as `false`.
+		it( 'records the success only after the token is stored', async () => {
+			setPendingAuthContext( 'onboarding', 'new' );
+			const order: string[] = [];
+			vi.mocked( writeFile ).mockImplementation( async () => {
+				order.push( 'write' );
+			} );
+			vi.mocked( recordTracksEvent ).mockImplementation( async () => {
+				order.push( 'record' );
+			} );
+
+			await handleAuthDeeplink( successUrl() );
+
+			expect( order.indexOf( 'write' ) ).toBeLessThan( order.indexOf( 'record' ) );
+		} );
+
+		it( 'records a denied authorization as a failure', async () => {
+			setPendingAuthContext( 'previews_tab', 'existing' );
+
+			await handleAuthDeeplink( new URL( 'wp-studio://auth#error=access_denied' ) );
+
+			expect( lastAuthEventProps() ).toEqual( {
+				success: false,
+				source: 'previews_tab',
+				account_type: 'existing',
+				failure_reason: 'access_denied',
+			} );
+		} );
+
+		it( 'classifies a missing token as a token error', async () => {
+			setPendingAuthContext( 'settings', 'existing' );
+
+			await handleAuthDeeplink( new URL( 'wp-studio://auth#expires_in=0' ) );
+
+			expect( lastAuthEventProps() ).toMatchObject( {
+				success: false,
+				failure_reason: 'token_error',
+			} );
+		} );
+
+		it( 'classifies a failing profile fetch', async () => {
+			setPendingAuthContext( 'settings', 'existing' );
+			mockWpcomGet.mockRejectedValue( new Error( 'network down' ) );
+
+			await handleAuthDeeplink( successUrl() );
+
+			expect( lastAuthEventProps() ).toMatchObject( {
+				success: false,
+				failure_reason: 'profile_fetch_failed',
+			} );
+		} );
+
+		it( 'reports an unknown source when auth was not initiated in this session', async () => {
+			await handleAuthDeeplink( successUrl() );
+
+			expect( lastAuthEventProps() ).toEqual( { success: true, source: 'unknown' } );
+		} );
+
+		// A stale context must not attach itself to an unrelated login.
+		it( 'attributes only the first deep link after an initiation', async () => {
+			setPendingAuthContext( 'add_site', 'existing' );
+
+			await handleAuthDeeplink( successUrl() );
+			await handleAuthDeeplink( successUrl() );
+
+			expect( lastAuthEventProps() ).toEqual( { success: true, source: 'unknown' } );
+		} );
 	} );
 } );

--- a/apps/studio/src/lib/deeplink/tests/auth.test.ts
+++ b/apps/studio/src/lib/deeplink/tests/auth.test.ts
@@ -172,6 +172,20 @@ describe( 'handleAuthDeeplink', () => {
 			} );
 		} );
 
+		// Same failure as the CLI's config-write case, so it must classify the same way — otherwise
+		// `profile_fetch_failed` would mean two different things depending on channel.
+		it( 'classifies a failure to store the token as unknown', async () => {
+			setPendingAuthContext( 'settings', 'existing' );
+			vi.mocked( writeFile ).mockRejectedValue( new Error( 'disk full' ) );
+
+			await handleAuthDeeplink( successUrl() );
+
+			expect( lastAuthEventProps() ).toMatchObject( {
+				success: false,
+				failure_reason: 'unknown',
+			} );
+		} );
+
 		it( 'reports an unknown source when auth was not initiated in this session', async () => {
 			await handleAuthDeeplink( successUrl() );
 

--- a/apps/studio/src/lib/tests/auth-tracks-context.test.ts
+++ b/apps/studio/src/lib/tests/auth-tracks-context.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, beforeEach, vi } from 'vitest';
+import {
+	__resetPendingAuthContext,
+	setPendingAuthContext,
+	takePendingAuthContext,
+} from 'src/lib/auth-tracks-context';
+
+describe( 'auth tracks context', () => {
+	beforeEach( () => {
+		__resetPendingAuthContext();
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+	} );
+
+	it( 'returns the context recorded at initiation', () => {
+		setPendingAuthContext( 'top_bar', 'existing' );
+
+		expect( takePendingAuthContext() ).toMatchObject( {
+			source: 'top_bar',
+			accountType: 'existing',
+		} );
+	} );
+
+	it( 'returns undefined when auth was never initiated', () => {
+		expect( takePendingAuthContext() ).toBeUndefined();
+	} );
+
+	// Otherwise a second deep link would silently inherit the first one's attribution.
+	it( 'consumes the context so only the first caller gets it', () => {
+		setPendingAuthContext( 'onboarding', 'new' );
+
+		expect( takePendingAuthContext() ).toBeDefined();
+		expect( takePendingAuthContext() ).toBeUndefined();
+	} );
+
+	it( 'keeps only the most recent initiation', () => {
+		setPendingAuthContext( 'onboarding', 'new' );
+		setPendingAuthContext( 'settings', 'existing' );
+
+		expect( takePendingAuthContext() ).toMatchObject( {
+			source: 'settings',
+			accountType: 'existing',
+		} );
+	} );
+
+	it( 'discards a context that outlived its TTL', () => {
+		vi.useFakeTimers();
+		setPendingAuthContext( 'sync_tab', 'existing' );
+
+		vi.advanceTimersByTime( 15 * 60 * 1000 + 1 );
+
+		expect( takePendingAuthContext() ).toBeUndefined();
+	} );
+
+	it( 'still returns a context that is within the TTL', () => {
+		vi.useFakeTimers();
+		setPendingAuthContext( 'sync_tab', 'existing' );
+
+		vi.advanceTimersByTime( 14 * 60 * 1000 );
+
+		expect( takePendingAuthContext() ).toMatchObject( { source: 'sync_tab' } );
+	} );
+} );

--- a/apps/studio/src/lib/tracks.ts
+++ b/apps/studio/src/lib/tracks.ts
@@ -17,6 +17,9 @@ export {
 	type TracksChannel,
 	type TracksUiVersion,
 	type TracksSiteCreateFlowType,
+	type TracksAuthSource,
+	type TracksAuthAccountType,
+	type TracksAuthFailureReason,
 } from '@studio/common/lib/record-tracks-event';
 
 async function commonProps(): Promise< TracksProps > {

--- a/apps/studio/src/modules/add-site/components/pull-remote-site.tsx
+++ b/apps/studio/src/modules/add-site/components/pull-remote-site.tsx
@@ -72,7 +72,7 @@ function NoAuthPullRemoteSiteView() {
 							if ( isOffline ) {
 								return;
 							}
-							authenticate();
+							authenticate( 'add_site' );
 						} }
 					>
 						<Icon icon={ wordpress } size={ 20 } />
@@ -97,7 +97,7 @@ function NoAuthPullRemoteSiteView() {
 								if ( isOffline ) {
 									return;
 								}
-								getIpcApi().authenticate( true );
+								getIpcApi().authenticate( true, 'add_site' );
 							} }
 						>
 							{ __( 'Create a free account' ) }

--- a/apps/studio/src/modules/onboarding/components/connect-to-wpcom.tsx
+++ b/apps/studio/src/modules/onboarding/components/connect-to-wpcom.tsx
@@ -89,7 +89,7 @@ export function OnboardingConnectToWpcom( {
 								if ( isOffline ) {
 									return;
 								}
-								authenticate();
+								authenticate( 'onboarding' );
 							} }
 						>
 							{ __( 'Log in to WordPress.com' ) }
@@ -120,7 +120,7 @@ export function OnboardingConnectToWpcom( {
 								if ( isOffline ) {
 									return;
 								}
-								getIpcApi().authenticate( true );
+								getIpcApi().authenticate( true, 'onboarding' );
 							} }
 						>
 							{ __( 'Create a free account' ) }

--- a/apps/studio/src/modules/sync/index.tsx
+++ b/apps/studio/src/modules/sync/index.tsx
@@ -84,7 +84,7 @@ function NoAuthSyncTab() {
 							if ( isOffline ) {
 								return;
 							}
-							authenticate();
+							authenticate( 'sync_tab' );
 						} }
 					>
 						{ __( 'Log in to WordPress.com' ) }
@@ -109,7 +109,7 @@ function NoAuthSyncTab() {
 								if ( isOffline ) {
 									return;
 								}
-								getIpcApi().authenticate( true );
+								getIpcApi().authenticate( true, 'sync_tab' );
 							} }
 						>
 							{ __( 'Create a free account' ) }

--- a/apps/studio/src/modules/user-settings/components/non-authenticated-account-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/non-authenticated-account-tab.tsx
@@ -25,7 +25,7 @@ export const NonAuthenticatedAccountTab = () => {
 							if ( isOffline ) {
 								return;
 							}
-							authenticate();
+							authenticate( 'settings' );
 						} }
 					>
 						{ __( 'Log in' ) }

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -51,7 +51,7 @@ const api: IpcApi = {
 	disconnectWpcomSites: ( ...args ) => ipcRendererInvoke( 'disconnectWpcomSites', ...args ),
 	updateConnectedWpcomSites: ( ...args ) =>
 		ipcRendererInvoke( 'updateConnectedWpcomSites', ...args ),
-	authenticate: ( isSignup ) => ipcRendererSend( 'authenticate', isSignup ),
+	authenticate: ( isSignup, source ) => ipcRendererSend( 'authenticate', isSignup, source ),
 	exportSite: ( site, destinationPath, options ) =>
 		ipcRendererInvoke( 'exportSite', site, destinationPath, options ),
 	isAuthenticated: () => ipcRendererInvoke( 'isAuthenticated' ),

--- a/apps/studio/src/tests/onboarding-tracks.test.ts
+++ b/apps/studio/src/tests/onboarding-tracks.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment node
+ */
+import { IpcMainInvokeEvent } from 'electron';
+import { beforeEach, vi } from 'vitest';
+import { saveOnboarding } from 'src/ipc-handlers';
+import * as oauthClient from 'src/lib/oauth';
+import { recordTracksEvent, TRACKS_EVENTS } from 'src/lib/tracks';
+import { loadUserData } from 'src/storage/user-data';
+
+vi.mock( 'src/lib/tracks', async ( importActual ) => {
+	const actual = await importActual< typeof import('src/lib/tracks') >();
+	return { ...actual, recordTracksEvent: vi.fn() };
+} );
+vi.mock( 'src/lib/oauth', () => ( { isAuthenticated: vi.fn() } ) );
+vi.mock( 'src/storage/user-data', async ( importActual ) => {
+	const actual = await importActual< typeof import('src/storage/user-data') >();
+	return { ...actual, loadUserData: vi.fn(), updateAppdata: vi.fn() };
+} );
+
+const event = {} as IpcMainInvokeEvent;
+
+function mockPreviouslyCompleted( onboardingCompleted: boolean ) {
+	vi.mocked( loadUserData ).mockResolvedValue( { onboardingCompleted } as never );
+}
+
+function onboardingEvents() {
+	return vi
+		.mocked( recordTracksEvent )
+		.mock.calls.filter( ( [ name ] ) => name === TRACKS_EVENTS.ONBOARDING_COMPLETE );
+}
+
+describe( 'saveOnboarding Tracks event', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.mocked( oauthClient.isAuthenticated ).mockResolvedValue( false );
+	} );
+
+	it( 'records the completion when onboarding is finished for the first time', async () => {
+		mockPreviouslyCompleted( false );
+		vi.mocked( oauthClient.isAuthenticated ).mockResolvedValue( true );
+
+		await saveOnboarding( event, true );
+
+		expect( onboardingEvents() ).toEqual( [
+			[ TRACKS_EVENTS.ONBOARDING_COMPLETE, { authenticated: true } ],
+		] );
+	} );
+
+	// Skipping is just finishing without an account — that is what `authenticated: false` records.
+	it( 'reports an unauthenticated completion when the user skipped signing in', async () => {
+		mockPreviouslyCompleted( false );
+
+		await saveOnboarding( event, true );
+
+		expect( onboardingEvents() ).toEqual( [
+			[ TRACKS_EVENTS.ONBOARDING_COMPLETE, { authenticated: false } ],
+		] );
+	} );
+
+	// Otherwise a re-save would look like another user finishing onboarding.
+	it( 'does not record a second time when onboarding was already complete', async () => {
+		mockPreviouslyCompleted( true );
+
+		await saveOnboarding( event, true );
+
+		expect( onboardingEvents() ).toEqual( [] );
+	} );
+
+	it( 'does not record when onboarding is reset', async () => {
+		mockPreviouslyCompleted( true );
+
+		await saveOnboarding( event, false );
+
+		expect( onboardingEvents() ).toEqual( [] );
+	} );
+} );

--- a/apps/ui/src/components/agentic-signin-banner/index.tsx
+++ b/apps/ui/src/components/agentic-signin-banner/index.tsx
@@ -6,6 +6,7 @@ import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
 import { useLogin } from '@/data/queries/use-auth-user';
 import styles from './style.module.css';
 import type { AgenticFeatureReason } from '@/data/queries/use-agentic-features';
+import type { TracksAuthSource } from '@studio/common/lib/record-tracks-event';
 
 export function AgenticSigninBanner() {
 	const { enabled, reason } = useAgenticFeatures();
@@ -27,13 +28,14 @@ export function AgenticSigninBanner() {
 		return null;
 	}
 
-	return <SigninNotice />;
+	return <SigninNotice source="overview_tab" />;
 }
 
 // The banner without the route-aware behaviour, for surfaces that must stay
-// put once the user signs in (e.g. Settings).
-export function SigninNotice() {
-	const login = useLogin();
+// put once the user signs in (e.g. Settings). `source` is a prop rather than a
+// constant because this renders on more than one surface.
+export function SigninNotice( { source }: { source: TracksAuthSource } ) {
+	const login = useLogin( { source } );
 
 	return (
 		<section className={ styles.root } aria-label={ __( 'Sign in to Studio' ) }>

--- a/apps/ui/src/components/auth-actions/index.tsx
+++ b/apps/ui/src/components/auth-actions/index.tsx
@@ -4,17 +4,19 @@ import { clsx } from 'clsx';
 import { useLogin } from '@/data/queries/use-auth-user';
 import { useOffline } from '@/hooks/use-offline';
 import styles from './style.module.css';
+import type { TracksAuthSource } from '@studio/common/lib/record-tracks-event';
 
 interface AuthActionsProps {
 	className?: string;
+	source: TracksAuthSource;
 }
 
 // Shared by the welcome, tour and connect screens so the sign-in prompts
 // can't drift apart.
-export function AuthActions( { className }: AuthActionsProps ) {
+export function AuthActions( { className, source }: AuthActionsProps ) {
 	const isOffline = useOffline();
-	const login = useLogin();
-	const signup = useLogin( { signup: true } );
+	const login = useLogin( { source } );
+	const signup = useLogin( { signup: true, source } );
 	const authError = login.error ?? signup.error;
 	const offlineMessage = __( "You're currently offline." );
 	const arrow = (

--- a/apps/ui/src/components/settings-view/account-section.tsx
+++ b/apps/ui/src/components/settings-view/account-section.tsx
@@ -62,7 +62,7 @@ function AccountHelpActions() {
 
 export function AccountSection() {
 	const { data: user, isLoading } = useAuthUser();
-	const login = useLogin();
+	const login = useLogin( { source: 'settings' } );
 	const logout = useLogout();
 	const themeIsDark = useColorScheme() === 'dark';
 	const isOffline = useOffline();

--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -213,7 +213,7 @@ export function UsagePanel() {
 	return (
 		<div className={ styles.usagePanel }>
 			{ reason === 'offline' ? <OfflineNotice /> : null }
-			{ reason === 'signed-out' ? <SigninNotice /> : null }
+			{ reason === 'signed-out' ? <SigninNotice source="settings" /> : null }
 			<section
 				className={ clsx( styles.settingsPanelSection, unavailable && styles.usageDisabled ) }
 			>

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -121,7 +121,7 @@ export function MainView( {
 	const connector = useConnector();
 	const { enabled: agenticEnabled, reason: agenticReason } = useAgenticFeatures();
 	const isOffline = agenticReason === 'offline';
-	const login = useLogin();
+	const login = useLogin( { source: 'site_header' } );
 	const { data: snapshots } = useSnapshots();
 	const { data: connectedSites } = useConnectedWpcomSites( site.id );
 

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -39,6 +39,7 @@ import type { AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { StoredAuthToken } from '@studio/common/lib/auth-token-schema';
 import type { SiteEvent } from '@studio/common/lib/cli-events';
 import type { ImportEventTuple } from '@studio/common/lib/import-export-events';
+import type { TracksAuthSource } from '@studio/common/lib/record-tracks-event';
 import type { RawDirectoryEntry } from '@studio/common/types/sync-tree';
 import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
 
@@ -241,8 +242,8 @@ export function createIpcConnector(): Connector {
 			};
 		},
 
-		async authenticate( signup = false ): Promise< void > {
-			await ipcApi.authenticate( signup );
+		async authenticate( signup = false, source: TracksAuthSource = 'unknown' ): Promise< void > {
+			await ipcApi.authenticate( signup, source );
 		},
 
 		async logout(): Promise< void > {

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -7,6 +7,7 @@ import type { SiteEvent } from '@studio/common/lib/cli-events';
 import type { ImportEventTuple } from '@studio/common/lib/import-export-events';
 import type { SupportedLocale } from '@studio/common/lib/locale';
 import type {
+	TracksAuthSource,
 	TracksEventName,
 	TracksProps,
 	TracksSiteCreateFlowType,
@@ -180,7 +181,9 @@ export interface Connector {
 	agenticRequiresAuth: boolean;
 	isAuthenticated(): Promise< boolean >;
 	getAuthUser(): Promise< AuthUser | null >;
-	authenticate( signup?: boolean ): Promise< void >;
+	// `source` records the affordance the login started from, for `studio_wpcom_auth`. Only the IPC
+	// connector can report it — the browser connectors have no Main process to record through.
+	authenticate( signup?: boolean, source?: TracksAuthSource ): Promise< void >;
 	logout(): Promise< void >;
 	onAuthStateChanged?( listener: () => void ): () => void;
 

--- a/apps/ui/src/data/queries/use-auth-user.ts
+++ b/apps/ui/src/data/queries/use-auth-user.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useConnector } from '@/data/core';
+import type { TracksAuthSource } from '@studio/common/lib/record-tracks-event';
 
 export const AUTH_USER_QUERY_KEY = [ 'auth-user' ] as const;
 
@@ -20,11 +21,19 @@ export function useAuthUser() {
 	} );
 }
 
-export function useLogin( { signup = false }: { signup?: boolean } = {} ) {
+// `source` is required so every login affordance names itself for `studio_wpcom_auth` — a missed one is
+// a type error rather than a silent `unknown` in the data.
+export function useLogin( {
+	signup = false,
+	source,
+}: {
+	signup?: boolean;
+	source: TracksAuthSource;
+} ) {
 	const connector = useConnector();
 	const queryClient = useQueryClient();
 	return useMutation( {
-		mutationFn: () => connector.authenticate( signup ),
+		mutationFn: () => connector.authenticate( signup, source ),
 		onSuccess: () => queryClient.invalidateQueries( { queryKey: AUTH_USER_QUERY_KEY } ),
 	} );
 }

--- a/apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx
@@ -161,7 +161,7 @@ function SignedOutView() {
 					<span>{ __( 'Supports staging and production sites.' ) }</span>
 				</li>
 			</ul>
-			<AuthActions className={ styles.authActions } />
+			<AuthActions className={ styles.authActions } source="onboarding" />
 		</div>
 	);
 }

--- a/apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx
@@ -161,7 +161,9 @@ function SignedOutView() {
 					<span>{ __( 'Supports staging and production sites.' ) }</span>
 				</li>
 			</ul>
-			<AuthActions className={ styles.authActions } source="onboarding" />
+			{ /* Despite the `/onboarding/connect` path, this is the add-site flow's
+			     "connect a site" step, not first-run onboarding. */ }
+			<AuthActions className={ styles.authActions } source="add_site" />
 		</div>
 	);
 }

--- a/apps/ui/src/ui-classic/router/route-onboarding-tour/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-onboarding-tour/index.tsx
@@ -109,7 +109,7 @@ export function OnboardingTourPage() {
 					<p className={ styles.tourAuthText }>
 						{ __( 'AI features require a free WordPress.com account.' ) }
 					</p>
-					<AuthActions />
+					<AuthActions source="onboarding" />
 				</div>
 			) }
 			<OnboardingFooter>

--- a/apps/ui/src/ui-classic/router/route-welcome/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-welcome/index.tsx
@@ -172,7 +172,7 @@ export function WelcomePage() {
 							</Button>
 						</>
 					) : (
-						<AuthActions />
+						<AuthActions source="onboarding" />
 					) }
 				</div>
 			</div>

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -409,6 +409,11 @@ when the initiation context can't be carried to the result. The two Settings sur
 (Account and Usage) both report `settings`, and the site dropdown reports `site_header` for both its
 Preview and Live prompts.
 
+`onboarding` means **first-run** onboarding only — the agentic UI's welcome and tour. Its add-site flow
+also lives under an `/onboarding/*` route namespace (`/onboarding/connect` and friends), but a login
+started there is `add_site`, matching Studio Classic's add-site prompt. Watch for this when adding a
+`source`: the route path is not the surface.
+
 **CLI semantics differ.** `channel=studio-cli` rows never carry `account_type` (the CLI has no signup
 path) and can't produce `failure_reason=access_denied` (there is no in-app deny step — the user pastes a
 token). Account for this before aggregating across channels. The CLI's "already authenticated" early

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -148,6 +148,28 @@ where the sender actually runs — see Testing below for what fires in which bui
   via `createOrReuseAiSession` rather than by forking the CLI, so it fires from desktop Main
   (`createAiSession`). `createOrReuseAiSession` reuses an existing empty draft instead of piling up
   orphans, and returns a `created` flag so a reuse isn't counted as a creation.
+- **`studio_onboarding_complete`** fires from desktop Main (`saveOnboarding`), the single funnel both
+  front-ends reach — Studio Classic when the user skips or logs in, the agentic UI when the welcome tour
+  ends (`connector.setOnboardingCompleted`). It is emitted only on a genuine `false → true` transition, so
+  a re-save can't look like a second user finishing. Its `authenticated` prop is resolved in Main from the
+  stored token, which is what makes it the funnel's denominator (see the caveat below).
+- **`studio_wpcom_auth`** fires from desktop Main's **auth deep-link handler** — the one place every
+  desktop login outcome lands, from either renderer — and separately from the **CLI** `auth login`.
+  `source` and `account_type` are known only when auth *starts* (which affordance was clicked, and whether
+  we opened the login or the signup URL), but the outcome arrives later in a deep link carrying only a
+  token. `apps/studio/src/lib/auth-tracks-context.ts` bridges the two with a Main-process pending context,
+  consumed once by the deep-link handler and expiring after 15 minutes. When that link can't be made — the
+  app restarted mid-flow, a cold-start deep link, an expired context, or a second deep link after one
+  initiation — the event still fires, reporting `source: unknown` rather than guessing. Concurrent
+  attempts are last-write-wins: the tab a user finishes is almost always the last one they opened.
+  Both emitters record **after** the token is written, because the wrappers derive `is_a11n` from it.
+- **⚠️ `studio_wpcom_auth` counts outcomes that reached the app, not attempts.** If the user closes the
+  browser tab, or the WordPress.com page errors before redirecting, no deep link fires and **no event is
+  recorded at all**. So `success=false` captures only failures that made it back (a denied authorization,
+  a broken token exchange) — never silent abandonment. Computing conversion as
+  `success / (success + failure)` therefore reads optimistically high. For the onboarding funnel, use
+  `studio_onboarding_complete`'s `authenticated` prop as the denominator instead: it is the only signal
+  that counts users who walked away.
 - **`studio ui`** (the browser UI served by `apps/local`) has no Tracks wrapper of its own, so it
   records nothing itself: only the chat events reach Tracks, via the CLI fork, and they land in
   `channel=studio-cli` — that bucket therefore mixes standalone-CLI and browser usage. Everything
@@ -182,6 +204,12 @@ CLI wrapper resolves `channel`/`ui_version` from `STUDIO_TRACKS_ORIGIN`.
 `surface` (in-app area, e.g. `onboarding`/`settings`) is live on `studio_setting_telemetry_change`; the renderer
 supplies it per change (Main can't infer it) and it is meant to generalize to other settings-change
 events. Reserved for later phases (documented so future events conform): `outcome` (`success`/`error`).
+
+`source` plays the same role for `studio_wpcom_auth` — which login affordance the attempt started from —
+with a wider value set than `surface`, since logins are offered from far more places than settings
+changes. Like `surface`, the renderer supplies it (Main can't infer it) and it is threaded from the
+initiating call. `account_type` (`new`/`existing`) and `authenticated` (boolean) are Studio-custom props
+introduced with those events; register them alongside the events.
 
 **AI / assistant events.** Studio Code assistant events use the data team's AI-event vocabulary so
 they aggregate with other Automattic AI products. The shared identity props are built once by
@@ -352,6 +380,39 @@ orphans, so opening a new chat and leaving it empty emits nothing — however ma
 repeated. A session is only created once the previous one has a prompt in it. That makes the event a
 sound denominator for messages-per-session, but it will read lower than any UI-level count of the new
 chat affordance.
+
+#### Onboarding & authentication events
+
+First-run onboarding and WordPress.com login. `studio_onboarding_complete` and the desktop half of
+`studio_wpcom_auth` are emitted from **desktop Main** (the `saveOnboarding` handler and the auth deep-link
+handler respectively — each the single funnel both front-ends converge on); the CLI emits
+`studio_wpcom_auth` for its own `auth login` flow. No email addresses, user ids, tokens, or raw error text
+are ever sent.
+
+| Event | Emitted from | Event-specific props |
+|---|---|---|
+| `studio_onboarding_complete` | Desktop Main (`saveOnboarding`) | `authenticated` (boolean — whether the user holds a WordPress.com token at the moment onboarding completes). Emitted once, only on a genuine `false → true` transition. |
+| `studio_wpcom_auth` | Desktop Main (auth deep-link handler) + CLI `auth login` | `success` (boolean), `source` (`onboarding`/`sync_tab`/`previews_tab`/`assistant_tab`/`overview_tab`/`settings`/`top_bar`/`site_header`/`add_site`/`cli`/`unknown`), `account_type` (`new`/`existing`). On failure also `failure_reason` (`access_denied`/`token_error`/`profile_fetch_failed`/`unknown`). |
+
+**Reading these events.** Onboarding conversion is `AVG(authenticated)` over
+`studio_onboarding_complete` — a single event, no join and no dedupe needed, and it counts users who
+arrive already signed in (Classic completes onboarding for them automatically). Drop-off decomposes by
+joining the two events on the install id: a completion with `authenticated=false` and **no**
+`studio_wpcom_auth` row means the user never tried (a messaging problem), while one with a
+`success=false` row means they tried and it broke (an auth-flow problem). Per-attempt conversion is
+`studio_wpcom_auth WHERE source='onboarding'` — but read the abandonment caveat under "Which surface
+emits what" before treating it as a rate.
+
+**Reading `source`.** It records the affordance the login started from, not the app: `ui_version` already
+separates Classic from the agentic UI. `unknown` is structural, not an error — see the caveat above for
+when the initiation context can't be carried to the result. The two Settings surfaces in the agentic UI
+(Account and Usage) both report `settings`, and the site dropdown reports `site_header` for both its
+Preview and Live prompts.
+
+**CLI semantics differ.** `channel=studio-cli` rows never carry `account_type` (the CLI has no signup
+path) and can't produce `failure_reason=access_denied` (there is no in-app deny step — the user pastes a
+token). Account for this before aggregating across channels. The CLI's "already authenticated" early
+return emits nothing, since no authentication took place.
 
 ### How to add a new event
 

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -419,6 +419,11 @@ path) and can't produce `failure_reason=access_denied` (there is no in-app deny 
 token). Account for this before aggregating across channels. The CLI's "already authenticated" early
 return emits nothing, since no authentication took place.
 
+Each `failure_reason` does mean the same thing in both channels, so the values themselves aggregate
+cleanly: `profile_fetch_failed` is always the `/me` lookup (the request or its schema), and `unknown` is
+always a failure neither emitter anticipated — in practice the config write. Only the availability of a
+reason differs, per above.
+
 ### How to add a new event
 
 1. Add the event name to `TRACKS_EVENTS` in `packages/common/lib/record-tracks-event.ts`.

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -42,6 +42,8 @@ export const TRACKS_EVENTS = {
 	CODE_MESSAGE_SENT: 'studio_code_message_sent',
 	CODE_TURN_COMPLETED: 'studio_code_turn_completed',
 	CODE_SESSION_CREATED: 'studio_code_session_created',
+	ONBOARDING_COMPLETE: 'studio_onboarding_complete',
+	WPCOM_AUTH: 'studio_wpcom_auth',
 } as const;
 
 export type TracksEventName = ( typeof TRACKS_EVENTS )[ keyof typeof TRACKS_EVENTS ];
@@ -116,6 +118,36 @@ export type TracksPanel =
 	| 'sync'
 	| 'import-export'
 	| 'previews';
+
+// Where a WordPress.com login was started from, sent as `source` on `studio_wpcom_auth`. The value is
+// captured at initiation (the renderer affordance the user clicked) and carried to the deep-link result;
+// `unknown` covers the cases where that link is broken — an app restart mid-flow, a cold-start deep link,
+// or a context that outlived its TTL. `cli` is the standalone `studio auth login` flow.
+export type TracksAuthSource =
+	| 'onboarding'
+	| 'sync_tab'
+	| 'previews_tab'
+	| 'assistant_tab'
+	| 'overview_tab'
+	| 'settings'
+	| 'top_bar'
+	| 'site_header'
+	| 'add_site'
+	| 'cli'
+	| 'unknown';
+
+// Whether the user signed up or logged in with an existing account. Known only at initiation (the
+// desktop opens a different URL for each); absent on CLI events, which have no signup path.
+export type TracksAuthAccountType = 'new' | 'existing';
+
+// Coarse, low-cardinality auth failure classification. The raw error is never sent — it can embed the
+// OAuth URL and the user's email. `access_denied` is the user declining on WordPress.com; the other two
+// are the token-exchange and profile-fetch steps failing.
+export type TracksAuthFailureReason =
+	| 'access_denied'
+	| 'token_error'
+	| 'profile_fetch_failed'
+	| 'unknown';
 
 // Builds the Tracks pixel URL. Isolated so a param-name correction is a one-file change. These are
 // the reserved Tracks pixel params: `_en` event name, `_ut`/`_ui` identity, `_ts` timestamp (ms).

--- a/packages/common/lib/tests/record-tracks-event.test.ts
+++ b/packages/common/lib/tests/record-tracks-event.test.ts
@@ -17,6 +17,8 @@ describe( 'isTracksEventName', () => {
 		expect( isTracksEventName( TRACKS_EVENTS.CODE_TURN_COMPLETED ) ).toBe( true );
 		expect( isTracksEventName( TRACKS_EVENTS.CODE_SESSION_CREATED ) ).toBe( true );
 		expect( isTracksEventName( TRACKS_EVENTS.SETTING_INSTRUCTIONS_CHANGE ) ).toBe( true );
+		expect( isTracksEventName( TRACKS_EVENTS.ONBOARDING_COMPLETE ) ).toBe( true );
+		expect( isTracksEventName( TRACKS_EVENTS.WPCOM_AUTH ) ).toBe( true );
 	} );
 
 	it( 'rejects unknown or non-string values', () => {


### PR DESCRIPTION
## Related issues

- Fixes [STU-2114](https://linear.app/a8c/issue/STU-2114/tracks-onboarding-and-authentication-events)

## How AI was used in this PR

I used Claude Code to explore the onboarding and auth flows, drafted the plan, and iteratively wrote the implementation and tests. I reviewed the emission points, and the privacy boundaries.

## Proposed Changes

Onboarding and WordPress.com login had no Tracks coverage at all, which made the onboarding funnel our biggest blind spot: we could not say how many new users finish onboarding, how many leave with an account connected, where people log in from, or how often auth fails.

This adds two events:

| Event | Answers |
| -- | -- |
| `studio_onboarding_complete` | Completion volume, and whether the user finished with an account (`authenticated`) |
| `studio_wpcom_auth` | Login outcomes by entry point (`source`), new vs existing account, and why auth failed |

I decided to merge `studio_onboarding_wpcom_auth` and `studio_wpcom_auth` events as they would be almost duplicates.

Two smaller changes to scope from Linear issue: `success` + `failure_reason` instead of `result`, to match every other outcome event in the catalog (`studio_site_start`, `studio_site_imported`, …); and `source` gained four values for entry points the issue's list missed (`overview_tab`, `site_header`, `add_site`, `cli`) plus `unknown`.

### Implementation notes for reviewers

- `source`/`account_type` are known only when auth *starts*, but the outcome arrives later in a deep link carrying only a token. A Main-process pending context (`apps/studio/src/lib/auth-tracks-context.ts`) bridges the two — consumed once, 15-minute TTL, last-write-wins on concurrent attempts. When the link can't be made (restart mid-flow, cold-start deep link, expiry) the event still fires with `source: unknown` rather than guessing.
- Both emitters record **after** the token is written, because the wrappers derive `is_a11n` from it. Recording earlier would tag every Automattician's login as `false`. There are tests pinning this ordering.
- `source` is a **required** parameter on `useAuth().authenticate` / `useLogin` / `AuthActions`, so a missed call site is a compile error rather than silent `unknown` data. This is what confirmed all 13 sites were covered.
- No emails, user ids, tokens, or raw error text are ever sent.

## Testing Instructions

Events are logged to console instead of sending in dev mode.

**CLI**:

1. Build the CLI: `npm run cli:build`
2. Then, against a throwaway HOME so your real token is untouched:

```bash
TMPHOME=$(mktemp -d)
HOME="$TMPHOME" STUDIO_FORCE_CLI_TELEMETRY=1 NODE_ENV=development node apps/cli/dist/cli/main.mjs auth login
```

3. Test the flow providing the bad token.
4. Then try again with correct token.
5. Confirm `Would have recorded Tracks event: studio_wpcom_auth` was logged to console.
6. When done, remove the temp directory:

```
rm -rf "$TMPHOME"
```

**Desktop** 

1. Start the app against throwaway home: (`TMPHOME=$(mktemp -d); DEV_CONFIG_DIR="$TMPHOME" npm start`, watch the **Main-process terminal**):
2. With no sites and onboarding not yet completed, press **Skip** → `studio_onboarding_complete` with `authenticated: false`. To test the other case, stop the app, remove home, and create a new one
4. Log in from the Classic UI's top bar → `studio_wpcom_auth` with `success: true`, `source: top_bar`, `account_type: existing`.
7. Deny authorization on WordPress.com → `success: false`, `failure_reason: access_denied`, with the same `source`/`account_type`.
8. Spot-check other entry points report their own `source`: Sync tab (`sync_tab`), Previews (`previews_tab`), Settings → Account (`settings`), the agentic Overview sign-in box (`overview_tab`), and the agentic UI's top-bar site dropdown (`site_header`).
9. **Add site → Connect a site**, signed out → `add_site`.
10. "Create a free account" anywhere → `account_type: new`.
11. When done, remove the temp directory:

```
rm -rf "$TMPHOME"
```

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
