### PR TITLE
Studio Code CLI: show remaining AI credits in the end-of-turn stats line

### DIFF
--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -1,6 +1,10 @@
 import { initTheme, ToolExecutionComponent } from '@earendil-works/pi-coding-agent';
 import { Container } from '@earendil-works/pi-tui';
-import { ADD_AI_CREDITS_URL } from '@studio/common/lib/studio-assistant-quota';
+import { readAuthToken } from '@studio/common/lib/shared-config';
+import {
+	ADD_AI_CREDITS_URL,
+	fetchStudioAssistantQuota,
+} from '@studio/common/lib/studio-assistant-quota';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { toolResultRenderers } from 'cli/ai/tool-result-renderers';
 import { AiChatUI } from 'cli/ai/ui';
@@ -40,6 +44,23 @@ vi.mock( 'cli/lib/cli-config/sites', async ( importOriginal ) => {
 vi.mock( 'cli/lib/browser', () => ( {
 	openBrowser: vi.fn(),
 } ) );
+
+vi.mock( '@studio/common/lib/shared-config', async ( importOriginal ) => {
+	const actual = await importOriginal< typeof import('@studio/common/lib/shared-config') >();
+	return {
+		...actual,
+		readAuthToken: vi.fn(),
+	};
+} );
+
+vi.mock( '@studio/common/lib/studio-assistant-quota', async ( importOriginal ) => {
+	const actual =
+		await importOriginal< typeof import('@studio/common/lib/studio-assistant-quota') >();
+	return {
+		...actual,
+		fetchStudioAssistantQuota: vi.fn(),
+	};
+} );
 
 vi.mock( 'cli/lib/site-utils', () => ( {
 	isSiteRunning: vi.fn(),
@@ -894,5 +915,80 @@ describe( 'AiChatUI.handleEvent', () => {
 		const joined = renderedContainerText( messages );
 		expect( joined ).toContain( 'Screenshot captured' );
 		expect( joined ).not.toContain( 'mediaWidgetPayload' );
+	} );
+} );
+
+describe( 'AiChatUI.showTurnStats', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	const quota = ( overrides: Record< string, unknown > = {} ) =>
+		( {
+			costUsage: 5,
+			costCap: 100,
+			emailVerified: true,
+			hasPaymentMethod: true,
+			...overrides,
+		} ) as never;
+
+	function makeStatsUi( overrides: Record< string, unknown > = {} ) {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			showTurnStats: ( stats: string ) => void;
+			[ key: string ]: unknown;
+		};
+		const messages = new Container();
+		Object.assign( ui, {
+			messages,
+			tui: { requestRender: vi.fn() },
+			currentProvider: 'wpcom',
+			replayMode: false,
+			...overrides,
+		} );
+		return { ui, messages };
+	}
+
+	it( 'appends the remaining AI credit balance to the stats line', async () => {
+		vi.mocked( readAuthToken ).mockResolvedValue( { accessToken: 'token' } as never );
+		vi.mocked( fetchStudioAssistantQuota ).mockResolvedValue(
+			quota( { allowanceRemaining: 100000, purchasedRemaining: 10000 } )
+		);
+		const { ui, messages } = makeStatsUi();
+
+		ui.showTurnStats( 'Thought for 5s · 1 turn' );
+
+		expect( renderedContainerText( messages ) ).toContain( 'Thought for 5s · 1 turn' );
+		const formatted = new Intl.NumberFormat().format( 110000 );
+		await vi.waitFor( () => {
+			expect( renderedContainerText( messages ) ).toContain(
+				`Thought for 5s · 1 turn · ${ formatted } credits left`
+			);
+		} );
+	} );
+
+	it( 'does not fetch the quota on the Anthropic API key provider', async () => {
+		const { ui, messages } = makeStatsUi( { currentProvider: 'anthropic-api-key' } );
+
+		ui.showTurnStats( 'Thought for 5s · 1 turn' );
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
+
+		expect( readAuthToken ).not.toHaveBeenCalled();
+		expect( fetchStudioAssistantQuota ).not.toHaveBeenCalled();
+		expect( renderedContainerText( messages ) ).toContain( 'Thought for 5s · 1 turn' );
+	} );
+
+	it( 'keeps the bare stats line when the quota has no credit pools', async () => {
+		vi.mocked( readAuthToken ).mockResolvedValue( { accessToken: 'token' } as never );
+		vi.mocked( fetchStudioAssistantQuota ).mockResolvedValue( quota() );
+		const { ui, messages } = makeStatsUi();
+
+		ui.showTurnStats( 'Thought for 5s · 1 turn' );
+		await vi.waitFor( () => {
+			expect( fetchStudioAssistantQuota ).toHaveBeenCalled();
+		} );
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
+
+		expect( renderedContainerText( messages ) ).toContain( 'Thought for 5s · 1 turn' );
+		expect( renderedContainerText( messages ) ).not.toContain( 'credits left' );
 	} );
 } );

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -38,6 +38,7 @@ import {
 	formatOutOfCreditsNotice,
 	formatQuotaResetDate,
 	formatUsageCapNotice,
+	getTotalRemainingAiCredits,
 } from '@studio/common/lib/studio-assistant-quota';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {
@@ -1427,6 +1428,37 @@ export class AiChatUI implements AiOutputAdapter {
 		);
 	}
 
+	// Shows the end-of-turn stats line immediately, then appends the remaining
+	// AI credit balance in place once the WordPress.com quota endpoint answers.
+	private showTurnStats( stats: string ): void {
+		const line = new Text( '\n' + theme.fg( 'muted', stats ) + '\n', 1, 0 );
+		this.messages.addChild( line );
+		this.tui.requestRender();
+		void this.appendRemainingCredits( line, stats );
+	}
+
+	private async appendRemainingCredits( line: Text, stats: string ): Promise< void > {
+		if ( this.replayMode || this.currentProvider !== 'wpcom' ) {
+			return;
+		}
+		const token = await readAuthToken();
+		if ( ! token?.accessToken ) {
+			return;
+		}
+		const quota = await fetchStudioAssistantQuota( token.accessToken );
+		const remaining = quota ? getTotalRemainingAiCredits( quota ) : undefined;
+		if ( remaining === undefined ) {
+			return;
+		}
+		const credits = sprintf(
+			/* translators: %s: total number of AI credits remaining (e.g. 1,110,000). */
+			__( '%s credits left' ),
+			new Intl.NumberFormat().format( remaining )
+		);
+		line.setText( '\n' + theme.fg( 'muted', `${ stats } · ${ credits }` ) + '\n' );
+		this.tui.requestRender();
+	}
+
 	showOnboarding(): void {
 		const text =
 			' ' +
@@ -1946,7 +1978,7 @@ export class AiChatUI implements AiOutputAdapter {
 						new Text( '\n ' + theme.fg( 'accent', '⏺' ) + ' ' + __( 'Done' ), 0, 0 )
 					);
 				}
-				this.showInfo(
+				this.showTurnStats(
 					sprintf(
 						/* translators: 1: seconds spent thinking, 2: number of turns */
 						_n( 'Thought for %1$ds · %2$d turn', 'Thought for %1$ds · %2$d turns', this.numTurns ),

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -97,6 +97,20 @@ export const studioAssistantQuotaSchema = z
 
 export type StudioAssistantQuota = z.infer< typeof studioAssistantQuotaSchema >;
 
+/**
+ * Total AI credits remaining across the allowance and purchased pools, or
+ * `undefined` when the server omits both fields (AI credits off for the
+ * account) — callers must hide the balance then, not show 0.
+ */
+export function getTotalRemainingAiCredits(
+	quota: Pick< StudioAssistantQuota, 'allowanceRemaining' | 'purchasedRemaining' >
+): number | undefined {
+	if ( quota.allowanceRemaining === undefined && quota.purchasedRemaining === undefined ) {
+		return undefined;
+	}
+	return ( quota.allowanceRemaining ?? 0 ) + ( quota.purchasedRemaining ?? 0 );
+}
+
 export type StudioCodeAiAccessState = 'available' | 'blocked' | 'not-enabled';
 
 /**


### PR DESCRIPTION
## Related issues

<!-- Link a related issue to this PR. -->

- N/A

## How AI was used in this PR

Implemented with Claude Code (design discussed and reviewed by the author).

## Proposed Changes

When a Studio Code turn finishes in the CLI, the end-of-turn stats line now also shows the account's remaining AI credit balance:

```
Thought for 42s · 3 turns · 1,110,000 credits left
```

This gives terminal users the same at-a-glance balance the browser UI's credits control already offers, right where they'd look after each turn — no need to open the app or the usage settings to know how much is left.

The stats line still renders immediately; the balance is fetched from the WordPress.com quota endpoint in the background and appended in place when it arrives. The segment is quietly omitted whenever it wouldn't be meaningful: sessions replayed from history, turns run on the user's own Anthropic API key (no credits burned), signed-out sessions, a failed quota fetch, or accounts without the AI Credits feature (where the server omits the per-pool balances — deliberately treated as "hide", not a zero balance).

## Testing Instructions

- `npm run cli:build && node apps/cli/dist/cli/main.mjs code` with the WordPress.com provider, send a prompt, and check the stats line after the turn ends shows `· N credits left`.
- Switch to the Anthropic API key provider (`/provider`) and confirm the line stays bare.
- Unit tests: `npm test -- apps/cli/ai/tests/ui.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
