### PR TITLE
Move per-site agent instructions and skill catalog into packages/common

### DIFF
--- a/apps/studio/src/modules/agent-instructions/constants.ts
+++ b/apps/studio/src/modules/agent-instructions/constants.ts
@@ -1,31 +1,6 @@
-export type InstructionFileType = 'agents' | 'claude' | 'studio';
-
-export interface InstructionFileConfig {
-	id: InstructionFileType;
-	fileName: string;
-	displayName: string;
-	description: string;
-}
-
-export const INSTRUCTION_FILES: Record< InstructionFileType, InstructionFileConfig > = {
-	agents: {
-		id: 'agents',
-		fileName: 'AGENTS.md',
-		displayName: 'AGENTS.md',
-		description: 'Instructions for Codex, Goose, and other AI agents',
-	},
-	claude: {
-		id: 'claude',
-		fileName: 'CLAUDE.md',
-		displayName: 'CLAUDE.md',
-		description: 'Reference for Claude Code to read AGENTS.md',
-	},
-	studio: {
-		id: 'studio',
-		fileName: 'STUDIO.md',
-		displayName: 'STUDIO.md',
-		description: 'Detailed Studio-specific WordPress development instructions',
-	},
-};
-
-export const INSTRUCTION_FILE_TYPES: InstructionFileType[] = [ 'agents', 'claude', 'studio' ];
+export {
+	INSTRUCTION_FILES,
+	INSTRUCTION_FILE_TYPES,
+	type InstructionFileConfig,
+	type InstructionFileType,
+} from '@studio/common/lib/agent-instructions';

--- a/apps/studio/src/modules/agent-instructions/lib/instructions.ts
+++ b/apps/studio/src/modules/agent-instructions/lib/instructions.ts
@@ -1,84 +1,22 @@
-import fs from 'fs/promises';
-import nodePath from 'path';
-import { pathExists } from '@studio/common/lib/fs-utils';
+import {
+	getAllInstructionFilesStatus,
+	getInstructionFilePath,
+	getInstructionFileStatus,
+	installInstructionFile as installInstructionFileShared,
+	removeInstructionFile,
+} from '@studio/common/lib/agent-instructions';
 import { getAiInstructionsPath } from 'src/lib/server-files-paths';
-import { INSTRUCTION_FILES, INSTRUCTION_FILE_TYPES, type InstructionFileType } from '../constants';
+import type { InstructionFileType } from '../constants';
 
-export interface InstructionFileStatus {
-	id: InstructionFileType;
-	fileName: string;
-	displayName: string;
-	description: string;
-	exists: boolean;
-	path: string;
-}
-
-export function getInstructionFilePath( sitePath: string, fileType: InstructionFileType ): string {
-	return nodePath.join( sitePath, INSTRUCTION_FILES[ fileType ].fileName );
-}
-
-async function getBundledContent( fileType: InstructionFileType ): Promise< string | null > {
-	const bundledPath = nodePath.join(
-		getAiInstructionsPath(),
-		INSTRUCTION_FILES[ fileType ].fileName
-	);
-	try {
-		return await fs.readFile( bundledPath, 'utf-8' );
-	} catch {
-		return null;
-	}
-}
-
-export async function getInstructionFileStatus(
-	sitePath: string,
-	fileType: InstructionFileType
-): Promise< InstructionFileStatus > {
-	const config = INSTRUCTION_FILES[ fileType ];
-	const filePath = getInstructionFilePath( sitePath, fileType );
-
-	const exists = await pathExists( filePath );
-
-	return {
-		...config,
-		exists,
-		path: filePath,
-	};
-}
-
-export async function getAllInstructionFilesStatus(
-	sitePath: string
-): Promise< InstructionFileStatus[] > {
-	return Promise.all(
-		INSTRUCTION_FILE_TYPES.map( ( fileType ) => getInstructionFileStatus( sitePath, fileType ) )
-	);
-}
+export type { InstructionFileStatus } from '@studio/common/lib/agent-instructions';
+export { getAllInstructionFilesStatus, getInstructionFilePath, getInstructionFileStatus };
 
 export async function installInstructionFile(
 	sitePath: string,
 	fileType: InstructionFileType,
 	overwrite: boolean
 ): Promise< { path: string; overwritten: boolean } > {
-	const filePath = getInstructionFilePath( sitePath, fileType );
-	const bundledContent = await getBundledContent( fileType );
-
-	if ( ! bundledContent ) {
-		throw new Error( `Bundled content not found for ${ fileType }` );
-	}
-
-	if ( ! overwrite ) {
-		if ( await pathExists( filePath ) ) {
-			return { path: filePath, overwritten: false };
-		}
-	}
-
-	await fs.writeFile( filePath, bundledContent, 'utf-8' );
-	return { path: filePath, overwritten: overwrite };
+	return installInstructionFileShared( sitePath, fileType, getAiInstructionsPath(), overwrite );
 }
 
