### PR TITLE
Agentic UI: Ensure that we disable the share button after 10 previews

### DIFF
--- a/apps/ui/src/components/site-dropdown/main-view.test.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.test.tsx
@@ -27,6 +27,12 @@ const {
 	stopSiteMutate: vi.fn(),
 } ) );
 
+let snapshotUsage: {
+	siteCount: number;
+	siteLimit: number;
+	siteCreationBlocked: boolean;
+} | null = null;
+
 vi.mock( '@tanstack/react-query', async ( importOriginal ) => {
 	const actual = await importOriginal< typeof import('@tanstack/react-query') >();
 	return {
@@ -66,6 +72,7 @@ vi.mock( '@/data/queries/use-sites', () => ( {
 
 vi.mock( '@/data/queries/use-snapshots', () => ( {
 	useSnapshots: () => ( { data: snapshots } ),
+	useSnapshotUsage: () => ( { data: snapshotUsage } ),
 } ) );
 
 const cancelSyncMutate = vi.fn();
@@ -141,6 +148,7 @@ describe( 'MainView', () => {
 			localSiteId: site.id,
 			date: Date.now(),
 		} );
+		snapshotUsage = null;
 		connectedSites.splice( 0, connectedSites.length );
 	} );
 
@@ -317,6 +325,36 @@ describe( 'MainView', () => {
 
 		expect( blocked ).toHaveAttribute( 'aria-disabled', 'true' );
 		expect( cancelSyncMutate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'disables the Share button when the preview site limit is reached', () => {
+		snapshots.splice( 0, snapshots.length );
+		snapshotUsage = { siteCount: 10, siteLimit: 10, siteCreationBlocked: false };
+
+		renderMainView();
+
+		expect(
+			screen.getByText( "You've used all 10 preview sites available on your account." )
+		).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Share' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	it( 'disables the Share button when preview site creation is blocked', () => {
+		snapshots.splice( 0, snapshots.length );
+		snapshotUsage = { siteCount: 0, siteLimit: 10, siteCreationBlocked: true };
+
+		renderMainView();
+
+		expect(
+			screen.getByText( 'Preview sites are not available for your account.' )
+		).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Share' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
 	} );
 
 	it( 'stops offering to cancel a pull once the local import has started', () => {

--- a/apps/ui/src/components/site-dropdown/main-view.tsx
+++ b/apps/ui/src/components/site-dropdown/main-view.tsx
@@ -23,7 +23,7 @@ import {
 	useStartSite,
 	useStopSite,
 } from '@/data/queries/use-sites';
-import { useSnapshots } from '@/data/queries/use-snapshots';
+import { useSnapshotUsage, useSnapshots } from '@/data/queries/use-snapshots';
 import {
 	PULL_FROM_LIVE_MUTATION_KEY,
 	PUSH_TO_LIVE_MUTATION_KEY,
@@ -87,9 +87,20 @@ function useIsSiteSyncing( siteId: string ): { push: boolean; pull: boolean } {
 function getPreviewPanelCopy(
 	agenticEnabled: boolean,
 	isOffline: boolean,
-	isPreviewExpired: boolean
+	isPreviewExpired: boolean,
+	snapshotUsage?: { siteCount: number; siteLimit: number; siteCreationBlocked: boolean } | null
 ): string {
 	if ( agenticEnabled ) {
+		if ( snapshotUsage?.siteCreationBlocked ) {
+			return __( 'Preview sites are not available for your account.' );
+		}
+		if ( snapshotUsage && snapshotUsage.siteCount >= snapshotUsage.siteLimit ) {
+			return sprintf(
+				/* translators: %d: maximum number of preview sites allowed */
+				__( "You've used all %d preview sites available on your account." ),
+				snapshotUsage.siteLimit
+			);
+		}
 		return isPreviewExpired
 			? __( 'The previous preview has expired.' )
 			: __( 'Share a review link for this version.' );
@@ -123,6 +134,7 @@ export function MainView( {
 	const isOffline = agenticReason === 'offline';
 	const login = useLogin( { source: 'site_header' } );
 	const { data: snapshots } = useSnapshots();
+	const { data: snapshotUsage } = useSnapshotUsage();
 	const { data: connectedSites } = useConnectedWpcomSites( site.id );
 
 	const previewSnapshot = useMemo(
@@ -153,6 +165,10 @@ export function MainView( {
 	// controls on both, so an operation the agent took disables them visibly rather
 	// than leaving buttons that swallow the click.
 	const isSiteBusy = isSyncing || isOperationInProgress;
+
+	const isPreviewLimitReached =
+		snapshotUsage?.siteCreationBlocked === true ||
+		( snapshotUsage?.siteCount ?? 0 ) >= ( snapshotUsage?.siteLimit ?? Infinity );
 
 	const { localSublabel } = deriveSiteStatus( site, isStarting, isStopping, operation );
 	const localSiteUrl = getSiteUrl( site );
@@ -354,13 +370,13 @@ export function MainView( {
 			) : (
 				<EnvironmentActionPanel
 					title={ __( 'Preview' ) }
-					copy={ getPreviewPanelCopy( agenticEnabled, isOffline, isPreviewExpired ) }
+					copy={ getPreviewPanelCopy( agenticEnabled, isOffline, isPreviewExpired, snapshotUsage ) }
 					buttonLabel={ isPreviewExpired ? __( 'Share a new one' ) : __( 'Share' ) }
 					variant="outline"
 					tone="neutral"
 					loading={ isPreviewPending }
 					loadingAnnouncement={ __( 'Creating preview' ) }
-					disabled={ isSiteBusy || ! agenticEnabled }
+					disabled={ isSiteBusy || ! agenticEnabled || isPreviewLimitReached }
 					onClick={ handlePreviewClick }
 				/>
 			) }


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-2256

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

It was used to identify and solve the issue

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

This PR ensures that after the user created 10 preview sites, the `Share` button becomes disabled in the agentic UI:

<img width="531" height="276" alt="Screenshot 2026-08-17 at 11 21 09 AM" src="https://github.com/user-attachments/assets/398e7346-a652-431a-98ff-6a57d575f759" />

Previously it was throwing an error when you click on it and tried to create 11th preview.

## Testing Instructions

* Pull the changes from this branch
* Start Studio with `npm start`
* Ensure that you are using the agentic UI
* Create 10 preview sites 
* Confirm that when you are trying to create an 11th preview site, the `Share` button is disabled and the relevant copy is displayed


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
