### PR TITLE
Agentic UI: Improve switching between chat and site overview

### DIFF
--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -330,6 +330,30 @@ describe( 'SiteList', () => {
 		} );
 	} );
 
+	it( 'shows the overview shortcut as pressed and toggles back to chat', () => {
+		paramsMock = { siteId: 'stopped-site' };
+		pathnameMock = '/sites/stopped-site/overview';
+
+		render( <SiteList /> );
+
+		const stoppedRow = screen.getByText( 'Stopped Site' ).closest( 'section' )!;
+		const overviewButton = within( stoppedRow ).getByRole( 'button', {
+			name: 'Site overview',
+		} );
+		expect( overviewButton ).toHaveAttribute( 'aria-pressed', 'true' );
+
+		fireEvent.click( overviewButton );
+
+		expect( useConnectorMock().trackEvent ).toHaveBeenCalledWith( 'studio_panel_opened', {
+			panel: 'assistant',
+		} );
+		expect( navigateMock ).toHaveBeenCalledTimes( 1 );
+		expect( navigateMock ).toHaveBeenLastCalledWith( {
+			to: '/sites/$siteId/new',
+			params: { siteId: 'stopped-site' },
+		} );
+	} );
+
 	it( 'dims stopped site titles without dimming running sites', () => {
 		render( <SiteList /> );
 

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -212,7 +212,15 @@ function sortSitesByManualOrder( sites: SiteDetails[], manualOrder: string[] ): 
 	);
 }
 
