### PR TITLE
Agentic UI: Fix welcome tour skip button hover on dark artwork

### DIFF
--- a/apps/ui/src/components/onboarding-guide/style.module.css
+++ b/apps/ui/src/components/onboarding-guide/style.module.css
@@ -31,8 +31,12 @@
 	background: rgb(0 0 0 / 70%);
 }
 
-/* Over a dark full-bleed illustration the default (dark) icon vanishes; force a
-   light icon so Skip stays legible. */
+/* This artwork stays dark in both themes, so match the dark theme's neutral
+   hover fill and keep the icon light in both themes. */
+.closeOnDark {
+	--wp-ui-button-background-color-active: #282828;
+}
+
 .closeOnDark,
 .closeOnDark svg {
 	color: #fff;


### PR DESCRIPTION
## Related issues

- None.

## How AI was used in this PR

AI was used to trace the close-button styling, compare the light and dark `@wordpress/ui` active-state values, implement the scoped CSS change, run verification, and capture matching before/after screenshots. I reviewed the resulting diff and visual states.

## Proposed Changes

- Keep the welcome tour's Skip button hover dark when it appears over the dark, full-bleed illustration in light mode.
- Match the existing dark-mode neutral hover fill while preserving the default button behavior on other tour illustrations.

## Screenshots

Light mode, with the Skip button hovered:

| Before | After |
|---|---|
| ![Before: light hover fill over dark artwork](https://github.com/Automattic/studio/blob/165872ab2997c3b1ed7cffdca278635d2f7bbf2b/before-v2.png?raw=true) | ![After: dark hover fill over dark artwork](https://github.com/Automattic/studio/blob/165872ab2997c3b1ed7cffdca278635d2f7bbf2b/after-v2.png?raw=true) |

## Testing Instructions

1. Run `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`.
2. Set Studio to light mode and open the welcome tour.
3. Hover the Skip button on the first page and confirm it uses a dark-gray background with a white icon.
4. Repeat in dark mode and confirm the hover treatment matches.

Automated verification:

- `npm run typecheck`
- `npm test -- apps/ui/src/data/onboarding/use-orientation-autostart.test.ts apps/ui/src/data/onboarding/use-whats-new-autostart.test.ts`
- `npm run cli:build:ui`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
