### PR TITLE
Add a /credits command so CLI users can check their balance and buy more

### DIFF
--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -2,6 +2,17 @@ import { getAiModelFamily, getVisibleAiModels } from '@studio/common/ai/models';
 import { getAiModelLabel, type AiModelId } from '@studio/common/ai/models';
 import { getAiSkillCommands } from '@studio/common/ai/slash-commands';
 import { isAutomatticianFromToken, readAuthToken } from '@studio/common/lib/shared-config';
+import {
+	clampQuotaFraction,
+	fetchStudioAssistantQuota,
+	formatQuotaPercentage,
+	getAddAiCreditsUrl,
+	type StudioAssistantQuota,
+} from '@studio/common/lib/studio-assistant-quota';
+import {
+	fetchStudioAssistantTopUpPricing,
+	formatTopUpOptionCreditsLabel,
+} from '@studio/common/lib/studio-assistant-top-up-pricing';
 import { __, sprintf } from '@wordpress/i18n';
 import { getAvailableAiProviders, isAiProviderReady } from 'cli/ai/auth';
 import { AI_PROVIDERS, getAiProviderDefinition, type AiProviderId } from 'cli/ai/providers';
@@ -234,6 +245,49 @@ async function runRemoteSessionSlashCommand(
 	return 'continue';
 }
 
