### PR TITLE
Regenerate `bundle-strings.pot` after #4536 resync of release/1.18.0 from trunk

### DIFF
--- a/i18n/bundle-strings.pot
+++ b/i18n/bundle-strings.pot
@@ -10,17 +10,17 @@ msgstr "Content-Type: text/plain; charset=utf-8\n"
 msgid "WordPress.com login required. Use /login to authenticate."
 msgstr ""
 
-#: apps/cli/ai/providers.ts:212
+#: apps/cli/ai/providers.ts:210
 msgid ""
 "Anthropic API key required. Switch to Anthropic · API key with /provider to "
 "save one."
 msgstr ""
 
-#: apps/cli/ai/providers.ts:85
+#: apps/cli/ai/providers.ts:83
 msgid "Enter your Anthropic API key (will be saved for future use):"
 msgstr ""
 
-#: apps/cli/ai/providers.ts:89
+#: apps/cli/ai/providers.ts:88
 msgid "API key is required"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgid "API key update canceled."
 msgstr ""
 
 #: apps/cli/ai/slash-commands.ts:285
-#: apps/cli/commands/auth/login.ts:98
+#: apps/cli/commands/auth/login.ts:115
 #: apps/studio/src/components/content-tab-previews.tsx:106
 #: apps/studio/src/components/studio-code-session/index.tsx:166
 #: apps/studio/src/modules/onboarding/components/connect-to-wpcom.tsx:95
@@ -60,14 +60,14 @@ msgid "Log in to WordPress.com"
 msgstr ""
 
 #: apps/cli/ai/slash-commands.ts:296
-#: apps/cli/commands/ai/index.ts:384
+#: apps/cli/commands/ai/index.ts:414
 #. 1: display name, 2: email
 msgid "Logged in as %1$s (%2$s)"
 msgstr ""
 
 #: apps/cli/ai/slash-commands.ts:304
-#: apps/cli/commands/ai/index.ts:392
 #: apps/cli/commands/ai/index.ts:422
+#: apps/cli/commands/ai/index.ts:452
 #. %s: display name
 #. %s: display name
 #. %s: user display name
@@ -108,7 +108,7 @@ msgid ""
 msgstr ""
 
 #: apps/cli/ai/slash-commands.ts:382
-#: apps/cli/commands/ai/index.ts:294
+#: apps/cli/commands/ai/index.ts:325
 #. %s: model name
 #. %s: provider name
 msgid "Switched to %s"
@@ -267,7 +267,7 @@ msgstr ""
 #: apps/cli/ai/slash-commands.ts:185
 #: apps/studio/src/components/action-button.tsx:124
 #: apps/studio/src/components/running-sites.tsx:43
-#: apps/studio/src/ipc-handlers.ts:2022
+#: apps/studio/src/ipc-handlers.ts:2117
 msgid "Start"
 msgid_plural "Start all"
 msgstr[0] ""
@@ -278,9 +278,9 @@ msgstr[1] ""
 #: apps/studio/src/components/running-sites.tsx:34
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:703
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:706
-#: apps/studio/src/ipc-handlers.ts:2005
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:658
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:998
+#: apps/studio/src/ipc-handlers.ts:2100
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:674
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:1019
 msgid "Stop"
 msgid_plural "Stop all"
 msgstr[0] ""
@@ -320,7 +320,7 @@ msgid "[Local]"
 msgstr ""
 
 #: apps/cli/ai/ui.ts:788
-#: apps/ui/src/ui-classic/components/session-view/index.tsx:97
+#: apps/ui/src/ui-classic/components/session-view/index.tsx:98
 msgid "Local"
 msgstr ""
 
@@ -595,13 +595,14 @@ msgid "Temporary provider error — retrying in %3$ds (attempt %1$d of %2$d)…"
 msgstr ""
 
 #: apps/cli/ai/ui.ts:2214
-#: apps/studio/src/modules/sync/lib/ipc-handlers.ts:406
+#: apps/studio/src/modules/sync/lib/ipc-handlers.ts:411
 msgid "Unknown error"
 msgstr ""
 
 #: apps/cli/ai/ui.ts:2221
 #: apps/cli/remote-session/progress-streamer.ts:105
 #: apps/studio/src/modules/whats-new/components/whats-new-modal.tsx:130
+#: apps/ui/src/data/onboarding/whats-new.ts:56
 msgid "Done"
 msgstr ""
 
@@ -612,101 +613,101 @@ msgid_plural "Thought for %1$ds · %2$d turns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: apps/cli/commands/_events.ts:183
-#: apps/cli/commands/site/list.ts:111
+#: apps/cli/commands/_events.ts:187
+#: apps/cli/commands/site/list.ts:116
 msgid "Connecting to process daemon…"
 msgstr ""
 
-#: apps/cli/commands/_events.ts:185
-#: apps/cli/commands/site/list.ts:113
+#: apps/cli/commands/_events.ts:189
+#: apps/cli/commands/site/list.ts:118
 msgid "Connected to process daemon"
 msgstr ""
 
-#: apps/cli/commands/_events.ts:230
+#: apps/cli/commands/_events.ts:234
 msgid "Events watcher failed"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:754
+#: apps/cli/commands/ai/index.ts:808
 msgid "Start an interactive AI chat to build WordPress sites"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:759
+#: apps/cli/commands/ai/index.ts:813
 msgid "Initial message to send to the AI agent"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:767
+#: apps/cli/commands/ai/index.ts:821
 msgid "Name of the active WordPress site"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:772
+#: apps/cli/commands/ai/index.ts:826
 #: apps/cli/commands/ai/sessions/resume.ts:105
 msgid "Output events as NDJSON to stdout (headless mode)"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:777
+#: apps/cli/commands/ai/index.ts:831
 msgid "SDK session ID to resume (for JSON mode multi-turn)"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:782
+#: apps/cli/commands/ai/index.ts:836
 msgid "JSON-encoded permission response for a paused session"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:792
+#: apps/cli/commands/ai/index.ts:846
 msgid "Read the initial message from stdin (for headless drivers)"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:797
+#: apps/cli/commands/ai/index.ts:851
 msgid "--json requires an initial message argument"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:820
+#: apps/cli/commands/ai/index.ts:874
 msgid "--message-from-stdin requires non-empty input on stdin"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:855
-#: apps/cli/commands/ai/index.ts:332
+#: apps/cli/commands/ai/index.ts:909
+#: apps/cli/commands/ai/index.ts:363
 msgid "AI agent failed"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:136
+#: apps/cli/commands/ai/index.ts:167
 msgid "ⓘ The \"studio ai\" command is now \"studio code\"."
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:167
+#: apps/cli/commands/ai/index.ts:198
 #. %s: agent session ID
 msgid "No AI session found for resume ID: %s"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:253
+#: apps/cli/commands/ai/index.ts:284
 #. %s: session ID
 msgid "Resuming session %s"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:336
+#: apps/cli/commands/ai/index.ts:367
 msgid "Use /api-key to update the Anthropic API key."
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:356
+#: apps/cli/commands/ai/index.ts:386
 msgid "WordPress.com (recommended)"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:362
+#: apps/cli/commands/ai/index.ts:392
 msgid "Choose how to connect"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:427
+#: apps/cli/commands/ai/index.ts:457
 msgid "Use /login to authenticate to WordPress.com"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:430
+#: apps/cli/commands/ai/index.ts:460
 msgid "No Anthropic API key saved. Use /api-key to enter one."
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:678
+#: apps/cli/commands/ai/index.ts:732
 msgid "Conversation cleared"
 msgstr ""
 
-#: apps/cli/commands/ai/index.ts:312
+#: apps/cli/commands/ai/index.ts:343
 #. 1: previous provider name, 2: new provider name
 msgid "%1$s is no longer available. Switched to %2$s."
 msgstr ""
@@ -877,7 +878,7 @@ msgstr ""
 #: apps/cli/commands/auth/status.ts:70
 #: apps/cli/commands/blueprint/list.ts:95
 #: apps/cli/commands/preview/list.ts:171
-#: apps/cli/commands/site/list.ts:133
+#: apps/cli/commands/site/list.ts:138
 #: apps/cli/commands/site/status.ts:133
 #. Refers to the output format of the `studio site list` CLI command ("table" or "json")
 msgid "Output format"
@@ -919,44 +920,44 @@ msgstr ""
 msgid "Select a session to resume:"
 msgstr ""
 
-#: apps/cli/commands/auth/login.ts:23
+#: apps/cli/commands/auth/login.ts:24
 msgid "Already authenticated with WordPress.com"
 msgstr ""
 
-#: apps/cli/commands/auth/login.ts:36
+#: apps/cli/commands/auth/login.ts:37
 msgid "Opening browser for authentication…"
 msgstr ""
 
-#: apps/cli/commands/auth/login.ts:39
+#: apps/cli/commands/auth/login.ts:40
 msgid "Browser opened successfully"
 msgstr ""
 
-#: apps/cli/commands/auth/login.ts:42
+#: apps/cli/commands/auth/login.ts:43
 msgid "Couldn't open a browser automatically. Use the URL below instead."
 msgstr ""
 
-#: apps/cli/commands/auth/login.ts:50
+#: apps/cli/commands/auth/login.ts:51
 msgid "To authenticate, open this URL in a browser on any device:"
 msgstr ""
 
-#: apps/cli/commands/auth/login.ts:53
+#: apps/cli/commands/auth/login.ts:54
 msgid "After approving access, copy the generated token and paste it here."
 msgstr ""
 
-#: apps/cli/commands/auth/login.ts:60
+#: apps/cli/commands/auth/login.ts:64
 msgid "Authentication token:"
 msgstr ""
 
-#: apps/cli/commands/auth/login.ts:62
+#: apps/cli/commands/auth/login.ts:66
 msgid "Authentication completed successfully!"
 msgstr ""
 
-#: apps/cli/commands/auth/login.ts:64
-#: apps/ui/src/components/auth-actions/index.tsx:58
+#: apps/cli/commands/auth/login.ts:73
+#: apps/ui/src/components/auth-actions/index.tsx:60
 msgid "Authentication failed. Please try again."
 msgstr ""
 
-#: apps/cli/commands/auth/login.ts:83
+#: apps/cli/commands/auth/login.ts:97
 msgid "Authentication failed"
 msgstr ""
 
@@ -1114,7 +1115,7 @@ msgstr ""
 
 #: apps/cli/commands/blueprint/use.ts:202
 #: apps/cli/commands/site/create.ts:630
-#: apps/cli/commands/site/start.ts:121
+#: apps/cli/commands/site/start.ts:132
 msgid "Skip opening the site in browser after starting"
 msgstr ""
 
@@ -1182,247 +1183,234 @@ msgstr ""
 msgid "Unknown config key \"%1$s\". Valid keys: %2$s"
 msgstr ""
 
-#: apps/cli/commands/export.ts:66
-#: apps/studio/src/hooks/use-import-export.tsx:322
-#: apps/studio/src/hooks/use-import-export.tsx:406
+#: apps/cli/commands/export.ts:67
+#: apps/studio/src/hooks/use-import-export.tsx:325
+#: apps/studio/src/hooks/use-import-export.tsx:409
 msgid "Starting export…"
 msgstr ""
 
-#: apps/cli/commands/export.ts:70
+#: apps/cli/commands/export.ts:71
 msgid "Creating backup file…"
 msgstr ""
 
-#: apps/cli/commands/export.ts:74
+#: apps/cli/commands/export.ts:75
 msgid "Traversing WordPress content…"
 msgstr ""
 
-#: apps/cli/commands/export.ts:78
+#: apps/cli/commands/export.ts:79
 msgid "WordPress content traversed"
 msgstr ""
 
-#: apps/cli/commands/export.ts:82
+#: apps/cli/commands/export.ts:83
 msgid "Exporting database…"
 msgstr ""
 
-#: apps/cli/commands/export.ts:86
+#: apps/cli/commands/export.ts:87
 msgid "Database exported"
 msgstr ""
 
-#: apps/cli/commands/export.ts:93
+#: apps/cli/commands/export.ts:94
 msgid "Backing up file… (%d processed)"
 msgid_plural "Backing up files… (%d processed)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: apps/cli/commands/export.ts:100
+#: apps/cli/commands/export.ts:101
 msgid "Backup file created"
 msgstr ""
 
-#: apps/cli/commands/export.ts:104
-#: apps/studio/src/hooks/use-import-export.tsx:426
+#: apps/cli/commands/export.ts:105
+#: apps/studio/src/hooks/use-import-export.tsx:429
 msgid "Exporting configuration…"
 msgstr ""
 
-#: apps/cli/commands/export.ts:108
+#: apps/cli/commands/export.ts:109
 msgid "Configuration exported"
 msgstr ""
 
-#: apps/cli/commands/export.ts:112
+#: apps/cli/commands/export.ts:113
 msgid "Site exported successfully"
 msgstr ""
 
-#: apps/cli/commands/export.ts:117
-msgid "Export failed"
-msgstr ""
-
-#: apps/cli/commands/export.ts:202
+#: apps/cli/commands/export.ts:239
 msgid "Export site to a backup file"
 msgstr ""
 
-#: apps/cli/commands/export.ts:209
+#: apps/cli/commands/export.ts:246
 msgid ""
 "Path to the export file. All exports can use .zip or .tar.gz. Database-only "
 "exports can also use .sql."
 msgstr ""
 
-#: apps/cli/commands/export.ts:220
+#: apps/cli/commands/export.ts:257
 msgid ""
 "Export the full site, just the content, or just the database. Default "
 "exports full site."
 msgstr ""
 
-#: apps/cli/commands/export.ts:227
+#: apps/cli/commands/export.ts:264
 msgid "Split the database dump by table"
 msgstr ""
 
-#: apps/cli/commands/export.ts:232
+#: apps/cli/commands/export.ts:269
 msgid "Include only the specified paths in the export"
 msgstr ""
 
-#: apps/cli/commands/export.ts:235
+#: apps/cli/commands/export.ts:272
 msgid "include-only must be an array"
 msgstr ""
 
-#: apps/cli/commands/export.ts:244
+#: apps/cli/commands/export.ts:281
 msgid "Apply .deployignore patterns when exporting"
 msgstr ""
 
-#: apps/cli/commands/export.ts:267
+#: apps/cli/commands/export.ts:309
 msgid ""
 "Invalid export file extension. Must be .zip or .tar.gz when exporting the "
 "full site."
 msgstr ""
 
-#: apps/cli/commands/export.ts:285
+#: apps/cli/commands/export.ts:328
 msgid "Failed to export site"
 msgstr ""
 
-#: apps/cli/commands/export.ts:132
-#: apps/cli/commands/import.ts:269
-#: apps/cli/commands/pull.ts:62
+#: apps/cli/commands/export.ts:131
+#: apps/cli/commands/import.ts:271
+#: apps/cli/commands/pull.ts:64
 #: apps/cli/commands/site/create.ts:373
 #: apps/cli/commands/site/create.ts:414
-#: apps/cli/commands/site/delete.ts:73
-#: apps/cli/commands/site/start.ts:22
+#: apps/cli/commands/site/delete.ts:79
+#: apps/cli/commands/site/start.ts:33
 #: apps/cli/commands/site/status.ts:19
 msgid "Starting process daemon…"
 msgstr ""
 
-#: apps/cli/commands/export.ts:134
-#: apps/cli/commands/import.ts:271
-#: apps/cli/commands/pull.ts:64
+#: apps/cli/commands/export.ts:133
+#: apps/cli/commands/import.ts:273
+#: apps/cli/commands/pull.ts:66
 #: apps/cli/commands/site/create.ts:375
 #: apps/cli/commands/site/create.ts:416
-#: apps/cli/commands/site/delete.ts:75
-#: apps/cli/commands/site/start.ts:24
+#: apps/cli/commands/site/delete.ts:81
+#: apps/cli/commands/site/start.ts:35
 #: apps/cli/commands/site/status.ts:21
 msgid "Process daemon started"
 msgstr ""
 
-#: apps/cli/commands/export.ts:136
-#: apps/cli/commands/import.ts:273
-#: apps/cli/commands/pull-reprint.ts:292
-#: apps/cli/commands/pull.ts:66
-#: apps/cli/commands/push.ts:51
-#: apps/cli/commands/site/delete.ts:77
-#: apps/cli/commands/site/start.ts:26
+#: apps/cli/commands/export.ts:135
+#: apps/cli/commands/import.ts:275
+#: apps/cli/commands/pull-reprint.ts:268
+#: apps/cli/commands/pull.ts:68
+#: apps/cli/commands/push.ts:52
+#: apps/cli/commands/site/delete.ts:83
+#: apps/cli/commands/site/start.ts:37
 #: apps/cli/commands/site/status.ts:23
 msgid "Loading site…"
 msgstr ""
 
-#: apps/cli/commands/export.ts:138
-#: apps/cli/commands/import.ts:275
-#: apps/cli/commands/pull-reprint.ts:294
-#: apps/cli/commands/pull.ts:68
-#: apps/cli/commands/push.ts:53
-#: apps/cli/commands/site/delete.ts:79
-#: apps/cli/commands/site/start.ts:28
+#: apps/cli/commands/export.ts:137
+#: apps/cli/commands/import.ts:277
+#: apps/cli/commands/pull-reprint.ts:270
+#: apps/cli/commands/pull.ts:70
+#: apps/cli/commands/push.ts:54
+#: apps/cli/commands/site/delete.ts:85
+#: apps/cli/commands/site/start.ts:39
 #: apps/cli/commands/site/status.ts:25
 msgid "Site loaded"
 msgstr ""
 
-#: apps/cli/commands/export.ts:142
-#: apps/cli/commands/import.ts:327
-#: apps/cli/commands/push.ts:57
-#: apps/cli/commands/site/start.ts:69
+#: apps/cli/commands/export.ts:141
+#: apps/cli/commands/import.ts:336
+#: apps/cli/commands/push.ts:58
+#: apps/cli/commands/site/start.ts:80
 msgid "Setting up SQLite integration, if needed…"
 msgstr ""
 
-#: apps/cli/commands/export.ts:145
-#: apps/cli/commands/import.ts:330
-#: apps/cli/commands/push.ts:60
-#: apps/cli/commands/site/start.ts:72
+#: apps/cli/commands/export.ts:144
+#: apps/cli/commands/import.ts:339
+#: apps/cli/commands/push.ts:61
+#: apps/cli/commands/site/start.ts:83
 msgid "SQLite integration configured as needed"
 msgstr ""
 
 #: apps/cli/commands/export.ts:170
-#: apps/cli/commands/push.ts:127
+#: apps/cli/commands/push.ts:128
 msgid "No suitable exporter found for the provided backup file"
 msgstr ""
 
-#: apps/cli/commands/export.ts:180
+#: apps/cli/commands/export.ts:183
 msgid "%s successfully exported"
 msgstr ""
 
-#: apps/cli/commands/import.ts:39
+#: apps/cli/commands/import.ts:41
 #: apps/studio/src/hooks/use-import-export.tsx:70
-#: packages/common/lib/import-progress.ts:5
 msgid "Importing plugins…"
 msgstr ""
 
-#: apps/cli/commands/import.ts:40
+#: apps/cli/commands/import.ts:42
 #: apps/studio/src/hooks/use-import-export.tsx:71
-#: packages/common/lib/import-progress.ts:6
 msgid "Importing themes…"
 msgstr ""
 
-#: apps/cli/commands/import.ts:41
+#: apps/cli/commands/import.ts:43
 #: apps/studio/src/hooks/use-import-export.tsx:72
-#: packages/common/lib/import-progress.ts:7
 msgid "Importing media uploads…"
 msgstr ""
 
-#: apps/cli/commands/import.ts:42
+#: apps/cli/commands/import.ts:44
 #: apps/studio/src/hooks/use-import-export.tsx:73
-#: packages/common/lib/import-progress.ts:8
 msgid "Importing other files…"
 msgstr ""
 
-#: apps/cli/commands/import.ts:126
+#: apps/cli/commands/import.ts:130
 msgid "Started import…"
 msgstr ""
 
-#: apps/cli/commands/import.ts:127
+#: apps/cli/commands/import.ts:131
 msgid "Validating backup…"
 msgstr ""
 
-#: apps/cli/commands/import.ts:131
+#: apps/cli/commands/import.ts:135
 msgid "Backup validated"
 msgstr ""
 
-#: apps/cli/commands/import.ts:136
+#: apps/cli/commands/import.ts:140
 msgid "Backup validation failed"
 msgstr ""
 
-#: apps/cli/commands/import.ts:142
-#: apps/studio/src/hooks/use-import-export.tsx:156
-#: apps/studio/src/hooks/use-import-export.tsx:170
-#: packages/common/lib/import-progress.ts:14
-#: packages/common/lib/import-progress.ts:26
+#: apps/cli/commands/import.ts:146
+#: apps/studio/src/hooks/use-import-export.tsx:159
+#: apps/studio/src/hooks/use-import-export.tsx:173
 msgid "Extracting backup files…"
 msgstr ""
 
-#: apps/cli/commands/import.ts:153
+#: apps/cli/commands/import.ts:157
 msgid "Extracting backup file… (%1$d/%2$d)"
 msgid_plural "Extracting backup files… (%1$d/%2$d)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: apps/cli/commands/import.ts:166
+#: apps/cli/commands/import.ts:170
 msgid "Backup extraction completed"
 msgstr ""
 
-#: apps/cli/commands/import.ts:170
+#: apps/cli/commands/import.ts:174
 msgid "A warning occurred while extracting backup"
 msgstr ""
 
-#: apps/cli/commands/import.ts:175
-msgid "Failed to extract backup"
-msgstr ""
-
 #: apps/cli/commands/import.ts:181
-#: apps/studio/src/hooks/use-import-export.tsx:199
+#: apps/studio/src/hooks/use-import-export.tsx:202
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:120
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:29
 #: apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx:112
-#: packages/common/lib/import-progress.ts:28
+#: packages/common/lib/import-progress.ts:35
 msgid "Importing backup…"
 msgstr ""
 
 #: apps/cli/commands/import.ts:185
-#: apps/studio/src/hooks/use-import-export.tsx:209
-#: apps/studio/src/hooks/use-import-export.tsx:215
-#: packages/common/lib/import-progress.ts:30
-#: packages/common/lib/import-progress.ts:42
+#: apps/studio/src/hooks/use-import-export.tsx:212
+#: apps/studio/src/hooks/use-import-export.tsx:218
+#: packages/common/lib/import-progress.ts:37
+#: packages/common/lib/import-progress.ts:49
 msgid "Importing database…"
 msgstr ""
 
@@ -1438,10 +1426,8 @@ msgstr ""
 
 #: apps/cli/commands/import.ts:213
 #: apps/cli/commands/import.ts:224
