### PR TITLE
Agentic UI: Show remaining AI credits in the Studio Code composer

### DIFF
--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -54,7 +54,13 @@ function AiCreditsSummary() {
 	const locale = useUserLocale();
 	const connector = useConnector();
 	const [ detailsOpen, setDetailsOpen ] = useState( false );
-	const { data: quota, isLoading, isError } = useStudioAssistantQuota();
+	// The balance may have changed outside the app (e.g. a credits purchase on
+	// WordPress.com), so opening the panel always fetches a fresh figure.
+	const {
+		data: quota,
+		isLoading,
+		isError,
+	} = useStudioAssistantQuota( { refetchOnMount: 'always' } );
 	const accessState = quota ? getStudioCodeAiAccessState( quota ) : 'available';
 	// The server includes the per-pool balances only when AI credits are
 	// enabled for the account (STU-2235); their absence — not a 0 — means the

--- a/apps/ui/src/data/queries/use-agent-run.test.tsx
+++ b/apps/ui/src/data/queries/use-agent-run.test.tsx
@@ -120,7 +120,13 @@ describe( 'useAgentRun queued handoff', () => {
 			)
 		);
 
-		expect( invalidateSpy ).not.toHaveBeenCalled();
+		expect( invalidateSpy ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { queryKey: SESSIONS_QUERY_KEY } ),
+			expect.anything()
+		);
+		// The old run still consumed AI credits, so the balance refreshes even
+		// while the queued prompt takes over.
+		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ 'assistant-quota' ] } );
 		expect(
 			queryClient
 				.getQueryData< LoadedAiSession >( [ ...SESSIONS_QUERY_KEY, 'session-1' ] )
@@ -164,5 +170,6 @@ describe( 'useAgentRun queued handoff', () => {
 			{ queryKey: SESSIONS_QUERY_KEY },
 			{ cancelRefetch: false }
 		);
+		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ 'assistant-quota' ] } );
 	} );
 } );

--- a/apps/ui/src/data/queries/use-agent-run.tsx
+++ b/apps/ui/src/data/queries/use-agent-run.tsx
@@ -13,6 +13,7 @@ import {
 	type PropsWithChildren,
 } from 'react';
 import { useConnector } from '@/data/core';
+import { ASSISTANT_QUOTA_QUERY_KEY } from '@/data/queries/use-assistant-quota';
 import { SESSIONS_QUERY_KEY } from '@/data/queries/use-sessions';
 import type {
 	AgentEvent,
@@ -395,6 +396,9 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					}
 					dispatchSession( payload.sessionId, { type: 'run_ended' } );
 					subscribedRunIdsBySessionRef.current.delete( payload.sessionId );
