### PR TITLE
Add GLM 5.3 Flash model (Automattician-only)

### DIFF
--- a/packages/common/ai/models.ts
+++ b/packages/common/ai/models.ts
@@ -34,6 +34,7 @@ export const AI_MODELS = [
 	{ id: 'claude-sonnet-5', label: 'Sonnet 5', family: 'anthropic' },
 	{ id: 'claude-opus-5', label: 'Opus 5', family: 'anthropic' },
 	{ id: 'gpt-5.6-sol', label: 'GPT 5.6 Sol', family: 'openai' },
+	{ id: 'gpt-5.6-luna', label: 'GPT 5.6 Luna', family: 'openai', requiresAutomattician: true },
 	// Hosted models keep their vendor-prefixed ids — the proxy passes them
 	// upstream verbatim.
 	{ id: 'moonshotai/Kimi-K3', label: 'Kimi K3', family: 'hosted', requiresAutomattician: true },
@@ -41,6 +42,13 @@ export const AI_MODELS = [
 		id: 'moonshotai/Kimi-K2.6',
 		label: 'Kimi K2.6',
 		family: 'hosted',
+		requiresAutomattician: true,
+	},
+	{
+		id: 'zai-org/GLM-5.3-Flash',
+		label: 'GLM 5.3 Flash',
+		family: 'hosted',
+		supportsImages: false,
 		requiresAutomattician: true,
 	},
 	{

--- a/packages/common/ai/models.ts
+++ b/packages/common/ai/models.ts
@@ -34,7 +34,6 @@ export const AI_MODELS = [
 	{ id: 'claude-sonnet-5', label: 'Sonnet 5', family: 'anthropic' },
 	{ id: 'claude-opus-5', label: 'Opus 5', family: 'anthropic' },
 	{ id: 'gpt-5.6-sol', label: 'GPT 5.6 Sol', family: 'openai' },
-	{ id: 'gpt-5.6-luna', label: 'GPT 5.6 Luna', family: 'openai', requiresAutomattician: true },
 	// Hosted models keep their vendor-prefixed ids — the proxy passes them
 	// upstream verbatim.
 	{ id: 'moonshotai/Kimi-K3', label: 'Kimi K3', family: 'hosted', requiresAutomattician: true },


### PR DESCRIPTION
## Related issues

<!-- No linked issue — model roster update requested directly. -->

## How AI was used in this PR

This PR was authored by Claude Code (model registry edit, verification, and PR creation), with the model choice and rollout constraints specified by @youknowriad.

## Proposed Changes

- Adds **GLM 5.3 Flash** (`zai-org/GLM-5.3-Flash`) to the Studio Code model picker on the hosted family, text-only like the other GLM entries.
- It is **Automattician-only for now** (`requiresAutomattician`), so it stays hidden from non-a11n pickers while it is evaluated.
- No runtime changes: providers route by family, so the registry entry is the whole client-side change.

Note for reviewers: picker visibility is client-side only — serving this model also requires the wpcom-side allowlist to include the new id before it works end to end. Until that ships, selecting it returns a 403.

## Testing Instructions

- `npm test -- apps/cli/ai/tests/pi-runtime.test.ts`
- In the app (as an Automattician), open the Studio Code model picker and confirm "GLM 5.3 Flash" is listed; as a non-Automattician account it should not appear.
- End-to-end turns against the model depend on the server-side allowlist update.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
