### PR TITLE
Tracks: log browser UI events on their own studio-web channel (STU-2247)

### DIFF
--- a/apps/cli/commands/ui.ts
+++ b/apps/cli/commands/ui.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { __ } from '@wordpress/i18n';
 import { openBrowser } from 'cli/lib/browser';
-import { getTracksOrigin, recordTracksEvent } from 'cli/lib/tracks';
+import { getTracksOrigin, recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { StudioArgv } from 'cli/types';
 
 export const registerCommand = ( yargs: StudioArgv ) => {
@@ -59,6 +59,14 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				recordTracksEvent: ( event, props ) =>
 					recordTracksEvent( event, { ...getTracksOrigin(), ...props } ),
 			} );
+
+			// The browser UI's equivalent of the desktop's `appBoot` launch event. No
+			// `is_first_launch`: the marker the desktop reads lives in its own `app.json`,
+			// and the install id is shared, so neither can tell a first browser launch
+			// from a first desktop one.
+			void recordTracksEvent( TRACKS_EVENTS.APP_LAUNCH, { ...getTracksOrigin() } ).catch(
+				() => undefined
+			);
 
 			console.log( '' );
 			console.log( __( 'WordPress Studio is running at:' ) );

--- a/apps/cli/commands/ui.ts
+++ b/apps/cli/commands/ui.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { __ } from '@wordpress/i18n';
 import { openBrowser } from 'cli/lib/browser';
+import { getTracksOrigin, recordTracksEvent } from 'cli/lib/tracks';
 import { StudioArgv } from 'cli/types';
 
 export const registerCommand = ( yargs: StudioArgv ) => {
@@ -36,6 +37,10 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 			// `STUDIO_CLI_BIN` overrides it for development.
 			const cliBinary = process.env.STUDIO_CLI_BIN ?? process.argv[ 1 ];
 
+			// Everything forked from here inherits this, so browser usage isn't counted as
+			// bare CLI. `v2` because the browser serves `apps/ui`.
+			process.env.STUDIO_TRACKS_ORIGIN = 'studio-web:v2';
+
 			// The built browser UI (apps/ui `dist-local`) is copied next to the CLI
 			// bundle at build time. In dev it may be absent — the server then
 			// serves the API only and the UI is run via
@@ -50,6 +55,9 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				sitesRoot: STUDIO_SITES_ROOT,
 				port: argv.port as number | undefined,
 				uiDist,
+				// The CLI wrapper owns the opt-out and the common props.
+				recordTracksEvent: ( event, props ) =>
+					recordTracksEvent( event, { ...getTracksOrigin(), ...props } ),
 			} );
 
 			console.log( '' );

--- a/apps/cli/lib/tests/tracks.test.ts
+++ b/apps/cli/lib/tests/tracks.test.ts
@@ -57,6 +57,31 @@ describe( 'getTracksOrigin', () => {
 		process.env.STUDIO_TRACKS_ORIGIN = 'studio-ui:v2';
 		expect( getTracksOrigin() ).toEqual( { channel: 'studio-ui', ui_version: 'v2' } );
 	} );