-#: apps/studio/src/hooks/use-import-export.tsx:254
-#: apps/studio/src/hooks/use-import-export.tsx:259
-#: packages/common/lib/import-progress.ts:44
-#: packages/common/lib/import-progress.ts:58
+#: apps/studio/src/hooks/use-import-export.tsx:257
+#: apps/studio/src/hooks/use-import-export.tsx:262
 msgid "Importing WordPress content…"
 msgstr ""
 
@@ -1466,76 +1452,72 @@ msgstr ""
 msgid "Site imported successfully"
 msgstr ""
 
-#: apps/cli/commands/import.ts:254
-msgid "Import failed"
-msgstr ""
-
-#: apps/cli/commands/import.ts:359
+#: apps/cli/commands/import.ts:409
 msgid "Import a backup file to site"
 msgstr ""
 
-#: apps/cli/commands/import.ts:366
+#: apps/cli/commands/import.ts:416
 msgid "Path to the import file"
 msgstr ""
 
-#: apps/cli/commands/import.ts:384
+#: apps/cli/commands/import.ts:439
 msgid "Failed to import site"
 msgstr ""
 
-#: apps/cli/commands/import.ts:50
+#: apps/cli/commands/import.ts:52
 #: apps/cli/commands/site/create.ts:250
 msgid ""
 "Cannot set up WordPress. Bundled WordPress files not found. Please connect "
 "to the internet or reinstall Studio."
 msgstr ""
 
-#: apps/cli/commands/import.ts:278
+#: apps/cli/commands/import.ts:281
 msgid "Import file not found: %s"
 msgstr ""
 
-#: apps/cli/commands/import.ts:284
-#: apps/cli/commands/pull.ts:177
-#: apps/cli/commands/site/delete.ts:83
-#: apps/cli/commands/site/stop.ts:49
+#: apps/cli/commands/import.ts:290
+#: apps/cli/commands/pull.ts:182
+#: apps/cli/commands/site/delete.ts:89
+#: apps/cli/commands/site/stop.ts:79
 msgid "Stopping WordPress server…"
 msgstr ""
 
-#: apps/cli/commands/import.ts:287
-#: apps/cli/commands/pull.ts:180
-#: apps/cli/commands/site/delete.ts:85
-#: apps/cli/commands/site/stop.ts:54
+#: apps/cli/commands/import.ts:293
+#: apps/cli/commands/pull.ts:185
+#: apps/cli/commands/site/delete.ts:91
+#: apps/cli/commands/site/stop.ts:84
 msgid "WordPress server stopped"
 msgstr ""
 
-#: apps/cli/commands/import.ts:291
+#: apps/cli/commands/import.ts:297
 #: apps/cli/commands/site/create.ts:256
 msgid "Copying bundled WordPress…"
 msgstr ""
 
-#: apps/cli/commands/import.ts:293
+#: apps/cli/commands/import.ts:299
 #: apps/cli/commands/site/create.ts:258
 #: apps/cli/commands/site/create.ts:278
 msgid "WordPress files copied"
 msgstr ""
 
-#: apps/cli/commands/import.ts:296
+#: apps/cli/commands/import.ts:302
 msgid "Starting import…"
 msgstr ""
 
-#: apps/cli/commands/import.ts:332
-#: apps/cli/commands/pull-reprint.ts:475
-#: apps/cli/commands/pull.ts:215
+#: apps/cli/commands/import.ts:341
+#: apps/cli/commands/pull-reprint.ts:463
+#: apps/cli/commands/pull.ts:220
 #: apps/cli/commands/site/create.ts:381
-#: apps/cli/commands/site/start.ts:92
-#: apps/cli/lib/wordpress-server-manager.ts:284
+#: apps/cli/commands/site/start.ts:103
+#: apps/cli/lib/wordpress-server-manager.ts:299
 msgid "Starting WordPress server…"
 msgstr ""
 
-#: apps/cli/commands/import.ts:334
-#: apps/cli/commands/pull-reprint.ts:516
-#: apps/cli/commands/pull.ts:217
+#: apps/cli/commands/import.ts:343
+#: apps/cli/commands/pull-reprint.ts:504
+#: apps/cli/commands/pull.ts:222
 #: apps/cli/commands/site/create.ts:390
-#: apps/cli/commands/site/start.ts:96
+#: apps/cli/commands/site/start.ts:107
 msgid "WordPress server started"
 msgstr ""
 
@@ -1571,7 +1553,6 @@ msgstr ""
 
 #: apps/cli/commands/mcp.ts:53
 #: packages/common/lib/user-settings/editor.ts:82
-#. "Cursor" is the brand name for an IDE and does not need to be translated
 msgid "Cursor"
 msgstr ""
 
@@ -1597,127 +1578,129 @@ msgstr ""
 msgid "MCP server failed"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:91
+#: apps/cli/commands/preview/create.ts:115
 msgid "Create a preview site"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:95
+#: apps/cli/commands/preview/create.ts:119
 #: apps/cli/commands/preview/set.ts:45
 msgid "Preview site name"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:26
-#: apps/cli/commands/preview/delete.ts:44
+#: apps/cli/commands/preview/create.ts:29
+#: apps/cli/commands/preview/delete.ts:45
 #: apps/cli/commands/preview/list.ts:65
-#: apps/cli/commands/preview/update.ts:57
+#: apps/cli/commands/preview/update.ts:59
 msgid "Validating…"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:32
-#: apps/cli/commands/preview/delete.ts:37
+#: apps/cli/commands/preview/create.ts:35
+#: apps/cli/commands/preview/delete.ts:38
 #: apps/cli/commands/preview/list.ts:72
-#: apps/cli/commands/preview/update.ts:61
-#: apps/cli/commands/pull.ts:58
-#: apps/cli/commands/push.ts:47
+#: apps/cli/commands/preview/update.ts:63
+#: apps/cli/commands/pull.ts:60
+#: apps/cli/commands/push.ts:48
 msgid "Authentication required. Please log in with `studio auth login`."
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:36
-#: apps/cli/commands/preview/update.ts:73
+#: apps/cli/commands/preview/create.ts:39
+#: apps/cli/commands/preview/update.ts:75
 #: apps/studio/src/stores/snapshot-slice.ts:134
 #: apps/studio/src/stores/snapshot-slice.ts:279
 #: apps/studio/src/stores/snapshot-slice.ts:281
 msgid "Creating archive…"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:38
-#: apps/cli/commands/preview/update.ts:75
+#: apps/cli/commands/preview/create.ts:41
+#: apps/cli/commands/preview/update.ts:77
 msgid "Archive created"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:40
-#: apps/cli/commands/preview/update.ts:77
+#: apps/cli/commands/preview/create.ts:43
+#: apps/cli/commands/preview/update.ts:79
+#: apps/cli/commands/push.ts:161
+#: apps/cli/commands/push.ts:170
 #: apps/studio/src/stores/snapshot-slice.ts:283
 msgid "Uploading archive…"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:43
-#: apps/cli/commands/preview/update.ts:85
+#: apps/cli/commands/preview/create.ts:46
+#: apps/cli/commands/preview/update.ts:87
 msgid "Archive uploaded"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:45
+#: apps/cli/commands/preview/create.ts:48
 #: apps/studio/src/stores/snapshot-slice.ts:285
 msgid "Creating preview site…"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:48
-#: apps/cli/commands/preview/update.ts:90
+#: apps/cli/commands/preview/create.ts:51
+#: apps/cli/commands/preview/update.ts:92
 msgid "Preview site available at: %s"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:51
-#: apps/cli/commands/preview/update.ts:93
+#: apps/cli/commands/preview/create.ts:54
+#: apps/cli/commands/preview/update.ts:95
 msgid "Saving preview site to Studio…"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:59
+#: apps/cli/commands/preview/create.ts:62
 #. 1: Site name 2: Sequence number (e.g. "My Site Name Preview 1")
 msgid "%1$s Preview %2$d"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:71
-#: apps/cli/commands/preview/update.ts:96
+#: apps/cli/commands/preview/create.ts:74
+#: apps/cli/commands/preview/update.ts:99
 msgid "Preview site saved to Studio"
 msgstr ""
 
-#: apps/cli/commands/preview/create.ts:80
+#: apps/cli/commands/preview/create.ts:89
 msgid "Failed to create preview site"
 msgstr ""
 
-#: apps/cli/commands/preview/delete.ts:88
+#: apps/cli/commands/preview/delete.ts:103
 msgid "Delete preview site(s)"
 msgstr ""
 
-#: apps/cli/commands/preview/delete.ts:93
+#: apps/cli/commands/preview/delete.ts:108
 msgid "Delete all preview sites for your user"
 msgstr ""
 
-#: apps/cli/commands/preview/delete.ts:98
+#: apps/cli/commands/preview/delete.ts:113
 msgid "Hostname of the preview site to delete"
 msgstr ""
 
-#: apps/cli/commands/preview/delete.ts:102
+#: apps/cli/commands/preview/delete.ts:117
 msgid "Hostname is required unless --all is passed."
 msgstr ""
 
-#: apps/cli/commands/preview/delete.ts:49
+#: apps/cli/commands/preview/delete.ts:50
 msgid ""
 "Preview site not found. Use the `studio preview list` command to see "
 "available preview sites."
 msgstr ""
 
-#: apps/cli/commands/preview/delete.ts:56
+#: apps/cli/commands/preview/delete.ts:57
 msgid "Deleting…"
 msgstr ""
 
-#: apps/cli/commands/preview/delete.ts:65
-#: apps/cli/commands/preview/delete.ts:73
+#: apps/cli/commands/preview/delete.ts:67
+#: apps/cli/commands/preview/delete.ts:77
 msgid "Deletion successful"
 msgstr ""
 
-#: apps/cli/commands/preview/delete.ts:67
+#: apps/cli/commands/preview/delete.ts:69
 #: apps/ui/src/components/settings-view/usage-panel.tsx:133
 msgid "Deleting all preview sites…"
 msgstr ""
 
-#: apps/cli/commands/preview/delete.ts:79
+#: apps/cli/commands/preview/delete.ts:83
 #: apps/cli/lib/api.ts:135
 msgid "Failed to delete preview site"
 msgstr ""
 
 #: apps/cli/commands/preview/list.ts:22
-#: apps/cli/commands/site/list.ts:63
+#: apps/cli/commands/site/list.ts:68
 msgid "URL"
 msgstr ""
 
@@ -1726,7 +1709,7 @@ msgid "Site Name"
 msgstr ""
 
 #: apps/cli/commands/preview/list.ts:22
-#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:91
+#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:93
 #: apps/studio/src/modules/preview-site/components/preview-sites-table-header.tsx:11
 msgid "Updated"
 msgstr ""
@@ -1801,7 +1784,7 @@ msgid "Preview site name cannot be empty."
 msgstr ""
 
 #: apps/cli/commands/preview/set.ts:26
-#: apps/cli/commands/preview/update.ts:87
+#: apps/cli/commands/preview/update.ts:89
 msgid "Updating preview site…"
 msgstr ""
 
@@ -1809,327 +1792,319 @@ msgstr ""
 msgid "Preview site updated"
 msgstr ""
 
-#: apps/cli/commands/preview/update.ts:115
-#: apps/ui/src/components/site-dropdown/main-view.tsx:301
+#: apps/cli/commands/preview/update.ts:138
+#: apps/ui/src/components/site-dropdown/main-view.tsx:340
 msgid "Update preview site"
 msgstr ""
 
-#: apps/cli/commands/preview/update.ts:120
+#: apps/cli/commands/preview/update.ts:143
 msgid "Hostname of the preview site to update"
 msgstr ""
 
-#: apps/cli/commands/preview/update.ts:127
+#: apps/cli/commands/preview/update.ts:150
 msgid "Allow updating a preview site from a different directory"
 msgstr ""
 
-#: apps/cli/commands/preview/update.ts:36
+#: apps/cli/commands/preview/update.ts:37
 msgid ""
 "The specified directory does not match the original site for this preview. "
 "If you want to overwrite, run the command with --overwrite."
 msgstr ""
 
-#: apps/cli/commands/preview/update.ts:70
+#: apps/cli/commands/preview/update.ts:72
 msgid "Cannot update an expired preview site."
 msgstr ""
 
-#: apps/cli/commands/preview/update.ts:104
+#: apps/cli/commands/preview/update.ts:112
 msgid "Failed to update preview site"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:86
+#: apps/cli/commands/pull-reprint.ts:79
 msgid ""
 "Pull a remote WordPress site into an existing local site (run `studio "
 "create` first; remove with `studio delete`)"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:93
+#: apps/cli/commands/pull-reprint.ts:86
 msgid "URL of the remote WordPress site to pull from (remote source)"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:98
+#: apps/cli/commands/pull-reprint.ts:91
 msgid ""
 "Restrict the pull to specific wp-content folders (e.g. plugins/akismet, "
 "themes, uploads); repeatable."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:104
+#: apps/cli/commands/pull-reprint.ts:97
 msgid "Do not pull the database (keeps the local one)"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:109
-msgid "Do not pull the media library (uploads)"
-msgstr ""
-
-#: apps/cli/commands/pull-reprint.ts:114
+#: apps/cli/commands/pull-reprint.ts:102
 msgid "Show detailed error information and executed commands"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:129
-#: apps/cli/commands/pull.ts:265
+#: apps/cli/commands/pull-reprint.ts:116
+#: apps/cli/commands/pull.ts:292
 msgid "Pull failed"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:139
-#: apps/cli/commands/pull-reprint.ts:588
+#: apps/cli/commands/pull-reprint.ts:126
+#: apps/cli/commands/pull-reprint.ts:561
 msgid "Failed to pull site"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1479
+#: apps/cli/commands/pull-reprint.ts:1335
 #: apps/cli/lib/site-utils.ts:82
 msgid "Site URL: "
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1481
+#: apps/cli/commands/pull-reprint.ts:1337
 msgid "WP Admin: "
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:388
+#: apps/cli/commands/pull-reprint.ts:371
 msgid "Cancelled."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:490
+#: apps/cli/commands/pull-reprint.ts:478
 msgid "WordPress server restarted"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:507
+#: apps/cli/commands/pull-reprint.ts:495
 msgid "WordPress server already running"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:521
+#: apps/cli/commands/pull-reprint.ts:509
 msgid "Failed to start the WordPress server for the pulled site."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:633
+#: apps/cli/commands/pull-reprint.ts:606
 msgid ""
 "Could not determine where WordPress core lives on the remote site; pulling "
 "all files instead of the selection."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:679
+#: apps/cli/commands/pull-reprint.ts:651
 msgid ""
 "The local site has no database yet (it is created the first time the site "
 "starts), so the database cannot be excluded from this pull. Include the "
 "database, or start the site once and pull again."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:698
+#: apps/cli/commands/pull-reprint.ts:669
 msgid ""
 "Could not determine the remote wp-content path from preflight state, so "
 "--only cannot be used for this site. Run a full pull, or try again."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:810
+#: apps/cli/commands/pull-reprint.ts:754
 msgid "Initiating the migration…"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:834
+#: apps/cli/commands/pull-reprint.ts:778
 msgid "Could not connect to the remote site."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:845
+#: apps/cli/commands/pull-reprint.ts:789
 msgid "The remote site did not respond with a recognized format."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:856
+#: apps/cli/commands/pull-reprint.ts:800
 msgid "The remote site responded with HTML instead of the expected export API."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:857
+#: apps/cli/commands/pull-reprint.ts:801
 msgid "Remote site preflight check failed."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1064
+#: apps/cli/commands/pull-reprint.ts:990
 msgid "Pulling site…"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1069
+#: apps/cli/commands/pull-reprint.ts:993
 msgid "Pulling files"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1085
+#: apps/cli/commands/pull-reprint.ts:1005
 msgid "Pulling database"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1129
+#: apps/cli/commands/pull-reprint.ts:1041
 msgid "Flattening layout"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1141
+#: apps/cli/commands/pull-reprint.ts:1054
 msgid "Preparing runtime"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1149
+#: apps/cli/commands/pull-reprint.ts:1065
 msgid "Site pulled"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1171
-msgid "Downloading remaining files…"
-msgstr ""
-
-#: apps/cli/commands/pull-reprint.ts:1204
-msgid "Remaining files"
-msgstr ""
-
-#: apps/cli/commands/pull-reprint.ts:1209
-msgid "Remaining files downloaded"
-msgstr ""
-
-#: apps/cli/commands/pull-reprint.ts:1278
+#: apps/cli/commands/pull-reprint.ts:1134
 msgid ""
 "WordPress.com authentication is required. Run `studio auth login` to pull a "
 "WordPress.com or Pressable site."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1287
+#: apps/cli/commands/pull-reprint.ts:1143
 msgid "Failed to load WordPress.com sites"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1297
+#: apps/cli/commands/pull-reprint.ts:1153
 msgid "This URL is not a WordPress.com or Pressable site connected to your account."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1318
+#: apps/cli/commands/pull-reprint.ts:1174
 msgid ""
 "No pullable WordPress.com or Pressable sites found. Pulling requires a site "
 "with hosting features enabled."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1331
+#: apps/cli/commands/pull-reprint.ts:1187
 msgid "Multiple WordPress.com sites are available. Re-run with `--url <site-url>`."
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1337
-#: apps/cli/commands/pull.ts:78
+#: apps/cli/commands/pull-reprint.ts:1193
+#: apps/cli/commands/pull.ts:80
 msgid "Select a site to pull from"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1350
+#: apps/cli/commands/pull-reprint.ts:1206
 msgid "Using your only connected WordPress.com site:"
 msgstr ""
 
-#: apps/cli/commands/pull-reprint.ts:1468
+#: apps/cli/commands/pull-reprint.ts:1324
 #. %d: HTTP status code.
 msgid ""
 "Failed to re-apply the admin credentials after the database refresh (HTTP "
 "%d)."
 msgstr ""
 
-#: apps/cli/commands/pull.ts:242
+#: apps/cli/commands/pull.ts:253
 msgid "Pull a WordPress.com site to your local site"
 msgstr ""
 
-#: apps/cli/commands/pull.ts:247
-#: apps/cli/commands/push.ts:283
+#: apps/cli/commands/pull.ts:258
+#: apps/cli/commands/push.ts:287
 msgid "Comma-separated sync options: all, sqls, uploads, plugins, themes, contents"
 msgstr ""
 
-#: apps/cli/commands/pull.ts:255
-#: apps/cli/commands/push.ts:291
+#: apps/cli/commands/pull.ts:266
+#: apps/cli/commands/push.ts:295
 msgid "Remote site URL or ID"
 msgstr ""
 
-#: apps/cli/commands/pull.ts:70
-#: apps/cli/commands/push.ts:62
+#: apps/cli/commands/pull.ts:270
+msgid "Backup node ids to pull when using the \"paths\" option"
+msgstr ""
+
+#: apps/cli/commands/pull.ts:274
+msgid "include-path-list must be an array"
+msgstr ""
+
+#: apps/cli/commands/pull.ts:72
+#: apps/cli/commands/push.ts:63
 msgid "Fetching WordPress.com sites…"
 msgstr ""
 
-#: apps/cli/commands/pull.ts:90
+#: apps/cli/commands/pull.ts:93
 msgid "Fetching file tree…"
 msgstr ""
 
-#: apps/cli/commands/pull.ts:105
-msgid "Initializing remote backup… (%d%%)"
+#: apps/cli/commands/pull.ts:108
+#: apps/studio/src/stores/sync/sync-operations-slice.ts:117
+msgid "Initializing remote backup…"
 msgstr ""
 
-#: apps/cli/commands/pull.ts:120
+#: apps/cli/commands/pull.ts:123
 msgid "Remote backup failed"
 msgstr ""
 
-#: apps/cli/commands/pull.ts:138
-msgid "Creating remote backup… (%d%%)"
+#: apps/cli/commands/pull.ts:142
+msgid "Creating remote backup…"
 msgstr ""
 
-#: apps/cli/commands/pull.ts:144
+#: apps/cli/commands/pull.ts:149
 msgid "Backup timed out — no progress detected"
 msgstr ""
 
-#: apps/cli/commands/pull.ts:153
+#: apps/cli/commands/pull.ts:158
 msgid ""
 "Your site's backup exceeds %d GB. Pulling it will prevent you from pushing "
 "the site back. Do you want to continue?"
 msgstr ""
 
-#: apps/cli/commands/pull.ts:166
-msgid "Downloading backup… (%d%%)"
+#: apps/cli/commands/pull.ts:171
+#: apps/studio/src/stores/sync/sync-operations-slice.ts:119
+msgid "Downloading backup…"
 msgstr ""
 
-#: apps/cli/commands/pull.ts:205
+#: apps/cli/commands/pull.ts:210
 msgid "Pulled from %1$s (%2$s)"
 msgstr ""
 
-#: apps/cli/commands/push.ts:278
+#: apps/cli/commands/push.ts:282
 msgid "Push your local site to a WordPress.com site"
 msgstr ""
 
-#: apps/cli/commands/push.ts:301
+#: apps/cli/commands/push.ts:305
 msgid "Push failed"
 msgstr ""
 
-#: apps/cli/commands/push.ts:70
+#: apps/cli/commands/push.ts:71
 msgid "Select a site to push to"
 msgstr ""
 
-#: apps/cli/commands/push.ts:137
+#: apps/cli/commands/push.ts:138
 msgid ""
 "The archive exceeds the %d GB size limit. Please reduce the size of your "
 "site and try again."
 msgstr ""
 
-#: apps/cli/commands/push.ts:158
-#: apps/cli/commands/push.ts:166
-msgid "Uploading archive… (%d%%)"
-msgstr ""
-
-#: apps/cli/commands/push.ts:175
+#: apps/cli/commands/push.ts:179
 msgid ""
 "Press Ctrl+C again to cancel. The upload cannot be safely cancelled "
 "mid-transfer."
 msgstr ""
 
-#: apps/cli/commands/push.ts:179
+#: apps/cli/commands/push.ts:183
 msgid "Upload cancelled"
 msgstr ""
 
-#: apps/cli/commands/push.ts:193
-msgid "Initiating import… (%d%%)"
+#: apps/cli/commands/push.ts:197
+msgid "Initiating import…"
 msgstr ""
 
-#: apps/cli/commands/push.ts:208
+#: apps/cli/commands/push.ts:212
 msgid "Import failed on %s"
 msgstr ""
 
-#: apps/cli/commands/push.ts:223
+#: apps/cli/commands/push.ts:227
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:99
+#: apps/ui/src/data/sync-activity.ts:102
 msgid "Backing up remote site…"
 msgstr ""
 
-#: apps/cli/commands/push.ts:227
-#: apps/cli/commands/push.ts:235
+#: apps/cli/commands/push.ts:231
+#: apps/cli/commands/push.ts:239
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:101
+#: apps/ui/src/data/sync-activity.ts:103
 msgid "Applying changes…"
 msgstr ""
 
-#: apps/cli/commands/push.ts:231
+#: apps/cli/commands/push.ts:235
 #: apps/studio/src/components/site-is-being-created.tsx:17
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:102
+#: apps/ui/src/data/sync-activity.ts:104
 msgid "Almost there…"
 msgstr ""
 
