### PR TITLE
Show an AI credits usage meter in Settings → Usage

### DIFF
--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -27,6 +27,9 @@
 	--color-frame-code-text: #1d2327;
 	--color-frame-running: #008a20;
 	--color-frame-error: #d63638;
+	/* AI credits meter escalation fills (80% / 90% spent). */
+	--color-frame-warning: #f0b849;
+	--color-frame-critical: #e68b20;
 	--color-frame-tab-active: #000;
 	--color-frame-diff-add-text: #008a20;
 	--color-frame-diff-add-bg: #edfaef;
@@ -60,6 +63,8 @@
 		--color-frame-code-text: #e0e0e0;
 		--color-frame-running: #1ed15a;
 		--color-frame-error: #f87171;
+		--color-frame-warning: #f2c14e;
+		--color-frame-critical: #f09b47;
 		--color-frame-tab-active: #fff;
 		--color-frame-diff-add-text: #1ed15a;
 		--color-frame-diff-add-bg: rgba( 30, 209, 90, 0.12 );

--- a/apps/studio/src/modules/user-settings/components/prompt-info.tsx
+++ b/apps/studio/src/modules/user-settings/components/prompt-info.tsx
@@ -1,7 +1,12 @@
 import {
 	clampQuotaFraction,
+	formatAiCreditsAvailableLabel,
+	formatAiCreditsCallout,
+	formatAiCreditsUsedLabel,
 	formatQuotaPercentage,
 	formatQuotaResetDate,
+	getAiCreditsMeter,
+	getAiCreditsMeterIntent,
 	getStudioCodeAiAccessState,
 } from '@studio/common/lib/studio-assistant-quota';
 import { sprintf } from '@wordpress/i18n';
@@ -30,25 +35,30 @@ export function PromptInfo() {
 			? getStudioCodeAiAccessState( assistantQuota )
 			: 'available';
 	const isDenied = accessState !== 'available';
-	const creditBalances =
-		assistantQuota &&
+	const showsCreditBalances =
+		!! assistantQuota &&
 		! isOffline &&
 		! isError &&
 		! isDenied &&
 		( assistantQuota.allowanceRemaining !== undefined ||
-			assistantQuota.purchasedRemaining !== undefined )
-			? {
-					allowance: assistantQuota.allowanceRemaining ?? 0,
-					purchased: assistantQuota.purchasedRemaining ?? 0,
-			  }
-			: undefined;
+			assistantQuota.purchasedRemaining !== undefined );
+	const creditMeter = showsCreditBalances ? getAiCreditsMeter( assistantQuota ) : null;
+	const creditMeterIntent = creditMeter ? getAiCreditsMeterIntent( creditMeter.fraction ) : 'ok';
+	// The meter's fill escalates with the fraction spent, matching the callout
+	// copy's thresholds.
+	const creditMeterFillClass = {
+		ok: 'bg-frame-text',
+		warning: 'bg-[var(--color-frame-warning)]',
+		critical: 'bg-[var(--color-frame-critical)]',
+		exhausted: 'bg-frame-error',
+	}[ creditMeterIntent ];
 	const assistantQuotaWithCostCap =
 		assistantQuota &&
 		assistantQuota.costCap > 0 &&
 		! isOffline &&
 		! isError &&
 		! isDenied &&
-		! creditBalances
+		! showsCreditBalances
 			? assistantQuota
 			: undefined;
 	const usedPercentage = assistantQuotaWithCostCap
@@ -76,24 +86,33 @@ export function PromptInfo() {
 									<AiAccessRequiredNotice quota={ assistantQuota } />
 								) }
 								{ ! isOffline && ! isDenied && isLoading && __( 'Loading Studio Code limits…' ) }
