### PR TITLE
Agentic UI: Add a changed-file inventory

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/changes-tracker.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/changes-tracker.module.css
@@ -4,20 +4,15 @@
 	-webkit-app-region: no-drag;
 }
 
-.summary {
-	box-sizing: border-box;
-	display: flex;
-	align-items: center;
-	gap: var(--wpds-dimension-gap-xs);
-	block-size: 28px;
-	padding: 2px var(--wpds-dimension-padding-md);
-	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+.trigger {
+	--wp-ui-button-font-weight: var(--wpds-typography-font-weight-regular);
+	--wp-ui-button-height: 28px;
+	--wp-ui-button-padding-block: 2px;
+	--wp-ui-button-padding-inline: var(--wpds-dimension-padding-md);
+	--wp-ui-button-background-color: var(--wpds-color-bg-surface-neutral-strong);
+	--wp-ui-button-border-color: var(--wpds-color-stroke-surface-neutral-weak);
+
 	border-radius: 999px;
-	background: var(--wpds-color-bg-surface-neutral-strong);
-	color: var(--wpds-color-fg-content-neutral);
-	font-size: var(--wpds-typography-font-size-sm);
-	font-weight: var(--wpds-typography-font-weight-regular);
-	line-height: var(--wpds-typography-line-height-sm);
 }
 
 .lineCounts {
@@ -35,4 +30,76 @@
 
 .deletions {
 	color: var(--wpds-color-stroke-surface-error-strong);
+}
+
+.popup {
+	width: 400px;
+	max-width: calc(100vw - (var(--wpds-dimension-padding-lg) * 2));
+	padding: var(--wpds-dimension-padding-xs) !important;
+}
+
+.fileList {
+	max-height: min(288px, 50vh);
+	overflow-y: auto;
+}
+
+.fileRow {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-gap-md);
+	min-height: 48px;
+	padding-block: var(--wpds-dimension-padding-xs);
+	padding-inline: var(--wpds-dimension-padding-sm);
+}
+
+.fileRow > .lineCounts {
+	padding-block-start: 2px;
+}
+
+.fileIdentity {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: 0;
+	min-width: 0;
+	color: var(--wpds-color-fg-content-neutral);
+	font-family: var(--wpds-typography-font-family-body);
+}
+
+.fileName {
+	overflow: hidden;
+	font-size: var(--wpds-typography-font-size-sm);
+	font-weight: var(--wpds-typography-font-weight-medium);
+	line-height: var(--wpds-typography-line-height-sm);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	unicode-bidi: isolate;
+}
+
+.fileDirectory {
+	display: flex;
+	min-width: 0;
+	max-width: 100%;
+	overflow: hidden;
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+	white-space: nowrap;
+	unicode-bidi: isolate;
+}
+
+.directoryStart {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.directoryEnd {
+	flex-shrink: 0;
+	max-width: 55%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }

--- a/apps/ui/src/ui-classic/components/session-view/changes-tracker.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/changes-tracker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import {
 	ChangesTracker,
@@ -42,7 +42,7 @@ function toolResultEntry( id: string, diff?: string, isError = false ): SessionE
 }
 
 describe( 'getSessionFileChanges', () => {
-	it( 'aggregates successful file edits by normalized path', () => {
+	it( 'aggregates successful file edits and makes site paths relative', () => {
 		const entries = [
 			toolCallEntry( 'edit-1', 'Edit', { path: '/sites/demo/wp-content/theme.css' } ),
 			toolResultEntry( 'edit-1', '@@ -1 +1 @@\n-old\n+new' ),
@@ -52,14 +52,14 @@ describe( 'getSessionFileChanges', () => {
 			toolResultEntry( 'write-1' ),
 		];
 
-		expect( getSessionFileChanges( entries ) ).toEqual( [
+		expect( getSessionFileChanges( entries, '/sites/demo' ) ).toEqual( [
 			expect.objectContaining( {
-				path: '/sites/demo/wp-content/theme.css',
+				displayPath: 'wp-content/theme.css',
 				additions: 2,
 				deletions: 1,
 			} ),
 			expect.objectContaining( {
-				path: '/sites/demo/index.php',
+				displayPath: 'index.php',
 				additions: 1,
 				deletions: 0,
 			} ),
@@ -72,7 +72,7 @@ describe( 'getSessionFileChanges', () => {
 			toolResultEntry( 'edit-1', '-old\n+new', true ),
 		];
 
-		expect( getSessionFileChanges( entries ) ).toEqual( [] );
+		expect( getSessionFileChanges( entries, '/sites/demo' ) ).toEqual( [] );
 	} );
 
 	it( 'counts each tool call at most once', () => {
@@ -82,7 +82,7 @@ describe( 'getSessionFileChanges', () => {
 			toolResultEntry( 'edit-1', '-old\n+new' ),
 		];
 
-		expect( getSessionFileChanges( entries ) ).toEqual( [
+		expect( getSessionFileChanges( entries, '/sites/demo' ) ).toEqual( [
 			expect.objectContaining( { additions: 1, deletions: 1 } ),
 		] );
 	} );
@@ -105,7 +105,7 @@ describe( 'formatChangeCount', () => {
 } );
 
 describe( 'ChangesTracker', () => {
-	it( 'renders a display-only summary pill', () => {
+	it( 'opens a per-file summary from the pill', async () => {
 		const entries = [
 			toolCallEntry( 'edit-1', 'Edit', {
 				path: '/sites/demo/wp-content/themes/twentytwentyfive-child/templates/front-page.html',
@@ -113,12 +113,18 @@ describe( 'ChangesTracker', () => {
 			toolResultEntry( 'edit-1', '@@ -1 +1 @@\n-old\n+new' ),
 		];
 
-		render( <ChangesTracker entries={ entries } /> );
+		render( <ChangesTracker entries={ entries } ownerSitePath="/sites/demo" /> );
+		fireEvent.click( screen.getByRole( 'button', { name: 'View changed files: 1 file' } ) );
 
-		expect( screen.getByText( '1 file' ) ).toBeVisible();
-		expect( screen.getByText( '+1' ) ).toBeVisible();
-		expect( screen.getByText( '-1' ) ).toBeVisible();
-		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+		const popup = await screen.findByRole( 'dialog' );
+		expect( within( popup ).getByText( 'front-page.html' ) ).toBeVisible();
+		expect(
+			within( popup ).getByLabelText( 'wp-content/themes/twentytwentyfive-child/templates' )
+		).toBeVisible();
+		expect( within( popup ).getByText( 'wp-content/themes/twentytwentyfive-child' ) ).toBeVisible();
+		expect( within( popup ).getByText( '/templates' ) ).toBeVisible();
+		expect( within( popup ).getByText( '+1' ) ).toBeVisible();
+		expect( within( popup ).getByText( '-1' ) ).toBeVisible();
 	} );
 
 	it( 'formats totals in the pill using the active locale', () => {
@@ -133,7 +139,7 @@ describe( 'ChangesTracker', () => {
 		];
 
 		try {
-			render( <ChangesTracker entries={ entries } /> );
+			render( <ChangesTracker entries={ entries } ownerSitePath="/sites/demo" /> );
 			expect( screen.getByText( '+1,468' ) ).toBeVisible();
 		} finally {
 			document.documentElement.lang = originalLanguage;

--- a/apps/ui/src/ui-classic/components/session-view/changes-tracker.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/changes-tracker.tsx
@@ -1,6 +1,7 @@
 import { getToolResultDiff } from '@studio/common/ai/tools';
-import { _n, sprintf } from '@wordpress/i18n';
-import { useMemo } from 'react';
+import { _n, __, sprintf } from '@wordpress/i18n';
+import { Button, Popover, Tooltip, VisuallyHidden } from '@wordpress/ui';
+import { useId, useMemo, useRef, useState } from 'react';
 import styles from './changes-tracker.module.css';
 import type { SessionEntry } from '@earendil-works/pi-coding-agent';
 
@@ -12,6 +13,7 @@ interface FileToolCall {
 
 export interface SessionFileChange {
 	path: string;
+	displayPath: string;
 	additions: number;
 	deletions: number;
 }
@@ -23,6 +25,40 @@ function getFilePath( input: Record< string, unknown > ): string | undefined {
 
 function normalizePath( filePath: string ): string {
 	return filePath.replace( /\\/g, '/' );
+}
+
+function getPathParts( filePath: string ): { directory?: string; fileName: string } {
+	const separatorIndex = filePath.lastIndexOf( '/' );
+	if ( separatorIndex < 0 ) {
+		return { fileName: filePath };
+	}
+	return {
+		directory: filePath.slice( 0, separatorIndex ),
+		fileName: filePath.slice( separatorIndex + 1 ),
+	};
+}
+
+function DirectoryPath( { directory }: { directory: string } ) {
+	const separatorIndex = directory.lastIndexOf( '/' );
+	if ( separatorIndex < 0 ) {
+		return <span className={ styles.fileDirectory }>{ directory }</span>;
+	}
+
+	return (
+		<span className={ styles.fileDirectory } aria-label={ directory }>
+			<span className={ styles.directoryStart }>{ directory.slice( 0, separatorIndex ) }</span>
+			<span className={ styles.directoryEnd }>{ directory.slice( separatorIndex ) }</span>
+		</span>
+	);
+}
+
+function getDisplayPath( filePath: string, ownerSitePath?: string ): string {
+	const normalizedPath = normalizePath( filePath );
+	const normalizedRoot = ownerSitePath?.replace( /\\/g, '/' ).replace( /\/$/, '' );
+	if ( normalizedRoot && normalizedPath.startsWith( `${ normalizedRoot }/` ) ) {
+		return normalizedPath.slice( normalizedRoot.length + 1 );
+	}
+	return normalizedPath.split( '/' ).filter( Boolean ).slice( -2 ).join( '/' ) || normalizedPath;
 }
 
 function synthesizeDiff( call: FileToolCall ): string | undefined {
@@ -63,7 +99,10 @@ export function countDiffLines( diff: string ): { additions: number; deletions: 
 	return { additions, deletions };
 }
 
-export function getSessionFileChanges( entries: SessionEntry[] ): SessionFileChange[] {
+export function getSessionFileChanges(
+	entries: SessionEntry[],
+	ownerSitePath?: string
+): SessionFileChange[] {
 	const calls = new Map< string, FileToolCall >();
 	const changes = new Map< string, SessionFileChange >();
 
@@ -107,6 +146,7 @@ export function getSessionFileChanges( entries: SessionEntry[] ): SessionFileCha
 		const previous = changes.get( normalizedPath );
 		changes.set( normalizedPath, {
 			path: normalizedPath,
+			displayPath: getDisplayPath( normalizedPath, ownerSitePath ),
 			additions: ( previous?.additions ?? 0 ) + counts.additions,
 			deletions: ( previous?.deletions ?? 0 ) + counts.deletions,
 		} );
@@ -122,8 +162,20 @@ export function formatChangeCount( count: number, locale?: string ): string {
 	return new Intl.NumberFormat( resolvedLocale ).format( count );
 }
 
-export function ChangesTracker( { entries }: { entries: SessionEntry[] } ) {
-	const changes = useMemo( () => getSessionFileChanges( entries ), [ entries ] );
+export function ChangesTracker( {
+	entries,
+	ownerSitePath,
+}: {
+	entries: SessionEntry[];
+	ownerSitePath?: string;
+} ) {
+	const changes = useMemo(
+		() => getSessionFileChanges( entries, ownerSitePath ),
+		[ entries, ownerSitePath ]
+	);
+	const triggerRef = useRef< HTMLButtonElement >( null );
+	const popupId = useId();
+	const [ open, setOpen ] = useState( false );
 	const additions = changes.reduce( ( total, change ) => total + change.additions, 0 );
 	const deletions = changes.reduce( ( total, change ) => total + change.deletions, 0 );
 
@@ -138,13 +190,69 @@ export function ChangesTracker( { entries }: { entries: SessionEntry[] } ) {
 
 	return (
 		<div className={ styles.anchor }>
-			<div className={ styles.summary }>
-				<span>{ fileCountLabel }</span>
-				<span className={ styles.lineCounts }>
-					<span className={ styles.additions }>+{ formatChangeCount( additions ) }</span>
-					<span className={ styles.deletions }>-{ formatChangeCount( deletions ) }</span>
-				</span>
-			</div>
+			<Popover.Root open={ open } modal={ false } onOpenChange={ setOpen }>
+				<Tooltip.Root disabled={ open }>
+					<Tooltip.Trigger
+						render={
+							<Button
+								ref={ triggerRef }
+								type="button"
+								variant="outline"
+								tone="neutral"
+								size="small"
+								className={ styles.trigger }
+								aria-label={ sprintf( __( 'View changed files: %s' ), fileCountLabel ) }
+								aria-expanded={ open }
+								aria-controls={ open ? popupId : undefined }
+								aria-haspopup="dialog"
+								onClick={ () => setOpen( ( current ) => ! current ) }
+							/>
+						}
+					>
+						<span>{ fileCountLabel }</span>
+						<span className={ styles.lineCounts }>
+							<span className={ styles.additions }>+{ formatChangeCount( additions ) }</span>
+							<span className={ styles.deletions }>-{ formatChangeCount( deletions ) }</span>
+						</span>
+					</Tooltip.Trigger>
+					<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+						{ __( 'View changed files' ) }
+					</Tooltip.Popup>
+				</Tooltip.Root>
+				<Popover.Popup
+					id={ popupId }
+					className={ styles.popup }
+					initialFocus={ false }
+					positioner={
+						<Popover.Positioner anchor={ triggerRef } side="top" align="end" sideOffset={ 8 } />
+					}
+				>
+					<VisuallyHidden render={ <Popover.Title /> }>
+						{ __( 'Files changed in this chat' ) }
+					</VisuallyHidden>
+					<div className={ styles.fileList } role="list">
+						{ changes.map( ( change ) => {
+							const { directory, fileName } = getPathParts( change.displayPath );
+							return (
+								<div key={ change.path } className={ styles.fileRow } role="listitem">
+									<span className={ styles.fileIdentity } dir="ltr" title={ change.displayPath }>
+										<span className={ styles.fileName }>{ fileName }</span>
+										{ directory ? <DirectoryPath directory={ directory } /> : null }
+									</span>
+									<span className={ styles.lineCounts }>
+										<span className={ styles.additions }>
+											+{ formatChangeCount( change.additions ) }
+										</span>
+										<span className={ styles.deletions }>
+											-{ formatChangeCount( change.deletions ) }
+										</span>
+									</span>
+								</div>
+							);
+						} ) }
+					</div>
+				</Popover.Popup>
+			</Popover.Root>
 		</div>
 	);
 }

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -524,7 +524,10 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 				>
 					<ComposerEndOverlay>
 						<div className={ styles.changesTrackerSlot }>
-							<ChangesTracker entries={ data.entries } />
+							<ChangesTracker
+								entries={ data.entries }
+								ownerSitePath={ ownerSite?.path ?? data.summary.ownerSitePath }
+							/>
 						</div>
 						<span
 							aria-hidden


### PR DESCRIPTION
## Related issues

- None. A companion issue was intentionally not opened for this Studio proof of concept.
- Stacked on #4590, which independently adds the display-only chat change summary.
- #4580 follows this PR and adds the full Review destination.

## How AI was used in this PR

This feature was designed and implemented collaboratively with Codex. AI helped separate the interactive inventory from the summary foundation, implement and test the popover behavior, and verify the result in light, dark, LTR, and RTL layouts. The interaction and visual result were reviewed manually in the running agentic UI.

## Executive summary

This is the second PR in a three-PR stack. It turns the display-only change summary from #4590 into an interactive control and adds a lightweight per-file inventory. It intentionally stops before rendering diffs or introducing the Review destination.

## Proposed Changes

- Make the chat change-summary pill interactive, keyboard accessible, and discoverable with a tooltip.
- Open a non-modal inventory with each changed filename, directory context, and localized addition/deletion counts.
- Keep filenames visible on their own line while long directories truncate responsively in the middle.
- Align the inventory's inline-end edge with the pill in both LTR and RTL layouts.
- Bound longer inventories to six complete rows before scrolling so the viewport does not clip through a partially visible file row.

## Review guide

The product boundary is deliberate: this PR answers “which files changed?” without trying to show the changes themselves. The next PR adds the Review action and full diff surface.

Please focus on the popover's keyboard behavior, path readability, six-row scroll boundary, mixed-direction content, and whether the transition from a glanceable summary to a per-file inventory feels appropriately lightweight.

## Safety and scope

- No new runtime dependency or external service.
- No mutation of project files or the session transcript.
- The popover is non-modal, keyboard dismissible, and built from existing `@wordpress/ui` primitives and theme tokens.
- Only successful built-in `Edit` and `Write` activity from the stored transcript is represented.
- This PR contains no diff renderer, Preview destination, or Review action.

## Screenshots

Native 2560×1440 PNG captures at 100% page scale and 2× device scale. The inventory shows exactly six complete rows before scrolling and intentionally contains no Review action.

| Light | Dark |
|---|---|
| ![Changed-file inventory in light mode](https://github.com/Automattic/studio/blob/e1d34b9d2c31a86eadeeffc47b2e98bb0643b643/pr4594-inventory-light-retina.png?raw=true) | ![Changed-file inventory in dark mode](https://github.com/Automattic/studio/blob/e1d34b9d2c31a86eadeeffc47b2e98bb0643b643/pr4594-inventory-dark-retina.png?raw=true) |

## Testing Instructions

1. Check out #4590, then this PR, and launch Studio's agentic UI.
2. Open a chat with changes to more than six files.
3. Select the change-summary pill and confirm the file inventory opens above it.
4. Verify six complete rows are visible before scrolling and no filename or directory line is clipped by the bottom edge.
5. Confirm each filename is visible on the first line, the directory appears below, and long directories truncate in the middle.
6. Confirm localized addition/deletion counts remain associated with the correct file.
7. Dismiss the inventory with Escape and by selecting outside it.
8. Repeat in light and dark appearances and in a representative RTL locale such as Hebrew or Arabic.

Automated verification completed locally:

- `npx eslint --fix` on every modified TypeScript/TSX file
- `npm test -- apps/ui/src/ui-classic/components/session-view/changes-tracker.test.tsx apps/ui/src/ui-classic/components/session-view/index.test.tsx` — 2 files and 23 tests passed
- `npm run typecheck`
- `npm run cli:build:ui`
- `git diff --check`

Manual browser measurement: the inventory viewport is `288px` high, containing six complete `48px` rows. The seventh row begins exactly at the scroll boundary, so no partial row is visible.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Verified the popover with more than six changed files.
- [x] Verified complete-row scrolling and responsive path truncation.
- [x] Verified light and dark appearances.
- [x] Verified representative RTL behavior and mixed-direction paths/counts.
- [x] Confirmed #4590 remains useful without this PR.
- [ ] Confirm the product direction before promoting this proof of concept from draft.