-#: apps/cli/commands/push.ts:254
+#: apps/cli/commands/push.ts:258
 msgid "Import timed out on %s — no progress detected"
 msgstr ""
 
-#: apps/cli/commands/push.ts:268
+#: apps/cli/commands/push.ts:272
 msgid "Successfully pushed to %1$s (%2$s)"
 msgstr ""
 
@@ -2157,7 +2132,7 @@ msgstr ""
 
 #: apps/cli/commands/site/create.ts:551
 #: apps/ui/src/ui-classic/router/route-onboarding-create/index.tsx:156
-#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:111
+#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:113
 msgid "Create a new site"
 msgstr ""
 
@@ -2271,7 +2246,7 @@ msgid "Admin email:"
 msgstr ""
 
 #: apps/cli/commands/site/create.ts:887
-#: apps/studio/src/hooks/use-site-details.tsx:333
+#: apps/studio/src/hooks/use-site-details.tsx:346
 msgid "Failed to create site"
 msgstr ""
 
@@ -2360,17 +2335,17 @@ msgid "Site created successfully"
 msgstr ""
 
 #: apps/cli/commands/site/create.ts:380
-#: apps/cli/lib/wordpress-server-manager.ts:283
+#: apps/cli/lib/wordpress-server-manager.ts:298
 msgid "Starting WordPress server and applying Blueprint…"
 msgstr ""
 
 #: apps/cli/commands/site/create.ts:410
-#: apps/cli/commands/site/start.ts:106
+#: apps/cli/commands/site/start.ts:117
 msgid "Failed to start WordPress server"
 msgstr ""
 
 #: apps/cli/commands/site/create.ts:418
-#: apps/cli/lib/wordpress-server-manager.ts:678
+#: apps/cli/lib/wordpress-server-manager.ts:730
 msgid "Applying Blueprint…"
 msgstr ""
 
@@ -2398,170 +2373,170 @@ msgstr ""
 msgid "Failed to parse Blueprint JSON"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:172
+#: apps/cli/commands/site/delete.ts:190
 #: apps/studio/src/components/content-tab-settings.tsx:141
 #: apps/studio/src/hooks/use-delete-site.ts:28
-#: apps/ui/src/components/delete-site-dialog/index.tsx:80
-#: apps/ui/src/components/site-list/index.tsx:477
+#: apps/ui/src/components/delete-site-dialog/index.tsx:38
+#: apps/ui/src/components/site-list/index.tsx:500
 #: packages/common/ai/tools.ts:302
 msgid "Delete site"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:176
+#: apps/cli/commands/site/delete.ts:194
 msgid "Move site files to trash (use --no-files to keep files)"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:187
+#: apps/cli/commands/site/delete.ts:205
 msgid "Failed to delete site"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:39
+#: apps/cli/commands/site/delete.ts:41
 msgid "Deleting %d associated preview site…"
 msgid_plural "Deleting %d associated preview sites…"
 msgstr[0] ""
 msgstr[1] ""
 
-#: apps/cli/commands/site/delete.ts:55
+#: apps/cli/commands/site/delete.ts:57
 msgid "Associated preview sites deleted"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:60
+#: apps/cli/commands/site/delete.ts:62
 msgid "Failed to delete associated preview sites. Proceeding anyway…"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:92
+#: apps/cli/commands/site/delete.ts:98
 msgid "Removing domain from hosts file…"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:95
+#: apps/cli/commands/site/delete.ts:101
 msgid "Domain removed from hosts file"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:98
+#: apps/cli/commands/site/delete.ts:104
 msgid "Deleting SSL certificates…"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:100
+#: apps/cli/commands/site/delete.ts:106
 msgid "SSL certificates deleted"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:114
+#: apps/cli/commands/site/delete.ts:120
 #: apps/cli/lib/cli-config/sites.ts:23
 msgid "The specified directory is not added to Studio."
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:127
+#: apps/cli/commands/site/delete.ts:133
 msgid "Failed to remove WordPress.com connections. Proceeding anyway…"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:141
+#: apps/cli/commands/site/delete.ts:147
 msgid "Failed to delete chat sessions. Proceeding anyway…"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:155
+#: apps/cli/commands/site/delete.ts:161
 msgid "Moving site files to trash…"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:157
+#: apps/cli/commands/site/delete.ts:163
 msgid "Site files moved to trash"
 msgstr ""
 
-#: apps/cli/commands/site/delete.ts:159
+#: apps/cli/commands/site/delete.ts:165
 msgid "Site files already removed"
 msgstr ""
 
-#: apps/cli/commands/site/list.ts:63
+#: apps/cli/commands/site/list.ts:68
 #: apps/cli/commands/site/status.ts:71
 msgid "Status"
 msgstr ""
 
-#: apps/cli/commands/site/list.ts:63
+#: apps/cli/commands/site/list.ts:68
 #: apps/studio/src/modules/preview-site/components/rename-preview-modal.tsx:31
 msgid "Name"
 msgstr ""
 
-#: apps/cli/commands/site/list.ts:63
+#: apps/cli/commands/site/list.ts:68
 msgid "Path"
 msgstr ""
 
-#: apps/cli/commands/site/list.ts:125
+#: apps/cli/commands/site/list.ts:130
 #: packages/common/ai/tools.ts:298
 msgid "List sites"
 msgstr ""
 
-#: apps/cli/commands/site/list.ts:146
+#: apps/cli/commands/site/list.ts:151
 msgid "Failed to list sites"
 msgstr ""
 
-#: apps/cli/commands/site/list.ts:35
+#: apps/cli/commands/site/list.ts:36
 #: apps/cli/commands/site/status.ts:28
 msgid "Online"
 msgstr ""
 
-#: apps/cli/commands/site/list.ts:35
+#: apps/cli/commands/site/list.ts:36
 #: apps/cli/commands/site/status.ts:28
 msgid "Offline"
 msgstr ""
 
-#: apps/cli/commands/site/list.ts:94
+#: apps/cli/commands/site/list.ts:99
 #: apps/ui/src/components/site-dropdown/publish-picker-view.tsx:76
 msgid "Loading sites…"
 msgstr ""
 
-#: apps/cli/commands/site/list.ts:98
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:373
+#: apps/cli/commands/site/list.ts:103
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:377
 msgid "No sites found"
 msgstr ""
 
-#: apps/cli/commands/site/list.ts:106
+#: apps/cli/commands/site/list.ts:111
 msgid "Found %d site"
 msgid_plural "Found %d sites"
 msgstr[0] ""
 msgstr[1] ""
 
-#: apps/cli/commands/site/start.ts:116
-#: apps/studio/src/components/site-menu.tsx:86
-#: apps/ui/src/components/site-dropdown/main-view.tsx:496
-#: apps/ui/src/components/site-list/index.tsx:253
-#: apps/ui/src/components/site-list/index.tsx:421
-#: apps/ui/src/components/site-preview/index.tsx:1084
+#: apps/cli/commands/site/start.ts:127
+#: apps/studio/src/components/site-menu.tsx:88
+#: apps/ui/src/components/site-dropdown/main-view.tsx:566
+#: apps/ui/src/components/site-list/index.tsx:265
+#: apps/ui/src/components/site-list/index.tsx:436
+#: apps/ui/src/components/site-preview/index.tsx:1233
 #: packages/common/ai/tools.ts:300
 msgid "Start site"
 msgstr ""
 
-#: apps/cli/commands/site/start.ts:126
+#: apps/cli/commands/site/start.ts:137
 msgid "Skip printing site URL and admin credentials after starting"
 msgstr ""
 
-#: apps/cli/commands/site/start.ts:137
-#: apps/ui/src/data/queries/use-sites.ts:104
+#: apps/cli/commands/site/start.ts:148
+#: apps/ui/src/data/queries/use-sites.ts:134
 msgid "Failed to start site"
 msgstr ""
 
-#: apps/cli/commands/site/start.ts:37
+#: apps/cli/commands/site/start.ts:48
 msgid "A pull is in progress or was interrupted before it finished."
 msgstr ""
 
-#: apps/cli/commands/site/start.ts:38
+#: apps/cli/commands/site/start.ts:49
 msgid "Its last pull failed and the site is incomplete."
 msgstr ""
 
-#: apps/cli/commands/site/start.ts:42
+#: apps/cli/commands/site/start.ts:53
 #. %s: explanation of why the site is not ready to start.
 msgid ""
 "This site is not ready to start. %s Re-run `studio pull-reprint` to finish "
 "the pull, or `studio delete` to remove the site."
 msgstr ""
 
-#: apps/cli/commands/site/start.ts:52
+#: apps/cli/commands/site/start.ts:63
 msgid "WordPress server is already running"
 msgstr ""
 
-#: apps/cli/commands/site/start.ts:78
+#: apps/cli/commands/site/start.ts:89
 msgid "Failed to update AI instructions. Proceeding anyway…"
 msgstr ""
 
-#: apps/cli/commands/site/start.ts:86
+#: apps/cli/commands/site/start.ts:97
 msgid ""
 "This site is in maintenance mode. WordPress is currently performing an "
 "update. The maintenance lock should expire automatically within 10 minutes. "
@@ -2662,40 +2637,40 @@ msgstr ""
 msgid "Xdebug"
 msgstr ""
 
-#: apps/cli/commands/site/stop.ts:111
+#: apps/cli/commands/site/stop.ts:148
 msgid "Stop site(s)"
 msgstr ""
 
-#: apps/cli/commands/site/stop.ts:115
+#: apps/cli/commands/site/stop.ts:152
 msgid "Stop all sites"
 msgstr ""
 
-#: apps/cli/commands/site/stop.ts:131
+#: apps/cli/commands/site/stop.ts:168
 msgid "Failed to stop sites"
 msgstr ""
 
-#: apps/cli/commands/site/stop.ts:131
-#: apps/ui/src/data/queries/use-sites.ts:118
+#: apps/cli/commands/site/stop.ts:168
+#: apps/ui/src/data/queries/use-sites.ts:149
 msgid "Failed to stop site"
 msgstr ""
 
-#: apps/cli/commands/site/stop.ts:45
+#: apps/cli/commands/site/stop.ts:75
 msgid "WordPress server is not running"
 msgstr ""
 
-#: apps/cli/commands/site/stop.ts:57
+#: apps/cli/commands/site/stop.ts:88
 msgid "Failed to stop WordPress server"
 msgstr ""
 
-#: apps/cli/commands/site/stop.ts:73
+#: apps/cli/commands/site/stop.ts:104
 msgid "No sites are currently running"
 msgstr ""
 
-#: apps/cli/commands/site/stop.ts:88
+#: apps/cli/commands/site/stop.ts:119
 msgid "Stopping all WordPress servers…"
 msgstr ""
 
-#: apps/cli/commands/site/stop.ts:93
+#: apps/cli/commands/site/stop.ts:124
 msgid "Successfully stopped %d site"
 msgid_plural "Successfully stopped %d sites"
 msgstr[0] ""
@@ -2949,27 +2924,27 @@ msgstr ""
 msgid "Failed to create archive"
 msgstr ""
 
-#: apps/cli/lib/cli-config/core.ts:116
-#: apps/cli/lib/cli-config/core.ts:139
+#: apps/cli/lib/cli-config/core.ts:113
+#: apps/cli/lib/cli-config/core.ts:136
 msgid "Failed to read CLI config file."
 msgstr ""
 
-#: apps/cli/lib/cli-config/core.ts:125
+#: apps/cli/lib/cli-config/core.ts:122
 msgid ""
 "Invalid CLI config version. It looks like you have a different version of "
 "the `studio` CLI installed on your system. Please modify your $PATH "
 "environment variable to use the correct version."
 msgstr ""
 
-#: apps/cli/lib/cli-config/core.ts:132
+#: apps/cli/lib/cli-config/core.ts:129
 msgid "Invalid CLI config file format."
 msgstr ""
 
-#: apps/cli/lib/cli-config/core.ts:136
+#: apps/cli/lib/cli-config/core.ts:133
 msgid "CLI config file is corrupted."
 msgstr ""
 
-#: apps/cli/lib/cli-config/core.ts:165
+#: apps/cli/lib/cli-config/core.ts:149
 msgid "Failed to save CLI config file"
 msgstr ""
 
@@ -2982,7 +2957,8 @@ msgstr ""
 #: apps/cli/lib/cli-config/sites.ts:59
 #: apps/cli/lib/cli-config/sites.ts:76
 #: apps/cli/lib/cli-config/sites.ts:93
-#: apps/ui/src/components/site-overview-view/index.tsx:133
+#: apps/cli/lib/site-operations.ts:65
+#: apps/ui/src/components/site-overview-view/index.tsx:209
 msgid "Site not found"
 msgstr ""
 
@@ -2994,32 +2970,32 @@ msgstr ""
 msgid "Preview site not found in config"
 msgstr ""
 
-#: apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts:187
-#: apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts:225
+#: apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts:188
+#: apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts:228
 msgid "Input file at location \"%s\" could not be found."
 msgstr ""
 
-#: apps/cli/lib/import-export/import/import-manager.ts:63
+#: apps/cli/lib/import-export/import/import-manager.ts:65
 msgid "No suitable backup handler found for the provided backup file"
 msgstr ""
 
-#: apps/cli/lib/import-export/import/import-manager.ts:76
+#: apps/cli/lib/import-export/import/import-manager.ts:82
 msgid "No suitable importer found for the provided backup contents"
+msgstr ""
+
+#: apps/cli/lib/import-export/import/import-manager.ts:107
+msgid "Failed to extract backup"
 msgstr ""
 
 #: apps/cli/lib/php-versions.ts:11
 msgid "PHP %1$s is not supported. Supported versions: %2$s."
 msgstr ""
 
-#: apps/cli/lib/pull/reprint-selector.ts:398
-msgid "Scanning remote files"
-msgstr ""
-
-#: apps/cli/lib/pull/reprint-selector.ts:426
+#: apps/cli/lib/pull/reprint-selector.ts:146
 msgid "Select what to pull from the remote site"
 msgstr ""
 
-#: apps/cli/lib/pull/reprint-selector.ts:438
+#: apps/cli/lib/pull/reprint-selector.ts:172
 msgid ""
 "Refreshing the database on its own is not supported yet. Select at least "
 "one folder to refresh."
@@ -3027,6 +3003,13 @@ msgstr ""
 
 #: apps/cli/lib/run-wp-cli-command.ts:364
 msgid "An error occurred while running the WP-CLI command."
+msgstr ""
+
+#: apps/cli/lib/site-operations.ts:20
+#. 1: operation the user asked for, e.g. "a site start". 2: operation already running, e.g. "a settings change".
+msgid ""
+"Cannot run %1$s: %2$s is already in progress for this site. Wait for it to "
+"finish and try again."
 msgstr ""
 
 #: apps/cli/lib/site-utils.ts:83
@@ -3126,7 +3109,9 @@ msgstr ""
 
 #: apps/cli/lib/sync-selector.ts:51
 #: apps/studio/src/modules/sync/hooks/use-top-level-sync-tree.tsx:35
-#: apps/ui/src/components/site-preview/address-bar.tsx:160
+#: apps/ui/src/components/selective-sync/hooks/use-top-level-sync-tree.tsx:35
+#: apps/ui/src/components/site-overview-view/about-section.tsx:15
+#: apps/ui/src/components/site-preview/address-bar.tsx:174
 msgid "Database"
 msgstr ""
 
@@ -3200,7 +3185,7 @@ msgid "Unsupported site"
 msgstr ""
 
 #: apps/cli/lib/sync-site-picker.ts:138
-#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:174
+#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:179
 #: apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx:528
 msgid "Deleted"
 msgstr ""
@@ -3283,7 +3268,7 @@ msgstr ""
 msgid "Changelog: %s"
 msgstr ""
 
-#: apps/cli/lib/utils.ts:20
+#: apps/cli/lib/utils.ts:93
 msgid "Unsupported PHP version: %s"
 msgstr ""
 
@@ -3361,7 +3346,7 @@ msgid "WordPress Studio"
 msgstr ""
 
 #: apps/studio/src/about-menu/open-about-menu.ts:68
-#: apps/studio/src/menu.ts:242
+#: apps/studio/src/menu.ts:270
 msgid "About WordPress Studio"
 msgstr ""
 
@@ -3381,25 +3366,33 @@ msgstr ""
 msgid "Local sites powered by"
 msgstr ""
 
-#: apps/studio/src/additional-phrases.ts:10
+#: apps/studio/src/additional-phrases.ts:13
 #: apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx:631
 #: apps/studio/src/modules/whats-new/components/whats-new-modal.tsx:131
+#: apps/ui/src/data/onboarding/orientation-guide.ts:30
+#: apps/ui/src/data/onboarding/orientation-guide.ts:41
+#: apps/ui/src/data/onboarding/orientation-guide.ts:56
+#: apps/ui/src/data/onboarding/orientation-guide.ts:66
+#: apps/ui/src/data/onboarding/whats-new.ts:18
+#: apps/ui/src/data/onboarding/whats-new.ts:28
+#: apps/ui/src/data/onboarding/whats-new.ts:38
+#: apps/ui/src/data/onboarding/whats-new.ts:47
 msgid "Next"
 msgstr ""
 
-#: apps/studio/src/additional-phrases.ts:11
+#: apps/studio/src/additional-phrases.ts:14
 #: apps/studio/src/modules/whats-new/components/whats-new-modal.tsx:132
 msgid "Previous"
 msgstr ""
 
 #: apps/studio/src/components/action-button.tsx:132
-#: apps/ui/src/components/site-dropdown/utils.ts:72
+#: apps/ui/src/components/site-dropdown/utils.ts:126
 msgid "Stopping…"
 msgstr ""
 
 #: apps/studio/src/components/action-button.tsx:132
-#: apps/ui/src/components/site-dropdown/utils.ts:73
-#: apps/ui/src/components/site-list/index.tsx:421
+#: apps/ui/src/components/site-dropdown/utils.ts:126
+#: apps/ui/src/components/site-list/index.tsx:436
 msgid "Starting…"
 msgstr ""
 
@@ -3408,14 +3401,13 @@ msgid "Server is running, click to stop."
 msgstr ""
 
 #: apps/studio/src/components/action-button.tsx:155
-#: apps/ui/src/components/site-dropdown/main-view.tsx:468
-#: apps/ui/src/components/site-list/index.tsx:243
+#: apps/ui/src/components/site-dropdown/utils.ts:79
 msgid "Running"
 msgstr ""
 
 #: apps/studio/src/components/agentic-ui-banner/index.tsx:81
 #: apps/ui/src/components/app-message-cards/index.tsx:41
-#: apps/ui/src/components/app-toasts/index.tsx:72
+#: apps/ui/src/components/app-toasts/index.tsx:80
 msgid "Dismiss"
 msgstr ""
 
@@ -3434,27 +3426,27 @@ msgstr ""
 msgid "Try it"
 msgstr ""
 
-#: apps/studio/src/components/auth-provider.tsx:69
+#: apps/studio/src/components/auth-provider.tsx:75
 msgid "Authentication error"
 msgstr ""
 
-#: apps/studio/src/components/auth-provider.tsx:70
+#: apps/studio/src/components/auth-provider.tsx:76
 #: apps/studio/src/modules/sync/index.tsx:177
 msgid "Please try again."
 msgstr ""
 
-#: apps/studio/src/components/auth-provider.tsx:74
+#: apps/studio/src/components/auth-provider.tsx:80
 msgid "Authorization denied"
 msgstr ""
 
-#: apps/studio/src/components/auth-provider.tsx:75
+#: apps/studio/src/components/auth-provider.tsx:81
 msgid ""
 "It looks like you denied the authorization request. To proceed, please "
 "click \"Approve\""
 msgstr ""
 
 #: apps/studio/src/components/clear-action.tsx:29
-#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:192
+#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:197
 msgid "Clear"
 msgstr ""
 
@@ -3471,7 +3463,6 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/components/content-tab-import-export.tsx:66
-#: apps/ui/src/hooks/use-site-management-actions.ts:61
 msgid "Export"
 msgstr ""
 
@@ -3480,12 +3471,16 @@ msgid "Export your entire site or only the database."
 msgstr ""
 
 #: apps/studio/src/components/content-tab-import-export.tsx:100
-#: apps/ui/src/components/site-list/index.tsx:467
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:273
+#: apps/ui/src/components/site-list/index.tsx:486
+#: apps/ui/src/hooks/use-site-management-actions.ts:108
 msgid "Export entire site"
 msgstr ""
 
 #: apps/studio/src/components/content-tab-import-export.tsx:109
-#: apps/ui/src/components/site-list/index.tsx:470
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:279
+#: apps/ui/src/components/site-list/index.tsx:492
+#: apps/ui/src/hooks/use-site-management-actions.ts:118
 msgid "Export database"
 msgstr ""
 
@@ -3502,6 +3497,7 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/components/content-tab-import-export.tsx:184
+#: apps/ui/src/components/import-site-dialog/index.tsx:152
 msgid "Overwrite %s?"
 msgstr ""
 
@@ -3512,6 +3508,7 @@ msgid "Don't ask again"
 msgstr ""
 
 #: apps/studio/src/components/content-tab-import-export.tsx:186
+#: apps/ui/src/components/import-site-dialog/index.tsx:153
 msgid ""
 "Importing a backup will replace the existing files and database for your "
 "site."
@@ -3519,6 +3516,8 @@ msgstr ""
 
 #: apps/studio/src/components/content-tab-import-export.tsx:187
 #: apps/studio/src/components/content-tab-import-export.tsx:253
+#: apps/ui/src/components/import-site-dialog/index.tsx:156
+#: apps/ui/src/hooks/use-site-management-actions.ts:96
 msgid "Import"
 msgstr ""
 
@@ -3573,92 +3572,107 @@ msgid ""
 "integration."
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:64
-#: apps/ui/src/components/site-overview-view/index.tsx:208
+#: apps/studio/src/components/content-tab-overview.tsx:74
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:237
+#: apps/ui/src/components/site-overview-view/index.tsx:302
 #: apps/ui/src/hooks/use-customize-links.ts:55
 msgid "Site Editor"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:69
-#: apps/ui/src/components/site-overview-view/index.tsx:214
+#: apps/studio/src/components/content-tab-overview.tsx:79
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:240
+#: apps/ui/src/components/site-overview-view/index.tsx:308
 #: apps/ui/src/hooks/use-customize-links.ts:61
 msgid "Styles"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:74
-#: apps/ui/src/components/site-overview-view/index.tsx:222
+#: apps/studio/src/components/content-tab-overview.tsx:87
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:241
+#: apps/ui/src/components/site-overview-view/index.tsx:319
 #: apps/ui/src/hooks/use-customize-links.ts:67
 msgid "Patterns"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:79
