### PR TITLE
Studio Code: generate AI images during site builds (generate_images tool + imagery skill)

### DIFF
--- a/apps/cli/ai/image-generation.ts
+++ b/apps/cli/ai/image-generation.ts
@@ -1,5 +1,5 @@
 import { readAuthToken } from '@studio/common/lib/shared-config';
-import { getWpcomAiGatewayBaseUrl } from 'cli/ai/providers';
+import { getStudioUserAgent, getWpcomAiGatewayBaseUrl } from 'cli/ai/providers';
 
 /**
  * AI image generation through the WP.com AI proxy's Google Vertex Gemini route.
@@ -16,9 +16,10 @@ import { getWpcomAiGatewayBaseUrl } from 'cli/ai/providers';
  */
 
 const DEFAULT_IMAGE_MODEL = 'gemini-3.1-flash-image';
-// Slug already allowlisted on the proxy's Google publisher route (shared with
-// the site builder and telex, which generate theme images the same way).
-const IMAGE_FEATURE_SLUG = 'builder-theme-image';
+// Studio's slug on the proxy's Google publisher route; unlike the site
+// builder's `builder-theme-image` (which requires a Vertex-scoped token), this
+// one accepts regular user OAuth tokens.
+const IMAGE_FEATURE_SLUG = 'studio-image';
 const MAX_CONCURRENT_REQUESTS = 5;
 const RETRY_DELAYS_SECONDS = [ 2, 5, 12 ];
 // Prompt budget inherited from the builder: Gemini accepts longer prompts, but
@@ -66,16 +67,16 @@ const FILTERED_REASONS = new Set( [
 ] );
 
 /**
- * Whether the generate_images capability is enabled for this process.
- *
- * Gated on the explicit token until the WP.com AI proxy accepts Studio user
- * OAuth tokens on the Google publisher route (they currently get a 403 with
- * every Studio feature slug). resolveImageAuthToken already prefers the env
- * token and falls back to the WP.com login, so once the proxy-side allowlist
- * lands this check is the only thing to relax.
+ * Whether the generate_images capability is enabled for this session: an
+ * explicit token, or a valid WP.com login (the proxy's `studio-image` slug
+ * accepts user OAuth tokens). Sessions with neither — e.g. BYO Anthropic key
+ * without a WP.com login — get no tool and no imagery prompt sections.
  */
-export function isImageGenerationAvailable(): boolean {
-	return Boolean( process.env.STUDIO_IMAGE_API_TOKEN?.trim() );
+export async function isImageGenerationAvailable(): Promise< boolean > {
+	if ( process.env.STUDIO_IMAGE_API_TOKEN?.trim() ) {
+		return true;
+	}
+	return ( await readAuthToken() ) !== null;
 }
 
 async function resolveImageAuthToken(): Promise< string > {
@@ -355,6 +356,7 @@ async function generateOne(
 					authorization: `Bearer ${ authToken }`,
 					'x-wpcom-ai-feature': IMAGE_FEATURE_SLUG,
 					'content-type': 'application/json',
+					'user-agent': getStudioUserAgent(),
 				},
 				body,
 			} );

