### PR TITLE
Add studio create --from for static sources

### DIFF
--- a/apps/cli/ai/block-validator.ts
+++ b/apps/cli/ai/block-validator.ts
@@ -25,35 +25,6 @@ export interface ValidationReport extends ValidationReportBase {
 	proposedFix?: BlockFixProposal;
 }
 
-/** Serialize content exactly as the target site's registered editor would save it. */
-export async function canonicalizeBlocks( content: string, siteUrl: string ): Promise< string > {
-	const editorPage = getEditorPage( siteUrl );
-
-	try {
-		const page = await editorPage.getPage();
-		return await page.evaluate( ( html: string ) => {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const wpBlocks = ( window as any ).wp?.blocks;
-			if ( ! wpBlocks ) {
-				throw new Error( 'wp.blocks is not available on this page.' );
-			}
-
-			const canonical = wpBlocks.serialize( wpBlocks.parse( html ) );
-			if ( canonical !== wpBlocks.serialize( wpBlocks.parse( canonical ) ) ) {
-				throw new Error( 'The target block registry did not produce a stable serialization.' );
-			}
-
-			return canonical;
-		}, content );
-	} catch ( error ) {
-		await editorPage.close();
-		editorPages.delete( siteUrl );
-		throw new Error(
-			`Block canonicalization error: ${ error instanceof Error ? error.message : String( error ) }`
-		);
-	}
-}
-
 // Cache one EditorPage per site URL so repeated validations reuse the same
 // browser tab instead of navigating and loading the block editor each time.
 const editorPages = new Map< string, EditorPage >();

--- a/apps/cli/ai/block-validator.ts
+++ b/apps/cli/ai/block-validator.ts
@@ -25,6 +25,35 @@ export interface ValidationReport extends ValidationReportBase {
 	proposedFix?: BlockFixProposal;
 }
 
+/** Serialize content exactly as the target site's registered editor would save it. */
+export async function canonicalizeBlocks( content: string, siteUrl: string ): Promise< string > {
+	const editorPage = getEditorPage( siteUrl );
+
+	try {
+		const page = await editorPage.getPage();
+		return await page.evaluate( ( html: string ) => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const wpBlocks = ( window as any ).wp?.blocks;
+			if ( ! wpBlocks ) {
+				throw new Error( 'wp.blocks is not available on this page.' );
+			}
+
+			const canonical = wpBlocks.serialize( wpBlocks.parse( html ) );
+			if ( canonical !== wpBlocks.serialize( wpBlocks.parse( canonical ) ) ) {
+				throw new Error( 'The target block registry did not produce a stable serialization.' );
+			}
+
+			return canonical;
+		}, content );
+	} catch ( error ) {
+		await editorPage.close();
+		editorPages.delete( siteUrl );
+		throw new Error(
+			`Block canonicalization error: ${ error instanceof Error ? error.message : String( error ) }`
+		);
+	}
+}
+
 // Cache one EditorPage per site URL so repeated validations reuse the same
 // browser tab instead of navigating and loading the block editor each time.
 const editorPages = new Map< string, EditorPage >();

--- a/apps/cli/commands/preview/tests/create.test.ts
+++ b/apps/cli/commands/preview/tests/create.test.ts
@@ -197,7 +197,7 @@ describe( 'Preview Create Command', () => {
 
 	it( 'should handle errors when folder is not a Studio site', async () => {
 		const errorMessage =
-			'The specified folder is not added to Studio. Please use `studio site create` to add it first.';
+			'The specified folder is not added to Studio. Please use `studio create` to add it first.';
 		vi.mocked( getSiteByFolder ).mockImplementation( () => {
 			throw new LoggerError( errorMessage );
 		} );

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -102,8 +102,13 @@ import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
 const defaultLogger = new Logger< LoggerAction >();
+// The importer vendors its own transformer layers (blocks-engine php-transformer and
+// figma-transformer) inside this zip, so pinning the plugin pins the whole stack. To run
+// against an unreleased transformer, build a paired zip with the importer's
+// `npm run build:dev-package -- --blocks-engine-path <path>` and pass it to
+// `--static-site-importer-path`.
 const DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL =
-	'https://github.com/Automattic/static-site-importer/releases/download/v1.7.0/static-site-importer.zip';
+	'https://github.com/Automattic/static-site-importer/releases/download/v1.8.0/static-site-importer.zip';
 const STATIC_SITE_IMPORT_CONTRACT = 'ssi-import-v5-plan-first';
 const STATIC_SITE_IMPORT_DIR = '.studio-import';
 const STATIC_SITE_IMPORT_SCRIPT_FILE = 'import.php';
@@ -1725,7 +1730,9 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				} )
 				.option( 'static-site-importer-path', {
 					type: 'string',
-					describe: __( 'Local Static Site Importer plugin zip for --from imports' ),
+					describe: __(
+						'Local Static Site Importer plugin zip for --from imports, including a paired build from the importer’s build:dev-package'
+					),
 					conflicts: 'static-site-importer-url',
 					coerce: ( value ) => {
 						const pluginPath = path.resolve( untildify( value ) );

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -108,7 +108,7 @@ const defaultLogger = new Logger< LoggerAction >();
 // `npm run build:dev-package -- --blocks-engine-path <path>` and pass it to
 // `--static-site-importer-path`.
 const DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL =
-	'https://github.com/Automattic/static-site-importer/releases/download/v1.8.4/static-site-importer.zip';
+	'https://github.com/Automattic/static-site-importer/releases/download/v1.8.5/static-site-importer.zip';
 const SSI_PLUGIN_SLUG = 'static-site-importer';
 const STATIC_SITE_IMPORT_DIR = '.studio-import';
 const STATIC_SITE_IMPORT_REQUEST_FILE = 'request.json';

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { confirm, input, password, select } from '@inquirer/prompts';
 import { DEFAULT_WORDPRESS_VERSION, MINIMUM_WORDPRESS_VERSION } from '@studio/common/constants';
@@ -39,6 +40,7 @@ import {
 	type SiteFileAccess,
 } from '@studio/common/lib/site-file-access';
 import {
+	getSiteRuntime,
 	SITE_MODE_NATIVE,
 	SITE_MODE_SANDBOX,
 	SITE_RUNTIME_NATIVE_PHP,
@@ -60,6 +62,8 @@ import {
 } from '@studio/common/types/php-versions';
 import { __, sprintf } from '@wordpress/i18n';
 import { isStepDefinition, type BlueprintV1Declaration } from '@wp-playground/blueprints';
+import { canonicalizeBlocks, cleanupValidatorPages } from 'cli/ai/block-validator';
+import { closeSharedBrowser } from 'cli/ai/browser-utils';
 import { bumpStat, getPlatformMetric } from 'cli/lib/bump-stat';
 import {
 	lockCliConfig,
@@ -68,7 +72,7 @@ import {
 	SiteData,
 	unlockCliConfig,
 } from 'cli/lib/cli-config/core';
-import { removeSiteFromConfig } from 'cli/lib/cli-config/sites';
+import { getSiteUrl, removeSiteFromConfig } from 'cli/lib/cli-config/sites';
 import { connectToDaemon, disconnectFromDaemon, emitCliEvent } from 'cli/lib/daemon-client';
 import {
 	getAiInstructionsPath,
@@ -78,6 +82,7 @@ import { updateServerFiles } from 'cli/lib/dependency-management/setup';
 import { downloadWordPress } from 'cli/lib/dependency-management/wordpress';
 import { copyLanguagePackToSite } from 'cli/lib/language-packs';
 import { validateSupportedPhpVersion } from 'cli/lib/php-versions';
+import { runWpCliCommandWithMessaging } from 'cli/lib/run-wp-cli-command';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
 import { generateSiteName } from 'cli/lib/site-name';
 import { getDefaultSitePath } from 'cli/lib/site-paths';
@@ -87,11 +92,40 @@ import { getTracksOrigin, recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/track
 import { StatsGroup } from 'cli/lib/types/bump-stats';
 import { untildify } from 'cli/lib/utils';
 import { ValidationError } from 'cli/lib/validation-error';
-import { runBlueprint, startWordPressServer } from 'cli/lib/wordpress-server-manager';
+import {
+	isServerRunning,
+	runBlueprint,
+	startWordPressServer,
+	stopWordPressServer,
+} from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
 const defaultLogger = new Logger< LoggerAction >();
+const DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL =
+	'https://github.com/Automattic/static-site-importer/releases/download/v1.7.0/static-site-importer.zip';
+const STATIC_SITE_IMPORT_CONTRACT = 'ssi-import-v5-plan-first';
+const STATIC_SITE_IMPORT_DIR = '.studio-import';
+const STATIC_SITE_IMPORT_SCRIPT_FILE = 'import.php';
+const STATIC_SITE_IMPORT_FIGMA_FILE = 'source.fig';
+const STATIC_SITE_IMPORT_IDENTITY_FILE = 'static-site-importer.json';
+const STATIC_SITE_IMPORT_RESULT_FILE = 'result.json';
+const STATIC_SITE_IMPORT_SOURCE_FILE = 'source.json';
+const STATIC_SITE_IMPORT_STATE_FILE = 'state.json';
+const STATIC_SITE_IMPORT_CANONICAL_DOCUMENTS_FILE = 'client-canonical-documents.json';
+const STATIC_SITE_IMPORT_CANONICAL_UPDATES_FILE = 'client-canonical-updates.json';
+const MAX_STATIC_SITE_IMPORT_INVOCATIONS = 10000;
+const STATIC_SITE_IMPORT_PROGRESS_INTERVAL_MS = 30_000;
+const DATA_LIBERATION_CAPTURE_RECEIPT_SCHEMA = 'data-liberation/capture-receipt/v1';
+type StaticSiteImportProgressPhase = 'dependency-preparation' | 'compiler-import' | 'finalization';
+type StaticSiteImportIdentity = { source: string; contract: string; phase?: 'cleanup_pending' };
+
+type StaticSiteImporterSource = {
+	path: string;
+	payload: Record< string, unknown >;
+};
+
+type StaticSiteImporterPlugin = string | { path: string };
 
 export type CreateCommandOptions = {
 	name?: string;
@@ -105,6 +139,17 @@ export type CreateCommandOptions = {
 	blueprint?: {
 		contents: unknown;
 		uri: string;
+		staticSiteImport?: {
+			code: string;
+			source: string;
+			storeResult: boolean;
+			stagedSource?: {
+				sourcePath: string;
+				targetName: string;
+			};
+			identity?: StaticSiteImportIdentity;
+			bundlePath?: string;
+		};
 	};
 	adminUsername?: string;
 	adminPassword?: string;
@@ -127,6 +172,969 @@ function parseFlowType( value: string | undefined ): TracksSiteCreateFlowType | 
 	return SITE_CREATE_FLOW_TYPES.find( ( flowType ) => flowType === value );
 }
 
+function readSiteArtifact( artifactPath: string ): Record< string, unknown > {
+	if ( ! fs.existsSync( artifactPath ) ) {
+		throw new LoggerError( sprintf( __( 'Artifact file not found: %s' ), artifactPath ) );
+	}
+
+	try {
+		const artifactContent = fs.readFileSync( artifactPath, 'utf-8' );
+		const artifact = JSON.parse( artifactContent );
+		if ( ! artifact || typeof artifact !== 'object' || Array.isArray( artifact ) ) {
+			throw new Error( __( 'Artifact JSON must be an object.' ) );
+		}
+		return artifact as Record< string, unknown >;
+	} catch ( error ) {
+		throw new LoggerError(
+			sprintf( __( 'Failed to parse artifact JSON file: %s' ), artifactPath ),
+			error
+		);
+	}
+}
+
+function isUrl( value: string ): boolean {
+	return value.startsWith( 'http://' ) || value.startsWith( 'https://' );
+}
+
+function sourceFilePayload( filePath: string, relativePath: string ): Record< string, string > {
+	return {
+		path: relativePath.replace( /\\/g, '/' ),
+		content_base64: fs.readFileSync( filePath ).toString( 'base64' ),
+	};
+}
+
+function collectSourceFiles( sourceDir: string ): Record< string, string >[] {
+	const files: Record< string, string >[] = [];
+	const walk = ( currentDir: string ) => {
+		for ( const entry of fs.readdirSync( currentDir, { withFileTypes: true } ) ) {
+			if ( entry.name === '.DS_Store' || entry.name === '__MACOSX' ) {
+				continue;
+			}
+
+			const entryPath = path.join( currentDir, entry.name );
+			if ( entry.isDirectory() ) {
+				walk( entryPath );
+				continue;
+			}
+
+			if ( entry.isFile() ) {
+				files.push( sourceFilePayload( entryPath, path.relative( sourceDir, entryPath ) ) );
+			}
+		}
+	};
+	walk( sourceDir );
+	return files;
+}
+
+function resolveDataLiberationWebsiteRoot( sourceDir: string ): string {
+	const receiptPath = path.join( sourceDir, 'capture-receipt.json' );
+	if ( ! fs.existsSync( receiptPath ) ) {
+		return sourceDir;
+	}
+
+	const receipt = readSiteArtifact( receiptPath );
+	if ( receipt.schema !== DATA_LIBERATION_CAPTURE_RECEIPT_SCHEMA ) {
+		return sourceDir;
+	}
+
+	if ( typeof receipt.websiteRoot !== 'string' || ! receipt.websiteRoot.trim() ) {
+		throw new LoggerError( __( 'Data Liberation capture receipt must declare a website root.' ) );
+	}
+
+	const outputRoot = path.resolve( sourceDir );
+	const websiteRoot = path.resolve( sourceDir, receipt.websiteRoot );
+	const relativeRoot = path.relative( outputRoot, websiteRoot );
+	if ( relativeRoot === '..' || relativeRoot.startsWith( `..${ path.sep }` ) ) {
+		throw new LoggerError(
+			__( 'Data Liberation website root must stay inside the capture directory.' )
+		);
+	}
+	if ( ! fs.existsSync( websiteRoot ) || ! fs.statSync( websiteRoot ).isDirectory() ) {
+		throw new LoggerError(
+			sprintf( __( 'Data Liberation capture root not found: %s' ), websiteRoot )
+		);
+	}
+
+	return websiteRoot;
+}
+
+function resolveStaticSiteImporterSource(
+	sourcePath: string,
+	stagedFigmaPath?: string
+): StaticSiteImporterSource {
+	if ( isUrl( sourcePath ) ) {
+		throw new LoggerError(
+			__( 'Remote URLs must be rendered by Data Liberation before SSI materialization.' )
+		);
+	}
+
+	if ( ! fs.existsSync( sourcePath ) ) {
+		throw new LoggerError( sprintf( __( 'Import source not found: %s' ), sourcePath ) );
+	}
+
+	const stat = fs.statSync( sourcePath );
+	if ( stat.isDirectory() ) {
+		const artifactPath = path.join( sourcePath, 'artifact.json' );
+		if ( fs.existsSync( artifactPath ) ) {
+			const artifact = readSiteArtifact( artifactPath );
+			if ( artifact.schema === 'blocks-engine/php-transformer/site-artifact/v1' ) {
+				return {
+					path: artifactPath,
+					payload: { artifact },
+				};
+			}
+		}
+
+		const files = collectSourceFiles( resolveDataLiberationWebsiteRoot( sourcePath ) );
+		if ( files.length > 0 ) {
+			return {
+				path: sourcePath,
+				payload: { files },
+			};
+		}
+
+		throw new LoggerError( sprintf( __( 'Import source directory is empty: %s' ), sourcePath ) );
+	}
+
+	if ( ! stat.isFile() ) {
+		throw new LoggerError(
+			sprintf( __( 'Import source must be a file or directory: %s' ), sourcePath )
+		);
+	}
+
+	const extension = path.extname( sourcePath ).toLowerCase();
+	if ( extension === '.json' ) {
+		const artifact = readSiteArtifact( sourcePath );
+		return {
+			path: sourcePath,
+			payload: { artifact },
+		};
+	}
+
+	if ( extension === '.zip' ) {
+		return {
+			path: sourcePath,
+			payload: {
+				archive: {
+					name: path.basename( sourcePath ),
+					content_base64: fs.readFileSync( sourcePath ).toString( 'base64' ),
+				},
+			},
+		};
+	}
+
+	if ( extension === '.fig' ) {
+		if ( ! stagedFigmaPath ) {
+			throw new LoggerError( __( 'A staging path is required for Figma imports.' ) );
+		}
+		return {
+			path: sourcePath,
+			payload: {
+				figma_file: {
+					name: path.basename( sourcePath ),
+					staged_path: stagedFigmaPath,
+				},
+				transform_options: {
+					multi_page: true,
+				},
+			},
+		};
+	}
+
+	return {
+		path: sourcePath,
+		payload: {
+			files: [ sourceFilePayload( sourcePath, path.basename( sourcePath ) ) ],
+		},
+	};
+}
+
+function buildStaticSiteImporterPhp(
+	sourcePath: string,
+	siteName: string,
+	storeImportResult: boolean,
+	adminUsername: string
+): string {
+	return `<?php
+if ( ! function_exists( 'did_action' ) || ! did_action( 'plugins_loaded' ) ) {
+	require_once getcwd() . '/wp-load.php';
+}
+
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+
+$source_path = ABSPATH . '${ STATIC_SITE_IMPORT_DIR }/${ STATIC_SITE_IMPORT_SOURCE_FILE }';
+$source_raw = is_file( $source_path ) ? file_get_contents( $source_path ) : false;
+$source = is_string( $source_raw ) ? json_decode( $source_raw, true ) : null;
+if ( ! is_array( $source ) ) {
+	throw new RuntimeException( 'Static Site Importer source payload could not be decoded.' );
+}
+
+$admin_user = get_user_by( 'login', ${ phpString( adminUsername ) } );
+if ( ! $admin_user instanceof WP_User ) {
+	throw new RuntimeException( 'Static Site Importer requires the created local administrator.' );
+}
+wp_set_current_user( $admin_user->ID, $admin_user->user_login );
+if ( ! current_user_can( 'manage_options' ) || ! current_user_can( 'unfiltered_html' ) ) {
+	throw new RuntimeException( 'Static Site Importer requires the created local administrator.' );
+}
+
+$input = array(
+	'name'            => ${ phpString( siteName ) },
+	'site_title'      => ${ phpString( siteName ) },
+	'activate'        => true,
+	'overwrite'       => true,
+	'client_script_policy' => 'isolated_preview',
+	'client_script_isolated' => true,
+	'client_script_provenance' => array( 'ref' => 'studio-create-from:sha256:' . hash( 'sha256', (string) wp_json_encode( $source ) ) ),
+	'source_metadata' => array(
+		'source'      => 'studio-create-from',
+		'source_path' => ${ phpString( sourcePath ) },
+	),
+);
+$state_path = ABSPATH . '${ STATIC_SITE_IMPORT_DIR }/${ STATIC_SITE_IMPORT_STATE_FILE }';
+$state_raw = is_file( $state_path ) ? file_get_contents( $state_path ) : false;
+$state = is_string( $state_raw ) ? json_decode( $state_raw, true ) : array();
+$state = is_array( $state ) ? $state : array();
+
+function static_site_importer_studio_failure_message( $result, string $fallback ): string {
+	if ( ! is_array( $result ) || ! is_array( $result['error'] ?? null ) ) {
+		return $fallback;
+	}
+	$code = is_scalar( $result['error']['code'] ?? null ) ? sanitize_key( (string) $result['error']['code'] ) : '';
+	$message = is_scalar( $result['error']['message'] ?? null ) ? sanitize_text_field( (string) $result['error']['message'] ) : '';
+	$detail = implode( ': ', array_filter( array( $code, $message ) ) );
+	return '' !== $detail ? $fallback . ': ' . substr( $detail, 0, 1000 ) : $fallback;
+}
+
+function static_site_importer_studio_bounded_value( $value, int $depth = 0 ) {
+	if ( $depth >= 5 ) {
+		return null;
+	}
+	if ( is_bool( $value ) || is_int( $value ) || is_float( $value ) || null === $value ) {
+		return $value;
+	}
+	if ( is_string( $value ) ) {
+		return substr( sanitize_text_field( $value ), 0, 1000 );
+	}
+	if ( ! is_array( $value ) ) {
+		return null;
+	}
+	$projection = array();
+	foreach ( array_slice( $value, 0, 50, true ) as $key => $item ) {
+		$projected_item = static_site_importer_studio_bounded_value( $item, $depth + 1 );
+		if ( null === $projected_item && null !== $item ) {
+			continue;
+		}
+		if ( is_int( $key ) ) {
+			$projection[ $key ] = $projected_item;
+			continue;
+		}
+		$projected_key = substr( sanitize_key( (string) $key ), 0, 100 );
+		if ( '' !== $projected_key ) {
+			$projection[ $projected_key ] = $projected_item;
+		}
+	}
+	return $projection;
+}
+
+function static_site_importer_studio_result_projection( $result ): array {
+	$projection = array( 'success' => is_array( $result ) && ! empty( $result['success'] ) );
+	if ( ! is_array( $result ) ) {
+		return $projection;
+	}
+	if ( is_array( $result['error'] ?? null ) ) {
+		$projection['error'] = array(
+			'code'    => substr( sanitize_key( (string) ( $result['error']['code'] ?? '' ) ), 0, 200 ),
+			'message' => substr( sanitize_text_field( (string) ( $result['error']['message'] ?? '' ) ), 0, 1000 ),
+		);
+		if ( array_key_exists( 'data', $result['error'] ) ) {
+			$projection['error']['data'] = static_site_importer_studio_bounded_value( $result['error']['data'] );
+		}
+	}
+	$import_result = isset( $result['result'] ) && is_array( $result['result'] ) ? $result['result'] : $result;
+	$stored_result = array(
+		'schema'       => 'studio/static-site-import-result/v1',
+		'status'       => substr( sanitize_key( (string) ( $import_result['status'] ?? ( $projection['success'] ? 'completed' : 'failed' ) ) ), 0, 100 ),
+		'continuation' => ! empty( $import_result['continuation'] ),
+		'pages'        => array_slice( array_map( 'intval', array_values( is_array( $import_result['pages'] ?? null ) ? $import_result['pages'] : array() ) ), 0, 5000 ),
+	);
+	$request_id = is_array( $import_result['fresh_runtime'] ?? null ) ? (string) ( $import_result['fresh_runtime']['request_id'] ?? '' ) : '';
+	if ( '' !== $request_id ) {
+		$stored_result['fresh_runtime'] = array( 'request_id' => substr( sanitize_text_field( $request_id ), 0, 200 ) );
+	}
+	foreach ( array( 'theme', 'theme_slug', 'front_page' ) as $field ) {
+		if ( isset( $import_result[ $field ] ) && is_scalar( $import_result[ $field ] ) ) {
+			$stored_result[ $field ] = substr( sanitize_text_field( (string) $import_result[ $field ] ), 0, 500 );
+		}
+	}
+	$projection['result'] = $stored_result;
+	if ( is_array( $result['diagnostics'] ?? null ) ) {
+		$projection['diagnostic_count'] = count( $result['diagnostics'] );
+		$projection['diagnostics'] = static_site_importer_studio_bounded_value( $result['diagnostics'] );
+	}
+	return $projection;
+}
+
+function static_site_importer_studio_write_result( array $result ): void {
+	$encoded = wp_json_encode( $result );
+	if ( ! is_string( $encoded ) ) {
+		throw new RuntimeException( 'Static Site Importer result receipt could not be encoded.' );
+	}
+	$result_path = ABSPATH . '${ STATIC_SITE_IMPORT_DIR }/${ STATIC_SITE_IMPORT_RESULT_FILE }';
+	$temp_path = $result_path . '.tmp-' . wp_generate_uuid4();
+	if ( false === file_put_contents( $temp_path, $encoded ) ) {
+		throw new RuntimeException( 'Static Site Importer result receipt could not be saved.' );
+	}
+	if ( ! rename( $temp_path, $result_path ) ) {
+		unlink( $temp_path );
+		throw new RuntimeException( 'Static Site Importer result receipt could not be finalized.' );
+	}
+}
+
+function static_site_importer_studio_record_failure( $result, string $fallback, bool $store_import_result ): void {
+	$projection = static_site_importer_studio_result_projection( $result );
+	if ( $store_import_result ) {
+		update_option( 'studio_create_from_import_result', $projection, false );
+	}
+	static_site_importer_studio_write_result(
+		array(
+			'continuation'  => false,
+			'failed'        => true,
+			'failure'       => $projection,
+			'import_receipt' => $projection,
+		)
+	);
+	throw new RuntimeException( static_site_importer_studio_failure_message( $result, $fallback ) );
+}
+
+function static_site_importer_studio_reject_catastrophic_content_loss( array $source, array $documents ): void { $st = $si = $it = $ii = 0; foreach ( $source['artifact']['files'] ?? array() as $f ) { if ( is_array( $f ) && str_ends_with( (string) ( $f['path'] ?? '' ), '.html' ) && isset( $f['content'] ) ) { $c = (string) $f['content']; $st += strlen( trim( wp_strip_all_tags( $c, true ) ) ); $si += preg_match_all( '/<img\\b/i', $c ); } } foreach ( $documents as $d ) { $c = (string) ( $d['content'] ?? '' ); $it += strlen( trim( wp_strip_all_tags( $c, true ) ) ); $ii += preg_match_all( '/<!--\\s+wp:image\\b|<img\\b/i', $c ); } if ( $st >= 160 && $si && $documents && $it <= 80 && ! $ii ) throw new RuntimeException( 'Static Site Importer rejected catastrophic content loss: source became navigation-only with no images. Inspect diagnostics.' ); }
+
+$store_import_result = ${ storeImportResult ? 'true' : 'false' };
+
+if ( isset( $source['figma_file'] ) ) {
+	if ( ! function_exists( 'static_site_importer_ability_import_figma' ) ) {
+		throw new RuntimeException( 'Static Site Importer Figma import ability is unavailable.' );
+	}
+	$input['source'] = $source;
+	$input['transform_options'] = isset( $source['transform_options'] ) && is_array( $source['transform_options'] ) ? $source['transform_options'] : array();
+	if ( ! empty( $state['runtime_lifecycle_request_id'] ) ) {
+		$input['runtime_lifecycle_phase'] = 'resume';
+		$input['runtime_lifecycle_request_id'] = (string) $state['runtime_lifecycle_request_id'];
+		if ( ! empty( $state['runtime_lifecycle_checkpoint'] ) ) {
+			$input['runtime_lifecycle_checkpoint'] = (string) $state['runtime_lifecycle_checkpoint'];
+		}
+	} else {
+		$input['runtime_lifecycle_phase'] = 'prepare';
+	}
+	$result = static_site_importer_ability_import_figma( $input );
+} else {
+	if ( ! function_exists( 'static_site_importer_ability_import' ) ) {
+		throw new RuntimeException( 'Static Site Importer canonical import ability is unavailable.' );
+	}
+
+	$artifact = isset( $source['artifact'] ) && is_array( $source['artifact'] ) ? $source['artifact'] : array();
+	if ( ! empty( $artifact ) ) {
+		$input['fail_on_quality'] = true;
+		$input['require_proven_dynamic_client_assets'] = true;
+		$input['seed_entities'] = true;
+		$input['materialize_dependencies'] = true;
+		if ( in_array( $artifact['theme_materialization'] ?? '', array( 'block', 'classic' ), true ) ) {
+			$input['theme_materialization'] = (string) $artifact['theme_materialization'];
+		}
+		$input['source_metadata']['semantic_evidence'] = is_array( $artifact['semantic_evidence'] ?? null ) ? $artifact['semantic_evidence'] : array();
+	}
+	if ( ! empty( $state['import_id'] ) ) {
+		$input['source'] = array( 'type' => 'files', 'import_id' => (string) $state['import_id'] );
+	} elseif ( ! empty( $artifact ) ) {
+		$metadata = $artifact;
+		unset( $metadata['schema'], $metadata['entrypoint'], $metadata['files'] );
+		$input['source'] = array(
+			'type'       => 'files',
+			'entrypoint' => (string) ( $artifact['entrypoint'] ?? '' ),
+			'files'      => isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array(),
+			'metadata'   => $metadata,
+		);
+	} elseif ( isset( $source['archive'] ) && is_array( $source['archive'] ) ) {
+		$input['source'] = array(
+			'type' => 'zip',
+			'zip'  => $source['archive'],
+		);
+	} else {
+		$input['source'] = array(
+			'type'  => 'files',
+			'files' => isset( $source['files'] ) && is_array( $source['files'] ) ? $source['files'] : array(),
+		);
+	}
+	if ( ! empty( $state['runtime_lifecycle_request_id'] ) ) {
+		$input['runtime_lifecycle_phase'] = 'resume';
+		$input['runtime_lifecycle_request_id'] = (string) $state['runtime_lifecycle_request_id'];
+		if ( ! empty( $state['runtime_lifecycle_checkpoint'] ) ) {
+			$input['runtime_lifecycle_checkpoint'] = (string) $state['runtime_lifecycle_checkpoint'];
+		}
+	} else {
+		$input['runtime_lifecycle_phase'] = 'prepare';
+	}
+
+	$result = static_site_importer_ability_import( $input );
+}
+
+if ( ! is_array( $result ) || empty( $result['success'] ) ) {
+	static_site_importer_studio_record_failure( $result, 'Static Site Importer import failed', $store_import_result );
+}
+if ( $store_import_result ) {
+	update_option( 'studio_create_from_import_result', static_site_importer_studio_result_projection( $result ), false );
+}
+$import_result = isset( $result['result'] ) && is_array( $result['result'] ) ? $result['result'] : $result;
+if ( ! empty( $import_result['continuation'] ) && preg_match( '/^[a-f0-9]{64}$/', (string) ( $import_result['import_id'] ?? '' ) ) ) {
+	$state = array( 'import_id' => (string) $import_result['import_id'] );
+	if ( false === file_put_contents( $state_path, wp_json_encode( $state ) ) ) {
+		throw new RuntimeException( 'Static Site Importer direct continuation state could not be saved.' );
+	}
+	$continuation_receipt = array( 'continuation' => true );
+	if ( is_scalar( $import_result['status'] ?? null ) && '' !== (string) $import_result['status'] ) {
+		$continuation_receipt['status'] = substr( sanitize_key( (string) $import_result['status'] ), 0, 100 );
+	}
+	if ( isset( $import_result['url_batch_run']['completed_routes'], $import_result['url_batch_run']['total_routes'] ) ) {
+		$continuation_receipt['completed_routes'] = (int) $import_result['url_batch_run']['completed_routes'];
+		$continuation_receipt['total_routes'] = (int) $import_result['url_batch_run']['total_routes'];
+	}
+	static_site_importer_studio_write_result( $continuation_receipt );
+	return;
+}
+if ( 'dependencies_prepared' === ( $import_result['status'] ?? '' ) ) {
+	$request_id = (string) ( $import_result['fresh_runtime']['request_id'] ?? '' );
+	$checkpoint = (string) ( $import_result['fresh_runtime']['lifecycle_checkpoint_id'] ?? $import_result['runtime_lifecycle_checkpoint'] ?? '' );
+	$lifecycle_state = array( 'runtime_lifecycle_request_id' => $request_id );
+	if ( '' !== $checkpoint ) {
+		$lifecycle_state['runtime_lifecycle_checkpoint'] = $checkpoint;
+	}
+	if ( '' === $request_id || false === file_put_contents( $state_path, wp_json_encode( $lifecycle_state ) ) ) {
+		throw new RuntimeException( 'Static Site Importer lifecycle state could not be saved.' );
+	}
+	static_site_importer_studio_write_result( array( 'continuation' => true, 'status' => 'dependencies_prepared' ) );
+	return;
+}
+if ( '' !== $state_path && is_file( $state_path ) ) {
+	unlink( $state_path );
+}
+$canonical_documents = array();
+foreach ( array_unique( array_map( 'intval', array_values( isset( $import_result['pages'] ) && is_array( $import_result['pages'] ) ? $import_result['pages'] : array() ) ) ) as $post_id ) {
+	$post = get_post( $post_id );
+	if ( $post instanceof WP_Post ) {
+		$canonical_documents[] = array(
+			'post_id' => $post_id,
+			'content' => (string) $post->post_content,
+			'sha256'  => hash( 'sha256', (string) $post->post_content ),
+		);
+	}
+}
+if ( ! empty( $canonical_documents ) && false === file_put_contents( ABSPATH . '${ STATIC_SITE_IMPORT_DIR }/${ STATIC_SITE_IMPORT_CANONICAL_DOCUMENTS_FILE }', wp_json_encode( $canonical_documents ) ) ) {
+	throw new RuntimeException( 'Static Site Importer client canonicalization handoff could not be saved.' );
+}
+static_site_importer_studio_reject_catastrophic_content_loss( $source, $canonical_documents );
+
+$studio_result = array(
+	'continuation'             => ! empty( $import_result['continuation'] ),
+	'canonicalization_pending' => ! empty( $canonical_documents ),
+	'status'                    => (string) ( $import_result['url_batch_run']['status'] ?? $import_result['status'] ?? 'completed' ),
+	'completed_routes'          => (int) ( $import_result['url_batch_run']['completed_routes'] ?? count( $canonical_documents ) ),
+	'total_routes'              => (int) ( $import_result['url_batch_run']['total_routes'] ?? count( $canonical_documents ) ),
+	'import_receipt'            => static_site_importer_studio_result_projection( $result ),
+);
+static_site_importer_studio_write_result( $studio_result );
+?>`
+		.replace( /\s*\n\s*/g, '' )
+		.replace( '<?phpif', '<?php if' );
+}
+
+function artifactTitle( artifact: Record< string, unknown > ): string | undefined {
+	const directTitle = artifact.site_title || artifact.title || artifact.name;
+	if ( typeof directTitle === 'string' && directTitle.trim() ) {
+		return directTitle.trim();
+	}
+
+	const provenance = artifact.provenance;
+	if ( provenance && typeof provenance === 'object' && ! Array.isArray( provenance ) ) {
+		const provenanceTitle = ( provenance as Record< string, unknown > ).title;
+		if ( typeof provenanceTitle === 'string' && provenanceTitle.trim() ) {
+			return provenanceTitle.trim();
+		}
+	}
+
+	return undefined;
+}
+
+function phpString( value: string ): string {
+	return JSON.stringify( value );
+}
+
+export function buildCreateFromSourceBlueprint(
+	sourcePath: string,
+	siteName: string,
+	staticSiteImporterPlugin: StaticSiteImporterPlugin = DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL,
+	storeImportResult = false,
+	adminUsername = 'admin',
+	originalSourceUrl?: string
+): {
+	contents: BlueprintV1Declaration;
+	uri: string;
+	staticSiteImport: {
+		code: string;
+		source: string;
+		storeResult: boolean;
+		stagedSource?: { sourcePath: string; targetName: string };
+		identity?: StaticSiteImportIdentity;
+		bundlePath?: string;
+	};
+} {
+	const stagedFigmaName =
+		path.extname( sourcePath ).toLowerCase() === '.fig' ? STATIC_SITE_IMPORT_FIGMA_FILE : undefined;
+	const source = resolveStaticSiteImporterSource(
+		sourcePath,
+		stagedFigmaName ? path.join( STATIC_SITE_IMPORT_DIR, stagedFigmaName ) : undefined
+	);
+	const tempDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-create-from-' ) );
+	const blueprintPath = path.join( tempDir, 'blueprint.json' );
+	const pluginData =
+		typeof staticSiteImporterPlugin === 'string'
+			? { resource: 'url' as const, url: staticSiteImporterPlugin }
+			: { resource: 'bundled' as const, path: 'static-site-importer.zip' };
+	const blueprint: BlueprintV1Declaration = {
+		landingPage: '/',
+		features: {
+			networking: true,
+		},
+		steps: [
+			{
+				step: 'installPlugin',
+				pluginData,
+				options: {
+					activate: true,
+					targetFolderName: 'static-site-importer',
+				},
+			},
+		],
+	};
+
+	try {
+		if ( typeof staticSiteImporterPlugin !== 'string' ) {
+			fs.copyFileSync(
+				staticSiteImporterPlugin.path,
+				path.join( tempDir, 'static-site-importer.zip' )
+			);
+		}
+		fs.writeFileSync( blueprintPath, `${ JSON.stringify( blueprint, null, 2 ) }\n` );
+	} catch ( error ) {
+		fs.rmSync( tempDir, { recursive: true, force: true } );
+		throw error;
+	}
+	return {
+		contents: blueprint,
+		uri: blueprintPath,
+		staticSiteImport: {
+			code: buildStaticSiteImporterPhp( source.path, siteName, storeImportResult, adminUsername ),
+			source: JSON.stringify( source.payload ),
+			storeResult: storeImportResult,
+			...( stagedFigmaName ? { stagedSource: { sourcePath, targetName: stagedFigmaName } } : {} ),
+			identity: { source: originalSourceUrl ?? source.path, contract: STATIC_SITE_IMPORT_CONTRACT },
+			bundlePath: tempDir,
+		},
+	};
+}
+
+function staticSiteImportIdentityPath( sitePath: string ): string {
+	return path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_IDENTITY_FILE );
+}
+
+function cleanupSuccessfulStaticSiteImport( sitePath: string, preserveResult = false ): void {
+	fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_SCRIPT_FILE ), {
+		force: true,
+	} );
+	if ( ! preserveResult ) {
+		fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_RESULT_FILE ), {
+			force: true,
+		} );
+	}
+	fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_SOURCE_FILE ), {
+		force: true,
+	} );
+	fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_FIGMA_FILE ), {
+		force: true,
+	} );
+	fs.rmSync( staticSiteImportIdentityPath( sitePath ), { force: true } );
+	fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_STATE_FILE ), {
+		force: true,
+	} );
+	fs.rmSync(
+		path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_CANONICAL_DOCUMENTS_FILE ),
+		{ force: true }
+	);
+	fs.rmSync(
+		path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_CANONICAL_UPDATES_FILE ),
+		{ force: true }
+	);
+}
+
+async function canonicalizeStaticSiteImport( site: SiteData, stagingDir: string ): Promise< void > {
+	const documentsPath = path.join( stagingDir, STATIC_SITE_IMPORT_CANONICAL_DOCUMENTS_FILE );
+	if ( ! fs.existsSync( documentsPath ) ) {
+		throw new Error( 'Static site import completed without its canonicalization handoff.' );
+	}
+
+	const documents = JSON.parse( fs.readFileSync( documentsPath, 'utf-8' ) ) as Array< {
+		post_id: number;
+		content: string;
+		sha256: string;
+	} >;
+	if ( ! Array.isArray( documents ) || documents.length === 0 ) {
+		throw new Error( 'Static site import returned an invalid canonicalization handoff.' );
+	}
+
+	const updates = [];
+	const siteUrl = getSiteUrl( site );
+	for ( const document of documents ) {
+		if (
+			! Number.isInteger( document.post_id ) ||
+			document.post_id <= 0 ||
+			typeof document.content !== 'string' ||
+			document.sha256 !== crypto.createHash( 'sha256' ).update( document.content ).digest( 'hex' )
+		) {
+			throw new Error( 'Static site import returned a corrupt canonicalization document.' );
+		}
+		const content = await canonicalizeBlocks( document.content, siteUrl );
+		if ( content !== document.content ) {
+			updates.push( {
+				post_id: document.post_id,
+				before_sha256: document.sha256,
+				after_sha256: crypto.createHash( 'sha256' ).update( content ).digest( 'hex' ),
+				content,
+			} );
+		}
+	}
+
+	if ( updates.length > 0 ) {
+		const updatesPath = path.join( stagingDir, STATIC_SITE_IMPORT_CANONICAL_UPDATES_FILE );
+		fs.writeFileSync( updatesPath, JSON.stringify( updates ) );
+		await using command = await runWpCliCommandWithMessaging( site, [
+			'eval',
+			`$path = ABSPATH . '${ STATIC_SITE_IMPORT_DIR }/${ STATIC_SITE_IMPORT_CANONICAL_UPDATES_FILE }';
+$documents = json_decode( (string) file_get_contents( $path ), true );
+if ( ! is_array( $documents ) ) {
+	throw new RuntimeException( 'Client canonicalization updates are invalid.' );
+}
+foreach ( $documents as $document ) {
+	$post = get_post( (int) ( $document['post_id'] ?? 0 ) );
+	if ( ! $post instanceof WP_Post || ! hash_equals( (string) ( $document['before_sha256'] ?? '' ), hash( 'sha256', (string) $post->post_content ) ) ) {
+		throw new RuntimeException( 'Client canonicalization preimage changed before persistence.' );
+	}
+	$result = wp_update_post( array( 'ID' => $post->ID, 'post_content' => wp_slash( (string) ( $document['content'] ?? '' ) ) ), true );
+	$updated = get_post( $post->ID );
+	if ( is_wp_error( $result ) || ! $updated instanceof WP_Post || ! hash_equals( (string) ( $document['after_sha256'] ?? '' ), hash( 'sha256', (string) $updated->post_content ) ) ) {
+		throw new RuntimeException( 'Client canonicalization did not persist exact target-registry bytes.' );
+	}
+}`,
+		] );
+		const [ exitCode, stdout, stderr ] = await Promise.all( [
+			command.response.exitCode,
+			command.response.stdoutText,
+			command.response.stderrText,
+		] );
+		if ( exitCode !== 0 ) {
+			throw new Error(
+				stderr.trim() || stdout.trim() || sprintf( __( 'WP-CLI exited with code %d.' ), exitCode )
+			);
+		}
+		fs.rmSync( updatesPath, { force: true } );
+	}
+
+	fs.rmSync( documentsPath, { force: true } );
+}
+
+export function staticSiteImportProgressMessage(
+	phase: StaticSiteImportProgressPhase,
+	elapsedMs: number,
+	invocation = 1
+): string {
+	const elapsedSeconds = Math.floor( elapsedMs / 1000 );
+	if ( phase === 'dependency-preparation' ) {
+		return sprintf( __( 'Dependency preparation… %d sec elapsed' ), elapsedSeconds );
+	}
+	if ( phase === 'compiler-import' ) {
+		return sprintf(
+			/* translators: 1: importer invocation, 2: elapsed seconds */
+			__( 'Compiler/import… invocation %1$d, %2$d sec elapsed' ),
+			invocation,
+			elapsedSeconds
+		);
+	}
+	return sprintf( __( 'Finalization… %d sec elapsed' ), elapsedSeconds );
+}
+
+export function staticSiteImportContinuationMessage( result: {
+	completed_routes?: number;
+	total_routes?: number;
+	status?: string;
+} ): string {
+	if (
+		typeof result.completed_routes === 'number' &&
+		typeof result.total_routes === 'number' &&
+		result.total_routes > 0
+	) {
+		return sprintf(
+			/* translators: 1: completed route count, 2: total route count */
+			__( 'Static site import progress: %1$d/%2$d routes' ),
+			result.completed_routes,
+			result.total_routes
+		);
+	}
+	const stage = typeof result.status === 'string' ? result.status.trim().replace( /_/g, ' ' ) : '';
+	if ( stage !== '' ) {
+		/* translators: %s: stage the importer reported for its last continuation */
+		return sprintf( __( 'Static site import continuing: %s' ), stage );
+	}
+	return __( 'Static site import continuing…' );
+}
+
+async function runStaticSiteImport(
+	site: SiteData,
+	code: string,
+	source: string,
+	stagedSource?: { sourcePath: string; targetName: string },
+	identity?: StaticSiteImportIdentity,
+	preserveResult = false,
+	resume = false,
+	logger: Logger< LoggerAction > = defaultLogger
+): Promise< boolean > {
+	const stagingDir = path.join( site.path, STATIC_SITE_IMPORT_DIR );
+	const scriptName = STATIC_SITE_IMPORT_SCRIPT_FILE;
+	const scriptPath = path.join( stagingDir, scriptName );
+	const resultPath = path.join( stagingDir, STATIC_SITE_IMPORT_RESULT_FILE );
+	const statePath = path.join( stagingDir, STATIC_SITE_IMPORT_STATE_FILE );
+	if ( ! resume ) {
+		fs.mkdirSync( stagingDir, { recursive: true } );
+		if ( stagedSource ) {
+			fs.copyFileSync( stagedSource.sourcePath, path.join( stagingDir, stagedSource.targetName ) );
+		}
+		fs.writeFileSync( path.join( stagingDir, STATIC_SITE_IMPORT_SOURCE_FILE ), source );
+		if ( identity ) {
+			fs.writeFileSync( staticSiteImportIdentityPath( site.path ), JSON.stringify( identity ) );
+		}
+		fs.writeFileSync( scriptPath, code );
+	}
+
+	const liveOutput = getSiteRuntime( site ) === SITE_RUNTIME_NATIVE_PHP;
+	type ImportResult = {
+		continuation?: boolean;
+		canonicalization_pending?: boolean;
+		completed_routes?: number;
+		total_routes?: number;
+		status?: string;
+	};
+	let finalizationStartedAt: number | undefined;
+	for ( let invocation = 1; invocation <= MAX_STATIC_SITE_IMPORT_INVOCATIONS; invocation++ ) {
+		let result: ImportResult | undefined;
+		if ( resume && invocation === 1 && fs.existsSync( resultPath ) ) {
+			try {
+				const persistedResult = JSON.parse(
+					fs.readFileSync( resultPath, 'utf-8' )
+				) as ImportResult;
+				if ( ! persistedResult.continuation && persistedResult.canonicalization_pending ) {
+					result = persistedResult;
+				}
+			} catch {
+				// The normal import path below reports malformed or missing receipts.
+			}
+		}
+		if ( ! result ) {
+			fs.rmSync( resultPath, { force: true } );
+			const phase: StaticSiteImportProgressPhase =
+				invocation === 1 && ! resume && ! fs.existsSync( statePath )
+					? 'dependency-preparation'
+					: 'compiler-import';
+			const startedAt = Date.now();
+			logger.reportStart(
+				LoggerAction.IMPORT_SITE,
+				staticSiteImportProgressMessage( phase, 0, invocation )
+			);
+			const progressTimer = setInterval( () => {
+				logger.reportProgress(
+					staticSiteImportProgressMessage( phase, Date.now() - startedAt, invocation )
+				);
+			}, STATIC_SITE_IMPORT_PROGRESS_INTERVAL_MS );
+			progressTimer.unref?.();
+			let exitCode: number;
+			let stdout: string;
+			let stderr: string;
+			try {
+				await using command = await runWpCliCommandWithMessaging(
+					site,
+					[ 'eval-file', `${ path.basename( stagingDir ) }/${ scriptName }` ],
+					liveOutput ? { liveOutput, onLiveOutput: () => logger.spinner.stop() } : {}
+				);
+				[ exitCode, stdout, stderr ] = await Promise.all( [
+					command.response.exitCode,
+					command.response.stdoutText,
+					command.response.stderrText,
+				] );
+			} finally {
+				clearInterval( progressTimer );
+			}
+			logger.reportProgress(
+				staticSiteImportProgressMessage( phase, Date.now() - startedAt, invocation )
+			);
+			if ( exitCode !== 0 ) {
+				throw new LoggerError(
+					__( 'Static site import failed.' ),
+					new Error(
+						stderr.trim() ||
+							stdout.trim() ||
+							sprintf( __( 'WP-CLI exited with code %d.' ), exitCode )
+					)
+				);
+			}
+
+			if ( ! fs.existsSync( resultPath ) ) {
+				throw new LoggerError(
+					__( 'Static site import completed without a result receipt.' ),
+					new Error( __( 'The importer did not write .studio-import/result.json.' ) )
+				);
+			}
+		}
+		try {
+			result ??= JSON.parse( fs.readFileSync( resultPath, 'utf-8' ) );
+		} catch ( error ) {
+			throw new LoggerError( __( 'Static site import returned an invalid result.' ), error );
+		} finally {
+			if ( ! preserveResult ) fs.rmSync( resultPath, { force: true } );
+		}
+		if ( ! result ) {
+			throw new LoggerError( __( 'Static site import returned an invalid result.' ) );
+		}
+		if ( ! result.continuation ) {
+			finalizationStartedAt = Date.now();
+			logger.reportProgress( staticSiteImportProgressMessage( 'finalization', 0 ) );
+			if ( result.canonicalization_pending ) {
+				await connectToDaemon();
+				const startForCanonicalization = ! ( await isServerRunning( site.id ) );
+				if ( startForCanonicalization ) {
+					await startWordPressServer( site, logger );
+					site.running = true;
+				}
+				try {
+					try {
+						await canonicalizeStaticSiteImport( site, stagingDir );
+					} finally {
+						try {
+							await cleanupValidatorPages();
+						} finally {
+							await closeSharedBrowser();
+						}
+					}
+				} finally {
+					if ( startForCanonicalization ) {
+						await stopWordPressServer( site.id );
+						site.running = false;
+					}
+				}
+			}
+			break;
+		}
+		logger.reportSuccess( staticSiteImportContinuationMessage( result ) );
+		if ( invocation === MAX_STATIC_SITE_IMPORT_INVOCATIONS ) {
+			throw new LoggerError( __( 'Static site import exceeded its continuation limit.' ) );
+		}
+	}
+	if ( identity ) {
+		fs.writeFileSync(
+			staticSiteImportIdentityPath( site.path ),
+			JSON.stringify( { ...identity, phase: 'cleanup_pending' } )
+		);
+	}
+	const cleanupSucceeded = await cleanupStaticSiteImporterPlugin( site, logger );
+	logger.reportProgress(
+		staticSiteImportProgressMessage(
+			'finalization',
+			finalizationStartedAt === undefined ? 0 : Date.now() - finalizationStartedAt
+		)
+	);
+	logger.reportSuccess( __( 'Static site imported successfully' ) );
+	return cleanupSucceeded;
+}
+
+async function cleanupStaticSiteImporterPlugin(
+	site: SiteData,
+	logger: Logger< LoggerAction > = defaultLogger
+): Promise< boolean > {
+	try {
+		await using command = await runWpCliCommandWithMessaging( site, [
+			'eval',
+			`require_once ABSPATH . 'wp-admin/includes/plugin.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+$plugin = 'static-site-importer/static-site-importer.php';
+if ( is_plugin_active( $plugin ) ) {
+	deactivate_plugins( $plugin, true );
+}
+if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin ) ) {
+	$result = delete_plugins( array( $plugin ) );
+	if ( is_wp_error( $result ) ) {
+		throw new RuntimeException( $result->get_error_message() );
+	}
+}`,
+		] );
+		const [ exitCode, stdout, stderr ] = await Promise.all( [
+			command.response.exitCode,
+			command.response.stdoutText,
+			command.response.stderrText,
+		] );
+		if ( exitCode !== 0 ) {
+			throw new Error(
+				stderr.trim() || stdout.trim() || sprintf( __( 'WP-CLI exited with code %d.' ), exitCode )
+			);
+		}
+		return true;
+	} catch ( error ) {
+		logger.reportError(
+			new LoggerError(
+				__(
+					'Static Site Importer cleanup failed. The imported site and resumable import state were preserved.'
+				),
+				error
+			),
+			false
+		);
+		return false;
+	}
+}
+
+function resumableStaticSiteImportPhase(
+	sitePath: string,
+	code: string,
+	identity: StaticSiteImportIdentity | undefined
+): 'import' | 'cleanup_pending' | null {
+	if ( ! identity ) {
+		return null;
+	}
+	const scriptPath = path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_SCRIPT_FILE );
+	const identityPath = staticSiteImportIdentityPath( sitePath );
+	if ( ! fs.existsSync( scriptPath ) || ! fs.existsSync( identityPath ) ) {
+		return null;
+	}
+	try {
+		const persistedIdentity = JSON.parse( fs.readFileSync( identityPath, 'utf-8' ) );
+		if (
+			persistedIdentity?.source !== identity.source ||
+			persistedIdentity?.contract !== identity.contract ||
+			fs.readFileSync( scriptPath, 'utf-8' ) !== code
+		) {
+			return null;
+		}
+		return persistedIdentity.phase === 'cleanup_pending' ? 'cleanup_pending' : 'import';
+	} catch {
+		return null;
+	}
+}
+
 export async function runCommand(
 	sitePath: string,
 	options: CreateCommandOptions,
@@ -142,6 +1150,11 @@ export async function runCommand(
 	}
 	const phpVersion = validateSupportedPhpVersion( options.phpVersion );
 	const isOnlineStatus = await isOnline();
+	const staticSiteImport = options.blueprint?.staticSiteImport;
+	let resumedStaticSiteImport = false;
+	let staticSiteImportSucceeded = false;
+	let staticSiteImportResultObserved = false;
+	let registeredSite = false;
 
 	try {
 		if ( isOnlineStatus ) {
@@ -213,7 +1226,42 @@ export async function runCommand(
 		}
 
 		const cliConfig = await readCliConfig();
-		if ( cliConfig.sites.some( ( site ) => arePathsEqual( site.path, sitePath ) ) ) {
+		const existingSite = cliConfig.sites.find( ( site ) => arePathsEqual( site.path, sitePath ) );
+		registeredSite = Boolean( existingSite );
+		const resumePhase =
+			existingSite && staticSiteImport
+				? resumableStaticSiteImportPhase(
+						sitePath,
+						staticSiteImport.code,
+						staticSiteImport.identity
+				  )
+				: null;
+		if ( existingSite && staticSiteImport && resumePhase ) {
+			resumedStaticSiteImport = true;
+			try {
+				staticSiteImportSucceeded =
+					resumePhase === 'cleanup_pending'
+						? await cleanupStaticSiteImporterPlugin( existingSite, logger )
+						: await runStaticSiteImport(
+								existingSite,
+								staticSiteImport.code,
+								staticSiteImport.source,
+								staticSiteImport.stagedSource,
+								staticSiteImport.identity,
+								staticSiteImport.storeResult,
+								true,
+								logger
+						  );
+				staticSiteImportResultObserved = true;
+			} catch ( error ) {
+				throw new LoggerError( __( 'Failed to import static site' ), error );
+			}
+			if ( staticSiteImportSucceeded ) {
+				cleanupSuccessfulStaticSiteImport( sitePath, staticSiteImport.storeResult );
+			}
+			return;
+		}
+		if ( existingSite ) {
 			throw new LoggerError( __( 'The selected directory is already in use.' ) );
 		}
 
@@ -397,6 +1445,20 @@ export async function runCommand(
 					? `${ siteDetails.enableHttps ? 'https' : 'http' }://${ siteDetails.customDomain }`
 					: `http://localhost:${ siteDetails.port }`;
 
+				if ( staticSiteImport ) {
+					staticSiteImportResultObserved = true;
+					staticSiteImportSucceeded = await runStaticSiteImport(
+						siteDetails,
+						staticSiteImport.code,
+						staticSiteImport.source,
+						staticSiteImport.stagedSource,
+						staticSiteImport.identity,
+						staticSiteImport.storeResult,
+						false,
+						logger
+					);
+				}
+
 				if ( ! options.skipLogDetails ) {
 					logSiteDetails( siteDetails );
 				}
@@ -404,11 +1466,18 @@ export async function runCommand(
 					await openSiteInBrowser( siteDetails );
 				}
 			} catch ( error ) {
-				await removeSiteFromConfig( siteDetails.id );
-				if ( ! isWordPressDirResult ) {
-					await fs.promises.rm( sitePath, { recursive: true, force: true } );
+				if ( ! staticSiteImportResultObserved ) {
+					await removeSiteFromConfig( siteDetails.id );
+					if ( ! isWordPressDirResult ) {
+						await fs.promises.rm( sitePath, { recursive: true, force: true } );
+					}
 				}
-				throw new LoggerError( __( 'Failed to start WordPress server' ), error );
+				throw new LoggerError(
+					staticSiteImport
+						? __( 'Failed to import static site' )
+						: __( 'Failed to start WordPress server' ),
+					error
+				);
 			}
 		} else {
 			if ( blueprint ) {
@@ -430,12 +1499,32 @@ export async function runCommand(
 					logger.reportSuccess( __( 'Blueprint applied successfully' ) );
 
 					stripWpConfigDbConstants( sitePath );
-				} catch ( error ) {
-					await removeSiteFromConfig( siteDetails.id );
-					if ( ! isWordPressDirResult ) {
-						await fs.promises.rm( sitePath, { recursive: true, force: true } );
+					if ( staticSiteImport ) {
+						staticSiteImportResultObserved = true;
+						staticSiteImportSucceeded = await runStaticSiteImport(
+							siteDetails,
+							staticSiteImport.code,
+							staticSiteImport.source,
+							staticSiteImport.stagedSource,
+							staticSiteImport.identity,
+							staticSiteImport.storeResult,
+							false,
+							logger
+						);
 					}
-					throw new LoggerError( __( 'Failed to apply Blueprint' ), error );
+				} catch ( error ) {
+					if ( ! staticSiteImportResultObserved ) {
+						await removeSiteFromConfig( siteDetails.id );
+						if ( ! isWordPressDirResult ) {
+							await fs.promises.rm( sitePath, { recursive: true, force: true } );
+						}
+					}
+					throw new LoggerError(
+						staticSiteImport
+							? __( 'Failed to import static site' )
+							: __( 'Failed to apply Blueprint' ),
+						error
+					);
 				}
 			}
 			console.log( '' );
@@ -470,6 +1559,19 @@ export async function runCommand(
 
 		await emitCliEvent( { event: SITE_EVENTS.CREATED, data: { siteId: siteDetails.id } } );
 	} finally {
+		if ( staticSiteImport && staticSiteImportSucceeded ) {
+			cleanupSuccessfulStaticSiteImport( sitePath, staticSiteImport.storeResult );
+		} else if (
+			staticSiteImport &&
+			! resumedStaticSiteImport &&
+			! registeredSite &&
+			! staticSiteImportResultObserved
+		) {
+			fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR ), {
+				recursive: true,
+				force: true,
+			} );
+		}
 		await disconnectFromDaemon();
 	}
 }
@@ -603,6 +1705,56 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					type: 'string',
 					describe: __( 'Path or URL to Blueprint JSON file' ),
 				} )
+				.option( 'from', {
+					type: 'string',
+					describe: __( 'Create the site from a static import source' ),
+					conflicts: 'blueprint',
+					coerce: ( value ) => {
+						if ( isUrl( value ) ) {
+							return value;
+						}
+
+						return path.resolve( untildify( value ) );
+					},
+				} )
+				.option( 'static-site-importer-url', {
+					type: 'string',
+					describe: __( 'Static Site Importer plugin zip URL for --from imports' ),
+					defaultDescription: DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL,
+					conflicts: 'static-site-importer-path',
+				} )
+				.option( 'static-site-importer-path', {
+					type: 'string',
+					describe: __( 'Local Static Site Importer plugin zip for --from imports' ),
+					conflicts: 'static-site-importer-url',
+					coerce: ( value ) => {
+						const pluginPath = path.resolve( untildify( value ) );
+						if ( path.extname( pluginPath ).toLowerCase() !== '.zip' ) {
+							throw new ValidationError(
+								'static-site-importer-path',
+								value,
+								__( 'Must be a .zip file' )
+							);
+						}
+						try {
+							if ( ! fs.statSync( pluginPath ).isFile() ) {
+								throw new Error();
+							}
+						} catch {
+							throw new ValidationError(
+								'static-site-importer-path',
+								value,
+								__( 'Must be an existing regular .zip file' )
+							);
+						}
+						return pluginPath;
+					},
+				} )
+				.option( 'store-import-result', {
+					type: 'boolean',
+					describe: __( 'Store the import result in the created site database' ),
+					default: false,
+				} )
 				.option( 'original-blueprint-path', {
 					type: 'string',
 					hidden: true,
@@ -644,7 +1796,11 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				} );
 		},
 		handler: async ( argv ) => {
-			let siteName = argv.name;
+			const artifact =
+				argv.from && ! isUrl( argv.from ) && path.extname( argv.from ).toLowerCase() === '.json'
+					? readSiteArtifact( argv.from )
+					: undefined;
+			let siteName = argv.name ?? ( artifact ? artifactTitle( artifact ) : undefined );
 			let sitePath = argv.path;
 			let wpVersion = argv.wp;
 			let phpVersion = argv.php;
@@ -843,35 +1999,61 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				flowType: parseFlowType( argv.flowType ),
 			};
 