+
+	it( 'resolves studio-web:v2, the value `studio ui` sets', () => {
+		process.env.STUDIO_TRACKS_ORIGIN = 'studio-web:v2';
+		expect( getTracksOrigin() ).toEqual( { channel: 'studio-web', ui_version: 'v2' } );
+	} );
+
+	it( 'resolves studio-web:v1', () => {
+		process.env.STUDIO_TRACKS_ORIGIN = 'studio-web:v1';
+		expect( getTracksOrigin() ).toEqual( { channel: 'studio-web', ui_version: 'v1' } );
+	} );
+
+	it( 'defaults the ui_version to v1 when the origin carries no version', () => {
+		process.env.STUDIO_TRACKS_ORIGIN = 'studio-web';
+		expect( getTracksOrigin() ).toEqual( { channel: 'studio-web', ui_version: 'v1' } );
+	} );
+
+	it( 'falls back to studio-cli for an unknown channel', () => {
+		process.env.STUDIO_TRACKS_ORIGIN = 'studio-desktop:v2';
+		expect( getTracksOrigin() ).toEqual( { channel: 'studio-cli' } );
+	} );
+
+	it( 'never reports a ui_version for studio-cli', () => {
+		process.env.STUDIO_TRACKS_ORIGIN = 'studio-cli:v2';
+		expect( getTracksOrigin() ).toEqual( { channel: 'studio-cli' } );
+	} );
 } );
 
 describe( 'recordTracksEvent', () => {

--- a/apps/cli/lib/tracks.ts
+++ b/apps/cli/lib/tracks.ts
@@ -1,5 +1,6 @@
 import {
 	__recordTracksEvent,
+	isTracksChannel,
 	type TracksChannel,
 	type TracksEventName,
 	type TracksProps,
@@ -23,19 +24,15 @@ export interface TracksOrigin {
 	ui_version?: TracksUiVersion;
 }
 
-// Resolves the event origin from `STUDIO_TRACKS_ORIGIN`, set by the desktop app when it spawns the CLI
-// (e.g. `studio-ui:v1`, `studio-ui:v2`). Absent for a standalone CLI invocation, which is
-// `studio-cli`. See `docs/design-docs/analytics-tracks.md`.
+// Resolves the origin from `STUDIO_TRACKS_ORIGIN`, a `<channel>:<ui_version>` string set by the host
+// that spawned the CLI (e.g. `studio-ui:v2`, `studio-web:v2`). Absent or unrecognized means a
+// standalone invocation. See `docs/design-docs/analytics-tracks.md`.
 export function getTracksOrigin(): TracksOrigin {
-	const raw = process.env.STUDIO_TRACKS_ORIGIN;
-	if ( raw?.startsWith( 'studio-ui' ) ) {
-		const [ , version ] = raw.split( ':' );
-		return {
-			channel: 'studio-ui',
-			ui_version: version === 'v2' ? 'v2' : 'v1',
-		};
+	const [ channel, version ] = ( process.env.STUDIO_TRACKS_ORIGIN ?? '' ).split( ':' );
+	if ( ! isTracksChannel( channel ) || channel === 'studio-cli' ) {
+		return { channel: 'studio-cli' };
 	}
-	return { channel: 'studio-cli' };
+	return { channel, ui_version: version === 'v2' ? 'v2' : 'v1' };
 }
 
 async function commonProps(): Promise< TracksProps > {

--- a/apps/local/package.json
+++ b/apps/local/package.json
@@ -17,6 +17,7 @@
 	},
 	"scripts": {
 		"lint": "eslint .",
+		"test": "vitest run",
 		"typecheck": "tsc -p tsconfig.json --noEmit"
 	},
 	"dependencies": {

--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -32,6 +32,7 @@ import {
 	setAiProvider,
 } from '@studio/common/ai/settings-store';
 import { expandSkillCommandPrompt } from '@studio/common/ai/slash-commands';
+import { getAiTracksIdentity } from '@studio/common/ai/tracks-identity';
 import { DEFAULT_TOKEN_LIFETIME_MS } from '@studio/common/constants';
 import { createCliRunner } from '@studio/common/lib/cli-process';
 import {
@@ -53,6 +54,11 @@ import { importIpcEventSchema } from '@studio/common/lib/import-export-events';
 import { isErrnoException } from '@studio/common/lib/is-errno-exception';
 import { getAuthenticationUrl, getSignUpUrl } from '@studio/common/lib/oauth';
 import { decodePassword } from '@studio/common/lib/passwords';
+import {
+	getInstructionsLengthBucket,
+	isTracksEventName,
+	TRACKS_EVENTS,
+} from '@studio/common/lib/record-tracks-event';
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
 import {
 	deleteSharedSession,
@@ -82,7 +88,9 @@ import express from 'express';
 import { rateLimit } from 'express-rate-limit';
 import { z } from 'zod';
 import { isEditor, isTerminal, openInEditor, openInTerminal, openPath } from './open-in-os';
+import type { AiSettings } from '@studio/common/ai/providers';
 import type { SiteListItem } from '@studio/common/lib/cli-events';
+import type { TracksEventName, TracksProps } from '@studio/common/lib/record-tracks-event';
 import type { EditSiteOptions } from '@studio/common/sites/edit';
 import type { PullSyncOptions, PushSyncOptions, SyncSite } from '@studio/common/types/sync';
 import type { Request, Response } from 'express';
@@ -119,6 +127,9 @@ export interface LocalServerOptions {
 	// Path to the built browser UI (apps/ui `dist-local`). Served when present
 	// so the server is the only process needed; omitted in dev (Vite serves it).
 	uiDist?: string;
+	// Injected by `studio ui` rather than imported, so this package doesn't depend
+	// on the CLI.
+	recordTracksEvent?: ( event: TracksEventName, props?: TracksProps ) => Promise< void >;
 }
 
 export interface LocalServer {
@@ -196,10 +207,40 @@ function asyncHandler( fn: ( req: Request, res: Response ) => Promise< void > ) 
 	};
 }
 
+// The server owns these; a client that could set them would disguise its origin.
+const CLIENT_RESERVED_TRACKS_PROPS = new Set( [ 'channel', 'ui_version' ] );
+
+// Browser props arrive as untyped JSON, without the structured-clone guarantees
+// IPC gives the desktop. Keep only what Tracks can send.
+function sanitizeTracksProps( value: unknown ): TracksProps {
+	if ( typeof value !== 'object' || value === null ) {
+		return {};
+	}
+	const props: TracksProps = {};
+	for ( const [ key, propValue ] of Object.entries( value ) ) {
+		if ( CLIENT_RESERVED_TRACKS_PROPS.has( key ) ) {
+			continue;
+		}
+		if (
+			typeof propValue === 'string' ||
+			typeof propValue === 'number' ||
+			typeof propValue === 'boolean'
+		) {
+			props[ key ] = propValue;
+		}
+	}
+	return props;
+}
+
 export async function startLocalServer( options: LocalServerOptions ): Promise< LocalServer > {
 	const { cliBinary, nodeBinary, sessionsRoot, sitesRoot, uiDist } = options;
 	const port = options.port ?? Number( process.env.STUDIO_LOCAL_SERVER_PORT ?? DEFAULT_PORT );
 	const host = options.host ?? '127.0.0.1';
+
+	// Analytics must never fail a user action, so every call is fire-and-forget.
+	function trackEvent( event: TracksEventName, props?: TracksProps ): void {
+		void options.recordTracksEvent?.( event, props ).catch( () => undefined );
+	}
 
 	const cliRunner = createCliRunner( { cliBinary, nodeBinary } );
 	const execute = cliRunner.executeCliCommand;
@@ -376,6 +417,23 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 		res.json( { status: 'ok' } );
 	} );
 
+	// --- Analytics — the browser UI's equivalent of the desktop's IPC handler --
+	// Unknown names are dropped, not forwarded, as in `recordAnalyticsEvent`.
+	api.post( '/analytics/event', ( req: Request, res: Response ) => {
+		const eventName = req.body?.eventName;
+		if ( typeof eventName !== 'string' ) {
+			res.status( 400 ).json( { error: 'eventName required' } );
+			return;
+		}
+		if ( ! isTracksEventName( eventName ) ) {
+			console.warn( `Ignoring unknown analytics event name: ${ eventName }` );
+			res.status( 204 ).end();
+			return;
+		}
+		trackEvent( eventName, sanitizeTracksProps( req.body?.props ) );
+		res.status( 204 ).end();
+	} );
+
 	// --- Auth — the WordPress.com user the CLI is already logged in as ---------
 	// Read straight from the shared auth token (`~/.studio/shared.json`); the
 	// stored token carries the user's id/email/displayName, so no API call.
@@ -474,7 +532,6 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 		} )
 	);
 
-	// No `studio_setting_instructions_change` — this server has no Tracks emitter. See STU-2247.
 	api.post(
 		'/agent-instructions',
 		asyncHandler( async ( req: Request, res: Response ) => {
@@ -485,17 +542,43 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 			}
 			await writeGlobalInstructions( content );
 			res.status( 204 ).end();
+
+			// Only a save that ends an edit session counts, not the debounced autosaves.
+			const previousContent = req.body?.editSession?.previousContent;
+			if ( typeof previousContent === 'string' && previousContent !== content ) {
+				trackEvent( TRACKS_EVENTS.SETTING_INSTRUCTIONS_CHANGE, {
+					has_content: content.trim().length > 0,
+					length_bucket: getInstructionsLengthBucket( content ),
+					surface: 'settings',
+				} );
+			}
 		} )
 	);
 
 	// --- AI settings — provider + Anthropic API key in shared.json ------------
-	// No `studio_setting_ai_provider_change` — this server has no Tracks emitter. See STU-2247.
 	api.get(
 		'/ai-settings',
 		asyncHandler( async ( _req: Request, res: Response ) => {
 			res.json( await readAiSettings() );
 		} )
 	);
+
+	// Clearing the key also falls the provider back to WordPress.com, so both writes
+	// report through one event, as on the desktop.
+	function trackAiSettingsChange( previous: AiSettings, next: AiSettings ): void {
+		const unchanged =
+			previous.provider === next.provider &&
+			previous.hasAnthropicApiKey === next.hasAnthropicApiKey &&
+			previous.anthropicApiKeyPreview === next.anthropicApiKeyPreview;
+		if ( unchanged ) {
+			return;
+		}
+		trackEvent( TRACKS_EVENTS.SETTING_AI_PROVIDER_CHANGE, {
+			provider: next.provider,
+			has_anthropic_api_key: next.hasAnthropicApiKey,
+			surface: 'settings',
+		} );
+	}
 
 	// Write-only: responses carry a truncated preview, never the key. A key
 	// Anthropic rejects answers 400 and is not stored.
@@ -507,7 +590,10 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 				res.status( 400 ).json( { error: 'anthropicApiKey must be a string or null' } );
 				return;
 			}
