### PR TITLE
Agentic UI: Preserve chat drafts when switching sites

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/composer/draft-store.ts
+++ b/apps/ui/src/ui-classic/components/session-view/composer/draft-store.ts
@@ -3,6 +3,7 @@ import type { ComposerAttachment } from '@studio/common/ai/composer-attachments'
 export interface ComposerDraft {
 	text: string;
 	attachments: ComposerAttachment[];
+	suggestionBaseline: string | null;
 }
 
 const MAX_CACHED_DRAFTS = 10;
@@ -13,6 +14,7 @@ export function getComposerDraft( sessionId: string | undefined ): ComposerDraft
 		( sessionId ? draftsBySessionId.get( sessionId ) : undefined ) ?? {
 			text: '',
 			attachments: [],
+			suggestionBaseline: null,
 		}
 	);
 }

--- a/apps/ui/src/ui-classic/components/session-view/composer/draft-store.ts
+++ b/apps/ui/src/ui-classic/components/session-view/composer/draft-store.ts
@@ -1,0 +1,48 @@
+import type { ComposerAttachment } from '@studio/common/ai/composer-attachments';
+
+export interface ComposerDraft {
+	text: string;
+	attachments: ComposerAttachment[];
+}
+
+const MAX_CACHED_DRAFTS = 10;
+const draftsBySessionId = new Map< string, ComposerDraft >();
+
+export function getComposerDraft( sessionId: string | undefined ): ComposerDraft {
+	return (
+		( sessionId ? draftsBySessionId.get( sessionId ) : undefined ) ?? {
+			text: '',
+			attachments: [],
+		}
+	);
+}
+
+export function saveComposerDraft( sessionId: string | undefined, draft: ComposerDraft ): void {
+	if ( ! sessionId ) {
+		return;
+	}
+
+	draftsBySessionId.delete( sessionId );
+	if ( ! draft.text && draft.attachments.length === 0 ) {
+		return;
+	}
+
+	draftsBySessionId.set( sessionId, draft );
+	while ( draftsBySessionId.size > MAX_CACHED_DRAFTS ) {
+		const oldestSessionId = draftsBySessionId.keys().next().value;
+		if ( oldestSessionId === undefined ) {
+			break;
+		}
+		draftsBySessionId.delete( oldestSessionId );
+	}
+}
+
+export function clearComposerDraft( sessionId: string | undefined ): void {
+	if ( sessionId ) {
+		draftsBySessionId.delete( sessionId );
+	}
+}
+
+export function clearComposerDrafts(): void {
+	draftsBySessionId.clear();
+}

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
@@ -341,6 +341,47 @@ describe( 'Composer menu', () => {
 		expect( screen.getByRole( 'combobox' ) ).toHaveValue( '' );
 	} );
 