-#: apps/ui/src/components/site-overview-view/index.tsx:230
+#: apps/studio/src/components/content-tab-overview.tsx:95
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:242
+#: apps/ui/src/components/site-overview-view/index.tsx:330
 #: apps/ui/src/hooks/use-customize-links.ts:73
 msgid "Navigation"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:84
-#: apps/ui/src/components/site-overview-view/index.tsx:238
+#: apps/studio/src/components/content-tab-overview.tsx:103
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:243
+#: apps/ui/src/components/site-overview-view/index.tsx:341
 #: apps/ui/src/hooks/use-customize-links.ts:79
 msgid "Templates"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:89
-#: apps/ui/src/components/site-overview-view/index.tsx:246
+#: apps/studio/src/components/content-tab-overview.tsx:111
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:244
+#: apps/ui/src/components/site-overview-view/index.tsx:352
 #: apps/ui/src/hooks/use-customize-links.ts:113
 msgid "Pages"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:97
-#: apps/ui/src/components/site-overview-view/index.tsx:257
+#: apps/studio/src/components/content-tab-overview.tsx:119
+#: apps/ui/src/components/site-overview-view/index.tsx:366
 #: apps/ui/src/hooks/use-customize-links.ts:87
 msgid "Customizer"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:105
-#: apps/ui/src/components/site-overview-view/index.tsx:264
+#: apps/studio/src/components/content-tab-overview.tsx:127
+#: apps/ui/src/components/site-overview-view/index.tsx:373
 #: apps/ui/src/hooks/use-customize-links.ts:95
 msgid "Menus"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:113
-#: apps/ui/src/components/site-overview-view/index.tsx:272
+#: apps/studio/src/components/content-tab-overview.tsx:135
+#: apps/ui/src/components/site-overview-view/index.tsx:381
 #: apps/ui/src/hooks/use-customize-links.ts:105
 msgid "Widgets"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:126
-#: apps/ui/src/components/site-overview-view/index.tsx:203
+#: apps/studio/src/components/content-tab-overview.tsx:148
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:233
+#: apps/ui/src/components/site-overview-view/index.tsx:297
 msgid "Customize"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:174
-#: apps/studio/src/components/site-menu.tsx:341
+#: apps/studio/src/components/content-tab-overview.tsx:198
+#: apps/studio/src/components/site-menu.tsx:351
+#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:133
 msgid "Could not open the terminal."
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:180
+#: apps/studio/src/components/content-tab-overview.tsx:204
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:262
+#: apps/ui/src/components/site-overview-view/index.tsx:179
 msgid "phpMyAdmin"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:195
-#: apps/ui/src/components/open-in-menu/index.tsx:105
-#: apps/ui/src/components/open-in-menu/index.tsx:122
+#: apps/studio/src/components/content-tab-overview.tsx:220
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:249
+#: apps/ui/src/components/open-in-menu/index.tsx:106
+#: apps/ui/src/components/open-in-menu/index.tsx:123
+#: apps/ui/src/components/site-overview-view/index.tsx:165
 msgid "Open in…"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:229
+#: apps/studio/src/components/content-tab-overview.tsx:255
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:212
+#: apps/ui/src/components/site-overview-view/about-section.tsx:88
 msgid "Theme"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:240
-#: apps/studio/src/components/content-tab-overview.tsx:256
+#: apps/studio/src/components/content-tab-overview.tsx:266
+#: apps/studio/src/components/content-tab-overview.tsx:282
 #: apps/studio/src/components/studio-code-session/site-created-dialog.tsx:71
-#: apps/studio/src/ipc-handlers.ts:2042
+#: apps/studio/src/ipc-handlers.ts:2137
+#: apps/ui/src/components/site-overview-view/about-section.tsx:83
 msgid "Open site"
 msgstr ""
 
-#: apps/studio/src/components/content-tab-overview.tsx:261
+#: apps/studio/src/components/content-tab-overview.tsx:287
 msgid "Preview unavailable"
 msgstr ""
 
@@ -3690,7 +3704,7 @@ msgstr ""
 #: apps/studio/src/modules/onboarding/components/connect-to-wpcom.tsx:26
 #: apps/studio/src/modules/sync/index.tsx:73
 #: apps/studio/src/modules/user-settings/components/non-authenticated-account-tab.tsx:13
-#: apps/ui/src/components/auth-actions/index.tsx:19
+#: apps/ui/src/components/auth-actions/index.tsx:21
 msgid "You're currently offline."
 msgstr ""
 
@@ -3719,12 +3733,12 @@ msgstr ""
 #: apps/studio/src/components/content-tab-settings.tsx:126
 #: apps/studio/src/modules/user-settings/components/snapshot-info.tsx:65
 #: apps/studio/src/modules/user-settings/components/wapuu-score.tsx:54
-#: apps/ui/src/components/site-preview/index.tsx:442
+#: apps/ui/src/components/site-preview/index.tsx:488
 msgid "More options"
 msgstr ""
 
 #: apps/studio/src/components/content-tab-settings.tsx:132
-#: apps/ui/src/components/site-list/index.tsx:437
+#: apps/ui/src/components/site-list/index.tsx:456
 msgid "Duplicate site"
 msgstr ""
 
@@ -3758,7 +3772,7 @@ msgstr ""
 
 #: apps/studio/src/components/content-tab-settings.tsx:185
 #: apps/studio/src/modules/add-site/components/create-site-form.tsx:476
-#: apps/ui/src/components/create-site-form/index.tsx:455
+#: apps/ui/src/components/create-site-form/index.tsx:456
 msgid "Local path"
 msgstr ""
 
@@ -3781,7 +3795,7 @@ msgstr ""
 
 #: apps/studio/src/components/content-tab-settings.tsx:260
 #: apps/studio/src/modules/site-settings/edit-site-details.tsx:379
-#: apps/ui/src/components/site-overview-view/index.tsx:193
+#: apps/ui/src/components/site-overview-view/index.tsx:281
 msgid "Debugging"
 msgstr ""
 
@@ -3896,7 +3910,7 @@ msgid "Try restarting the app, if the problem persists"
 msgstr ""
 
 #: apps/studio/src/components/default-error-fallback.tsx:71
-#: apps/studio/src/menu.ts:414
+#: apps/studio/src/menu.ts:442
 msgid "Help"
 msgstr ""
 
@@ -3915,7 +3929,8 @@ msgstr ""
 
 #: apps/studio/src/components/fullscreen-modal.tsx:78
 #: apps/studio/src/components/modal.tsx:23
-#: apps/ui/src/components/fullscreen-chrome/index.tsx:41
+#: apps/ui/src/components/fullscreen-chrome/index.tsx:47
+#: apps/ui/src/components/selective-sync/primitives/modal.tsx:23
 #: apps/ui/src/ui-classic/components/session-view/session-chat-actions.tsx:224
 msgid "Close"
 msgstr ""
@@ -3924,12 +3939,12 @@ msgstr ""
 msgid "User avatar"
 msgstr ""
 
-#: apps/studio/src/components/header.tsx:48
-#: apps/studio/src/ipc-handlers.ts:2059
+#: apps/studio/src/components/header.tsx:52
+#: apps/studio/src/ipc-handlers.ts:2154
 msgid "WP admin"
 msgstr ""
 
-#: apps/studio/src/components/header.tsx:59
+#: apps/studio/src/components/header.tsx:63
 #. "Open local site" refers to the action of opening the local site in a browser
 msgid "Open local site"
 msgstr ""
@@ -3995,7 +4010,7 @@ msgstr ""
 msgid "Preview of the %s site"
 msgstr ""
 
-#: apps/studio/src/components/site-content-tabs.tsx:79
+#: apps/studio/src/components/site-content-tabs.tsx:81
 msgid "Select a site to view details."
 msgstr ""
 
@@ -4027,59 +4042,59 @@ msgstr ""
 msgid "A site can't be stopped or started during import."
 msgstr ""
 
-#: apps/studio/src/components/site-menu.tsx:31
+#: apps/studio/src/components/site-menu.tsx:33
 #. %s is the site name.
 msgid "%s site started."
 msgstr ""
 
-#: apps/studio/src/components/site-menu.tsx:36
+#: apps/studio/src/components/site-menu.tsx:38
 #. %s is the site name.
 msgid "%s site stopped."
 msgstr ""
 
-#: apps/studio/src/components/site-menu.tsx:83
-#: apps/ui/src/components/site-dropdown/main-view.tsx:466
-#: apps/ui/src/components/site-list/index.tsx:247
+#: apps/studio/src/components/site-menu.tsx:85
+#: apps/ui/src/components/site-dropdown/utils.ts:77
+#: packages/common/lib/site-operation-labels.ts:12
 msgid "Starting"
 msgstr ""
 
-#: apps/studio/src/components/site-menu.tsx:85
+#: apps/studio/src/components/site-menu.tsx:87
 #: apps/studio/src/index.ts:531
-#: apps/ui/src/components/site-dropdown/main-view.tsx:496
-#: apps/ui/src/components/site-list/index.tsx:253
-#: apps/ui/src/components/site-list/index.tsx:417
+#: apps/ui/src/components/site-dropdown/main-view.tsx:566
+#: apps/ui/src/components/site-list/index.tsx:265
+#: apps/ui/src/components/site-list/index.tsx:432
 #: packages/common/ai/tools.ts:301
 msgid "Stop site"
 msgid_plural "Stop sites"
 msgstr[0] ""
 msgstr[1] ""
 
-#: apps/studio/src/components/site-menu.tsx:100
+#: apps/studio/src/components/site-menu.tsx:102
 msgid "stop %s site"
 msgstr ""
 
-#: apps/studio/src/components/site-menu.tsx:100
+#: apps/studio/src/components/site-menu.tsx:102
 msgid "start %s site"
 msgstr ""
 
-#: apps/studio/src/components/site-menu.tsx:177
+#: apps/studio/src/components/site-menu.tsx:179
 msgid "Adding"
 msgstr ""
 
-#: apps/studio/src/components/site-menu.tsx:179
+#: apps/studio/src/components/site-menu.tsx:181
 msgid "Importing"
 msgstr ""
 
-#: apps/studio/src/components/site-menu.tsx:181
+#: apps/studio/src/components/site-menu.tsx:183
 msgid "Syncing"
 msgstr ""
 
-#: apps/studio/src/components/site-menu.tsx:183
+#: apps/studio/src/components/site-menu.tsx:185
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:660
 msgid "Loading"
 msgstr ""
 
-#: apps/studio/src/components/site-menu.tsx:386
+#: apps/studio/src/components/site-menu.tsx:396
 msgid "Sites"
 msgstr ""
 
@@ -4218,29 +4233,34 @@ msgstr ""
 msgid "Contact support"
 msgstr ""
 
-#: apps/studio/src/components/studio-code-session/access-requirements.tsx:126
-#: apps/ui/src/ui-classic/components/session-view/access-requirements.tsx:121
-msgid "Waiting for account update"
-msgstr ""
-
-#: apps/studio/src/components/studio-code-session/access-requirements.tsx:129
-#: apps/ui/src/ui-classic/components/session-view/access-requirements.tsx:130
+#: apps/studio/src/components/studio-code-session/access-requirements.tsx:108
+#: apps/studio/src/components/studio-code-session/access-requirements.tsx:132
+#: apps/ui/src/ui-classic/components/session-view/access-requirements.tsx:113
+#: apps/ui/src/ui-classic/components/session-view/access-requirements.tsx:139
 msgid "Checking…"
 msgstr ""
 
-#: apps/studio/src/components/studio-code-session/access-requirements.tsx:129
-#: apps/ui/src/ui-classic/components/session-view/access-requirements.tsx:130
+#: apps/studio/src/components/studio-code-session/access-requirements.tsx:108
+#: apps/studio/src/components/studio-code-session/access-requirements.tsx:132
+#: apps/ui/src/ui-classic/components/session-view/access-requirements.tsx:113
+#: apps/ui/src/ui-classic/components/session-view/access-requirements.tsx:139
 msgid "Check again"
 msgstr ""
 
-#: apps/studio/src/components/studio-code-session/access-requirements.tsx:132
+#: apps/studio/src/components/studio-code-session/access-requirements.tsx:129
+#: apps/ui/src/ui-classic/components/session-view/access-requirements.tsx:130
+msgid "Waiting for account update"
+msgstr ""
+
+#: apps/studio/src/components/studio-code-session/access-requirements.tsx:135
 #: apps/studio/src/modules/add-site/components/stepper.tsx:59
-#: apps/ui/src/components/create-site-form/index.tsx:614
+#: apps/ui/src/components/create-site-form/index.tsx:631
+#: apps/ui/src/components/onboarding-guide/index.tsx:115
 #: apps/ui/src/components/site-dropdown/publish-picker-view.tsx:68
-#: apps/ui/src/components/site-preview/index.tsx:861
-#: apps/ui/src/ui-classic/components/session-view/access-requirements.tsx:138
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:486
-#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:145
+#: apps/ui/src/components/site-preview/index.tsx:1021
+#: apps/ui/src/ui-classic/components/session-view/access-requirements.tsx:147
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:490
+#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:147
 #: apps/ui/src/ui-classic/router/route-onboarding-tour/index.tsx:127
 msgid "Back"
 msgstr ""
@@ -4271,9 +4291,9 @@ msgstr ""
 #: apps/studio/src/modules/user-settings/components/preferences-tab.tsx:234
 #: apps/studio/src/modules/user-settings/components/user-settings.tsx:57
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:911
-#: apps/ui/src/components/delete-site-dialog/index.tsx:71
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:541
 #: apps/ui/src/components/site-dropdown/disconnect-site-dialog.tsx:61
-#: apps/ui/src/data/core/connectors/ipc/index.ts:842
+#: apps/ui/src/data/core/connectors/ipc/index.ts:961
 #: apps/ui/src/ui-classic/components/session-view/composer/family-switch-confirm-dialog.tsx:63
 #: apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.tsx:181
 msgid "Cancel"
@@ -4288,32 +4308,32 @@ msgid "Start new conversation"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:201
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:644
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:660
 msgid "What should we make better?"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:202
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:645
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:661
 msgid "What’s the next move?"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:203
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:646
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:662
 msgid "Tell me what to change next…"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:204
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:647
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:663
 msgid "Drop the next idea here…"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:205
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:648
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:664
 msgid "What are we tuning now?"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:321
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:421
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:437
 msgid "Please review the attached files."
 msgstr ""
 
@@ -4322,51 +4342,51 @@ msgid "Queue a follow-up instruction…"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:451
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:653
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:669
 msgid "Queue"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:451
 #: apps/studio/src/components/studio-code-session/conversation/index.tsx:387
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:653
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:669
 msgid "Send"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:459
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:665
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:681
 msgid "FILE"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:460
-#: apps/studio/src/menu.ts:325
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:666
+#: apps/studio/src/menu.ts:353
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:682
 msgid "File"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:484
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:709
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:725
 msgid "Drop files to attach"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:488
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:713
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:729
 msgid "Attachments"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:499
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:724
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:740
 #. 1: attachment file name, 2: attachment type, 3: attachment size.
 msgid "Attachment: %1$s, %2$s, %3$s"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:506
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:731
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:747
 #. 1: attachment file name, 2: attachment type.
 msgid "Attachment: %1$s, %2$s"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:564
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:789
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:805
 #. %s: attachment file name.
 msgid "Remove attachment: %s"
 msgstr ""
@@ -4374,9 +4394,9 @@ msgstr ""
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:649
 #: apps/studio/src/modules/site-settings/edit-site-details.tsx:380
 #: apps/studio/src/modules/user-settings/components/user-settings.tsx:95
-#: apps/ui/src/components/settings-view/index.tsx:112
+#: apps/ui/src/components/settings-view/index.tsx:131
 #: apps/ui/src/components/settings-view/skills-panel.tsx:75
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:915
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:936
 msgid "Skills"
 msgstr ""
 
@@ -4386,20 +4406,20 @@ msgid "Attach files"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:678
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:964
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:974
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:985
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:995
 msgid "Select model"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:703
-#: apps/ui/src/components/site-dropdown/main-view.tsx:463
-#: apps/ui/src/components/site-list/index.tsx:246
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:998
+#: apps/ui/src/components/site-dropdown/utils.ts:74
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:1019
+#: packages/common/lib/site-operation-labels.ts:14
 msgid "Stopping"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/index.tsx:706
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:657
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:673
 msgid "Stopping… click again to force stop"
 msgstr ""
 
@@ -4445,6 +4465,7 @@ msgid "You can attach up to %d files."
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/composer/use-slash-commands.tsx:215
+#: apps/ui/src/ui-classic/components/session-view/composer/use-slash-commands.tsx:198
 msgid "Slash commands"
 msgstr ""
 
@@ -4453,13 +4474,13 @@ msgid "Edit your last message"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/conversation/index.tsx:431
-#: apps/studio/src/menu.ts:351
+#: apps/studio/src/menu.ts:379
 #: packages/common/ai/tools.ts:328
 msgid "Edit"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/conversation/index.tsx:446
-#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:488
+#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:499
 msgid "Copy message"
 msgstr ""
 
@@ -4472,22 +4493,22 @@ msgid "Show more"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/conversation/index.tsx:594
-#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:828
+#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:839
 msgid "Image unavailable"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/conversation/index.tsx:608
-#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:842
+#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:853
 msgid "Image"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/conversation/index.tsx:671
-#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:1207
+#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:1257
 msgid "Something went wrong and this turn was stopped. Please try again."
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/conversation/index.tsx:797
-#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:1310
+#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:1361
 msgid "Interrupted by you"
 msgstr ""
 
@@ -4550,7 +4571,8 @@ msgid "Scroll to bottom"
 msgstr ""
 
 #: apps/studio/src/components/studio-code-session/markdown/index.tsx:53
-#: apps/ui/src/components/markdown/index.tsx:39
+#: apps/studio/src/text-context-menu.ts:96
+#: apps/ui/src/components/markdown/index.tsx:40
 msgid "Copy code"
 msgstr ""
 
@@ -4708,14 +4730,14 @@ msgstr ""
 #: apps/studio/src/components/top-bar.tsx:109
 #: apps/studio/src/modules/user-settings/components/non-authenticated-account-tab.tsx:31
 #: apps/ui/src/components/settings-view/account-section.tsx:119
-#: apps/ui/src/components/site-dropdown/main-view.tsx:397
+#: apps/ui/src/components/site-dropdown/main-view.tsx:436
 msgid "Log in"
 msgstr ""
 
 #: apps/studio/src/components/top-bar.tsx:119
 #: apps/studio/src/modules/user-settings/components/user-settings.tsx:110
-#: apps/ui/src/components/settings-view/index.tsx:108
-#: apps/ui/src/components/site-overview-view/index.tsx:192
+#: apps/ui/src/components/settings-view/index.tsx:127
+#: apps/ui/src/components/site-overview-view/index.tsx:280
 #: apps/ui/src/components/user-menu/index.tsx:35
 msgid "Settings"
 msgstr ""
@@ -4731,20 +4753,26 @@ msgid "Get help"
 msgstr ""
 
 #: apps/studio/src/components/tree-view.tsx:141
+#: apps/ui/src/components/selective-sync/tree-view.tsx:141
 msgid "Collapse"
 msgstr ""
 
 #: apps/studio/src/components/tree-view.tsx:141
+#: apps/ui/src/components/selective-sync/tree-view.tsx:141
 msgid "Expand"
 msgstr ""
 
 #: apps/studio/src/components/tree-view.tsx:174
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:444
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:445
+#: apps/ui/src/components/selective-sync/tree-view.tsx:174
 msgid "Empty folder"
 msgstr ""
 
 #: apps/studio/src/components/tree-view.tsx:175
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:446
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:447
+#: apps/ui/src/components/selective-sync/tree-view.tsx:175
 msgid "Empty"
 msgstr ""
 
@@ -4812,7 +4840,7 @@ msgid "Don't show this warning again"
 msgstr ""
 
 #: apps/studio/src/hooks/use-content-tabs.tsx:17
-#: apps/ui/src/components/site-overview-view/index.tsx:191
+#: apps/ui/src/components/site-overview-view/index.tsx:279
 msgid "Overview"
 msgstr ""
 
@@ -4829,7 +4857,7 @@ msgid "Import / Export"
 msgstr ""
 
 #: apps/studio/src/hooks/use-content-tabs.tsx:40
-#: apps/ui/src/components/site-list/index.tsx:434
+#: apps/ui/src/components/site-list/index.tsx:450
 msgid "Site settings"
 msgstr ""
 
@@ -4841,21 +4869,21 @@ msgid "Studio Code"
 msgstr ""
 
 #: apps/studio/src/hooks/use-delete-site.ts:24
-#: apps/ui/src/components/delete-site-dialog/index.tsx:51
+#: apps/ui/src/components/delete-site-dialog/index.tsx:34
 #: packages/common/ai/tools.ts:191
 #. %s: post type, such as post or page.
 msgid "Delete %s"
 msgstr ""
 
 #: apps/studio/src/hooks/use-delete-site.ts:25
-#: apps/ui/src/components/delete-site-dialog/index.tsx:55
+#: apps/ui/src/components/delete-site-dialog/index.tsx:35
 msgid ""
 "The site's database will be lost, including all posts, pages, comments, and "
 "media."
 msgstr ""
 
 #: apps/studio/src/hooks/use-delete-site.ts:30
-#: apps/ui/src/components/delete-site-dialog/index.tsx:65
+#: apps/ui/src/components/delete-site-dialog/index.tsx:46
 msgid "Delete site files from my computer"
 msgstr ""
 
@@ -4868,62 +4896,61 @@ msgid "We couldn't delete the site '%s'. Please try again"
 msgstr ""
 
 #: apps/studio/src/hooks/use-import-export.tsx:117
+#: packages/common/lib/import-progress.ts:21
+#: packages/common/lib/import-progress.ts:33
 msgid "Extracting backup…"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:178
-#: packages/common/lib/import-progress.ts:22
+#: apps/studio/src/hooks/use-import-export.tsx:181
 msgid "Extracting backup… (%d%%)"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:223
-#: packages/common/lib/import-progress.ts:38
+#: apps/studio/src/hooks/use-import-export.tsx:226
 msgid "Importing database… (%d%%)"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:268
-#: packages/common/lib/import-progress.ts:54
+#: apps/studio/src/hooks/use-import-export.tsx:271
 msgid "Importing files…"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:269
-#: packages/common/lib/import-progress.ts:53
+#: apps/studio/src/hooks/use-import-export.tsx:272
 msgid "%1$s (%2$d%%)"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:300
-#: packages/common/lib/import-progress.ts:60
+#: apps/studio/src/hooks/use-import-export.tsx:303
+#: packages/common/lib/import-progress.ts:66
 msgid "Importing completed"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:351
-#: apps/ui/src/data/core/connectors/ipc/index.ts:436
+#: apps/studio/src/hooks/use-import-export.tsx:354
+#: apps/ui/src/data/core/connectors/ipc/index.ts:461
 msgid "Save backup file"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:372
