### PR TITLE
Skip CLI E2E on draft PRs

### DIFF
--- a/.buildkite/commands/run-cli-e2e-tests.sh
+++ b/.buildkite/commands/run-cli-e2e-tests.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 PLATFORM=${1:-mac}
 
+# Skipped here rather than with an `if:` guard on the group, which would stop
+# the required check reporting — see the CLI E2E group in .buildkite/pipeline.yml.
+if [[ "${BUILDKITE_PULL_REQUEST_DRAFT:-false}" == "true" ]]; then
+  message="Skipping CLI E2E - draft PR. They run in full once it is marked ready for review."
+  if command -v buildkite-agent &> /dev/null; then
+    echo "$message" | buildkite-agent annotate --style "info" --context "skip-cli-e2e-draft" || true
+  fi
+  echo "~~~ :fast_forward: $message"
+  exit 0
+fi
+
 if .buildkite/commands/should-skip-job.sh --job-type validation; then
   exit 0
 fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -133,7 +133,8 @@ steps:
         if: (build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft) && !(build.pull_request.labels includes 'native-php')
 
   # No `if:` guard: a required status check must report on every build, or PRs
-  # that skip it hang waiting for it. Doc-only PRs exit early but still report.
+  # that skip it hang waiting for it. Doc-only and draft PRs exit early in
+  # run-cli-e2e-tests.sh but still report.
   - group: CLI E2E Tests
     key: cli-e2e-tests
     notify:


### PR DESCRIPTION
## Related issues

- Closes [AINFRA-3003](https://linear.app/a8c/issue/AINFRA-3003)

## How AI was used in this PR

Claude Code wrote the change and ran the verification below. I reviewed the diff.

Claude Code also noticed the issue this PR addresses, when prompted by me to research opportunities to improve the DX of the tools Apps Infra provides to our "users", CI being a core one of them.

## Proposed Changes

`E2E Tests` skips draft PRs through an `if:` guard on the group. `CLI E2E Tests` cannot use one — a required status check that never reports leaves the PR waiting on it — so it runs on 99% of builds, costing **859 agent-hours a month** across mac, windows and linux.

The repo already solved this the other way round: `run-cli-e2e-tests.sh` exits 0 early for doc-only PRs, and the check still reports green in seconds. This extends that early exit to drafts. Expected saving is roughly a third of those hours, and up to 20 minutes of wait on every draft PR (`CLI E2E Tests on windows` is 20.0 min p50).

## Testing Instructions

<details>
<summary>Steps the AI took</summary>

`BUILDKITE_PULL_REQUEST_DRAFT` is exported **only when the PR is a draft**, which is what makes the `:-false` default load-bearing. Confirmed against the real job environments of two studio builds:

| Build | PR state | `BUILDKITE_PULL_REQUEST_DRAFT` |
|---|---|---|
| [21213](https://buildkite.com/automattic/studio/builds/21213) | draft | `'true'` |
| [21397](https://buildkite.com/automattic/studio/builds/21397) | not a draft | absent |

I also checked that the `if:` guard genuinely suppresses reporting, rather than reporting a skip: on build 21213 the `E2E Tests` group was skipped and its commit status is **missing entirely** from the head SHA's statuses, while the four groups that ran all reported. The comment in `pipeline.yml` is right, and the guard has to stay in the script.

Locally, the four branches of the new guard, with `should-skip-job.sh` stubbed so the case is isolated:

| `BUILDKITE_PULL_REQUEST_DRAFT` | Result |
|---|---|
| `true` | draft skip, exit 0, `should-skip-job.sh` never reached |
| unset | falls through to `should-skip-job.sh` |
| `false` | falls through |
| `TRUE` | falls through (Buildkite emits lowercase) |

**This PR is opened as a draft on purpose** — CLI E2E should skip on it with the annotation `Skipping CLI E2E - draft PR`, distinct from the doc-only message. Note the diff is `.buildkite/**`-only, which `should-skip-job.sh` already treats as non-code, so marking it ready will swap one skip message for the other rather than running the suite in full. That still demonstrates the load-bearing half: the draft guard stops firing once the PR is ready.

</details>

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? — N.A. this is a CI only change
