### PR TITLE
Add an AI tab to the site overview for per-site skills and instructions

### DIFF
--- a/apps/ui/src/components/site-ai-panel/index.tsx
+++ b/apps/ui/src/components/site-ai-panel/index.tsx
@@ -1,0 +1,192 @@
+import { FormToggle } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
+import { useMemo } from 'react';
+import {
+	useInstallAllSiteAgentInstructionFiles,
+	useInstallAllSiteSkills,
+	useInstallSiteAgentInstructionFile,
+	useInstallSiteSkill,
+	useRemoveSiteAgentInstructionFile,
+	useRemoveSiteSkill,
+	useSiteAgentInstructions,
+	useSiteSkills,
+} from '@/data/queries/use-site-ai';
+import styles from './style.module.css';
+
+function getErrorMessage( error: unknown ): string | null {
+	return error instanceof Error ? error.message : error ? String( error ) : null;
+}
+
+function ListRow( {
+	displayName,
+	description,
+	checked,
+	disabled,
+	onToggle,
+}: {
+	displayName: string;
+	description: string;
+	checked: boolean;
+	disabled: boolean;
+	onToggle: () => void;
+} ) {
+	return (
+		<li className={ styles.row }>
+			<div className={ styles.rowDetails }>
+				<span className={ styles.rowName }>{ displayName }</span>
+				<span className={ styles.rowDescription }>{ description }</span>
+			</div>
+			<FormToggle
+				checked={ checked }
+				disabled={ disabled }
+				aria-label={ displayName }
+				onChange={ onToggle }
+			/>
+		</li>
+	);
+}
+
+function SiteSkillsSection( { siteId }: { siteId: string } ) {
+	const { data: skills, isLoading, error } = useSiteSkills( siteId );
+	const installSkill = useInstallSiteSkill( siteId );
+	const installAllSkills = useInstallAllSiteSkills( siteId );
+	const removeSkill = useRemoveSiteSkill( siteId );
+	const skillList = skills ?? [];
+	const availableSkills = useMemo(
+		() => ( skills ?? [] ).filter( ( skill ) => ! skill.installed ),
+		[ skills ]
+	);
+	const visibleError =
+		getErrorMessage( error ) ??
+		getErrorMessage( installSkill.error ) ??
+		getErrorMessage( installAllSkills.error ) ??
+		getErrorMessage( removeSkill.error );
+
+	return (
+		<section className={ styles.section }>
+			<div className={ styles.sectionHeader }>
+				<div className={ styles.sectionHeaderRow }>
+					<h2>{ __( 'Skills' ) }</h2>
+					{ availableSkills.length > 0 ? (
+						<Button
+							type="button"
+							variant="outline"
+							tone="neutral"
+							size="compact"
+							disabled={ installAllSkills.isPending }
+							loading={ installAllSkills.isPending }
+							loadingAnnouncement={ __( 'Installing all skills' ) }
+							onClick={ () =>
+								installAllSkills.mutate( availableSkills.map( ( skill ) => skill.id ) )
+							}
+						>
+							{ __( 'Install all' ) }
+						</Button>
+					) : null }
+				</div>
+				<p>
+					{ __(
+						'Skills teach agents how to complete specialized WordPress tasks. These override the global selection from Settings for just this site.'
+					) }
+				</p>
+			</div>
+			{ visibleError ? <div className={ styles.errorMessage }>{ visibleError }</div> : null }
+			{ isLoading ? <div className={ styles.state }>{ __( 'Loading skills…' ) }</div> : null }
+			{ ! isLoading && skillList.length === 0 ? (
+				<div className={ styles.state }>{ __( 'No skills are available.' ) }</div>
+			) : null }
+			{ skillList.length > 0 ? (
+				<ul className={ styles.list }>
+					{ skillList.map( ( skill ) => (
+						<ListRow
+							key={ skill.id }
+							displayName={ skill.displayName }
+							description={ skill.description }
+							checked={ skill.installed }
+							disabled={ installAllSkills.isPending }
+							onToggle={ () =>
+								skill.installed ? removeSkill.mutate( skill.id ) : installSkill.mutate( skill.id )
+							}
+						/>
+					) ) }
+				</ul>
+			) : null }
+		</section>
+	);
+}
+
+function SiteInstructionsSection( { siteId }: { siteId: string } ) {
+	const { data: statuses, isLoading, error } = useSiteAgentInstructions( siteId );
+	const installFile = useInstallSiteAgentInstructionFile( siteId );
+	const installAllFiles = useInstallAllSiteAgentInstructionFiles( siteId );
+	const removeFile = useRemoveSiteAgentInstructionFile( siteId );
+	const fileList = statuses ?? [];
+	const availableFiles = useMemo(
+		() => ( statuses ?? [] ).filter( ( status ) => ! status.installed ),
+		[ statuses ]
+	);
+	const visibleError =
+		getErrorMessage( error ) ??
+		getErrorMessage( installFile.error ) ??
+		getErrorMessage( installAllFiles.error ) ??
+		getErrorMessage( removeFile.error );
+
+	return (
+		<section className={ styles.section }>
+			<div className={ styles.sectionHeader }>
+				<div className={ styles.sectionHeaderRow }>
+					<h2>{ __( 'Instructions' ) }</h2>
+					{ availableFiles.length > 0 ? (
+						<Button
+							type="button"
+							variant="outline"
+							tone="neutral"
+							size="compact"
+							disabled={ installAllFiles.isPending }
+							loading={ installAllFiles.isPending }
+							loadingAnnouncement={ __( 'Installing all instruction files' ) }
+							onClick={ () =>
+								installAllFiles.mutate( availableFiles.map( ( status ) => status.id ) )
+							}
+						>
+							{ __( 'Install all' ) }
+						</Button>
+					) : null }
+				</div>
+				<p>
+					{ __(
+						'Instruction files like AGENTS.md are installed at the site root so AI agents know how to work with this site.'
+					) }
+				</p>
+			</div>
+			{ visibleError ? <div className={ styles.errorMessage }>{ visibleError }</div> : null }
+			{ isLoading ? <div className={ styles.state }>{ __( 'Loading instructions…' ) }</div> : null }
+			{ fileList.length > 0 ? (
+				<ul className={ styles.list }>
+					{ fileList.map( ( status ) => (
+						<ListRow
+							key={ status.id }
+							displayName={ status.displayName }
+							description={ status.description }
+							checked={ status.installed }
+							disabled={ installAllFiles.isPending }
+							onToggle={ () =>
+								status.installed ? removeFile.mutate( status.id ) : installFile.mutate( status.id )
+							}
+						/>
+					) ) }
+				</ul>
+			) : null }
+		</section>
+	);
+}
+
+export function SiteAiPanel( { siteId }: { siteId: string } ) {
+	return (
+		<div className={ styles.root }>
+			<SiteSkillsSection siteId={ siteId } />
+			<SiteInstructionsSection siteId={ siteId } />
+		</div>
+	);
+}