-#: apps/ui/src/data/core/connectors/ipc/index.ts:466
+#: apps/studio/src/hooks/use-import-export.tsx:375
+#: apps/ui/src/data/core/connectors/ipc/index.ts:491
 msgid "Save database file"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:416
+#: apps/studio/src/hooks/use-import-export.tsx:419
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:88
+#: apps/ui/src/data/sync-activity.ts:100
 msgid "Creating backup…"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:446
+#: apps/studio/src/hooks/use-import-export.tsx:449
 msgid "Backing up files…"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:459
+#: apps/studio/src/hooks/use-import-export.tsx:462
 msgid "Database export completed"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:460
+#: apps/studio/src/hooks/use-import-export.tsx:463
 msgid "Site export completed"
 msgstr ""
 
-#: apps/studio/src/hooks/use-import-export.tsx:471
+#: apps/studio/src/hooks/use-import-export.tsx:474
 msgid "Export failed. Please try again."
 msgstr ""
 
@@ -4940,109 +4967,109 @@ msgstr ""
 msgid "Failed to stop remote session"
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:327
+#: apps/studio/src/hooks/use-site-details.tsx:340
 msgid "Blueprint execution failed"
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:328
+#: apps/studio/src/hooks/use-site-details.tsx:341
 msgid ""
 "The selected Blueprint failed to execute properly. This could be due to "
 "invalid PHP code, missing plugins, or other issues in the Blueprint file. "
 "Please check your Blueprint file and try again."
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:334
+#: apps/studio/src/hooks/use-site-details.tsx:347
 msgid ""
 "An error occurred while creating the site. Verify your selected local path "
 "is an empty directory or an existing WordPress folder and try again. If "
 "this problem persists, please contact support."
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:475
-#: apps/studio/src/hooks/use-site-details.tsx:486
+#: apps/studio/src/hooks/use-site-details.tsx:488
+#: apps/studio/src/hooks/use-site-details.tsx:499
 msgid "Failed to initialize custom domains for '%s'"
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:476
+#: apps/studio/src/hooks/use-site-details.tsx:489
 msgid ""
 "Studio needs to use port 80 and 443 to enable custom domains and SSL, but "
 "one of these ports are already in use by another app. Close any local "
 "development apps and restart Studio."
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:487
+#: apps/studio/src/hooks/use-site-details.tsx:500
 msgid ""
 "Please restart Studio and try again. If this problem persists, please "
 "contact support."
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:497
+#: apps/studio/src/hooks/use-site-details.tsx:510
 msgid "Not enough memory to start '%s'"
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:498
+#: apps/studio/src/hooks/use-site-details.tsx:511
 msgid ""
 "Please stop some of your running sites first. If this problem persists, try "
 "closing other apps that might be using memory and try again."
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:506
 #: apps/studio/src/hooks/use-site-details.tsx:519
-#: apps/studio/src/hooks/use-site-details.tsx:537
+#: apps/studio/src/hooks/use-site-details.tsx:532
+#: apps/studio/src/hooks/use-site-details.tsx:550
 msgid "Failed to start '%s'"
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:507
+#: apps/studio/src/hooks/use-site-details.tsx:520
 msgid ""
 "The site server failed to start because the port is already in use. Please "
 "close any local development apps that may be using port  and try again."
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:520
-#: apps/studio/src/hooks/use-site-details.tsx:569
+#: apps/studio/src/hooks/use-site-details.tsx:533
+#: apps/studio/src/hooks/use-site-details.tsx:582
 msgid ""
 "The maximum number of running sites has been reached. Please stop some "
 "running sites before starting new ones."
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:528
+#: apps/studio/src/hooks/use-site-details.tsx:541
 msgid "'%s' is in maintenance mode"
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:529
+#: apps/studio/src/hooks/use-site-details.tsx:542
 msgid ""
 "WordPress is currently performing an update. The maintenance lock should "
 "expire automatically within 10 minutes. Please wait for the update to "
 "finish and try starting the site again."
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:538
+#: apps/studio/src/hooks/use-site-details.tsx:551
 msgid ""
 "Please verify your site's local path directory contains the standard "
 "WordPress installation files and try again. If this problem persists, "
 "please contact support."
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:568
+#: apps/studio/src/hooks/use-site-details.tsx:581
 msgid "Some sites could not be started"
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:594
-#: apps/ui/src/data/queries/use-sites.ts:74
+#: apps/studio/src/hooks/use-site-details.tsx:607
+#: apps/ui/src/data/queries/use-sites.ts:87
 msgid "Failed to copy site"
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:595
+#: apps/studio/src/hooks/use-site-details.tsx:608
 msgid ""
 "An error occurred while copying the site. Please try again. If this problem "
 "persists, please contact support."
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:608
+#: apps/studio/src/hooks/use-site-details.tsx:621
 msgid "%s Copy"
 msgstr ""
 
-#: apps/studio/src/hooks/use-site-details.tsx:653
+#: apps/studio/src/hooks/use-site-details.tsx:666
 msgid "Your site %s was copied successfully"
 msgstr ""
 
@@ -5100,12 +5127,12 @@ msgstr[1] ""
 msgid "Remember my choice"
 msgstr ""
 
-#: apps/studio/src/ipc-handlers.ts:2080
-#: apps/studio/src/ipc-handlers.ts:2102
-#: apps/studio/src/ipc-handlers.ts:2124
-#: apps/ui/src/components/open-in-menu/index.tsx:68
-#: apps/ui/src/components/site-list/index.tsx:445
-#: apps/ui/src/components/site-list/index.tsx:454
+#: apps/studio/src/ipc-handlers.ts:2175
+#: apps/studio/src/ipc-handlers.ts:2197
+#: apps/studio/src/ipc-handlers.ts:2219
+#: apps/ui/src/components/open-in-menu/index.tsx:69
+#: apps/ui/src/components/site-list/index.tsx:464
+#: apps/ui/src/components/site-list/index.tsx:473
 #. %s is the name of the file explorer. E.g. "Open in Finder"
 #. %s is the name of the editor. E.g. "Open in Cursor"
 #. %s is the name of the terminal. E.g. "Open in Terminal"
@@ -5115,36 +5142,37 @@ msgstr ""
 msgid "Open in %s"
 msgstr ""
 
-#: apps/studio/src/ipc-handlers.ts:2145
+#: apps/studio/src/ipc-handlers.ts:2240
 msgid "Edit site…"
 msgstr ""
 
-#: apps/studio/src/ipc-handlers.ts:2162
+#: apps/studio/src/ipc-handlers.ts:2257
 msgid "Duplicate site…"
 msgstr ""
 
-#: apps/studio/src/ipc-handlers.ts:2179
+#: apps/studio/src/ipc-handlers.ts:2274
 msgid "Delete site…"
 msgstr ""
 
-#: apps/studio/src/ipc-handlers.ts:419
+#: apps/studio/src/ipc-handlers.ts:434
 msgid "WordPress.com login required. Log in to use Studio Code."
 msgstr ""
 
-#: apps/studio/src/ipc-handlers.ts:1307
+#: apps/studio/src/ipc-handlers.ts:1374
 msgid "Failed to open link"
 msgstr ""
 
-#: apps/studio/src/ipc-handlers.ts:1308
+#: apps/studio/src/ipc-handlers.ts:1375
 msgid "Please ensure your site files have not been moved or deleted."
 msgstr ""
 
-#: apps/studio/src/ipc-handlers.ts:1794
+#: apps/studio/src/ipc-handlers.ts:1889
 #: apps/studio/src/lib/deeplink/handlers/add-site-with-blueprint.ts:97
+#: apps/ui/src/data/queries/use-sync-site.ts:151
 msgid "Open Studio Logs"
 msgstr ""
 
-#: apps/studio/src/ipc-handlers.ts:1794
+#: apps/studio/src/ipc-handlers.ts:1889
 #: apps/studio/src/lib/deeplink/handlers/add-site-with-blueprint.ts:97
 #: apps/studio/src/lib/shell-open-external-wrapper.ts:47
 #: apps/studio/src/modules/user-settings/components/user-settings.tsx:69
@@ -5154,11 +5182,11 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: apps/studio/src/ipc-handlers.ts:1963
+#: apps/studio/src/ipc-handlers.ts:2058
 msgid "Certificate Trust Failed"
 msgstr ""
 
-#: apps/studio/src/ipc-handlers.ts:1964
+#: apps/studio/src/ipc-handlers.ts:2059
 msgid ""
 "Studio was unable to trust the certificate automatically. You may need to "
 "trust it manually using certificate manager."
@@ -5214,7 +5242,7 @@ msgid "Failed to load Blueprint"
 msgstr ""
 
 #: apps/studio/src/lib/file-manager.ts:7
-#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:25
+#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:29
 #. name of app used to navigate files and folders on Windows
 msgid "File Explorer"
 msgstr ""
@@ -5225,7 +5253,8 @@ msgid "File Manager"
 msgstr ""
 
 #: apps/studio/src/lib/file-manager.ts:14
-#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:30
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:251
+#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:34
 #. name of app used to navigate files and folders on macOS
 msgid "Finder"
 msgstr ""
@@ -5347,197 +5376,204 @@ msgid ""
 "faster?\" in the application menu."
 msgstr ""
 
-#: apps/studio/src/menu.ts:140
+#: apps/studio/src/menu.ts:149
 msgid "Toggle Sidebar"
 msgstr ""
 
-#: apps/studio/src/menu.ts:148
+#: apps/studio/src/menu.ts:157
 msgid "Toggle Site Preview"
 msgstr ""
 
-#: apps/studio/src/menu.ts:157
+#: apps/studio/src/menu.ts:166
 msgid "Actual Size"
 msgstr ""
 
-#: apps/studio/src/menu.ts:161
+#: apps/studio/src/menu.ts:170
 msgid "Zoom In"
 msgstr ""
 
-#: apps/studio/src/menu.ts:165
+#: apps/studio/src/menu.ts:174
 msgid "Zoom Out"
 msgstr ""
 
-#: apps/studio/src/menu.ts:170
+#: apps/studio/src/menu.ts:179
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: apps/studio/src/menu.ts:175
+#: apps/studio/src/menu.ts:184
 msgid "Float on Top of All Other Windows"
 msgstr ""
 
-#: apps/studio/src/menu.ts:196
+#: apps/studio/src/menu.ts:205
 msgid "Test Hard Crash (dev only)"
 msgstr ""
 
-#: apps/studio/src/menu.ts:202
+#: apps/studio/src/menu.ts:211
 msgid "Test Render Failure (dev only)"
 msgstr ""
 
-#: apps/studio/src/menu.ts:210
-msgid "Reload"
+#: apps/studio/src/menu.ts:227
+msgid "Reload App"
 msgstr ""
 
-#: apps/studio/src/menu.ts:211
-msgid "Force Reload"
+#: apps/studio/src/menu.ts:232
+msgid "Force Reload App"
 msgstr ""
 
-#: apps/studio/src/menu.ts:212
+#: apps/studio/src/menu.ts:237
 msgid "Toggle DevTools"
 msgstr ""
 
-#: apps/studio/src/menu.ts:248
+#: apps/studio/src/menu.ts:276
 msgid "Restart to Apply Updates"
 msgstr ""
 
-#: apps/studio/src/menu.ts:252
+#: apps/studio/src/menu.ts:280
 msgid "Check for Updates"
 msgstr ""
 
-#: apps/studio/src/menu.ts:255
+#: apps/studio/src/menu.ts:283
 msgid "Settings…"
 msgstr ""
 
-#: apps/studio/src/menu.ts:262
+#: apps/studio/src/menu.ts:290
 msgid "Beta Features"
 msgstr ""
 
-#: apps/studio/src/menu.ts:269
+#: apps/studio/src/menu.ts:297
 msgid "Services"
 msgstr ""
 
-#: apps/studio/src/menu.ts:273
+#: apps/studio/src/menu.ts:301
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:500
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:501
 msgid "Hide"
 msgstr ""
 
-#: apps/studio/src/menu.ts:279
+#: apps/studio/src/menu.ts:307
 msgid "Open Config Files (dev only)"
 msgstr ""
 
-#: apps/studio/src/menu.ts:282
+#: apps/studio/src/menu.ts:310
 msgid "App Config (app.json)"
 msgstr ""
 
-#: apps/studio/src/menu.ts:292
+#: apps/studio/src/menu.ts:320
 msgid "Shared Config (shared.json)"
 msgstr ""
 
-#: apps/studio/src/menu.ts:302
+#: apps/studio/src/menu.ts:330
 msgid "CLI Config (cli.json)"
 msgstr ""
 
-#: apps/studio/src/menu.ts:314
+#: apps/studio/src/menu.ts:342
 msgid "Feature Flags"
 msgstr ""
 
-#: apps/studio/src/menu.ts:321
+#: apps/studio/src/menu.ts:349
 msgid "Quit"
 msgstr ""
 
-#: apps/studio/src/menu.ts:329
+#: apps/studio/src/menu.ts:357
 msgid "Add Site…"
 msgstr ""
 
-#: apps/studio/src/menu.ts:340
+#: apps/studio/src/menu.ts:368
 msgid "Close Window"
 msgstr ""
 
-#: apps/studio/src/menu.ts:355
+#: apps/studio/src/menu.ts:383
 msgid "Undo"
 msgstr ""
 
-#: apps/studio/src/menu.ts:359
+#: apps/studio/src/menu.ts:387
 msgid "Redo"
 msgstr ""
 
-#: apps/studio/src/menu.ts:363
+#: apps/studio/src/menu.ts:391
 msgid "Cut"
 msgstr ""
 
-#: apps/studio/src/menu.ts:364
+#: apps/studio/src/menu.ts:392
 #: apps/studio/src/modules/mcp/components/mcp-settings.tsx:33
+#: apps/studio/src/text-context-menu.ts:92
 msgid "Copy"
 msgstr ""
 
-#: apps/studio/src/menu.ts:365
+#: apps/studio/src/menu.ts:393
+#: apps/studio/src/text-context-menu.ts:107
 msgid "Paste"
 msgstr ""
 
-#: apps/studio/src/menu.ts:367
+#: apps/studio/src/menu.ts:395
 msgid "Paste and Match Style"
 msgstr ""
 
-#: apps/studio/src/menu.ts:370
+#: apps/studio/src/menu.ts:398
 #: apps/studio/src/modules/preview-site/components/preview-action-buttons-menu.tsx:61
 #: apps/studio/src/modules/preview-site/components/preview-action-buttons-menu.tsx:131
-#: apps/ui/src/hooks/use-site-management-actions.ts:81
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:281
+#: apps/ui/src/hooks/use-site-management-actions.ts:128
 msgid "Delete"
 msgstr ""
 
-#: apps/studio/src/menu.ts:371
+#: apps/studio/src/menu.ts:399
 msgid "Select All"
 msgstr ""
 
-#: apps/studio/src/menu.ts:374
+#: apps/studio/src/menu.ts:402
 msgid "Speech"
 msgstr ""
 
-#: apps/studio/src/menu.ts:376
+#: apps/studio/src/menu.ts:404
 msgid "Start Speaking"
 msgstr ""
 
-#: apps/studio/src/menu.ts:377
+#: apps/studio/src/menu.ts:405
 msgid "Stop Speaking"
 msgstr ""
 
-#: apps/studio/src/menu.ts:383
-#: apps/ui/src/components/site-dropdown/main-view.tsx:284
+#: apps/studio/src/menu.ts:411
 msgid "View"
 msgstr ""
 
-#: apps/studio/src/menu.ts:402
+#: apps/studio/src/menu.ts:430
 msgid "Window"
 msgstr ""
 
-#: apps/studio/src/menu.ts:408
+#: apps/studio/src/menu.ts:436
 msgid "Minimize"
 msgstr ""
 
-#: apps/studio/src/menu.ts:409
+#: apps/studio/src/menu.ts:437
 msgid "Zoom"
 msgstr ""
 
-#: apps/studio/src/menu.ts:418
+#: apps/studio/src/menu.ts:446
 msgid "WordPress Studio Help"
 msgstr ""
 
-#: apps/studio/src/menu.ts:425
+#: apps/studio/src/menu.ts:453
 msgid "What's New"
 msgstr ""
 
-#: apps/studio/src/menu.ts:435
+#: apps/studio/src/menu.ts:460
+msgid "Getting Started"
+msgstr ""
+
+#: apps/studio/src/menu.ts:470
 msgid "How can I make WordPress Studio faster?"
 msgstr ""
 
-#: apps/studio/src/menu.ts:443
+#: apps/studio/src/menu.ts:478
 msgid "Open Application Logs"
 msgstr ""
 
-#: apps/studio/src/menu.ts:454
+#: apps/studio/src/menu.ts:489
 msgid "Report an Issue"
 msgstr ""
 
-#: apps/studio/src/menu.ts:460
+#: apps/studio/src/menu.ts:495
 msgid "Propose a Feature"
 msgstr ""
 
@@ -5567,12 +5603,12 @@ msgid "Admin password is required"
 msgstr ""
 
 #: apps/studio/src/modules/add-site/components/create-site-form.tsx:444
-#: apps/ui/src/components/create-site-form/index.tsx:650
+#: apps/ui/src/components/create-site-form/index.tsx:667
 msgid "Advanced settings"
 msgstr ""
 
 #: apps/studio/src/modules/add-site/components/create-site-form.tsx:452
-#: apps/ui/src/components/create-site-form/index.tsx:655
+#: apps/ui/src/components/create-site-form/index.tsx:672
 #. %d: number of errors found
 #. %d: number of validation errors.
 msgid "%d error found"
@@ -5659,14 +5695,14 @@ msgstr ""
 
 #: apps/studio/src/modules/add-site/components/create-site-form.tsx:712
 #: apps/studio/src/modules/site-settings/edit-site-details.tsx:564
-#: apps/ui/src/components/create-site-form/index.tsx:480
-#: apps/ui/src/components/site-settings-view/index.tsx:165
+#: apps/ui/src/components/create-site-form/index.tsx:481
+#: apps/ui/src/components/site-settings-view/index.tsx:166
 msgid "Enable HTTPS"
 msgstr ""
 
 #: apps/studio/src/modules/add-site/components/create-site-form.tsx:717
 #: apps/ui/src/components/create-site-form/index.tsx:360
-#: apps/ui/src/components/site-settings-view/index.tsx:91
+#: apps/ui/src/components/site-settings-view/index.tsx:92
 msgid ""
 "You need to manually add the Studio root certificate authority to your "
 "keychain and trust it to enable HTTPS."
@@ -5674,7 +5710,7 @@ msgstr ""
 
 #: apps/studio/src/modules/add-site/components/create-site.tsx:55
 #: apps/studio/src/modules/add-site/components/options.tsx:179
-#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:103
+#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:105
 msgid "Add a site"
 msgstr ""
 
@@ -5740,7 +5776,7 @@ msgid "Unsupported file type."
 msgstr ""
 
 #: apps/studio/src/modules/add-site/components/options.tsx:145
-#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:83
+#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:85
 msgid "Import from a backup"
 msgstr ""
 
@@ -5749,12 +5785,12 @@ msgid "Drop a file or click to browse (.zip, .tar.gz, .wpress, .xml)"
 msgstr ""
 
 #: apps/studio/src/modules/add-site/components/options.tsx:182
-#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:105
+#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:107
 msgid "Start fresh or bring an existing site into your Studio."
 msgstr ""
 
 #: apps/studio/src/modules/add-site/components/options.tsx:189
-#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:113
+#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:115
 msgid ""
 "Start from scratch or use a Blueprint. Perfect for theme and plugin "
 "development."
@@ -5768,8 +5804,8 @@ msgstr ""
 
 #: apps/studio/src/modules/add-site/components/options.tsx:203
 #: apps/studio/src/modules/add-site/components/pull-remote-site.tsx:164
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:320
-#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:127
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:324
+#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:129
 msgid "Connect a site"
 msgstr ""
 
@@ -5803,8 +5839,8 @@ msgid "Supports staging and production sites."
 msgstr ""
 
 #: apps/studio/src/modules/add-site/components/pull-remote-site.tsx:79
-#: apps/ui/src/components/agentic-signin-banner/index.tsx:56
-#: apps/ui/src/components/auth-actions/index.tsx:50
+#: apps/ui/src/components/agentic-signin-banner/index.tsx:62
+#: apps/ui/src/components/auth-actions/index.tsx:52
 msgid "Log in with WordPress.com"
 msgstr ""
 
@@ -5816,7 +5852,7 @@ msgstr ""
 
 #: apps/studio/src/modules/add-site/components/pull-remote-site.tsx:164
 #: apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx:76
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:320
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:324
 msgid "Connect your site"
 msgstr ""
 
@@ -5825,7 +5861,7 @@ msgid "Ready to bring into your Studio."
 msgstr ""
 
 #: apps/studio/src/modules/add-site/components/pull-remote-site.tsx:169
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:324
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:328
 msgid "Select a WordPress.com or Pressable site to bring into your Studio."
 msgstr ""
 
@@ -5850,7 +5886,7 @@ msgstr ""
 
 #: apps/studio/src/modules/add-site/hooks/use-stepper.ts:49
 #: apps/studio/src/modules/add-site/index.tsx:709
-#: apps/ui/src/components/sidebar-header/index.tsx:37
+#: apps/ui/src/components/sidebar-header/index.tsx:55
 msgid "Add site"
 msgstr ""
 
@@ -5957,7 +5993,7 @@ msgstr ""
 
 #: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:39
 #: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:53
-#: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:182
+#: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:188
 msgid "Check Studio Logs for more details."
 msgstr ""
 
@@ -5979,21 +6015,21 @@ msgid ""
 "again. If this problem persists, please contact support."
 msgstr ""
 
-#: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:147
+#: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:153
 msgid "Import completed"
 msgstr ""
 
-#: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:186
+#: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:192
 msgid "Failed exporting site"
 msgstr ""
 
-#: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:187
+#: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:193
 msgid ""
 "An error occurred while exporting the site. If this problem persists, "
 "please contact support."
 msgstr ""
 
-#: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:257
+#: apps/studio/src/modules/import-export/lib/ipc-handlers.ts:269
 msgid "Export completed"
 msgstr ""
 
@@ -6006,6 +6042,7 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/modules/onboarding/components/connect-to-wpcom.tsx:34
+#: apps/ui/src/data/onboarding/orientation-guide.ts:35
 msgid "Welcome to WordPress Studio"
 msgstr ""
 
@@ -6035,13 +6072,14 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/modules/onboarding/components/connect-to-wpcom.tsx:100
+#: apps/ui/src/components/onboarding-guide/index.tsx:66
 #: apps/ui/src/ui-classic/router/route-welcome/index.tsx:91
 msgid "Skip"
 msgstr ""
 
 #: apps/studio/src/modules/onboarding/components/connect-to-wpcom.tsx:138
 #: apps/studio/src/modules/user-settings/components/analytics-toggle.tsx:17