-			res.json( await saveAnthropicApiKey( key ) );
+			const previous = await readAiSettings();
+			const settings = await saveAnthropicApiKey( key );
+			res.json( settings );
+			trackAiSettingsChange( previous, settings );
 		} )
 	);
 
@@ -521,7 +607,10 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 				res.status( 400 ).json( { error: 'provider must be a known AI provider id' } );
 				return;
 			}
-			res.json( await setAiProvider( provider ) );
+			const previous = await readAiSettings();
+			const settings = await setAiProvider( provider );
+			res.json( settings );
+			trackAiSettingsChange( previous, settings );
 		} )
 	);
 
@@ -1393,11 +1482,19 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 					site = { id: found.id, name: found.name, path: found.path };
 				}
 			}
-			// `created` is an analytics signal for the desktop, not part of the session shape.
-			const { created: _created, ...summary } = await createOrReuseAiSession( sessionsRoot, {
+			// `created` is an analytics signal, not part of the session shape.
+			const { created, ...summary } = await createOrReuseAiSession( sessionsRoot, {
 				site,
 			} );
 			res.json( summary );
+
+			// Created in-process here, as in the desktop's Main. Reused drafts don't count.
+			if ( created ) {
+				trackEvent( TRACKS_EVENTS.CODE_SESSION_CREATED, {
+					...getAiTracksIdentity( summary.id ),
+					has_site: Boolean( site ),
+				} );
+			}
 		} )
 	);
 

