### PR TITLE
Skip CLI E2E on drafts with a pipeline guard

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -132,8 +132,9 @@ steps:
           DEBUG: "pw:browser"
         if: (build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft) && !(build.pull_request.labels includes 'native-php')
 
-  # No `if:` guard: a required status check must report on every build, or PRs
-  # that skip it hang waiting for it. Doc-only PRs exit early but still report.
+  # The `if:` guards below stop the required `CLI E2E Tests` status reporting on
+  # drafts, which is only safe while draft-ness is the condition: a PR has to be
+  # marked ready to merge, and that transition builds again and reports.
   - group: CLI E2E Tests
     key: cli-e2e-tests
     notify:
@@ -150,6 +151,7 @@ steps:
         matrix:
           - mac
           - windows
+        if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
 
       # Separate from the matrix above: Mac and Windows share queue/plugin
       # defaults that Linux doesn't. Same pattern as the unit-test group.
@@ -164,6 +166,7 @@ steps:
               image: "$NODE_DOCKER_IMAGE"
               propagate-environment: true
               mount-buildkite-agent: true
+        if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
 
   - label: ":chart_with_upwards_trend: Performance Metrics"
     key: metrics


### PR DESCRIPTION
## Related issues

- Alternative to #4700, same issue: [AINFRA-3003](https://linear.app/a8c/issue/AINFRA-3003)

## How AI was used in this PR

Claude Code wrote the change and ran the verification below. I reviewed the diff.

## Proposed Changes

Two ways to stop `CLI E2E Tests` running on draft PRs. **Pick one; close the other.**

- **#4700** skips inside `run-cli-e2e-tests.sh`, so the required check still reports on drafts. The cost is that Buildkite still boots two macOS VMs, a Windows VM and a Linux container per draft build, to run a script that exits in seconds.
- **This PR** guards the steps with `if:`, exactly as the `E2E Tests` group directly above it already does. Nothing boots. The cost is that the required check does not report on drafts.

I'd previously assumed the `if:` route was closed off because a required check has to report on every build. It isn't: `E2E Tests` and `Performance Metrics` are both required contexts on `trunk` today, and both already skip drafts through an `if:`. This PR moves `CLI E2E Tests` into the same bucket rather than inventing a third pattern.

### The catch, stated plainly

Marking a draft ready does **not** produce a build that reports the skipped checks. `build_pull_request_ready_for_review` is `false` on the `studio` pipeline, and the Apps Infra Checkov policy `BK_PIPELINE_DONT_REBUILD_ON_UNDRAFTING` requires it to stay `false`. So a PR marked ready reports the guarded checks on the **next push**, not on the state change.

That is already the status quo for two required checks, and in practice authors push again before merging: all five studio PRs merged in the last fortnight had a commit after `ready_for_review`. But it does mean this PR takes the count of "required checks that go quiet on drafts" from two to three. If that trade is unwelcome, #4700 is the one to take.

## Testing Instructions

<details>
<summary>Steps the AI took</summary>

**The `if:` guard genuinely suppresses reporting.** On PR #4689 — marked ready with no subsequent push — the head SHA has statuses for `CLI E2E Tests`, `Lint`, `Unit Tests`, `Data Liberation` and `fastlane Helper Tests`, and **no** `E2E Tests` or `Performance Metrics` at all. One Buildkite build (21382), created by the push, none created by the ready transition.

**Both are required checks.** `GET /repos/Automattic/studio/branches/trunk/protection` lists exactly: `Lint`, `Unit Tests`, `E2E Tests`, `Performance Metrics`, `CLI E2E Tests`.

**The rebuild-on-ready setting.** `GET /v2/organizations/automattic/pipelines/studio` reports `build_pull_request_ready_for_review: false`, and `src/buildkite/policies/` in `buildkite-ci` pins it there.

**This PR is a draft on purpose.** The `CLI E2E Tests` check should be absent from its status list — that absence is the whole tradeoff, visible rather than argued.

</details>

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? — N.A. this is a CI-only change