+					// The finished run consumed AI credits; refresh the balance shown
+					// in the composer and in Settings → Usage.
+					void queryClient.invalidateQueries( { queryKey: ASSISTANT_QUOTA_QUERY_KEY } );
 					if ( ! hasQueuedFollowUp ) {
 						// Refetch to replace optimistic entries with disk-backed ones.
 						// `cancelRefetch: false` so a run ending as its site is deleted

--- a/apps/ui/src/data/queries/use-assistant-quota.ts
+++ b/apps/ui/src/data/queries/use-assistant-quota.ts
@@ -4,7 +4,10 @@ import { useAuthUser } from '@/data/queries/use-auth-user';
 
 export const ASSISTANT_QUOTA_QUERY_KEY = [ 'assistant-quota' ] as const;
 
-export function useStudioAssistantQuota( { enabled = true }: { enabled?: boolean } = {} ) {
+export function useStudioAssistantQuota( {
+	enabled = true,
+	refetchOnMount,
+}: { enabled?: boolean; refetchOnMount?: 'always' } = {} ) {
 	const connector = useConnector();
 	const { data: authUser } = useAuthUser();
 	const query = useQuery( {
@@ -14,8 +17,11 @@ export function useStudioAssistantQuota( { enabled = true }: { enabled?: boolean
 		queryFn: () => connector.getStudioAssistantQuota(),
 		enabled: enabled && !! authUser,
 		// Quota moves slowly; avoid refetching on every panel mount and
-		// window focus.
+		// window focus. Spending credits invalidates the query explicitly
+		// (see use-agent-run), and surfaces where the user is actively
+		// checking the balance opt into `refetchOnMount: 'always'`.
 		staleTime: 5 * 60 * 1000,
+		refetchOnMount,
 		meta: { persist: false },
 	} );
 	// The quota belongs to the signed-in WordPress.com account; hide any

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { ADD_AI_CREDITS_URL } from '@studio/common/lib/studio-assistant-quota';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Tooltip } from '@wordpress/ui';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -20,6 +21,7 @@ vi.mock( '@/data/core', () => ( {
 } ) );
 
 vi.mock( '@/data/queries/use-assistant-quota', () => ( {
+	ASSISTANT_QUOTA_QUERY_KEY: [ 'assistant-quota' ],
 	useStudioAssistantQuota: vi.fn(),
 } ) );
 
@@ -34,11 +36,13 @@ vi.mock( '@/components/ai-credits-details-dialog', () => ( {
 
 const useStudioAssistantQuotaMock = vi.mocked( useStudioAssistantQuota );
 
-function renderControl() {
+function renderControl( queryClient = new QueryClient() ) {
 	return render(
-		<Tooltip.Provider delay={ 0 }>
-			<AiCreditsControl />
-		</Tooltip.Provider>
+		<QueryClientProvider client={ queryClient }>
+			<Tooltip.Provider delay={ 0 }>
+				<AiCreditsControl />
+			</Tooltip.Provider>
+		</QueryClientProvider>
 	);
 }
 
@@ -133,6 +137,17 @@ describe( 'AiCreditsControl', () => {
 		await waitFor( () =>
 			expect( screen.getByRole( 'dialog' ) ).toHaveTextContent( 'How AI credits work' )
 		);
+	} );
+
+	it( 'marks the quota stale when the menu opens so the balance refreshes', async () => {
+		const queryClient = new QueryClient();
+		const invalidateSpy = vi.spyOn( queryClient, 'invalidateQueries' );
+
+		renderControl( queryClient );
+
+		await openMenu();
+
+		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ 'assistant-quota' ] } );
 	} );
 
 	it( 'navigates to the usage settings tab from the menu', async () => {

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
@@ -1,0 +1,149 @@
+import '@testing-library/jest-dom/vitest';
+import { ADD_AI_CREDITS_URL } from '@studio/common/lib/studio-assistant-quota';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Tooltip } from '@wordpress/ui';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useStudioAssistantQuota } from '@/data/queries/use-assistant-quota';
+import { AiCreditsControl } from './ai-credits-control';
+
+const { navigateMock, openExternalUrl } = vi.hoisted( () => ( {
+	navigateMock: vi.fn(),
+	openExternalUrl: vi.fn(),
+} ) );
+
+vi.mock( '@tanstack/react-router', () => ( {
+	useNavigate: () => navigateMock,
+} ) );
+
+vi.mock( '@/data/core', () => ( {
+	useConnector: () => ( { openExternalUrl } ),
+} ) );
+
+vi.mock( '@/data/queries/use-assistant-quota', () => ( {
+	useStudioAssistantQuota: vi.fn(),
+} ) );
+
+vi.mock( '@/data/queries/use-user-locale', () => ( {
+	useUserLocale: () => 'en',
+} ) );
+
+vi.mock( '@/components/ai-credits-details-dialog', () => ( {
+	AiCreditsDetailsDialog: ( { open }: { open: boolean } ) =>
+		open ? <div role="dialog">How AI credits work</div> : null,
+} ) );
+
+const useStudioAssistantQuotaMock = vi.mocked( useStudioAssistantQuota );
+
+function renderControl() {
+	return render(
+		<Tooltip.Provider delay={ 0 }>
+			<AiCreditsControl />
+		</Tooltip.Provider>
+	);
+}
+
+async function openMenu() {
+	fireEvent.click( screen.getByRole( 'button', { name: 'AI credits' } ) );
+	await waitFor( () => expect( screen.getAllByRole( 'menuitem' ).length ).toBe( 3 ) );
+}
+
+describe( 'AiCreditsControl', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 0,
+				allowanceRemaining: 960000,
+				purchasedRemaining: 150000,
+			},
+		} as never );
+	} );
+
+	it( 'renders nothing when the quota has no per-pool balance fields', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: { costUsage: 25, costCap: 100, costResetDate: '2026-08-01T12:00:00' },
+		} as never );
+
+		const { container } = renderControl();
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing while the quota is still unknown', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( { data: undefined } as never );
+
+		const { container } = renderControl();
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing for an account without Studio Code AI access', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 0,
+				studioCodeAiHasAccess: false,
+				studioCodeAiAccess: 'blocked',
+				allowanceRemaining: 960000,
+				purchasedRemaining: 0,
+			},
+		} as never );
+
+		const { container } = renderControl();
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'sums the allowance and purchased pools in the menu summary', async () => {
+		renderControl();
+
+		await openMenu();
+
+		expect( screen.getByText( '1,110,000 remaining' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the summed balance even when both pools are exhausted', async () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: { costUsage: 0, costCap: 0, allowanceRemaining: 0, purchasedRemaining: 0 },
+		} as never );
+
+		renderControl();
+
+		await openMenu();
+
+		expect( screen.getByText( '0 remaining' ) ).toBeInTheDocument();
+	} );
+
+	it( 'opens the WordPress.com checkout from the add-credits item', async () => {
+		renderControl();
+
+		await openMenu();
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /Add AI credits/ } ) );
+
+		expect( openExternalUrl ).toHaveBeenCalledWith( ADD_AI_CREDITS_URL );
+	} );
+
+	it( 'opens the credits explainer dialog from the menu', async () => {
+		renderControl();
+
+		await openMenu();
+		fireEvent.click( screen.getByRole( 'menuitem', { name: 'How AI credits work' } ) );
+
+		await waitFor( () =>
+			expect( screen.getByRole( 'dialog' ) ).toHaveTextContent( 'How AI credits work' )
+		);
+	} );
+
+	it( 'navigates to the usage settings tab from the menu', async () => {
+		renderControl();
+
+		await openMenu();
+		fireEvent.click( screen.getByRole( 'menuitem', { name: 'Usage settings' } ) );
+
+		expect( navigateMock ).toHaveBeenCalledWith( {
+			to: '/settings',
+			search: { tab: 'usage' },
+		} );
+	} );
+} );

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
@@ -4,8 +4,8 @@ import {
 } from '@studio/common/lib/studio-assistant-quota';
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
-import { chartBar, external, Icon } from '@wordpress/icons';
-import { Tooltip } from '@wordpress/ui';
+import { chartBar, external } from '@wordpress/icons';
+import { Icon, Tooltip } from '@wordpress/ui';
 import { useState } from 'react';
 import { AiCreditsDetailsDialog } from '@/components/ai-credits-details-dialog';
 import * as Menu from '@/components/menu';

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
@@ -1,0 +1,95 @@
+import {
+	ADD_AI_CREDITS_URL,
+	getStudioCodeAiAccessState,
+} from '@studio/common/lib/studio-assistant-quota';
+import { useNavigate } from '@tanstack/react-router';
+import { __, sprintf } from '@wordpress/i18n';
+import { chartBar, external, Icon } from '@wordpress/icons';
+import { Tooltip } from '@wordpress/ui';
+import { useState } from 'react';
+import { AiCreditsDetailsDialog } from '@/components/ai-credits-details-dialog';
+import * as Menu from '@/components/menu';
+import { useConnector } from '@/data/core';
+import { useStudioAssistantQuota } from '@/data/queries/use-assistant-quota';
+import { useUserLocale } from '@/data/queries/use-user-locale';
+import styles from './style.module.css';
+
+export function AiCreditsControl() {
+	const connector = useConnector();
+	const locale = useUserLocale();
+	const navigate = useNavigate();
+	const [ menuOpen, setMenuOpen ] = useState( false );
+	const [ detailsOpen, setDetailsOpen ] = useState( false );
+	const { data: quota } = useStudioAssistantQuota();
+
+	// The server includes the per-pool balances only when AI credits are
+	// enabled for the account (STU-2235); without them the composer keeps its
+	// pre-credits layout.
+	if (
+		! quota ||
+		getStudioCodeAiAccessState( quota ) !== 'available' ||
+		( quota.allowanceRemaining === undefined && quota.purchasedRemaining === undefined )
+	) {
+		return null;
+	}
+
+	const remaining = ( quota.allowanceRemaining ?? 0 ) + ( quota.purchasedRemaining ?? 0 );
+	const formattedRemaining = new Intl.NumberFormat( locale ).format( remaining );
+
+	return (
+		<>
+			<Menu.Root modal={ false } open={ menuOpen } onOpenChange={ setMenuOpen }>
+				<Tooltip.Root disabled={ menuOpen }>
+					<Menu.Trigger
+						render={
+							<Tooltip.Trigger
+								render={
+									<button
+										type="button"
+										className={ styles.iconButton }
+										aria-label={ __( 'AI credits' ) }
+									/>
+								}
+							>
+								<Icon icon={ chartBar } size={ 16 } />
+							</Tooltip.Trigger>
+						}
+					/>
+					<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
+						{ sprintf(
+							/* translators: %s: total number of AI credits remaining (e.g. 1,110,000). */
+							__( 'AI credits · %s remaining' ),
+							formattedRemaining
+						) }
+					</Tooltip.Popup>
+				</Tooltip.Root>
+				<Menu.Popup side="top" align="end">
+					<div className={ styles.aiCreditsSummary }>
+						<span>{ __( 'AI credits' ) }</span>
+						<strong>
+							{ sprintf(
+								/* translators: %s: total number of AI credits remaining (e.g. 1,110,000). */
+								__( '%s remaining' ),
+								formattedRemaining
+							) }
+						</strong>
+					</div>
+					<Menu.Separator />
+					<Menu.Item onClick={ () => void connector.openExternalUrl( ADD_AI_CREDITS_URL ) }>
+						{ __( 'Add AI credits' ) }
+						<Icon icon={ external } size={ 14 } aria-hidden="true" />
+					</Menu.Item>
+					<Menu.Item onClick={ () => setDetailsOpen( true ) }>
+						{ __( 'How AI credits work' ) }
+					</Menu.Item>
+					<Menu.Item
+						onClick={ () => void navigate( { to: '/settings', search: { tab: 'usage' } } ) }
+					>
+						{ __( 'Usage settings' ) }
+					</Menu.Item>
+				</Menu.Popup>
+			</Menu.Root>
+			<AiCreditsDetailsDialog open={ detailsOpen } onOpenChange={ setDetailsOpen } />
+		</>
+	);
+}

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
@@ -2,6 +2,7 @@ import {
 	ADD_AI_CREDITS_URL,
 	getStudioCodeAiAccessState,
 } from '@studio/common/lib/studio-assistant-quota';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
 import { chartBar, external } from '@wordpress/icons';