--- a/apps/cli/ai/image-generation.ts
+++ b/apps/cli/ai/image-generation.ts
@@ -1,0 +1,407 @@
+import { readAuthToken } from '@studio/common/lib/shared-config';
+import { getWpcomAiGatewayBaseUrl } from 'cli/ai/providers';
+
+/**
+ * AI image generation through the WP.com AI proxy's Google Vertex Gemini route.
+ *
+ * A TypeScript port of minimalistic-site-builder's image subsystem
+ * (GeminiImage / WpcomImageClient / ImagePromptComposer), trimmed for an
+ * agentic host: the agent authors each image spec at call time following the
+ * `imagery` skill's rules, so the builder's deterministic prompt-sanitization
+ * machinery (grade-token stripping, pictorial page-context recasting) is
+ * replaced by authoring guidance, and its LLM prompt-repair pass is replaced by
+ * reporting safety-filtered failures back to the agent to rewrite and retry.
+ * Only JPEG output is supported — the skill forbids decorative/transparent
+ * imagery, which is what PNG output existed for.
+ */
+
+const DEFAULT_IMAGE_MODEL = 'gemini-3.1-flash-image';
+// Slug already allowlisted on the proxy's Google publisher route (shared with
+// the site builder and telex, which generate theme images the same way).
+const IMAGE_FEATURE_SLUG = 'builder-theme-image';
+const MAX_CONCURRENT_REQUESTS = 5;
+const RETRY_DELAYS_SECONDS = [ 2, 5, 12 ];
+// Prompt budget inherited from the builder: Gemini accepts longer prompts, but
+// a tight prompt keeps the subject dominant instead of drowning it in context.
+export const MAX_PROMPT_TOKENS = 480;
+
+export const IMAGE_STYLES = [
+	'photorealistic',
+	'digital-art',
+	'illustration',
+	'minimalist',
+	'flat-design',
+	'3d-render',
+	'abstract',
+	'watercolor',
+] as const;
+export type ImageStyle = ( typeof IMAGE_STYLES )[ number ];
+
+const ASPECT_RATIO_BY_KEYWORD = {
+	square: '1:1',
+	landscape: '16:9',
+	ultrawide: '21:9',
+	portrait: '9:16',
+	'card-landscape': '4:3',
+	'card-portrait': '3:4',
+} as const;
+export const IMAGE_ASPECT_RATIOS = Object.keys(
+	ASPECT_RATIO_BY_KEYWORD
+) as ImageAspectRatioKeyword[];
+export type ImageAspectRatioKeyword = keyof typeof ASPECT_RATIO_BY_KEYWORD;
+
+// Gemini outcomes that unambiguously mean a policy/safety filter rejected the
+// prompt. Everything else (MAX_TOKENS, NO_IMAGE, …) is an ordinary no-image
+// response and must not be reported as repairable-by-rewriting.
+const FILTERED_REASONS = new Set( [
+	'SAFETY',
+	'RECITATION',
+	'BLOCKLIST',
+	'PROHIBITED_CONTENT',
+	'SPII',
+	'IMAGE_SAFETY',
+	'IMAGE_PROHIBITED_CONTENT',
+	'IMAGE_RECITATION',
+	'MODEL_ARMOR',
+] );
+
+/**
+ * Whether the generate_images capability is enabled for this process.
+ *
+ * Gated on the explicit token until the WP.com AI proxy accepts Studio user
+ * OAuth tokens on the Google publisher route (they currently get a 403 with
+ * every Studio feature slug). resolveImageAuthToken already prefers the env
+ * token and falls back to the WP.com login, so once the proxy-side allowlist
+ * lands this check is the only thing to relax.
+ */
+export function isImageGenerationAvailable(): boolean {
+	return Boolean( process.env.STUDIO_IMAGE_API_TOKEN?.trim() );
+}
+
+async function resolveImageAuthToken(): Promise< string > {
+	const envToken = process.env.STUDIO_IMAGE_API_TOKEN?.trim();
+	if ( envToken ) {
+		return envToken;
+	}
+	const token = await readAuthToken();
+	if ( ! token?.accessToken ) {
+		throw new Error(
+			'Image generation requires a WordPress.com login (studio auth login) or STUDIO_IMAGE_API_TOKEN.'
+		);
+	}
+	return token.accessToken;
+}
+
+function getImageModel(): string {
+	return process.env.STUDIO_IMAGE_MODEL?.trim() || DEFAULT_IMAGE_MODEL;
+}
+
+function getImageEndpoint(): string {
+	const base = getWpcomAiGatewayBaseUrl().replace( /\/+$/, '' );
+	return `${ base }/v1/publishers/google/models/${ getImageModel() }:generateContent`;
+}
+
+export function resolveAspectRatio( keyword: string | undefined ): string {
+	return ASPECT_RATIO_BY_KEYWORD[ ( keyword ?? 'landscape' ) as ImageAspectRatioKeyword ] ?? '16:9';
+}
+
+// Wide ratios are used full-bleed (heroes, banners) where a 1K render goes
+// soft; the smaller contained slots stay at 1K to keep cost down.
+function imageSizeForRatio( aspectRatio: string ): '1K' | '2K' {
+	return aspectRatio === '16:9' || aspectRatio === '21:9' ? '2K' : '1K';
+}
+
+export interface ImagePromptSpec {
+	subject: string;
+	pageContext?: string;
+	style?: string;
+}
+
+export interface ImagePromptContext {
+	siteContext?: string;
+	imageGrade?: string;
+}
+
+// Text-carrying objects the image model reliably completes with garbled fake
+// lettering. Deliberately a noun allowlist: a false positive only adds a
+// harmless render instruction, while an unconditional clause would plant the
+// signage concept into clean prompts. English + Spanish, like the builder.
+const TEXT_CARRIER_PATTERN =
+	/\b(?:signs?|signages?|signboards?|storefronts?|shop ?fronts?|facades?|fa[çc]ades?|marquees?|billboards?|posters?|placards?|banners?|plaques?|awnings?|men[uú]s?|menu ?boards?|chalkboards?|blackboards?|whiteboards?|screens?|smartphones?|phones?|tablets?|laptops?|monitors?|dashboards?|newspapers?|magazines?|books?|labels?|packagings?|record ?sleeves?|album ?covers?|letreros?|carteles?|pancartas?|r[oó]tulos?|vallas?|marquesinas?|toldos?|pizarras?|pantallas?|tel[eé]fonos?|m[oó]viles?|peri[oó]dicos?|revistas?|libros?|etiquetas?|placas?|fachadas?|portadas?|escaparates?)\b/iu;
+
+function estimateTokens( text: string ): number {
+	const trimmed = text.trim();
+	if ( ! trimmed ) {
+		return 0;
+	}
+	const words = trimmed.split( /\s+/ ).length;
+	return Math.max( Math.ceil( words * 1.4 ), Math.ceil( trimmed.length / 4 ) );
+}
+
+// Trim from the end on word boundaries; the subject leads the prompt, so this
+// sheds trailing context first and preserves the subject.
+export function fitToTokens( text: string, maxTokens: number ): string {
+	if ( estimateTokens( text ) <= maxTokens ) {
+		return text;
+	}
+	const words = text.trim().split( /\s+/ );
+	while ( words.length && estimateTokens( words.join( ' ' ) ) > maxTokens ) {
+		words.pop();
+	}
+	return words.join( ' ' ).replace( /[ ,.;:—-]+$/, '' );
+}
+
+/**
+ * Compose the text prompt for one image. Subject and style are what the model
+ * renders; the site-wide grade is a render instruction shared by all imagery so
+ * independently generated images read as one photographic series; page and site
+ * context only steer subject choice, mood, and composition — the guidance frame
+ * states so explicitly, and the no-text guard describes reserved regions
+ * positively (continuous empty scenery) rather than enumerating forbidden text
+ * artifacts, which image models follow unreliably as negations.
+ */
+export function composeImagePrompt(
+	spec: ImagePromptSpec,
+	context: ImagePromptContext = {}
+): string {
+	const subject = spec.subject.trim();
+	const style = spec.style?.trim() ?? '';
+	const pageContext = spec.pageContext?.trim().replace( /\.$/, '' ) ?? '';
+	const siteContext = context.siteContext?.trim() ?? '';
+	const imageGrade = context.imageGrade?.trim() ?? '';
+
+	const parts = [ style ? `${ subject }. Style: ${ style }` : subject ];
+
+	if ( imageGrade ) {
+		parts.push( `Art direction for all site imagery: ${ imageGrade.replace( /\.$/, '' ) }.` );
+	}
+
+	if ( TEXT_CARRIER_PATTERN.test( subject ) ) {
+		parts.push(
+			'Any sign, board, screen or printed surface in the scene is quiet set dressing: its face is unmarked — bare wood, clear glass, dark glass or blank chalk — or kept so distant, obliquely angled or softly out of focus that it reads as simple shapes, glare and texture, and the image tells its story through form, light and color alone.'
+		);
+	}
+
+	const where = [ pageContext ? `Composition: ${ pageContext }.` : '', siteContext ]
+		.filter( Boolean )
+		.join( ' ' );
+	if ( where ) {
+		parts.push(
+			'Purely pictorial imagery: every part of the frame is the scene itself, and any region described below as open, calm or low-detail is continuous unbroken scenery — open sky, plain wall, still water, bare ground or soft-focus depth — left completely empty. The notes below steer subject, mood and composition only and are never depicted literally: ' +
+				where
+		);
+	}
+
+	return fitToTokens( parts.join( '\n\n' ), MAX_PROMPT_TOKENS );
+}
+
+export function buildImageRequestBody(
+	prompt: string,
+	aspectRatioKeyword: string | undefined
+): Record< string, unknown > {
+	const aspectRatio = resolveAspectRatio( aspectRatioKeyword );
+	return {
+		contents: [ { role: 'user', parts: [ { text: prompt } ] } ],
+		generationConfig: {
+			// TEXT rides along because not every Gemini image model accepts an
+			// IMAGE-only response; interpretation scans past text parts.
+			responseModalities: [ 'TEXT', 'IMAGE' ],
+			imageConfig: {
+				aspectRatio,
+				imageSize: imageSizeForRatio( aspectRatio ),
+				imageOutputOptions: { mimeType: 'image/jpeg', compressionQuality: 85 },
+			},
+		},
+	};
+}
+
+export class TransientImageError extends Error {}
+export class ImageFilteredError extends Error {}
+
+interface GeminiResponsePart {
+	thought?: boolean;
+	text?: string;
+	inlineData?: { data?: string; mimeType?: string };
+	inline_data?: { data?: string; mimeType?: string };
+}
+
+interface GeminiResponse {
+	promptFeedback?: { blockReason?: string };
+	candidates?: Array< {
+		finishReason?: string;
+		finishMessage?: string;
+		content?: { parts?: GeminiResponsePart[] };
+	} >;
+}
+
+function imagePartData( data: GeminiResponse ): string | null {
+	for ( const candidate of data.candidates ?? [] ) {
+		for ( const part of candidate.content?.parts ?? [] ) {
+			// Gemini 3 may include internal `thought: true` image parts before
+			// the authored result; those are never a deliverable asset.
+			if ( part.thought === true ) {
+				continue;
+			}
+			const inline = part.inlineData ?? part.inline_data;
+			if ( inline?.data ) {
+				return inline.data;
+			}
+		}
+	}
+	return null;
+}
+
+function filteredReason( data: GeminiResponse ): string | null {
+	if ( imagePartData( data ) !== null ) {
+		return null;
+	}
+	const block = data.promptFeedback?.blockReason?.toUpperCase().trim();
+	if ( block && FILTERED_REASONS.has( block ) ) {
+		return `prompt blocked: ${ block }`;
+	}
+	for ( const candidate of data.candidates ?? [] ) {
+		const finish = candidate.finishReason?.toUpperCase().trim();
+		if ( finish && FILTERED_REASONS.has( finish ) ) {
+			return `candidate finished: ${ finish }`;
+		}
+	}
+	return null;
+}
+
+function noImageReason( data: GeminiResponse ): string {
+	for ( const candidate of data.candidates ?? [] ) {
+		const finish = candidate.finishReason?.trim();
+		const text = candidate.content?.parts
+			?.map( ( part ) => part.text?.trim() )
+			.find( ( value ) => value );
+		if ( finish && finish.toUpperCase() !== 'STOP' ) {
+			return `candidate finished: ${ finish }${ text ? `; text: ${ text.slice( 0, 200 ) }` : '' }`;
+		}
+		if ( text ) {
+			return `text-only response: ${ text.slice( 0, 200 ) }`;
+		}
+	}
+	return 'no candidates';
+}
+
+/**
+ * Interpret a completed transfer: HTTP-status classification plus
+ * generateContent body parsing. Returns decoded JPEG bytes or throws
+ * TransientImageError (429/5xx — retryable), ImageFilteredError (safety filter
+ * — retryable, and repairable by rewriting the subject), or Error (permanent).
+ */
+export function interpretImageResponse( raw: string, status: number ): Buffer {
+	if ( status === 429 || status >= 500 ) {
+		throw new TransientImageError( `HTTP ${ status }: ${ raw.slice( 0, 300 ) }` );
+	}
+	if ( status < 200 || status >= 300 ) {
+		throw new Error( `Image proxy HTTP ${ status }: ${ raw.slice( 0, 500 ) }` );
+	}
+
+	let data: GeminiResponse;
+	try {
+		data = JSON.parse( raw ) as GeminiResponse;
+	} catch {
+		throw new Error( `Image proxy returned non-JSON response: ${ raw.slice( 0, 300 ) }` );
+	}
+
+	const filtered = filteredReason( data );
+	if ( filtered ) {
+		throw new ImageFilteredError( `Image safety filter rejected the prompt: ${ filtered }` );
+	}
+
+	const base64 = imagePartData( data );
+	if ( ! base64 ) {
+		throw new Error( `Image proxy response had no image data: ${ noImageReason( data ) }` );
+	}
+
+	const bytes = Buffer.from( base64, 'base64' );
+	// Byte magic is the source of truth: never deliver non-JPEG bytes under a
+	// .jpg filename, whatever the response metadata declares.
+	if ( bytes.length < 4 || bytes[ 0 ] !== 0xff || bytes[ 1 ] !== 0xd8 || bytes[ 2 ] !== 0xff ) {
+		throw new Error( 'Image proxy returned bytes that are not a JPEG' );
+	}
+	return bytes;
+}
+
+export interface GenerateImageRequest {
+	prompt: string;
+	aspectRatio?: string;
+}
+
+export interface GenerateImageResult {
+	ok: boolean;
+	bytes?: Buffer;
+	error?: string;
+	filtered?: boolean;
+}
+
+const sleep = ( seconds: number ) =>
+	new Promise< void >( ( resolve ) => setTimeout( resolve, seconds * 1000 ) );
+
+async function generateOne(
+	endpoint: string,
+	authToken: string,
+	request: GenerateImageRequest
+): Promise< GenerateImageResult > {
+	const body = JSON.stringify( buildImageRequestBody( request.prompt, request.aspectRatio ) );
+	// Transient transport errors AND safety-filtered prompts retry: the
+	// non-deterministic filter can pass the same prompt on a later attempt.
+	for ( let attempt = 0; ; attempt++ ) {
+		try {
+			const response = await fetch( endpoint, {
+				method: 'POST',
+				headers: {
+					authorization: `Bearer ${ authToken }`,
+					'x-wpcom-ai-feature': IMAGE_FEATURE_SLUG,
+					'content-type': 'application/json',
+				},
+				body,
+			} );
+			const raw = await response.text();
+			return { ok: true, bytes: interpretImageResponse( raw, response.status ) };
+		} catch ( error ) {
+			const transient =
+				error instanceof TransientImageError ||
+				error instanceof ImageFilteredError ||
+				// fetch network failures (DNS, reset, timeout) surface as TypeError.
+				error instanceof TypeError;
+			if ( transient && attempt < RETRY_DELAYS_SECONDS.length ) {
+				await sleep( RETRY_DELAYS_SECONDS[ attempt ] );
+				continue;
+			}
+			return {
+				ok: false,
+				error: error instanceof Error ? error.message : String( error ),
+				...( error instanceof ImageFilteredError ? { filtered: true } : {} ),
+			};
+		}
+	}
+}
+
+/**
+ * Generate a batch of images concurrently (bounded pool). Results are keyed by
+ * the same index as the requests; a failure never aborts the rest.
+ */
+export async function generateImages(
+	requests: GenerateImageRequest[],
+	onResult?: ( index: number, result: GenerateImageResult ) => void
+): Promise< GenerateImageResult[] > {
+	const endpoint = getImageEndpoint();
+	const authToken = await resolveImageAuthToken();
+	const results: GenerateImageResult[] = new Array( requests.length );
+	let next = 0;
+
+	const worker = async () => {
+		while ( next < requests.length ) {
+			const index = next++;
+			const result = await generateOne( endpoint, authToken, requests[ index ] );
+			results[ index ] = result;
+			onResult?.( index, result );
+		}
+	};
+	await Promise.all(
+		Array.from( { length: Math.min( MAX_CONCURRENT_REQUESTS, requests.length ) }, worker )
+	);
+	return results;
+}