-function SiteOverviewButton( { site }: { site: SiteDetails } ) {
+function SiteOverviewButton( {
+	site,
+	isOverviewActive,
+	onBackToChat,
+}: {
+	site: SiteDetails;
+	isOverviewActive: boolean;
+	onBackToChat: () => void;
+} ) {
 	const navigate = useNavigate();
 	const connector = useConnector();
 
@@ -223,9 +231,14 @@ function SiteOverviewButton( { site }: { site: SiteDetails } ) {
 			size="small"
 			icon={ settings }
 			label={ __( 'Site overview' ) }
+			aria-pressed={ isOverviewActive }
 			className={ styles.siteAction }
 			onClick={ ( event ) => {
 				event.stopPropagation();
+				if ( isOverviewActive ) {
+					onBackToChat();
+					return;
+				}
 				void connector.trackEvent( TRACKS_EVENTS.PANEL_OPENED, { panel: 'overview' } );
 				void navigate( {
 					to: '/sites/$siteId/overview',
@@ -625,7 +638,13 @@ function SiteSection( {
 							</SidebarButton>
 						</div>
 						<div className={ styles.siteActions } data-reorder-exclude>
-							{ chatEnabled ? <SiteOverviewButton site={ site } /> : null }
+							{ chatEnabled ? (
+								<SiteOverviewButton
+									site={ site }
+									isOverviewActive={ isContextActive }
+									onBackToChat={ handleOpenSite }
+								/>
+							) : null }
 							<SiteStatusButton site={ site } isStarting={ isStarting } isStopping={ isStopping } />
 						</div>
 					</header>

--- a/apps/ui/src/components/site-list/style.module.css
+++ b/apps/ui/src/components/site-list/style.module.css
@@ -274,6 +274,13 @@
 	outline-offset: -2px;
 }
 
+.siteAction[aria-pressed='true'] {
+	--wp-ui-button-background-color: var(--wpds-color-fg-content-neutral);
+	--wp-ui-button-background-color-active: var(--wpds-color-fg-content-neutral);
+	--wp-ui-button-foreground-color: var(--wpds-color-bg-surface-neutral);
+	--wp-ui-button-foreground-color-active: var(--wpds-color-bg-surface-neutral);
+}
+
 /* Collapsed, only the trailing status button shows; hover/focus/active
    reveals the overview button next to it. The header carries
    `data-popup-open` while its right-click menu is open (Base UI sets it on

--- a/apps/ui/src/ui-classic/components/site-workspace/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/site-workspace/index.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SiteWorkspace } from './index';
+
+vi.mock( '@/ui-classic/components/session-view', () => ( {
+	SessionView: ( { sessionId }: { sessionId: string } ) => (
+		<div data-testid="chat">Chat { sessionId }</div>
+	),
+} ) );
+
+vi.mock( '@/components/site-overview-view', () => ( {
+	SiteOverviewView: ( {
+		siteId,
+		activeTab,
+		onTabChange,
+	}: {
+		siteId: string;
+		activeTab: string;
+		onTabChange: ( tab: 'general' ) => void;
+	} ) => (
+		<div data-testid="overview">
+			Overview { siteId } { activeTab }
+			<button type="button" onClick={ () => onTabChange( 'general' ) }>
+				Open general
+			</button>
+		</div>
+	),
+} ) );
+
+describe( 'SiteWorkspace', () => {
+	it( 'keeps chat and overview mounted while switching the active layer', () => {
+		const onOverviewTabChange = vi.fn();
+		const { rerender } = render(
+			<SiteWorkspace
+				siteId="site-1"
+				activeView="chat"
+				sessionId="session-1"
+				overviewTab="overview"
+				onOverviewTabChange={ onOverviewTabChange }
+			/>
+		);
+
+		const chat = screen.getByTestId( 'chat' );
+		expect( screen.queryByTestId( 'overview' ) ).not.toBeInTheDocument();
+		expect( chat.parentElement ).not.toHaveAttribute( 'aria-hidden' );
+
+		rerender(
+			<SiteWorkspace
+				siteId="site-1"
+				activeView="overview"
+				overviewTab="overview"
+				onOverviewTabChange={ onOverviewTabChange }
+			/>
+		);
+
+		const overview = screen.getByTestId( 'overview' );
+		expect( screen.getByTestId( 'chat' ) ).toBe( chat );
+		expect( chat.parentElement ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( chat.parentElement ).toHaveAttribute( 'inert' );
+		expect( overview.parentElement ).not.toHaveAttribute( 'aria-hidden' );
+
+		rerender(
+			<SiteWorkspace
+				siteId="site-1"
+				activeView="chat"
+				sessionId="session-1"
+				overviewTab="overview"
+				onOverviewTabChange={ onOverviewTabChange }
+			/>
+		);
+
+		expect( screen.getByTestId( 'chat' ) ).toBe( chat );
+		expect( screen.getByTestId( 'overview' ) ).toBe( overview );
+		expect( chat.parentElement ).not.toHaveAttribute( 'aria-hidden' );
+		expect( overview.parentElement ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( overview.parentElement ).toHaveAttribute( 'inert' );
+	} );
+
+	it( 'keeps the last overview tab while chat is active', () => {
+		const onOverviewTabChange = vi.fn();
+		const { rerender } = render(
+			<SiteWorkspace
+				siteId="site-1"
+				activeView="overview"
+				overviewTab="general"
+				onOverviewTabChange={ onOverviewTabChange }
+			/>
+		);
+
+		rerender(
+			<SiteWorkspace
+				siteId="site-1"
+				activeView="chat"
+				sessionId="session-1"
+				overviewTab="overview"
+				onOverviewTabChange={ onOverviewTabChange }
+			/>
+		);
+
+		expect( screen.getByTestId( 'overview' ) ).toHaveTextContent( 'general' );
+	} );
+} );

--- a/apps/ui/src/ui-classic/components/site-workspace/index.tsx
+++ b/apps/ui/src/ui-classic/components/site-workspace/index.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { SiteOverviewView } from '@/components/site-overview-view';
+import { SessionView } from '@/ui-classic/components/session-view';
+import styles from './style.module.css';
+import type { SiteSettingsTabId } from '@/components/site-settings-view';
+
+interface SiteWorkspaceProps {
+	siteId: string;
+	activeView: 'chat' | 'overview';
+	sessionId?: string;
+	overviewTab: SiteSettingsTabId;
+	openSiteDropdown?: boolean;
+	onOverviewTabChange: ( tab: SiteSettingsTabId ) => void;
+}
+
+export function SiteWorkspace( {
+	siteId,
+	activeView,
+	sessionId,
+	overviewTab,
+	openSiteDropdown = false,
+	onOverviewTabChange,
+}: SiteWorkspaceProps ) {
+	const [ retainedSessionId, setRetainedSessionId ] = useState( sessionId );
+	const [ hasVisitedOverview, setHasVisitedOverview ] = useState( activeView === 'overview' );
+	const [ retainedOverviewTab, setRetainedOverviewTab ] = useState( overviewTab );
+
+	if ( sessionId && sessionId !== retainedSessionId ) {
+		setRetainedSessionId( sessionId );
+	}
+	if ( activeView === 'overview' && ! hasVisitedOverview ) {
+		setHasVisitedOverview( true );
+	}
+	if ( activeView === 'overview' && overviewTab !== retainedOverviewTab ) {
+		setRetainedOverviewTab( overviewTab );
+	}
+
+	const chatActive = activeView === 'chat';
+	const overviewActive = activeView === 'overview';
+	const renderedSessionId = sessionId ?? retainedSessionId;
+	const renderedOverviewTab = overviewActive ? overviewTab : retainedOverviewTab;
+
+	return (
+		<div className={ styles.root }>
+			{ renderedSessionId ? (
+				<div
+					className={ `${ styles.layer } ${ chatActive ? styles.layerActive : '' }` }
+					inert={ ! chatActive }
+					aria-hidden={ ! chatActive || undefined }
+				>
+					<SessionView key={ renderedSessionId } sessionId={ renderedSessionId } />
+				</div>
+			) : null }
+			{ overviewActive || hasVisitedOverview ? (
+				<div
+					className={ `${ styles.layer } ${ overviewActive ? styles.layerActive : '' }` }
+					inert={ ! overviewActive }
+					aria-hidden={ ! overviewActive || undefined }
+				>
+					<SiteOverviewView
+						siteId={ siteId }
+						activeTab={ renderedOverviewTab }
+						openSiteDropdown={ overviewActive && openSiteDropdown }
+						onTabChange={ onOverviewTabChange }
+					/>
+				</div>
+			) : null }
+		</div>
+	);
+}

--- a/apps/ui/src/ui-classic/components/site-workspace/style.module.css
+++ b/apps/ui/src/ui-classic/components/site-workspace/style.module.css
@@ -1,0 +1,20 @@
+.root {
+	position: relative;
+	flex: 1;
+	width: 100%;
+	height: 100%;
+	min-width: 0;
+	min-height: 0;
+}
+
+.layer {
+	position: absolute;
+	inset: 0;
+	visibility: hidden;
+	pointer-events: none;
+}
+
+.layerActive {
+	visibility: visible;
+	pointer-events: auto;
+}

--- a/apps/ui/src/ui-classic/router/layout-dashboard/index.tsx
+++ b/apps/ui/src/ui-classic/router/layout-dashboard/index.tsx
@@ -1,5 +1,6 @@
 import { findAiSessionOwnerSite } from '@studio/common/ai/sessions/owner-site';
-import { createRoute, Outlet, useRouterState } from '@tanstack/react-router';
+import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
+import { createRoute, Outlet, useNavigate, useRouterState } from '@tanstack/react-router';
 import { useCallback, useEffect, useState } from 'react';
 import {
 	PreviewSplitFrame,
@@ -7,10 +8,13 @@ import {
 } from '@/components/preview-split-frame';
 import { SidebarLayout } from '@/components/sidebar-layout';
 import { SitePreview } from '@/components/site-preview';
+import { isSiteSettingsTab, siteSettingsTabToPanel } from '@/components/site-settings-view';
+import { useConnector } from '@/data/core';
 import { useOrientationAutostart } from '@/data/onboarding/use-orientation-autostart';
 import { useOrientationReplay } from '@/data/onboarding/use-orientation-replay';
 import { useWhatsNewAutostart } from '@/data/onboarding/use-whats-new-autostart';
 import { useWhatsNewReplay } from '@/data/onboarding/use-whats-new-replay';
+import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
 import { useSession, useSessionEffectiveEnvironment } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import {
@@ -20,7 +24,9 @@ import {
 	useSessionPreviewUI,
 } from '@/hooks/use-session-ui';
 import { writeLastVisited } from '@/lib/last-visited';
+import { SiteWorkspace } from '@/ui-classic/components/site-workspace';
 import { rootRoute } from '../layout-root';
+import type { SiteSettingsTabId } from '@/components/site-settings-view';
 
 // Session detail routes and the site overview host the preview; on every
 // other route (settings, site settings…) the last previewed site stays
@@ -53,14 +59,36 @@ function DashboardLayout() {
 // previewed site follows the current session; routes without one keep the
 // last previewed site loaded behind a closed panel.
 function DashboardLayoutContent() {
+	const navigate = useNavigate();
+	const connector = useConnector();
 	const routePreviewContext = useRouterState( {
 		select: ( state ) => ( {
 			sessionId: getRouteSessionId( state.location.pathname ),
 			overviewSiteId: getRouteOverviewSiteId( state.location.pathname ),
 			newSessionSiteId: getNewSessionSiteId( state.location.pathname ),
+			overviewTab:
+				typeof state.location.search.tab === 'string' &&
+				isSiteSettingsTab( state.location.search.tab )
+					? state.location.search.tab
+					: undefined,
+			openSiteDropdown: state.location.search.sync === 'pull',
 		} ),
 	} );
-	const { sessionId, overviewSiteId, newSessionSiteId } = routePreviewContext;
+	const { sessionId, overviewSiteId, newSessionSiteId, overviewTab, openSiteDropdown } =
+		routePreviewContext;
+	const [ overviewTabsBySite, setOverviewTabsBySite ] = useState<
+		Record< string, SiteSettingsTabId >
+	>( {} );
+	useEffect( () => {
+		if ( overviewSiteId && overviewTab ) {
+			setOverviewTabsBySite( ( current ) =>
+				current[ overviewSiteId ] === overviewTab
+					? current
+					: { ...current, [ overviewSiteId ]: overviewTab }
+			);
+		}
+	}, [ overviewSiteId, overviewTab ] );
+	const { isReady: agenticFeaturesReady, chatEnabled } = useAgenticFeatures();
 	const { data: sites } = useSites();
 	const { data: sessionData } = useSession( sessionId );
 	// Open the orientation guide on first workbench arrival, and let Help ▸
@@ -70,6 +98,11 @@ function DashboardLayoutContent() {
 	// Same, for the per-release announcements behind Help ▸ What's New.
 	useWhatsNewAutostart();
 	useWhatsNewReplay();
+	useEffect( () => {
+		if ( sessionId && agenticFeaturesReady && ! chatEnabled ) {
+			void navigate( { to: '/' } );
+		}
+	}, [ agenticFeaturesReady, chatEnabled, navigate, sessionId ] );
 	const preview = useSessionPreviewUI();
 	const onAnnotationsDone = useSessionPreviewAnnotationsHandler();
 	const sessionSite = findAiSessionOwnerSite( sites, sessionData?.summary );
@@ -164,6 +197,46 @@ function DashboardLayoutContent() {
 			setPreviewFullscreen,
 		]
 	);
+	const activeWorkspaceView = sessionId ? 'chat' : overviewSiteId ? 'overview' : undefined;
+	const routeWorkspaceSiteId = overviewSiteId ?? sessionSite?.id;
+	const [ retainedWorkspaceSiteId, setRetainedWorkspaceSiteId ] = useState( routeWorkspaceSiteId );
+	if ( routeWorkspaceSiteId && routeWorkspaceSiteId !== retainedWorkspaceSiteId ) {
+		setRetainedWorkspaceSiteId( routeWorkspaceSiteId );
+	}
+	const workspaceSiteId =
+		routeWorkspaceSiteId ?? ( activeWorkspaceView ? retainedWorkspaceSiteId : undefined );
+	const activeOverviewTab =
+		overviewTab ??
+		( workspaceSiteId ? overviewTabsBySite[ workspaceSiteId ] : undefined ) ??
+		'overview';
+	const workspace =
+		activeWorkspaceView && workspaceSiteId ? (
+			<SiteWorkspace
+				key={ workspaceSiteId }
+				siteId={ workspaceSiteId }
+				activeView={ activeWorkspaceView }
+				sessionId={ sessionId }
+				overviewTab={ activeOverviewTab }
+				openSiteDropdown={ openSiteDropdown }
+				onOverviewTabChange={ ( next ) => {
+					setOverviewTabsBySite( ( current ) => ( {
+						...current,
+						[ workspaceSiteId ]: next,
+					} ) );
+					void connector.trackEvent( TRACKS_EVENTS.PANEL_OPENED, {
+						panel: siteSettingsTabToPanel( next ),
+					} );
+					void navigate( {
+						to: '/sites/$siteId/overview',
+						params: { siteId: workspaceSiteId },
+						search: { tab: next },
+						replace: true,
+					} );
+				} }
+			/>
+		) : (
+			<Outlet />
+		);
 
 	return (
 		<SidebarLayout
@@ -175,7 +248,7 @@ function DashboardLayoutContent() {
 				previewFullscreen={ previewFullscreen }
 				preview={ renderPreview }
 			>
-				<Outlet />
+				{ workspace }
 			</PreviewSplitFrame>
 		</SidebarLayout>
 	);

--- a/apps/ui/src/ui-classic/router/route-site-overview/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-site-overview/index.tsx
@@ -70,10 +70,13 @@ export const siteOverviewRoute = createRoute( {
 		return validated;
 	},
 	beforeLoad: async ( { params, context } ) => {
-		const sites = await context.queryClient.fetchQuery( {
-			queryKey: SITES_QUERY_KEY,
-			queryFn: () => context.connector.getSites(),
-		} );
+		const cachedSites = context.queryClient.getQueryData< SiteDetails[] >( SITES_QUERY_KEY );
+		const sites = cachedSites?.some( ( site ) => site.id === params.siteId )
+			? cachedSites
+			: ( await context.queryClient.fetchQuery( {
+					queryKey: SITES_QUERY_KEY,
+					queryFn: () => context.connector.getSites(),
+			  } ) ) ?? [];
 		if ( ! sites.some( ( site: SiteDetails ) => site.id === params.siteId ) ) {
 			throw redirect( { to: '/' } );
 		}


### PR DESCRIPTION
## Related issues

- None.

## How AI was used in this PR

Codex was used to implement the UI behavior, add focused tests, run the repository checks, verify the interaction in the browser in light and dark color schemes, and draft this PR description.

## Proposed Changes

- Make the site overview shortcut behave like a toggle for signed-in users with agentic features enabled, with a clear pressed state while overview is active.
- Keep chat and site overview mounted when switching between them so the transcript, overview tab, and other in-view state are preserved instead of being rebuilt.
- Reuse cached site data when opening an existing site's overview to avoid an unnecessary blocking refresh.

## Testing Instructions

1. Sign in with agentic features enabled and open a site's chat.
2. Click the site overview shortcut and confirm it has a white pressed state.
3. Switch between chat and overview and confirm both return immediately with their prior state intact.
4. Select a different overview tab, switch to chat, then return and confirm the tab remains selected.
5. Repeat the visual check in light and dark color schemes.

Automated checks:

- `npx eslint --fix` on the modified TypeScript and TSX files
- `npm run typecheck`
- `npm test -- apps/ui/src/components/site-list/index.test.tsx apps/ui/src/ui-classic/components/site-workspace/index.test.tsx`
- `npm run cli:build:ui`
- `git diff --check`

### Screenshots

| Chat | Site overview |
|---|---|
| ![Chat with the site overview toggle inactive](https://github.com/Automattic/studio/blob/73dc44935fa4ca66f6b565de04f686cfa2b71cda/codex-clipboard-e70cbf25-80d6-4147-a7ea-780bbcc7679f.png?raw=true) | ![Site overview with the toggle in its white pressed state](https://github.com/Automattic/studio/blob/73dc44935fa4ca66f6b565de04f686cfa2b71cda/codex-clipboard-19ff22c5-42d4-4930-9389-b90ddde44458.png?raw=true) |

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
