### PR TITLE
Agentic UI: Fix version mismatch between Beta menu and About window

### DIFF
--- a/apps/ui/src/data/onboarding/use-whats-new-autostart.test.ts
+++ b/apps/ui/src/data/onboarding/use-whats-new-autostart.test.ts
@@ -48,9 +48,10 @@ describe( 'deriveWhatsNewAutostart', () => {
 		expect( deriveWhatsNewAutostart( { ...base, siteCount: 0 } ) ).toBeNull();
 	} );
 
-	it( 'waits until hints and the stored version have loaded', () => {
+	it( 'waits until hints, the stored version, and the current version have loaded', () => {
 		expect( deriveWhatsNewAutostart( { ...base, hints: undefined } ) ).toBeNull();
 		expect( deriveWhatsNewAutostart( { ...base, lastSeenVersion: undefined } ) ).toBeNull();
+		expect( deriveWhatsNewAutostart( { ...base, currentVersion: undefined } ) ).toBeNull();
 	} );
 
 	it( 'does not re-show once the announcements have been dismissed', () => {

--- a/apps/ui/src/data/onboarding/use-whats-new-autostart.ts
+++ b/apps/ui/src/data/onboarding/use-whats-new-autostart.ts
@@ -44,7 +44,7 @@ export function deriveWhatsNewAutostart( {
 	if ( siteCount < 1 ) {
 		return null;
 	}
-	if ( hints === undefined || lastSeenVersion === undefined ) {
+	if ( hints === undefined || lastSeenVersion === undefined || currentVersion === undefined ) {
 		return null;
 	}
 	if ( ! hasUnseenWhatsNew( lastSeenVersion ?? undefined, currentVersion ) ) {
@@ -81,6 +81,9 @@ export function useWhatsNewAutostart(): void {
 	const startTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 
 	useEffect( () => {
+		if ( currentVersion === undefined ) {
+			return;
+		}
 		const decision = deriveWhatsNewAutostart( {
 			siteCount: sites?.length ?? 0,
 			hints,

--- a/apps/ui/src/data/onboarding/use-whats-new-replay.ts
+++ b/apps/ui/src/data/onboarding/use-whats-new-replay.ts
@@ -26,7 +26,11 @@ export function useWhatsNewReplay(): void {
 	useEffect( () => {
 		return connector.onShowWhatsNew( () => {
 			openGuide( getWhatsNewGuide(), {
-				onEnd: () => saveLastSeenVersion.mutate( versionRef.current ),
+				onEnd: () => {
+					if ( versionRef.current !== undefined ) {
+						saveLastSeenVersion.mutate( versionRef.current );
+					}
+				},
 			} );
 		} );
 	}, [ connector, openGuide, saveLastSeenVersion ] );

--- a/apps/ui/src/data/queries/use-app-globals.ts
+++ b/apps/ui/src/data/queries/use-app-globals.ts
@@ -9,5 +9,6 @@ export function useAppGlobals() {
 		queryKey: APP_GLOBALS_QUERY_KEY,
 		queryFn: () => connector.getAppGlobals(),
 		staleTime: Infinity,
+		meta: { persist: false },
 	} );
 }

--- a/apps/ui/src/data/queries/use-whats-new-seen.ts
+++ b/apps/ui/src/data/queries/use-whats-new-seen.ts
@@ -13,10 +13,15 @@ export const LAST_SEEN_VERSION_QUERY_KEY = [ 'whats-new-last-seen-version' ] as 
 // replace FORCE_SHOW_WHATS_NEW — worth doing, but not in this PR.
 const BROWSER_VERSION = 'browser';
 
-// The version both the comparison and the write should use.
-export function useWhatsNewVersion(): string {
+// The version both the comparison and the write should use. Undefined until the
+// app globals have loaded — falling back to BROWSER_VERSION early would let the
+// desktop app record 'browser' as the seen marker.
+export function useWhatsNewVersion(): string | undefined {
 	const { data: appGlobals } = useAppGlobals();
-	return appGlobals?.appVersion ?? BROWSER_VERSION;
+	if ( ! appGlobals ) {
+		return undefined;
+	}
+	return appGlobals.appVersion ?? BROWSER_VERSION;
 }
 
 export function useLastSeenVersion() {


### PR DESCRIPTION
## Related issues

- Related to internal report from Birgit Pauli-Haack: Beta menu shows an older version than About WordPress Studio after an update.

## How AI was used in this PR

Investigated and fixed autonomously with Claude Code: traced both version displays to their sources, found the root cause, applied the same fix already used elsewhere in the codebase for an identical issue.

## Proposed Changes

- The version shown in the Studio Beta menu (bottom-left corner) could lag behind the version shown in the native About window after an app update, until the browser cache expired up to 24 hours later.
- The About window always reads the live version from the running app, so it's correct immediately after an update.
- The Beta menu's version comes from a query that is cached to localStorage across app restarts. Because that query never refetches once loaded, it kept showing whatever version was cached before the most recent update.
- The query is now excluded from persistence, so it's always fetched fresh for the current session — matching the pattern already used for the app-update-status query.

- Root cause, validated: the app awaits the persisted query cache before first render, and the app-globals query uses `staleTime: Infinity`, so a version cached by a previous build renders and is never refetched. The persister also refreshes its timestamp on every cache change, so the 24h `maxAge` never purges it for a daily user.
- Follow-up hardening: with app globals now fetched fresh each launch, the What's New version briefly reads as the `browser` stand-in on desktop; the autostart could record that as the last-seen marker. It now waits for the real version before comparing or saving.

## Testing Instructions

- Install/run an older Studio build, let the Beta menu version populate, then update to a newer build without clearing app storage.
- Before the fix: Beta menu (bottom-left) shows the old version while About WordPress Studio shows the new one.
- After the fix: both show the same, current version.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

