### PR TITLE
Agentic UI: Make empty sidebar space draggable

### DIFF
--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -22,6 +22,7 @@
 	   inner wrapper. */
 	overflow-y: auto;
 	transition: width 150ms ease;
+	-webkit-app-region: drag;
 }
 
 /* Inside the sidebar's dark ThemeProvider; generates no box, but declares
@@ -49,6 +50,7 @@
 	bottom: 0;
 	z-index: 1;
 	background-color: var(--app-chrome-bg);
+	-webkit-app-region: no-drag;
 }
 
 .sidebarCollapsed {

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -21,6 +21,7 @@
 	flex-direction: column;
 	gap: var(--wpds-dimension-padding-sm);
 	user-select: none;
+	-webkit-app-region: no-drag;
 }
 
 .sites {


### PR DESCRIPTION
## Related issues

- None.

## How AI was used in this PR

Codex helped trace the active v2 sidebar layout, implement the Electron drag-region boundaries, and run the repository checks. I manually verified the window-drag behavior in the running desktop app.

## Proposed Changes

- Make unused space in the expanded sidebar act as a window drag handle, giving users a much larger and easier target for moving the Studio window.
- Keep the site list and footer controls outside the drag region so site selection, reordering, settings, and other sidebar actions remain interactive.

## Testing Instructions

1. Run `npm start` and open Studio with the sidebar expanded.
2. Drag from the empty space between the site list and the sidebar footer; confirm the window moves.
3. Confirm site rows can still be selected and reordered.
4. Confirm the Settings, sidebar toggle, site action, and sidebar resize controls still work.
5. Repeat in light and dark appearance modes. The change should not affect sidebar colors or layout.

Automated verification:

- `npm run lint --workspace=@studio/ui` (passes with one unrelated existing unused-variable warning)
- `npm run typecheck`
- `npm test -- apps/ui/src/components/sidebar-layout/index.test.tsx apps/ui/src/components/site-list/index.test.tsx` (31 tests passed)

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
