### PR TITLE
Agentic UI: Surface publish-picker load and connect failures

### DIFF
--- a/apps/ui/src/components/site-dropdown/publish-picker-view.module.css
+++ b/apps/ui/src/components/site-dropdown/publish-picker-view.module.css
@@ -23,10 +23,60 @@
 }
 
 .status {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-xs);
 	padding: var(--wpds-dimension-padding-lg);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font-size: var(--wpds-typography-font-size-sm);
 	text-align: center;
+}
+
+.statusHint {
+	font-size: var(--wpds-typography-font-size-xs);
+}
+
+.statusError {
+	margin: 0;
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-lg);
+	color: var(--wpds-color-fg-content-error);
+	font-size: var(--wpds-typography-font-size-sm);
+}
+
+.loadError {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--wpds-dimension-gap-xs);
+	padding: var(--wpds-dimension-padding-lg);
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.loadError strong {
+	color: var(--wpds-color-fg-content-neutral);
+	font-weight: 500;
+}
+
+.retry {
+	background: transparent;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	font: inherit;
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-interactive-brand);
+}
+
+.retry:hover,
+.retry:focus-visible {
+	text-decoration: underline;
+	outline: none;
+}
+
+.item:disabled {
+	cursor: default;
+	opacity: 0.6;
 }
 
 .list {

--- a/apps/ui/src/components/site-dropdown/publish-picker-view.module.css
+++ b/apps/ui/src/components/site-dropdown/publish-picker-view.module.css
@@ -29,6 +29,7 @@
 	padding: var(--wpds-dimension-padding-lg);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
 	text-align: center;
 }
 
