### PR TITLE
Delete multiple Studio sites through one bounded daemon session

### DIFF
--- a/apps/cli/commands/site/delete.ts
+++ b/apps/cli/commands/site/delete.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import { deleteAiSessionsForSite } from '@studio/common/ai/sessions/manage';
 import { SITE_EVENTS } from '@studio/common/lib/cli-events';
 import { removeAllConnectedWpcomSitesForLocalSite } from '@studio/common/lib/connected-sites';
@@ -7,6 +8,7 @@ import { readAuthToken, type StoredAuthToken } from '@studio/common/lib/shared-c
 import { getSessionsDirectory } from '@studio/common/lib/well-known-paths';
 import { SiteCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import CliTable3 from 'cli-table3';
 import trash from 'trash';
 import { deleteSnapshot } from 'cli/lib/api';
 import { deleteSiteCertificate } from 'cli/lib/certificate-manager';
@@ -15,19 +17,165 @@ import {
 	readCliConfig,
 	saveCliConfig,
 	unlockCliConfig,
+	type SiteData,
 } from 'cli/lib/cli-config/core';
-import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { findSiteById, getSiteByFolder } from 'cli/lib/cli-config/sites';
 import { connectToDaemon, disconnectFromDaemon, emitCliEvent } from 'cli/lib/daemon-client';
 import { removeDomainFromHosts } from 'cli/lib/hosts-file';
 import { withSiteOperation } from 'cli/lib/site-operations';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { getSnapshotsFromConfig, deleteSnapshotFromConfig } from 'cli/lib/snapshots';
 import { getTracksOrigin, recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
+import { getColumnWidths, getPrettyPath, untildify } from 'cli/lib/utils';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
 const defaultLogger = new Logger< LoggerAction >();
+
+export type DeleteSiteStatus = 'deleted' | 'skipped' | 'failed';
+
+export type DeleteSiteOutcome = {
+	identity: string;
+	status: DeleteSiteStatus;
+	id?: string;
+	name?: string;
+	path?: string;
+	files?: string[];
+	error?: string;
+};
+
+export type DeleteRunOptions = {
+	dryRun?: boolean;
+	format?: 'table' | 'json';
+};
+
+type DeleteIdentityArgv = {
+	path: string;
+	id?: Array< string | number > | string | number;
+	sites?: Array< string | number > | string | number;
+};
+
+function toIdentityList(
+	value: DeleteIdentityArgv[ 'id' ] | DeleteIdentityArgv[ 'sites' ]
+): string[] {
+	if ( value === undefined || value === null ) {
+		return [];
+	}
+
+	return ( Array.isArray( value ) ? value : [ value ] ).map( String ).filter( Boolean );
+}
+
+export function isPathFlagProvided( argv: readonly string[] = process.argv ): boolean {
+	return argv.some( ( arg ) => arg === '--path' || arg === '-p' || arg.startsWith( '--path=' ) );
+}
+
+export function collectDeleteIdentities( argv: DeleteIdentityArgv ): string[] {
+	const identities = [ ...toIdentityList( argv.id ), ...toIdentityList( argv.sites ) ];
+	if ( identities.length === 0 || isPathFlagProvided() ) {
+		identities.unshift( argv.path );
+	}
+	return identities;
+}
+
+function normalizeIdentities( identities: string | readonly string[] ): string[] {
+	return ( Array.isArray( identities ) ? [ ...identities ] : [ identities ] )
+		.map( ( identity ) => identity.trim() )
+		.filter( Boolean );
+}
+
+async function resolveSiteIdentity( identity: string ): Promise< SiteData > {
+	const siteById = await findSiteById( identity );
+	if ( siteById ) {
+		return siteById;
+	}
+
+	return getSiteByFolder( path.resolve( untildify( identity ) ) );
+}
+
+function getDeleteFileTargets( site: SiteData, deleteFiles: boolean ): string[] {
+	if ( ! deleteFiles ) {
+		return [];
+	}
+
+	return [ site.path, site.technicalSiteDirectory ].filter(
+		( value ): value is string => typeof value === 'string' && fs.existsSync( value )
+	);
+}
+
+function outcomeFromSite(
+	identity: string,
+	status: DeleteSiteStatus,
+	site: SiteData,
+	files: string[],
+	error?: string
+): DeleteSiteOutcome {
+	return {
+		identity,
+		status,
+		id: site.id,
+		name: site.name,
+		path: site.path,
+		files,
+		...( error ? { error } : {} ),
+	};
+}
+
+function errorMessage( error: unknown ): string {
+	return error instanceof Error ? error.message : String( error );
+}
+
+function emitOutcomes(
+	outcomes: DeleteSiteOutcome[],
+	format: 'table' | 'json',
+	logger: Logger< LoggerAction >
+): void {
+	const json = JSON.stringify( outcomes );
+	logger.reportKeyValuePair( 'results', json );
+
+	if ( format === 'json' ) {
+		console.log( json );
+		return;
+	}
+
+	if ( outcomes.length === 0 ) {
+		return;
+	}
+
+	const colWidths = getColumnWidths( [ 0.15, 0.2, 0.25, 0.4 ] );
+	const table = new CliTable3( {
+		head: [ __( 'Status' ), __( 'Name' ), __( 'Path' ), __( 'Files' ) ],
+		wordWrap: true,
+		wrapOnWordBoundary: false,
+		colWidths,
+		style: {
+			head: [],
+			border: [],
+		},
+	} );
+
+	const statusLabel = ( status: DeleteSiteStatus ): string => {
+		switch ( status ) {
+			case 'deleted':
+				return __( 'Deleted' );
+			case 'skipped':
+				return __( 'Skipped' );
+			case 'failed':
+				return __( 'Failed' );
+		}
+	};
+
+	table.push(
+		...outcomes.map( ( outcome ) => [
+			statusLabel( outcome.status ),
+			outcome.name ?? outcome.identity,
+			outcome.path ? getPrettyPath( outcome.path ) : outcome.identity,
+			( outcome.files ?? [] ).map( getPrettyPath ).join( '\n' ),
+		] )
+	);
+
+	console.log( table.toString() );
+}
 
 async function deletePreviewSites(
 	authToken: StoredAuthToken,
@@ -71,125 +219,253 @@ async function deletePreviewSites(
 	}
 }
 
-export async function runCommand(
-	siteFolder: string,
-	deleteFiles: boolean = true,
-	logger: Logger< LoggerAction > = defaultLogger
-): Promise< void > {
-	return withSiteOperation( siteFolder, 'delete', () =>
-		deleteSite( siteFolder, deleteFiles, logger )
-	);
-}
-
 async function deleteSite(
 	siteFolder: string,
 	deleteFiles: boolean,
 	logger: Logger< LoggerAction >
 ): Promise< void > {
+	logger.reportStart( LoggerAction.LOAD_SITES, __( 'Loading site…' ) );
+	const site = await getSiteByFolder( siteFolder );
+	logger.reportSuccess( __( 'Site loaded' ) );
+
+	const runningProcess = await isServerRunning( site.id );
+	if ( runningProcess ) {
+		logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress server…' ) );
+		await stopWordPressServer( site.id );
+		logger.reportSuccess( __( 'WordPress server stopped' ) );
+		await stopProxyIfNoSitesNeedIt( site.id, logger );
+	}
+
+	if ( site.customDomain ) {
+		logger.reportStart(
+			LoggerAction.REMOVE_DOMAIN_FROM_HOSTS,
+			__( 'Removing domain from hosts file…' )
+		);
+		await removeDomainFromHosts( site.customDomain );
+		logger.reportSuccess( __( 'Domain removed from hosts file' ) );
+
+		if ( site.enableHttps ) {
+			logger.reportStart( LoggerAction.DELETE_CERT, __( 'Deleting SSL certificates…' ) );
+			deleteSiteCertificate( site.customDomain );
+			logger.reportSuccess( __( 'SSL certificates deleted' ) );
+		}
+	}
+
+	const authToken = await readAuthToken();
+	if ( authToken ) {
+		await deletePreviewSites( authToken, siteFolder, logger );
+	}
+
 	try {
-		logger.reportStart( LoggerAction.START_DAEMON, __( 'Starting process daemon…' ) );
+		await lockCliConfig();
+		const cliConfig = await readCliConfig();
+		const siteIndex = cliConfig.sites.findIndex( ( s ) => arePathsEqual( s.path, siteFolder ) );
+		if ( siteIndex === -1 ) {
+			throw new LoggerError( __( 'The specified directory is not added to Studio.' ) );
+		}
+		cliConfig.sites.splice( siteIndex, 1 );
+		await saveCliConfig( cliConfig );
+	} finally {
+		await unlockCliConfig();
+	}
+
+	try {
+		await removeAllConnectedWpcomSitesForLocalSite( site.id );
+	} catch ( error ) {
+		logger.reportError(
+			new LoggerError(
+				__( 'Failed to remove WordPress.com connections. Proceeding anyway…' ),
+				error
+			),
+			false
+		);
+	}
+
+	try {
+		await deleteAiSessionsForSite( getSessionsDirectory(), {
+			id: site.id,
+			path: site.path,
+		} );
+	} catch ( error ) {
+		logger.reportError(
+			new LoggerError( __( 'Failed to delete chat sessions. Proceeding anyway…' ), error ),
+			false
+		);
+	}
+
+	if ( deleteFiles ) {
+		const deleteTargets = getDeleteFileTargets( site, true );
+
+		if ( deleteTargets.length > 0 ) {
+			logger.reportStart( LoggerAction.DELETE_FILES, __( 'Moving site files to trash…' ) );
+			await trash( deleteTargets );
+			logger.reportSuccess( __( 'Site files moved to trash' ) );
+		} else {
+			logger.reportSuccess( __( 'Site files already removed' ) );
+		}
+	}
+
+	await emitCliEvent( { event: SITE_EVENTS.DELETED, data: { siteId: site.id } } );
+
+	try {
+		await recordTracksEvent( TRACKS_EVENTS.SITE_DELETE, {
+			...getTracksOrigin(),
+			delete_files: deleteFiles,
+		} );
+	} catch {
+		// Best-effort telemetry — never block or fail a delete.
+	}
+}
+
+export async function runCommand(
+	identities: string | readonly string[],
+	deleteFiles: boolean = true,
+	logger: Logger< LoggerAction > = defaultLogger,
+	options: DeleteRunOptions = {}
+): Promise< DeleteSiteOutcome[] > {
+	const commandLogger = logger ?? defaultLogger;
+	const format = options.format ?? 'table';
+	const requested = normalizeIdentities( identities );
+	if ( requested.length === 0 ) {
+		throw new LoggerError( __( 'No sites specified.' ) );
+	}
+
+	commandLogger.reportStart(
+		LoggerAction.LOAD_SITES,
+		sprintf( _n( 'Resolving %d site…', 'Resolving %d sites…', requested.length ), requested.length )
+	);
+
+	type ResolvedIdentity =
+		| { identity: string; site: SiteData; files: string[]; duplicate: false }
+		| { identity: string; site: SiteData; files: string[]; duplicate: true }
+		| { identity: string; site?: undefined; files?: undefined; error: string };
+
+	const seenIds = new Set< string >();
+	const resolved: ResolvedIdentity[] = [];
+
+	for ( const identity of requested ) {
+		try {
+			const site = await resolveSiteIdentity( identity );
+			const files = getDeleteFileTargets( site, deleteFiles );
+			if ( seenIds.has( site.id ) ) {
+				resolved.push( { identity, site, files, duplicate: true } );
+				continue;
+			}
+			seenIds.add( site.id );
+			resolved.push( { identity, site, files, duplicate: false } );
+		} catch ( error ) {
+			resolved.push( { identity, error: errorMessage( error ) } );
+		}
+	}
+
+	const pending = resolved.filter(
+		( item ): item is { identity: string; site: SiteData; files: string[]; duplicate: false } =>
+			item.site !== undefined && item.duplicate === false
+	);
+
+	commandLogger.reportSuccess(
+		sprintf( _n( 'Resolved %d site', 'Resolved %d sites', pending.length ), pending.length )
+	);
+
+	const toOutcome = ( item: ResolvedIdentity, status: DeleteSiteStatus ): DeleteSiteOutcome => {
+		if ( ! item.site ) {
+			return { identity: item.identity, status: 'failed', error: item.error };
+		}
+		if ( item.duplicate ) {
+			return outcomeFromSite(
+				item.identity,
+				'skipped',
+				item.site,
+				item.files,
+				__( 'Already selected' )
+			);
+		}
+		return outcomeFromSite( item.identity, status, item.site, item.files );
+	};
+
+	if ( options.dryRun ) {
+		const previewOutcomes = resolved.map( ( item ) =>
+			toOutcome( item, item.site && ! item.duplicate ? 'skipped' : 'failed' )
+		);
+		emitOutcomes( previewOutcomes, format, commandLogger );
+		return previewOutcomes;
+	}
+
+	const shouldEmit = format === 'json' || requested.length > 1;
+	const unresolved = resolved.filter( ( item ) => ! item.site );
+
+	if ( pending.length === 0 || unresolved.length > 0 ) {
+		const failedOutcomes = resolved.map( ( item ) => {
+			if ( ! item.site || item.duplicate ) {
+				return toOutcome( item, 'failed' );
+			}
+			return outcomeFromSite(
+				item.identity,
+				'skipped',
+				item.site,
+				item.files,
+				__( 'Skipped because the requested set could not be fully resolved' )
+			);
+		} );
+		if ( shouldEmit ) {
+			emitOutcomes( failedOutcomes, format, commandLogger );
+		}
+		if ( requested.length === 1 && failedOutcomes[ 0 ]?.error ) {
+			throw new LoggerError( failedOutcomes[ 0 ].error );
+		}
+		throw new LoggerError( __( 'Failed to delete one or more sites' ) );
+	}
+
+	try {
+		commandLogger.reportStart( LoggerAction.START_DAEMON, __( 'Starting process daemon…' ) );
 		await connectToDaemon();
-		logger.reportSuccess( __( 'Process daemon started' ) );
+		commandLogger.reportSuccess( __( 'Process daemon started' ) );
 
-		logger.reportStart( LoggerAction.LOAD_SITES, __( 'Loading site…' ) );
-		const site = await getSiteByFolder( siteFolder );
-		logger.reportSuccess( __( 'Site loaded' ) );
+		const mutationByIdentity = new Map< string, DeleteSiteOutcome >();
+		let firstMutationError: unknown;
 
-		const runningProcess = await isServerRunning( site.id );
-		if ( runningProcess ) {
-			logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress server…' ) );
-			await stopWordPressServer( site.id );
-			logger.reportSuccess( __( 'WordPress server stopped' ) );
-			await stopProxyIfNoSitesNeedIt( site.id, logger );
-		}
-
-		if ( site.customDomain ) {
-			logger.reportStart(
-				LoggerAction.REMOVE_DOMAIN_FROM_HOSTS,
-				__( 'Removing domain from hosts file…' )
-			);
-			await removeDomainFromHosts( site.customDomain );
-			logger.reportSuccess( __( 'Domain removed from hosts file' ) );
-
-			if ( site.enableHttps ) {
-				logger.reportStart( LoggerAction.DELETE_CERT, __( 'Deleting SSL certificates…' ) );
-				deleteSiteCertificate( site.customDomain );
-				logger.reportSuccess( __( 'SSL certificates deleted' ) );
+		for ( const item of pending ) {
+			try {
+				await withSiteOperation( item.site.path, 'delete', () =>
+					deleteSite( item.site.path, deleteFiles, commandLogger )
+				);
+				mutationByIdentity.set(
+					item.identity,
+					outcomeFromSite( item.identity, 'deleted', item.site, item.files )
+				);
+			} catch ( error ) {
+				if ( firstMutationError === undefined ) {
+					firstMutationError = error;
+				}
+				mutationByIdentity.set(
+					item.identity,
+					outcomeFromSite( item.identity, 'failed', item.site, item.files, errorMessage( error ) )
+				);
 			}
 		}
 
-		const authToken = await readAuthToken();
-		if ( authToken ) {
-			await deletePreviewSites( authToken, siteFolder, logger );
-		}
-
-		try {
-			await lockCliConfig();
-			const cliConfig = await readCliConfig();
-			const siteIndex = cliConfig.sites.findIndex( ( s ) => arePathsEqual( s.path, siteFolder ) );
-			if ( siteIndex === -1 ) {
-				throw new LoggerError( __( 'The specified directory is not added to Studio.' ) );
+		const orderedOutcomes = resolved.map( ( item ) => {
+			if ( item.site && ! item.duplicate ) {
+				return (
+					mutationByIdentity.get( item.identity ) ??
+					outcomeFromSite( item.identity, 'failed', item.site, item.files )
+				);
 			}
-			cliConfig.sites.splice( siteIndex, 1 );
-			await saveCliConfig( cliConfig );
-		} finally {
-			await unlockCliConfig();
+			return toOutcome( item, 'failed' );
+		} );
+
+		if ( shouldEmit ) {
+			emitOutcomes( orderedOutcomes, format, commandLogger );
 		}
 
-		try {
-			await removeAllConnectedWpcomSitesForLocalSite( site.id );
-		} catch ( error ) {
-			logger.reportError(
-				new LoggerError(
-					__( 'Failed to remove WordPress.com connections. Proceeding anyway…' ),
-					error
-				),
-				false
-			);
-		}
-
-		try {
-			await deleteAiSessionsForSite( getSessionsDirectory(), {
-				id: site.id,
-				path: site.path,
-			} );
-		} catch ( error ) {
-			logger.reportError(
-				new LoggerError( __( 'Failed to delete chat sessions. Proceeding anyway…' ), error ),
-				false
-			);
-		}
-
-		if ( deleteFiles ) {
-			// Imported sites have both a visible site directory and a
-			// hidden technical directory under ~/.studio/imports; delete
-			// both if they exist.
-			const deleteTargets = [ siteFolder, site.technicalSiteDirectory ].filter(
-				( value ): value is string => typeof value === 'string' && fs.existsSync( value )
-			);
-
-			if ( deleteTargets.length > 0 ) {
-				logger.reportStart( LoggerAction.DELETE_FILES, __( 'Moving site files to trash…' ) );
-				await trash( deleteTargets );
-				logger.reportSuccess( __( 'Site files moved to trash' ) );
-			} else {
-				logger.reportSuccess( __( 'Site files already removed' ) );
+		if ( orderedOutcomes.some( ( outcome ) => outcome.status === 'failed' ) ) {
+			if ( requested.length === 1 && firstMutationError ) {
+				throw firstMutationError;
 			}
+			throw new LoggerError( __( 'Failed to delete one or more sites' ) );
 		}
 
-		await emitCliEvent( { event: SITE_EVENTS.DELETED, data: { siteId: site.id } } );
-
-		// Tracks: the CLI is the sole emitter of site-delete, whether deleted standalone or by the
-		// desktop app (which delegates to `site delete` and passes its origin via STUDIO_TRACKS_ORIGIN).
-		// Best-effort — wrapped so telemetry can never fail a delete.
-		try {
-			await recordTracksEvent( TRACKS_EVENTS.SITE_DELETE, {
-				...getTracksOrigin(),
-				delete_files: deleteFiles,
-			} );
-		} catch {
-			// Best-effort telemetry — never block or fail a delete.
-		}
+		return orderedOutcomes;
 	} finally {
 		await disconnectFromDaemon();
 	}
@@ -197,18 +473,43 @@ async function deleteSite(
 
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
-		command: 'delete',
-		describe: __( 'Delete site' ),
+		command: 'delete [sites..]',
+		describe: __( 'Delete site(s)' ),
 		builder: ( yargs ) => {
-			return yargs.option( 'files', {
-				type: 'boolean',
-				description: __( 'Move site files to trash (use --no-files to keep files)' ),
-				default: true,
-			} );
+			return yargs
+				.positional( 'sites', {
+					describe: __( 'Site paths or IDs' ),
+					type: 'string',
+					array: true,
+				} )
+				.option( 'id', {
+					type: 'array',
+					string: true,
+					description: __( 'Site ID(s) to delete' ),
+				} )
+				.option( 'files', {
+					type: 'boolean',
+					description: __( 'Move site files to trash (use --no-files to keep files)' ),
+					default: true,
+				} )
+				.option( 'dry-run', {
+					type: 'boolean',
+					description: __( 'Preview selected sites and file paths without deleting' ),
+					default: false,
+				} )
+				.option( 'format', {
+					type: 'string',
+					choices: [ 'table', 'json' ] as const,
+					default: 'table' as const,
+					description: __( 'Output format' ),
+				} );
 		},
 		handler: async ( argv ) => {
 			try {
-				await runCommand( argv.path, argv.files );
+				await runCommand( collectDeleteIdentities( argv ), argv.files, defaultLogger, {
+					dryRun: argv.dryRun,
+					format: argv.format,
+				} );
 			} catch ( error ) {
 				if ( error instanceof LoggerError ) {
 					defaultLogger.reportError( error );

--- a/apps/cli/commands/site/tests/delete.test.ts
+++ b/apps/cli/commands/site/tests/delete.test.ts
@@ -15,7 +15,7 @@ import {
 	saveCliConfig,
 	unlockCliConfig,
 } from 'cli/lib/cli-config/core';
-import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { findSiteById, getSiteByFolder } from 'cli/lib/cli-config/sites';
 import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
 import { removeDomainFromHosts } from 'cli/lib/hosts-file';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
@@ -23,7 +23,7 @@ import { getSnapshotsFromConfig, deleteSnapshotFromConfig } from 'cli/lib/snapsh
 import { recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { ProcessDescription } from 'cli/lib/types/process-manager-ipc';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
-import { runCommand } from '../delete';
+import { collectDeleteIdentities, runCommand } from '../delete';
 
 vi.mock( 'fs' );
 vi.mock( 'cli/lib/api' );
@@ -50,6 +50,7 @@ vi.mock( 'cli/lib/cli-config/sites', async () => {
 	return {
 		...actual,
 		getSiteByFolder: vi.fn(),
+		findSiteById: vi.fn(),
 	};
 } );
 vi.mock( 'cli/lib/certificate-manager' );
@@ -129,6 +130,7 @@ describe( 'CLI: studio site delete', () => {
 		testSite = createTestSite();
 
 		vi.mocked( getSiteByFolder ).mockResolvedValue( testSite );
+		vi.mocked( findSiteById ).mockResolvedValue( undefined );
 		vi.mocked( connectToDaemon ).mockResolvedValue( undefined );
 		vi.mocked( disconnectFromDaemon ).mockResolvedValue( undefined );
 		vi.mocked( readAuthToken ).mockResolvedValue( testAuthToken );
@@ -420,6 +422,163 @@ describe( 'CLI: studio site delete', () => {
 				TRACKS_EVENTS.SITE_DELETE,
 				expect.objectContaining( { delete_files: false } )
 			);
+		} );
+	} );
+
+	describe( 'Batch deletion', () => {
+		const siteCount = 9;
+
+		function setupBatchSites() {
+			const folders = Array.from(
+				{ length: siteCount },
+				( _, index ) => `/test/site/${ index + 1 }`
+			);
+			const sites = folders.map( ( folder, index ) =>
+				createTestSite( {
+					id: `site-${ index + 1 }`,
+					name: `Site ${ index + 1 }`,
+					path: folder,
+				} )
+			);
+			const sitesByPath = new Map( sites.map( ( site ) => [ site.path, site ] ) );
+			const sitesById = new Map( sites.map( ( site ) => [ site.id, site ] ) );
+			const cliConfig = {
+				version: 1 as const,
+				sites,
+				snapshots: [],
+			};
+
+			vi.mocked( getSiteByFolder ).mockImplementation( async ( folder ) => {
+				const site = sitesByPath.get( folder );
+				if ( ! site ) {
+					throw new Error( `Unknown folder ${ folder }` );
+				}
+				return site;
+			} );
+			vi.mocked( findSiteById ).mockImplementation( async ( siteId ) => sitesById.get( siteId ) );
+			vi.mocked( readCliConfig ).mockResolvedValue( cliConfig );
+
+			return { folders, sites, cliConfig };
+		}
+
+		it( 'connects to the process daemon once when deleting nine sites', async () => {
+			const { folders } = setupBatchSites();
+
+			const outcomes = await runCommand( folders );
+
+			expect( connectToDaemon ).toHaveBeenCalledTimes( 1 );
+			expect( disconnectFromDaemon ).toHaveBeenCalledTimes( 1 );
+			expect( trash ).toHaveBeenCalledTimes( siteCount );
+			expect( outcomes ).toHaveLength( siteCount );
+			expect( outcomes.every( ( outcome ) => outcome.status === 'deleted' ) ).toBe( true );
+		} );
+
+		it( 'resolves site IDs in one daemon session', async () => {
+			const { sites } = setupBatchSites();
+
+			await runCommand( sites.map( ( site ) => site.id ) );
+
+			expect( connectToDaemon ).toHaveBeenCalledTimes( 1 );
+			expect( trash ).toHaveBeenCalledTimes( siteCount );
+		} );
+
+		it( 'previews selected sites and file paths without mutating', async () => {
+			const { folders, sites } = setupBatchSites();
+
+			const outcomes = await runCommand( folders, true, undefined, { dryRun: true } );
+
+			expect( connectToDaemon ).not.toHaveBeenCalled();
+			expect( trash ).not.toHaveBeenCalled();
+			expect( saveCliConfig ).not.toHaveBeenCalled();
+			expect( stopWordPressServer ).not.toHaveBeenCalled();
+			expect( outcomes ).toEqual(
+				sites.map( ( site ) =>
+					expect.objectContaining( {
+						identity: site.path,
+						status: 'skipped',
+						id: site.id,
+						path: site.path,
+						files: [ site.path ],
+					} )
+				)
+			);
+		} );
+
+		it( 'validates the full set before mutating files', async () => {
+			const { folders } = setupBatchSites();
+			vi.mocked( getSiteByFolder ).mockImplementation( async ( folder ) => {
+				if ( folder === folders[ 4 ] ) {
+					throw new Error( 'The specified directory is not added to Studio.' );
+				}
+				return createTestSite( { id: folder, path: folder } );
+			} );
+
+			await expect( runCommand( folders ) ).rejects.toThrow( 'Failed to delete one or more sites' );
+
+			expect( connectToDaemon ).not.toHaveBeenCalled();
+			expect( trash ).not.toHaveBeenCalled();
+			expect( saveCliConfig ).not.toHaveBeenCalled();
+		} );
+
+		it( 'continues after a per-site mutation failure and keeps completed evidence', async () => {
+			const { folders } = setupBatchSites();
+			vi.mocked( trash ).mockImplementation( async ( targets ) => {
+				if ( Array.isArray( targets ) && targets[ 0 ] === folders[ 2 ] ) {
+					throw new Error( 'File deletion failed' );
+				}
+			} );
+
+			await expect( runCommand( folders, true, undefined, { format: 'json' } ) ).rejects.toThrow(
+				'Failed to delete one or more sites'
+			);
+
+			expect( connectToDaemon ).toHaveBeenCalledTimes( 1 );
+			expect( trash ).toHaveBeenCalledTimes( siteCount );
+			expect( saveCliConfig ).toHaveBeenCalledTimes( siteCount );
+		} );
+
+		it( 'skips duplicate identities without extra daemon sessions', async () => {
+			const { folders } = setupBatchSites();
+
+			const outcomes = await runCommand( [ folders[ 0 ], folders[ 0 ], folders[ 1 ] ] );
+
+			expect( connectToDaemon ).toHaveBeenCalledTimes( 1 );
+			expect( trash ).toHaveBeenCalledTimes( 2 );
+			expect( outcomes.map( ( outcome ) => outcome.status ) ).toEqual( [
+				'deleted',
+				'skipped',
+				'deleted',
+			] );
+		} );
+	} );
+
+	describe( 'collectDeleteIdentities', () => {
+		const originalArgv = process.argv;
+
+		afterEach( () => {
+			process.argv = originalArgv;
+		} );
+
+		it( 'uses the path when no explicit identities are given', () => {
+			process.argv = [ 'node', 'studio', 'delete' ];
+			expect( collectDeleteIdentities( { path: '/cwd/site' } ) ).toEqual( [ '/cwd/site' ] );
+		} );
+
+		it( 'does not add the default path when IDs are explicit', () => {
+			process.argv = [ 'node', 'studio', 'delete', '--id', 'site-1' ];
+			expect(
+				collectDeleteIdentities( { path: '/cwd/site', id: [ 'site-1', 'site-2' ] } )
+			).toEqual( [ 'site-1', 'site-2' ] );
+		} );
+
+		it( 'includes an explicit --path with additional identities', () => {
+			process.argv = [ 'node', 'studio', 'delete', '--path', '/explicit/site', 'site-2' ];
+			expect(
+				collectDeleteIdentities( {
+					path: '/explicit/site',
+					sites: [ 'site-2' ],
+				} )
+			).toEqual( [ '/explicit/site', 'site-2' ] );
 		} );
 	} );
 } );

--- a/skills/studio-cli/SKILL.md
+++ b/skills/studio-cli/SKILL.md
@@ -89,11 +89,14 @@ studio stop --all                                       # Stop all sites
 ### Deleting a site
 
 ```bash
-studio delete --path ~/Studio/my-site          # Remove site record only
-studio delete --path ~/Studio/my-site --files   # Also trash site files
+studio delete --path ~/Studio/my-site                 # Trash site files (default)
+studio delete --path ~/Studio/my-site --no-files      # Remove site record only
+studio delete ~/Studio/a ~/Studio/b --id <id>         # Delete multiple explicit sites
+studio delete ~/Studio/a ~/Studio/b --dry-run         # Preview selected sites and file paths
+studio delete ~/Studio/a ~/Studio/b --format json     # Per-site deleted/skipped/failed outcomes
 ```
 
-Deleting a site also removes its associated preview sites if authenticated.
+Pass explicit paths or IDs. The full set is resolved before any files are mutated, and one process-daemon session is reused for the batch. `--dry-run` prints the selected sites and file paths without deleting. Partial failure returns a nonzero status and still reports completed items. Deleting a site also removes its associated preview sites if authenticated.
 
 ## Authentication
 


### PR DESCRIPTION
Closes #4728.

## Summary

- `studio delete` accepts multiple explicit site paths or IDs in one invocation (`studio delete <path>… --id <id>…`).
- The full requested set is resolved and validated before any files are mutated. An unresolved identity skips the rest of the batch.
- One process-daemon session is reused across the batch instead of starting a new daemon per site.
- Default move-to-Trash behavior is unchanged (`--files` / `--no-files`).
- Machine-readable per-site outcomes report `deleted`, `skipped`, and `failed`. Partial failure returns a nonzero status and still reports completed items.
- `--dry-run` previews the exact sites and file paths without connecting the daemon or mutating anything.
- Interactive confirmation stays separate from noninteractive explicit-path/ID authorization: passing explicit identities is sufficient authorization.

## Design

`runCommand` now takes one or more identities. It resolves IDs via `findSiteById` and paths via `getSiteByFolder`, deduplicates by site ID, then either:

1. **Preview** (`--dry-run`): emit selected sites and trash targets, no daemon, no mutation.
2. **Validate-fail**: if any identity cannot be resolved, emit failed/skipped outcomes and throw before `connectToDaemon` or `trash`.
3. **Mutate**: `connectToDaemon` once, delete each pending site with the existing per-site Trash/registry/preview/session cleanup, `disconnectFromDaemon` once. Per-site mutation errors are recorded and the remaining sites still run.

## Files

- `apps/cli/commands/site/delete.ts`
- `apps/cli/commands/site/tests/delete.test.ts`
- `skills/studio-cli/SKILL.md`

## Verification

- `npx vitest run apps/cli/commands/site/tests/delete.test.ts` (31 passed), including coverage that nine sites call `connectToDaemon` once
- `npx eslint --fix` on the changed CLI files (no findings)
- `npm -w wp-studio run typecheck` (passed)

Did not delete real sites. Did not release or merge.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagent inspected the CLI delete/daemon/registry/test surface, implemented bounded batch deletion, added tests, and opened this PR. Chris Huber directed the work and remains responsible for the change.