-#: apps/ui/src/components/settings-view/index.tsx:335
+#: apps/ui/src/components/settings-view/index.tsx:347
 #: apps/ui/src/ui-classic/router/route-welcome/index.tsx:116
 msgid "Help improve Studio by sharing anonymous usage statistics"
 msgstr ""
@@ -6118,6 +6156,7 @@ msgstr ""
 
 #: apps/studio/src/modules/preview-site/components/create-preview-button.tsx:159
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:492
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:493
 #. %d: number of warnings
 msgid "%d warning"
 msgid_plural "%d warnings"
@@ -6167,25 +6206,25 @@ msgstr ""
 msgid "Deleting a preview site requires an internet connection."
 msgstr ""
 
-#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:101
+#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:103
 msgid "Failed"
 msgstr ""
 
-#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:107
+#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:109
 msgid "%s ago"
 msgstr ""
 
-#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:120
+#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:122
 msgid ""
 "This preview site has been deleted from the server. You can remove it from "
 "the list by clicking Clear button."
 msgstr ""
 
-#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:134
+#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:136
 msgid "%s Preview"
 msgstr ""
 
-#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:163
+#: apps/studio/src/modules/preview-site/components/preview-site-row.tsx:168
 msgid "Updating"
 msgstr ""
 
@@ -6220,7 +6259,7 @@ msgid "Saving and restarting…"
 msgstr ""
 
 #: apps/studio/src/modules/site-settings/edit-site-details.tsx:343
-#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:65
+#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:68
 msgid "Saving…"
 msgstr ""
 
@@ -6232,14 +6271,14 @@ msgstr ""
 
 #: apps/studio/src/modules/site-settings/edit-site-details.tsx:378
 #: apps/studio/src/modules/user-settings/components/user-settings.tsx:79
-#: apps/ui/src/components/settings-view/index.tsx:288
+#: apps/ui/src/components/settings-view/index.tsx:300
 #: apps/ui/src/components/settings-view/keyboard-panel.tsx:36
 msgid "General"
 msgstr ""
 
 #: apps/studio/src/modules/site-settings/edit-site-details.tsx:381
-#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:76
-#: apps/ui/src/components/settings-view/studio-code-panel.tsx:20
+#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:79
+#: apps/ui/src/components/settings-view/studio-code-panel.tsx:21
 msgid "Instructions"
 msgstr ""
 
@@ -6303,8 +6342,9 @@ msgid "Creating a site requires an internet connection."
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/environment-badge.tsx:38
-#: apps/ui/src/components/site-dropdown/main-view.tsx:243
-#: apps/ui/src/components/site-dropdown/main-view.tsx:247
+#: apps/ui/src/components/selective-sync/environment-badge.tsx:41
+#: apps/ui/src/components/site-dropdown/main-view.tsx:282
+#: apps/ui/src/components/site-dropdown/main-view.tsx:286
 msgid "Studio"
 msgstr ""
 
@@ -6348,6 +6388,7 @@ msgstr ""
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:100
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:121
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:53
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:53
 msgid "Pull"
 msgstr ""
 
@@ -6366,6 +6407,7 @@ msgstr ""
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:140
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:161
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:81
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:81
 msgid "Push"
 msgstr ""
 
@@ -6396,15 +6438,19 @@ msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:324
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:341
+#: apps/ui/src/data/sync-activity.ts:196
 msgid "Cancel pull"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:325
+#: apps/ui/src/data/sync-activity.ts:197
 msgid "Pull can not be cancelled while importing changes to your local site"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:353
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:487
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:48
+#: apps/ui/src/data/queries/use-sync-site.ts:136
 msgid "Pull cancelled"
 msgstr ""
 
@@ -6420,7 +6466,7 @@ msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:393
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:121
-#: apps/ui/src/data/queries/use-sync-site.ts:95
+#: apps/ui/src/data/queries/use-sync-site.ts:128
 msgid "Pull complete"
 msgstr ""
 
@@ -6443,6 +6489,7 @@ msgstr ""
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:455
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:509
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:526
+#: apps/ui/src/data/sync-activity.ts:188
 msgid "Cancel push"
 msgstr ""
 
@@ -6452,11 +6499,14 @@ msgid "Pause upload"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:510
+#: apps/ui/src/data/sync-activity.ts:189
 msgid "Push can not be cancelled while applying changes to the remote site"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:547
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:459
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:48
+#: apps/ui/src/data/queries/use-sync-site.ts:52
 msgid "Push cancelled"
 msgstr ""
 
@@ -6478,7 +6528,7 @@ msgstr ""
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:628
 #: apps/studio/src/modules/sync/components/sync-connected-sites.tsx:697
 #: apps/ui/src/components/site-dropdown/disconnect-site-dialog.tsx:70
-#: apps/ui/src/components/site-dropdown/main-view.tsx:386
+#: apps/ui/src/components/site-dropdown/main-view.tsx:425
 msgid "Disconnect"
 msgstr ""
 
@@ -6504,24 +6554,28 @@ msgid "Reconnect"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:206
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:207
 msgid ""
 "Your Studio site is using different WordPress and PHP versions than your "
 "remote site. The remote site will keep using the newest supported versions."
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:210
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:211
 msgid ""
 "Your Studio site is using a different PHP version than your remote site. "
 "The remote site will keep using the newest supported version."
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:214
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:215
 msgid ""
 "Your Studio site is using a different WordPress version than your remote "
 "site. The remote site will keep using the newest supported version."
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:242
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:243
 msgid ""
 "Selecting individual items to pull will be enabled automatically once your "
 "first backup is complete.<br/>Wait a few minutes or run a full sync in the "
@@ -6529,54 +6583,66 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:333
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:334
 msgid "From %1$s to %2$s"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:376
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:377
 msgid "All files and folders"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:380
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:381
 msgid "Specific files and folders"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:388
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:389
 msgid "Select files and folders to sync"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:406
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:407
 msgid "Content from the latest backup: %s."
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:412
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:413
 msgid "Create new backup ↗"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:423
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:424
 msgid "Could not load files. Please close and reopen this dialog to try again."
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:435
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:436
 msgid ""
 "Error retrieving remote files and directories. Please close and reopen this "
 "dialog to try again."
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:467
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:468
 msgid "%s over"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:475
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:476
 msgid ""
 "The current selection exceeds the %d GB push limit. To continue, please "
 "change your selection to reduce the total size."
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:500
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:501
 msgid "Show"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-dialog.tsx:513
+#: apps/ui/src/components/selective-sync/sync-dialog.tsx:514
 msgid ""
 "Your Studio site is configured as a multisite network. WordPress.com does "
 "not support multisite, so pushing may cause unexpected issues on the remote "
@@ -6592,23 +6658,23 @@ msgid "Select a site to import"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx:136
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:411
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:415
 msgid "Refreshing…"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx:136
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:411
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:415
 msgid "Refresh list"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx:146
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:425
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:429
 msgid "Supported sites"
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx:172
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:393
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:396
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:397
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:400
 msgid "Search sites"
 msgstr ""
 
@@ -6621,7 +6687,7 @@ msgid "No WordPress.com sites found on this account."
 msgstr ""
 
 #: apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx:277
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:351
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:355
 msgid "Loading your sites…"
 msgstr ""
 
@@ -6694,48 +6760,58 @@ msgid "Importing a remote site requires an internet connection."
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:30
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:30
 msgid "Pull from Production"
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:31
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:31
 msgid ""
 "Pulling will overwrite your Studio site's selected files and database with "
 "a copy from your production site. Unchecked items will not be changed."
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:36
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:36
 msgid "Pull from Staging"
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:37
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:37
 msgid ""
 "Pulling will overwrite your Studio site's selected files and database with "
 "a copy from your staging site. Unchecked items will not be changed."
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:42
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:42
 msgid "Pull from Development"
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:43
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:43
 msgid ""
 "Pulling will overwrite your Studio site's selected files and database with "
 "a copy from your development site. Unchecked items will not be changed."
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:51
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:51
 msgid "What would you like to pull?"
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:52
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:52
 msgid "Read more about <a>environment pull <ArrowIcon /></a>"
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:58
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:58
 msgid "Push to Production"
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:59
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:59
 msgid ""
 "Pushing will overwrite your production site's selected files and database "
 "with content from your Studio site. Unchecked items will not be changed. "
@@ -6743,10 +6819,12 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:64
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:64
 msgid "Push to Staging"
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:65
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:65
 msgid ""
 "Pushing will overwrite your staging site's selected files and database with "
 "content from your Studio site. Unchecked items will not be changed. The "
@@ -6754,10 +6832,12 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:70
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:70
 msgid "Push to Development"
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:71
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:71
 msgid ""
 "Pushing will overwrite your development site's selected files and database "
 "with content from your Studio site. Unchecked items will not be changed. "
@@ -6765,14 +6845,17 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:79
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:79
 msgid "What would you like to push?"
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-sync-dialog-texts.tsx:80
+#: apps/ui/src/components/selective-sync/hooks/use-sync-dialog-texts.tsx:80
 msgid "Read more about <a>environment push <ArrowIcon /></a>"
 msgstr ""
 
 #: apps/studio/src/modules/sync/hooks/use-top-level-sync-tree.tsx:14
+#: apps/ui/src/components/selective-sync/hooks/use-top-level-sync-tree.tsx:14
 msgid "Files and folders"
 msgstr ""
 
@@ -6799,54 +6882,57 @@ msgid "Connect another site"
 msgstr ""
 
 #: apps/studio/src/modules/sync/index.tsx:219
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:497
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:501
 msgid "Connect site"
 msgstr ""
 
 #: apps/studio/src/modules/sync/lib/environment-utils.ts:18
+#: apps/ui/src/components/selective-sync/lib/environment-utils.ts:18
 #: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:35
 msgid "Production"
 msgstr ""
 
 #: apps/studio/src/modules/sync/lib/environment-utils.ts:19
+#: apps/ui/src/components/selective-sync/lib/environment-utils.ts:19
 #: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:33
 #: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:34
 msgid "Staging"
 msgstr ""
 
 #: apps/studio/src/modules/sync/lib/environment-utils.ts:20
+#: apps/ui/src/components/selective-sync/lib/environment-utils.ts:20
 #: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:32
 msgid "Development"
 msgstr ""
 
-#: apps/studio/src/modules/sync/lib/ipc-handlers.ts:395
+#: apps/studio/src/modules/sync/lib/ipc-handlers.ts:400
 msgid "The site archive is too large to upload right now. Please try again later."
 msgstr ""
 
-#: apps/studio/src/modules/sync/lib/ipc-handlers.ts:402
+#: apps/studio/src/modules/sync/lib/ipc-handlers.ts:407
 #. %d is the HTTP status code of the failed upload, e.g. 500.
 msgid "Upload failed with HTTP status %d."
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/color-scheme-picker.tsx:20
-#: apps/ui/src/components/settings-view/index.tsx:70
+#: apps/ui/src/components/settings-view/index.tsx:71
 msgid "System"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/color-scheme-picker.tsx:21
-#: apps/ui/src/components/settings-view/index.tsx:71
+#: apps/ui/src/components/settings-view/index.tsx:72
 msgid "Light"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/color-scheme-picker.tsx:22
-#: apps/ui/src/components/settings-view/index.tsx:72
+#: apps/ui/src/components/settings-view/index.tsx:73
 msgid "Dark"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/color-scheme-picker.tsx:26
 #: apps/studio/src/modules/user-settings/components/color-scheme-picker.tsx:27
-#: apps/ui/src/components/settings-view/index.tsx:168
-#: apps/ui/src/components/settings-view/index.tsx:172
+#: apps/ui/src/components/settings-view/index.tsx:180
+#: apps/ui/src/components/settings-view/index.tsx:184
 msgid "Appearance"
 msgstr ""
 
@@ -6868,8 +6954,8 @@ msgid "Not installed"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/language-picker.tsx:14
-#: apps/ui/src/components/settings-view/index.tsx:295
-#: apps/ui/src/components/settings-view/index.tsx:297
+#: apps/ui/src/components/settings-view/index.tsx:307
+#: apps/ui/src/components/settings-view/index.tsx:309
 msgid "Language"
 msgstr ""
 
@@ -6880,22 +6966,22 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/preferences-tab.tsx:190
-#: apps/ui/src/data/core/connectors/ipc/index.ts:756
+#: apps/ui/src/data/core/connectors/ipc/index.ts:852
 msgid "Select default site directory"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/preferences-tab.tsx:211
-#: apps/ui/src/components/settings-view/index.tsx:227
+#: apps/ui/src/components/settings-view/index.tsx:239
 msgid "Default site directory"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/preferences-tab.tsx:213
-#: apps/ui/src/components/settings-view/index.tsx:416
-#: apps/ui/src/components/settings-view/studio-code-panel.tsx:71
+#: apps/ui/src/components/settings-view/index.tsx:428
+#: apps/ui/src/components/settings-view/studio-code-panel.tsx:92
 #: apps/ui/src/components/settings-view/usage-panel.tsx:59
 #: apps/ui/src/components/settings-view/usage-panel.tsx:181
-#: apps/ui/src/components/site-list/index.tsx:723
-#: apps/ui/src/components/site-overview-view/index.tsx:127
+#: apps/ui/src/components/site-list/index.tsx:755
+#: apps/ui/src/components/site-overview-view/index.tsx:203
 msgid "Loading…"
 msgstr ""
 
@@ -6919,28 +7005,28 @@ msgid "Studio Code limits are temporarily unavailable."
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/quit-sites-behavior-picker.tsx:15
-#: apps/ui/src/components/settings-view/index.tsx:323
-#: apps/ui/src/components/settings-view/index.tsx:325
+#: apps/ui/src/components/settings-view/index.tsx:335
+#: apps/ui/src/components/settings-view/index.tsx:337
 msgid "When quitting with running sites"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/quit-sites-behavior-picker.tsx:20
-#: apps/ui/src/components/settings-view/index.tsx:83
+#: apps/ui/src/components/settings-view/index.tsx:84
 msgid "Ask every time"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/quit-sites-behavior-picker.tsx:21
-#: apps/ui/src/components/settings-view/index.tsx:84
+#: apps/ui/src/components/settings-view/index.tsx:85
 msgid "Keep sites running"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/quit-sites-behavior-picker.tsx:22
-#: apps/ui/src/components/settings-view/index.tsx:85
+#: apps/ui/src/components/settings-view/index.tsx:86
 msgid "Stop, restart on next launch"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/quit-sites-behavior-picker.tsx:23
-#: apps/ui/src/components/settings-view/index.tsx:86
+#: apps/ui/src/components/settings-view/index.tsx:87
 msgid "Stop sites"
 msgstr ""
 
@@ -6969,7 +7055,7 @@ msgstr ""
 #: apps/studio/src/modules/user-settings/components/snapshot-info.tsx:98
 #: apps/studio/src/modules/user-settings/components/user-settings.tsx:53
 #: apps/ui/src/components/settings-view/usage-panel.tsx:134
-#: apps/ui/src/data/core/connectors/ipc/index.ts:838
+#: apps/ui/src/data/core/connectors/ipc/index.ts:957
 msgid "Delete all preview sites"
 msgstr ""
 
@@ -6984,23 +7070,23 @@ msgid ""
 "WP-CLI commands, and control your local environment. <learn_more_link/>"
 msgstr ""
 
-#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:67
+#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:70
 msgid "Saved"
 msgstr ""
 
-#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:68
+#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:71
 msgid "Save instructions"
 msgstr ""
 
-#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:77
-#: apps/ui/src/components/settings-view/studio-code-panel.tsx:21
+#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:80
+#: apps/ui/src/components/settings-view/studio-code-panel.tsx:22
 msgid ""
 "Global instructions for the Studio Code agent. They are included in every "
 "new conversation, across all sites."
 msgstr ""
 
-#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:85
-#: apps/ui/src/components/settings-view/studio-code-panel.tsx:24
+#: apps/studio/src/modules/user-settings/components/studio-code-tab.tsx:88
+#: apps/ui/src/components/settings-view/studio-code-panel.tsx:25
 msgid "e.g. Always answer in French. My sites are for restaurants."
 msgstr ""
 
@@ -7024,16 +7110,16 @@ msgid "Log out"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/user-settings.tsx:54
-#: apps/ui/src/data/core/connectors/hosted/index.ts:417
-#: apps/ui/src/data/core/connectors/ipc/index.ts:839
-#: apps/ui/src/data/core/connectors/local/index.ts:832
+#: apps/ui/src/data/core/connectors/hosted/index.ts:461
+#: apps/ui/src/data/core/connectors/ipc/index.ts:958
+#: apps/ui/src/data/core/connectors/local/index.ts:947
 msgid ""
 "All preview sites that exist for your WordPress.com account, along with all "
 "posts, pages, comments, and media, will be lost."
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/user-settings.tsx:57
-#: apps/ui/src/data/core/connectors/ipc/index.ts:842
+#: apps/ui/src/data/core/connectors/ipc/index.ts:961
 msgid "Delete all"
 msgstr ""
 
@@ -7048,7 +7134,7 @@ msgid "Account"
 msgstr ""
 
 #: apps/studio/src/modules/user-settings/components/user-settings.tsx:100
-#: apps/ui/src/components/settings-view/index.tsx:113
+#: apps/ui/src/components/settings-view/index.tsx:132
 #: apps/ui/src/components/settings-view/mcp-panel.tsx:13
 msgid "MCP"
 msgstr ""
@@ -7092,16 +7178,19 @@ msgid "Arrow keys / WASD to move · Up / W / Space to jump"
 msgstr ""
 
 #: apps/studio/src/modules/whats-new/components/whats-new-modal.tsx:55
+#: apps/ui/src/data/onboarding/whats-new.ts:13
 msgid "Studio Code helps you get it done"
 msgstr ""
 
 #: apps/studio/src/modules/whats-new/components/whats-new-modal.tsx:56
+#: apps/ui/src/data/onboarding/whats-new.ts:15
 msgid ""
 "From quick edits to new features, Studio Code helps you move faster by "
 "translating your ideas into working code."
 msgstr ""
 
 #: apps/studio/src/modules/whats-new/components/whats-new-modal.tsx:63
+#: apps/ui/src/data/onboarding/whats-new.ts:23
 msgid "Faster local sites with native PHP"
 msgstr ""
 
@@ -7113,16 +7202,19 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/modules/whats-new/components/whats-new-modal.tsx:71
+#: apps/ui/src/data/onboarding/whats-new.ts:33
 msgid "Dark mode is here"
 msgstr ""
 
 #: apps/studio/src/modules/whats-new/components/whats-new-modal.tsx:72
+#: apps/ui/src/data/onboarding/whats-new.ts:35
 msgid ""
 "Studio now supports light, dark, and system appearance modes. Head to "
 "Settings to choose your preferred look."
 msgstr ""
 
 #: apps/studio/src/modules/whats-new/components/whats-new-modal.tsx:78
+#: apps/ui/src/data/onboarding/whats-new.ts:42
 msgid "Manage your database with phpMyAdmin"
 msgstr ""
 
@@ -7133,6 +7225,7 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/modules/whats-new/components/whats-new-modal.tsx:85
+#: apps/ui/src/data/onboarding/whats-new.ts:51
 msgid "WP-CLI support and CLI site management"
 msgstr ""
 
@@ -7152,6 +7245,8 @@ msgid "What's new"
 msgstr ""
 
 #: apps/studio/src/modules/whats-new/components/whats-new-modal.tsx:123
+#: apps/ui/src/components/onboarding-guide/illustrations/index.tsx:51
+#. %s is the title of the guide page the illustration belongs to.
 msgid "Illustration for %s"
 msgstr ""
 
@@ -7206,6 +7301,7 @@ msgid "Preview site '%s' has been deleted."
 msgstr ""
 
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:89
+#: apps/ui/src/data/sync-activity.ts:101
 msgid "Uploading site…"
 msgstr ""
 
@@ -7215,21 +7311,13 @@ msgid "Uploading paused"
 msgstr ""
 
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:103
-#: apps/ui/src/data/queries/use-sync-site.ts:41
+#: apps/ui/src/data/queries/use-sync-site.ts:47
 msgid "Push complete"
 msgstr ""
 
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:105
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:123
 msgid "Cancelled"
-msgstr ""
-
-#: apps/studio/src/stores/sync/sync-operations-slice.ts:117
-msgid "Initializing remote backup…"
-msgstr ""
-
-#: apps/studio/src/stores/sync/sync-operations-slice.ts:119
-msgid "Downloading backup…"
 msgstr ""
 
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:460
@@ -7260,7 +7348,7 @@ msgid ""
 msgstr ""
 
 #: apps/studio/src/stores/sync/sync-operations-slice.ts:703
-#: apps/studio/src/stores/sync/sync-operations-slice.ts:1042
+#: apps/studio/src/stores/sync/sync-operations-slice.ts:1043
 msgid "Error pulling from %s"
 msgstr ""
 
@@ -7314,9 +7402,23 @@ msgid ""
 "Do you want to continue?"
 msgstr ""
 
-#: apps/studio/src/stores/sync/sync-operations-slice.ts:1002
+#: apps/studio/src/stores/sync/sync-operations-slice.ts:1003
 #. %s is the site url without the protocol.
 msgid "Studio site has been updated from %s"
+msgstr ""
+
+#: apps/studio/src/text-context-menu.ts:58
+#. %s: the text the user selected.
+msgid "Look Up “%s”"
+msgstr ""
+
+#: apps/studio/src/text-context-menu.ts:102
+msgid "Copy All"
+msgstr ""
+
+#: apps/studio/src/text-context-menu.ts:114
+#. Context-menu action that inserts selected text into the message composer as a quote.
+msgid "Quote in composer"
 msgstr ""
 
 #: apps/studio/src/updates.ts:250
@@ -7412,31 +7514,33 @@ msgid "Error updating Studio"
 msgstr ""
 
 #: apps/ui/src/components/agent-working-indicator/index.tsx:27
-#: apps/ui/src/components/site-list/index.tsx:111
+#: apps/ui/src/components/site-list/index.tsx:116
 msgid "Working…"
 msgstr ""
 
-#: apps/ui/src/components/agentic-signin-banner/index.tsx:39
+#: apps/ui/src/components/agentic-signin-banner/index.tsx:41
 msgid "Sign in to Studio"
 msgstr ""
 
-#: apps/ui/src/components/agentic-signin-banner/index.tsx:41
+#: apps/ui/src/components/agentic-signin-banner/index.tsx:43
 msgid "Sign in to do more with Studio"
 msgstr ""
 
-#: apps/ui/src/components/agentic-signin-banner/index.tsx:43
-msgid "Chat with a WordPress expert that builds and edits your site for you"
+#: apps/ui/src/components/agentic-signin-banner/index.tsx:46
+msgid ""
+"Chat with an AI WordPress expert that helps build and edit your site "
+"alongside you"
 msgstr ""
 
