### PR TITLE
Fix trunk typecheck errors introduced by the generate_images tool

### DIFF
--- a/apps/cli/ai/tools/generate-images.ts
+++ b/apps/cli/ai/tools/generate-images.ts
@@ -2,7 +2,6 @@ import fs from 'fs/promises';
 import path from 'path';
 import { Type } from 'typebox';
 import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
-import { emitProgress } from 'cli/logger';
 import {
 	composeImagePrompt,
 	generateImages,
@@ -84,7 +83,7 @@ export const generateImagesTool = defineTool(
 			} )
 		),
 	},
-	async ( args ) => {
+	async ( args, context ) => {
 		if ( ! ( await isImageGenerationAvailable() ) ) {
 			throw new Error(
 				'Image generation is not available in this session. Build the site without generated imagery.'
@@ -96,7 +95,9 @@ export const generateImagesTool = defineTool(
 			resolvedPath: resolveImageFilePath( image.path ),
 		} ) );
 
-		emitProgress( `Generating ${ targets.length } image${ targets.length === 1 ? '' : 's' }…` );
+		context.onProgress(
+			`Generating ${ targets.length } image${ targets.length === 1 ? '' : 's' }…`
+		);
 
 		const requests = targets.map( ( image ) => ( {
 			prompt: composeImagePrompt( image, {
@@ -111,7 +112,7 @@ export const generateImagesTool = defineTool(
 		const results = await generateImages( requests, ( _index, result ) => {
 			if ( result.ok ) {
 				generated++;
-				emitProgress( `Generated ${ generated }/${ targets.length } images` );
+				context.onProgress( `Generated ${ generated }/${ targets.length } images`, true );
 			}
 		} );
 

--- a/packages/common/ai/tools.ts
+++ b/packages/common/ai/tools.ts
@@ -1,4 +1,4 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 export function getInputString(
 	input: Record< string, unknown > | undefined,


### PR DESCRIPTION
## Related issues

- Related to #4668

## How AI was used in this PR

Diagnosed and fixed entirely with Claude Code; changes reviewed by the author.

## Proposed Changes

#4668 landed with two TypeScript errors that break `npm run typecheck` on trunk (and with it any CI job that type-checks or builds):

- `generate-images.ts` imported a nonexistent `emitProgress` from `cli/logger`. Progress is now reported through the tool handler's `context.onProgress`, the same mechanism every other Studio tool uses — so progress messages actually reach the UI instead of being dead code.
- `packages/common/ai/tools.ts` used `_n()` without importing it from `@wordpress/i18n`.

## Testing Instructions

- `npm run typecheck` passes (it fails on trunk with 2 errors).
- `npm test -- apps/cli/ai/tests` — 227 tests pass, including the 13 image-generation tests.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)