### PR TITLE
AI Credits: Stop requiring cost_reset_date from the quota endpoint

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1427,8 +1427,8 @@ export class AiChatUI implements AiOutputAdapter {
 
 	// Follows the usage-cap notice with the date the monthly limit resets,
 	// fetched from the WordPress.com quota endpoint. Silently skips when
-	// signed out or the quota can't be fetched — the cap notice on its own is
-	// already actionable.
+	// signed out, the quota can't be fetched, or the server no longer reports a
+	// reset date — the cap notice on its own is already actionable.
 	private async showUsageCapResetDate(): Promise< void > {
 		const token = await readAuthToken();
 		if ( ! token?.accessToken ) {

--- a/apps/studio/src/modules/user-settings/components/prompt-info.tsx
+++ b/apps/studio/src/modules/user-settings/components/prompt-info.tsx
@@ -33,6 +33,15 @@ export function PromptInfo() {
 		assistantQuota && assistantQuota.costCap > 0 && ! isOffline && ! isError && ! isDenied
 			? assistantQuota
 			: undefined;
+	const usedPercentage = assistantQuotaWithCostCap
+		? formatQuotaPercentage(
+				clampQuotaFraction(
+					assistantQuotaWithCostCap.costUsage,
+					assistantQuotaWithCostCap.costCap
+				),
+				locale
+		  )
+		: '';
 
 	return (
 		<div className="flex gap-3 flex-col">
@@ -49,18 +58,18 @@ export function PromptInfo() {
 								) }
 								{ ! isOffline && ! isDenied && isLoading && __( 'Loading Studio Code limits…' ) }
 								{ assistantQuotaWithCostCap &&
-									sprintf(
-										/* translators: %1$s: percentage of monthly limit used (e.g. 7.5%). %2$s: date the limit resets (e.g. July 1, 2026). */
-										__( '%1$s of monthly limit used (resets on %2$s)' ),
-										formatQuotaPercentage(
-											clampQuotaFraction(
-												assistantQuotaWithCostCap.costUsage,
-												assistantQuotaWithCostCap.costCap
-											),
-											locale
-										),
-										formatQuotaResetDate( assistantQuotaWithCostCap.costResetDate, locale )
-									) }
+									( assistantQuotaWithCostCap.costResetDate
+										? sprintf(
+												/* translators: %1$s: percentage of monthly limit used (e.g. 7.5%). %2$s: date the limit resets (e.g. July 1, 2026). */
+												__( '%1$s of monthly limit used (resets on %2$s)' ),
+												usedPercentage,
+												formatQuotaResetDate( assistantQuotaWithCostCap.costResetDate, locale )
+										  )
+										: sprintf(
+												/* translators: %s: percentage of monthly limit used (e.g. 7.5%). */
+												__( '%s of monthly limit used' ),
+												usedPercentage
+										  ) ) }
 								{ ! isLoading &&
 									! isOffline &&
 									! isDenied &&

--- a/apps/studio/src/modules/user-settings/components/tests/prompt-info.test.tsx
+++ b/apps/studio/src/modules/user-settings/components/tests/prompt-info.test.tsx
@@ -41,6 +41,25 @@ describe( 'PromptInfo', () => {
 		expect( screen.getByRole( 'progressbar' ) ).toBeInTheDocument();
 	} );
 
+	it( 'drops the reset sentence when the server no longer reports a reset date', () => {
+		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
+			data: {
+				costUsage: 33392,
+				costCap: 20000000,
+				costResetDate: undefined,
+			},
+			isError: false,
+			isLoading: false,
+			refetch: vi.fn(),
+		} );
+
+		render( <PromptInfo /> );
+
+		expect( screen.getByText( '0.17% of monthly limit used' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /resets on/ ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'progressbar' ) ).toBeInTheDocument();
+	} );
+
 	it( 'shows unavailable message when cost cap is missing', () => {
 		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
 			data: {

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -193,6 +193,18 @@ describe( 'UsagePanel', () => {
 		).not.toBeInTheDocument();
 	} );
 
+	it( 'drops the reset sentence when the server no longer reports a reset date', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: { costUsage: 25, costCap: 100, costResetDate: undefined },
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect( screen.getByText( '25% of monthly limit used' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /resets on/ ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'shows an unavailable message when the quota fetch fails', () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: undefined,

--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -137,12 +137,18 @@ function AiCreditsSummary() {
 		content = (
 			<>
 				<div className={ styles.previewUsageText }>
-					{ sprintf(
-						/* translators: %1$s: percentage of monthly limit used (e.g. 7.5%). %2$s: date the limit resets (e.g. July 1, 2026). */
-						__( '%1$s of monthly limit used (resets on %2$s)' ),
-						formatQuotaPercentage( fraction, locale ),
-						formatQuotaResetDate( quota.costResetDate, locale )
-					) }
+					{ quota.costResetDate
+						? sprintf(
+								/* translators: %1$s: percentage of monthly limit used (e.g. 7.5%). %2$s: date the limit resets (e.g. July 1, 2026). */
+								__( '%1$s of monthly limit used (resets on %2$s)' ),
+								formatQuotaPercentage( fraction, locale ),
+								formatQuotaResetDate( quota.costResetDate, locale )
+						  )
+						: sprintf(
+								/* translators: %s: percentage of monthly limit used (e.g. 7.5%). */
+								__( '%s of monthly limit used' ),
+								formatQuotaPercentage( fraction, locale )
+						  ) }
 				</div>
 				<UsageProgressBar fraction={ fraction } />
 			</>

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -18,7 +18,11 @@ export const studioAssistantQuotaSchema = z
 	.object( {
 		cost_usage: z.number(),
 		cost_cap: z.number(),
-		cost_reset_date: z.string(),
+		// Optional on purpose: the monthly reset is being retired server-side and
+		// the field is currently a hardcoded stand-in, so it can disappear from the
+		// response at any time. Every surface must read it as "reset date unknown"
+		// and drop the reset sentence rather than break.
+		cost_reset_date: z.string().optional(),
 		// Entitlement gates (STU-2174); older servers omit both fields. Default to
 		// true so a stale server never locks the UI — the proxy still enforces.
 		email_verified: z.boolean().optional(),

--- a/packages/common/lib/tests/studio-assistant-quota.test.ts
+++ b/packages/common/lib/tests/studio-assistant-quota.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	formatAiAccessRequiredNotice,
+	formatUsageCapNotice,
 	getStudioCodeAiAccessState,
 	studioAssistantQuotaSchema,
 } from '@studio/common/lib/studio-assistant-quota';
@@ -86,6 +87,21 @@ describe( 'studioAssistantQuotaSchema per-pool balances', () => {
 		const quota = studioAssistantQuotaSchema.parse( baseResponse );
 		expect( quota.allowanceRemaining ).toBeUndefined();
 		expect( quota.purchasedRemaining ).toBeUndefined();
+	} );
+} );
+
+describe( 'studioAssistantQuotaSchema reset date', () => {
+	it( 'parses a response without a reset date, leaving it undefined', () => {
+		const quota = studioAssistantQuotaSchema.parse( { cost_usage: 10, cost_cap: 100 } );
+		expect( quota.costResetDate ).toBeUndefined();
+		expect( quota.costUsage ).toBe( 10 );
+		expect( quota.costCap ).toBe( 100 );
+	} );
+
+	it( 'falls back to the try-again cap notice without a reset date', () => {
+		expect( formatUsageCapNotice( undefined, 'en-US' ) ).toBe(
+			'You’ve reached your monthly AI usage limit. Try again later.'
+		);
 	} );
 } );
 


### PR DESCRIPTION
## Related issues

- Related to STU-2296

## How AI was used in this PR

Assisted

## Proposed Changes

We need to make cost_reset_date optional, since it's no longer used on the backend, and we hardcoded it temporarily to not break old Studio versions - 235726-ghe-Automattic/wpcom/files#diff-ba500fb8cb1eba412bc75be2d76b09249cac97cca0e2616fa434a1755c210424R266

## Testing Instructions
1. Sandbox public-api.wordpress.com
2. Remove `'cost_reset_date'   => $quota->get_quota_reset_date(),` in `class-studio-app-ai-assistant.php` on the backend
3. `npm start`
4. Setting -> Usage
5. Assert that nothing is broken<br />:<img width="545" height="109" alt="Screenshot 2026-08-20 at 19 17 35" src="https://github.com/user-attachments/assets/ca14ad27-cb4d-4832-b122-4bba3a68c6d7" />