-#: apps/ui/src/components/agentic-signin-banner/index.tsx:44
+#: apps/ui/src/components/agentic-signin-banner/index.tsx:50
 msgid "Share your work instantly with preview links"
 msgstr ""
 
-#: apps/ui/src/components/agentic-signin-banner/index.tsx:45
+#: apps/ui/src/components/agentic-signin-banner/index.tsx:51
 msgid "Publish to a real WordPress.com site when you're ready"
 msgstr ""
 
-#: apps/ui/src/components/auth-actions/index.tsx:38
+#: apps/ui/src/components/auth-actions/index.tsx:40
 msgid "Sign up"
 msgstr ""
 
@@ -7497,7 +7601,7 @@ msgid "Select a folder"
 msgstr ""
 
 #: apps/ui/src/components/create-site-form/index.tsx:339
-#: apps/ui/src/components/settings-view/index.tsx:239
+#: apps/ui/src/components/settings-view/index.tsx:251
 msgid "Choose a folder…"
 msgstr ""
 
@@ -7505,33 +7609,48 @@ msgstr ""
 msgid "Choose…"
 msgstr ""
 
-#: apps/ui/src/components/create-site-form/index.tsx:463
+#: apps/ui/src/components/create-site-form/index.tsx:464
 msgid "Local path is required."
 msgstr ""
 
-#: apps/ui/src/components/create-site-form/index.tsx:622
+#: apps/ui/src/components/create-site-form/index.tsx:639
 msgid "Creating site"
 msgstr ""
 
-#: apps/ui/src/components/create-site-form/index.tsx:625
+#: apps/ui/src/components/create-site-form/index.tsx:642
 #: packages/common/ai/tools.ts:297
 msgid "Create site"
 msgstr ""
 
-#: apps/ui/src/components/create-site-form/index.tsx:691
+#: apps/ui/src/components/create-site-form/index.tsx:708
 msgid "View technical details"
 msgstr ""
 
-#: apps/ui/src/components/delete-site-dialog/index.tsx:30
+#: apps/ui/src/components/delete-site-dialog/index.tsx:25
 msgid "Unable to delete the site. Please try again."
 msgstr ""
 
-#: apps/ui/src/components/delete-site-dialog/index.tsx:77
-msgid "Deleting site"
+#: apps/ui/src/components/import-site-dialog/index.tsx:55
+msgid ""
+"This file type is not supported. Please use a .zip, .gz, .gzip, .tar, "
+".tar.gz, .wpress, .sql, or .xml file."
+msgstr ""
+
+#: apps/ui/src/components/import-site-dialog/index.tsx:85
+#: apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx:93
+msgid "Unable to access the selected backup. Please try again."
+msgstr ""
+
+#: apps/ui/src/components/import-site-dialog/index.tsx:103
+msgid "Failed to import the backup. Please try again."
+msgstr ""
+
+#: apps/ui/src/components/import-site-dialog/index.tsx:105
+msgid "Import didn't complete"
 msgstr ""
 
 #: apps/ui/src/components/offline-banner/index.tsx:36
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:343
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:347
 msgid "You're offline"
 msgstr ""
 
@@ -7541,24 +7660,100 @@ msgid ""
 "sites still work normally."
 msgstr ""
 
-#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:28
-msgid "File manager"
+#: apps/ui/src/components/onboarding-guide/illustrations/chat.tsx:57
+msgid "Add a contact form to the homepage"
 msgstr ""
 
-#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:57
-msgid "Editor"
+#: apps/ui/src/components/onboarding-guide/illustrations/chat.tsx:58
+msgid ""
+"Good idea! I’ll open the homepage and check to see where the best place "
+"would be for a contact form."
 msgstr ""
 
-#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:61
+#: apps/ui/src/components/onboarding-guide/illustrations/chat.tsx:78
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:655
+msgid "Queue the next message while I work…"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/chat.tsx:79
+msgid "What can Studio build today?"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/chat.tsx:97
+#: apps/ui/src/components/onboarding-guide/illustrations/preview.tsx:109
+msgid "Replay"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/chat.tsx:114
+msgid "Reading"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:203
+#: apps/ui/src/components/site-overview-view/index.tsx:291
+msgid "About"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:213
+msgid "My Happy Website (Dark Mode)"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:219
+#: apps/ui/src/components/site-overview-view/about-section.tsx:99
+msgid "Disk"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:245
+#: apps/ui/src/components/site-overview-view/index.tsx:390
+#: apps/ui/src/hooks/use-customize-links.ts:114
+msgid "Media Library"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:258
+#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:65
 #: packages/common/lib/user-settings/terminal.ts:16
 msgid "Terminal"
 msgstr ""
 
-#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:69
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:268
+#: apps/ui/src/components/site-overview-view/index.tsx:400
+msgid "Manage"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/overview.tsx:270
+#: apps/ui/src/hooks/use-site-management-actions.ts:84
+msgid "Duplicate"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/sites.tsx:123
+#: apps/ui/src/components/site-list/index.tsx:225
+msgid "Site overview"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/sites.tsx:144
+msgid "Site status: Stopped"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/sites.tsx:146
+msgid "Starting site…"
+msgstr ""
+
+#: apps/ui/src/components/onboarding-guide/illustrations/sites.tsx:148
+msgid "Site status: Running"
+msgstr ""
+
+#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:32
+msgid "File manager"
+msgstr ""
+
+#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:61
+msgid "Editor"
+msgstr ""
+
+#: apps/ui/src/components/open-in-menu/use-open-in-destinations.tsx:73
 msgid "Browser"
 msgstr ""
 
-#: apps/ui/src/components/preview-split-frame/index.tsx:120
+#: apps/ui/src/components/preview-split-frame/index.tsx:125
 msgid "Resize site preview"
 msgstr ""
 
@@ -7579,6 +7774,7 @@ msgid "Documentation"
 msgstr ""
 
 #: apps/ui/src/components/settings-view/account-section.tsx:51
+#: apps/ui/src/components/studio-beta-menu/index.tsx:33
 msgid "Report an issue"
 msgstr ""
 
@@ -7602,69 +7798,89 @@ msgstr ""
 msgid "Logging in"
 msgstr ""
 
-#: apps/ui/src/components/settings-view/ai-panel.tsx:18
-#: apps/ui/src/components/settings-view/ai-panel.tsx:29
+#: apps/ui/src/components/settings-view/ai-panel.tsx:27
+#: apps/ui/src/components/settings-view/ai-panel.tsx:38
 msgid "Agentic features"
 msgstr ""
 
-#: apps/ui/src/components/settings-view/ai-panel.tsx:20
+#: apps/ui/src/components/settings-view/ai-panel.tsx:29
 msgid ""
 "Chat with an agent that builds and edits your sites. Turning this off hides "
 "chat — your existing conversations are kept."
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:109
+#: apps/ui/src/components/settings-view/ai-panel.tsx:69
+#: apps/ui/src/components/settings-view/ai-panel.tsx:82
+msgid "Use your Anthropic API key"
+msgstr ""
+
+#: apps/ui/src/components/settings-view/ai-panel.tsx:71
+msgid ""
+"Use your own API key, which bills against your Anthropic account. When off, "
+"Studio uses your WordPress.com AI credits."
+msgstr ""
+
+#: apps/ui/src/components/settings-view/ai-panel.tsx:91
+msgid "Anthropic API key"
+msgstr ""
+
+#: apps/ui/src/components/settings-view/ai-panel.tsx:93
+msgid "Paste your API key: sk-…"
+msgstr ""
+
+#: apps/ui/src/components/settings-view/index.tsx:112
+msgid "Close settings"
+msgstr ""
+
+#: apps/ui/src/components/settings-view/index.tsx:128
 msgid "AI"
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:110
+#: apps/ui/src/components/settings-view/index.tsx:129
 #: apps/ui/src/components/settings-view/usage-panel.tsx:221
 msgid "Usage"
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:111
+#: apps/ui/src/components/settings-view/index.tsx:130
 msgid "Keyboard"
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:123
-msgid "Close settings"
-msgstr ""
-
-#: apps/ui/src/components/settings-view/index.tsx:233
+#: apps/ui/src/components/settings-view/index.tsx:245
 msgid "Default site directory: %s. Choose a different folder."
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:234
+#: apps/ui/src/components/settings-view/index.tsx:246
 msgid "Choose a default site directory"
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:254
+#: apps/ui/src/components/settings-view/index.tsx:266
 msgid "Studio experience"
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:255
+#: apps/ui/src/components/settings-view/index.tsx:267
 msgid "You are using the new Studio experience."
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:263
+#: apps/ui/src/components/settings-view/index.tsx:275
+#: apps/ui/src/components/studio-beta-menu/index.tsx:29
 msgid "Switch to classic"
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:291
+#: apps/ui/src/components/settings-view/index.tsx:303
 msgid "An error occurred while saving settings. Please try again."
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:303
-#: apps/ui/src/components/settings-view/index.tsx:305
+#: apps/ui/src/components/settings-view/index.tsx:315
+#: apps/ui/src/components/settings-view/index.tsx:317
 msgid "Preferred editor"
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:311
-#: apps/ui/src/components/settings-view/index.tsx:313
+#: apps/ui/src/components/settings-view/index.tsx:323
+#: apps/ui/src/components/settings-view/index.tsx:325
 msgid "Preferred terminal"
 msgstr ""
 
-#: apps/ui/src/components/settings-view/index.tsx:332
+#: apps/ui/src/components/settings-view/index.tsx:344
 msgid "Usage statistics"
 msgstr ""
 
@@ -7718,7 +7934,7 @@ msgid "Stop response"
 msgstr ""
 
 #: apps/ui/src/components/settings-view/keyboard-panel.tsx:49
-#: apps/ui/src/components/site-preview/index.tsx:812
+#: apps/ui/src/components/site-preview/index.tsx:978
 msgid "Site preview"
 msgstr ""
 
@@ -7782,12 +7998,12 @@ msgstr ""
 msgid "Use the studio command in any terminal to manage sites and run WP-CLI."
 msgstr ""
 
-#: apps/ui/src/components/settings-view/studio-code-panel.tsx:90
+#: apps/ui/src/components/settings-view/studio-code-panel.tsx:111
 msgid "Saving the instructions failed. Please try again."
 msgstr ""
 
 #: apps/ui/src/components/settings-view/usage-panel.tsx:37
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:213
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:215
 msgid "Unavailable"
 msgstr ""
 
@@ -7817,15 +8033,15 @@ msgstr[1] ""
 msgid "Track your preview site usage and Studio Code AI credits."
 msgstr ""
 
-#: apps/ui/src/components/sidebar-header/index.tsx:27
+#: apps/ui/src/components/sidebar-header/index.tsx:45
 msgid "Menu"
 msgstr ""
 
-#: apps/ui/src/components/sidebar-layout/index.tsx:112
+#: apps/ui/src/components/sidebar-layout/index.tsx:110
 msgid "Resize sidebar"
 msgstr ""
 
-#: apps/ui/src/components/sidebar-layout/index.tsx:136
+#: apps/ui/src/components/sidebar-layout/index.tsx:134
 msgid "Show sidebar"
 msgstr ""
 
@@ -7844,14 +8060,14 @@ msgid "Disconnecting"
 msgstr ""
 
 #: apps/ui/src/components/site-dropdown/dropdown-trigger.tsx:57
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:150
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:171
 msgid "Live site"
 msgstr ""
 
 #: apps/ui/src/components/site-dropdown/dropdown-trigger.tsx:75
-#: apps/ui/src/components/site-dropdown/main-view.tsx:331
-#: apps/ui/src/components/site-dropdown/main-view.tsx:395
-#: apps/ui/src/ui-classic/components/session-view/index.tsx:97
+#: apps/ui/src/components/site-dropdown/main-view.tsx:370
+#: apps/ui/src/components/site-dropdown/main-view.tsx:434
+#: apps/ui/src/ui-classic/components/session-view/index.tsx:98
 msgid "Live"
 msgstr ""
 
@@ -7859,152 +8075,152 @@ msgstr ""
 msgid "Publish, preview, and more"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:84
+#: apps/ui/src/components/site-dropdown/main-view.tsx:94
 msgid "The previous preview has expired."
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:85
+#: apps/ui/src/components/site-dropdown/main-view.tsx:95
 msgid "Share a review link for this version."
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:88
+#: apps/ui/src/components/site-dropdown/main-view.tsx:98
 msgid "Go online to share a review link."
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:90
+#: apps/ui/src/components/site-dropdown/main-view.tsx:100
 msgid "Sign in to share a review link."
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:95
+#: apps/ui/src/components/site-dropdown/main-view.tsx:105
 msgid "No connected site."
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:98
+#: apps/ui/src/components/site-dropdown/main-view.tsx:108
 msgid "Go online to publish your site."
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:100
+#: apps/ui/src/components/site-dropdown/main-view.tsx:110
 msgid "Sign in to publish your site."
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:147
+#: apps/ui/src/components/site-dropdown/main-view.tsx:172
+#. 1: a sync action, e.g. "Pull from live". 2: an operation in progress, e.g. "Saving settings".
+msgid "%1$s (%2$s)"
+msgstr ""
+
+#: apps/ui/src/components/site-dropdown/main-view.tsx:179
 #. %s: a sync action, e.g. "Pull from live".
 msgid "%s (sync in progress)"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:152
+#: apps/ui/src/components/site-dropdown/main-view.tsx:184
 #. %s: a sync action, e.g. "Pull from live".
 msgid "%s (offline)"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:154
+#: apps/ui/src/components/site-dropdown/main-view.tsx:186
 #. %s: a sync action, e.g. "Pull from live".
 msgid "%s (sign in required)"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:255
+#: apps/ui/src/components/site-dropdown/main-view.tsx:294
 msgid "Open Studio site in your browser"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:273
 #: apps/ui/src/components/site-dropdown/main-view.tsx:317
+#: apps/ui/src/components/site-dropdown/main-view.tsx:356
 msgid "Preview"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:274
-msgid "Ready to share for feedback."
-msgstr ""
-
-#: apps/ui/src/components/site-dropdown/main-view.tsx:278
+#: apps/ui/src/components/site-dropdown/main-view.tsx:321
 msgid "Open preview site in your browser"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:291
+#: apps/ui/src/components/site-dropdown/main-view.tsx:330
 msgid "Copy preview URL"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:302
+#: apps/ui/src/components/site-dropdown/main-view.tsx:341
 msgid "Updating preview…"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:307
+#: apps/ui/src/components/site-dropdown/main-view.tsx:346
 msgid "Updating preview"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:319
+#: apps/ui/src/components/site-dropdown/main-view.tsx:358
 msgid "Share a new one"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:319
+#: apps/ui/src/components/site-dropdown/main-view.tsx:358
 msgid "Share"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:323
+#: apps/ui/src/components/site-dropdown/main-view.tsx:362
 msgid "Creating preview"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:335
+#: apps/ui/src/components/site-dropdown/main-view.tsx:374
 msgid "Open live site in your browser"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:345
+#: apps/ui/src/components/site-dropdown/main-view.tsx:384
 msgid "Pull from live"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:346
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:28
+#: apps/ui/src/components/site-dropdown/main-view.tsx:385
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:31
 msgid "Pulling from live…"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:351
+#: apps/ui/src/components/site-dropdown/main-view.tsx:390
 msgid "Pulling from live"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:362
+#: apps/ui/src/components/site-dropdown/main-view.tsx:401
 msgid "Push to live"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:363
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:28
+#: apps/ui/src/components/site-dropdown/main-view.tsx:402
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:31
 msgid "Pushing to live…"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:368
+#: apps/ui/src/components/site-dropdown/main-view.tsx:407
 msgid "Pushing to live"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:377
+#: apps/ui/src/components/site-dropdown/main-view.tsx:416
 msgid "More live site actions"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:397
+#: apps/ui/src/components/site-dropdown/main-view.tsx:436
 msgid "Publish"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:401
+#: apps/ui/src/components/site-dropdown/main-view.tsx:440
 msgid "Opening login page"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:411
+#: apps/ui/src/components/site-dropdown/main-view.tsx:450
 msgid "Xdebug enabled"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:447
+#: apps/ui/src/components/site-dropdown/main-view.tsx:496
+msgid "Preparing the backup…"
+msgstr ""
+
+#: apps/ui/src/components/site-dropdown/main-view.tsx:497
 msgid "Preparing the live site…"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:468
-#: apps/ui/src/components/site-list/index.tsx:248
-msgid "Stopped"
-msgstr ""
-
-#: apps/ui/src/components/site-dropdown/main-view.tsx:493
-#: apps/ui/src/components/site-list/index.tsx:252
+#: apps/ui/src/components/site-dropdown/main-view.tsx:563
+#: apps/ui/src/components/site-list/index.tsx:264
 msgid "Site status: %s"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/main-view.tsx:510
-#: apps/ui/src/components/site-list/index.tsx:254
+#: apps/ui/src/components/site-dropdown/main-view.tsx:580
+#: apps/ui/src/components/site-list/index.tsx:266
 msgid "%1$s. %2$s"
 msgstr ""
 
@@ -8020,79 +8236,100 @@ msgstr ""
 msgid "Publishing preview…"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:33
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:36
 msgid "Preview published"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:35
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:39
+msgid "Backup imported"
+msgstr ""
+
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:41
 msgid "Pushed to live"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:35
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:41
 msgid "Pulled from live"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:39
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:46
+msgid "Preview publishing cancelled"
+msgstr ""
+
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:52
 msgid "Publishing preview failed"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:42
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:55
+msgid "Importing backup failed"
+msgstr ""
+
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:58
 msgid "Pushing to live failed"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:43
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:59
 msgid "Pulling from live failed"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:92
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:113
 msgid "Preview expired"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:97
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:118
 msgid "Preview updated now"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:101
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:122
 #. %s: compact relative time, e.g. "4m" or "2h".
 msgid "Preview updated %s ago"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:110
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:131
 msgid "Pushed just now"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:114
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:135
 #. %s: compact relative time, e.g. "4m" or "2h".
 msgid "Pushed %s ago"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:123
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:144
 msgid "Pulled just now"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:127
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:148
 #. %s: compact relative time, e.g. "4m" or "2h".
 msgid "Pulled %s ago"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:156
+#: apps/ui/src/components/site-dropdown/trigger-secondary.ts:177
 msgid "Local preview"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/utils.ts:62
+#: apps/ui/src/components/site-dropdown/utils.ts:79
+msgid "Stopped"
+msgstr ""
+
+#: apps/ui/src/components/site-dropdown/utils.ts:104
 msgid "Site is running"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/utils.ts:65
+#: apps/ui/src/components/site-dropdown/utils.ts:107
+msgid "Site is stopped"
+msgstr ""
+
+#: apps/ui/src/components/site-dropdown/utils.ts:109
 msgid "Site is stopping"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/utils.ts:66
+#: apps/ui/src/components/site-dropdown/utils.ts:109
 msgid "Site is starting"
 msgstr ""
 
-#: apps/ui/src/components/site-dropdown/utils.ts:67
-msgid "Site is stopped"
+#: apps/ui/src/components/site-dropdown/utils.ts:121
+#. %s: an operation in progress, e.g. "Saving settings".
+msgid "%s…"
 msgstr ""
 
 #: apps/ui/src/components/site-fields/index.ts:247
@@ -8115,236 +8352,385 @@ msgstr ""
 msgid "Display PHP errors and warnings directly in the browser."
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:112
+#: apps/ui/src/components/site-list/index.tsx:117
 msgid "Needs an answer"
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:113
+#: apps/ui/src/components/site-list/index.tsx:118
 msgid "Studio needs an answer."
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:114
+#: apps/ui/src/components/site-list/index.tsx:119
 msgid "New message"
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:115
+#: apps/ui/src/components/site-list/index.tsx:120
 msgid "Syncing live site"
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:215
-msgid "Site overview"
+#: apps/ui/src/components/site-list/index.tsx:121
+msgid "Importing backup"
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:251
+#: apps/ui/src/components/site-list/index.tsx:263
 msgid "Site status: %s. Xdebug enabled"
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:437
+#: apps/ui/src/components/site-list/index.tsx:456
 msgid "Duplicating…"
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:440
+#: apps/ui/src/components/site-list/index.tsx:459
 msgid "Open folder"
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:460
+#: apps/ui/src/components/site-list/index.tsx:479
 msgid "Open phpMyAdmin"
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:463
+#: apps/ui/src/components/site-list/index.tsx:482
 msgid "Open WP admin"
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:467
-#: apps/ui/src/components/site-list/index.tsx:470
+#: apps/ui/src/components/site-list/index.tsx:486
+#: apps/ui/src/components/site-list/index.tsx:492
 msgid "Exporting…"
 msgstr ""
 
-#: apps/ui/src/components/site-list/index.tsx:725
+#: apps/ui/src/components/site-list/index.tsx:757
 msgid "No sites yet"
 msgstr ""
 
-#: apps/ui/src/components/site-overview-view/index.tsx:281
-#: apps/ui/src/hooks/use-customize-links.ts:114
-msgid "Media Library"
+#: apps/ui/src/components/site-overview-view/about-section.tsx:12
+msgid "Media"
 msgstr ""
 
-#: apps/ui/src/components/site-overview-view/index.tsx:287
-msgid "Manage"
+#: apps/ui/src/components/site-overview-view/about-section.tsx:13
+msgid "Plugins"
 msgstr ""
 
-#: apps/ui/src/components/site-preview/address-bar.tsx:158
-msgid "View site front end"
+#: apps/ui/src/components/site-overview-view/about-section.tsx:14
+msgid "Themes"
 msgstr ""
 
-#: apps/ui/src/components/site-preview/address-bar.tsx:159
-#: apps/ui/src/components/site-preview/address-bar.tsx:383
-msgid "WordPress"
+#: apps/ui/src/components/site-overview-view/about-section.tsx:16
+msgid "Other"
 msgstr ""
 
-#: apps/ui/src/components/site-preview/address-bar.tsx:159
-msgid "View WP Admin"
+#: apps/ui/src/components/site-overview-view/about-section.tsx:41
+#. %s: WordPress version number
+msgid "WP v%s"
 msgstr ""
 
-#: apps/ui/src/components/site-preview/address-bar.tsx:160
-msgid "View database"
+#: apps/ui/src/components/site-overview-view/about-section.tsx:44
+msgid "WP —"
 msgstr ""
 
-#: apps/ui/src/components/site-preview/address-bar.tsx:326
-msgid "Home"
+#: apps/ui/src/components/site-overview-view/about-section.tsx:47
+#. %s: PHP version number
+msgid "PHP v%s"
 msgstr ""
 
-#: apps/ui/src/components/site-preview/address-bar.tsx:331
-msgid "404 page"
+#: apps/ui/src/components/site-overview-view/about-section.tsx:69
+msgid "Open site in browser"
 msgstr ""
 
