### PR TITLE
Agentic UI: Summarize chat file changes

### DIFF
--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -160,7 +160,18 @@
 	position: absolute;
 	bottom: calc(52px + var(--app-main-composer-height, 0px));
 	inset-inline-start: var(--wpds-dimension-padding-xl);
-	width: min(320px, calc(100% - 2 * var(--wpds-dimension-padding-xl)));
+	/* The session publishes the actual width of its inline-end controls (change
+	   tracker and scroll-to-latest), so this inline-start shelf never covers them. */
+	width: min(
+		320px,
+		max(
+			0px,
+			calc(
+				100% - 2 * var(--wpds-dimension-padding-xl) -
+					var(--app-main-composer-end-overlay-width, 0px)
+			)
+		)
+	);
 	z-index: 110;
 	pointer-events: auto;
 	-webkit-app-region: no-drag;

--- a/apps/ui/src/data/core/query-client.ts
+++ b/apps/ui/src/data/core/query-client.ts
@@ -36,7 +36,7 @@ const maxAge = 1000 * 60 * 60 * 24; // 24 hours
 const [ , persistPromise ] = persistQueryClient( {
 	queryClient,
 	persister,
-	buster: '4', // Bump when query data shape changes.
+	buster: '5', // Bump when query data shape or persistence policy changes.
 	maxAge,
 	dehydrateOptions: {
 		shouldRedactErrors: () => false,

--- a/apps/ui/src/data/queries/use-sessions.ts
+++ b/apps/ui/src/data/queries/use-sessions.ts
@@ -67,6 +67,10 @@ export function useSession( sessionId: string | undefined ) {
 		queryKey: [ ...SESSIONS_QUERY_KEY, sessionId ],
 		queryFn: () => connector.getSession( sessionId! ),
 		enabled: !! sessionId,
+		// The JSONL transcript is authoritative across launches. Persisting this
+		// infinitely-fresh query can resurrect a pre-run snapshot after an abrupt
+		// renderer exit and hide tool results that were already written to disk.
+		meta: { persist: false },
 		// `useAgentRun` mutates the cache during a live run and invalidates
 		// explicitly on `run.exited`. Any implicit refetch would race those
 		// cache writes and flicker the transcript.

--- a/apps/ui/src/ui-classic/components/session-view/changes-tracker.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/changes-tracker.module.css
@@ -1,0 +1,38 @@
+.anchor {
+	display: flex;
+	pointer-events: auto;
+	-webkit-app-region: no-drag;
+}
+
+.summary {
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-gap-xs);
+	block-size: 28px;
+	padding: 2px var(--wpds-dimension-padding-md);
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+	border-radius: 999px;
+	background: var(--wpds-color-bg-surface-neutral-strong);
+	color: var(--wpds-color-fg-content-neutral);
+	font-size: var(--wpds-typography-font-size-sm);
+	font-weight: var(--wpds-typography-font-weight-regular);
+	line-height: var(--wpds-typography-line-height-sm);
+}
+
+.lineCounts {
+	display: flex;
+	gap: var(--wpds-dimension-gap-xs);
+	flex-shrink: 0;
+	direction: ltr;
+	font-variant-numeric: tabular-nums;
+	unicode-bidi: isolate;
+}
+
+.additions {
+	color: var(--wpds-color-stroke-surface-success-strong);
+}
+
+.deletions {
+	color: var(--wpds-color-stroke-surface-error-strong);
+}

--- a/apps/ui/src/ui-classic/components/session-view/changes-tracker.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/changes-tracker.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+	ChangesTracker,
+	countDiffLines,
+	formatChangeCount,
+	getSessionFileChanges,
+} from './changes-tracker';
+import type { SessionEntry } from '@earendil-works/pi-coding-agent';
+
+function toolCallEntry(
+	id: string,
+	name: 'Edit' | 'Write',
+	args: Record< string, unknown >
+): SessionEntry {
+	return {
+		type: 'message',
+		id: `assistant-${ id }`,
+		parentId: null,
+		timestamp: '2026-08-17T12:00:00.000Z',
+		message: {
+			role: 'assistant',
+			content: [ { type: 'toolCall', id, name, arguments: args } ],
+		},
+	} as unknown as SessionEntry;
+}
+
+function toolResultEntry( id: string, diff?: string, isError = false ): SessionEntry {
+	return {
+		type: 'message',
+		id: `result-${ id }`,
+		parentId: null,
+		timestamp: '2026-08-17T12:00:01.000Z',
+		message: {
+			role: 'toolResult',
+			toolCallId: id,
+			content: [ { type: 'text', text: 'Done' } ],
+			details: diff ? { diff } : undefined,
+			isError,
+		},
+	} as unknown as SessionEntry;
+}
+
+describe( 'getSessionFileChanges', () => {
+	it( 'aggregates successful file edits by normalized path', () => {
+		const entries = [
+			toolCallEntry( 'edit-1', 'Edit', { path: '/sites/demo/wp-content/theme.css' } ),
+			toolResultEntry( 'edit-1', '@@ -1 +1 @@\n-old\n+new' ),
+			toolCallEntry( 'edit-2', 'Edit', { path: '/sites/demo/wp-content/theme.css' } ),
+			toolResultEntry( 'edit-2', '@@ -4 +4,2 @@\n context\n+extra' ),
+			toolCallEntry( 'write-1', 'Write', { path: '/sites/demo/index.php', content: '<?php' } ),
+			toolResultEntry( 'write-1' ),
+		];
+
+		expect( getSessionFileChanges( entries ) ).toEqual( [
+			expect.objectContaining( {
+				path: '/sites/demo/wp-content/theme.css',
+				additions: 2,
+				deletions: 1,
+			} ),
+			expect.objectContaining( {
+				path: '/sites/demo/index.php',
+				additions: 1,
+				deletions: 0,
+			} ),
+		] );
+	} );
+
+	it( 'ignores failed edits', () => {
+		const entries = [
+			toolCallEntry( 'edit-1', 'Edit', { path: '/sites/demo/index.php' } ),
+			toolResultEntry( 'edit-1', '-old\n+new', true ),
+		];
+
+		expect( getSessionFileChanges( entries ) ).toEqual( [] );
+	} );
+
+	it( 'counts each tool call at most once', () => {
+		const entries = [
+			toolCallEntry( 'edit-1', 'Edit', { path: '/sites/demo/index.php' } ),
+			toolResultEntry( 'edit-1', '-old\n+new' ),
+			toolResultEntry( 'edit-1', '-old\n+new' ),
+		];
+
+		expect( getSessionFileChanges( entries ) ).toEqual( [
+			expect.objectContaining( { additions: 1, deletions: 1 } ),
+		] );
+	} );
+} );
+
+describe( 'countDiffLines', () => {
+	it( 'does not count diff headers', () => {
+		expect( countDiffLines( '--- a/file\n+++ b/file\n-old\n+new\n context' ) ).toEqual( {
+			additions: 1,
+			deletions: 1,
+		} );
+	} );
+} );
+
+describe( 'formatChangeCount', () => {
+	it( 'uses locale-specific number separators', () => {
+		expect( formatChangeCount( 1468, 'en-US' ) ).toBe( '1,468' );
+		expect( formatChangeCount( 1468, 'de-DE' ) ).toBe( '1.468' );
+	} );
+} );
+
+describe( 'ChangesTracker', () => {
+	it( 'renders a display-only summary pill', () => {
+		const entries = [
+			toolCallEntry( 'edit-1', 'Edit', {
+				path: '/sites/demo/wp-content/themes/twentytwentyfive-child/templates/front-page.html',
+			} ),
+			toolResultEntry( 'edit-1', '@@ -1 +1 @@\n-old\n+new' ),
+		];
+
+		render( <ChangesTracker entries={ entries } /> );
+
+		expect( screen.getByText( '1 file' ) ).toBeVisible();
+		expect( screen.getByText( '+1' ) ).toBeVisible();
+		expect( screen.getByText( '-1' ) ).toBeVisible();
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'formats totals in the pill using the active locale', () => {
+		const originalLanguage = document.documentElement.lang;
+		document.documentElement.lang = 'en-US';
+		const entries = [
+			toolCallEntry( 'write-1', 'Write', {
+				path: '/sites/demo/large.txt',
+				content: Array.from( { length: 1468 }, () => 'line' ).join( '\n' ),
+			} ),
+			toolResultEntry( 'write-1' ),
+		];
+
+		try {
+			render( <ChangesTracker entries={ entries } /> );
+			expect( screen.getByText( '+1,468' ) ).toBeVisible();
+		} finally {
+			document.documentElement.lang = originalLanguage;
+		}
+	} );
+
+	it( 'does not render without successful file changes', () => {
+		const { container } = render( <ChangesTracker entries={ [] } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/apps/ui/src/ui-classic/components/session-view/changes-tracker.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/changes-tracker.tsx
@@ -1,0 +1,150 @@
+import { getToolResultDiff } from '@studio/common/ai/tools';
+import { _n, sprintf } from '@wordpress/i18n';
+import { useMemo } from 'react';
+import styles from './changes-tracker.module.css';
+import type { SessionEntry } from '@earendil-works/pi-coding-agent';
+
+interface FileToolCall {
+	path: string;
+	name: 'Edit' | 'Write';
+	arguments: Record< string, unknown >;
+}
+
+export interface SessionFileChange {
+	path: string;
+	additions: number;
+	deletions: number;
+}
+
+function getFilePath( input: Record< string, unknown > ): string | undefined {
+	const filePath = input.file_path ?? input.path;
+	return typeof filePath === 'string' && filePath.length > 0 ? filePath : undefined;
+}
+
+function normalizePath( filePath: string ): string {
+	return filePath.replace( /\\/g, '/' );
+}
+
+function synthesizeDiff( call: FileToolCall ): string | undefined {
+	if ( call.name === 'Edit' ) {
+		const before = call.arguments.old_string ?? call.arguments.oldText;
+		const after = call.arguments.new_string ?? call.arguments.newText;
+		if ( typeof before === 'string' && typeof after === 'string' ) {
+			return [
+				`--- ${ call.path }`,
+				`+++ ${ call.path }`,
+				...before.split( '\n' ).map( ( line ) => `-${ line }` ),
+				...after.split( '\n' ).map( ( line ) => `+${ line }` ),
+			].join( '\n' );
+		}
+	}
+
+	if ( call.name === 'Write' && typeof call.arguments.content === 'string' ) {
+		return [
+			'--- /dev/null',
+			`+++ ${ call.path }`,
+			...call.arguments.content.split( '\n' ).map( ( line ) => `+${ line }` ),
+		].join( '\n' );
+	}
+
+	return undefined;
+}
+
+export function countDiffLines( diff: string ): { additions: number; deletions: number } {
+	let additions = 0;
+	let deletions = 0;
+	for ( const line of diff.split( '\n' ) ) {
+		if ( line.startsWith( '+' ) && ! line.startsWith( '+++' ) ) {
+			additions += 1;
+		} else if ( line.startsWith( '-' ) && ! line.startsWith( '---' ) ) {
+			deletions += 1;
+		}
+	}
+	return { additions, deletions };
+}
+
+export function getSessionFileChanges( entries: SessionEntry[] ): SessionFileChange[] {
+	const calls = new Map< string, FileToolCall >();
+	const changes = new Map< string, SessionFileChange >();
+
+	for ( const entry of entries ) {
+		if ( entry.type !== 'message' ) {
+			continue;
+		}
+		const message = entry.message;
+		if ( message?.role === 'assistant' ) {
+			for ( const block of message.content ?? [] ) {
+				if (
+					block.type !== 'toolCall' ||
+					! block.id ||
+					( block.name !== 'Edit' && block.name !== 'Write' )
+				) {
+					continue;
+				}
+				const toolArguments = block.arguments ?? {};
+				const filePath = getFilePath( toolArguments );
+				if ( filePath ) {
+					calls.set( block.id, { path: filePath, name: block.name, arguments: toolArguments } );
+				}
+			}
+			continue;
+		}
+
+		if ( message?.role !== 'toolResult' || ! message.toolCallId ) {
+			continue;
+		}
+		const call = calls.get( message.toolCallId );
+		calls.delete( message.toolCallId );
+		if ( message.isError || ! call ) {
+			continue;
+		}
+		const diff = getToolResultDiff( message.details ) ?? synthesizeDiff( call );
+		if ( ! diff ) {
+			continue;
+		}
+		const normalizedPath = normalizePath( call.path );
+		const counts = countDiffLines( diff );
+		const previous = changes.get( normalizedPath );
+		changes.set( normalizedPath, {
+			path: normalizedPath,
+			additions: ( previous?.additions ?? 0 ) + counts.additions,
+			deletions: ( previous?.deletions ?? 0 ) + counts.deletions,
+		} );
+	}
+
+	return [ ...changes.values() ];
+}
+
+export function formatChangeCount( count: number, locale?: string ): string {
+	const resolvedLocale =
+		locale ||
+		( typeof document !== 'undefined' ? document.documentElement.lang || undefined : undefined );
+	return new Intl.NumberFormat( resolvedLocale ).format( count );
+}
+
+export function ChangesTracker( { entries }: { entries: SessionEntry[] } ) {
+	const changes = useMemo( () => getSessionFileChanges( entries ), [ entries ] );
+	const additions = changes.reduce( ( total, change ) => total + change.additions, 0 );
+	const deletions = changes.reduce( ( total, change ) => total + change.deletions, 0 );
+
+	if ( changes.length === 0 ) {
+		return null;
+	}
+
+	const fileCountLabel = sprintf(
+		_n( '%s file', '%s files', changes.length ),
+		formatChangeCount( changes.length )
+	);
+
+	return (
+		<div className={ styles.anchor }>
+			<div className={ styles.summary }>
+				<span>{ fileCountLabel }</span>
+				<span className={ styles.lineCounts }>
+					<span className={ styles.additions }>+{ formatChangeCount( additions ) }</span>
+					<span className={ styles.deletions }>-{ formatChangeCount( deletions ) }</span>
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -37,6 +37,7 @@ import { useTrafficLightSpace } from '@/hooks/use-traffic-light-space';
 import { formatComposerTextQuote, watchComposerTextQuote } from '@/lib/composer-text-quote';
 import { AccessRequirements } from './access-requirements';
 import { formatAnnotationsAsPrompt, formatAnnotationsSubmittedMessage } from './annotations';
+import { ChangesTracker } from './changes-tracker';
 import { Composer, ComposerSkeleton, type ComposerHandle } from './composer';
 import { Conversation } from './conversation';
 import { EmptyBackground } from './empty-background';
@@ -49,6 +50,7 @@ import type { AiSessionSummary } from '@/data/core';
 // Slack below the bottom edge that still counts as "at the latest message",
 // so sub-pixel rounding or a barely-started scroll doesn't flash the button.
 const SCROLL_AWAY_FROM_LATEST_THRESHOLD_PX = 48;
+const MAIN_COMPOSER_END_OVERLAY_WIDTH_PROPERTY = '--app-main-composer-end-overlay-width';
 
 export function isScrolledAwayFromLatest( node: {
 	scrollTop: number;
@@ -111,6 +113,49 @@ interface SessionFrameProps {
 	footerEnd?: ReactNode;
 	scrollRef?: Ref< HTMLDivElement >;
 	children?: ReactNode;
+}
+
+function ComposerEndOverlay( { children }: { children: ReactNode } ) {
+	const ref = useRef< HTMLDivElement >( null );
+
+	useLayoutEffect( () => {
+		const node = ref.current;
+		if ( ! node ) {
+			return;
+		}
+
+		const publishWidth = () => {
+			const width = node.offsetWidth;
+			document.documentElement.style.setProperty(
+				MAIN_COMPOSER_END_OVERLAY_WIDTH_PROPERTY,
+				width > 0 ? `${ width + 8 }px` : '0px'
+			);
+		};
+		const clearWidth = () =>
+			document.documentElement.style.removeProperty( MAIN_COMPOSER_END_OVERLAY_WIDTH_PROPERTY );
+
+		publishWidth();
+		if ( typeof ResizeObserver === 'undefined' ) {
+			window.addEventListener( 'resize', publishWidth );
+			return () => {
+				window.removeEventListener( 'resize', publishWidth );
+				clearWidth();
+			};
+		}
+
+		const resizeObserver = new ResizeObserver( publishWidth );
+		resizeObserver.observe( node );
+		return () => {
+			resizeObserver.disconnect();
+			clearWidth();
+		};
+	}, [] );
+
+	return (
+		<div ref={ ref } className={ styles.composerEndOverlay }>
+			{ children }
+		</div>
+	);
 }
 
 // Lays out the chat column as fixed chrome over a full-height conversation
@@ -477,19 +522,32 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 						fadeAfterQuotaCheck && styles.fadeInQuick
 					) }
 				>
-					{ isScrolledAway ? (
-						<div className={ styles.scrollToLatestWrap }>
-							<IconButton
-								className={ styles.scrollToLatestButton }
-								icon={ arrowDown }
-								label={ __( 'Scroll to latest message' ) }
-								size="small"
-								variant="minimal"
-								tone="neutral"
-								onClick={ scrollToLatest }
-							/>
+					<ComposerEndOverlay>
+						<div className={ styles.changesTrackerSlot }>
+							<ChangesTracker entries={ data.entries } />
 						</div>
-					) : null }
+						<span
+							aria-hidden
+							className={ clsx(
+								styles.scrollToLatestSlot,
+								isScrolledAway && styles.scrollToLatestSlotVisible
+							) }
+						/>
+						<IconButton
+							aria-hidden={ ! isScrolledAway }
+							className={ clsx(
+								styles.scrollToLatestButton,
+								isScrolledAway && styles.scrollToLatestButtonVisible
+							) }
+							icon={ arrowDown }
+							label={ __( 'Scroll to latest message' ) }
+							size="small"
+							tabIndex={ isScrolledAway ? undefined : -1 }
+							variant="outline"
+							tone="neutral"
+							onClick={ scrollToLatest }
+						/>
+					</ComposerEndOverlay>
 					<Composer
 						ref={ composerRef }
 						busy={ composerBusy }

--- a/apps/ui/src/ui-classic/components/session-view/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/style.module.css
@@ -192,21 +192,42 @@
 	inset-inline-end: var(--classic-panel-control-left);
 }
 
-/* Anchors the scroll-to-latest button to the composer column, floating it
-   above the composer without contributing to the measured composer height. */
-.scrollToLatestWrap {
+/* Keeps inline-end controls in one row above the composer. Its measured width
+   is published for the collapsed-sidebar toast shelf, which occupies the
+   inline-start side of the same band. */
+.composerEndOverlay {
+	--composer-action-inline-end-offset: calc(
+		var(--wpds-dimension-padding-lg) - var(--wpds-dimension-padding-xs)
+	);
+
 	position: absolute;
 	bottom: calc(100% + var(--wpds-dimension-padding-md));
-	inset-inline-start: 0;
-	/* Match the send button's inset: the composer toolbar's inline padding is
-	   the shell inline padding minus padding-xs (see composer .toolbar). */
-	inset-inline-end: calc(
-		var(--classic-composer-shell-inline-padding) - var(--wpds-dimension-padding-xs)
-	);
+	inset-inline-end: 0;
 	display: flex;
-	justify-content: flex-end;
+	align-items: center;
+	width: fit-content;
 	pointer-events: none;
 	-webkit-app-region: no-drag;
+}
+
+.changesTrackerSlot:empty {
+	display: none;
+}
+
+.scrollToLatestSlot {
+	inline-size: 0;
+	block-size: 28px;
+	margin-inline-start: 0;
+	transition: inline-size 120ms ease, margin-inline-start 120ms ease;
+}
+
+.scrollToLatestSlotVisible {
+	inline-size: calc(28px + var(--composer-action-inline-end-offset));
+	margin-inline-start: var(--wpds-dimension-gap-sm);
+}
+
+.changesTrackerSlot:empty + .scrollToLatestSlotVisible {
+	margin-inline-start: 0;
 }
 
 .scrollToLatestButton {
@@ -218,27 +239,31 @@
 	--wp-ui-button-background-color: var(--wpds-color-bg-surface-neutral-strong);
 	--wp-ui-button-border-color: var(--wpds-color-stroke-surface-neutral-weak);
 
-	pointer-events: auto;
+	position: absolute;
+	inset-inline-end: var(--composer-action-inline-end-offset);
+	opacity: 0;
+	transform: translateY(4px);
+	pointer-events: none;
 	border-radius: 50%;
-	box-shadow: var(--wpds-elevation-md);
-	animation: scroll-to-latest-appear 120ms ease-out;
+	visibility: hidden;
+	transition:
+		opacity 120ms ease-out,
+		transform 120ms ease-out,
+		visibility 0s linear 120ms;
 }
 
-@keyframes scroll-to-latest-appear {
-	from {
-		opacity: 0;
-		transform: translateY(4px);
-	}
-
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
+.scrollToLatestButtonVisible {
+	opacity: 1;
+	transform: translateY(0);
+	pointer-events: auto;
+	visibility: visible;
+	transition-delay: 0s;
 }
 
 @media (prefers-reduced-motion: reduce) {
+	.scrollToLatestSlot,
 	.scrollToLatestButton {
-		animation: none;
+		transition: none;
 	}
 }
 


### PR DESCRIPTION
## Related issues

- None. A companion issue was intentionally not opened for this Studio proof of concept.

## How AI was used in this PR

This feature was designed and implemented collaboratively with Codex. AI helped isolate the smallest independently useful slice from a larger review experiment, implement the transcript-derived summary and tests, and verify its layout in light, dark, LTR, and RTL contexts.

## Stack

This is the first of three stacked pull requests. It is intentionally useful on its own: chats that changed files gain a compact, display-only summary above the composer. #4594 makes that summary interactive and adds the per-file inventory. #4580 then adds the full diff-review destination.

## Proposed Changes

- Keep a compact summary of the files and line counts changed during the current chat directly above the composer.
- Reconstruct the summary from successful `Edit` and `Write` activity already stored in the chat transcript, including after Studio restarts.
- Aggregate repeated edits to the same path and format file and line totals with locale-aware number grouping.
- Coordinate the summary with the scroll-to-latest control and collapsed-sidebar toast shelf. The controls have matching 28px heights, no shadows, and animate into aligned positions without covering other UI.
- Keep count pairs LTR while the surrounding layout mirrors in RTL locales.

## Review guide

The product boundary is deliberate: this PR answers only “how much changed?” The pill is display-only, has no hover or button semantics, and does not expose filenames or diffs. That keeps the transcript reconstruction and composer integration reviewable without coupling them to a specific review surface.

The displayed data is an activity summary of successful agent tool calls in the chat transcript. It is not a live Git working-tree diff, and repeated edits to one path have their counts aggregated.

## Safety and scope

- No new runtime dependency or external service.
- No mutation of project files or the session transcript.
- Only successful built-in `Edit` and `Write` activity is summarized.
- Failed tool calls are ignored, and each tool result is counted at most once.
- This PR contains no interactive popover, file paths, diff renderer, or Review destination.

## Screenshots

Native 2560×1440 PNG captures at 100% page scale and 2× device scale. These show the first PR's complete scope: the display-only pill matches the scroll control's 28px height, with no inventory or Review action.

| Light | Dark |
|---|---|
| ![Matched 28px change summary in light mode](https://github.com/Automattic/studio/blob/782ca6148b5b32629618b1e016880561f7aaeb88/pr4590-pill-28px-light-retina.png?raw=true) | ![Matched 28px change summary in dark mode](https://github.com/Automattic/studio/blob/782ca6148b5b32629618b1e016880561f7aaeb88/pr4590-pill-28px-dark-retina.png?raw=true) |

## Testing Instructions

1. Launch Studio's agentic UI and open a chat associated with a local site.
2. Ask the agent to create or edit several files. Confirm a display-only pill appears above the composer with file, addition, and deletion totals.
3. Confirm the pill has no hover treatment, tooltip, focus stop, or click behavior.
4. Confirm large totals use the active locale's grouping convention, such as `+1,468` in English.
5. Scroll away from the latest message. Confirm the scroll-to-latest button enters smoothly, matches the pill's height, and remains centered over the Send button.
6. Return to the latest message. Confirm the scroll button disappears and the pill's inline-end edge aligns with the composer.
7. Collapse the sidebar and trigger a toast above the composer. Confirm the toast shelf does not overlap the controls.
8. Restart Studio and reopen the chat. Confirm the summary is reconstructed from the stored transcript.
9. Repeat in light and dark appearances and in a representative RTL locale such as Hebrew or Arabic.

Automated verification completed locally:

- `npx eslint --fix` on every modified TypeScript/TSX file
- `npm test -- apps/ui/src/ui-classic/components/session-view/changes-tracker.test.tsx apps/ui/src/ui-classic/components/session-view/index.test.tsx` — 2 files and 23 tests passed
- `npm run typecheck`
- `npm run cli:build:ui`
- `git diff --check`

Manual measurements in the local agentic UI:

- Scroll-to-latest and Send center delta: `0px` in both LTR and RTL
- Pill/composer inline-end delta without the scroll button: `0px` in both LTR and RTL
- Pill and scroll-button computed shadow: `none`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Verified locale-aware line-count formatting.
- [x] Verified light and dark appearances.
- [x] Verified LTR and representative RTL alignment.
- [x] Verified the change summary after loading an existing transcript.
- [ ] Confirm the product direction before promoting this proof of concept from draft.