-export async function removeInstructionFile(
-	sitePath: string,
-	fileType: InstructionFileType
-): Promise< void > {
-	const filePath = getInstructionFilePath( sitePath, fileType );
-	await fs.rm( filePath, { force: true } );
-}
+export { removeInstructionFile };

--- a/apps/studio/src/modules/agent-instructions/lib/skills-constants.ts
+++ b/apps/studio/src/modules/agent-instructions/lib/skills-constants.ts
@@ -1,44 +1,5 @@
-import { __ } from '@wordpress/i18n';
-
-export interface SkillConfig {
-	id: string;
-	displayName: string;
-	description: string;
-}
-
-export interface SkillStatus extends SkillConfig {
-	installed: boolean;
-}
-
-export const getBundledSkills = (): SkillConfig[] => [
-	{
-		id: 'studio-cli',
-		displayName: __( 'Studio CLI' ),
-		description: __( 'WordPress development workflows using Studio CLI' ),
-	},
-	{
-		id: 'wp-plugin-development',
-		displayName: __( 'Plugin Development' ),
-		description: __( 'Hooks, settings API, security, and packaging' ),
-	},
-	{
-		id: 'wp-block-development',
-		displayName: __( 'Block Development' ),
-		description: __( 'Block.json, attributes, rendering, and deprecations' ),
-	},
-	{
-		id: 'wp-block-themes',
-		displayName: __( 'Block Themes' ),
-		description: __( 'Theme.json, templates, patterns, and style variations' ),
-	},
-	{
-		id: 'wp-rest-api',
-		displayName: __( 'REST API' ),
-		description: __( 'Routes, endpoints, schema, and authentication' ),
-	},
-	{
-		id: 'wp-wpcli-and-ops',
-		displayName: __( 'WP-CLI & Ops' ),
-		description: __( 'CLI commands, automation, and search-replace' ),
-	},
-];
+export {
+	getBundledSkills,
+	type SkillConfig,
+	type SkillStatus,
+} from '@studio/common/lib/agent-skills-catalog';

--- a/apps/studio/src/modules/agent-instructions/lib/skills.ts
+++ b/apps/studio/src/modules/agent-instructions/lib/skills.ts
@@ -1,21 +1,14 @@
-import nodePath from 'path';
 import { installSkillToSite, removeSkillFromSite } from '@studio/common/lib/agent-skills';
-import { pathExists } from '@studio/common/lib/fs-utils';
+import { getBundledSkills } from '@studio/common/lib/agent-skills-catalog';
 import { getAiInstructionsPath } from 'src/lib/server-files-paths';
-import { getBundledSkills, type SkillStatus } from './skills-constants';
 import type { SiteRuntime } from '@studio/common/lib/site-runtime';
 