--- a/apps/local/src/tests/analytics-route.test.ts
+++ b/apps/local/src/tests/analytics-route.test.ts
@@ -1,0 +1,112 @@
+import os from 'node:os';
+import path from 'node:path';
+import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { startLocalServer, type LocalServer } from '../index';
+
+const recordTracksEvent = vi.fn( async () => undefined );
+
+let server: LocalServer;
+
+async function postEvent( body: unknown ): Promise< Response > {
+	return fetch( `${ server.url }/api/analytics/event`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify( body ),
+	} );
+}
+
+beforeEach( async () => {
+	vi.clearAllMocks();
+	server = await startLocalServer( {
+		cliBinary: path.join( os.tmpdir(), 'studio-test-cli.mjs' ),
+		sessionsRoot: path.join( os.tmpdir(), 'studio-test-sessions' ),
+		sitesRoot: path.join( os.tmpdir(), 'studio-test-sites' ),
+		port: 0,
+		recordTracksEvent,
+	} );
+} );
+
+afterEach( async () => {
+	await server.close();
+} );
+
+describe( 'POST /api/analytics/event', () => {
+	it( 'records a known event with its props', async () => {
+		const response = await postEvent( {
+			eventName: TRACKS_EVENTS.SITE_OPEN_PHPMYADMIN,
+			props: { browser: 'external' },
+		} );
+
+		expect( response.status ).toBe( 204 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( TRACKS_EVENTS.SITE_OPEN_PHPMYADMIN, {
+			browser: 'external',
+		} );
+	} );
+
+	it( 'accepts an event with no props', async () => {
+		const response = await postEvent( { eventName: TRACKS_EVENTS.APP_LAUNCH } );
+
+		expect( response.status ).toBe( 204 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( TRACKS_EVENTS.APP_LAUNCH, {} );
+	} );
+
+	it( 'drops an unknown event name instead of forwarding it', async () => {
+		const warn = vi.spyOn( console, 'warn' ).mockImplementation( () => undefined );
+
+		const response = await postEvent( { eventName: 'studio_not_a_real_event' } );
+
+		expect( response.status ).toBe( 204 );
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+		expect( warn ).toHaveBeenCalled();
+		warn.mockRestore();
+	} );
+
+	it( 'rejects a body with no event name', async () => {
+		const response = await postEvent( { props: { browser: 'external' } } );
+
+		expect( response.status ).toBe( 400 );
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'strips client-supplied channel and ui_version', async () => {
+		await postEvent( {
+			eventName: TRACKS_EVENTS.PANEL_OPENED,
+			props: { panel: 'settings', channel: 'studio-ui', ui_version: 'v1' },
+		} );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( TRACKS_EVENTS.PANEL_OPENED, {
+			panel: 'settings',
+		} );
+	} );
+
+	// Tracks coerces every value to a string, so an object would be sent as "[object Object]".
+	it( 'keeps only primitive prop values', async () => {
+		await postEvent( {
+			eventName: TRACKS_EVENTS.PANEL_OPENED,
+			props: {
+				panel: 'settings',
+				count: 2,
+				enabled: true,
+				nested: { a: 1 },
+				list: [ 1, 2 ],
+				missing: null,
+			},
+		} );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( TRACKS_EVENTS.PANEL_OPENED, {
+			panel: 'settings',
+			count: 2,
+			enabled: true,
+		} );
+	} );
+
+	// Telemetry is fire-and-forget: a recorder failure must not surface to the UI.
+	it( 'still answers 204 when recording rejects', async () => {
+		recordTracksEvent.mockRejectedValueOnce( new Error( 'network down' ) );
+
+		const response = await postEvent( { eventName: TRACKS_EVENTS.APP_LAUNCH } );
+
+		expect( response.status ).toBe( 204 );
+	} );
+} );

--- a/apps/local/vitest.config.ts
+++ b/apps/local/vitest.config.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import { defineProject, mergeConfig } from 'vitest/config';
+import sharedConfig from '../../vitest.shared';
+
+export default mergeConfig(
+	sharedConfig,
+	defineProject( {
+		test: {
+			name: 'local',
+			include: [ '**/*.test.{ts,tsx}' ],
+			pool: 'forks',
+		},
+		resolve: {
+			alias: {
+				'@studio/common': path.resolve( __dirname, '../../packages/common' ),
+			},
+		},
+	} )
+);

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -353,7 +353,7 @@ export async function createAiSession(
 	} );
 
 	// Fires from Main, not the CLI: sessions are created in-process. Reused drafts don't count.
-	// Missing for `studio ui`, which has no Tracks emitter — see STU-2247.
+	// `studio ui` emits the same event from its own session route.
 	if ( created ) {
 		await recordTracksEvent( TRACKS_EVENTS.CODE_SESSION_CREATED, {
 			...getAiTracksIdentity( summary.id ),

--- a/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
@@ -8,7 +8,7 @@ import {
 	saveAnthropicApiKey as saveAnthropicApiKeyToConfig,
 	setAiProvider as setAiProviderInConfig,
 } from '@studio/common/ai/settings-store';
-import { type TracksInstructionsLengthBucket } from '@studio/common/lib/record-tracks-event';
+import { getInstructionsLengthBucket } from '@studio/common/lib/record-tracks-event';
 import {
 	isAnalyticsOptedOut,
 	readSharedConfig,
@@ -326,18 +326,6 @@ export async function setAiProvider( _event: IpcMainInvokeEvent, provider: AiPro
 	const settings = await setAiProviderInConfig( provider );
 	await recordAiSettingsChange( previous, settings );
 	return settings;
-}
-
-// Bucketed for `studio_setting_instructions_change`; the text itself is never sent.
-function getInstructionsLengthBucket( content: string ): TracksInstructionsLengthBucket {
-	const length = content.trim().length;
-	if ( length === 0 ) {
-		return 'empty';
-	}
-	if ( length <= 200 ) {
-		return 'short';
-	}
-	return length <= 1000 ? 'medium' : 'long';
 }
 
 export async function saveGlobalAgentInstructions(

--- a/apps/ui/src/components/settings-view/studio-code-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/studio-code-panel.test.tsx
@@ -31,8 +31,7 @@ vi.mock( '@/data/queries/use-agent-instructions', () => ( {
 const useAgentInstructionsMock = vi.mocked( useAgentInstructions );
 const useSaveAgentInstructionsMock = vi.mocked( useSaveAgentInstructions );
 
-// Renderer only. The `apps/local` connector drops `editSession`, so these passing is not evidence the
-// Tracks event fires under `studio ui`. See STU-2247.
+// These assert the panel supplies `editSession`, not that an event was recorded.
 describe( 'StudioCodePanel', () => {
 	const save = vi.fn();
 

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -435,8 +435,8 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 			throw new UnsupportedError( 'openStudioLogs' );
 		},
 
-		// Analytics — no-op here. Tracks currently flows through the desktop IPC connector; the
-		// hosted (browser) target has no Main-process choke point yet. See the design doc.
+		// Deliberately a no-op: the anonymous per-install id `studio ui` records against
+		// doesn't carry over to a multi-user deployment, which needs its own consent model.
 		async trackEvent() {
 			// intentionally empty
 		},

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -829,12 +829,13 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			const { content } = await api< { content: string } >( '/agent-instructions' );
 			return content;
 		},
-		// Drops the panel's `editSession` option: it only drives a Tracks event, and this server has
-		// no emitter. Instructions still save. See STU-2247.
-		async saveAgentInstructions( content: string ): Promise< void > {
+		async saveAgentInstructions(
+			content: string,
+			options: { editSession?: { previousContent: string } } = {}
+		): Promise< void > {
 			await api< void >( '/agent-instructions', {
 				method: 'POST',
-				body: JSON.stringify( { content } ),
+				body: JSON.stringify( { content, editSession: options.editSession } ),
 			} );
 		},
 
@@ -891,10 +892,13 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			throw new UnsupportedError( 'openStudioLogs' );
 		},
 
-		// Analytics — no-op here. Tracks currently flows through the desktop IPC connector; the
-		// local (browser) target has no Main-process choke point yet. See the design doc.
-		async trackEvent() {
-			// intentionally empty
+		// The server attaches the origin and common props. Callers fire and forget, so a
+		// failure here must not become an unhandled rejection.
+		async trackEvent( eventName, props = {} ) {
+			await api< void >( '/analytics/event', {
+				method: 'POST',
+				body: JSON.stringify( { eventName, props } ),
+			} ).catch( () => undefined );
 		},
 
 		// External links work natively in the browser.

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -103,7 +103,10 @@ where the sender actually runs — see Testing below for what fires in which bui
 ### Which surface emits what
 
 - **`studio_app_launch`** fires once per launch from the desktop Main process (`apps/studio/src/index.ts`
-  `appBoot`), in parallel with the MC Stats launch bumps.
+  `appBoot`), in parallel with the MC Stats launch bumps, and once per `studio ui` server start
+  (`apps/cli/commands/ui.ts`). Only the desktop sends `is_first_launch`: the marker it derives that from
+  lives in its own `app.json`, and the install id is shared with the CLI, so neither can tell a first
+  browser launch from a first desktop one.
 - **`studio_site_start`** is emitted **only** by the CLI, from the `recordSiteRuntimeUsage()` funnel in
   `apps/cli/lib/wordpress-server-manager.ts` — the single point every site start passes through. Every
   desktop site start delegates to the app-spawned CLI, so the CLI is the sole emitter and a start is
@@ -252,7 +255,7 @@ start / creation is counted once whether it originated in a UI or the standalone
 
 | Event | Emitted from | Event-specific props |
 |---|---|---|
-| `studio_app_launch` | Desktop Main (`appBoot`) | `is_first_launch` |
+| `studio_app_launch` | Desktop Main (`appBoot`); `studio ui` server start | `is_first_launch` (desktop only) |
 | `studio_site_start` | CLI site-start funnel | `success` (boolean), `time_ms` (start duration). On success also `running_site_count` (running Studio sites after this one comes up). On failure instead `failure_reason` (coarse, low-cardinality: `timeout`/`port_unavailable`/`php_error`/`process_exited`/`unknown` — the raw error is never sent). |
 | `studio_site_created` | CLI site-create funnel | `flow_type` (`new`/`blueprint`/`import`/`sync`/`duplicate`), `php_version`, `wp_version` (resolved from disk; `-` if unknown), `custom_domain` (boolean — the domain string is **never** sent), `ssl_enabled` (boolean), `time_ms` (creation duration). Emitted once per **successful** creation. |
 
@@ -503,10 +506,11 @@ What fires depends on the build, so pick the right method:
     node apps/cli/dist/cli/main.mjs ui --no-open
   ```
 
-  Then drive the UI at `http://localhost:8081`. Everything prints in the terminal that ran `studio ui`,
-  with `channel: studio-web`, `ui_version: v2`:
-  - Events the server records itself (renderer events posted to `/api/analytics/event`, settings
-    changes, session creation) log directly.
+  `studio_app_launch` logs as the server comes up; drive the UI at `http://localhost:8081` for the
+  rest. Everything prints in the terminal that ran `studio ui`, with `channel: studio-web`,
+  `ui_version: v2`:
+  - Events the server records itself (the launch event, renderer events posted to
+    `/api/analytics/event`, settings changes, session creation) log directly.
   - Events from forked CLI children (site start/stop, import/export, preview CRUD) log because
     `createCliRunner` inherits the child's stdio in a dev run — `NODE_ENV=development` or
     `STUDIO_DEBUG_TRACKS` — and echoes Tracks lines from commands that capture output.

--- a/docs/design-docs/analytics-tracks.md
+++ b/docs/design-docs/analytics-tracks.md
@@ -39,7 +39,7 @@ The pieces mirror the MC Stats layering:
 |---|---|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Shared core | `packages/common/lib/record-tracks-event.ts` | Pure, environment-agnostic URL builder + fire-and-forget pixel sender. No config/opt-out logic. No-ops in E2E/dev.                                          |
 | Desktop wrapper | `apps/studio/src/lib/tracks.ts` | Single entry point for the desktop (Main process). Enforces the opt-out, attaches common props including `channel` and `ui_version` (derived from the active renderer).                                                             |
-| CLI wrapper | `apps/cli/lib/tracks.ts` | Single entry point for the CLI. Enforces the opt-out **and** the build-time `__ENABLE_CLI_TELEMETRY__` switch. Resolves origin from `STUDIO_TRACKS_ORIGIN`. |
+| CLI wrapper | `apps/cli/lib/tracks.ts` | Single entry point for the CLI **and** the `studio ui` server, which is bundled into it. Enforces the opt-out **and** the build-time `__ENABLE_CLI_TELEMETRY__` switch. Resolves origin from `STUDIO_TRACKS_ORIGIN`. |
 | Identity + opt-out | `packages/common/lib/shared-config.ts` | `getOrCreateAnalyticsInstallId()`, `isAnalyticsOptedOut()`, `isAutomatticianFromToken()`. Persisted in `shared.json`.                                       |
 
 Events are sent as a **pixel GET** to `https://pixel.wp.com/t.gif` with query params. The reserved
@@ -170,16 +170,21 @@ where the sender actually runs — see Testing below for what fires in which bui
   `success / (success + failure)` therefore reads optimistically high. For the onboarding funnel, use
   `studio_onboarding_complete`'s `authenticated` prop as the denominator instead: it is the only signal
   that counts users who walked away.
-- **`studio ui`** (the browser UI served by `apps/local`) has no Tracks wrapper of its own, so it
-  records nothing itself: only the chat events reach Tracks, via the CLI fork, and they land in
-  `channel=studio-cli` — that bucket therefore mixes standalone-CLI and browser usage. Everything
-  still works; only the analytics is missing. See [STU-2247](https://linear.app/a8c/issue/STU-2247).
+- **`studio ui`** (the browser UI served by `apps/local`) sets `STUDIO_TRACKS_ORIGIN=studio-web:v2` on
+  its own process, so everything it forks — site operations and agent runs alike — inherits it and
+  lands in `channel=studio-web` rather than being mistaken for standalone-CLI usage. The server has no
+  Tracks wrapper of its own: `studio ui` injects the CLI's `recordTracksEvent` as the
+  `recordTracksEvent` option of `startLocalServer`, which is what the events it records in-process
+  (settings changes, session creation) and the ones the browser posts to it go through.
 - **Renderer-originated events** go through the `recordAnalyticsEvent` IPC handler
   (`apps/studio/src/ipc-handlers.ts`). Both renderers share the same Main single entry point, and the
   desktop wrapper's `commonProps()` attaches `channel`/`ui_version` centrally — the `ui_version` is
   derived from the active renderer via `getPreferredUiVersion()`, so callers pass only event-specific
-  props. The agentic `apps/ui` renderer routes through its `Connector.trackEvent` (IPC connector); the
-  `apps/ui` browser (`local`/`hosted`) connectors have no Main process and currently no-op `trackEvent`.
+  props. The agentic `apps/ui` renderer routes through its `Connector.trackEvent`: the IPC connector
+  reaches Main directly, while the `local` connector posts to `POST /api/analytics/event`, the
+  browser's equivalent choke point. That route drops unknown event names and strips client-supplied
+  `channel`/`ui_version`, so the server stays the only thing that labels an event's origin. The
+  `hosted` connector still no-ops — a multi-user deployment needs an identity and consent model first.
 
 ## Property vocabulary
 
@@ -189,12 +194,12 @@ none fits, and flag it for registration.
 
 | Property | Meaning | Studio values |
 |---|---|---|
-| `channel` | Entry platform / application | `studio-ui`, `studio-cli` |
+| `channel` | Entry platform / application | `studio-ui` (Electron app), `studio-web` (browser UI served by `studio ui`), `studio-cli` (bare terminal invocation) |
 | `is_a11n` | Automattician flag (shared across products) | `true` / `false` (derived from the auth token email domain) |
 | `platform` | OS | `darwin`, `win32`, `linux` |
 | `arch` | CPU architecture | `arm64`, `x64`, … |
 | `app_version` | Product version | e.g. `1.15.0` |
-| `ui_version` | **Custom (Studio-only):** which desktop renderer | `v1` (legacy), `v2` (agentic). No standard slot — must be registered as a Studio-custom property. |
+| `ui_version` | **Custom (Studio-only):** which renderer chrome is running | `v1` (legacy), `v2` (agentic). Orthogonal to `channel`: it does **not** encode Electron-vs-browser, so the browser UI is `studio-web` + `v2` — it serves the same `apps/ui` bundle the desktop reports as `v2`. Absent for `studio-cli`. No standard slot — must be registered as a Studio-custom property. |
 
 Common props (`platform`, `arch`, `app_version`, `is_a11n`, and `channel`/`ui_version`) are attached by the
 wrappers — pass only event-specific props. On the desktop the wrapper's `commonProps()` attaches
@@ -345,7 +350,7 @@ Sensitive values are never sent as strings (see `is_default` and the directory n
 | `studio_setting_agentic_features_change` | `saveAgenticFeaturesEnabled` | `enabled` (boolean), `surface` (`settings`) |
 | `studio_setting_ui_change` | `updateBetaFeature` (`enableAgenticUi` key) | `type` (`classic`/`agentic`), `surface` (`settings`/`banner`/`menu`) — the switch has several entry points; the caller supplies the surface. Not emitted for the boot-time seeding migration (no surface). |
 | `studio_setting_instructions_change` | `saveGlobalAgentInstructions` | `has_content` (boolean), `length_bucket` (`empty`/`short` ≤200/`medium` ≤1000/`long`), `surface` (`settings`) — the instructions text is **never** sent. See the edit-session note below. |
-| `studio_setting_ai_provider_change` | `saveAnthropicApiKey`/`setAiProvider` | `provider` (`wpcom`/`anthropic-api-key`), `has_anthropic_api_key` (boolean), `surface` (`settings`) — the API key is **never** sent. One event covers both handlers, since clearing the key also falls the provider back to WordPress.com. Browser-hosted `studio ui` writes these settings through `apps/local`, which has no Tracks emitter, so those changes go uncounted — see [STU-2247](https://linear.app/a8c/issue/STU-2247). |
+| `studio_setting_ai_provider_change` | `saveAnthropicApiKey`/`setAiProvider` | `provider` (`wpcom`/`anthropic-api-key`), `has_anthropic_api_key` (boolean), `surface` (`settings`) — the API key is **never** sent. One event covers both handlers, since clearing the key also falls the provider back to WordPress.com. `studio ui` emits the same event from its own `/ai-settings` routes. |
 
 `studio_setting_instructions_change` is the one settings event Main cannot detect on its own. Classic
 saves on an explicit button press, but the agentic UI autosaves on an 800 ms debounce, so by the time
@@ -358,10 +363,10 @@ autosaves, which write without recording. Main emits only when that comparison s
 #### Studio Code events
 
 Studio Code (AI assistant) usage. The chat events are emitted by the **CLI** (the sole funnel — every
-surface forks it to run a turn), `session_created` from **desktop Main** (sessions are created
-in-process). All carry the shared AI identity props described under "Property vocabulary" above.
-Browser-hosted `studio ui` chat currently lands in `channel=studio-cli` and its session creations are
-not counted at all — see [STU-2247](https://linear.app/a8c/issue/STU-2247).
+surface forks it to run a turn), `session_created` from whichever host created the session in-process
+— **desktop Main**, or the **`studio ui` server** via its own `/sessions` route. All carry the shared
+AI identity props described under "Property vocabulary" above. Filter by `channel` to tell desktop
+(`studio-ui`) and browser (`studio-web`) chat apart.
 
 | Event | Emitted from | Event-specific props |
 |---|---|---|
@@ -487,9 +492,24 @@ What fires depends on the build, so pick the right method:
   - **Watch the terminal, not a log file.** The line is `console` output from the CLI child; it goes to
     the terminal that ran it — for the desktop path, that's the `npm start` terminal, not
     `~/Library/Logs/Studio/`.
-  - **`channel`** is `studio-cli` standalone, or `studio-ui` (with `ui_version`) when
-    `STUDIO_TRACKS_ORIGIN` is set — as the desktop injects when it spawns the CLI (e.g.
-    `STUDIO_TRACKS_ORIGIN=studio-ui:v2`).
+  - **`channel`** is `studio-cli` standalone, or the value in `STUDIO_TRACKS_ORIGIN` (with
+    `ui_version`) when the host sets one — `studio-ui:v2` as the desktop injects when it spawns the
+    CLI, `studio-web:v2` under `studio ui`.
+- **The browser UI (`studio ui`).** Build the UI first (plain `cli:build` does not rebuild `apps/ui`):
+
+  ```
+  npm run cli:build:ui
+  STUDIO_FORCE_CLI_TELEMETRY=1 STUDIO_DEBUG_TRACKS=1 NODE_ENV=development \
+    node apps/cli/dist/cli/main.mjs ui --no-open
+  ```
+
+  Then drive the UI at `http://localhost:8081`. Everything prints in the terminal that ran `studio ui`,
+  with `channel: studio-web`, `ui_version: v2`:
+  - Events the server records itself (renderer events posted to `/api/analytics/event`, settings
+    changes, session creation) log directly.
+  - Events from forked CLI children (site start/stop, import/export, preview CRUD) log because
+    `createCliRunner` inherits the child's stdio in a dev run — `NODE_ENV=development` or
+    `STUDIO_DEBUG_TRACKS` — and echoes Tracks lines from commands that capture output.
 - **Live pixel to `pixel.wp.com`.** Only a shipped npm/prod build sends the real request (dev/E2E always
   no-ops). Confirm server-side by querying `tracks.prod_events` in Superset.
 

--- a/packages/common/ai/run-manager.ts
+++ b/packages/common/ai/run-manager.ts
@@ -9,6 +9,7 @@ import {
 	setAiSessionSitePlacement,
 	type AiSessionPlacementUpdatedEvent,
 } from '@studio/common/ai/sessions/placement';
+import { isDevRun } from '@studio/common/lib/dev-run';
 import { captureException } from '@studio/common/lib/error-reporting';
 import type { ActiveAgentRun, AgentRunEvent } from '@studio/common/ai/agent-events';
 import type { StudioChatFileAttachment } from '@studio/common/ai/chat-files';
@@ -76,12 +77,6 @@ export interface AgentRunManager {
 }
 
 const INTERRUPT_FORCE_KILL_TIMEOUT_MS = 2000;
-
-// Matches the condition the Tracks core uses to log instead of send, so a dev run can see the
-// child's output. Never true in a packaged build.
-function isDevRun(): boolean {
-	return process.env.NODE_ENV === 'development' || Boolean( process.env.STUDIO_DEBUG_TRACKS );
-}
 
 function nowIso(): string {
 	return new Date().toISOString();

--- a/packages/common/ai/tests/run-manager.test.ts
+++ b/packages/common/ai/tests/run-manager.test.ts
@@ -71,7 +71,7 @@ describe( 'createAgentRunManager fork environment', () => {
 		expect( getForkEnv( 1 ).STUDIO_TRACKS_ORIGIN ).toBe( 'studio-ui:v2' );
 	} );
 
-	// `studio ui` leaves it unset, so its runs fall through to `channel: studio-cli` — see STU-2247.
+	// `studio ui` instead sets `STUDIO_TRACKS_ORIGIN` on its own process, which the fork inherits.
 	it( 'omits the origin when the host does not supply one', () => {
 		const manager = createAgentRunManager( {
 			cliBinary: '/cli.mjs',

--- a/packages/common/lib/cli-process.ts
+++ b/packages/common/lib/cli-process.ts
@@ -224,9 +224,11 @@ export function createCliRunner( config: CliRunnerConfig ): CliRunner {
 			// large structured payloads on stdout that would otherwise spam the
 			// console every time snapshots are fetched.
 			const logPrefix = options.logPrefix ? `[CLI - ${ options.logPrefix }]` : null;
-			// Without a prefix a dev run would see nothing, so echo the analytics lines
-			// only — never a JSON payload.
+			// Without a prefix a dev run would see nothing, so echo the analytics output
+			// only — never a JSON payload. The "Would have recorded" line is followed by a
+			// pretty-printed props object, so echoing continues until it closes.
 			const echoAnalytics = ! logPrefix && isDevRun();
+			let echoingAnalytics = false;
 			child.stdout?.on( 'data', ( data: Buffer ) => {
 				const text = data.toString();
 				stdout += text;
@@ -237,9 +239,16 @@ export function createCliRunner( config: CliRunnerConfig ): CliRunner {
 					}
 				} else if ( echoAnalytics ) {
 					for ( const line of text.split( '\n' ) ) {
-						if ( line.includes( 'Tracks event' ) ) {
-							console.log( `[CLI] ${ line.trimEnd() }` );
+						if ( ! echoingAnalytics ) {
+							// A props object opens on the same line and closes on its own `}`.
+							echoingAnalytics = line.includes( 'Tracks event' ) && line.endsWith( '{' );
+							if ( ! line.includes( 'Tracks event' ) ) {
+								continue;
+							}
+						} else if ( line.startsWith( '}' ) ) {
+							echoingAnalytics = false;
 						}
+						console.log( `[CLI] ${ line.trimEnd() }` );
 					}
 				}
 			} );

--- a/packages/common/lib/cli-process.ts
+++ b/packages/common/lib/cli-process.ts
@@ -1,5 +1,6 @@
 import { fork, spawnSync, type ChildProcess, type StdioOptions } from 'node:child_process';
 import { z } from 'zod';
+import { isDevRun } from '@studio/common/lib/dev-run';
 import { TypedEventEmitter } from '@studio/common/lib/typed-event-emitter';
 
 /** Spawns the Studio CLI binary and relays its lifecycle as typed events. */
@@ -188,7 +189,10 @@ export function createCliRunner( config: CliRunnerConfig ): CliRunner {
 		if ( options.output === 'capture' ) {
 			stdio = [ 'ignore', 'pipe', 'pipe', 'ipc' ];
 		} else if ( options.output === 'ignore' ) {
-			stdio = [ 'ignore', 'ignore', 'ignore', 'ipc' ];
+			// A dev run inherits the child's logging so it reaches the host's terminal.
+			stdio = isDevRun()
+				? [ 'ignore', 'inherit', 'inherit', 'ipc' ]
+				: [ 'ignore', 'ignore', 'ignore', 'ipc' ];
 		}
 
 		const child = fork( cliBinary, [ ...args, '--avoid-telemetry' ], {
@@ -220,6 +224,9 @@ export function createCliRunner( config: CliRunnerConfig ): CliRunner {
 			// large structured payloads on stdout that would otherwise spam the
 			// console every time snapshots are fetched.
 			const logPrefix = options.logPrefix ? `[CLI - ${ options.logPrefix }]` : null;
+			// Without a prefix a dev run would see nothing, so echo the analytics lines
+			// only — never a JSON payload.
+			const echoAnalytics = ! logPrefix && isDevRun();
 			child.stdout?.on( 'data', ( data: Buffer ) => {
 				const text = data.toString();
 				stdout += text;
@@ -227,6 +234,12 @@ export function createCliRunner( config: CliRunnerConfig ): CliRunner {
 					const trimmed = text.trimEnd();
 					if ( trimmed ) {
 						console.log( `${ logPrefix } ${ trimmed }` );
+					}
+				} else if ( echoAnalytics ) {
+					for ( const line of text.split( '\n' ) ) {
+						if ( line.includes( 'Tracks event' ) ) {
+							console.log( `[CLI] ${ line.trimEnd() }` );
+						}
 					}
 				}
 			} );

--- a/packages/common/lib/dev-run.ts
+++ b/packages/common/lib/dev-run.ts
@@ -1,0 +1,4 @@
+// Matches the condition the Tracks core uses to log instead of send. Never true in a packaged build.
+export function isDevRun(): boolean {
+	return process.env.NODE_ENV === 'development' || Boolean( process.env.STUDIO_DEBUG_TRACKS );
+}

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -65,10 +65,16 @@ export interface TracksIdentity {
 
 export type TracksProps = Record< string, string | number | boolean | undefined >;
 
-// Shared origin vocabulary — which application/renderer an event came from. Kept here so the desktop
-// and CLI wrappers stay in sync. See `docs/design-docs/analytics-tracks.md`.
-export type TracksChannel = 'studio-ui' | 'studio-cli';
+// Which application an event came from: the Electron app, the browser UI served by `studio ui`, or a
+// bare terminal invocation. Orthogonal to `ui_version`, which is the renderer chrome.
+// See `docs/design-docs/analytics-tracks.md`.
+export const TRACKS_CHANNELS = [ 'studio-ui', 'studio-cli', 'studio-web' ] as const;
+export type TracksChannel = ( typeof TRACKS_CHANNELS )[ number ];
 export type TracksUiVersion = 'v1' | 'v2';
+
+export function isTracksChannel( value: unknown ): value is TracksChannel {
+	return TRACKS_CHANNELS.includes( value as TracksChannel );
+}
 
 // The path a site came into existence through, for `studio_site_created`. `blueprint` is inferred by
 // the CLI from the presence of a blueprint; the other non-`new` values are threaded down from the
@@ -107,6 +113,17 @@ export type TracksAiClient = 'studio-code';
 
 // Sent as `length_bucket`; bucketed because the instructions text is never sent.
 export type TracksInstructionsLengthBucket = 'empty' | 'short' | 'medium' | 'long';
+
+export function getInstructionsLengthBucket( content: string ): TracksInstructionsLengthBucket {
+	const length = content.trim().length;
+	if ( length === 0 ) {
+		return 'empty';
+	}
+	if ( length <= 200 ) {
+		return 'short';
+	}
+	return length <= 1000 ? 'medium' : 'long';
+}
 
 // The site panel/tab a `studio_panel_opened` event refers to. Studio Classic emits the tab-strip names
 // (`sync`/`import-export`/`previews` are Classic-only); the agentic UI reuses the shared names —

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig( {
 	test: {
 		projects: [
 			'./apps/cli/vitest.config.ts',
+			'./apps/local/vitest.config.ts',
 			'./apps/studio/vitest.config.ts',
 			'./apps/ui/vitest.config.ts',
 			'./packages/common/vitest.config.ts',


### PR DESCRIPTION
## Related issues

- Fixes [STU-2247](https://linear.app/a8c/issue/STU-2247/check-if-we-should-log-events-from-browser-ui-separarely)

## How AI was used in this PR

Claude Code investigated the two gaps, wrote the implementation and tests, and ran the verification below. I reviewed the diff, tested locally alongside CI, and iterated to fix issues.

## Proposed Changes

Browser-UI usage was invisible in Tracks, in two separate ways:

- **Site operations looked like terminal usage.** The desktop tags the CLI children it forks with `STUDIO_TRACKS_ORIGIN`, but the `studio ui` server forks through a different code path that never set it. Every browser-driven site start/stop/create/delete, import/export and preview action therefore reported `channel: studio-cli` — indistinguishable from someone typing `studio start` in a terminal.
- **Renderer actions weren't counted at all.** The browser connector's `trackEvent` was an empty no-op, so `open_in_*`, `panel_opened` and friends were silently dropped. The same was true of the settings and session-creation events the server handles, which several `// See STU-2247` comments in the codebase were waiting on.

The browser UI now reports as its own **`studio-web`** channel, so we can answer "how many people use the browser UI" and keep `studio-cli` meaning what it says. `ui_version` stays orthogonal — it records which renderer chrome is running (`v2`, since the browser serves the same `apps/ui` bundle the desktop reports as `v2`), not whether it renders in Electron or a browser tab. Adding a value to an existing prop needs no data-team registration to be queryable.

Two things worth calling out for review:

- **The origin is set once on the `studio ui` process** rather than plumbed through each fork site. Both fork paths (site commands and agent runs) inherit `process.env`, so this also fixes the Studio Code chat events, which were unattributed under `studio ui`.
- **The browser posts events to a new `/api/analytics/event` route**, which is a trust boundary in the same sense as the desktop's IPC handler: unknown event names are dropped rather than forwarded, and client-supplied `channel`/`ui_version` are stripped so the server stays the only thing that labels an event's origin.

Also fixes a debuggability gap found along the way: `Would have recorded Tracks event…` from forked CLI children was being swallowed under `studio ui`, so there was previously no way to verify any of this locally.

## Testing Instructions

For the end-to-end path:

```
npm run cli:build:ui
STUDIO_FORCE_CLI_TELEMETRY=1 STUDIO_DEBUG_TRACKS=1 NODE_ENV=development \
  node apps/cli/dist/cli/main.mjs ui --no-open
```

In the browser at http://localhost:8081, start a site, stop it, and open phpMyAdmin or the Customizer. In the terminal that ran `studio ui`, every event should carry `channel: studio-web` and `ui_version: v2` — the forked-CLI ones (`studio_site_start`) prefixed with `[CLI]`, the renderer ones (`studio_site_open_phpmyadmin`) logged directly. Before this change the first group said `studio-cli` and the second didn't appear at all.

**Control — the fallback must survive.** A bare CLI run must still report `channel: studio-cli` with no `ui_version` (pick a site that is offline; `start` no-ops on a running one and never reaches the event):

```
STUDIO_FORCE_CLI_TELEMETRY=1 STUDIO_DEBUG_TRACKS=1 NODE_ENV=development \
  node apps/cli/dist/cli/main.mjs start --path <offline-site>
```

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
