### PR TITLE
Agentic UI: Fix zoom shortcuts with focused preview

### DIFF
--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -29,6 +29,7 @@ import {
 	hasActiveSyncOperations,
 	hasUploadingPushOperations,
 } from 'src/lib/active-sync-operations';
+import { applyAppZoomCommand, getAppZoomCommand } from 'src/lib/app-zoom';
 import { getBetaFeatures } from 'src/lib/beta-features';
 import {
 	bumpStat,
@@ -204,6 +205,20 @@ async function appBoot() {
 	// and exempted from the renderer-origin restriction below.
 	app.on( 'web-contents-created', ( _event, contents ) => {
 		const isSitePreviewWebview = contents.getType() === 'webview';
+		if ( isSitePreviewWebview ) {
+			contents.on( 'before-input-event', ( event, input ) => {
+				const zoomCommand = getAppZoomCommand( input );
+				if ( ! zoomCommand ) {
+					return;
+				}
+				event.preventDefault();
+				void getMainWindow().then( ( window ) => {
+					if ( ! window.isDestroyed() && ! window.webContents.isDestroyed() ) {
+						applyAppZoomCommand( window.webContents, zoomCommand );
+					}
+				} );
+			} );
+		}
 
 		contents.on( 'will-navigate', ( event, navigationUrl ) => {
 			if ( isSitePreviewWebview ) {

--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -29,7 +29,7 @@ import {
 	hasActiveSyncOperations,
 	hasUploadingPushOperations,
 } from 'src/lib/active-sync-operations';
-import { applyAppZoomCommand, getAppZoomCommand } from 'src/lib/app-zoom';
+import { applyAppZoomCommand, getAppZoomCommand, resetPreviewZoom } from 'src/lib/app-zoom';
 import { getBetaFeatures } from 'src/lib/beta-features';
 import {
 	bumpStat,
@@ -217,6 +217,12 @@ async function appBoot() {
 						applyAppZoomCommand( window.webContents, zoomCommand );
 					}
 				} );
+			} );
+			// Electron re-applies the embedder's zoom to a guest after each of its
+			// navigations, from an observer that runs after this event — so the
+			// reset waits a tick.
+			contents.on( 'did-navigate', () => {
+				setImmediate( () => resetPreviewZoom( contents ) );
 			} );
 		}
 

--- a/apps/studio/src/ipc-types.d.ts
+++ b/apps/studio/src/ipc-types.d.ts
@@ -104,6 +104,8 @@ type IpcApi = {
 	// function is exception and need to be defined here manually. See
 	// https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-320
 	getPathForFile: ( file: File ) => string;
+	// The renderer's own zoom factor, read synchronously from `webFrame` — also preload-only.
+	getAppZoomFactor: () => number;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- no flags in flight; see `src/lib/feature-flags.ts`

--- a/apps/studio/src/lib/app-zoom.test.ts
+++ b/apps/studio/src/lib/app-zoom.test.ts
@@ -1,8 +1,13 @@
 /**
  * @vitest-environment node
  */
-import { describe, expect, it, vi } from 'vitest';
-import { applyAppZoomCommand, getAppZoomCommand } from 'src/lib/app-zoom';
+import { webContents } from 'electron';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { applyAppZoomCommand, getAppZoomCommand, resetPreviewZoom } from 'src/lib/app-zoom';
+
+vi.mock( 'electron', () => ( {
+	webContents: { getAllWebContents: vi.fn().mockReturnValue( [] ) },
+} ) );
 
 const input = {
 	type: 'keyDown',
@@ -17,6 +22,22 @@ const input = {
 	location: 0,
 	modifiers: [],
 } as Electron.Input;
+
+function createContents( {
+	id = 1,
+	type = 'window',
+	zoomLevel = 0,
+	hostId,
+}: { id?: number; type?: string; zoomLevel?: number; hostId?: number } = {} ) {
+	return {
+		id,
+		getType: vi.fn().mockReturnValue( type ),
+		hostWebContents: hostId === undefined ? undefined : { id: hostId },
+		isDestroyed: vi.fn().mockReturnValue( false ),
+		getZoomLevel: vi.fn().mockReturnValue( zoomLevel ),
+		setZoomLevel: vi.fn(),
+	};
+}
 
 describe( 'getAppZoomCommand', () => {
 	it.each( [
@@ -40,18 +61,67 @@ describe( 'getAppZoomCommand', () => {
 } );
 
 describe( 'applyAppZoomCommand', () => {
+	beforeEach( () => {
+		vi.mocked( webContents.getAllWebContents ).mockReturnValue( [] );
+	} );
+
 	it.each( [
 		[ 'reset', 0 ],
 		[ 'in', 1.5 ],
 		[ 'out', 0.5 ],
 	] as const )( 'applies %s to the app web contents', ( command, expectedLevel ) => {
-		const contents = {
-			getZoomLevel: vi.fn().mockReturnValue( 1 ),
-			setZoomLevel: vi.fn(),
-		};
+		const contents = createContents( { zoomLevel: 1 } );
 
 		applyAppZoomCommand( contents as never, command );
 
 		expect( contents.setZoomLevel ).toHaveBeenCalledWith( expectedLevel );
+	} );
+
+	it( 'pins the site previews hosted by that window back to 1:1', () => {
+		const app = createContents( { id: 1, zoomLevel: 1 } );
+		// By the time `setZoomLevel` returns, Electron has already copied the
+		// app's new level onto its guests.
+		const preview = createContents( { id: 2, type: 'webview', hostId: 1, zoomLevel: 1.5 } );
+		const otherWindowPreview = createContents( {
+			id: 3,
+			type: 'webview',
+			hostId: 9,
+			zoomLevel: 1.5,
+		} );
+		const otherWindow = createContents( { id: 4, zoomLevel: 1.5 } );
+		vi.mocked( webContents.getAllWebContents ).mockReturnValue( [
+			app,
+			preview,
+			otherWindowPreview,
+			otherWindow,
+		] as never );
+
+		applyAppZoomCommand( app as never, 'in' );
+
+		expect( preview.setZoomLevel ).toHaveBeenCalledWith( 0 );
+		expect( otherWindowPreview.setZoomLevel ).not.toHaveBeenCalled();
+		expect( otherWindow.setZoomLevel ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'resetPreviewZoom', () => {
+	it( 'resets a zoomed guest', () => {
+		const guest = createContents( { type: 'webview', zoomLevel: 0.5 } );
+
+		resetPreviewZoom( guest as never );
+
+		expect( guest.setZoomLevel ).toHaveBeenCalledWith( 0 );
+	} );
+
+	it( 'leaves an unzoomed or destroyed guest alone', () => {
+		const unzoomed = createContents( { type: 'webview', zoomLevel: 0 } );
+		const destroyed = createContents( { type: 'webview', zoomLevel: 0.5 } );
+		destroyed.isDestroyed.mockReturnValue( true );
+
+		resetPreviewZoom( unzoomed as never );
+		resetPreviewZoom( destroyed as never );
+
+		expect( unzoomed.setZoomLevel ).not.toHaveBeenCalled();
+		expect( destroyed.setZoomLevel ).not.toHaveBeenCalled();
 	} );
 } );

--- a/apps/studio/src/lib/app-zoom.test.ts
+++ b/apps/studio/src/lib/app-zoom.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { applyAppZoomCommand, getAppZoomCommand } from 'src/lib/app-zoom';
+
+const input = {
+	type: 'keyDown',
+	key: '',
+	code: '',
+	isAutoRepeat: false,
+	isComposing: false,
+	shift: false,
+	control: false,
+	alt: false,
+	meta: false,
+	location: 0,
+	modifiers: [],
+} as Electron.Input;
+
+describe( 'getAppZoomCommand', () => {
+	it.each( [
+		[ 'darwin', { key: '+', meta: true, shift: true }, 'in' ],
+		[ 'darwin', { key: '=', meta: true }, 'in' ],
+		[ 'darwin', { key: '-', meta: true }, 'out' ],
+		[ 'darwin', { key: '0', meta: true }, 'reset' ],
+		[ 'win32', { key: '+', control: true, shift: true }, 'in' ],
+		[ 'win32', { key: '-', control: true }, 'out' ],
+		[ 'win32', { key: '0', control: true }, 'reset' ],
+		[ 'linux', { key: '=', control: true }, 'in' ],
+		[ 'linux', { key: '_', control: true, shift: true }, 'out' ],
+	] as const )( 'maps %s %j to %s', ( platform, overrides, command ) => {
+		expect( getAppZoomCommand( { ...input, ...overrides }, platform ) ).toBe( command );
+	} );
+
+	it( 'ignores shortcuts with the wrong platform modifier', () => {
+		expect( getAppZoomCommand( { ...input, key: '+', control: true }, 'darwin' ) ).toBeNull();
+		expect( getAppZoomCommand( { ...input, key: '+', meta: true }, 'win32' ) ).toBeNull();
+	} );
+} );
+
+describe( 'applyAppZoomCommand', () => {
+	it.each( [
+		[ 'reset', 0 ],
+		[ 'in', 1.5 ],
+		[ 'out', 0.5 ],
+	] as const )( 'applies %s to the app web contents', ( command, expectedLevel ) => {
+		const contents = {
+			getZoomLevel: vi.fn().mockReturnValue( 1 ),
+			setZoomLevel: vi.fn(),
+		};
+
+		applyAppZoomCommand( contents as never, command );
+
+		expect( contents.setZoomLevel ).toHaveBeenCalledWith( expectedLevel );
+	} );
+} );

--- a/apps/studio/src/lib/app-zoom.ts
+++ b/apps/studio/src/lib/app-zoom.ts
@@ -1,0 +1,39 @@
+import type { WebContents } from 'electron';
+
+export type AppZoomCommand = 'reset' | 'in' | 'out';
+
+export function getAppZoomCommand(
+	input: Electron.Input,
+	platform: NodeJS.Platform = process.platform
+): AppZoomCommand | null {
+	if ( input.type !== 'keyDown' || input.isComposing || input.alt ) {
+		return null;
+	}
+
+	const hasPrimaryModifier =
+		platform === 'darwin' ? input.meta && ! input.control : input.control && ! input.meta;
+	if ( ! hasPrimaryModifier ) {
+		return null;
+	}
+
+	if ( input.key === '+' || input.key === '=' ) {
+		return 'in';
+	}
+	if ( input.key === '-' || input.key === '_' ) {
+		return 'out';
+	}
+	if ( input.key === '0' && ! input.shift ) {
+		return 'reset';
+	}
+
+	return null;
+}
+
+export function applyAppZoomCommand( contents: WebContents, command: AppZoomCommand ) {
+	if ( command === 'reset' ) {
+		contents.setZoomLevel( 0 );
+		return;
+	}
+
+	contents.setZoomLevel( contents.getZoomLevel() + ( command === 'in' ? 0.5 : -0.5 ) );
+}

--- a/apps/studio/src/lib/app-zoom.ts
+++ b/apps/studio/src/lib/app-zoom.ts
@@ -1,4 +1,4 @@
-import type { WebContents } from 'electron';
+import { webContents, type WebContents } from 'electron';
 
 export type AppZoomCommand = 'reset' | 'in' | 'out';
 
@@ -32,8 +32,34 @@ export function getAppZoomCommand(
 export function applyAppZoomCommand( contents: WebContents, command: AppZoomCommand ) {
 	if ( command === 'reset' ) {
 		contents.setZoomLevel( 0 );
-		return;
+	} else {
+		contents.setZoomLevel( contents.getZoomLevel() + ( command === 'in' ? 0.5 : -0.5 ) );
 	}
 
-	contents.setZoomLevel( contents.getZoomLevel() + ( command === 'in' ? 0.5 : -0.5 ) );
+	for ( const guest of getHostedWebviews( contents ) ) {
+		resetPreviewZoom( guest );
+	}
+}
+
+/**
+ * Pins a site-preview `<webview>` back to 1:1.
+ *
+ * Electron copies an embedder's zoom level onto its guests: immediately when
+ * the embedder zooms, and again on each guest navigation. The app's zoom is
+ * for the surrounding UI only — the preview simulates real viewports, so its
+ * guests always render unzoomed.
+ */
+export function resetPreviewZoom( guest: WebContents ) {
+	if ( guest.isDestroyed() || guest.getZoomLevel() === 0 ) {
+		return;
+	}
+	guest.setZoomLevel( 0 );
+}
+
+function getHostedWebviews( host: WebContents ): WebContents[] {
+	return webContents
+		.getAllWebContents()
+		.filter(
+			( contents ) => contents.getType() === 'webview' && contents.hostWebContents?.id === host.id
+		);
 }

--- a/apps/studio/src/main-window.ts
+++ b/apps/studio/src/main-window.ts
@@ -20,6 +20,7 @@ import {
 	WINDOWS_TITLEBAR_HEIGHT,
 } from 'src/constants';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
+import { applyAppZoomCommand, getAppZoomCommand } from 'src/lib/app-zoom';
 import { getPreferredStudioUiMode, type StudioUiMode } from 'src/lib/studio-ui-mode';
 import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
 import { removeMenu } from 'src/menu';
@@ -219,7 +220,14 @@ export async function createMainWindow(): Promise< BrowserWindow > {
 		mainWindow.on( 'closed', () => nativeTheme.removeListener( 'updated', updateTitleBarOverlay ) );
 	}
 
-	mainWindow.webContents.on( 'before-input-event', ( event, input ) => {
+	const mainWebContents = mainWindow.webContents;
+	mainWebContents.on( 'before-input-event', ( event, input ) => {
+		const zoomCommand = getAppZoomCommand( input );
+		if ( zoomCommand ) {
+			event.preventDefault();
+			applyAppZoomCommand( mainWebContents, zoomCommand );
+			return;
+		}
 		if ( isToggleSidebarShortcut( input ) ) {
 			event.preventDefault();
 			sendIpcEventToRendererWithWindow( mainWindow, 'toggle-sidebar' );

--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 import { openAboutWindow } from 'src/about-menu/open-about-menu';
 import { BUG_REPORT_URL, FEATURE_REQUEST_URL } from 'src/constants';
 import { sendIpcEventToRenderer } from 'src/ipc-utils';
+import { applyAppZoomCommand } from 'src/lib/app-zoom';
 import {
 	BetaFeatureDefinition,
 	getBetaFeatures,
@@ -431,17 +432,13 @@ async function getAppMenu(
 					void sendIpcEventToRenderer( 'toggle-site-preview' );
 				},
 				onResetZoom: () => {
-					void withAppWebContents( ( contents ) => contents.setZoomLevel( 0 ) );
+					void withAppWebContents( ( contents ) => applyAppZoomCommand( contents, 'reset' ) );
 				},
 				onZoomIn: () => {
-					void withAppWebContents( ( contents ) =>
-						contents.setZoomLevel( contents.getZoomLevel() + 0.5 )
-					);
+					void withAppWebContents( ( contents ) => applyAppZoomCommand( contents, 'in' ) );
 				},
 				onZoomOut: () => {
-					void withAppWebContents( ( contents ) =>
-						contents.setZoomLevel( contents.getZoomLevel() - 0.5 )
-					);
+					void withAppWebContents( ( contents ) => applyAppZoomCommand( contents, 'out' ) );
 				},
 			} ),
 		},

--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -136,6 +136,9 @@ export function buildViewMenuItems( {
 	devTools,
 	onToggleSidebar,
 	onToggleSitePreview,
+	onResetZoom,
+	onZoomIn,
+	onZoomOut,
 }: {
 	needsOnboarding: boolean;
 	isDevelopment: boolean;
@@ -143,6 +146,9 @@ export function buildViewMenuItems( {
 	devTools: MenuItemConstructorOptions[];
 	onToggleSidebar: () => void;
 	onToggleSitePreview: () => void;
+	onResetZoom: () => void;
+	onZoomIn: () => void;
+	onZoomOut: () => void;
 } ): MenuItemConstructorOptions[] {
 	return [
 		{
@@ -164,15 +170,18 @@ export function buildViewMenuItems( {
 		...( isDevelopment ? devTools : [] ),
 		{
 			label: __( 'Actual Size' ),
-			role: 'resetZoom',
+			accelerator: 'CommandOrControl+0',
+			click: onResetZoom,
 		},
 		{
 			label: __( 'Zoom In' ),
-			role: 'zoomIn',
+			accelerator: 'CommandOrControl+Plus',
+			click: onZoomIn,
 		},
 		{
 			label: __( 'Zoom Out' ),
-			role: 'zoomOut',
+			accelerator: 'CommandOrControl+-',
+			click: onZoomOut,
 		},
 		{ type: 'separator' },
 		{
@@ -420,6 +429,19 @@ async function getAppMenu(
 				},
 				onToggleSitePreview: () => {
 					void sendIpcEventToRenderer( 'toggle-site-preview' );
+				},
+				onResetZoom: () => {
+					void withAppWebContents( ( contents ) => contents.setZoomLevel( 0 ) );
+				},
+				onZoomIn: () => {
+					void withAppWebContents( ( contents ) =>
+						contents.setZoomLevel( contents.getZoomLevel() + 0.5 )
+					);
+				},
+				onZoomOut: () => {
+					void withAppWebContents( ( contents ) =>
+						contents.setZoomLevel( contents.getZoomLevel() - 0.5 )
+					);
 				},
 			} ),
 		},

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -2,7 +2,7 @@
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
 
 import '@sentry/electron/preload';
-import { IpcRendererEvent, contextBridge, ipcRenderer, webUtils } from 'electron';
+import { IpcRendererEvent, contextBridge, ipcRenderer, webFrame, webUtils } from 'electron';
 import { IpcEvents } from 'src/ipc-utils';
 import type { AgenticUiSurface } from 'src/lib/beta-features';
 
@@ -171,6 +171,7 @@ const api: IpcApi = {
 	getDirectorySize: ( id, subdir ) => ipcRendererInvoke( 'getDirectorySize', id, subdir ),
 	getFileSize: ( id, filePath ) => ipcRendererInvoke( 'getFileSize', id, filePath ),
 	getPathForFile: ( file ) => webUtils.getPathForFile( file ),
+	getAppZoomFactor: () => webFrame.getZoomFactor(),
 	readLocalMediaFile: ( path ) => ipcRendererInvoke( 'readLocalMediaFile', path ),
 	setWebviewViewport: ( webContentsId, viewport ) =>
 		ipcRendererInvoke( 'setWebviewViewport', webContentsId, viewport ),

--- a/apps/studio/src/tests/index.test.ts
+++ b/apps/studio/src/tests/index.test.ts
@@ -234,6 +234,48 @@ describe( 'App initialization', () => {
 		} );
 	} );
 
+	describe( 'app zoom in the site preview', () => {
+		async function captureWebContents( contentsType: string ) {
+			const { mockedEvents } = mockElectron();
+			vi.resetModules();
+			await import( '../index' );
+			await mockedEvents.ready();
+
+			const contents = {
+				getType: () => contentsType,
+				on: vi.fn(),
+				setWindowOpenHandler: vi.fn(),
+				isDestroyed: vi.fn().mockReturnValue( false ),
+				getZoomLevel: vi.fn().mockReturnValue( 0.5 ),
+				setZoomLevel: vi.fn(),
+			};
+			await mockedEvents[ 'web-contents-created' ]( {}, contents );
+
+			const onNavigate = contents.on.mock.calls.find(
+				( [ event ] ) => event === 'did-navigate'
+			)?.[ 1 ] as ( () => void ) | undefined;
+
+			return { contents, onNavigate };
+		}
+
+		it( 'pins a site preview back to 1:1 after Electron re-applies the app zoom on navigation', async () => {
+			const { contents, onNavigate } = await captureWebContents( 'webview' );
+
+			onNavigate?.();
+			// Electron's own zoom observer runs after `did-navigate`, so the reset is deferred a tick.
+			expect( contents.setZoomLevel ).not.toHaveBeenCalled();
+			await new Promise( ( resolve ) => setImmediate( resolve ) );
+
+			expect( contents.setZoomLevel ).toHaveBeenCalledWith( 0 );
+		} );
+
+		it( 'leaves web contents outside the site preview alone', async () => {
+			const { onNavigate } = await captureWebContents( 'window' );
+
+			expect( onNavigate ).toBeUndefined();
+		} );
+	} );
+
 	describe( 'unsaved changes in the site preview', () => {
 		// Electron inverts the usual contract here: `preventDefault()` on
 		// `will-prevent-unload` *allows* the page to be unloaded, and doing

--- a/apps/studio/src/tests/main-window.test.ts
+++ b/apps/studio/src/tests/main-window.test.ts
@@ -87,6 +87,9 @@ vi.mock( 'electron', () => {
 		screen: {
 			getAllDisplays: vi.fn().mockReturnValue( [] ),
 		},
+		webContents: {
+			getAllWebContents: vi.fn().mockReturnValue( [] ),
+		},
 		BrowserWindow: MockBrowserWindow,
 		shell: {
 			trashItem: vi.fn(),

--- a/apps/studio/src/tests/main-window.test.ts
+++ b/apps/studio/src/tests/main-window.test.ts
@@ -49,6 +49,8 @@ vi.mock( 'electron', () => {
 
 		webContents = {
 			isDestroyed: vi.fn().mockReturnValue( false ),
+			getZoomLevel: vi.fn().mockReturnValue( 0 ),
+			setZoomLevel: vi.fn(),
 			send: vi.fn(),
 			on: vi.fn().mockImplementation( ( event: string, handler: ( ...args: any[] ) => void ) => {
 				if ( ! mockWebContentsEventHandlers.has( event ) ) {
@@ -259,6 +261,29 @@ describe( 'sidebar shortcut', () => {
 			createdWindow,
 			'toggle-sidebar'
 		);
+	} );
+
+	it( 'handles app zoom shortcuts without relying on the application menu', async () => {
+		const createdWindow = await createMainWindow();
+		const handlers = mockWebContentsEventHandlers.get( 'before-input-event' );
+		const event = { preventDefault: vi.fn() };
+
+		handlers![ 0 ]( event, {
+			type: 'keyDown',
+			key: '+',
+			code: 'Equal',
+			isAutoRepeat: false,
+			isComposing: false,
+			shift: true,
+			control: process.platform !== 'darwin',
+			alt: false,
+			meta: process.platform === 'darwin',
+			location: 0,
+			modifiers: [],
+		} as Electron.Input );
+
+		expect( event.preventDefault ).toHaveBeenCalled();
+		expect( createdWindow.webContents.setZoomLevel ).toHaveBeenCalledWith( 0.5 );
 	} );
 } );
 

--- a/apps/studio/src/tests/menu.test.ts
+++ b/apps/studio/src/tests/menu.test.ts
@@ -15,6 +15,9 @@ function buildTestViewMenuItems(
 		devTools: [],
 		onToggleSidebar: vi.fn(),
 		onToggleSitePreview: vi.fn(),
+		onResetZoom: vi.fn(),
+		onZoomIn: vi.fn(),
+		onZoomOut: vi.fn(),
 		...overrides,
 	} );
 }
@@ -83,5 +86,23 @@ describe( 'buildViewMenuItems', () => {
 			'Toggle Fullscreen',
 			'Float on Top of All Other Windows',
 		] );
+	} );
+
+	it.each( [
+		[ 'Actual Size', 'CommandOrControl+0', 'onResetZoom' ],
+		[ 'Zoom In', 'CommandOrControl+Plus', 'onZoomIn' ],
+		[ 'Zoom Out', 'CommandOrControl+-', 'onZoomOut' ],
+	] as const )( 'targets the app for %s', ( label, accelerator, callbackName ) => {
+		const callback = vi.fn();
+		const item = buildTestViewMenuItems( { [ callbackName ]: callback } ).find(
+			( candidate ) => candidate.label === label
+		);
+
+		expect( item ).toMatchObject( { accelerator } );
+		expect( item?.role ).toBeUndefined();
+
+		item?.click?.( {} as never, undefined as never, undefined as never );
+
+		expect( callback ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -12,6 +12,7 @@ import {
 	isOffOriginRedirect,
 	isThemeActivationUrl,
 	getPathFromPreviewUrl,
+	getFrameSize,
 	getSimulatedViewport,
 	SitePreview,
 } from './index';
@@ -917,6 +918,38 @@ describe( 'getSimulatedViewport', () => {
 			mobile: false,
 		} );
 	} );
+
+	it( 'fits the pane in device px when the app UI is zoomed', () => {
+		// At 1.25× the pane measures 720 CSS px but is really 900 device px
+		// wide, and that's the space a 1440 px desktop has to fit into.
+		expect(
+			getSimulatedViewport( { width: 1440, height: 900 }, { width: 720, height: 800 }, 1.25 )
+		).toEqual( {
+			width: 1440,
+			height: 900,
+			scale: 0.625,
+			mobile: false,
+		} );
+		// A phone that fits at device size still never scales up.
+		expect(
+			getSimulatedViewport( { width: 390, height: 844 }, { width: 400, height: 900 }, 1.25 )
+		).toEqual( {
+			width: 390,
+			height: 844,
+			scale: 1,
+			mobile: false,
+		} );
+	} );
+} );
+
+describe( 'getFrameSize', () => {
+	it( 'lays the scaled device box out in the host document CSS px', () => {
+		const viewport = { width: 1440, height: 900, scale: 0.5 };
+
+		expect( getFrameSize( viewport ) ).toEqual( { width: 720, height: 450 } );
+		// The app's zoom scales CSS px up, so the same device box takes fewer of them.
+		expect( getFrameSize( viewport, 1.25 ) ).toEqual( { width: 576, height: 360 } );
+	} );
 } );
 
 describe( 'getPathFromPreviewUrl', () => {
@@ -970,12 +1003,19 @@ class ResizeObserverStub {
 	disconnect() {}
 }
 
-function renderWebviewPreview( props: Partial< ComponentProps< typeof SitePreview > > = {} ) {
+function renderWebviewPreview(
+	props: Partial< ComponentProps< typeof SitePreview > > = {},
+	{ zoomFactor }: { zoomFactor?: number } = {}
+) {
 	setUserAgent( `${ REAL_USER_AGENT } Electron/38.0.0` );
 	vi.stubGlobal( 'ResizeObserver', ResizeObserverStub );
 	const clearWebviewCache = vi.fn().mockResolvedValue( undefined );
 	const setWebviewViewport = vi.fn().mockResolvedValue( undefined );
-	vi.stubGlobal( 'ipcApi', { clearWebviewCache, setWebviewViewport } );
+	vi.stubGlobal( 'ipcApi', {
+		clearWebviewCache,
+		setWebviewViewport,
+		...( zoomFactor === undefined ? {} : { getAppZoomFactor: () => zoomFactor } ),
+	} );
 	useConnectorMock.mockReturnValue( {
 		startSite: vi.fn().mockResolvedValue( undefined ),
 		trackEvent: vi.fn().mockResolvedValue( undefined ),
@@ -1089,6 +1129,26 @@ describe( 'SitePreview responsive emulation', () => {
 				mobile: false,
 			} )
 		);
+	} );
+
+	it( 'keeps a preset at device size while the app UI is zoomed', async () => {
+		const { webview, setWebviewViewport } = renderWebviewPreview( {}, { zoomFactor: 1.25 } );
+
+		await selectResponsiveMode( 'Desktop · 1440×900' );
+
+		// The padded pane measures 1.25× narrower in CSS px than the device
+		// space the desktop has to fit, so the emulation scale comes from the
+		// latter, and the frame is laid out in the former.
+		const scale = ( ( PANE_SIZE.width - 32 ) * 1.25 ) / 1440;
+		await waitFor( () =>
+			expect( setWebviewViewport ).toHaveBeenCalledWith(
+				7,
+				expect.objectContaining( { width: 1440, height: 900, scale } )
+			)
+		);
+		expect( webview.parentElement ).toHaveStyle( {
+			width: `${ ( 1440 * scale ) / 1.25 }px`,
+		} );
 	} );
 
 	it( 're-applies the simulated viewport after each load', async () => {

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -31,6 +31,7 @@ import {
 	useSiteOperation,
 	useStartSite,
 } from '@/data/queries/use-sites';
+import { useAppZoomFactor } from '@/hooks/use-app-zoom-factor';
 import { refreshThemeDetails } from '@/hooks/use-theme-details';
 import { useTrafficLightSpace } from '@/hooks/use-traffic-light-space';
 import { getSiteUrl } from '@/lib/get-site-url';
@@ -230,10 +231,15 @@ export interface PreviewViewport {
  * The viewport to simulate for a preset inside a pane of the given size:
  * the preset's exact dimensions, scaled down (never up) to fit both axes,
  * like a device frame.
+ *
+ * The pane is measured in the host document's CSS px, which the app's zoom
+ * scales; the preset is in device px, which it doesn't. `zoomFactor` converts
+ * the pane so a preset keeps its real size whatever the UI is scaled to.
  */
 export function getSimulatedViewport(
 	preset: { width: number; height: number; mobile?: boolean } | null,
-	pane: { width: number; height: number } | null
+	pane: { width: number; height: number } | null,
+	zoomFactor = 1
 ): PreviewViewport | null {
 	if ( ! preset || ! pane || pane.width <= 0 || pane.height <= 0 ) {
 		return null;
@@ -241,8 +247,24 @@ export function getSimulatedViewport(
 	return {
 		width: preset.width,
 		height: preset.height,
-		scale: Math.min( 1, pane.width / preset.width, pane.height / preset.height ),
+		scale: Math.min(
+			1,
+			( pane.width * zoomFactor ) / preset.width,
+			( pane.height * zoomFactor ) / preset.height
+		),
 		mobile: Boolean( preset.mobile ),
+	};
+}
+
+// The box a simulated viewport occupies in the host document, in its CSS px:
+// the scaled device size, brought back through the app's zoom.
+export function getFrameSize(
+	viewport: PreviewViewport,
+	zoomFactor = 1
+): { width: number; height: number } {
+	return {
+		width: ( viewport.width * viewport.scale ) / zoomFactor,
+		height: ( viewport.height * viewport.scale ) / zoomFactor,
 	};
 }
 
@@ -395,29 +417,35 @@ function createPreviewSurface( path: string, reloadNonce: number ): PreviewSurfa
 
 // Sizing for the frame around a surface: the preset's exact scaled box (the
 // emulation paints it edge to edge), or nothing when the surface fills its layer.
-function getFrameStyle( viewport: PreviewViewport | null ): CSSProperties | undefined {
+function getFrameStyle(
+	viewport: PreviewViewport | null,
+	zoomFactor: number
+): CSSProperties | undefined {
 	if ( ! viewport ) {
 		return undefined;
 	}
-	return {
-		flex: '0 0 auto',
-		width: viewport.width * viewport.scale,
-		height: viewport.height * viewport.scale,
-	};
+	return { flex: '0 0 auto', ...getFrameSize( viewport, zoomFactor ) };
 }
 
 // The iframe fallback has no device emulation, so scaling is a CSS transform
 // instead: lay out at full size, scale down to fit; the frame clips the
 // transform's leftover layout box.
-function getIframeStyle( viewport: PreviewViewport | null ): CSSProperties | undefined {
-	if ( ! viewport || viewport.scale === 1 ) {
+function getIframeStyle(
+	viewport: PreviewViewport | null,
+	zoomFactor: number
+): CSSProperties | undefined {
+	if ( ! viewport ) {
+		return undefined;
+	}
+	const scale = viewport.scale / zoomFactor;
+	if ( scale === 1 ) {
 		return undefined;
 	}
 	return {
 		flex: '0 0 auto',
 		width: viewport.width,
 		height: viewport.height,
-		transform: `scale(${ viewport.scale })`,
+		transform: `scale(${ scale })`,
 		transformOrigin: 'top left',
 	};
 }
@@ -851,6 +879,9 @@ export function SitePreview( {
 		? Math.max( browserState.progress, 0.12 )
 		: browserState.progress;
 	const showLoadingProgress = canPreview && progress > 0;
+	// The app's zoom scales the host document's CSS px but not the device
+	// sizes the presets simulate, so the pane math converts between the two.
+	const zoomFactor = useAppZoomFactor();
 	// Presets are module constants, so this stays referentially stable per
 	// mode + orientation.
 	const activePreset = getActivePreset( viewportMode, mobileOrientation );
@@ -875,11 +906,18 @@ export function SitePreview( {
 			return null;
 		}
 		const preset = getMobilePreset( mobileOrientation );
-		return getSimulatedViewport( preset, {
-			width: Math.max( 160, Math.min( preset.width, Math.round( simulatedPaneSize.width / 2 ) ) ),
-			height: Math.max( 120, simulatedPaneSize.height - PREVIEW_PANE_PADDING * 2 ),
-		} );
-	}, [ mobileOrientation, simulatedPaneSize, splitPreview ] );
+		return getSimulatedViewport(
+			preset,
+			{
+				width: Math.max(
+					160,
+					Math.min( preset.width / zoomFactor, Math.round( simulatedPaneSize.width / 2 ) )
+				),
+				height: Math.max( 120, simulatedPaneSize.height - PREVIEW_PANE_PADDING * 2 ),
+			},
+			zoomFactor
+		);
+	}, [ mobileOrientation, simulatedPaneSize, splitPreview, zoomFactor ] );
 	// In split mode the desktop simulation fits the space left beside the
 	// rendered mobile frame, including its pane padding. This keeps the page
 	// at the desktop breakpoint even when the comparison itself is narrow.
@@ -888,18 +926,18 @@ export function SitePreview( {
 			return simulatedPaneSize;
 		}
 		const mobilePaneWidth =
-			splitMobileViewport.width * splitMobileViewport.scale + PREVIEW_PANE_PADDING * 2;
+			getFrameSize( splitMobileViewport, zoomFactor ).width + PREVIEW_PANE_PADDING * 2;
 		return {
 			width: Math.max( 1, simulatedPaneSize.width - mobilePaneWidth ),
 			height: simulatedPaneSize.height,
 		};
-	}, [ simulatedPaneSize, splitMobileViewport, splitPreview ] );
+	}, [ simulatedPaneSize, splitMobileViewport, splitPreview, zoomFactor ] );
 	// The viewport a responsive surface simulates. No emulation while the site
 	// is stopped: the empty state renders in the plain pane, and the chosen mode
 	// re-applies on start.
 	const previewViewport = useMemo(
-		() => ( canPreview ? getSimulatedViewport( activePreset, primaryPaneSize ) : null ),
-		[ activePreset, canPreview, primaryPaneSize ]
+		() => ( canPreview ? getSimulatedViewport( activePreset, primaryPaneSize, zoomFactor ) : null ),
+		[ activePreset, canPreview, primaryPaneSize, zoomFactor ]
 	);
 
 	const patchSurface = useCallback(
@@ -1316,7 +1354,7 @@ export function SitePreview( {
 									) : null }
 									<div
 										className={ clsx( styles.surfaceFrame, viewport && styles.deviceFrame ) }
-										style={ getFrameStyle( viewport ) }
+										style={ getFrameStyle( viewport, zoomFactor ) }
 									>
 										{ canUseWebview ? (
 											<WebviewSurface
@@ -1345,7 +1383,7 @@ export function SitePreview( {
 													surface.browserCommand?.type === 'reload' ? surface.browserCommand.id : 0
 												}` }
 												className={ styles.iframe }
-												style={ getIframeStyle( viewport ) }
+												style={ getIframeStyle( viewport, zoomFactor ) }
 												src={ surfaceUrl }
 												title={ site.name }
 												onLoad={ ( event ) => {
@@ -1369,11 +1407,7 @@ export function SitePreview( {
 										<div className={ styles.splitMobilePane }>
 											<div
 												className={ clsx( styles.surfaceFrame, styles.deviceFrame ) }
-												style={ {
-													flex: '0 0 auto',
-													width: splitMobileViewport.width * splitMobileViewport.scale,
-													height: splitMobileViewport.height * splitMobileViewport.scale,
-												} }
+												style={ getFrameStyle( splitMobileViewport, zoomFactor ) }
 											>
 												{ canUseWebview ? (
 													<WebviewSurface
@@ -1393,7 +1427,7 @@ export function SitePreview( {
 													<iframe
 														key={ `${ surfaceUrl }#${ surface.reloadNonce }` }
 														className={ styles.iframe }
-														style={ getIframeStyle( splitMobileViewport ) }
+														style={ getIframeStyle( splitMobileViewport, zoomFactor ) }
 														src={ surfaceUrl }
 														title={ sprintf(
 															/* translators: %s: site name */

--- a/apps/ui/src/hooks/use-app-zoom-factor.test.ts
+++ b/apps/ui/src/hooks/use-app-zoom-factor.test.ts
@@ -1,0 +1,37 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useAppZoomFactor } from './use-app-zoom-factor';
+
+describe( 'useAppZoomFactor', () => {
+	afterEach( () => {
+		vi.unstubAllGlobals();
+	} );
+
+	it( 'is 1 without the Electron preload', () => {
+		const { result } = renderHook( () => useAppZoomFactor() );
+
+		expect( result.current ).toBe( 1 );
+	} );
+
+	it( 'reads the app zoom factor and follows it across resizes', () => {
+		const getAppZoomFactor = vi.fn().mockReturnValue( 1.25 );
+		vi.stubGlobal( 'ipcApi', { getAppZoomFactor } );
+		const { result } = renderHook( () => useAppZoomFactor() );
+
+		expect( result.current ).toBe( 1.25 );
+
+		// Zooming the page resizes its layout viewport.
+		getAppZoomFactor.mockReturnValue( 1.5 );
+		act( () => {
+			window.dispatchEvent( new Event( 'resize' ) );
+		} );
+
+		expect( result.current ).toBe( 1.5 );
+	} );
+
+	it( 'falls back to 1 for a value that is not a usable factor', () => {
+		vi.stubGlobal( 'ipcApi', { getAppZoomFactor: () => Number.NaN } );
+
+		expect( renderHook( () => useAppZoomFactor() ).result.current ).toBe( 1 );
+	} );
+} );

--- a/apps/ui/src/hooks/use-app-zoom-factor.ts
+++ b/apps/ui/src/hooks/use-app-zoom-factor.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+interface AppZoomWindow extends Window {
+	ipcApi?: { getAppZoomFactor?: () => number };
+}
+
+// Only the Electron preload exposes the renderer's zoom factor. In a browser
+// the app never zooms the page itself, so the factor is 1.
+function readAppZoomFactor(): number {
+	if ( typeof window === 'undefined' ) {
+		return 1;
+	}
+	const factor = ( window as AppZoomWindow ).ipcApi?.getAppZoomFactor?.();
+	return typeof factor === 'number' && Number.isFinite( factor ) && factor > 0 ? factor : 1;
+}
+
+/**
+ * The factor the app UI is zoomed by (1 at "Actual Size").
+ *
+ * Zooming the page resizes its layout viewport, which fires `resize`; that's
+ * the cue to re-read it.
+ */
+export function useAppZoomFactor(): number {
+	const [ zoomFactor, setZoomFactor ] = useState( readAppZoomFactor );
+
+	useEffect( () => {
+		const update = () => setZoomFactor( readAppZoomFactor() );
+		update();
+		window.addEventListener( 'resize', update );
+		return () => window.removeEventListener( 'resize', update );
+	}, [] );
+
+	return zoomFactor;
+}


### PR DESCRIPTION
## Related issues

None.

## How AI was used in this PR

Codex was used to trace the shortcut behavior across the Electron menu, main-process input handling, and embedded site preview; implement the fix; and add cross-platform regression coverage. The result was reviewed through the focused diff, linting, tests, type checking, and manual testing in the macOS development app. Claude Code then traced Electron's guest zoom propagation from its source, fixed the preview scaling under app zoom, and added the tests for it.

## Proposed Changes

- Ensure Cmd/Ctrl `+`, `-`, and `0` scale or reset the Studio interface on macOS, Windows, and Linux, even when the embedded site preview has focus.
- Keep the preview at 1:1 while the surrounding agentic UI is zoomed. Electron copies the app's zoom onto every `<webview>` (immediately, and again on each guest navigation), so previews are pinned back to actual size.
- Keep the responsive presets (Mobile, Tablet, Desktop, Split) at device size under app zoom. The pane is measured in zoomed CSS px while the presets are device px; the fit math now converts between them, which is what made the desktop frame resize oddly in review.
- Support Windows and Linux production builds, where Studio does not install an application menu, through main-process keyboard handling.
- Preserve the existing View menu commands on platforms where the menu is available.

## Testing Instructions

1. Start Studio with `npm start` and open the agentic UI.
2. Open a site preview and click inside the preview so it owns keyboard focus.
3. Press Cmd/Ctrl `+` and `-` and confirm that the Studio interface scales while the preview remains unchanged.
4. Press Cmd/Ctrl `0` and confirm that the Studio interface returns to its actual size.
5. Repeat using View → Zoom In, Zoom Out, and Actual Size.
6. Pick Desktop, Mobile, and Split from the preview's more-options menu, then zoom again. The device frame keeps its physical size and the page inside it doesn't zoom. Navigate inside the preview and confirm it stays that way.

On Windows and Linux, repeat steps 2–4 with Ctrl `+`, `-`, and `0`. These shortcuts should work in production builds without an application menu.

Automated verification:

- `npx eslint --fix` on all modified TypeScript files
- `npm test -- apps/studio/src/lib/app-zoom.test.ts apps/studio/src/tests/main-window.test.ts apps/studio/src/tests/menu.test.ts apps/studio/src/tests/index.test.ts apps/ui/src/components/site-preview/index.test.tsx apps/ui/src/hooks/use-app-zoom-factor.test.ts` (98 tests passed)
- `npm run typecheck`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

