### PR TITLE
Studio Code: run a WordPress language server (wp-lsp) alongside the agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ For in-depth information, see these docs:
 - **Custom Domains/SSL**: `docs/design-docs/custom-domains-and-ssl.md` - Proxy server, certificates, hosts file
 - **Analytics (Tracks)**: `docs/design-docs/analytics-tracks.md` - Tracks vs MC Stats, anonymous identity, opt-out, event catalog
 - **Localization**: `docs/localization.md` - GlotPress workflow, translation process
+- **wp-lsp Agent Integration**: `docs/design-docs/wp-lsp-agent.md` - WordPress language server in Studio Code, Lsp tool, post-edit diagnostics, impact measurement
 - **Release Process**: `docs/release-process.md` - ReleasesV2 + Fastlane lifecycle, running lanes locally
 - **Overview**: `README.md` - Features, download links, contribution guidelines
 

--- a/apps/cli/ai/lsp/client.ts
+++ b/apps/cli/ai/lsp/client.ts
@@ -1,0 +1,217 @@
+import { pathToFileURL } from 'url';
+import {
+	encodeMessage,
+	LspMessageReader,
+	type JsonRpcMessage,
+	type JsonRpcRequest,
+	type JsonRpcResponse,
+	type LspDiagnostic,
+	type LspPublishDiagnosticsParams,
+} from './protocol';
+import type { Readable, Writable } from 'stream';
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+
+interface PendingRequest {
+	resolve: ( result: unknown ) => void;
+	reject: ( error: Error ) => void;
+	timer: NodeJS.Timeout;
+}
+
+interface DiagnosticsWaiter {
+	resolve: ( diagnostics: LspDiagnostic[] ) => void;
+	timer: NodeJS.Timeout;
+}
+
+export function toFileUri( absolutePath: string ): string {
+	return pathToFileURL( absolutePath ).href;
+}
+
+/**
+ * JSON-RPC client for a language server speaking LSP over a stream pair.
+ * Takes streams rather than a child process so tests can drive it with
+ * in-memory pipes. Tracks open documents (didOpen/didChange versioning,
+ * full-text sync) and caches the last `textDocument/publishDiagnostics`
+ * per URI so callers can wait for the push that follows an edit.
+ */
+export class LspClient {
+	private readonly reader = new LspMessageReader();
+	private readonly pending = new Map< number, PendingRequest >();
+	private readonly documentVersions = new Map< string, number >();
+	private readonly diagnosticsByUri = new Map< string, LspDiagnostic[] >();
+	private readonly diagnosticsWaiters = new Map< string, DiagnosticsWaiter[] >();
+	private nextRequestId = 1;
+	private disposed = false;
+
+	constructor(
+		private readonly stdin: Writable,
+		stdout: Readable
+	) {
+		stdout.on( 'data', ( chunk: Buffer ) => {
+			let messages: JsonRpcMessage[];
+			try {
+				messages = this.reader.push( chunk );
+			} catch ( error ) {
+				this.dispose( error instanceof Error ? error.message : String( error ) );
+				return;
+			}
+			for ( const message of messages ) {
+				this.handleMessage( message );
+			}
+		} );
+	}
+
+	async request< T >(
+		method: string,
+		params: unknown,
+		timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS
+	): Promise< T > {
+		if ( this.disposed ) {
+			throw new Error( 'wp-lsp: server connection is closed' );
+		}
+		const id = this.nextRequestId++;
+		const message: JsonRpcRequest = { jsonrpc: '2.0', id, method, params };
+		return new Promise< T >( ( resolve, reject ) => {
+			const timer = setTimeout( () => {
+				this.pending.delete( id );
+				reject( new Error( `wp-lsp: '${ method }' timed out after ${ timeoutMs }ms` ) );
+			}, timeoutMs );
+			timer.unref?.();
+			this.pending.set( id, {
+				resolve: ( result ) => resolve( result as T ),
+				reject,
+				timer,
+			} );
+			this.stdin.write( encodeMessage( message ) );
+		} );
+	}
+
+	notify( method: string, params?: unknown ): void {
+		if ( this.disposed ) {
+			return;
+		}
+		this.stdin.write( encodeMessage( { jsonrpc: '2.0', method, params } ) );
+	}
+
+	/**
+	 * Bring the server's view of a file in line with the given content:
+	 * `didOpen` on first sight, full-text `didChange` afterwards. wp-lsp
+	 * pushes diagnostics for the file after either notification.
+	 */
+	syncDocument( absolutePath: string, content: string ): string {
+		const uri = toFileUri( absolutePath );
+		const version = this.documentVersions.get( uri );
+		if ( version === undefined ) {
+			this.documentVersions.set( uri, 1 );
+			this.notify( 'textDocument/didOpen', {
+				textDocument: { uri, languageId: 'php', version: 1, text: content },
+			} );
+		} else {
+			const nextVersion = version + 1;
+			this.documentVersions.set( uri, nextVersion );
+			this.notify( 'textDocument/didChange', {
+				textDocument: { uri, version: nextVersion },
+				contentChanges: [ { text: content } ],
+			} );
+		}
+		return uri;
+	}
+
+	/**
+	 * Resolve with the next diagnostics push for the URI, or with the last
+	 * cached set if nothing arrives before the timeout. Call after
+	 * `syncDocument` so the push being awaited reflects the new content.
+	 */
+	waitForDiagnostics( uri: string, timeoutMs: number ): Promise< LspDiagnostic[] > {
+		if ( this.disposed ) {
+			return Promise.resolve( this.diagnosticsByUri.get( uri ) ?? [] );
+		}
+		return new Promise< LspDiagnostic[] >( ( resolve ) => {
+			const waiters = this.diagnosticsWaiters.get( uri ) ?? [];
+			const waiter: DiagnosticsWaiter = {
+				resolve,
+				timer: setTimeout( () => {
+					const current = this.diagnosticsWaiters.get( uri ) ?? [];
+					this.diagnosticsWaiters.set(
+						uri,
+						current.filter( ( w ) => w !== waiter )
+					);
+					resolve( this.diagnosticsByUri.get( uri ) ?? [] );
+				}, timeoutMs ),
+			};
+			waiter.timer.unref?.();
+			waiters.push( waiter );
+			this.diagnosticsWaiters.set( uri, waiters );
+		} );
+	}
+
+	getCachedDiagnostics( uri: string ): LspDiagnostic[] {
+		return this.diagnosticsByUri.get( uri ) ?? [];
+	}
+
+	isDisposed(): boolean {
+		return this.disposed;
+	}
+
+	dispose( reason = 'connection closed' ): void {
+		if ( this.disposed ) {
+			return;
+		}
+		this.disposed = true;
+		for ( const [ , entry ] of this.pending ) {
+			clearTimeout( entry.timer );
+			entry.reject( new Error( `wp-lsp: ${ reason }` ) );
+		}
+		this.pending.clear();
+		for ( const [ uri, waiters ] of this.diagnosticsWaiters ) {
+			for ( const waiter of waiters ) {
+				clearTimeout( waiter.timer );
+				waiter.resolve( this.diagnosticsByUri.get( uri ) ?? [] );
+			}
+		}
+		this.diagnosticsWaiters.clear();
+	}
+
+	private handleMessage( message: JsonRpcMessage ): void {
+		if ( 'id' in message && ! ( 'method' in message ) ) {
+			this.handleResponse( message );
+			return;
+		}
+		if ( 'id' in message && 'method' in message ) {
+			// Server-to-client request (e.g. client/registerCapability). Studio's
+			// client supports none of them; an empty result keeps the server from
+			// stalling on the reply.
+			this.stdin.write(
+				encodeMessage( { jsonrpc: '2.0', id: ( message as JsonRpcRequest ).id, result: null } )
+			);
+			return;
+		}
+		if ( 'method' in message && message.method === 'textDocument/publishDiagnostics' ) {
+			const params = message.params as LspPublishDiagnosticsParams;
+			this.diagnosticsByUri.set( params.uri, params.diagnostics );
+			const waiters = this.diagnosticsWaiters.get( params.uri );
+			if ( waiters?.length ) {
+				this.diagnosticsWaiters.delete( params.uri );
+				for ( const waiter of waiters ) {
+					clearTimeout( waiter.timer );
+					waiter.resolve( params.diagnostics );
+				}
+			}
+		}
+		// Other notifications (window/logMessage, …) are intentionally ignored.
+	}
+
+	private handleResponse( response: JsonRpcResponse ): void {
+		const entry = typeof response.id === 'number' ? this.pending.get( response.id ) : undefined;
+		if ( ! entry ) {
+			return;
+		}
+		this.pending.delete( response.id as number );
+		clearTimeout( entry.timer );
+		if ( response.error ) {
+			entry.reject( new Error( `wp-lsp: ${ response.error.message }` ) );
+		} else {
+			entry.resolve( response.result );
+		}
+	}
+}

