### PR TITLE
AI Credits: Show remaining credit balances in Studio Classic settings

### DIFF
--- a/apps/studio/src/modules/user-settings/components/prompt-info.tsx
+++ b/apps/studio/src/modules/user-settings/components/prompt-info.tsx
@@ -29,8 +29,28 @@ export function PromptInfo() {
 			? getStudioCodeAiAccessState( assistantQuota )
 			: 'available';
 	const isDenied = accessState !== 'available';
+	// The server includes the per-pool balances only when AI credits are
+	// enabled for the account (STU-2235); their absence — not a 0 — means the
+	// pre-credits monthly-limit design should render.
+	const creditBalances =
+		assistantQuota &&
+		! isOffline &&
+		! isError &&
+		! isDenied &&
+		( assistantQuota.allowanceRemaining !== undefined ||
+			assistantQuota.purchasedRemaining !== undefined )
+			? {
+					allowance: assistantQuota.allowanceRemaining ?? 0,
+					purchased: assistantQuota.purchasedRemaining ?? 0,
+			  }
+			: undefined;
 	const assistantQuotaWithCostCap =
-		assistantQuota && assistantQuota.costCap > 0 && ! isOffline && ! isError && ! isDenied
+		assistantQuota &&
+		assistantQuota.costCap > 0 &&
+		! isOffline &&
+		! isError &&
+		! isDenied &&
+		! creditBalances
 			? assistantQuota
 			: undefined;
 	const usedPercentage = assistantQuotaWithCostCap
@@ -42,6 +62,7 @@ export function PromptInfo() {
 				locale
 		  )
 		: '';
+	const credits = new Intl.NumberFormat( locale );
 
 	return (
 		<div className="flex gap-3 flex-col">
@@ -57,6 +78,26 @@ export function PromptInfo() {
 									<AiAccessRequiredNotice quota={ assistantQuota } />
 								) }
 								{ ! isOffline && ! isDenied && isLoading && __( 'Loading Studio Code limits…' ) }
+								{ creditBalances && (
+									<span className="flex flex-col gap-1 tabular-nums">
+										{ creditBalances.allowance > 0 && (
+											<span>
+												{ sprintf(
+													/* translators: %s: number of free AI credits remaining (e.g. 960,000). */
+													__( 'Free credits remaining: %s' ),
+													credits.format( creditBalances.allowance )
+												) }
+											</span>
+										) }
+										<span>
+											{ sprintf(
+												/* translators: %s: number of purchased AI credits remaining (e.g. 150,000). */
+												__( 'Purchased credits remaining: %s' ),
+												credits.format( creditBalances.purchased )
+											) }
+										</span>
+									</span>
+								) }
 								{ assistantQuotaWithCostCap &&
 									( assistantQuotaWithCostCap.costResetDate
 										? sprintf(
@@ -74,6 +115,7 @@ export function PromptInfo() {
 									! isOffline &&
 									! isDenied &&
 									! assistantQuotaWithCostCap &&
+									! creditBalances &&
 									__( 'Studio Code limits are temporarily unavailable.' ) }
 							</span>
 						</div>

--- a/apps/studio/src/modules/user-settings/components/prompt-info.tsx
+++ b/apps/studio/src/modules/user-settings/components/prompt-info.tsx
@@ -1,15 +1,19 @@
 import {
+	ADD_AI_CREDITS_URL,
 	clampQuotaFraction,
 	formatQuotaPercentage,
 	formatQuotaResetDate,
 	getStudioCodeAiAccessState,
 } from '@studio/common/lib/studio-assistant-quota';
 import { sprintf } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { AiAccessRequiredNotice, AiBlockedNotice } from 'src/components/ai-access-required-notice';
+import Button from 'src/components/button';
 import ProgressBar from 'src/components/progress-bar';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
+import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useI18nLocale } from 'src/stores';
 import { useGetStudioAssistantQuota } from 'src/stores/wpcom-api';
 
@@ -29,9 +33,6 @@ export function PromptInfo() {
 			? getStudioCodeAiAccessState( assistantQuota )
 			: 'available';
 	const isDenied = accessState !== 'available';
-	// The server includes the per-pool balances only when AI credits are
-	// enabled for the account (STU-2235); their absence — not a 0 — means the
-	// pre-credits monthly-limit design should render.
 	const creditBalances =
 		assistantQuota &&
 		! isOffline &&
@@ -79,7 +80,7 @@ export function PromptInfo() {
 								) }
 								{ ! isOffline && ! isDenied && isLoading && __( 'Loading Studio Code limits…' ) }
 								{ creditBalances && (
-									<span className="flex flex-col gap-1 tabular-nums">
+									<span className="flex flex-col gap-1 tabular-nums text-left">
 										{ creditBalances.allowance > 0 && (
 											<span>
 												{ sprintf(
@@ -126,6 +127,18 @@ export function PromptInfo() {
 							value={ assistantQuotaWithCostCap.costUsage }
 							maxValue={ assistantQuotaWithCostCap.costCap }
 						/>
+					) }
+					{ creditBalances && (
+						<Button
+							className="self-start"
+							variant="secondary"
+							icon={ external }
+							iconPosition="right"
+							iconSize={ 16 }
+							onClick={ () => void getIpcApi().openURL( ADD_AI_CREDITS_URL ) }
+						>
+							{ __( 'Add AI credits' ) }
+						</Button>
 					) }
 				</div>
 				<div className="h-6 w-6"></div>

--- a/apps/studio/src/modules/user-settings/components/tests/prompt-info.test.tsx
+++ b/apps/studio/src/modules/user-settings/components/tests/prompt-info.test.tsx
@@ -60,6 +60,68 @@ describe( 'PromptInfo', () => {
 		expect( screen.getByRole( 'progressbar' ) ).toBeInTheDocument();
 	} );
 
+	it( 'shows both credit balances when the account has AI credits', () => {
+		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
+			data: {
+				costUsage: 33392,
+				costCap: 20000000,
+				costResetDate: '2026-07-01T00:00:00+00:00',
+				allowanceRemaining: 960000,
+				purchasedRemaining: 150000,
+			},
+			isError: false,
+			isLoading: false,
+			refetch: vi.fn(),
+		} );
+
+		render( <PromptInfo /> );
+
+		expect( screen.getByText( 'Free credits remaining: 960,000' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Purchased credits remaining: 150,000' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /monthly limit used/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'progressbar' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the free pool once it is spent, and keeps a zero purchased balance', () => {
+		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
+			data: {
+				costUsage: 33392,
+				costCap: 20000000,
+				costResetDate: '2026-07-01T00:00:00+00:00',
+				allowanceRemaining: 0,
+				purchasedRemaining: 0,
+			},
+			isError: false,
+			isLoading: false,
+			refetch: vi.fn(),
+		} );
+
+		render( <PromptInfo /> );
+
+		expect( screen.queryByText( /Free credits remaining/ ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Purchased credits remaining: 0' ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps the monthly limit design when the account has no AI credits', () => {
+		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
+			data: {
+				costUsage: 33392,
+				costCap: 20000000,
+				costResetDate: '2026-07-01T00:00:00+00:00',
+			},
+			isError: false,
+			isLoading: false,
+			refetch: vi.fn(),
+		} );
+
+		render( <PromptInfo /> );
+
+		expect( screen.queryByText( /credits remaining/ ) ).not.toBeInTheDocument();
+		expect(
+			screen.getByText( '0.17% of monthly limit used (resets on July 1, 2026)' )
+		).toBeInTheDocument();
+	} );
+
 	it( 'shows unavailable message when cost cap is missing', () => {
 		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
 			data: {


### PR DESCRIPTION
## Related issues

- Related to STU-2235
- Follows #4602, which added the same balances to the Agentic UI

## How AI was used in this PR

Assisted

## Proposed Changes

Accounts with AI credits see their free and purchased balances in the Agentic UI, but Studio Classic still showed only the old limit percentage — so Classic users had no way to tell how many credits they had left, or that they had run out.

Classic now shows the same two balances, on the same rules as the Agentic UI: the free pool disappears once it is spent, and the purchased pool is always shown so a zero balance is visible.

## Testing Instructions

1. In Studio Classic, open **Settings → Account**
2. With credits on both pools, it reads:<br /><img width="278" height="135" alt="Screenshot 2026-08-21 at 11 52 21" src="https://github.com/user-attachments/assets/b32cc3b5-b3a3-4afb-8f4d-45e07503e924" />
3. Click on "Add AI Credits"
4. Follow the purchase flow
5. Assert that you were landed back to Studio with Setting popup open
