### PR TITLE
Site preview: show a dialog when a page has unsaved changes

### DIFF
--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -224,11 +224,6 @@ async function appBoot() {
 				return;
 			}
 
-			if ( process.env.E2E ) {
-				event.preventDefault();
-				return;
-			}
-
 			const LEAVE_BUTTON_INDEX = 0;
 			const STAY_BUTTON_INDEX = 1;
 			const options: MessageBoxSyncOptions = {

--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -215,6 +215,39 @@ async function appBoot() {
 				event.preventDefault();
 			}
 		} );
+		// Electron never renders Chromium's `beforeunload` dialog — it emits this
+		// event instead, and cancels the unload unless we call `preventDefault()`.
+		// Without it, unsaved-changes guards (the block editor's, most visibly)
+		// block navigation in the preview with no way for the user to respond.
+		contents.on( 'will-prevent-unload', ( event ) => {
+			if ( ! isSitePreviewWebview ) {
+				return;
+			}
+
+			if ( process.env.E2E ) {
+				event.preventDefault();
+				return;
+			}
+
+			const LEAVE_BUTTON_INDEX = 0;
+			const STAY_BUTTON_INDEX = 1;
+			const options: MessageBoxSyncOptions = {
+				type: 'question',
+				message: __( 'Leave page with unsaved changes?' ),
+				detail: __( 'Changes you made may not be saved.' ),
+				buttons: [ __( 'Leave' ), __( 'Stay' ) ],
+				cancelId: STAY_BUTTON_INDEX,
+				defaultId: STAY_BUTTON_INDEX,
+			};
+			const parentWindow = BrowserWindow.getFocusedWindow();
+			const clickedButtonIndex = parentWindow
+				? dialog.showMessageBoxSync( parentWindow, options )
+				: dialog.showMessageBoxSync( options );
+
+			if ( clickedButtonIndex === LEAVE_BUTTON_INDEX ) {
+				event.preventDefault();
+			}
+		} );
 		contents.setWindowOpenHandler( ( details ) => {
 			// Site-preview popups (target="_blank", admin-bar links, …) open
 			// in the user's browser rather than spawning a new Electron window.

--- a/apps/studio/src/tests/index.test.ts
+++ b/apps/studio/src/tests/index.test.ts
@@ -148,6 +148,7 @@ function mockElectron() {
 			},
 			BrowserWindow: Object.assign( vi.fn(), {
 				getAllWindows: vi.fn().mockReturnValue( [] ),
+				getFocusedWindow: vi.fn().mockReturnValue( null ),
 			} ),
 			ipcMain: {
 				on: vi.fn(),
@@ -230,6 +231,70 @@ describe( 'App initialization', () => {
 				Accept: 'text/html',
 				Referer: 'https://developer.wordpress.com/studio/',
 			},
+		} );
+	} );
+
+	describe( 'unsaved changes in the site preview', () => {
+		// Electron inverts the usual contract here: `preventDefault()` on
+		// `will-prevent-unload` *allows* the page to be unloaded, and doing
+		// nothing keeps the user on the page.
+		async function captureUnloadListener( contentsType: string ) {
+			const { mockedEvents } = mockElectron();
+			vi.resetModules();
+			const electron = await import( 'electron' );
+			await import( '../index' );
+			await mockedEvents.ready();
+
+			const contents = {
+				getType: () => contentsType,
+				on: vi.fn(),
+				setWindowOpenHandler: vi.fn(),
+			};
+			await mockedEvents[ 'web-contents-created' ]( {}, contents );
+
+			const listener = contents.on.mock.calls.find(
+				( [ event ] ) => event === 'will-prevent-unload'
+			)?.[ 1 ] as ( ( event: { preventDefault: () => void } ) => void ) | undefined;
+
+			return { listener, dialog: electron.dialog };
+		}
+
+		it( 'should unload the page when the user chooses to leave', async () => {
+			const { listener, dialog } = await captureUnloadListener( 'webview' );
+			vi.mocked( dialog.showMessageBoxSync ).mockReturnValue( 0 );
+			const event = { preventDefault: vi.fn() };
+
+			listener?.( event );
+
+			expect( dialog.showMessageBoxSync ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					message: 'Leave page with unsaved changes?',
+					buttons: [ 'Leave', 'Stay' ],
+				} )
+			);
+			expect( event.preventDefault ).toHaveBeenCalled();
+		} );
+
+		it( 'should keep the page when the user chooses to stay', async () => {
+			const { listener, dialog } = await captureUnloadListener( 'webview' );
+			vi.mocked( dialog.showMessageBoxSync ).mockReturnValue( 1 );
+			const event = { preventDefault: vi.fn() };
+
+			listener?.( event );
+
+			expect( dialog.showMessageBoxSync ).toHaveBeenCalled();
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should not prompt for web contents outside the site preview', async () => {
+			const { listener, dialog } = await captureUnloadListener( 'window' );
+			const event = { preventDefault: vi.fn() };
+
+			expect( listener ).toBeDefined();
+			listener?.( event );
+
+			expect( dialog.showMessageBoxSync ).not.toHaveBeenCalled();
+			expect( event.preventDefault ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -1332,6 +1332,9 @@ function WebviewSurface( {
 	}, [ url ] );
 	// Only loads we started (the mount-time `src` counts) are judged for redirects.
 	const pendingLoadRef = useRef( true );
+	// Identifies the most recent load we started, so a rejection from a load
+	// that a newer one superseded can't roll the address bar backwards.
+	const loadGenerationRef = useRef( 0 );
 
 	const publishBrowserState = useCallback( ( patch: Partial< BrowserNavigationState > = {} ) => {
 		const webview = ref.current as WebviewTag | null;
@@ -1554,10 +1557,20 @@ function WebviewSurface( {
 		if ( url === currentUrlRef.current && reloadNonce === lastReloadNonceRef.current ) return;
 		const webview = ref.current as WebviewTag | null;
 		if ( ! webview ) return;
-		currentUrlRef.current = url;
+		const previousUrl = currentUrlRef.current;
+		const generation = ++loadGenerationRef.current;
 		lastReloadNonceRef.current = reloadNonce;
 		pendingLoadRef.current = true;
-		webview.loadURL( url ).catch( () => undefined );
+		// `currentUrlRef` is advanced by `did-navigate`, never optimistically:
+		// a load the guest refuses — an unsaved-changes guard, a dead url —
+		// must leave the host showing the page that's actually on screen.
+		webview.loadURL( url ).catch( () => {
+			if ( loadGenerationRef.current !== generation ) {
+				return;
+			}
+			pendingLoadRef.current = false;
+			onNavigateRef.current?.( previousUrl );
+		} );
 	}, [ url, reloadNonce, ready ] );
 
 	useEffect( () => {

--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -1565,7 +1565,13 @@ function WebviewSurface( {
 		// a load the guest refuses — an unsaved-changes guard, a dead url —
 		// must leave the host showing the page that's actually on screen.
 		webview.loadURL( url ).catch( () => {
+			// A newer load we started, or one the guest committed on its own
+			// (a link click, a back navigation), owns the address bar now —
+			// both can abort this load, and neither should be rolled back.
 			if ( loadGenerationRef.current !== generation ) {
+				return;
+			}
+			if ( currentUrlRef.current !== previousUrl ) {
 				return;
 			}
 			pendingLoadRef.current = false;


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude Code diagnosed the missing `will-prevent-unload` handler, wrote both changes, and I tested the dialog by hand in the block editor.

## Proposed Changes

- Editing a post in the site preview and then navigating away used to lose the edits silently — or, worse, appear to do nothing at all. The block editor's unsaved-changes guard was firing, but Electron does not render Chromium's `beforeunload` dialog, so the navigation was cancelled with no way for the user to respond.
- The preview now asks: **Leave page with unsaved changes?** with Stay / Leave. Stay keeps you on the page, Leave discards and navigates. Applies to in-page links, the address bar, back/forward, and reload.
- Second fix: when a navigation is refused, the preview's address bar no longer shows a URL the page never went to. It now stays on the page that's actually on screen.
- Scoped to the site-preview webview; the rest of the app is unaffected.

![The site preview showing the Leave / Stay dialog over the block editor](https://github.com/Automattic/studio/blob/663871ed056c5d96d469dece0753af11c5383e65/unsaved-changes-dialog.png?raw=true)

## Known gaps

Two paths still discard edits without asking, and neither has an Electron hook to attach to:

- Switching sites or quitting destroys the preview's guest page outright — `will-prevent-unload` is not emitted on destroy.
- In the browser front end (`studio ui`), the preview is a cross-origin `<iframe>`, so there is no equivalent hook at all.

Both need a guest-side dirty-state signal to cover, which is a larger change.

## Testing Instructions

1. Open a site preview and go to `/wp-admin/`, then edit a post and type something.
2. Click any admin-bar link. You should get a **Leave / Stay** sheet. Stay keeps your edits; Leave discards them.
3. Repeat with the preview's back button and with reload — same prompt.
4. Type a new URL in the preview's address bar, then choose **Stay**. The address bar should snap back to the editor URL rather than showing the URL you tried to visit.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?


