### PR TITLE
AI Credits: Print the error to top up balance when you run out of credits

### DIFF
--- a/apps/cli/ai/runtimes/pi/tests/usage-cap.test.ts
+++ b/apps/cli/ai/runtimes/pi/tests/usage-cap.test.ts
@@ -1,8 +1,16 @@
-import { createAssistantMessageEventStream } from '@earendil-works/pi-ai';
-import { USAGE_CAP_ERROR_PREFIX } from '@studio/common/ai/json-events';
+import {
+	createAssistantMessageEventStream,
+	isRetryableAssistantError,
+} from '@earendil-works/pi-ai';
+import { isOutOfCreditsError, USAGE_CAP_ERROR_PREFIX } from '@studio/common/ai/json-events';
 import { describe, expect, it } from 'vitest';
 import { withUsageCapErrorRewrite } from '../usage-cap';
 import type { AssistantMessage } from '@earendil-works/pi-ai';
+
+// The proxy's 402 body, as the Anthropic/OpenAI SDKs flatten it into the
+// error message (STU-2236).
+const OUT_OF_CREDITS_MESSAGE =
+	'402 {"code":"studio_out_of_credits","message":"studio_out_of_credits: You\'ve used your free monthly AI allowance and have no credits left. Buy credits in WordPress Studio to continue.","data":{"status":402}}';
 
 function errorMessageWith( errorMessage: string ): AssistantMessage {
 	return {
@@ -56,6 +64,25 @@ describe( 'withUsageCapErrorRewrite', () => {
 
 		const result = await wrapped.result();
 		expect( result.errorMessage ).toBe( '429 {"error":{"type":"rate_limit_error"}}' );
+	} );
+
+	// The out-of-credits 402 (STU-2236) keeps its message verbatim — the
+	// `studio_out_of_credits` token in it is what the UI surfaces detect —
+	// and pi must not auto-retry it: only buying credits clears the state.
+	it( 'passes the out-of-credits 402 through unrewritten and non-retryable', async () => {
+		const source = createAssistantMessageEventStream();
+		const wrapped = withUsageCapErrorRewrite( source );
+		source.push( {
+			type: 'error',
+			reason: 'error',
+			error: errorMessageWith( OUT_OF_CREDITS_MESSAGE ),
+		} );
+		source.end();
+
+		const result = await wrapped.result();
+		expect( result.errorMessage ).toBe( OUT_OF_CREDITS_MESSAGE );
+		expect( isOutOfCreditsError( result.errorMessage ) ).toBe( true );
+		expect( isRetryableAssistantError( result ) ).toBe( false );
 	} );
 
 	it( 'leaves non-429 errors untouched', async () => {

--- a/apps/cli/ai/runtimes/pi/usage-cap.ts
+++ b/apps/cli/ai/runtimes/pi/usage-cap.ts
@@ -12,6 +12,13 @@ import type { AssistantMessageEventStream } from '@earendil-works/pi-ai';
  *
  * The code, not the status, is the gate: hosted upstreams behind the proxy
  * return their own 429s for rate limits, and those *should* keep retrying.
+ *
+ * The proxy's out-of-credits refusal (402 `studio_out_of_credits`, STU-2236)
+ * deliberately passes through unrewritten: pi only retries errors matching
+ * its transient patterns (429/5xx/transport), which the 402 message never
+ * does, and the `studio_out_of_credits` token in the message is the stable
+ * marker the UI surfaces key on (see `isOutOfCreditsError`). The tests pin
+ * both properties.
  */
 export function withUsageCapErrorRewrite(
 	source: AssistantMessageEventStream

--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -316,7 +316,6 @@ describe( 'AiChatUI.handleEvent', () => {
 		expect( showError ).not.toHaveBeenCalledWith(
 			expect.stringContaining( 'monthly AI usage limit' )
 		);
-		// The terminal can't render links — the buy URL is printed as-is.
 		expect( showInfo ).toHaveBeenCalledWith( expect.stringContaining( ADD_AI_CREDITS_URL ) );
 		expect( ui.showUsageCapResetDate ).not.toHaveBeenCalled();
 		expect( ui.usageCapReached ).toBe( true );

--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -1,4 +1,5 @@
 import { Container, resetCapabilitiesCache, setCapabilities } from '@earendil-works/pi-tui';
+import { ADD_AI_CREDITS_URL } from '@studio/common/lib/studio-assistant-quota';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AiChatUI } from 'cli/ai/ui';
 import { openBrowser } from 'cli/lib/browser';
@@ -315,6 +316,8 @@ describe( 'AiChatUI.handleEvent', () => {
 		expect( showError ).not.toHaveBeenCalledWith(
 			expect.stringContaining( 'monthly AI usage limit' )
 		);
+		// The terminal can't render links — the buy URL is printed as-is.
+		expect( showInfo ).toHaveBeenCalledWith( expect.stringContaining( ADD_AI_CREDITS_URL ) );
 		expect( ui.showUsageCapResetDate ).not.toHaveBeenCalled();
 		expect( ui.usageCapReached ).toBe( true );
 		expect( ui.currentMarkdown ).toBeNull();

--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -280,6 +280,47 @@ describe( 'AiChatUI.handleEvent', () => {
 		expect( ui.currentResponseText ).toBe( '' );
 	} );
 
+	// STU-2236: distinct copy — no "try again later"/reset-date framing, and no
+	// reset-date fetch, because only buying credits clears this state.
+	it( 'surfaces the out-of-credits message when an assistant error carries the 402 marker', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			handleEvent: ( e: unknown ) => unknown;
+			[ key: string ]: unknown;
+		};
+		const hideLoader = vi.fn();
+		const showError = vi.fn();
+		const showInfo = vi.fn();
+
+		ui.hideLoader = hideLoader;
+		ui.showError = showError;
+		ui.showInfo = showInfo;
+		ui.showUsageCapResetDate = vi.fn( async () => undefined );
+		ui.currentProvider = 'wpcom';
+		ui.currentMarkdown = { setText: vi.fn() };
+		ui.currentResponseText = 'previous content';
+		ui.usageCapReached = false;
+
+		ui.handleEvent(
+			buildAssistantMessageEnd( {
+				stopReason: 'error',
+				errorMessage:
+					'402 {"code":"studio_out_of_credits","message":"studio_out_of_credits: You\'ve used your free monthly AI allowance and have no credits left. Buy credits in WordPress Studio to continue.","data":{"status":402}}',
+			} )
+		);
+
+		expect( hideLoader ).toHaveBeenCalled();
+		expect( showError ).toHaveBeenCalledWith(
+			expect.stringContaining( 'You’re out of AI credits' )
+		);
+		expect( showError ).not.toHaveBeenCalledWith(
+			expect.stringContaining( 'monthly AI usage limit' )
+		);
+		expect( ui.showUsageCapResetDate ).not.toHaveBeenCalled();
+		expect( ui.usageCapReached ).toBe( true );
+		expect( ui.currentMarkdown ).toBeNull();
+		expect( ui.currentResponseText ).toBe( '' );
+	} );
+
 	it( 'renders each tool result directly under its matching tool row', () => {
 		const ui = Object.create( AiChatUI.prototype ) as {
 			handleEvent: ( e: unknown ) => unknown;

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -2110,31 +2110,33 @@ export class AiChatUI implements AiOutputAdapter {
 				// surfaces both via `stopReason: 'error'` with the upstream body
 				// in `errorMessage`. Out of credits gets its own copy: waiting
 				// for the reset doesn't clear it — buying credits does.
-				if ( message.stopReason === 'error' && this.currentProvider === 'wpcom' ) {
-					const outOfCredits = isOutOfCreditsError( message.errorMessage );
-					if ( outOfCredits || isUsageCapError( message.errorMessage ) ) {
-						this.hideLoader();
-						this.usageCapReached = true;
-						this.showError( outOfCredits ? formatOutOfCreditsNotice() : formatUsageCapNotice() );
-						if ( outOfCredits ) {
-							// The terminal can't render a link, so print the URL as-is —
-							// it stays copyable and most terminals auto-link it.
-							this.showInfo(
-								sprintf(
-									/* translators: %s: URL of the page where the user can buy AI credits. */
-									__( 'Add credits at %s' ),
-									ADD_AI_CREDITS_URL
-								)
-							);
-						} else {
-							// Async on purpose: the reset date needs a wpcom round trip
-							// and must not block rendering the cap notice.
-							void this.showUsageCapResetDate();
-						}
-						this.currentMarkdown = null;
-						this.currentResponseText = '';
-						return;
+				const outOfCredits = isOutOfCreditsError( message.errorMessage );
+				if (
+					message.stopReason === 'error' &&
+					this.currentProvider === 'wpcom' &&
+					( outOfCredits || isUsageCapError( message.errorMessage ) )
+				) {
+					this.hideLoader();
+					this.usageCapReached = true;
+					this.showError( outOfCredits ? formatOutOfCreditsNotice() : formatUsageCapNotice() );
+					if ( outOfCredits ) {
+						// The terminal can't render a link, so print the URL as-is —
+						// it stays copyable and most terminals auto-link it.
+						this.showInfo(
+							sprintf(
+								/* translators: %s: URL of the page where the user can buy AI credits. */
+								__( 'Add credits at %s' ),
+								ADD_AI_CREDITS_URL
+							)
+						);
+					} else {
+						// Async on purpose: the reset date needs a wpcom round trip
+						// and must not block rendering the cap notice.
+						void this.showUsageCapResetDate();
 					}
+					this.currentMarkdown = null;
+					this.currentResponseText = '';
+					return;
 				}
 
 				for ( const block of message.content ) {

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -34,6 +34,7 @@ import { getToolDetail, getToolDisplayName, getToolResultPreview } from '@studio
 import chalk from '@studio/common/lib/chalk';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import {
+	ADD_AI_CREDITS_URL,
 	fetchStudioAssistantQuota,
 	formatOutOfCreditsNotice,
 	formatQuotaResetDate,
@@ -2115,7 +2116,17 @@ export class AiChatUI implements AiOutputAdapter {
 						this.hideLoader();
 						this.usageCapReached = true;
 						this.showError( outOfCredits ? formatOutOfCreditsNotice() : formatUsageCapNotice() );
-						if ( ! outOfCredits ) {
+						if ( outOfCredits ) {
+							// The terminal can't render a link, so print the URL as-is —
+							// it stays copyable and most terminals auto-link it.
+							this.showInfo(
+								sprintf(
+									/* translators: %s: URL of the page where the user can buy AI credits. */
+									__( 'Add credits at %s' ),
+									ADD_AI_CREDITS_URL
+								)
+							);
+						} else {
 							// Async on purpose: the reset date needs a wpcom round trip
 							// and must not block rendering the cap notice.
 							void this.showUsageCapResetDate();

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -26,7 +26,7 @@ import {
 	Spacer,
 } from '@earendil-works/pi-tui';
 import { stripMediaWidgetPayloadLines } from '@studio/common/ai/chat-artifacts';
-import { isUsageCapError } from '@studio/common/ai/json-events';
+import { isOutOfCreditsError, isUsageCapError } from '@studio/common/ai/json-events';
 import { DEFAULT_MODEL, getAiModelLabel, type AiModelId } from '@studio/common/ai/models';
 import { findLastAssistant } from '@studio/common/ai/session-events';
 import { randomThinkingMessage } from '@studio/common/ai/thinking-messages';
@@ -35,6 +35,7 @@ import chalk from '@studio/common/lib/chalk';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import {
 	fetchStudioAssistantQuota,
+	formatOutOfCreditsNotice,
 	formatQuotaResetDate,
 	formatUsageCapNotice,
 } from '@studio/common/lib/studio-assistant-quota';
@@ -1414,10 +1415,10 @@ export class AiChatUI implements AiOutputAdapter {
 	}
 
 	/**
-	 * Returns true when the current/last turn surfaced the AI usage cap
-	 * message to the user. Lets callers suppress redundant downstream
-	 * errors (e.g. the SDK's "process exited with code 1" that follows
-	 * the upstream 429).
+	 * Returns true when the current/last turn surfaced a quota refusal
+	 * notice — the usage cap or out-of-credits — to the user. Lets callers
+	 * suppress redundant downstream errors (e.g. the SDK's "process exited
+	 * with code 1" that follows the upstream 429/402).
 	 */
 	hasErrorBeenSurfaced(): boolean {
 		return this.usageCapReached;
@@ -2103,23 +2104,26 @@ export class AiChatUI implements AiOutputAdapter {
 					return;
 				}
 
-				// Detect the AI usage cap response from the WordPress.com proxy.
-				// On wpcom a 429 is always a cap issue — pi-ai surfaces it via
-				// `stopReason: 'error'` with the upstream body in `errorMessage`.
-				if (
-					message.stopReason === 'error' &&
-					this.currentProvider === 'wpcom' &&
-					isUsageCapError( message.errorMessage )
-				) {
-					this.hideLoader();
-					this.usageCapReached = true;
-					this.showError( formatUsageCapNotice() );
-					// Async on purpose: the reset date needs a wpcom round trip and
-					// must not block rendering the cap notice.
-					void this.showUsageCapResetDate();
-					this.currentMarkdown = null;
-					this.currentResponseText = '';
-					return;
+				// Detect the WordPress.com proxy's quota refusals — the monthly
+				// usage cap (429) and out-of-credits (402, STU-2236). pi-ai
+				// surfaces both via `stopReason: 'error'` with the upstream body
+				// in `errorMessage`. Out of credits gets its own copy: waiting
+				// for the reset doesn't clear it — buying credits does.
+				if ( message.stopReason === 'error' && this.currentProvider === 'wpcom' ) {
+					const outOfCredits = isOutOfCreditsError( message.errorMessage );
+					if ( outOfCredits || isUsageCapError( message.errorMessage ) ) {
+						this.hideLoader();
+						this.usageCapReached = true;
+						this.showError( outOfCredits ? formatOutOfCreditsNotice() : formatUsageCapNotice() );
+						if ( ! outOfCredits ) {
+							// Async on purpose: the reset date needs a wpcom round trip
+							// and must not block rendering the cap notice.
+							void this.showUsageCapResetDate();
+						}
+						this.currentMarkdown = null;
+						this.currentResponseText = '';
+						return;
+					}
 				}
 
 				for ( const block of message.content ) {

--- a/apps/studio/src/components/ai-access-required-notice.tsx
+++ b/apps/studio/src/components/ai-access-required-notice.tsx
@@ -36,8 +36,6 @@ export function AiBlockedNotice() {
 	} );
 }
 
-// Both AI credit pools are empty (STU-2236); buying credits is the fix, so
-// the notice links straight to the checkout.
 export function OutOfCreditsNotice() {
 	return createInterpolateElement( formatOutOfCreditsNoticeWithLink(), {
 		buyLink: <NoticeLink url={ ADD_AI_CREDITS_URL } />,

--- a/apps/studio/src/components/ai-access-required-notice.tsx
+++ b/apps/studio/src/components/ai-access-required-notice.tsx
@@ -1,6 +1,8 @@
 import {
+	ADD_AI_CREDITS_URL,
 	formatAiAccessRequiredNotice,
 	formatAiBlockedNotice,
+	formatOutOfCreditsNoticeWithLink,
 	STUDIO_CODE_AI_BETA_APPLY_URL,
 	WPCOM_SUPPORT_CONTACT_URL,
 	type StudioAssistantQuota,
@@ -31,5 +33,13 @@ export function AiAccessRequiredNotice( {
 export function AiBlockedNotice() {
 	return createInterpolateElement( formatAiBlockedNotice(), {
 		supportLink: <NoticeLink url={ WPCOM_SUPPORT_CONTACT_URL } />,
+	} );
+}
+
+// Both AI credit pools are empty (STU-2236); buying credits is the fix, so
+// the notice links straight to the checkout.
+export function OutOfCreditsNotice() {
+	return createInterpolateElement( formatOutOfCreditsNoticeWithLink(), {
+		buyLink: <NoticeLink url={ ADD_AI_CREDITS_URL } />,
 	} );
 }

--- a/apps/studio/src/components/studio-code-session/conversation/index.tsx
+++ b/apps/studio/src/components/studio-code-session/conversation/index.tsx
@@ -11,6 +11,7 @@ import { readBlobAsDataUrl } from '@studio/common/ai/composer-attachments';
 import {
 	isAiAccessRequiredError,
 	isAiBlockedError,
+	isOutOfCreditsError,
 	isUsageCapError,
 } from '@studio/common/ai/json-events';
 import {
@@ -29,7 +30,11 @@ import { __ } from '@wordpress/i18n';
 import { image, page } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { AiAccessRequiredNotice, AiBlockedNotice } from 'src/components/ai-access-required-notice';
+import {
+	AiAccessRequiredNotice,
+	AiBlockedNotice,
+	OutOfCreditsNotice,
+} from 'src/components/ai-access-required-notice';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useGetStudioAssistantQuota } from 'src/stores/wpcom-api';
@@ -651,9 +656,11 @@ function AgentQuestion( {
 	);
 }
 
-// In-flow marker for a turn that ended in an error. The monthly usage cap
-// gets dedicated copy — with the reset date once the quota query resolves —
-// instead of the raw provider message.
+// In-flow marker for a turn that ended in an error. The proxy's quota
+// refusals get dedicated copy instead of the raw provider message: the
+// monthly usage cap shows the reset date once the quota query resolves, and
+// out-of-credits (STU-2236) points at buying credits — waiting doesn't fix
+// that one.
 function TurnErrorMarker( { message }: { message: string } ) {
 	const isUsageCap = isUsageCapError( message );
 	const isAccessRequired = isAiAccessRequiredError( message );
@@ -665,6 +672,8 @@ function TurnErrorMarker( { message }: { message: string } ) {
 		text = <AiBlockedNotice />;
 	} else if ( isAccessRequired ) {
 		text = <AiAccessRequiredNotice quota={ quota } />;
+	} else if ( isOutOfCreditsError( message ) ) {
+		text = <OutOfCreditsNotice />;
 	} else if ( isUsageCap ) {
 		text = formatUsageCapNotice( quota?.costResetDate );
 	} else {

--- a/apps/studio/src/components/studio-code-session/use-agent-run.tsx
+++ b/apps/studio/src/components/studio-code-session/use-agent-run.tsx
@@ -1,6 +1,13 @@
 import { buildChatAttachmentSummaries } from '@studio/common/ai/chat-attachments';
-import { getAgentEndFailure, isUsageCapError } from '@studio/common/ai/json-events';
-import { formatUsageCapNotice } from '@studio/common/lib/studio-assistant-quota';
+import {
+	getAgentEndFailure,
+	isOutOfCreditsError,
+	isUsageCapError,
+} from '@studio/common/ai/json-events';
+import {
+	formatOutOfCreditsNotice,
+	formatUsageCapNotice,
+} from '@studio/common/lib/studio-assistant-quota';
 import { useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import {
@@ -119,6 +126,20 @@ const initialState: State = {
 	answeredQuestions: {},
 	queuedPrompts: [],
 };
+
+// Rewrites the WordPress.com proxy's quota refusals to their dedicated copy.
+// Both ride the composer's non-blocking banner (`usageCapReached`) so the user
+// can keep typing — out of credits (STU-2236) resolves by buying credits, the
+// monthly cap by waiting for the reset.
+function toQuotaAwareError( rawMessage: string ): { message: string; usageCapReached: boolean } {
+	if ( isOutOfCreditsError( rawMessage ) ) {
+		return { message: formatOutOfCreditsNotice(), usageCapReached: true };
+	}
+	if ( isUsageCapError( rawMessage ) ) {
+		return { message: formatUsageCapNotice(), usageCapReached: true };
+	}
+	return { message: rawMessage, usageCapReached: false };
+}
 
 type Action =
 	| { type: 'hydrate_active_run'; runId: string; startedAt: number; interrupting: boolean }
@@ -353,12 +374,9 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					} );
 					return;
 				case 'error': {
-					const isUsageCap = isUsageCapError( event.message );
-					const message = isUsageCap ? formatUsageCapNotice() : event.message;
 					dispatchSession( payload.sessionId, {
 						type: 'error_set',
-						message,
-						usageCapReached: isUsageCap,
+						...toQuotaAwareError( event.message ),
 					} );
 					return;
 				}
@@ -557,9 +575,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					return [ ...entries.slice( 0, idx ), ...entries.slice( idx + 1 ) ];
 				} );
 				const rawMessage = err instanceof Error ? err.message : String( err );
-				const isUsageCap = isUsageCapError( rawMessage );
-				const message = isUsageCap ? formatUsageCapNotice() : rawMessage;
-				dispatchSession( sessionId, { type: 'error_set', message, usageCapReached: isUsageCap } );
+				dispatchSession( sessionId, { type: 'error_set', ...toQuotaAwareError( rawMessage ) } );
 				throw err;
 			}
 		},

--- a/apps/studio/src/components/studio-code-session/use-agent-run.tsx
+++ b/apps/studio/src/components/studio-code-session/use-agent-run.tsx
@@ -127,20 +127,6 @@ const initialState: State = {
 	queuedPrompts: [],
 };
 
-// Rewrites the WordPress.com proxy's quota refusals to their dedicated copy.
-// Both ride the composer's non-blocking banner (`usageCapReached`) so the user
-// can keep typing — out of credits (STU-2236) resolves by buying credits, the
-// monthly cap by waiting for the reset.
-function toQuotaAwareError( rawMessage: string ): { message: string; usageCapReached: boolean } {
-	if ( isOutOfCreditsError( rawMessage ) ) {
-		return { message: formatOutOfCreditsNotice(), usageCapReached: true };
-	}
-	if ( isUsageCapError( rawMessage ) ) {
-		return { message: formatUsageCapNotice(), usageCapReached: true };
-	}
-	return { message: rawMessage, usageCapReached: false };
-}
-
 type Action =
 	| { type: 'hydrate_active_run'; runId: string; startedAt: number; interrupting: boolean }
 	| { type: 'send_pending'; startedAt: number }
@@ -374,9 +360,21 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					} );
 					return;
 				case 'error': {
+					const isUsageCap = isUsageCapError( event.message );
+					// Out of credits (STU-2236) rides the same non-blocking banner
+					// as the cap, with its own copy: buying credits is the fix, not
+					// waiting for the monthly reset.
+					const isOutOfCredits = isOutOfCreditsError( event.message );
+					let message = event.message;
+					if ( isOutOfCredits ) {
+						message = formatOutOfCreditsNotice();
+					} else if ( isUsageCap ) {
+						message = formatUsageCapNotice();
+					}
 					dispatchSession( payload.sessionId, {
 						type: 'error_set',
-						...toQuotaAwareError( event.message ),
+						message,
+						usageCapReached: isUsageCap || isOutOfCredits,
 					} );
 					return;
 				}
@@ -575,7 +573,19 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					return [ ...entries.slice( 0, idx ), ...entries.slice( idx + 1 ) ];
 				} );
 				const rawMessage = err instanceof Error ? err.message : String( err );
-				dispatchSession( sessionId, { type: 'error_set', ...toQuotaAwareError( rawMessage ) } );
+				const isUsageCap = isUsageCapError( rawMessage );
+				const isOutOfCredits = isOutOfCreditsError( rawMessage );
+				let message = rawMessage;
+				if ( isOutOfCredits ) {
+					message = formatOutOfCreditsNotice();
+				} else if ( isUsageCap ) {
+					message = formatUsageCapNotice();
+				}
+				dispatchSession( sessionId, {
+					type: 'error_set',
+					message,
+					usageCapReached: isUsageCap || isOutOfCredits,
+				} );
 				throw err;
 			}
 		},

--- a/apps/ui/src/components/ai-access-required-notice/index.tsx
+++ b/apps/ui/src/components/ai-access-required-notice/index.tsx
@@ -1,6 +1,8 @@
 import {
+	ADD_AI_CREDITS_URL,
 	formatAiAccessRequiredNotice,
 	formatAiBlockedNotice,
+	formatOutOfCreditsNoticeWithLink,
 	STUDIO_CODE_AI_BETA_APPLY_URL,
 	WPCOM_SUPPORT_CONTACT_URL,
 	type StudioAssistantQuota,
@@ -41,5 +43,13 @@ export function AiAccessRequiredNotice( {
 export function AiBlockedNotice() {
 	return createInterpolateElement( formatAiBlockedNotice(), {
 		supportLink: <NoticeLink url={ WPCOM_SUPPORT_CONTACT_URL } />,
+	} );
+}
+
+// Both AI credit pools are empty (STU-2236); buying credits is the fix, so
+// the notice links straight to the checkout.
+export function OutOfCreditsNotice() {
+	return createInterpolateElement( formatOutOfCreditsNoticeWithLink(), {
+		buyLink: <NoticeLink url={ ADD_AI_CREDITS_URL } />,
 	} );
 }

--- a/apps/ui/src/components/ai-access-required-notice/index.tsx
+++ b/apps/ui/src/components/ai-access-required-notice/index.tsx
@@ -46,8 +46,6 @@ export function AiBlockedNotice() {
 	} );
 }
 
-// Both AI credit pools are empty (STU-2236); buying credits is the fix, so
-// the notice links straight to the checkout.
 export function OutOfCreditsNotice() {
 	return createInterpolateElement( formatOutOfCreditsNoticeWithLink(), {
 		buyLink: <NoticeLink url={ ADD_AI_CREDITS_URL } />,

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -10,6 +10,7 @@ import {
 import {
 	isAiAccessRequiredError,
 	isAiBlockedError,
+	isOutOfCreditsError,
 	isUsageCapError,
 } from '@studio/common/ai/json-events';
 import {
@@ -79,7 +80,11 @@ import {
 	type ReactNode,
 	MouseEvent as ReactMouseEvent,
 } from 'react';
-import { AiAccessRequiredNotice, AiBlockedNotice } from '@/components/ai-access-required-notice';
+import {
+	AiAccessRequiredNotice,
+	AiBlockedNotice,
+	OutOfCreditsNotice,
+} from '@/components/ai-access-required-notice';
 import { CopyButton } from '@/components/copy-button';
 import { Markdown } from '@/components/markdown';
 import { useConnector, type LoadedAiSession } from '@/data/core';
@@ -1239,9 +1244,11 @@ function AgentQuestionBatch( {
 	);
 }
 
-// In-flow marker for a turn that ended in an error. The monthly usage cap
-// gets dedicated copy — with the reset date once the quota query resolves —
-// instead of the raw provider message.
+// In-flow marker for a turn that ended in an error. The proxy's quota
+// refusals get dedicated copy instead of the raw provider message: the
+// monthly usage cap shows the reset date once the quota query resolves, and
+// out-of-credits (STU-2236) points at buying credits — waiting doesn't fix
+// that one.
 function TurnErrorMarker( { message }: { message: string } ) {
 	const isUsageCap = isUsageCapError( message );
 	const isAccessRequired = isAiAccessRequiredError( message );
@@ -1251,6 +1258,8 @@ function TurnErrorMarker( { message }: { message: string } ) {
 		text = <AiBlockedNotice />;
 	} else if ( isAccessRequired ) {
 		text = <AiAccessRequiredNotice quota={ quota } />;
+	} else if ( isOutOfCreditsError( message ) ) {
+		text = <OutOfCreditsNotice />;
 	} else if ( isUsageCap ) {
 		text = formatUsageCapNotice( quota?.costResetDate );
 	} else {

--- a/packages/common/ai/json-events.ts
+++ b/packages/common/ai/json-events.ts
@@ -58,7 +58,15 @@ export function buildUsageCapErrorMessage( originalMessage: string ): string {
 	return `${ USAGE_CAP_ERROR_PREFIX }: ${ originalMessage }`;
 }
 
-const USAGE_CAP_PATTERN = new RegExp( `(?:${ USAGE_CAP_ERROR_PREFIX }|cost_cap_exceeded)`, 'i' );
+// The proxy has stamped the cap with `cost_cap_exceeded` (#3102) and later
+// `studio_cap_exceeded` (STU-2236) — match both so either wire format maps to
+// the cap state.
+const COST_CAP_CODE_PATTERN = /\b(?:cost|studio)_cap_exceeded\b/i;
+
+const USAGE_CAP_PATTERN = new RegExp(
+	`(?:${ USAGE_CAP_ERROR_PREFIX }|${ COST_CAP_CODE_PATTERN.source })`,
+	'i'
+);
 
 /**
  * Returns true when an error message indicates the user hit the AI usage cap:
@@ -78,7 +86,20 @@ export function isUsageCapError( message: string | undefined | null ): boolean {
  * alone can't tell the two apart — the `cost_cap_exceeded` code can.
  */
 export function isCostCapErrorMessage( message: string | undefined | null ): boolean {
-	return /\bcost_cap_exceeded\b/i.test( message ?? '' );
+	return COST_CAP_CODE_PATTERN.test( message ?? '' );
+}
+
+/**
+ * Returns true when the WordPress.com proxy refused the request because both
+ * AI credit pools are empty — the free monthly allowance is used up and no
+ * purchased credits remain (STU-2236). The proxy's 402 repeats the
+ * `studio_out_of_credits` code inside its message text; as with the other
+ * refusal codes, the AI SDKs surface only the message string, so the token is
+ * the load-bearing marker. Distinct from the monthly cap on purpose: waiting
+ * for the reset doesn't clear this state — the user has to buy credits.
+ */
+export function isOutOfCreditsError( message: string | undefined | null ): boolean {
+	return /studio_out_of_credits/i.test( message ?? '' );
 }
 
 /**

--- a/packages/common/ai/json-events.ts
+++ b/packages/common/ai/json-events.ts
@@ -58,15 +58,7 @@ export function buildUsageCapErrorMessage( originalMessage: string ): string {
 	return `${ USAGE_CAP_ERROR_PREFIX }: ${ originalMessage }`;
 }
 
-// The proxy has stamped the cap with `cost_cap_exceeded` (#3102) and later
-// `studio_cap_exceeded` (STU-2236) — match both so either wire format maps to
-// the cap state.
-const COST_CAP_CODE_PATTERN = /\b(?:cost|studio)_cap_exceeded\b/i;
-
-const USAGE_CAP_PATTERN = new RegExp(
-	`(?:${ USAGE_CAP_ERROR_PREFIX }|${ COST_CAP_CODE_PATTERN.source })`,
-	'i'
-);
+const USAGE_CAP_PATTERN = new RegExp( `(?:${ USAGE_CAP_ERROR_PREFIX }|cost_cap_exceeded)`, 'i' );
 
 /**
  * Returns true when an error message indicates the user hit the AI usage cap:
@@ -86,7 +78,7 @@ export function isUsageCapError( message: string | undefined | null ): boolean {
  * alone can't tell the two apart — the `cost_cap_exceeded` code can.
  */
 export function isCostCapErrorMessage( message: string | undefined | null ): boolean {
-	return COST_CAP_CODE_PATTERN.test( message ?? '' );
+	return /\bcost_cap_exceeded\b/i.test( message ?? '' );
 }
 
 /**

--- a/packages/common/ai/tests/json-events.test.ts
+++ b/packages/common/ai/tests/json-events.test.ts
@@ -56,7 +56,6 @@ describe( 'isUsageCapError', () => {
 		expect(
 			isUsageCapError( 'OpenAI API error (429): {"error":{"code":"cost_cap_exceeded"}}' )
 		).toBe( true );
-		expect( isUsageCapError( '429 studio_cap_exceeded: Monthly cost cap exceeded.' ) ).toBe( true );
 	} );
 
 	// STU-2236: both credit pools empty is its own state — the fix is buying
@@ -98,7 +97,7 @@ describe( 'isOutOfCreditsError', () => {
 	} );
 
 	it( 'does not match the cap refusal or unrelated errors', () => {
-		expect( isOutOfCreditsError( '429 studio_cap_exceeded: Monthly cost cap exceeded.' ) ).toBe(
+		expect( isOutOfCreditsError( '429 cost_cap_exceeded: Monthly cost cap exceeded.' ) ).toBe(
 			false
 		);
 		expect( isOutOfCreditsError( buildUsageCapErrorMessage( '429 exceeded' ) ) ).toBe( false );

--- a/packages/common/ai/tests/json-events.test.ts
+++ b/packages/common/ai/tests/json-events.test.ts
@@ -4,6 +4,7 @@ import {
 	getAgentEndFailure,
 	isAiAccessRequiredError,
 	isAiBlockedError,
+	isOutOfCreditsError,
 	isUsageCapError,
 	USAGE_CAP_ERROR_PREFIX,
 } from '../json-events';
@@ -55,6 +56,17 @@ describe( 'isUsageCapError', () => {
 		expect(
 			isUsageCapError( 'OpenAI API error (429): {"error":{"code":"cost_cap_exceeded"}}' )
 		).toBe( true );
+		expect( isUsageCapError( '429 studio_cap_exceeded: Monthly cost cap exceeded.' ) ).toBe( true );
+	} );
+
+	// STU-2236: both credit pools empty is its own state — the fix is buying
+	// credits, not waiting for the reset — so it must not read as the cap.
+	it( 'does not match the out-of-credits refusal', () => {
+		expect(
+			isUsageCapError(
+				"402 studio_out_of_credits: You've used your free monthly AI allowance and have no credits left."
+			)
+		).toBe( false );
 	} );
 
 	// A hosted upstream 429s for its own token-per-minute limits, which
@@ -68,6 +80,32 @@ describe( 'isUsageCapError', () => {
 	it( 'does not match raw un-rewritten 429s (non-wpcom rate limits)', () => {
 		expect( isUsageCapError( '429 rate limited' ) ).toBe( false );
 		expect( isUsageCapError( 'OpenAI API error (429): rate limited' ) ).toBe( false );
+	} );
+} );
+
+describe( 'isOutOfCreditsError', () => {
+	it( 'matches the load-bearing code token wherever it appears in the message', () => {
+		expect(
+			isOutOfCreditsError(
+				"studio_out_of_credits: You've used your free monthly AI allowance and have no credits left. Buy credits in WordPress Studio to continue."
+			)
+		).toBe( true );
+		expect(
+			isOutOfCreditsError(
+				'402 {"code":"studio_out_of_credits","message":"studio_out_of_credits: You\'ve used your free monthly AI allowance and have no credits left.","data":{"status":402}}'
+			)
+		).toBe( true );
+	} );
+
+	it( 'does not match the cap refusal or unrelated errors', () => {
+		expect( isOutOfCreditsError( '429 studio_cap_exceeded: Monthly cost cap exceeded.' ) ).toBe(
+			false
+		);
+		expect( isOutOfCreditsError( buildUsageCapErrorMessage( '429 exceeded' ) ) ).toBe( false );
+		expect( isOutOfCreditsError( '402 payment required' ) ).toBe( false );
+		expect( isOutOfCreditsError( '500 internal server error' ) ).toBe( false );
+		expect( isOutOfCreditsError( undefined ) ).toBe( false );
+		expect( isOutOfCreditsError( null ) ).toBe( false );
 	} );
 } );
 

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -185,3 +185,27 @@ export function formatUsageCapNotice( resetDate?: string | null, locale?: string
 	}
 	return __( 'You’ve reached your monthly AI usage limit. Try again later.' );
 }
+
+/**
+ * User-facing copy for having exhausted both AI credit pools — the free
+ * monthly allowance and purchased credits (STU-2236). Shared by every surface
+ * so the wording stays consistent. Deliberately never mentions the monthly
+ * reset: unlike the usage cap, waiting doesn't fix this state — buying
+ * credits does.
+ */
+export function formatOutOfCreditsNotice(): string {
+	return __( 'You’re out of AI credits. Add more credits to continue using Studio Code.' );
+}
+
+/**
+ * Linked variant of the out-of-credits notice for surfaces that can render a
+ * purchase link. Wraps the call-to-action in a `<buyLink>` token: render it
+ * with `createInterpolateElement`, pointing the token at
+ * `ADD_AI_CREDITS_URL`.
+ */
+export function formatOutOfCreditsNoticeWithLink(): string {
+	return __(
+		/* translators: <buyLink> and </buyLink> wrap the link to buy AI credits and must be kept as-is. */
+		'You’re out of AI credits. <buyLink>Add AI credits</buyLink> to continue using Studio Code.'
+	);
+}


### PR DESCRIPTION
## Related issues

- Fixes STU-2298

## How AI was used in this PR

Assisted

## Proposed Changes

We need to print error with a link to top up balance when user runs out of credits.

<img width="672" height="245" alt="Screenshot 2026-08-19 at 22 17 41" src="https://github.com/user-attachments/assets/4a90f0b6-9180-41cf-96a4-916398b9b2fb" />


## Testing Instructions
See 235535-ghe-Automattic/wpcom