### PR TITLE
Agentic UI: pause chat autoscroll while reading earlier messages

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -301,6 +301,10 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 		updateIsScrolledAway();
 	}, [ data, pendingQuestions.length, queuedPrompts.length, updateIsScrolledAway ] );
 
+	useLayoutEffect( () => {
+		setIsScrolledAway( false );
+	}, [ sessionId ] );
+
 	const scrollToLatest = useCallback( () => {
 		const node = scrollRef.current;
 		if ( ! node ) {
@@ -375,7 +379,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 
 	useLayoutEffect( () => {
 		const node = scrollRef.current;
-		if ( ! node || pendingQuestions.length > 0 ) {
+		if ( ! node || isScrolledAway || pendingQuestions.length > 0 ) {
 			return;
 		}
 		node.scrollTop = node.scrollHeight;
@@ -383,7 +387,14 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 			node.scrollTop = node.scrollHeight;
 		} );
 		return () => cancelAnimationFrame( id );
-	}, [ sessionId, data, isRunning, pendingQuestions.length, queuedPrompts.length ] );
+	}, [
+		sessionId,
+		data,
+		isRunning,
+		isScrolledAway,
+		pendingQuestions.length,
+		queuedPrompts.length,
+	] );
 
 	const {
 		data: quota,


### PR DESCRIPTION
## Related issues

- Related to #3657 (the same fix, previously shipped for the Desktop Classic Studio Code tab)

## How AI was used in this PR

Claude Code investigated whether this was a regression, located the divergence between the two chat implementations, and wrote the fix. I reviewed the diff.

Worth knowing for review: this is *not* a regression. The autoscroll pause was fixed in #3657 for the Desktop Classic Studio Code tab (`apps/studio/src/components/studio-code-session/`), which has its own `stickToBottom` state. The Agentic UI chat is a separate implementation that never had the guard — `git log -L` on the autoscroll effect shows it has been unconditional since it was introduced in #3138.

## Proposed Changes

Scrolling up in a chat to re-read an earlier message no longer yanks you back to the bottom on the next agent update. Previously any streaming token pulled the view down again, which made reading anything but the newest message impossible during an active turn — and left the scroll-to-latest button (added in #4328) appearing and then immediately scrolling away underneath itself.

The view now stays where you put it until you return to the bottom, either by scrolling or via the scroll-to-latest button, at which point it resumes following the agent. Switching sessions always starts pinned to the newest message.

One deliberate carry-over from the Desktop Classic behavior: sending a new prompt while scrolled up does not re-pin you — you stay where you are, with the scroll-to-latest button showing. Happy to change that if reviewers prefer submit-implies-jump-to-bottom.

## Testing Instructions

1. `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`, open http://localhost:8081.
2. Open a chat with enough history to scroll, and start an agent turn that streams for a while.
3. While the agent is working, scroll up. The view should stay put as new content streams in, and the scroll-to-latest button should remain visible.
4. Scroll back to the bottom (or click the button). The view should resume following the agent automatically.
5. Scroll up, then switch to another session — the new session should open pinned to its newest message.

`npx eslint --fix` clean, `npm run typecheck` clean, and the 15 existing `session-view` tests pass, including the scroll-to-latest one.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
