### PR TITLE
Agentic UI: Dedupe the sidebar's site start/stop toggle into a shared hook

### DIFF
--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -13,8 +13,6 @@ import {
 	useIsSiteStarting,
 	useIsSiteStopping,
 	useSites,
-	useStartSite,
-	useStopSite,
 	useToggleSiteRunning,
 	useUpdateSitesSortOrder,
 } from '@/data/queries/use-sites';
@@ -64,8 +62,6 @@ vi.mock( '@/data/queries/use-sites', () => ( {
 	useIsSiteStarting: vi.fn(),
 	useIsSiteStopping: vi.fn(),
 	useSites: vi.fn(),
-	useStartSite: vi.fn(),
-	useStopSite: vi.fn(),
 	useToggleSiteRunning: vi.fn(),
 	useUpdateSitesSortOrder: vi.fn(),
 } ) );
@@ -98,8 +94,6 @@ const useIsSiteStoppingMock = vi.mocked( useIsSiteStopping );
 const useSiteAgentActivityMock = vi.mocked( useSiteAgentActivity );
 const useSessionsMock = vi.mocked( useSessions, { partial: true } );
 const useSitesMock = vi.mocked( useSites, { partial: true } );
-const useStartSiteMock = vi.mocked( useStartSite, { partial: true } );
-const useStopSiteMock = vi.mocked( useStopSite, { partial: true } );
 const useToggleSiteRunningMock = vi.mocked( useToggleSiteRunning );
 const useUpdateSitesSortOrderMock = vi.mocked( useUpdateSitesSortOrder, { partial: true } );
 const useSiteSyncActivityMock = vi.mocked( useSiteSyncActivity );