-			if ( argv.blueprint ) {
-				if ( argv.blueprint.startsWith( 'http://' ) || argv.blueprint.startsWith( 'https://' ) ) {
-					config.blueprint = {
-						uri: argv.blueprint,
-						contents: await fetchBlueprint( argv.blueprint ),
-					};
-				} else {
-					const uri = path.resolve( untildify( argv.blueprint ) );
+			try {
+				const importSource = argv.from;
+				// Remote URLs are rendered into a local source by Data Liberation before they
+				// reach SSI; until that path exists here, `resolveStaticSiteImporterSource`
+				// rejects them. `sourceUrl` still carries provenance for local captures.
+				const sourceUrl = importSource && isUrl( importSource ) ? importSource : undefined;
 
-					config.blueprint = {
-						uri,
-						contents: readBlueprint( uri ),
-					};
+				if ( importSource ) {
+					config.blueprint = buildCreateFromSourceBlueprint(
+						importSource,
+						siteName || __( 'Imported Site' ),
+						argv.staticSiteImporterPath
+							? { path: argv.staticSiteImporterPath }
+							: argv.staticSiteImporterUrl ?? DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL,
+						argv.storeImportResult,
+						adminUsername ?? 'admin',
+						sourceUrl
+					);
+				} else if ( argv.blueprint ) {
+					if ( argv.blueprint.startsWith( 'http://' ) || argv.blueprint.startsWith( 'https://' ) ) {
+						config.blueprint = {
+							uri: argv.blueprint,
+							contents: await fetchBlueprint( argv.blueprint ),
+						};
+					} else {
+						const uri = path.resolve( untildify( argv.blueprint ) );
 
-					// When invoked by the desktop app, the blueprint contents come from a temp file
-					// but resources should be resolved relative to the original file location.
-					// For gallery blueprints the path is a URL; use it directly.
-					if ( argv.originalBlueprintPath ) {
-						const originalPath = argv.originalBlueprintPath;
-						config.blueprint.uri =
-							originalPath.startsWith( 'http://' ) || originalPath.startsWith( 'https://' )
-								? originalPath
-								: path.resolve( originalPath );
+						config.blueprint = {
+							uri,
+							contents: readBlueprint( uri ),
+						};
+
+						// When invoked by the desktop app, the blueprint contents come from a temp file
+						// but resources should be resolved relative to the original file location.
+						// For gallery blueprints the path is a URL; use it directly.
+						if ( argv.originalBlueprintPath ) {
+							const originalPath = argv.originalBlueprintPath;
+							config.blueprint.uri =
+								originalPath.startsWith( 'http://' ) || originalPath.startsWith( 'https://' )
+									? originalPath
+									: path.resolve( originalPath );
+						}
 					}
 				}
-			}
 
-			try {
-				await runCommand( sitePath, config );
+				try {
+					await runCommand( sitePath, config );
+				} finally {
+					if ( config.blueprint?.staticSiteImport?.bundlePath ) {
+						fs.rmSync( config.blueprint.staticSiteImport.bundlePath, {
+							recursive: true,
+							force: true,
+						} );
+					}
+				}
 
 				if ( __ENABLE_CLI_TELEMETRY__ && ! argv.avoidTelemetry ) {
 					bumpStat(

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -108,7 +108,7 @@ const defaultLogger = new Logger< LoggerAction >();
 // `npm run build:dev-package -- --blocks-engine-path <path>` and pass it to
 // `--static-site-importer-path`.
 const DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL =
-	'https://github.com/Automattic/static-site-importer/releases/download/v1.8.2/static-site-importer.zip';
+	'https://github.com/Automattic/static-site-importer/releases/download/v1.8.4/static-site-importer.zip';
 const SSI_PLUGIN_SLUG = 'static-site-importer';
 const STATIC_SITE_IMPORT_DIR = '.studio-import';
 const STATIC_SITE_IMPORT_REQUEST_FILE = 'request.json';
@@ -120,6 +120,7 @@ type StaticSiteImportProgressPhase = 'import' | 'finalization';
 type StaticSiteImporterSource = {
 	path: string;
 	payload: Record< string, unknown >;
+	stagedSourcePath?: string;
 };
 
 type StaticSiteImporterPlugin = string | { path: string };
@@ -139,6 +140,7 @@ export type CreateCommandOptions = {
 		staticSiteImport?: {
 			request: string;
 			bundlePath?: string;
+			sourcePath?: string;
 		};
 	};
 	adminUsername?: string;
@@ -191,29 +193,6 @@ function sourceFilePayload( filePath: string, relativePath: string ): Record< st
 		path: relativePath.replace( /\\/g, '/' ),
 		content_base64: fs.readFileSync( filePath ).toString( 'base64' ),
 	};
-}
-
-function collectSourceFiles( sourceDir: string ): Record< string, string >[] {
-	const files: Record< string, string >[] = [];
-	const walk = ( currentDir: string ) => {
-		for ( const entry of fs.readdirSync( currentDir, { withFileTypes: true } ) ) {
-			if ( entry.name === '.DS_Store' || entry.name === '__MACOSX' ) {
-				continue;
-			}
-
-			const entryPath = path.join( currentDir, entry.name );
-			if ( entry.isDirectory() ) {
-				walk( entryPath );
-				continue;
-			}
-
-			if ( entry.isFile() ) {
-				files.push( sourceFilePayload( entryPath, path.relative( sourceDir, entryPath ) ) );
-			}
-		}
-	};
-	walk( sourceDir );
-	return files;
 }
 
 function resolveDataLiberationWebsiteRoot( sourceDir: string ): string {
@@ -272,15 +251,15 @@ function resolveStaticSiteImporterSource( sourcePath: string ): StaticSiteImport
 			}
 		}
 
-		const files = collectSourceFiles( resolveDataLiberationWebsiteRoot( sourcePath ) );
-		if ( files.length > 0 ) {
-			return {
-				path: sourcePath,
-				payload: { files },
-			};
+		const stagedSourcePath = resolveDataLiberationWebsiteRoot( sourcePath );
+		if ( fs.readdirSync( stagedSourcePath ).length === 0 ) {
+			throw new LoggerError( sprintf( __( 'Import source directory is empty: %s' ), sourcePath ) );
 		}
-
-		throw new LoggerError( sprintf( __( 'Import source directory is empty: %s' ), sourcePath ) );
+		return {
+			path: sourcePath,
+			payload: {},
+			stagedSourcePath,
+		};
 	}
 
 	if ( ! stat.isFile() ) {
@@ -334,7 +313,9 @@ function buildStaticSiteImporterRequest(
 	let themeMaterialization: unknown;
 	const artifact = payload.artifact;
 
-	if ( artifact && typeof artifact === 'object' && ! Array.isArray( artifact ) ) {
+	if ( source.stagedSourcePath ) {
+		requestSource = { type: 'files', ref: 'request-bundle:source' };
+	} else if ( artifact && typeof artifact === 'object' && ! Array.isArray( artifact ) ) {
 		const {
 			schema: _schema,
 			entrypoint,
@@ -368,7 +349,7 @@ function buildStaticSiteImporterRequest(
 		client_script_provenance: {
 			ref: `studio-create-from:sha256:${ crypto
 				.createHash( 'sha256' )
-				.update( JSON.stringify( payload ) )
+				.update( JSON.stringify( requestSource ) )
 				.digest( 'hex' ) }`,
 		},
 		source_metadata: {
@@ -415,6 +396,7 @@ export function buildCreateFromSourceBlueprint(
 	staticSiteImport: {
 		request: string;
 		bundlePath?: string;
+		sourcePath?: string;
 	};
 } {
 	const source = resolveStaticSiteImporterSource( sourcePath );
@@ -460,6 +442,7 @@ export function buildCreateFromSourceBlueprint(
 		staticSiteImport: {
 			request: `${ JSON.stringify( request, null, 2 ) }\n`,
 			bundlePath: tempDir,
+			sourcePath: source.stagedSourcePath,
 		},
 	};
 }
@@ -477,6 +460,10 @@ export function staticSiteImportProgressMessage(
 
 function staticSiteImportRequestPath( sitePath: string ): string {
 	return path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_REQUEST_FILE );
+}
+
+function staticSiteImportSourcePath( sitePath: string ): string {
+	return path.join( sitePath, STATIC_SITE_IMPORT_DIR, 'source' );
 }
 
 type WpCliResult = { exitCode: number; stdout: string; stderr: string };
@@ -535,6 +522,7 @@ function staticSiteImportReceiptError( receipt: Record< string, unknown > | unde
 async function runStaticSiteImport(
 	site: SiteData,
 	request: string,
+	sourcePath?: string,
 	resume = false,
 	logger: Logger< LoggerAction > = defaultLogger
 ): Promise< boolean > {
@@ -545,6 +533,13 @@ async function runStaticSiteImport(
 		}
 	} else {
 		fs.mkdirSync( path.dirname( requestPath ), { recursive: true } );
+		if ( sourcePath ) {
+			await fs.promises.cp( sourcePath, staticSiteImportSourcePath( site.path ), {
+				recursive: true,
+				errorOnExist: true,
+				force: false,
+			} );
+		}
 		fs.writeFileSync( requestPath, request );
 	}
 
@@ -738,6 +733,8 @@ export async function runCommand(
 			existingSite &&
 			staticSiteImport &&
 			fs.existsSync( staticSiteImportRequestPath( sitePath ) ) &&
+			( ! staticSiteImport.sourcePath ||
+				fs.existsSync( staticSiteImportSourcePath( sitePath ) ) ) &&
 			fs.readFileSync( staticSiteImportRequestPath( sitePath ), 'utf-8' ) ===
 				staticSiteImport.request;
 		if ( existingSite && staticSiteImport && canResumeStaticSiteImport ) {
@@ -746,6 +743,7 @@ export async function runCommand(
 				const cleanupSucceeded = await runStaticSiteImport(
 					existingSite,
 					staticSiteImport.request,
+					staticSiteImport.sourcePath,
 					true,
 					logger
 				);
@@ -944,6 +942,7 @@ export async function runCommand(
 					const cleanupSucceeded = await runStaticSiteImport(
 						siteDetails,
 						staticSiteImport.request,
+						staticSiteImport.sourcePath,
 						false,
 						logger
 					);
@@ -995,6 +994,7 @@ export async function runCommand(
 						const cleanupSucceeded = await runStaticSiteImport(
 							siteDetails,
 							staticSiteImport.request,
+							staticSiteImport.sourcePath,
 							false,
 							logger
 						);

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -1,10 +1,14 @@
 import crypto from 'crypto';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { confirm, input, password, select } from '@inquirer/prompts';
 import { DEFAULT_WORDPRESS_VERSION, MINIMUM_WORDPRESS_VERSION } from '@studio/common/constants';
 import { installAiInstructionsToSite } from '@studio/common/lib/agent-skills';
+import {
+	createBlueprintTempDirSync,
+	removeBlueprintTempDir,
+	removeBlueprintTempDirSync,
+} from '@studio/common/lib/blueprint-bundle';
 import { extractFormValuesFromBlueprint } from '@studio/common/lib/blueprint-settings';
 import { validateBlueprintData } from '@studio/common/lib/blueprint-validation';
 import { SITE_EVENTS } from '@studio/common/lib/cli-events';
@@ -80,7 +84,10 @@ import { updateServerFiles } from 'cli/lib/dependency-management/setup';
 import { downloadWordPress } from 'cli/lib/dependency-management/wordpress';
 import { copyLanguagePackToSite } from 'cli/lib/language-packs';
 import { validateSupportedPhpVersion } from 'cli/lib/php-versions';
-import { runWpCliCommandWithMessaging } from 'cli/lib/run-wp-cli-command';
+import {
+	runWpCliCommandWithMessaging,
+	type RunWpCliCommandOptions,
+} from 'cli/lib/run-wp-cli-command';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
 import { generateSiteName } from 'cli/lib/site-name';
 import { getDefaultSitePath } from 'cli/lib/site-paths';
@@ -101,7 +108,8 @@ const defaultLogger = new Logger< LoggerAction >();
 // `npm run build:dev-package -- --blocks-engine-path <path>` and pass it to
 // `--static-site-importer-path`.
 const DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL =
-	'https://github.com/Automattic/static-site-importer/releases/download/v1.8.0/static-site-importer.zip';
+	'https://github.com/Automattic/static-site-importer/releases/download/v1.8.2/static-site-importer.zip';
+const SSI_PLUGIN_SLUG = 'static-site-importer';
 const STATIC_SITE_IMPORT_DIR = '.studio-import';
 const STATIC_SITE_IMPORT_REQUEST_FILE = 'request.json';
 const STATIC_SITE_IMPORT_PROGRESS_INTERVAL_MS = 30_000;
@@ -411,12 +419,12 @@ export function buildCreateFromSourceBlueprint(
 } {
 	const source = resolveStaticSiteImporterSource( sourcePath );
 	const request = buildStaticSiteImporterRequest( source, siteName, originalSourceUrl );
-	const tempDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-create-from-' ) );
+	const tempDir = createBlueprintTempDirSync();
 	const blueprintPath = path.join( tempDir, 'blueprint.json' );
 	const pluginData =
 		typeof staticSiteImporterPlugin === 'string'
 			? { resource: 'url' as const, url: staticSiteImporterPlugin }
-			: { resource: 'bundled' as const, path: 'static-site-importer.zip' };
+			: { resource: 'bundled' as const, path: `${ SSI_PLUGIN_SLUG }.zip` };
 	const blueprint: BlueprintV1Declaration = {
 		landingPage: '/',
 		features: {
@@ -428,7 +436,7 @@ export function buildCreateFromSourceBlueprint(
 				pluginData,
 				options: {
 					activate: true,
-					targetFolderName: 'static-site-importer',
+					targetFolderName: SSI_PLUGIN_SLUG,
 				},
 			},
 		],
@@ -438,12 +446,12 @@ export function buildCreateFromSourceBlueprint(
 		if ( typeof staticSiteImporterPlugin !== 'string' ) {
 			fs.copyFileSync(
 				staticSiteImporterPlugin.path,
-				path.join( tempDir, 'static-site-importer.zip' )
+				path.join( tempDir, `${ SSI_PLUGIN_SLUG }.zip` )
 			);
 		}
 		fs.writeFileSync( blueprintPath, `${ JSON.stringify( blueprint, null, 2 ) }\n` );
 	} catch ( error ) {
-		fs.rmSync( tempDir, { recursive: true, force: true } );
+		removeBlueprintTempDirSync( tempDir );
 		throw error;
 	}
 	return {
@@ -471,7 +479,27 @@ function staticSiteImportRequestPath( sitePath: string ): string {
 	return path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_REQUEST_FILE );
 }
 
-function cleanupSuccessfulStaticSiteImport( sitePath: string ): void {
+type WpCliResult = { exitCode: number; stdout: string; stderr: string };
+
+async function runWpCli(
+	site: SiteData,
+	args: string[],
+	options: RunWpCliCommandOptions = {}
+): Promise< WpCliResult > {
+	await using command = await runWpCliCommandWithMessaging( site, args, options );
+	const [ exitCode, stdout, stderr ] = await Promise.all( [
+		command.response.exitCode,
+		command.response.stdoutText,
+		command.response.stderrText,
+	] );
+	return { exitCode, stdout, stderr };
+}
+
+function wpCliFailureDetail( { exitCode, stdout, stderr }: WpCliResult ): string {
+	return stderr.trim() || stdout.trim() || sprintf( __( 'WP-CLI exited with code %d.' ), exitCode );
+}
+
+function removeStagedStaticSiteImport( sitePath: string ): void {
 	fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR ), { recursive: true, force: true } );
 }
 
@@ -527,12 +555,10 @@ async function runStaticSiteImport(
 	}, STATIC_SITE_IMPORT_PROGRESS_INTERVAL_MS );
 	progressTimer.unref?.();
 
-	let exitCode: number;
-	let stdout: string;
-	let stderr: string;
+	let result: WpCliResult;
 	try {
 		const liveOutput = getSiteRuntime( site ) === SITE_RUNTIME_NATIVE_PHP;
-		await using command = await runWpCliCommandWithMessaging(
+		result = await runWpCli(
 			site,
 			[
 				'static-site-importer',
@@ -541,27 +567,18 @@ async function runStaticSiteImport(
 			],
 			liveOutput ? { liveOutput, onLiveOutput: () => logger.spinner.stop() } : {}
 		);
-		[ exitCode, stdout, stderr ] = await Promise.all( [
-			command.response.exitCode,
-			command.response.stdoutText,
-			command.response.stderrText,
-		] );
 	} finally {
 		clearInterval( progressTimer );
 	}
 
 	logger.reportProgress( staticSiteImportProgressMessage( 'import', Date.now() - startedAt ) );
+	const { exitCode, stdout } = result;
 	const receipt = decodeStaticSiteImportReceipt( stdout );
 	const receiptError = staticSiteImportReceiptError( receipt );
 	if ( exitCode !== 0 ) {
 		throw new LoggerError(
 			__( 'Static site import failed.' ),
-			new Error(
-				receiptError ||
-					stderr.trim() ||
-					stdout.trim() ||
-					sprintf( __( 'WP-CLI exited with code %d.' ), exitCode )
-			)
+			new Error( receiptError || wpCliFailureDetail( result ) )
 		);
 	}
 	if ( receipt?.schema !== STATIC_SITE_IMPORT_RECEIPT_SCHEMA || receipt.status !== 'completed' ) {
@@ -586,30 +603,26 @@ async function cleanupStaticSiteImporterPlugin(
 	logger: Logger< LoggerAction > = defaultLogger
 ): Promise< boolean > {
 	try {
-		await using command = await runWpCliCommandWithMessaging( site, [
-			'eval',
-			`require_once ABSPATH . 'wp-admin/includes/plugin.php';
-require_once ABSPATH . 'wp-admin/includes/file.php';
-$plugin = 'static-site-importer/static-site-importer.php';
-if ( is_plugin_active( $plugin ) ) {
-	deactivate_plugins( $plugin, true );
-}
-if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin ) ) {
-	$result = delete_plugins( array( $plugin ) );
-	if ( is_wp_error( $result ) ) {
-		throw new RuntimeException( $result->get_error_message() );
-	}
-}`,
+		// `is-installed` exits non-zero when the plugin is absent, which keeps cleanup
+		// idempotent across a rerun that already removed it.
+		const installed = await runWpCli( site, [ 'plugin', 'is-installed', SSI_PLUGIN_SLUG ] );
+		if ( installed.exitCode !== 0 ) {
+			return true;
+		}
+
+		const deactivated = await runWpCli( site, [
+			'plugin',
+			'deactivate',
+			SSI_PLUGIN_SLUG,
+			'--quiet',
 		] );
-		const [ exitCode, stdout, stderr ] = await Promise.all( [
-			command.response.exitCode,
-			command.response.stdoutText,
-			command.response.stderrText,
-		] );
-		if ( exitCode !== 0 ) {
-			throw new Error(
-				stderr.trim() || stdout.trim() || sprintf( __( 'WP-CLI exited with code %d.' ), exitCode )
-			);
+		if ( deactivated.exitCode !== 0 ) {
+			throw new Error( wpCliFailureDetail( deactivated ) );
+		}
+
+		const deleted = await runWpCli( site, [ 'plugin', 'delete', SSI_PLUGIN_SLUG ] );
+		if ( deleted.exitCode !== 0 ) {
+			throw new Error( wpCliFailureDetail( deleted ) );
 		}
 		return true;
 	} catch ( error ) {
@@ -642,10 +655,12 @@ export async function runCommand(
 	const phpVersion = validateSupportedPhpVersion( options.phpVersion );
 	const isOnlineStatus = await isOnline();
 	const staticSiteImport = options.blueprint?.staticSiteImport;
-	let resumedStaticSiteImport = false;
-	let staticSiteImportSucceeded = false;
-	let staticSiteImportResultObserved = false;
-	let registeredSite = false;
+	// How far the static import got. `attempted` means the site now holds real import
+	// state, so failure handling must preserve it (and the staged request) for a rerun
+	// instead of tearing the site down.
+	let importOutcome: 'not-attempted' | 'attempted' | 'succeeded' = 'not-attempted';
+	// A site already registered at this path owns its own staged request; never clean it up.
+	let siteAlreadyExisted = false;
 
 	try {
 		if ( isOnlineStatus ) {
@@ -718,7 +733,7 @@ export async function runCommand(
 
 		const cliConfig = await readCliConfig();
 		const existingSite = cliConfig.sites.find( ( site ) => arePathsEqual( site.path, sitePath ) );
-		registeredSite = Boolean( existingSite );
+		siteAlreadyExisted = Boolean( existingSite );
 		const canResumeStaticSiteImport =
 			existingSite &&
 			staticSiteImport &&
@@ -726,15 +741,15 @@ export async function runCommand(
 			fs.readFileSync( staticSiteImportRequestPath( sitePath ), 'utf-8' ) ===
 				staticSiteImport.request;
 		if ( existingSite && staticSiteImport && canResumeStaticSiteImport ) {
-			resumedStaticSiteImport = true;
 			try {
-				staticSiteImportSucceeded = await runStaticSiteImport(
+				importOutcome = 'attempted';
+				const cleanupSucceeded = await runStaticSiteImport(
 					existingSite,
 					staticSiteImport.request,
 					true,
 					logger
 				);
-				staticSiteImportResultObserved = true;
+				importOutcome = cleanupSucceeded ? 'succeeded' : 'attempted';
 			} catch ( error ) {
 				throw new LoggerError( __( 'Failed to import static site' ), error );
 			}
@@ -925,13 +940,14 @@ export async function runCommand(
 					: `http://localhost:${ siteDetails.port }`;
 
 				if ( staticSiteImport ) {
-					staticSiteImportResultObserved = true;
-					staticSiteImportSucceeded = await runStaticSiteImport(
+					importOutcome = 'attempted';
+					const cleanupSucceeded = await runStaticSiteImport(
 						siteDetails,
 						staticSiteImport.request,
 						false,
 						logger
 					);
+					importOutcome = cleanupSucceeded ? 'succeeded' : 'attempted';
 				}
 
 				if ( ! options.skipLogDetails ) {
@@ -941,7 +957,7 @@ export async function runCommand(
 					await openSiteInBrowser( siteDetails );
 				}
 			} catch ( error ) {
-				if ( ! staticSiteImportResultObserved ) {
+				if ( importOutcome === 'not-attempted' ) {
 					await removeSiteFromConfig( siteDetails.id );
 					if ( ! isWordPressDirResult ) {
 						await fs.promises.rm( sitePath, { recursive: true, force: true } );
@@ -975,16 +991,17 @@ export async function runCommand(
 
 					stripWpConfigDbConstants( sitePath );
 					if ( staticSiteImport ) {
-						staticSiteImportResultObserved = true;
-						staticSiteImportSucceeded = await runStaticSiteImport(
+						importOutcome = 'attempted';
+						const cleanupSucceeded = await runStaticSiteImport(
 							siteDetails,
 							staticSiteImport.request,
 							false,
 							logger
 						);
+						importOutcome = cleanupSucceeded ? 'succeeded' : 'attempted';
 					}
 				} catch ( error ) {
-					if ( ! staticSiteImportResultObserved ) {
+					if ( importOutcome === 'not-attempted' ) {
 						await removeSiteFromConfig( siteDetails.id );
 						if ( ! isWordPressDirResult ) {
 							await fs.promises.rm( sitePath, { recursive: true, force: true } );
@@ -1030,18 +1047,14 @@ export async function runCommand(
 
 		await emitCliEvent( { event: SITE_EVENTS.CREATED, data: { siteId: siteDetails.id } } );
 	} finally {
-		if ( staticSiteImport && staticSiteImportSucceeded ) {
-			cleanupSuccessfulStaticSiteImport( sitePath );
-		} else if (
+		// Keep the staged request only when it is resumable: the import ran but did not
+		// finish. A site that already existed always keeps its own staged request.
+		if (
 			staticSiteImport &&
-			! resumedStaticSiteImport &&
-			! registeredSite &&
-			! staticSiteImportResultObserved
+			( importOutcome === 'succeeded' ||
+				( importOutcome === 'not-attempted' && ! siteAlreadyExisted ) )
 		) {
-			fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR ), {
-				recursive: true,
-				force: true,
-			} );
+			removeStagedStaticSiteImport( sitePath );
 		}
 		await disconnectFromDaemon();
 	}
@@ -1484,7 +1497,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 						sourceUrl
 					);
 				} else if ( argv.blueprint ) {
-					if ( argv.blueprint.startsWith( 'http://' ) || argv.blueprint.startsWith( 'https://' ) ) {
+					if ( isUrl( argv.blueprint ) ) {
 						config.blueprint = {
 							uri: argv.blueprint,
 							contents: await fetchBlueprint( argv.blueprint ),
@@ -1502,10 +1515,9 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 						// For gallery blueprints the path is a URL; use it directly.
 						if ( argv.originalBlueprintPath ) {
 							const originalPath = argv.originalBlueprintPath;
-							config.blueprint.uri =
-								originalPath.startsWith( 'http://' ) || originalPath.startsWith( 'https://' )
-									? originalPath
-									: path.resolve( originalPath );
+							config.blueprint.uri = isUrl( originalPath )
+								? originalPath
+								: path.resolve( originalPath );
 						}
 					}
 				}
@@ -1513,11 +1525,9 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				try {
 					await runCommand( sitePath, config );
 				} finally {
-					if ( config.blueprint?.staticSiteImport?.bundlePath ) {
-						fs.rmSync( config.blueprint.staticSiteImport.bundlePath, {
-							recursive: true,
-							force: true,
-						} );
+					const bundlePath = config.blueprint?.staticSiteImport?.bundlePath;
+					if ( bundlePath ) {
+						await removeBlueprintTempDir( bundlePath ).catch( () => {} );
 					}
 				}
 

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -62,8 +62,6 @@ import {
 } from '@studio/common/types/php-versions';
 import { __, sprintf } from '@wordpress/i18n';
 import { isStepDefinition, type BlueprintV1Declaration } from '@wp-playground/blueprints';
-import { canonicalizeBlocks, cleanupValidatorPages } from 'cli/ai/block-validator';
-import { closeSharedBrowser } from 'cli/ai/browser-utils';
 import { bumpStat, getPlatformMetric } from 'cli/lib/bump-stat';
 import {
 	lockCliConfig,
@@ -72,7 +70,7 @@ import {
 	SiteData,
 	unlockCliConfig,
 } from 'cli/lib/cli-config/core';
-import { getSiteUrl, removeSiteFromConfig } from 'cli/lib/cli-config/sites';
+import { removeSiteFromConfig } from 'cli/lib/cli-config/sites';
 import { connectToDaemon, disconnectFromDaemon, emitCliEvent } from 'cli/lib/daemon-client';
 import {
 	getAiInstructionsPath,
@@ -92,12 +90,7 @@ import { getTracksOrigin, recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/track
 import { StatsGroup } from 'cli/lib/types/bump-stats';
 import { untildify } from 'cli/lib/utils';
 import { ValidationError } from 'cli/lib/validation-error';
-import {
-	isServerRunning,
-	runBlueprint,
-	startWordPressServer,
-	stopWordPressServer,
-} from 'cli/lib/wordpress-server-manager';
+import { runBlueprint, startWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -109,21 +102,12 @@ const defaultLogger = new Logger< LoggerAction >();
 // `--static-site-importer-path`.
 const DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL =
 	'https://github.com/Automattic/static-site-importer/releases/download/v1.8.0/static-site-importer.zip';
-const STATIC_SITE_IMPORT_CONTRACT = 'ssi-import-v5-plan-first';
 const STATIC_SITE_IMPORT_DIR = '.studio-import';
-const STATIC_SITE_IMPORT_SCRIPT_FILE = 'import.php';
-const STATIC_SITE_IMPORT_FIGMA_FILE = 'source.fig';
-const STATIC_SITE_IMPORT_IDENTITY_FILE = 'static-site-importer.json';
-const STATIC_SITE_IMPORT_RESULT_FILE = 'result.json';
-const STATIC_SITE_IMPORT_SOURCE_FILE = 'source.json';
-const STATIC_SITE_IMPORT_STATE_FILE = 'state.json';
-const STATIC_SITE_IMPORT_CANONICAL_DOCUMENTS_FILE = 'client-canonical-documents.json';
-const STATIC_SITE_IMPORT_CANONICAL_UPDATES_FILE = 'client-canonical-updates.json';
-const MAX_STATIC_SITE_IMPORT_INVOCATIONS = 10000;
+const STATIC_SITE_IMPORT_REQUEST_FILE = 'request.json';
 const STATIC_SITE_IMPORT_PROGRESS_INTERVAL_MS = 30_000;
 const DATA_LIBERATION_CAPTURE_RECEIPT_SCHEMA = 'data-liberation/capture-receipt/v1';
-type StaticSiteImportProgressPhase = 'dependency-preparation' | 'compiler-import' | 'finalization';
-type StaticSiteImportIdentity = { source: string; contract: string; phase?: 'cleanup_pending' };
+const STATIC_SITE_IMPORT_RECEIPT_SCHEMA = 'static-site-importer/import-cli-receipt/v1';
+type StaticSiteImportProgressPhase = 'import' | 'finalization';
 
 type StaticSiteImporterSource = {
 	path: string;
@@ -145,14 +129,7 @@ export type CreateCommandOptions = {
 		contents: unknown;
 		uri: string;
 		staticSiteImport?: {
-			code: string;
-			source: string;
-			storeResult: boolean;
-			stagedSource?: {
-				sourcePath: string;
-				targetName: string;
-			};
-			identity?: StaticSiteImportIdentity;
+			request: string;
 			bundlePath?: string;
 		};
 	};
@@ -263,10 +240,7 @@ function resolveDataLiberationWebsiteRoot( sourceDir: string ): string {
 	return websiteRoot;
 }
 
-function resolveStaticSiteImporterSource(
-	sourcePath: string,
-	stagedFigmaPath?: string
-): StaticSiteImporterSource {
+function resolveStaticSiteImporterSource( sourcePath: string ): StaticSiteImporterSource {
 	if ( isUrl( sourcePath ) ) {
 		throw new LoggerError(
 			__( 'Remote URLs must be rendered by Data Liberation before SSI materialization.' )
@@ -329,21 +303,9 @@ function resolveStaticSiteImporterSource(
 	}
 
 	if ( extension === '.fig' ) {
-		if ( ! stagedFigmaPath ) {
-			throw new LoggerError( __( 'A staging path is required for Figma imports.' ) );
-		}
-		return {
-			path: sourcePath,
-			payload: {
-				figma_file: {
-					name: path.basename( sourcePath ),
-					staged_path: stagedFigmaPath,
-				},
-				transform_options: {
-					multi_page: true,
-				},
-			},
-		};
+		throw new LoggerError(
+			__( 'Figma files are not supported by the canonical Static Site Importer command.' )
+		);
 	}
 
 	return {
@@ -354,303 +316,67 @@ function resolveStaticSiteImporterSource(
 	};
 }
 
-function buildStaticSiteImporterPhp(
-	sourcePath: string,
+function buildStaticSiteImporterRequest(
+	source: StaticSiteImporterSource,
 	siteName: string,
-	storeImportResult: boolean,
-	adminUsername: string
-): string {
-	return `<?php
-if ( ! function_exists( 'did_action' ) || ! did_action( 'plugins_loaded' ) ) {
-	require_once getcwd() . '/wp-load.php';
-}
+	originalSourceUrl?: string
+): Record< string, unknown > {
+	const payload = source.payload;
+	let requestSource: Record< string, unknown >;
+	let themeMaterialization: unknown;
+	const artifact = payload.artifact;
 
-require_once ABSPATH . 'wp-admin/includes/plugin.php';
-require_once ABSPATH . 'wp-admin/includes/file.php';
-
-$source_path = ABSPATH . '${ STATIC_SITE_IMPORT_DIR }/${ STATIC_SITE_IMPORT_SOURCE_FILE }';
-$source_raw = is_file( $source_path ) ? file_get_contents( $source_path ) : false;
-$source = is_string( $source_raw ) ? json_decode( $source_raw, true ) : null;
-if ( ! is_array( $source ) ) {
-	throw new RuntimeException( 'Static Site Importer source payload could not be decoded.' );
-}
-
-$admin_user = get_user_by( 'login', ${ phpString( adminUsername ) } );
-if ( ! $admin_user instanceof WP_User ) {
-	throw new RuntimeException( 'Static Site Importer requires the created local administrator.' );
-}
-wp_set_current_user( $admin_user->ID, $admin_user->user_login );
-if ( ! current_user_can( 'manage_options' ) || ! current_user_can( 'unfiltered_html' ) ) {
-	throw new RuntimeException( 'Static Site Importer requires the created local administrator.' );
-}
-
-$input = array(
-	'name'            => ${ phpString( siteName ) },
-	'site_title'      => ${ phpString( siteName ) },
-	'activate'        => true,
-	'overwrite'       => true,
-	'client_script_policy' => 'isolated_preview',
-	'client_script_isolated' => true,
-	'client_script_provenance' => array( 'ref' => 'studio-create-from:sha256:' . hash( 'sha256', (string) wp_json_encode( $source ) ) ),
-	'source_metadata' => array(
-		'source'      => 'studio-create-from',
-		'source_path' => ${ phpString( sourcePath ) },
-	),
-);
-$state_path = ABSPATH . '${ STATIC_SITE_IMPORT_DIR }/${ STATIC_SITE_IMPORT_STATE_FILE }';
-$state_raw = is_file( $state_path ) ? file_get_contents( $state_path ) : false;
-$state = is_string( $state_raw ) ? json_decode( $state_raw, true ) : array();
-$state = is_array( $state ) ? $state : array();
-
-function static_site_importer_studio_failure_message( $result, string $fallback ): string {
-	if ( ! is_array( $result ) || ! is_array( $result['error'] ?? null ) ) {
-		return $fallback;
-	}
-	$code = is_scalar( $result['error']['code'] ?? null ) ? sanitize_key( (string) $result['error']['code'] ) : '';
-	$message = is_scalar( $result['error']['message'] ?? null ) ? sanitize_text_field( (string) $result['error']['message'] ) : '';
-	$detail = implode( ': ', array_filter( array( $code, $message ) ) );
-	return '' !== $detail ? $fallback . ': ' . substr( $detail, 0, 1000 ) : $fallback;
-}
-
-function static_site_importer_studio_bounded_value( $value, int $depth = 0 ) {
-	if ( $depth >= 5 ) {
-		return null;
-	}
-	if ( is_bool( $value ) || is_int( $value ) || is_float( $value ) || null === $value ) {
-		return $value;
-	}
-	if ( is_string( $value ) ) {
-		return substr( sanitize_text_field( $value ), 0, 1000 );
-	}
-	if ( ! is_array( $value ) ) {
-		return null;
-	}
-	$projection = array();
-	foreach ( array_slice( $value, 0, 50, true ) as $key => $item ) {
-		$projected_item = static_site_importer_studio_bounded_value( $item, $depth + 1 );
-		if ( null === $projected_item && null !== $item ) {
-			continue;
-		}
-		if ( is_int( $key ) ) {
-			$projection[ $key ] = $projected_item;
-			continue;
-		}
-		$projected_key = substr( sanitize_key( (string) $key ), 0, 100 );
-		if ( '' !== $projected_key ) {
-			$projection[ $projected_key ] = $projected_item;
-		}
-	}
-	return $projection;
-}
-
-function static_site_importer_studio_result_projection( $result ): array {
-	$projection = array( 'success' => is_array( $result ) && ! empty( $result['success'] ) );
-	if ( ! is_array( $result ) ) {
-		return $projection;
-	}
-	if ( is_array( $result['error'] ?? null ) ) {
-		$projection['error'] = array(
-			'code'    => substr( sanitize_key( (string) ( $result['error']['code'] ?? '' ) ), 0, 200 ),
-			'message' => substr( sanitize_text_field( (string) ( $result['error']['message'] ?? '' ) ), 0, 1000 ),
-		);
-		if ( array_key_exists( 'data', $result['error'] ) ) {
-			$projection['error']['data'] = static_site_importer_studio_bounded_value( $result['error']['data'] );
-		}
-	}
-	$import_result = isset( $result['result'] ) && is_array( $result['result'] ) ? $result['result'] : $result;
-	$stored_result = array(
-		'schema'       => 'studio/static-site-import-result/v1',
-		'status'       => substr( sanitize_key( (string) ( $import_result['status'] ?? ( $projection['success'] ? 'completed' : 'failed' ) ) ), 0, 100 ),
-		'continuation' => ! empty( $import_result['continuation'] ),
-		'pages'        => array_slice( array_map( 'intval', array_values( is_array( $import_result['pages'] ?? null ) ? $import_result['pages'] : array() ) ), 0, 5000 ),
-	);
-	$request_id = is_array( $import_result['fresh_runtime'] ?? null ) ? (string) ( $import_result['fresh_runtime']['request_id'] ?? '' ) : '';
-	if ( '' !== $request_id ) {
-		$stored_result['fresh_runtime'] = array( 'request_id' => substr( sanitize_text_field( $request_id ), 0, 200 ) );
-	}
-	foreach ( array( 'theme', 'theme_slug', 'front_page' ) as $field ) {
-		if ( isset( $import_result[ $field ] ) && is_scalar( $import_result[ $field ] ) ) {
-			$stored_result[ $field ] = substr( sanitize_text_field( (string) $import_result[ $field ] ), 0, 500 );
-		}
-	}
-	$projection['result'] = $stored_result;
-	if ( is_array( $result['diagnostics'] ?? null ) ) {
-		$projection['diagnostic_count'] = count( $result['diagnostics'] );
-		$projection['diagnostics'] = static_site_importer_studio_bounded_value( $result['diagnostics'] );
-	}
-	return $projection;
-}
-
-function static_site_importer_studio_write_result( array $result ): void {
-	$encoded = wp_json_encode( $result );
-	if ( ! is_string( $encoded ) ) {
-		throw new RuntimeException( 'Static Site Importer result receipt could not be encoded.' );
-	}
-	$result_path = ABSPATH . '${ STATIC_SITE_IMPORT_DIR }/${ STATIC_SITE_IMPORT_RESULT_FILE }';
-	$temp_path = $result_path . '.tmp-' . wp_generate_uuid4();
-	if ( false === file_put_contents( $temp_path, $encoded ) ) {
-		throw new RuntimeException( 'Static Site Importer result receipt could not be saved.' );
-	}
-	if ( ! rename( $temp_path, $result_path ) ) {
-		unlink( $temp_path );
-		throw new RuntimeException( 'Static Site Importer result receipt could not be finalized.' );
-	}
-}
-
-function static_site_importer_studio_record_failure( $result, string $fallback, bool $store_import_result ): void {
-	$projection = static_site_importer_studio_result_projection( $result );
-	if ( $store_import_result ) {
-		update_option( 'studio_create_from_import_result', $projection, false );
-	}
-	static_site_importer_studio_write_result(
-		array(
-			'continuation'  => false,
-			'failed'        => true,
-			'failure'       => $projection,
-			'import_receipt' => $projection,
-		)
-	);
-	throw new RuntimeException( static_site_importer_studio_failure_message( $result, $fallback ) );
-}
-
-function static_site_importer_studio_reject_catastrophic_content_loss( array $source, array $documents ): void { $st = $si = $it = $ii = 0; foreach ( $source['artifact']['files'] ?? array() as $f ) { if ( is_array( $f ) && str_ends_with( (string) ( $f['path'] ?? '' ), '.html' ) && isset( $f['content'] ) ) { $c = (string) $f['content']; $st += strlen( trim( wp_strip_all_tags( $c, true ) ) ); $si += preg_match_all( '/<img\\b/i', $c ); } } foreach ( $documents as $d ) { $c = (string) ( $d['content'] ?? '' ); $it += strlen( trim( wp_strip_all_tags( $c, true ) ) ); $ii += preg_match_all( '/<!--\\s+wp:image\\b|<img\\b/i', $c ); } if ( $st >= 160 && $si && $documents && $it <= 80 && ! $ii ) throw new RuntimeException( 'Static Site Importer rejected catastrophic content loss: source became navigation-only with no images. Inspect diagnostics.' ); }
-
-$store_import_result = ${ storeImportResult ? 'true' : 'false' };
-
-if ( isset( $source['figma_file'] ) ) {
-	if ( ! function_exists( 'static_site_importer_ability_import_figma' ) ) {
-		throw new RuntimeException( 'Static Site Importer Figma import ability is unavailable.' );
-	}
-	$input['source'] = $source;
-	$input['transform_options'] = isset( $source['transform_options'] ) && is_array( $source['transform_options'] ) ? $source['transform_options'] : array();
-	if ( ! empty( $state['runtime_lifecycle_request_id'] ) ) {
-		$input['runtime_lifecycle_phase'] = 'resume';
-		$input['runtime_lifecycle_request_id'] = (string) $state['runtime_lifecycle_request_id'];
-		if ( ! empty( $state['runtime_lifecycle_checkpoint'] ) ) {
-			$input['runtime_lifecycle_checkpoint'] = (string) $state['runtime_lifecycle_checkpoint'];
-		}
+	if ( artifact && typeof artifact === 'object' && ! Array.isArray( artifact ) ) {
+		const {
+			schema: _schema,
+			entrypoint,
+			files,
+			theme_materialization,
+			...metadata
+		} = artifact as Record< string, unknown >;
+		themeMaterialization = theme_materialization;
+		requestSource = {
+			type: 'files',
+			entrypoint: typeof entrypoint === 'string' ? entrypoint : '',
+			files: Array.isArray( files ) ? files : [],
+			metadata,
+		};
+	} else if ( payload.archive && typeof payload.archive === 'object' ) {
+		requestSource = { type: 'zip', zip: payload.archive };
+	} else if ( Array.isArray( payload.files ) ) {
+		requestSource = { type: 'files', files: payload.files };
 	} else {
-		$input['runtime_lifecycle_phase'] = 'prepare';
-	}
-	$result = static_site_importer_ability_import_figma( $input );
-} else {
-	if ( ! function_exists( 'static_site_importer_ability_import' ) ) {
-		throw new RuntimeException( 'Static Site Importer canonical import ability is unavailable.' );
+		throw new LoggerError( __( 'This source type is not supported by the canonical importer.' ) );
 	}
 
-	$artifact = isset( $source['artifact'] ) && is_array( $source['artifact'] ) ? $source['artifact'] : array();
-	if ( ! empty( $artifact ) ) {
-		$input['fail_on_quality'] = true;
-		$input['require_proven_dynamic_client_assets'] = true;
-		$input['seed_entities'] = true;
-		$input['materialize_dependencies'] = true;
-		if ( in_array( $artifact['theme_materialization'] ?? '', array( 'block', 'classic' ), true ) ) {
-			$input['theme_materialization'] = (string) $artifact['theme_materialization'];
-		}
-		$input['source_metadata']['semantic_evidence'] = is_array( $artifact['semantic_evidence'] ?? null ) ? $artifact['semantic_evidence'] : array();
+	const request: Record< string, unknown > = {
+		operation: 'apply',
+		name: siteName,
+		site_title: siteName,
+		activate: true,
+		overwrite: true,
+		client_script_policy: 'isolated_preview',
+		client_script_isolated: true,
+		client_script_provenance: {
+			ref: `studio-create-from:sha256:${ crypto
+				.createHash( 'sha256' )
+				.update( JSON.stringify( payload ) )
+				.digest( 'hex' ) }`,
+		},
+		source_metadata: {
+			source: 'studio-create-from',
+			source_path: originalSourceUrl ?? source.path,
+		},
+		fail_on_quality: true,
+		require_proven_dynamic_client_assets: true,
+		seed_entities: true,
+		materialize_dependencies: true,
+		source: requestSource,
+	};
+	if ( themeMaterialization === 'block' || themeMaterialization === 'classic' ) {
+		request.theme_materialization = themeMaterialization;
 	}
-	if ( ! empty( $state['import_id'] ) ) {
-		$input['source'] = array( 'type' => 'files', 'import_id' => (string) $state['import_id'] );
-	} elseif ( ! empty( $artifact ) ) {
-		$metadata = $artifact;
-		unset( $metadata['schema'], $metadata['entrypoint'], $metadata['files'] );
-		$input['source'] = array(
-			'type'       => 'files',
-			'entrypoint' => (string) ( $artifact['entrypoint'] ?? '' ),
-			'files'      => isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array(),
-			'metadata'   => $metadata,
-		);
-	} elseif ( isset( $source['archive'] ) && is_array( $source['archive'] ) ) {
-		$input['source'] = array(
-			'type' => 'zip',
-			'zip'  => $source['archive'],
-		);
-	} else {
-		$input['source'] = array(
-			'type'  => 'files',
-			'files' => isset( $source['files'] ) && is_array( $source['files'] ) ? $source['files'] : array(),
-		);
-	}
-	if ( ! empty( $state['runtime_lifecycle_request_id'] ) ) {
-		$input['runtime_lifecycle_phase'] = 'resume';
-		$input['runtime_lifecycle_request_id'] = (string) $state['runtime_lifecycle_request_id'];
-		if ( ! empty( $state['runtime_lifecycle_checkpoint'] ) ) {
-			$input['runtime_lifecycle_checkpoint'] = (string) $state['runtime_lifecycle_checkpoint'];
-		}
-	} else {
-		$input['runtime_lifecycle_phase'] = 'prepare';
-	}
-
-	$result = static_site_importer_ability_import( $input );
-}
-
-if ( ! is_array( $result ) || empty( $result['success'] ) ) {
-	static_site_importer_studio_record_failure( $result, 'Static Site Importer import failed', $store_import_result );
-}
-if ( $store_import_result ) {
-	update_option( 'studio_create_from_import_result', static_site_importer_studio_result_projection( $result ), false );
-}
-$import_result = isset( $result['result'] ) && is_array( $result['result'] ) ? $result['result'] : $result;
-if ( ! empty( $import_result['continuation'] ) && preg_match( '/^[a-f0-9]{64}$/', (string) ( $import_result['import_id'] ?? '' ) ) ) {
-	$state = array( 'import_id' => (string) $import_result['import_id'] );
-	if ( false === file_put_contents( $state_path, wp_json_encode( $state ) ) ) {
-		throw new RuntimeException( 'Static Site Importer direct continuation state could not be saved.' );
-	}
-	$continuation_receipt = array( 'continuation' => true );
-	if ( is_scalar( $import_result['status'] ?? null ) && '' !== (string) $import_result['status'] ) {
-		$continuation_receipt['status'] = substr( sanitize_key( (string) $import_result['status'] ), 0, 100 );
-	}
-	if ( isset( $import_result['url_batch_run']['completed_routes'], $import_result['url_batch_run']['total_routes'] ) ) {
-		$continuation_receipt['completed_routes'] = (int) $import_result['url_batch_run']['completed_routes'];
-		$continuation_receipt['total_routes'] = (int) $import_result['url_batch_run']['total_routes'];
-	}
-	static_site_importer_studio_write_result( $continuation_receipt );
-	return;
-}
-if ( 'dependencies_prepared' === ( $import_result['status'] ?? '' ) ) {
-	$request_id = (string) ( $import_result['fresh_runtime']['request_id'] ?? '' );
-	$checkpoint = (string) ( $import_result['fresh_runtime']['lifecycle_checkpoint_id'] ?? $import_result['runtime_lifecycle_checkpoint'] ?? '' );
-	$lifecycle_state = array( 'runtime_lifecycle_request_id' => $request_id );
-	if ( '' !== $checkpoint ) {
-		$lifecycle_state['runtime_lifecycle_checkpoint'] = $checkpoint;
-	}
-	if ( '' === $request_id || false === file_put_contents( $state_path, wp_json_encode( $lifecycle_state ) ) ) {
-		throw new RuntimeException( 'Static Site Importer lifecycle state could not be saved.' );
-	}
-	static_site_importer_studio_write_result( array( 'continuation' => true, 'status' => 'dependencies_prepared' ) );
-	return;
-}
-if ( '' !== $state_path && is_file( $state_path ) ) {
-	unlink( $state_path );
-}
-$canonical_documents = array();
-foreach ( array_unique( array_map( 'intval', array_values( isset( $import_result['pages'] ) && is_array( $import_result['pages'] ) ? $import_result['pages'] : array() ) ) ) as $post_id ) {
-	$post = get_post( $post_id );
-	if ( $post instanceof WP_Post ) {
-		$canonical_documents[] = array(
-			'post_id' => $post_id,
-			'content' => (string) $post->post_content,
-			'sha256'  => hash( 'sha256', (string) $post->post_content ),
-		);
-	}
-}
-if ( ! empty( $canonical_documents ) && false === file_put_contents( ABSPATH . '${ STATIC_SITE_IMPORT_DIR }/${ STATIC_SITE_IMPORT_CANONICAL_DOCUMENTS_FILE }', wp_json_encode( $canonical_documents ) ) ) {
-	throw new RuntimeException( 'Static Site Importer client canonicalization handoff could not be saved.' );
-}
-static_site_importer_studio_reject_catastrophic_content_loss( $source, $canonical_documents );
-
-$studio_result = array(
-	'continuation'             => ! empty( $import_result['continuation'] ),
-	'canonicalization_pending' => ! empty( $canonical_documents ),
-	'status'                    => (string) ( $import_result['url_batch_run']['status'] ?? $import_result['status'] ?? 'completed' ),
-	'completed_routes'          => (int) ( $import_result['url_batch_run']['completed_routes'] ?? count( $canonical_documents ) ),
-	'total_routes'              => (int) ( $import_result['url_batch_run']['total_routes'] ?? count( $canonical_documents ) ),
-	'import_receipt'            => static_site_importer_studio_result_projection( $result ),
-);
-static_site_importer_studio_write_result( $studio_result );
-?>`
-		.replace( /\s*\n\s*/g, '' )
-		.replace( '<?phpif', '<?php if' );
+	return request;
 }
 
 function artifactTitle( artifact: Record< string, unknown > ): string | undefined {
@@ -670,35 +396,21 @@ function artifactTitle( artifact: Record< string, unknown > ): string | undefine
 	return undefined;
 }
 
-function phpString( value: string ): string {
-	return JSON.stringify( value );
-}
-
 export function buildCreateFromSourceBlueprint(
 	sourcePath: string,
 	siteName: string,
 	staticSiteImporterPlugin: StaticSiteImporterPlugin = DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL,
-	storeImportResult = false,
-	adminUsername = 'admin',
 	originalSourceUrl?: string
 ): {
 	contents: BlueprintV1Declaration;
 	uri: string;
 	staticSiteImport: {
-		code: string;
-		source: string;
-		storeResult: boolean;
-		stagedSource?: { sourcePath: string; targetName: string };
-		identity?: StaticSiteImportIdentity;
+		request: string;
 		bundlePath?: string;
 	};
 } {
-	const stagedFigmaName =
-		path.extname( sourcePath ).toLowerCase() === '.fig' ? STATIC_SITE_IMPORT_FIGMA_FILE : undefined;
-	const source = resolveStaticSiteImporterSource(
-		sourcePath,
-		stagedFigmaName ? path.join( STATIC_SITE_IMPORT_DIR, stagedFigmaName ) : undefined
-	);
+	const source = resolveStaticSiteImporterSource( sourcePath );
+	const request = buildStaticSiteImporterRequest( source, siteName, originalSourceUrl );
 	const tempDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-create-from-' ) );
 	const blueprintPath = path.join( tempDir, 'blueprint.json' );
 	const pluginData =
@@ -738,330 +450,132 @@ export function buildCreateFromSourceBlueprint(
 		contents: blueprint,
 		uri: blueprintPath,
 		staticSiteImport: {
-			code: buildStaticSiteImporterPhp( source.path, siteName, storeImportResult, adminUsername ),
-			source: JSON.stringify( source.payload ),
-			storeResult: storeImportResult,
-			...( stagedFigmaName ? { stagedSource: { sourcePath, targetName: stagedFigmaName } } : {} ),
-			identity: { source: originalSourceUrl ?? source.path, contract: STATIC_SITE_IMPORT_CONTRACT },
+			request: `${ JSON.stringify( request, null, 2 ) }\n`,
 			bundlePath: tempDir,
 		},
 	};
 }
 
-function staticSiteImportIdentityPath( sitePath: string ): string {
-	return path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_IDENTITY_FILE );
-}
-
-function cleanupSuccessfulStaticSiteImport( sitePath: string, preserveResult = false ): void {
-	fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_SCRIPT_FILE ), {
-		force: true,
-	} );
-	if ( ! preserveResult ) {
-		fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_RESULT_FILE ), {
-			force: true,
-		} );
-	}
-	fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_SOURCE_FILE ), {
-		force: true,
-	} );
-	fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_FIGMA_FILE ), {
-		force: true,
-	} );
-	fs.rmSync( staticSiteImportIdentityPath( sitePath ), { force: true } );
-	fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_STATE_FILE ), {
-		force: true,
-	} );
-	fs.rmSync(
-		path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_CANONICAL_DOCUMENTS_FILE ),
-		{ force: true }
-	);
-	fs.rmSync(
-		path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_CANONICAL_UPDATES_FILE ),
-		{ force: true }
-	);
-}
-
-async function canonicalizeStaticSiteImport( site: SiteData, stagingDir: string ): Promise< void > {
-	const documentsPath = path.join( stagingDir, STATIC_SITE_IMPORT_CANONICAL_DOCUMENTS_FILE );
-	if ( ! fs.existsSync( documentsPath ) ) {
-		throw new Error( 'Static site import completed without its canonicalization handoff.' );
-	}
-
-	const documents = JSON.parse( fs.readFileSync( documentsPath, 'utf-8' ) ) as Array< {
-		post_id: number;
-		content: string;
-		sha256: string;
-	} >;
-	if ( ! Array.isArray( documents ) || documents.length === 0 ) {
-		throw new Error( 'Static site import returned an invalid canonicalization handoff.' );
-	}
-
-	const updates = [];
-	const siteUrl = getSiteUrl( site );
-	for ( const document of documents ) {
-		if (
-			! Number.isInteger( document.post_id ) ||
-			document.post_id <= 0 ||
-			typeof document.content !== 'string' ||
-			document.sha256 !== crypto.createHash( 'sha256' ).update( document.content ).digest( 'hex' )
-		) {
-			throw new Error( 'Static site import returned a corrupt canonicalization document.' );
-		}
-		const content = await canonicalizeBlocks( document.content, siteUrl );
-		if ( content !== document.content ) {
-			updates.push( {
-				post_id: document.post_id,
-				before_sha256: document.sha256,
-				after_sha256: crypto.createHash( 'sha256' ).update( content ).digest( 'hex' ),
-				content,
-			} );
-		}
-	}
-
-	if ( updates.length > 0 ) {
-		const updatesPath = path.join( stagingDir, STATIC_SITE_IMPORT_CANONICAL_UPDATES_FILE );
-		fs.writeFileSync( updatesPath, JSON.stringify( updates ) );
-		await using command = await runWpCliCommandWithMessaging( site, [
-			'eval',
-			`$path = ABSPATH . '${ STATIC_SITE_IMPORT_DIR }/${ STATIC_SITE_IMPORT_CANONICAL_UPDATES_FILE }';
-$documents = json_decode( (string) file_get_contents( $path ), true );
-if ( ! is_array( $documents ) ) {
-	throw new RuntimeException( 'Client canonicalization updates are invalid.' );
-}
-foreach ( $documents as $document ) {
-	$post = get_post( (int) ( $document['post_id'] ?? 0 ) );
-	if ( ! $post instanceof WP_Post || ! hash_equals( (string) ( $document['before_sha256'] ?? '' ), hash( 'sha256', (string) $post->post_content ) ) ) {
-		throw new RuntimeException( 'Client canonicalization preimage changed before persistence.' );
-	}
-	$result = wp_update_post( array( 'ID' => $post->ID, 'post_content' => wp_slash( (string) ( $document['content'] ?? '' ) ) ), true );
-	$updated = get_post( $post->ID );
-	if ( is_wp_error( $result ) || ! $updated instanceof WP_Post || ! hash_equals( (string) ( $document['after_sha256'] ?? '' ), hash( 'sha256', (string) $updated->post_content ) ) ) {
-		throw new RuntimeException( 'Client canonicalization did not persist exact target-registry bytes.' );
-	}
-}`,
-		] );
-		const [ exitCode, stdout, stderr ] = await Promise.all( [
-			command.response.exitCode,
-			command.response.stdoutText,
-			command.response.stderrText,
-		] );
-		if ( exitCode !== 0 ) {
-			throw new Error(
-				stderr.trim() || stdout.trim() || sprintf( __( 'WP-CLI exited with code %d.' ), exitCode )
-			);
-		}
-		fs.rmSync( updatesPath, { force: true } );
-	}
-
-	fs.rmSync( documentsPath, { force: true } );
-}
-
 export function staticSiteImportProgressMessage(
 	phase: StaticSiteImportProgressPhase,
-	elapsedMs: number,
-	invocation = 1
+	elapsedMs: number
 ): string {
 	const elapsedSeconds = Math.floor( elapsedMs / 1000 );
-	if ( phase === 'dependency-preparation' ) {
-		return sprintf( __( 'Dependency preparation… %d sec elapsed' ), elapsedSeconds );
-	}
-	if ( phase === 'compiler-import' ) {
-		return sprintf(
-			/* translators: 1: importer invocation, 2: elapsed seconds */
-			__( 'Compiler/import… invocation %1$d, %2$d sec elapsed' ),
-			invocation,
-			elapsedSeconds
-		);
+	if ( phase === 'import' ) {
+		return sprintf( __( 'Static site import… %d sec elapsed' ), elapsedSeconds );
 	}
 	return sprintf( __( 'Finalization… %d sec elapsed' ), elapsedSeconds );
 }
 
-export function staticSiteImportContinuationMessage( result: {
-	completed_routes?: number;
-	total_routes?: number;
-	status?: string;
-} ): string {
-	if (
-		typeof result.completed_routes === 'number' &&
-		typeof result.total_routes === 'number' &&
-		result.total_routes > 0
-	) {
-		return sprintf(
-			/* translators: 1: completed route count, 2: total route count */
-			__( 'Static site import progress: %1$d/%2$d routes' ),
-			result.completed_routes,
-			result.total_routes
-		);
+function staticSiteImportRequestPath( sitePath: string ): string {
+	return path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_REQUEST_FILE );
+}
+
+function cleanupSuccessfulStaticSiteImport( sitePath: string ): void {
+	fs.rmSync( path.join( sitePath, STATIC_SITE_IMPORT_DIR ), { recursive: true, force: true } );
+}
+
+function decodeStaticSiteImportReceipt( output: string ): Record< string, unknown > | undefined {
+	const lines = output.trim().split( /\r?\n/ );
+	for ( let index = lines.length - 1; index >= 0; index-- ) {
+		try {
+			const receipt = JSON.parse( lines[ index ] );
+			if ( receipt && typeof receipt === 'object' && ! Array.isArray( receipt ) ) {
+				return receipt as Record< string, unknown >;
+			}
+		} catch {
+			// WP-CLI may print informational lines before the terminal JSON receipt.
+		}
 	}
-	const stage = typeof result.status === 'string' ? result.status.trim().replace( /_/g, ' ' ) : '';
-	if ( stage !== '' ) {
-		/* translators: %s: stage the importer reported for its last continuation */
-		return sprintf( __( 'Static site import continuing: %s' ), stage );
+	return undefined;
+}
+
+function staticSiteImportReceiptError( receipt: Record< string, unknown > | undefined ): string {
+	const response = receipt?.response;
+	if ( ! response || typeof response !== 'object' || Array.isArray( response ) ) {
+		return '';
 	}
-	return __( 'Static site import continuing…' );
+	const error = ( response as Record< string, unknown > ).error;
+	if ( ! error || typeof error !== 'object' || Array.isArray( error ) ) {
+		return '';
+	}
+	const code = ( error as Record< string, unknown > ).code;
+	const message = ( error as Record< string, unknown > ).message;
+	return [ code, message ].filter( ( value ) => typeof value === 'string' && value ).join( ': ' );
 }
 
 async function runStaticSiteImport(
 	site: SiteData,
-	code: string,
-	source: string,
-	stagedSource?: { sourcePath: string; targetName: string },
-	identity?: StaticSiteImportIdentity,
-	preserveResult = false,
+	request: string,
 	resume = false,
 	logger: Logger< LoggerAction > = defaultLogger
 ): Promise< boolean > {
-	const stagingDir = path.join( site.path, STATIC_SITE_IMPORT_DIR );
-	const scriptName = STATIC_SITE_IMPORT_SCRIPT_FILE;
-	const scriptPath = path.join( stagingDir, scriptName );
-	const resultPath = path.join( stagingDir, STATIC_SITE_IMPORT_RESULT_FILE );
-	const statePath = path.join( stagingDir, STATIC_SITE_IMPORT_STATE_FILE );
-	if ( ! resume ) {
-		fs.mkdirSync( stagingDir, { recursive: true } );
-		if ( stagedSource ) {
-			fs.copyFileSync( stagedSource.sourcePath, path.join( stagingDir, stagedSource.targetName ) );
+	const requestPath = staticSiteImportRequestPath( site.path );
+	if ( resume ) {
+		if ( ! fs.existsSync( requestPath ) || fs.readFileSync( requestPath, 'utf-8' ) !== request ) {
+			throw new LoggerError( __( 'The staged static site import request does not match.' ) );
 		}
-		fs.writeFileSync( path.join( stagingDir, STATIC_SITE_IMPORT_SOURCE_FILE ), source );
-		if ( identity ) {
-			fs.writeFileSync( staticSiteImportIdentityPath( site.path ), JSON.stringify( identity ) );
-		}
-		fs.writeFileSync( scriptPath, code );
+	} else {
+		fs.mkdirSync( path.dirname( requestPath ), { recursive: true } );
+		fs.writeFileSync( requestPath, request );
 	}
 
-	const liveOutput = getSiteRuntime( site ) === SITE_RUNTIME_NATIVE_PHP;
-	type ImportResult = {
-		continuation?: boolean;
-		canonicalization_pending?: boolean;
-		completed_routes?: number;
-		total_routes?: number;
-		status?: string;
-	};
-	let finalizationStartedAt: number | undefined;
-	for ( let invocation = 1; invocation <= MAX_STATIC_SITE_IMPORT_INVOCATIONS; invocation++ ) {
-		let result: ImportResult | undefined;
-		if ( resume && invocation === 1 && fs.existsSync( resultPath ) ) {
-			try {
-				const persistedResult = JSON.parse(
-					fs.readFileSync( resultPath, 'utf-8' )
-				) as ImportResult;
-				if ( ! persistedResult.continuation && persistedResult.canonicalization_pending ) {
-					result = persistedResult;
-				}
-			} catch {
-				// The normal import path below reports malformed or missing receipts.
-			}
-		}
-		if ( ! result ) {
-			fs.rmSync( resultPath, { force: true } );
-			const phase: StaticSiteImportProgressPhase =
-				invocation === 1 && ! resume && ! fs.existsSync( statePath )
-					? 'dependency-preparation'
-					: 'compiler-import';
-			const startedAt = Date.now();
-			logger.reportStart(
-				LoggerAction.IMPORT_SITE,
-				staticSiteImportProgressMessage( phase, 0, invocation )
-			);
-			const progressTimer = setInterval( () => {
-				logger.reportProgress(
-					staticSiteImportProgressMessage( phase, Date.now() - startedAt, invocation )
-				);
-			}, STATIC_SITE_IMPORT_PROGRESS_INTERVAL_MS );
-			progressTimer.unref?.();
-			let exitCode: number;
-			let stdout: string;
-			let stderr: string;
-			try {
-				await using command = await runWpCliCommandWithMessaging(
-					site,
-					[ 'eval-file', `${ path.basename( stagingDir ) }/${ scriptName }` ],
-					liveOutput ? { liveOutput, onLiveOutput: () => logger.spinner.stop() } : {}
-				);
-				[ exitCode, stdout, stderr ] = await Promise.all( [
-					command.response.exitCode,
-					command.response.stdoutText,
-					command.response.stderrText,
-				] );
-			} finally {
-				clearInterval( progressTimer );
-			}
-			logger.reportProgress(
-				staticSiteImportProgressMessage( phase, Date.now() - startedAt, invocation )
-			);
-			if ( exitCode !== 0 ) {
-				throw new LoggerError(
-					__( 'Static site import failed.' ),
-					new Error(
-						stderr.trim() ||
-							stdout.trim() ||
-							sprintf( __( 'WP-CLI exited with code %d.' ), exitCode )
-					)
-				);
-			}
+	const startedAt = Date.now();
+	logger.reportStart( LoggerAction.IMPORT_SITE, staticSiteImportProgressMessage( 'import', 0 ) );
+	const progressTimer = setInterval( () => {
+		logger.reportProgress( staticSiteImportProgressMessage( 'import', Date.now() - startedAt ) );
+	}, STATIC_SITE_IMPORT_PROGRESS_INTERVAL_MS );
+	progressTimer.unref?.();
 
-			if ( ! fs.existsSync( resultPath ) ) {
-				throw new LoggerError(
-					__( 'Static site import completed without a result receipt.' ),
-					new Error( __( 'The importer did not write .studio-import/result.json.' ) )
-				);
-			}
-		}
-		try {
-			result ??= JSON.parse( fs.readFileSync( resultPath, 'utf-8' ) );
-		} catch ( error ) {
-			throw new LoggerError( __( 'Static site import returned an invalid result.' ), error );
-		} finally {
-			if ( ! preserveResult ) fs.rmSync( resultPath, { force: true } );
-		}
-		if ( ! result ) {
-			throw new LoggerError( __( 'Static site import returned an invalid result.' ) );
-		}
-		if ( ! result.continuation ) {
-			finalizationStartedAt = Date.now();
-			logger.reportProgress( staticSiteImportProgressMessage( 'finalization', 0 ) );
-			if ( result.canonicalization_pending ) {
-				await connectToDaemon();
-				const startForCanonicalization = ! ( await isServerRunning( site.id ) );
-				if ( startForCanonicalization ) {
-					await startWordPressServer( site, logger );
-					site.running = true;
-				}
-				try {
-					try {
-						await canonicalizeStaticSiteImport( site, stagingDir );
-					} finally {
-						try {
-							await cleanupValidatorPages();
-						} finally {
-							await closeSharedBrowser();
-						}
-					}
-				} finally {
-					if ( startForCanonicalization ) {
-						await stopWordPressServer( site.id );
-						site.running = false;
-					}
-				}
-			}
-			break;
-		}
-		logger.reportSuccess( staticSiteImportContinuationMessage( result ) );
-		if ( invocation === MAX_STATIC_SITE_IMPORT_INVOCATIONS ) {
-			throw new LoggerError( __( 'Static site import exceeded its continuation limit.' ) );
-		}
+	let exitCode: number;
+	let stdout: string;
+	let stderr: string;
+	try {
+		const liveOutput = getSiteRuntime( site ) === SITE_RUNTIME_NATIVE_PHP;
+		await using command = await runWpCliCommandWithMessaging(
+			site,
+			[
+				'static-site-importer',
+				'import',
+				`--request=${ path.posix.join( STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_REQUEST_FILE ) }`,
+			],
+			liveOutput ? { liveOutput, onLiveOutput: () => logger.spinner.stop() } : {}
+		);
+		[ exitCode, stdout, stderr ] = await Promise.all( [
+			command.response.exitCode,
+			command.response.stdoutText,
+			command.response.stderrText,
+		] );
+	} finally {
+		clearInterval( progressTimer );
 	}
-	if ( identity ) {
-		fs.writeFileSync(
-			staticSiteImportIdentityPath( site.path ),
-			JSON.stringify( { ...identity, phase: 'cleanup_pending' } )
+
+	logger.reportProgress( staticSiteImportProgressMessage( 'import', Date.now() - startedAt ) );
+	const receipt = decodeStaticSiteImportReceipt( stdout );
+	const receiptError = staticSiteImportReceiptError( receipt );
+	if ( exitCode !== 0 ) {
+		throw new LoggerError(
+			__( 'Static site import failed.' ),
+			new Error(
+				receiptError ||
+					stderr.trim() ||
+					stdout.trim() ||
+					sprintf( __( 'WP-CLI exited with code %d.' ), exitCode )
+			)
 		);
 	}
+	if ( receipt?.schema !== STATIC_SITE_IMPORT_RECEIPT_SCHEMA || receipt.status !== 'completed' ) {
+		throw new LoggerError(
+			__( 'Static site import returned an invalid terminal receipt.' ),
+			new Error( receiptError || stdout.trim() || __( 'The importer did not return a receipt.' ) )
+		);
+	}
+
+	const finalizationStartedAt = Date.now();
+	logger.reportProgress( staticSiteImportProgressMessage( 'finalization', 0 ) );
 	const cleanupSucceeded = await cleanupStaticSiteImporterPlugin( site, logger );
 	logger.reportProgress(
-		staticSiteImportProgressMessage(
-			'finalization',
-			finalizationStartedAt === undefined ? 0 : Date.now() - finalizationStartedAt
-		)
+		staticSiteImportProgressMessage( 'finalization', Date.now() - finalizationStartedAt )
 	);
 	logger.reportSuccess( __( 'Static site imported successfully' ) );
 	return cleanupSucceeded;
@@ -1102,41 +616,13 @@ if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin ) ) {
 		logger.reportError(
 			new LoggerError(
 				__(
-					'Static Site Importer cleanup failed. The imported site and resumable import state were preserved.'
+					'Static Site Importer cleanup failed. The imported site and staged request were preserved.'
 				),
 				error
 			),
 			false
 		);
 		return false;
-	}
-}
-
-function resumableStaticSiteImportPhase(
-	sitePath: string,
-	code: string,
-	identity: StaticSiteImportIdentity | undefined
-): 'import' | 'cleanup_pending' | null {
-	if ( ! identity ) {
-		return null;
-	}
-	const scriptPath = path.join( sitePath, STATIC_SITE_IMPORT_DIR, STATIC_SITE_IMPORT_SCRIPT_FILE );
-	const identityPath = staticSiteImportIdentityPath( sitePath );
-	if ( ! fs.existsSync( scriptPath ) || ! fs.existsSync( identityPath ) ) {
-		return null;
-	}
-	try {
-		const persistedIdentity = JSON.parse( fs.readFileSync( identityPath, 'utf-8' ) );
-		if (
-			persistedIdentity?.source !== identity.source ||
-			persistedIdentity?.contract !== identity.contract ||
-			fs.readFileSync( scriptPath, 'utf-8' ) !== code
-		) {
-			return null;
-		}
-		return persistedIdentity.phase === 'cleanup_pending' ? 'cleanup_pending' : 'import';
-	} catch {
-		return null;
 	}
 }
 
@@ -1233,36 +719,24 @@ export async function runCommand(
 		const cliConfig = await readCliConfig();
 		const existingSite = cliConfig.sites.find( ( site ) => arePathsEqual( site.path, sitePath ) );
 		registeredSite = Boolean( existingSite );
-		const resumePhase =
-			existingSite && staticSiteImport
-				? resumableStaticSiteImportPhase(
-						sitePath,
-						staticSiteImport.code,
-						staticSiteImport.identity
-				  )
-				: null;
-		if ( existingSite && staticSiteImport && resumePhase ) {
+		const canResumeStaticSiteImport =
+			existingSite &&
+			staticSiteImport &&
+			fs.existsSync( staticSiteImportRequestPath( sitePath ) ) &&
+			fs.readFileSync( staticSiteImportRequestPath( sitePath ), 'utf-8' ) ===
+				staticSiteImport.request;
+		if ( existingSite && staticSiteImport && canResumeStaticSiteImport ) {
 			resumedStaticSiteImport = true;
 			try {
-				staticSiteImportSucceeded =
-					resumePhase === 'cleanup_pending'
-						? await cleanupStaticSiteImporterPlugin( existingSite, logger )
-						: await runStaticSiteImport(
-								existingSite,
-								staticSiteImport.code,
-								staticSiteImport.source,
-								staticSiteImport.stagedSource,
-								staticSiteImport.identity,
-								staticSiteImport.storeResult,
-								true,
-								logger
-						  );
+				staticSiteImportSucceeded = await runStaticSiteImport(
+					existingSite,
+					staticSiteImport.request,
+					true,
+					logger
+				);
 				staticSiteImportResultObserved = true;
 			} catch ( error ) {
 				throw new LoggerError( __( 'Failed to import static site' ), error );
-			}
-			if ( staticSiteImportSucceeded ) {
-				cleanupSuccessfulStaticSiteImport( sitePath, staticSiteImport.storeResult );
 			}
 			return;
 		}
@@ -1454,11 +928,7 @@ export async function runCommand(
 					staticSiteImportResultObserved = true;
 					staticSiteImportSucceeded = await runStaticSiteImport(
 						siteDetails,
-						staticSiteImport.code,
-						staticSiteImport.source,
-						staticSiteImport.stagedSource,
-						staticSiteImport.identity,
-						staticSiteImport.storeResult,
+						staticSiteImport.request,
 						false,
 						logger
 					);
@@ -1508,11 +978,7 @@ export async function runCommand(
 						staticSiteImportResultObserved = true;
 						staticSiteImportSucceeded = await runStaticSiteImport(
 							siteDetails,
-							staticSiteImport.code,
-							staticSiteImport.source,
-							staticSiteImport.stagedSource,
-							staticSiteImport.identity,
-							staticSiteImport.storeResult,
+							staticSiteImport.request,
 							false,
 							logger
 						);
@@ -1565,7 +1031,7 @@ export async function runCommand(
 		await emitCliEvent( { event: SITE_EVENTS.CREATED, data: { siteId: siteDetails.id } } );
 	} finally {
 		if ( staticSiteImport && staticSiteImportSucceeded ) {
-			cleanupSuccessfulStaticSiteImport( sitePath, staticSiteImport.storeResult );
+			cleanupSuccessfulStaticSiteImport( sitePath );
 		} else if (
 			staticSiteImport &&
 			! resumedStaticSiteImport &&
@@ -1756,11 +1222,6 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 						}
 						return pluginPath;
 					},
-				} )
-				.option( 'store-import-result', {
-					type: 'boolean',
-					describe: __( 'Store the import result in the created site database' ),
-					default: false,
 				} )
 				.option( 'original-blueprint-path', {
 					type: 'string',
@@ -2020,8 +1481,6 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 						argv.staticSiteImporterPath
 							? { path: argv.staticSiteImporterPath }
 							: argv.staticSiteImporterUrl ?? DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL,
-						argv.storeImportResult,
-						adminUsername ?? 'admin',
 						sourceUrl
 					);
 				} else if ( argv.blueprint ) {

--- a/apps/cli/commands/site/tests/create.test.ts
+++ b/apps/cli/commands/site/tests/create.test.ts
@@ -27,8 +27,6 @@ import { type SupportedPHPVersion } from '@studio/common/types/php-versions';
 import { Blueprint, BlueprintV1Declaration } from '@wp-playground/blueprints';
 import { vi, type MockInstance } from 'vitest';
 import yargs from 'yargs';
-import { canonicalizeBlocks, cleanupValidatorPages } from 'cli/ai/block-validator';
-import { closeSharedBrowser } from 'cli/ai/browser-utils';
 import {
 	lockCliConfig,
 	readCliConfig,
@@ -47,20 +45,9 @@ import { logSiteDetails, openSiteInBrowser, setupCustomDomain } from 'cli/lib/si
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
 import { recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { ProcessDescription } from 'cli/lib/types/process-manager-ipc';
-import {
-	isServerRunning,
-	runBlueprint,
-	startWordPressServer,
-	stopWordPressServer,
-} from 'cli/lib/wordpress-server-manager';
+import { runBlueprint, startWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger } from 'cli/logger';
-import {
-	buildCreateFromSourceBlueprint,
-	registerCommand,
-	runCommand,
-	staticSiteImportContinuationMessage,
-	staticSiteImportProgressMessage,
-} from '../create';
+import { buildCreateFromSourceBlueprint, registerCommand, runCommand } from '../create';
 
 vi.mock( '@studio/common/lib/fs-utils' );
 vi.mock( '@studio/common/lib/network-utils' );
@@ -110,13 +97,6 @@ vi.mock( '@studio/common/lib/agent-skills' );
 vi.mock( 'cli/lib/sqlite-integration' );
 vi.mock( 'cli/lib/run-wp-cli-command' );
 vi.mock( 'cli/lib/wordpress-server-manager' );
-vi.mock( 'cli/ai/block-validator', () => ( {
-	canonicalizeBlocks: vi.fn(),
-	cleanupValidatorPages: vi.fn(),
-} ) );
-vi.mock( 'cli/ai/browser-utils', () => ( {
-	closeSharedBrowser: vi.fn(),
-} ) );
 vi.mock( 'cli/lib/tracks', async ( importActual ) => {
 	const actual = await importActual< typeof import('cli/lib/tracks') >();
 	return { ...actual, recordTracksEvent: vi.fn() };
@@ -126,31 +106,25 @@ vi.mock( '@studio/common/lib/get-wordpress-version' );
 describe( 'CLI: studio create', () => {
 	const mockSitePath = '/test/site/new-site';
 	const mockPort = 8881;
-
-	it( 'reports distinct bounded static import phases with elapsed timing', () => {
-		expect( staticSiteImportProgressMessage( 'dependency-preparation', 65_999 ) ).toBe(
-			'Dependency preparation… 65 sec elapsed'
-		);
-		expect( staticSiteImportProgressMessage( 'compiler-import', 125_000, 3 ) ).toBe(
-			'Compiler/import… invocation 3, 125 sec elapsed'
-		);
-		expect( staticSiteImportProgressMessage( 'finalization', 9_999 ) ).toBe(
-			'Finalization… 9 sec elapsed'
-		);
-	} );
-
-	it( 'reports continuation progress only from measured data', () => {
-		expect( staticSiteImportContinuationMessage( { completed_routes: 3, total_routes: 12 } ) ).toBe(
-			'Static site import progress: 3/12 routes'
-		);
-		expect( staticSiteImportContinuationMessage( { status: 'dependencies_prepared' } ) ).toBe(
-			'Static site import continuing: dependencies prepared'
-		);
-		expect( staticSiteImportContinuationMessage( {} ) ).toBe( 'Static site import continuing…' );
-		expect( staticSiteImportContinuationMessage( { completed_routes: 0, total_routes: 0 } ) ).toBe(
-			'Static site import continuing…'
-		);
-	} );
+	const completedSsiReceipt =
+		'{"schema":"static-site-importer/import-cli-receipt/v1","status":"completed","steps":1,"response":{"success":true}}';
+	const mockWpCli = ( {
+		exitCode = 0,
+		stdout = completedSsiReceipt,
+		stderr = '',
+	}: {
+		exitCode?: number;
+		stdout?: string;
+		stderr?: string;
+	} = {} ) =>
+		( {
+			response: {
+				exitCode: Promise.resolve( exitCode ),
+				stdoutText: Promise.resolve( stdout ),
+				stderrText: Promise.resolve( stderr ),
+			},
+			[ Symbol.dispose ]: vi.fn(),
+		} ) as never;
 
 	const defaultTestOptions = {
 		wpVersion: 'latest',
@@ -234,19 +208,8 @@ describe( 'CLI: studio create', () => {
 		vi.mocked( downloadWordPress ).mockResolvedValue( undefined );
 		vi.mocked( setupCustomDomain ).mockResolvedValue( undefined );
 		vi.mocked( startWordPressServer ).mockResolvedValue( mockProcessDescription );
-		vi.mocked( isServerRunning ).mockResolvedValue( undefined );
-		vi.mocked( stopWordPressServer ).mockResolvedValue( undefined );
 		vi.mocked( runBlueprint ).mockResolvedValue( undefined );
-		vi.mocked( runWpCliCommandWithMessaging )
-			.mockReset()
-			.mockResolvedValue( {
-				response: {
-					exitCode: Promise.resolve( 0 ),
-					stdoutText: Promise.resolve( '' ),
-					stderrText: Promise.resolve( '' ),
-				},
-				[ Symbol.dispose ]: vi.fn(),
-			} as never );
+		vi.mocked( runWpCliCommandWithMessaging ).mockReset().mockResolvedValue( mockWpCli() );
 		vi.mocked( logSiteDetails ).mockImplementation( () => {} );
 		vi.mocked( openSiteInBrowser ).mockResolvedValue( undefined );
 		vi.mocked( validateBlueprintData ).mockResolvedValue( { valid: true } );
@@ -276,53 +239,13 @@ describe( 'CLI: studio create', () => {
 		return artifactPath;
 	};
 
-	const buildCapturedSiteBlueprint = ( storeImportResult = false ) => {
+	const buildCapturedSiteBlueprint = () => {
 		return buildCreateFromSourceBlueprint(
 			createCapturedSiteArtifact(),
 			'Captured Site',
 			'https://example.com/static-site-importer.zip',
-			storeImportResult,
-			'admin',
 			'https://example.com/'
 		);
-	};
-
-	const setupResumableCanonicalization = () => {
-		const blueprint = buildCapturedSiteBlueprint();
-		const existingSite = { ...mockExistingSite, path: mockSitePath };
-		const documents = JSON.stringify( [
-			{
-				post_id: 1,
-				content: '',
-				sha256: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-			},
-		] );
-
-		vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
-			version: 1,
-			sites: [ existingSite ],
-		} );
-		createPathExistsMock( true );
-		vi.mocked( isEmptyDir ).mockResolvedValue( false );
-		vi.mocked( isWordPressDirectory ).mockReturnValue( true );
-		vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
-		vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) => {
-			const value = filePath.toString();
-			if ( value.endsWith( 'result.json' ) ) {
-				return JSON.stringify( { continuation: false, canonicalization_pending: true } );
-			}
-			if ( value.endsWith( 'client-canonical-documents.json' ) ) {
-				return documents;
-			}
-			if ( value.endsWith( 'static-site-importer.json' ) ) {
-				return JSON.stringify( blueprint.staticSiteImport.identity );
-			}
-			return blueprint.staticSiteImport.code;
-		} );
-		vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
-		vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
-
-		return blueprint;
 	};
 
 	describe( 'Validation Errors', () => {
@@ -542,23 +465,46 @@ describe( 'CLI: studio create', () => {
 			expect( process.exitCode ).toBe( 1 );
 		} );
 
-		it( 'retains the URL resume identity after capture produces an artifact', () => {
-			const blueprint = buildCreateFromSourceBlueprint(
-				createCapturedSiteArtifact(),
-				'Captured Site',
-				'https://example.com/static-site-importer.zip',
-				false,
-				'admin',
-				'https://example.com/'
-			);
+		it( 'stages the canonical Static Site Importer request', () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			const request = JSON.parse( blueprint.staticSiteImport.request );
 
-			expect( blueprint.staticSiteImport.identity ).toEqual( {
-				source: 'https://example.com/',
-				contract: 'ssi-import-v5-plan-first',
+			expect( request ).toMatchObject( {
+				operation: 'apply',
+				name: 'Captured Site',
+				site_title: 'Captured Site',
+				activate: true,
+				overwrite: true,
+				fail_on_quality: true,
+				require_proven_dynamic_client_assets: true,
+				seed_entities: true,
+				materialize_dependencies: true,
+				client_script_policy: 'isolated_preview',
+				source_metadata: {
+					source: 'studio-create-from',
+					source_path: 'https://example.com/',
+				},
+				source: {
+					type: 'files',
+					entrypoint: 'website/index.html',
+					files: [ { path: 'website/index.html', content: '<main>Captured</main>' } ],
+				},
 			} );
+			expect( blueprint.staticSiteImport ).not.toHaveProperty( 'code' );
+			expect( blueprint.staticSiteImport ).not.toHaveProperty( 'source' );
+			expect(
+				JSON.parse(
+					buildCreateFromSourceBlueprint(
+						createCapturedSiteArtifact(),
+						'Captured Site',
+						'https://example.com/static-site-importer.zip',
+						'https://example.com/'
+					).staticSiteImport.request
+				)
+			).toMatchObject( { operation: 'apply', fail_on_quality: true } );
 		} );
 
-		it( 'forwards an artifact-declared classic materialization strategy', () => {
+		it( 'forwards artifact-declared classic materialization on the request', () => {
 			const artifactDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-classic-artifact-' ) );
 			const artifactPath = path.join( artifactDir, 'artifact.json' );
 			fs.writeFileSync(
@@ -571,340 +517,18 @@ describe( 'CLI: studio create', () => {
 				} )
 			);
 
-			const blueprint = buildCreateFromSourceBlueprint(
-				artifactPath,
-				'Classic Site',
-				'https://example.com/static-site-importer.zip'
-			);
-
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$input['theme_materialization'] = (string) $artifact['theme_materialization'];"
-			);
+			expect(
+				JSON.parse(
+					buildCreateFromSourceBlueprint(
+						artifactPath,
+						'Classic Site',
+						'https://example.com/static-site-importer.zip'
+					).staticSiteImport.request
+				).theme_materialization
+			).toBe( 'classic' );
 		} );
 
-		it( 'does not include Static Site Importer URL capture paths', () => {
-			const blueprint = buildCapturedSiteBlueprint();
-
-			expect( blueprint.staticSiteImport.code ).not.toContain(
-				'static_site_importer_ability_import_url'
-			);
-			expect( blueprint.staticSiteImport.code ).not.toContain( "'collect_site'" );
-			expect( blueprint.staticSiteImport.source ).not.toContain( '"url"' );
-		} );
-
-		it( 'rejects remote URLs at the SSI materialization boundary', () => {
-			expect( () =>
-				buildCreateFromSourceBlueprint( 'https://example.com/', 'Imported Site' )
-			).toThrow( 'must be rendered by Data Liberation' );
-		} );
-
-		it( 'should build a Blueprint that imports a static site artifact through Static Site Importer', () => {
-			const artifactDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-artifact-test-' ) );
-			const artifactPath = path.join( artifactDir, 'artifact.json' );
-			fs.writeFileSync(
-				artifactPath,
-				JSON.stringify( {
-					schema: 'blocks-engine/php-transformer/site-artifact/v1',
-					root: 'website',
-					entrypoint: 'website/index.html',
-					files: [
-						{
-							path: 'website/index.html',
-							content: '<main><h1>Hello</h1></main>',
-						},
-					],
-				} )
-			);
-
-			const blueprint = buildCreateFromSourceBlueprint(
-				artifactPath,
-				'Imported Artifact',
-				'https://example.com/static-site-importer.zip',
-				false,
-				'artifact-admin'
-			);
-
-			expect( blueprint.uri ).toContain( 'blueprint.json' );
-			expect( blueprint.contents.steps ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						step: 'installPlugin',
-						pluginData: expect.objectContaining( {
-							url: 'https://example.com/static-site-importer.zip',
-						} ),
-					} ),
-				] )
-			);
-			expect( blueprint.staticSiteImport.code ).toContain( "$input['source'] = array(" );
-			expect( blueprint.staticSiteImport.code ).toMatch( /^<\?php if/ );
-			expect( blueprint.staticSiteImport.code ).toContain( "$input['fail_on_quality'] = true;" );
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$input['require_proven_dynamic_client_assets'] = true;"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain( "$input['seed_entities'] = true;" );
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$input['materialize_dependencies'] = true;"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				'$admin_user = get_user_by( \'login\', "artifact-admin" );'
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"current_user_can( 'manage_options' ) || ! current_user_can( 'unfiltered_html' )"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				'wp_set_current_user( $admin_user->ID, $admin_user->user_login );'
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				'$result = static_site_importer_ability_import( $input );'
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$input['runtime_lifecycle_phase'] = 'prepare';"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$input['runtime_lifecycle_phase'] = 'resume';"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"'dependencies_prepared' === ( $import_result['status'] ?? '' )"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$input['runtime_lifecycle_checkpoint'] = (string) $state['runtime_lifecycle_checkpoint'];"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"if ( ! empty( $state['import_id'] ) )"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"array( 'type' => 'files', 'import_id' => (string) $state['import_id'] )"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"preg_match( '/^[a-f0-9]{64}$/', (string) ( $import_result['import_id'] ?? '' ) )"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$state = array( 'import_id' => (string) $import_result['import_id'] );"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$import_result['fresh_runtime']['lifecycle_checkpoint_id']"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"'canonicalization_pending' => ! empty( $canonical_documents )"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"'sha256'  => hash( 'sha256', (string) $post->post_content )"
-			);
-			expect( blueprint.staticSiteImport.code ).not.toContain(
-				'static_site_importer_ability_import_website_artifact'
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"if ( ! function_exists( 'did_action' ) || ! did_action( 'plugins_loaded' ) )"
-			);
-			expect( blueprint.staticSiteImport.code ).not.toContain(
-				"if ( ! function_exists( 'add_action' ) )"
-			);
-			expect( blueprint.staticSiteImport.code ).not.toContain( "if ( ! defined( 'ABSPATH' ) )" );
-			expect( blueprint.staticSiteImport.code ).not.toContain( 'delete_plugins' );
-			expect( blueprint.staticSiteImport.code ).toContain( '$store_import_result = false;' );
-		} );
-
-		it( 'forwards semantic evidence and rejects navigation-only catastrophic loss', () => {
-			const artifactDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-semantic-artifact-' ) );
-			const artifactPath = path.join( artifactDir, 'artifact.json' );
-			fs.writeFileSync(
-				artifactPath,
-				JSON.stringify( {
-					schema: 'blocks-engine/php-transformer/site-artifact/v1',
-					entrypoint: 'website/index.html',
-					semantic_evidence: {
-						schema: 'data-liberation/captured-semantic-evidence/v1',
-						path: 'semantic-evidence.json',
-						page_count: 1,
-					},
-					files: [
-						{
-							path: 'website/index.html',
-							content:
-								'<main><h1>Tianna Wolfson</h1><p>' +
-								'Biography '.repeat( 30 ) +
-								'</p><img src="portrait.jpg"></main>',
-						},
-					],
-				} )
-			);
-
-			const blueprint = buildCreateFromSourceBlueprint(
-				artifactPath,
-				'Tianna',
-				'https://example.com/static-site-importer.zip'
-			);
-
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$input['source_metadata']['semantic_evidence']"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				'static_site_importer_studio_reject_catastrophic_content_loss'
-			);
-			expect( blueprint.staticSiteImport.code ).toContain( 'rejected catastrophic content loss' );
-		} );
-
-		it( 'should store the import result only when requested', () => {
-			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
-			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main></main>' );
-
-			const blueprint = buildCreateFromSourceBlueprint(
-				sourceDir,
-				'Imported Directory',
-				'https://example.com/static-site-importer.zip',
-				true
-			);
-			expect( blueprint.staticSiteImport.code ).toContain( 'studio_create_from_import_result' );
-			expect( blueprint.staticSiteImport.code ).toContain(
-				'static_site_importer_studio_result_projection( $result )'
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"'schema'       => 'studio/static-site-import-result/v1'"
-			);
-			expect( blueprint.staticSiteImport.code ).not.toContain(
-				"update_option( 'studio_create_from_import_result', $result"
-			);
-		} );
-
-		it( 'should preserve bounded failure diagnostics and a bounded import receipt', () => {
-			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
-			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main></main>' );
-
-			const blueprint = buildCreateFromSourceBlueprint(
-				sourceDir,
-				'Imported Directory',
-				'https://example.com/static-site-importer.zip',
-				true
-			);
-
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$projection['error']['data'] = static_site_importer_studio_bounded_value( $result['error']['data'] );"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$projection['diagnostics'] = static_site_importer_studio_bounded_value( $result['diagnostics'] );"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain( "'failure'       => $projection" );
-			expect( blueprint.staticSiteImport.code ).toContain( "'import_receipt' => $projection" );
-			expect( blueprint.staticSiteImport.code ).not.toContain( "'import_receipt' => $result" );
-		} );
-
-		it( 'should bound the stored import receipt so oversized importer responses cannot break the handoff', () => {
-			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
-			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main></main>' );
-
-			const blueprint = buildCreateFromSourceBlueprint(
-				sourceDir,
-				'Imported Directory',
-				'https://example.com/static-site-importer.zip'
-			);
-
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"'import_receipt'            => static_site_importer_studio_result_projection( $result )"
-			);
-			expect( blueprint.staticSiteImport.code ).not.toContain(
-				"'import_receipt'            => $result"
-			);
-		} );
-
-		it( 'should atomically write a bounded receipt for generic failed imports', () => {
-			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
-			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main></main>' );
-
-			const blueprint = buildCreateFromSourceBlueprint(
-				sourceDir,
-				'Imported Directory',
-				'https://example.com/static-site-importer.zip'
-			);
-
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$temp_path = $result_path . '.tmp-' . wp_generate_uuid4();"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain( 'rename( $temp_path, $result_path )' );
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"static_site_importer_studio_record_failure( $result, 'Static Site Importer import failed', $store_import_result );"
-			);
-		} );
-
-		it( 'should build a Blueprint that imports a static site directory through Static Site Importer', () => {
-			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
-			const indexPath = path.join( sourceDir, 'index.html' );
-			fs.writeFileSync( indexPath, '<main><h1>Hello</h1></main>' );
-
-			const blueprint = buildCreateFromSourceBlueprint(
-				sourceDir,
-				'Imported Directory',
-				'https://example.com/static-site-importer.zip'
-			);
-
-			expect( blueprint.staticSiteImport.code ).toContain( "'type'  => 'files'" );
-			expect( blueprint.staticSiteImport.code ).not.toContain(
-				'static_site_importer_rest_source_artifact'
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				JSON.stringify( sourceDir ).slice( 1, -1 )
-			);
-		} );
-
-		it( 'should stage Figma files for the dedicated SSI import ability', async () => {
-			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-figma-source-test-' ) );
-			const sourcePath = path.join( sourceDir, 'design.fig' );
-			fs.writeFileSync( sourcePath, 'figma-source-bytes' );
-			const blueprint = buildCreateFromSourceBlueprint(
-				sourcePath,
-				'Imported Figma',
-				'https://example.com/static-site-importer.zip'
-			);
-
-			expect( blueprint.staticSiteImport.stagedSource ).toEqual( {
-				sourcePath,
-				targetName: 'source.fig',
-			} );
-			expect( JSON.parse( blueprint.staticSiteImport.source ) ).toEqual( {
-				figma_file: {
-					name: 'design.fig',
-					staged_path: path.join( '.studio-import', 'source.fig' ),
-				},
-				transform_options: {
-					multi_page: true,
-				},
-			} );
-			expect( blueprint.staticSiteImport.source ).not.toContain(
-				Buffer.from( 'figma-source-bytes' ).toString( 'base64' )
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				'static_site_importer_ability_import_figma( $input )'
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$input['transform_options'] = isset( $source['transform_options'] )"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				'static_site_importer_studio_failure_message'
-			);
-			expect( blueprint.staticSiteImport.code ).not.toContain(
-				"file_put_contents( ABSPATH . '.studio-import/result.json', wp_json_encode( $result ) )"
-			);
-
-			const copySpy = vi.spyOn( fs, 'copyFileSync' ).mockImplementation( () => {} );
-			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( 'result.json' )
-			);
-			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( 'result.json' )
-					? JSON.stringify( { continuation: false } )
-					: ''
-			);
-			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
-			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
-
-			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
-
-			expect( copySpy ).toHaveBeenCalledWith(
-				sourcePath,
-				path.join( mockSitePath, '.studio-import', 'source.fig' )
-			);
-		} );
-
-		it( 'should import only the website root from a Data Liberation capture directory', () => {
+		it( 'imports only the website root from a Data Liberation capture directory', () => {
 			const captureDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-capture-test-' ) );
 			const websiteDir = fs.mkdtempSync( path.join( captureDir, 'website-' ) );
 			fs.writeFileSync( path.join( websiteDir, 'index.html' ), '<main>Captured site</main>' );
@@ -914,79 +538,197 @@ describe( 'CLI: studio create', () => {
 				JSON.stringify( {
 					schema: 'data-liberation/capture-receipt/v1',
 					websiteRoot: path.basename( websiteDir ),
-					entrypoint: `${ path.basename( websiteDir ) }/index.html`,
 				} )
 			);
 
-			const blueprint = buildCreateFromSourceBlueprint(
-				captureDir,
-				'Liberated Site',
-				'https://example.com/static-site-importer.zip'
-			);
-			const payload = JSON.parse( blueprint.staticSiteImport.source );
+			const files = JSON.parse(
+				buildCreateFromSourceBlueprint(
+					captureDir,
+					'Liberated Site',
+					'https://example.com/static-site-importer.zip'
+				).staticSiteImport.request
+			).source.files as Array< { path: string } >;
 
-			expect( payload.files ).toEqual( [ expect.objectContaining( { path: 'index.html' } ) ] );
-			expect( payload.files ).not.toEqual(
+			expect( files ).toEqual( [ expect.objectContaining( { path: 'index.html' } ) ] );
+			expect( files ).not.toEqual(
 				expect.arrayContaining( [ expect.objectContaining( { path: 'diagnostics.json' } ) ] )
 			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"ABSPATH . '.studio-import/source.json'"
-			);
-			expect( blueprint.staticSiteImport.code.length ).toBeLessThan( 16000 );
 		} );
 
-		it( 'preserves a bounded completed result receipt when requested', () => {
-			const blueprint = buildCapturedSiteBlueprint( true );
+		it( 'rejects sources outside the canonical importer contract', () => {
+			expect( () =>
+				buildCreateFromSourceBlueprint( 'https://example.com/', 'Remote Site' )
+			).toThrow( 'must be rendered by Data Liberation' );
 
-			expect( blueprint.staticSiteImport.storeResult ).toBe( true );
-			expect( blueprint.staticSiteImport.code ).toContain(
-				'static_site_importer_studio_write_result( $studio_result )'
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"'import_receipt'            => static_site_importer_studio_result_projection( $result )"
-			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"'completed_routes'          => (int) ( $import_result['url_batch_run']['completed_routes'] ?? count( $canonical_documents ) )"
+			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-figma-source-' ) );
+			const figmaPath = path.join( sourceDir, 'design.fig' );
+			fs.writeFileSync( figmaPath, 'figma' );
+			expect( () => buildCreateFromSourceBlueprint( figmaPath, 'Figma Site' ) ).toThrow(
+				'Figma files are not supported by the canonical Static Site Importer command.'
 			);
 		} );
 
-		it( 'requires proven dynamic client assets for canonical imports', () => {
+		it( 'invokes the SSI host command once and consumes its terminal receipt', async () => {
 			const blueprint = buildCapturedSiteBlueprint();
+			const writeSpy = vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
 
-			expect( blueprint.staticSiteImport.code ).not.toContain(
-				"$input['require_proven_dynamic_client_assets'] = false;"
+			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } );
+
+			const importCalls = vi
+				.mocked( runWpCliCommandWithMessaging )
+				.mock.calls.filter( ( call ) => call[ 1 ][ 0 ] === 'static-site-importer' );
+			expect( importCalls ).toEqual( [
+				[
+					expect.objectContaining( { path: mockSitePath } ),
+					[ 'static-site-importer', 'import', '--request=.studio-import/request.json' ],
+					{},
+				],
+			] );
+			expect( writeSpy ).toHaveBeenCalledWith(
+				path.join( mockSitePath, '.studio-import', 'request.json' ),
+				blueprint.staticSiteImport.request
 			);
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"$input['require_proven_dynamic_client_assets'] = true;"
+			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledTimes( 2 );
+			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining( { path: mockSitePath } ),
+				expect.arrayContaining( [
+					'eval',
+					expect.stringContaining( 'delete_plugins( array( $plugin ) )' ),
+				] )
+			);
+			expect( rmSpy ).toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
+				recursive: true,
+				force: true,
+			} );
+		} );
+
+		it( 'rejects a successful process without a terminal SSI receipt', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+			vi.mocked( runWpCliCommandWithMessaging ).mockResolvedValue(
+				mockWpCli( { stdout: '{"status":"completed"}' } )
+			);
+
+			await expect(
+				runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } )
+			).rejects.toThrow( 'Failed to import static site' );
+			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
+				recursive: true,
+				force: true,
+			} );
+		} );
+
+		it( 'reruns a matching staged request without reprovisioning the site', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			const existingSite = { ...mockExistingSite, path: mockSitePath };
+			vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
+				version: 1,
+				sites: [ existingSite ],
+			} );
+			createPathExistsMock( true );
+			vi.mocked( isEmptyDir ).mockResolvedValue( false );
+			vi.mocked( isWordPressDirectory ).mockReturnValue( true );
+			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( path.join( '.studio-import', 'request.json' ) )
+			);
+			vi.spyOn( fs, 'readFileSync' ).mockReturnValue( blueprint.staticSiteImport.request );
+			const writeSpy = vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } );
+
+			expect( runBlueprint ).not.toHaveBeenCalled();
+			expect( writeSpy ).not.toHaveBeenCalledWith(
+				path.join( mockSitePath, '.studio-import', 'request.json' ),
+				expect.anything()
+			);
+			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledWith(
+				existingSite,
+				[ 'static-site-importer', 'import', '--request=.studio-import/request.json' ],
+				expect.objectContaining( {
+					liveOutput: true,
+					onLiveOutput: expect.any( Function ),
+				} )
 			);
 		} );
 
-		it( 'should preserve the canonical artifact envelope from a capture directory', () => {
-			const captureDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-artifact-capture-' ) );
-			const artifact = {
-				schema: 'blocks-engine/php-transformer/site-artifact/v1',
-				root: 'website',
-				entrypoint: 'website/index.html',
-				compiler_limits: { max_file_bytes: 10485760 },
-				files: [ { path: 'website/index.html', content: '<main>Captured site</main>' } ],
-			};
-			fs.writeFileSync( path.join( captureDir, 'artifact.json' ), JSON.stringify( artifact ) );
-
-			const blueprint = buildCreateFromSourceBlueprint(
-				captureDir,
-				'Artifact Capture',
-				'https://example.com/static-site-importer.zip'
-			);
-
-			expect( JSON.parse( blueprint.staticSiteImport.source ) ).toEqual( { artifact } );
-			expect( blueprint.staticSiteImport.identity ).toEqual( {
-				source: path.join( captureDir, 'artifact.json' ),
-				contract: 'ssi-import-v5-plan-first',
+		it( 'rejects a registered site whose staged request does not match', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			const existingSite = { ...mockExistingSite, path: mockSitePath };
+			vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
+				version: 1,
+				sites: [ existingSite ],
 			} );
-			expect( blueprint.staticSiteImport.code ).toContain( '$metadata = $artifact;' );
-			expect( blueprint.staticSiteImport.code ).toContain(
-				"unset( $metadata['schema'], $metadata['entrypoint'], $metadata['files'] );"
+			createPathExistsMock( true );
+			vi.mocked( isEmptyDir ).mockResolvedValue( false );
+			vi.mocked( isWordPressDirectory ).mockReturnValue( true );
+			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( path.join( '.studio-import', 'request.json' ) )
 			);
+			vi.spyOn( fs, 'readFileSync' ).mockReturnValue( '{"operation":"apply"}\n' );
+			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+
+			await expect(
+				runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } )
+			).rejects.toThrow( 'The selected directory is already in use.' );
+
+			expect( runWpCliCommandWithMessaging ).not.toHaveBeenCalled();
+			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
+				recursive: true,
+				force: true,
+			} );
+		} );
+
+		it( 'streams live WP-CLI output for native PHP imports', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+
+			await runCommand( mockSitePath, {
+				...defaultTestOptions,
+				blueprint,
+				noStart: true,
+				runtime: SITE_RUNTIME_NATIVE_PHP,
+			} );
+
+			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledWith(
+				expect.objectContaining( { runtime: SITE_RUNTIME_NATIVE_PHP } ),
+				[ 'static-site-importer', 'import', '--request=.studio-import/request.json' ],
+				expect.objectContaining( {
+					liveOutput: true,
+					onLiveOutput: expect.any( Function ),
+				} )
+			);
+		} );
+
+		it( 'keeps staging when plugin cleanup fails after a successful import', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+			const reportErrorSpy = vi.spyOn( Logger.prototype, 'reportError' );
+			vi.mocked( runWpCliCommandWithMessaging )
+				.mockReset()
+				.mockResolvedValueOnce( mockWpCli() )
+				.mockResolvedValueOnce(
+					mockWpCli( { exitCode: 1, stdout: '', stderr: 'cleanup failed' } )
+				);
+
+			await expect(
+				runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } )
+			).resolves.toBeUndefined();
+
+			expect( reportErrorSpy ).toHaveBeenCalledWith(
+				expect.objectContaining( { message: expect.stringContaining( 'cleanup failed' ) } ),
+				false
+			);
+			expect( removeSiteFromConfig ).not.toHaveBeenCalled();
+			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
+				recursive: true,
+				force: true,
+			} );
 		} );
 
 		it( 'should create a basic site successfully', async () => {
@@ -1003,288 +745,6 @@ describe( 'CLI: studio create', () => {
 			expect( logSiteDetails ).toHaveBeenCalled();
 			expect( openSiteInBrowser ).toHaveBeenCalled();
 			expect( disconnectFromDaemon ).toHaveBeenCalled();
-		} );
-
-		it( 'should resume a legacy native import with live output without reprovisioning the site', async () => {
-			const blueprint = buildCapturedSiteBlueprint();
-			const existingSite = { ...mockExistingSite, path: mockSitePath };
-			const identity = JSON.stringify( blueprint.staticSiteImport.identity );
-			vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
-				version: 1,
-				sites: [ existingSite ],
-			} );
-			createPathExistsMock( true );
-			vi.mocked( isEmptyDir ).mockResolvedValue( false );
-			vi.mocked( isWordPressDirectory ).mockReturnValue( true );
-			vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
-			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( '.json' ) ? identity : blueprint.staticSiteImport.code
-			);
-			const writeFileSpy = vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
-			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
-
-			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
-
-			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledWith(
-				existingSite,
-				[ 'eval-file', '.studio-import/import.php' ],
-				expect.objectContaining( { liveOutput: true, onLiveOutput: expect.any( Function ) } )
-			);
-			expect( startWordPressServer ).not.toHaveBeenCalled();
-			expect( runBlueprint ).not.toHaveBeenCalled();
-			expect( saveCliConfig ).not.toHaveBeenCalled();
-			expect( writeFileSpy ).not.toHaveBeenCalledWith(
-				path.join( mockSitePath, '.studio-import', 'source.json' ),
-				expect.anything()
-			);
-		} );
-
-		it( 'cleans up validator pages after canonicalizing a resumed import', async () => {
-			const blueprint = setupResumableCanonicalization();
-			const events: string[] = [];
-			vi.mocked( canonicalizeBlocks ).mockImplementation( async () => {
-				events.push( 'canonicalize' );
-				return '';
-			} );
-			vi.mocked( cleanupValidatorPages ).mockImplementation( async () => {
-				events.push( 'cleanup' );
-			} );
-			vi.mocked( closeSharedBrowser ).mockImplementation( async () => {
-				events.push( 'close-browser' );
-			} );
-			vi.mocked( stopWordPressServer ).mockImplementation( async () => {
-				events.push( 'stop' );
-			} );
-
-			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
-
-			expect( events ).toEqual( [ 'canonicalize', 'cleanup', 'close-browser', 'stop' ] );
-			expect(
-				vi
-					.mocked( runWpCliCommandWithMessaging )
-					.mock.calls.some( ( [ , args ] ) => args[ 0 ] === 'eval-file' )
-			).toBe( false );
-		} );
-
-		it( 'reuses a live daemon server while canonicalizing a resumed import', async () => {
-			const blueprint = setupResumableCanonicalization();
-			vi.mocked( isServerRunning ).mockResolvedValue( mockProcessDescription );
-			vi.mocked( canonicalizeBlocks ).mockResolvedValue( '' );
-
-			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
-
-			expect( connectToDaemon ).toHaveBeenCalled();
-			expect( startWordPressServer ).not.toHaveBeenCalled();
-			expect( stopWordPressServer ).not.toHaveBeenCalled();
-		} );
-
-		it( 'cleans up validator pages when canonicalizing a resumed import fails', async () => {
-			const blueprint = setupResumableCanonicalization();
-			const events: string[] = [];
-			vi.mocked( canonicalizeBlocks ).mockImplementation( async () => {
-				events.push( 'canonicalize' );
-				throw new Error( 'canonicalization failed' );
-			} );
-			vi.mocked( cleanupValidatorPages ).mockImplementation( async () => {
-				events.push( 'cleanup' );
-			} );
-			vi.mocked( closeSharedBrowser ).mockImplementation( async () => {
-				events.push( 'close-browser' );
-			} );
-			vi.mocked( stopWordPressServer ).mockImplementation( async () => {
-				events.push( 'stop' );
-			} );
-
-			await expect(
-				runCommand( mockSitePath, { ...defaultTestOptions, blueprint } )
-			).rejects.toThrow( 'Failed to import static site' );
-
-			expect( events ).toEqual( [ 'canonicalize', 'cleanup', 'close-browser', 'stop' ] );
-			expect( fs.rmSync ).not.toHaveBeenCalledWith(
-				path.join( mockSitePath, '.studio-import', 'client-canonical-documents.json' ),
-				{ force: true }
-			);
-			expect( fs.rmSync ).not.toHaveBeenCalledWith(
-				path.join( mockSitePath, '.studio-import', 'client-canonical-updates.json' ),
-				{ force: true }
-			);
-		} );
-
-		it( 'should continue bounded artifact imports until SSI reports completion', async () => {
-			const blueprint = buildCapturedSiteBlueprint();
-			const results = [
-				{ continuation: true, completed_routes: 1, total_routes: 2 },
-				{ continuation: false, completed_routes: 2, total_routes: 2 },
-			];
-			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( 'result.json' )
-			);
-			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) => {
-				if ( filePath.toString().endsWith( 'result.json' ) ) {
-					return JSON.stringify( results.shift() );
-				}
-				return '';
-			} );
-			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
-			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
-			vi.mocked( runWpCliCommandWithMessaging )
-				.mockResolvedValueOnce( {
-					response: {
-						exitCode: Promise.resolve( 0 ),
-						stdoutText: Promise.resolve( '' ),
-						stderrText: Promise.resolve( '' ),
-					},
-					[ Symbol.dispose ]: vi.fn(),
-				} as never )
-				.mockResolvedValueOnce( {
-					response: {
-						exitCode: Promise.resolve( 0 ),
-						stdoutText: Promise.resolve( '' ),
-						stderrText: Promise.resolve( '' ),
-					},
-					[ Symbol.dispose ]: vi.fn(),
-				} as never )
-				.mockResolvedValueOnce( {
-					response: {
-						exitCode: Promise.resolve( 0 ),
-						stdoutText: Promise.resolve( '' ),
-						stderrText: Promise.resolve( '' ),
-					},
-					[ Symbol.dispose ]: vi.fn(),
-				} as never );
-
-			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
-
-			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledTimes( 3 );
-			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
-				2,
-				expect.objectContaining( { path: mockSitePath } ),
-				[ 'eval-file', '.studio-import/import.php' ],
-				{}
-			);
-		} );
-
-		it( 'reports the continuation stage instead of unmeasured route counts', async () => {
-			const blueprint = buildCapturedSiteBlueprint();
-			const results = [
-				{ continuation: true, status: 'dependencies_prepared' },
-				{ continuation: false, completed_routes: 2, total_routes: 2 },
-			];
-			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( 'result.json' )
-			);
-			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) => {
-				if ( filePath.toString().endsWith( 'result.json' ) ) {
-					return JSON.stringify( results.shift() );
-				}
-				return '';
-			} );
-			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
-			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
-			for ( let call = 0; call < 3; call++ ) {
-				vi.mocked( runWpCliCommandWithMessaging ).mockResolvedValueOnce( {
-					response: {
-						exitCode: Promise.resolve( 0 ),
-						stdoutText: Promise.resolve( '' ),
-						stderrText: Promise.resolve( '' ),
-					},
-					[ Symbol.dispose ]: vi.fn(),
-				} as never );
-			}
-
-			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
-
-			expect( Logger.prototype.reportSuccess ).toHaveBeenCalledWith(
-				'Static site import continuing: dependencies prepared'
-			);
-			expect( Logger.prototype.reportSuccess ).not.toHaveBeenCalledWith(
-				'Static site import progress: 0/0 routes'
-			);
-		} );
-
-		it( 'should fail when a successful WP-CLI process emits no import result receipt', async () => {
-			const blueprint = buildCapturedSiteBlueprint();
-			vi.spyOn( fs, 'existsSync' ).mockReturnValue( false );
-			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
-			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
-
-			await expect(
-				runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } )
-			).rejects.toThrow( 'Failed to import static site' );
-			expect( Logger.prototype.reportSuccess ).not.toHaveBeenCalledWith(
-				'Static site imported successfully'
-			);
-		} );
-
-		it( 'should preserve a resumable site and its import state when resuming fails', async () => {
-			const blueprint = buildCapturedSiteBlueprint();
-			const existingSite = { ...mockExistingSite, path: mockSitePath };
-			vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
-				version: 1,
-				sites: [ existingSite ],
-			} );
-			createPathExistsMock( true );
-			vi.mocked( isEmptyDir ).mockResolvedValue( false );
-			vi.mocked( isWordPressDirectory ).mockReturnValue( true );
-			vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
-			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( '.json' )
-					? JSON.stringify( blueprint.staticSiteImport.identity )
-					: blueprint.staticSiteImport.code
-			);
-			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
-			const removeDirectorySpy = vi.spyOn( fs.promises, 'rm' ).mockResolvedValue( undefined );
-			vi.mocked( runWpCliCommandWithMessaging ).mockResolvedValue( {
-				response: {
-					exitCode: Promise.resolve( 1 ),
-					stdoutText: Promise.resolve( '' ),
-					stderrText: Promise.resolve( 'import failed' ),
-				},
-				[ Symbol.dispose ]: vi.fn(),
-			} as never );
-
-			await expect(
-				runCommand( mockSitePath, { ...defaultTestOptions, blueprint } )
-			).rejects.toThrow( 'Failed to import static site' );
-
-			expect( removeSiteFromConfig ).not.toHaveBeenCalled();
-			expect( removeDirectorySpy ).not.toHaveBeenCalled();
-			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
-				recursive: true,
-				force: true,
-			} );
-		} );
-
-		it( 'should reject a registered import with a mismatched source identity without removing its state', async () => {
-			const blueprint = buildCapturedSiteBlueprint();
-			const existingSite = { ...mockExistingSite, path: mockSitePath };
-			vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
-				version: 1,
-				sites: [ existingSite ],
-			} );
-			createPathExistsMock( true );
-			vi.mocked( isEmptyDir ).mockResolvedValue( false );
-			vi.mocked( isWordPressDirectory ).mockReturnValue( true );
-			vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
-			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( '.json' )
-					? JSON.stringify( {
-							...blueprint.staticSiteImport.identity,
-							source: 'https://other.example/',
-					  } )
-					: blueprint.staticSiteImport.code
-			);
-			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
-
-			await expect(
-				runCommand( mockSitePath, { ...defaultTestOptions, blueprint } )
-			).rejects.toThrow( 'The selected directory is already in use.' );
-
-			expect( runWpCliCommandWithMessaging ).not.toHaveBeenCalled();
-			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
-				recursive: true,
-				force: true,
-			} );
 		} );
 
 		it( 'should persist the runtime and file access on the created site', async () => {
@@ -1648,181 +1108,6 @@ describe( 'CLI: studio create', () => {
 			expect( disconnectFromDaemon ).toHaveBeenCalled();
 		} );
 
-		it( 'should import a static site after applying its dependency Blueprint', async () => {
-			const blueprint = buildCapturedSiteBlueprint();
-			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( 'result.json' )
-			);
-			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( 'result.json' ) ? '{"continuation":false}' : ''
-			);
-			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
-			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
-
-			await runCommand( mockSitePath, {
-				...defaultTestOptions,
-				blueprint,
-				noStart: true,
-			} );
-
-			expect( runBlueprint ).toHaveBeenCalledOnce();
-			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
-				1,
-				expect.objectContaining( { path: mockSitePath } ),
-				[ 'eval-file', '.studio-import/import.php' ],
-				{}
-			);
-			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
-				2,
-				expect.objectContaining( { path: mockSitePath } ),
-				expect.arrayContaining( [
-					'eval',
-					expect.stringContaining( 'delete_plugins( array( $plugin ) )' ),
-				] )
-			);
-			expect( vi.mocked( runBlueprint ).mock.invocationCallOrder[ 0 ] ).toBeLessThan(
-				vi.mocked( runWpCliCommandWithMessaging ).mock.invocationCallOrder[ 0 ]
-			);
-			expect( rmSpy ).toHaveBeenCalledWith(
-				path.join( mockSitePath, '.studio-import', 'import.php' ),
-				{ force: true }
-			);
-			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
-				recursive: true,
-				force: true,
-			} );
-		} );
-
-		it( 'should enable live import output only for native PHP sites', async () => {
-			const blueprint = buildCapturedSiteBlueprint();
-			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( 'result.json' )
-			);
-			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( 'result.json' ) ? '{"continuation":false}' : ''
-			);
-			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
-			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
-
-			await runCommand( mockSitePath, {
-				...defaultTestOptions,
-				blueprint,
-				noStart: true,
-				runtime: SITE_RUNTIME_NATIVE_PHP,
-			} );
-
-			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
-				1,
-				expect.objectContaining( { runtime: SITE_RUNTIME_NATIVE_PHP } ),
-				[ 'eval-file', '.studio-import/import.php' ],
-				expect.objectContaining( { liveOutput: true, onLiveOutput: expect.any( Function ) } )
-			);
-		} );
-
-		it( 'should preserve retry state when post-import plugin cleanup fails', async () => {
-			const blueprint = buildCapturedSiteBlueprint();
-			const successResponse = {
-				response: {
-					exitCode: Promise.resolve( 0 ),
-					stdoutText: Promise.resolve( '' ),
-					stderrText: Promise.resolve( '' ),
-				},
-				[ Symbol.dispose ]: vi.fn(),
-			} as never;
-			vi.mocked( runWpCliCommandWithMessaging )
-				.mockReset()
-				.mockResolvedValueOnce( successResponse )
-				.mockResolvedValueOnce( {
-					response: {
-						exitCode: Promise.resolve( 1 ),
-						stdoutText: Promise.resolve( '' ),
-						stderrText: Promise.resolve( 'cleanup failed' ),
-					},
-					[ Symbol.dispose ]: vi.fn(),
-				} as never );
-			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( 'result.json' )
-			);
-			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( 'result.json' ) ? '{"continuation":false}' : ''
-			);
-			let persistedIdentity = '';
-			let persistedScript = '';
-			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( ( filePath, data ) => {
-				if ( filePath.toString().endsWith( 'static-site-importer.json' ) ) {
-					persistedIdentity = data.toString();
-				}
-				if ( filePath.toString().endsWith( 'import.php' ) ) {
-					persistedScript = data.toString();
-				}
-			} );
-			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
-			const removeDirectorySpy = vi.spyOn( fs.promises, 'rm' ).mockResolvedValue( undefined );
-			const reportErrorSpy = vi.spyOn( Logger.prototype, 'reportError' );
-
-			await expect(
-				runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } )
-			).resolves.toBeUndefined();
-
-			expect( removeSiteFromConfig ).not.toHaveBeenCalled();
-			expect( removeDirectorySpy ).not.toHaveBeenCalled();
-			expect( reportErrorSpy ).toHaveBeenCalledWith(
-				expect.objectContaining( { message: expect.stringContaining( 'cleanup failed' ) } ),
-				false
-			);
-			expect( rmSpy ).not.toHaveBeenCalledWith(
-				path.join( mockSitePath, '.studio-import', 'import.php' ),
-				{ force: true }
-			);
-			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
-				recursive: true,
-				force: true,
-			} );
-			expect( JSON.parse( persistedIdentity ) ).toMatchObject( { phase: 'cleanup_pending' } );
-
-			const existingSite = { ...mockExistingSite, path: mockSitePath };
-			vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
-				version: 1,
-				sites: [ existingSite ],
-			} );
-			createPathExistsMock( true );
-			vi.mocked( isEmptyDir ).mockResolvedValue( false );
-			vi.mocked( isWordPressDirectory ).mockReturnValue( true );
-			vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
-			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
-				filePath.toString().endsWith( 'static-site-importer.json' )
-					? persistedIdentity
-					: persistedScript
-			);
-			vi.mocked( runWpCliCommandWithMessaging ).mockReset().mockResolvedValue( successResponse );
-			vi.mocked( runBlueprint ).mockClear();
-			rmSpy.mockClear();
-
-			await expect(
-				runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } )
-			).resolves.toBeUndefined();
-
-			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledOnce();
-			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledWith(
-				existingSite,
-				expect.arrayContaining( [ 'eval' ] )
-			);
-			expect( runWpCliCommandWithMessaging ).not.toHaveBeenCalledWith( existingSite, [
-				'eval-file',
-				'.studio-import/import.php',
-			] );
-			expect( runBlueprint ).not.toHaveBeenCalled();
-			expect( removeSiteFromConfig ).not.toHaveBeenCalled();
-			expect( rmSpy ).toHaveBeenCalledWith(
-				path.join( mockSitePath, '.studio-import', 'import.php' ),
-				{ force: true }
-			);
-			expect( rmSpy ).toHaveBeenCalledWith(
-				path.join( mockSitePath, '.studio-import', 'static-site-importer.json' ),
-				{ force: true }
-			);
-		} );
-
 		it( 'should create site with siteLanguage when preferred language is configured but no Blueprint given', async () => {
 			vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'es_ES' );
 
@@ -1928,17 +1213,27 @@ describe( 'CLI: studio create', () => {
 		it( 'should retain a new site and its state when the out-of-band static import fails', async () => {
 			const blueprint = buildCapturedSiteBlueprint();
 			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
-			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
 			const fsRmSpy = vi.spyOn( fs.promises, 'rm' ).mockResolvedValue( undefined );
-			vi.mocked( runWpCliCommandWithMessaging ).mockReset();
-			vi.mocked( runWpCliCommandWithMessaging ).mockResolvedValue( {
-				response: {
-					exitCode: Promise.resolve( 1 ),
-					stdoutText: Promise.resolve( '' ),
-					stderrText: Promise.resolve( 'import failed' ),
-				},
-				[ Symbol.dispose ]: vi.fn(),
-			} as never );
+			vi.mocked( runWpCliCommandWithMessaging )
+				.mockReset()
+				.mockResolvedValue(
+					mockWpCli( {
+						exitCode: 1,
+						stdout: JSON.stringify( {
+							schema: 'static-site-importer/import-cli-receipt/v1',
+							status: 'failed',
+							steps: 1,
+							response: {
+								success: false,
+								error: {
+									code: 'static_site_importer_quality_failed',
+									message: 'quality gate failed',
+								},
+							},
+						} ),
+					} )
+				);
 
 			await expect(
 				runCommand( mockSitePath, {
@@ -1946,10 +1241,15 @@ describe( 'CLI: studio create', () => {
 					blueprint,
 					noStart: true,
 				} )
-			).rejects.toThrow( 'Failed to import static site' );
+			).rejects.toThrow( /quality gate failed/ );
 
+			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledTimes( 1 );
 			expect( removeSiteFromConfig ).not.toHaveBeenCalled();
 			expect( fsRmSpy ).not.toHaveBeenCalledWith( mockSitePath, {
+				recursive: true,
+				force: true,
+			} );
+			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
 				recursive: true,
 				force: true,
 			} );

--- a/apps/cli/commands/site/tests/create.test.ts
+++ b/apps/cli/commands/site/tests/create.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { validateBlueprintData } from '@studio/common/lib/blueprint-validation';
 import {
@@ -25,6 +26,9 @@ import { getServerFilesPath } from '@studio/common/lib/well-known-paths';
 import { type SupportedPHPVersion } from '@studio/common/types/php-versions';
 import { Blueprint, BlueprintV1Declaration } from '@wp-playground/blueprints';
 import { vi, type MockInstance } from 'vitest';
+import yargs from 'yargs';
+import { canonicalizeBlocks, cleanupValidatorPages } from 'cli/ai/block-validator';
+import { closeSharedBrowser } from 'cli/ai/browser-utils';
 import {
 	lockCliConfig,
 	readCliConfig,
@@ -37,14 +41,26 @@ import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
 import { updateServerFiles } from 'cli/lib/dependency-management/setup';
 import { downloadWordPress } from 'cli/lib/dependency-management/wordpress';
 import { copyLanguagePackToSite } from 'cli/lib/language-packs';
+import { runWpCliCommandWithMessaging } from 'cli/lib/run-wp-cli-command';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
 import { logSiteDetails, openSiteInBrowser, setupCustomDomain } from 'cli/lib/site-utils';
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
 import { recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { ProcessDescription } from 'cli/lib/types/process-manager-ipc';
-import { runBlueprint, startWordPressServer } from 'cli/lib/wordpress-server-manager';
+import {
+	isServerRunning,
+	runBlueprint,
+	startWordPressServer,
+	stopWordPressServer,
+} from 'cli/lib/wordpress-server-manager';
 import { Logger } from 'cli/logger';
-import { runCommand } from '../create';
+import {
+	buildCreateFromSourceBlueprint,
+	registerCommand,
+	runCommand,
+	staticSiteImportContinuationMessage,
+	staticSiteImportProgressMessage,
+} from '../create';
 
 vi.mock( '@studio/common/lib/fs-utils' );
 vi.mock( '@studio/common/lib/network-utils' );
@@ -92,16 +108,49 @@ vi.mock( 'cli/lib/site-language' );
 vi.mock( 'cli/lib/site-utils' );
 vi.mock( '@studio/common/lib/agent-skills' );
 vi.mock( 'cli/lib/sqlite-integration' );
+vi.mock( 'cli/lib/run-wp-cli-command' );
 vi.mock( 'cli/lib/wordpress-server-manager' );
+vi.mock( 'cli/ai/block-validator', () => ( {
+	canonicalizeBlocks: vi.fn(),
+	cleanupValidatorPages: vi.fn(),
+} ) );
+vi.mock( 'cli/ai/browser-utils', () => ( {
+	closeSharedBrowser: vi.fn(),
+} ) );
 vi.mock( 'cli/lib/tracks', async ( importActual ) => {
 	const actual = await importActual< typeof import('cli/lib/tracks') >();
 	return { ...actual, recordTracksEvent: vi.fn() };
 } );
 vi.mock( '@studio/common/lib/get-wordpress-version' );
 
-describe( 'CLI: studio site create', () => {
+describe( 'CLI: studio create', () => {
 	const mockSitePath = '/test/site/new-site';
 	const mockPort = 8881;
+
+	it( 'reports distinct bounded static import phases with elapsed timing', () => {
+		expect( staticSiteImportProgressMessage( 'dependency-preparation', 65_999 ) ).toBe(
+			'Dependency preparation… 65 sec elapsed'
+		);
+		expect( staticSiteImportProgressMessage( 'compiler-import', 125_000, 3 ) ).toBe(
+			'Compiler/import… invocation 3, 125 sec elapsed'
+		);
+		expect( staticSiteImportProgressMessage( 'finalization', 9_999 ) ).toBe(
+			'Finalization… 9 sec elapsed'
+		);
+	} );
+
+	it( 'reports continuation progress only from measured data', () => {
+		expect( staticSiteImportContinuationMessage( { completed_routes: 3, total_routes: 12 } ) ).toBe(
+			'Static site import progress: 3/12 routes'
+		);
+		expect( staticSiteImportContinuationMessage( { status: 'dependencies_prepared' } ) ).toBe(
+			'Static site import continuing: dependencies prepared'
+		);
+		expect( staticSiteImportContinuationMessage( {} ) ).toBe( 'Static site import continuing…' );
+		expect( staticSiteImportContinuationMessage( { completed_routes: 0, total_routes: 0 } ) ).toBe(
+			'Static site import continuing…'
+		);
+	} );
 
 	const defaultTestOptions = {
 		wpVersion: 'latest',
@@ -159,6 +208,7 @@ describe( 'CLI: studio site create', () => {
 
 	beforeEach( () => {
 		vi.clearAllMocks();
+		process.exitCode = undefined;
 
 		consoleLogSpy = vi.spyOn( console, 'log' ).mockImplementation( () => {} );
 		fsMkdirSyncSpy = vi.spyOn( fs, 'mkdirSync' ).mockReturnValue( undefined );
@@ -184,7 +234,19 @@ describe( 'CLI: studio site create', () => {
 		vi.mocked( downloadWordPress ).mockResolvedValue( undefined );
 		vi.mocked( setupCustomDomain ).mockResolvedValue( undefined );
 		vi.mocked( startWordPressServer ).mockResolvedValue( mockProcessDescription );
+		vi.mocked( isServerRunning ).mockResolvedValue( undefined );
+		vi.mocked( stopWordPressServer ).mockResolvedValue( undefined );
 		vi.mocked( runBlueprint ).mockResolvedValue( undefined );
+		vi.mocked( runWpCliCommandWithMessaging )
+			.mockReset()
+			.mockResolvedValue( {
+				response: {
+					exitCode: Promise.resolve( 0 ),
+					stdoutText: Promise.resolve( '' ),
+					stderrText: Promise.resolve( '' ),
+				},
+				[ Symbol.dispose ]: vi.fn(),
+			} as never );
 		vi.mocked( logSiteDetails ).mockImplementation( () => {} );
 		vi.mocked( openSiteInBrowser ).mockResolvedValue( undefined );
 		vi.mocked( validateBlueprintData ).mockResolvedValue( { valid: true } );
@@ -195,11 +257,123 @@ describe( 'CLI: studio site create', () => {
 	} );
 
 	afterEach( () => {
+		process.exitCode = undefined;
 		vi.unstubAllEnvs();
 		vi.restoreAllMocks();
 	} );
 
+	const createCapturedSiteArtifact = () => {
+		const artifactDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-captured-artifact-' ) );
+		const artifactPath = path.join( artifactDir, 'artifact.json' );
+		fs.writeFileSync(
+			artifactPath,
+			JSON.stringify( {
+				schema: 'blocks-engine/php-transformer/site-artifact/v1',
+				entrypoint: 'website/index.html',
+				files: [ { path: 'website/index.html', content: '<main>Captured</main>' } ],
+			} )
+		);
+		return artifactPath;
+	};
+
+	const buildCapturedSiteBlueprint = ( storeImportResult = false ) => {
+		return buildCreateFromSourceBlueprint(
+			createCapturedSiteArtifact(),
+			'Captured Site',
+			'https://example.com/static-site-importer.zip',
+			storeImportResult,
+			'admin',
+			'https://example.com/'
+		);
+	};
+
+	const setupResumableCanonicalization = () => {
+		const blueprint = buildCapturedSiteBlueprint();
+		const existingSite = { ...mockExistingSite, path: mockSitePath };
+		const documents = JSON.stringify( [
+			{
+				post_id: 1,
+				content: '',
+				sha256: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+			},
+		] );
+
+		vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
+			version: 1,
+			sites: [ existingSite ],
+		} );
+		createPathExistsMock( true );
+		vi.mocked( isEmptyDir ).mockResolvedValue( false );
+		vi.mocked( isWordPressDirectory ).mockReturnValue( true );
+		vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
+		vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) => {
+			const value = filePath.toString();
+			if ( value.endsWith( 'result.json' ) ) {
+				return JSON.stringify( { continuation: false, canonicalization_pending: true } );
+			}
+			if ( value.endsWith( 'client-canonical-documents.json' ) ) {
+				return documents;
+			}
+			if ( value.endsWith( 'static-site-importer.json' ) ) {
+				return JSON.stringify( blueprint.staticSiteImport.identity );
+			}
+			return blueprint.staticSiteImport.code;
+		} );
+		vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+		vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+
+		return blueprint;
+	};
+
 	describe( 'Validation Errors', () => {
+		it( 'validates and resolves the local Static Site Importer zip option', async () => {
+			const pluginDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-ssi-plugin-' ) );
+			const createParser = () =>
+				registerCommand(
+					yargs( [] ).option( 'path', { type: 'string', default: mockSitePath } )
+				).exitProcess( false );
+
+			expect( () =>
+				createParser().parse( [
+					'create',
+					'--from',
+					'/tmp/source',
+					'--static-site-importer-path',
+					path.join( pluginDir, 'missing.zip' ),
+				] )
+			).toThrow( 'Must be an existing regular .zip file' );
+			expect( () =>
+				createParser().parse( [
+					'create',
+					'--from',
+					'/tmp/source',
+					'--static-site-importer-path',
+					path.join( pluginDir, 'not-a-zip.txt' ),
+				] )
+			).toThrow( 'Must be a .zip file' );
+		} );
+
+		it( 'rejects simultaneous local and URL Static Site Importer inputs', async () => {
+			const pluginDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-ssi-plugin-' ) );
+			const pluginPath = path.join( pluginDir, 'static-site-importer.zip' );
+			fs.writeFileSync( pluginPath, 'plugin-bytes' );
+			const parser = registerCommand(
+				yargs( [] ).option( 'path', { type: 'string', default: mockSitePath } )
+			).exitProcess( false );
+
+			expect( () =>
+				parser.parse( [
+					'create',
+					'--from',
+					'/tmp/source',
+					'--static-site-importer-path',
+					pluginPath,
+					'--static-site-importer-url',
+					'https://example.com/static-site-importer.zip',
+				] )
+			).toThrow( 'mutually exclusive' );
+		} );
+
 		it( 'should error if directory exists and is not empty nor a WordPress site', async () => {
 			vi.mocked( pathExists ).mockResolvedValue( true );
 			vi.mocked( isEmptyDir ).mockResolvedValue( false );
@@ -297,6 +471,524 @@ describe( 'CLI: studio site create', () => {
 	} );
 
 	describe( 'Success Cases', () => {
+		it( 'bundles a local Static Site Importer zip until Blueprint execution finishes', async () => {
+			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
+			const pluginDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-ssi-plugin-' ) );
+			const pluginPath = path.join( pluginDir, 'static-site-importer.zip' );
+			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main>Source</main>' );
+			fs.writeFileSync( pluginPath, 'plugin-bytes' );
+			const copySpy = vi.spyOn( fs, 'copyFileSync' );
+			const rmSpy = vi.spyOn( fs, 'rmSync' );
+			vi.mocked( runBlueprint ).mockImplementation( async ( _site, _logger, options ) => {
+				const bundlePath = path.dirname( options.blueprintUri! );
+				const blueprint = JSON.parse( fs.readFileSync( options.blueprintUri!, 'utf8' ) );
+				expect( blueprint.steps[ 0 ].pluginData ).toEqual( {
+					resource: 'bundled',
+					path: 'static-site-importer.zip',
+				} );
+				expect(
+					fs.readFileSync( path.join( bundlePath, 'static-site-importer.zip' ), 'utf8' )
+				).toBe( 'plugin-bytes' );
+			} );
+			const parser = registerCommand(
+				yargs( [] ).option( 'path', { type: 'string', default: mockSitePath } )
+			).exitProcess( false );
+
+			await parser.parseAsync( [
+				'create',
+				'--from',
+				sourceDir,
+				'--static-site-importer-path',
+				pluginPath,
+				'--no-start',
+				'--skip-browser',
+			] );
+
+			const bundlePath = path.dirname( copySpy.mock.calls[ 0 ][ 1 ] as string );
+			expect( copySpy ).toHaveBeenCalledWith(
+				pluginPath,
+				path.join( bundlePath, 'static-site-importer.zip' )
+			);
+			expect( rmSpy ).toHaveBeenCalledWith( bundlePath, { recursive: true, force: true } );
+			expect( rmSpy ).not.toHaveBeenCalledWith( pluginPath, expect.anything() );
+		} );
+
+		it( 'removes the bundled Blueprint when Blueprint execution fails', async () => {
+			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
+			const pluginDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-ssi-plugin-' ) );
+			const pluginPath = path.join( pluginDir, 'static-site-importer.zip' );
+			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main>Source</main>' );
+			fs.writeFileSync( pluginPath, 'plugin-bytes' );
+			const copySpy = vi.spyOn( fs, 'copyFileSync' );
+			const rmSpy = vi.spyOn( fs, 'rmSync' );
+			vi.mocked( runBlueprint ).mockRejectedValue( new Error( 'Blueprint failed' ) );
+			const parser = registerCommand(
+				yargs( [] ).option( 'path', { type: 'string', default: mockSitePath } )
+			).exitProcess( false );
+
+			await parser.parseAsync( [
+				'create',
+				'--from',
+				sourceDir,
+				'--static-site-importer-path',
+				pluginPath,
+				'--no-start',
+				'--skip-browser',
+			] );
+
+			const bundlePath = path.dirname( copySpy.mock.calls[ 0 ][ 1 ] as string );
+			expect( rmSpy ).toHaveBeenCalledWith( bundlePath, { recursive: true, force: true } );
+			expect( rmSpy ).not.toHaveBeenCalledWith( pluginPath, expect.anything() );
+			expect( process.exitCode ).toBe( 1 );
+		} );
+
+		it( 'retains the URL resume identity after capture produces an artifact', () => {
+			const blueprint = buildCreateFromSourceBlueprint(
+				createCapturedSiteArtifact(),
+				'Captured Site',
+				'https://example.com/static-site-importer.zip',
+				false,
+				'admin',
+				'https://example.com/'
+			);
+
+			expect( blueprint.staticSiteImport.identity ).toEqual( {
+				source: 'https://example.com/',
+				contract: 'ssi-import-v5-plan-first',
+			} );
+		} );
+
+		it( 'forwards an artifact-declared classic materialization strategy', () => {
+			const artifactDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-classic-artifact-' ) );
+			const artifactPath = path.join( artifactDir, 'artifact.json' );
+			fs.writeFileSync(
+				artifactPath,
+				JSON.stringify( {
+					schema: 'blocks-engine/php-transformer/site-artifact/v1',
+					entrypoint: 'website/index.html',
+					theme_materialization: 'classic',
+					files: [ { path: 'website/index.html', content: '<main>Home</main>' } ],
+				} )
+			);
+
+			const blueprint = buildCreateFromSourceBlueprint(
+				artifactPath,
+				'Classic Site',
+				'https://example.com/static-site-importer.zip'
+			);
+
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$input['theme_materialization'] = (string) $artifact['theme_materialization'];"
+			);
+		} );
+
+		it( 'does not include Static Site Importer URL capture paths', () => {
+			const blueprint = buildCapturedSiteBlueprint();
+
+			expect( blueprint.staticSiteImport.code ).not.toContain(
+				'static_site_importer_ability_import_url'
+			);
+			expect( blueprint.staticSiteImport.code ).not.toContain( "'collect_site'" );
+			expect( blueprint.staticSiteImport.source ).not.toContain( '"url"' );
+		} );
+
+		it( 'rejects remote URLs at the SSI materialization boundary', () => {
+			expect( () =>
+				buildCreateFromSourceBlueprint( 'https://example.com/', 'Imported Site' )
+			).toThrow( 'must be rendered by Data Liberation' );
+		} );
+
+		it( 'should build a Blueprint that imports a static site artifact through Static Site Importer', () => {
+			const artifactDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-artifact-test-' ) );
+			const artifactPath = path.join( artifactDir, 'artifact.json' );
+			fs.writeFileSync(
+				artifactPath,
+				JSON.stringify( {
+					schema: 'blocks-engine/php-transformer/site-artifact/v1',
+					root: 'website',
+					entrypoint: 'website/index.html',
+					files: [
+						{
+							path: 'website/index.html',
+							content: '<main><h1>Hello</h1></main>',
+						},
+					],
+				} )
+			);
+
+			const blueprint = buildCreateFromSourceBlueprint(
+				artifactPath,
+				'Imported Artifact',
+				'https://example.com/static-site-importer.zip',
+				false,
+				'artifact-admin'
+			);
+
+			expect( blueprint.uri ).toContain( 'blueprint.json' );
+			expect( blueprint.contents.steps ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						step: 'installPlugin',
+						pluginData: expect.objectContaining( {
+							url: 'https://example.com/static-site-importer.zip',
+						} ),
+					} ),
+				] )
+			);
+			expect( blueprint.staticSiteImport.code ).toContain( "$input['source'] = array(" );
+			expect( blueprint.staticSiteImport.code ).toMatch( /^<\?php if/ );
+			expect( blueprint.staticSiteImport.code ).toContain( "$input['fail_on_quality'] = true;" );
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$input['require_proven_dynamic_client_assets'] = true;"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain( "$input['seed_entities'] = true;" );
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$input['materialize_dependencies'] = true;"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				'$admin_user = get_user_by( \'login\', "artifact-admin" );'
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"current_user_can( 'manage_options' ) || ! current_user_can( 'unfiltered_html' )"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				'wp_set_current_user( $admin_user->ID, $admin_user->user_login );'
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				'$result = static_site_importer_ability_import( $input );'
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$input['runtime_lifecycle_phase'] = 'prepare';"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$input['runtime_lifecycle_phase'] = 'resume';"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"'dependencies_prepared' === ( $import_result['status'] ?? '' )"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$input['runtime_lifecycle_checkpoint'] = (string) $state['runtime_lifecycle_checkpoint'];"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"if ( ! empty( $state['import_id'] ) )"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"array( 'type' => 'files', 'import_id' => (string) $state['import_id'] )"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"preg_match( '/^[a-f0-9]{64}$/', (string) ( $import_result['import_id'] ?? '' ) )"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$state = array( 'import_id' => (string) $import_result['import_id'] );"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$import_result['fresh_runtime']['lifecycle_checkpoint_id']"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"'canonicalization_pending' => ! empty( $canonical_documents )"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"'sha256'  => hash( 'sha256', (string) $post->post_content )"
+			);
+			expect( blueprint.staticSiteImport.code ).not.toContain(
+				'static_site_importer_ability_import_website_artifact'
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"if ( ! function_exists( 'did_action' ) || ! did_action( 'plugins_loaded' ) )"
+			);
+			expect( blueprint.staticSiteImport.code ).not.toContain(
+				"if ( ! function_exists( 'add_action' ) )"
+			);
+			expect( blueprint.staticSiteImport.code ).not.toContain( "if ( ! defined( 'ABSPATH' ) )" );
+			expect( blueprint.staticSiteImport.code ).not.toContain( 'delete_plugins' );
+			expect( blueprint.staticSiteImport.code ).toContain( '$store_import_result = false;' );
+		} );
+
+		it( 'forwards semantic evidence and rejects navigation-only catastrophic loss', () => {
+			const artifactDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-semantic-artifact-' ) );
+			const artifactPath = path.join( artifactDir, 'artifact.json' );
+			fs.writeFileSync(
+				artifactPath,
+				JSON.stringify( {
+					schema: 'blocks-engine/php-transformer/site-artifact/v1',
+					entrypoint: 'website/index.html',
+					semantic_evidence: {
+						schema: 'data-liberation/captured-semantic-evidence/v1',
+						path: 'semantic-evidence.json',
+						page_count: 1,
+					},
+					files: [
+						{
+							path: 'website/index.html',
+							content:
+								'<main><h1>Tianna Wolfson</h1><p>' +
+								'Biography '.repeat( 30 ) +
+								'</p><img src="portrait.jpg"></main>',
+						},
+					],
+				} )
+			);
+
+			const blueprint = buildCreateFromSourceBlueprint(
+				artifactPath,
+				'Tianna',
+				'https://example.com/static-site-importer.zip'
+			);
+
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$input['source_metadata']['semantic_evidence']"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				'static_site_importer_studio_reject_catastrophic_content_loss'
+			);
+			expect( blueprint.staticSiteImport.code ).toContain( 'rejected catastrophic content loss' );
+		} );
+
+		it( 'should store the import result only when requested', () => {
+			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
+			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main></main>' );
+
+			const blueprint = buildCreateFromSourceBlueprint(
+				sourceDir,
+				'Imported Directory',
+				'https://example.com/static-site-importer.zip',
+				true
+			);
+			expect( blueprint.staticSiteImport.code ).toContain( 'studio_create_from_import_result' );
+			expect( blueprint.staticSiteImport.code ).toContain(
+				'static_site_importer_studio_result_projection( $result )'
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"'schema'       => 'studio/static-site-import-result/v1'"
+			);
+			expect( blueprint.staticSiteImport.code ).not.toContain(
+				"update_option( 'studio_create_from_import_result', $result"
+			);
+		} );
+
+		it( 'should preserve bounded failure diagnostics and a bounded import receipt', () => {
+			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
+			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main></main>' );
+
+			const blueprint = buildCreateFromSourceBlueprint(
+				sourceDir,
+				'Imported Directory',
+				'https://example.com/static-site-importer.zip',
+				true
+			);
+
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$projection['error']['data'] = static_site_importer_studio_bounded_value( $result['error']['data'] );"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$projection['diagnostics'] = static_site_importer_studio_bounded_value( $result['diagnostics'] );"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain( "'failure'       => $projection" );
+			expect( blueprint.staticSiteImport.code ).toContain( "'import_receipt' => $projection" );
+			expect( blueprint.staticSiteImport.code ).not.toContain( "'import_receipt' => $result" );
+		} );
+
+		it( 'should bound the stored import receipt so oversized importer responses cannot break the handoff', () => {
+			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
+			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main></main>' );
+
+			const blueprint = buildCreateFromSourceBlueprint(
+				sourceDir,
+				'Imported Directory',
+				'https://example.com/static-site-importer.zip'
+			);
+
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"'import_receipt'            => static_site_importer_studio_result_projection( $result )"
+			);
+			expect( blueprint.staticSiteImport.code ).not.toContain(
+				"'import_receipt'            => $result"
+			);
+		} );
+
+		it( 'should atomically write a bounded receipt for generic failed imports', () => {
+			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
+			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main></main>' );
+
+			const blueprint = buildCreateFromSourceBlueprint(
+				sourceDir,
+				'Imported Directory',
+				'https://example.com/static-site-importer.zip'
+			);
+
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$temp_path = $result_path . '.tmp-' . wp_generate_uuid4();"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain( 'rename( $temp_path, $result_path )' );
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"static_site_importer_studio_record_failure( $result, 'Static Site Importer import failed', $store_import_result );"
+			);
+		} );
+
+		it( 'should build a Blueprint that imports a static site directory through Static Site Importer', () => {
+			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-test-' ) );
+			const indexPath = path.join( sourceDir, 'index.html' );
+			fs.writeFileSync( indexPath, '<main><h1>Hello</h1></main>' );
+
+			const blueprint = buildCreateFromSourceBlueprint(
+				sourceDir,
+				'Imported Directory',
+				'https://example.com/static-site-importer.zip'
+			);
+
+			expect( blueprint.staticSiteImport.code ).toContain( "'type'  => 'files'" );
+			expect( blueprint.staticSiteImport.code ).not.toContain(
+				'static_site_importer_rest_source_artifact'
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				JSON.stringify( sourceDir ).slice( 1, -1 )
+			);
+		} );
+
+		it( 'should stage Figma files for the dedicated SSI import ability', async () => {
+			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-figma-source-test-' ) );
+			const sourcePath = path.join( sourceDir, 'design.fig' );
+			fs.writeFileSync( sourcePath, 'figma-source-bytes' );
+			const blueprint = buildCreateFromSourceBlueprint(
+				sourcePath,
+				'Imported Figma',
+				'https://example.com/static-site-importer.zip'
+			);
+
+			expect( blueprint.staticSiteImport.stagedSource ).toEqual( {
+				sourcePath,
+				targetName: 'source.fig',
+			} );
+			expect( JSON.parse( blueprint.staticSiteImport.source ) ).toEqual( {
+				figma_file: {
+					name: 'design.fig',
+					staged_path: path.join( '.studio-import', 'source.fig' ),
+				},
+				transform_options: {
+					multi_page: true,
+				},
+			} );
+			expect( blueprint.staticSiteImport.source ).not.toContain(
+				Buffer.from( 'figma-source-bytes' ).toString( 'base64' )
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				'static_site_importer_ability_import_figma( $input )'
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$input['transform_options'] = isset( $source['transform_options'] )"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				'static_site_importer_studio_failure_message'
+			);
+			expect( blueprint.staticSiteImport.code ).not.toContain(
+				"file_put_contents( ABSPATH . '.studio-import/result.json', wp_json_encode( $result ) )"
+			);
+
+			const copySpy = vi.spyOn( fs, 'copyFileSync' ).mockImplementation( () => {} );
+			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( 'result.json' )
+			);
+			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( 'result.json' )
+					? JSON.stringify( { continuation: false } )
+					: ''
+			);
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
+
+			expect( copySpy ).toHaveBeenCalledWith(
+				sourcePath,
+				path.join( mockSitePath, '.studio-import', 'source.fig' )
+			);
+		} );
+
+		it( 'should import only the website root from a Data Liberation capture directory', () => {
+			const captureDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-capture-test-' ) );
+			const websiteDir = fs.mkdtempSync( path.join( captureDir, 'website-' ) );
+			fs.writeFileSync( path.join( websiteDir, 'index.html' ), '<main>Captured site</main>' );
+			fs.writeFileSync( path.join( captureDir, 'diagnostics.json' ), '{"failures":[]}' );
+			fs.writeFileSync(
+				path.join( captureDir, 'capture-receipt.json' ),
+				JSON.stringify( {
+					schema: 'data-liberation/capture-receipt/v1',
+					websiteRoot: path.basename( websiteDir ),
+					entrypoint: `${ path.basename( websiteDir ) }/index.html`,
+				} )
+			);
+
+			const blueprint = buildCreateFromSourceBlueprint(
+				captureDir,
+				'Liberated Site',
+				'https://example.com/static-site-importer.zip'
+			);
+			const payload = JSON.parse( blueprint.staticSiteImport.source );
+
+			expect( payload.files ).toEqual( [ expect.objectContaining( { path: 'index.html' } ) ] );
+			expect( payload.files ).not.toEqual(
+				expect.arrayContaining( [ expect.objectContaining( { path: 'diagnostics.json' } ) ] )
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"ABSPATH . '.studio-import/source.json'"
+			);
+			expect( blueprint.staticSiteImport.code.length ).toBeLessThan( 16000 );
+		} );
+
+		it( 'preserves a bounded completed result receipt when requested', () => {
+			const blueprint = buildCapturedSiteBlueprint( true );
+
+			expect( blueprint.staticSiteImport.storeResult ).toBe( true );
+			expect( blueprint.staticSiteImport.code ).toContain(
+				'static_site_importer_studio_write_result( $studio_result )'
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"'import_receipt'            => static_site_importer_studio_result_projection( $result )"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"'completed_routes'          => (int) ( $import_result['url_batch_run']['completed_routes'] ?? count( $canonical_documents ) )"
+			);
+		} );
+
+		it( 'requires proven dynamic client assets for canonical imports', () => {
+			const blueprint = buildCapturedSiteBlueprint();
+
+			expect( blueprint.staticSiteImport.code ).not.toContain(
+				"$input['require_proven_dynamic_client_assets'] = false;"
+			);
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"$input['require_proven_dynamic_client_assets'] = true;"
+			);
+		} );
+
+		it( 'should preserve the canonical artifact envelope from a capture directory', () => {
+			const captureDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-artifact-capture-' ) );
+			const artifact = {
+				schema: 'blocks-engine/php-transformer/site-artifact/v1',
+				root: 'website',
+				entrypoint: 'website/index.html',
+				compiler_limits: { max_file_bytes: 10485760 },
+				files: [ { path: 'website/index.html', content: '<main>Captured site</main>' } ],
+			};
+			fs.writeFileSync( path.join( captureDir, 'artifact.json' ), JSON.stringify( artifact ) );
+
+			const blueprint = buildCreateFromSourceBlueprint(
+				captureDir,
+				'Artifact Capture',
+				'https://example.com/static-site-importer.zip'
+			);
+
+			expect( JSON.parse( blueprint.staticSiteImport.source ) ).toEqual( { artifact } );
+			expect( blueprint.staticSiteImport.identity ).toEqual( {
+				source: path.join( captureDir, 'artifact.json' ),
+				contract: 'ssi-import-v5-plan-first',
+			} );
+			expect( blueprint.staticSiteImport.code ).toContain( '$metadata = $artifact;' );
+			expect( blueprint.staticSiteImport.code ).toContain(
+				"unset( $metadata['schema'], $metadata['entrypoint'], $metadata['files'] );"
+			);
+		} );
+
 		it( 'should create a basic site successfully', async () => {
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
@@ -311,6 +1003,288 @@ describe( 'CLI: studio site create', () => {
 			expect( logSiteDetails ).toHaveBeenCalled();
 			expect( openSiteInBrowser ).toHaveBeenCalled();
 			expect( disconnectFromDaemon ).toHaveBeenCalled();
+		} );
+
+		it( 'should resume a legacy native import with live output without reprovisioning the site', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			const existingSite = { ...mockExistingSite, path: mockSitePath };
+			const identity = JSON.stringify( blueprint.staticSiteImport.identity );
+			vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
+				version: 1,
+				sites: [ existingSite ],
+			} );
+			createPathExistsMock( true );
+			vi.mocked( isEmptyDir ).mockResolvedValue( false );
+			vi.mocked( isWordPressDirectory ).mockReturnValue( true );
+			vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
+			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( '.json' ) ? identity : blueprint.staticSiteImport.code
+			);
+			const writeFileSpy = vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
+
+			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledWith(
+				existingSite,
+				[ 'eval-file', '.studio-import/import.php' ],
+				expect.objectContaining( { liveOutput: true, onLiveOutput: expect.any( Function ) } )
+			);
+			expect( startWordPressServer ).not.toHaveBeenCalled();
+			expect( runBlueprint ).not.toHaveBeenCalled();
+			expect( saveCliConfig ).not.toHaveBeenCalled();
+			expect( writeFileSpy ).not.toHaveBeenCalledWith(
+				path.join( mockSitePath, '.studio-import', 'source.json' ),
+				expect.anything()
+			);
+		} );
+
+		it( 'cleans up validator pages after canonicalizing a resumed import', async () => {
+			const blueprint = setupResumableCanonicalization();
+			const events: string[] = [];
+			vi.mocked( canonicalizeBlocks ).mockImplementation( async () => {
+				events.push( 'canonicalize' );
+				return '';
+			} );
+			vi.mocked( cleanupValidatorPages ).mockImplementation( async () => {
+				events.push( 'cleanup' );
+			} );
+			vi.mocked( closeSharedBrowser ).mockImplementation( async () => {
+				events.push( 'close-browser' );
+			} );
+			vi.mocked( stopWordPressServer ).mockImplementation( async () => {
+				events.push( 'stop' );
+			} );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
+
+			expect( events ).toEqual( [ 'canonicalize', 'cleanup', 'close-browser', 'stop' ] );
+			expect(
+				vi
+					.mocked( runWpCliCommandWithMessaging )
+					.mock.calls.some( ( [ , args ] ) => args[ 0 ] === 'eval-file' )
+			).toBe( false );
+		} );
+
+		it( 'reuses a live daemon server while canonicalizing a resumed import', async () => {
+			const blueprint = setupResumableCanonicalization();
+			vi.mocked( isServerRunning ).mockResolvedValue( mockProcessDescription );
+			vi.mocked( canonicalizeBlocks ).mockResolvedValue( '' );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
+
+			expect( connectToDaemon ).toHaveBeenCalled();
+			expect( startWordPressServer ).not.toHaveBeenCalled();
+			expect( stopWordPressServer ).not.toHaveBeenCalled();
+		} );
+
+		it( 'cleans up validator pages when canonicalizing a resumed import fails', async () => {
+			const blueprint = setupResumableCanonicalization();
+			const events: string[] = [];
+			vi.mocked( canonicalizeBlocks ).mockImplementation( async () => {
+				events.push( 'canonicalize' );
+				throw new Error( 'canonicalization failed' );
+			} );
+			vi.mocked( cleanupValidatorPages ).mockImplementation( async () => {
+				events.push( 'cleanup' );
+			} );
+			vi.mocked( closeSharedBrowser ).mockImplementation( async () => {
+				events.push( 'close-browser' );
+			} );
+			vi.mocked( stopWordPressServer ).mockImplementation( async () => {
+				events.push( 'stop' );
+			} );
+
+			await expect(
+				runCommand( mockSitePath, { ...defaultTestOptions, blueprint } )
+			).rejects.toThrow( 'Failed to import static site' );
+
+			expect( events ).toEqual( [ 'canonicalize', 'cleanup', 'close-browser', 'stop' ] );
+			expect( fs.rmSync ).not.toHaveBeenCalledWith(
+				path.join( mockSitePath, '.studio-import', 'client-canonical-documents.json' ),
+				{ force: true }
+			);
+			expect( fs.rmSync ).not.toHaveBeenCalledWith(
+				path.join( mockSitePath, '.studio-import', 'client-canonical-updates.json' ),
+				{ force: true }
+			);
+		} );
+
+		it( 'should continue bounded artifact imports until SSI reports completion', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			const results = [
+				{ continuation: true, completed_routes: 1, total_routes: 2 },
+				{ continuation: false, completed_routes: 2, total_routes: 2 },
+			];
+			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( 'result.json' )
+			);
+			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) => {
+				if ( filePath.toString().endsWith( 'result.json' ) ) {
+					return JSON.stringify( results.shift() );
+				}
+				return '';
+			} );
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+			vi.mocked( runWpCliCommandWithMessaging )
+				.mockResolvedValueOnce( {
+					response: {
+						exitCode: Promise.resolve( 0 ),
+						stdoutText: Promise.resolve( '' ),
+						stderrText: Promise.resolve( '' ),
+					},
+					[ Symbol.dispose ]: vi.fn(),
+				} as never )
+				.mockResolvedValueOnce( {
+					response: {
+						exitCode: Promise.resolve( 0 ),
+						stdoutText: Promise.resolve( '' ),
+						stderrText: Promise.resolve( '' ),
+					},
+					[ Symbol.dispose ]: vi.fn(),
+				} as never )
+				.mockResolvedValueOnce( {
+					response: {
+						exitCode: Promise.resolve( 0 ),
+						stdoutText: Promise.resolve( '' ),
+						stderrText: Promise.resolve( '' ),
+					},
+					[ Symbol.dispose ]: vi.fn(),
+				} as never );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
+
+			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledTimes( 3 );
+			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining( { path: mockSitePath } ),
+				[ 'eval-file', '.studio-import/import.php' ],
+				{}
+			);
+		} );
+
+		it( 'reports the continuation stage instead of unmeasured route counts', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			const results = [
+				{ continuation: true, status: 'dependencies_prepared' },
+				{ continuation: false, completed_routes: 2, total_routes: 2 },
+			];
+			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( 'result.json' )
+			);
+			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) => {
+				if ( filePath.toString().endsWith( 'result.json' ) ) {
+					return JSON.stringify( results.shift() );
+				}
+				return '';
+			} );
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+			for ( let call = 0; call < 3; call++ ) {
+				vi.mocked( runWpCliCommandWithMessaging ).mockResolvedValueOnce( {
+					response: {
+						exitCode: Promise.resolve( 0 ),
+						stdoutText: Promise.resolve( '' ),
+						stderrText: Promise.resolve( '' ),
+					},
+					[ Symbol.dispose ]: vi.fn(),
+				} as never );
+			}
+
+			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint } );
+
+			expect( Logger.prototype.reportSuccess ).toHaveBeenCalledWith(
+				'Static site import continuing: dependencies prepared'
+			);
+			expect( Logger.prototype.reportSuccess ).not.toHaveBeenCalledWith(
+				'Static site import progress: 0/0 routes'
+			);
+		} );
+
+		it( 'should fail when a successful WP-CLI process emits no import result receipt', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			vi.spyOn( fs, 'existsSync' ).mockReturnValue( false );
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+
+			await expect(
+				runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } )
+			).rejects.toThrow( 'Failed to import static site' );
+			expect( Logger.prototype.reportSuccess ).not.toHaveBeenCalledWith(
+				'Static site imported successfully'
+			);
+		} );
+
+		it( 'should preserve a resumable site and its import state when resuming fails', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			const existingSite = { ...mockExistingSite, path: mockSitePath };
+			vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
+				version: 1,
+				sites: [ existingSite ],
+			} );
+			createPathExistsMock( true );
+			vi.mocked( isEmptyDir ).mockResolvedValue( false );
+			vi.mocked( isWordPressDirectory ).mockReturnValue( true );
+			vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
+			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( '.json' )
+					? JSON.stringify( blueprint.staticSiteImport.identity )
+					: blueprint.staticSiteImport.code
+			);
+			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+			const removeDirectorySpy = vi.spyOn( fs.promises, 'rm' ).mockResolvedValue( undefined );
+			vi.mocked( runWpCliCommandWithMessaging ).mockResolvedValue( {
+				response: {
+					exitCode: Promise.resolve( 1 ),
+					stdoutText: Promise.resolve( '' ),
+					stderrText: Promise.resolve( 'import failed' ),
+				},
+				[ Symbol.dispose ]: vi.fn(),
+			} as never );
+
+			await expect(
+				runCommand( mockSitePath, { ...defaultTestOptions, blueprint } )
+			).rejects.toThrow( 'Failed to import static site' );
+
+			expect( removeSiteFromConfig ).not.toHaveBeenCalled();
+			expect( removeDirectorySpy ).not.toHaveBeenCalled();
+			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
+				recursive: true,
+				force: true,
+			} );
+		} );
+
+		it( 'should reject a registered import with a mismatched source identity without removing its state', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			const existingSite = { ...mockExistingSite, path: mockSitePath };
+			vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
+				version: 1,
+				sites: [ existingSite ],
+			} );
+			createPathExistsMock( true );
+			vi.mocked( isEmptyDir ).mockResolvedValue( false );
+			vi.mocked( isWordPressDirectory ).mockReturnValue( true );
+			vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
+			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( '.json' )
+					? JSON.stringify( {
+							...blueprint.staticSiteImport.identity,
+							source: 'https://other.example/',
+					  } )
+					: blueprint.staticSiteImport.code
+			);
+			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+
+			await expect(
+				runCommand( mockSitePath, { ...defaultTestOptions, blueprint } )
+			).rejects.toThrow( 'The selected directory is already in use.' );
+
+			expect( runWpCliCommandWithMessaging ).not.toHaveBeenCalled();
+			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
+				recursive: true,
+				force: true,
+			} );
 		} );
 
 		it( 'should persist the runtime and file access on the created site', async () => {
@@ -674,6 +1648,181 @@ describe( 'CLI: studio site create', () => {
 			expect( disconnectFromDaemon ).toHaveBeenCalled();
 		} );
 
+		it( 'should import a static site after applying its dependency Blueprint', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( 'result.json' )
+			);
+			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( 'result.json' ) ? '{"continuation":false}' : ''
+			);
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+
+			await runCommand( mockSitePath, {
+				...defaultTestOptions,
+				blueprint,
+				noStart: true,
+			} );
+
+			expect( runBlueprint ).toHaveBeenCalledOnce();
+			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
+				1,
+				expect.objectContaining( { path: mockSitePath } ),
+				[ 'eval-file', '.studio-import/import.php' ],
+				{}
+			);
+			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining( { path: mockSitePath } ),
+				expect.arrayContaining( [
+					'eval',
+					expect.stringContaining( 'delete_plugins( array( $plugin ) )' ),
+				] )
+			);
+			expect( vi.mocked( runBlueprint ).mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+				vi.mocked( runWpCliCommandWithMessaging ).mock.invocationCallOrder[ 0 ]
+			);
+			expect( rmSpy ).toHaveBeenCalledWith(
+				path.join( mockSitePath, '.studio-import', 'import.php' ),
+				{ force: true }
+			);
+			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
+				recursive: true,
+				force: true,
+			} );
+		} );
+
+		it( 'should enable live import output only for native PHP sites', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( 'result.json' )
+			);
+			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( 'result.json' ) ? '{"continuation":false}' : ''
+			);
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+
+			await runCommand( mockSitePath, {
+				...defaultTestOptions,
+				blueprint,
+				noStart: true,
+				runtime: SITE_RUNTIME_NATIVE_PHP,
+			} );
+
+			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
+				1,
+				expect.objectContaining( { runtime: SITE_RUNTIME_NATIVE_PHP } ),
+				[ 'eval-file', '.studio-import/import.php' ],
+				expect.objectContaining( { liveOutput: true, onLiveOutput: expect.any( Function ) } )
+			);
+		} );
+
+		it( 'should preserve retry state when post-import plugin cleanup fails', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			const successResponse = {
+				response: {
+					exitCode: Promise.resolve( 0 ),
+					stdoutText: Promise.resolve( '' ),
+					stderrText: Promise.resolve( '' ),
+				},
+				[ Symbol.dispose ]: vi.fn(),
+			} as never;
+			vi.mocked( runWpCliCommandWithMessaging )
+				.mockReset()
+				.mockResolvedValueOnce( successResponse )
+				.mockResolvedValueOnce( {
+					response: {
+						exitCode: Promise.resolve( 1 ),
+						stdoutText: Promise.resolve( '' ),
+						stderrText: Promise.resolve( 'cleanup failed' ),
+					},
+					[ Symbol.dispose ]: vi.fn(),
+				} as never );
+			vi.spyOn( fs, 'existsSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( 'result.json' )
+			);
+			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( 'result.json' ) ? '{"continuation":false}' : ''
+			);
+			let persistedIdentity = '';
+			let persistedScript = '';
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( ( filePath, data ) => {
+				if ( filePath.toString().endsWith( 'static-site-importer.json' ) ) {
+					persistedIdentity = data.toString();
+				}
+				if ( filePath.toString().endsWith( 'import.php' ) ) {
+					persistedScript = data.toString();
+				}
+			} );
+			const rmSpy = vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+			const removeDirectorySpy = vi.spyOn( fs.promises, 'rm' ).mockResolvedValue( undefined );
+			const reportErrorSpy = vi.spyOn( Logger.prototype, 'reportError' );
+
+			await expect(
+				runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } )
+			).resolves.toBeUndefined();
+
+			expect( removeSiteFromConfig ).not.toHaveBeenCalled();
+			expect( removeDirectorySpy ).not.toHaveBeenCalled();
+			expect( reportErrorSpy ).toHaveBeenCalledWith(
+				expect.objectContaining( { message: expect.stringContaining( 'cleanup failed' ) } ),
+				false
+			);
+			expect( rmSpy ).not.toHaveBeenCalledWith(
+				path.join( mockSitePath, '.studio-import', 'import.php' ),
+				{ force: true }
+			);
+			expect( rmSpy ).not.toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
+				recursive: true,
+				force: true,
+			} );
+			expect( JSON.parse( persistedIdentity ) ).toMatchObject( { phase: 'cleanup_pending' } );
+
+			const existingSite = { ...mockExistingSite, path: mockSitePath };
+			vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
+				version: 1,
+				sites: [ existingSite ],
+			} );
+			createPathExistsMock( true );
+			vi.mocked( isEmptyDir ).mockResolvedValue( false );
+			vi.mocked( isWordPressDirectory ).mockReturnValue( true );
+			vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
+			vi.spyOn( fs, 'readFileSync' ).mockImplementation( ( filePath ) =>
+				filePath.toString().endsWith( 'static-site-importer.json' )
+					? persistedIdentity
+					: persistedScript
+			);
+			vi.mocked( runWpCliCommandWithMessaging ).mockReset().mockResolvedValue( successResponse );
+			vi.mocked( runBlueprint ).mockClear();
+			rmSpy.mockClear();
+
+			await expect(
+				runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } )
+			).resolves.toBeUndefined();
+
+			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledOnce();
+			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledWith(
+				existingSite,
+				expect.arrayContaining( [ 'eval' ] )
+			);
+			expect( runWpCliCommandWithMessaging ).not.toHaveBeenCalledWith( existingSite, [
+				'eval-file',
+				'.studio-import/import.php',
+			] );
+			expect( runBlueprint ).not.toHaveBeenCalled();
+			expect( removeSiteFromConfig ).not.toHaveBeenCalled();
+			expect( rmSpy ).toHaveBeenCalledWith(
+				path.join( mockSitePath, '.studio-import', 'import.php' ),
+				{ force: true }
+			);
+			expect( rmSpy ).toHaveBeenCalledWith(
+				path.join( mockSitePath, '.studio-import', 'static-site-importer.json' ),
+				{ force: true }
+			);
+		} );
+
 		it( 'should create site with siteLanguage when preferred language is configured but no Blueprint given', async () => {
 			vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'es_ES' );
 
@@ -774,6 +1923,36 @@ describe( 'CLI: studio site create', () => {
 			).rejects.toThrow( 'Failed to apply Blueprint' );
 
 			expect( disconnectFromDaemon ).toHaveBeenCalled();
+		} );
+
+		it( 'should retain a new site and its state when the out-of-band static import fails', async () => {
+			const blueprint = buildCapturedSiteBlueprint();
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+			const fsRmSpy = vi.spyOn( fs.promises, 'rm' ).mockResolvedValue( undefined );
+			vi.mocked( runWpCliCommandWithMessaging ).mockReset();
+			vi.mocked( runWpCliCommandWithMessaging ).mockResolvedValue( {
+				response: {
+					exitCode: Promise.resolve( 1 ),
+					stdoutText: Promise.resolve( '' ),
+					stderrText: Promise.resolve( 'import failed' ),
+				},
+				[ Symbol.dispose ]: vi.fn(),
+			} as never );
+
+			await expect(
+				runCommand( mockSitePath, {
+					...defaultTestOptions,
+					blueprint,
+					noStart: true,
+				} )
+			).rejects.toThrow( 'Failed to import static site' );
+
+			expect( removeSiteFromConfig ).not.toHaveBeenCalled();
+			expect( fsRmSpy ).not.toHaveBeenCalledWith( mockSitePath, {
+				recursive: true,
+				force: true,
+			} );
 		} );
 
 		it( 'should handle SQLite setup failure', async () => {

--- a/apps/cli/commands/site/tests/create.test.ts
+++ b/apps/cli/commands/site/tests/create.test.ts
@@ -401,7 +401,7 @@ describe( 'CLI: studio create', () => {
 			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main>Source</main>' );
 			fs.writeFileSync( pluginPath, 'plugin-bytes' );
 			const copySpy = vi.spyOn( fs, 'copyFileSync' );
-			const rmSpy = vi.spyOn( fs, 'rmSync' );
+			const rmSpy = vi.spyOn( fs.promises, 'rm' );
 			vi.mocked( runBlueprint ).mockImplementation( async ( _site, _logger, options ) => {
 				const bundlePath = path.dirname( options.blueprintUri! );
 				const blueprint = JSON.parse( fs.readFileSync( options.blueprintUri!, 'utf8' ) );
@@ -443,7 +443,7 @@ describe( 'CLI: studio create', () => {
 			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main>Source</main>' );
 			fs.writeFileSync( pluginPath, 'plugin-bytes' );
 			const copySpy = vi.spyOn( fs, 'copyFileSync' );
-			const rmSpy = vi.spyOn( fs, 'rmSync' );
+			const rmSpy = vi.spyOn( fs.promises, 'rm' );
 			vi.mocked( runBlueprint ).mockRejectedValue( new Error( 'Blueprint failed' ) );
 			const parser = registerCommand(
 				yargs( [] ).option( 'path', { type: 'string', default: mockSitePath } )
@@ -589,14 +589,24 @@ describe( 'CLI: studio create', () => {
 				path.join( mockSitePath, '.studio-import', 'request.json' ),
 				blueprint.staticSiteImport.request
 			);
-			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledTimes( 2 );
+			expect( runWpCliCommandWithMessaging ).toHaveBeenCalledTimes( 4 );
 			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
 				2,
 				expect.objectContaining( { path: mockSitePath } ),
-				expect.arrayContaining( [
-					'eval',
-					expect.stringContaining( 'delete_plugins( array( $plugin ) )' ),
-				] )
+				[ 'plugin', 'is-installed', 'static-site-importer' ],
+				{}
+			);
+			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
+				3,
+				expect.objectContaining( { path: mockSitePath } ),
+				[ 'plugin', 'deactivate', 'static-site-importer', '--quiet' ],
+				{}
+			);
+			expect( runWpCliCommandWithMessaging ).toHaveBeenNthCalledWith(
+				4,
+				expect.objectContaining( { path: mockSitePath } ),
+				[ 'plugin', 'delete', 'static-site-importer' ],
+				{}
 			);
 			expect( rmSpy ).toHaveBeenCalledWith( path.join( mockSitePath, '.studio-import' ), {
 				recursive: true,
@@ -711,7 +721,9 @@ describe( 'CLI: studio create', () => {
 			const reportErrorSpy = vi.spyOn( Logger.prototype, 'reportError' );
 			vi.mocked( runWpCliCommandWithMessaging )
 				.mockReset()
+				// import succeeds, the plugin is installed, then deactivation fails.
 				.mockResolvedValueOnce( mockWpCli() )
+				.mockResolvedValueOnce( mockWpCli( { stdout: '' } ) )
 				.mockResolvedValueOnce(
 					mockWpCli( { exitCode: 1, stdout: '', stderr: 'cleanup failed' } )
 				);

--- a/apps/cli/commands/site/tests/create.test.ts
+++ b/apps/cli/commands/site/tests/create.test.ts
@@ -528,7 +528,7 @@ describe( 'CLI: studio create', () => {
 			).toBe( 'classic' );
 		} );
 
-		it( 'imports only the website root from a Data Liberation capture directory', () => {
+		it( 'stages only the website root from a Data Liberation capture directory', () => {
 			const captureDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-capture-test-' ) );
 			const websiteDir = fs.mkdtempSync( path.join( captureDir, 'website-' ) );
 			fs.writeFileSync( path.join( websiteDir, 'index.html' ), '<main>Captured site</main>' );
@@ -541,17 +541,39 @@ describe( 'CLI: studio create', () => {
 				} )
 			);
 
-			const files = JSON.parse(
-				buildCreateFromSourceBlueprint(
-					captureDir,
-					'Liberated Site',
-					'https://example.com/static-site-importer.zip'
-				).staticSiteImport.request
-			).source.files as Array< { path: string } >;
+			const blueprint = buildCreateFromSourceBlueprint(
+				captureDir,
+				'Liberated Site',
+				'https://example.com/static-site-importer.zip'
+			);
+			const request = JSON.parse( blueprint.staticSiteImport.request );
 
-			expect( files ).toEqual( [ expect.objectContaining( { path: 'index.html' } ) ] );
-			expect( files ).not.toEqual(
-				expect.arrayContaining( [ expect.objectContaining( { path: 'diagnostics.json' } ) ] )
+			expect( request.source ).toEqual( {
+				type: 'files',
+				ref: 'request-bundle:source',
+			} );
+			expect( blueprint.staticSiteImport.sourcePath ).toBe( websiteDir );
+			expect( blueprint.staticSiteImport.request.length ).toBeLessThan( 4096 );
+		} );
+
+		it( 'copies a request-bundled directory into the site before import', async () => {
+			const sourceDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-source-bundle-' ) );
+			fs.writeFileSync( path.join( sourceDir, 'index.html' ), '<main>Source bundle</main>' );
+			const blueprint = buildCreateFromSourceBlueprint(
+				sourceDir,
+				'Bundled Site',
+				'https://example.com/static-site-importer.zip'
+			);
+			const copySpy = vi.spyOn( fs.promises, 'cp' ).mockResolvedValue( undefined );
+			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
+			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions, blueprint, noStart: true } );
+
+			expect( copySpy ).toHaveBeenCalledWith(
+				sourceDir,
+				path.join( mockSitePath, '.studio-import', 'source' ),
+				{ recursive: true, errorOnExist: true, force: false }
 			);
 		} );
 
@@ -692,10 +714,20 @@ describe( 'CLI: studio create', () => {
 			} );
 		} );
 
-		it( 'streams live WP-CLI output for native PHP imports', async () => {
+		it( 'consumes a complete terminal receipt larger than the former 64 KiB tail', async () => {
 			const blueprint = buildCapturedSiteBlueprint();
 			vi.spyOn( fs, 'writeFileSync' ).mockImplementation( () => {} );
 			vi.spyOn( fs, 'rmSync' ).mockImplementation( () => {} );
+			vi.mocked( runWpCliCommandWithMessaging ).mockResolvedValue(
+				mockWpCli( {
+					stdout: JSON.stringify( {
+						schema: 'static-site-importer/import-cli-receipt/v1',
+						status: 'completed',
+						steps: 1,
+						response: { success: true, artifact: 'x'.repeat( 128 * 1024 ) },
+					} ),
+				} )
+			);
 
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,

--- a/apps/cli/lib/native-php/blueprints.ts
+++ b/apps/cli/lib/native-php/blueprints.ts
@@ -176,7 +176,6 @@ export async function runBlueprint(
 			],
 			{
 				phpVersion,
-				mode: 'capture',
 				signal,
 				// blueprints.phar runs `wp-cli` steps by shelling out to `php` on the
 				// PATH. Expose the bundled binary so blueprints work on machines

--- a/apps/cli/lib/native-php/blueprints.ts
+++ b/apps/cli/lib/native-php/blueprints.ts
@@ -5,6 +5,7 @@ import {
 	removeBlueprintTempDir,
 } from '@studio/common/lib/blueprint-bundle';
 import { getBlueprintsPharPath, getPhpBinaryPath } from 'cli/lib/dependency-management/paths';
+import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
 import { PhpCommandError, runPhpCommand } from './php-process';
 import type { NativePhpSupportedVersion } from '@studio/common/lib/php-binary-metadata';
 import type { ServerConfig } from 'cli/lib/types/wordpress-server-ipc';
@@ -33,6 +34,19 @@ export function normalizeBlueprintForRunner( contents: Record< string, unknown >
 		contents.features = supported;
 	} else {
 		delete contents.features;
+	}
+}
+
+export async function removeOwnedSqliteSymlink(
+	symlinkPath: string,
+	symlinkIno: number
+): Promise< void > {
+	try {
+		if ( fs.lstatSync( symlinkPath ).ino === symlinkIno ) {
+			await fs.promises.rm( symlinkPath, { recursive: true, force: true } );
+		}
+	} catch {
+		// Best effort - an already-removed symlink needs no cleanup.
 	}
 }
 
@@ -145,7 +159,7 @@ export async function runBlueprint(
 	if ( needsSymlink ) {
 		fs.symlinkSync( muPluginsSqlite, pluginsSqlite, 'junction' );
 		// Remove only the entry created here, not unrelated content that replaced it.
-		symlinkIno = fs.statSync( pluginsSqlite ).ino;
+		symlinkIno = fs.lstatSync( pluginsSqlite ).ino;
 	}
 
 	try {
@@ -158,9 +172,11 @@ export async function runBlueprint(
 				`--site-path=${ config.sitePath }`,
 				`--site-url=${ config.absoluteUrl ?? `http://localhost:${ config.port }` }`,
 				'--db-engine=sqlite',
+				`--db-path=${ path.join( config.sitePath, 'wp-content', 'database', '.ht.sqlite' ) }`,
 			],
 			{
 				phpVersion,
+				mode: 'capture',
 				signal,
 				// blueprints.phar runs `wp-cli` steps by shelling out to `php` on the
 				// PATH. Expose the bundled binary so blueprints work on machines
@@ -183,13 +199,9 @@ export async function runBlueprint(
 			await removeBlueprintTempDir( fallbackTempDir ).catch( () => {} );
 		}
 		if ( needsSymlink ) {
-			try {
-				if ( fs.statSync( pluginsSqlite ).ino === symlinkIno ) {
-					await fs.promises.rm( pluginsSqlite, { recursive: true, force: true } );
-				}
-			} catch {
-				// Best effort - leaving the symlink behind is non-fatal.
-			}
+			await removeOwnedSqliteSymlink( pluginsSqlite, symlinkIno! );
+			// The runner may remove the symlink target while managing its SQLite driver.
+			await keepSqliteIntegrationUpdated( config.sitePath );
 		}
 	}
 }

--- a/apps/cli/lib/native-php/php-process.ts
+++ b/apps/cli/lib/native-php/php-process.ts
@@ -56,6 +56,20 @@ type RunPhpCommandOptions = BasePhpOptions & {
 	mode?: 'pipe' | 'no-pipe' | 'capture';
 };
 
+function formatCommandOutputTail( label: string, output: string ): string | undefined {
+	const trimmedOutput = output.trim();
+	if ( ! trimmedOutput ) {
+		return undefined;
+	}
+
+	const maxLength = 4_000;
+	const tail =
+		trimmedOutput.length > maxLength
+			? trimmedOutput.slice( trimmedOutput.length - maxLength )
+			: trimmedOutput;
+	return `${ label }:\n${ tail }`;
+}
+
 export function spawnPhpProcess(
 	args: string[],
 	{
@@ -212,7 +226,16 @@ export async function runPhpCommand(
 				return;
 			}
 
-			reject( new PhpCommandError( `PHP command failed (code: ${ code })`, code, stdout, stderr ) );
+			const outputDetails = [
+				formatCommandOutputTail( 'PHP stdout', stdout ),
+				formatCommandOutputTail( 'PHP stderr', stderr ),
+			]
+				.filter( Boolean )
+				.join( '\n\n' );
+			const message = outputDetails
+				? `PHP command failed (code: ${ code })\n\n${ outputDetails }`
+				: `PHP command failed (code: ${ code })`;
+			reject( new PhpCommandError( message, code, stdout, stderr ) );
 		} );
 	} );
 }

--- a/apps/cli/lib/native-php/tests/blueprints.test.ts
+++ b/apps/cli/lib/native-php/tests/blueprints.test.ts
@@ -1,9 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
 	formatBlueprintRunnerError,
 	normalizeBlueprintForRunner,
+	removeOwnedSqliteSymlink,
 } from 'cli/lib/native-php/blueprints';
 import { PhpCommandError } from 'cli/lib/native-php/php-process';
+
+const tempDirs: string[] = [];
+
+afterEach( () => {
+	for ( const tempDir of tempDirs.splice( 0 ) ) {
+		fs.rmSync( tempDir, { recursive: true, force: true } );
+	}
+} );
 
 describe( 'normalizeBlueprintForRunner', () => {
 	it( 'drops preferredVersions', () => {
@@ -43,6 +55,40 @@ describe( 'normalizeBlueprintForRunner', () => {
 		const contents: Record< string, unknown > = { features: null, steps: [] };
 
 		expect( () => normalizeBlueprintForRunner( contents ) ).not.toThrow();
+	} );
+} );
+
+describe( 'removeOwnedSqliteSymlink', () => {
+	it( 'removes its symlink after the target has been deleted', async () => {
+		const tempDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-blueprint-sqlite-' ) );
+		tempDirs.push( tempDir );
+		const target = path.join( tempDir, 'mu-plugin' );
+		const symlink = path.join( tempDir, 'plugin' );
+		fs.mkdirSync( target );
+		fs.symlinkSync( target, symlink, 'junction' );
+		const symlinkIno = fs.lstatSync( symlink ).ino;
+		fs.rmSync( target, { recursive: true } );
+
+		await removeOwnedSqliteSymlink( symlink, symlinkIno );
+
+		expect( fs.existsSync( symlink ) ).toBe( false );
+		expect( () => fs.lstatSync( symlink ) ).toThrow();
+	} );
+
+	it( 'preserves a replacement entry', async () => {
+		const tempDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-blueprint-sqlite-' ) );
+		tempDirs.push( tempDir );
+		const target = path.join( tempDir, 'mu-plugin' );
+		const symlink = path.join( tempDir, 'plugin' );
+		fs.mkdirSync( target );
+		fs.symlinkSync( target, symlink, 'junction' );
+		const symlinkIno = fs.lstatSync( symlink ).ino;
+		fs.rmSync( symlink );
+		fs.mkdirSync( symlink );
+
+		await removeOwnedSqliteSymlink( symlink, symlinkIno );
+
+		expect( fs.statSync( symlink ).isDirectory() ).toBe( true );
 	} );
 } );
 

--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -1,6 +1,6 @@
 import { ChildProcess, spawn } from 'node:child_process';
 import path from 'node:path';
-import { PassThrough, Readable } from 'node:stream';
+import { PassThrough, Readable, Writable } from 'node:stream';
 import { buffer, text } from 'node:stream/consumers';
 import { rootCertificates } from 'node:tls';
 import { loadNodeRuntime, createNodeFsMountHandler } from '@php-wasm/node';
@@ -47,15 +47,16 @@ import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 
 const processIdAllocator = new ProcessIdAllocator();
 const PLAYGROUND_INTERNAL_SHARED_FOLDER = '/internal/shared';
+const OUTPUT_TAIL_BYTES = 64 * 1024;
 
 /**
  * Runtime-agnostic WP-CLI invocation result. Both the native PHP runtime and
  * the Playground runtime produce instances of this class, so callers stay
  * decoupled from Playground's `StreamedPHPResponse`.
  *
- * `stdout`/`stderr` are always in-memory streams (Playground produces them in
- * memory; the native runtime pre-drains its OS pipes via `drainToMemory`), so
- * the text getters are safe to read in any order relative to `exitCode`.
+ * `stdout`/`stderr` are always in-memory streams. Playground produces complete
+ * output in memory; native live output retains only a bounded tail. The text
+ * getters are safe to read in any order relative to `exitCode`.
  *
  * For Playground-produced stdout the leading shebang line is already stripped at
  * construction (see `stripLeadingShebang`), so consumers get clean output.
@@ -88,8 +89,8 @@ export class WpCliResponse {
 }
 
 /**
- * Eagerly drain a child process's OS-pipe `stdout`/`stderr` into an in-memory
- * stream.
+ * Eagerly drain a child process's OS-pipe `stdout`/`stderr`, optionally writing
+ * each chunk to the terminal, while retaining only its final bounded tail.
  *
  * Once the OS pipe's buffer fills up and nothing is reading the other end, the
  * child process can't write any more and stalls — so a caller that awaits
@@ -97,17 +98,77 @@ export class WpCliResponse {
  * until we read, and we don't read until it exits. Draining now keeps the pipe
  * flowing no matter when, or whether, a consumer reads.
  */
-function drainToMemory( source: Readable ): Readable {
+export function teeToBoundedTail(
+	source: Readable,
+	destination?: Writable,
+	onOutput?: () => void
+): Readable {
 	const sink = new PassThrough();
+	let tail = Buffer.alloc( 0 );
+	let outputStarted = false;
+	let paused = false;
 
-	// `buffer()` reads `source` right away; replay it once drained, or forward
-	// a read error to whoever consumes `sink`.
-	buffer( source )
-		.then( ( data ) => sink.end( data ) )
-		.catch( ( error ) => sink.destroy( error ) );
+	const cleanupDestination = () => {
+		destination?.off( 'drain', onDrain );
+		destination?.off( 'error', onDestinationError );
+	};
+	const finish = () => {
+		cleanupDestination();
+		sink.end( tail );
+	};
+	const fail = ( error: Error ) => {
+		cleanupDestination();
+		source.destroy( error );
+		sink.destroy( error );
+	};
+	const onDrain = () => {
+		if ( paused ) {
+			paused = false;
+			source.resume();
+		}
+	};
+	const onDestinationError = ( error: Error ) => fail( error );
+
+	// Flow immediately so the child cannot block on a full OS pipe. The retained
+	// tail is enough to diagnose a failed long-running command without retaining
+	// all of its output.
+	source.on( 'data', ( chunk: Buffer | string ) => {
+		const data = Buffer.isBuffer( chunk ) ? chunk : Buffer.from( chunk );
+		tail = Buffer.concat( [ tail, data ] ).subarray( -OUTPUT_TAIL_BYTES );
+		if ( ! outputStarted ) {
+			outputStarted = true;
+			onOutput?.();
+		}
+		try {
+			if ( destination && ! destination.write( data ) ) {
+				paused = true;
+				source.pause();
+			}
+		} catch ( error ) {
+			fail( error instanceof Error ? error : new Error( String( error ) ) );
+		}
+	} );
+	source.once( 'end', finish );
+	source.once( 'error', ( error ) => {
+		cleanupDestination();
+		sink.destroy( error );
+	} );
+	destination?.on( 'drain', onDrain );
+	destination?.on( 'error', onDestinationError );
 
 	// `sink` may go unread (a caller may only await `exitCode`), so swallow the
 	// error to avoid an uncaught exception; a consumer still sees it via its read.
+	sink.on( 'error', () => {} );
+
+	return sink;
+}
+
+function drainToMemory( source: Readable ): Readable {
+	const sink = new PassThrough();
+
+	buffer( source )
+		.then( ( data ) => sink.end( data ) )
+		.catch( ( error ) => sink.destroy( error ) );
 	sink.on( 'error', () => {} );
 
 	return sink;
@@ -118,6 +179,10 @@ type RunWpCliCommandOptions = {
 	requireSqliteCliCommand?: boolean;
 	siteUrl?: string;
 	stdio?: 'inherit' | 'pipe';
+	/** Stream native child output to the terminal while retaining a bounded failure tail. */
+	liveOutput?: boolean;
+	/** Runs once immediately before the first native live output is written. */
+	onLiveOutput?: () => void;
 };
 
 const WASM_SQLITE_COMMAND_PATH = '/tmp/sqlite-command/command.php';
@@ -227,12 +292,23 @@ async function runNativeWpCliCommand(
 			[ Symbol.dispose ]: dispose,
 		};
 	}
+	let liveOutputStarted = false;
+	const onLiveOutput = () => {
+		if ( ! liveOutputStarted ) {
+			liveOutputStarted = true;
+			options.onLiveOutput?.();
+		}
+	};
 
 	return {
 		response: new WpCliResponse(
 			// Non-null: the 'pipe' stdio mode always provides stdout/stderr streams.
-			drainToMemory( child.stdout! ),
-			drainToMemory( child.stderr! ),
+			options.liveOutput
+				? teeToBoundedTail( child.stdout!, process.stdout, onLiveOutput )
+				: drainToMemory( child.stdout! ),
+			options.liveOutput
+				? teeToBoundedTail( child.stderr!, process.stderr, onLiveOutput )
+				: drainToMemory( child.stderr! ),
 			exitCode
 		),
 		[ Symbol.dispose ]: dispose,

--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -174,7 +174,7 @@ function drainToMemory( source: Readable ): Readable {
 	return sink;
 }
 
-type RunWpCliCommandOptions = {
+export type RunWpCliCommandOptions = {
 	phpVersion?: SupportedPHPVersion;
 	requireSqliteCliCommand?: boolean;
 	siteUrl?: string;

--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -47,7 +47,7 @@ import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 
 const processIdAllocator = new ProcessIdAllocator();
 const PLAYGROUND_INTERNAL_SHARED_FOLDER = '/internal/shared';
-const OUTPUT_TAIL_BYTES = 64 * 1024;
+const OUTPUT_TAIL_BYTES = 1024 * 1024;
 
 /**
  * Runtime-agnostic WP-CLI invocation result. Both the native PHP runtime and
@@ -129,9 +129,9 @@ export function teeToBoundedTail(
 	};
 	const onDestinationError = ( error: Error ) => fail( error );
 
-	// Flow immediately so the child cannot block on a full OS pipe. The retained
-	// tail is enough to diagnose a failed long-running command without retaining
-	// all of its output.
+	// Flow immediately so the child cannot block on a full OS pipe. One MiB is
+	// enough for SSI's bounded terminal receipt while keeping arbitrary command
+	// output out of memory.
 	source.on( 'data', ( chunk: Buffer | string ) => {
 		const data = Buffer.isBuffer( chunk ) ? chunk : Buffer.from( chunk );
 		tail = Buffer.concat( [ tail, data ] ).subarray( -OUTPUT_TAIL_BYTES );
@@ -165,12 +165,10 @@ export function teeToBoundedTail(
 
 function drainToMemory( source: Readable ): Readable {
 	const sink = new PassThrough();
-
 	buffer( source )
 		.then( ( data ) => sink.end( data ) )
 		.catch( ( error ) => sink.destroy( error ) );
 	sink.on( 'error', () => {} );
-
 	return sink;
 }
 
@@ -299,7 +297,6 @@ async function runNativeWpCliCommand(
 			options.onLiveOutput?.();
 		}
 	};
-
 	return {
 		response: new WpCliResponse(
 			// Non-null: the 'pipe' stdio mode always provides stdout/stderr streams.

--- a/apps/cli/lib/tests/run-wp-cli-command.test.ts
+++ b/apps/cli/lib/tests/run-wp-cli-command.test.ts
@@ -1,0 +1,71 @@
+import { once } from 'node:events';
+import { PassThrough, Writable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import { teeToBoundedTail } from '../run-wp-cli-command';
+
+async function readText( stream: PassThrough ): Promise< string > {
+	const chunks: Buffer[] = [];
+	for await ( const chunk of stream ) {
+		chunks.push( Buffer.from( chunk ) );
+	}
+	return Buffer.concat( chunks ).toString();
+}
+
+describe( 'teeToBoundedTail', () => {
+	it( 'pauses for a slow destination, resumes on drain, and retains a 64 KiB tail', async () => {
+		const source = new PassThrough();
+		const received: Buffer[] = [];
+		let releaseWrite: () => void;
+		const destination = new Writable( {
+			write( chunk, _encoding, callback ) {
+				received.push( Buffer.from( chunk ) );
+				releaseWrite = callback;
+			},
+			highWaterMark: 1,
+		} );
+		const onOutput = vi.fn();
+		const tail = teeToBoundedTail( source, destination, onOutput ) as PassThrough;
+		const resumeSpy = vi.spyOn( source, 'resume' );
+		const output = Buffer.alloc( 128 * 1024, 'x' );
+
+		source.write( output );
+		expect( source.isPaused() ).toBe( true );
+		expect( onOutput ).toHaveBeenCalledOnce();
+		const drained = once( destination, 'drain' );
+		releaseWrite!();
+		await drained;
+		expect( resumeSpy ).toHaveBeenCalledOnce();
+		source.end();
+
+		expect( await readText( tail ) ).toBe( output.subarray( -( 64 * 1024 ) ).toString() );
+		expect( Buffer.concat( received ) ).toEqual( output );
+	} );
+
+	it( 'propagates a destination error and destroys the source', async () => {
+		const source = new PassThrough();
+		const destination = new Writable( {
+			write( _chunk, _encoding, callback ) {
+				callback( new Error( 'terminal unavailable' ) );
+			},
+		} );
+		const tail = teeToBoundedTail( source, destination );
+
+		const failure = expect( readText( tail as PassThrough ) ).rejects.toThrow(
+			'terminal unavailable'
+		);
+		source.write( 'progress' );
+
+		await failure;
+		expect( source.destroyed ).toBe( true );
+	} );
+
+	it( 'propagates a source error without retaining unbounded output', async () => {
+		const source = new PassThrough();
+		const tail = teeToBoundedTail( source ) as PassThrough;
+		const failure = expect( readText( tail ) ).rejects.toThrow( 'import pipe failed' );
+
+		source.emit( 'error', new Error( 'import pipe failed' ) );
+
+		await failure;
+	} );
+} );

--- a/apps/cli/lib/tests/run-wp-cli-command.test.ts
+++ b/apps/cli/lib/tests/run-wp-cli-command.test.ts
@@ -12,7 +12,7 @@ async function readText( stream: PassThrough ): Promise< string > {
 }
 
 describe( 'teeToBoundedTail', () => {
-	it( 'pauses for a slow destination, resumes on drain, and retains a 64 KiB tail', async () => {
+	it( 'pauses for a slow destination, resumes on drain, and retains a 1 MiB tail', async () => {
 		const source = new PassThrough();
 		const received: Buffer[] = [];
 		let releaseWrite: () => void;
@@ -26,7 +26,7 @@ describe( 'teeToBoundedTail', () => {
 		const onOutput = vi.fn();
 		const tail = teeToBoundedTail( source, destination, onOutput ) as PassThrough;
 		const resumeSpy = vi.spyOn( source, 'resume' );
-		const output = Buffer.alloc( 128 * 1024, 'x' );
+		const output = Buffer.alloc( 1024 * 1024 + 1024, 'x' );
 
 		source.write( output );
 		expect( source.isPaused() ).toBe( true );
@@ -37,7 +37,7 @@ describe( 'teeToBoundedTail', () => {
 		expect( resumeSpy ).toHaveBeenCalledOnce();
 		source.end();
 
-		expect( await readText( tail ) ).toBe( output.subarray( -( 64 * 1024 ) ).toString() );
+		expect( await readText( tail ) ).toBe( output.subarray( -( 1024 * 1024 ) ).toString() );
 		expect( Buffer.concat( received ) ).toEqual( output );
 	} );
 

--- a/apps/studio/src/tests/index.test.ts
+++ b/apps/studio/src/tests/index.test.ts
@@ -190,7 +190,7 @@ describe( 'App initialization', () => {
 		mockElectron();
 		vi.resetModules();
 		await expect( import( '../index' ) ).resolves.toBeDefined();
-	} );
+	}, 10_000 );
 
 	it( 'should identify YouTube embed requests with the Studio referrer', async () => {
 		const { mockedEvents } = mockElectron();

--- a/apps/studio/src/tests/ipc-handlers-remote-session.test.ts
+++ b/apps/studio/src/tests/ipc-handlers-remote-session.test.ts
@@ -1,7 +1,15 @@
 /**
  * @vitest-environment node
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DaemonStartTimeoutError, getDaemonStatus } from '@studio/common/lib/remote-session';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	getRemoteSessionDaemonStatus,
+	startRemoteSessionDaemon,
+	stopRemoteSessionDaemon,
+} from 'src/ipc-handlers';
+import * as bumpStats from 'src/lib/bump-stats';
+import { executeCliCommand } from 'src/modules/cli/lib/execute-command';
 import { TypedEventEmitter } from 'src/modules/cli/lib/typed-event-emitter';
 import type { IpcMainInvokeEvent } from 'electron';
 
@@ -45,28 +53,20 @@ const mockIpcEvent = {
 function stubExecuteCliCommand(
 	behavior: ( emitter: CliEmitter, args: string[], options: unknown ) => void
 ) {
-	void ( async () => {
-		const { executeCliCommand } = await import( 'src/modules/cli/lib/execute-command' );
-		vi.mocked( executeCliCommand ).mockImplementation( ( ( args: string[], options: unknown ) => {
-			const emitter = new TypedEventEmitter() as CliEmitter;
-			// Defer so the IPC handler can subscribe before events fire.
-			queueMicrotask( () => behavior( emitter, args, options ) );
-			return [ emitter, {} as never ];
-		} ) as unknown as typeof executeCliCommand );
-	} )();
+	vi.mocked( executeCliCommand ).mockImplementation( ( ( args: string[], options: unknown ) => {
+		const emitter = new TypedEventEmitter() as CliEmitter;
+		// Defer so the IPC handler can subscribe before events fire.
+		queueMicrotask( () => behavior( emitter, args, options ) );
+		return [ emitter, {} as never ];
+	} ) as unknown as typeof executeCliCommand );
 }
 
 beforeEach( () => {
 	vi.clearAllMocks();
 } );
 
-afterEach( () => {
-	vi.resetModules();
-} );
-
 describe( 'getRemoteSessionDaemonStatus', () => {
 	it( 'projects the underlying daemon status to the renderer-facing shape', async () => {
-		const { getDaemonStatus } = await import( '@studio/common/lib/remote-session' );
 		// Internal `DaemonStatus` is the rich shape — pid, pidFile, etc.
 		vi.mocked( getDaemonStatus ).mockReturnValue( {
 			running: true,
@@ -74,7 +74,6 @@ describe( 'getRemoteSessionDaemonStatus', () => {
 			pidFile: '/tmp/remote-session.pid',
 		} );
 
-		const { getRemoteSessionDaemonStatus } = await import( 'src/ipc-handlers' );
 		const result = await getRemoteSessionDaemonStatus( mockIpcEvent );
 
 		// IPC return only carries what the renderer needs (`running`). The
@@ -85,13 +84,11 @@ describe( 'getRemoteSessionDaemonStatus', () => {
 	} );
 
 	it( 'returns "not running" when no daemon is present', async () => {
-		const { getDaemonStatus } = await import( '@studio/common/lib/remote-session' );
 		vi.mocked( getDaemonStatus ).mockReturnValue( {
 			running: false,
 			pidFile: '/tmp/remote-session.pid',
 		} );
 
-		const { getRemoteSessionDaemonStatus } = await import( 'src/ipc-handlers' );
 		const result = await getRemoteSessionDaemonStatus( mockIpcEvent );
 
 		expect( result.running ).toBe( false );
@@ -106,14 +103,12 @@ describe( 'startRemoteSessionDaemon', () => {
 			emitter.emit( 'success', { result: undefined } );
 		} );
 
-		const { getDaemonStatus } = await import( '@studio/common/lib/remote-session' );
 		vi.mocked( getDaemonStatus ).mockReturnValue( {
 			running: true,
 			pid: 12345,
 			pidFile: '/tmp/remote-session.pid',
 		} );
 
-		const { startRemoteSessionDaemon } = await import( 'src/ipc-handlers' );
 		const result = await startRemoteSessionDaemon( mockIpcEvent );
 
 		expect( recordedCalls ).toHaveLength( 1 );
@@ -130,15 +125,10 @@ describe( 'startRemoteSessionDaemon', () => {
 			emitter.emit( 'success', { result: undefined } );
 		} );
 
-		const { getDaemonStatus, DaemonStartTimeoutError } = await import(
-			'@studio/common/lib/remote-session'
-		);
 		vi.mocked( getDaemonStatus ).mockReturnValue( {
 			running: false,
 			pidFile: '/tmp/remote-session.pid',
 		} );
-
-		const { startRemoteSessionDaemon } = await import( 'src/ipc-handlers' );
 
 		await expect( startRemoteSessionDaemon( mockIpcEvent ) ).rejects.toBeInstanceOf(
 			DaemonStartTimeoutError
@@ -151,8 +141,6 @@ describe( 'startRemoteSessionDaemon', () => {
 			emitter.emit( 'failure', { error: failure } );
 		} );
 
-		const { startRemoteSessionDaemon } = await import( 'src/ipc-handlers' );
-
 		await expect( startRemoteSessionDaemon( mockIpcEvent ) ).rejects.toBe( failure );
 	} );
 
@@ -161,15 +149,11 @@ describe( 'startRemoteSessionDaemon', () => {
 			emitter.emit( 'success', { result: undefined } );
 		} );
 
-		const { getDaemonStatus } = await import( '@studio/common/lib/remote-session' );
 		vi.mocked( getDaemonStatus ).mockReturnValue( {
 			running: true,
 			pid: 12345,
 			pidFile: '/tmp/remote-session.pid',
 		} );
-
-		const bumpStats = await import( 'src/lib/bump-stats' );
-		const { startRemoteSessionDaemon } = await import( 'src/ipc-handlers' );
 
 		await startRemoteSessionDaemon( mockIpcEvent );
 
@@ -198,13 +182,11 @@ describe( 'stopRemoteSessionDaemon', () => {
 			emitter.emit( 'success', { result: undefined } );
 		} );
 
-		const { getDaemonStatus } = await import( '@studio/common/lib/remote-session' );
 		vi.mocked( getDaemonStatus ).mockReturnValue( {
 			running: false,
 			pidFile: '/tmp/remote-session.pid',
 		} );
 
-		const { stopRemoteSessionDaemon } = await import( 'src/ipc-handlers' );
 		const result = await stopRemoteSessionDaemon( mockIpcEvent );
 
 		expect( recordedCalls ).toHaveLength( 1 );
@@ -225,8 +207,6 @@ describe( 'stopRemoteSessionDaemon', () => {
 			emitter.emit( 'failure', { error: failure } );
 		} );
 
-		const { stopRemoteSessionDaemon } = await import( 'src/ipc-handlers' );
-
 		await expect( stopRemoteSessionDaemon( mockIpcEvent ) ).rejects.toBe( failure );
 	} );
 
@@ -234,9 +214,6 @@ describe( 'stopRemoteSessionDaemon', () => {
 		stubExecuteCliCommand( ( emitter ) => {
 			emitter.emit( 'success', { result: undefined } );
 		} );
-
-		const bumpStats = await import( 'src/lib/bump-stats' );
-		const { stopRemoteSessionDaemon } = await import( 'src/ipc-handlers' );
 
 		await stopRemoteSessionDaemon( mockIpcEvent );
 

--- a/packages/common/lib/blueprint-bundle.ts
+++ b/packages/common/lib/blueprint-bundle.ts
@@ -6,12 +6,29 @@ import { extractZip } from './extract-zip';
 
 const TEMP_DIR_PREFIX = 'studio-blueprint-bundle-';
 
+function resolveBlueprintTempDir( tempDir: string ): string {
+	const allowedPrefix = path.join( os.tmpdir(), TEMP_DIR_PREFIX );
+	const resolvedDir = path.resolve( tempDir );
+	if ( ! resolvedDir.startsWith( allowedPrefix ) ) {
+		throw new Error( 'Invalid temp directory path' );
+	}
+	return resolvedDir;
+}
+
 /**
  * Creates a temp directory for blueprint operations. Use removeBlueprintTempDir()
  * to clean up — it validates the path prefix to prevent accidental deletions.
  */
 export async function createBlueprintTempDir(): Promise< string > {
 	return fs.promises.mkdtemp( path.join( os.tmpdir(), TEMP_DIR_PREFIX ) );
+}
+
+/**
+ * Synchronous counterpart to createBlueprintTempDir(), for callers that assemble a
+ * blueprint synchronously. Clean up with removeBlueprintTempDir().
+ */
+export function createBlueprintTempDirSync(): string {
+	return fs.mkdtempSync( path.join( os.tmpdir(), TEMP_DIR_PREFIX ) );
 }
 
 /**
@@ -66,10 +83,9 @@ export async function downloadAndExtractBlueprintBundle( bundleUrl: string ): Pr
 }
 
 export async function removeBlueprintTempDir( tempDir: string ): Promise< void > {
-	const allowedPrefix = path.join( os.tmpdir(), TEMP_DIR_PREFIX );
-	const resolvedDir = path.resolve( tempDir );
-	if ( ! resolvedDir.startsWith( allowedPrefix ) ) {
-		throw new Error( 'Invalid temp directory path' );
-	}
-	await fs.promises.rm( resolvedDir, { recursive: true, force: true } );
+	await fs.promises.rm( resolveBlueprintTempDir( tempDir ), { recursive: true, force: true } );
+}
+
+export function removeBlueprintTempDirSync( tempDir: string ): void {
+	fs.rmSync( resolveBlueprintTempDir( tempDir ), { recursive: true, force: true } );
 }

--- a/packages/common/lib/bump-stat.ts
+++ b/packages/common/lib/bump-stat.ts
@@ -31,6 +31,7 @@ export function __bumpStat( group: string, stat: string, bumpInDev = false ) {
 	// Fire and forget POST request
 	fetch( 'https://public-api.wordpress.com/wpcom/v2/studio-app/bump-stat', {
 		method: 'POST',
+		signal: AbortSignal.timeout( 5_000 ),
 		headers: {
 			'Content-Type': 'application/json',
 		},

--- a/packages/common/lib/record-tracks-event.ts
+++ b/packages/common/lib/record-tracks-event.ts
@@ -202,7 +202,8 @@ function omitUndefined( props: TracksProps ): TracksProps {
 }
 
 // Returns true if we attempted to record the event. Fire-and-forget, no-ops in E2E/dev like
-// `__bumpStat`.
+// `__bumpStat`. The timeout prevents an unreachable endpoint from keeping short-lived CLI processes
+// alive after their command has completed.
 export function __recordTracksEvent(
 	eventName: TracksEventName,
 	identity: TracksIdentity,
@@ -222,7 +223,7 @@ export function __recordTracksEvent(
 	}
 
 	// Fire and forget GET request (pixel).
-	fetch( url, { method: 'GET' } ).catch( () => {
+	fetch( url, { method: 'GET', signal: AbortSignal.timeout( 5_000 ) } ).catch( () => {
 		// A failed request typically indicates a network issue, which we don't need to report
 	} );
 

--- a/packages/common/lib/tests/bump-stat.test.ts
+++ b/packages/common/lib/tests/bump-stat.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, vi } from 'vitest';
+import { __bumpStat } from '../bump-stat';
+
+describe( '__bumpStat', () => {
+	const originalEnv = { ...process.env };
+
+	beforeEach( () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( () => Promise.resolve( new Response() ) )
+		);
+		delete process.env.E2E;
+		process.env.NODE_ENV = 'production';
+	} );
+
+	afterEach( () => {
+		vi.unstubAllGlobals();
+		process.env = { ...originalEnv };
+	} );
+
+	it( 'bounds the fire-and-forget request', () => {
+		expect( __bumpStat( 'studio-cli', 'mac-arm64' ) ).toBe( true );
+		expect( fetch ).toHaveBeenCalledWith(
+			'https://public-api.wordpress.com/wpcom/v2/studio-app/bump-stat',
+			expect.objectContaining( {
+				method: 'POST',
+				signal: expect.any( AbortSignal ),
+			} )
+		);
+	} );
+} );

--- a/packages/common/lib/tests/record-tracks-event.test.ts
+++ b/packages/common/lib/tests/record-tracks-event.test.ts
@@ -106,7 +106,7 @@ describe( '__recordTracksEvent', () => {
 		const [ calledUrl, options ] = ( fetch as ReturnType< typeof vi.fn > ).mock.calls[ 0 ];
 		expect( calledUrl ).toContain( 'https://pixel.wp.com/t.gif' );
 		expect( calledUrl ).toContain( '_en=studio_app_launch' );
-		expect( options ).toMatchObject( { method: 'GET' } );
+		expect( options ).toMatchObject( { method: 'GET', signal: expect.any( AbortSignal ) } );
 	} );
 
 	it( 'no-ops in E2E', () => {


### PR DESCRIPTION
## Summary

- add `studio create --from <path>` for compiled site artifacts, static directories, zip archives, and Data Liberation capture directories
- stage the canonical `static-site-importer/import` request and invoke one `wp static-site-importer import --request=.studio-import/request.json` host command
- leave source normalization, dependency materialization, bounded continuation, canonical block generation, persistence, and terminal receipts inside Static Site Importer
- validate the terminal `static-site-importer/import-cli-receipt/v1` response, preserve failed requests for matching reruns, and clean staging after success
- support local SSI packages through `--static-site-importer-path` and alternate release URLs through `--static-site-importer-url`
- keep native imports observable and bounded through live WP-CLI output with a retained 64 KiB diagnostic tail

## Importer version

The branch currently defaults to [Static Site Importer v1.8.2](https://github.com/Automattic/static-site-importer/releases/tag/v1.8.2), which contains the unified import command from [Static Site Importer #1385](https://github.com/Automattic/static-site-importer/pull/1385), but that pin is stale.

[Static Site Importer v1.8.3](https://github.com/Automattic/static-site-importer/releases/tag/v1.8.3) subsequently shipped source-fidelity, standalone-materializer, form-topology, visual-comparison, and PHP transformer 0.8.1 updates. SSI `main` also contains three changes that postdate v1.8.3:

- [#1421](https://github.com/Automattic/static-site-importer/pull/1421) updates the PHP transformer to 0.8.2
- [#1412](https://github.com/Automattic/static-site-importer/pull/1412) builds release ZIPs from the runtime package profile
- [#1416](https://github.com/Automattic/static-site-importer/pull/1416) adds the portable source manifest contract

This PR should pin the next SSI release containing those changes before merge. Until then, `--static-site-importer-path` provides the complete paired package used by the end-to-end verification.

URL capture remains a Data Liberation concern: it produces a portable local source directory for this command. Figma input remains outside the canonical import command contract.

## Verification

- CLI E2E Tests
- Data Liberation
- Lint
- Unit Tests
- CodeQL
- end-to-end fixture 89 import with a local SSI package containing #1416, including generated artifact and source-projection verification

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode refactored the Studio integration to the unified SSI CLI boundary, rewrote the focused tests, verified the end-to-end import, and updated this description against the landed SSI contracts and current diff. Chris Huber directed and reviewed the work.
