### PR TITLE
Agentic UI: Disable responsive preview controls on the database tab

### DIFF
--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
 import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
 import { themeDetailsQueryKey } from '@/hooks/use-theme-details';
+import { DATABASE_HOME_PATH } from './address-bar';
 import {
 	getBrowserShortcutCommand,
 	isOffOriginRedirect,
@@ -484,6 +485,32 @@ describe( 'SitePreview', () => {
 		await waitFor( () =>
 			expect( screen.queryByText( 'Responsive mode' ) ).not.toBeInTheDocument()
 		);
+	} );
+
+	it( 'disables the responsive mode controls while previewing the database realm', async () => {
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
+			capabilities: CAPABILITIES,
+		} as never );
+
+		renderPreview(
+			<SitePreview
+				site={ createSite( { running: true } ) }
+				path={ DATABASE_HOME_PATH }
+				reloadNonce={ 0 }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'More options' } ) );
+
+		expect( await screen.findByText( 'Responsive mode' ) ).toBeVisible();
+		const fitPane = screen.getByRole( 'menuitemradio', { name: 'Fit pane' } );
+		expect( fitPane ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		// Disabled radio items swallow the click — the mode doesn't change.
+		fireEvent.click( screen.getByRole( 'menuitemradio', { name: 'Mobile · 390×844' } ) );
+		expect( fitPane ).toBeChecked();
 	} );
 
 	it( 'toggles full preview from the More options menu', async () => {

--- a/apps/ui/src/components/site-preview/index.test.tsx
+++ b/apps/ui/src/components/site-preview/index.test.tsx
@@ -378,6 +378,81 @@ describe( 'SitePreview', () => {
 		);
 	} );
 
+	it( 'keeps the front end and WP Admin on one shared surface', () => {
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
+			capabilities: CAPABILITIES,
+		} as never );
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		} );
+		const ui = ( path: string ) => (
+			<QueryClientProvider client={ queryClient }>
+				<Tooltip.Provider>
+					<SitePreview site={ createSite( { running: true } ) } path={ path } reloadNonce={ 0 } />
+				</Tooltip.Provider>
+			</QueryClientProvider>
+		);
+
+		const { container, rerender } = render( ui( '/' ) );
+		expect( container.querySelectorAll( 'iframe' ) ).toHaveLength( 1 );
+
+		// The two realms that link to each other and share a login stay a single
+		// surface, so history and session carry across them.
+		rerender( ui( '/wp-admin/' ) );
+		expect( container.querySelectorAll( 'iframe' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'gives the database its own surface and reveals it without reloading', () => {
+		useConnectorMock.mockReturnValue( {
+			startSite: vi.fn().mockResolvedValue( undefined ),
+			trackEvent: vi.fn().mockResolvedValue( undefined ),
+			capabilities: CAPABILITIES,
+		} as never );
+		const onPathChange = vi.fn();
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		} );
+		const ui = ( path: string ) => (
+			<QueryClientProvider client={ queryClient }>
+				<Tooltip.Provider>
+					<SitePreview
+						site={ createSite( { running: true } ) }
+						path={ path }
+						reloadNonce={ 0 }
+						onPathChange={ onPathChange }
+					/>
+				</Tooltip.Provider>
+			</QueryClientProvider>
+		);
+
+		const { container, rerender } = render( ui( '/' ) );
+		const siteSurface = container.querySelector( 'iframe' );
+
+		// The database mounts alongside the site surface rather than replacing it,
+		// and the site layer is hidden rather than torn down.
+		rerender( ui( DATABASE_HOME_PATH ) );
+		expect( container.querySelectorAll( 'iframe' ) ).toHaveLength( 2 );
+		expect( siteSurface?.closest( '[inert]' ) ).not.toBeNull();
+		const databaseSurface = container.querySelectorAll( 'iframe' )[ 1 ];
+
+		// Leaving and returning is a visibility swap: both elements survive, so
+		// neither the site nor the database reloads, and the database is
+		// reactivated at its own path instead of being renavigated.
+		rerender( ui( '/' ) );
+		expect( container.querySelector( 'iframe' ) ).toBe( siteSurface );
+		expect( siteSurface?.closest( '[inert]' ) ).toBeNull();
+
+		onPathChange.mockClear();
+		fireEvent.keyDown( document.body, { key: '3', ctrlKey: true } );
+		expect( onPathChange ).toHaveBeenCalledWith( DATABASE_HOME_PATH );
+
+		rerender( ui( DATABASE_HOME_PATH ) );
+		expect( container.querySelectorAll( 'iframe' ) ).toHaveLength( 2 );
+		expect( container.querySelectorAll( 'iframe' )[ 1 ] ).toBe( databaseSurface );
+	} );
+
 	it( 'hides the Annotate control when the host cannot annotate the preview', () => {
 		useConnectorMock.mockReturnValue( {
 			startSite: vi.fn().mockResolvedValue( undefined ),

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -204,9 +204,10 @@ function getActivePreset(
 	return VIEWPORT_PRESETS.find( ( preset ) => preset.id === mode ) ?? null;
 }
 
-// Breathing room around the split view's phone frame (matches the pane's
-// CSS padding, subtracted before computing the frame's fit-to-height scale).
-const SPLIT_MOBILE_PANE_PADDING = 16;
+// Breathing room around a floating device frame, mirroring the CSS padding on
+// `.realmLayerSimulated` and `.splitMobilePane`. Subtracted from the measured
+// pane before computing a frame's fit-to-pane scale.
+const PREVIEW_PANE_PADDING = 16;
 
 // A simulated guest viewport: the page lays out at `width`×`height` CSS px
 // and its rendering is scaled by `scale` to fit the preview pane. `mobile`
@@ -330,6 +331,107 @@ const DEFAULT_REALM_PATHS: Record< PreviewRealm, string > = {
 	admin: '/wp-admin/',
 	database: DATABASE_HOME_PATH,
 };
+
+/**
+ * Realms that share a browsing session share a surface.
+ *
+ * The front end and WP Admin link to each other and share a login, so they stay
+ * one webview: one history stack, and a page loaded after signing in reflects
+ * it. phpMyAdmin is a separate tool nothing links to, and the only realm that
+ * isn't responsive — so it gets its own surface, which never resizes or reloads
+ * when the preview flips to it.
+ */
+type PreviewSurfaceKey = 'site' | 'database';
+
+function getSurfaceKey( realm: PreviewRealm ): PreviewSurfaceKey {
+	return realm === 'database' ? 'database' : 'site';
+}
+
+// Whether a surface previews responsive pages. phpMyAdmin has no mobile layout,
+// so its surface always renders at the pane's natural size and the viewport
+// controls don't apply to it.
+function isResponsiveSurface( key: PreviewSurfaceKey ): boolean {
+	return key === 'site';
+}
+
+// A mounted preview surface: its url, plus the load state and pending commands
+// belonging to that webview. Kept alive once created so returning to it is a
+// visibility swap rather than a resize plus a fresh load.
+interface PreviewSurfaceState {
+	path: string;
+	browser: BrowserNavigationState;
+	inspector: InspectorState;
+	browserCommand: BrowserCommand | null;
+	inspectorCommand: InspectorCommand | null;
+	reloadNonce: number;
+}
+
+type PreviewSurfaces = Partial< Record< PreviewSurfaceKey, PreviewSurfaceState > >;
+
+// Surfaces belong to the site they were opened for, so the owning id travels
+// with them: moving to another site replaces the whole set rather than leaving
+// the previous site's webviews behind.
+interface MountedSurfaces {
+	siteId: string;
+	byKey: PreviewSurfaces;
+}
+
+function createPreviewSurface( path: string, reloadNonce: number ): PreviewSurfaceState {
+	return {
+		path,
+		browser: EMPTY_BROWSER_STATE,
+		inspector: EMPTY_INSPECTOR_STATE,
+		browserCommand: null,
+		inspectorCommand: null,
+		reloadNonce,
+	};
+}
+
+// Sizing for the frame around a surface: the preset's exact scaled box (the
+// emulation paints it edge to edge), or nothing when the surface fills its layer.
+function getFrameStyle( viewport: PreviewViewport | null ): CSSProperties | undefined {
+	if ( ! viewport ) {
+		return undefined;
+	}
+	return {
+		flex: '0 0 auto',
+		width: viewport.width * viewport.scale,
+		height: viewport.height * viewport.scale,
+	};
+}
+
+// The iframe fallback has no device emulation, so scaling is a CSS transform
+// instead: lay out at full size, scale down to fit; the frame clips the
+// transform's leftover layout box.
+function getIframeStyle( viewport: PreviewViewport | null ): CSSProperties | undefined {
+	if ( ! viewport || viewport.scale === 1 ) {
+		return undefined;
+	}
+	return {
+		flex: '0 0 auto',
+		width: viewport.width,
+		height: viewport.height,
+		transform: `scale(${ viewport.scale })`,
+		transformOrigin: 'top left',
+	};
+}
+
+function areInspectorStatesEqual( a: InspectorState, b: InspectorState ) {
+	return (
+		a.ready === b.ready && a.isPicking === b.isPicking && a.annotationCount === b.annotationCount
+	);
+}
+
+function arePreviewSurfacesEqual( a: PreviewSurfaceState, b: PreviewSurfaceState ) {
+	return (
+		a.path === b.path &&
+		a.reloadNonce === b.reloadNonce &&
+		a.browserCommand === b.browserCommand &&
+		a.inspectorCommand === b.inspectorCommand &&
+		areBrowserStatesEqual( a.browser, b.browser ) &&
+		areInspectorStatesEqual( a.inspector, b.inspector )
+	);
+}
 
 function safeWebviewBoolean( webview: WebviewTag | null, method: 'canGoBack' | 'canGoForward' ) {
 	try {
@@ -468,10 +570,8 @@ function PreviewOverflowMenu( {
 }: {
 	viewportMode: ViewportMode;
 	onViewportModeChange: ( mode: ViewportMode ) => void;
-	// The database realm (phpMyAdmin) isn't a responsive surface, so the
-	// simulated-viewport controls are disabled rather than hidden — the
-	// chosen mode is kept for when the preview returns to the front end or
-	// WP Admin.
+	// Greys out the viewport controls for a surface that can't simulate one,
+	// keeping the chosen mode for when the preview returns to one that can.
 	viewportControlsDisabled: boolean;
 	mobileOrientation: MobileOrientation;
 	onMobileOrientationChange: ( orientation: MobileOrientation ) => void;
@@ -705,18 +805,27 @@ export function SitePreview( {
 	const canPreview = site.running;
 	const canUseWebview = isElectron();
 	const trafficLightSpace = useTrafficLightSpace();
-	const previewUrl = `${ siteUrl }${ getSafePath( path ) }`;
+	const safePath = getSafePath( path );
+	// Which realm the host is pointing the preview at. Derived from the path
+	// rather than stored alongside it, so the parent stays the single source of
+	// truth for where the preview is aimed.
+	const activeRealm = getPreviewRealm( safePath );
+	const activeSurfaceKey = getSurfaceKey( activeRealm );
 	const siteThumbnail = useQuery( {
 		queryKey: [ ...SITE_THUMBNAIL_QUERY_KEY, site.id ],
 		queryFn: () => connector.getSiteThumbnail( site.id ),
 		enabled: ! canPreview,
 		meta: { persist: false },
 	} );
-	const [ browserState, setBrowserState ] =
-		useState< BrowserNavigationState >( EMPTY_BROWSER_STATE );
-	const [ browserCommand, setBrowserCommand ] = useState< BrowserCommand | null >( null );
-	const [ inspectorState, setInspectorState ] = useState< InspectorState >( EMPTY_INSPECTOR_STATE );
-	const [ inspectorCommand, setInspectorCommand ] = useState< InspectorCommand | null >( null );
+	// Surfaces mounted so far. Once created a surface stays mounted and warm;
+	// only the active one is visible.
+	const [ surfaces, setSurfaces ] = useState< MountedSurfaces >( () => ( {
+		siteId: site.id,
+		byKey: { [ activeSurfaceKey ]: createPreviewSurface( safePath, reloadNonce ) },
+	} ) );
+	const activeSurface = surfaces.byKey[ activeSurfaceKey ];
+	const browserState = activeSurface?.browser ?? EMPTY_BROWSER_STATE;
+	const inspectorState = activeSurface?.inspector ?? EMPTY_INSPECTOR_STATE;
 	// 'fit' renders at the pane's natural size; a preset id simulates that
 	// viewport; 'split' shows the desktop and mobile presets together.
 	const [ viewportMode, setViewportMode ] = useState< ViewportMode >( 'fit' );
@@ -733,100 +842,118 @@ export function SitePreview( {
 		? Math.max( browserState.progress, 0.12 )
 		: browserState.progress;
 	const showLoadingProgress = canPreview && progress > 0;
-	// phpMyAdmin isn't a responsive surface: keep the simulated viewport from
-	// applying while the database realm is open, without losing the chosen
-	// mode for when the preview returns to the front end or WP Admin.
-	const isDatabaseRealm = getPreviewRealm( getSafePath( path ) ) === 'database';
 	// Presets are module constants, so this stays referentially stable per
 	// mode + orientation.
-	const activePreset = isDatabaseRealm ? null : getActivePreset( viewportMode, mobileOrientation );
-	const splitPreview = ! isDatabaseRealm && viewportMode === 'split';
+	const activePreset = getActivePreset( viewportMode, mobileOrientation );
+	const splitPreview = isResponsiveSurface( activeSurfaceKey ) && viewportMode === 'split';
+	// Simulated frames float inside the layer's padding, so the space they fit
+	// into is the measured pane minus that padding.
+	const simulatedPaneSize = useMemo(
+		() =>
+			paneSize
+				? {
+						width: Math.max( 1, paneSize.width - PREVIEW_PANE_PADDING * 2 ),
+						height: Math.max( 1, paneSize.height - PREVIEW_PANE_PADDING * 2 ),
+				  }
+				: null,
+		[ paneSize ]
+	);
 	// The split view's phone pane: the mobile preset (in its current
 	// orientation) scaled to fit the pane height, and capped at half the
 	// pane's width so a landscape frame can't crowd out the primary view.
 	const splitMobileViewport = useMemo( () => {
-		if ( ! splitPreview || ! paneSize ) {
+		if ( ! splitPreview || ! simulatedPaneSize ) {
 			return null;
 		}
 		const preset = getMobilePreset( mobileOrientation );
 		return getSimulatedViewport( preset, {
-			width: Math.max( 160, Math.min( preset.width, Math.round( paneSize.width / 2 ) ) ),
-			height: Math.max( 120, paneSize.height - SPLIT_MOBILE_PANE_PADDING * 2 ),
+			width: Math.max( 160, Math.min( preset.width, Math.round( simulatedPaneSize.width / 2 ) ) ),
+			height: Math.max( 120, simulatedPaneSize.height - PREVIEW_PANE_PADDING * 2 ),
 		} );
-	}, [ mobileOrientation, paneSize, splitPreview ] );
+	}, [ mobileOrientation, simulatedPaneSize, splitPreview ] );
 	// In split mode the desktop simulation fits the space left beside the
 	// rendered mobile frame, including its pane padding. This keeps the page
 	// at the desktop breakpoint even when the comparison itself is narrow.
 	const primaryPaneSize = useMemo( () => {
-		if ( ! splitPreview || ! paneSize || ! splitMobileViewport ) {
-			return paneSize;
+		if ( ! splitPreview || ! simulatedPaneSize || ! splitMobileViewport ) {
+			return simulatedPaneSize;
 		}
 		const mobilePaneWidth =
-			splitMobileViewport.width * splitMobileViewport.scale + SPLIT_MOBILE_PANE_PADDING * 2;
+			splitMobileViewport.width * splitMobileViewport.scale + PREVIEW_PANE_PADDING * 2;
 		return {
-			width: Math.max( 1, paneSize.width - mobilePaneWidth ),
-			height: paneSize.height,
+			width: Math.max( 1, simulatedPaneSize.width - mobilePaneWidth ),
+			height: simulatedPaneSize.height,
 		};
-	}, [ paneSize, splitMobileViewport, splitPreview ] );
-	// No emulation while the site is stopped: the empty state renders in the
-	// plain pane, and the chosen mode re-applies on start.
+	}, [ simulatedPaneSize, splitMobileViewport, splitPreview ] );
+	// The viewport a responsive surface simulates. No emulation while the site
+	// is stopped: the empty state renders in the plain pane, and the chosen mode
+	// re-applies on start.
 	const previewViewport = useMemo(
 		() => ( canPreview ? getSimulatedViewport( activePreset, primaryPaneSize ) : null ),
 		[ activePreset, canPreview, primaryPaneSize ]
 	);
-	// Sizing for the frame around the primary surface: the preset's exact
-	// scaled box (the emulation paints it edge to edge).
-	const frameStyle = useMemo< CSSProperties | undefined >( () => {
-		if ( ! previewViewport ) {
-			return undefined;
-		}
-		return {
-			flex: '0 0 auto',
-			width: previewViewport.width * previewViewport.scale,
-			height: previewViewport.height * previewViewport.scale,
-		};
-	}, [ previewViewport ] );
-	// The iframe fallback has no device emulation, so scaling is a CSS
-	// transform instead: lay out at full size, scale down to fit; the frame
-	// clips the transform's leftover layout box.
-	const iframeStyle: CSSProperties | undefined =
-		previewViewport && previewViewport.scale !== 1
-			? {
-					flex: '0 0 auto',
-					width: previewViewport.width,
-					height: previewViewport.height,
-					transform: `scale(${ previewViewport.scale })`,
-					transformOrigin: 'top left',
-			  }
-			: undefined;
 
-	const handlePreviewNavigation = useCallback(
-		( url: string ) => {
+	const patchSurface = useCallback(
+		( key: PreviewSurfaceKey, patch: Partial< PreviewSurfaceState > ) => {
+			setSurfaces( ( current ) => {
+				const surface = current.byKey[ key ];
+				if ( ! surface ) {
+					return current;
+				}
+				const next = { ...surface, ...patch };
+				return arePreviewSurfacesEqual( surface, next )
+					? current
+					: { ...current, byKey: { ...current.byKey, [ key ]: next } };
+			} );
+		},
+		[]
+	);
+	const handleSurfaceNavigation = useCallback(
+		( key: PreviewSurfaceKey, url: string ) => {
 			if ( isThemeActivationUrl( url ) && connector.getThemeDetails ) {
 				void refreshThemeDetails( connector, queryClient, site.id ).catch( () => undefined );
 			}
 			const nextPath = getPathFromPreviewUrl( url, siteUrl );
-			if ( ! nextPath || nextPath === path ) {
+			if ( ! nextPath ) {
 				return;
 			}
-			onPathChange?.( nextPath );
+			patchSurface( key, { path: nextPath } );
+			// Only the visible surface speaks for the preview's location, so the
+			// hidden one settling a redirect can't move the address bar. This is also
+			// what lights up the WordPress segment when a front-end link points at
+			// wp-admin: same surface, new path, new realm.
+			if ( key === activeSurfaceKey && nextPath !== safePath ) {
+				onPathChange?.( nextPath );
+			}
 		},
-		[ connector, onPathChange, path, queryClient, site.id, siteUrl ]
+		[
+			activeSurfaceKey,
+			connector,
+			onPathChange,
+			patchSurface,
+			queryClient,
+			safePath,
+			site.id,
+			siteUrl,
+		]
 	);
-	const handleBrowserStateChange = useCallback( ( state: BrowserNavigationState ) => {
-		setBrowserState( ( current ) => ( areBrowserStatesEqual( current, state ) ? current : state ) );
-	}, [] );
-	const handleInspectorState = useCallback( ( state: InspectorState ) => {
-		setInspectorState( state );
-	}, [] );
-	const sendBrowserCommand = useCallback( ( type: BrowserCommand[ 'type' ] ) => {
-		commandIdRef.current += 1;
-		setBrowserCommand( { id: commandIdRef.current, type } );
-	}, [] );
-	const sendInspectorCommand = useCallback( ( type: InspectorCommand[ 'type' ] ) => {
-		commandIdRef.current += 1;
-		setInspectorCommand( { id: commandIdRef.current, type } );
-	}, [] );
+	// Commands are addressed to the surface on screen. Each has its own slot, so
+	// the hidden one never sees a command it should have missed — and never
+	// replays a stale one when it comes back into view.
+	const sendBrowserCommand = useCallback(
+		( type: BrowserCommand[ 'type' ] ) => {
+			commandIdRef.current += 1;
+			patchSurface( activeSurfaceKey, { browserCommand: { id: commandIdRef.current, type } } );
+		},
+		[ activeSurfaceKey, patchSurface ]
+	);
+	const sendInspectorCommand = useCallback(
+		( type: InspectorCommand[ 'type' ] ) => {
+			commandIdRef.current += 1;
+			patchSurface( activeSurfaceKey, { inspectorCommand: { id: commandIdRef.current, type } } );
+		},
+		[ activeSurfaceKey, patchSurface ]
+	);
 	// Shortcuts the guest page swallowed and forwarded back over the console
 	// bridge: browser commands go to the webview, full preview to the host.
 	const handleForwardedShortcut = useCallback(
@@ -840,38 +967,80 @@ export function SitePreview( {
 		[ fullscreen, onFullscreenChange, sendBrowserCommand ]
 	);
 
-	// Realm segments (front end / WP Admin / database). Each realm remembers
-	// where you last were: flipping to WP Admin and back returns to the exact
-	// front-end page, and vice versa. Admin targets go through the site's
-	// /studio-auto-login endpoint so they never land on the login form.
+	// Point the active surface at whatever path the host is asking for, creating
+	// it the first time it's needed. The other surface keeps the url it was left
+	// on, so it doesn't reload. A brand-new surface starts level with the host's
+	// reload nonce, so mounting it doesn't count as a reload request.
+	useEffect( () => {
+		setSurfaces( ( current ) => {
+			const mounted = createPreviewSurface( safePath, reloadNonce );
+			if ( current.siteId !== site.id ) {
+				return { siteId: site.id, byKey: { [ activeSurfaceKey ]: mounted } };
+			}
+			const surface = current.byKey[ activeSurfaceKey ];
+			if ( ! surface ) {
+				return { ...current, byKey: { ...current.byKey, [ activeSurfaceKey ]: mounted } };
+			}
+			return surface.path === safePath
+				? current
+				: {
+						...current,
+						byKey: { ...current.byKey, [ activeSurfaceKey ]: { ...surface, path: safePath } },
+				  };
+		} );
+	}, [ activeSurfaceKey, reloadNonce, safePath, site.id ] );
+
+	// A host-driven reload targets what's on screen. Tracked against the last
+	// seen nonce so merely switching surfaces never reloads the one arrived at.
+	const lastHostReloadNonceRef = useRef( reloadNonce );
+	useEffect( () => {
+		if ( lastHostReloadNonceRef.current === reloadNonce ) {
+			return;
+		}
+		lastHostReloadNonceRef.current = reloadNonce;
+		patchSurface( activeSurfaceKey, { reloadNonce } );
+	}, [ activeSurfaceKey, patchSurface, reloadNonce ] );
+
+	// Where each realm was last seen, so flipping to WP Admin and back returns
+	// to the exact front-end page rather than the site root.
 	const lastRealmPathsRef = useRef< Record< PreviewRealm, string > >( {
 		...DEFAULT_REALM_PATHS,
 	} );
 	useEffect( () => {
-		// Reset the per-realm memory when the preview moves to another site.
 		lastRealmPathsRef.current = { ...DEFAULT_REALM_PATHS };
 	}, [ site.id ] );
 	useEffect( () => {
-		const safePath = getSafePath( path );
 		// Auto-login is a transient hop, not a place to return to.
 		if ( safePath.startsWith( '/studio-auto-login' ) ) {
 			return;
 		}
 		lastRealmPathsRef.current[ getPreviewRealm( safePath ) ] = safePath;
-	}, [ path ] );
+	}, [ safePath ] );
+
+	// Realm segments (front end / WP Admin / database). Moving between the front
+	// end and WP Admin is a navigation inside the shared site surface, so they
+	// keep one history and one login; admin targets go through the site's
+	// /studio-auto-login endpoint so they never land on the login form. Moving to
+	// or from the database only swaps which surface is visible — it's already
+	// loaded, at its own size, so there's nothing to reload or resize.
 	const handleSwitchRealm = useCallback(
 		( realm: PreviewRealm ) => {
-			// Re-selecting the active realm (e.g. via its shortcut) is a no-op —
-			// don't bounce the current page through another auto-login hop.
-			if ( getPreviewRealm( getSafePath( path ) ) === realm ) {
+			// Re-selecting the active realm (e.g. via its shortcut) is a no-op.
+			if ( activeRealm === realm ) {
 				return;
 			}
 			// The agentic UI opens the realm in its in-app preview panel.
 			void connector.trackEvent( getRealmOpenEvent( realm ), { browser: 'internal' } );
 			const target = lastRealmPathsRef.current[ realm ];
+			// Returning to a surface that's already sitting on the target path just
+			// reveals it; anything else is a real navigation.
+			if ( surfaces.byKey[ getSurfaceKey( realm ) ]?.path === target ) {
+				onPathChange?.( target );
+				return;
+			}
 			onPathChange?.( getRealmNavigationPath( target, siteUrl ) );
 		},
-		[ connector, onPathChange, path, siteUrl ]
+		[ activeRealm, connector, onPathChange, siteUrl, surfaces ]
 	);
 
 	const browserShortcuts = useMemo(
@@ -922,8 +1091,6 @@ export function SitePreview( {
 	}, [ fullscreen, handleViewportModeChange, onFullscreenChange, viewportMode ] );
 
 	useEffect( () => {
-		setBrowserState( EMPTY_BROWSER_STATE );
-		setInspectorState( EMPTY_INSPECTOR_STATE );
 		const remembered = viewportBySiteRef.current[ site.id ];
 		setViewportMode( remembered?.mode ?? 'fit' );
 		setMobileOrientation( remembered?.orientation ?? 'portrait' );
@@ -1088,7 +1255,7 @@ export function SitePreview( {
 						<PreviewOverflowMenu
 							viewportMode={ viewportMode }
 							onViewportModeChange={ handleViewportModeChange }
-							viewportControlsDisabled={ isDatabaseRealm }
+							viewportControlsDisabled={ ! isResponsiveSurface( activeSurfaceKey ) }
 							mobileOrientation={ mobileOrientation }
 							onMobileOrientationChange={ handleMobileOrientationChange }
 							fullscreen={ fullscreen }
@@ -1103,119 +1270,135 @@ export function SitePreview( {
 				) : null }
 			</div>
 			<div className={ styles.body }>
-				<div
-					ref={ paneRef }
-					className={ clsx(
-						styles.previewViewport,
-						previewViewport && styles.previewViewportSimulated
-					) }
-				>
+				<div ref={ paneRef } className={ styles.previewViewport }>
 					{ canPreview ? (
-						<>
-							{ previewViewport ? (
-								<div className={ styles.viewportGrid } aria-hidden="true">
-									<DotGrid
-										spacing={ 32 }
-										crossSize={ 5 }
-										crossThickness={ 0.75 }
-										opacity={ 0.16 }
-										intro={ false }
-									/>
-								</div>
-							) : null }
-							<div
-								className={ clsx( styles.surfaceFrame, previewViewport && styles.deviceFrame ) }
-								style={ frameStyle }
-							>
-								{ canUseWebview ? (
-									<WebviewSurface
-										key={ site.id }
-										url={ previewUrl }
-										reloadNonce={ reloadNonce }
-										onAnnotationsDone={ onAnnotationsDone }
-										onInspectorState={ handleInspectorState }
-										inspectorCommand={ inspectorCommand }
-										browserCommand={ browserCommand }
-										onBrowserStateChange={ handleBrowserStateChange }
-										onBrowserCommand={ handleForwardedShortcut }
-										onNavigate={ handlePreviewNavigation }
-										viewport={ previewViewport }
-									/>
-								) : (
-									// Non-Electron fallback: plain iframe, no inspector. Reloads
-									// by remounting; back/forward aren't reachable from the host.
-									<iframe
-										key={ `${ previewUrl }#${ reloadNonce }#${
-											browserCommand?.type === 'reload' ? browserCommand.id : 0
-										}` }
-										className={ styles.iframe }
-										style={ iframeStyle }
-										src={ previewUrl }
-										title={ site.name }
-										onLoad={ ( event ) => {
-											handlePreviewNavigation( event.currentTarget.src );
-											setBrowserState( ( current ) => {
-												const next = {
-													...current,
-													loading: false,
-													progress: 0,
-													title: getIframeTitle( event.currentTarget ),
-												};
-												return areBrowserStatesEqual( current, next ) ? current : next;
-											} );
-										} }
-									/>
-								) }
-							</div>
-							{ splitPreview && splitMobileViewport ? (
-								// The comparison's phone pane: a lean companion surface that
-								// follows the primary's navigation (shared `path`) but keeps
-								// annotations and history on the primary pane.
-								<div className={ styles.splitMobilePane }>
+						// One stacked layer per mounted surface. Only the active layer is
+						// visible; the other stays mounted and laid out at its own size, so
+						// coming back to it is a visibility swap with nothing to resize,
+						// reload or re-emulate.
+						( Object.keys( surfaces.byKey ) as PreviewSurfaceKey[] ).map( ( key ) => {
+							const surface = surfaces.byKey[ key ];
+							if ( ! surface ) {
+								return null;
+							}
+							const active = key === activeSurfaceKey;
+							const viewport = isResponsiveSurface( key ) ? previewViewport : null;
+							const surfaceUrl = `${ siteUrl }${ surface.path }`;
+							return (
+								<div
+									key={ key }
+									className={ clsx(
+										styles.realmLayer,
+										viewport && styles.realmLayerSimulated,
+										! active && styles.realmLayerHidden
+									) }
+									inert={ active ? undefined : true }
+								>
+									{ viewport ? (
+										<div className={ styles.viewportGrid } aria-hidden="true">
+											<DotGrid
+												spacing={ 32 }
+												crossSize={ 5 }
+												crossThickness={ 0.75 }
+												opacity={ 0.16 }
+												intro={ false }
+											/>
+										</div>
+									) : null }
 									<div
-										className={ clsx( styles.surfaceFrame, styles.deviceFrame ) }
-										style={ {
-											flex: '0 0 auto',
-											width: splitMobileViewport.width * splitMobileViewport.scale,
-											height: splitMobileViewport.height * splitMobileViewport.scale,
-										} }
+										className={ clsx( styles.surfaceFrame, viewport && styles.deviceFrame ) }
+										style={ getFrameStyle( viewport ) }
 									>
 										{ canUseWebview ? (
 											<WebviewSurface
-												key={ `${ site.id }-mobile` }
-												url={ previewUrl }
-												reloadNonce={ reloadNonce }
-												viewport={ splitMobileViewport }
-												browserCommand={ browserCommand?.type === 'reload' ? browserCommand : null }
-												onNavigate={ handlePreviewNavigation }
+												key={ `${ site.id }-${ key }` }
+												url={ surfaceUrl }
+												reloadNonce={ surface.reloadNonce }
+												// phpMyAdmin isn't an annotation target, so the
+												// inspector never goes near it.
+												inspector={ isResponsiveSurface( key ) }
+												onAnnotationsDone={ onAnnotationsDone }
+												onInspectorState={ ( state ) => patchSurface( key, { inspector: state } ) }
+												inspectorCommand={ surface.inspectorCommand }
+												browserCommand={ surface.browserCommand }
+												onBrowserStateChange={ ( state ) =>
+													patchSurface( key, { browser: state } )
+												}
+												onBrowserCommand={ handleForwardedShortcut }
+												onNavigate={ ( url ) => handleSurfaceNavigation( key, url ) }
+												viewport={ viewport }
 											/>
 										) : (
+											// Non-Electron fallback: plain iframe, no inspector. Reloads
+											// by remounting; back/forward aren't reachable from the host.
 											<iframe
-												key={ `${ previewUrl }#${ reloadNonce }` }
+												key={ `${ surfaceUrl }#${ surface.reloadNonce }#${
+													surface.browserCommand?.type === 'reload' ? surface.browserCommand.id : 0
+												}` }
 												className={ styles.iframe }
-												style={
-													splitMobileViewport.scale !== 1
-														? {
-																flex: '0 0 auto',
-																width: splitMobileViewport.width,
-																height: splitMobileViewport.height,
-																transform: `scale(${ splitMobileViewport.scale })`,
-																transformOrigin: 'top left',
-														  }
-														: undefined
-												}
-												src={ previewUrl }
-												title={ sprintf(
-													/* translators: %s: site name */
-													__( '%s (mobile)' ),
-													site.name
-												) }
+												style={ getIframeStyle( viewport ) }
+												src={ surfaceUrl }
+												title={ site.name }
+												onLoad={ ( event ) => {
+													handleSurfaceNavigation( key, event.currentTarget.src );
+													patchSurface( key, {
+														browser: {
+															...surface.browser,
+															loading: false,
+															progress: 0,
+															title: getIframeTitle( event.currentTarget ),
+														},
+													} );
+												} }
 											/>
 										) }
 									</div>
+									{ active && splitPreview && splitMobileViewport ? (
+										// The comparison's phone pane: a lean companion surface that
+										// follows the primary's navigation (shared url) but keeps
+										// annotations and history on the primary pane.
+										<div className={ styles.splitMobilePane }>
+											<div
+												className={ clsx( styles.surfaceFrame, styles.deviceFrame ) }
+												style={ {
+													flex: '0 0 auto',
+													width: splitMobileViewport.width * splitMobileViewport.scale,
+													height: splitMobileViewport.height * splitMobileViewport.scale,
+												} }
+											>
+												{ canUseWebview ? (
+													<WebviewSurface
+														key={ `${ site.id }-${ key }-mobile` }
+														url={ surfaceUrl }
+														reloadNonce={ surface.reloadNonce }
+														inspector={ false }
+														viewport={ splitMobileViewport }
+														browserCommand={
+															surface.browserCommand?.type === 'reload'
+																? surface.browserCommand
+																: null
+														}
+														onNavigate={ ( url ) => handleSurfaceNavigation( key, url ) }
+													/>
+												) : (
+													<iframe
+														key={ `${ surfaceUrl }#${ surface.reloadNonce }` }
+														className={ styles.iframe }
+														style={ getIframeStyle( splitMobileViewport ) }
+														src={ surfaceUrl }
+														title={ sprintf(
+															/* translators: %s: site name */
+															__( '%s (mobile)' ),
+															site.name
+														) }
+													/>
+												) }
+											</div>
+										</div>
+									) : null }
 								</div>
-							) : null }
-						</>
+							);
+						} )
 					) : (
 						<div className={ styles.empty }>
 							<div className={ styles.emptyGrid } aria-hidden="true">
@@ -1287,6 +1470,9 @@ interface WebviewSurfaceProps {
 	onNavigate?: ( url: string ) => void;
 	// Simulated guest viewport, or null for the webview's natural size.
 	viewport?: PreviewViewport | null;
+	// Whether to inject the annotation inspector into the guest page. Off for
+	// surfaces that can't be annotated (phpMyAdmin, the split companion).
+	inspector?: boolean;
 }
 
 /**
@@ -1308,6 +1494,7 @@ function WebviewSurface( {
 	onBrowserCommand,
 	onNavigate,
 	viewport = null,
+	inspector = true,
 }: WebviewSurfaceProps ) {
 	const ref = useRef< HTMLElement | null >( null );
 	const [ ready, setReady ] = useState( false );
@@ -1318,6 +1505,7 @@ function WebviewSurface( {
 	const onNavigateRef = useRef( onNavigate );
 	const browserStateRef = useRef< BrowserNavigationState >( EMPTY_BROWSER_STATE );
 	const domReadyRef = useRef( false );
+	const inspectorEnabledRef = useRef( inspector );
 	const currentUrlRef = useRef( url );
 	const storedAnnotationsRef = useRef< Annotation[] >( [] );
 	const lastReloadNonceRef = useRef( reloadNonce );
@@ -1338,6 +1526,9 @@ function WebviewSurface( {
 	useEffect( () => {
 		onNavigateRef.current = onNavigate;
 	}, [ onNavigate ] );
+	useEffect( () => {
+		inspectorEnabledRef.current = inspector;
+	}, [ inspector ] );
 	// The url we want shown; `currentUrlRef` is where the webview actually landed.
 	const urlRef = useRef( url );
 	useEffect( () => {
@@ -1434,6 +1625,9 @@ function WebviewSurface( {
 			domReadyRef.current = true;
 			setReady( true );
 			publishDocumentTitle();
+			if ( ! inspectorEnabledRef.current ) {
+				return;
+			}
 			// If annotations were collected on a previous page, seed
 			// window.__studioInspectorState before the IIFE runs so the
 			// freshly-injected inspector picks them up on init.
@@ -1514,10 +1708,12 @@ function WebviewSurface( {
 		};
 		const handleStartLoading = () => {
 			didReadTitleAfterLoad = false;
-			onInspectorStateRef.current?.( {
-				...EMPTY_INSPECTOR_STATE,
-				annotationCount: storedAnnotationsRef.current.length,
-			} );
+			if ( inspectorEnabledRef.current ) {
+				onInspectorStateRef.current?.( {
+					...EMPTY_INSPECTOR_STATE,
+					annotationCount: storedAnnotationsRef.current.length,
+				} );
+			}
 			publishBrowserState( { title: null } );
 			startProgress();
 		};

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -460,6 +460,7 @@ function isPreviewShortcutCommand( command: unknown ): command is PreviewShortcu
 function PreviewOverflowMenu( {
 	viewportMode,
 	onViewportModeChange,
+	viewportControlsDisabled,
 	mobileOrientation,
 	onMobileOrientationChange,
 	fullscreen,
@@ -467,6 +468,11 @@ function PreviewOverflowMenu( {
 }: {
 	viewportMode: ViewportMode;
 	onViewportModeChange: ( mode: ViewportMode ) => void;
+	// The database realm (phpMyAdmin) isn't a responsive surface, so the
+	// simulated-viewport controls are disabled rather than hidden — the
+	// chosen mode is kept for when the preview returns to the front end or
+	// WP Admin.
+	viewportControlsDisabled: boolean;
 	mobileOrientation: MobileOrientation;
 	onMobileOrientationChange: ( orientation: MobileOrientation ) => void;
 	fullscreen: boolean;
@@ -508,6 +514,7 @@ function PreviewOverflowMenu( {
 					<Menu.RadioGroup
 						value={ viewportMode }
 						onValueChange={ ( next ) => onViewportModeChange( next as ViewportMode ) }
+						disabled={ viewportControlsDisabled }
 					>
 						<Menu.RadioItem value="fit">{ __( 'Fit pane' ) }</Menu.RadioItem>
 						{ VIEWPORT_PRESETS.map( ( preset ) => (
@@ -529,6 +536,7 @@ function PreviewOverflowMenu( {
 							<Menu.RadioGroup
 								value={ mobileOrientation }
 								onValueChange={ ( next ) => onMobileOrientationChange( next as MobileOrientation ) }
+								disabled={ viewportControlsDisabled }
 							>
 								<Menu.RadioItem value="portrait">{ __( 'Portrait' ) }</Menu.RadioItem>
 								<Menu.RadioItem value="landscape">{ __( 'Landscape' ) }</Menu.RadioItem>
@@ -725,10 +733,14 @@ export function SitePreview( {
 		? Math.max( browserState.progress, 0.12 )
 		: browserState.progress;
 	const showLoadingProgress = canPreview && progress > 0;
+	// phpMyAdmin isn't a responsive surface: keep the simulated viewport from
+	// applying while the database realm is open, without losing the chosen
+	// mode for when the preview returns to the front end or WP Admin.
+	const isDatabaseRealm = getPreviewRealm( getSafePath( path ) ) === 'database';
 	// Presets are module constants, so this stays referentially stable per
 	// mode + orientation.
-	const activePreset = getActivePreset( viewportMode, mobileOrientation );
-	const splitPreview = viewportMode === 'split';
+	const activePreset = isDatabaseRealm ? null : getActivePreset( viewportMode, mobileOrientation );
+	const splitPreview = ! isDatabaseRealm && viewportMode === 'split';
 	// The split view's phone pane: the mobile preset (in its current
 	// orientation) scaled to fit the pane height, and capped at half the
 	// pane's width so a landscape frame can't crowd out the primary view.
@@ -1076,6 +1088,7 @@ export function SitePreview( {
 						<PreviewOverflowMenu
 							viewportMode={ viewportMode }
 							onViewportModeChange={ handleViewportModeChange }
+							viewportControlsDisabled={ isDatabaseRealm }
 							mobileOrientation={ mobileOrientation }
 							onMobileOrientationChange={ handleMobileOrientationChange }
 							fullscreen={ fullscreen }

--- a/apps/ui/src/components/site-preview/style.module.css
+++ b/apps/ui/src/components/site-preview/style.module.css
@@ -148,14 +148,35 @@
 	overflow: hidden;
 }
 
+/* One stacked layer per visited realm (front end / WP Admin / database). Each
+   holds that realm's own surface at its own size, so switching segments never
+   resizes or reloads anything — it just changes which layer is visible. */
+.realmLayer {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	min-width: 0;
+	min-height: 0;
+	overflow: hidden;
+}
+
 /* While simulating a viewport, the preset's frame floats centered with
-   breathing room; the padding is excluded from the measured pane, so the
-   frame's fit-to-pane scale accounts for it automatically. */
-.previewViewportSimulated {
+   breathing room. The padding is mirrored by PREVIEW_PANE_PADDING, which is
+   subtracted from the measured pane before the frame's fit-to-pane scale.
+   Only this mode centers: an unsimulated surface must stay stretched, or its
+   frame collapses to the webview's intrinsic height. */
+.realmLayerSimulated {
 	align-items: safe center;
 	justify-content: safe center;
 	padding: 16px;
 	background-color: var(--wpds-color-bg-surface-neutral);
+}
+
+/* Kept mounted and laid out — so the guest holds its size, scroll position and
+   viewport emulation — but out of sight and out of reach. */
+.realmLayerHidden {
+	visibility: hidden;
+	pointer-events: none;
 }
 
 /* The letterbox behind simulated viewports carries a dot grid so it reads


### PR DESCRIPTION
## Related issues

-

## How AI was used in this PR

Written entirely by Claude Code: located the responsive controls, scoped them off the database realm, then reworked how preview realms map onto webviews to remove the switch flash. Reviewed and tested by me in the running app.

## Proposed Changes

- The responsive controls (Mobile/Tablet/Desktop/Split) no longer apply to the database segment — phpMyAdmin has no mobile layout. They grey out in the "•••" menu and the chosen mode is kept for when the preview returns to the front end or WP Admin.
- Switching to the database no longer flashes. Previously one webview served all three segments, so the frame resized the instant the segment changed while the pixels waited on the load — most visible here, since this is the segment that drops the device frame.
- Realms that share a browsing session now share a surface: the front end and WP Admin stay one webview (one history, one login, and a front-end link to wp-admin still lights up the WordPress segment); the database gets its own, kept mounted at its own size, so revealing it is a visibility swap with nothing to resize or reload.
- Known change in behaviour: back/forward inside phpMyAdmin now walks phpMyAdmin's own history rather than stepping back out into the front end.

## Testing Instructions

1. Open a running site's preview and pick a responsive mode (e.g. Mobile) from the "•••" menu.
2. Switch to the Database segment — it should appear at natural size with no resize step or blank flash, and the Responsive mode / Mobile orientation options should be greyed out.
3. Switch back to the front end — the responsive mode should still be applied, at the size and scroll position you left it, with no reload.
4. Confirm the shared session still holds: sign in via WP Admin and load a front-end page (it should reflect being signed in), use back/forward across front end ↔ WP Admin, and click a wp-admin link from the front end (the WordPress segment should activate).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
