### PR TITLE
Agentic UI: Add a Learn more modal explaining publishing and syncing

### DIFF
--- a/apps/ui/src/components/site-toolbar/index.tsx
+++ b/apps/ui/src/components/site-toolbar/index.tsx
@@ -39,6 +39,7 @@ import { useSiteSyncActivity } from '@/data/sync-activity';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
 import { getSiteDisplayUrl, getSiteUrl } from '@/lib/get-site-url';
 import { DisconnectSiteDialog } from './disconnect-site-dialog';
+import { LearnMoreDialog } from './learn-more-dialog';
 import { PublishPickerView } from './publish-picker-view';
 import styles from './style.module.css';
 import {
@@ -99,6 +100,7 @@ export function SiteToolbar( { site, className, openPullOnLoad = false }: SiteTo
 	const [ syncDialogType, setSyncDialogType ] = useState< 'push' | 'pull' | null >( null );
 	const [ publishOpen, setPublishOpen ] = useState( false );
 	const [ disconnectOpen, setDisconnectOpen ] = useState( false );
+	const [ learnMoreOpen, setLearnMoreOpen ] = useState( false );
 	const [ shareMenuOpen, setShareMenuOpen ] = useState( false );
 	const [ siteMenuOpen, setSiteMenuOpen ] = useState( false );
 	const [ publishedPreviewUrl, setPublishedPreviewUrl ] = useState< string | undefined >();
@@ -387,6 +389,10 @@ export function SiteToolbar( { site, className, openPullOnLoad = false }: SiteTo
 										{ __( 'Pull…' ) }
 									</Menu.Item>
 								</div>
+								<Menu.Separator />
+								<Menu.Item onClick={ () => setLearnMoreOpen( true ) }>
+									{ __( 'Learn more' ) }
+								</Menu.Item>
 							</Menu.Popup>
 						</Menu.Root>
 						<Menu.Root>
@@ -430,7 +436,11 @@ export function SiteToolbar( { site, className, openPullOnLoad = false }: SiteTo
 						/>
 						{ publishOpen ? (
 							<Menu.Popup side="bottom" align="end" className={ styles.publishMenu }>
-								<PublishPickerView site={ site } onClose={ () => setPublishOpen( false ) } />
+								<PublishPickerView
+									site={ site }
+									onLearnMore={ () => setLearnMoreOpen( true ) }
+									onClose={ () => setPublishOpen( false ) }
+								/>
 							</Menu.Popup>
 						) : null }
 					</Menu.Root>
@@ -456,6 +466,8 @@ export function SiteToolbar( { site, className, openPullOnLoad = false }: SiteTo
 					onOpenChange={ setDisconnectOpen }
 				/>
 			) : null }
+
+			<LearnMoreDialog open={ learnMoreOpen } onOpenChange={ setLearnMoreOpen } />
 		</div>
 	);
 }

--- a/apps/ui/src/components/site-toolbar/info-dialog.module.css
+++ b/apps/ui/src/components/site-toolbar/info-dialog.module.css
@@ -1,0 +1,12 @@
+.content {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-md);
+	color: var(--wpds-color-fg-content-neutral);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
+}
+
+.content p {
+	margin: 0;
+}

--- a/apps/ui/src/components/site-toolbar/info-dialog.tsx
+++ b/apps/ui/src/components/site-toolbar/info-dialog.tsx
@@ -1,0 +1,29 @@
+import { __ } from '@wordpress/i18n';
+import { Dialog } from '@wordpress/ui';
+import styles from './info-dialog.module.css';
+import type { ReactNode } from 'react';
+
+type Props = {
+	open: boolean;
+	onOpenChange: ( open: boolean ) => void;
+	title: string;
+	children: ReactNode;
+};
+
+export function InfoDialog( { open, onOpenChange, title, children }: Props ) {
+	return (
+		<Dialog.Root open={ open } onOpenChange={ onOpenChange }>
+			<Dialog.Popup size="small">
+				<Dialog.Header>
+					<Dialog.Title>{ title }</Dialog.Title>
+				</Dialog.Header>
+				<Dialog.Content className={ styles.content }>{ children }</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action variant="solid" tone="brand">
+						{ __( 'Got it' ) }
+					</Dialog.Action>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
+	);
+}

