### PR TITLE
CLI: Bound the stored static import receipt

### DIFF
--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -503,7 +503,7 @@ function static_site_importer_studio_record_failure( $result, string $fallback, 
 			'continuation'  => false,
 			'failed'        => true,
 			'failure'       => $projection,
-			'import_receipt' => $result,
+			'import_receipt' => static_site_importer_studio_result_projection( $result ),
 		)
 	);
 	throw new RuntimeException( static_site_importer_studio_failure_message( $result, $fallback ) );
@@ -633,7 +633,7 @@ $studio_result = array(
 	'status'                    => (string) ( $import_result['url_batch_run']['status'] ?? $import_result['status'] ?? 'completed' ),
 	'completed_routes'          => (int) ( $import_result['url_batch_run']['completed_routes'] ?? count( $canonical_documents ) ),
 	'total_routes'              => (int) ( $import_result['url_batch_run']['total_routes'] ?? count( $canonical_documents ) ),
-	'import_receipt'            => $result,
+	'import_receipt'            => static_site_importer_studio_result_projection( $result ),
 );
 static_site_importer_studio_write_result( $studio_result );
 ?>`

--- a/apps/cli/commands/site/tests/create.test.ts
+++ b/apps/cli/commands/site/tests/create.test.ts
@@ -821,7 +821,28 @@ describe( 'CLI: studio create', () => {
 				"$projection['diagnostics'] = static_site_importer_studio_bounded_value( $result['diagnostics'] );"
 			);
 			expect( blueprint.staticSiteImport.code ).toContain( "'failure'       => $projection" );
-			expect( blueprint.staticSiteImport.code ).toContain( "'import_receipt' => $result" );
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"'import_receipt' => static_site_importer_studio_result_projection( $result )"
+			);
+			expect( blueprint.staticSiteImport.code ).not.toContain( "'import_receipt' => $result" );
+		} );
+
+		it( 'should bound the stored import receipt so oversized importer responses cannot break the handoff', () => {
+			const sourceDir = fs.mkdtempSync( path.join( '/tmp', 'studio-source-test-' ) );
+			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main></main>' );
+
+			const blueprint = buildCreateFromSourceBlueprint(
+				sourceDir,
+				'Imported Directory',
+				'https://example.com/static-site-importer.zip'
+			);
+
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"'import_receipt'            => static_site_importer_studio_result_projection( $result )"
+			);
+			expect( blueprint.staticSiteImport.code ).not.toContain(
+				"'import_receipt'            => $result"
+			);
 		} );
 
 		it( 'should atomically write a bounded receipt for generic failed imports', () => {
@@ -959,7 +980,7 @@ describe( 'CLI: studio create', () => {
 				'static_site_importer_studio_write_result( $studio_result )'
 			);
 			expect( blueprint.staticSiteImport.code ).toContain(
-				"'import_receipt'            => $result"
+				"'import_receipt'            => static_site_importer_studio_result_projection( $result )"
 			);
 			expect( blueprint.staticSiteImport.code ).toContain(
 				"'completed_routes'          => (int) ( $import_result['url_batch_run']['completed_routes'] ?? count( $canonical_documents ) )"


### PR DESCRIPTION
## What

The generated `.studio-import/import.php` now stores the bounded result projection as `import_receipt` in `result.json`, on both the success and the failure path. It used to store Static Site Importer's full response.

## Why

On a 28-page Wix artifact, SSI's import response was 3.04 GB (`import_report` 2.72 GB, `materialization_receipt` 325 MB). macOS `write(2)` rejects a single write of 2 GB or more, so `file_put_contents` returned false and the import failed with "Static Site Importer result receipt could not be saved" after every page and the theme had already been materialized. Node could not have parsed a receipt that size either.

The CLI reads only `continuation`, `canonicalization_pending`, `completed_routes`, and `total_routes` from the receipt, and the database option already stores the same bounded projection.

With this change the same import completes, canonicalizes 32 pages, and writes a 124 KB receipt. The oversized SSI response itself is reported separately in the static-site-importer repo.

## How to test

- `npx vitest run apps/cli/commands/site/tests/create.test.ts`
- `studio create --from <artifact dir or url>` on a large site and confirm `.studio-import/result.json` stays small and the import finishes.

Part of the `studio create --from` work in #3952.

AI assistance: Claude Code (Claude Fable 5) traced the failed write to the 2 GB limit and drafted the change. Aagam Shah directed the work and is responsible for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