--- a/apps/ui/src/components/site-ai-panel/style.module.css
+++ b/apps/ui/src/components/site-ai-panel/style.module.css
@@ -1,0 +1,121 @@
+.root {
+	display: flex;
+	flex-direction: column;
+	gap: var( --wpds-dimension-padding-xl );
+	width: 100%;
+	max-width: 560px;
+	margin: 0 auto;
+}
+
+.section {
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: var( --wpds-dimension-padding-lg );
+	padding: var( --wpds-dimension-padding-lg ) var( --wpds-dimension-padding-xl )
+		var( --wpds-dimension-padding-xl );
+	border: 1px solid var( --wpds-color-stroke-surface-neutral );
+	border-radius: 8px;
+	background: color-mix( in srgb, var( --wpds-color-bg-surface-neutral-weak ) 56%, transparent );
+}
+
+.sectionHeader {
+	display: flex;
+	flex-direction: column;
+	gap: var( --wpds-dimension-padding-xs );
+}
+
+.sectionHeaderRow {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var( --wpds-dimension-padding-md );
+	/* Reserve the compact wpds Button height so the header doesn't jump when
+	   the Install all button appears or disappears. */
+	min-block-size: 32px;
+}
+
+.sectionHeader h2 {
+	margin: 0;
+	color: var( --wpds-color-fg-content-neutral );
+	font-size: var( --wpds-typography-font-size-lg );
+	font-weight: 600;
+	line-height: var( --wpds-typography-line-height-md );
+}
+
+.sectionHeader p {
+	margin: 0;
+	color: var( --wpds-color-fg-content-neutral-weak );
+	font-size: var( --wpds-typography-font-size-sm );
+	line-height: var( --wpds-typography-line-height-sm );
+}
+
+.state {
+	padding-block: var( --wpds-dimension-padding-md );
+	color: var( --wpds-color-fg-content-neutral-weak );
+	font-size: var( --wpds-typography-font-size-sm );
+	line-height: var( --wpds-typography-line-height-sm );
+}
+
+.errorMessage {
+	margin-block-end: var( --wpds-dimension-padding-md );
+	padding: var( --wpds-dimension-padding-sm ) var( --wpds-dimension-padding-md );
+	border: 1px solid color-mix( in srgb, var( --wpds-color-fg-content-error ) 35%, transparent );
+	border-radius: 6px;
+	background: color-mix(
+		in srgb,
+		var( --wpds-color-fg-content-error ) 8%,
+		var( --wpds-color-bg-surface-neutral-strong )
+	);
+	color: var( --wpds-color-fg-content-error );
+	font-size: var( --wpds-typography-font-size-sm );
+	line-height: var( --wpds-typography-line-height-sm );
+}
+
+.list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	border-top: 1px solid var( --wpds-color-stroke-surface-neutral );
+}
+
+.row {
+	display: grid;
+	grid-template-columns: minmax( 0, 1fr ) auto;
+	align-items: center;
+	gap: var( --wpds-dimension-padding-xl );
+	padding-block: var( --wpds-dimension-padding-lg );
+	border-bottom: 1px solid var( --wpds-color-stroke-surface-neutral );
+}
+
+.row:last-child {
+	border-bottom: 0;
+}
+
+.rowDetails {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.rowName {
+	color: var( --wpds-color-fg-content-neutral );
+	font-size: var( --wpds-typography-font-size-sm );
+	font-weight: 600;
+	line-height: var( --wpds-typography-line-height-sm );
+}
+
+.rowDescription {
+	color: var( --wpds-color-fg-content-neutral-weak );
+	font-size: var( --wpds-typography-font-size-sm );
+	line-height: var( --wpds-typography-line-height-sm );
+}
+
+@media ( max-width: 640px ) {
+	.row {
+		align-items: stretch;
+		grid-template-columns: 1fr;
+	}
+}

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -30,6 +30,7 @@ import { OfflineBanner } from '@/components/offline-banner';
 import { useOpenInDestinations } from '@/components/open-in-menu/use-open-in-destinations';
 import { PreviewToggleButton } from '@/components/preview-toggle-button';
 import { ProgressiveBlur } from '@/components/progressive-blur';
+import { SiteAiPanel } from '@/components/site-ai-panel';
 import { SiteDropdown } from '@/components/site-dropdown';
 import { DATABASE_HOME_PATH } from '@/components/site-preview/address-bar';
 import { isSiteSettingsTab, SiteSettingsForm } from '@/components/site-settings-view';
@@ -308,6 +309,9 @@ function SiteOverviewBody( {
 								<Tabs.Tab tabId="overview">{ __( 'Overview' ) }</Tabs.Tab>
 								<Tabs.Tab tabId="general">{ __( 'Settings' ) }</Tabs.Tab>
 								<Tabs.Tab tabId="debugging">{ __( 'Debugging' ) }</Tabs.Tab>
+								{ connector.capabilities.siteAgentSkills ? (
+									<Tabs.Tab tabId="ai">{ __( 'AI' ) }</Tabs.Tab>
+								) : null }
 							</Tabs.List>
 						</div>
 					</div>
@@ -467,6 +471,11 @@ function SiteOverviewBody( {
 								</div>
 							</Tabs.Panel>
 							<SiteSettingsForm site={ site } activeTab={ activeTab } />
+							{ connector.capabilities.siteAgentSkills ? (
+								<Tabs.Panel tabId="ai" className={ styles.panel }>
+									<SiteAiPanel siteId={ site.id } />
+								</Tabs.Panel>
+							) : null }
 						</main>
 					</div>
 				</Tabs.Root>

--- a/apps/ui/src/components/site-settings-view/index.tsx
+++ b/apps/ui/src/components/site-settings-view/index.tsx
@@ -39,7 +39,7 @@ import type { SupportedPHPVersion } from '@studio/common/types/php-versions';
 import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
 import type { FormEvent } from 'react';
 
-type TabId = 'overview' | 'general' | 'debugging';
+type TabId = 'overview' | 'general' | 'debugging' | 'ai';
 
 interface FormData {
 	name: string;
@@ -315,8 +315,8 @@ export function SiteSettingsForm( { site, activeTab }: { site: SiteDetails; acti
 
 			{ submitError && <div className={ styles.submitError }>{ submitError }</div> }
 
-			{ /* The save actions apply to the form tabs only, not Overview. */ }
-			{ activeTab !== 'overview' && (
+			{ /* The save actions apply to the form tabs only, not Overview or AI. */ }
+			{ ( activeTab === 'general' || activeTab === 'debugging' ) && (
 				<div className={ styles.actions }>
 					<Button
 						type="submit"
@@ -335,13 +335,13 @@ export function SiteSettingsForm( { site, activeTab }: { site: SiteDetails; acti
 }
 
 export function isSiteSettingsTab( value: string ): value is TabId {
-	return value === 'overview' || value === 'general' || value === 'debugging';
+	return value === 'overview' || value === 'general' || value === 'debugging' || value === 'ai';
 }
 
 export type SiteSettingsTabId = TabId;
 
 // The `studio_panel_opened` value for a tab. The General tab reports `settings` so it lines up with
-// Studio Classic's Settings panel; overview and debugging keep their own names.
+// Studio Classic's Settings panel; overview, debugging, and AI keep their own names.
 export function siteSettingsTabToPanel( tab: TabId ): TracksPanel {
 	return tab === 'general' ? 'settings' : tab;
 }

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -132,6 +132,7 @@ export type TracksPanel =
 	| 'overview'
 	| 'settings'
 	| 'debugging'
+	| 'ai'
 	| 'assistant'
 	| 'sync'
 	| 'import-export'


### PR DESCRIPTION
## Related issues

- Related to the site-skills-instructions-migration work
- Stacked on #4646 (and #4645 below it)

## How AI was used in this PR

- Fully AI-authored (Claude Code): implementation and manual visual verification against a real local site via `studio ui`.

## Proposed Changes

- Third and last PR of the stack (base is #4646; #4645 and #4646 must land first) — this is the actual user-visible feature.
- New "AI" tab on the site overview with two sections, matching the existing global Skills settings tab's style:
  - **Skills** — toggle any bundled skill on/off for just this site, overriding the global selection from Settings. "Install all" bulk action.
  - **Instructions** — same toggle pattern for AGENTS.md / CLAUDE.md / STUDIO.md.
- Gated behind `capabilities.siteAgentSkills` (added in #4646) so hosted mode, which has no local site filesystem, hides the tab entirely.
- Studio Classic has had this per-site override (Edit Site > Skills / Instructions tabs) since it shipped; it never made it into the new agentic UI.

| Light | Dark |
|---|---|
| ![AI tab, light mode](https://github.com/Automattic/studio/blob/c01f5ac820d08ed10ebf74cab3de17614e97c763/ai-tab-light.png?raw=true) | ![AI tab, dark mode](https://github.com/Automattic/studio/blob/c01f5ac820d08ed10ebf74cab3de17614e97c763/ai-tab-dark.png?raw=true) |

Screenshots are a real site (`studio ui`, browser connector) — WP-CLI & Ops genuinely isn't installed there, which is why "Install all" shows up.

## Testing Instructions

- `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`, open `localhost:8081`, pick a site → AI tab.
- Toggle a skill and an instruction file off/on — confirms install/remove round-trips against the real site folder.
- Desktop: same tab appears in `apps/studio`'s Electron build; not yet visually verified there — flagging for review.
- `npm run typecheck` and `npm test` pass across all workspaces.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?