--- a/apps/cli/ai/lsp/diagnostics.ts
+++ b/apps/cli/ai/lsp/diagnostics.ts
@@ -1,0 +1,78 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
+import { formatDiagnosticLine } from './format';
+import { getLspServerForSiteRoot, getSiteRootForFile, isWpLspAvailable } from './pool';
+
+// wp-lsp pushes diagnostics right after a document sync; the initial index of
+// a site blocks requests, so the first collection after a spawn waits longer.
+const DIAGNOSTICS_WAIT_MS = 3_000;
+const COLD_DIAGNOSTICS_WAIT_MS = 10_000;
+
+export function isPhpFile( filePath: string ): boolean {
+	return /\.(php|phtml)$/i.test( filePath );
+}
+
+/**
+ * Report wp-lsp's problems for a just-edited PHP file, or null when there is
+ * nothing to say (non-PHP file, file outside a site, wp-lsp unavailable, no
+ * diagnostics, or any failure — diagnostics must never break the edit).
+ */
+export async function collectPhpFileDiagnostics( absolutePath: string ): Promise< string | null > {
+	if ( ! isPhpFile( absolutePath ) || ! isWpLspAvailable() ) {
+		return null;
+	}
+	const siteRoot = getSiteRootForFile( absolutePath );
+	if ( ! siteRoot ) {
+		return null;
+	}
+	try {
+		const server = await getLspServerForSiteRoot( siteRoot );
+		if ( ! server ) {
+			return null;
+		}
+		const wasWarm = server.warmedUp;
+		const content = await readFile( absolutePath, 'utf8' );
+		const uri = server.client.syncDocument( absolutePath, content );
+		const diagnostics = await server.client.waitForDiagnostics(
+			uri,
+			wasWarm ? DIAGNOSTICS_WAIT_MS : COLD_DIAGNOSTICS_WAIT_MS
+		);
+		server.warmedUp = true;
+		if ( ! diagnostics.length ) {
+			return null;
+		}
+		const lines = diagnostics.map( formatDiagnosticLine ).join( '\n' );
+		return `wp-lsp found problems in this file:\n${ lines }`;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Diagnostics hook for the agent's file-editing tools: given an Edit/Write
+ * tool call's name and arguments, report wp-lsp problems for the edited file.
+ * Returns null for other tools, non-PHP files, or files outside a site.
+ */
+export async function collectEditToolDiagnostics(
+	toolName: string,
+	params: unknown
+): Promise< string | null > {
+	if ( toolName !== 'Edit' && toolName !== 'Write' ) {
+		return null;
+	}
+	const args = params as { path?: unknown; file_path?: unknown } | undefined;
+	const rawPath =
+		typeof args?.path === 'string'
+			? args.path
+			: typeof args?.file_path === 'string'
+			? args.file_path
+			: null;
+	if ( ! rawPath ) {
+		return null;
+	}
+	const absolutePath = path.isAbsolute( rawPath )
+		? rawPath
+		: path.join( STUDIO_SITES_ROOT, rawPath );
+	return collectPhpFileDiagnostics( absolutePath );
+}

--- a/apps/cli/ai/lsp/format.ts
+++ b/apps/cli/ai/lsp/format.ts
@@ -1,0 +1,183 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import type {
+	LspCallHierarchyIncomingCall,
+	LspCallHierarchyItem,
+	LspCallHierarchyOutgoingCall,
+	LspDiagnostic,
+	LspDocumentSymbol,
+	LspHover,
+	LspLocation,
+	LspLocationLink,
+	LspMarkedString,
+	LspSymbolInformation,
+} from './protocol';
+
+// LSP SymbolKind numbers → readable names (the subset wp-lsp emits).
+const SYMBOL_KINDS: Record< number, string > = {
+	1: 'file',
+	2: 'module',
+	3: 'namespace',
+	4: 'package',
+	5: 'class',
+	6: 'method',
+	7: 'property',
+	8: 'field',
+	9: 'constructor',
+	10: 'enum',
+	11: 'interface',
+	12: 'function',
+	13: 'variable',
+	14: 'constant',
+	15: 'string',
+	16: 'number',
+	17: 'boolean',
+	18: 'array',
+	19: 'object',
+	20: 'key',
+	21: 'null',
+	22: 'enum member',
+	23: 'struct',
+	24: 'event',
+	25: 'operator',
+	26: 'type parameter',
+};
+
+const DIAGNOSTIC_SEVERITIES: Record< number, string > = {
+	1: 'Error',
+	2: 'Warning',
+	3: 'Info',
+	4: 'Hint',
+};
+
+export function describeLocation( uri: string, line: number, baseDir: string ): string {
+	let filePath: string;
+	try {
+		filePath = fileURLToPath( uri );
+	} catch {
+		filePath = uri;
+	}
+	const relative = path.relative( baseDir, filePath );
+	const display = relative && ! relative.startsWith( '..' ) ? relative : filePath;
+	// LSP positions are 0-based; agents and editors count from 1.
+	return `${ display }:${ line + 1 }`;
+}
+
+function isLocationLink( value: LspLocation | LspLocationLink ): value is LspLocationLink {
+	return 'targetUri' in value;
+}
+
+export function formatLocations(
+	result: LspLocation | LspLocation[] | LspLocationLink[] | null,
+	baseDir: string
+): string {
+	if ( ! result ) {
+		return 'No results.';
+	}
+	const list = Array.isArray( result ) ? result : [ result ];
+	if ( ! list.length ) {
+		return 'No results.';
+	}
+	return list
+		.map( ( entry ) =>
+			isLocationLink( entry )
+				? describeLocation( entry.targetUri, entry.targetRange.start.line, baseDir )
+				: describeLocation( entry.uri, entry.range.start.line, baseDir )
+		)
+		.join( '\n' );
+}
+
+function markedStringToText( content: LspMarkedString ): string {
+	return typeof content === 'string' ? content : content.value;
+}
+
+export function formatHover( hover: LspHover | null ): string {
+	if ( ! hover ) {
+		return 'No hover information.';
+	}
+	const { contents } = hover;
+	if ( Array.isArray( contents ) ) {
+		return contents.map( markedStringToText ).join( '\n\n' ) || 'No hover information.';
+	}
+	if ( typeof contents === 'object' && 'kind' in contents ) {
+		return contents.value || 'No hover information.';
+	}
+	return markedStringToText( contents ) || 'No hover information.';
+}
+
+function isDocumentSymbol(
+	symbol: LspDocumentSymbol | LspSymbolInformation
+): symbol is LspDocumentSymbol {
+	return 'selectionRange' in symbol;
+}
+
+export function formatSymbols(
+	symbols: LspDocumentSymbol[] | LspSymbolInformation[] | null,
+	baseDir: string
+): string {
+	if ( ! symbols?.length ) {
+		return 'No symbols found.';
+	}
+	const lines: string[] = [];
+	const walk = ( symbol: LspDocumentSymbol, depth: number ) => {
+		const kind = SYMBOL_KINDS[ symbol.kind ] ?? 'symbol';
+		lines.push(
+			`${ '  '.repeat( depth ) }${ symbol.name } (${ kind }) — line ${
+				symbol.selectionRange.start.line + 1
+			}`
+		);
+		for ( const child of symbol.children ?? [] ) {
+			walk( child, depth + 1 );
+		}
+	};
+	for ( const symbol of symbols ) {
+		if ( isDocumentSymbol( symbol ) ) {
+			walk( symbol, 0 );
+		} else {
+			const kind = SYMBOL_KINDS[ symbol.kind ] ?? 'symbol';
+			lines.push(
+				`${ symbol.name } (${ kind }) — ${ describeLocation(
+					symbol.location.uri,
+					symbol.location.range.start.line,
+					baseDir
+				) }`
+			);
+		}
+	}
+	return lines.join( '\n' );
+}
+
+function formatCallHierarchyItem( item: LspCallHierarchyItem, baseDir: string ): string {
+	const kind = SYMBOL_KINDS[ item.kind ] ?? 'symbol';
+	const location = describeLocation( item.uri, item.selectionRange.start.line, baseDir );
+	const detail = item.detail ? ` — ${ item.detail }` : '';
+	return `${ item.name } (${ kind }) — ${ location }${ detail }`;
+}
+
+export function formatCallHierarchy(
+	calls: LspCallHierarchyIncomingCall[] | LspCallHierarchyOutgoingCall[] | null,
+	direction: 'incoming' | 'outgoing',
+	baseDir: string
+): string {
+	if ( ! calls?.length ) {
+		return direction === 'incoming' ? 'No incoming calls.' : 'No outgoing calls.';
+	}
+	return calls
+		.map( ( call ) => formatCallHierarchyItem( 'from' in call ? call.from : call.to, baseDir ) )
+		.join( '\n' );
+}
+
+export function formatDiagnosticLine( diagnostic: LspDiagnostic ): string {
+	const severity = DIAGNOSTIC_SEVERITIES[ diagnostic.severity ?? 2 ] ?? 'Warning';
+	const code = diagnostic.code !== undefined ? ` [${ diagnostic.code }]` : '';
+	return `${ severity } line ${ diagnostic.range.start.line + 1 }: ${
+		diagnostic.message
+	}${ code }`;
+}
+
+export function formatDiagnostics( diagnostics: LspDiagnostic[] ): string {
+	if ( ! diagnostics.length ) {
+		return 'No problems reported.';
+	}
+	return diagnostics.map( formatDiagnosticLine ).join( '\n' );
+}

--- a/apps/cli/ai/lsp/pool.ts
+++ b/apps/cli/ai/lsp/pool.ts
@@ -1,0 +1,276 @@
+import { spawn, type ChildProcess } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
+import { getConfigDirectory } from '@studio/common/lib/well-known-paths';
+import { getPhpBinaryPath, getWpLspPath } from 'cli/lib/dependency-management/paths';
+import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
+import { LspClient, toFileUri } from './client';
+
+const IDLE_SHUTDOWN_MS = 10 * 60_000;
+const REAP_INTERVAL_MS = 60_000;
+const INITIALIZE_TIMEOUT_MS = 30_000;
+
+// Mirrors the launch recipe wp-lsp ships in its own `.lsp.json`: pin errors to
+// stderr and neutralise php.ini settings that could print to stdout, which the
+// client reads as protocol frames.
+const PHP_GUARD_ARGS = [
+	'-d',
+	'display_errors=stderr',
+	'-d',
+	'auto_prepend_file=',
+	'-d',
+	'auto_append_file=',
+	'-d',
+	'output_buffering=0',
+	'-d',
+	'memory_limit=768M',
+];
+
+const INITIALIZATION_OPTIONS = {
+	logLevel: 'warn',
+	indexCore: false,
+	indexVendor: false,
+	checkHookNames: true,
+	checkTextDomain: true,
+};
+
+export interface LspServer {
+	client: LspClient;
+	siteRoot: string;
+	lastUsedAt: number;
+	// False until the first operation completes: the initial index blocks
+	// requests, so first callers should allow extra time.
+	warmedUp: boolean;
+}
+
+interface LspServerEntry {
+	promise: Promise< LspServer >;
+	child?: ChildProcess;
+}
+
+const servers = new Map< string, LspServerEntry >();
+let reapTimer: NodeJS.Timeout | undefined;
+let exitHookInstalled = false;
+
+function resolveWpLspRoot(): string | null {
+	const override = process.env.STUDIO_WP_LSP_PATH?.trim();
+	const root = override || getWpLspPath();
+	return fs.existsSync( path.join( root, 'bin', 'wp-lsp' ) ) ? root : null;
+}
+
+function resolvePhpBinary(): string | null {
+	const override = process.env.STUDIO_WP_LSP_PHP?.trim();
+	if ( override ) {
+		return override;
+	}
+	const bundled = getPhpBinaryPath( DEFAULT_PHP_VERSION );
+	if ( fs.existsSync( bundled ) ) {
+		return bundled;
+	}
+	// Fall back to PATH resolution; a missing binary surfaces as a spawn error.
+	return 'php';
+}
+
+export function isWpLspAvailable(): boolean {
+	return resolveWpLspRoot() !== null;
+}
+
+/**
+ * Map an absolute file path to the root of the Studio site containing it.
+ * Agent file tools are rooted at `STUDIO_SITES_ROOT`, so the site is the
+ * first path segment below it. Returns null for paths outside the sites root
+ * (remote-session scratch files, arbitrary absolute paths).
+ */
+export function getSiteRootForFile( absolutePath: string ): string | null {
+	const relative = path.relative( STUDIO_SITES_ROOT, absolutePath );
+	if ( ! relative || relative.startsWith( '..' ) || path.isAbsolute( relative ) ) {
+		return null;
+	}
+	const [ siteFolder ] = relative.split( path.sep );
+	if ( ! siteFolder ) {
+		return null;
+	}
+	const siteRoot = path.join( STUDIO_SITES_ROOT, siteFolder );
+	return fs.existsSync( siteRoot ) ? siteRoot : null;
+}
+
+export async function getLspServerForSiteRoot( siteRoot: string ): Promise< LspServer | null > {
+	const key = path.resolve( siteRoot );
+	const existing = servers.get( key );
+	if ( existing ) {
+		try {
+			const server = await existing.promise;
+			if ( ! server.client.isDisposed() ) {
+				server.lastUsedAt = Date.now();
+				return server;
+			}
+		} catch {
+			// Fall through and respawn below.
+		}
+		servers.delete( key );
+	}
+
+	const wpLspRoot = resolveWpLspRoot();
+	if ( ! wpLspRoot ) {
+		return null;
+	}
+
+	const entry = {} as LspServerEntry;
+	entry.promise = startServer( key, wpLspRoot, ( child ) => {
+		entry.child = child;
+	} );
+	servers.set( key, entry );
+	ensureLifecycleHooks();
+
+	try {
+		return await entry.promise;
+	} catch {
+		if ( servers.get( key ) === entry ) {
+			servers.delete( key );
+		}
+		return null;
+	}
+}
+
+async function startServer(
+	siteRoot: string,
+	wpLspRoot: string,
+	setChild: ( child: ChildProcess ) => void
+): Promise< LspServer > {
+	const phpBinary = resolvePhpBinary();
+	if ( ! phpBinary ) {
+		throw new Error( 'wp-lsp: no PHP binary available' );
+	}
+	const cacheDir = path.join( getConfigDirectory(), 'wp-lsp-cache' );
+	fs.mkdirSync( cacheDir, { recursive: true } );
+
+	const child = spawn(
+		phpBinary,
+		[ ...PHP_GUARD_ARGS, path.join( wpLspRoot, 'bin', 'wp-lsp' ), '--stdio' ],
+		{
+			cwd: siteRoot,
+			env: { ...process.env, WP_LSP_CACHE_DIR: cacheDir },
+			stdio: [ 'pipe', 'pipe', 'ignore' ],
+		}
+	);
+	setChild( child );
+	// The server must never keep the CLI process alive on its own: unref the
+	// child and its pipes so a forgotten server can't block a natural exit.
+	child.unref();
+	( child.stdin as unknown as { unref?: () => void } ).unref?.();
+	( child.stdout as unknown as { unref?: () => void } ).unref?.();
+
+	const client = new LspClient( child.stdin!, child.stdout! );
+	const server: LspServer = { client, siteRoot, lastUsedAt: Date.now(), warmedUp: false };
+
+	child.on( 'error', ( error ) => {
+		client.dispose( `failed to start (${ error.message })` );
+		deleteIfCurrent( siteRoot, client );
+	} );
+	child.on( 'exit', ( code ) => {
+		client.dispose( `server exited with code ${ code ?? 'unknown' }` );
+		deleteIfCurrent( siteRoot, client );
+	} );
+
+	const spawnFailure = new Promise< never >( ( _, reject ) => {
+		child.once( 'error', ( error ) =>
+			reject( new Error( `wp-lsp: failed to start: ${ error.message }` ) )
+		);
+		child.once( 'exit', ( code ) =>
+			reject( new Error( `wp-lsp: exited during startup with code ${ code ?? 'unknown' }` ) )
+		);
+	} );
+
+	await Promise.race( [
+		( async () => {
+			await client.request(
+				'initialize',
+				{
+					processId: process.pid,
+					rootUri: toFileUri( siteRoot ),
+					capabilities: {},
+					initializationOptions: INITIALIZATION_OPTIONS,
+				},
+				INITIALIZE_TIMEOUT_MS
+			);
+			client.notify( 'initialized', {} );
+		} )(),
+		spawnFailure,
+	] );
+
+	return server;
+}
+
+function deleteIfCurrent( siteRoot: string, client: LspClient ): void {
+	const key = path.resolve( siteRoot );
+	const entry = servers.get( key );
+	if ( ! entry ) {
+		return;
+	}
+	entry.promise.then(
+		( server ) => {
+			if ( server.client === client ) {
+				servers.delete( key );
+			}
+		},
+		() => servers.delete( key )
+	);
+}
+
+function ensureLifecycleHooks(): void {
+	if ( ! reapTimer ) {
+		reapTimer = setInterval( reapIdleServers, REAP_INTERVAL_MS );
+		reapTimer.unref?.();
+	}
+	if ( ! exitHookInstalled ) {
+		exitHookInstalled = true;
+		process.once( 'exit', () => {
+			for ( const entry of servers.values() ) {
+				entry.child?.kill();
+			}
+		} );
+	}
+}
+
+function reapIdleServers(): void {
+	const now = Date.now();
+	for ( const [ key, entry ] of servers ) {
+		entry.promise.then(
+			( server ) => {
+				if ( now - server.lastUsedAt > IDLE_SHUTDOWN_MS ) {
+					shutdownEntry( entry, server );
+					if ( servers.get( key ) === entry ) {
+						servers.delete( key );
+					}
+				}
+			},
+			() => servers.delete( key )
+		);
+	}
+}
+
+function shutdownEntry( entry: LspServerEntry, server: LspServer ): void {
+	try {
+		server.client.notify( 'exit' );
+	} catch {
+		// The process is killed below regardless.
+	}
+	server.client.dispose( 'shut down' );
+	entry.child?.kill();
+}
+
+export async function shutdownAllLspServers(): Promise< void > {
+	const entries = [ ...servers.values() ];
+	servers.clear();
+	await Promise.all(
+		entries.map( async ( entry ) => {
+			try {
+				const server = await entry.promise;
+				shutdownEntry( entry, server );
+			} catch {
+				entry.child?.kill();
+			}
+		} )
+	);
+}

--- a/apps/cli/ai/lsp/protocol.ts
+++ b/apps/cli/ai/lsp/protocol.ts
@@ -1,0 +1,148 @@
+/**
+ * Minimal LSP wire protocol: Content-Length framed JSON-RPC 2.0 over stdio.
+ * Hand-rolled instead of depending on vscode-jsonrpc — the client only needs
+ * the handful of requests wp-lsp serves.
+ */
+
+export interface JsonRpcRequest {
+	jsonrpc: '2.0';
+	id: number;
+	method: string;
+	params?: unknown;
+}
+
+export interface JsonRpcNotification {
+	jsonrpc: '2.0';
+	method: string;
+	params?: unknown;
+}
+
+export interface JsonRpcResponse {
+	jsonrpc: '2.0';
+	id: number | string | null;
+	result?: unknown;
+	error?: { code: number; message: string; data?: unknown };
+}
+
+export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse;
+
+// LSP structures, limited to the fields Studio reads.
+export interface LspPosition {
+	line: number;
+	character: number;
+}
+
+export interface LspRange {
+	start: LspPosition;
+	end: LspPosition;
+}
+
+export interface LspLocation {
+	uri: string;
+	range: LspRange;
+}
+
+export interface LspLocationLink {
+	targetUri: string;
+	targetRange: LspRange;
+	targetSelectionRange?: LspRange;
+}
+
+export interface LspDiagnostic {
+	range: LspRange;
+	severity?: number;
+	code?: string | number;
+	source?: string;
+	message: string;
+}
+
+export interface LspPublishDiagnosticsParams {
+	uri: string;
+	diagnostics: LspDiagnostic[];
+}
+
+export type LspMarkedString = string | { language: string; value: string };
+
+export interface LspHover {
+	contents: LspMarkedString | LspMarkedString[] | { kind: string; value: string };
+	range?: LspRange;
+}
+
+export interface LspDocumentSymbol {
+	name: string;
+	detail?: string;
+	kind: number;
+	range: LspRange;
+	selectionRange: LspRange;
+	children?: LspDocumentSymbol[];
+}
+
+export interface LspSymbolInformation {
+	name: string;
+	kind: number;
+	location: LspLocation;
+	containerName?: string;
+}
+
+export interface LspCallHierarchyItem {
+	name: string;
+	kind: number;
+	detail?: string;
+	uri: string;
+	range: LspRange;
+	selectionRange: LspRange;
+}
+
+export interface LspCallHierarchyIncomingCall {
+	from: LspCallHierarchyItem;
+	fromRanges: LspRange[];
+}
+
+export interface LspCallHierarchyOutgoingCall {
+	to: LspCallHierarchyItem;
+	fromRanges: LspRange[];
+}
+
+export function encodeMessage( message: JsonRpcMessage ): Buffer {
+	const body = Buffer.from( JSON.stringify( message ), 'utf8' );
+	return Buffer.concat( [
+		Buffer.from( `Content-Length: ${ body.length }\r\n\r\n`, 'ascii' ),
+		body,
+	] );
+}
+
+/**
+ * Incremental Content-Length frame decoder. Feed it raw chunks; it returns
+ * every complete message contained so far, buffering partial frames across
+ * pushes (frames can be split or coalesced arbitrarily by the pipe).
+ */
+export class LspMessageReader {
+	private buffer: Buffer = Buffer.alloc( 0 );
+
+	push( chunk: Buffer ): JsonRpcMessage[] {
+		this.buffer = Buffer.concat( [ this.buffer, chunk ] );
+		const messages: JsonRpcMessage[] = [];
+
+		for (;;) {
+			const headerEnd = this.buffer.indexOf( '\r\n\r\n' );
+			if ( headerEnd === -1 ) {
+				break;
+			}
+			const header = this.buffer.subarray( 0, headerEnd ).toString( 'ascii' );
+			const lengthMatch = header.match( /Content-Length:\s*(\d+)/i );
+			if ( ! lengthMatch ) {
+				throw new Error( `wp-lsp: malformed protocol header: ${ header }` );
+			}
+			const contentLength = parseInt( lengthMatch[ 1 ], 10 );
+			const bodyStart = headerEnd + 4;
+			if ( this.buffer.length < bodyStart + contentLength ) {
+				break;
+			}
+			const body = this.buffer.subarray( bodyStart, bodyStart + contentLength ).toString( 'utf8' );
+			this.buffer = this.buffer.subarray( bodyStart + contentLength );
+			messages.push( JSON.parse( body ) as JsonRpcMessage );
+		}
+
+		return messages;
+	}
+}

--- a/apps/cli/ai/lsp/tests/client.test.ts
+++ b/apps/cli/ai/lsp/tests/client.test.ts
@@ -1,0 +1,140 @@
+import { PassThrough } from 'stream';
+import { describe, expect, it } from 'vitest';
+import { LspClient, toFileUri } from '../client';
+import { encodeMessage, LspMessageReader, type JsonRpcMessage } from '../protocol';
+
+interface TestHarness {
+	client: LspClient;
+	// Messages the client wrote, in order.
+	sent: JsonRpcMessage[];
+	// Push a message from the "server" to the client.
+	receive: ( message: JsonRpcMessage ) => void;
+	// Resolves once the client has written `count` messages.
+	whenSent: ( count: number ) => Promise< void >;
+}
+
+function createHarness(): TestHarness {
+	const toServer = new PassThrough();
+	const toClient = new PassThrough();
+	const reader = new LspMessageReader();
+	const sent: JsonRpcMessage[] = [];
+	const sentWaiters: Array< { count: number; resolve: () => void } > = [];
+	toServer.on( 'data', ( chunk: Buffer ) => {
+		sent.push( ...reader.push( chunk ) );
+		for ( const waiter of [ ...sentWaiters ] ) {
+			if ( sent.length >= waiter.count ) {
+				sentWaiters.splice( sentWaiters.indexOf( waiter ), 1 );
+				waiter.resolve();
+			}
+		}
+	} );
+	return {
+		client: new LspClient( toServer, toClient ),
+		sent,
+		receive: ( message ) => toClient.write( encodeMessage( message ) ),
+		whenSent: ( count ) =>
+			new Promise( ( resolve ) => {
+				if ( sent.length >= count ) {
+					resolve();
+				} else {
+					sentWaiters.push( { count, resolve } );
+				}
+			} ),
+	};
+}
+
+describe( 'LspClient', () => {
+	it( 'resolves a request with the matching response result', async () => {
+		const harness = createHarness();
+		const pending = harness.client.request( 'initialize', { rootUri: 'file:///x' } );
+		await harness.whenSent( 1 );
+		const request = harness.sent[ 0 ] as { id: number; method: string };
+		expect( request.method ).toBe( 'initialize' );
+		harness.receive( { jsonrpc: '2.0', id: request.id, result: { capabilities: {} } } );
+		await expect( pending ).resolves.toEqual( { capabilities: {} } );
+	} );
+
+	it( 'rejects a request when the server answers with an error', async () => {
+		const harness = createHarness();
+		const pending = harness.client.request( 'textDocument/hover', {} );
+		await harness.whenSent( 1 );
+		const request = harness.sent[ 0 ] as { id: number };
+		harness.receive( {
+			jsonrpc: '2.0',
+			id: request.id,
+			error: { code: -32601, message: 'method not found' },
+		} );
+		await expect( pending ).rejects.toThrow( 'method not found' );
+	} );
+
+	it( 'times out a request that never gets a response', async () => {
+		const harness = createHarness();
+		await expect( harness.client.request( 'slow/method', {}, 20 ) ).rejects.toThrow( 'timed out' );
+	} );
+
+	it( 'answers server-to-client requests with a null result', async () => {
+		const harness = createHarness();
+		harness.receive( { jsonrpc: '2.0', id: 42, method: 'client/registerCapability', params: {} } );
+		await harness.whenSent( 1 );
+		expect( harness.sent[ 0 ] ).toEqual( { jsonrpc: '2.0', id: 42, result: null } );
+	} );
+
+	it( 'sends didOpen on first sync and versioned didChange afterwards', async () => {
+		const harness = createHarness();
+		const uri = harness.client.syncDocument( '/tmp/site/a.php', '<?php one();' );
+		harness.client.syncDocument( '/tmp/site/a.php', '<?php two();' );
+		await harness.whenSent( 2 );
+		expect( uri ).toBe( toFileUri( '/tmp/site/a.php' ) );
+		expect( harness.sent[ 0 ] ).toMatchObject( {
+			method: 'textDocument/didOpen',
+			params: { textDocument: { uri, version: 1, text: '<?php one();' } },
+		} );
+		expect( harness.sent[ 1 ] ).toMatchObject( {
+			method: 'textDocument/didChange',
+			params: {
+				textDocument: { uri, version: 2 },
+				contentChanges: [ { text: '<?php two();' } ],
+			},
+		} );
+	} );
+
+	it( 'resolves waitForDiagnostics with the next publish for the uri', async () => {
+		const harness = createHarness();
+		const uri = 'file:///tmp/site/a.php';
+		const pending = harness.client.waitForDiagnostics( uri, 1_000 );
+		const diagnostics = [
+			{ range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } }, message: 'x' },
+		];
+		harness.receive( {
+			jsonrpc: '2.0',
+			method: 'textDocument/publishDiagnostics',
+			params: { uri, diagnostics },
+		} );
+		await expect( pending ).resolves.toEqual( diagnostics );
+		expect( harness.client.getCachedDiagnostics( uri ) ).toEqual( diagnostics );
+	} );
+
+	it( 'falls back to cached diagnostics when no publish arrives in time', async () => {
+		const harness = createHarness();
+		const uri = 'file:///tmp/site/b.php';
+		harness.receive( {
+			jsonrpc: '2.0',
+			method: 'textDocument/publishDiagnostics',
+			params: { uri, diagnostics: [] },
+		} );
+		// Give the receive a tick to be processed, then wait with a tiny timeout.
+		await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
+		await expect( harness.client.waitForDiagnostics( uri, 20 ) ).resolves.toEqual( [] );
+	} );
+
+	it( 'rejects pending requests and resolves waiters on dispose', async () => {
+		const harness = createHarness();
+		const pendingRequest = harness.client.request( 'initialize', {} );
+		const pendingDiagnostics = harness.client.waitForDiagnostics( 'file:///x.php', 5_000 );
+		harness.client.dispose( 'server exited with code 1' );
+		await expect( pendingRequest ).rejects.toThrow( 'server exited with code 1' );
+		await expect( pendingDiagnostics ).resolves.toEqual( [] );
+		expect( harness.client.isDisposed() ).toBe( true );
+		await expect( harness.client.request( 'x', {} ) ).rejects.toThrow( 'closed' );
+	} );
+} );