-								{ creditBalances && (
+								{ showsCreditBalances && creditMeter && (
 									<span className="flex flex-col gap-1 tabular-nums text-left">
-										{ creditBalances.allowance > 0 && (
+										{ formatAiCreditsUsedLabel( creditMeter, locale ) }
+									</span>
+								) }
+								{ showsCreditBalances && ! creditMeter && (
+									// No usable denominator (e.g. billing unreachable):
+									// plain figures instead of a bar, only the known ones.
+									<span className="flex flex-col gap-1 tabular-nums text-left">
+										{ assistantQuota?.allowanceRemaining !== undefined && (
 											<span>
 												{ sprintf(
 													/* translators: %s: number of free AI credits remaining (e.g. 960,000). */
 													__( 'Free credits remaining: %s' ),
-													credits.format( creditBalances.allowance )
+													credits.format( assistantQuota.allowanceRemaining )
 												) }
 											</span>
 										) }
-										<span>
-											{ sprintf(
-												/* translators: %s: number of purchased AI credits remaining (e.g. 150,000). */
-												__( 'Purchased credits remaining: %s' ),
-												credits.format( creditBalances.purchased )
-											) }
-										</span>
+										{ assistantQuota?.purchasedRemaining !== undefined && (
+											<span>
+												{ sprintf(
+													/* translators: %s: number of purchased AI credits remaining (e.g. 150,000). */
+													__( 'Purchased credits remaining: %s' ),
+													credits.format( assistantQuota.purchasedRemaining )
+												) }
+											</span>
+										) }
 									</span>
 								) }
 								{ assistantQuotaWithCostCap &&
@@ -113,10 +132,15 @@ export function PromptInfo() {
 									! isOffline &&
 									! isDenied &&
 									! assistantQuotaWithCostCap &&
-									! creditBalances &&
+									! showsCreditBalances &&
 									__( 'Studio Code limits are temporarily unavailable.' ) }
 							</span>
 						</div>
+						{ showsCreditBalances && creditMeter && (
+							<strong className="text-frame-text self-end font-semibold tabular-nums whitespace-nowrap">
+								{ formatAiCreditsAvailableLabel( creditMeter, locale ) }
+							</strong>
+						) }
 					</div>
 					{ ! isOffline && isLoading && <ProgressBar /> }
 					{ assistantQuotaWithCostCap && (
@@ -125,7 +149,30 @@ export function PromptInfo() {
 							maxValue={ assistantQuotaWithCostCap.costCap }
 						/>
 					) }
-					{ creditBalances && <AddAiCreditsButton className="self-start" /> }
+					{ showsCreditBalances && creditMeter && (
+						<div
+							className="bg-frame-border h-1.5 w-full overflow-hidden rounded-full"
+							data-testid="ai-credits-meter"
+							aria-hidden="true"
+						>
+							<div
+								className={ cx( 'h-full rounded-full', creditMeterFillClass ) }
+								style={ { width: `${ creditMeter.fraction * 100 }%` } }
+							/>
+						</div>
+					) }
+					{ showsCreditBalances && (
+						<div className="flex flex-wrap items-center gap-3">
+							<AddAiCreditsButton
+								variant={ creditMeterIntent === 'exhausted' ? 'primary' : 'secondary' }
+							/>
+							{ creditMeter && (
+								<span className="text-frame-text-secondary text-sm">
+									{ formatAiCreditsCallout( assistantQuota, creditMeter, locale ) }
+								</span>
+							) }
+						</div>
+					) }
 				</div>
 				<div className="h-6 w-6"></div>
 			</div>

--- a/apps/studio/src/modules/user-settings/components/tests/prompt-info.test.tsx
+++ b/apps/studio/src/modules/user-settings/components/tests/prompt-info.test.tsx
@@ -132,7 +132,8 @@ describe( 'PromptInfo', () => {
 
 		render( <PromptInfo /> );
 
-		expect( screen.getByText( '2,000,000 of 2,000,000 AI credits used' ) ).toBeInTheDocument();
+		// The spent allowance drops out of the total: the purchased pool is the bar.
+		expect( screen.getByText( '500,000 of 500,000 AI credits used' ) ).toBeInTheDocument();
 		expect( screen.getByText( '0 available' ) ).toBeInTheDocument();
 		expect(
 			screen.getByText( 'Your next idea is ready when you are. Top up to bring it to life.' )

--- a/apps/studio/src/modules/user-settings/components/tests/prompt-info.test.tsx
+++ b/apps/studio/src/modules/user-settings/components/tests/prompt-info.test.tsx
@@ -73,14 +73,82 @@ describe( 'PromptInfo', () => {
 		expect( screen.getByRole( 'progressbar' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows both credit balances when the account has AI credits', () => {
+	it( 'shows one combined meter across both credit pools', () => {
 		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
 			data: {
-				costUsage: 33392,
-				costCap: 20000000,
-				costResetDate: '2026-07-01T00:00:00+00:00',
+				costUsage: 25,
+				costCap: 1500000,
 				allowanceRemaining: 960000,
 				purchasedRemaining: 150000,
+				purchasedAtTopUp: 500000,
+			},
+			isError: false,
+			isLoading: false,
+			refetch: vi.fn(),
+		} );
+
+		render( <PromptInfo /> );
+
+		expect( screen.getByText( '890,000 of 2,000,000 AI credits used' ) ).toBeInTheDocument();
+		expect( screen.getByText( '1,110,000 available' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'ai-credits-meter' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /Add AI credits/ } ) ).toBeInTheDocument();
+		expect( screen.queryByText( /monthly limit used/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'welcomes a never-bought account with the allowance size from the quota', () => {
+		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 1500000,
+				allowanceRemaining: 1400000,
+				purchasedRemaining: 0,
+				purchasedAtTopUp: 0,
+			},
+			isError: false,
+			isLoading: false,
+			refetch: vi.fn(),
+		} );
+
+		render( <PromptInfo /> );
+
+		expect( screen.getByText( '100,000 of 1,500,000 AI credits used' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Your first 1,500,000 AI credits are on us.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'reads exhausted pools as a full meter with the exhausted callout', () => {
+		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
+			data: {
+				costUsage: 25,
+				costCap: 1500000,
+				allowanceRemaining: 0,
+				purchasedRemaining: 0,
+				purchasedAtTopUp: 500000,
+			},
+			isError: false,
+			isLoading: false,
+			refetch: vi.fn(),
+		} );
+
+		render( <PromptInfo /> );
+
+		expect( screen.getByText( '2,000,000 of 2,000,000 AI credits used' ) ).toBeInTheDocument();
+		expect( screen.getByText( '0 available' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Your next idea is ready when you are. Top up to bring it to life.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'falls back to plain known figures when no bar can be drawn', () => {
+		// Billing unreachable on an account with no usable free allowance:
+		// the purchased balance is unknown, so neither pool has a meter.
+		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 0,
+				allowanceRemaining: 960000,
+				purchasedRemaining: undefined,
+				purchasedAtTopUp: 500000,
 			},
 			isError: false,
 			isLoading: false,
@@ -90,47 +158,9 @@ describe( 'PromptInfo', () => {
 		render( <PromptInfo /> );
 
 		expect( screen.getByText( 'Free credits remaining: 960,000' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Purchased credits remaining: 150,000' ) ).toBeInTheDocument();
-		expect( screen.queryByText( /monthly limit used/ ) ).not.toBeInTheDocument();
-		expect( screen.queryByRole( 'progressbar' ) ).not.toBeInTheDocument();
-	} );
-
-	it( 'offers a way to buy once the account has credit balances', () => {
-		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
-			data: {
-				costUsage: 33392,
-				costCap: 20000000,
-				allowanceRemaining: 960000,
-				purchasedRemaining: 150000,
-			},
-			isError: false,
-			isLoading: false,
-			refetch: vi.fn(),
-		} );
-
-		render( <PromptInfo /> );
-
+		expect( screen.queryByText( /Purchased credits remaining/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'ai-credits-meter' ) ).not.toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: /Add AI credits/ } ) ).toBeInTheDocument();
-	} );
-
-	it( 'hides the free pool once it is spent, and keeps a zero purchased balance', () => {
-		vi.mocked( useGetStudioAssistantQuota, { partial: true } ).mockReturnValue( {
-			data: {
-				costUsage: 33392,
-				costCap: 20000000,
-				costResetDate: '2026-07-01T00:00:00+00:00',
-				allowanceRemaining: 0,
-				purchasedRemaining: 0,
-			},
-			isError: false,
-			isLoading: false,
-			refetch: vi.fn(),
-		} );
-
-		render( <PromptInfo /> );
-
-		expect( screen.queryByText( /Free credits remaining/ ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'Purchased credits remaining: 0' ) ).toBeInTheDocument();
 	} );
 
 	it( 'keeps the monthly limit design when the account has no AI credits', () => {

--- a/apps/ui/src/components/settings-view/style.module.css
+++ b/apps/ui/src/components/settings-view/style.module.css
@@ -907,7 +907,71 @@
 .progressValue {
 	block-size: 100%;
 	border-radius: inherit;
-	background: var( --wpds-color-fg-interactive-brand );
+	background: var( --wpds-color-fg-content-neutral );
+}
+
+/* Escalation colors for the AI credits meter (80% / 90% / exhausted). The
+   filters brighten the wpds caution/warning weak tokens toward the design's
+   yellow and orange — taken as-is from the usage-interfaces exploration. */
+.progressValueWarning {
+	background: var( --wpds-color-fg-content-caution-weak );
+	filter: saturate( 2 ) brightness( 1.8 );
+}
+
+.progressValueCritical {
+	background: var( --wpds-color-fg-content-warning-weak );
+	filter: saturate( 1.6 ) brightness( 1.35 );
+}
+
+.progressValueExhausted {
+	background: var( --wpds-color-bg-interactive-error-strong );
+}
+
+.creditMeter {
+	display: flex;
+	flex-direction: column;
+	gap: var( --wpds-dimension-padding-xs );
+}
+
+.creditMeterSummary {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: var( --wpds-dimension-padding-md );
+}
+
+.creditMeterCredits {
+	color: var( --wpds-color-fg-content-neutral-weak );
+	font-size: var( --wpds-typography-font-size-sm );
+	font-variant-numeric: tabular-nums;
+	line-height: var( --wpds-typography-line-height-sm );
+}
+
+.creditMeterAvailable {
+	flex: none;
+	color: var( --wpds-color-fg-content-neutral );
+	font-size: var( --wpds-typography-font-size-sm );
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+	line-height: var( --wpds-typography-line-height-sm );
+}
+
+.creditCallout {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: var( --wpds-dimension-padding-md );
+}
+
+.creditCallout > :first-child {
+	flex: none;
+}
+
+.creditCalloutText {
+	min-width: 0;
+	color: var( --wpds-color-fg-content-neutral-weak );
+	font-size: var( --wpds-typography-font-size-sm );
+	line-height: var( --wpds-typography-line-height-sm );
 }
 
 .previewActionsButton {

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom/vitest';
-import { getAddAiCreditsUrl } from '@studio/common/lib/studio-assistant-quota';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
@@ -266,14 +265,79 @@ describe( 'UsagePanel', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'shows remaining credit balances when the quota includes the per-pool fields', () => {
+	it( 'shows one combined meter across both credit pools', () => {
 		useStudioAssistantQuotaMock.mockReturnValue( {
 			data: {
 				costUsage: 25,
-				costCap: 100,
-				costResetDate: '2026-08-01T12:00:00',
+				costCap: 1500000,
 				allowanceRemaining: 960000,
 				purchasedRemaining: 150000,
+				purchasedAtTopUp: 500000,
+			},
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect( screen.getByText( '890,000 of 2,000,000 AI credits used' ) ).toBeInTheDocument();
+		expect( screen.getByText( '1,110,000 available' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Add AI credits' } ) ).toBeInTheDocument();
+		// The meter replaces the monthly-limit and Alpha designs.
+		expect( screen.queryByText( /of monthly limit used/ ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( /AI credits are currently free while Studio Code is in Alpha/ )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'welcomes a never-bought account with the allowance size from the quota', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 1500000,
+				allowanceRemaining: 1400000,
+				purchasedRemaining: 0,
+				purchasedAtTopUp: 0,
+			},
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect( screen.getByText( '100,000 of 1,500,000 AI credits used' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Your first 1,500,000 AI credits are on us.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'reads exhausted pools as a full meter with the exhausted callout', () => {
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 25,
+				costCap: 1500000,
+				allowanceRemaining: 0,
+				purchasedRemaining: 0,
+				purchasedAtTopUp: 500000,
+			},
+			isLoading: false,
+		} as never );
+
+		render( <UsagePanel /> );
+
+		expect( screen.getByText( '2,000,000 of 2,000,000 AI credits used' ) ).toBeInTheDocument();
+		expect( screen.getByText( '0 available' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Your next idea is ready when you are. Top up to bring it to life.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'falls back to plain known figures when no bar can be drawn', () => {
+		// Billing unreachable on an account with no usable free allowance:
+		// the purchased balance is unknown, so neither pool has a meter.
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: {
+				costUsage: 0,
+				costCap: 0,
+				allowanceRemaining: 960000,
+				purchasedRemaining: undefined,
+				purchasedAtTopUp: 500000,
 			},
 			isLoading: false,
 		} as never );
@@ -281,31 +345,7 @@ describe( 'UsagePanel', () => {
 		render( <UsagePanel /> );
 
 		expect( screen.getByText( 'Free credits remaining: 960,000' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Purchased credits remaining: 150,000' ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'Add AI credits' } ) ).toBeInTheDocument();
-		// The credit balances replace the monthly-limit and Alpha designs.
-		expect( screen.queryByText( /of monthly limit used/ ) ).not.toBeInTheDocument();
-		expect(
-			screen.queryByText( /AI credits are currently free while Studio Code is in Alpha/ )
-		).not.toBeInTheDocument();
-	} );
-
-	it( 'hides the free-credits line once the allowance is exhausted', () => {
-		useStudioAssistantQuotaMock.mockReturnValue( {
-			data: {
-				costUsage: 25,
-				costCap: 100,
-				costResetDate: '2026-08-01T12:00:00',
-				allowanceRemaining: 0,
-				purchasedRemaining: 0,
-			},
-			isLoading: false,
-		} as never );
-
-		render( <UsagePanel /> );
-
-		expect( screen.queryByText( /Free credits remaining/ ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'Purchased credits remaining: 0' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Purchased credits remaining/ ) ).not.toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Add AI credits' } ) ).toBeInTheDocument();
 	} );
 

--- a/apps/ui/src/components/settings-view/usage-panel.test.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.test.tsx
@@ -321,7 +321,8 @@ describe( 'UsagePanel', () => {
 
 		render( <UsagePanel /> );
 
-		expect( screen.getByText( '2,000,000 of 2,000,000 AI credits used' ) ).toBeInTheDocument();
+		// The spent allowance drops out of the total: the purchased pool is the bar.
+		expect( screen.getByText( '500,000 of 500,000 AI credits used' ) ).toBeInTheDocument();
 		expect( screen.getByText( '0 available' ) ).toBeInTheDocument();
 		expect(
 			screen.getByText( 'Your next idea is ready when you are. Top up to bring it to life.' )

--- a/apps/ui/src/components/settings-view/usage-panel.tsx
+++ b/apps/ui/src/components/settings-view/usage-panel.tsx
@@ -1,7 +1,12 @@
 import {
 	clampQuotaFraction,
+	formatAiCreditsAvailableLabel,
+	formatAiCreditsCallout,
+	formatAiCreditsUsedLabel,
 	formatQuotaPercentage,
 	formatQuotaResetDate,
+	getAiCreditsMeter,
+	getAiCreditsMeterIntent,
 	getStudioCodeAiAccessState,
 } from '@studio/common/lib/studio-assistant-quota';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -42,13 +47,31 @@ function UnavailableSection( { title }: { title: string } ) {
 	);
 }
 
-function UsageProgressBar( { fraction }: { fraction: number } ) {
+function UsageProgressBar( {
+	fraction,
+	valueClassName,
+}: {
+	fraction: number;
+	valueClassName?: string;
+} ) {
 	return (
 		<div className={ styles.progressTrack } data-testid="usage-progress-bar" aria-hidden="true">
-			<div className={ styles.progressValue } style={ { inlineSize: `${ fraction * 100 }%` } } />
+			<div
+				className={ clsx( styles.progressValue, valueClassName ) }
+				style={ { inlineSize: `${ fraction * 100 }%` } }
+			/>
 		</div>
 	);
 }
+
+// The meter's fill color escalates with the fraction spent, matching the
+// callout copy's thresholds.
+const METER_INTENT_CLASS_NAMES: Record< string, string | undefined > = {
+	ok: undefined,
+	warning: styles.progressValueWarning,
+	critical: styles.progressValueCritical,
+	exhausted: styles.progressValueExhausted,
+};
 
 function AiCreditsSummary() {
 	const locale = useUserLocale();
@@ -96,30 +119,61 @@ function AiCreditsSummary() {
 			</div>
 		);
 	} else if ( quota && showsCreditBalances ) {
+		const meter = getAiCreditsMeter( quota );
+		const intent = meter ? getAiCreditsMeterIntent( meter.fraction ) : 'ok';
 		const credits = new Intl.NumberFormat( locale );
-		const allowanceRemaining = quota.allowanceRemaining ?? 0;
-		const purchasedRemaining = quota.purchasedRemaining ?? 0;
 		content = (
 			<>
-				<div className={ styles.creditBalances }>
-					{ allowanceRemaining > 0 ? (
-						<div className={ styles.previewUsageText }>
-							{ sprintf(
-								/* translators: %s: number of free AI credits remaining (e.g. 960,000). */
-								__( 'Free credits remaining: %s' ),
-								credits.format( allowanceRemaining )
-							) }
+				{ meter ? (
+					<div className={ styles.creditMeter }>
+						<div className={ styles.creditMeterSummary }>
+							<span className={ styles.creditMeterCredits }>
+								{ formatAiCreditsUsedLabel( meter, locale ) }
+							</span>
+							<strong className={ styles.creditMeterAvailable }>
+								{ formatAiCreditsAvailableLabel( meter, locale ) }
+							</strong>
 						</div>
-					) : null }
-					<div className={ styles.previewUsageText }>
-						{ sprintf(
-							/* translators: %s: number of purchased AI credits remaining (e.g. 150,000). */
-							__( 'Purchased credits remaining: %s' ),
-							credits.format( purchasedRemaining )
-						) }
+						<UsageProgressBar
+							fraction={ meter.fraction }
+							valueClassName={ METER_INTENT_CLASS_NAMES[ intent ] }
+						/>
 					</div>
+				) : (
+					// No usable denominator (e.g. billing unreachable): plain
+					// figures instead of a bar, and only the known ones.
+					<div className={ styles.creditBalances }>
+						{ quota.allowanceRemaining !== undefined ? (
+							<div className={ styles.previewUsageText }>
+								{ sprintf(
+									/* translators: %s: number of free AI credits remaining (e.g. 960,000). */
+									__( 'Free credits remaining: %s' ),
+									credits.format( quota.allowanceRemaining )
+								) }
+							</div>
+						) : null }
+						{ quota.purchasedRemaining !== undefined ? (
+							<div className={ styles.previewUsageText }>
+								{ sprintf(
+									/* translators: %s: number of purchased AI credits remaining (e.g. 150,000). */
+									__( 'Purchased credits remaining: %s' ),
+									credits.format( quota.purchasedRemaining )
+								) }
+							</div>
+						) : null }
+					</div>
+				) }
+				<div className={ styles.creditCallout }>
+					<AddAiCreditsButton
+						variant={ intent === 'exhausted' ? 'solid' : 'outline' }
+						tone={ intent === 'exhausted' ? 'brand' : 'neutral' }
+					/>
+					{ meter ? (
+						<span className={ styles.creditCalloutText }>
+							{ formatAiCreditsCallout( quota, meter, locale ) }
+						</span>
+					) : null }
 				</div>
-				<AddAiCreditsButton className={ styles.usageSectionAction } />
 			</>
 		);
 	} else if ( quota && quota.costCap > 0 ) {

--- a/apps/ui/src/ui-classic/components/session-view/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.test.tsx
@@ -82,6 +82,7 @@ function makeQuota( overrides: Partial< { hasPaymentMethod: boolean; emailVerifi
 		studioCodeAiAccess: 'granted',
 		allowanceRemaining: undefined,
 		purchasedRemaining: undefined,
+		purchasedAtTopUp: undefined,
 		...overrides,
 	};
 }

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -80,8 +80,20 @@ export const studioAssistantQuotaSchema = z
 		// when the AI Credits feature is off for the account — the UI keys the
 		// credit-balance design off their presence, so `undefined` (not 0) must
 		// mean "feature off, keep the old design".
+		//
+		// `purchased_remaining` also arrives as null when billing is
+		// unreachable. That is "unknown", not zero, and both read as "no
+		// figure to show" — so null normalizes to undefined below rather than
+		// failing the whole parse and taking the access gates down with it.
 		allowance_remaining: z.number().optional(),
-		purchased_remaining: z.number().optional(),
+		purchased_remaining: z.number().nullish(),
+		// Size of the purchased pool as of the last top-up: what was left then,
+		// plus what was bought. The denominator for `purchased_remaining`, the
+		// way `cost_cap` is for `allowance_remaining` — not a lifetime total,
+		// so it can legitimately fall after a purchase. Omitted by older
+		// servers; 0 means the account has never bought credits, which is "no
+		// pool", not an empty one — never divide by it.
+		purchased_at_top_up: z.number().nullish(),
 	} )
 	.transform( ( data ) => ( {
 		costUsage: data.cost_usage,
@@ -92,7 +104,8 @@ export const studioAssistantQuotaSchema = z
 		studioCodeAiHasAccess: data.studio_code_ai_has_access,
 		studioCodeAiAccess: data.studio_code_ai_access,
 		allowanceRemaining: data.allowance_remaining,
-		purchasedRemaining: data.purchased_remaining,
+		purchasedRemaining: data.purchased_remaining ?? undefined,
+		purchasedAtTopUp: data.purchased_at_top_up ?? undefined,
 	} ) );
 
 export type StudioAssistantQuota = z.infer< typeof studioAssistantQuotaSchema >;

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -200,14 +200,25 @@ export function getAiCreditsMeter(
 ): AiCreditsMeter | null {
 	let totalCredits = 0;
 	let remainingCredits = 0;
-	if ( quota.allowanceRemaining !== undefined && quota.costCap > 0 ) {
+	const purchasedAtTopUp = quota.purchasedAtTopUp ?? 0;
+	const hasPurchasedPool = purchasedAtTopUp > 0 && quota.purchasedRemaining !== undefined;
+	// A spent welcome allowance drops out of the meter once a purchased pool
+	// can be measured instead: right after a top-up the bar should read as the
+	// fresh purchase, not as mostly-consumed because the old gift still counts
+	// against the total. Without a purchased pool the spent allowance stays —
+	// it is the only thing left to draw, and it reads as the full exhausted
+	// bar rather than no bar at all.
+	if (
+		quota.allowanceRemaining !== undefined &&
+		quota.costCap > 0 &&
+		( quota.allowanceRemaining > 0 || ! hasPurchasedPool )
+	) {
 		totalCredits += quota.costCap;
 		remainingCredits += quota.allowanceRemaining;
 	}
-	const purchasedAtTopUp = quota.purchasedAtTopUp ?? 0;
-	if ( purchasedAtTopUp > 0 && quota.purchasedRemaining !== undefined ) {
+	if ( hasPurchasedPool ) {
 		totalCredits += purchasedAtTopUp;
-		remainingCredits += quota.purchasedRemaining;
+		remainingCredits += quota.purchasedRemaining ?? 0;
 	}
 	if ( totalCredits <= 0 ) {
 		return null;

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -171,6 +171,126 @@ export function formatQuotaResetDate( date: string, locale?: string ): string {
 }
 
 /**
+ * The combined AI credits meter (STU-2326): one bar over both pools, free and
+ * purchased. Each pool contributes its own denominator — `costCap` for the
+ * free allowance, `purchasedAtTopUp` for the purchased pool — and a pool
+ * stays out of the meter entirely when it has nothing to measure:
+ *
+ * - `purchasedAtTopUp` of 0/undefined means the account has never bought
+ *   credits — there is no purchased pool, not an empty one.
+ * - `purchasedRemaining` undefined with a real pool means billing was
+ *   unreachable — the balance is unknown, and folding it in would draw the
+ *   pool as fully spent.
+ *
+ * Resolves `null` when nothing is measurable (feature off, or no usable
+ * denominator) so callers fall back to plain figures instead of a bar.
+ */
+export interface AiCreditsMeter {
+	usedCredits: number;
+	totalCredits: number;
+	remainingCredits: number;
+	fraction: number;
+}
+
+export function getAiCreditsMeter(
+	quota: Pick<
+		StudioAssistantQuota,
+		'costCap' | 'allowanceRemaining' | 'purchasedRemaining' | 'purchasedAtTopUp'
+	>
+): AiCreditsMeter | null {
+	let totalCredits = 0;
+	let remainingCredits = 0;
+	if ( quota.allowanceRemaining !== undefined && quota.costCap > 0 ) {
+		totalCredits += quota.costCap;
+		remainingCredits += quota.allowanceRemaining;
+	}
+	const purchasedAtTopUp = quota.purchasedAtTopUp ?? 0;
+	if ( purchasedAtTopUp > 0 && quota.purchasedRemaining !== undefined ) {
+		totalCredits += purchasedAtTopUp;
+		remainingCredits += quota.purchasedRemaining;
+	}
+	if ( totalCredits <= 0 ) {
+		return null;
+	}
+	const usedCredits = Math.max( 0, totalCredits - remainingCredits );
+	return {
+		usedCredits,
+		totalCredits,
+		remainingCredits,
+		fraction: clampQuotaFraction( usedCredits, totalCredits ),
+	};
+}
+
+export type AiCreditsMeterIntent = 'ok' | 'warning' | 'critical' | 'exhausted';
+
+/** Escalation steps for the meter's color and copy. */
+export function getAiCreditsMeterIntent( fraction: number ): AiCreditsMeterIntent {
+	if ( fraction >= 1 ) {
+		return 'exhausted';
+	}
+	if ( fraction >= 0.9 ) {
+		return 'critical';
+	}
+	if ( fraction >= 0.8 ) {
+		return 'warning';
+	}
+	return 'ok';
+}
+
+export function formatAiCreditsUsedLabel(
+	meter: Pick< AiCreditsMeter, 'usedCredits' | 'totalCredits' >,
+	locale?: string
+): string {
+	const credits = new Intl.NumberFormat( locale );
+	return sprintf(
+		/* translators: 1: AI credits used (e.g. 1,200,000). 2: total AI credits the meter is measured against (e.g. 1,500,000). */
+		__( '%1$s of %2$s AI credits used' ),
+		credits.format( meter.usedCredits ),
+		credits.format( meter.totalCredits )
+	);
+}
+
+export function formatAiCreditsAvailableLabel(
+	meter: Pick< AiCreditsMeter, 'remainingCredits' >,
+	locale?: string
+): string {
+	return sprintf(
+		/* translators: %s: number of AI credits still available (e.g. 300,000). */
+		__( '%s available' ),
+		new Intl.NumberFormat( locale ).format( meter.remainingCredits )
+	);
+}
+
+/**
+ * Encouragement line next to the "Add AI credits" button, escalating with the
+ * meter. The welcome line shows the size of the free allowance (`costCap`,
+ * never a hardcoded figure) and only while some of it is left — an account
+ * that has bought credits, or spent the gift, gets the regular rotation.
+ */
+export function formatAiCreditsCallout(
+	quota: Pick< StudioAssistantQuota, 'costCap' | 'allowanceRemaining' | 'purchasedAtTopUp' >,
+	meter: Pick< AiCreditsMeter, 'fraction' >,
+	locale?: string
+): string {
+	switch ( getAiCreditsMeterIntent( meter.fraction ) ) {
+		case 'exhausted':
+			return __( 'Your next idea is ready when you are. Top up to bring it to life.' );
+		case 'critical':
+			return __( 'You’re on a roll. Top up now and keep building.' );
+		case 'warning':
+			return __( 'Top up now so your next build doesn’t stop short.' );
+	}
+	if ( ( quota.purchasedAtTopUp ?? 0 ) === 0 && ( quota.allowanceRemaining ?? 0 ) > 0 ) {
+		return sprintf(
+			/* translators: %s: size of the free AI credits allowance (e.g. 1,500,000). */
+			__( 'Your first %s AI credits are on us.' ),
+			new Intl.NumberFormat( locale ).format( quota.costCap )
+		);
+	}
+	return __( 'Keep the ideas flowing. Stock up for whatever you build next.' );
+}
+
+/**
  * User-facing copy for an account whose Studio Code AI access was explicitly
  * blocked (access === "blocked", STU-2143/STU-2146). Shared by every surface
  * so the wording stays consistent. The string wraps the support

--- a/packages/common/lib/tests/studio-assistant-quota.test.ts
+++ b/packages/common/lib/tests/studio-assistant-quota.test.ts
@@ -88,6 +88,52 @@ describe( 'studioAssistantQuotaSchema per-pool balances', () => {
 		expect( quota.allowanceRemaining ).toBeUndefined();
 		expect( quota.purchasedRemaining ).toBeUndefined();
 	} );
+
+	it( 'reads an unreachable-billing null balance as unknown, not zero', () => {
+		const quota = studioAssistantQuotaSchema.parse( {
+			...baseResponse,
+			allowance_remaining: 960000,
+			purchased_remaining: null,
+		} );
+		expect( quota.purchasedRemaining ).toBeUndefined();
+		// The rest of the quota still parses — the access gates read from it.
+		expect( quota.allowanceRemaining ).toBe( 960000 );
+	} );
+} );
+
+describe( 'studioAssistantQuotaSchema purchased pool size', () => {
+	it( 'parses the pool size the purchased balance is measured against', () => {
+		const quota = studioAssistantQuotaSchema.parse( {
+			...baseResponse,
+			purchased_remaining: 150000,
+			purchased_at_top_up: 500000,
+		} );
+		expect( quota.purchasedAtTopUp ).toBe( 500000 );
+	} );
+
+	it( 'is undefined on servers that do not report it', () => {
+		expect( studioAssistantQuotaSchema.parse( baseResponse ).purchasedAtTopUp ).toBeUndefined();
+	} );
+
+	it( 'keeps a never-bought zero, so callers can tell it from a missing field', () => {
+		const quota = studioAssistantQuotaSchema.parse( {
+			...baseResponse,
+			purchased_remaining: 0,
+			purchased_at_top_up: 0,
+		} );
+		expect( quota.purchasedAtTopUp ).toBe( 0 );
+	} );
+
+	it( 'can be smaller than an earlier top-up: it is the last pool, not a lifetime total', () => {
+		const quota = studioAssistantQuotaSchema.parse( {
+			...baseResponse,
+			purchased_remaining: 20000,
+			purchased_at_top_up: 120000,
+		} );
+		// 20,000 left of the 120,000 the pool held at the last top-up.
+		expect( quota.purchasedRemaining ).toBe( 20000 );
+		expect( quota.purchasedAtTopUp ).toBe( 120000 );
+	} );
 } );
 
 describe( 'studioAssistantQuotaSchema reset date', () => {

--- a/packages/common/lib/tests/studio-assistant-quota.test.ts
+++ b/packages/common/lib/tests/studio-assistant-quota.test.ts
@@ -209,10 +209,23 @@ describe( 'getAiCreditsMeter', () => {
 		expect( meter?.remainingCredits ).toBe( 960000 );
 	} );
 
-	it( 'still meters the purchased pool when the free allowance is gone', () => {
+	it( 'drops the spent allowance from the total once a purchased pool exists', () => {
+		// Measuring against the purchased pool alone: right after a top-up the
+		// bar reads as the fresh purchase, not as mostly consumed by the gift.
 		const meter = getAiCreditsMeter( { ...creditQuota, allowanceRemaining: 0 } );
-		expect( meter?.totalCredits ).toBe( 2000000 );
+		expect( meter?.totalCredits ).toBe( 500000 );
 		expect( meter?.remainingCredits ).toBe( 150000 );
+	} );
+
+	it( 'keeps the spent allowance as the meter when nothing was ever bought', () => {
+		const meter = getAiCreditsMeter( {
+			costCap: 1500000,
+			allowanceRemaining: 0,
+			purchasedRemaining: 0,
+			purchasedAtTopUp: 0,
+		} );
+		expect( meter?.totalCredits ).toBe( 1500000 );
+		expect( meter?.fraction ).toBe( 1 );
 	} );
 
 	it( 'resolves null when nothing is measurable', () => {
@@ -244,6 +257,8 @@ describe( 'getAiCreditsMeter', () => {
 			purchasedAtTopUp: 500000,
 		} );
 		expect( meter?.fraction ).toBe( 1 );
+		// The spent allowance is out of the total; the purchased pool is the bar.
+		expect( meter?.totalCredits ).toBe( 500000 );
 	} );
 } );
 

--- a/packages/common/lib/tests/studio-assistant-quota.test.ts
+++ b/packages/common/lib/tests/studio-assistant-quota.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
 	formatAiAccessRequiredNotice,
+	formatAiCreditsAvailableLabel,
+	formatAiCreditsCallout,
+	formatAiCreditsUsedLabel,
+	getAiCreditsMeter,
+	getAiCreditsMeterIntent,
 	formatUsageCapNotice,
 	getStudioCodeAiAccessState,
 	studioAssistantQuotaSchema,
@@ -164,5 +169,143 @@ describe( 'formatAiAccessRequiredNotice', () => {
 		expect( formatAiAccessRequiredNotice( { costUsage: 0 } ) ).toBe( genericNotice );
 		expect( formatAiAccessRequiredNotice( undefined ) ).toBe( genericNotice );
 		expect( formatAiAccessRequiredNotice( null ) ).toBe( genericNotice );
+	} );
+} );
+
+describe( 'getAiCreditsMeter', () => {
+	// Realistic credit account: 1.5M-credit welcome allowance, part spent,
+	// plus a 500k purchased pool from the last top-up.
+	const creditQuota = {
+		costCap: 1500000,
+		allowanceRemaining: 960000,
+		purchasedRemaining: 150000,
+		purchasedAtTopUp: 500000,
+	};
+
+	it( 'combines both pools into one bar', () => {
+		const meter = getAiCreditsMeter( creditQuota );
+		expect( meter ).toEqual( {
+			totalCredits: 2000000,
+			remainingCredits: 1110000,
+			usedCredits: 890000,
+			fraction: 0.445,
+		} );
+	} );
+
+	it( 'measures a never-bought account against the free allowance alone', () => {
+		const meter = getAiCreditsMeter( {
+			costCap: 1500000,
+			allowanceRemaining: 960000,
+			purchasedRemaining: 0,
+			purchasedAtTopUp: 0,
+		} );
+		expect( meter?.totalCredits ).toBe( 1500000 );
+		expect( meter?.remainingCredits ).toBe( 960000 );
+	} );
+
+	it( 'leaves the purchased pool out when billing is unreachable (unknown, not spent)', () => {
+		const meter = getAiCreditsMeter( { ...creditQuota, purchasedRemaining: undefined } );
+		expect( meter?.totalCredits ).toBe( 1500000 );
+		expect( meter?.remainingCredits ).toBe( 960000 );
+	} );
+
+	it( 'still meters the purchased pool when the free allowance is gone', () => {
+		const meter = getAiCreditsMeter( { ...creditQuota, allowanceRemaining: 0 } );
+		expect( meter?.totalCredits ).toBe( 2000000 );
+		expect( meter?.remainingCredits ).toBe( 150000 );
+	} );
+
+	it( 'resolves null when nothing is measurable', () => {
+		// Feature off: no pool figures at all.
+		expect(
+			getAiCreditsMeter( {
+				costCap: 1500000,
+				allowanceRemaining: undefined,
+				purchasedRemaining: undefined,
+				purchasedAtTopUp: undefined,
+			} )
+		).toBeNull();
+		// No usable denominator: zero cap and a never-bought purchased pool.
+		expect(
+			getAiCreditsMeter( {
+				costCap: 0,
+				allowanceRemaining: 0,
+				purchasedRemaining: 0,
+				purchasedAtTopUp: 0,
+			} )
+		).toBeNull();
+	} );
+
+	it( 'reads exhausted pools as a full bar', () => {
+		const meter = getAiCreditsMeter( {
+			costCap: 1500000,
+			allowanceRemaining: 0,
+			purchasedRemaining: 0,
+			purchasedAtTopUp: 500000,
+		} );
+		expect( meter?.fraction ).toBe( 1 );
+	} );
+} );
+
+describe( 'getAiCreditsMeterIntent', () => {
+	it( 'escalates at 80%, 90%, and exhaustion', () => {
+		expect( getAiCreditsMeterIntent( 0 ) ).toBe( 'ok' );
+		expect( getAiCreditsMeterIntent( 0.79 ) ).toBe( 'ok' );
+		expect( getAiCreditsMeterIntent( 0.8 ) ).toBe( 'warning' );
+		expect( getAiCreditsMeterIntent( 0.9 ) ).toBe( 'critical' );
+		expect( getAiCreditsMeterIntent( 1 ) ).toBe( 'exhausted' );
+	} );
+} );
+
+describe( 'AI credits meter labels', () => {
+	it( 'formats used and available figures for the reader', () => {
+		expect(
+			formatAiCreditsUsedLabel( { usedCredits: 1200000, totalCredits: 1500000 }, 'en-US' )
+		).toBe( '1,200,000 of 1,500,000 AI credits used' );
+		expect( formatAiCreditsAvailableLabel( { remainingCredits: 300000 }, 'en-US' ) ).toBe(
+			'300,000 available'
+		);
+	} );
+} );
+
+describe( 'formatAiCreditsCallout', () => {
+	const neverBought = { costCap: 1500000, allowanceRemaining: 960000, purchasedAtTopUp: 0 };
+
+	it( 'welcomes with the allowance size from the quota, not a hardcoded figure', () => {
+		expect( formatAiCreditsCallout( neverBought, { fraction: 0.36 }, 'en-US' ) ).toBe(
+			'Your first 1,500,000 AI credits are on us.'
+		);
+	} );
+
+	it( 'drops the welcome once the free credits are spent, even with no purchase', () => {
+		expect(
+			formatAiCreditsCallout(
+				{ ...neverBought, allowanceRemaining: 0 },
+				{ fraction: 0.5 },
+				'en-US'
+			)
+		).toBe( 'Keep the ideas flowing. Stock up for whatever you build next.' );
+	} );
+
+	it( 'drops the welcome once the account has bought credits', () => {
+		expect(
+			formatAiCreditsCallout(
+				{ ...neverBought, purchasedAtTopUp: 500000 },
+				{ fraction: 0.36 },
+				'en-US'
+			)
+		).toBe( 'Keep the ideas flowing. Stock up for whatever you build next.' );
+	} );
+
+	it( 'escalates with the meter, beating the welcome', () => {
+		expect( formatAiCreditsCallout( neverBought, { fraction: 0.8 } ) ).toBe(
+			'Top up now so your next build doesn’t stop short.'
+		);
+		expect( formatAiCreditsCallout( neverBought, { fraction: 0.9 } ) ).toBe(
+			'You’re on a roll. Top up now and keep building.'
+		);
+		expect( formatAiCreditsCallout( neverBought, { fraction: 1 } ) ).toBe(
+			'Your next idea is ready when you are. Top up to bring it to life.'
+		);
 	} );
 } );


### PR DESCRIPTION
## Related issues

- Fixes STU-2345

## How AI was used in this PR

Assisted

## Proposed Changes
With this PR we are adding progress bar for used credits instead of plain text:<br /><img width="603" height="376" alt="Screenshot 2026-08-26 at 12 51 11" src="https://github.com/user-attachments/assets/a999d0bd-0517-437c-91c1-124f5a6c9597" />

The next approach was requested by Shaun:
```
If you have 1M credits (not tokens!) and lets say you've used 500K, so you have 500K left. Your bar looks something like this:

[=====-----] 500K / 1M

If you then go and purchase another 100K credits, your total amount is reset, so now you have 600K credits to use. Your bar looks something like this:

[==========] 600K / 600K
```

## Testing Instructions
1. Apply this diff (236947-ghe-Automattic/wpcom) and follow the "Preparation" section there
2. Open Settings -> Usage and assert that you see 0/20 000 000 available and message `Your first 20,000,000 AI credits are on us.`:<br /><img width="617" height="377" alt="Screenshot 2026-08-26 at 12 54 58" src="https://github.com/user-attachments/assets/02cdeb90-220e-4c8a-b35a-ff010a02d388" />
3. <img width="563" height="435" alt="Screenshot 2026-08-26 at 12 55 28" src="https://github.com/user-attachments/assets/2fac4bb5-ac04-4af1-a196-f73ce0fcf3c1" />
4. Send a prompt in Studio Code tab
5. Open Usage settings again and assert that it works:<br /><img width="547" height="134" alt="Screenshot 2026-08-26 at 12 56 19" src="https://github.com/user-attachments/assets/171d547c-b314-440b-9c69-9a8cce165223" />
6. Follow "Simulate no free credits" steps here- 236947-ghe-Automattic/wpcom
7. Come back to Studio and assert that you see with a new copy:<br /><img width="549" height="141" alt="Screenshot 2026-08-26 at 13 15 12" src="https://github.com/user-attachments/assets/a19240a9-cd38-4917-be4f-692e5e7b3946" />
8. Click on "Add AI Credits" and proceed
9. Assert that you see 0/100 000, so we render the cap state as it was during the latest top-up 
10. Send a prompt
11. Assert that you still see 100 000 cap and ~XXXused :<br /><img width="541" height="122" alt="Screenshot 2026-08-26 at 13 23 52" src="https://github.com/user-attachments/assets/76692f40-de4f-4735-9514-65a4794e7602" />
12. Top up balance again
13. Assert that you see the new cap `199,891`:<br /><img width="543" height="140" alt="Screenshot 2026-08-26 at 13 24 59" src="https://github.com/user-attachments/assets/874aad23-7811-4994-b63b-256fbabf0754" />
14. Set purchased cost usage to ~81% and assert the next UI and copy:<br /><img width="545" height="133" alt="Screenshot 2026-08-26 at 13 32 41" src="https://github.com/user-attachments/assets/983b4a82-a32e-4b45-9c09-30dd2b53df7a" />
15. Set purchased cost usage to ~91% and assert the next UI and copy:<br /><img width="549" height="137" alt="Screenshot 2026-08-26 at 13 33 33" src="https://github.com/user-attachments/assets/1f8168b1-d424-4e65-953b-55e5e50a816d" />



