### PR TITLE
Improve AI credit balance meter

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
@@ -57,9 +57,10 @@ describe( 'AiCreditsControl', () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: {
 				costUsage: 0,
-				costCap: 0,
+				costCap: 1_000_000,
 				allowanceRemaining: 960000,
 				purchasedRemaining: 150000,
+				purchasedAtTopUp: 200_000,
 			},
 		} as never );
 	} );
@@ -107,13 +108,14 @@ describe( 'AiCreditsControl', () => {
 		expect( screen.getByText( '1,110,000 remaining' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows the plenty state from the combined balance, regardless of the legacy quota usage', () => {
+	it( 'resets the ring to the purchased pool once the allowance is spent', () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: {
 				costUsage: 100,
-				costCap: 100,
+				costCap: 1_000_000,
 				allowanceRemaining: 0,
 				purchasedRemaining: 150000,
+				purchasedAtTopUp: 200_000,
 			},
 		} as never );
 
@@ -123,19 +125,22 @@ describe( 'AiCreditsControl', () => {
 		expect( ring ).toBeInTheDocument();
 		expect( ring ).not.toHaveAttribute( 'data-caution' );
 		expect( ring ).not.toHaveAttribute( 'data-exhausted' );
+		// The spent allowance drops out of the meter: 50,000 of 200,000
+		// purchased credits used, same as the Settings → Usage bar.
 		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
 			'stroke-dashoffset',
-			'40'
+			'75'
 		);
 	} );
 
-	it( 'shows the low state when the combined balance reaches 100,000 credits', () => {
+	it( 'shows the low state when at least 80% of the metered credits are used', () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: {
 				costUsage: 0,
-				costCap: 0,
+				costCap: 1_000_000,
 				allowanceRemaining: 70000,
 				purchasedRemaining: 30000,
+				purchasedAtTopUp: 100_000,
 			},
 		} as never );
 
@@ -144,18 +149,19 @@ describe( 'AiCreditsControl', () => {
 
 		expect( ring ).toHaveAttribute( 'data-caution', 'true' );
 		expect( ring ).not.toHaveAttribute( 'data-exhausted' );
+		// 1,000,000 of 1,100,000 used → 91% fill.
 		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
 			'stroke-dashoffset',
-			'30'
+			'9'
 		);
 	} );
 
-	it( 'keeps the plenty state above the low-credit boundary', () => {
+	it( 'keeps the plenty state below 80% usage', () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: {
 				costUsage: 0,
-				costCap: 0,
-				allowanceRemaining: 100001,
+				costCap: 1_000_000,
+				allowanceRemaining: 200001,
 				purchasedRemaining: 0,
 			},
 		} as never );
@@ -166,22 +172,17 @@ describe( 'AiCreditsControl', () => {
 	} );
 
 	it.each( [
-		[ 1_000_001, '100' ],
-		[ 1_000_000, '90' ],
-		[ 750_000, '80' ],
-		[ 500_000, '70' ],
-		[ 375_000, '60' ],
-		[ 250_000, '50' ],
-		[ 175_000, '40' ],
-		[ 100_000, '30' ],
-		[ 75_000, '20' ],
-		[ 50_000, '10' ],
+		[ 1_000_000, '100' ],
+		[ 750_000, '75' ],
+		[ 500_000, '50' ],
+		[ 250_000, '25' ],
+		[ 100_000, '10' ],
 		[ 0, '0' ],
-	] )( 'shows the expected ring step at %i remaining credits', ( remaining, dashOffset ) => {
+	] )( 'draws the used fraction of the ring at %i remaining credits', ( remaining, dashOffset ) => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: {
 				costUsage: 0,
-				costCap: 0,
+				costCap: 1_000_000,
 				allowanceRemaining: remaining,
 				purchasedRemaining: 0,
 			},
@@ -192,6 +193,27 @@ describe( 'AiCreditsControl', () => {
 		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
 			'stroke-dashoffset',
 			dashOffset
+		);
+	} );
+
+	it( 'falls back to the low-balance threshold when no denominator is measurable', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 0,
+				allowanceRemaining: 50000,
+			},
+		} as never );
+
+		const { container } = renderControl();
+		const ring = container.querySelector( 'svg' );
+
+		expect( ring ).toHaveAttribute( 'data-caution', 'true' );
+		expect( ring ).not.toHaveAttribute( 'data-exhausted' );
+		// No exact fraction without a denominator — the arc stays empty.
+		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
+			'stroke-dashoffset',
+			'100'
 		);
 	} );
 

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
@@ -107,6 +107,25 @@ describe( 'AiCreditsControl', () => {
 		expect( screen.getByText( '1,110,000 remaining' ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders the circular usage chart from the current quota', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 25,
+				costCap: 100,
+				allowanceRemaining: 960000,
+				purchasedRemaining: 150000,
+			},
+		} as never );
+
+		const { container } = renderControl();
+
+		expect( container.querySelector( 'svg' ) ).toBeInTheDocument();
+		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
+			'stroke-dashoffset',
+			'75'
+		);
+	} );
+
 	it( 'shows the summed balance even when both pools are exhausted', async () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: { costUsage: 0, costCap: 0, allowanceRemaining: 0, purchasedRemaining: 0 },
@@ -116,7 +135,50 @@ describe( 'AiCreditsControl', () => {
 
 		await openMenu();
 
-		expect( screen.getByText( '0 remaining' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'No AI credits remaining' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows a zero-state message at 100% usage', async () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: { costUsage: 100, costCap: 100, allowanceRemaining: 0, purchasedRemaining: 0 },
+		} as never );
+		const { container } = renderControl();
+
+		await openMenu();
+
+		expect( screen.getByText( 'No AI credits remaining' ) ).toBeInTheDocument();
+		expect( container.querySelector( 'svg' ) ).toHaveAttribute( 'data-exhausted', 'true' );
+		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
+			'stroke-dashoffset',
+			'0'
+		);
+	} );
+
+	it( 'shows a compact balance in the tooltip', async () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 25,
+				costCap: 100,
+				allowanceRemaining: 800000,
+				purchasedRemaining: 32500,
+			},
+		} as never );
+		renderControl();
+
+		fireEvent.mouseEnter( screen.getByRole( 'button', { name: 'AI credits' } ) );
+
+		expect( await screen.findByText( 'AI credits · 832.5K remaining' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows an out-of-credits tooltip at 100% usage', async () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: { costUsage: 100, costCap: 100, allowanceRemaining: 0, purchasedRemaining: 0 },
+		} as never );
+		renderControl();
+
+		fireEvent.mouseEnter( screen.getByRole( 'button', { name: 'AI credits' } ) );
+
+		expect( await screen.findByText( 'AI credits · Out of credits' ) ).toBeInTheDocument();
 	} );
 
 	it( 'opens the WordPress.com checkout from the add-credits item', async () => {

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
@@ -123,8 +123,7 @@ describe( 'AiCreditsControl', () => {
 		const ring = container.querySelector( 'svg' );
 
 		expect( ring ).toBeInTheDocument();
-		expect( ring ).not.toHaveAttribute( 'data-caution' );
-		expect( ring ).not.toHaveAttribute( 'data-exhausted' );
+		expect( ring ).not.toHaveAttribute( 'data-intent' );
 		// The spent allowance drops out of the meter: 50,000 of 200,000
 		// purchased credits used, same as the Settings → Usage bar.
 		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
@@ -133,7 +132,24 @@ describe( 'AiCreditsControl', () => {
 		);
 	} );
 
-	it( 'shows the low state when at least 80% of the metered credits are used', () => {
+	it( 'escalates to the warning intent at 80% of the metered credits used', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 1_000_000,
+				allowanceRemaining: 150000,
+				purchasedRemaining: 30000,
+				purchasedAtTopUp: 100_000,
+			},
+		} as never );
+
+		const { container } = renderControl();
+
+		// 920,000 of 1,100,000 used → ~84%.
+		expect( container.querySelector( 'svg' ) ).toHaveAttribute( 'data-intent', 'warning' );
+	} );
+
+	it( 'escalates to the critical intent at 90% of the metered credits used', () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: {
 				costUsage: 0,
@@ -145,10 +161,8 @@ describe( 'AiCreditsControl', () => {
 		} as never );
 
 		const { container } = renderControl();
-		const ring = container.querySelector( 'svg' );
 
-		expect( ring ).toHaveAttribute( 'data-caution', 'true' );
-		expect( ring ).not.toHaveAttribute( 'data-exhausted' );
+		expect( container.querySelector( 'svg' ) ).toHaveAttribute( 'data-intent', 'critical' );
 		// 1,000,000 of 1,100,000 used → 91% fill.
 		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
 			'stroke-dashoffset',
@@ -156,7 +170,7 @@ describe( 'AiCreditsControl', () => {
 		);
 	} );
 
-	it( 'keeps the plenty state below 80% usage', () => {
+	it( 'keeps the plain ring below 80% usage', () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: {
 				costUsage: 0,
@@ -168,7 +182,7 @@ describe( 'AiCreditsControl', () => {
 
 		const { container } = renderControl();
 
-		expect( container.querySelector( 'svg' ) ).not.toHaveAttribute( 'data-caution' );
+		expect( container.querySelector( 'svg' ) ).not.toHaveAttribute( 'data-intent' );
 	} );
 
 	it.each( [
@@ -196,7 +210,7 @@ describe( 'AiCreditsControl', () => {
 		);
 	} );
 
-	it( 'falls back to the low-balance threshold when no denominator is measurable', () => {
+	it( 'renders a plain empty ring when no denominator is measurable', () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: {
 				costUsage: 0,
@@ -206,11 +220,10 @@ describe( 'AiCreditsControl', () => {
 		} as never );
 
 		const { container } = renderControl();
-		const ring = container.querySelector( 'svg' );
 
-		expect( ring ).toHaveAttribute( 'data-caution', 'true' );
-		expect( ring ).not.toHaveAttribute( 'data-exhausted' );
-		// No exact fraction without a denominator — the arc stays empty.
+		// No fraction to escalate on — no intent color, and the arc stays
+		// empty; the tooltip still carries the remaining figure.
+		expect( container.querySelector( 'svg' ) ).not.toHaveAttribute( 'data-intent' );
 		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
 			'stroke-dashoffset',
 			'100'
@@ -238,7 +251,7 @@ describe( 'AiCreditsControl', () => {
 		await openMenu();
 
 		expect( screen.getByText( 'No AI credits remaining' ) ).toBeInTheDocument();
-		expect( container.querySelector( 'svg' ) ).toHaveAttribute( 'data-exhausted', 'true' );
+		expect( container.querySelector( 'svg' ) ).toHaveAttribute( 'data-intent', 'exhausted' );
 		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
 			'stroke-dashoffset',
 			'0'

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.test.tsx
@@ -107,22 +107,91 @@ describe( 'AiCreditsControl', () => {
 		expect( screen.getByText( '1,110,000 remaining' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the circular usage chart from the current quota', () => {
+	it( 'shows the plenty state from the combined balance, regardless of the legacy quota usage', () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: {
-				costUsage: 25,
+				costUsage: 100,
 				costCap: 100,
-				allowanceRemaining: 960000,
+				allowanceRemaining: 0,
 				purchasedRemaining: 150000,
 			},
 		} as never );
 
 		const { container } = renderControl();
+		const ring = container.querySelector( 'svg' );
 
-		expect( container.querySelector( 'svg' ) ).toBeInTheDocument();
+		expect( ring ).toBeInTheDocument();
+		expect( ring ).not.toHaveAttribute( 'data-caution' );
+		expect( ring ).not.toHaveAttribute( 'data-exhausted' );
 		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
 			'stroke-dashoffset',
-			'75'
+			'40'
+		);
+	} );
+
+	it( 'shows the low state when the combined balance reaches 100,000 credits', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 0,
+				allowanceRemaining: 70000,
+				purchasedRemaining: 30000,
+			},
+		} as never );
+
+		const { container } = renderControl();
+		const ring = container.querySelector( 'svg' );
+
+		expect( ring ).toHaveAttribute( 'data-caution', 'true' );
+		expect( ring ).not.toHaveAttribute( 'data-exhausted' );
+		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
+			'stroke-dashoffset',
+			'30'
+		);
+	} );
+
+	it( 'keeps the plenty state above the low-credit boundary', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 0,
+				allowanceRemaining: 100001,
+				purchasedRemaining: 0,
+			},
+		} as never );
+
+		const { container } = renderControl();
+
+		expect( container.querySelector( 'svg' ) ).not.toHaveAttribute( 'data-caution' );
+	} );
+
+	it.each( [
+		[ 1_000_001, '100' ],
+		[ 1_000_000, '90' ],
+		[ 750_000, '80' ],
+		[ 500_000, '70' ],
+		[ 375_000, '60' ],
+		[ 250_000, '50' ],
+		[ 175_000, '40' ],
+		[ 100_000, '30' ],
+		[ 75_000, '20' ],
+		[ 50_000, '10' ],
+		[ 0, '0' ],
+	] )( 'shows the expected ring step at %i remaining credits', ( remaining, dashOffset ) => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 0,
+				allowanceRemaining: remaining,
+				purchasedRemaining: 0,
+			},
+		} as never );
+
+		const { container } = renderControl();
+
+		expect( container.querySelector( 'circle:last-child' ) ).toHaveAttribute(
+			'stroke-dashoffset',
+			dashOffset
 		);
 	} );
 