+/**
+ * Print the account's AI credit balance. Which figure exists depends on the
+ * account: the server reports the two credit pools only where AI credits are
+ * enabled (their absence — not a zero — means the older monthly-cap design),
+ * and reports neither when it can't price the account at all.
+ */
+function showCreditBalance( ctx: SlashCommandContext, quota: StudioAssistantQuota | null ): void {
+	const credits = new Intl.NumberFormat();
+	if (
+		quota &&
+		( quota.allowanceRemaining !== undefined || quota.purchasedRemaining !== undefined )
+	) {
+		if ( ( quota.allowanceRemaining ?? 0 ) > 0 ) {
+			ctx.ui.showInfo(
+				sprintf(
+					/* translators: %s: number of free AI credits remaining (e.g. 960,000). */
+					__( 'Free credits remaining: %s' ),
+					credits.format( quota.allowanceRemaining ?? 0 )
+				)
+			);
+		}
+		ctx.ui.showInfo(
+			sprintf(
+				/* translators: %s: number of purchased AI credits remaining (e.g. 150,000). */
+				__( 'Purchased credits remaining: %s' ),
+				credits.format( quota.purchasedRemaining ?? 0 )
+			)
+		);
+		return;
+	}
+	if ( quota && quota.costCap > 0 ) {
+		ctx.ui.showInfo(
+			sprintf(
+				/* translators: %s: percentage of monthly limit used (e.g. 7.5%). */
+				__( '%s of monthly limit used' ),
+				formatQuotaPercentage( clampQuotaFraction( quota.costUsage, quota.costCap ) )
+			)
+		);
+		return;
+	}
+	ctx.ui.showInfo( __( 'Studio Code limits are temporarily unavailable.' ) );
+}
+
 export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 	{
 		name: 'browser',
@@ -251,6 +305,81 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 		description: __( 'Clear the conversation and start a fresh session' ),
 		handler: async ( _prompt, ctx ) => {
 			await ctx.clearSession();
+			return 'continue';
+		},
+	},
+	{
+		name: 'credits',
+		description: __( 'Show your AI credit balance and buy more' ),
+		handler: async ( _prompt, ctx ) => {
+			const token = await readAuthToken();
+			if ( ! token?.accessToken ) {
+				ctx.ui.showInfo( __( 'WordPress.com login required. Use /login to authenticate.' ) );
+				return 'continue';
+			}
+
+			ctx.ui.showProgress( __( 'Fetching your AI credits…' ) );
+			ctx.ui.setBusy( true );
+			// Independent endpoints, and neither is a gate on the other: the
+			// balance is worth printing when pricing is down, and the top-ups
+			// are worth offering when the balance can't be read.
+			const [ quota, pricing ] = await Promise.all( [
+				fetchStudioAssistantQuota( token.accessToken ),
+				fetchStudioAssistantTopUpPricing( token.accessToken ),
+			] );
+			ctx.ui.setBusy( false );
+
+			showCreditBalance( ctx, quota );
+
+			// Whatever the store priced for this account, in whatever number.
+			// With no pricing at all the fixed top-up still checks out, so it
+			// stands in rather than leaving the user with nothing to pick.
+			const options = pricing?.options ?? [];
+			const choices: { label: string; description: string; credits?: number }[] = options.length
+				? options.map( ( option ) => ( {
+						label: formatTopUpOptionCreditsLabel( option ),
+						description: option.display,
+						credits: option.credits,
+				  } ) )
+				: [
+						{
+							label: __( 'Add AI credits' ),
+							description: __( 'Pricing unavailable — opens WordPress.com checkout' ),
+						},
+				  ];
+
+			try {
+				const answer = await ctx.ui.askUser( [
+					{
+						question: __( 'Select a top-up to buy' ),
+						options: choices.map( ( { label, description } ) => ( { label, description } ) ),
+					},
+				] );
+				const selectedLabel = Object.values( answer )[ 0 ] as string;
+				const choice = choices.find( ( candidate ) => candidate.label === selectedLabel );
+				if ( ! choice ) {
+					ctx.ui.showInfo( __( 'No top-up selected.' ) );
+					return 'continue';
+				}
+
+				// The terminal has nothing for checkout to return to, so the URL
+				// carries no `wp-studio://` return parameters.
+				const url = getAddAiCreditsUrl( { returnsToDesktop: false, credits: choice.credits } );
+				await openBrowser( url );
+				// The terminal can't render a link, so the URL goes on its own
+				// line, as-is — it stays copyable and most terminals auto-link it.
+				ctx.ui.showInfo(
+					__( 'Opening WordPress.com checkout. If your browser didn’t open, use the link below:' )
+				);
+				ctx.ui.showInfo( url );
+			} catch ( error ) {
+				ctx.ui.setBusy( false );
+				if ( isPromptAbortError( error ) ) {
+					ctx.ui.showInfo( __( 'Canceled.' ) );
+					return 'continue';
+				}
+				ctx.ui.showError( __( 'Failed to open WordPress.com checkout.' ) );
+			}
 			return 'continue';
 		},
 	},

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -257,8 +257,11 @@ function showCreditBalance( ctx: SlashCommandContext, quota: StudioAssistantQuot
 		quota &&
 		( quota.allowanceRemaining !== undefined || quota.purchasedRemaining !== undefined )
 	) {
+		// One showInfo for all the lines: each call pads itself with blank
+		// lines, so per-line calls read as separate paragraphs.
+		const lines = [];
 		if ( ( quota.allowanceRemaining ?? 0 ) > 0 ) {
-			ctx.ui.showInfo(
+			lines.push(
 				sprintf(
 					/* translators: %s: number of free AI credits remaining (e.g. 960,000). */
 					__( 'Free credits remaining: %s' ),
@@ -266,13 +269,14 @@ function showCreditBalance( ctx: SlashCommandContext, quota: StudioAssistantQuot
 				)
 			);
 		}
-		ctx.ui.showInfo(
+		lines.push(
 			sprintf(
 				/* translators: %s: number of purchased AI credits remaining (e.g. 150,000). */
 				__( 'Purchased credits remaining: %s' ),
 				credits.format( quota.purchasedRemaining ?? 0 )
 			)
 		);
+		ctx.ui.showInfo( lines.join( '\n' ) );
 		return;
 	}
 	if ( quota && quota.costCap > 0 ) {
@@ -369,9 +373,10 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 				// The terminal can't render a link, so the URL goes on its own
 				// line, as-is — it stays copyable and most terminals auto-link it.
 				ctx.ui.showInfo(
-					__( 'Opening WordPress.com checkout. If your browser didn’t open, use the link below:' )
+					__( 'Opening WordPress.com checkout. If your browser didn’t open, use the link below:' ) +
+						'\n' +
+						url
 				);
-				ctx.ui.showInfo( url );
 			} catch ( error ) {
 				ctx.ui.setBusy( false );
 				if ( isPromptAbortError( error ) ) {

--- a/apps/cli/ai/tests/slash-commands.test.ts
+++ b/apps/cli/ai/tests/slash-commands.test.ts
@@ -404,3 +404,187 @@ describe( '/model slash command', () => {
 		expect( persistMock ).not.toHaveBeenCalled();
 	} );
 } );
+
+vi.mock( '@studio/common/lib/studio-assistant-quota', async ( importOriginal ) => {
+	const actual = await importOriginal< object >();
+	return { ...actual, fetchStudioAssistantQuota: vi.fn() };
+} );
+
+vi.mock( '@studio/common/lib/studio-assistant-top-up-pricing', async ( importOriginal ) => {
+	const actual = await importOriginal< object >();
+	return { ...actual, fetchStudioAssistantTopUpPricing: vi.fn() };
+} );
+
+vi.mock( 'cli/lib/browser', () => ( { openBrowser: vi.fn() } ) );
+
+describe( '/credits slash command', () => {
+	const cmd = AI_CHAT_SLASH_COMMANDS.find( ( c ) => c.name === 'credits' )!;
+
+	function makeUi() {
+		return {
+			showInfo: vi.fn(),
+			showError: vi.fn(),
+			showSuccess: vi.fn(),
+			showProgress: vi.fn(),
+			setBusy: vi.fn(),
+			askUser: vi.fn(),
+		};
+	}
+
+	function makeCtx( ui: ReturnType< typeof makeUi > ): SlashCommandContext {
+		return {
+			ui: ui as unknown as SlashCommandContext[ 'ui' ],
+			currentModel: 'claude-sonnet-4-5' as SlashCommandContext[ 'currentModel' ],
+			currentProvider: 'wpcom' as SlashCommandContext[ 'currentProvider' ],
+			showCapabilitiesOnConnect: false,
+			switchProvider: vi.fn().mockResolvedValue( undefined ),
+			prepareProviderSelection: vi.fn().mockResolvedValue( undefined ),
+			maybeAutoSwitchProvider: vi.fn().mockResolvedValue( undefined ),
+			persistSessionContext: vi.fn().mockResolvedValue( undefined ),
+			clearSession: vi.fn().mockResolvedValue( undefined ),
+		};
+	}
+
+	const gbpPricing = {
+		options: [
+			{ credits: 100000, display: '£7.50' },
+			{ credits: 500000, display: '£37.50' },
+		],
+	};
+
+	async function mocks() {
+		return {
+			auth: await import( '@studio/common/lib/shared-config' ),
+			quota: await import( '@studio/common/lib/studio-assistant-quota' ),
+			pricing: await import( '@studio/common/lib/studio-assistant-top-up-pricing' ),
+			browser: await import( 'cli/lib/browser' ),
+		};
+	}
+
+	beforeEach( async () => {
+		const m = await mocks();
+		vi.mocked( m.auth.readAuthToken ).mockResolvedValue( {
+			accessToken: 'token',
+		} as Awaited< ReturnType< typeof m.auth.readAuthToken > > );
+		vi.mocked( m.quota.fetchStudioAssistantQuota ).mockResolvedValue( null );
+		vi.mocked( m.pricing.fetchStudioAssistantTopUpPricing ).mockResolvedValue( null );
+		vi.mocked( m.browser.openBrowser ).mockResolvedValue( undefined );
+	} );
+
+	it( 'is registered with a handler', () => {
+		expect( cmd ).toBeDefined();
+		expect( typeof cmd.handler ).toBe( 'function' );
+		expect( cmd.description ).toBeTruthy();
+	} );
+
+	it( 'asks the user to sign in instead of calling WordPress.com', async () => {
+		const m = await mocks();
+		vi.mocked( m.auth.readAuthToken ).mockResolvedValue( null );
+		const ui = makeUi();
+
+		const result = await cmd.handler!( '/credits', makeCtx( ui ) );
+
+		expect( m.quota.fetchStudioAssistantQuota ).not.toHaveBeenCalled();
+		expect( ui.showInfo ).toHaveBeenCalledWith( expect.stringContaining( '/login' ) );
+		expect( ui.askUser ).not.toHaveBeenCalled();
+		expect( result ).toBe( 'continue' );
+	} );
+
+	it( 'shows both credit pools, then offers every priced top-up', async () => {
+		const m = await mocks();
+		vi.mocked( m.quota.fetchStudioAssistantQuota ).mockResolvedValue( {
+			costUsage: 1,
+			costCap: 100,
+			emailVerified: true,
+			hasPaymentMethod: true,
+			allowanceRemaining: 960000,
+			purchasedRemaining: 150000,
+		} as Awaited< ReturnType< typeof m.quota.fetchStudioAssistantQuota > > );
+		vi.mocked( m.pricing.fetchStudioAssistantTopUpPricing ).mockResolvedValue( gbpPricing );
+
+		const ui = makeUi();
+		ui.askUser.mockResolvedValue( { 0: '500,000 credits' } );
+
+		await cmd.handler!( '/credits', makeCtx( ui ) );
+
+		expect( ui.showInfo ).toHaveBeenCalledWith( 'Free credits remaining: 960,000' );
+		expect( ui.showInfo ).toHaveBeenCalledWith( 'Purchased credits remaining: 150,000' );
+		const options = ui.askUser.mock.calls[ 0 ][ 0 ][ 0 ].options;
+		expect( options ).toEqual( [
+			{ label: '100,000 credits', description: '£7.50' },
+			{ label: '500,000 credits', description: '£37.50' },
+		] );
+		expect( m.browser.openBrowser ).toHaveBeenCalledWith(
+			'https://wordpress.com/checkout/wpcom/studio-code-ai-credits:-q-500000'
+		);
+	} );
+
+	it( 'hides the free pool once it is spent', async () => {
+		const m = await mocks();
+		vi.mocked( m.quota.fetchStudioAssistantQuota ).mockResolvedValue( {
+			costUsage: 1,
+			costCap: 100,
+			emailVerified: true,
+			hasPaymentMethod: true,
+			allowanceRemaining: 0,
+			purchasedRemaining: 0,
+		} as Awaited< ReturnType< typeof m.quota.fetchStudioAssistantQuota > > );
+
+		const ui = makeUi();
+		ui.askUser.mockResolvedValue( { 0: 'Add AI credits' } );
+
+		await cmd.handler!( '/credits', makeCtx( ui ) );
+
+		expect( ui.showInfo ).not.toHaveBeenCalledWith(
+			expect.stringContaining( 'Free credits remaining' )
+		);
+		expect( ui.showInfo ).toHaveBeenCalledWith( 'Purchased credits remaining: 0' );
+	} );
+
+	it( 'falls back to the fixed top-up when nothing could be priced', async () => {
+		const m = await mocks();
+		vi.mocked( m.pricing.fetchStudioAssistantTopUpPricing ).mockResolvedValue( { options: [] } );
+
+		const ui = makeUi();
+		ui.askUser.mockResolvedValue( { 0: 'Add AI credits' } );
+
+		await cmd.handler!( '/credits', makeCtx( ui ) );
+
+		const options = ui.askUser.mock.calls[ 0 ][ 0 ][ 0 ].options;
+		expect( options ).toHaveLength( 1 );
+		expect( options[ 0 ].label ).toBe( 'Add AI credits' );
+		expect( m.browser.openBrowser ).toHaveBeenCalledWith(
+			'https://wordpress.com/checkout/wpcom/studio-code-ai-credits:-q-100000'
+		);
+	} );
+
+	it( 'still offers top-ups when the balance cannot be read', async () => {
+		const m = await mocks();
+		vi.mocked( m.pricing.fetchStudioAssistantTopUpPricing ).mockResolvedValue( gbpPricing );
+
+		const ui = makeUi();
+		ui.askUser.mockResolvedValue( { 0: '100,000 credits' } );
+
+		await cmd.handler!( '/credits', makeCtx( ui ) );
+
+		expect( ui.showInfo ).toHaveBeenCalledWith( 'Studio Code limits are temporarily unavailable.' );
+		expect( ui.askUser ).toHaveBeenCalledOnce();
+		expect( m.browser.openBrowser ).toHaveBeenCalled();
+	} );
+
+	it( 'opens nothing when the picker is canceled (Esc)', async () => {
+		const m = await mocks();
+		vi.mocked( m.pricing.fetchStudioAssistantTopUpPricing ).mockResolvedValue( gbpPricing );
+
+		const ui = makeUi();
+		ui.askUser.mockRejectedValue(
+			Object.assign( new Error( 'aborted' ), { name: 'AbortPromptError' } )
+		);
+
+		const result = await cmd.handler!( '/credits', makeCtx( ui ) );
+
+		expect( m.browser.openBrowser ).not.toHaveBeenCalled();
+		expect( ui.showInfo ).toHaveBeenCalledWith( 'Canceled.' );
+		expect( result ).toBe( 'continue' );
+	} );
+} );

--- a/apps/cli/ai/tests/slash-commands.test.ts
+++ b/apps/cli/ai/tests/slash-commands.test.ts
@@ -507,8 +507,11 @@ describe( '/credits slash command', () => {
 
 		await cmd.handler!( '/credits', makeCtx( ui ) );
 
-		expect( ui.showInfo ).toHaveBeenCalledWith( 'Free credits remaining: 960,000' );
-		expect( ui.showInfo ).toHaveBeenCalledWith( 'Purchased credits remaining: 150,000' );
+		// One paragraph: separate showInfo calls each pad themselves with
+		// blank lines, so the two figures must travel together.
+		expect( ui.showInfo ).toHaveBeenCalledWith(
+			'Free credits remaining: 960,000\nPurchased credits remaining: 150,000'
+		);
 		const options = ui.askUser.mock.calls[ 0 ][ 0 ][ 0 ].options;
 		expect( options ).toEqual( [
 			{ label: '100,000 credits', description: '£7.50' },

--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -341,13 +341,10 @@ describe( 'AiChatUI.handleEvent', () => {
 		expect( showError ).not.toHaveBeenCalledWith(
 			expect.stringContaining( 'monthly AI usage limit' )
 		);
-		expect( showInfo ).toHaveBeenCalledWith(
-			'Run /credits to see your balance and buy more, or use the link below:'
-		);
-		// The terminal has nothing for checkout to return to, so the URL it
-		// prints carries no return parameters.
-		expect( showInfo ).toHaveBeenCalledWith( ADD_AI_CREDITS_URL );
-		expect( ADD_AI_CREDITS_URL ).not.toContain( 'studioReturnTo' );
+		expect( showInfo ).toHaveBeenCalledWith( 'Use /credits to see your balance and buy more.' );
+		// No direct checkout URL here — /credits is the single entry point, so
+		// the user sees every top-up option instead of one preset quantity.
+		expect( showInfo ).not.toHaveBeenCalledWith( ADD_AI_CREDITS_URL );
 		expect( ui.showUsageCapResetDate ).not.toHaveBeenCalled();
 		expect( ui.usageCapReached ).toBe( true );
 		expect( ui.currentMarkdown ).toBeNull();

--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -342,7 +342,7 @@ describe( 'AiChatUI.handleEvent', () => {
 			expect.stringContaining( 'monthly AI usage limit' )
 		);
 		expect( showInfo ).toHaveBeenCalledWith(
-			'Add credits at the link below, then come back to continue using Studio Code:'
+			'Run /credits to see your balance and buy more, or use the link below:'
 		);
 		// The terminal has nothing for checkout to return to, so the URL it
 		// prints carries no return parameters.

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -33,7 +33,6 @@ import { findLastAssistant } from '@studio/common/ai/session-events';
 import { randomThinkingMessage } from '@studio/common/ai/thinking-messages';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import {
-	ADD_AI_CREDITS_URL,
 	fetchStudioAssistantQuota,
 	formatOutOfCreditsNotice,
 	formatQuotaResetDate,
@@ -1837,12 +1836,7 @@ export class AiChatUI implements AiOutputAdapter {
 					this.usageCapReached = true;
 					this.showError( outOfCredits ? formatOutOfCreditsNotice() : formatUsageCapNotice() );
 					if ( outOfCredits ) {
-						// The terminal can't render a link, so the URL goes on its own
-						// line, as-is — it stays copyable and most terminals auto-link it.
-						this.showInfo(
-							__( 'Use /credits to see your balance and buy more, or open the link below:' )
-						);
-						this.showInfo( ADD_AI_CREDITS_URL );
+						this.showInfo( __( 'Use /credits to see your balance and buy more.' ) );
 					} else {
 						// Async on purpose: the reset date needs a wpcom round trip
 						// and must not block rendering the cap notice.

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1840,7 +1840,7 @@ export class AiChatUI implements AiOutputAdapter {
 						// The terminal can't render a link, so the URL goes on its own
 						// line, as-is — it stays copyable and most terminals auto-link it.
 						this.showInfo(
-							__( 'Add credits at the link below, then come back to continue using Studio Code:' )
+							__( 'Run /credits to see your balance and buy more, or use the link below:' )
 						);
 						this.showInfo( ADD_AI_CREDITS_URL );
 					} else {

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1840,7 +1840,7 @@ export class AiChatUI implements AiOutputAdapter {
 						// The terminal can't render a link, so the URL goes on its own
 						// line, as-is — it stays copyable and most terminals auto-link it.
 						this.showInfo(
-							__( 'Run /credits to see your balance and buy more, or use the link below:' )
+							__( 'Use /credits to see your balance and buy more, or open the link below:' )
 						);
 						this.showInfo( ADD_AI_CREDITS_URL );
 					} else {


### PR DESCRIPTION
Fixes STU-2327

## How AI was used in this PR

Assisted

## Proposed Changes

With this PR we are adding /credits command to see info about remaining balance and top-up options

## Testing Instructions
1. `npm run cli:build && node apps/cli/dist/cli/main.mjs code`
1. Type `/credits`. Expect your balance, then a picker listing every priced top-up:<br /><img width="339" height="273" alt="Screenshot 2026-08-26 at 15 19 55" src="https://github.com/user-attachments/assets/565f46e5-0b83-44ea-86f6-337faa2501f7" />
2. Press Enter on one — checkout opens at that quantity.
3. Press Esc — /credits are closed
4. `/logout`, then `/credits` — expect the `/login` prompt.
5. Exhaust credits and send a prompt:<br /><img width="656" height="177" alt="Screenshot 2026-08-26 at 15 22 35" src="https://github.com/user-attachments/assets/dee39d8b-18ef-4348-ba71-c7dc2fc96ebf" />

