### PR TITLE
Fix Studio WP-CLI process exit

### DIFF
--- a/apps/cli/commands/tests/wp.test.ts
+++ b/apps/cli/commands/tests/wp.test.ts
@@ -1,0 +1,60 @@
+import { PassThrough } from 'node:stream';
+import { vi } from 'vitest';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
+import { runWpCliCommandWithMessaging } from 'cli/lib/run-wp-cli-command';
+import { runCommand } from '../wp';
+
+vi.mock( '@studio/common/lib/site-runtime', () => ( {
+	SITE_RUNTIME_NATIVE_PHP: 'native-php',
+	getSiteRuntime: () => 'playground',
+} ) );
+vi.mock( 'cli/lib/cli-config/sites', () => ( { getSiteByFolder: vi.fn() } ) );
+vi.mock( 'cli/lib/daemon-client', () => ( {
+	connectToDaemon: vi.fn(),
+	disconnectFromDaemon: vi.fn(),
+} ) );
+vi.mock( 'cli/lib/run-wp-cli-command', () => ( { runWpCliCommandWithMessaging: vi.fn() } ) );
+vi.mock( 'cli/logger', () => ( {
+	Logger: class {},
+	LoggerError: class LoggerError extends Error {},
+} ) );
+
+describe( 'CLI: studio wp', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.mocked( getSiteByFolder ).mockResolvedValue( {
+			id: 'site-id',
+			path: '/site',
+			phpVersion: '8.3',
+		} as Awaited< ReturnType< typeof getSiteByFolder > > );
+		vi.mocked( connectToDaemon ).mockResolvedValue( undefined );
+		vi.mocked( disconnectFromDaemon ).mockResolvedValue( undefined );
+	} );
+
+	it( 'disposes the PHP-WASM command before waiting for its response streams to end', async () => {
+		const stdout = new PassThrough();
+		const stderr = new PassThrough();
+		const dispose = vi.fn( () => {
+			stdout.end( 'complete output\n' );
+			stderr.end();
+		} );
+		const stdoutSpy = vi.spyOn( process.stdout, 'write' ).mockImplementation( () => true );
+
+		vi.mocked( runWpCliCommandWithMessaging ).mockResolvedValue( {
+			response: { stdout, stderr, exitCode: Promise.resolve( 0 ) },
+			[ Symbol.dispose ]: dispose,
+		} as never );
+
+		await runCommand( '/site', [ '--help' ] );
+
+		expect( stdoutSpy ).toHaveBeenCalledWith( expect.any( Buffer ) );
+		expect( dispose ).toHaveBeenCalledOnce();
+		expect( disconnectFromDaemon ).toHaveBeenCalled();
+		const disposeOrder = dispose.mock.invocationCallOrder[ 0 ];
+		const outputOrder = stdoutSpy.mock.invocationCallOrder[ 0 ];
+		expect( disposeOrder ).toBeLessThan( outputOrder );
+
+		stdoutSpy.mockRestore();
+	} );
+} );

--- a/apps/cli/commands/wp.ts
+++ b/apps/cli/commands/wp.ts
@@ -63,9 +63,25 @@ export async function runCommand(
 	try {
 		await connectToDaemon();
 
-		await using command = await runWpCliCommandWithMessaging( site, args, { phpVersion } );
-		await pipePHPResponse( command.response );
-		process.exitCode = await command.response.exitCode;
+		const command = await runWpCliCommandWithMessaging( site, args, { phpVersion } );
+		let disposed = false;
+		const disposeCommand = () => {
+			if ( ! disposed ) {
+				disposed = true;
+				command[ Symbol.dispose ]();
+			}
+		};
+		try {
+			const exitCode = await command.response.exitCode;
+
+			// PHP-WASM owns the response streams. Release it after the command exits so
+			// those streams can reach EOF before waiting for their output to drain.
+			disposeCommand();
+			await pipePHPResponse( command.response );
+			process.exitCode = exitCode;
+		} finally {
+			disposeCommand();
+		}
 	} finally {
 		await disconnectFromDaemon();
 	}


### PR DESCRIPTION
Fixes #4657

## Summary

Release the in-process PHP-WASM command after its WP-CLI exit status resolves, before waiting for its stdout and stderr streams to reach EOF. This breaks the circular wait that could leave `studio wp` alive after it had produced its result.

## Tests

- `npm test -- apps/cli/commands/tests/wp.test.ts`
- `npm -w wp-studio run typecheck`
- `npm -w wp-studio run lint -- commands/wp.ts commands/tests/wp.test.ts` (passes with one pre-existing warning in `commands/tests/pull-reprint.test.ts`)
- `npm run cli:build`

The focused regression test holds response streams open until disposal and verifies the command disposes the PHP-WASM runtime before waiting for those streams, preserves output forwarding, and closes its daemon connection.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to investigate/draft; Chris Huber remains responsible.