@@ -138,7 +207,7 @@ describe( 'AiCreditsControl', () => {
 		expect( screen.getByText( 'No AI credits remaining' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows a zero-state message at 100% usage', async () => {
+	it( 'shows the out state when the combined balance is empty', async () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: { costUsage: 100, costCap: 100, allowanceRemaining: 0, purchasedRemaining: 0 },
 		} as never );
@@ -170,7 +239,7 @@ describe( 'AiCreditsControl', () => {
 		expect( await screen.findByText( 'AI credits · 832.5K remaining' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows an out-of-credits tooltip at 100% usage', async () => {
+	it( 'shows an out-of-credits tooltip when the combined balance is empty', async () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: { costUsage: 100, costCap: 100, allowanceRemaining: 0, purchasedRemaining: 0 },
 		} as never );

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
@@ -2,8 +2,7 @@ import { getStudioCodeAiAccessState } from '@studio/common/lib/studio-assistant-
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
-import { chartBar } from '@wordpress/icons';
-import { Icon, Tooltip } from '@wordpress/ui';
+import { Tooltip } from '@wordpress/ui';
 import { useState } from 'react';
 import { AiCreditsDetailsDialog } from '@/components/ai-credits-details-dialog';
 import { AiCreditsPurchaseDialog } from '@/components/ai-credits-purchase-dialog';
@@ -17,6 +16,41 @@ import { useStudioAssistantTopUpPricing } from '@/data/queries/use-top-up-pricin
 import { useUserLocale } from '@/data/queries/use-user-locale';
 import { useAddAiCreditsUrl } from '@/hooks/use-add-ai-credits-url';
 import styles from './style.module.css';
+
+function AiCreditsRing( { usedFraction }: { usedFraction: number } ) {
+	const usedPercentage = Math.max( 0, Math.min( 1, usedFraction ) ) * 100;
+	const isCaution = usedPercentage >= 80 && usedPercentage < 90;
+	const isWarning = usedPercentage >= 90;
+	const isExhausted = usedPercentage >= 100;
+
+	return (
+		<svg
+			className={ styles.aiCreditsRing }
+			viewBox="0 0 24 24"
+			width="20"
+			height="20"
+			fill="none"
+			aria-hidden="true"
+			data-caution={ isCaution || undefined }
+			data-warning={ isWarning || undefined }
+			data-exhausted={ isExhausted || undefined }
+		>
+			<circle className={ styles.aiCreditsRingTrack } cx="12" cy="12" r="8" strokeWidth="2" />
+			<circle
+				className={ styles.aiCreditsRingValue }
+				cx="12"
+				cy="12"
+				r="8"
+				pathLength="100"
+				strokeWidth="2"
+				strokeDasharray="100"
+				strokeDashoffset={ 100 - usedPercentage }
+				strokeLinecap="round"
+				transform="rotate(-90 12 12)"
+			/>
+		</svg>
+	);
+}
 
 export function AiCreditsControl() {
 	const connector = useConnector();
@@ -45,7 +79,28 @@ export function AiCreditsControl() {
 
 	const hasTopUpOptions = ( pricing?.options.length ?? 0 ) > 0;
 	const remaining = ( quota.allowanceRemaining ?? 0 ) + ( quota.purchasedRemaining ?? 0 );
+	const usedFraction = quota.costCap > 0 ? quota.costUsage / quota.costCap : 0;
 	const formattedRemaining = new Intl.NumberFormat( locale ).format( remaining );
+	const compactRemaining = new Intl.NumberFormat( locale, {
+		notation: 'compact',
+		maximumFractionDigits: 1,
+	} ).format( remaining );
+	const remainingLabel =
+		remaining === 0
+			? __( 'No AI credits remaining' )
+			: sprintf(
+					/* translators: %s: total number of AI credits remaining (e.g. 1,110,000). */
+					__( '%s remaining' ),
+					formattedRemaining
+			  );
+	const tooltipLabel =
+		remaining === 0
+			? __( 'AI credits · Out of credits' )
+			: sprintf(
+					/* translators: %s: compact number of AI credits remaining (e.g. 200K or 1.5M). */
+					__( 'AI credits · %s remaining' ),
+					compactRemaining
+			  );
 
 	return (
 		<>
@@ -73,28 +128,21 @@ export function AiCreditsControl() {
 									/>
 								}
 							>
-								<Icon icon={ chartBar } size={ 16 } />
+								<AiCreditsRing usedFraction={ usedFraction } />
 							</Tooltip.Trigger>
 						}
 					/>
 					<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" /> }>
-						{ sprintf(
-							/* translators: %s: total number of AI credits remaining (e.g. 1,110,000). */
-							__( 'AI credits · %s remaining' ),
-							formattedRemaining
-						) }
+						{ tooltipLabel }
 					</Tooltip.Popup>
 				</Tooltip.Root>
 				<Menu.Popup side="top" align="end">
-					<div className={ styles.aiCreditsSummary }>
+					<div
+						className={ styles.aiCreditsSummary }
+						data-exhausted={ remaining === 0 || undefined }
+					>
 						<span>{ __( 'AI credits' ) }</span>
-						<strong>
-							{ sprintf(
-								/* translators: %s: total number of AI credits remaining (e.g. 1,110,000). */
-								__( '%s remaining' ),
-								formattedRemaining
-							) }
-						</strong>
+						<strong>{ remainingLabel }</strong>
 					</div>
 					<Menu.Separator />
 					<Menu.Item

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
@@ -17,11 +17,41 @@ import { useUserLocale } from '@/data/queries/use-user-locale';
 import { useAddAiCreditsUrl } from '@/hooks/use-add-ai-credits-url';
 import styles from './style.module.css';
 
-function AiCreditsRing( { usedFraction }: { usedFraction: number } ) {
-	const usedPercentage = Math.max( 0, Math.min( 1, usedFraction ) ) * 100;
-	const isCaution = usedPercentage >= 80 && usedPercentage < 90;
-	const isWarning = usedPercentage >= 90;
-	const isExhausted = usedPercentage >= 100;
+const LOW_AI_CREDITS_THRESHOLD = 100_000;
+
+type AiCreditsStatus = 'plenty' | 'low' | 'out';
+
+// The API exposes the combined remaining balance, but not the original total
+// of purchased credits. The ring therefore uses discrete low-balance states
+// rather than presenting its arc as an exact usage percentage.
+const AI_CREDITS_RING_STEPS = [
+	{ maximum: 50_000, fillPercentage: 90 },
+	{ maximum: 75_000, fillPercentage: 80 },
+	{ maximum: 100_000, fillPercentage: 70 },
+	{ maximum: 175_000, fillPercentage: 60 },
+	{ maximum: 250_000, fillPercentage: 50 },
+	{ maximum: 375_000, fillPercentage: 40 },
+	{ maximum: 500_000, fillPercentage: 30 },
+	{ maximum: 750_000, fillPercentage: 20 },
+	{ maximum: 1_000_000, fillPercentage: 10 },
+] as const;
+
+function getAiCreditsStatus( remaining: number ): AiCreditsStatus {
+	if ( remaining === 0 ) {
+		return 'out';
+	}
+	return remaining <= LOW_AI_CREDITS_THRESHOLD ? 'low' : 'plenty';
+}
+
+function getAiCreditsRingPercentage( remaining: number ): number {
+	if ( remaining === 0 ) {
+		return 100;
+	}
+	return AI_CREDITS_RING_STEPS.find( ( step ) => remaining <= step.maximum )?.fillPercentage ?? 0;
+}
+
+function AiCreditsRing( { remaining, status }: { remaining: number; status: AiCreditsStatus } ) {
+	const fillPercentage = getAiCreditsRingPercentage( remaining );
 
 	return (
 		<svg
@@ -31,9 +61,8 @@ function AiCreditsRing( { usedFraction }: { usedFraction: number } ) {
 			height="20"
 			fill="none"
 			aria-hidden="true"
-			data-caution={ isCaution || undefined }
-			data-warning={ isWarning || undefined }
-			data-exhausted={ isExhausted || undefined }
+			data-caution={ status === 'low' || undefined }
+			data-exhausted={ status === 'out' || undefined }
 		>
 			<circle className={ styles.aiCreditsRingTrack } cx="12" cy="12" r="8" strokeWidth="2" />
 			<circle
@@ -44,7 +73,7 @@ function AiCreditsRing( { usedFraction }: { usedFraction: number } ) {
 				pathLength="100"
 				strokeWidth="2"
 				strokeDasharray="100"
-				strokeDashoffset={ 100 - usedPercentage }
+				strokeDashoffset={ 100 - fillPercentage }
 				strokeLinecap="round"
 				transform="rotate(-90 12 12)"
 			/>
@@ -79,7 +108,7 @@ export function AiCreditsControl() {
 
 	const hasTopUpOptions = ( pricing?.options.length ?? 0 ) > 0;
 	const remaining = ( quota.allowanceRemaining ?? 0 ) + ( quota.purchasedRemaining ?? 0 );
-	const usedFraction = quota.costCap > 0 ? quota.costUsage / quota.costCap : 0;
+	const status = getAiCreditsStatus( remaining );
 	const formattedRemaining = new Intl.NumberFormat( locale ).format( remaining );
 	const compactRemaining = new Intl.NumberFormat( locale, {
 		notation: 'compact',
@@ -128,7 +157,7 @@ export function AiCreditsControl() {
 									/>
 								}
 							>
-								<AiCreditsRing usedFraction={ usedFraction } />
+								<AiCreditsRing remaining={ remaining } status={ status } />
 							</Tooltip.Trigger>
 						}
 					/>

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
@@ -1,4 +1,9 @@
-import { getStudioCodeAiAccessState } from '@studio/common/lib/studio-assistant-quota';
+import {
+	getAiCreditsMeter,
+	getAiCreditsMeterIntent,
+	getStudioCodeAiAccessState,
+	type AiCreditsMeterIntent,
+} from '@studio/common/lib/studio-assistant-quota';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
@@ -21,38 +26,31 @@ const LOW_AI_CREDITS_THRESHOLD = 100_000;
 
 type AiCreditsStatus = 'plenty' | 'low' | 'out';
 
-// The API exposes the combined remaining balance, but not the original total
-// of purchased credits. The ring therefore uses discrete low-balance states
-// rather than presenting its arc as an exact usage percentage.
-const AI_CREDITS_RING_STEPS = [
-	{ maximum: 50_000, fillPercentage: 90 },
-	{ maximum: 75_000, fillPercentage: 80 },
-	{ maximum: 100_000, fillPercentage: 70 },
-	{ maximum: 175_000, fillPercentage: 60 },
-	{ maximum: 250_000, fillPercentage: 50 },
-	{ maximum: 375_000, fillPercentage: 40 },
-	{ maximum: 500_000, fillPercentage: 30 },
-	{ maximum: 750_000, fillPercentage: 20 },
-	{ maximum: 1_000_000, fillPercentage: 10 },
-] as const;
-
-function getAiCreditsStatus( remaining: number ): AiCreditsStatus {
+// The ring arc draws the same used-over-total fraction as the Settings →
+// Usage meter (`getAiCreditsMeter`, STU-2326). The meter resolves null when
+// no denominator is measurable (e.g. billing unreachable) — there is no
+// exact fraction then, so the coloring falls back to an absolute
+// low-balance threshold and the arc stays empty (or full at zero balance).
+function getAiCreditsStatus(
+	remaining: number,
+	intent: AiCreditsMeterIntent | null
+): AiCreditsStatus {
 	if ( remaining === 0 ) {
 		return 'out';
+	}
+	if ( intent !== null ) {
+		return intent === 'ok' ? 'plenty' : 'low';
 	}
 	return remaining <= LOW_AI_CREDITS_THRESHOLD ? 'low' : 'plenty';
 }
 
-function getAiCreditsRingPercentage( remaining: number ): number {
-	if ( remaining === 0 ) {
-		return 100;
-	}
-	return AI_CREDITS_RING_STEPS.find( ( step ) => remaining <= step.maximum )?.fillPercentage ?? 0;
-}
-
-function AiCreditsRing( { remaining, status }: { remaining: number; status: AiCreditsStatus } ) {
-	const fillPercentage = getAiCreditsRingPercentage( remaining );
-
+function AiCreditsRing( {
+	fillPercentage,
+	status,
+}: {
+	fillPercentage: number;
+	status: AiCreditsStatus;
+} ) {
 	return (
 		<svg
 			className={ styles.aiCreditsRing }
@@ -108,7 +106,10 @@ export function AiCreditsControl() {
 
 	const hasTopUpOptions = ( pricing?.options.length ?? 0 ) > 0;
 	const remaining = ( quota.allowanceRemaining ?? 0 ) + ( quota.purchasedRemaining ?? 0 );
-	const status = getAiCreditsStatus( remaining );
+	const meter = getAiCreditsMeter( quota );
+	const intent = meter ? getAiCreditsMeterIntent( meter.fraction ) : null;
+	const status = getAiCreditsStatus( remaining, intent );
+	const fillPercentage = status === 'out' ? 100 : meter ? Math.round( meter.fraction * 100 ) : 0;
 	const formattedRemaining = new Intl.NumberFormat( locale ).format( remaining );
 	const compactRemaining = new Intl.NumberFormat( locale, {
 		notation: 'compact',
@@ -157,7 +158,7 @@ export function AiCreditsControl() {
 									/>
 								}
 							>
-								<AiCreditsRing remaining={ remaining } status={ status } />
+								<AiCreditsRing fillPercentage={ fillPercentage } status={ status } />
 							</Tooltip.Trigger>
 						}
 					/>

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
@@ -22,34 +22,18 @@ import { useUserLocale } from '@/data/queries/use-user-locale';
 import { useAddAiCreditsUrl } from '@/hooks/use-add-ai-credits-url';
 import styles from './style.module.css';
 
-const LOW_AI_CREDITS_THRESHOLD = 100_000;
-
-type AiCreditsStatus = 'plenty' | 'low' | 'out';
-
 // The ring arc draws the same used-over-total fraction as the Settings →
-// Usage meter (`getAiCreditsMeter`, STU-2326). The meter resolves null when
-// no denominator is measurable (e.g. billing unreachable) — there is no
-// exact fraction then, so the coloring falls back to an absolute
-// low-balance threshold and the arc stays empty (or full at zero balance).
-function getAiCreditsStatus(
-	remaining: number,
-	intent: AiCreditsMeterIntent | null
-): AiCreditsStatus {
-	if ( remaining === 0 ) {
-		return 'out';
-	}
-	if ( intent !== null ) {
-		return intent === 'ok' ? 'plenty' : 'low';
-	}
-	return remaining <= LOW_AI_CREDITS_THRESHOLD ? 'low' : 'plenty';
-}
-
+// Usage meter (`getAiCreditsMeter`, STU-2326), and its color escalates
+// through the same intent steps. The meter resolves null when no denominator
+// is measurable (e.g. billing unreachable) — there is no fraction to
+// escalate on then, so the ring stays plain (or exhausted at zero balance)
+// and the tooltip keeps carrying the figure.
 function AiCreditsRing( {
 	fillPercentage,
-	status,
+	intent,
 }: {
 	fillPercentage: number;
-	status: AiCreditsStatus;
+	intent: AiCreditsMeterIntent;
 } ) {
 	return (
 		<svg
@@ -59,8 +43,7 @@ function AiCreditsRing( {
 			height="20"
 			fill="none"
 			aria-hidden="true"
-			data-caution={ status === 'low' || undefined }
-			data-exhausted={ status === 'out' || undefined }
+			data-intent={ intent === 'ok' ? undefined : intent }
 		>
 			<circle className={ styles.aiCreditsRingTrack } cx="12" cy="12" r="8" strokeWidth="2" />
 			<circle
@@ -107,9 +90,13 @@ export function AiCreditsControl() {
 	const hasTopUpOptions = ( pricing?.options.length ?? 0 ) > 0;
 	const remaining = ( quota.allowanceRemaining ?? 0 ) + ( quota.purchasedRemaining ?? 0 );
 	const meter = getAiCreditsMeter( quota );
-	const intent = meter ? getAiCreditsMeterIntent( meter.fraction ) : null;
-	const status = getAiCreditsStatus( remaining, intent );
-	const fillPercentage = status === 'out' ? 100 : meter ? Math.round( meter.fraction * 100 ) : 0;
+	const intent: AiCreditsMeterIntent = meter
+		? getAiCreditsMeterIntent( meter.fraction )
+		: remaining === 0
+		? 'exhausted'
+		: 'ok';
+	const fillPercentage =
+		intent === 'exhausted' ? 100 : meter ? Math.round( meter.fraction * 100 ) : 0;
 	const formattedRemaining = new Intl.NumberFormat( locale ).format( remaining );
 	const compactRemaining = new Intl.NumberFormat( locale, {
 		notation: 'compact',
@@ -158,7 +145,7 @@ export function AiCreditsControl() {
 									/>
 								}
 							>
-								<AiCreditsRing fillPercentage={ fillPercentage } status={ status } />
+								<AiCreditsRing fillPercentage={ fillPercentage } intent={ intent } />
 							</Tooltip.Trigger>
 						}
 					/>

--- a/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
@@ -511,11 +511,18 @@
 	stroke: var(--wpds-color-bg-interactive-brand-strong);
 }
 
-.aiCreditsRing[data-caution] .aiCreditsRingValue {
-	stroke: var(--wpds-color-fg-content-warning-weak);
+/* Same escalation colors as the Settings → Usage meter. */
+.aiCreditsRing[data-intent='warning'] .aiCreditsRingValue {
+	stroke: var(--wpds-color-fg-content-caution-weak);
+	filter: saturate(2) brightness(1.8);
 }
 
-.aiCreditsRing[data-exhausted] .aiCreditsRingValue {
+.aiCreditsRing[data-intent='critical'] .aiCreditsRingValue {
+	stroke: var(--wpds-color-fg-content-warning-weak);
+	filter: saturate(1.6) brightness(1.35);
+}
+
+.aiCreditsRing[data-intent='exhausted'] .aiCreditsRingValue {
 	stroke: var(--wpds-color-bg-interactive-error-strong);
 }
 

--- a/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
@@ -494,8 +494,39 @@
 .aiCreditsSummary strong {
 	color: var(--wpds-color-foreground-content-neutral);
 	font-size: var(--wpds-typography-font-size-md);
+	font-weight: 500;
 	font-variant-numeric: tabular-nums;
 	line-height: var(--wpds-typography-line-height-sm);
+}
+
+.aiCreditsSummary[data-exhausted] strong {
+	color: var(--wpds-color-fg-content-error);
+}
+
+.aiCreditsRingTrack {
+	stroke: var(--wpds-color-stroke-surface-neutral);
+}
+
+.aiCreditsRingValue {
+	stroke: var(--wpds-color-bg-interactive-brand-strong);
+}
+
+.aiCreditsRing[data-caution] .aiCreditsRingValue {
+	stroke: var(--wpds-color-fg-content-warning-weak);
+}
+
+.aiCreditsRing[data-warning] .aiCreditsRingValue {
+	stroke: var(--wpds-color-fg-content-error-weak);
+}
+
+.aiCreditsRing[data-exhausted] .aiCreditsRingValue {
+	stroke: var(--wpds-color-bg-interactive-error-strong);
+}
+
+@media not (prefers-reduced-motion) {
+	.aiCreditsRingValue {
+		transition: stroke-dashoffset 180ms ease;
+	}
 }
 
 .pill {

--- a/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
@@ -500,7 +500,7 @@
 }
 
 .aiCreditsSummary[data-exhausted] strong {
-	color: var(--wpds-color-fg-content-error);
+	color: var(--wpds-color-foreground-content-error);
 }
 
 .aiCreditsRingTrack {
@@ -508,22 +508,22 @@
 }
 
 .aiCreditsRingValue {
-	stroke: var(--wpds-color-bg-interactive-brand-strong);
+	stroke: var(--wpds-color-background-interactive-brand-strong);
 }
 
 /* Same escalation colors as the Settings → Usage meter. */
 .aiCreditsRing[data-intent='warning'] .aiCreditsRingValue {
-	stroke: var(--wpds-color-fg-content-caution-weak);
+	stroke: var(--wpds-color-foreground-content-caution-weak);
 	filter: saturate(2) brightness(1.8);
 }
 
 .aiCreditsRing[data-intent='critical'] .aiCreditsRingValue {
-	stroke: var(--wpds-color-fg-content-warning-weak);
+	stroke: var(--wpds-color-foreground-content-warning-weak);
 	filter: saturate(1.6) brightness(1.35);
 }
 
 .aiCreditsRing[data-intent='exhausted'] .aiCreditsRingValue {
-	stroke: var(--wpds-color-bg-interactive-error-strong);
+	stroke: var(--wpds-color-background-interactive-error-strong);
 }
 
 @media not (prefers-reduced-motion) {

--- a/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/composer/style.module.css
@@ -515,10 +515,6 @@
 	stroke: var(--wpds-color-fg-content-warning-weak);
 }
 
-.aiCreditsRing[data-warning] .aiCreditsRingValue {
-	stroke: var(--wpds-color-fg-content-error-weak);
-}
-
 .aiCreditsRing[data-exhausted] .aiCreditsRingValue {
 	stroke: var(--wpds-color-bg-interactive-error-strong);
 }


### PR DESCRIPTION
## Related issues
Fixes STU-2334

## How AI was used in this PR
Assisted

## Proposed Changes
With this PR we are adding AI credits balance meter to composer, which reflects the state from Settings -> Usage

## Testing Instructions
See testing instruction here - https://github.com/Automattic/studio/pull/4758 as that PR adds the same meter to Classic UI. I decided to keep them as separate PRs to simplify review and to easier distinguish the changes added by me from Shaun's changes.