-#: apps/ui/src/components/site-preview/address-bar.tsx:382
-msgid "Front end"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/address-bar.tsx:485
-msgid "Search unavailable"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/address-bar.tsx:487
-msgid "Searching…"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/address-bar.tsx:489
-msgid "No matches"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/address-bar.tsx:511
-msgid "Address"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/address-bar.tsx:580
-msgid "Type a path, or search pages and posts"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/address-bar.tsx:581
-msgid "Type a path"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/address-bar.tsx:583
-msgid "Address and search"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:417
-msgid "Mobile"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:418
-msgid "Tablet"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:419
-msgid "Desktop"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:424
-#. 1: device name (e.g. Mobile), 2: viewport width, 3: viewport height in pixels
-msgid "%1$s · %2$d×%3$d"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:448
-msgid "Responsive mode"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:453
-msgid "Fit pane"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:462
-msgid "Desktop + Mobile"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:469
-msgid "Mobile orientation"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:474
-msgid "Portrait"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:475
-msgid "Landscape"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:484
-msgid "Exit full preview"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:484
-msgid "Full preview"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:844
-msgid "Refresh"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:880
-msgid "Forward"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:896
-msgid "Stop annotating"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:896
-msgid "Annotate"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:907
-msgid "Submit annotations"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:910
-msgid "Submit"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:1038
-#. %s: site name
-msgid "%s (mobile)"
-msgstr ""
-
-#: apps/ui/src/components/site-preview/index.tsx:1065
+#: apps/ui/src/components/site-overview-view/about-section.tsx:77
+#: apps/ui/src/components/site-preview/index.tsx:1207
 #. %s: site name
 msgid "Screenshot of %s"
 msgstr ""
 
-#: apps/ui/src/components/site-preview/index.tsx:1072
+#: apps/ui/src/components/site-overview-view/about-section.tsx:102
+msgid "Measuring…"
+msgstr ""
+
+#: apps/ui/src/components/site-overview-view/about-section.tsx:132
+#. 1: storage category, 2: formatted size, 3: percentage
+msgid "%1$s — %2$s (%3$s)"
+msgstr ""
+
+#: apps/ui/src/components/site-overview-view/about-section.tsx:140
+#. %s: comma-separated disk usage category descriptions
+msgid "Disk usage breakdown: %s"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:172
+msgid "View site front end"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:173
+#: apps/ui/src/components/site-preview/address-bar.tsx:397
+msgid "WordPress"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:173
+msgid "View WP Admin"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:174
+msgid "View database"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:340
+msgid "Home"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:345
+msgid "404 page"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:396
+msgid "Front end"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:499
+msgid "Search unavailable"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:501
+msgid "Searching…"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:503
+msgid "No matches"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:525
+msgid "Address"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:594
+msgid "Type a path, or search pages and posts"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:595
+msgid "Type a path"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/address-bar.tsx:597
+msgid "Address and search"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:463
+msgid "Mobile"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:464
+msgid "Tablet"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:465
+msgid "Desktop"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:470
+#. 1: device name (e.g. Mobile), 2: viewport width, 3: viewport height in pixels
+msgid "%1$s · %2$d×%3$d"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:494
+msgid "Responsive mode"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:499
+msgid "Fit pane"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:508
+msgid "Desktop + Mobile"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:515
+msgid "Mobile orientation"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:520
+msgid "Portrait"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:521
+msgid "Landscape"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:530
+msgid "Exit full preview"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:530
+msgid "Full preview"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:555
+msgid "Stop annotating"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:555
+msgid "Annotate"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:556
+msgid "Send annotations to chat"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:582
+msgid "Send to chat"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:626
+#: apps/ui/src/components/site-preview/index.tsx:641
+msgid "Annotation options"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:1004
+msgid "Refresh"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:1040
+msgid "Forward"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:1180
+#. %s: site name
+msgid "%s (mobile)"
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:1217
+#. %s: an operation in progress, e.g. "Saving settings".
+msgid "%s… the site can start once this finishes."
+msgstr ""
+
+#: apps/ui/src/components/site-preview/index.tsx:1220
 msgid "Start the site to see a live preview."
 msgstr ""
 
-#: apps/ui/src/components/site-preview/index.tsx:1078
+#: apps/ui/src/components/site-preview/index.tsx:1226
 msgid "Starting site"
 msgstr ""
 
-#: apps/ui/src/components/site-settings-view/index.tsx:278
+#: apps/ui/src/components/site-settings-view/index.tsx:283
 msgid "Unable to save changes."
 msgstr ""
 
-#: apps/ui/src/components/site-settings-view/index.tsx:316
+#: apps/ui/src/components/site-settings-view/index.tsx:321
+#: packages/common/lib/site-operation-labels.ts:18
 msgid "Saving settings"
 msgstr ""
 
-#: apps/ui/src/components/site-settings-view/index.tsx:318
+#: apps/ui/src/components/site-settings-view/index.tsx:323
 msgid "Save settings"
+msgstr ""
+
+#: apps/ui/src/components/studio-beta-menu/index.tsx:20
+msgid "Studio Beta options"
+msgstr ""
+
+#: apps/ui/src/components/studio-beta-menu/index.tsx:24
+msgid "Beta"
+msgstr ""
+
+#: apps/ui/src/components/studio-beta-menu/index.tsx:42
+#. %s: the running Studio version, e.g. "1.18.0-beta1".
+msgid "Studio %s"
 msgstr ""
 
 #: apps/ui/src/components/user-menu/index.tsx:43
 msgid "Hide sidebar"
 msgstr ""
 
-#: apps/ui/src/data/core/connectors/ipc/index.ts:370
+#: apps/ui/src/data/core/connectors/ipc/index.ts:389
 msgid "Unable to resolve the ZIP file path. Try choosing the file via the button."
 msgstr ""
 
-#: apps/ui/src/data/core/connectors/local/index.ts:291
+#: apps/ui/src/data/core/connectors/local/index.ts:315
 msgid ""
 "After approving access on WordPress.com, paste the authentication token "
 "here:"
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:25
+msgid "Welcome to WordPress Studio 2.0"
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:27
+msgid ""
+"Everything you built in Studio is right here in the sidebar. Same sites, "
+"same files with a new workbench around them."
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:38
+#. "on the left" describes the sidebar in left-to-right layouts; in right-to-left languages it sits on the right — adapt the direction accordingly.
+msgid ""
+"Every site you build lives in the sidebar on the left. Switch between them "
+"anytime. The sidebar is where you’ll find site settings and a quick way to "
+"start and stop your site."
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:51
+msgid "Build by asking"
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:53
+msgid ""
+"Describe what you want in plain language. Add a page, change the design, "
+"fix a bug — and our AI agent, Studio Code, builds it."
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:61
+msgid "Manage your site"
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:63
+msgid ""
+"The site overview is your control panel — open the editor and admin tools, "
+"or duplicate, export, and manage your site from one place."
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:76
+msgid "See your site update in realtime"
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:79
+#. "on the right" describes the preview in left-to-right layouts; in right-to-left languages it sits on the left — adapt the direction accordingly.
+msgid ""
+"Your site is shown on the right, automatically refreshing as you make "
+"changes with Studio Code. Switch between the front-end, wp-admin, and the "
+"database from the toolbar."
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:82
+#: apps/ui/src/data/onboarding/orientation-guide.ts:93
+msgid "Let’s go"
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:87
+msgid "See your site inline"
+msgstr ""
+
+#: apps/ui/src/data/onboarding/orientation-guide.ts:90
+#. "on the right" describes the preview in left-to-right layouts; in right-to-left languages it sits on the left — adapt the direction accordingly.
+msgid ""
+"Your site is shown on the right. Switch between the front-end, wp-admin, "
+"and the database from the toolbar."
+msgstr ""
+
+#: apps/ui/src/data/onboarding/whats-new.ts:25
+msgid ""
+"Studio now runs WordPress on native PHP by default — fewer abstractions, "
+"better performance. Switch between Native and Sandbox runtimes in your site "
+"settings."
+msgstr ""
+
+#: apps/ui/src/data/onboarding/whats-new.ts:44
+msgid ""
+"Manage your site's database visually with phpMyAdmin, from the Database tab "
+"above the preview."
+msgstr ""
+
+#: apps/ui/src/data/onboarding/whats-new.ts:53
+msgid ""
+"Install the studio CLI to run WP-CLI commands from your terminal and "
+"create, start, stop, or update your sites."
 msgstr ""
 
 #: apps/ui/src/data/queries/use-app-messages.ts:48
@@ -8364,7 +8750,7 @@ msgstr ""
 msgid "Restart now"
 msgstr ""
 
-#: apps/ui/src/data/queries/use-import-site.ts:27
+#: apps/ui/src/data/queries/use-import-site.ts:39
 msgid "Import finished"
 msgstr ""
 
@@ -8376,29 +8762,38 @@ msgstr ""
 msgid "Failed to publish preview site"
 msgstr ""
 
-#: apps/ui/src/data/queries/use-sites.ts:103
+#: apps/ui/src/data/queries/use-sites.ts:130
 msgid "Site started"
 msgstr ""
 
-#: apps/ui/src/data/queries/use-sites.ts:117
+#: apps/ui/src/data/queries/use-sites.ts:147
 msgid "Site stopped"
 msgstr ""
 
-#: apps/ui/src/data/queries/use-sites.ts:188
+#: apps/ui/src/data/queries/use-sites.ts:219
 msgid "Settings saved"
 msgstr ""
 
-#: apps/ui/src/data/queries/use-sync-site.ts:46
+#: apps/ui/src/data/queries/use-sites.ts:272
+#. %s: an operation already running, e.g. "a settings change".
+msgid "This site is busy: %s is in progress. Try again once it finishes."
+msgstr ""
+
+#: apps/ui/src/data/queries/use-sync-site.ts:57
 msgid "Push didn't complete"
 msgstr ""
 
-#: apps/ui/src/data/queries/use-sync-site.ts:98
+#: apps/ui/src/data/queries/use-sync-site.ts:142
 msgid ""
 "Studio couldn't copy the live site. Try again. If the problem continues, "
 "check Studio Logs for details."
 msgstr ""
 
-#: apps/ui/src/data/queries/use-sync-site.ts:102
+#: apps/ui/src/data/queries/use-sync-site.ts:145
+msgid "Studio couldn't copy the live site. Try again."
+msgstr ""
+
+#: apps/ui/src/data/queries/use-sync-site.ts:147
 msgid "Pull didn't complete"
 msgstr ""
 
@@ -8410,23 +8805,20 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: apps/ui/src/hooks/use-site-management-actions.ts:51
-msgid "Duplicate"
-msgstr ""
-
-#: apps/ui/src/hooks/use-site-management-actions.ts:53
+#: apps/ui/src/hooks/use-site-management-actions.ts:86
 msgid "Duplicating site"
 msgstr ""
 
-#: apps/ui/src/hooks/use-site-management-actions.ts:63
+#: apps/ui/src/hooks/use-site-management-actions.ts:98
+#: apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx:178
+msgid "Importing site"
+msgstr ""
+
+#: apps/ui/src/hooks/use-site-management-actions.ts:110
 msgid "Exporting site"
 msgstr ""
 
-#: apps/ui/src/hooks/use-site-management-actions.ts:71
-msgid "Export DB"
-msgstr ""
-
-#: apps/ui/src/hooks/use-site-management-actions.ts:73
+#: apps/ui/src/hooks/use-site-management-actions.ts:120
 msgid "Exporting database"
 msgstr ""
 
@@ -8476,60 +8868,56 @@ msgstr ""
 msgid "Yes, new chat"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:639
-msgid "Queue the next message while I work…"
-msgstr ""
-
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:640
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:656
 msgid "Type a follow-up and I’ll send it next…"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:641
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:657
 msgid "Add the next step to the queue…"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:654
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:670
 msgid "Return to send"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:693
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:709
 msgid "Resize composer"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:899
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:908
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:920
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:929
 msgid "Add skill or attachment"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:912
+#: apps/ui/src/ui-classic/components/session-view/composer/index.tsx:933
 msgid "Upload attachment"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:556
+#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:567
 msgid "Run terminal command"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:769
+#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:780
 msgid "Hide tool details"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:769
+#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:780
 msgid "Show tool details"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:1000
+#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:1050
 msgid "Edit question %1$d of %2$d: %3$s. Selected answer: %4$s"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:1169
+#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:1219
 msgid "Current question: %s"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:1174
+#: apps/ui/src/ui-classic/components/session-view/conversation/index.tsx:1224
 msgid "Asking question %1$d of %2$d"
 msgstr ""
 
-#: apps/ui/src/ui-classic/components/session-view/index.tsx:461
+#: apps/ui/src/ui-classic/components/session-view/index.tsx:485
 msgid "Scroll to latest message"
 msgstr ""
 
@@ -8845,75 +9233,75 @@ msgstr ""
 msgid "View plans"
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:207
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:209
 msgid "Available to connect"
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:208
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:210
 msgid "Select a site to create its local copy."
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:214
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:216
 msgid "These sites cannot currently be connected to Studio."
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:271
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:275
 msgid "Creating the local site…"
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:272
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:276
 msgid "Saving the WordPress.com connection…"
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:273
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:277
 msgid "Pulling the live site into Studio…"
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:274
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:278
 msgid "Opening the local site…"
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:286
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:290
 msgid "Setup did not finish. The local site and WordPress.com connection were kept."
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:296
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:300
 msgid "Failed to connect the site. Please try again."
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:325
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:329
 msgid "Log in with your WordPress.com account to see your sites."
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:336
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:340
 msgid "Checking your account…"
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:344
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:348
 msgid "Reconnect to load your WordPress.com and Pressable sites."
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:357
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:361
 msgid "We couldn't load your sites"
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:358
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:362
 msgid "Check your connection and try again."
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:366
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:370
 msgid "Retry"
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:374
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:378
 msgid "This account has no WordPress.com or Pressable sites to show."
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:381
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:385
 msgid "Create a WordPress.com site"
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:436
+#: apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx:440
 #. %s is the site search query.
 msgid "No sites match “%s”."
 msgstr ""
@@ -8935,21 +9323,21 @@ msgstr ""
 msgid "Create site from Blueprint"
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:35
+#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:37
 msgid ""
 "This file type is not supported. Please use a .zip, .gz, .gzip, .tar, "
-".tar.gz, .wpress, .sql, or .xml file."
+".tar.gz, .wpress, or .xml file."
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:84
+#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:86
 msgid "Drop a file or click to browse."
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:129
+#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:131
 msgid "Pull a WordPress.com or Pressable site into a new local Studio site."
 msgstr ""
 
-#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:131
+#: apps/ui/src/ui-classic/router/route-onboarding-home/index.tsx:133
 msgid "Available online"
 msgstr ""
 
@@ -8989,10 +9377,6 @@ msgstr ""
 
 #: apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx:86
 msgid "Preparing backup…"
-msgstr ""
-
-#: apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx:93
-msgid "Unable to access the selected backup. Please try again."
 msgstr ""
 
 #: apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx:126
@@ -9049,10 +9433,6 @@ msgstr ""
 
 #: apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx:177
 msgid "Choose another backup"
-msgstr ""
-
-#: apps/ui/src/ui-classic/router/route-onboarding-import/index.tsx:178
-msgid "Importing site"
 msgstr ""
 
 #: apps/ui/src/ui-classic/router/route-onboarding-tour/index.tsx:21
@@ -9153,6 +9533,18 @@ msgstr ""
 
 #: apps/ui/src/ui-classic/router/route-welcome/index.tsx:106
 msgid "Your local studio for building WordPress sites, plugins, and themes."
+msgstr ""
+
+#: packages/common/ai/anthropic-key.ts:34
+msgid "Could not reach Anthropic to verify the API key."
+msgstr ""
+
+#: packages/common/ai/anthropic-key.ts:44
+msgid "Anthropic rejected this API key. Check the key and try again."
+msgstr ""
+
+#: packages/common/ai/anthropic-key.ts:49
+msgid "Could not verify the API key with Anthropic."
 msgstr ""
 
 #: packages/common/ai/slash-commands.ts:9
@@ -9819,6 +10211,39 @@ msgstr ""
 msgid "My True Website"
 msgstr ""
 
+#: packages/common/lib/import-progress.ts:10
+msgid "Plugins…"
+msgstr ""
+
+#: packages/common/lib/import-progress.ts:11
+msgid "Themes…"
+msgstr ""
+
+#: packages/common/lib/import-progress.ts:12
+msgid "Media uploads…"
+msgstr ""
+
+#: packages/common/lib/import-progress.ts:13
+msgid "Other files…"
+msgstr ""
+
+#: packages/common/lib/import-progress.ts:29
+msgid "Extracting…"
+msgstr ""
+
+#: packages/common/lib/import-progress.ts:45
+msgid "Database…"
+msgstr ""
+
+#: packages/common/lib/import-progress.ts:51
+#: packages/common/lib/import-progress.ts:64
+msgid "Importing content…"
+msgstr ""
+
+#: packages/common/lib/import-progress.ts:60
+msgid "Files…"
+msgstr ""
+
 #: packages/common/lib/passwords.ts:46
 msgid "Admin email cannot be empty."
 msgstr ""
@@ -9863,6 +10288,39 @@ msgstr ""
 
 #: packages/common/lib/playground-cli-messages.ts:33
 msgid "Preparing workers…"
+msgstr ""
+
+#: packages/common/lib/progress-label.ts:12
+#. %1$s: percentage complete, zero-padded to two digits. %2$s: what is in progress.
+msgid "%1$s%% · %2$s"
+msgstr ""
+
+#: packages/common/lib/site-operation-labels.ts:16
+msgid "Deleting"
+msgstr ""
+
+#: packages/common/lib/site-operation-labels.ts:20
+msgid "Duplicating"
+msgstr ""
+
+#: packages/common/lib/site-operation-labels.ts:30
+msgid "a site start"
+msgstr ""
+
+#: packages/common/lib/site-operation-labels.ts:32
+msgid "a site stop"
+msgstr ""
+
+#: packages/common/lib/site-operation-labels.ts:34
+msgid "a site deletion"
+msgstr ""
+
+#: packages/common/lib/site-operation-labels.ts:36
+msgid "a settings change"
+msgstr ""
+
+#: packages/common/lib/site-operation-labels.ts:38
+msgid "a duplication"
 msgstr ""
 
 #: packages/common/lib/site-path-validation.ts:34
@@ -9924,52 +10382,42 @@ msgid "You’ve reached your monthly AI usage limit. Try again later."
 msgstr ""
 
 #: packages/common/lib/user-settings/editor.ts:26
-#. "Antigravity" is the brand name for an IDE and does not need to be translated
 msgid "Antigravity"
 msgstr ""
 
 #: packages/common/lib/user-settings/editor.ts:37
-#. "Visual Studio Code" is the brand name for an IDE and does not need to be translated
 msgid "Visual Studio Code"
 msgstr ""
 
 #: packages/common/lib/user-settings/editor.ts:49
-#. "PhpStorm" is the brand name for an IDE and does not need to be translated
 msgid "PhpStorm"
 msgstr ""
 
 #: packages/common/lib/user-settings/editor.ts:60
-#. "WebStorm" is the brand name for an IDE and does not need to be translated
 msgid "WebStorm"
 msgstr ""
 
 #: packages/common/lib/user-settings/editor.ts:71
-#. "Windsurf" is the brand name for an IDE and does not need to be translated
 msgid "Windsurf"
 msgstr ""
 
 #: packages/common/lib/user-settings/editor.ts:93
-#. "Sublime Text" is the brand name for an IDE and does not need to be translated
 msgid "Sublime Text"
 msgstr ""
 
 #: packages/common/lib/user-settings/editor.ts:105
-#. "Zed" is the brand name for an IDE and does not need to be translated
 msgid "Zed"
 msgstr ""
 
 #: packages/common/lib/user-settings/terminal.ts:22
-#. "iTerm" is the brand name for a terminal app and does not need to be translated
 msgid "iTerm"
 msgstr ""
 
 #: packages/common/lib/user-settings/terminal.ts:28
-#. "Warp" is the brand name for a terminal app and does not need to be translated
 msgid "Warp"
 msgstr ""
 
 #: packages/common/lib/user-settings/terminal.ts:34
-#. "Ghostty" is the brand name for a terminal app and does not need to be translated
 msgid "Ghostty"
 msgstr ""
 
@@ -9981,6 +10429,27 @@ msgstr ""
 msgid ""
 "No blueprint.json found in the ZIP file. Please ensure the ZIP contains a "
 "blueprint.json at its root."
+msgstr ""
+
+#: packages/common/sites/sync.ts:201
+msgid ""
+"The database failed to import on the live site. Review your database and "
+"try again."
+msgstr ""
+
+#: packages/common/sites/sync.ts:206
+msgid ""
+"The live site timed out while importing, likely because the site is too "
+"large. Try reducing its content or files."
+msgstr ""
+
+#: packages/common/sites/sync.ts:210
+#: packages/common/sites/sync.ts:161
+msgid "Something went wrong while updating the live site."
+msgstr ""
+
+#: packages/common/sites/sync.ts:178
+msgid "The live site stopped reporting progress. Check the site and try again."
 msgstr ""
 
 #: apps/studio/src/hooks/use-localization-support.ts:26


### PR DESCRIPTION
## Related issues

N/A

## How AI was used in this PR

No AI was ~~harmed~~ used in the making of this PR

## Proposed Changes

Resynchronizing `bundle-strings.pot` after #4536

### Why? / Context

The team recently decided to delay the Studio release `1.18.0` to Friday, Aug 14, and as a result merged all the recent commits from `trunk` into `release/1.18.0` (via #4536) to incoroprate all the latest features/fixes from `trunk` in that `1.18.0` release.

As discussed in https://github.com/Automattic/studio/pull/4536#issuecomment-5285867791, because this was done by merging `trunk` into the existing `release/1.18.0` (that had been cut during the code-freeze one week ago on Aug 6)—as opposed to the `release/1.18.0` branch being deleted and the code-freeze being re-done from scratch—this means that the `generate_pot_file` action that is usually called during `code_freeze`, to generate the `bundle-strings.pot` file with strings to be sent for translation, was not called again, and that `bundle-strings.pot` file was thus not updated with any new string that might have been added in `trunk` since Aug 6.

### How? / The fix

To fix that, I've run `npm install && bundle exec fastlane generate_pot_file` from the `release/1.18.0` manually (after #4536 got merged) to update the `bundle-strings.pot`, resulting the diff in this PR.

Note that I've encountered the ``The await using declaration should be first transformed by `@babel/plugin-transform-explicit-resource-management` `` errors in the logs when running this lane on my machine, but this is an unrelated known issue, for which there's already a Draft PR https://github.com/Automattic/studio/pull/4467 

## Testing Instructions

N/A Just check the diff makes sense

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
