### PR TITLE
Agentic UI: Suppress "Site started" toasts for automatic site starts

### DIFF
--- a/apps/ui/src/data/queries/use-sites.test.tsx
+++ b/apps/ui/src/data/queries/use-sites.test.tsx
@@ -1,8 +1,10 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getVisibleToasts, resetAppMessagesForTests } from '@/data/app-messages';
 import { useConnector } from '@/data/core';
 import { useAutoStartSites, useStartSite, useStopSite } from './use-sites';
+import type { StartSiteOptions } from './use-sites';
 import type { Connector, SiteDetails } from '@/data/core';
 import type { ReactNode } from 'react';
 
@@ -38,6 +40,7 @@ describe( 'useAutoStartSites', () => {
 
 	beforeEach( () => {
 		vi.clearAllMocks();
+		resetAppMessagesForTests();
 		useConnectorMock.mockReturnValue( {
 			getSites: vi.fn( () =>
 				Promise.resolve( [
@@ -64,6 +67,21 @@ describe( 'useAutoStartSites', () => {
 		await waitFor( () => expect( startSite ).toHaveBeenCalledWith( 'stopped-auto-start' ) );
 		expect( startSite ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'does not announce the sites it started', async () => {
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		} );
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<Harness />
+			</QueryClientProvider>
+		);
+
+		await waitFor( () => expect( startSite ).toHaveBeenCalledWith( 'stopped-auto-start' ) );
+		expect( getVisibleToasts() ).toHaveLength( 0 );
+	} );
 } );
 
 describe( 'useStartSite', () => {
@@ -73,6 +91,7 @@ describe( 'useStartSite', () => {
 
 	beforeEach( () => {
 		vi.clearAllMocks();
+		resetAppMessagesForTests();
 		stopSite = vi.fn(
 			() =>
 				new Promise< void >( ( resolve ) => {
@@ -86,16 +105,33 @@ describe( 'useStartSite', () => {
 		} as unknown as Connector );
 	} );
 
-	function renderMutations() {
+	function renderMutations( options: StartSiteOptions = {} ) {
 		const queryClient = new QueryClient( {
 			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 		} );
-		return renderHook( () => ( { start: useStartSite(), stop: useStopSite() } ), {
+		return renderHook( () => ( { start: useStartSite( options ), stop: useStopSite() } ), {
 			wrapper: ( { children }: { children: ReactNode } ) => (
 				<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 			),
 		} ).result;
 	}
+
+	it( 'announces an explicit start', async () => {
+		const result = renderMutations();
+
+		await result.current.start.mutateAsync( 'site-1' );
+
+		expect( getVisibleToasts().map( ( item ) => item.title ) ).toEqual( [ 'Site started' ] );
+	} );
+
+	it( 'stays quiet for a silent start', async () => {
+		const result = renderMutations( { silent: true } );
+
+		await result.current.start.mutateAsync( 'site-1' );
+
+		expect( startSite ).toHaveBeenCalledWith( 'site-1' );
+		expect( getVisibleToasts() ).toHaveLength( 0 );
+	} );
 
 	it( 'skips the start while a stop for the same site is in flight', async () => {
 		const result = renderMutations();

--- a/apps/ui/src/data/queries/use-sites.ts
+++ b/apps/ui/src/data/queries/use-sites.ts
@@ -104,9 +104,18 @@ export function useExportDatabase() {
 	} );
 }
 
+export interface StartSiteOptions {
+	// Set by callers whose start is a side effect of something else — boot
+	// auto-start, the connect-site lifecycle, opening a link on a stopped site.
+	// The site's own status already reports the start, and a batch of them
+	// would otherwise fill the shelf with notifications nobody asked for.
+	// Failures still surface: a site that never came up is worth a toast.
+	silent?: boolean;
+}
+
 // Invalidation is awaited inside `mutationFn` (not `onSettled`) so
 // `isPending` stays true until `site.running` reflects the new state.
-export function useStartSite() {
+export function useStartSite( { silent = false }: StartSiteOptions = {} ) {
 	const connector = useConnector();
 	const queryClient = useQueryClient();
 	return useMutation( {
@@ -126,7 +135,7 @@ export function useStartSite() {
 			return true;
 		},
 		onSuccess: ( started ) => {
-			if ( started ) {
+			if ( started && ! silent ) {
 				toast.success( __( 'Site started' ) );
 			}
 		},
@@ -340,7 +349,7 @@ export function useSyncSitesWithEvents(): void {
 // with stale flags can't trigger starts.
 export function useAutoStartSites(): void {
 	const { data: sites, isFetchedAfterMount } = useSites();
-	const { mutate: startSite } = useStartSite();
+	const { mutate: startSite } = useStartSite( { silent: true } );
 	const startedRef = useRef( false );
 	useEffect( () => {
 		if ( ! isFetchedAfterMount || ! sites || startedRef.current ) {

--- a/apps/ui/src/hooks/use-open-site-url.ts
+++ b/apps/ui/src/hooks/use-open-site-url.ts
@@ -15,7 +15,7 @@ import type { SiteDetails } from '@/data/core';
 export function useOpenSiteUrl( site: SiteDetails ) {
 	const connector = useConnector();
 	const preview = useOptionalSessionPreviewUI();
-	const startSite = useStartSite();
+	const startSite = useStartSite( { silent: true } );
 
 	return async ( relativeUrl: string ) => {
 		if ( ! preview ) {

--- a/apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx
+++ b/apps/ui/src/ui-classic/router/route-onboarding-connect/index.tsx
@@ -182,7 +182,7 @@ export function OnboardingConnectPage() {
 	const createSite = useCreateSite();
 	const deleteSite = useDeleteSite();
 	const pullSite = usePullSiteFromLive();
-	const startSite = useStartSite();
+	const startSite = useStartSite( { silent: true } );
 	const [ searchQuery, setSearchQuery ] = useState( '' );
 	const [ selectedId, setSelectedId ] = useState< number | null >( null );
 	const [ isConnecting, setIsConnecting ] = useState( false );


### PR DESCRIPTION
## Related issues

- Fixes STU-2079 (the notification half — the icon/label alignment note in that issue is not addressed here)

## How AI was used in this PR

Claude Code found the start paths that were toasting, added the opt-out, and wrote the tests. Reviewed by the author.

## Proposed Changes

- Opening the app with "Stop, restart on next launch" no longer fires a "Site started" toast per site — a run of 3+ low-value notifications on every launch.
- Same for the other starts the user didn't ask for: the connect-a-site onboarding flow (which reports its own progress and then navigates), and clicking a link on a stopped site (the preview panel or browser is the feedback).
- Explicit starts — the start button, the site row toggle, the site menu — still toast.
- Failures still toast in every case, automatic ones included: a site that never came up is worth saying out loud.
- No automatic *stop* path exists in the Agentic UI today, so nothing changed there.

## Testing Instructions

1. Settings → set quit behavior to "Stop, restart on next launch".
2. Start 2+ sites, quit Studio, reopen it.
3. The sites come back up with no toasts; the site rows show the start themselves.
4. Click a site's start button — "Site started" still appears.
5. Open wp-admin from a stopped site — it starts and opens with no toast.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
