### PR TITLE
Drop bundle_id from the DMG notarize call

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -87,7 +87,6 @@ lane :notarize_binary do
 
   Dir[File.join(BUILDS_FOLDER, '**', 'Studio-*.dmg')].each do |path|
     notarize(
-      bundle_id: APPLE_BUNDLE_IDENTIFIER,
       package: path,
       api_key: app_store_connect_api_key,
       print_log: true


### PR DESCRIPTION
## Proposed Changes

* Remove `bundle_id:` from the `.dmg` `notarize` call in `notarize_binary`.
* See [AINFRA-2927](https://linear.app/a8c/issue/AINFRA-2927).

## Why are these changes being made?

[fastlane 2.238.0 removed the `notarize` action's `bundle_id` option](https://github.com/fastlane/fastlane/pull/29736), and #4566 bumped us onto it. `trunk` has been failing since that merged because of it.

<details>
<summary>Details</summary>

From [build 20972](https://buildkite.com/automattic/studio/builds/20972), the `.app` loop succeeds and the `.dmg` loop immediately after it does not:

```
[03:52:48]: Successfully notarized and stapled package
[03:52:48]: You passed invalid parameters to 'notarize'.
[!] Could not find option 'bundle_id' in the list of available options: package, skip_stapling, username, asc_provider, print_log, verbose, api_key_path, api_key
```

</details>

## Testing Instructions

Notice `notarize` works [in CI](https://buildkite.com/automattic/studio/builds/21013/canvas?jid=01a012ca-be92-4ea9-abea-52505b1298af&tab=output), unlike [current `trunk`](https://buildkite.com/automattic/studio/builds/21019/canvas?sid=01a01411-b8ba-45ee-a2ea-2406a0bce962):

<img width="1036" height="171" alt="image" src="https://github.com/user-attachments/assets/c7f1e2b4-0a16-4a40-8825-8ce7d75c84e5" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)

---

*Posted by Claude Code (Opus 5) on behalf of @mokagio with approval.*
