### PR TITLE
Agentic UI: Make the site identity a menu with start/stop and quick actions

### DIFF
--- a/apps/ui/src/components/site-toolbar/index.tsx
+++ b/apps/ui/src/components/site-toolbar/index.tsx
@@ -22,6 +22,12 @@ import {
 	PUBLISH_PREVIEW_MUTATION_KEY,
 	usePublishPreviewSite,
 } from '@/data/queries/use-preview-site';
+import {
+	useIsSiteStarting,
+	useIsSiteStopping,
+	useSiteOperation,
+	useToggleSiteRunning,
+} from '@/data/queries/use-sites';
 import { useSnapshots, useSnapshotUsage } from '@/data/queries/use-snapshots';
 import {
 	PULL_FROM_LIVE_MUTATION_KEY,
@@ -30,11 +36,13 @@ import {
 	usePushSiteToLive,
 } from '@/data/queries/use-sync-site';
 import { useSiteSyncActivity } from '@/data/sync-activity';
-import { getSiteDisplayUrl } from '@/lib/get-site-url';
+import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
+import { getSiteDisplayUrl, getSiteUrl } from '@/lib/get-site-url';
 import { DisconnectSiteDialog } from './disconnect-site-dialog';
 import { PublishPickerView } from './publish-picker-view';
 import styles from './style.module.css';
 import {
+	deriveSiteStatus,
 	ensureProtocol,
 	getSnapshotHostname,
 	pickLatestSnapshot,
@@ -68,9 +76,9 @@ function useIsSiteBusy( siteId: string ): boolean {
 }
 
 /**
- * The site's permanent header: who you're working on on the left, its actions
- * on the right. Replaces the old site dropdown, whose actions were hidden
- * behind a trigger that read as a status indicator.
+ * The site's permanent header: who you're working on and what state it's in on
+ * the left, its actions on the right. Replaces the old site dropdown, whose
+ * actions were hidden behind a trigger that read as a status indicator.
  *
  * A connected site gets a Sync menu (push/pull) and Share; an unconnected one
  * gets Publish to connect a WordPress.com site. Signed-out users see Log in.
@@ -78,17 +86,25 @@ function useIsSiteBusy( siteId: string ): boolean {
 export function SiteToolbar( { site, className, openPullOnLoad = false }: SiteToolbarProps ) {
 	const connector = useConnector();
 	const { enabled: agenticEnabled, reason: agenticReason } = useAgenticFeatures();
+	// The sidebar's site rows already carry a run-state dot, so the header only
+	// shows its own once the sidebar is hidden.
+	const showRunState = useSidebarCollapsed();
 	const login = useLogin( { source: 'site_header' } );
 	const pushSiteToLive = usePushSiteToLive();
 	const pullSiteFromLive = usePullSiteFromLive();
 	const publishPreviewSite = usePublishPreviewSite();
+	const { toggle: toggleSiteRunning } = useToggleSiteRunning( site );
+	const operation = useSiteOperation( site );
 
 	const [ syncDialogType, setSyncDialogType ] = useState< 'push' | 'pull' | null >( null );
 	const [ publishOpen, setPublishOpen ] = useState( false );
 	const [ disconnectOpen, setDisconnectOpen ] = useState( false );
 	const [ shareMenuOpen, setShareMenuOpen ] = useState( false );
+	const [ siteMenuOpen, setSiteMenuOpen ] = useState( false );
 	const [ publishedPreviewUrl, setPublishedPreviewUrl ] = useState< string | undefined >();
 
+	const isStarting = useIsSiteStarting( site.id );
+	const isStopping = useIsSiteStopping( site.id );
 	const isBusy = useIsSiteBusy( site.id );
 	const syncActivity = useSiteSyncActivity( site.id );
 	const isPreviewPending =
@@ -183,19 +199,64 @@ export function SiteToolbar( { site, className, openPullOnLoad = false }: SiteTo
 		);
 	};
 
+	const localSiteUrl = getSiteUrl( site );
+	const canOpenLocalSite = site.running && ! isStopping;
+	const { status, statusLabel, localSublabel } = deriveSiteStatus(
+		site,
+		isStarting,
+		isStopping,
+		operation
+	);
+
 	return (
 		<div className={ clsx( styles.toolbar, className ) }>
-			<div className={ styles.identity }>
-				<SiteIcon
-					className={ styles.siteIcon }
-					seed={ `${ site.id }:${ site.name }:${ site.path }` }
-					imageSrc={ site.siteIcon }
+			<Menu.Root open={ siteMenuOpen } onOpenChange={ setSiteMenuOpen }>
+				<Menu.Trigger
+					render={
+						<button type="button" className={ styles.identity }>
+							<span className={ styles.siteIconWrap }>
+								<SiteIcon
+									className={ clsx( styles.siteIcon, showRunState && styles.siteIconCutout ) }
+									seed={ `${ site.id }:${ site.name }:${ site.path }` }
+									imageSrc={ site.siteIcon }
+								/>
+								{ showRunState ? (
+									<span
+										className={ clsx(
+											styles.statusBadge,
+											status === 'transitioning' && styles.statusBadgeBlink
+										) }
+										role="img"
+										aria-label={ statusLabel }
+									>
+										<span
+											className={ clsx( styles.statusDot, styles[ `statusDot_${ status }` ] ) }
+											aria-hidden="true"
+										/>
+									</span>
+								) : null }
+							</span>
+							<span className={ styles.identityText }>
+								<span className={ styles.siteName }>{ site.name }</span>
+								<span className={ styles.siteUrlStatic }>{ localSublabel }</span>
+							</span>
+						</button>
+					}
 				/>
-				<div className={ styles.identityText }>
-					<span className={ styles.siteName }>{ site.name }</span>
-					<span className={ styles.siteUrlStatic }>{ getSiteDisplayUrl( site ) }</span>
-				</div>
-			</div>
+				<Menu.Popup side="bottom" align="start" className={ styles.siteMenu }>
+					<Menu.Item disabled={ isStarting || isStopping } onClick={ toggleSiteRunning }>
+						{ site.running ? __( 'Stop site' ) : __( 'Start site' ) }
+					</Menu.Item>
+					<Menu.Item disabled={ ! canOpenLocalSite } onClick={ () => openExternal( localSiteUrl ) }>
+						{ __( 'Open in browser' ) }
+					</Menu.Item>
+					<Menu.Separator />
+					<div className={ styles.siteMenuDetail }>
+						<span className={ styles.siteMenuDetailLabel }>{ __( 'Local address' ) }</span>
+						<span className={ styles.siteMenuDetailValue }>{ getSiteDisplayUrl( site ) }</span>
+					</div>
+				</Menu.Popup>
+			</Menu.Root>
 
 			<div className={ styles.actions }>
 				{ ! isSignedOut ? (

--- a/apps/ui/src/components/site-toolbar/index.tsx
+++ b/apps/ui/src/components/site-toolbar/index.tsx
@@ -237,7 +237,10 @@ export function SiteToolbar( { site, className, openPullOnLoad = false }: SiteTo
 								) : null }
 							</span>
 							<span className={ styles.identityText }>
-								<span className={ styles.siteName }>{ site.name }</span>
+								<span className={ styles.siteNameRow }>
+									<span className={ styles.siteName }>{ site.name }</span>
+									<Icon className={ styles.menuChevron } icon={ chevronDownSmall } size={ 16 } />
+								</span>
 								<span className={ styles.siteUrlStatic }>{ localSublabel }</span>
 							</span>
 						</button>

--- a/apps/ui/src/components/site-toolbar/style.module.css
+++ b/apps/ui/src/components/site-toolbar/style.module.css
@@ -119,7 +119,15 @@
 	min-width: 0;
 }
 
+.siteNameRow {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	min-width: 0;
+}
+
 .siteName {
+	min-width: 0;
 	font-size: var(--wpds-typography-font-size-md);
 	font-weight: 600;
 	line-height: 1.25;
@@ -200,6 +208,7 @@
 }
 
 .menuChevron {
+	flex-shrink: 0;
 	fill: currentColor;
 	transition: transform 150ms ease;
 }

--- a/apps/ui/src/components/site-toolbar/style.module.css
+++ b/apps/ui/src/components/site-toolbar/style.module.css
@@ -15,18 +15,102 @@
 	-webkit-app-region: drag;
 }
 
+/* The identity is a menu trigger, but seated exactly where the plain block
+   sat: the padding that carries the hover fill is cancelled by a matching
+   negative margin, so only the fill grows, not the layout. */
 .identity {
 	display: flex;
 	align-items: center;
 	gap: var(--wpds-dimension-gap-md);
 	min-width: 0;
+	padding: var(--wpds-dimension-padding-xs);
+	margin: calc(-1 * var(--wpds-dimension-padding-xs));
+	border: 0;
+	border-radius: var(--wpds-border-radius-md);
+	background: transparent;
+	text-align: start;
+	cursor: var(--wpds-cursor-control);
+	-webkit-app-region: no-drag;
+	transition: background-color 100ms ease;
+}
+
+.identity:hover {
+	background: var(--wpds-color-bg-interactive-neutral-weak-active);
+}
+
+.identity:focus-visible {
+	outline: 2px solid var(--wpds-color-stroke-interactive-brand);
+	outline-offset: -2px;
+}
+
+.siteIconWrap {
+	position: relative;
+	display: inline-flex;
+	flex: 0 0 auto;
 }
 
 .siteIcon {
-	flex: 0 0 auto;
 	inline-size: 32px;
 	block-size: 32px;
 	border-radius: var(--wpds-border-radius-sm);
+}
+
+/* Only applied when the dot shows (sidebar hidden): punch a real hole in the
+   icon where the dot sits — a genuine cutout, not a ring drawn on top — 2px
+   wider than the dot and centred on the hostname line, not the icon corner. */
+.siteIconCutout {
+	--status-cutout: radial-gradient(
+		circle 6px at calc(100% - 1px) 24px,
+		transparent 0 6px,
+		#000 6.5px
+	);
+	-webkit-mask: var(--status-cutout);
+	mask: var(--status-cutout);
+}
+
+/* Positions the run-state dot inside the icon's cutout, vertically centred on
+   the hostname line and nudged to the icon's right edge. Non-interactive. */
+.statusBadge {
+	position: absolute;
+	inset-inline-end: -5px;
+	inset-block-start: 18px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	inline-size: 12px;
+	block-size: 12px;
+}
+
+.statusDot {
+	inline-size: 8px;
+	block-size: 8px;
+	border-radius: 50%;
+}
+
+.statusDot_running {
+	background: var(--studio-color-status-running);
+}
+
+.statusDot_stopped {
+	background: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.statusDot_transitioning {
+	background: var(--studio-color-status-transitioning);
+}
+
+.statusBadgeBlink {
+	animation: statusBadgeBlink 1s ease-in-out infinite;
+}
+
+@keyframes statusBadgeBlink {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.25;
+	}
 }
 
 .identityText {
@@ -69,6 +153,28 @@
 
 .syncMenu {
 	width: 240px;
+}
+
+.siteMenu {
+	min-width: 240px;
+}
+
+.siteMenuDetail {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
+}
+
+.siteMenuDetailLabel {
+	font-size: var(--wpds-typography-font-size-xs);
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.siteMenuDetailValue {
+	font-size: var(--wpds-typography-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral);
+	word-break: break-all;
 }
 
 .menuIntro {
@@ -244,11 +350,16 @@
 @media (prefers-reduced-motion: reduce) {
 	.action,
 	.actionProgress,
-	.menuChevron {
+	.menuChevron,
+	.identity {
 		transition: none;
 	}
 
 	.actionLabel {
+		animation: none;
+	}
+
+	.statusBadgeBlink {
 		animation: none;
 	}
 }


### PR DESCRIPTION
## Related issues

- STU-2162

> ⚠️ Visual change: needs human review in light + dark mode.

## How AI was used in this PR

AI built the menu and the masked-dot treatment to the design direction set in the exploration.

## Proposed Changes

Make the header identity interactive.

- The site icon + name + address become one button opening a site menu: **Start/Stop site** (via the shared toggle hook from the bottom of this stack), **Open in browser**, and the **Local address**.
- A run-state dot is masked into the icon's corner — a genuine CSS-mask cutout, not a drawn ring — shown only when the sidebar is hidden (the sidebar rows already carry status). Green running, grey stopped, blue blinking transitioning; respects `prefers-reduced-motion`.

## Screenshots

| Site menu · light | Site menu · dark |
|---|---|
| ![Site menu light](https://github.com/Automattic/studio/blob/af660219afe7b8f05a818c5f463d9f6169854a71/pr5-site-menu-light.png?raw=true) | ![Site menu dark](https://github.com/Automattic/studio/blob/af660219afe7b8f05a818c5f463d9f6169854a71/pr5-site-menu-dark.png?raw=true) |

| Masked status dot |
|---|
| ![Masked status dot](https://github.com/Automattic/studio/blob/af660219afe7b8f05a818c5f463d9f6169854a71/pr5-header-dot-light.png?raw=true) |

## Testing Instructions

1. Click the header identity — the menu opens; Start/Stop toggles the site; Open in browser disables when stopped.
2. Hide the sidebar — the dot appears on the icon, centred on the address line; show it and the dot disappears.
3. Light + dark appearance; console clean.

### Verification completed

- `npm run typecheck` · toolbar suite passes

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