+	it( 'restores the cached draft after a failed send', async () => {
+		const onSend = vi.fn().mockRejectedValue( new Error( 'network error' ) );
+		const firstRender = renderComposer( { onSend } );
+		fireEvent.change( screen.getByRole( 'combobox' ), {
+			target: { value: 'Retry this draft' },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Send' } ) );
+		await waitFor( () =>
+			expect( screen.getByRole( 'combobox' ) ).toHaveValue( 'Retry this draft' )
+		);
+		firstRender.unmount();
+
+		renderComposer();
+		expect( screen.getByRole( 'combobox' ) ).toHaveValue( 'Retry this draft' );
+	} );
+
+	it( 'caches a failed send for retry even if the session was switched away first', async () => {
+		let rejectSend: ( error: Error ) => void = () => {};
+		const onSend = vi.fn(
+			() =>
+				new Promise< void >( ( _resolve, reject ) => {
+					rejectSend = reject;
+				} )
+		);
+		const firstRender = renderComposer( { onSend } );
+		fireEvent.change( screen.getByRole( 'combobox' ), {
+			target: { value: 'Retry after switching away' },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Send' } ) );
+		await waitFor( () => expect( onSend ).toHaveBeenCalled() );
+
+		firstRender.unmount();
+		await act( async () => {
+			rejectSend( new Error( 'network error' ) );
+			await Promise.resolve();
+		} );
+
+		renderComposer();
+		expect( screen.getByRole( 'combobox' ) ).toHaveValue( 'Retry after switching away' );
+	} );
+
 	it( 'grows, clamps, and shrinks the textarea with draft content', async () => {
 		Object.defineProperty( window, 'innerHeight', {
 			configurable: true,

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
@@ -13,6 +13,7 @@ import {
 import { Tooltip } from '@wordpress/ui';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SESSIONS_QUERY_KEY } from '@/data/queries/use-sessions';
+import { clearComposerDrafts } from './draft-store';
 import { Composer } from '.';
 import type { ComposerSendAttachments } from './use-composer-attachments';
 import type { AiSessionSummary, LoadedAiSession, SessionEntry } from '@/data/core';
@@ -50,15 +51,19 @@ function renderComposer(
 	props: Partial< ComponentProps< typeof Composer > > = {},
 	queryClient = new QueryClient()
 ) {
+	const renderTree = ( nextProps: Partial< ComponentProps< typeof Composer > > = {} ) => (
+		<QueryClientProvider client={ queryClient }>
+			<Tooltip.Provider delay={ 0 }>
+				<Composer { ...defaultProps } sessionId="session-1" { ...nextProps } />
+			</Tooltip.Provider>
+		</QueryClientProvider>
+	);
+	const rendered = render( renderTree( props ) );
 	return {
-		...render(
-			<QueryClientProvider client={ queryClient }>
-				<Tooltip.Provider delay={ 0 }>
-					<Composer { ...defaultProps } sessionId="session-1" { ...props } />
-				</Tooltip.Provider>
-			</QueryClientProvider>
-		),
+		...rendered,
 		queryClient,
+		rerenderComposer: ( nextProps: Partial< ComponentProps< typeof Composer > > = {} ) =>
+			rendered.rerender( renderTree( nextProps ) ),
 	};
 }
 
@@ -76,6 +81,7 @@ function firePointerEventWithClientY( element: Element, type: string, clientY: n
 describe( 'Composer menu', () => {
 	beforeEach( () => {
 		vi.clearAllMocks();
+		clearComposerDrafts();
 		connectorMocks.capabilities.aiSettings = false;
 	} );
 
@@ -285,6 +291,54 @@ describe( 'Composer menu', () => {
 		const preview = await screen.findByRole( 'tooltip' );
 		expect( preview ).toHaveTextContent( 'notes.txt' );
 		expect( preview.parentElement ).toBe( document.body );
+	} );
+
+	it( 'restores text and attachments independently for each session', async () => {
+		const firstSession = renderComposer();
+		fireEvent.change( screen.getByRole( 'combobox' ), {
+			target: { value: 'Keep this draft for session one' },
+		} );
+		const textFile = new File( [ 'Attachment text' ], 'notes.txt', {
+			type: 'text/plain',
+		} );
+		fireEvent.change(
+			firstSession.container.querySelector( 'input[type="file"]' ) as HTMLInputElement,
+			{ target: { files: [ textFile ] } }
+		);
+		await screen.findByRole( 'button', { name: 'Remove attachment: notes.txt' } );
+		firstSession.rerenderComposer( { sessionId: 'session-2' } );
+		expect( screen.getByRole( 'combobox' ) ).toHaveValue( '' );
+		expect(
+			screen.queryByRole( 'button', { name: 'Remove attachment: notes.txt' } )
+		).not.toBeInTheDocument();
+		fireEvent.change( screen.getByRole( 'combobox' ), {
+			target: { value: 'A different draft for session two' },
+		} );
+
+		firstSession.rerenderComposer();
+		expect( screen.getByRole( 'combobox' ) ).toHaveValue( 'Keep this draft for session one' );
+		expect(
+			screen.getByRole( 'button', { name: 'Remove attachment: notes.txt' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'clears the cached draft after sending', async () => {
+		const onSend = vi.fn().mockResolvedValue( undefined );
+		const firstRender = renderComposer( { onSend } );
+		fireEvent.change( screen.getByRole( 'combobox' ), {
+			target: { value: 'Send and clear this draft' },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Send' } ) );
+		await waitFor( () =>
+			expect( onSend ).toHaveBeenCalledWith( 'Send and clear this draft', {
+				files: [],
+				images: [],
+			} )
+		);
+		firstRender.unmount();
+
+		renderComposer();
+		expect( screen.getByRole( 'combobox' ) ).toHaveValue( '' );
 	} );
 
 	it( 'grows, clamps, and shrinks the textarea with draft content', async () => {

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
@@ -11,13 +11,13 @@ import {
 	within,
 } from '@testing-library/react';
 import { Tooltip } from '@wordpress/ui';
+import { createRef, type ComponentProps } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SESSIONS_QUERY_KEY } from '@/data/queries/use-sessions';
 import { clearComposerDrafts } from './draft-store';
-import { Composer } from '.';
+import { Composer, type ComposerHandle } from '.';
 import type { ComposerSendAttachments } from './use-composer-attachments';
 import type { AiSessionSummary, LoadedAiSession, SessionEntry } from '@/data/core';
-import type { ComponentProps } from 'react';
 
 // The AI credits control inside the composer reads the router; the quota it
 // also needs stays undefined here, so the control itself renders nothing.
@@ -51,16 +51,18 @@ function renderComposer(
 	props: Partial< ComponentProps< typeof Composer > > = {},
 	queryClient = new QueryClient()
 ) {
+	const composerRef = createRef< ComposerHandle >();
 	const renderTree = ( nextProps: Partial< ComponentProps< typeof Composer > > = {} ) => (
 		<QueryClientProvider client={ queryClient }>
 			<Tooltip.Provider delay={ 0 }>
-				<Composer { ...defaultProps } sessionId="session-1" { ...nextProps } />
+				<Composer ref={ composerRef } { ...defaultProps } sessionId="session-1" { ...nextProps } />
 			</Tooltip.Provider>
 		</QueryClientProvider>
 	);
 	const rendered = render( renderTree( props ) );
 	return {
 		...rendered,
+		composerRef,
 		queryClient,
 		rerenderComposer: ( nextProps: Partial< ComponentProps< typeof Composer > > = {} ) =>
 			rendered.rerender( renderTree( nextProps ) ),
@@ -320,6 +322,31 @@ describe( 'Composer menu', () => {
 		expect(
 			screen.getByRole( 'button', { name: 'Remove attachment: notes.txt' } )
 		).toBeInTheDocument();
+	} );
+
+	it( 'restores the suggestion baseline with its session draft', async () => {
+		const firstSession = renderComposer();
+		act( () => {
+			firstSession.composerRef.current?.replaceDraft( 'A suggested prompt', {
+				suggestionBaseline: 'A suggested prompt',
+			} );
+		} );
+		await waitFor( () =>
+			expect( firstSession.composerRef.current?.getDraft() ).toEqual( {
+				text: 'A suggested prompt',
+				hasAttachments: false,
+				suggestionBaseline: 'A suggested prompt',
+			} )
+		);
+
+		firstSession.rerenderComposer( { sessionId: 'session-2' } );
+		firstSession.rerenderComposer();
+
+		expect( firstSession.composerRef.current?.getDraft() ).toEqual( {
+			text: 'A suggested prompt',
+			hasAttachments: false,
+			suggestionBaseline: 'A suggested prompt',
+		} );
 	} );
 
 	it( 'clears the cached draft after sending', async () => {

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
@@ -348,9 +348,7 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 	const [ isResizingComposer, setIsResizingComposer ] = useState( false );
 	const textareaRef = useRef< HTMLTextAreaElement | null >( null );
 	const fileInputRef = useRef< HTMLInputElement | null >( null );
-	const latestDraftRef = useRef( initialDraft );
 	const draftEffectInitializedRef = useRef( false );
-	const draftChangedRef = useRef( false );
 	const manualTextareaHeightRef = useRef< number | null >( null );
 	const resizeDragRef = useRef< { startY: number; startHeight: number } | null >( null );
 	const connector = useConnector();
@@ -400,23 +398,12 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 	const hasAttachments = attachments.length > 0;
 
 	useEffect( () => {
-		const draft = { text: value, attachments };
-		latestDraftRef.current = draft;
 		if ( draftEffectInitializedRef.current ) {
-			draftChangedRef.current = true;
-			saveComposerDraft( sessionId, draft );
+			saveComposerDraft( sessionId, { text: value, attachments } );
 		} else {
 			draftEffectInitializedRef.current = true;
 		}
 	}, [ attachments, sessionId, value ] );
-	useEffect(
-		() => () => {
-			if ( draftChangedRef.current ) {
-				saveComposerDraft( sessionId, latestDraftRef.current );
-			}
-		},
-		[ sessionId ]
-	);
 
 	// Cross-family swap state. We hold the picked model here while the
 	// confirmation dialog is open; nothing is persisted until the user
@@ -525,6 +512,9 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 			// surfaces the error message via `error`. Queued sends never throw from
 			// onSend (the parent swallows the failure and clears the queue instead),
 			// so this path only trips for direct sends from the idle state.
+			// Saved directly (not left to the state-sync effect) so the retry isn't
+			// lost if the user already switched away from this session.
+			saveComposerDraft( sessionId, { text: trimmed, attachments: sentAttachments } );
 			setValue( trimmed );
 			restoreAttachments( sentAttachments );
 		}

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
@@ -264,11 +264,15 @@ export interface ComposerHandle {
 	appendDraft( text: string ): void;
 	replaceDraft(
 		text: string,
-		attachments?: { images?: StudioChatImage[]; files?: StudioChatFileAttachment[] }
+		options?: {
+			images?: StudioChatImage[];
+			files?: StudioChatFileAttachment[];
+			suggestionBaseline?: string;
+		}
 	): void;
 	// What replaceDraft would discard — lets callers decide whether the
 	// replacement warrants a confirmation.
-	getDraft(): { text: string; hasAttachments: boolean };
+	getDraft(): { text: string; hasAttachments: boolean; suggestionBaseline: string | null };
 }
 
 function shouldShellFocusTextarea( target: EventTarget ) {
@@ -339,6 +343,7 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 ) {
 	const [ initialDraft ] = useState( () => getComposerDraft( sessionId ) );
 	const [ value, setValue ] = useState( initialDraft.text );
+	const [ suggestionBaseline, setSuggestionBaseline ] = useState( initialDraft.suggestionBaseline );
 	const [ placeholderIndex, setPlaceholderIndex ] = useState( 0 );
 	const [ hoverPreview, setHoverPreview ] = useState< ComposerAttachmentHoverPreviewState | null >(
 		null
@@ -399,11 +404,11 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 
 	useEffect( () => {
 		if ( draftEffectInitializedRef.current ) {
-			saveComposerDraft( sessionId, { text: value, attachments } );
+			saveComposerDraft( sessionId, { text: value, attachments, suggestionBaseline } );
 		} else {
 			draftEffectInitializedRef.current = true;
 		}
-	}, [ attachments, sessionId, value ] );
+	}, [ attachments, sessionId, suggestionBaseline, value ] );
 
 	// Cross-family swap state. We hold the picked model here while the
 	// confirmation dialog is open; nothing is persisted until the user
@@ -472,9 +477,10 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 					node.setSelectionRange( len, len );
 				} );
 			},
-			replaceDraft( text, draftAttachments ) {
+			replaceDraft( text, options ) {
 				setValue( text );
-				restoreAttachments( toComposerDraftAttachments( draftAttachments ?? {} ) );
+				setSuggestionBaseline( options?.suggestionBaseline ?? null );
+				restoreAttachments( toComposerDraftAttachments( options ?? {} ) );
 				queueMicrotask( () => {
 					const node = textareaRef.current;
 					if ( ! node ) return;
@@ -484,10 +490,10 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 				} );
 			},
 			getDraft() {
-				return { text: value, hasAttachments: attachments.length > 0 };
+				return { text: value, hasAttachments: attachments.length > 0, suggestionBaseline };
 			},
 		} ),
-		[ restoreAttachments, value, attachments ]
+		[ restoreAttachments, value, attachments, suggestionBaseline ]
 	);
 
 	const send = useCallback( async () => {
@@ -499,8 +505,10 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 		}
 		const prompt = trimmed || __( 'Please review the attached files.' );
 		const sentAttachments = attachments;
+		const sentSuggestionBaseline = suggestionBaseline;
 		clearComposerDraft( sessionId );
 		setValue( '' );
+		setSuggestionBaseline( null );
 		clearAttachments();
 		// A send is the only thing that swaps the suggestion; it is static
 		// otherwise, so the empty composer never changes under the user.
@@ -514,11 +522,24 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 			// so this path only trips for direct sends from the idle state.
 			// Saved directly (not left to the state-sync effect) so the retry isn't
 			// lost if the user already switched away from this session.
-			saveComposerDraft( sessionId, { text: trimmed, attachments: sentAttachments } );
+			saveComposerDraft( sessionId, {
+				text: trimmed,
+				attachments: sentAttachments,
+				suggestionBaseline: sentSuggestionBaseline,
+			} );
 			setValue( trimmed );
+			setSuggestionBaseline( sentSuggestionBaseline );
 			restoreAttachments( sentAttachments );
 		}
-	}, [ value, attachments, clearAttachments, restoreAttachments, onSend, sessionId ] );
+	}, [
+		value,
+		attachments,
+		suggestionBaseline,
+		clearAttachments,
+		restoreAttachments,
+		onSend,
+		sessionId,
+	] );
 
 	const openFilePicker = useCallback( () => {
 		fileInputRef.current?.click();

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
@@ -66,6 +66,7 @@ import {
 	SESSIONS_QUERY_KEY,
 } from '@/data/queries/use-sessions';
 import { AiCreditsControl } from './ai-credits-control';
+import { clearComposerDraft, getComposerDraft, saveComposerDraft } from './draft-store';
 import { FamilySwitchConfirmDialog } from './family-switch-confirm-dialog';
 import styles from './style.module.css';
 import {
@@ -320,7 +321,7 @@ function resizeComposerTextarea(
 	return nextHeight;
 }
 
-export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Composer(
+const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function ComposerContent(
 	{
 		busy,
 		isInterrupting = false,
@@ -336,7 +337,8 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 	},
 	ref
 ) {
-	const [ value, setValue ] = useState( '' );
+	const [ initialDraft ] = useState( () => getComposerDraft( sessionId ) );
+	const [ value, setValue ] = useState( initialDraft.text );
 	const [ placeholderIndex, setPlaceholderIndex ] = useState( 0 );
 	const [ hoverPreview, setHoverPreview ] = useState< ComposerAttachmentHoverPreviewState | null >(
 		null
@@ -346,6 +348,9 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 	const [ isResizingComposer, setIsResizingComposer ] = useState( false );
 	const textareaRef = useRef< HTMLTextAreaElement | null >( null );
 	const fileInputRef = useRef< HTMLInputElement | null >( null );
+	const latestDraftRef = useRef( initialDraft );
+	const draftEffectInitializedRef = useRef( false );
+	const draftChangedRef = useRef( false );
 	const manualTextareaHeightRef = useRef< number | null >( null );
 	const resizeDragRef = useRef< { startY: number; startHeight: number } | null >( null );
 	const connector = useConnector();
@@ -391,8 +396,27 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 		restore: restoreAttachments,
 		dragHandlers,
 		pasteHandlers,
-	} = useComposerAttachments();
+	} = useComposerAttachments( initialDraft.attachments );
 	const hasAttachments = attachments.length > 0;
+
+	useEffect( () => {
+		const draft = { text: value, attachments };
+		latestDraftRef.current = draft;
+		if ( draftEffectInitializedRef.current ) {
+			draftChangedRef.current = true;
+			saveComposerDraft( sessionId, draft );
+		} else {
+			draftEffectInitializedRef.current = true;
+		}
+	}, [ attachments, sessionId, value ] );
+	useEffect(
+		() => () => {
+			if ( draftChangedRef.current ) {
+				saveComposerDraft( sessionId, latestDraftRef.current );
+			}
+		},
+		[ sessionId ]
+	);
 
 	// Cross-family swap state. We hold the picked model here while the
 	// confirmation dialog is open; nothing is persisted until the user
@@ -488,6 +512,7 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 		}
 		const prompt = trimmed || __( 'Please review the attached files.' );
 		const sentAttachments = attachments;
+		clearComposerDraft( sessionId );
 		setValue( '' );
 		clearAttachments();
 		// A send is the only thing that swaps the suggestion; it is static
@@ -503,7 +528,7 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 			setValue( trimmed );
 			restoreAttachments( sentAttachments );
 		}
-	}, [ value, attachments, clearAttachments, restoreAttachments, onSend ] );
+	}, [ value, attachments, clearAttachments, restoreAttachments, onSend, sessionId ] );
 
 	const openFilePicker = useCallback( () => {
 		fileInputRef.current?.click();
@@ -1164,3 +1189,9 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 		</>
 	);
 } );
+
+export const Composer = forwardRef< ComposerHandle, ComposerProps >(
+	function Composer( props, ref ) {
+		return <ComposerContent key={ props.sessionId } { ...props } ref={ ref } />;
+	}
+);

--- a/apps/ui/src/ui-classic/components/session-view/composer/use-composer-attachments.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/use-composer-attachments.tsx
@@ -15,10 +15,10 @@ import { useConnector } from '@/data/core';
 export { toComposerSendAttachments };
 export type { ComposerAttachment, ComposerSendAttachments };
 
-export function useComposerAttachments() {
+export function useComposerAttachments( initialAttachments: ComposerAttachment[] = [] ) {
 	const connector = useConnector();
-	const [ attachments, setAttachments ] = useState< ComposerAttachment[] >( [] );
-	const attachmentsRef = useRef< ComposerAttachment[] >( [] );
+	const [ attachments, setAttachments ] = useState< ComposerAttachment[] >( initialAttachments );
+	const attachmentsRef = useRef< ComposerAttachment[] >( initialAttachments );
 	const [ error, setError ] = useState< string | null >( null );
 	const [ isDraggingOver, setIsDraggingOver ] = useState( false );
 

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -544,8 +544,16 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 				<SuggestedPrompts
 					fadeIn={ fadeAfterQuotaCheck }
 					siteName={ ownerSite.name }
-					onPick={ ( prompt ) => composerRef.current?.replaceDraft( prompt ) }
-					getDraft={ () => composerRef.current?.getDraft() ?? { text: '', hasAttachments: false } }
+					onPick={ ( prompt ) =>
+						composerRef.current?.replaceDraft( prompt, { suggestionBaseline: prompt } )
+					}
+					getDraft={ () =>
+						composerRef.current?.getDraft() ?? {
+							text: '',
+							hasAttachments: false,
+							suggestionBaseline: null,
+						}
+					}
 				/>
 			) : null }
 			<div className={ clsx( styles.classicColumn, styles.classicConversationSpacing ) }>

--- a/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.test.tsx
@@ -4,12 +4,15 @@ import { Tooltip } from '@wordpress/ui';
 import { describe, expect, it, vi } from 'vitest';
 import { SuggestedPrompts } from '.';
 
-function renderPrompts( initialDraft = { text: '', hasAttachments: false } ) {
+function renderPrompts(
+	initialDraft = { text: '', hasAttachments: false, suggestionBaseline: null as string | null }
+) {
 	// Mirrors the composer: onPick replaces the draft with the picked prompt.
 	const draft = { ...initialDraft };
 	const onPick = vi.fn( ( prompt: string ) => {
 		draft.text = prompt;
 		draft.hasAttachments = false;
+		draft.suggestionBaseline = prompt;
 	} );
 	render(
 		<Tooltip.Provider delay={ 0 }>
@@ -73,8 +76,24 @@ describe( 'SuggestedPrompts', () => {
 		expect( screen.queryByText( 'Replace your draft?' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'replaces a restored untouched suggestion without asking', () => {
+		const restoredSuggestion = 'A suggestion restored with the session draft';
+		const { onPick } = renderPrompts( {
+			text: restoredSuggestion,
+			hasAttachments: false,
+			suggestionBaseline: restoredSuggestion,
+		} );
+		pickSuggestion( 0 );
+		expect( onPick ).toHaveBeenCalledTimes( 1 );
+		expect( screen.queryByText( 'Replace your draft?' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'asks before replacing a user-written draft', () => {
-		const { onPick } = renderPrompts( { text: 'my own words', hasAttachments: false } );
+		const { onPick } = renderPrompts( {
+			text: 'my own words',
+			hasAttachments: false,
+			suggestionBaseline: null,
+		} );
 		pickSuggestion( 0 );
 		expect( onPick ).not.toHaveBeenCalled();
 		expect( screen.getByText( 'Replace your draft?' ) ).toBeInTheDocument();
@@ -118,7 +137,11 @@ describe( 'SuggestedPrompts', () => {
 	} );
 
 	it( 'keeps the draft on cancel', () => {
-		const { onPick } = renderPrompts( { text: 'my own words', hasAttachments: false } );
+		const { onPick } = renderPrompts( {
+			text: 'my own words',
+			hasAttachments: false,
+			suggestionBaseline: null,
+		} );
 		pickSuggestion( 0 );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 		expect( onPick ).not.toHaveBeenCalled();

--- a/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/suggested-prompts/index.tsx
@@ -16,7 +16,11 @@ interface SuggestedPromptsProps {
 	// Checked at click time; confirmation is only asked when the draft
 	// diverged from the last suggestion we inserted (user edits count,
 	// switching between untouched suggestions does not).
-	getDraft: () => { text: string; hasAttachments: boolean };
+	getDraft: () => {
+		text: string;
+		hasAttachments: boolean;
+		suggestionBaseline: string | null;
+	};
 }
 
 interface PendingPrompt {
@@ -56,12 +60,8 @@ export function SuggestedPrompts( {
 	const handleReplaceKeyDown = useConfirmOnEnter( replaceLabel );
 	const [ transfer, setTransfer ] = useState< PromptTransfer | null >( null );
 	const transferIdRef = useRef( 0 );
-	// Text of the last suggestion we inserted. While the draft still equals it
-	// (and no attachments were added), another suggestion may replace it freely.
-	const baselineRef = useRef< string | null >( null );
 
 	const apply = ( prompt: string ) => {
-		baselineRef.current = prompt;
 		onPick( prompt );
 	};
 
@@ -97,7 +97,7 @@ export function SuggestedPrompts( {
 		const draft = getDraft();
 		const isUntouched =
 			! draft.hasAttachments &&
-			( draft.text.trim().length === 0 || draft.text === baselineRef.current );
+			( draft.text.trim().length === 0 || draft.text === draft.suggestionBaseline );
 		if ( isUntouched ) {
 			applyWithTransfer( prompt, label, sourceRect );
 		} else {


### PR DESCRIPTION
## Related issues

- Follow-up to #4560.

## How AI was used in this PR

Codex was used to implement the focused draft-preservation behavior, add regression tests, run repository checks, verify the interaction in the browser across light, dark, and RTL layouts, and draft this PR description. The resulting code and behavior were reviewed during implementation.

## Proposed Changes

- Preserve unsent composer text and attachments independently for each site when switching between sites.
- Clear a site's cached draft after it is sent, while restoring it if sending fails.
- Keep drafts in memory only, with a small bounded cache of up to 10 non-empty site drafts. Reloading Studio intentionally starts fresh.

This follows #4560, which is now merged into trunk. This PR covers switching between different sites.

## Testing Instructions

1. Sign in with agentic features enabled and open Site A's chat.
2. Enter text and attach a file without sending.
3. Switch to Site B and confirm its composer is empty and independent.
4. Enter a different draft on Site B, then switch back to Site A.
5. Confirm Site A's original text and attachment are restored.
6. Send the draft, leave the site, and return; confirm the sent draft is no longer restored.
7. Repeat the visual check in light and dark color schemes.
8. Repeat in a representative RTL locale such as Hebrew with mixed-direction text containing a URL. Confirm the attachment, text, control order, alignment, wrapping, and truncation remain correct.

Automated checks:

- `npx eslint --fix` on all modified TypeScript and TSX files
- `npm run typecheck`
- `npm test -- apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx apps/ui/src/ui-classic/components/site-workspace/index.test.tsx apps/ui/src/components/site-list/index.test.tsx`
- `npm run cli:build:ui`
- `git diff --check`

### Screenshots

| LTR dark mode | Hebrew RTL with a mixed-direction URL |
|---|---|
| ![Composer draft restored with text and an attachment in dark mode](https://github.com/Automattic/studio/blob/d00c5a7a10ce23fbfd8fbf64b184eaa57720c1ee/preserved-chat-draft-final-dark.png?raw=true) | ![Composer draft with text and an attachment in a Hebrew RTL layout](https://github.com/Automattic/studio/blob/d00c5a7a10ce23fbfd8fbf64b184eaa57720c1ee/preserved-chat-draft-rtl.png?raw=true) |

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?