### PR TITLE
Design Exploration: Add a file-change Review tab

### DIFF
--- a/apps/ui/src/components/site-preview/address-bar.test.tsx
+++ b/apps/ui/src/components/site-preview/address-bar.test.tsx
@@ -48,14 +48,20 @@ function renderAddressBar( {
 	fetchSiteRest = vi.fn().mockResolvedValue( createSearchResponse( [] ) ),
 	onNavigate = vi.fn(),
 	onSwitchRealm = vi.fn(),
+	onSwitchReview = vi.fn(),
 	path = '/',
+	reviewActive = false,
+	reviewAvailable = false,
 	searchEnabled = true,
 	site = SITE,
 }: {
 	fetchSiteRest?: Mock;
 	onNavigate?: Mock;
 	onSwitchRealm?: Mock;
+	onSwitchReview?: Mock;
 	path?: string;
+	reviewActive?: boolean;
+	reviewAvailable?: boolean;
 	searchEnabled?: boolean;
 	site?: SiteDetails;
 } = {} ) {
@@ -74,11 +80,14 @@ function renderAddressBar( {
 					anchorRef={ { current: document.body } }
 					onNavigate={ onNavigate }
 					onSwitchRealm={ onSwitchRealm }
+					onSwitchReview={ onSwitchReview }
+					reviewActive={ reviewActive }
+					reviewAvailable={ reviewAvailable }
 				/>
 			</Tooltip.Provider>
 		</QueryClientProvider>
 	);
-	return { fetchSiteRest, onNavigate, onSwitchRealm };
+	return { fetchSiteRest, onNavigate, onSwitchRealm, onSwitchReview };
 }
 
 async function openOmnibox( activeRealmTitle = 'Example Site' ) {
@@ -207,6 +216,24 @@ describe( 'PreviewAddressBar', () => {
 		expect(
 			screen.queryByRole( 'button', { name: 'View site front end' } )
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'shows and activates the review segment when changes are available', () => {
+		const { onSwitchReview } = renderAddressBar( { reviewAvailable: true } );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Review changes' } ) );
+		expect( onSwitchReview ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'returns to a site realm from the active review segment', () => {
+		const { onSwitchRealm } = renderAddressBar( {
+			reviewAvailable: true,
+			reviewActive: true,
+		} );
+
+		expect( screen.getByText( 'Review' ) ).toBeVisible();
+		fireEvent.click( screen.getByRole( 'button', { name: 'View site front end' } ) );
+		expect( onSwitchRealm ).toHaveBeenCalledWith( 'frontend' );
 	} );
 
 	it( 'always offers the database segment', () => {

--- a/apps/ui/src/components/site-preview/address-bar.tsx
+++ b/apps/ui/src/components/site-preview/address-bar.tsx
@@ -1,7 +1,15 @@
 import { Autocomplete } from '@base-ui/react/autocomplete';
 import { TRACKS_EVENTS, type TracksEventName } from '@studio/common/lib/record-tracks-event';
 import { __ } from '@wordpress/i18n';
-import { globe, help, home, page as pageIcon, post as postIcon, wordpress } from '@wordpress/icons';
+import {
+	globe,
+	help,
+	home,
+	page as pageIcon,
+	post as postIcon,
+	seen,
+	wordpress,
+} from '@wordpress/icons';
 import { ariaKeyShortcut, displayShortcut } from '@wordpress/keycodes';
 import { privateApis } from '@wordpress/theme';
 import { Icon, Tooltip } from '@wordpress/ui';
@@ -249,6 +257,9 @@ interface PreviewAddressBarProps {
 	// Called when the user clicks an inactive segment; the host navigates to
 	// its remembered path for that realm.
 	onSwitchRealm: ( realm: PreviewRealm ) => void;
+	reviewAvailable?: boolean;
+	reviewActive?: boolean;
+	onSwitchReview?: () => void;
 }
 
 /**
@@ -266,6 +277,9 @@ export function PreviewAddressBar( {
 	anchorRef,
 	onNavigate,
 	onSwitchRealm,
+	reviewAvailable = false,
+	reviewActive = false,
+	onSwitchReview,
 }: PreviewAddressBarProps ) {
 	const [ open, setOpen ] = useState( false );
 	const [ inputValue, setInputValue ] = useState( '' );
@@ -295,7 +309,7 @@ export function PreviewAddressBar( {
 			current && current.left === left && current.width === width ? current : { left, width }
 		);
 	}, [] );
-	useLayoutEffect( measureIndicator, [ measureIndicator, realm, site.name ] );
+	useLayoutEffect( measureIndicator, [ measureIndicator, realm, reviewActive, site.name ] );
 	useEffect( () => {
 		const root = segmentsRef.current;
 		if ( ! root || typeof ResizeObserver === 'undefined' ) {
@@ -534,7 +548,7 @@ export function PreviewAddressBar( {
 					}
 				/>
 				{ REALM_SEGMENTS.map( ( segment ) => {
-					const isActive = segment.realm === realm;
+					const isActive = ! reviewActive && segment.realm === realm;
 					const content = (
 						<>
 							<span className={ styles.segmentIcon } aria-hidden="true">
@@ -571,6 +585,29 @@ export function PreviewAddressBar( {
 						</Tooltip.Root>
 					);
 				} ) }
+				{ reviewAvailable ? (
+					<Tooltip.Root>
+						<Tooltip.Trigger
+							render={
+								<button
+									type="button"
+									className={ styles.segment }
+									data-active={ reviewActive || undefined }
+									aria-label={ reviewActive ? undefined : __( 'Review changes' ) }
+									onClick={ reviewActive ? undefined : onSwitchReview }
+								/>
+							}
+						>
+							<span className={ styles.segmentIcon } aria-hidden="true">
+								<Icon icon={ seen } size={ 16 } />
+							</span>
+							<span className={ styles.segmentTitle }>{ __( 'Review' ) }</span>
+						</Tooltip.Trigger>
+						<Tooltip.Popup positioner={ <Tooltip.Positioner side="bottom" /> }>
+							{ __( 'Review changes' ) }
+						</Tooltip.Popup>
+					</Tooltip.Root>
+				) : null }
 			</div>
 			<Autocomplete.Portal>
 				<Autocomplete.Positioner

--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -79,6 +79,39 @@ function createSite( overrides: Partial< SiteDetails > = {} ): SiteDetails {
 }
 
 describe( 'SitePreview', () => {
+	it( 'shows chat changes on the review surface and returns to the site', () => {
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
+			capabilities: CAPABILITIES,
+		} as never );
+		const onReviewActiveChange = vi.fn();
+
+		renderPreview(
+			<SitePreview
+				site={ createSite( { running: true } ) }
+				path="/"
+				reloadNonce={ 0 }
+				reviewActive
+				onReviewActiveChange={ onReviewActiveChange }
+				changes={ [
+					{
+						path: '/site/index.php',
+						displayPath: 'index.php',
+						additions: 1,
+						deletions: 1,
+						diff: '@@ -1 +1 @@\n-old\n+new',
+					},
+				] }
+			/>
+		);
+
+		expect( screen.getByLabelText( 'Diff for index.php' ) ).toHaveTextContent( '+new' );
+		expect( screen.queryByRole( 'button', { name: 'Refresh' } ) ).not.toBeInTheDocument();
+		fireEvent.click( screen.getByRole( 'button', { name: 'View site front end' } ) );
+		expect( onReviewActiveChange ).toHaveBeenCalledWith( false );
+	} );
+
 	it( 'recognizes WordPress theme activation navigations', () => {
 		expect(
 			isThemeActivationUrl( 'http://localhost:8881/wp-admin/themes.php?activated=true' )

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -30,6 +30,10 @@ import { useTrafficLightSpace } from '@/hooks/use-traffic-light-space';
 import { getSiteUrl } from '@/lib/get-site-url';
 import { playIcon, refreshIcon } from '@/lib/icons';
 import {
+	ChangesReview,
+	type SessionFileChange,
+} from '@/ui-classic/components/session-view/changes-tracker';
+import {
 	DATABASE_HOME_PATH,
 	getPathFromPreviewUrl,
 	getPreviewRealm,
@@ -75,6 +79,9 @@ interface SitePreviewProps {
 	fullscreen?: boolean;
 	// Enters/leaves full preview. The "•••" menu only offers it when provided.
 	onFullscreenChange?: ( value: boolean ) => void;
+	changes?: SessionFileChange[];
+	reviewActive?: boolean;
+	onReviewActiveChange?: ( value: boolean ) => void;
 }
 
 interface InspectorEvent {
@@ -685,6 +692,9 @@ export function SitePreview( {
 	collapsed = false,
 	fullscreen = false,
 	onFullscreenChange,
+	changes = [],
+	reviewActive = false,
+	onReviewActiveChange,
 }: SitePreviewProps ) {
 	const connector = useConnector();
 	const queryClient = useQueryClient();
@@ -849,6 +859,7 @@ export function SitePreview( {
 	}, [ path ] );
 	const handleSwitchRealm = useCallback(
 		( realm: PreviewRealm ) => {
+			onReviewActiveChange?.( false );
 			// Re-selecting the active realm (e.g. via its shortcut) is a no-op —
 			// don't bounce the current page through another auto-login hop.
 			if ( getPreviewRealm( getSafePath( path ) ) === realm ) {
@@ -859,7 +870,7 @@ export function SitePreview( {
 			const target = lastRealmPathsRef.current[ realm ];
 			onPathChange?.( getRealmNavigationPath( target, siteUrl ) );
 		},
-		[ connector, onPathChange, path, siteUrl ]
+		[ connector, onPathChange, onReviewActiveChange, path, siteUrl ]
 	);
 
 	const browserShortcuts = useMemo(
@@ -1012,7 +1023,7 @@ export function SitePreview( {
 				{ /* Equal-flex side tracks keep the address control truly centered
 					in the toolbar regardless of what each side holds. */ }
 				<div className={ styles.headerSide }>
-					{ canPreview ? (
+					{ canPreview && ! reviewActive ? (
 						<IconButton
 							variant="minimal"
 							tone="neutral"
@@ -1030,16 +1041,18 @@ export function SitePreview( {
 				<div ref={ locationRef } className={ styles.browserLocation }>
 					{ canPreview ? (
 						<>
-							<IconButton
-								variant="minimal"
-								tone="neutral"
-								size="small"
-								icon={ chevronLeft }
-								label={ __( 'Back' ) }
-								shortcut={ browserShortcuts.back }
-								disabled={ ! browserState.canGoBack }
-								onClick={ () => sendBrowserCommand( 'back' ) }
-							/>
+							{ ! reviewActive ? (
+								<IconButton
+									variant="minimal"
+									tone="neutral"
+									size="small"
+									icon={ chevronLeft }
+									label={ __( 'Back' ) }
+									shortcut={ browserShortcuts.back }
+									disabled={ ! browserState.canGoBack }
+									onClick={ () => sendBrowserCommand( 'back' ) }
+								/>
+							) : null }
 							<PreviewAddressBar
 								site={ site }
 								siteUrl={ siteUrl }
@@ -1048,22 +1061,30 @@ export function SitePreview( {
 								anchorRef={ locationRef }
 								onNavigate={ ( nextPath ) => onPathChange?.( nextPath ) }
 								onSwitchRealm={ handleSwitchRealm }
+								reviewAvailable={ changes.length > 0 }
+								reviewActive={ reviewActive }
+								onSwitchReview={ () => onReviewActiveChange?.( true ) }
 							/>
-							<IconButton
-								variant="minimal"
-								tone="neutral"
-								size="small"
-								icon={ chevronRight }
-								label={ __( 'Forward' ) }
-								shortcut={ browserShortcuts.forward }
-								disabled={ ! browserState.canGoForward }
-								onClick={ () => sendBrowserCommand( 'forward' ) }
-							/>
+							{ ! reviewActive ? (
+								<IconButton
+									variant="minimal"
+									tone="neutral"
+									size="small"
+									icon={ chevronRight }
+									label={ __( 'Forward' ) }
+									shortcut={ browserShortcuts.forward }
+									disabled={ ! browserState.canGoForward }
+									onClick={ () => sendBrowserCommand( 'forward' ) }
+								/>
+							) : null }
 						</>
 					) : null }
 				</div>
 				<div className={ clsx( styles.headerSide, styles.headerSideEnd ) }>
-					{ canPreview && chatEnabled && connector.capabilities.annotatePreview ? (
+					{ canPreview &&
+					! reviewActive &&
+					chatEnabled &&
+					connector.capabilities.annotatePreview ? (
 						<PreviewAnnotationControls
 							isPicking={ inspectorState.isPicking }
 							annotationCount={ inspectorState.annotationCount }
@@ -1071,8 +1092,10 @@ export function SitePreview( {
 							onCommand={ sendInspectorCommand }
 						/>
 					) : null }
-					<OpenInMenu key={ site.id } site={ site } browserPath={ getSafePath( path ) } />
-					{ canPreview ? (
+					{ ! reviewActive ? (
+						<OpenInMenu key={ site.id } site={ site } browserPath={ getSafePath( path ) } />
+					) : null }
+					{ canPreview && ! reviewActive ? (
 						<PreviewOverflowMenu
 							viewportMode={ viewportMode }
 							onViewportModeChange={ handleViewportModeChange }
@@ -1083,17 +1106,19 @@ export function SitePreview( {
 						/>
 					) : null }
 				</div>
-				{ showLoadingProgress ? (
+				{ showLoadingProgress && ! reviewActive ? (
 					<div className={ styles.loadingProgress } aria-hidden="true">
 						<span style={ { transform: `scaleX(${ Math.min( progress, 1 ) })` } } />
 					</div>
 				) : null }
 			</div>
 			<div className={ styles.body }>
+				{ reviewActive && changes.length > 0 ? <ChangesReview changes={ changes } /> : null }
 				<div
 					ref={ paneRef }
 					className={ clsx(
 						styles.previewViewport,
+						reviewActive && styles.previewViewportHidden,
 						previewViewport && styles.previewViewportSimulated
 					) }
 				>

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -148,6 +148,10 @@
 	overflow: hidden;
 }
 
+.previewViewportHidden {
+	display: none;
+}
+
 /* While simulating a viewport, the preset's frame floats centered with
    breathing room; the padding is excluded from the measured pane, so the
    frame's fit-to-pane scale accounts for it automatically. */

--- a/apps/ui/src/hooks/use-session-ui.test.tsx
+++ b/apps/ui/src/hooks/use-session-ui.test.tsx
@@ -22,6 +22,18 @@ function wrapper( { children }: { children: ReactNode } ) {
 }
 
 describe( 'useSessionPreviewUI site switching', () => {
+	it( 'opens the preview on the review surface and returns to the site', () => {
+		const { result } = renderHook( () => useSessionPreviewUI(), { wrapper } );
+
+		act( () => result.current.setOpen( false ) );
+		act( () => result.current.showReview() );
+		expect( result.current.open ).toBe( true );
+		expect( result.current.surface ).toBe( 'review' );
+
+		act( () => result.current.showSite() );
+		expect( result.current.surface ).toBe( 'site' );
+	} );
+
 	it( 'opens a never-previewed site at home instead of the previous site path', () => {
 		const { result } = renderHook( () => useSessionPreviewUI(), { wrapper } );
 

--- a/apps/ui/src/hooks/use-session-ui.tsx
+++ b/apps/ui/src/hooks/use-session-ui.tsx
@@ -27,6 +27,7 @@ import type { Annotation } from '@/components/site-preview/types';
 
 interface PreviewUIState {
 	open: boolean;
+	surface: 'site' | 'review';
 	// Full preview: the preview fills the window (sidebar and chat hidden).
 	// Only meaningful while `open`; closing the panel always clears it.
 	fullscreen: boolean;
@@ -52,6 +53,8 @@ export interface SessionUIState {
 export type SessionUIAction =
 	| { type: 'preview/set-open'; value: boolean }
 	| { type: 'preview/toggle' }
+	| { type: 'preview/show-review' }
+	| { type: 'preview/show-site' }
 	| { type: 'preview/set-fullscreen'; value: boolean }
 	| { type: 'preview/navigate'; path: string }
 	| { type: 'preview/reload' }
@@ -59,7 +62,14 @@ export type SessionUIAction =
 	| { type: 'preview/set-site'; siteId: string };
 
 const INITIAL_STATE: SessionUIState = {
-	preview: { open: true, fullscreen: false, reloadNonce: 0, siteId: null, pathsBySiteId: {} },
+	preview: {
+		open: true,
+		surface: 'site',
+		fullscreen: false,
+		reloadNonce: 0,
+		siteId: null,
+		pathsBySiteId: {},
+	},
 };
 
 function reducer( state: SessionUIState, action: SessionUIAction ): SessionUIState {
@@ -81,6 +91,15 @@ function reducer( state: SessionUIState, action: SessionUIAction ): SessionUISta
 				...state,
 				preview: { ...state.preview, open: ! state.preview.open, fullscreen: false },
 			};
+		case 'preview/show-review':
+			return {
+				...state,
+				preview: { ...state.preview, open: true, surface: 'review' },
+			};
+		case 'preview/show-site':
+			return state.preview.surface === 'site'
+				? state
+				: { ...state, preview: { ...state.preview, surface: 'site' } };
 		case 'preview/set-fullscreen':
 			return state.preview.fullscreen === action.value
 				? state
@@ -188,6 +207,7 @@ export function useSessionUIDispatch(): Dispatch< SessionUIAction > {
 
 export interface SessionPreviewUI {
 	readonly open: boolean;
+	readonly surface: 'site' | 'review';
 	readonly fullscreen: boolean;
 	readonly path: string;
 	readonly reloadNonce: number;
@@ -195,6 +215,8 @@ export interface SessionPreviewUI {
 	readonly pathsBySiteId: Record< string, string >;
 	setOpen: ( value: boolean ) => void;
 	toggle: () => void;
+	showReview: () => void;
+	showSite: () => void;
 	setFullscreen: ( value: boolean ) => void;
 	updatePath: ( path: string ) => void;
 	setSite: ( siteId: string ) => void;
@@ -211,6 +233,11 @@ export function useOptionalSessionPreviewUI(): SessionPreviewUI | null {
 		[ dispatch ]
 	);
 	const toggle = useCallback( () => dispatch?.( { type: 'preview/toggle' } ), [ dispatch ] );
+	const showReview = useCallback(
+		() => dispatch?.( { type: 'preview/show-review' } ),
+		[ dispatch ]
+	);
+	const showSite = useCallback( () => dispatch?.( { type: 'preview/show-site' } ), [ dispatch ] );
 	const setFullscreen = useCallback(
 		( value: boolean ) => dispatch?.( { type: 'preview/set-fullscreen', value } ),
 		[ dispatch ]
@@ -229,6 +256,7 @@ export function useOptionalSessionPreviewUI(): SessionPreviewUI | null {
 		}
 		return {
 			open: state.preview.open,
+			surface: state.preview.surface,
 			fullscreen: state.preview.fullscreen,
 			path: pathForSite( state.preview.pathsBySiteId, state.preview.siteId ),
 			reloadNonce: state.preview.reloadNonce,
@@ -236,11 +264,23 @@ export function useOptionalSessionPreviewUI(): SessionPreviewUI | null {
 			pathsBySiteId: state.preview.pathsBySiteId,
 			setOpen,
 			toggle,
+			showReview,
+			showSite,
 			setFullscreen,
 			updatePath,
 			setSite,
 		};
-	}, [ state, dispatch, setOpen, toggle, setFullscreen, updatePath, setSite ] );
+	}, [
+		state,
+		dispatch,
+		setOpen,
+		toggle,
+		showReview,
+		showSite,
+		setFullscreen,
+		updatePath,
+		setSite,
+	] );
 }
 
 export function useSessionPreviewUI(): SessionPreviewUI {

--- a/apps/ui/src/ui-classic/components/session-view/changes-tracker.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/changes-tracker.module.css
@@ -15,66 +15,141 @@
 	border-radius: 999px;
 }
 
-.lineCounts {
-	display: flex;
-	gap: var(--wpds-dimension-gap-xs);
-	flex-shrink: 0;
-	direction: ltr;
-	font-variant-numeric: tabular-nums;
-	unicode-bidi: isolate;
-}
-
 .additions {
 	color: var(--wpds-color-stroke-surface-success-strong);
+	direction: ltr;
+	unicode-bidi: isolate;
 }
 
 .deletions {
 	color: var(--wpds-color-stroke-surface-error-strong);
+	direction: ltr;
+	unicode-bidi: isolate;
 }
 
-.popup {
-	width: 400px;
-	max-width: calc(100vw - (var(--wpds-dimension-padding-lg) * 2));
-	padding: var(--wpds-dimension-padding-xs) !important;
+.review {
+	position: relative;
+	display: flex;
+	flex: 1;
+	width: 100%;
+	min-width: 0;
+	min-height: 0;
+	overflow: hidden;
+	background: var(--wpds-color-bg-surface-neutral);
 }
 
-.fileList {
-	max-height: min(288px, 50vh);
+.reviewNav {
+	position: absolute;
+	inset-block-start: var(--wpds-dimension-padding-md);
+	inset-inline-end: var(--wpds-dimension-padding-lg);
+	z-index: 2;
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	padding: 2px;
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+	border-radius: 999px;
+	background: var(--wpds-color-bg-surface-neutral-strong);
+	box-shadow: var(--wpds-elevation-sm);
+}
+
+.reviewNavPosition {
+	min-width: 48px;
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-xs);
+	font-variant-numeric: tabular-nums;
+	text-align: center;
+	direction: ltr;
+	unicode-bidi: isolate;
+}
+
+.changeList {
+	width: 100%;
+	min-height: 0;
+	padding: 52px var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-xl);
 	overflow-y: auto;
 }
 
-.fileRow {
-	display: flex;
-	align-items: flex-start;
-	justify-content: space-between;
-	gap: var(--wpds-dimension-gap-md);
-	min-height: 48px;
-	padding-block: var(--wpds-dimension-padding-xs);
-	padding-inline: var(--wpds-dimension-padding-sm);
+.changeSection {
+	overflow: hidden;
+	scroll-margin-block-start: 52px;
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+	border-radius: var(--wpds-border-radius-md);
+	background: var(--wpds-color-bg-surface-neutral-strong);
 }
 
-.fileRow > .lineCounts {
-	padding-block-start: 2px;
+.changeSection + .changeSection {
+	margin-block-start: var(--wpds-dimension-gap-md);
+}
+
+.changeSection[data-active] {
+	border-color: var(--wpds-color-stroke-surface-neutral-strong);
+}
+
+.changeHeader {
+	--wp-ui-button-background-color: transparent;
+
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-gap-sm);
+	width: 100%;
+	min-height: 56px;
+	padding: var(--wpds-dimension-padding-md);
+	border: 0;
+	background: var(--wp-ui-button-background-color);
+	color: var(--wpds-color-fg-content-neutral);
+	font: inherit;
+	text-align: start;
+	cursor: pointer;
+}
+
+.changeHeader:hover,
+.changeHeader:focus-visible {
+	--wp-ui-button-background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
+
+	background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
+}
+
+.changeSection[data-active] .changeHeader {
+	--wp-ui-button-background-color: var(--wpds-color-bg-interactive-neutral-weak);
+
+	background-color: var(--wp-ui-button-background-color);
+}
+
+.changeSection[data-active] .changeHeader:hover,
+.changeSection[data-active] .changeHeader:focus-visible {
+	--wp-ui-button-background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
+}
+
+.disclosureIcon {
+	flex-shrink: 0;
+	transition: transform 120ms ease;
+}
+
+.changeHeader[aria-expanded='false'] .disclosureIcon {
+	transform: rotate(-90deg);
 }
 
 .fileIdentity {
 	display: flex;
+	min-width: 0;
 	flex: 1;
 	flex-direction: column;
 	gap: 0;
-	min-width: 0;
 	color: var(--wpds-color-fg-content-neutral);
 	font-family: var(--wpds-typography-font-family-body);
+	text-align: start;
+	unicode-bidi: isolate;
 }
 
 .fileName {
+	min-width: 0;
 	overflow: hidden;
 	font-size: var(--wpds-typography-font-size-sm);
 	font-weight: var(--wpds-typography-font-weight-medium);
 	line-height: var(--wpds-typography-line-height-sm);
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	unicode-bidi: isolate;
 }
 
 .fileDirectory {
@@ -102,4 +177,112 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.lineCounts {
+	display: flex;
+	gap: var(--wpds-dimension-gap-xs);
+	flex-shrink: 0;
+	direction: ltr;
+	font-variant-numeric: tabular-nums;
+	unicode-bidi: isolate;
+}
+
+.diffPanel {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	border-block-start: var(--wpds-border-width-xs) solid
+		var(--wpds-color-stroke-surface-neutral-weak);
+	background: var(--wpds-color-bg-surface-neutral-weak);
+}
+
+.diff {
+	min-width: 0;
+	margin: 0;
+	padding: var(--wpds-dimension-padding-sm) 0;
+	overflow-x: auto;
+	color: var(--wpds-color-fg-content-neutral);
+	font-family: var(--wpds-typography-font-family-mono);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: 1.6;
+	tab-size: 4;
+}
+
+.diffAddition,
+.diffDeletion,
+.diffContext,
+.diffTruncated {
+	display: block;
+	min-width: max-content;
+	padding-inline: var(--wpds-dimension-padding-lg);
+}
+
+.diffAddition {
+	background: var(--wpds-color-bg-surface-success-weak);
+	color: var(--wpds-color-fg-content-success);
+}
+
+.diffDeletion {
+	background: var(--wpds-color-bg-surface-error-weak);
+	color: var(--wpds-color-fg-content-error);
+}
+
+.diffContext {
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.diffTruncated {
+	padding-block: var(--wpds-dimension-padding-md);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-family: var(--wpds-typography-font-family-body);
+	font-style: italic;
+}
+
+.showMore {
+	display: flex;
+	justify-content: center;
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-md)
+		var(--wpds-dimension-padding-sm);
+	border-block-start: var(--wpds-border-width-xs) solid
+		var(--wpds-color-stroke-surface-neutral-weak);
+}
+
+[dir='rtl'] .changeHeader[aria-expanded='false'] .disclosureIcon {
+	transform: rotate(90deg);
+}
+
+.popup {
+	width: 400px;
+	max-width: calc(100vw - (var(--wpds-dimension-padding-lg) * 2));
+	padding: var(--wpds-dimension-padding-xs) !important;
+}
+
+.fileList {
+	max-height: min(288px, 50vh);
+	overflow-y: auto;
+}
+
+.fileRow {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-gap-md);
+	min-height: 48px;
+	padding-block: var(--wpds-dimension-padding-xs);
+	padding-inline: var(--wpds-dimension-padding-sm);
+}
+
+.fileRow > .lineCounts {
+	padding-block-start: 2px;
+}
+
+.popupFooter {
+	padding-block-start: var(--wpds-dimension-padding-xs);
+	border-block-start: var(--wpds-border-width-xs) solid
+		var(--wpds-color-stroke-surface-neutral-weak);
+}
+
+.reviewAction {
+	width: 100%;
 }

--- a/apps/ui/src/ui-classic/components/session-view/changes-tracker.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/changes-tracker.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+	ChangesReview,
 	ChangesTracker,
 	countDiffLines,
 	formatChangeCount,
@@ -97,6 +98,75 @@ describe( 'countDiffLines', () => {
 	} );
 } );
 
+describe( 'ChangesReview', () => {
+	it( 'expands and collapses file diffs', async () => {
+		const entries = [
+			toolCallEntry( 'edit-1', 'Edit', { path: '/sites/demo/index.php' } ),
+			toolResultEntry( 'edit-1', '@@ -1 +1 @@\n-old\n+new' ),
+			toolCallEntry( 'edit-2', 'Edit', { path: '/sites/demo/theme.css' } ),
+			toolResultEntry( 'edit-2', '@@ -1 +1 @@\n-red\n+blue' ),
+		];
+
+		render( <ChangesReview changes={ getSessionFileChanges( entries, '/sites/demo' ) } /> );
+
+		const indexDiff = await screen.findByLabelText( 'Diff for index.php' );
+		const indexButton = screen.getByRole( 'button', { name: /index\.php/ } );
+		const themeButton = screen.getByRole( 'button', { name: /theme\.css/ } );
+		expect( indexDiff ).toHaveTextContent( '-old' );
+		expect( indexDiff ).toHaveTextContent( '+new' );
+		expect( indexButton ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect( themeButton ).toHaveAttribute( 'aria-expanded', 'false' );
+
+		fireEvent.click( themeButton );
+		const themeDiff = await screen.findByLabelText( 'Diff for theme.css' );
+		expect( themeDiff ).toHaveTextContent( '-red' );
+		expect( themeDiff ).toHaveTextContent( '+blue' );
+		expect( indexButton ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect( themeButton ).toHaveAttribute( 'aria-expanded', 'true' );
+
+		fireEvent.click( indexButton );
+		expect( indexButton ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect( screen.queryByLabelText( 'Diff for index.php' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'caps long previews until Show more is pressed', () => {
+		const diff = Array.from( { length: 50 }, ( _, index ) => `+line ${ index + 1 }` ).join( '\n' );
+		const entries = [
+			toolCallEntry( 'edit-1', 'Edit', { path: '/sites/demo/index.php' } ),
+			toolResultEntry( 'edit-1', diff ),
+		];
+
+		render( <ChangesReview changes={ getSessionFileChanges( entries, '/sites/demo' ) } /> );
+
+		const indexDiff = screen.getByLabelText( 'Diff for index.php' );
+		expect( indexDiff ).toHaveTextContent( '+line 40' );
+		expect( indexDiff ).not.toHaveTextContent( '+line 41' );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Show more' } ) );
+		expect( indexDiff ).toHaveTextContent( '+line 50' );
+		expect( screen.getByRole( 'button', { name: 'Show less' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'navigates between changed files', () => {
+		const entries = [
+			toolCallEntry( 'edit-1', 'Edit', { path: '/sites/demo/index.php' } ),
+			toolResultEntry( 'edit-1', '-old\n+new' ),
+			toolCallEntry( 'edit-2', 'Edit', { path: '/sites/demo/theme.css' } ),
+			toolResultEntry( 'edit-2', '-red\n+blue' ),
+		];
+
+		render( <ChangesReview changes={ getSessionFileChanges( entries, '/sites/demo' ) } /> );
+
+		expect( screen.getByText( '1 of 2' ) ).toBeInTheDocument();
+		fireEvent.click( screen.getByRole( 'button', { name: 'Next changed file' } ) );
+		expect( screen.getByText( '2 of 2' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /theme\.css/ } ) ).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+	} );
+} );
+
 describe( 'formatChangeCount', () => {
 	it( 'uses locale-specific number separators', () => {
 		expect( formatChangeCount( 1468, 'en-US' ) ).toBe( '1,468' );
@@ -105,6 +175,26 @@ describe( 'formatChangeCount', () => {
 } );
 
 describe( 'ChangesTracker', () => {
+	it( 'opens the review surface from the file summary', async () => {
+		const onOpenReview = vi.fn();
+		const entries = [
+			toolCallEntry( 'edit-1', 'Edit', { path: '/sites/demo/index.php' } ),
+			toolResultEntry( 'edit-1', '@@ -1 +1 @@\n-old\n+new' ),
+		];
+
+		render(
+			<ChangesTracker
+				entries={ entries }
+				ownerSitePath="/sites/demo"
+				onOpenReview={ onOpenReview }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'View changed files: 1 file' } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Review changes' } ) );
+
+		expect( onOpenReview ).toHaveBeenCalledOnce();
+	} );
+
 	it( 'opens a per-file summary from the pill', async () => {
 		const entries = [
 			toolCallEntry( 'edit-1', 'Edit', {
@@ -113,7 +203,9 @@ describe( 'ChangesTracker', () => {
 			toolResultEntry( 'edit-1', '@@ -1 +1 @@\n-old\n+new' ),
 		];
 
-		render( <ChangesTracker entries={ entries } ownerSitePath="/sites/demo" /> );
+		render(
+			<ChangesTracker entries={ entries } ownerSitePath="/sites/demo" onOpenReview={ vi.fn() } />
+		);
 		fireEvent.click( screen.getByRole( 'button', { name: 'View changed files: 1 file' } ) );
 
 		const popup = await screen.findByRole( 'dialog' );
@@ -139,7 +231,9 @@ describe( 'ChangesTracker', () => {
 		];
 
 		try {
-			render( <ChangesTracker entries={ entries } ownerSitePath="/sites/demo" /> );
+			render(
+				<ChangesTracker entries={ entries } ownerSitePath="/sites/demo" onOpenReview={ vi.fn() } />
+			);
 			expect( screen.getByText( '+1,468' ) ).toBeVisible();
 		} finally {
 			document.documentElement.lang = originalLanguage;
@@ -147,7 +241,7 @@ describe( 'ChangesTracker', () => {
 	} );
 
 	it( 'does not render without successful file changes', () => {
-		const { container } = render( <ChangesTracker entries={ [] } /> );
+		const { container } = render( <ChangesTracker entries={ [] } onOpenReview={ vi.fn() } /> );
 		expect( container ).toBeEmptyDOMElement();
 	} );
 } );

--- a/apps/ui/src/ui-classic/components/session-view/changes-tracker.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/changes-tracker.tsx
@@ -1,9 +1,14 @@
 import { getToolResultDiff } from '@studio/common/ai/tools';
 import { _n, __, sprintf } from '@wordpress/i18n';
-import { Button, Popover, Tooltip, VisuallyHidden } from '@wordpress/ui';
+import { arrowDown, arrowUp, chevronDownSmall } from '@wordpress/icons';
+import { Button, Icon, IconButton, Popover, Tooltip, VisuallyHidden } from '@wordpress/ui';
 import { useId, useMemo, useRef, useState } from 'react';
 import styles from './changes-tracker.module.css';
 import type { SessionEntry } from '@earendil-works/pi-coding-agent';
+
+const MAX_RENDERED_DIFF_LINES = 5000;
+const MAX_RENDERED_DIFF_LINES_PER_EDGE = MAX_RENDERED_DIFF_LINES / 2;
+const MAX_PREVIEW_DIFF_LINES = 40;
 
 interface FileToolCall {
 	path: string;
@@ -16,6 +21,7 @@ export interface SessionFileChange {
 	displayPath: string;
 	additions: number;
 	deletions: number;
+	diff: string;
 }
 
 function getFilePath( input: Record< string, unknown > ): string | undefined {
@@ -149,10 +155,211 @@ export function getSessionFileChanges(
 			displayPath: getDisplayPath( normalizedPath, ownerSitePath ),
 			additions: ( previous?.additions ?? 0 ) + counts.additions,
 			deletions: ( previous?.deletions ?? 0 ) + counts.deletions,
+			diff: previous ? `${ previous.diff }\n\n${ diff }` : diff,
 		} );
 	}
 
 	return [ ...changes.values() ];
+}
+
+function DiffLine( { line }: { line: string } ) {
+	const isHeader = line.startsWith( '+++' ) || line.startsWith( '---' );
+	const className =
+		! isHeader && line.startsWith( '+' )
+			? styles.diffAddition
+			: ! isHeader && line.startsWith( '-' )
+			? styles.diffDeletion
+			: styles.diffContext;
+	return <span className={ className }>{ line || ' ' }</span>;
+}
+
+function ChangeDiff( { change }: { change: SessionFileChange } ) {
+	const [ showAll, setShowAll ] = useState( false );
+	const diffLines = change.diff.split( '\n' );
+	const previewIsTruncated = diffLines.length > MAX_PREVIEW_DIFF_LINES;
+	const renderedDiffLines = showAll ? diffLines : diffLines.slice( 0, MAX_PREVIEW_DIFF_LINES );
+	const omittedDiffLineCount = Math.max( 0, renderedDiffLines.length - MAX_RENDERED_DIFF_LINES );
+	const leadingDiffLines = omittedDiffLineCount
+		? renderedDiffLines.slice( 0, MAX_RENDERED_DIFF_LINES_PER_EDGE )
+		: renderedDiffLines;
+	const trailingDiffLines = omittedDiffLineCount
+		? renderedDiffLines.slice( -MAX_RENDERED_DIFF_LINES_PER_EDGE )
+		: [];
+
+	return (
+		<div className={ styles.diffPanel }>
+			<pre className={ styles.diff } dir="ltr">
+				{ leadingDiffLines.map( ( line, index ) => (
+					<DiffLine key={ `start-${ index }` } line={ line } />
+				) ) }
+				{ omittedDiffLineCount > 0 && (
+					<span className={ styles.diffTruncated }>
+						{ sprintf(
+							_n( '%d diff line omitted.', '%d diff lines omitted.', omittedDiffLineCount ),
+							omittedDiffLineCount
+						) }
+					</span>
+				) }
+				{ trailingDiffLines.map( ( line, index ) => (
+					<DiffLine key={ `end-${ index }` } line={ line } />
+				) ) }
+			</pre>
+			{ previewIsTruncated && (
+				<div className={ styles.showMore }>
+					<Button
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						onClick={ () => setShowAll( ( current ) => ! current ) }
+					>
+						{ showAll ? __( 'Show less' ) : __( 'Show more' ) }
+					</Button>
+				</div>
+			) }
+		</div>
+	);
+}
+
+export function ChangesReview( { changes }: { changes: SessionFileChange[] } ) {
+	const reviewId = useId();
+	const listRef = useRef< HTMLDivElement >( null );
+	const sectionRefs = useRef< Array< HTMLElement | null > >( [] );
+	const [ activePath, setActivePath ] = useState( changes[ 0 ]?.path );
+	const [ expandedPaths, setExpandedPaths ] = useState(
+		() => new Set( changes[ 0 ] ? [ changes[ 0 ].path ] : [] )
+	);
+	const activeIndex = Math.max(
+		0,
+		changes.findIndex( ( change ) => change.path === activePath )
+	);
+
+	if ( changes.length === 0 ) {
+		return null;
+	}
+
+	const toggleChange = ( path: string ) => {
+		setActivePath( path );
+		setExpandedPaths( ( current ) => {
+			const next = new Set( current );
+			if ( next.has( path ) ) {
+				next.delete( path );
+			} else {
+				next.add( path );
+			}
+			return next;
+		} );
+	};
+
+	const navigateToChange = ( index: number ) => {
+		const change = changes[ index ];
+		if ( ! change ) {
+			return;
+		}
+		setActivePath( change.path );
+		setExpandedPaths( ( current ) => new Set( current ).add( change.path ) );
+		window.requestAnimationFrame( () => {
+			sectionRefs.current[ index ]?.scrollIntoView?.( {
+				behavior: 'auto',
+				block: 'start',
+			} );
+		} );
+	};
+
+	const handleListScroll = () => {
+		const list = listRef.current;
+		if ( ! list ) {
+			return;
+		}
+		const threshold = list.scrollTop + 80;
+		let visibleIndex = 0;
+		for ( let index = 0; index < sectionRefs.current.length; index += 1 ) {
+			const section = sectionRefs.current[ index ];
+			if ( section && section.offsetTop <= threshold ) {
+				visibleIndex = index;
+			}
+		}
+		setActivePath( changes[ visibleIndex ]?.path );
+	};
+
+	return (
+		<div className={ styles.review }>
+			<nav className={ styles.reviewNav } aria-label={ __( 'Changed file navigation' ) }>
+				<IconButton
+					variant="minimal"
+					tone="neutral"
+					size="small"
+					icon={ arrowUp }
+					label={ __( 'Previous changed file' ) }
+					disabled={ activeIndex === 0 }
+					onClick={ () => navigateToChange( activeIndex - 1 ) }
+				/>
+				<span className={ styles.reviewNavPosition } aria-live="polite">
+					{ sprintf( __( '%1$d of %2$d' ), activeIndex + 1, changes.length ) }
+				</span>
+				<IconButton
+					variant="minimal"
+					tone="neutral"
+					size="small"
+					icon={ arrowDown }
+					label={ __( 'Next changed file' ) }
+					disabled={ activeIndex === changes.length - 1 }
+					onClick={ () => navigateToChange( activeIndex + 1 ) }
+				/>
+			</nav>
+			<div
+				ref={ listRef }
+				className={ styles.changeList }
+				aria-label={ __( 'Files changed' ) }
+				onScroll={ handleListScroll }
+			>
+				{ changes.map( ( change, index ) => {
+					const { directory, fileName } = getPathParts( change.displayPath );
+					const isExpanded = expandedPaths.has( change.path );
+					const panelId = `${ reviewId }-change-${ index }`;
+					return (
+						<section
+							key={ change.path }
+							ref={ ( node ) => {
+								sectionRefs.current[ index ] = node;
+							} }
+							className={ styles.changeSection }
+							data-active={ activeIndex === index || undefined }
+						>
+							<button
+								type="button"
+								className={ styles.changeHeader }
+								aria-expanded={ isExpanded }
+								aria-controls={ panelId }
+								onClick={ () => toggleChange( change.path ) }
+							>
+								<Icon className={ styles.disclosureIcon } icon={ chevronDownSmall } size={ 18 } />
+								<span className={ styles.fileIdentity } dir="ltr" title={ change.displayPath }>
+									<span className={ styles.fileName }>{ fileName }</span>
+									{ directory ? <DirectoryPath directory={ directory } /> : null }
+								</span>
+								<span className={ styles.lineCounts }>
+									<span className={ styles.additions }>
+										+{ formatChangeCount( change.additions ) }
+									</span>
+									<span className={ styles.deletions }>
+										-{ formatChangeCount( change.deletions ) }
+									</span>
+								</span>
+							</button>
+							{ isExpanded && (
+								<div
+									id={ panelId }
+									aria-label={ sprintf( __( 'Diff for %s' ), change.displayPath ) }
+								>
+									<ChangeDiff change={ change } />
+								</div>
+							) }
+						</section>
+					);
+				} ) }
+			</div>
+		</div>
+	);
 }
 
 export function formatChangeCount( count: number, locale?: string ): string {
@@ -165,9 +372,11 @@ export function formatChangeCount( count: number, locale?: string ): string {
 export function ChangesTracker( {
 	entries,
 	ownerSitePath,
+	onOpenReview,
 }: {
 	entries: SessionEntry[];
 	ownerSitePath?: string;
+	onOpenReview: () => void;
 } ) {
 	const changes = useMemo(
 		() => getSessionFileChanges( entries, ownerSitePath ),
@@ -250,6 +459,20 @@ export function ChangesTracker( {
 								</div>
 							);
 						} ) }
+					</div>
+					<div className={ styles.popupFooter }>
+						<Button
+							variant="minimal"
+							tone="neutral"
+							size="small"
+							className={ styles.reviewAction }
+							onClick={ () => {
+								setOpen( false );
+								onOpenReview();
+							} }
+						>
+							{ __( 'Review changes' ) }
+						</Button>
 					</div>
 				</Popover.Popup>
 			</Popover.Root>

--- a/apps/ui/src/ui-classic/components/session-view/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.test.tsx
@@ -53,6 +53,7 @@ vi.mock( '@/hooks/use-session-commands', () => ( { useSessionCommands: vi.fn() }
 vi.mock( '@/hooks/use-session-ui', () => ( {
 	SessionUIProvider: ( { children }: { children: React.ReactNode } ) => children,
 	useSessionPreviewAnnotations: vi.fn(),
+	useSessionPreviewUI: () => ( { showReview: vi.fn() } ),
 } ) );
 
 vi.mock( '@/hooks/use-traffic-light-space', () => ( {

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -31,7 +31,11 @@ import {
 } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { useSessionCommands } from '@/hooks/use-session-commands';
-import { SessionUIProvider, useSessionPreviewAnnotations } from '@/hooks/use-session-ui';
+import {
+	SessionUIProvider,
+	useSessionPreviewAnnotations,
+	useSessionPreviewUI,
+} from '@/hooks/use-session-ui';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
 import { useTrafficLightSpace } from '@/hooks/use-traffic-light-space';
 import { formatComposerTextQuote, watchComposerTextQuote } from '@/lib/composer-text-quote';
@@ -274,6 +278,7 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 
 function SessionViewContent( { sessionId }: { sessionId: string } ) {
 	const navigate = useNavigate();
+	const preview = useSessionPreviewUI();
 	const { data, isLoading, error } = useSession( sessionId );
 	const { data: sites } = useSites();
 	const { data: sessions } = useSessions();
@@ -527,6 +532,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 							<ChangesTracker
 								entries={ data.entries }
 								ownerSitePath={ ownerSite?.path ?? data.summary.ownerSitePath }
+								onOpenReview={ preview.showReview }
 							/>
 						</div>
 						<span

--- a/apps/ui/src/ui-classic/router/layout-dashboard/index.tsx
+++ b/apps/ui/src/ui-classic/router/layout-dashboard/index.tsx
@@ -1,6 +1,6 @@
 import { findAiSessionOwnerSite } from '@studio/common/ai/sessions/owner-site';
 import { createRoute, Outlet, useRouterState } from '@tanstack/react-router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
 	PreviewSplitFrame,
 	type PreviewSplitFramePreviewProps,
@@ -20,6 +20,7 @@ import {
 	useSessionPreviewUI,
 } from '@/hooks/use-session-ui';
 import { writeLastVisited } from '@/lib/last-visited';
+import { getSessionFileChanges } from '../../components/session-view/changes-tracker';
 import { rootRoute } from '../layout-root';
 
 // Session detail routes and the site overview host the preview; on every
@@ -73,6 +74,14 @@ function DashboardLayoutContent() {
 	const preview = useSessionPreviewUI();
 	const onAnnotationsDone = useSessionPreviewAnnotationsHandler();
 	const sessionSite = findAiSessionOwnerSite( sites, sessionData?.summary );
+	const sessionChanges = useMemo(
+		() =>
+			getSessionFileChanges(
+				sessionData?.entries ?? [],
+				sessionSite?.path ?? sessionData?.summary.ownerSitePath
+			),
+		[ sessionData?.entries, sessionData?.summary.ownerSitePath, sessionSite?.path ]
+	);
 	const effectiveEnvironment = useSessionEffectiveEnvironment(
 		sessionData?.summary,
 		sessionSite?.id
@@ -128,6 +137,12 @@ function DashboardLayoutContent() {
 	const previewPath = pathForSite( preview.pathsBySiteId, previewSiteId );
 	const showPreview = preview.open && supportsPreview && !! previewSite;
 	const previewFullscreen = preview.fullscreen && showPreview;
+	const reviewActive = preview.surface === 'review' && sessionChanges.length > 0;
+	useEffect( () => {
+		if ( preview.surface === 'review' && sessionChanges.length === 0 ) {
+			preview.showSite();
+		}
+	}, [ preview, sessionChanges.length ] );
 	// Leave full preview when the route stops supporting a preview (settings,
 	// site settings…) so the user is never left staring at a hidden layout.
 	const { setFullscreen: setPreviewFullscreen } = preview;
@@ -152,15 +167,21 @@ function DashboardLayoutContent() {
 					collapsed={ collapsed }
 					fullscreen={ previewFullscreen }
 					onFullscreenChange={ setPreviewFullscreen }
+					changes={ sessionChanges }
+					reviewActive={ reviewActive }
+					onReviewActiveChange={ ( active ) =>
+						active ? preview.showReview() : preview.showSite()
+					}
 				/>
 			) : null,
 		[
 			onAnnotationsDone,
+			preview,
 			previewFullscreen,
 			previewPath,
-			preview.reloadNonce,
-			preview.updatePath,
 			previewSite,
+			reviewActive,
+			sessionChanges,
 			setPreviewFullscreen,
 		]
 	);


### PR DESCRIPTION
## Related issues

- None. A companion issue was intentionally not opened for this Studio proof of concept.
- Stacked on #4594, which independently adds the interactive changed-file inventory on top of #4590.

## How AI was used in this PR

This feature was designed and implemented collaboratively with Codex. AI helped explore several review surfaces, implement the transcript-derived diff view, add tests, and exercise the production build. The interaction and visual design were iterated manually in the running agentic UI.

## Executive summary

This is the third PR in a three-PR stack. #4590 adds the display-only change summary, and #4594 adds the per-file inventory. This follow-up adds an optional Review destination to the existing Preview surface, giving larger diffs enough space without replacing the conversation, composer, or live site preview state.

The inventory gains a **Review changes** action that opens the Preview panel and selects Review. Review presents each file as a collapsible section in a single scrolling column, with bounded previews and lightweight previous/next navigation.

## Proposed Changes

- Add Review as an optional destination alongside the existing Preview destinations when the current chat has file changes.
- Let people move naturally from the pill's per-file inventory into the full review surface.
- Present changed files as a single-column, collapsible list so scanning follows the normal vertical reading flow.
- Keep the first file expanded, cap initial previews at 40 lines, and offer Show more/Show less without allowing unbounded DOM growth.
- Provide a compact floating previous/next control for moving between changed files.
- Preserve preview continuity by keeping the site webview mounted while Review is visible; returning to Site reveals the same live preview.
- Keep the conversation and composer in place throughout review.

## Review guide

### 1. Stacked boundary

Review #4590 and #4594 first. They independently own change derivation, localized totals, composer integration, and the interactive file inventory. This PR should contain only the Review destination and the transition into it.

### 2. Relationship to Preview

Please focus on whether Review feels like a natural peer to Site, WP Admin, and Database. Selecting Review hides—but does not unmount—the preview webview. Selecting any site destination returns immediately to the warm preview.

### 3. Diff scanability

Files appear in transcript order. The first is expanded; other sections can be opened independently. Initial previews show 40 lines. Expanded diffs render at most 5,000 lines, retaining both the beginning and end when a diff exceeds the cap.

### 4. Change semantics

The view reconstructs successful `Edit` and `Write` activity already stored in the session transcript. Repeated edits to one path are shown consecutively and their counts are aggregated. This is a record of agent activity in the chat, not a reconciliation against Git's current working tree.

## Screenshots

Native 2560×1440 PNG captures at 100% page scale and 2× device scale, captured from the rebuilt third layer of the stack.

| Light | Dark |
|---|---|
| ![File-change Review tab in light mode](https://github.com/Automattic/studio/blob/51ae969c82d060b7ccc29653688299e5ad917167/pr4580-review-stack-light-retina.png?raw=true) | ![File-change Review tab in dark mode](https://github.com/Automattic/studio/blob/51ae969c82d060b7ccc29653688299e5ad917167/pr4580-review-stack-dark-retina.png?raw=true) |

## Known tradeoffs and follow-ups

- The custom renderer does not yet provide syntax highlighting, intra-line highlighting, side-by-side mode, or Git working-tree reconciliation.
- Only built-in `Edit` and `Write` tool activity is represented. File mutation through shell commands or WordPress-specific tools remains outside this proof of concept.
- Expansion and navigation state are intentionally in-memory.
- Inline comments and GitHub-style batched review feedback are not part of this PR. The goal here is a focused read-only review surface.

## Safety checklist

- [x] No new runtime dependency or external service.
- [x] No migration or mutation of user-owned project data.
- [x] Session JSONL remains the source of truth and is not modified by the viewer.
- [x] Diff content is rendered as React text, not injected HTML.
- [x] Initial previews and expanded large diffs have bounded DOM sizes.
- [x] The site preview stays mounted and retains its current location while Review is visible.
- [x] The default conversation and composer are not replaced.
- [x] The feature is isolated to the agentic UI.

## Testing Instructions

1. Check out #4590, then #4594, then this PR, and launch Studio's agentic UI.
2. Open a chat associated with a local site and make changes to multiple files, including one change longer than 40 diff lines.
3. Select the change pill, confirm its file inventory remains available, then choose **Review changes**.
4. Confirm the Preview panel opens on Review while the chat and composer remain unchanged.
5. Expand and collapse several files. Verify filenames, paths, and localized addition/deletion counts remain readable and correctly associated.
6. Use the floating previous/next controls and confirm the corresponding file expands and scrolls into view.
7. Use Show more/Show less on a long change and confirm the page remains responsive.
8. Select Site, WP Admin, or Database and confirm the live preview returns without reloading or losing its prior location. Select Review again from the Preview toolbar.
9. Repeat in light and dark appearances.
10. Repeat in a representative RTL locale such as Hebrew or Arabic. Verify the surrounding controls mirror while paths, line counts, and diff content remain LTR and truncate without clipping.

Automated verification completed locally:

- `npx eslint --fix` on every modified TypeScript/TSX file
- `npm test -- apps/ui/src/ui-classic/components/session-view/changes-tracker.test.tsx apps/ui/src/ui-classic/components/session-view/index.test.tsx apps/ui/src/hooks/use-session-ui.test.tsx apps/ui/src/components/site-preview/index.test.tsx apps/ui/src/components/site-preview/address-bar.test.tsx` — 5 files and 107 tests passed
- `npm run typecheck`
- `npm run cli:build:ui`
- `git diff --check`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Verified the Review flow in the agentic UI.
- [x] Verified light and dark appearances.
- [x] Verified representative RTL behavior and mixed-direction paths/counts.
- [x] Verified long-diff preview and rendering caps.
- [x] Confirmed #4594 remains useful without this follow-up.
- [ ] Confirm the product direction before promoting this proof of concept from draft.
