### PR TITLE
Agentic UI: Show remaining AI credit balances in Usage settings

### DIFF
--- a/apps/ui/src/components/ai-credits-details-dialog/index.tsx
+++ b/apps/ui/src/components/ai-credits-details-dialog/index.tsx
@@ -24,7 +24,7 @@ export function AiCreditsDetailsDialog( {
 						</span>
 						<span>
 							{ __(
-								'You get a welcome gift of 1.5 million free AI credits. AI credits do not expire, including credits you purchase later.'
+								'You start with a welcome gift of free AI credits. AI credits do not expire, including credits you purchase later.'
 							) }
 						</span>
 						<span>

--- a/apps/ui/src/components/ai-credits-details-dialog/index.tsx
+++ b/apps/ui/src/components/ai-credits-details-dialog/index.tsx
@@ -1,0 +1,45 @@
+import { __ } from '@wordpress/i18n';
+import { Dialog } from '@wordpress/ui';
+import styles from './style.module.css';
+
+export function AiCreditsDetailsDialog( {
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: ( open: boolean ) => void;
+} ) {
+	return (
+		<Dialog.Root open={ open } onOpenChange={ onOpenChange }>
+			<Dialog.Popup size="small" initialFocus={ false }>
+				<Dialog.Header>
+					<Dialog.Title>{ __( 'How AI credits work' ) }</Dialog.Title>
+				</Dialog.Header>
+				<Dialog.Content>
+					<Dialog.Description className={ styles.details }>
+						<span>
+							{ __(
+								'AI credits are Studio’s way of measuring AI-powered work. They are not cash, and they are different from the tokens an AI provider uses to count pieces of text.'
+							) }
+						</span>
+						<span>
+							{ __(
+								'You get a welcome gift of 1.5 million free AI credits. AI credits do not expire, including credits you purchase later.'
+							) }
+						</span>
+						<span>
+							{ __(
+								'Different models use AI credits at different rates. More capable models generally use more credits, and longer or more complex tasks can cost more because they require more model work.'
+							) }
+						</span>
+					</Dialog.Description>
+				</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action variant="minimal" tone="neutral">
+						{ __( 'Close' ) }
+					</Dialog.Action>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
+	);
+}

--- a/apps/ui/src/components/ai-credits-details-dialog/style.module.css
+++ b/apps/ui/src/components/ai-credits-details-dialog/style.module.css
@@ -1,0 +1,7 @@
+.details {
+	display: flex;
+	flex-direction: column;
+	gap: var( --wpds-dimension-padding-sm );
+	color: var( --wpds-color-fg-content-neutral );
+	line-height: var( --wpds-typography-line-height-sm );
+}

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -918,6 +918,28 @@
 	align-self: flex-start;
 }
 
+.aiCreditsHeading {
+	display: flex;
+	align-items: center;
+	gap: var( --wpds-dimension-padding-xs );
+}
+
+.aiCreditsDetailsButton {
+	flex: none;
+}
+
+.aiCreditsDetailsButton svg {
+	inline-size: 16px;
+	block-size: 16px;
+}
+
+.creditBalances {
+	display: flex;
+	flex-direction: column;
+	gap: var( --wpds-dimension-padding-xs );
+	font-variant-numeric: tabular-nums;
+}
+
 .aiCreditsTrack {
 	position: relative;
 	background: color-mix(

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom/vitest';
+import { ADD_AI_CREDITS_URL } from '@studio/common/lib/studio-assistant-quota';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
@@ -36,9 +37,20 @@ vi.mock( '@wordpress/ui', () => ( {
 		void size;
 		return <button { ...props }>{ loading ? loadingAnnouncement : children }</button>;
 	},
-	IconButton: ( { label, disabled }: { label: string; disabled?: boolean } ) => (
-		<button type="button" aria-label={ label } disabled={ disabled } />
-	),
+	IconButton: ( {
+		label,
+		disabled,
+		onClick,
+	}: {
+		label: string;
+		disabled?: boolean;
+		onClick?: () => void;
+	} ) => <button type="button" aria-label={ label } disabled={ disabled } onClick={ onClick } />,
+} ) );
+
+vi.mock( '@/components/ai-credits-details-dialog', () => ( {
+	AiCreditsDetailsDialog: ( { open }: { open: boolean } ) =>
+		open ? <div role="dialog">How AI credits work</div> : null,
 } ) );
 
 vi.mock( '@/components/menu', () => ( {
@@ -108,15 +120,18 @@ describe( 'UsagePanel', () => {
 	const loginMutate = vi.fn();
 	const deleteSnapshotsMutate = vi.fn();
 	const confirmDeleteAllPreviewSites = vi.fn();
+	const openExternalUrl = vi.fn();
 
 	beforeEach( () => {
 		vi.clearAllMocks();
 
 		confirmDeleteAllPreviewSites.mockResolvedValue( true );
+		openExternalUrl.mockResolvedValue( undefined );
 		// `agenticRequiresAuth` lets the real useAgenticFeatures derive the
 		// signed-out/offline reason from the mocked auth + offline hooks.
 		useConnectorMock.mockReturnValue( {
 			confirmDeleteAllPreviewSites,
+			openExternalUrl,
 			agenticRequiresAuth: true,
 		} as never );
 		useOfflineMock.mockReturnValue( false );
@@ -207,6 +222,118 @@ describe( 'UsagePanel', () => {
 				'AI credits are currently free while Studio Code is in Alpha. Build, iterate, and experiment, but know that credits will eventually have a cost.'
 			)
 		).toBeInTheDocument();
+	} );
+
+	it( 'shows remaining credit balances when the quota includes the per-pool fields', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 25,
+				costCap: 100,
+				costResetDate: '2026-08-01T12:00:00',
+				allowanceRemaining: 960000,
+				purchasedRemaining: 150000,
+			},
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect( screen.getByText( 'Free credits remaining: 960,000' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Purchased credits remaining: 150,000' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Add AI credits' } ) ).toBeInTheDocument();
+		// The credit balances replace the monthly-limit and Alpha designs.
+		expect( screen.queryByText( /of monthly limit used/ ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( /AI credits are currently free while Studio Code is in Alpha/ )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the free-credits line once the allowance is exhausted', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 25,
+				costCap: 100,
+				costResetDate: '2026-08-01T12:00:00',
+				allowanceRemaining: 0,
+				purchasedRemaining: 0,
+			},
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect( screen.queryByText( /Free credits remaining/ ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Purchased credits remaining: 0' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Add AI credits' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps the old design when the quota has no per-pool balance fields', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: { costUsage: 25, costCap: 100, costResetDate: '2026-08-01T12:00:00' },
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect( screen.queryByText( /credits remaining/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Add AI credits' } ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'How AI credits work' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByText( '25% of monthly limit used (resets on August 1, 2026)' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'opens the WordPress.com checkout from the add-credits button', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: { costUsage: 0, costCap: 0, allowanceRemaining: 960000, purchasedRemaining: 0 },
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add AI credits' } ) );
+
+		expect( openExternalUrl ).toHaveBeenCalledWith( ADD_AI_CREDITS_URL );
+	} );
+
+	it( 'opens the credits explainer dialog from the help icon', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: { costUsage: 0, costCap: 0, allowanceRemaining: 960000, purchasedRemaining: 0 },
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'How AI credits work' } ) );
+
+		expect( screen.getByRole( 'dialog' ) ).toHaveTextContent( 'How AI credits work' );
+	} );
+
+	it( 'lets access gates take precedence over the credit balances', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 100,
+				costResetDate: '2026-08-01T12:00:00',
+				studioCodeAiHasAccess: false,
+				studioCodeAiAccess: 'blocked',
+				allowanceRemaining: 960000,
+				purchasedRemaining: 0,
+			},
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect(
+			screen.getByText( /Studio Code AI is blocked for this WordPress.com account/ )
+		).toBeInTheDocument();
+		expect( screen.queryByText( /Free credits remaining/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Add AI credits' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'shows the suspension copy for an explicitly blocked account', () => {

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -16,27 +16,30 @@ import { UsagePanel } from './usage-panel';
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
 vi.mock( '@wordpress/ui', () => ( {
-	Button: ( {
-		children,
-		loading,
-		loadingAnnouncement,
-		tone,
-		variant,
-		size,
-		...props
-	}: ButtonHTMLAttributes< HTMLButtonElement > & {
-		children?: ReactNode;
-		loading?: boolean;
-		loadingAnnouncement?: string;
-		tone?: string;
-		variant?: string;
-		size?: string;
-	} ) => {
-		void tone;
-		void variant;
-		void size;
-		return <button { ...props }>{ loading ? loadingAnnouncement : children }</button>;
-	},
+	Button: Object.assign(
+		( {
+			children,
+			loading,
+			loadingAnnouncement,
+			tone,
+			variant,
+			size,
+			...props
+		}: ButtonHTMLAttributes< HTMLButtonElement > & {
+			children?: ReactNode;
+			loading?: boolean;
+			loadingAnnouncement?: string;
+			tone?: string;
+			variant?: string;
+			size?: string;
+		} ) => {
+			void tone;
+			void variant;
+			void size;
+			return <button { ...props }>{ loading ? loadingAnnouncement : children }</button>;
+		},
+		{ Icon: () => null }
+	),
 	IconButton: ( {
 		label,
 		disabled,

--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -1,15 +1,18 @@
 import {
+	ADD_AI_CREDITS_URL,
 	clampQuotaFraction,
 	formatQuotaPercentage,
 	formatQuotaResetDate,
 	getStudioCodeAiAccessState,
 } from '@studio/common/lib/studio-assistant-quota';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { moreHorizontal } from '@wordpress/icons';
-import { IconButton } from '@wordpress/ui';
+import { external, help, Icon, moreHorizontal } from '@wordpress/icons';
+import { Button, IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
+import { useState } from 'react';
 import { SigninNotice } from '@/components/agentic-signin-banner';
 import { AiAccessRequiredNotice, AiBlockedNotice } from '@/components/ai-access-required-notice';
+import { AiCreditsDetailsDialog } from '@/components/ai-credits-details-dialog';
 import * as Menu from '@/components/menu';
 import { OfflineNotice } from '@/components/offline-banner';
 import { useConnector } from '@/data/core';
@@ -49,8 +52,19 @@ function UsageProgressBar( { fraction }: { fraction: number } ) {
 
 function AiCreditsSummary() {
 	const locale = useUserLocale();
+	const connector = useConnector();
+	const [ detailsOpen, setDetailsOpen ] = useState( false );
 	const { data: quota, isLoading, isError } = useStudioAssistantQuota();
 	const accessState = quota ? getStudioCodeAiAccessState( quota ) : 'available';
+	// The server includes the per-pool balances only when AI credits are
+	// enabled for the account (STU-2235); their absence — not a 0 — means the
+	// pre-credits design should render.
+	const showsCreditBalances =
+		! isLoading &&
+		! isError &&
+		accessState === 'available' &&
+		!! quota &&
+		( quota.allowanceRemaining !== undefined || quota.purchasedRemaining !== undefined );
 
 	let content;
 	if ( isLoading ) {
@@ -75,6 +89,42 @@ function AiCreditsSummary() {
 					<AiAccessRequiredNotice quota={ quota } />
 				) }
 			</div>
+		);
+	} else if ( quota && showsCreditBalances ) {
+		const credits = new Intl.NumberFormat( locale );
+		const allowanceRemaining = quota.allowanceRemaining ?? 0;
+		const purchasedRemaining = quota.purchasedRemaining ?? 0;
+		content = (
+			<>
+				<div className={ styles.creditBalances }>
+					{ allowanceRemaining > 0 ? (
+						<div className={ styles.previewUsageText }>
+							{ sprintf(
+								/* translators: %s: number of free AI credits remaining (e.g. 960,000). */
+								__( 'Free credits remaining: %s' ),
+								credits.format( allowanceRemaining )
+							) }
+						</div>
+					) : null }
+					<div className={ styles.previewUsageText }>
+						{ sprintf(
+							/* translators: %s: number of purchased AI credits remaining (e.g. 150,000). */
+							__( 'Purchased credits remaining: %s' ),
+							credits.format( purchasedRemaining )
+						) }
+					</div>
+				</div>
+				<Button
+					className={ styles.usageSectionAction }
+					size="small"
+					variant="outline"
+					tone="neutral"
+					onClick={ () => void connector.openExternalUrl( ADD_AI_CREDITS_URL ) }
+				>
+					{ __( 'Add AI credits' ) }
+					<Icon icon={ external } size={ 14 } aria-hidden="true" />
+				</Button>
+			</>
 		);
 	} else if ( quota && quota.costCap > 0 ) {
 		const fraction = clampQuotaFraction( quota.costUsage, quota.costCap );
@@ -109,9 +159,25 @@ function AiCreditsSummary() {
 	return (
 		<section className={ styles.usageSection }>
 			<div className={ styles.usageSectionHeader }>
-				<h2>{ __( 'AI credits' ) }</h2>
+				<div className={ styles.aiCreditsHeading }>
+					<h2>{ __( 'AI credits' ) }</h2>
+					{ showsCreditBalances ? (
+						<IconButton
+							className={ styles.aiCreditsDetailsButton }
+							icon={ help }
+							label={ __( 'How AI credits work' ) }
+							size="small"
+							variant="minimal"
+							tone="neutral"
+							onClick={ () => setDetailsOpen( true ) }
+						/>
+					) : null }
+				</div>
 			</div>
 			{ content }
+			{ showsCreditBalances ? (
+				<AiCreditsDetailsDialog open={ detailsOpen } onOpenChange={ setDetailsOpen } />
+			) : null }
 		</section>
 	);
 }

--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -6,7 +6,7 @@ import {
 	getStudioCodeAiAccessState,
 } from '@studio/common/lib/studio-assistant-quota';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { external, help, Icon, moreHorizontal } from '@wordpress/icons';
+import { external, help, moreHorizontal } from '@wordpress/icons';
 import { Button, IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useState } from 'react';
@@ -122,7 +122,7 @@ function AiCreditsSummary() {
 					onClick={ () => void connector.openExternalUrl( ADD_AI_CREDITS_URL ) }
 				>
 					{ __( 'Add AI credits' ) }
-					<Icon icon={ external } size={ 14 } aria-hidden="true" />
+					<Button.Icon icon={ external } size={ 12 } />
 				</Button>
 			</>
 		);

--- a/apps/ui/src/ui-classic/components/session-view/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.test.tsx
@@ -80,6 +80,8 @@ function makeQuota( overrides: Partial< { hasPaymentMethod: boolean; emailVerifi
 		hasPaymentMethod: true,
 		studioCodeAiHasAccess: true,
 		studioCodeAiAccess: 'granted',
+		allowanceRemaining: undefined,
+		purchasedRemaining: undefined,
 		...overrides,
 	};
 }

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -8,6 +8,10 @@ export const ADD_PAYMENT_METHOD_URL = 'https://my.wordpress.com/me/billing/payme
 
 export const WPCOM_SUPPORT_CONTACT_URL = 'https://wordpress.com/support/contact/';
 
+// Placeholder until the WordPress.com checkout page for Studio AI credits
+// exists (STU-2292).
+export const ADD_AI_CREDITS_URL = 'https://wordpress.com/checkout/studio-ai-credits';
+
 export const studioAssistantQuotaSchema = z
 	.object( {
 		cost_usage: z.number(),
@@ -24,6 +28,12 @@ export const studioAssistantQuotaSchema = z
 		// server-side values never fail the parse).
 		studio_code_ai_has_access: z.boolean().optional(),
 		studio_code_ai_access: z.string().optional(),
+		// Remaining AI credits per pool (STU-2235). The server omits both fields
+		// when the AI Credits feature is off for the account — the UI keys the
+		// credit-balance design off their presence, so `undefined` (not 0) must
+		// mean "feature off, keep the old design".
+		allowance_remaining: z.number().optional(),
+		purchased_remaining: z.number().optional(),
 	} )
 	.transform( ( data ) => ( {
 		costUsage: data.cost_usage,
@@ -33,6 +43,8 @@ export const studioAssistantQuotaSchema = z
 		hasPaymentMethod: data.has_payment_method ?? true,
 		studioCodeAiHasAccess: data.studio_code_ai_has_access,
 		studioCodeAiAccess: data.studio_code_ai_access,
+		allowanceRemaining: data.allowance_remaining,
+		purchasedRemaining: data.purchased_remaining,
 	} ) );
 
 export type StudioAssistantQuota = z.infer< typeof studioAssistantQuotaSchema >;

--- a/packages/common/lib/tests/studio-assistant-quota.test.ts
+++ b/packages/common/lib/tests/studio-assistant-quota.test.ts
@@ -61,6 +61,34 @@ describe( 'getStudioCodeAiAccessState', () => {
 	} );
 } );
 
+describe( 'studioAssistantQuotaSchema per-pool balances', () => {
+	it( 'parses the remaining balance per pool when present', () => {
+		const quota = studioAssistantQuotaSchema.parse( {
+			...baseResponse,
+			allowance_remaining: 960000,
+			purchased_remaining: 150000,
+		} );
+		expect( quota.allowanceRemaining ).toBe( 960000 );
+		expect( quota.purchasedRemaining ).toBe( 150000 );
+	} );
+
+	it( 'keeps zero balances distinct from absent fields', () => {
+		const quota = studioAssistantQuotaSchema.parse( {
+			...baseResponse,
+			allowance_remaining: 0,
+			purchased_remaining: 0,
+		} );
+		expect( quota.allowanceRemaining ).toBe( 0 );
+		expect( quota.purchasedRemaining ).toBe( 0 );
+	} );
+
+	it( 'leaves the balances undefined when the server omits them (feature off)', () => {
+		const quota = studioAssistantQuotaSchema.parse( baseResponse );
+		expect( quota.allowanceRemaining ).toBeUndefined();
+		expect( quota.purchasedRemaining ).toBeUndefined();
+	} );
+} );
+
 describe( 'formatAiAccessRequiredNotice', () => {
 	it( 'tells accounts with spend this billing cycle that beta access is now required', () => {
 		expect( formatAiAccessRequiredNotice( { costUsage: 3 } ) ).toBe(


### PR DESCRIPTION
## Related issues
- Fixes STU-2292

## How AI was used in this PR
Assisted


## Proposed Changes
With this PR, we start printing free allowance and purchased allowance info in Settings.

## Testing Instructions
1. `wpsh`
2. 
```
require_lib( 'studio' );
$uid = <your_user_id>;
$q = new \WPCOM\Studio\AI_Assistant_Quota( get_user_by( 'id', $uid ) );

// Clean slate
$q->reset_cost_usage();
delete_user_attribute( $uid, 'studio_ai_purchased_pool_used' );
$q->clear_purchased_pool_cache();

// 1. Used free allowance = 300 (we need to disable AI credits to do it)
\WPCOM\Studio\AI_Credits::disable( $uid );
$q->bump_cost_usage( 300 );

// 2) Free allowance = 1000 (so in Studio UI we will see 700 as remaining balance)
\WPCOM\Studio\AI_Credits::enable( $uid );
\WPCOM\Studio\AI_Credits::set_allowance_override( $uid, 1000 );

// 3) Used purchased pool = 250
$q->bump_purchased_pool_used( 250 );

// Make the mocked purchase total (next step) take effect immediately
\WPCOM\Studio\AI_Credits_Purchases::invalidate( $uid );
```

3. Then the purchased total (there's no real purchase path yet) — add this line at the end of `wp-content/lib/studio/0-load.php`: `add_filter( 'wpcom_studio_ai_purchased_quantity_pre', fn () => 7 ); // 7 credits = 700 units (so in UI we will see 450 remaining as 700 - 250)`
4. Open Studio Settings
5. Assert that you see the next numbers:<br /><img width="706" height="520" alt="Screenshot 2026-08-19 at 19 03 55" src="https://github.com/user-attachments/assets/9ed62d81-f75f-47e5-995a-f03d833e2871" />
6. you can try to disable AI Credits `\WPCOM\Studio\AI_Credits::disable( $uid );`
7. Assert that nothign broken w/o them and looks the same as before<br /><img width="590" height="344" alt="Screenshot 2026-08-19 at 19 06 36" src="https://github.com/user-attachments/assets/fcc0ad28-af7a-4be6-8ad6-f54d83759f3b" />

To play with different numbers: rerun the block changing the 300 (usage), 1000 (allowance), 250 (purchased spent), or the 7 in the filter (purchased bought — after changing it, rerun invalidate( $uid )).

Cleanup when done:
```
\WPCOM\Studio\AI_Credits::disable( $uid );   // also drops the allowance override
$q->reset_cost_usage();
delete_user_attribute( $uid, 'studio_ai_purchased_pool_used' );
$q->clear_purchased_pool_cache();
\WPCOM\Studio\AI_Credits_Purchases::invalidate( $uid );
```