### PR TITLE
Ship a registered no-title page template so designed pages don't duplicate their title

### DIFF
--- a/apps/cli/ai/skills/block-content/SKILL.md
+++ b/apps/cli/ai/skills/block-content/SKILL.md
@@ -45,6 +45,25 @@ WordPress inserts `margin-block-start: var(--wp--style--block-gap)` between the 
 - Do not zero the gap by setting `styles.spacing.blockGap: "0"` in `theme.json` — that value cascades as the default gap inside every flow and constrained layout and collapses content rhythm site-wide.
 - When you want visible space between top-level sections, add it deliberately (padding on the sections) so the spacing is designed, not inherited.
 
+## Page Titles
+
+`templates/page.html` renders `core/post-title` as the page's `h1`, above `core/post-content`. Page content must not repeat that title — a designed hero with its own heading stacked under the template's title gives the page a stray "Home" above the hero and **two `h1` elements**, which is an accessibility and SEO problem, not just a visual duplication.
+
+Pick one of the two per page:
+
+- **Ordinary page** (Privacy Policy, Terms, a plain About): let the template's title stand and start the page content at `h2`.
+- **Designed page** whose hero carries its own heading (home, landing, anything built from sections): assign the no-title template. Themes from `scaffold_theme` ship `templates/page-no-title.html`, registered in `theme.json` under `customTemplates`. Assign it to the page after creating it:
+
+```text
+wp_cli post meta update <id> _wp_page_template page-no-title
+```
+
+Do **not** solve this by deleting `core/post-title` from `page.html` — every ordinary page then renders untitled, and a missing `h1` is worse than a duplicated one. In a theme with no no-title template, add one (a copy of `page.html` without the title group) and register it in `customTemplates` rather than stripping the title.
+
+A site's home page is the usual case for this: with a static front page and no `front-page.html`, WordPress falls through to `page.html`, so the page least likely to want a title block gets one by default.
+
+**Do not add a `front-page.html` to solve it.** That template overrides *every* other template for the front page — the hierarchy is `front-page → home → index` — and it applies whether the front page shows a static page or the latest posts. One containing `core/post-content` therefore breaks a blog-first site, whose front page belongs to `home.html`/`index.html`. Assigning `page-no-title` to the home page achieves the same result with no hierarchy side effects. Add a `front-page.html` only when the front page needs a structure that genuinely differs from a page's, and the site's front page is definitely static.
+
 ## Skeleton-First Recipes
 
 For long files over about 200 lines, write a small skeleton first and fill anchors across later `Edit` calls.

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -1526,6 +1526,7 @@ describe( 'Studio AI MCP tools', () => {
 				'templates/index.html',
 				'templates/single.html',
 				'templates/page.html',
+				'templates/page-no-title.html',
 				'templates/archive.html',
 				'templates/404.html',
 				'parts/header.html',
@@ -1572,6 +1573,29 @@ describe( 'Studio AI MCP tools', () => {
 			 )?.padding;
 			expect( rootPadding?.left ).toBeTruthy();
 			expect( rootPadding?.right ).toBeTruthy();
+
+			// The no-title template is only assignable to a page if it is registered
+			// here, so the file and the registration have to stay in step.
+			const customTemplates = themeJson.customTemplates as Array< Record< string, unknown > >;
+			expect( customTemplates ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( { name: 'page-no-title', postTypes: [ 'page' ] } ),
+				] )
+			);
+
+			// A designed page opts out of the template's h1 by switching template, so
+			// page.html must keep the title and page-no-title.html must omit it.
+			const pageTemplate = await readFile(
+				path.join( themeDir, 'templates', 'page.html' ),
+				'utf8'
+			);
+			expect( pageTemplate ).toContain( 'wp:post-title' );
+			const pageNoTitleTemplate = await readFile(
+				path.join( themeDir, 'templates', 'page-no-title.html' ),
+				'utf8'
+			);
+			expect( pageNoTitleTemplate ).not.toContain( 'wp:post-title' );
+			expect( pageNoTitleTemplate ).toContain( 'wp:post-content' );
 
 			const functionsPhp = await readFile( path.join( themeDir, 'functions.php' ), 'utf8' );
 			expect( functionsPhp ).toContain( "'acme-studio-style'" );

--- a/apps/cli/ai/tools/scaffold-theme.ts
+++ b/apps/cli/ai/tools/scaffold-theme.ts
@@ -135,6 +135,16 @@ function renderThemeJson(): string {
 				},
 			},
 		},
+		// `page.html` renders the post title as the page's h1. A designed page whose
+		// hero carries its own heading needs a way to opt out of that title without
+		// removing it from `page.html`, which every ordinary page still wants.
+		customTemplates: [
+			{
+				name: 'page-no-title',
+				title: 'Page (no title)',
+				postTypes: [ 'page' ],
+			},
+		],
 	};
 	return JSON.stringify( data, null, '\t' ) + '\n';
 }
@@ -278,6 +288,17 @@ const TEMPLATE_PAGE = `<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:template-part {"slug":"footer"} /-->
 `;
 
