### PR TITLE
Agentic UI: Use site icon in preview tab

### DIFF
--- a/apps/ui/src/components/site-preview/address-bar.test.tsx
+++ b/apps/ui/src/components/site-preview/address-bar.test.tsx
@@ -63,7 +63,7 @@ function renderAddressBar( {
 	const queryClient = new QueryClient( {
 		defaultOptions: { queries: { retry: false } },
 	} );
-	render(
+	const renderResult = render(
 		<QueryClientProvider client={ queryClient }>
 			<Tooltip.Provider>
 				<PreviewAddressBar
@@ -78,7 +78,7 @@ function renderAddressBar( {
 			</Tooltip.Provider>
 		</QueryClientProvider>
 	);
-	return { fetchSiteRest, onNavigate, onSwitchRealm };
+	return { fetchSiteRest, onNavigate, onSwitchRealm, ...renderResult };
 }
 
 async function openOmnibox( activeRealmTitle = 'Example Site' ) {
@@ -183,6 +183,24 @@ describe( 'getRealmNavigationPath', () => {
 } );
 
 describe( 'PreviewAddressBar', () => {
+	it( 'shows the configured site icon in the front-end segment', () => {
+		const siteIcon = 'data:image/png;base64,c2l0ZS1pY29u';
+		const { container } = renderAddressBar( { site: { ...SITE, siteIcon } } );
+
+		expect( container.querySelector( `img[src="${ siteIcon }"]` ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the generated fallback when the site has no icon', () => {
+		const { container } = renderAddressBar( { site: { ...SITE, siteIcon: null } } );
+		const frontEndSegment = screen.getByText( SITE.name ).closest( 'button' );
+
+		expect( frontEndSegment?.querySelector( 'img' ) ).not.toBeInTheDocument();
+		expect(
+			frontEndSegment?.querySelector< HTMLElement >( '[style*="--site-icon-color-a"]' )
+		).toBeInTheDocument();
+		expect( container.querySelectorAll( 'button' ) ).toHaveLength( 3 );
+	} );
+
 	it( 'opens with the current path prefilled and selected', async () => {
 		renderAddressBar( { path: '/wp-admin/' } );
 

--- a/apps/ui/src/components/site-preview/address-bar.tsx
+++ b/apps/ui/src/components/site-preview/address-bar.tsx
@@ -1,13 +1,14 @@
 import { Autocomplete } from '@base-ui/react/autocomplete';
 import { TRACKS_EVENTS, type TracksEventName } from '@studio/common/lib/record-tracks-event';
 import { __ } from '@wordpress/i18n';
-import { globe, help, home, page as pageIcon, post as postIcon, wordpress } from '@wordpress/icons';
+import { help, home, page as pageIcon, post as postIcon, wordpress } from '@wordpress/icons';
 import { ariaKeyShortcut, displayShortcut } from '@wordpress/keycodes';
 import { privateApis } from '@wordpress/theme';
 import { Icon, Tooltip } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import motionStyles from '@/components/floating-surface-motion/style.module.css';
+import { SiteIcon } from '@/components/site-icon';
 import { useSiteFrontLinks } from '@/data/queries/use-site-front-links';
 import { useSiteSearch } from '@/data/queries/use-site-search';
 import { useCustomizeLinks } from '@/hooks/use-customize-links';
@@ -165,11 +166,11 @@ export const REALM_SHORTCUT_KEYS: Record< PreviewRealm, string > = {
 // title (resolved in the render), like a browser tab for the site itself.
 const REALM_SEGMENTS: {
 	realm: PreviewRealm;
-	icon: IconElement;
+	icon: IconElement | null;
 	title: string | null;
 	label: string;
 }[] = [
-	{ realm: 'frontend', icon: globe, title: null, label: __( 'View site front end' ) },
+	{ realm: 'frontend', icon: null, title: null, label: __( 'View site front end' ) },
 	{ realm: 'admin', icon: wordpress, title: __( 'WordPress' ), label: __( 'View WP Admin' ) },
 	{ realm: 'database', icon: databaseIcon, title: __( 'Database' ), label: __( 'View database' ) },
 ];
@@ -538,7 +539,14 @@ export function PreviewAddressBar( {
 					const content = (
 						<>
 							<span className={ styles.segmentIcon } aria-hidden="true">
-								<Icon icon={ segment.icon } size={ 16 } />
+								{ segment.realm === 'frontend' ? (
+									<SiteIcon
+										seed={ `${ site.id }:${ site.name }:${ site.path }` }
+										imageSrc={ site.siteIcon }
+									/>
+								) : (
+									<Icon icon={ segment.icon as IconElement } size={ 16 } />
+								) }
 							</span>
 							<span className={ styles.segmentTitle }>{ segment.title ?? site.name }</span>
 						</>


### PR DESCRIPTION
## Related issues

- None.

## How AI was used in this PR

Codex was used to trace the preview tab implementation, reuse Studio's existing site-icon fallback behavior, add regression coverage, and verify the rendered result across themes and text directions. The resulting diff and visual behavior were reviewed during implementation.

## Proposed Changes

- Show each site's configured WordPress Site Icon in the front-end preview tab so the control is recognizable at a glance.
- Use Studio's deterministic generated site icon when a site has no configured icon, replacing the generic globe without changing the existing preview navigation behavior.

## Screenshots

**Preview tab site icon**

<img src="https://github.com/Automattic/studio/blob/d86e59216483f15cf0edc554fb5c98e75c75dd39/preview-tab-site-icon-crop@2x.png?raw=true" alt="Preview tab showing the generated site icon beside the site name" width="320">

## Testing Instructions

1. Run `npm test -- apps/ui/src/components/site-preview/address-bar.test.tsx` and confirm all 40 tests pass.
2. Run `npm run typecheck`.
3. Run `npm run cli:build:ui`, then start `studio ui` and open a running site's preview.
4. Confirm the front-end preview tab uses the configured Site Icon, or the generated fallback when no icon exists.
5. Confirm the 16px icon remains aligned in light and dark themes, at 100% browser zoom, in both LTR and a representative RTL locale such as Hebrew.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
