### PR TITLE
Fix preview back/forward buttons show the wrong enabled state until you interact

### DIFF
--- a/apps/ui/src/components/site-preview/index.tsx
+++ b/apps/ui/src/components/site-preview/index.tsx
@@ -308,6 +308,9 @@ async function applyWebviewViewport(
 	await ipcApi?.setWebviewViewport?.( getWebviewContentsId( webview ), viewport );
 }
 
+// The ordered list of preview realms the chevron buttons cycle through.
+const REALM_ORDER: PreviewRealm[] = [ 'frontend', 'admin', 'database' ];
+
 const EMPTY_BROWSER_STATE: BrowserNavigationState = {
 	canGoBack: false,
 	canGoForward: false,
@@ -810,6 +813,9 @@ export function SitePreview( {
 	// rather than stored alongside it, so the parent stays the single source of
 	// truth for where the preview is aimed.
 	const activeRealm = getPreviewRealm( safePath );
+	const realmIndex = REALM_ORDER.indexOf( activeRealm );
+	const previousRealm: PreviewRealm | undefined = REALM_ORDER[ realmIndex - 1 ];
+	const nextRealm: PreviewRealm | undefined = REALM_ORDER[ realmIndex + 1 ];
 	const activeSurfaceKey = getSurfaceKey( activeRealm );
 	const siteThumbnail = useQuery( {
 		queryKey: [ ...SITE_THUMBNAIL_QUERY_KEY, site.id ],
@@ -1203,9 +1209,10 @@ export function SitePreview( {
 						/>
 					) : null }
 				</div>
-				{ /* Back/forward flank the address segments so history controls sit
-					with the place they navigate; symmetric widths keep the segments
-					(and the omnibox popup anchored to this element) centered. */ }
+				{ /* Chevrons cycle through the three realm segments
+					(frontend → admin → database); symmetric widths keep the
+					segments (and the omnibox popup anchored to this element)
+					centered. */ }
 				<div ref={ locationRef } className={ styles.browserLocation }>
 					{ canPreview ? (
 						<>
@@ -1214,10 +1221,9 @@ export function SitePreview( {
 								tone="neutral"
 								size="small"
 								icon={ chevronLeft }
-								label={ __( 'Back' ) }
-								shortcut={ browserShortcuts.back }
-								disabled={ ! browserState.canGoBack }
-								onClick={ () => sendBrowserCommand( 'back' ) }
+								label={ __( 'Previous' ) }
+								disabled={ ! previousRealm }
+								onClick={ previousRealm ? () => handleSwitchRealm( previousRealm ) : undefined }
 							/>
 							<PreviewAddressBar
 								site={ site }
@@ -1233,10 +1239,9 @@ export function SitePreview( {
 								tone="neutral"
 								size="small"
 								icon={ chevronRight }
-								label={ __( 'Forward' ) }
-								shortcut={ browserShortcuts.forward }
-								disabled={ ! browserState.canGoForward }
-								onClick={ () => sendBrowserCommand( 'forward' ) }
+								label={ __( 'Next' ) }
+								disabled={ ! nextRealm }
+								onClick={ nextRealm ? () => handleSwitchRealm( nextRealm ) : undefined }
 							/>
 						</>
 					) : null }


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-2225

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

It was used to identify and resolve the issue

## Proposed Changes

<!--
Explain the intent of this PR:
- What problem does it solve, or what need does it address?
- How does it affect the user (new capability, fix, performance, accessibility, etc.)?
- Note any user-visible behavior changes or trade-offs.

Focus on the "why" and the user impact. Avoid listing modified files or describing implementation mechanics — the diff already shows that.
-->
This PR ensures that navigation buttons have the correct enabled state for the preview when the site first starts:

<img width="231" height="52" alt="Screenshot 2026-08-26 at 1 28 06 PM" src="https://github.com/user-attachments/assets/b6a78ec2-419a-4654-a87d-93e44fa894d0" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Enable Agentic UI
* Start a site
* Confirm that the forward button is enabled and you can navigate forward as soon as the site is started
* Confirm that the navigation works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
