### PR TITLE
Agentic UI: Fix broken settings alignment in some languages

### DIFF
--- a/apps/ui/src/components/settings-view/index.tsx
+++ b/apps/ui/src/components/settings-view/index.tsx
@@ -347,8 +347,8 @@ function PreferencesPanel( {
 				>
 					<CheckboxControl
 						__nextHasNoMarginBottom
-						label={ __( 'Usage statistics' ) }
-						hideLabelFromVision
+						label=""
+						aria-label={ __( 'Usage statistics' ) }
 						checked={ data.analyticsEnabled }
 						onChange={ ( analyticsEnabled ) => onChange( { analyticsEnabled } ) }
 					/>

--- a/apps/ui/src/components/settings-view/index.tsx
+++ b/apps/ui/src/components/settings-view/index.tsx
@@ -341,10 +341,14 @@ function PreferencesPanel( {
 						onChange={ ( quitSitesBehavior ) => onChange( { quitSitesBehavior } ) }
 					/>
 				</PreferenceRow>
-				<PreferenceRow title={ __( 'Usage statistics' ) }>
+				<PreferenceRow
+					title={ __( 'Usage statistics' ) }
+					description={ __( 'Help improve Studio by sharing anonymous usage statistics' ) }
+				>
 					<CheckboxControl
 						__nextHasNoMarginBottom
-						label={ __( 'Help improve Studio by sharing anonymous usage statistics' ) }
+						label={ __( 'Usage statistics' ) }
+						hideLabelFromVision
 						checked={ data.analyticsEnabled }
 						onChange={ ( analyticsEnabled ) => onChange( { analyticsEnabled } ) }
 					/>

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -217,7 +217,6 @@
 	font-size: var( --wpds-typography-font-size-md );
 	font-weight: 400;
 	line-height: var( --wpds-typography-line-height-sm );
-	white-space: nowrap;
 }
 
 .preferenceText p {
@@ -781,10 +780,6 @@
 	.accountSummary {
 		align-items: flex-start;
 		flex-direction: column;
-	}
-
-	.preferenceText h2 {
-		white-space: normal;
 	}
 
 	.skillRow {


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes DOTPROD-188

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->
It was used to identify and solve the issue


## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->

This PR ensures that the items in settings are aligned when you use language other than English in the agentic UI.

**Before**

<img width="674" height="148" alt="Screenshot 2026-08-26 at 7 57 01 AM" src="https://github.com/user-attachments/assets/11f7f065-fd5a-498d-b196-c20b3bb96778" />

**After**

<img width="669" height="575" alt="Screenshot 2026-08-26 at 9 58 07 AM" src="https://github.com/user-attachments/assets/3fbab844-5ce4-4d3c-9c7a-03094db71d33" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Set Studio language to French in the Agentic UI
* Navigate to `Settings`
* Confirm that the item of the statistics usage looks properly aligned 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