@@ -137,14 +131,24 @@ describe( 'SiteList', () => {
 		useDeleteSiteMock.mockReturnValue( { isPending: false, mutate: vi.fn() } );
 		useExportDatabaseMock.mockReturnValue( { isPending: false, mutate: vi.fn() } );
 		useExportFullSiteMock.mockReturnValue( { isPending: false, mutate: vi.fn() } );
-		useStartSiteMock.mockReturnValue( { isPending: false, mutate: startSite } );
-		useStopSiteMock.mockReturnValue( { isPending: false, mutate: stopSite } );
-		// Mirrors the real hook's behavior over the startSite/stopSite spies so
-		// assertions on those keep working.
-		useToggleSiteRunningMock.mockImplementation( ( site ) => ( {
-			busy: false,
-			toggle: () => ( site.running ? stopSite( site.id ) : startSite( site.id ) ),
-		} ) );
+		// Mirrors the real hook's behavior over the startSite/stopSite spies —
+		// including the busy no-op — so assertions on those keep working.
+		useToggleSiteRunningMock.mockImplementation( ( site ) => {
+			const busy = useIsSiteBusyMock( site );
+			return {
+				busy,
+				toggle: () => {
+					if ( busy ) {
+						return;
+					}
+					if ( site.running ) {
+						stopSite( site.id );
+					} else {
+						startSite( site.id );
+					}
+				},
+			};
+		} );
 		useUpdateSitesSortOrderMock.mockReturnValue( {
 			isPending: false,
 			mutate: updateSitesSortOrder,
@@ -212,6 +216,20 @@ describe( 'SiteList', () => {
 
 		expect( runningButton.querySelectorAll( 'svg' ) ).toHaveLength( 1 );
 		expect( actionGlyph?.querySelector( 'span' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not start or stop a site while it is busy', () => {
+		useIsSiteBusyMock.mockReturnValue( true );
+		render( <SiteList /> );
+
+		// Busy drops the action suffix from the label (see getSiteStatusName).
+		const stoppedButton = screen.getByRole( 'button', { name: 'Site status: Stopped' } );
+		expect( stoppedButton ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		fireEvent.click( stoppedButton );
+
+		expect( startSite ).not.toHaveBeenCalled();
+		expect( stopSite ).not.toHaveBeenCalled();
 	} );
 
 	it( 'opens site actions from a row right-click without opening the latest chat', async () => {

--- a/apps/ui/src/components/site-list/index.test.tsx
+++ b/apps/ui/src/components/site-list/index.test.tsx
@@ -15,6 +15,7 @@ import {
 	useSites,
 	useStartSite,
 	useStopSite,
+	useToggleSiteRunning,
 	useUpdateSitesSortOrder,
 } from '@/data/queries/use-sites';
 import { useUserPreferences } from '@/data/queries/use-user-preferences';
@@ -65,6 +66,7 @@ vi.mock( '@/data/queries/use-sites', () => ( {
 	useSites: vi.fn(),
 	useStartSite: vi.fn(),
 	useStopSite: vi.fn(),
+	useToggleSiteRunning: vi.fn(),
 	useUpdateSitesSortOrder: vi.fn(),
 } ) );
 
@@ -98,6 +100,7 @@ const useSessionsMock = vi.mocked( useSessions, { partial: true } );
 const useSitesMock = vi.mocked( useSites, { partial: true } );
 const useStartSiteMock = vi.mocked( useStartSite, { partial: true } );
 const useStopSiteMock = vi.mocked( useStopSite, { partial: true } );
+const useToggleSiteRunningMock = vi.mocked( useToggleSiteRunning );
 const useUpdateSitesSortOrderMock = vi.mocked( useUpdateSitesSortOrder, { partial: true } );
 const useSiteSyncActivityMock = vi.mocked( useSiteSyncActivity );
 const useUserPreferencesMock = vi.mocked( useUserPreferences, { partial: true } );
@@ -136,6 +139,12 @@ describe( 'SiteList', () => {
 		useExportFullSiteMock.mockReturnValue( { isPending: false, mutate: vi.fn() } );
 		useStartSiteMock.mockReturnValue( { isPending: false, mutate: startSite } );
 		useStopSiteMock.mockReturnValue( { isPending: false, mutate: stopSite } );
+		// Mirrors the real hook's behavior over the startSite/stopSite spies so
+		// assertions on those keep working.
+		useToggleSiteRunningMock.mockImplementation( ( site ) => ( {
+			busy: false,
+			toggle: () => ( site.running ? stopSite( site.id ) : startSite( site.id ) ),
+		} ) );
 		useUpdateSitesSortOrderMock.mockReturnValue( {
 			isPending: false,
 			mutate: updateSitesSortOrder,

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -35,13 +35,11 @@ import { useSiteAgentActivity, type SiteAgentActivity } from '@/data/queries/use
 import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
 import { useSessions } from '@/data/queries/use-sessions';
 import {
-	useIsSiteBusy,
 	useIsSiteStarting,
 	useIsSiteStopping,
 	useSiteOperation,
 	useSites,
-	useStartSite,
-	useStopSite,
+	useToggleSiteRunning,
 	useUpdateSitesSortOrder,
 } from '@/data/queries/use-sites';
 import { useUserPreferences } from '@/data/queries/use-user-preferences';
@@ -301,9 +299,7 @@ function SiteStatusButton( {
 	isStarting: boolean;
 	isStopping: boolean;
 } ) {
-	const startSite = useStartSite();
-	const stopSite = useStopSite();
-	const busy = useIsSiteBusy( site );
+	const { busy, toggle } = useToggleSiteRunning( site );
 	const operation = useSiteOperation( site );
 	const { status } = deriveSiteStatus( site, isStarting, isStopping, operation );
 	// The recorded operation wins: it names work this window didn't start (an
@@ -322,14 +318,7 @@ function SiteStatusButton( {
 	const label = busy ? tooltipLabel : sprintf( __( '%1$s. %2$s' ), tooltipLabel, actionLabel );
 	const handleClick = ( event: MouseEvent< HTMLButtonElement > ) => {
 		event.stopPropagation();
-		if ( busy ) {
-			return;
-		}
-		if ( site.running ) {
-			stopSite.mutate( site.id );
-		} else {
-			startSite.mutate( site.id );
-		}
+		toggle();
 	};
 
 	return (
@@ -411,9 +400,7 @@ function SiteActionsMenu( {
 	const params = useParams( { strict: false } ) as { sessionId?: string; siteId?: string };
 	const connector = useConnector();
 	const { data: userPreferences } = useUserPreferences();
-	const startSite = useStartSite();
-	const stopSite = useStopSite();
-	const busy = useIsSiteBusy( site );
+	const { busy, toggle } = useToggleSiteRunning( site );
 	const [ deleteOpen, setDeleteOpen ] = useState( false );
 	// Same source as the overview screen's Manage section, so the two can't drift
 	// on what's blocked or what's in flight. Only the labels differ here.
@@ -486,11 +473,11 @@ function SiteActionsMenu( {
 					onPointerDown={ stopMenuEventPropagation }
 				>
 					{ site.running ? (
-						<Menu.Item disabled={ busy } onClick={ () => stopSite.mutate( site.id ) }>
+						<Menu.Item disabled={ busy } onClick={ toggle }>
 							{ __( 'Stop site' ) }
 						</Menu.Item>
 					) : (
-						<Menu.Item disabled={ busy } onClick={ () => startSite.mutate( site.id ) }>
+						<Menu.Item disabled={ busy } onClick={ toggle }>
 							{ isStarting ? __( 'Starting…' ) : __( 'Start site' ) }
 						</Menu.Item>
 					) }

--- a/apps/ui/src/components/site-list/index.tsx
+++ b/apps/ui/src/components/site-list/index.tsx
@@ -472,15 +472,13 @@ function SiteActionsMenu( {
 					onClick={ stopMenuEventPropagation }
 					onPointerDown={ stopMenuEventPropagation }
 				>
-					{ site.running ? (
-						<Menu.Item disabled={ busy } onClick={ toggle }>
-							{ __( 'Stop site' ) }
-						</Menu.Item>
-					) : (
-						<Menu.Item disabled={ busy } onClick={ toggle }>
-							{ isStarting ? __( 'Starting…' ) : __( 'Start site' ) }
-						</Menu.Item>
-					) }
+					<Menu.Item disabled={ busy } onClick={ toggle }>
+						{ site.running
+							? __( 'Stop site' )
+							: isStarting
+							? __( 'Starting…' )
+							: __( 'Start site' ) }
+					</Menu.Item>
 					<Menu.Separator />
 					<Menu.Item
 						onClick={ () => {

--- a/apps/ui/src/data/queries/use-sites.test.tsx
+++ b/apps/ui/src/data/queries/use-sites.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
-import { useAutoStartSites, useStartSite, useStopSite } from './use-sites';
+import { useAutoStartSites, useStartSite, useStopSite, useToggleSiteRunning } from './use-sites';
 import type { Connector, SiteDetails } from '@/data/core';
 import type { ReactNode } from 'react';
 
@@ -131,5 +131,60 @@ describe( 'useStartSite', () => {
 
 		await expect( result.current.start.mutateAsync( 'site-1' ) ).resolves.toBe( true );
 		expect( startSite ).toHaveBeenCalledWith( 'site-1' );
+	} );
+} );
+
+describe( 'useToggleSiteRunning', () => {
+	const startSite = vi.fn( () => Promise.resolve() );
+	const stopSite = vi.fn( () => Promise.resolve() );
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		useConnectorMock.mockReturnValue( {
+			getSites: vi.fn( () => Promise.resolve( [] ) ),
+			startSite,
+			stopSite,
+		} as unknown as Connector );
+	} );
+
+	function renderToggle( site: SiteDetails ) {
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		} );
+		return renderHook( () => useToggleSiteRunning( site ), {
+			wrapper: ( { children }: { children: ReactNode } ) => (
+				<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+			),
+		} ).result;
+	}
+
+	it( 'starts a stopped site', async () => {
+		const result = renderToggle( createSite( { running: false } ) );
+
+		result.current.toggle();
+
+		await waitFor( () => expect( startSite ).toHaveBeenCalledWith( 'site-1' ) );
+		expect( stopSite ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stops a running site', async () => {
+		const result = renderToggle( createSite( { running: true } ) );
+
+		result.current.toggle();
+
+		await waitFor( () => expect( stopSite ).toHaveBeenCalledWith( 'site-1' ) );
+		expect( startSite ).not.toHaveBeenCalled();
+	} );
+
+	it( 'no-ops while an operation already owns the site', () => {
+		const result = renderToggle(
+			createSite( { running: false, operation: { pid: 1, kind: 'start' } } )
+		);
+
+		expect( result.current.busy ).toBe( true );
+		result.current.toggle();
+
+		expect( startSite ).not.toHaveBeenCalled();
+		expect( stopSite ).not.toHaveBeenCalled();
 	} );
 } );

--- a/apps/ui/src/data/queries/use-sites.ts
+++ b/apps/ui/src/data/queries/use-sites.ts
@@ -310,8 +310,9 @@ export function useIsSiteBusy( site: SiteDetails | undefined ): boolean {
 }
 
 /**
- * The start/stop toggle every site control shares: no-ops while the site is
- * busy, otherwise starts a stopped site and stops a running one.
+ * The start/stop toggle the sidebar's status button and row menu share:
+ * no-ops while the site is busy, otherwise starts a stopped site and stops a
+ * running one.
  */
 export function useToggleSiteRunning( site: SiteDetails ): { busy: boolean; toggle: () => void } {
 	const startSite = useStartSite();

--- a/apps/ui/src/data/queries/use-sites.ts
+++ b/apps/ui/src/data/queries/use-sites.ts
@@ -310,6 +310,27 @@ export function useIsSiteBusy( site: SiteDetails | undefined ): boolean {
 }
 
 /**
+ * The start/stop toggle every site control shares: no-ops while the site is
+ * busy, otherwise starts a stopped site and stops a running one.
+ */
+export function useToggleSiteRunning( site: SiteDetails ): { busy: boolean; toggle: () => void } {
+	const startSite = useStartSite();
+	const stopSite = useStopSite();
+	const busy = useIsSiteBusy( site );
+	const toggle = () => {
+		if ( busy ) {
+			return;
+		}
+		if ( site.running ) {
+			stopSite.mutate( site.id );
+		} else {
+			startSite.mutate( site.id );
+		}
+	};
+	return { busy, toggle };
+}
+
+/**
  * Keeps the cached site list in sync with main-process events (site created,
  * updated, started, stopped, deleted). Mount once near the app root.
  */


### PR DESCRIPTION
## Related issues

- STU-2162 (prep)

## How AI was used in this PR

AI carved this from the larger site-header exploration as a standalone dedupe.

## Proposed Changes

The sidebar's status button and its row context menu each re-implemented the same busy-guarded start/stop toggle. `useToggleSiteRunning` is now the single source; both consume it. The upcoming site header menu becomes a third consumer.

## Testing Instructions

1. In the sidebar, click a site's status dot — the site starts/stops as before, and the control no-ops while the site is busy.
2. Right-click a site row — Start/Stop in the context menu behaves identically.

### Verification completed

- `npm run typecheck` · site-list suite 30/30

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