--- a/apps/cli/ai/lsp/tests/diagnostics.test.ts
+++ b/apps/cli/ai/lsp/tests/diagnostics.test.ts
@@ -1,0 +1,146 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
+import { collectEditToolDiagnostics, collectPhpFileDiagnostics, isPhpFile } from '../diagnostics';
+import {
+	getLspServerForSiteRoot,
+	getSiteRootForFile,
+	isWpLspAvailable,
+	type LspServer,
+} from '../pool';
+import type { LspDiagnostic } from '../protocol';
+
+vi.mock( '../pool', () => ( {
+	isWpLspAvailable: vi.fn(),
+	getSiteRootForFile: vi.fn(),
+	getLspServerForSiteRoot: vi.fn(),
+} ) );
+
+const mockedAvailability = vi.mocked( isWpLspAvailable );
+const mockedSiteRoot = vi.mocked( getSiteRootForFile );
+const mockedGetServer = vi.mocked( getLspServerForSiteRoot );
+
+function fakeServer( diagnostics: LspDiagnostic[] ): LspServer {
+	return {
+		siteRoot: '/site',
+		lastUsedAt: 0,
+		warmedUp: true,
+		client: {
+			syncDocument: vi.fn( () => 'file:///site/a.php' ),
+			waitForDiagnostics: vi.fn( async () => diagnostics ),
+		},
+	} as unknown as LspServer;
+}
+
+describe( 'isPhpFile', () => {
+	it( 'matches php and phtml, not other extensions', () => {
+		expect( isPhpFile( '/a/b.php' ) ).toBe( true );
+		expect( isPhpFile( '/a/b.PHTML' ) ).toBe( true );
+		expect( isPhpFile( '/a/b.js' ) ).toBe( false );
+		expect( isPhpFile( '/a/php' ) ).toBe( false );
+	} );
+} );
+
+describe( 'collectPhpFileDiagnostics', () => {
+	let phpFile: string;
+	let tempDir: string;
+
+	beforeEach( () => {
+		tempDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-lsp-diag-' ) );
+		phpFile = path.join( tempDir, 'plugin.php' );
+		fs.writeFileSync( phpFile, "<?php add_action( 'ini', 'cb' );" );
+		mockedAvailability.mockReturnValue( true );
+		mockedSiteRoot.mockReturnValue( tempDir );
+	} );
+
+	afterEach( () => {
+		fs.rmSync( tempDir, { recursive: true, force: true } );
+		vi.clearAllMocks();
+	} );
+
+	it( 'formats pushed diagnostics into a problems report', async () => {
+		mockedGetServer.mockResolvedValue(
+			fakeServer( [
+				{
+					range: { start: { line: 0, character: 6 }, end: { line: 0, character: 16 } },
+					severity: 2,
+					code: 'unknown-hook',
+					message: "Unknown hook 'ini'. Did you mean 'init'?",
+				},
+			] )
+		);
+		const report = await collectPhpFileDiagnostics( phpFile );
+		expect( report ).toBe(
+			"wp-lsp found problems in this file:\nWarning line 1: Unknown hook 'ini'. Did you mean 'init'? [unknown-hook]"
+		);
+	} );
+
+	it( 'returns null when there are no diagnostics', async () => {
+		mockedGetServer.mockResolvedValue( fakeServer( [] ) );
+		await expect( collectPhpFileDiagnostics( phpFile ) ).resolves.toBeNull();
+	} );
+
+	it( 'returns null for non-PHP files without touching the pool', async () => {
+		await expect( collectPhpFileDiagnostics( '/site/style.css' ) ).resolves.toBeNull();
+		expect( mockedGetServer ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns null when wp-lsp is unavailable', async () => {
+		mockedAvailability.mockReturnValue( false );
+		await expect( collectPhpFileDiagnostics( phpFile ) ).resolves.toBeNull();
+	} );
+
+	it( 'returns null for files outside any site', async () => {
+		mockedSiteRoot.mockReturnValue( null );
+		await expect( collectPhpFileDiagnostics( phpFile ) ).resolves.toBeNull();
+	} );
+
+	it( 'returns null instead of throwing when the server errors', async () => {
+		mockedGetServer.mockRejectedValue( new Error( 'boom' ) );
+		await expect( collectPhpFileDiagnostics( phpFile ) ).resolves.toBeNull();
+	} );
+
+	it( 'marks the server warm after a successful wait', async () => {
+		const server = fakeServer( [] );
+		server.warmedUp = false;
+		mockedGetServer.mockResolvedValue( server );
+		await collectPhpFileDiagnostics( phpFile );
+		expect( server.warmedUp ).toBe( true );
+	} );
+} );
+
+describe( 'collectEditToolDiagnostics', () => {
+	afterEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'ignores tools other than Edit and Write', async () => {
+		await expect(
+			collectEditToolDiagnostics( 'Bash', { path: '/site/a.php' } )
+		).resolves.toBeNull();
+		expect( mockedAvailability ).not.toHaveBeenCalled();
+	} );
+
+	it( 'ignores calls without a usable path argument', async () => {
+		await expect( collectEditToolDiagnostics( 'Edit', {} ) ).resolves.toBeNull();
+		await expect( collectEditToolDiagnostics( 'Write', undefined ) ).resolves.toBeNull();
+	} );
+
+	it( 'resolves relative paths against the sites root', async () => {
+		mockedAvailability.mockReturnValue( true );
+		mockedSiteRoot.mockReturnValue( null );
+		await collectEditToolDiagnostics( 'Edit', { path: 'my-site/wp-content/a.php' } );
+		expect( mockedSiteRoot ).toHaveBeenCalledWith(
+			path.join( STUDIO_SITES_ROOT, 'my-site/wp-content/a.php' )
+		);
+	} );
+
+	it( 'accepts the file_path argument alias', async () => {
+		mockedAvailability.mockReturnValue( true );
+		mockedSiteRoot.mockReturnValue( null );
+		await collectEditToolDiagnostics( 'Write', { file_path: '/abs/site/b.php' } );
+		expect( mockedSiteRoot ).toHaveBeenCalledWith( '/abs/site/b.php' );
+	} );
+} );

