### PR TITLE
Revert "Ask for confirmation before deleting a site (#4090)"

### DIFF
--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -67,7 +67,6 @@ import {
 } from './tool-safety';
 import { withUsageCapErrorRewrite } from './usage-cap';
 import type { StudioChatImage } from '@studio/common/ai/chat-images';
-import type { ConfirmSiteDeletion } from 'cli/ai/tools/delete-site';
 import type { AskUserHandler, SiteInfo } from 'cli/ai/types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -731,81 +730,8 @@ function buildAgentTools(
 	const studioTools = resolveStudioToolDefinitions( {
 		emitChatArtifacts: chatArtifactsEnabled,
 		remoteSession,
-		confirmSiteDeletion: config.onAskUser
-			? buildSiteDeletionConfirm( config.onAskUser )
-			: undefined,
 	} ) as unknown as AgentToolAny[];
 	return withoutUnusableTools( [ ...studioTools, ...askUserTool, ...skillTool, ...piTools ] );
-}
-
-// Two-step confirmation for site deletion:
-// 1. Choose what happens to the files (trash / keep / cancel)
-// 2. Final safety gate naming the site (delete / cancel)
-// Cancelling at either step leaves the site intact.
-const DELETE_AND_TRASH_LABEL = 'Delete and trash files';
-const DELETE_AND_KEEP_LABEL = 'Delete and keep files';
-const CONFIRM_DELETE_LABEL = 'Delete site';
-
-function buildSiteDeletionConfirm( onAskUser: AskUserHandler ): ConfirmSiteDeletion {
-	return async ( { name } ) => {
-		// Step 1: file handling choice
-		const fileQuestion = `What should happen to the files for "${ name }"?`;
-		const fileAnswers = await onAskUser( [
-			{
-				question: fileQuestion,
-				options: [
-					{
-						label: DELETE_AND_TRASH_LABEL,
-						description: `Remove "${ name }" from Studio and move its files to the trash.`,
-					},
-					{
-						label: DELETE_AND_KEEP_LABEL,
-						description: `Remove "${ name }" from Studio but keep its files on disk.`,
-					},
-					{
-						label: 'Cancel',
-						description: 'Keep the site. Nothing will be deleted.',
-					},
-				],
-				allowFreeForm: true,
-			},
-		] );
-		const fileChoice = fileAnswers[ fileQuestion ];
-		let deleteFiles: boolean;
-		if ( fileChoice === DELETE_AND_TRASH_LABEL ) {
-			deleteFiles = true;
-		} else if ( fileChoice === DELETE_AND_KEEP_LABEL ) {
-			deleteFiles = false;
-		} else {
-			return { confirmed: false };
-		}
-
-		// Step 2: final confirmation
-		const confirmQuestion = `Permanently delete the site "${ name }"? This cannot be undone.`;
-		const confirmAnswers = await onAskUser( [
-			{
-				question: confirmQuestion,
-				options: [
-					{
-						label: CONFIRM_DELETE_LABEL,
-						description: deleteFiles
-							? `Permanently remove "${ name }" and move its files to the trash.`
-							: `Permanently remove "${ name }" from Studio. Its files will stay on disk.`,
-					},
-					{
-						label: 'Cancel',
-						description: 'Keep the site. Nothing will be deleted.',
-					},
-				],
-				allowFreeForm: true,
-			},
-		] );
-		if ( confirmAnswers[ confirmQuestion ] !== CONFIRM_DELETE_LABEL ) {
-			return { confirmed: false };
-		}
-
-		return { confirmed: true, deleteFiles };
-	};
 }
 
 function parseJsonHeaderEnv(

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -205,7 +205,7 @@ For long CSS or page-content files (>~200 lines), load the \`block-content\` ski
 - site_info: Get details about a specific site (path, URL, credentials, running status)
 - site_start: Start a stopped site
 - site_stop: Stop a running site
-- site_delete: Delete a site from Studio and optionally move its files to trash. The tool prompts the user for confirmation itself — do NOT add your own AskUserQuestion before calling it. Never infer a deletion from an ambiguous request such as "undo", "revert", "start over", or "remove that".
+- site_delete: Delete a site from Studio and optionally move its files to trash
 - preview_create: Create a preview site (a temporary, expiring hosted preview) for a local site; when a local site is selected, preview that site instead of creating a new local site; requires WordPress.com authentication and can take a few minutes, so tell the user to wait
 - preview_list: List preview sites (temporary, expiring hosted previews) for a local site. These are NOT connected WordPress.com remote sites.
 - preview_update: Update an existing preview site from a local site; this can take a few minutes, so tell the user to wait
@@ -227,7 +227,6 @@ ${ studioPresentToolBullet }${ automaticArtifactSection }
 
 ## General rules
 
-- Deleting a site is destructive and irreversible. The \`site_delete\` tool handles its own two-step confirmation with the user — do NOT call \`AskUserQuestion\` yourself before invoking it. Never treat an ambiguous or corrective request — "undo", "undo that", "revert my last change", "start over", "remove that" — as a request to delete a site; those refer to the most recent edit or content, not the whole site. When unsure what the user means, ask instead of deleting.
 - Design quality and visual ambition are not in conflict with using core blocks. Custom CSS targeting block classNames can achieve any visual design. The block structure is for editability; the CSS is for aesthetics.
 - Do NOT modify WordPress core files. Only work within wp-content/.
 - Do NOT edit the files of installed third-party themes (default themes like twentytwentyfive, marketplace/community themes such as Ollie, anything installed via \`wp theme install\` or already present on the site) — a theme update silently wipes such edits. Default to a child theme: call \`scaffold_theme\` with \`parentTheme\` set to the installed theme's slug, then make every customization (style.css, theme.json, templates, parts, patterns) in the child theme. Themes Studio Code created — their style.css Description says "scaffolded by Studio Code" — are safe to edit directly. If the user explicitly asks you to edit an installed theme's files directly, comply, but first warn once that a theme update will overwrite the changes.

--- a/apps/cli/ai/tests/system-prompt.test.ts
+++ b/apps/cli/ai/tests/system-prompt.test.ts
@@ -52,16 +52,6 @@ describe( 'buildSystemPrompt', () => {
 		expect( prompt ).toContain( '- pdf:' );
 	} );
 
-	it( 'guards site deletion via the tool confirmation, not an extra AskUserQuestion', () => {
-		const prompt = buildSystemPrompt( { chatArtifactsEnabled: true } );
-
-		expect( prompt ).toContain( 'Deleting a site is destructive and irreversible' );
-		expect( prompt ).toContain( 'do NOT call `AskUserQuestion` yourself before invoking it' );
-		expect( prompt ).toContain(
-			'Never treat an ambiguous or corrective request — "undo", "undo that", "revert my last change", "start over", "remove that" — as a request to delete a site'
-		);
-	} );
-
 	it( 'routes plugin-specific feature work to the plugin recommendations skill', () => {
 		const prompt = buildSystemPrompt( { chatArtifactsEnabled: true } );
 

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -18,7 +18,6 @@ import {
 import { runCommand as runListPreviewCommand } from 'cli/commands/preview/list';
 import { runCommand as runUpdatePreviewCommand } from 'cli/commands/preview/update';
 import { runCommand as runCreateSiteCommand } from 'cli/commands/site/create';
-import { runCommand as runDeleteSiteCommand } from 'cli/commands/site/delete';
 import { readCliConfig } from 'cli/lib/cli-config/core';
 import { getSiteByFolder } from 'cli/lib/cli-config/sites';
 import { runWpCliCommandWithMessaging } from 'cli/lib/run-wp-cli-command';
@@ -347,78 +346,6 @@ describe( 'Studio AI MCP tools', () => {
 		expect( emitEventMock ).toHaveBeenCalledWith(
 			expect.objectContaining( { type: 'preview.reload' } )
 		);
-	} );
-
-	describe( 'site_delete confirmation', () => {
-		const getConfirmingDeleteTool = (
-			confirmSiteDeletion: ( details: {
-				name: string;
-				path: string;
-			} ) => Promise< { confirmed: true; deleteFiles: boolean } | { confirmed: false } >
-		) => {
-			const tool = resolveStudioToolDefinitions( { confirmSiteDeletion } ).find(
-				( candidate ) => candidate.name === 'site_delete'
-			);
-			expect( tool ).toBeDefined();
-			return tool as ReturnType< typeof resolveStudioToolDefinitions >[ number ];
-		};
-
-		it( 'deletes without asking when no confirmation handler is wired', async () => {
-			const result = await getTool( 'site_delete' ).rawHandler( {
-				nameOrPath: 'My Site',
-			} as never );
-
-			expect( runDeleteSiteCommand ).toHaveBeenCalledWith( mockSite.path, true );
-			expect( getTextContent( result ) ).toBe( 'Site "My Site" deleted.' );
-		} );
-
-		it( 'deletes and trashes files when the user confirms with trash', async () => {
-			const confirm = vi.fn().mockResolvedValue( { confirmed: true, deleteFiles: true } );
-			const result = await executeTool( getConfirmingDeleteTool( confirm ), {
-				nameOrPath: 'My Site',
-			} );
-
-			expect( confirm ).toHaveBeenCalledWith( {
-				name: 'My Site',
-				path: mockSite.path,
-			} );
-			expect( runDeleteSiteCommand ).toHaveBeenCalledWith( mockSite.path, true );
-			expect( getTextContent( result ) ).toBe( 'Site "My Site" deleted.' );
-		} );
-
-		it( 'deletes and keeps files when the user confirms with keep', async () => {
-			const confirm = vi.fn().mockResolvedValue( { confirmed: true, deleteFiles: false } );
-			const result = await executeTool( getConfirmingDeleteTool( confirm ), {
-				nameOrPath: 'My Site',
-			} );
-
-			expect( runDeleteSiteCommand ).toHaveBeenCalledWith( mockSite.path, false );
-			expect( getTextContent( result ) ).toBe( 'Site "My Site" deleted.' );
-		} );
-
-		it( 'does not delete when the user declines', async () => {
-			const confirm = vi.fn().mockResolvedValue( { confirmed: false } );
-			const result = await executeTool( getConfirmingDeleteTool( confirm ), {
-				nameOrPath: 'My Site',
-			} );
-
-			expect( confirm ).toHaveBeenCalledOnce();
-			expect( runDeleteSiteCommand ).not.toHaveBeenCalled();
-			expect( getTextContent( result ) ).toBe(
-				'Site deletion cancelled. "My Site" was not deleted.'
-			);
-		} );
-
-		it( 'uses the confirmation choice even when the agent suggested deleteFiles', async () => {
-			const confirm = vi.fn().mockResolvedValue( { confirmed: true, deleteFiles: false } );
-			const result = await executeTool( getConfirmingDeleteTool( confirm ), {
-				nameOrPath: 'My Site',
-				deleteFiles: true,
-			} );
-
-			expect( runDeleteSiteCommand ).toHaveBeenCalledWith( mockSite.path, false );
-			expect( getTextContent( result ) ).toBe( 'Site "My Site" deleted.' );
-		} );
 	} );
 
 	it( 'keeps screenshot presentation guidance out of the screenshot tool description', () => {

--- a/apps/cli/ai/tools/delete-site.ts
+++ b/apps/cli/ai/tools/delete-site.ts
@@ -3,53 +3,26 @@ import { runCommand as runDeleteSiteCommand } from 'cli/commands/site/delete';
 import { defineTool } from './define-tool';
 import { resolveSite, textResult } from './utils';
 
-// Called right before a site is actually deleted so the user can explicitly
-// approve and choose whether to trash the files. Site deletion is irreversible,
-// so the destructive command is gated behind this callback.
-export type ConfirmSiteDeletionResult =
-	| { confirmed: true; deleteFiles: boolean }
-	| { confirmed: false };
-
-export type ConfirmSiteDeletion = ( details: {
-	name: string;
-	path: string;
-} ) => Promise< ConfirmSiteDeletionResult >;
-
-export function createDeleteSiteTool( confirm?: ConfirmSiteDeletion ) {
-	return defineTool(
-		'site_delete',
-		'Deletes a WordPress site by name or path. Removes the site from Studio and optionally moves site files to trash. This is irreversible and requires explicit user confirmation before it runs.',
-		{
-			nameOrPath: Type.String( { description: 'The site name or file system path to the site' } ),
-			deleteFiles: Type.Optional(
-				Type.Boolean( {
-					description: 'Move site files to trash. Defaults to true. Set to false to keep files.',
-				} )
-			),
-		},
-		async ( args ) => {
-			try {
-				const site = await resolveSite( args.nameOrPath );
-				let deleteFiles = args.deleteFiles ?? true;
-				if ( confirm ) {
-					const result = await confirm( { name: site.name, path: site.path } );
-					if ( ! result.confirmed ) {
-						return textResult( `Site deletion cancelled. "${ site.name }" was not deleted.` );
-					}
-					deleteFiles = result.deleteFiles;
-				}
-				await runDeleteSiteCommand( site.path, deleteFiles );
-				return textResult( `Site "${ site.name }" deleted.` );
-			} catch ( error ) {
-				throw new Error(
-					`Failed to delete site: ${ error instanceof Error ? error.message : String( error ) }`
-				);
-			}
+export const deleteSiteTool = defineTool(
+	'site_delete',
+	'Deletes a WordPress site by name or path. Removes the site from Studio and optionally moves site files to trash.',
+	{
+		nameOrPath: Type.String( { description: 'The site name or file system path to the site' } ),
+		deleteFiles: Type.Optional(
+			Type.Boolean( {
+				description: 'Move site files to trash. Defaults to true. Set to false to keep files.',
+			} )
+		),
+	},
+	async ( args ) => {
+		try {
+			const site = await resolveSite( args.nameOrPath );
+			await runDeleteSiteCommand( site.path, args.deleteFiles ?? true );
+			return textResult( `Site "${ site.name }" deleted.` );
+		} catch ( error ) {
+			throw new Error(
+				`Failed to delete site: ${ error instanceof Error ? error.message : String( error ) }`
+			);
 		}
-	);
-}
-
-// Default (unconfirmed) tool for the static registry and MCP dispatch, where the
-// host provides its own approval flow. The interactive agent swaps in a
-// confirmation-gated instance via `resolveStudioToolDefinitions`.
-export const deleteSiteTool = createDeleteSiteTool();
+	}
+);

--- a/apps/cli/ai/tools/index.ts
+++ b/apps/cli/ai/tools/index.ts
@@ -3,7 +3,7 @@ import { createPreviewTool } from './create-preview';
 import { createSiteTool } from './create-site';
 import { dataLiberationTool } from './data-liberation';
 import { deletePreviewTool } from './delete-preview';
-import { createDeleteSiteTool, deleteSiteTool, type ConfirmSiteDeletion } from './delete-site';
+import { deleteSiteTool } from './delete-site';
 import { exportSiteTool } from './export-site';
 import { importSiteTool } from './import-site';
 import { inspectDesignTool } from './inspect-design';
@@ -73,11 +73,6 @@ export interface CreateStudioToolsOptions {
 	// by `STUDIO_REMOTE_SESSION=1`. Direct `studio code` invocations leave
 	// this off because the image would have nowhere to go.
 	remoteSession?: boolean;
-	// When provided, site_delete asks the user to confirm before the
-	// irreversible deletion runs. Wired from the agent's AskUserQuestion
-	// handler; omitted for MCP/headless runs where the host owns its own
-	// approval flow.
-	confirmSiteDeletion?: ConfirmSiteDeletion;
 }
 
 export function resolveStudioToolDefinitions(
@@ -88,23 +83,11 @@ export function resolveStudioToolDefinitions(
 			? [ ...studioToolDefinitions, studioPresentTool ]
 			: studioToolDefinitions;
 
-	// Gate the irreversible site deletion behind an explicit confirmation when a
-	// handler is available (interactive agent). MCP/headless callers omit it and
-	// keep the plain tool.
-	const confirmingDeleteSiteTool =
-		options.confirmSiteDeletion !== undefined
-			? ( createDeleteSiteTool( options.confirmSiteDeletion ) as AnyStudioAgentTool )
-			: undefined;
-
 	return definitions.flatMap( ( candidate ) => {
 		if ( candidate.name === shareScreenshotTool.name && ! options.remoteSession ) {
 			return [];
 		}
-		const tool =
-			candidate.name === deleteSiteTool.name && confirmingDeleteSiteTool
-				? confirmingDeleteSiteTool
-				: candidate;
-		return [ withChatArtifactEmission( tool, options.emitChatArtifacts === true ) ];
+		return [ withChatArtifactEmission( candidate, options.emitChatArtifacts === true ) ];
 	} );
 }
 


### PR DESCRIPTION
This reverts commit e70a4c11aeab5d1d7fde55c40dc0298c169272a9.

## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to addressing the regression introduced in https://github.com/Automattic/studio/pull/4090#issuecomment-5370922849 for the double confirmation while deleting multiple sites.

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

It was used to prepare the revert commit.

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

This PR reverts the double confirmation change for deleting sites introduced in https://github.com/Automattic/studio/pull/4090#issuecomment-5370922849

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Build CLI with `npm run cli:build`
* Start Studio with `npm start`
* Navigate to Studio Code in the app
* Ask it to delete a site
* Confirm that it does not ask for the double confirmation
* Test deleting multiple sites in Studio Code
* Confirm that it does not ask for deletion confirmation for each site separately as mentioned in the example in https://github.com/Automattic/studio/pull/4090#issuecomment-5370762520

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