@@ -41,6 +42,7 @@
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-lg);
 	color: var(--wpds-color-fg-content-error);
 	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
 }
 
 .loadError {
@@ -50,6 +52,7 @@
 	gap: var(--wpds-dimension-gap-xs);
 	padding: var(--wpds-dimension-padding-lg);
 	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 

--- a/apps/ui/src/components/site-dropdown/publish-picker-view.tsx
+++ b/apps/ui/src/components/site-dropdown/publish-picker-view.tsx
@@ -2,10 +2,12 @@ import { useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { chevronLeft, plus } from '@wordpress/icons';
 import { Icon, IconButton } from '@wordpress/ui';
+import { useEffect, useState } from 'react';
 import { useConnector } from '@/data/core';
 import { useAuthUser } from '@/data/queries/use-auth-user';
 import { connectedWpcomSitesQueryKey } from '@/data/queries/use-connected-wpcom-sites';
 import { usePickableWpcomSites } from '@/data/queries/use-wpcom-sites';
+import { getWpcomLoadErrorDetail } from '@/lib/wpcom-load-error';
 import styles from './publish-picker-view.module.css';
 import { stripProtocol } from './utils';
 import type { SiteDetails, SyncSite } from '@/data/core';
@@ -23,12 +25,34 @@ export function PublishPickerView( { site, onClose }: Props ) {
 	const queryClient = useQueryClient();
 	const { data: authUser } = useAuthUser();
 	const pickableSites = usePickableWpcomSites();
+	const isLoading =
+		pickableSites.data === undefined && ( pickableSites.isLoading || pickableSites.isFetching );
+	const loadFailed = !! pickableSites.error && pickableSites.data === undefined;
+	const [ connectingId, setConnectingId ] = useState< number | null >( null );
+	const [ connectError, setConnectError ] = useState( '' );
+	const [ slowLoading, setSlowLoading ] = useState( false );
+
+	// Large accounts can take a while; surface a hint so a long load doesn't
+	// read as a hang.
+	useEffect( () => {
+		if ( ! isLoading ) {
+			setSlowLoading( false );
+			return;
+		}
+		const timer = window.setTimeout( () => setSlowLoading( true ), 6_000 );
+		return () => window.clearTimeout( timer );
+	}, [ isLoading ] );
 
 	const openExternal = ( url: string ) => {
 		void connector.openExternalUrl( url );
 	};
 
 	const handlePickSite = async ( pickedSite: SyncSite ) => {
+		if ( connectingId !== null ) {
+			return;
+		}
+		setConnectingId( pickedSite.id );
+		setConnectError( '' );
 		try {
 			await connector.connectWpcomSite( site.id, {
 				...pickedSite,
@@ -40,7 +64,13 @@ export function PublishPickerView( { site, onClose }: Props ) {
 			} );
 			onClose();
 		} catch ( error ) {
-			console.error( 'Failed to connect WordPress.com site:', error );
+			setConnectError(
+				error instanceof Error && error.message
+					? error.message
+					: __( 'Failed to connect the site. Please try again.' )
+			);
+		} finally {
+			setConnectingId( null );
 		}
 	};
 
@@ -70,10 +100,34 @@ export function PublishPickerView( { site, onClose }: Props ) {
 				/>
 				<span className={ styles.title }>{ __( 'Publish this site' ) }</span>
 			</div>
+			{ connectError ? (
+				<p role="alert" className={ styles.statusError }>
+					{ connectError }
+				</p>
+			) : null }
 			{ authUser ? (
 				<div className={ styles.body }>
-					{ pickableSites.isLoading ? (
-						<div className={ styles.status }>{ __( 'Loading sites…' ) }</div>
+					{ isLoading ? (
+						<div role="status" className={ styles.status }>
+							<span>{ __( 'Loading sites…' ) }</span>
+							{ slowLoading ? (
+								<span className={ styles.statusHint }>
+									{ __( 'Large accounts can take a little longer.' ) }
+								</span>
+							) : null }
+						</div>
+					) : loadFailed ? (
+						<div role="alert" className={ styles.loadError }>
+							<strong>{ __( 'Couldn’t load your WordPress.com sites.' ) }</strong>
+							<span>{ getWpcomLoadErrorDetail( pickableSites.error ) }</span>
+							<button
+								type="button"
+								className={ styles.retry }
+								onClick={ () => void pickableSites.refetch() }
+							>
+								{ __( 'Retry' ) }
+							</button>
+						</div>
 					) : pickableSites.data && pickableSites.data.length > 0 ? (
 						<ul className={ styles.list }>
 							{ pickableSites.data.map( ( candidate ) => (
@@ -81,9 +135,14 @@ export function PublishPickerView( { site, onClose }: Props ) {
 									<button
 										type="button"
 										className={ styles.item }
+										disabled={ connectingId !== null }
 										onClick={ () => void handlePickSite( candidate ) }
 									>
-										<span className={ styles.itemName }>{ candidate.name || candidate.url }</span>
+										<span className={ styles.itemName }>
+											{ connectingId === candidate.id
+												? __( 'Connecting…' )
+												: candidate.name || candidate.url }
+										</span>
 										<span className={ styles.itemUrl }>{ stripProtocol( candidate.url ) }</span>
 									</button>
 								</li>
@@ -96,7 +155,12 @@ export function PublishPickerView( { site, onClose }: Props ) {
 					) }
 				</div>
 			) : null }
-			<button type="button" className={ styles.create } onClick={ handleCreateNew }>
+			<button
+				type="button"
+				className={ styles.create }
+				disabled={ connectingId !== null }
+				onClick={ handleCreateNew }
+			>
 				<Icon icon={ plus } size={ 16 } />
 				<span>{ __( 'Create a new WordPress.com site' ) }</span>
 			</button>

--- a/apps/ui/src/lib/wpcom-load-error.test.ts
+++ b/apps/ui/src/lib/wpcom-load-error.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { getWpcomLoadErrorDetail } from './wpcom-load-error';
+
+describe( 'getWpcomLoadErrorDetail', () => {
+	it( 'suggests connectivity for empty errors', () => {
+		expect( getWpcomLoadErrorDetail( undefined ) ).toMatch( /internet connection/ );
+		expect( getWpcomLoadErrorDetail( new Error( '' ) ) ).toMatch( /internet connection/ );
+	} );
+
+	it( 'classifies expired-session errors', () => {
+		expect( getWpcomLoadErrorDetail( new Error( 'Unauthorized (401)' ) ) ).toMatch( /expired/ );
+		expect( getWpcomLoadErrorDetail( new Error( 'invalid token' ) ) ).toMatch( /expired/ );
+	} );
+
+	it( 'classifies network errors', () => {
+		expect( getWpcomLoadErrorDetail( new Error( 'request timed out' ) ) ).toMatch(
+			/internet connection/
+		);
+		expect( getWpcomLoadErrorDetail( new Error( 'fetch failed: ECONNREFUSED' ) ) ).toMatch(
+			/internet connection/
+		);
+	} );
+
+	it( 'classifies rate limiting and server errors', () => {
+		expect( getWpcomLoadErrorDetail( new Error( 'Too many requests' ) ) ).toMatch(
+			/too many requests/
+		);
+		expect( getWpcomLoadErrorDetail( new Error( '502 Bad Gateway' ) ) ).toMatch(
+			/temporarily unavailable/
+		);
+	} );
+
+	it( 'strips the Electron IPC prefix and surfaces short raw messages', () => {
+		expect(
+			getWpcomLoadErrorDetail(
+				new Error( "Error invoking remote method 'wpcom:sites': Something specific went wrong" )
+			)
+		).toBe( 'Something specific went wrong' );
+	} );
+
+	it( 'hides long messages and raw HTTP dumps', () => {
+		expect( getWpcomLoadErrorDetail( new Error( 'x'.repeat( 200 ) ) ) ).toMatch(
+			/internet connection/
+		);
+		expect( getWpcomLoadErrorDetail( new Error( 'GET /rest/v1.1/me/sites failed' ) ) ).toMatch(
+			/internet connection/
+		);
+	} );
+} );

--- a/apps/ui/src/lib/wpcom-load-error.ts
+++ b/apps/ui/src/lib/wpcom-load-error.ts
@@ -1,0 +1,36 @@
+import { getErrorMessage } from '@studio/common/lib/error-formatting';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * A short, user-facing explanation for a failed WordPress.com request.
+ * Classifies the common failure modes and falls back to a connectivity hint.
+ */
+export function getWpcomLoadErrorDetail( error: unknown ): string {
+	// Unwrap Electron's "Error invoking remote method '…':" IPC prefix so the
+	// user sees the underlying message, not the transport.
+	const message = getErrorMessage( error )
+		?.replace( /^Error invoking remote method '[^']+':\s*/i, '' )
+		.replace( /^Error:\s*/i, '' )
+		.trim();
+	if ( ! message ) {
+		return __( 'Check your internet connection and try again.' );
+	}
+	if ( /auth|token|sign[ -]?in|unauthori[sz]ed|\b401\b/i.test( message ) ) {
+		return __( 'Your WordPress.com session may have expired.' );
+	}
+	if ( /network|offline|timed? out|timeout|econn|enotfound|failed to fetch/i.test( message ) ) {
+		return __( 'Check your internet connection and try again.' );
+	}
+	if ( /rate.?limit|too many requests|\b429\b/i.test( message ) ) {
+		return __( 'WordPress.com is receiving too many requests. Try again in a moment.' );
+	}
+	if ( /\b5\d\d\b|service unavailable|bad gateway/i.test( message ) ) {
+		return __( 'WordPress.com may be temporarily unavailable. Try again in a moment.' );
+	}
+	// Only surface the raw message if it's short and not a raw HTTP-request
+	// dump; otherwise fall back to the generic hint.
+	if ( message.length <= 180 && ! /\b(?:GET|POST) \/.*failed/i.test( message ) ) {
+		return message;
+	}
+	return __( 'Check your internet connection and try again.' );
+}


### PR DESCRIPTION
## Related issues

- STU-2162 (prep)

## How AI was used in this PR

AI ported these states from the site-header exploration into the existing picker.

## Proposed Changes

The publish picker rendered nothing when the WordPress.com sites request failed and swallowed connect errors into the console.

- Failed loads show a classified, user-readable reason (expired session, offline, rate-limited, service down) with a Retry.
- Connect failures surface inline instead of silently doing nothing.
- Long loads get a "large accounts" hint after 6s; picking a site shows "Connecting…" and guards double-clicks.
- The error classifier is a shared, unit-tested helper (`lib/wpcom-load-error`).

## Screenshots

| Loading | Error + Retry |
|---|---|
| ![Loading state](https://github.com/Automattic/studio/blob/04fb6a1ba404c9a13be4913107dc17a484f92396/pr2-picker-loading-light.png?raw=true) | ![Error state light](https://github.com/Automattic/studio/blob/04fb6a1ba404c9a13be4913107dc17a484f92396/pr2-picker-error-light.png?raw=true) |

| Error + Retry (dark) |
|---|
| ![Error state dark](https://github.com/Automattic/studio/blob/04fb6a1ba404c9a13be4913107dc17a484f92396/pr2-picker-error-dark.png?raw=true) |

## Testing Instructions

1. Open **Publish** on an unconnected site while signed in — the sites list loads as before.
2. Kill your network and reopen it — a readable error with Retry appears instead of an empty panel.
3. Pick a site — the row reads "Connecting…" and other rows disable until it finishes.

### Verification completed

- `npm run typecheck` · new helper tests 6/6 · dropdown suites pass

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?