--- a/apps/cli/ai/lsp/tests/format.test.ts
+++ b/apps/cli/ai/lsp/tests/format.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import {
+	describeLocation,
+	formatCallHierarchy,
+	formatDiagnosticLine,
+	formatDiagnostics,
+	formatHover,
+	formatLocations,
+	formatSymbols,
+} from '../format';
+import type { LspLocation, LspRange } from '../protocol';
+
+const range = ( line: number ): LspRange => ( {
+	start: { line, character: 0 },
+	end: { line, character: 10 },
+} );
+
+const location = ( uri: string, line: number ): LspLocation => ( { uri, range: range( line ) } );
+
+describe( 'describeLocation', () => {
+	it( 'renders a site-relative path with a 1-based line', () => {
+		expect(
+			describeLocation(
+				'file:///home/user/Studio/my-site/wp-content/plugins/a/a.php',
+				4,
+				'/home/user/Studio/my-site'
+			)
+		).toBe( 'wp-content/plugins/a/a.php:5' );
+	} );
+
+	it( 'falls back to the absolute path outside the base directory', () => {
+		expect( describeLocation( 'file:///elsewhere/core.php', 0, '/home/user/Studio/my-site' ) ).toBe(
+			'/elsewhere/core.php:1'
+		);
+	} );
+} );
+
+describe( 'formatLocations', () => {
+	it( 'handles null, single, array, and location-link results', () => {
+		expect( formatLocations( null, '/site' ) ).toBe( 'No results.' );
+		expect( formatLocations( [], '/site' ) ).toBe( 'No results.' );
+		expect( formatLocations( location( 'file:///site/f.php', 2 ), '/site' ) ).toBe( 'f.php:3' );
+		expect(
+			formatLocations( [ { targetUri: 'file:///site/g.php', targetRange: range( 9 ) } ], '/site' )
+		).toBe( 'g.php:10' );
+	} );
+} );
+
+describe( 'formatHover', () => {
+	it( 'handles markup content, marked strings, and arrays', () => {
+		expect( formatHover( null ) ).toBe( 'No hover information.' );
+		expect( formatHover( { contents: { kind: 'markdown', value: '**init** hook' } } ) ).toBe(
+			'**init** hook'
+		);
+		expect( formatHover( { contents: 'plain' } ) ).toBe( 'plain' );
+		expect(
+			formatHover( { contents: [ 'first', { language: 'php', value: 'function x()' } ] } )
+		).toBe( 'first\n\nfunction x()' );
+	} );
+} );
+
+describe( 'formatSymbols', () => {
+	it( 'nests document symbols and flattens symbol information', () => {
+		expect( formatSymbols( null, '/site' ) ).toBe( 'No symbols found.' );
+		expect(
+			formatSymbols(
+				[
+					{
+						name: 'My_Class',
+						kind: 5,
+						range: range( 0 ),
+						selectionRange: range( 0 ),
+						children: [
+							{ name: 'render', kind: 6, range: range( 3 ), selectionRange: range( 3 ) },
+						],
+					},
+				],
+				'/site'
+			)
+		).toBe( 'My_Class (class) — line 1\n  render (method) — line 4' );
+		expect(
+			formatSymbols(
+				[ { name: 'my_func', kind: 12, location: location( 'file:///site/i.php', 6 ) } ],
+				'/site'
+			)
+		).toBe( 'my_func (function) — i.php:7' );
+	} );
+} );
+
+describe( 'formatCallHierarchy', () => {
+	it( 'labels empty results by direction and lists callers', () => {
+		expect( formatCallHierarchy( null, 'incoming', '/site' ) ).toBe( 'No incoming calls.' );
+		expect( formatCallHierarchy( [], 'outgoing', '/site' ) ).toBe( 'No outgoing calls.' );
+		expect(
+			formatCallHierarchy(
+				[
+					{
+						from: {
+							name: 'do_action(init)',
+							kind: 24,
+							uri: 'file:///site/hooks.php',
+							range: range( 11 ),
+							selectionRange: range( 11 ),
+						},
+						fromRanges: [ range( 11 ) ],
+					},
+				],
+				'incoming',
+				'/site'
+			)
+		).toBe( 'do_action(init) (event) — hooks.php:12' );
+	} );
+} );
+
+describe( 'formatDiagnostics', () => {
+	it( 'renders severity, 1-based line, message, and code', () => {
+		expect(
+			formatDiagnosticLine( {
+				range: range( 4 ),
+				severity: 2,
+				code: 'unknown-hook',
+				message: "Unknown hook 'ini'. Did you mean 'init'?",
+			} )
+		).toBe( "Warning line 5: Unknown hook 'ini'. Did you mean 'init'? [unknown-hook]" );
+		expect( formatDiagnostics( [] ) ).toBe( 'No problems reported.' );
+	} );
+} );