-export { getBundledSkills, type SkillConfig, type SkillStatus } from './skills-constants';
-
-export async function getSkillsStatus( sitePath: string ): Promise< SkillStatus[] > {
-	return Promise.all(
-		getBundledSkills().map( async ( skill ) => {
-			const skillMdPath = nodePath.join( sitePath, '.agents', 'skills', skill.id, 'SKILL.md' );
-			const installed = await pathExists( skillMdPath );
-			return { ...skill, installed };
-		} )
-	);
-}
+export {
+	getBundledSkills,
+	getSkillsStatus,
+	type SkillConfig,
+	type SkillStatus,
+} from '@studio/common/lib/agent-skills-catalog';
 
 export async function installAllSkills(
 	site: { path: string; runtime?: SiteRuntime },

--- a/packages/common/lib/agent-instructions.ts
+++ b/packages/common/lib/agent-instructions.ts
@@ -1,0 +1,115 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { pathExists } from './fs-utils';
+
+export type InstructionFileType = 'agents' | 'claude' | 'studio';
+
+export interface InstructionFileConfig {
+	id: InstructionFileType;
+	fileName: string;
+	displayName: string;
+	description: string;
+}
+
+export const INSTRUCTION_FILES: Record< InstructionFileType, InstructionFileConfig > = {
+	agents: {
+		id: 'agents',
+		fileName: 'AGENTS.md',
+		displayName: 'AGENTS.md',
+		description: 'Instructions for Codex, Goose, and other AI agents',
+	},
+	claude: {
+		id: 'claude',
+		fileName: 'CLAUDE.md',
+		displayName: 'CLAUDE.md',
+		description: 'Reference for Claude Code to read AGENTS.md',
+	},
+	studio: {
+		id: 'studio',
+		fileName: 'STUDIO.md',
+		displayName: 'STUDIO.md',
+		description: 'Detailed Studio-specific WordPress development instructions',
+	},
+};
+
+export const INSTRUCTION_FILE_TYPES: InstructionFileType[] = [ 'agents', 'claude', 'studio' ];
+
+export interface InstructionFileStatus {
+	id: InstructionFileType;
+	fileName: string;
+	displayName: string;
+	description: string;
+	exists: boolean;
+	path: string;
+}
+
+export function getInstructionFilePath( sitePath: string, fileType: InstructionFileType ): string {
+	return path.join( sitePath, INSTRUCTION_FILES[ fileType ].fileName );
+}
+
+async function getBundledContent(
+	bundledPath: string,
+	fileType: InstructionFileType
+): Promise< string | null > {
+	const source = path.join( bundledPath, INSTRUCTION_FILES[ fileType ].fileName );
+	try {
+		return await fs.readFile( source, 'utf-8' );
+	} catch {
+		return null;
+	}
+}
+
+export async function getInstructionFileStatus(
+	sitePath: string,
+	fileType: InstructionFileType
+): Promise< InstructionFileStatus > {
+	const config = INSTRUCTION_FILES[ fileType ];
+	const filePath = getInstructionFilePath( sitePath, fileType );
+
+	const exists = await pathExists( filePath );
+
+	return {
+		...config,
+		exists,
+		path: filePath,
+	};
+}
+
+export async function getAllInstructionFilesStatus(
+	sitePath: string
+): Promise< InstructionFileStatus[] > {
+	return Promise.all(
+		INSTRUCTION_FILE_TYPES.map( ( fileType ) => getInstructionFileStatus( sitePath, fileType ) )
+	);
+}
+
+export async function installInstructionFile(
+	sitePath: string,
+	fileType: InstructionFileType,
+	bundledPath: string,
+	overwrite: boolean
+): Promise< { path: string; overwritten: boolean } > {
+	const filePath = getInstructionFilePath( sitePath, fileType );
+	const bundledContent = await getBundledContent( bundledPath, fileType );
+
+	if ( ! bundledContent ) {
+		throw new Error( `Bundled content not found for ${ fileType }` );
+	}
+
+	if ( ! overwrite ) {
+		if ( await pathExists( filePath ) ) {
+			return { path: filePath, overwritten: false };
+		}
+	}
+
+	await fs.writeFile( filePath, bundledContent, 'utf-8' );
+	return { path: filePath, overwritten: overwrite };
+}
+
+export async function removeInstructionFile(
+	sitePath: string,
+	fileType: InstructionFileType
+): Promise< void > {
+	const filePath = getInstructionFilePath( sitePath, fileType );
+	await fs.rm( filePath, { force: true } );
+}

--- a/packages/common/lib/agent-skills-catalog.ts
+++ b/packages/common/lib/agent-skills-catalog.ts
@@ -1,0 +1,56 @@
+import path from 'path';
+import { __ } from '@wordpress/i18n';
+import { pathExists } from './fs-utils';
+
+export interface SkillConfig {
+	id: string;
+	displayName: string;
+	description: string;
+}
+
+export interface SkillStatus extends SkillConfig {
+	installed: boolean;
+}
+
+export const getBundledSkills = (): SkillConfig[] => [
+	{
+		id: 'studio-cli',
+		displayName: __( 'Studio CLI' ),
+		description: __( 'WordPress development workflows using Studio CLI' ),
+	},
+	{
+		id: 'wp-plugin-development',
+		displayName: __( 'Plugin Development' ),
+		description: __( 'Hooks, settings API, security, and packaging' ),
+	},
+	{
+		id: 'wp-block-development',
+		displayName: __( 'Block Development' ),
+		description: __( 'Block.json, attributes, rendering, and deprecations' ),
+	},
+	{
+		id: 'wp-block-themes',
+		displayName: __( 'Block Themes' ),
+		description: __( 'Theme.json, templates, patterns, and style variations' ),
+	},
+	{
+		id: 'wp-rest-api',
+		displayName: __( 'REST API' ),
+		description: __( 'Routes, endpoints, schema, and authentication' ),
+	},
+	{
+		id: 'wp-wpcli-and-ops',
+		displayName: __( 'WP-CLI & Ops' ),
+		description: __( 'CLI commands, automation, and search-replace' ),
+	},
+];
+
+export async function getSkillsStatus( sitePath: string ): Promise< SkillStatus[] > {
+	return Promise.all(
+		getBundledSkills().map( async ( skill ) => {
+			const skillMdPath = path.join( sitePath, '.agents', 'skills', skill.id, 'SKILL.md' );
+			const installed = await pathExists( skillMdPath );
+			return { ...skill, installed };
+		} )
+	);
+}

--- a/packages/common/lib/tests/agent-instructions.test.ts
+++ b/packages/common/lib/tests/agent-instructions.test.ts
@@ -1,0 +1,137 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { vi } from 'vitest';
+import {
+	getAllInstructionFilesStatus,
+	getInstructionFilePath,
+	getInstructionFileStatus,
+	installInstructionFile,
+	removeInstructionFile,
+} from '../agent-instructions';
+import { pathExists } from '../fs-utils';
+
+vi.mock( 'fs/promises', () => ( {
+	default: {
+		readFile: vi.fn(),
+		writeFile: vi.fn(),
+		rm: vi.fn(),
+	},
+} ) );
+
+vi.mock( '../fs-utils', () => ( {
+	pathExists: vi.fn(),
+} ) );
+
+const SITE_PATH = '/test/my-site';
+const BUNDLED_PATH = '/mock/server-files/skills';
+
+describe( 'getInstructionFilePath', () => {
+	it( 'returns correct path for agents file', () => {
+		expect( getInstructionFilePath( SITE_PATH, 'agents' ) ).toBe(
+			path.join( SITE_PATH, 'AGENTS.md' )
+		);
+	} );
+
+	it( 'returns correct path for studio file', () => {
+		expect( getInstructionFilePath( SITE_PATH, 'studio' ) ).toBe(
+			path.join( SITE_PATH, 'STUDIO.md' )
+		);
+	} );
+} );
+
+describe( 'getInstructionFileStatus', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'returns exists: false when file does not exist', async () => {
+		vi.mocked( pathExists ).mockResolvedValue( false );
+
+		const status = await getInstructionFileStatus( SITE_PATH, 'agents' );
+
+		expect( status.exists ).toBe( false );
+		expect( status.id ).toBe( 'agents' );
+		expect( status.fileName ).toBe( 'AGENTS.md' );
+		expect( status.path ).toBe( path.join( SITE_PATH, 'AGENTS.md' ) );
+	} );
+
+	it( 'returns exists: true when file exists', async () => {
+		vi.mocked( pathExists ).mockResolvedValue( true );
+
+		const status = await getInstructionFileStatus( SITE_PATH, 'agents' );
+
+		expect( status.exists ).toBe( true );
+	} );
+} );
+
+describe( 'getAllInstructionFilesStatus', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'returns status for all instruction file types', async () => {
+		vi.mocked( pathExists ).mockResolvedValue( false );
+
+		const statuses = await getAllInstructionFilesStatus( SITE_PATH );
+
+		expect( statuses ).toHaveLength( 3 );
+		expect( statuses.map( ( s ) => s.id ) ).toEqual( [ 'agents', 'claude', 'studio' ] );
+	} );
+} );
+
+describe( 'installInstructionFile', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.mocked( fs.readFile ).mockResolvedValue( 'bundled content' );
+		vi.mocked( fs.writeFile ).mockResolvedValue( undefined );
+	} );
+
+	it( 'writes the bundled content when the file does not exist', async () => {
+		vi.mocked( pathExists ).mockResolvedValue( false );
+
+		const result = await installInstructionFile( SITE_PATH, 'agents', BUNDLED_PATH, false );
+
+		expect( fs.writeFile ).toHaveBeenCalledWith(
+			path.join( SITE_PATH, 'AGENTS.md' ),
+			'bundled content',
+			'utf-8'
+		);
+		expect( result ).toEqual( { path: path.join( SITE_PATH, 'AGENTS.md' ), overwritten: false } );
+	} );
+
+	it( 'skips writing when the file exists and overwrite is false', async () => {
+		vi.mocked( pathExists ).mockResolvedValue( true );
+
+		const result = await installInstructionFile( SITE_PATH, 'agents', BUNDLED_PATH, false );
+
+		expect( fs.writeFile ).not.toHaveBeenCalled();
+		expect( result.overwritten ).toBe( false );
+	} );
+
+	it( 'overwrites an existing file when overwrite is true', async () => {
+		vi.mocked( pathExists ).mockResolvedValue( true );
+
+		const result = await installInstructionFile( SITE_PATH, 'agents', BUNDLED_PATH, true );
+
+		expect( fs.writeFile ).toHaveBeenCalled();
+		expect( result.overwritten ).toBe( true );
+	} );
+
+	it( 'throws when the bundled content is missing', async () => {
+		vi.mocked( fs.readFile ).mockRejectedValue( new Error( 'ENOENT' ) );
+
+		await expect(
+			installInstructionFile( SITE_PATH, 'agents', BUNDLED_PATH, false )
+		).rejects.toThrow( 'Bundled content not found for agents' );
+	} );
+} );
+
+describe( 'removeInstructionFile', () => {
+	it( 'removes the file at the site path', async () => {
+		vi.mocked( fs.rm ).mockResolvedValue( undefined );
+
+		await removeInstructionFile( SITE_PATH, 'claude' );
+
+		expect( fs.rm ).toHaveBeenCalledWith( path.join( SITE_PATH, 'CLAUDE.md' ), { force: true } );
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Related to the site-skills-instructions-migration work

## How AI was used in this PR

- Fully AI-authored (Claude Code): research, refactor, and test verification.

## Proposed Changes

- First of a 3-PR stack bringing per-site AI skills/instructions to the agentic UI (see PR #2 and #3, stacked on top of this one).
- Pure refactor, no behavior change: moves the per-site instruction-file (AGENTS.md/CLAUDE.md/STUDIO.md) install/remove logic out of `apps/studio` and into `packages/common`, alongside the skill-install logic that was already shared there.
- `apps/studio`'s own modules become thin wrappers with unchanged signatures — every existing call site keeps working exactly as before.
- Sets up the next PR in the stack: `apps/local` (the browser UI's backend) can now reuse this logic instead of duplicating it.

## Testing Instructions

- `npm run typecheck` and `npm test` pass across all workspaces, on this branch alone (not just the full stack).
- No user-visible change — this PR only moves code.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?