--- a/apps/ui/src/components/site-toolbar/learn-more-dialog.tsx
+++ b/apps/ui/src/components/site-toolbar/learn-more-dialog.tsx
@@ -1,0 +1,38 @@
+import { __ } from '@wordpress/i18n';
+import { InfoDialog } from './info-dialog';
+
+type Props = {
+	open: boolean;
+	onOpenChange: ( open: boolean ) => void;
+};
+
+export function LearnMoreDialog( { open, onOpenChange }: Props ) {
+	return (
+		<InfoDialog
+			open={ open }
+			onOpenChange={ onOpenChange }
+			title={ __( 'Publishing and syncing' ) }
+		>
+			<p>
+				{ __(
+					'Publishing connects this local Studio site to an eligible WordPress.com or Pressable site — pick an existing site or create a new one to take it live.'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Syncing moves work between the two afterward. Pull from live brings selected files and database content into Studio; push to live sends selected local changes to the connected site.'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Database sync replaces the entire destination database. Studio creates a backup first, but recent orders, customers, or content can still be overwritten.'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Available for paid WordPress.com sites and Pressable sites with Jetpack enabled. Studio supports sites up to 5 GB.'
+				) }
+			</p>
+		</InfoDialog>
+	);
+}

--- a/apps/ui/src/components/site-toolbar/publish-picker-view.tsx
+++ b/apps/ui/src/components/site-toolbar/publish-picker-view.tsx
@@ -15,9 +15,10 @@ import type { SiteDetails, SyncSite } from '@/data/core';
 type Props = {
 	site: SiteDetails;
 	onClose: () => void;
+	onLearnMore: () => void;
 };
 
-export function PublishPickerView( { site, onClose }: Props ) {
+export function PublishPickerView( { site, onClose, onLearnMore }: Props ) {
 	const connector = useConnector();
 	const queryClient = useQueryClient();
 	const pickableSites = usePickableWpcomSites();
@@ -145,6 +146,9 @@ export function PublishPickerView( { site, onClose }: Props ) {
 			>
 				<span>{ __( 'Create a site…' ) }</span>
 				<Icon className={ styles.menuIcon } icon={ external } size={ 14 } aria-hidden="true" />
+			</Menu.Item>
+			<Menu.Item onClick={ onLearnMore }>
+				<span>{ __( 'Learn more' ) }</span>
 			</Menu.Item>
 		</>
 	);


### PR DESCRIPTION
## Related issues

- STU-2162

> ⚠️ Visual change: needs human review in light + dark mode.

## How AI was used in this PR

AI wrote the modal copy and wiring per the exploration.

## Proposed Changes

Add one **Learn more** modal explaining publishing and syncing — how publishing connects a live WordPress.com/Pressable site, how push/pull moves work, the destination-database warning, and eligibility. Reachable from both the Sync menu and the Publish picker; backed by a small shared `InfoDialog`.

## Screenshots

| Modal · light | Modal · dark |
|---|---|
| ![Learn more modal light](https://github.com/Automattic/studio/blob/02f58c69bf750a17cbfb7ad3468156353f72b70b/pr6-learn-more-light.png?raw=true) | ![Learn more modal dark](https://github.com/Automattic/studio/blob/02f58c69bf750a17cbfb7ad3468156353f72b70b/pr6-learn-more-dark.png?raw=true) |

| Entry point in Publish picker |
|---|
| ![Publish picker entry point](https://github.com/Automattic/studio/blob/02f58c69bf750a17cbfb7ad3468156353f72b70b/pr6-publish-entry-light.png?raw=true) |

## Testing Instructions

1. Sync menu → Learn more opens the modal; Got it dismisses.
2. Publish picker → Learn more opens the same modal.
3. Light + dark appearance; console clean.

### Verification completed

- `npm run typecheck` · toolbar suite passes

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