--- a/apps/cli/ai/lsp/tests/integration.test.ts
+++ b/apps/cli/ai/lsp/tests/integration.test.ts
@@ -1,0 +1,107 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { STUDIO_SITES_ROOT as mockSitesRoot } from 'cli/lib/site-paths';
+import { getLspServerForSiteRoot, shutdownAllLspServers } from '../pool';
+
+vi.mock( 'cli/lib/site-paths', async () => {
+	const { mkdtempSync } = await import( 'fs' );
+	const { tmpdir } = await import( 'os' );
+	const { join } = await import( 'path' );
+	return { STUDIO_SITES_ROOT: mkdtempSync( join( tmpdir(), 'studio-lsp-int-' ) ) };
+} );
+
+// The real wp-lsp server, downloaded into `wp-files/` by postinstall, driven
+// over stdio exactly as the agent drives it. Requires a PHP CLI on PATH.
+const repoWpLspRoot = path.resolve(
+	path.dirname( fileURLToPath( import.meta.url ) ),
+	'../../../../..',
+	'wp-files',
+	'wp-lsp'
+);
+const wpLspInstalled = fs.existsSync( path.join( repoWpLspRoot, 'bin', 'wp-lsp' ) );
+const phpAvailable = spawnSync( 'php', [ '--version' ], { stdio: 'ignore' } ).status === 0;
+
+const PLUGIN_CONTENT = `<?php
+/**
+ * Plugin Name: Fixture
+ */
+add_action( 'init', 'fixture_setup' );
+add_action( 'ini', 'fixture_typo' );
+
+function fixture_setup() {}
+function fixture_typo() {}
+`;
+
+describe.skipIf( ! wpLspInstalled || ! phpAvailable )( 'wp-lsp integration', () => {
+	const siteRoot = path.join( mockSitesRoot, 'fixture-site' );
+	const pluginFile = path.join( siteRoot, 'wp-content', 'plugins', 'fixture', 'fixture.php' );
+	const savedEnv: Record< string, string | undefined > = {};
+
+	beforeAll( () => {
+		for ( const key of [ 'STUDIO_WP_LSP_PATH', 'STUDIO_WP_LSP_PHP', 'DEV_CONFIG_DIR' ] ) {
+			savedEnv[ key ] = process.env[ key ];
+		}
+		process.env.STUDIO_WP_LSP_PATH = repoWpLspRoot;
+		process.env.STUDIO_WP_LSP_PHP = 'php';
+		process.env.DEV_CONFIG_DIR = path.join( mockSitesRoot, 'config' );
+		fs.mkdirSync( path.dirname( pluginFile ), { recursive: true } );
+		fs.writeFileSync( pluginFile, PLUGIN_CONTENT );
+	} );
+
+	afterAll( async () => {
+		await shutdownAllLspServers();
+		for ( const [ key, value ] of Object.entries( savedEnv ) ) {
+			if ( value === undefined ) {
+				delete process.env[ key ];
+			} else {
+				process.env[ key ] = value;
+			}
+		}
+		fs.rmSync( mockSitesRoot, { recursive: true, force: true } );
+	} );
+
+	it(
+		'starts, reports the unknown hook, and resolves a string callback',
+		{ timeout: 120_000 },
+		async () => {
+			const server = await getLspServerForSiteRoot( siteRoot );
+			expect( server ).not.toBeNull();
+
+			const uri = server!.client.syncDocument( pluginFile, PLUGIN_CONTENT );
+			const diagnostics = await server!.client.waitForDiagnostics( uri, 30_000 );
+			expect( diagnostics.some( ( diagnostic ) => diagnostic.message.includes( "'ini'" ) ) ).toBe(
+				true
+			);
+
+			// Definition on the 'fixture_setup' string callback goes to the function.
+			const lines = PLUGIN_CONTENT.split( '\n' );
+			const callbackLine = lines.findIndex( ( line ) => line.includes( "'fixture_setup'" ) );
+			const callbackColumn = lines[ callbackLine ].indexOf( 'fixture_setup' );
+			const definition = await server!.client.request<
+				| Array< { uri?: string; targetUri?: string; range?: { start: { line: number } } } >
+				| {
+						uri: string;
+						range: { start: { line: number } };
+				  }
+				| null
+			>(
+				'textDocument/definition',
+				{
+					textDocument: { uri },
+					position: { line: callbackLine, character: callbackColumn },
+				},
+				30_000
+			);
+			const first = Array.isArray( definition ) ? definition[ 0 ] : definition;
+			expect( first ).toBeTruthy();
+			const functionLine = lines.findIndex( ( line ) => line.includes( 'function fixture_setup' ) );
+			const resolvedLine =
+				( first as { range?: { start: { line: number } } } ).range?.start.line ??
+				( first as { targetRange?: { start: { line: number } } } ).targetRange?.start.line;
+			expect( resolvedLine ).toBe( functionLine );
+		}
+	);
+} );

--- a/apps/cli/ai/lsp/tests/pool.test.ts
+++ b/apps/cli/ai/lsp/tests/pool.test.ts
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { STUDIO_SITES_ROOT as mockSitesRoot } from 'cli/lib/site-paths';
+import { getSiteRootForFile, isWpLspAvailable } from '../pool';
+
+vi.mock( 'cli/lib/site-paths', async () => {
+	const { mkdtempSync } = await import( 'fs' );
+	const { tmpdir } = await import( 'os' );
+	const { join } = await import( 'path' );
+	return { STUDIO_SITES_ROOT: mkdtempSync( join( tmpdir(), 'studio-lsp-pool-' ) ) };
+} );
+
+describe( 'getSiteRootForFile', () => {
+	beforeAll( () => {
+		fs.mkdirSync( path.join( mockSitesRoot, 'my-site', 'wp-content' ), { recursive: true } );
+	} );
+
+	afterAll( () => {
+		fs.rmSync( mockSitesRoot, { recursive: true, force: true } );
+	} );
+
+	it( 'maps a file inside a site to the site root', () => {
+		expect(
+			getSiteRootForFile( path.join( mockSitesRoot, 'my-site', 'wp-content', 'x.php' ) )
+		).toBe( path.join( mockSitesRoot, 'my-site' ) );
+	} );
+
+	it( 'returns null for the sites root itself', () => {
+		expect( getSiteRootForFile( mockSitesRoot ) ).toBeNull();
+	} );
+
+	it( 'returns null for files outside the sites root', () => {
+		expect( getSiteRootForFile( path.join( os.tmpdir(), 'elsewhere.php' ) ) ).toBeNull();
+	} );
+
+	it( 'returns null when the site folder does not exist', () => {
+		expect( getSiteRootForFile( path.join( mockSitesRoot, 'ghost-site', 'file.php' ) ) ).toBeNull();
+	} );
+} );
+
+describe( 'isWpLspAvailable', () => {
+	afterEach( () => {
+		delete process.env.STUDIO_WP_LSP_PATH;
+	} );
+
+	it( 'is false when the override points at a directory without bin/wp-lsp', () => {
+		const empty = fs.mkdtempSync( path.join( os.tmpdir(), 'wp-lsp-empty-' ) );
+		process.env.STUDIO_WP_LSP_PATH = empty;
+		expect( isWpLspAvailable() ).toBe( false );
+		fs.rmSync( empty, { recursive: true, force: true } );
+	} );
+
+	it( 'is true when the override contains bin/wp-lsp', () => {
+		const root = fs.mkdtempSync( path.join( os.tmpdir(), 'wp-lsp-real-' ) );
+		fs.mkdirSync( path.join( root, 'bin' ) );
+		fs.writeFileSync( path.join( root, 'bin', 'wp-lsp' ), '<?php // stub' );
+		process.env.STUDIO_WP_LSP_PATH = root;
+		expect( isWpLspAvailable() ).toBe( true );
+		fs.rmSync( root, { recursive: true, force: true } );
+	} );
+} );