+const TEMPLATE_PAGE_NO_TITLE = `<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group">
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->
+`;
+
 const TEMPLATE_ARCHIVE = `<!-- wp:template-part {"slug":"header"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
@@ -365,6 +386,7 @@ export const scaffoldThemeTool = defineTool(
 		'Drops in style.css (theme header plus a reset zeroing the default block gap between top-level template sections), ' +
 		'theme.json (appearanceTools, a content/wide layout width, and root-padding-aware horizontal padding so content never touches the viewport edge), ' +
 		'functions.php (frontend + editor style enqueue), default templates (index, single, page, archive, 404), ' +
+		'a registered page-no-title template to assign to designed pages whose content carries its own heading, ' +
 		'header/footer parts, and empty assets/fonts and patterns directories. ' +
 		'Use when the user wants to start a new custom theme — the agent fills in design-specific content afterwards. ' +
 		'Pass parentTheme to scaffold a child theme of an installed theme instead — required when customizing a third-party theme, whose files must never be edited directly. ' +
@@ -478,6 +500,7 @@ export const scaffoldThemeTool = defineTool(
 					[ path.join( 'templates', 'index.html' ), TEMPLATE_INDEX ],
 					[ path.join( 'templates', 'single.html' ), TEMPLATE_SINGLE ],
 					[ path.join( 'templates', 'page.html' ), TEMPLATE_PAGE ],
+					[ path.join( 'templates', 'page-no-title.html' ), TEMPLATE_PAGE_NO_TITLE ],
 					[ path.join( 'templates', 'archive.html' ), TEMPLATE_ARCHIVE ],
 					[ path.join( 'templates', '404.html' ), TEMPLATE_404 ],
 					[ path.join( 'parts', 'header.html' ), PART_HEADER ],


### PR DESCRIPTION
## Related issues

<!-- No tracking issue. Follow-up to #4571, which fixed the horizontal-padding
     half of the same "generated pages need manual repair" problem. -->

- Related to #4571

## How AI was used in this PR

Claude Code investigated the cause, wrote the change, and verified it.

Two findings from the investigation changed the shape of the fix, and are the
parts worth reviewing:

1. A theme built by the agent on a developer machine had independently created
   both a `front-page.html` and a `page-notitle.html` to work around this — and
   the two files were **byte-identical**. Shipping the no-title template makes a
   `front-page.html` redundant for this purpose, so only one mechanism is
   scaffolded.
2. `front-page` overrides every other template for the front page (hierarchy
   `front-page → home → index`) whether the front page shows a static page or
   the latest posts. Scaffolding one containing `core/post-content` would break
   blog-first sites, so this PR deliberately does **not** add one and documents
   the hazard instead.

Reviewers should focus on the template name (`page-no-title`, matching Twenty
Twenty-Four so it reads as conventional) and on the skill wording, which steers
agent behaviour.

## Proposed Changes

Pages generated by Studio Code frequently render their title twice. The page
template outputs the WordPress post title as the page's `h1`, and agents then
design page content with a hero that carries its own heading — so the page shows
a stray slug-derived title such as "Home" stacked above the real hero, and ends
up with two `h1` elements. That is an accessibility and SEO problem, not only a
visual duplication.

The home page is the worst case and also the default one: with a static front
page and no `front-page.html`, WordPress falls through to the page template, so
the page least likely to want a title block always gets one.

There was no sanctioned way to opt out. Agents either shipped the duplicate or
invented their own escape hatch, so the outcome varied from build to build.
Removing the title block from the page template would simply invert the problem —
ordinary pages such as Privacy Policy or Terms would render untitled, and a
missing `h1` is worse than a duplicated one.

Scaffolded themes now ship a no-title page template, registered so it is
selectable per page from the editor's template dropdown like any other. Ordinary
pages keep the template's title; designed pages switch to the no-title variant.
Posts and ordinary pages are unaffected.

## Testing Instructions

Automated:

- `npm test -- apps/cli/ai/tests/tools.test.ts` — the `scaffold_theme` case
  asserts the template file exists, that it is registered in `theme.json` under
  `customTemplates`, that `page.html` still contains `wp:post-title`, and that
  the no-title template does not.
- To confirm the assertions cover the change rather than merely passing: stash
  `apps/cli/ai/tools/scaffold-theme.ts`, re-run, and the case fails with
  `ENOENT … page-no-title.html`. Verified in both directions.

Manual:

1. `npm run cli:build && node apps/cli/dist/cli/main.mjs`
2. Ask the agent to build a small one-page site.
3. Confirm the home page renders a single heading — no slug-derived title above
   the hero — and that the page source contains one `h1`.
4. In the editor, open a page and confirm "Page (no title)" appears in the
   template dropdown.
5. Confirm an ordinary page (for example a Privacy Policy created without a hero)
   still renders its title.

Worth a reviewer's attention: step 3 depends on the agent *assigning* the
template after creating the page, which follows guidance rather than being
guaranteed by the scaffold. If it proves unreliable in practice, the next lever
is naming it in the build workflow in the system prompt rather than only in the
`block-content` skill.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