@@ -10,7 +11,10 @@ import { useState } from 'react';
 import { AiCreditsDetailsDialog } from '@/components/ai-credits-details-dialog';
 import * as Menu from '@/components/menu';
 import { useConnector } from '@/data/core';
-import { useStudioAssistantQuota } from '@/data/queries/use-assistant-quota';
+import {
+	ASSISTANT_QUOTA_QUERY_KEY,
+	useStudioAssistantQuota,
+} from '@/data/queries/use-assistant-quota';
 import { useUserLocale } from '@/data/queries/use-user-locale';
 import styles from './style.module.css';
 
@@ -18,6 +22,7 @@ export function AiCreditsControl() {
 	const connector = useConnector();
 	const locale = useUserLocale();
 	const navigate = useNavigate();
+	const queryClient = useQueryClient();
 	const [ menuOpen, setMenuOpen ] = useState( false );
 	const [ detailsOpen, setDetailsOpen ] = useState( false );
 	const { data: quota } = useStudioAssistantQuota();
@@ -38,7 +43,18 @@ export function AiCreditsControl() {
 
 	return (
 		<>
-			<Menu.Root modal={ false } open={ menuOpen } onOpenChange={ setMenuOpen }>
+			<Menu.Root
+				modal={ false }
+				open={ menuOpen }
+				onOpenChange={ ( open ) => {
+					setMenuOpen( open );
+					// The control never remounts, so opening the menu is its chance
+					// to pull a balance changed outside the app (e.g. a purchase).
+					if ( open ) {
+						void queryClient.invalidateQueries( { queryKey: ASSISTANT_QUOTA_QUERY_KEY } );
+					}
+				} }
+			>
 				<Tooltip.Root disabled={ menuOpen }>
 					<Menu.Trigger
 						render={

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
@@ -18,6 +18,12 @@ import type { ComposerSendAttachments } from './use-composer-attachments';
 import type { AiSessionSummary, LoadedAiSession, SessionEntry } from '@/data/core';
 import type { ComponentProps } from 'react';
 
+// The AI credits control inside the composer reads the router; the quota it
+// also needs stays undefined here, so the control itself renders nothing.
+vi.mock( '@tanstack/react-router', () => ( {
+	useNavigate: () => vi.fn(),
+} ) );
+
 const connectorMocks = vi.hoisted( () => ( {
 	capabilities: { aiSettings: false },
 	createSession: vi.fn(),

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
@@ -65,6 +65,7 @@ import {
 	reconcilePrimedSessionQueryData,
 	SESSIONS_QUERY_KEY,
 } from '@/data/queries/use-sessions';
+import { AiCreditsControl } from './ai-credits-control';
 import { FamilySwitchConfirmDialog } from './family-switch-confirm-dialog';
 import styles from './style.module.css';
 import {
@@ -1045,6 +1046,7 @@ export const Composer = forwardRef< ComposerHandle, ComposerProps >( function Co
 							/>
 						</div>
 						<div className={ styles.rightActions }>
+							<AiCreditsControl />
 							<Menu.Root modal={ false }>
 								<Tooltip.Root>
 									<Menu.Trigger

--- a/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
@@ -478,6 +478,26 @@
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
+.aiCreditsSummary {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
+}
+
+.aiCreditsSummary span {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+}
+
+.aiCreditsSummary strong {
+	color: var(--wpds-color-fg-content-neutral);
+	font-size: var(--wpds-typography-font-size-md);
+	font-variant-numeric: tabular-nums;
+	line-height: var(--wpds-typography-line-height-sm);
+}
+
 .pill {
 	display: inline-flex;
 	flex: 0 0 auto;


### PR DESCRIPTION
## Related issues

- Fixes STU-2293

## How AI was used in this PR
Assisted

## Proposed Changes
With this PR we are printing remaining credits in Studio Code chat
<img width="668" height="224" alt="Screenshot 2026-08-19 at 19 31 05" src="https://github.com/user-attachments/assets/babafebd-fbf8-46e9-8f7a-02536769b26c" />


## Testing Instructions
1. `wpsh`
2. 
```
require_lib( 'studio' );
$uid = <your_user_id>;
$q = new \WPCOM\Studio\AI_Assistant_Quota( get_user_by( 'id', $uid ) );

// Clean slate
$q->reset_cost_usage();
delete_user_attribute( $uid, 'studio_ai_purchased_pool_used' );
$q->clear_purchased_pool_cache();

// 1. Used free allowance = 300 (we need to disable AI credits to do it)
\WPCOM\Studio\AI_Credits::disable( $uid );
$q->bump_cost_usage( 300 );

// 2) Free allowance = 1000 (so in Studio UI we will see 700 as remaining balance)
\WPCOM\Studio\AI_Credits::enable( $uid );
\WPCOM\Studio\AI_Credits::set_allowance_override( $uid, 1000 );

// 3) Used purchased pool = 250
$q->bump_purchased_pool_used( 250 );

// Make the mocked purchase total (next step) take effect immediately
\WPCOM\Studio\AI_Credits_Purchases::invalidate( $uid );
```

3. Then the purchased total (there's no real purchase path yet) — add this line at the end of `wp-content/lib/studio/0-load.php`: `add_filter( 'wpcom_studio_ai_purchased_quantity_pre', fn () => 7 ); // 7 credits = 700 units (so in UI we will see 450 remaining as 700 - 250)`
4. Open Studio
5. Assert that you see the button next to the model selector:<br /><img width="1226" height="189" alt="Screenshot 2026-08-19 at 19 29 03" src="https://github.com/user-attachments/assets/d8e21d68-e54e-408f-943e-be0c151313f9" />
6. Click on it and assert that you see:<br /><img width="168" height="170" alt="Screenshot 2026-08-19 at 19 29 35" src="https://github.com/user-attachments/assets/aceca4d5-81ef-4dc0-93d7-1ea7386536af" />
7. Assert that buttons work correctly
8. You can try to disable AI Credits `\WPCOM\Studio\AI_Credits::disable( $uid );`
9. Assert that you don't see the button anymore next to the model selector

To play with different numbers: rerun the block changing the 300 (usage), 1000 (allowance), 250 (purchased spent), or the 7 in the filter (purchased bought — after changing it, rerun invalidate( $uid )).

Cleanup when done:
```
\WPCOM\Studio\AI_Credits::disable( $uid );   // also drops the allowance override
$q->reset_cost_usage();
delete_user_attribute( $uid, 'studio_ai_purchased_pool_used' );
$q->clear_purchased_pool_cache();
\WPCOM\Studio\AI_Credits_Purchases::invalidate( $uid );
```