--- a/apps/cli/ai/lsp/tests/protocol.test.ts
+++ b/apps/cli/ai/lsp/tests/protocol.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { encodeMessage, LspMessageReader, type JsonRpcMessage } from '../protocol';
+
+function frame( message: object ): Buffer {
+	return encodeMessage( message as JsonRpcMessage );
+}
+
+describe( 'encodeMessage', () => {
+	it( 'produces a Content-Length framed JSON body', () => {
+		const encoded = encodeMessage( { jsonrpc: '2.0', id: 1, method: 'initialize' } ).toString();
+		const body = JSON.stringify( { jsonrpc: '2.0', id: 1, method: 'initialize' } );
+		expect( encoded ).toBe( `Content-Length: ${ Buffer.byteLength( body ) }\r\n\r\n${ body }` );
+	} );
+
+	it( 'measures multibyte content in bytes, not characters', () => {
+		const message: JsonRpcMessage = { jsonrpc: '2.0', method: 'x', params: { text: 'héllo' } };
+		const encoded = encodeMessage( message );
+		const reader = new LspMessageReader();
+		expect( reader.push( encoded ) ).toEqual( [ message ] );
+	} );
+} );
+
+describe( 'LspMessageReader', () => {
+	it( 'parses a complete frame', () => {
+		const reader = new LspMessageReader();
+		const messages = reader.push( frame( { jsonrpc: '2.0', id: 1, result: { ok: true } } ) );
+		expect( messages ).toEqual( [ { jsonrpc: '2.0', id: 1, result: { ok: true } } ] );
+	} );
+
+	it( 'parses multiple frames in a single chunk', () => {
+		const reader = new LspMessageReader();
+		const chunk = Buffer.concat( [
+			frame( { jsonrpc: '2.0', id: 1, result: 1 } ),
+			frame( { jsonrpc: '2.0', id: 2, result: 2 } ),
+		] );
+		expect( reader.push( chunk ) ).toHaveLength( 2 );
+	} );
+
+	it( 'buffers a frame split across arbitrary chunk boundaries', () => {
+		const reader = new LspMessageReader();
+		const encoded = frame( { jsonrpc: '2.0', id: 7, result: 'split' } );
+		const collected: JsonRpcMessage[] = [];
+		for ( let i = 0; i < encoded.length; i += 3 ) {
+			collected.push( ...reader.push( encoded.subarray( i, i + 3 ) ) );
+		}
+		expect( collected ).toEqual( [ { jsonrpc: '2.0', id: 7, result: 'split' } ] );
+	} );
+
+	it( 'keeps trailing partial data for the next push', () => {
+		const reader = new LspMessageReader();
+		const first = frame( { jsonrpc: '2.0', id: 1, result: 'a' } );
+		const second = frame( { jsonrpc: '2.0', id: 2, result: 'b' } );
+		const joined = Buffer.concat( [ first, second ] );
+		const messages = reader.push( joined.subarray( 0, first.length + 5 ) );
+		expect( messages ).toHaveLength( 1 );
+		expect( reader.push( joined.subarray( first.length + 5 ) ) ).toEqual( [
+			{ jsonrpc: '2.0', id: 2, result: 'b' },
+		] );
+	} );
+
+	it( 'throws on a malformed header', () => {
+		const reader = new LspMessageReader();
+		expect( () => reader.push( Buffer.from( 'Not-A-Header: nope\r\n\r\n{}' ) ) ).toThrow(
+			'malformed protocol header'
+		);
+	} );
+} );

--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -47,10 +47,13 @@ import {
 } from '@studio/common/lib/site-runtime';
 import { getAiPayloadsPath, getConfigDirectory } from '@studio/common/lib/well-known-paths';
 import { type TSchema } from 'typebox';
+import { collectEditToolDiagnostics } from 'cli/ai/lsp/diagnostics';
+import { isWpLspAvailable } from 'cli/ai/lsp/pool';
 import { buildSystemPrompt } from 'cli/ai/system-prompt';
 import { resolveStudioToolDefinitions, withChatArtifactEmission } from 'cli/ai/tools';
 import { createAskUserQuestionTool } from 'cli/ai/tools/ask-user-question';
 import { createSiteTool } from 'cli/ai/tools/create-site';
+import { lspTool } from 'cli/ai/tools/lsp';
 import { pullSiteTool } from 'cli/ai/tools/pull-site';
 import { createSkillTool } from 'cli/ai/tools/skill';
 import { takeScreenshotTool } from 'cli/ai/tools/take-screenshot';
@@ -347,6 +350,7 @@ async function createStudioAgentSession(
 					chatArtifactsEnabled,
 					remoteSession,
 					runtime,
+					lspEnabled: isWpLspAvailable(),
 					userInstructions,
 			  }
 	);
@@ -662,7 +666,19 @@ function toToolDefinition(
 			if ( payloadLimitViolation ) {
 				throw new Error( payloadLimitViolation );
 			}
-			return tool.execute( toolCallId, params, signal, onUpdate );
+			const result = await tool.execute( toolCallId, params, signal, onUpdate );
+			// wp-lsp reports problems in a just-edited PHP file straight into the
+			// tool result so the model can correct itself in the same turn.
+			if ( ! signal?.aborted ) {
+				const diagnosticsText = await collectEditToolDiagnostics( tool.name, params );
+				if ( diagnosticsText ) {
+					return {
+						...result,
+						content: [ ...result.content, { type: 'text', text: diagnosticsText } ],
+					};
+				}
+			}
+			return result;
 		},
 	};
 }
@@ -735,7 +751,16 @@ function buildAgentTools(
 			? buildSiteDeletionConfirm( config.onAskUser )
 			: undefined,
 	} ) as unknown as AgentToolAny[];
-	return withoutUnusableTools( [ ...studioTools, ...askUserTool, ...skillTool, ...piTools ] );
+	// Lsp needs the bundled wp-lsp server and local site files, so it only
+	// exists for local sites and only when the dependency is installed.
+	const lspTools: AgentToolAny[] = isWpLspAvailable() ? [ lspTool as unknown as AgentToolAny ] : [];
+	return withoutUnusableTools( [
+		...studioTools,
+		...lspTools,
+		...askUserTool,
+		...skillTool,
+		...piTools,
+	] );
 }
 
 // Two-step confirmation for site deletion:

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -24,6 +24,8 @@ export interface BuildSystemPromptOptions {
 	// Runtime of the active local site. Playground (PHP WASM) needs extra WP-CLI
 	// constraints that the native PHP runtime does not. Defaults to native-php.
 	runtime?: SiteRuntime;
+	// True when the wp-lsp language server (and its Lsp tool) is available.
+	lspEnabled?: boolean;
 	// The user's global instructions (~/.studio/knowledge/instructions.md).
 	userInstructions?: string;
 }
@@ -45,6 +47,7 @@ ${ REMOTE_DESIGN_GUIDELINES }${ remoteSessionAddendum }${ userInstructionsSectio
 		chatArtifactsEnabled: options?.chatArtifactsEnabled ?? false,
 		remoteSession: options?.remoteSession ?? false,
 		runtime: options?.runtime,
+		lspEnabled: options?.lspEnabled ?? false,
 	} ) }
 
 ${ LOCAL_SKILL_ROUTING }${ remoteSessionAddendum }${ userInstructionsSection }