--- a/apps/cli/ai/mcp-server.ts
+++ b/apps/cli/ai/mcp-server.ts
@@ -6,13 +6,16 @@ import {
 	ListToolsRequestSchema,
 	// eslint-disable-next-line import-x/no-unresolved -- subpath resolved via package's wildcard export, which the lint resolver doesn't follow
 } from '@modelcontextprotocol/sdk/types.js';
+import { isImageGenerationAvailable } from 'cli/ai/image-generation';
 import { resolveStudioToolDefinitions } from 'cli/ai/tools';
 import type { StudioAgentTool } from 'cli/ai/tools/define-tool';
 
 // Uses the low-level Server API rather than McpServer.registerTool, which only
 // accepts zod-shaped inputs — our tools are typebox JSON Schema.
 export async function startMcpStdioServer(): Promise< void > {
-	const tools = resolveStudioToolDefinitions() as StudioAgentTool[];
+	const tools = resolveStudioToolDefinitions( {
+		imageGeneration: await isImageGenerationAvailable(),
+	} ) as StudioAgentTool[];
 	const toolsByName = new Map( tools.map( ( tool ) => [ tool.name, tool ] ) );
 
 	const server = new Server(

--- a/apps/cli/ai/providers.ts
+++ b/apps/cli/ai/providers.ts
@@ -98,7 +98,7 @@ async function resolveAnthropicApiKey( options?: {
 	return trimmedKey;
 }
 
-function getStudioUserAgent(): string {
+export function getStudioUserAgent(): string {
 	const version = typeof __STUDIO_CLI_VERSION__ === 'string' ? __STUDIO_CLI_VERSION__ : '';
 	return version ? `WordPressStudio/${ version }` : 'WordPressStudio';
 }

--- a/apps/cli/ai/providers.ts
+++ b/apps/cli/ai/providers.ts
@@ -109,7 +109,7 @@ function buildAnthropicCustomHeaders( headers: Record< string, string > ): strin
 		.join( '\n' );
 }
 
-function getWpcomAiGatewayBaseUrl(): string {
+export function getWpcomAiGatewayBaseUrl(): string {
 	const customBaseUrl = process.env.WPCOM_AI_PROXY_BASE_URL?.trim();
 	return customBaseUrl || DEFAULT_WPCOM_AI_GATEWAY_BASE_URL;
 }

--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -47,6 +47,7 @@ import {
 } from '@studio/common/lib/site-runtime';
 import { getAiPayloadsPath, getConfigDirectory } from '@studio/common/lib/well-known-paths';
 import { type TSchema } from 'typebox';
+import { isImageGenerationAvailable } from 'cli/ai/image-generation';
 import { buildSystemPrompt } from 'cli/ai/system-prompt';
 import { resolveStudioToolDefinitions, withChatArtifactEmission } from 'cli/ai/tools';
 import { createAskUserQuestionTool } from 'cli/ai/tools/ask-user-question';
@@ -347,6 +348,7 @@ async function createStudioAgentSession(
 					remoteSession,
 					runtime,
 					userInstructions,
+					imageGenerationEnabled: isImageGenerationAvailable(),
 			  }
 	);
 

--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -327,9 +327,10 @@ async function createStudioAgentSession(
 	const isRemoteSite = Boolean( config.activeSite?.remote && config.activeSite?.wpcomSiteId );
 	const remoteSession = config.env.STUDIO_REMOTE_SESSION === '1';
 	const chatArtifactsEnabled = typeof process.send === 'function';
-	const [ userInstructions, runtime ] = await Promise.all( [
+	const [ userInstructions, runtime, imageGenerationEnabled ] = await Promise.all( [
 		readGlobalInstructions(),
 		isRemoteSite ? undefined : resolveActiveSiteRuntime( config.activeSite ),
+		isImageGenerationAvailable(),
 	] );
 
 	const systemPrompt = buildSystemPrompt(
@@ -348,11 +349,16 @@ async function createStudioAgentSession(
 					remoteSession,
 					runtime,
 					userInstructions,
-					imageGenerationEnabled: isImageGenerationAvailable(),
+					imageGenerationEnabled,
 			  }
 	);
 
-	const tools = buildAgentTools( config, chatArtifactsEnabled, remoteSession );
+	const tools = buildAgentTools(
+		config,
+		chatArtifactsEnabled,
+		remoteSession,
+		imageGenerationEnabled
+	);
 	const toolDefinitions = tools.map( ( tool ) => toToolDefinition( tool, payloadGuardState ) );
 	const modelRuntime = await createModelRuntime( model, family, creds );
 	const settingsManager = createSettingsManager( config.env );
@@ -671,7 +677,8 @@ function toToolDefinition(
 function buildAgentTools(
 	config: ResolvedStudioAgentTurnConfig,
 	chatArtifactsEnabled: boolean,
-	remoteSession: boolean
+	remoteSession: boolean,
+	imageGenerationEnabled: boolean
 ): AgentToolAny[] {
 	const isRemoteSite = Boolean(
 		config.activeSite?.remote && config.activeSite?.wpcomSiteId && config.wpcomAccessToken
@@ -732,6 +739,7 @@ function buildAgentTools(
 	const studioTools = resolveStudioToolDefinitions( {
 		emitChatArtifacts: chatArtifactsEnabled,
 		remoteSession,
+		imageGeneration: imageGenerationEnabled,
 	} ) as unknown as AgentToolAny[];
 	return withoutUnusableTools( [ ...studioTools, ...askUserTool, ...skillTool, ...piTools ] );
 }

--- a/apps/cli/ai/skills/imagery/SKILL.md
+++ b/apps/cli/ai/skills/imagery/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: imagery
+description: Generate AI images for a site with generate_images — how to write image specs, pick aspect ratios, place files (theme assets vs media library), and handle failures.
+user-invokable: true
+---
+
+# Site Imagery
+
+Use this skill whenever a design calls for images — hero/cover backgrounds, feature, gallery, or card images, team photos, product shots — and before every `generate_images` call.
+
+## Workflow
+
+1. **Plan all imagery first.** While planning a page or theme, list every image it needs: filename, subject, placement, aspect ratio. Generate images BEFORE writing the markup that references them, so markup always points at real files.
+2. **Pick the destination per image:**
+   - **Theme imagery** (part of the theme's design: hero/cover backgrounds in templates or template parts, section background bands): write to `<site>/wp-content/themes/<theme-slug>/assets/images/<name>.jpg` and reference it in markup as `/wp-content/themes/<theme-slug>/assets/images/<name>.jpg`.
+   - **Site-specific content imagery** (images inside page/post content: products, team photos, gallery items, feature illustrations): generate to a staging path like `<site>/wp-content/uploads/studio-generated/<name>.jpg`, then import into the media library and use the attachment:
+     ```
+     wp_cli media import wp-content/uploads/studio-generated/<name>.jpg --porcelain   → <id>
+     wp_cli post list --post_type=attachment --post__in=<id> --field=guid             → URL
+     ```
+     Use the returned URL as the `src` and the id in the block attrs (e.g. `wp:image {"id":<id>,"sizeSlug":"large"}`). Delete the staging file afterwards.
+3. **Batch aggressively.** One `generate_images` call per page (or per site for small sites) with every image in the `images` array — generation is concurrent server-side. Never one call per image.
+4. **Write real alt text.** Generated images are content: give every `<img>` a short, descriptive alt in the markup (what the image shows, for a person who cannot see it). Never leave a spec string or an empty alt on a content image; cover backgrounds keep an empty alt (decorative).
+5. **Verify.** After applying markup, use take_screenshot to confirm the images render, fill their slots, and keep overlaid text legible.
+
+## Writing the spec fields
+
+Every image in the `images` array takes `path`, `subject`, `pageContext`, `style`, `aspectRatio`. The call also takes a shared `siteContext` and `imageGrade`.
+
+### subject — what the image shows
+
+1–3 specific sentences describing ONLY the image itself: what it shows and from what point of view (composition, framing, vantage, mood).
+
+- **NEVER ask the image to render text.** No words, names, letters, numerals, wordmarks, signage copy, or "hand-lettering of <words>" — in any language. Image models garble glyphs and invent fake scripts. Everything meant to be read is real HTML typography styled by the theme. Prefer scenes whose focal subject carries no lettering at all: the model completes any prominent sign, storefront, menu board, or screen with garbled fake text. When a text-bearing surface is unavoidable, describe it as bare (clear glass, an unmarked awning, a blank board) or keep it distant, oblique, or out of focus. Never write words for signage into the subject even to negate them — naming lettering plants it.
+- **Describe content and composition, NOT photographic grade.** The site-wide `imageGrade` is applied to every image; do not restate or contradict it per image (no "black and white", "golden hour", "35mm grain" in subjects) — per-image grading makes adjacent images clash.
+- Make sibling images in the same section describe distinct subjects so they don't read alike.
+- For cover backgrounds with overlaid copy, keep the focal subject off-center with calm, low-detail areas so the overlaid HTML text stays legible.
+
+### pageContext — where the image is used
+
+A short phrase in **pictorial slot language**, in **English** (it is machine guidance, not site copy). Examples: `contained editorial photograph in a 3-column gallery`, `menu item thumbnail`, `full-frame editorial photograph with the left third kept as open, low-detail negative space`.
+
+- Describe copy-overlay placement as **reserved empty space in photographic terms, never as text**: write `the left third kept as open, low-detail negative space` — NOT `hero with the headline overlaid on the left`. Naming a headline or menu in the pageContext is the trigger for the model painting ghost text into that exact region — and so is design-comp vocabulary like `hero cover background`: prefer photographic slot language (`editorial photograph`, `full-frame backdrop`) over web-layout language (`hero`, `banner`, `cover background`).
+- The structured `aspectRatio` field is authoritative for canvas shape; pageContext must not contradict it.
+
+### style
+
+One of: `photorealistic` (default), `digital-art`, `illustration`, `minimalist`, `flat-design`, `3d-render`, `abstract`, `watercolor`. Keep one style per site unless the design deliberately mixes.
+
+### aspectRatio — match the slot
+
+- `landscape` (16:9) — the default for hero and banner images and wide feature/gallery rows
+- `ultrawide` (21:9) — ONLY for full-bleed backgrounds spanning the viewport edge to edge; never for contained images, cards, or columns
+- `portrait` (9:16) — dramatic tall images: full-height editorial shots, tall side-by-side panels
+- `card-landscape` (4:3) — contained landscape slots: product cards, blog thumbnails, feature images in columns
+- `card-portrait` (3:4) — the natural portrait-card shape: team headshots, tall product cards, framed insets; prefer over `portrait` for anything in a card or column
+- `square` (1:1) — only when the layout slot is genuinely 1:1
+
+A full-bleed cover BACKGROUND must be `landscape` or `ultrawide` — never square, portrait, or a card ratio. **Grid/row consistency:** all images displayed together in one row or grid MUST share the same aspect ratio — never mix.
+
+### siteContext and imageGrade (shared per call)
+
+- `siteContext`: one sentence of subject matter ("A neighborhood bakery selling sourdough and pastries."). **NEVER include the site or business name** — a name in the prompt is what painted-in fake wordmarks stand in for.
+- `imageGrade`: ONE site-wide photographic treatment (e.g. "warm natural window light, soft muted color, gentle film grain"), derived from the visual direction. Use the identical grade in every call for the site so all imagery reads as one photographic series.
+
+## No decorative or transparent images
+
+Generated imagery is for CONTENT — covers, feature/gallery/card images, photographic bands. Never generate decorative assets: no ornaments, flourishes, crests, stamps, icons, or logo marks. They come out off-palette and geometrically wobbly, and small raster icons turn to mush. Decoration comes from theme primitives (separators, borders, spacing, type); feature icons: use none — let type and layout carry the hierarchy.
+
+## Cover blocks
+
+For `wp:cover` backgrounds, set the same image URL on BOTH the block's `url` attribute and the inner `<img>` src. Wide cover images (`landscape`/`ultrawide`) are generated at 2K automatically.
+
+## Failure handling
+
+- **Safety-filtered image**: rewrite that image's subject to avoid the flagged element and call `generate_images` again for just that image. One retry; if it fails again, treat as a permanent failure.
+- **Permanent failure**: adapt the layout to work without that image (a color/gradient background, a text-led card). NEVER substitute an unrelated image, source an image from a web URL, or leave a reference to a file that does not exist.

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -26,6 +26,10 @@ export interface BuildSystemPromptOptions {
 	runtime?: SiteRuntime;
 	// The user's global instructions (~/.studio/knowledge/instructions.md).
 	userInstructions?: string;
+	// True when the generate_images tool is registered for this session. Gates
+	// every imagery-related prompt section so unavailable sessions get exactly
+	// the pre-imagery prompt.
+	imageGenerationEnabled?: boolean;
 }
 
 export function buildSystemPrompt( options?: BuildSystemPromptOptions ): string {
@@ -41,13 +45,16 @@ ${ REMOTE_DESIGN_GUIDELINES }${ remoteSessionAddendum }${ userInstructionsSectio
 `;
 	}
 
+	const imageryRouting = options?.imageGenerationEnabled ? `\n\n${ IMAGERY_SKILL_ROUTING }` : '';
+
 	return `${ buildLocalIntro( {
 		chatArtifactsEnabled: options?.chatArtifactsEnabled ?? false,
 		remoteSession: options?.remoteSession ?? false,
 		runtime: options?.runtime,
+		imageGenerationEnabled: options?.imageGenerationEnabled ?? false,
 	} ) }
 
-${ LOCAL_SKILL_ROUTING }${ remoteSessionAddendum }${ userInstructionsSection }
+${ LOCAL_SKILL_ROUTING }${ imageryRouting }${ remoteSessionAddendum }${ userInstructionsSection }
 `;
 }
 
@@ -124,8 +131,18 @@ function buildLocalIntro( options: {
 	chatArtifactsEnabled: boolean;
 	remoteSession: boolean;
 	runtime?: SiteRuntime;
+	imageGenerationEnabled: boolean;
 } ): string {
 	const postContentGuidance = getPostContentGuidance( options.runtime );
+	const imageryWorkflowSection = options.imageGenerationEnabled
+		? `
+
+Whenever the design calls for imagery (hero/cover backgrounds, feature, gallery, or card images, team photos, product shots), load the \`imagery\` skill and generate the images with \`generate_images\` BEFORE writing the markup that references them: theme imagery goes into the active theme's assets directory, site-specific content imagery is imported into the media library via wp_cli. Never source images from web URLs and never leave a broken image reference — if an image cannot be generated, adapt the layout instead.`
+		: '';
+	const generateImagesToolBullet = options.imageGenerationEnabled
+		? `
+- generate_images: Generate AI images (JPEG) from text specs and write them to files inside a site. Batch all the images a page needs into one call. Load the \`imagery\` skill first for spec-writing rules and file placement.`
+		: '';
 	// Remote-bridge sessions also run without chat artifacts, but their user is
 	// on the other end of a messaging bridge: local file paths are unreachable
 	// and REMOTE_SESSION_GUIDANCE (share_screenshot) already covers delivery.
@@ -194,7 +211,7 @@ Then continue with:
 4. **Provision the site**: Use wp_cli to activate the theme, install and activate any plugins the design needs, and set options. Do this before validating — the live editor only recognizes the active theme and registered plugin blocks. The site must be running.
 5. **Validate block content**: Any block content you generate MUST pass validate_blocks before it reaches the site — before \`wp post create/update\` and before \`wp_cli eval\` that imports a scratch file such as \`<site>/tmp/page-<slug>.html\`. Call validate_blocks with \`filePath\` for file content, or pass inline content. It runs a static core/html policy check first: if that reports invalid core/html blocks, editor validation is skipped — rewrite those as editable core or plugin blocks and call again. Once the policy passes it validates in the live editor. If an auto-fix was applied, the file already holds the fixed content; do not replace markup or re-validate unless you change the markup. Use the diff only to update CSS selectors for class/nesting changes. For inline content, use the returned fixed content exactly. Never apply unvalidated block content — a build that skips validate_blocks is incomplete.
 6. **Apply content**: Once it passes validation, create/update/import the posts and pages with the validated content. ${ postContentGuidance }
-7. **Check and polish the result**: Load the \`visual-polish\` skill and run it to polish the design. The design must match your original expectations.
+7. **Check and polish the result**: Load the \`visual-polish\` skill and run it to polish the design. The design must match your original expectations.${ imageryWorkflowSection }
 
 ## Working cadence
 
@@ -222,7 +239,7 @@ For long CSS or page-content files (>~200 lines), load the \`block-content\` ski
 - scaffold_theme: Scaffold a minimal block theme (style.css, theme.json, functions.php with frontend + editor enqueue, default templates and parts, empty assets/fonts and patterns dirs) into a site and activate it. Use as the first step when starting a new custom theme; the agent fills design-specific content afterwards. Pass parentTheme with an installed theme's slug to scaffold a child theme instead of editing that theme's files. Block themes only.
 - validate_blocks: Validate block content in two stages and return a combined report. First a static core/html policy check; if it finds invalid core/html blocks it returns only those (rewrite them as editable core or plugin blocks and call again) and skips the editor. Once it passes, validates in the running site's real block editor: with filePath, applies safe editor fixes directly to the file and returns a CSS-review diff; with inline content, returns exact fixed block content plus the diff. Requires a site name or path. Call after every file write/edit that contains block content.
 - take_screenshot: Take a full-page screenshot of a URL (supports desktop, mobile, or \`viewport: "all"\` for both). Use this to visually check the site after building it.
-- inspect_design: Inspect the rendered DOM and computed styles of a page by CSS selector to root-cause visual issues. Pair with take_screenshot when verifying or polishing a design.
+- inspect_design: Inspect the rendered DOM and computed styles of a page by CSS selector to root-cause visual issues. Pair with take_screenshot when verifying or polishing a design.${ generateImagesToolBullet }
 - need_for_speed: Measure frontend performance metrics (TTFB, FCP, LCP, CLS, page weight, DOM size, JS/CSS/image/font asset breakdown) for a running site. Use this to identify performance bottlenecks and guide optimization.
 - rank_me_up: Run an on-page SEO audit (title/meta tags, headings, image alt text, OpenGraph/Twitter cards, JSON-LD structured data, robots.txt and sitemap.xml availability) for a running site. Use this to identify on-page SEO issues and guide fixes.
 - site_connected_remote_sites: List the durable WordPress.com remote sites (production/staging) already attached to a local site for syncing. These are distinct from temporary preview sites (preview_list). Call this before site_push to decide how to ask the user which remote site to target.
@@ -308,6 +325,8 @@ const REMOTE_DESIGN_GUIDELINES = `## Design capabilities by plan
 - Check the specific plan to determine exact capabilities.`;
 
 const PLAN_DATA_GUARDRAIL = `For ANY question about WordPress.com or Pressable plans, pricing, upgrades, or what a plan tier includes (plugins, themes, custom code, SSH, hosting, storage, etc.), you MUST load the \`hosting-plans-helper\` skill and answer only from the data it fetches. Do NOT answer from memory: your training knowledge of plan names, prices, and feature-tier gating is stale and frequently wrong. In particular, do not claim a tier lacks a feature (e.g. that Personal or Premium cannot install plugins) based on memory — check the fetched per-tier feature list, which is the only source of truth. If you cannot fetch the data, say you cannot verify current plan details and point the user to https://wordpress.com/pricing; never guess.`;
+
+const IMAGERY_SKILL_ROUTING = `For any work that adds or replaces site imagery — hero/cover backgrounds, feature or gallery images, team photos, product shots — load the \`imagery\` skill before writing image specs or calling \`generate_images\`.`;
 
 const LOCAL_SKILL_ROUTING = `## Skill routing
 

--- a/apps/cli/ai/tests/image-generation.test.ts
+++ b/apps/cli/ai/tests/image-generation.test.ts
@@ -1,0 +1,135 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { STUDIO_SITES_ROOT } from '../../lib/site-paths';
+import {
+	composeImagePrompt,
+	fitToTokens,
+	ImageFilteredError,
+	interpretImageResponse,
+	resolveAspectRatio,
+	TransientImageError,
+} from '../image-generation';
+import { resolveImageFilePath } from '../tools/generate-images';
+
+const JPEG_BASE64 = Buffer.from( [ 0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10 ] ).toString( 'base64' );
+
+function responseWith( parts: unknown[], extra: Record< string, unknown > = {} ): string {
+	return JSON.stringify( { candidates: [ { content: { parts }, ...extra } ] } );
+}
+
+describe( 'resolveAspectRatio', () => {
+	it( 'maps keywords and falls back to landscape', () => {
+		expect( resolveAspectRatio( 'square' ) ).toBe( '1:1' );
+		expect( resolveAspectRatio( 'card-portrait' ) ).toBe( '3:4' );
+		expect( resolveAspectRatio( undefined ) ).toBe( '16:9' );
+		expect( resolveAspectRatio( 'bogus' ) ).toBe( '16:9' );
+	} );
+} );
+
+describe( 'composeImagePrompt', () => {
+	it( 'leads with the subject and frames context as non-literal guidance', () => {
+		const prompt = composeImagePrompt(
+			{
+				subject: 'A rustic sourdough loaf on a floured board',
+				style: 'photorealistic',
+				pageContext: 'menu item thumbnail',
+			},
+			{ siteContext: 'A neighborhood bakery.', imageGrade: 'warm natural window light' }
+		);
+		expect(
+			prompt.startsWith( 'A rustic sourdough loaf on a floured board. Style: photorealistic' )
+		).toBe( true );
+		expect( prompt ).toContain( 'Art direction for all site imagery: warm natural window light.' );
+		expect( prompt ).toContain( 'Composition: menu item thumbnail. A neighborhood bakery.' );
+		expect( prompt ).toContain( 'never depicted literally' );
+	} );
+
+	it( 'adds the lettering clause only when the subject names a text carrier', () => {
+		const clean = composeImagePrompt( { subject: 'A misty mountain range at dawn' } );
+		expect( clean ).not.toContain( 'unmarked' );
+
+		const carrier = composeImagePrompt( { subject: 'A bakery storefront at dusk' } );
+		expect( carrier ).toContain( 'its face is unmarked' );
+	} );
+
+	it( 'caps prompt length by shedding trailing context, keeping the subject', () => {
+		const longContext = Array( 800 ).fill( 'context' ).join( ' ' );
+		const prompt = composeImagePrompt(
+			{ subject: 'A red canoe on a still lake' },
+			{ siteContext: longContext }
+		);
+		expect( prompt.startsWith( 'A red canoe on a still lake' ) ).toBe( true );
+		expect( prompt.length ).toBeLessThan( longContext.length );
+	} );
+} );
+
+describe( 'fitToTokens', () => {
+	it( 'returns short text unchanged', () => {
+		expect( fitToTokens( 'short prompt', 480 ) ).toBe( 'short prompt' );
+	} );
+} );
+
+describe( 'interpretImageResponse', () => {
+	it( 'classifies 429 and 5xx as transient', () => {
+		expect( () => interpretImageResponse( 'rate limited', 429 ) ).toThrow( TransientImageError );
+		expect( () => interpretImageResponse( 'oops', 503 ) ).toThrow( TransientImageError );
+	} );
+
+	it( 'classifies other non-2xx as permanent', () => {
+		expect( () => interpretImageResponse( 'forbidden', 403 ) ).toThrow( /HTTP 403/ );
+		expect( () => interpretImageResponse( 'forbidden', 403 ) ).not.toThrow( TransientImageError );
+	} );
+
+	it( 'detects safety filtering from finish reasons and block reasons', () => {
+		expect( () =>
+			interpretImageResponse( responseWith( [], { finishReason: 'IMAGE_SAFETY' } ), 200 )
+		).toThrow( ImageFilteredError );
+		expect( () =>
+			interpretImageResponse(
+				JSON.stringify( { promptFeedback: { blockReason: 'PROHIBITED_CONTENT' } } ),
+				200
+			)
+		).toThrow( ImageFilteredError );
+		// Ordinary no-image finish reasons are permanent failures, not filtering.
+		expect( () =>
+			interpretImageResponse( responseWith( [], { finishReason: 'MAX_TOKENS' } ), 200 )
+		).toThrow( /no image data/ );
+	} );
+
+	it( 'extracts JPEG bytes, skipping text and thought parts', () => {
+		const raw = responseWith( [
+			{ text: 'here is your image' },
+			{ thought: true, inlineData: { data: JPEG_BASE64 } },
+			{ inlineData: { data: JPEG_BASE64, mimeType: 'image/jpeg' } },
+		] );
+		const bytes = interpretImageResponse( raw, 200 );
+		expect( bytes[ 0 ] ).toBe( 0xff );
+		expect( bytes[ 1 ] ).toBe( 0xd8 );
+	} );
+
+	it( 'rejects non-JPEG bytes so they are never written under a .jpg name', () => {
+		const pngBase64 = Buffer.from( [ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a ] ).toString( 'base64' );
+		expect( () =>
+			interpretImageResponse( responseWith( [ { inlineData: { data: pngBase64 } } ] ), 200 )
+		).toThrow( /not a JPEG/ );
+	} );
+} );
+
+describe( 'resolveImageFilePath', () => {
+	it( 'accepts .jpg paths inside the sites root', () => {
+		const target = path.join( STUDIO_SITES_ROOT, 'my-site', 'wp-content', 'a.jpg' );
+		expect( resolveImageFilePath( target ) ).toBe( target );
+	} );
+
+	it( 'rejects paths escaping the sites root', () => {
+		expect( () =>
+			resolveImageFilePath( path.join( STUDIO_SITES_ROOT, '..', 'escape.jpg' ) )
+		).toThrow( /inside the Studio sites directory/ );
+	} );
+
+	it( 'rejects non-JPEG extensions', () => {
+		expect( () => resolveImageFilePath( path.join( STUDIO_SITES_ROOT, 'a.png' ) ) ).toThrow(
+			/end in .jpg/
+		);
+	} );
+} );

--- a/apps/cli/ai/tools/generate-images.ts
+++ b/apps/cli/ai/tools/generate-images.ts
@@ -1,0 +1,149 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { Type } from 'typebox';
+import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
+import { emitProgress } from 'cli/logger';
+import {
+	composeImagePrompt,
+	generateImages,
+	IMAGE_ASPECT_RATIOS,
+	IMAGE_STYLES,
+	isImageGenerationAvailable,
+} from '../image-generation';
+import { defineTool } from './define-tool';
+
+const MAX_IMAGES_PER_CALL = 20;
+
+// Exported for tests. Generated files are jailed to the sites root like the
+// pi Write tool, and must be JPEGs — the only format the pipeline delivers.
+export function resolveImageFilePath( filePath: string ): string {
+	const resolved = path.resolve( filePath );
+	if ( resolved !== STUDIO_SITES_ROOT && ! resolved.startsWith( STUDIO_SITES_ROOT + path.sep ) ) {
+		throw new Error(
+			`Image path must be inside the Studio sites directory (${ STUDIO_SITES_ROOT }): ${ filePath }`
+		);
+	}
+	if ( ! /\.jpe?g$/i.test( resolved ) ) {
+		throw new Error( `Image path must end in .jpg: ${ filePath }` );
+	}
+	return resolved;
+}
+
+export const generateImagesTool = defineTool(
+	'generate_images',
+	'Generate AI images (JPEG) from text specs and write them to files inside a site. ' +
+		'Load the `imagery` skill FIRST — it defines how to write subjects and page context, which aspect ratio fits which layout slot, and where generated files go (theme assets vs. media library import). ' +
+		'Batch every image a page or site needs into as few calls as possible; each call accepts up to ' +
+		`${ MAX_IMAGES_PER_CALL } images and generates them concurrently. ` +
+		'Generation takes several seconds per image, so tell the user to wait. ' +
+		'Failures are reported per image: a safety-filtered image should be retried once with a rewritten subject; other failures should lead you to adapt the layout rather than leave a broken image reference.',
+	{
+		images: Type.Array(
+			Type.Object( {
+				path: Type.String( {
+					description:
+						'Absolute file path to write the generated JPEG to. Must be inside the Studio sites directory and end in .jpg.',
+				} ),
+				subject: Type.String( {
+					description:
+						'What the image shows and from what point of view (composition, framing, vantage, mood). 1-3 sentences. Never ask for rendered text, and never restate the site-wide imageGrade here.',
+				} ),
+				pageContext: Type.Optional(
+					Type.String( {
+						description:
+							'Where and how the image is used, in pictorial slot language (e.g. "full-frame editorial photograph with the left third kept as open, low-detail negative space"). Steers mood and composition; it is not drawn. Write in English.',
+					} )
+				),
+				style: Type.Optional(
+					Type.Enum( Object.fromEntries( IMAGE_STYLES.map( ( style ) => [ style, style ] ) ), {
+						description: 'Rendering style. Defaults to photorealistic.',
+					} )
+				),
+				aspectRatio: Type.Optional(
+					Type.Enum(
+						Object.fromEntries( IMAGE_ASPECT_RATIOS.map( ( ratio ) => [ ratio, ratio ] ) ),
+						{
+							description:
+								'Canvas shape, matched to the layout slot (see the imagery skill). Defaults to landscape.',
+						}
+					)
+				),
+			} ),
+			{ minItems: 1, maxItems: MAX_IMAGES_PER_CALL }
+		),
+		siteContext: Type.Optional(
+			Type.String( {
+				description:
+					"One sentence of subject matter steering shared by all images (e.g. 'A neighborhood bakery selling sourdough and pastries.'). NEVER include the site or business name — a name in the prompt is what painted-in fake wordmarks stand in for.",
+			} )
+		),
+		imageGrade: Type.Optional(
+			Type.String( {
+				description:
+					'One site-wide photographic treatment applied to every image so they read as one series (e.g. "warm natural window light, soft muted color"). Keep it identical across calls for the same site.',
+			} )
+		),
+	},
+	async ( args ) => {
+		if ( ! isImageGenerationAvailable() ) {
+			throw new Error(
+				'Image generation is not available in this session. Build the site without generated imagery.'
+			);
+		}
+
+		const targets = args.images.map( ( image ) => ( {
+			...image,
+			resolvedPath: resolveImageFilePath( image.path ),
+		} ) );
+
+		emitProgress( `Generating ${ targets.length } image${ targets.length === 1 ? '' : 's' }…` );
+
+		const requests = targets.map( ( image ) => ( {
+			prompt: composeImagePrompt( image, {
+				siteContext: args.siteContext,
+				imageGrade: args.imageGrade,
+			} ),
+			aspectRatio: image.aspectRatio,
+		} ) );
+
+		const lines: string[] = new Array( targets.length );
+		let generated = 0;
+		const results = await generateImages( requests, ( _index, result ) => {
+			if ( result.ok ) {
+				generated++;
+				emitProgress( `Generated ${ generated }/${ targets.length } images` );
+			}
+		} );
+
+		await Promise.all(
+			results.map( async ( result, index ) => {
+				const target = targets[ index ];
+				if ( ! result.ok || ! result.bytes ) {
+					const hint = result.filtered
+						? ' (safety filter — rewrite the subject to avoid the sensitive element and call generate_images again for this image)'
+						: '';
+					lines[ index ] = `FAILED ${ target.path }: ${ result.error }${ hint }`;
+					return;
+				}
+				await fs.mkdir( path.dirname( target.resolvedPath ), { recursive: true } );
+				await fs.writeFile( target.resolvedPath, result.bytes );
+				lines[ index ] = `OK ${ target.path } (${ Math.round( result.bytes.length / 1024 ) } KB)`;
+			} )
+		);
+
+		const failures = results.filter( ( result ) => ! result.ok ).length;
+		if ( failures === targets.length ) {
+			throw new Error(
+				`All ${ targets.length } image generations failed:\n${ lines.join( '\n' ) }`
+			);
+		}
+
+		const summary =
+			failures === 0
+				? `Generated ${ targets.length } image${ targets.length === 1 ? '' : 's' }:`
+				: `Generated ${ targets.length - failures } of ${
+						targets.length
+				  } images (${ failures } failed):`;
+		return { content: [ { type: 'text', text: [ summary, ...lines ].join( '\n' ) } ] };
+	}
+);

--- a/apps/cli/ai/tools/generate-images.ts
+++ b/apps/cli/ai/tools/generate-images.ts
@@ -85,7 +85,7 @@ export const generateImagesTool = defineTool(
 		),
 	},
 	async ( args ) => {
-		if ( ! isImageGenerationAvailable() ) {
+		if ( ! ( await isImageGenerationAvailable() ) ) {
 			throw new Error(
 				'Image generation is not available in this session. Build the site without generated imagery.'
 			);

--- a/apps/cli/ai/tools/index.ts
+++ b/apps/cli/ai/tools/index.ts
@@ -1,5 +1,4 @@
 import { emitChatArtifactWidgets } from 'cli/ai/chat-artifacts';
-import { isImageGenerationAvailable } from '../image-generation';
 import { createPreviewTool } from './create-preview';
 import { createSiteTool } from './create-site';
 import { dataLiberationTool } from './data-liberation';
@@ -76,8 +75,8 @@ export interface CreateStudioToolsOptions {
 	// by `STUDIO_REMOTE_SESSION=1`. Direct `studio code` invocations leave
 	// this off because the image would have nowhere to go.
 	remoteSession?: boolean;
-	// Enable generate_images. Defaults to isImageGenerationAvailable(), so a
-	// session without image-generation auth behaves exactly as before the tool
+	// Enable generate_images. Callers resolve isImageGenerationAvailable()
+	// (async) and pass it; when off, sessions behave exactly as before the tool
 	// existed (no tool, no imagery prompt sections).
 	imageGeneration?: boolean;
 }
@@ -90,8 +89,6 @@ export function resolveStudioToolDefinitions(
 			? [ ...studioToolDefinitions, studioPresentTool ]
 			: studioToolDefinitions;
 
-	const imageGeneration = options.imageGeneration ?? isImageGenerationAvailable();
-
 	return definitions.flatMap( ( candidate ) => {
 		if ( candidate.name === shareScreenshotTool.name && ! options.remoteSession ) {
 			return [];
@@ -102,7 +99,7 @@ export function resolveStudioToolDefinitions(
 		if ( candidate.name === refreshBrowserTool.name && options.emitChatArtifacts !== true ) {
 			return [];
 		}
-		if ( candidate.name === generateImagesTool.name && ! imageGeneration ) {
+		if ( candidate.name === generateImagesTool.name && ! options.imageGeneration ) {
 			return [];
 		}
 		return [ withChatArtifactEmission( candidate, options.emitChatArtifacts === true ) ];

--- a/apps/cli/ai/tools/index.ts
+++ b/apps/cli/ai/tools/index.ts
@@ -1,10 +1,12 @@
 import { emitChatArtifactWidgets } from 'cli/ai/chat-artifacts';
+import { isImageGenerationAvailable } from '../image-generation';
 import { createPreviewTool } from './create-preview';
 import { createSiteTool } from './create-site';
 import { dataLiberationTool } from './data-liberation';
 import { deletePreviewTool } from './delete-preview';
 import { deleteSiteTool } from './delete-site';
 import { exportSiteTool } from './export-site';
+import { generateImagesTool } from './generate-images';
 import { importSiteTool } from './import-site';
 import { inspectDesignTool } from './inspect-design';
 import { installTaxonomyScriptsTool } from './install-taxonomy-scripts';
@@ -49,6 +51,7 @@ export const studioToolDefinitions: AnyStudioAgentTool[] = [
 	validateBlocksTool,
 	takeScreenshotTool,
 	inspectDesignTool,
+	generateImagesTool,
 	shareScreenshotTool,
 	installTaxonomyScriptsTool,
 	dataLiberationTool,
@@ -73,6 +76,10 @@ export interface CreateStudioToolsOptions {
 	// by `STUDIO_REMOTE_SESSION=1`. Direct `studio code` invocations leave
 	// this off because the image would have nowhere to go.
 	remoteSession?: boolean;
+	// Enable generate_images. Defaults to isImageGenerationAvailable(), so a
+	// session without image-generation auth behaves exactly as before the tool
+	// existed (no tool, no imagery prompt sections).
+	imageGeneration?: boolean;
 }
 
 export function resolveStudioToolDefinitions(
@@ -83,6 +90,8 @@ export function resolveStudioToolDefinitions(
 			? [ ...studioToolDefinitions, studioPresentTool ]
 			: studioToolDefinitions;
 
+	const imageGeneration = options.imageGeneration ?? isImageGenerationAvailable();
+
 	return definitions.flatMap( ( candidate ) => {
 		if ( candidate.name === shareScreenshotTool.name && ! options.remoteSession ) {
 			return [];
@@ -91,6 +100,9 @@ export function resolveStudioToolDefinitions(
 		// is attached to consume the preview.reload event; emitChatArtifacts is
 		// the existing "UI attached" signal (process.send available).
 		if ( candidate.name === refreshBrowserTool.name && options.emitChatArtifacts !== true ) {
+			return [];
+		}
+		if ( candidate.name === generateImagesTool.name && ! imageGeneration ) {
 			return [];
 		}
 		return [ withChatArtifactEmission( candidate, options.emitChatArtifacts === true ) ];

--- a/packages/common/ai/tools.ts
+++ b/packages/common/ai/tools.ts
@@ -315,6 +315,7 @@ export function getToolDisplayName( name: string, input?: Record< string, unknow
 		validate_blocks: __( 'Validate blocks' ),
 		take_screenshot: __( 'Take screenshot' ),
 		share_screenshot: __( 'Share screenshot' ),
+		generate_images: __( 'Generate images' ),
 		open_annotation_browser: __( 'Open annotation browser' ),
 		wait_for_annotations: __( 'Wait for annotations' ),
 		need_for_speed: __( 'Audit performance' ),
@@ -442,6 +443,10 @@ export function getToolDetail( name: string, input?: Record< string, unknown > )
 		case 'share_screenshot':
 		case 'open_annotation_browser':
 			return typeof input.url === 'string' ? input.url : '';
+		case 'generate_images': {
+			const count = Array.isArray( input.images ) ? input.images.length : 0;
+			return count > 0 ? sprintf( _n( '%d image', '%d images', count ), count ) : '';
+		}
 		case 'Read':
 		case 'Write':
 		case 'Edit': {


### PR DESCRIPTION
## Related issues

<!-- No tracked issue; feature discussed and specified in a Studio Code working session. -->

## How AI was used in this PR

Built end-to-end with Claude Code (Fable 5): it researched the image subsystem in `Automattic/minimalistic-site-builder`, ported the pattern to TypeScript, wrote the skill and tests, and verified the flow live against the WP.com AI proxy (including a real generation through the built CLI). Code reviewed and directed by @youknowriad.

## Proposed Changes

Studio Code can now generate real AI imagery while building sites, instead of leaving placeholders or curling arbitrary web URLs (previously the only recipe, and the slowest, least reliable part of a build).

- New `generate_images` tool: batch text-to-image generation (JPEG) through the WP.com AI proxy's Google Vertex Gemini route, using the new `studio-image` feature slug with the user's WordPress.com OAuth token. Wide ratios (heroes/banners) render at 2K, contained slots at 1K.
- New `imagery` skill guiding the agent: how to write subjects and page context that avoid the classic failure modes of image models (garbled fake text, mismatched grades between sibling images), which aspect ratio fits which layout slot, and where files go — theme-generic imagery into the theme's `assets/`, site-specific content imported into the media library.
- The prompt engineering is ported from `minimalistic-site-builder`'s image subsystem (site-wide photographic grade, pictorial-only context framing, conditional lettering guard), so both products speak the same conventions.
- Safety-filtered prompts are reported back to the agent with a rewrite-and-retry hint; permanent failures instruct the agent to adapt the layout rather than substitute unrelated images or leave broken references.
- Availability gating: the capability requires a WP.com login (or `STUDIO_IMAGE_API_TOKEN` override). Sessions without it — e.g. BYO Anthropic key without a login — get byte-identical behavior to today: no tool, no imagery prompt sections.
- Cost: measured against the AI-credit quota at ~$0.067 per 1K image and ~$0.10 per 2K image (~$0.70–$1.30 for a typical site build). No new metering code — the proxy meters the `studio-image` slug server-side.

## Testing Instructions

1. `npm run cli:build && node apps/cli/dist/cli/main.mjs code` (logged in via `studio auth login`).
2. Ask for a site build with photos (e.g. "build a site for a bakery with photos of the products").
3. The agent should load the `imagery` skill, call `generate_images` (shown as "Generate images · N images"), and produce pages whose imagery renders correctly — check heroes keep overlaid text legible and generated images contain no fake text.
4. Gating: log out (or use a BYO Anthropic key without login) and confirm `generate_images` is absent and builds behave exactly as on trunk.
5. Unit tests: `npm test -- apps/cli/ai/tests/image-generation.test.ts`.

Note for reviewers: verified end-to-end against a WP.com sandbox where the `studio-image` slug is live; worth one re-check once the proxy change ships to production. Evals: the existing suite is unaffected (with the feature unavailable the prompt and tool list are unchanged); an imagery eval case is a follow-up once the slug is in production.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
