### PR TITLE
AI Credits: Return to Studio and refresh the balance after a top-up

### DIFF
--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -316,7 +316,13 @@ describe( 'AiChatUI.handleEvent', () => {
 		expect( showError ).not.toHaveBeenCalledWith(
 			expect.stringContaining( 'monthly AI usage limit' )
 		);
-		expect( showInfo ).toHaveBeenCalledWith( expect.stringContaining( ADD_AI_CREDITS_URL ) );
+		expect( showInfo ).toHaveBeenCalledWith(
+			'Add credits at the link below, then come back to continue using Studio Code:'
+		);
+		// The terminal has nothing for checkout to return to, so the URL it
+		// prints carries no return parameters.
+		expect( showInfo ).toHaveBeenCalledWith( ADD_AI_CREDITS_URL );
+		expect( ADD_AI_CREDITS_URL ).not.toContain( 'studioReturnTo' );
 		expect( ui.showUsageCapResetDate ).not.toHaveBeenCalled();
 		expect( ui.usageCapReached ).toBe( true );
 		expect( ui.currentMarkdown ).toBeNull();

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -2120,15 +2120,12 @@ export class AiChatUI implements AiOutputAdapter {
 					this.usageCapReached = true;
 					this.showError( outOfCredits ? formatOutOfCreditsNotice() : formatUsageCapNotice() );
 					if ( outOfCredits ) {
-						// The terminal can't render a link, so print the URL as-is —
-						// it stays copyable and most terminals auto-link it.
+						// The terminal can't render a link, so the URL goes on its own
+						// line, as-is — it stays copyable and most terminals auto-link it.
 						this.showInfo(
-							sprintf(
-								/* translators: %s: URL of the page where the user can buy AI credits. */
-								__( 'Add credits at %s' ),
-								ADD_AI_CREDITS_URL
-							)
+							__( 'Add credits at the link below, then come back to continue using Studio Code:' )
 						);
+						this.showInfo( ADD_AI_CREDITS_URL );
 					} else {
 						// Async on purpose: the reset date needs a wpcom round trip
 						// and must not block rendering the cap notice.

--- a/apps/studio/src/components/ai-access-required-notice.tsx
+++ b/apps/studio/src/components/ai-access-required-notice.tsx
@@ -1,5 +1,5 @@
 import {
-	ADD_AI_CREDITS_URL,
+	getAddAiCreditsUrl,
 	formatAiAccessRequiredNotice,
 	formatAiBlockedNotice,
 	formatOutOfCreditsNoticeWithLink,
@@ -38,6 +38,6 @@ export function AiBlockedNotice() {
 
 export function OutOfCreditsNotice() {
 	return createInterpolateElement( formatOutOfCreditsNoticeWithLink(), {
-		buyLink: <NoticeLink url={ ADD_AI_CREDITS_URL } />,
+		buyLink: <NoticeLink url={ getAddAiCreditsUrl( { returnsToDesktop: true } ) } />,
 	} );
 }

--- a/apps/studio/src/modules/user-settings/components/prompt-info.tsx
+++ b/apps/studio/src/modules/user-settings/components/prompt-info.tsx
@@ -1,5 +1,5 @@
 import {
-	ADD_AI_CREDITS_URL,
+	getAddAiCreditsUrl,
 	clampQuotaFraction,
 	formatQuotaPercentage,
 	formatQuotaResetDate,
@@ -135,7 +135,9 @@ export function PromptInfo() {
 							icon={ external }
 							iconPosition="right"
 							iconSize={ 16 }
-							onClick={ () => void getIpcApi().openURL( ADD_AI_CREDITS_URL ) }
+							onClick={ () =>
+								void getIpcApi().openURL( getAddAiCreditsUrl( { returnsToDesktop: true } ) )
+							}
 						>
 							{ __( 'Add AI credits' ) }
 						</Button>

--- a/apps/ui/src/components/ai-access-required-notice/index.tsx
+++ b/apps/ui/src/components/ai-access-required-notice/index.tsx
@@ -1,5 +1,4 @@
 import {
-	ADD_AI_CREDITS_URL,
 	formatAiAccessRequiredNotice,
 	formatAiBlockedNotice,
 	formatOutOfCreditsNoticeWithLink,
@@ -9,6 +8,7 @@ import {
 } from '@studio/common/lib/studio-assistant-quota';
 import { createInterpolateElement } from '@wordpress/element';
 import { useConnector } from '@/data/core';
+import { useAddAiCreditsUrl } from '@/hooks/use-add-ai-credits-url';
 import type { ReactNode } from 'react';
 
 // Electron swallows plain `target="_blank"` navigations — route clicks
@@ -47,7 +47,8 @@ export function AiBlockedNotice() {
 }
 
 export function OutOfCreditsNotice() {
+	const addAiCreditsUrl = useAddAiCreditsUrl();
 	return createInterpolateElement( formatOutOfCreditsNoticeWithLink(), {
-		buyLink: <NoticeLink url={ ADD_AI_CREDITS_URL } />,
+		buyLink: <NoticeLink url={ addAiCreditsUrl } />,
 	} );
 }

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -1,8 +1,9 @@
 import '@testing-library/jest-dom/vitest';
-import { ADD_AI_CREDITS_URL } from '@studio/common/lib/studio-assistant-quota';
+import { getAddAiCreditsUrl } from '@studio/common/lib/studio-assistant-quota';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
+import { useAppGlobals } from '@/data/queries/use-app-globals';
 import { useStudioAssistantQuota } from '@/data/queries/use-assistant-quota';
 import { useAuthUser, useLogin } from '@/data/queries/use-auth-user';
 import {
@@ -102,6 +103,10 @@ vi.mock( '@/data/queries/use-user-locale', () => ( {
 	useUserLocale: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-app-globals', () => ( {
+	useAppGlobals: vi.fn(),
+} ) );
+
 // Reached through `useAgenticFeatures`, which reads the agentic-features
 // preference; this panel has no QueryClientProvider.
 vi.mock( '@/data/queries/use-user-preferences', () => ( {
@@ -118,6 +123,7 @@ const useSnapshotsMock = vi.mocked( useSnapshots );
 const useOfflineMock = vi.mocked( useOffline );
 const useStudioAssistantQuotaMock = vi.mocked( useStudioAssistantQuota );
 const useUserLocaleMock = vi.mocked( useUserLocale );
+const useAppGlobalsMock = vi.mocked( useAppGlobals );
 
 describe( 'UsagePanel', () => {
 	const loginMutate = vi.fn();
@@ -143,6 +149,7 @@ describe( 'UsagePanel', () => {
 			isLoading: false,
 		} as never );
 		useUserLocaleMock.mockReturnValue( 'en' );
+		useAppGlobalsMock.mockReturnValue( { data: { platform: 'darwin' } } as never );
 		useAuthUserMock.mockReturnValue( {
 			data: { id: 1, displayName: 'Ada Lovelace', email: 'ada@example.com' },
 			isLoading: false,
@@ -310,7 +317,25 @@ describe( 'UsagePanel', () => {
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Add AI credits' } ) );
 
-		expect( openExternalUrl ).toHaveBeenCalledWith( ADD_AI_CREDITS_URL );
+		expect( openExternalUrl ).toHaveBeenCalledWith(
+			getAddAiCreditsUrl( { returnsToDesktop: true } )
+		);
+	} );
+
+	it( 'drops the return-to-Studio link when running in a browser tab', () => {
+		useAppGlobalsMock.mockReturnValue( { data: { platform: 'browser' } } as never );
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: { costUsage: 0, costCap: 0, allowanceRemaining: 960000, purchasedRemaining: 0 },
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add AI credits' } ) );
+
+		expect( openExternalUrl ).toHaveBeenCalledWith(
+			getAddAiCreditsUrl( { returnsToDesktop: false } )
+		);
 	} );
 
 	it( 'opens the credits explainer dialog from the help icon', () => {

--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -1,5 +1,4 @@
 import {
-	ADD_AI_CREDITS_URL,
 	clampQuotaFraction,
 	formatQuotaPercentage,
 	formatQuotaResetDate,
@@ -25,6 +24,7 @@ import {
 	useSnapshots,
 } from '@/data/queries/use-snapshots';
 import { useUserLocale } from '@/data/queries/use-user-locale';
+import { useAddAiCreditsUrl } from '@/hooks/use-add-ai-credits-url';
 import styles from './style.module.css';
 
 const DEFAULT_PREVIEW_SITE_LIMIT = 10;
@@ -53,6 +53,7 @@ function UsageProgressBar( { fraction }: { fraction: number } ) {
 function AiCreditsSummary() {
 	const locale = useUserLocale();
 	const connector = useConnector();
+	const addAiCreditsUrl = useAddAiCreditsUrl();
 	const [ detailsOpen, setDetailsOpen ] = useState( false );
 	// The balance may have changed outside the app (e.g. a credits purchase on
 	// WordPress.com), so opening the panel always fetches a fresh figure.
@@ -125,7 +126,7 @@ function AiCreditsSummary() {
 					size="small"
 					variant="outline"
 					tone="neutral"
-					onClick={ () => void connector.openExternalUrl( ADD_AI_CREDITS_URL ) }
+					onClick={ () => void connector.openExternalUrl( addAiCreditsUrl ) }
 				>
 					{ __( 'Add AI credits' ) }
 					<Button.Icon icon={ external } size={ 12 } />

--- a/apps/ui/src/hooks/use-add-ai-credits-url.ts
+++ b/apps/ui/src/hooks/use-add-ai-credits-url.ts
@@ -1,0 +1,16 @@
+import { getAddAiCreditsUrl } from '@studio/common/lib/studio-assistant-quota';
+import { useAppGlobals } from '@/data/queries/use-app-globals';
+
+/**
+ * Checkout URL for the AI credits top-up. This app runs both inside the desktop
+ * app and as a plain browser tab, and only the former can be returned to by the
+ * `wp-studio://` deeplink — so the return is asked for at runtime, and while the
+ * host is still unknown we ask for nothing rather than risk sending a browser to
+ * a scheme it can't open.
+ */
+export function useAddAiCreditsUrl(): string {
+	const { data: appGlobals } = useAppGlobals();
+	return getAddAiCreditsUrl( {
+		returnsToDesktop: !! appGlobals && appGlobals.platform !== 'browser',
+	} );
+}

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
@@ -1,7 +1,4 @@
-import {
-	ADD_AI_CREDITS_URL,
-	getStudioCodeAiAccessState,
-} from '@studio/common/lib/studio-assistant-quota';
+import { getStudioCodeAiAccessState } from '@studio/common/lib/studio-assistant-quota';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
@@ -16,10 +13,12 @@ import {
 	useStudioAssistantQuota,
 } from '@/data/queries/use-assistant-quota';
 import { useUserLocale } from '@/data/queries/use-user-locale';
+import { useAddAiCreditsUrl } from '@/hooks/use-add-ai-credits-url';
 import styles from './style.module.css';
 
 export function AiCreditsControl() {
 	const connector = useConnector();
+	const addAiCreditsUrl = useAddAiCreditsUrl();
 	const locale = useUserLocale();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
@@ -91,7 +90,7 @@ export function AiCreditsControl() {
 						</strong>
 					</div>
 					<Menu.Separator />
-					<Menu.Item onClick={ () => void connector.openExternalUrl( ADD_AI_CREDITS_URL ) }>
+					<Menu.Item onClick={ () => void connector.openExternalUrl( addAiCreditsUrl ) }>
 						{ __( 'Add AI credits' ) }
 						<Icon icon={ external } size={ 14 } aria-hidden="true" />
 					</Menu.Item>

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -11,8 +11,7 @@ export const WPCOM_SUPPORT_CONTACT_URL = 'https://wordpress.com/support/contact/
 // Deeplink host checkout returns to once the top-up completes or is cancelled,
 // handled by `ai-credits-purchased` in the desktop deeplink router. Checkout
 // builds the full `wp-studio://` URL itself, so only the host travels in the
-// `studioReturnTo` parameter. Unreachable from `studio ui` in a browser, which
-// has no custom scheme.
+// `studioReturnTo` parameter.
 export const AI_CREDITS_PURCHASED_RETURN_TO = 'ai-credits-purchased';
 
 // Checkout requires a site id, but a credits top-up isn't tied to a site — this
@@ -22,10 +21,24 @@ const CHECKOUT_PLACEHOLDER_SITE_ID = 'b4b08783-91cd-4aa1-b2ee-28575c26a762';
 // WordPress.com checkout for a Studio Code AI credits top-up (STU-2299). The
 // `:-q-<n>` suffix is checkout's quantity syntax, in the same 1/10000 USD units
 // the quota reports — 100000 is the $10 top-up, the only one offered in v1.
+// Plain by default: checkout stays on WordPress.com when it's done.
 export const ADD_AI_CREDITS_URL =
 	'https://wordpress.com/checkout/wpcom/studio-code-ai-credits:-q-100000' +
-	`?studioSiteId=${ CHECKOUT_PLACEHOLDER_SITE_ID }` +
-	`&studioReturnTo=${ AI_CREDITS_PURCHASED_RETURN_TO }`;
+	`?studioSiteId=${ CHECKOUT_PLACEHOLDER_SITE_ID }`;
+
+/**
+ * Checkout URL for the surface the user is buying from. Only the desktop app
+ * registers the `wp-studio://` scheme, so only it may ask checkout to send the
+ * user back — the CLI has nothing to return to (see the OAuth flow, which uses
+ * a copy/paste page there for the same reason), and pointing a plain browser
+ * at an unopenable scheme is worse than leaving the user on WordPress.com.
+ */
+export function getAddAiCreditsUrl( { returnsToDesktop }: { returnsToDesktop: boolean } ): string {
+	if ( ! returnsToDesktop ) {
+		return ADD_AI_CREDITS_URL;
+	}
+	return `${ ADD_AI_CREDITS_URL }&studioReturnTo=${ AI_CREDITS_PURCHASED_RETURN_TO }`;
+}
 
 export const studioAssistantQuotaSchema = z
 	.object( {

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -14,17 +14,17 @@ export const WPCOM_SUPPORT_CONTACT_URL = 'https://wordpress.com/support/contact/
 // `studioReturnTo` parameter.
 export const AI_CREDITS_PURCHASED_RETURN_TO = 'ai-credits-purchased';
 
-// Checkout requires a site id, but a credits top-up isn't tied to a site — this
-// placeholder satisfies the parameter without pointing anywhere.
+// Checkout wants a site id alongside the return destination, but a credits
+// top-up isn't tied to a site — this placeholder satisfies the parameter
+// without pointing anywhere.
 const CHECKOUT_PLACEHOLDER_SITE_ID = 'b4b08783-91cd-4aa1-b2ee-28575c26a762';
 
 // WordPress.com checkout for a Studio Code AI credits top-up (STU-2299). The
 // `:-q-<n>` suffix is checkout's quantity syntax, in the same 1/10000 USD units
 // the quota reports — 100000 is the $10 top-up, the only one offered in v1.
-// Plain by default: checkout stays on WordPress.com when it's done.
+// Bare by default: checkout stays on WordPress.com when it's done.
 export const ADD_AI_CREDITS_URL =
-	'https://wordpress.com/checkout/wpcom/studio-code-ai-credits:-q-100000' +
-	`?studioSiteId=${ CHECKOUT_PLACEHOLDER_SITE_ID }`;
+	'https://wordpress.com/checkout/wpcom/studio-code-ai-credits:-q-100000';
 
 /**
  * Checkout URL for the surface the user is buying from. Only the desktop app
@@ -32,12 +32,16 @@ export const ADD_AI_CREDITS_URL =
  * user back — the CLI has nothing to return to (see the OAuth flow, which uses
  * a copy/paste page there for the same reason), and pointing a plain browser
  * at an unopenable scheme is worse than leaving the user on WordPress.com.
+ * Everywhere else gets the bare URL, down to the return-only site id.
  */
 export function getAddAiCreditsUrl( { returnsToDesktop }: { returnsToDesktop: boolean } ): string {
 	if ( ! returnsToDesktop ) {
 		return ADD_AI_CREDITS_URL;
 	}
-	return `${ ADD_AI_CREDITS_URL }&studioReturnTo=${ AI_CREDITS_PURCHASED_RETURN_TO }`;
+	return (
+		`${ ADD_AI_CREDITS_URL }?studioSiteId=${ CHECKOUT_PLACEHOLDER_SITE_ID }` +
+		`&studioReturnTo=${ AI_CREDITS_PURCHASED_RETURN_TO }`
+	);
 }
 
 export const studioAssistantQuotaSchema = z


### PR DESCRIPTION
## Related issues

## How AI was used in this PR

Assisted


## Proposed Changes

With this PR Studio UI works the same way, but when we top-up balance from StudioCode - we don't have return url after purchase. 
Also, we print `then come back to continue using Studio Code` as user can jsut purchase and continue using it w/o extra actions:
<img width="642" height="166" alt="Screenshot 2026-08-21 at 13 33 05" src="https://github.com/user-attachments/assets/027eb370-690c-4d26-ae6e-57650651fb21" />


## Testing Instructions
1. Assert that Agentioc and classic `return_url` fucntionality works as before
2. `node apps/cli/dist/cli/main.mjs code`
3. Assert that purchase link via Studi oCode doesn't leed to `return_url` functionality