@@ -124,6 +127,7 @@ function buildLocalIntro( options: {
 	chatArtifactsEnabled: boolean;
 	remoteSession: boolean;
 	runtime?: SiteRuntime;
+	lspEnabled: boolean;
 } ): string {
 	const postContentGuidance = getPostContentGuidance( options.runtime );
 	// Remote-bridge sessions also run without chat artifacts, but their user is
@@ -154,6 +158,21 @@ ${ getStudioWidgetPromptManifest() }`
 	const studioPresentToolBullet = options.chatArtifactsEnabled
 		? `
 - studio_present: Show one or more Studio desks widgets as inline visual artifacts.`
+		: '';
+	const lspToolBullet = options.lspEnabled
+		? `
+- Lsp: Exact WordPress code intelligence for PHP files (definitions, references, hook callbacks, call hierarchy, hover docs, diagnostics). See "Code intelligence".`
+		: '';
+	const lspSection = options.lspEnabled
+		? `
+
+## Code intelligence
+
+The active site's PHP (plus the JS half of blocks and hooks) is indexed by wp-lsp, a WordPress language server.
+
+- Prefer the \`Lsp\` tool over Grep when tracing any WordPress identifier: hook names, string callbacks, post type / taxonomy / shortcode slugs, block names, script and style handles, option and meta keys, functions, classes, and methods. Grep returns every textual match; Lsp returns the resolved answer — for example every callback attached to a hook, in priority order, including \`[ $this, 'method' ]\` ones.
+- Typical flow: Read the file to spot the identifier, then call Lsp with the operation and the identifier's 1-based line and column.
+- After every Edit or Write of a PHP file, wp-lsp problems in that file (unknown hook names, wrong callback argument counts, deprecated hooks, text-domain mismatches, unknown methods and properties) are appended to the tool result automatically. Fix them before moving on — the rules are high-precision, so a reported problem is almost always real.`
 		: '';
 
 	return `${ AGENT_IDENTITY } You manage and modify local WordPress sites using your Studio tools and generate content for these sites.
@@ -223,7 +242,7 @@ For long CSS or page-content files (>~200 lines), load the \`block-content\` ski
 - site_pull: Pull a WordPress.com site to a local site. Requires authentication. Specify the remote site URL or ID and sync options.
 - site_import: Import a backup file (.zip, .tar.gz, .sql, .wpress, .xml WordPress export) into a local site.
 - site_export: Export a local site to a backup file. Supports full-site (.zip, .tar.gz) or database-only (.sql) exports.
-${ studioPresentToolBullet }${ automaticArtifactSection }
+${ studioPresentToolBullet }${ lspToolBullet }${ automaticArtifactSection }${ lspSection }
 
 ## General rules
 

--- a/apps/cli/ai/tools/lsp.ts
+++ b/apps/cli/ai/tools/lsp.ts
@@ -1,0 +1,258 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import { Type } from 'typebox';
+import {
+	formatCallHierarchy,
+	formatDiagnostics,
+	formatHover,
+	formatLocations,
+	formatSymbols,
+} from 'cli/ai/lsp/format';
+import { getLspServerForSiteRoot, getSiteRootForFile, type LspServer } from 'cli/ai/lsp/pool';
+import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
+import { defineTool } from './define-tool';
+import { resolveSite, textResult } from './utils';
+import type {
+	LspCallHierarchyIncomingCall,
+	LspCallHierarchyItem,
+	LspCallHierarchyOutgoingCall,
+	LspDocumentSymbol,
+	LspHover,
+	LspLocation,
+	LspLocationLink,
+	LspSymbolInformation,
+} from 'cli/ai/lsp/protocol';
+
+const POSITION_OPERATIONS = [
+	'definition',
+	'implementation',
+	'references',
+	'hover',
+	'incomingCalls',
+	'outgoingCalls',
+] as const;
+
+const COLD_REQUEST_TIMEOUT_MS = 30_000;
+const DIAGNOSTICS_WAIT_MS = 3_000;
+const COLD_DIAGNOSTICS_WAIT_MS = 10_000;
+
+type PositionOperation = ( typeof POSITION_OPERATIONS )[ number ];
+
+function isPositionOperation( operation: string ): operation is PositionOperation {
+	return ( POSITION_OPERATIONS as readonly string[] ).includes( operation );
+}
+
+function resolveFilePath( filePath: string ): string {
+	return path.isAbsolute( filePath ) ? filePath : path.join( STUDIO_SITES_ROOT, filePath );
+}
+
+async function syncFromDisk( server: LspServer, absolutePath: string ): Promise< string > {
+	const content = await readFile( absolutePath, 'utf8' );
+	return server.client.syncDocument( absolutePath, content );
+}
+
+async function requestAtPosition< T >(
+	server: LspServer,
+	method: string,
+	uri: string,
+	line: number,
+	column: number,
+	extraParams: Record< string, unknown > = {}
+): Promise< T > {
+	const result = await server.client.request< T >(
+		method,
+		{
+			textDocument: { uri },
+			// The agent counts from 1, LSP from 0.
+			position: { line: line - 1, character: column - 1 },
+			...extraParams,
+		},
+		server.warmedUp ? undefined : COLD_REQUEST_TIMEOUT_MS
+	);
+	server.warmedUp = true;
+	return result;
+}
+
+async function runCallHierarchy(
+	server: LspServer,
+	uri: string,
+	line: number,
+	column: number,
+	direction: 'incoming' | 'outgoing'
+): Promise< string > {
+	const items = await requestAtPosition< LspCallHierarchyItem[] | null >(
+		server,
+		'textDocument/prepareCallHierarchy',
+		uri,
+		line,
+		column
+	);
+	const item = items?.[ 0 ];
+	if ( ! item ) {
+		return 'No callable symbol at this position.';
+	}
+	if ( direction === 'incoming' ) {
+		const calls = await server.client.request< LspCallHierarchyIncomingCall[] | null >(
+			'callHierarchy/incomingCalls',
+			{ item }
+		);
+		return formatCallHierarchy( calls, 'incoming', server.siteRoot );
+	}
+	const calls = await server.client.request< LspCallHierarchyOutgoingCall[] | null >(
+		'callHierarchy/outgoingCalls',
+		{ item }
+	);
+	return formatCallHierarchy( calls, 'outgoing', server.siteRoot );
+}
+
+export const lspTool = defineTool(
+	'Lsp',
+	'Query the WordPress language server (wp-lsp) for exact code intelligence on PHP files. It resolves WordPress strings the way core does: a hook name goes to where it is fired and to every attached callback (in priority order, including `[ $this, "method" ]`), a post type / taxonomy / shortcode slug goes to its `register_*()` call, a block name connects `block.json` with its PHP and JS halves, a script or style handle finds its registration and enqueues, and an option or meta key finds its reads and writes. Prefer this over Grep whenever you are tracing a WordPress identifier — it returns the resolved answer instead of every textual match. Operations: `definition` (where the thing under the cursor is declared or fired), `implementation` (the callbacks/registrations behind it), `references` (every mention, PHP and JS), `hover` (signature, docs, hook listeners), `documentSymbols` (outline of one file), `workspaceSymbols` (search symbols by name across the site), `incomingCalls` / `outgoingCalls` (call hierarchy; a hook counts as a call-graph node: incoming = where it is fired, outgoing = its listeners), `diagnostics` (current WordPress problems in a file). Position operations need filePath plus 1-based line and column pointing at the identifier. `workspaceSymbols` needs query, plus site when no filePath is given.',
+	{
+		operation: Type.Union(
+			[
+				Type.Literal( 'definition' ),
+				Type.Literal( 'implementation' ),
+				Type.Literal( 'references' ),
+				Type.Literal( 'hover' ),
+				Type.Literal( 'documentSymbols' ),
+				Type.Literal( 'workspaceSymbols' ),
+				Type.Literal( 'incomingCalls' ),
+				Type.Literal( 'outgoingCalls' ),
+				Type.Literal( 'diagnostics' ),
+			],
+			{ description: 'The code intelligence operation to run' }
+		),
+		filePath: Type.Optional(
+			Type.String( {
+				description:
+					'Path to a PHP file, absolute or relative to the sites root. Required for every operation except workspaceSymbols.',
+			} )
+		),
+		line: Type.Optional(
+			Type.Number( { description: '1-based line of the identifier (position operations)' } )
+		),
+		column: Type.Optional(
+			Type.Number( { description: '1-based column of the identifier (position operations)' } )
+		),
+		query: Type.Optional(
+			Type.String( { description: 'Symbol name to search for (workspaceSymbols only)' } )
+		),
+		site: Type.Optional(
+			Type.String( {
+				description:
+					'Site name or path used to pick the workspace when filePath is not given (workspaceSymbols only)',
+			} )
+		),
+	},
+	async ( { operation, filePath, line, column, query, site } ) => {
+		let siteRoot: string;
+		let absolutePath: string | undefined;
+
+		if ( filePath ) {
+			absolutePath = resolveFilePath( filePath );
+			const derived = getSiteRootForFile( absolutePath );
+			if ( ! derived ) {
+				throw new Error(
+					`File is not inside a Studio site: ${ filePath }. Pass a path under the sites root.`
+				);
+			}
+			siteRoot = derived;
+		} else if ( operation === 'workspaceSymbols' && site ) {
+			siteRoot = ( await resolveSite( site ) ).path;
+		} else {
+			throw new Error(
+				operation === 'workspaceSymbols'
+					? 'workspaceSymbols needs either filePath or site to pick the workspace.'
+					: `${ operation } requires filePath.`
+			);
+		}
+
+		const server = await getLspServerForSiteRoot( siteRoot );
+		if ( ! server ) {
+			throw new Error(
+				'wp-lsp is not available (server failed to start). Fall back to Grep and Read.'
+			);
+		}
+
+		if ( operation === 'workspaceSymbols' ) {
+			if ( ! query ) {
+				throw new Error( 'workspaceSymbols requires query.' );
+			}
+			const symbols = await server.client.request< LspSymbolInformation[] | null >(
+				'workspace/symbol',
+				{ query },
+				server.warmedUp ? undefined : COLD_REQUEST_TIMEOUT_MS
+			);
+			server.warmedUp = true;
+			return textResult( formatSymbols( symbols, server.siteRoot ) );
+		}
+
+		const uri = await syncFromDisk( server, absolutePath! );
+
+		if ( operation === 'documentSymbols' ) {
+			const symbols = await server.client.request<
+				LspDocumentSymbol[] | LspSymbolInformation[] | null
+			>(
+				'textDocument/documentSymbol',
+				{ textDocument: { uri } },
+				server.warmedUp ? undefined : COLD_REQUEST_TIMEOUT_MS
+			);
+			server.warmedUp = true;
+			return textResult( formatSymbols( symbols, server.siteRoot ) );
+		}
+
+		if ( operation === 'diagnostics' ) {
+			const diagnostics = await server.client.waitForDiagnostics(
+				uri,
+				server.warmedUp ? DIAGNOSTICS_WAIT_MS : COLD_DIAGNOSTICS_WAIT_MS
+			);
+			server.warmedUp = true;
+			return textResult( formatDiagnostics( diagnostics ) );
+		}
+
+		if ( ! isPositionOperation( operation ) || line === undefined || column === undefined ) {
+			throw new Error( `${ operation } requires filePath, line, and column.` );
+		}
+
+		switch ( operation ) {
+			case 'definition': {
+				const result = await requestAtPosition<
+					LspLocation | LspLocation[] | LspLocationLink[] | null
+				>( server, 'textDocument/definition', uri, line, column );
+				return textResult( formatLocations( result, server.siteRoot ) );
+			}
+			case 'implementation': {
+				const result = await requestAtPosition<
+					LspLocation | LspLocation[] | LspLocationLink[] | null
+				>( server, 'textDocument/implementation', uri, line, column );
+				return textResult( formatLocations( result, server.siteRoot ) );
+			}
+			case 'references': {
+				const result = await requestAtPosition< LspLocation[] | null >(
+					server,
+					'textDocument/references',
+					uri,
+					line,
+					column,
+					{ context: { includeDeclaration: true } }
+				);
+				return textResult( formatLocations( result, server.siteRoot ) );
+			}
+			case 'hover': {
+				const result = await requestAtPosition< LspHover | null >(
+					server,
+					'textDocument/hover',
+					uri,
+					line,
+					column
+				);
+				return textResult( formatHover( result ) );
+			}
+			case 'incomingCalls':
+				return textResult( await runCallHierarchy( server, uri, line, column, 'incoming' ) );
+			case 'outgoingCalls':
+				return textResult( await runCallHierarchy( server, uri, line, column, 'outgoing' ) );
+		}
+	}
+);

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -33,6 +33,7 @@ import {
 import { closeSharedBrowser } from 'cli/ai/browser-utils';
 import { setChatArtifactCallback } from 'cli/ai/chat-artifacts';
 import { startDaemonStatusPolling } from 'cli/ai/daemon-status-poll';
+import { shutdownAllLspServers } from 'cli/ai/lsp/pool';
 import { type AiOutputAdapter, JsonAdapter } from 'cli/ai/output-adapter';
 import {
 	AI_PROVIDERS,
@@ -708,6 +709,7 @@ export async function runCommand( options: {
 			setLocalSiteSelectedCallback( null );
 			ui.stop();
 			await closeSharedBrowser();
+			await shutdownAllLspServers();
 		}
 		return;
 	}

--- a/apps/cli/lib/dependency-management/paths.ts
+++ b/apps/cli/lib/dependency-management/paths.ts
@@ -81,6 +81,12 @@ export function getPhpMyAdminPath(): string {
 	return path.join( getWpFilesPath(), 'phpmyadmin' );
 }
 
+// wp-lsp (the WordPress language server) ships read-only with the CLI bundle. It runs on
+// the bundled native PHP binary; its writable stub cache lives under the config directory.
+export function getWpLspPath(): string {
+	return path.join( getWpFilesPath(), 'wp-lsp' );
+}
+
 export function getBlueprintsPharPath(): string {
 	return path.join( getWpFilesPath(), 'blueprints', 'blueprints.phar' );
 }

--- a/docs/design-docs/wp-lsp-agent.md
+++ b/docs/design-docs/wp-lsp-agent.md
@@ -1,0 +1,138 @@
+# wp-lsp in the Studio agent
+
+Studio Code runs [wp-lsp](https://github.com/draganescu/wp-lsp), a WordPress
+language server, next to the agent. It gives the agent exact answers about
+WordPress semantics — which callbacks run on a hook, where a post type slug is
+registered, which files make up a block — instead of grep matches, and it
+reports WordPress-specific problems (unknown hook names, wrong callback
+argument counts, deprecated hooks, text-domain mismatches) into the agent's
+context right after every PHP edit, so the agent corrects itself in the same
+turn.
+
+## Architecture
+
+```
+wp-files/wp-lsp/                 the wp-lsp release archive, pinned in
+                                 scripts/download-wp-server-files.ts and shipped
+                                 read-only with the CLI bundle
+apps/cli/ai/lsp/
+  protocol.ts                    Content-Length framing, JSON-RPC types
+  client.ts                      request/notify client, document sync, diagnostics cache
+  pool.ts                        one server per site, spawn/idle-reap/exit lifecycle
+  format.ts                      LSP results -> compact agent-readable text
+  diagnostics.ts                 post-edit diagnostics collection
+apps/cli/ai/tools/lsp.ts         the `Lsp` agent tool (nine operations)
+apps/cli/ai/runtimes/pi/index.ts registers the tool (local sites only) and appends
+                                 diagnostics to Edit/Write results
+```
+
+The server runs on Studio's bundled native PHP binary (any supported version
+satisfies wp-lsp's 8.2+ requirement), falling back to `php` on `PATH`. One
+server is spawned per site, keyed by the site root, kept warm across turns
+inside the long-lived CLI process, and reaped after 10 minutes idle. Site
+files live on disk for both the Playground and native-php runtimes, so the
+integration is runtime-independent.
+
+Environment overrides:
+
+| Variable | Meaning |
+| --- | --- |
+| `STUDIO_WP_LSP_PATH` | Use a wp-lsp checkout instead of the bundled archive. Pointing it at an empty directory disables the integration entirely — this is the A/B switch. |
+| `STUDIO_WP_LSP_PHP` | PHP binary for the server (default: bundled PHP, then `PATH`). |
+| `DEV_CONFIG_DIR` | Relocates `~/.studio`, including the `wp-lsp-cache/` stub cache. |
+
+## Measuring the positive impact
+
+The LSP changes agent behavior through two mechanisms, and each one maps to
+metrics that can be counted:
+
+1. **Navigation**: one `Lsp` call replaces a grep-read-grep chain when tracing
+   a WordPress identifier. Expected effect: fewer tool calls and fewer input
+   tokens per code-tracing task, and correct answers where grep is ambiguous
+   (`[ $this, 'method' ]` callbacks, slugs used far from their registration).
+2. **Diagnostics**: WordPress mistakes surface in the same turn as the edit
+   that introduced them. Expected effect: bugs fixed before the user (or a
+   screenshot loop) ever sees them, and fewer defects in the final site.
+
+### A/B evals (offline, deterministic)
+
+The PromptFoo eval runner (`apps/cli/ai/eval-runner.ts`) already hooks
+`runStudioAgentTurn()` and captures every tool call, tool result, and
+assistant message. Run each eval prompt twice — once normally, once with
+`STUDIO_WP_LSP_PATH` pointed at an empty directory — and diff the captured
+runs. With the switch off, the tool is not registered and the system prompt
+carries no LSP section, so the control arm is a true baseline.
+
+Metrics to extract from the captured events, per prompt and arm:
+
+- **Tool-call profile**: total calls; `Grep` + `Read` + `Glob` counts vs `Lsp`
+  counts. The navigation win shows up as substitution, not addition.
+- **Tokens and turns**: input/output token usage (on each assistant message)
+  and number of agent iterations to completion.
+- **Task success**: PromptFoo assertions on the final answer. For code-tracing
+  prompts the assertion is an exact fact ("lists `Byline::render` as an `init`
+  callback"), which grep-based agents get wrong at a measurable rate.
+- **Wall time**: per-turn duration, so the diagnostics wait (up to ~3s per PHP
+  edit, ~10s on the first edit while the site indexes) is counted against the
+  wins rather than ignored.
+
+Suggested eval set, exercising both mechanisms:
+
+- *Generation*: "create a plugin with a `book` custom post type and a
+  shortcode", "build a theme with a custom block bound to a view script" —
+  prompts whose output contains hooks, slugs, and handles that diagnostics can
+  catch.
+- *Tracing*: "what runs on `init` in this plugin?", "where is the `book` post
+  type registered?", "who listens to `acme_thing_saved`?" against a seeded
+  fixture site — prompts with one exact correct answer.
+
+Repeat each prompt N times per arm (agent runs are stochastic) and hold the
+model constant; a model change invalidates cross-run comparisons.
+
+### Grading the artifact, not the transcript
+
+The strongest impact signal is defect density in what the agent produced.
+After any site-generation run (eval or manual), score the site mechanically:
+
+- **`php -l`** over every generated PHP file: parse-error count.
+- **wp-lsp as grader**: `wp-lsp index <site>` runs the same indexer the agent
+  used and reports the final state — count remaining `unknown-hook`,
+  `accepted-args`, `deprecated-hook`, and `text-domain` findings. With
+  diagnostics on, this number should approach zero; the LSP-off arm reveals
+  how many such bugs the unaided agent ships.
+- **Boot check**: site starts, homepage returns 200, `wp-content/debug.log`
+  is free of warnings/fatals.
+- **`validate_blocks` pass rate** for generated block content.
+
+Because the grader is independent of the agent transcript, it works for both
+arms and for historical sites.
+
+### Counters in the wild (Tracks)
+
+For production measurement, add per-turn properties to the existing AI Tracks
+events (see `docs/design-docs/analytics-tracks.md`; naming follows
+`TRACKS_EVENTS` in `packages/common/lib/record-tracks-event.ts`):
+
+- `wp_lsp_available` (bool) — enables cohort comparison, since availability
+  varies by install (missing PHP, stripped bundle).
+- `wp_lsp_requests` and a per-operation breakdown — adoption: is the model
+  actually preferring `Lsp` over `Grep` when it should?
+- `wp_lsp_diagnostics_reported` — problems surfaced after edits.
+- `wp_lsp_diagnostics_resolved` — of those, how many disappeared in a later
+  successful edit of the same file within the session. This is the
+  self-correction rate: each resolved diagnostic is a bug the user never saw.
+
+The reported/resolved pair can also be computed retroactively from stored
+session transcripts (`getSessionsDirectory()`), which record every tool result
+including the appended diagnostics blocks — useful for analyzing sessions that
+predate any new Tracks properties.
+
+### What "positive impact" looks like
+
+- Tracing prompts: higher exact-answer rate, fewer tool calls, fewer input
+  tokens in the LSP arm.
+- Generation prompts: equal or slightly higher wall time per edit, but a lower
+  wp-lsp-graded defect count and fewer debug-log warnings in the artifact.
+- In the wild: a self-correction rate well above zero (each resolved
+  diagnostic is a shipped bug prevented), with `Lsp` adoption growing relative
+  to `Grep` on PHP-heavy sessions.

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -29,6 +29,7 @@ const WP_SERVER_FILES_PATH = path.join( import.meta.dirname, '..', 'wp-files' );
 
 // Pinned so builds are reproducible. Bump deliberately.
 const WORDPRESS_IMPORTER_VERSION = '0.9.5';
+const WP_LSP_VERSION = 'v0.2.0';
 const PHPMYADMIN_PATCH_FILES_PATH = path.join( import.meta.dirname, '..', 'apps', 'cli', 'php' );
 const PHPMYADMIN_LOCAL_PATCH_FILES = new Map< string, string >( [
 	[ 'config.inc.php', path.join( PHPMYADMIN_PATCH_FILES_PATH, 'config.inc.php' ) ],
@@ -133,6 +134,13 @@ const FILES_TO_DOWNLOAD: FileToDownload[] = [
 		description: `reprint.phar`,
 		getUrl: () => 'https://github.com/WordPress/reprint/releases/download/v0.9.4/reprint.phar',
 		destinationPath: path.join( WP_SERVER_FILES_PATH, 'reprint' ),
+	},
+	{
+		name: 'wp-lsp',
+		description: `wp-lsp ${ WP_LSP_VERSION }`,
+		getUrl: () =>
+			`https://github.com/draganescu/wp-lsp/releases/download/${ WP_LSP_VERSION }/wp-lsp.zip`,
+		destinationPath: path.join( WP_SERVER_FILES_PATH, 'wp-lsp' ),
 	},
 ];
 


### PR DESCRIPTION
## Related issues

- None yet — this is an exploratory Proof of Concept. If we decide to pursue it, a companion issue laying out the plan should come first (per CONTRIBUTING.md); happy to open one.

## How AI was used in this PR

Built end-to-end in a Claude Code session (Fable 5): the model read the wp-lsp README and the agent runtime, proposed the integration architecture, implemented it, and wrote the tests. The integration test it wrote against the real server caught one real bug during development (a TDZ crash in the server pool that would have silently disabled the whole feature). I steered and reviewed the direction; line-by-line human review is still pending — one more reason this is a draft.

## Proposed Changes

WordPress is held together by strings. `add_action( 'init', 'my_func' )` names a function nothing calls directly; `register_post_type( 'book' )` creates a slug that turns up in a query three files away; a block's identity is spread across `block.json`, PHP, and JS. None of that is visible to grep — and grep is what Studio Code does today when it needs to understand a site's code.

This PR runs [wp-lsp](https://github.com/draganescu/wp-lsp), a WordPress language server, next to the agent — one server per site, on Studio's bundled PHP, shipped with the CLI the same way phpMyAdmin is. The agent gets two things out of it:

1. **An `Lsp` tool** for exact answers instead of text matches: every callback attached to a hook (in priority order, including `[ $this, 'method' ]` ones), where a post type slug is registered, which files make up a block, where a script handle is enqueued.
2. **Automatic diagnostics after every PHP edit.** When the agent writes `add_action( 'ini', … )`, the warning — *Unknown hook 'ini'. Did you mean 'init'?* — lands directly in the Edit result, and the agent corrects itself in the same turn, before the user (or a screenshot loop) ever sees the bug. Same for wrong callback argument counts, deprecated hooks, and text-domain mismatches.

**Where the hopes are:**

- Fewer grep→read→grep loops on "trace this identifier" work — fewer tokens and turns, and correct answers where grep is structurally blind.
- WordPress-specific bugs caught at edit time instead of shipping inside generated sites.
- All of this is meant to be *counted*, not assumed: `docs/design-docs/wp-lsp-agent.md` describes concrete ways to measure the impact — A/B evals through the existing promptfoo runner (the `STUDIO_WP_LSP_PATH` override doubles as a clean off-switch), grading finished sites with wp-lsp itself as an independent defect counter, and proposed Tracks counters including a "self-correction rate" (diagnostics reported vs. resolved within the session).

**Trade-offs and behavior notes:**

- A PHP edit now waits up to ~3s for diagnostics (~10s on the first edit of a site, while the initial index runs). Counted against the wins in the measurement doc, not ignored.
- Zero new npm dependencies — the LSP client is ~200 lines of hand-rolled JSON-RPC framing.
- Local sites only; when the wp-lsp archive or a PHP binary is missing, everything degrades to exactly today's behavior (no tool, no prompt section, no waits).

## Testing Instructions

**Setup**

1. `npm install` (postinstall downloads wp-lsp v0.2.0 into `wp-files/`).
2. `npm run cli:build`
3. From the repo root: `node apps/cli/dist/cli/main.mjs`

**Watch the agent catch its own bug**

1. Pick or create a local site in the chat.
2. Say: *Add `add_action( 'ini', 'demo_setup' );` and an empty `demo_setup()` function to my theme's functions.php, spelled exactly like that.*
3. Watch the Edit result: it comes back with *Unknown hook 'ini'. Did you mean 'init'?* and the agent fixes it in the same turn.

**Use the Lsp tool**

1. Say: *Use the Lsp tool to list everything that runs on `wp_head` in this site.*
2. Expect resolved callbacks with file:line locations, not grep output.
3. Then try without naming the tool — *where is the `post` post type registered?* — to see it reach for Lsp on its own.

**Confirm the fallback is clean**

1. `mkdir -p /tmp/empty && STUDIO_WP_LSP_PATH=/tmp/empty node apps/cli/dist/cli/main.mjs`
2. Confirm the Lsp tool is not offered and PHP edits gain no diagnostics block — behavior is identical to trunk.

**Automated tests**

1. `npm test -- apps/cli/ai/lsp/tests/` — 41 tests; the integration test drives the real wp-lsp binary over stdio (needs `php` on PATH, auto-skips without it).
2. `npm run typecheck`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
