### PR TITLE
Delete multiple Studio sites through one bounded daemon session

### DIFF
--- a/apps/cli/commands/site/delete.ts
+++ b/apps/cli/commands/site/delete.ts
@@ -1,8 +1,9 @@
 import fs from 'fs';
+import path from 'path';
 import { deleteAiSessionsForSite } from '@studio/common/ai/sessions/manage';
 import { SITE_EVENTS } from '@studio/common/lib/cli-events';
 import { removeAllConnectedWpcomSitesForLocalSite } from '@studio/common/lib/connected-sites';
-import { arePathsEqual } from '@studio/common/lib/fs-utils';
+import { arePathsEqual, isWordPressDirectory } from '@studio/common/lib/fs-utils';
 import { readAuthToken, type StoredAuthToken } from '@studio/common/lib/shared-config';
 import { getSessionsDirectory } from '@studio/common/lib/well-known-paths';
 import { SiteCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
@@ -15,19 +16,53 @@ import {
 	readCliConfig,
 	saveCliConfig,
 	unlockCliConfig,
+	type SiteData,
 } from 'cli/lib/cli-config/core';
-import { getSiteByFolder } from 'cli/lib/cli-config/sites';
 import { connectToDaemon, disconnectFromDaemon, emitCliEvent } from 'cli/lib/daemon-client';
 import { removeDomainFromHosts } from 'cli/lib/hosts-file';
-import { withSiteOperation } from 'cli/lib/site-operations';
+import { withSiteOperations } from 'cli/lib/site-operations';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { getSnapshotsFromConfig, deleteSnapshotFromConfig } from 'cli/lib/snapshots';
 import { getTracksOrigin, recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
+import { untildify } from 'cli/lib/utils';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
 const defaultLogger = new Logger< LoggerAction >();
+
+export type DeleteSiteStatus = 'deleted' | 'skipped' | 'failed' | 'selected';
+
+export type DeleteSiteOutcome = {
+	identity: string;
+	status: DeleteSiteStatus;
+	id?: string;
+	name?: string;
+	path?: string;
+	filePaths?: string[];
+	error?: string;
+};
+
+export type DeleteCommandResult = {
+	dryRun: boolean;
+	deleteFiles: boolean;
+	sites: DeleteSiteOutcome[];
+};
+
+export type DeleteCommandOptions = {
+	identities: string[];
+	deleteFiles?: boolean;
+	dryRun?: boolean;
+	format?: 'text' | 'json';
+	logger?: Logger< LoggerAction >;
+	throwOnFailure?: boolean;
+};
+
+type ResolvedSite = {
+	identity: string;
+	site: SiteData;
+	filePaths: string[];
+};
 
 async function deletePreviewSites(
 	authToken: StoredAuthToken,
@@ -71,144 +106,419 @@ async function deletePreviewSites(
 	}
 }
 
+function getSelectedFilePaths( site: SiteData, deleteFiles: boolean ): string[] {
+	if ( ! deleteFiles ) {
+		return [];
+	}
+
+	return [ site.path, site.technicalSiteDirectory ].filter(
+		( value ): value is string => typeof value === 'string' && fs.existsSync( value )
+	);
+}
+
+function resolveSiteIdentity(
+	identity: string,
+	sites: SiteData[]
+): { site?: SiteData; error?: string } {
+	const trimmed = identity.trim();
+	if ( ! trimmed ) {
+		return { error: __( 'The specified directory is not added to Studio.' ) };
+	}
+
+	const byId = sites.find( ( site ) => site.id === trimmed );
+	if ( byId ) {
+		return { site: byId };
+	}
+
+	const resolvedPath = path.resolve( untildify( trimmed ) );
+	const byPath = sites.find( ( site ) => arePathsEqual( site.path, resolvedPath ) );
+	if ( byPath ) {
+		return { site: byPath };
+	}
+
+	if ( isWordPressDirectory( resolvedPath ) ) {
+		return {
+			error: __( 'The specified directory is not added to Studio. Use `studio create` to add it.' ),
+		};
+	}
+
+	return { error: __( 'The specified directory is not added to Studio.' ) };
+}
+
+function outcomeForSite(
+	item: ResolvedSite,
+	status: DeleteSiteStatus,
+	error?: string
+): DeleteSiteOutcome {
+	const outcome: DeleteSiteOutcome = {
+		identity: item.identity,
+		status,
+		id: item.site.id,
+		name: item.site.name,
+		path: item.site.path,
+		filePaths: item.filePaths,
+	};
+
+	if ( error ) {
+		outcome.error = error;
+	}
+
+	return outcome;
+}
+
+function emitMachineOutput( result: DeleteCommandResult, logger: Logger< LoggerAction > ): void {
+	const json = JSON.stringify( result );
+	console.log( json );
+	logger.reportKeyValuePair( 'deleteResult', json );
+}
+
+function firstFailureError( sites: DeleteSiteOutcome[] ): LoggerError {
+	const failed = sites.find( ( site ) => site.status === 'failed' );
+	return new LoggerError( failed?.error ?? __( 'Failed to delete site' ) );
+}
+
+function finishWithFailures(
+	result: DeleteCommandResult,
+	options: { format: 'text' | 'json'; throwOnFailure: boolean; logger: Logger< LoggerAction > }
+): DeleteCommandResult {
+	if ( options.format === 'json' ) {
+		emitMachineOutput( result, options.logger );
+	}
+
+	if ( options.throwOnFailure ) {
+		throw firstFailureError( result.sites );
+	}
+
+	process.exitCode = 1;
+	return result;
+}
+
 export async function runCommand(
 	siteFolder: string,
 	deleteFiles: boolean = true,
 	logger: Logger< LoggerAction > = defaultLogger
 ): Promise< void > {
-	return withSiteOperation( siteFolder, 'delete', () =>
-		deleteSite( siteFolder, deleteFiles, logger )
+	await runDeleteCommand( {
+		identities: [ siteFolder ],
+		deleteFiles,
+		logger,
+		throwOnFailure: true,
+	} );
+}
+
+export async function runDeleteCommand(
+	options: DeleteCommandOptions
+): Promise< DeleteCommandResult > {
+	const {
+		identities,
+		deleteFiles = true,
+		dryRun = false,
+		format = 'text',
+		logger = defaultLogger,
+		throwOnFailure = false,
+	} = options;
+
+	logger.reportStart( LoggerAction.LOAD_SITES, __( 'Resolving sites…' ) );
+	const cliConfig = await readCliConfig();
+
+	const resolved: ResolvedSite[] = [];
+	const seenIds = new Set< string >();
+	let validationFailed = false;
+	const validationOutcomes: DeleteSiteOutcome[] = [];
+
+	for ( const identity of identities ) {
+		const { site, error } = resolveSiteIdentity( identity, cliConfig.sites );
+		if ( ! site ) {
+			validationFailed = true;
+			validationOutcomes.push( { identity, status: 'failed', error } );
+			continue;
+		}
+
+		const item: ResolvedSite = {
+			identity,
+			site,
+			filePaths: getSelectedFilePaths( site, deleteFiles ),
+		};
+
+		if ( seenIds.has( site.id ) ) {
+			validationFailed = true;
+			validationOutcomes.push(
+				outcomeForSite( item, 'failed', __( 'The same site was specified more than once.' ) )
+			);
+			continue;
+		}
+
+		seenIds.add( site.id );
+		resolved.push( item );
+		validationOutcomes.push( outcomeForSite( item, 'selected' ) );
+	}
+
+	if ( validationFailed ) {
+		const result: DeleteCommandResult = {
+			dryRun,
+			deleteFiles,
+			sites: validationOutcomes.map( ( outcome ) => {
+				if ( outcome.status === 'selected' ) {
+					return {
+						...outcome,
+						status: 'skipped',
+						error: __( 'Skipped because the requested set failed validation.' ),
+					};
+				}
+				return outcome;
+			} ),
+		};
+
+		logger.reportError( firstFailureError( result.sites ), false );
+		return finishWithFailures( result, { format, throwOnFailure, logger } );
+	}
+
+	logger.reportSuccess(
+		sprintf( _n( 'Resolved %d site', 'Resolved %d sites', resolved.length ), resolved.length )
 	);
+
+	if ( dryRun ) {
+		const result: DeleteCommandResult = {
+			dryRun: true,
+			deleteFiles,
+			sites: validationOutcomes,
+		};
+
+		if ( format === 'json' ) {
+			emitMachineOutput( result, logger );
+		} else {
+			for ( const outcome of result.sites ) {
+				const fileSummary =
+					outcome.filePaths && outcome.filePaths.length > 0
+						? outcome.filePaths.join( ', ' )
+						: __( 'no files' );
+				logger.reportSuccess(
+					sprintf(
+						// translators: 1: site name, 2: site path, 3: file paths that would be moved to Trash
+						__( 'Would delete %1$s (%2$s); files: %3$s' ),
+						outcome.name ?? outcome.identity,
+						outcome.path ?? outcome.identity,
+						fileSummary
+					)
+				);
+			}
+		}
+
+		return result;
+	}
+
+	const outcomes: DeleteSiteOutcome[] = [];
+
+	try {
+		await withSiteOperations(
+			resolved.map( ( item ) => item.site.id ),
+			'delete',
+			async () => {
+				try {
+					logger.reportStart( LoggerAction.START_DAEMON, __( 'Starting process daemon…' ) );
+					await connectToDaemon();
+					logger.reportSuccess( __( 'Process daemon started' ) );
+
+					for ( const item of resolved ) {
+						try {
+							await deleteSite( item.site, item.filePaths, deleteFiles, logger );
+							outcomes.push( outcomeForSite( item, 'deleted' ) );
+						} catch ( error ) {
+							const message = error instanceof Error ? error.message : String( error );
+							logger.reportError( new LoggerError( message, error ), false );
+							outcomes.push( outcomeForSite( item, 'failed', message ) );
+						}
+					}
+				} finally {
+					await disconnectFromDaemon();
+				}
+			}
+		);
+	} catch ( error ) {
+		if ( outcomes.length === 0 && resolved.length > 0 ) {
+			const message = error instanceof Error ? error.message : String( error );
+			const [ first, ...rest ] = resolved;
+			outcomes.push( outcomeForSite( first, 'failed', message ) );
+			outcomes.push(
+				...rest.map( ( item ) =>
+					outcomeForSite( item, 'skipped', __( 'Skipped because the batch could not start.' ) )
+				)
+			);
+		} else if ( throwOnFailure ) {
+			throw error;
+		}
+	}
+
+	const result: DeleteCommandResult = {
+		dryRun: false,
+		deleteFiles,
+		sites: outcomes,
+	};
+
+	if ( outcomes.some( ( outcome ) => outcome.status === 'failed' ) ) {
+		return finishWithFailures( result, { format, throwOnFailure, logger } );
+	}
+
+	if ( format === 'json' ) {
+		emitMachineOutput( result, logger );
+	} else if ( resolved.length > 1 ) {
+		const deletedCount = outcomes.filter( ( outcome ) => outcome.status === 'deleted' ).length;
+		logger.reportSuccess(
+			sprintf( _n( 'Deleted %d site', 'Deleted %d sites', deletedCount ), deletedCount )
+		);
+	}
+
+	return result;
 }
 
 async function deleteSite(
-	siteFolder: string,
+	site: SiteData,
+	filePaths: string[],
 	deleteFiles: boolean,
 	logger: Logger< LoggerAction >
 ): Promise< void > {
-	try {
-		logger.reportStart( LoggerAction.START_DAEMON, __( 'Starting process daemon…' ) );
-		await connectToDaemon();
-		logger.reportSuccess( __( 'Process daemon started' ) );
-
-		logger.reportStart( LoggerAction.LOAD_SITES, __( 'Loading site…' ) );
-		const site = await getSiteByFolder( siteFolder );
-		logger.reportSuccess( __( 'Site loaded' ) );
-
-		const runningProcess = await isServerRunning( site.id );
-		if ( runningProcess ) {
-			logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress server…' ) );
-			await stopWordPressServer( site.id );
-			logger.reportSuccess( __( 'WordPress server stopped' ) );
-			await stopProxyIfNoSitesNeedIt( site.id, logger );
-		}
-
-		if ( site.customDomain ) {
-			logger.reportStart(
-				LoggerAction.REMOVE_DOMAIN_FROM_HOSTS,
-				__( 'Removing domain from hosts file…' )
-			);
-			await removeDomainFromHosts( site.customDomain );
-			logger.reportSuccess( __( 'Domain removed from hosts file' ) );
-
-			if ( site.enableHttps ) {
-				logger.reportStart( LoggerAction.DELETE_CERT, __( 'Deleting SSL certificates…' ) );
-				deleteSiteCertificate( site.customDomain );
-				logger.reportSuccess( __( 'SSL certificates deleted' ) );
-			}
-		}
-
-		const authToken = await readAuthToken();
-		if ( authToken ) {
-			await deletePreviewSites( authToken, siteFolder, logger );
-		}
-
-		try {
-			await lockCliConfig();
-			const cliConfig = await readCliConfig();
-			const siteIndex = cliConfig.sites.findIndex( ( s ) => arePathsEqual( s.path, siteFolder ) );
-			if ( siteIndex === -1 ) {
-				throw new LoggerError( __( 'The specified directory is not added to Studio.' ) );
-			}
-			cliConfig.sites.splice( siteIndex, 1 );
-			await saveCliConfig( cliConfig );
-		} finally {
-			await unlockCliConfig();
-		}
-
-		try {
-			await removeAllConnectedWpcomSitesForLocalSite( site.id );
-		} catch ( error ) {
-			logger.reportError(
-				new LoggerError(
-					__( 'Failed to remove WordPress.com connections. Proceeding anyway…' ),
-					error
-				),
-				false
-			);
-		}
-
-		try {
-			await deleteAiSessionsForSite( getSessionsDirectory(), {
-				id: site.id,
-				path: site.path,
-			} );
-		} catch ( error ) {
-			logger.reportError(
-				new LoggerError( __( 'Failed to delete chat sessions. Proceeding anyway…' ), error ),
-				false
-			);
-		}
-
-		if ( deleteFiles ) {
-			// Imported sites have both a visible site directory and a
-			// hidden technical directory under ~/.studio/imports; delete
-			// both if they exist.
-			const deleteTargets = [ siteFolder, site.technicalSiteDirectory ].filter(
-				( value ): value is string => typeof value === 'string' && fs.existsSync( value )
-			);
-
-			if ( deleteTargets.length > 0 ) {
-				logger.reportStart( LoggerAction.DELETE_FILES, __( 'Moving site files to trash…' ) );
-				await trash( deleteTargets );
-				logger.reportSuccess( __( 'Site files moved to trash' ) );
-			} else {
-				logger.reportSuccess( __( 'Site files already removed' ) );
-			}
-		}
-
-		await emitCliEvent( { event: SITE_EVENTS.DELETED, data: { siteId: site.id } } );
-
-		// Tracks: the CLI is the sole emitter of site-delete, whether deleted standalone or by the
-		// desktop app (which delegates to `site delete` and passes its origin via STUDIO_TRACKS_ORIGIN).
-		// Best-effort — wrapped so telemetry can never fail a delete.
-		try {
-			await recordTracksEvent( TRACKS_EVENTS.SITE_DELETE, {
-				...getTracksOrigin(),
-				delete_files: deleteFiles,
-			} );
-		} catch {
-			// Best-effort telemetry — never block or fail a delete.
-		}
-	} finally {
-		await disconnectFromDaemon();
+	const runningProcess = await isServerRunning( site.id );
+	if ( runningProcess ) {
+		logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress server…' ) );
+		await stopWordPressServer( site.id );
+		logger.reportSuccess( __( 'WordPress server stopped' ) );
+		await stopProxyIfNoSitesNeedIt( site.id, logger );
 	}
+
+	if ( site.customDomain ) {
+		logger.reportStart(
+			LoggerAction.REMOVE_DOMAIN_FROM_HOSTS,
+			__( 'Removing domain from hosts file…' )
+		);
+		await removeDomainFromHosts( site.customDomain );
+		logger.reportSuccess( __( 'Domain removed from hosts file' ) );
+
+		if ( site.enableHttps ) {
+			logger.reportStart( LoggerAction.DELETE_CERT, __( 'Deleting SSL certificates…' ) );
+			deleteSiteCertificate( site.customDomain );
+			logger.reportSuccess( __( 'SSL certificates deleted' ) );
+		}
+	}
+
+	const authToken = await readAuthToken();
+	if ( authToken ) {
+		await deletePreviewSites( authToken, site.path, logger );
+	}
+
+	try {
+		await lockCliConfig();
+		const cliConfig = await readCliConfig();
+		const siteIndex = cliConfig.sites.findIndex( ( s ) => arePathsEqual( s.path, site.path ) );
+		if ( siteIndex === -1 ) {
+			throw new LoggerError( __( 'The specified directory is not added to Studio.' ) );
+		}
+		cliConfig.sites.splice( siteIndex, 1 );
+		await saveCliConfig( cliConfig );
+	} finally {
+		await unlockCliConfig();
+	}
+
+	try {
+		await removeAllConnectedWpcomSitesForLocalSite( site.id );
+	} catch ( error ) {
+		logger.reportError(
+			new LoggerError(
+				__( 'Failed to remove WordPress.com connections. Proceeding anyway…' ),
+				error
+			),
+			false
+		);
+	}
+
+	try {
+		await deleteAiSessionsForSite( getSessionsDirectory(), {
+			id: site.id,
+			path: site.path,
+		} );
+	} catch ( error ) {
+		logger.reportError(
+			new LoggerError( __( 'Failed to delete chat sessions. Proceeding anyway…' ), error ),
+			false
+		);
+	}
+
+	if ( deleteFiles ) {
+		// Imported sites have both a visible site directory and a
+		// hidden technical directory under ~/.studio/imports; delete
+		// both if they exist.
+		if ( filePaths.length > 0 ) {
+			logger.reportStart( LoggerAction.DELETE_FILES, __( 'Moving site files to trash…' ) );
+			await trash( filePaths );
+			logger.reportSuccess( __( 'Site files moved to trash' ) );
+		} else {
+			logger.reportSuccess( __( 'Site files already removed' ) );
+		}
+	}
+
+	await emitCliEvent( { event: SITE_EVENTS.DELETED, data: { siteId: site.id } } );
+
+	// Tracks: the CLI is the sole emitter of site-delete, whether deleted standalone or by the
+	// desktop app (which delegates to `site delete` and passes its origin via STUDIO_TRACKS_ORIGIN).
+	// Best-effort — wrapped so telemetry can never fail a delete.
+	try {
+		await recordTracksEvent( TRACKS_EVENTS.SITE_DELETE, {
+			...getTracksOrigin(),
+			delete_files: deleteFiles,
+		} );
+	} catch {
+		// Best-effort telemetry — never block or fail a delete.
+	}
+}
+
+function collectIdentities( argv: { sites?: string | string[]; path: string } ): string[] {
+	if ( Array.isArray( argv.sites ) && argv.sites.length > 0 ) {
+		return argv.sites;
+	}
+
+	if ( typeof argv.sites === 'string' && argv.sites.length > 0 ) {
+		return [ argv.sites ];
+	}
+
+	return [ argv.path ];
 }
 
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
-		command: 'delete',
+		command: 'delete [sites..]',
 		describe: __( 'Delete site' ),
 		builder: ( yargs ) => {
-			return yargs.option( 'files', {
-				type: 'boolean',
-				description: __( 'Move site files to trash (use --no-files to keep files)' ),
-				default: true,
-			} );
+			return yargs
+				.positional( 'sites', {
+					type: 'string',
+					array: true,
+					description: __( 'Site paths or IDs to delete' ),
+				} )
+				.option( 'files', {
+					type: 'boolean',
+					description: __( 'Move site files to trash (use --no-files to keep files)' ),
+					default: true,
+				} )
+				.option( 'dry-run', {
+					alias: 'preview',
+					type: 'boolean',
+					description: __( 'Show which sites and files would be deleted without deleting them' ),
+					default: false,
+				} )
+				.option( 'format', {
+					type: 'string',
+					choices: [ 'text', 'json' ] as const,
+					default: 'text' as const,
+					description: __( 'Output format' ),
+				} );
 		},
 		handler: async ( argv ) => {
 			try {
-				await runCommand( argv.path, argv.files );
+				await runDeleteCommand( {
+					identities: collectIdentities( argv ),
+					deleteFiles: argv.files,
+					dryRun: argv.dryRun,
+					format: argv.format,
+				} );
 			} catch ( error ) {
 				if ( error instanceof LoggerError ) {
 					defaultLogger.reportError( error );

--- a/apps/cli/commands/site/delete.ts
+++ b/apps/cli/commands/site/delete.ts
@@ -133,8 +133,7 @@ function resolveSiteIdentity(
 	const expandedPath = untildify( trimmed );
 	const resolvedPath = path.resolve( expandedPath );
 	const byPath = sites.find(
-		( site ) =>
-			arePathsEqual( site.path, expandedPath ) || arePathsEqual( site.path, resolvedPath )
+		( site ) => arePathsEqual( site.path, expandedPath ) || arePathsEqual( site.path, resolvedPath )
 	);
 	if ( byPath ) {
 		return { site: byPath };

--- a/apps/cli/commands/site/delete.ts
+++ b/apps/cli/commands/site/delete.ts
@@ -130,8 +130,12 @@ function resolveSiteIdentity(
 		return { site: byId };
 	}
 
-	const resolvedPath = path.resolve( untildify( trimmed ) );
-	const byPath = sites.find( ( site ) => arePathsEqual( site.path, resolvedPath ) );
+	const expandedPath = untildify( trimmed );
+	const resolvedPath = path.resolve( expandedPath );
+	const byPath = sites.find(
+		( site ) =>
+			arePathsEqual( site.path, expandedPath ) || arePathsEqual( site.path, resolvedPath )
+	);
 	if ( byPath ) {
 		return { site: byPath };
 	}

--- a/apps/cli/commands/site/tests/delete.test.ts
+++ b/apps/cli/commands/site/tests/delete.test.ts
@@ -23,7 +23,7 @@ import { getSnapshotsFromConfig, deleteSnapshotFromConfig } from 'cli/lib/snapsh
 import { recordTracksEvent, TRACKS_EVENTS } from 'cli/lib/tracks';
 import { ProcessDescription } from 'cli/lib/types/process-manager-ipc';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
-import { runCommand } from '../delete';
+import { runCommand, runDeleteCommand } from '../delete';
 
 vi.mock( 'fs' );
 vi.mock( 'cli/lib/api' );
@@ -61,6 +61,7 @@ vi.mock( 'cli/lib/daemon-client' );
 vi.mock( 'cli/lib/site-operations', async ( importOriginal ) => ( {
 	...( await importOriginal< typeof import('cli/lib/site-operations') >() ),
 	withSiteOperation: ( _folder: string, _kind: string, fn: () => unknown ) => fn(),
+	withSiteOperations: ( _ids: string[], _kind: string, fn: () => unknown ) => fn(),
 } ) );
 vi.mock( 'cli/lib/site-utils' );
 vi.mock( 'cli/lib/snapshots' );
@@ -122,9 +123,11 @@ describe( 'CLI: studio site delete', () => {
 	};
 
 	let testSite: SiteData;
+	const originalExitCode = process.exitCode;
 
 	beforeEach( () => {
 		vi.clearAllMocks();
+		process.exitCode = originalExitCode;
 
 		testSite = createTestSite();
 
@@ -155,6 +158,7 @@ describe( 'CLI: studio site delete', () => {
 	} );
 
 	afterEach( () => {
+		process.exitCode = originalExitCode;
 		vi.restoreAllMocks();
 	} );
 
@@ -172,7 +176,8 @@ describe( 'CLI: studio site delete', () => {
 			vi.mocked( readCliConfig ).mockRejectedValue( new Error( 'Read failed' ) );
 
 			await expect( runCommand( testSiteFolder ) ).rejects.toThrow();
-			expect( disconnectFromDaemon ).toHaveBeenCalled();
+			expect( connectToDaemon ).not.toHaveBeenCalled();
+			expect( disconnectFromDaemon ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should throw when site not found in appdata', async () => {
@@ -185,7 +190,8 @@ describe( 'CLI: studio site delete', () => {
 			await expect( runCommand( testSiteFolder ) ).rejects.toThrow(
 				'The specified directory is not added to Studio.'
 			);
-			expect( disconnectFromDaemon ).toHaveBeenCalled();
+			expect( connectToDaemon ).not.toHaveBeenCalled();
+			expect( disconnectFromDaemon ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should throw when WordPress server stop fails', async () => {
@@ -420,6 +426,193 @@ describe( 'CLI: studio site delete', () => {
 				TRACKS_EVENTS.SITE_DELETE,
 				expect.objectContaining( { delete_files: false } )
 			);
+		} );
+	} );
+
+	describe( 'Batch deletion', () => {
+		const createSites = ( count: number ): SiteData[] =>
+			Array.from( { length: count }, ( _, index ) =>
+				createTestSite( {
+					id: `site-${ index + 1 }`,
+					name: `Site ${ index + 1 }`,
+					path: `/test/site/${ index + 1 }`,
+					port: 8881 + index,
+				} )
+			);
+
+		const mockSites = ( sites: SiteData[] ) => {
+			vi.mocked( readCliConfig, { partial: true } ).mockResolvedValue( {
+				version: 1,
+				sites,
+				snapshots: [],
+			} );
+		};
+
+		it( 'deletes nine sites with a single daemon session', async () => {
+			const sites = createSites( 9 );
+			mockSites( sites );
+
+			const result = await runDeleteCommand( {
+				identities: sites.map( ( site ) => site.path ),
+			} );
+
+			expect( connectToDaemon ).toHaveBeenCalledTimes( 1 );
+			expect( disconnectFromDaemon ).toHaveBeenCalledTimes( 1 );
+			expect( saveCliConfig ).toHaveBeenCalledTimes( 9 );
+			expect( trash ).toHaveBeenCalledTimes( 9 );
+			expect( result.sites ).toHaveLength( 9 );
+			expect( result.sites.every( ( site ) => site.status === 'deleted' ) ).toBe( true );
+			expect( process.exitCode ).toBe( originalExitCode );
+		} );
+
+		it( 'resolves site IDs and paths in one invocation', async () => {
+			const sites = createSites( 2 );
+			mockSites( sites );
+
+			const result = await runDeleteCommand( {
+				identities: [ sites[ 0 ].id, sites[ 1 ].path ],
+			} );
+
+			expect( connectToDaemon ).toHaveBeenCalledTimes( 1 );
+			expect( result.sites.map( ( site ) => site.id ) ).toEqual( [ 'site-1', 'site-2' ] );
+			expect( result.sites.every( ( site ) => site.status === 'deleted' ) ).toBe( true );
+		} );
+
+		it( 'validates the full set before mutating and skips remaining sites', async () => {
+			const sites = createSites( 2 );
+			mockSites( sites );
+
+			const result = await runDeleteCommand( {
+				identities: [ sites[ 0 ].path, '/missing/site', sites[ 1 ].path ],
+			} );
+
+			expect( connectToDaemon ).not.toHaveBeenCalled();
+			expect( saveCliConfig ).not.toHaveBeenCalled();
+			expect( trash ).not.toHaveBeenCalled();
+			expect( result.sites ).toEqual( [
+				expect.objectContaining( {
+					path: sites[ 0 ].path,
+					status: 'skipped',
+				} ),
+				expect.objectContaining( {
+					identity: '/missing/site',
+					status: 'failed',
+					error: 'The specified directory is not added to Studio.',
+				} ),
+				expect.objectContaining( {
+					path: sites[ 1 ].path,
+					status: 'skipped',
+				} ),
+			] );
+			expect( process.exitCode ).toBe( 1 );
+		} );
+
+		it( 'rejects duplicate identities before mutating', async () => {
+			mockSites( [ testSite ] );
+
+			const result = await runDeleteCommand( {
+				identities: [ testSite.path, testSite.id ],
+			} );
+
+			expect( connectToDaemon ).not.toHaveBeenCalled();
+			expect( trash ).not.toHaveBeenCalled();
+			expect( result.sites.map( ( site ) => site.status ) ).toEqual( [ 'skipped', 'failed' ] );
+			expect( result.sites[ 1 ]?.error ).toBe( 'The same site was specified more than once.' );
+			expect( process.exitCode ).toBe( 1 );
+		} );
+
+		it( 'continues after a per-site mutation failure and keeps completed evidence', async () => {
+			const sites = createSites( 3 );
+			mockSites( sites );
+			vi.mocked( trash )
+				.mockResolvedValueOnce( undefined )
+				.mockRejectedValueOnce( new Error( 'File deletion failed' ) )
+				.mockResolvedValueOnce( undefined );
+
+			const result = await runDeleteCommand( {
+				identities: sites.map( ( site ) => site.path ),
+			} );
+
+			expect( connectToDaemon ).toHaveBeenCalledTimes( 1 );
+			expect( disconnectFromDaemon ).toHaveBeenCalledTimes( 1 );
+			expect( saveCliConfig ).toHaveBeenCalledTimes( 3 );
+			expect( result.sites.map( ( site ) => site.status ) ).toEqual( [
+				'deleted',
+				'failed',
+				'deleted',
+			] );
+			expect( result.sites[ 1 ]?.error ).toBe( 'File deletion failed' );
+			expect( process.exitCode ).toBe( 1 );
+		} );
+
+		it( 'previews selected sites and file paths without starting the daemon', async () => {
+			const sites = [
+				createTestSite( {
+					id: 'site-1',
+					name: 'Site 1',
+					path: '/test/site/1',
+					technicalSiteDirectory: '/test/.studio/imports/1',
+				} ),
+				createTestSite( {
+					id: 'site-2',
+					name: 'Site 2',
+					path: '/test/site/2',
+				} ),
+			];
+			mockSites( sites );
+			vi.spyOn( fs, 'existsSync' ).mockImplementation(
+				( filePath ) =>
+					filePath === '/test/site/1' ||
+					filePath === '/test/.studio/imports/1' ||
+					filePath === '/test/site/2'
+			);
+
+			const result = await runDeleteCommand( {
+				identities: sites.map( ( site ) => site.path ),
+				dryRun: true,
+				format: 'json',
+			} );
+
+			expect( connectToDaemon ).not.toHaveBeenCalled();
+			expect( saveCliConfig ).not.toHaveBeenCalled();
+			expect( trash ).not.toHaveBeenCalled();
+			expect( result ).toEqual( {
+				dryRun: true,
+				deleteFiles: true,
+				sites: [
+					{
+						identity: '/test/site/1',
+						status: 'selected',
+						id: 'site-1',
+						name: 'Site 1',
+						path: '/test/site/1',
+						filePaths: [ '/test/site/1', '/test/.studio/imports/1' ],
+					},
+					{
+						identity: '/test/site/2',
+						status: 'selected',
+						id: 'site-2',
+						name: 'Site 2',
+						path: '/test/site/2',
+						filePaths: [ '/test/site/2' ],
+					},
+				],
+			} );
+		} );
+
+		it( 'emits machine-readable per-site outcomes', async () => {
+			const sites = createSites( 2 );
+			mockSites( sites );
+			const consoleSpy = vi.spyOn( console, 'log' ).mockImplementation( () => {} );
+
+			const result = await runDeleteCommand( {
+				identities: sites.map( ( site ) => site.path ),
+				format: 'json',
+			} );
+
+			expect( result.sites.map( ( site ) => site.status ) ).toEqual( [ 'deleted', 'deleted' ] );
+			expect( consoleSpy ).toHaveBeenCalledWith( JSON.stringify( result ) );
+			consoleSpy.mockRestore();
 		} );
 	} );
 } );

--- a/apps/cli/lib/site-operations.ts
+++ b/apps/cli/lib/site-operations.ts
@@ -53,24 +53,31 @@ export function getLiveSiteOperation( site: SiteData ): SiteOperation | undefine
  * across CLI processes — the agent, the desktop app and a terminal all reach
  * this through the same commands.
  */
-async function acquire( siteId: string, kind: SiteOperationKind ): Promise< SiteOperation > {
+async function acquire( siteIds: string[], kind: SiteOperationKind ): Promise< SiteOperation > {
 	const operation: SiteOperation = { pid: process.pid, kind };
 
 	try {
 		await lockCliConfig();
 		const config = await readCliConfig();
-		const site = config.sites.find( ( s ) => s.id === siteId );
+		const sites: SiteData[] = [];
 
-		if ( ! site ) {
-			throw new LoggerError( __( 'Site not found' ) );
+		for ( const siteId of siteIds ) {
+			const site = config.sites.find( ( candidate ) => candidate.id === siteId );
+			if ( ! site ) {
+				throw new LoggerError( __( 'Site not found' ) );
+			}
+
+			const blocking = getLiveSiteOperation( site );
+			if ( blocking ) {
+				throw siteBusyError( kind, blocking.kind );
+			}
+
+			sites.push( site );
 		}
 
-		const blocking = getLiveSiteOperation( site );
-		if ( blocking ) {
-			throw siteBusyError( kind, blocking.kind );
+		for ( const site of sites ) {
+			site.operation = operation;
 		}
-
-		site.operation = operation;
 		await saveCliConfig( config );
 	} finally {
 		await unlockCliConfig();
@@ -79,21 +86,20 @@ async function acquire( siteId: string, kind: SiteOperationKind ): Promise< Site
 	return operation;
 }
 
-async function release( siteId: string, operation: SiteOperation ): Promise< void > {
+async function release( siteIds: string[], operation: SiteOperation ): Promise< void > {
 	try {
 		await lockCliConfig();
 		const config = await readCliConfig();
-		const site = config.sites.find( ( s ) => s.id === siteId );
 
-		// A completed `site delete` removes the record entirely; nothing to release.
-		if ( ! site ) {
-			return;
-		}
+		for ( const siteId of siteIds ) {
+			const site = config.sites.find( ( candidate ) => candidate.id === siteId );
 
-		// Only clear our own: a reclaimed-then-reacquired site belongs to whoever
-		// holds it now.
-		if ( site.operation?.pid === operation.pid ) {
-			delete site.operation;
+			// A completed `site delete` removes the record entirely; nothing to release.
+			if ( site?.operation?.pid === operation.pid ) {
+				// Only clear our own: a reclaimed-then-reacquired site belongs to whoever
+				// holds it now.
+				delete site.operation;
+			}
 		}
 		await saveCliConfig( config );
 	} finally {
@@ -120,8 +126,21 @@ export async function withSiteOperation< T >(
 	fn: () => Promise< T >
 ): Promise< T > {
 	const { id: siteId } = await getSiteByFolder( siteFolder );
-	const operation = await acquire( siteId, kind );
-	await emitOperationsChanged( siteId );
+	return withSiteOperations( [ siteId ], kind, fn );
+}
+
+/**
+ * Acquires all requested sites in one config transaction before running `fn`.
+ * This prevents a batch operation from mutating earlier sites before discovering
+ * that a later site is missing or busy.
+ */
+export async function withSiteOperations< T >(
+	siteIds: string[],
+	kind: SiteOperationKind,
+	fn: () => Promise< T >
+): Promise< T > {
+	const operation = await acquire( siteIds, kind );
+	await Promise.all( siteIds.map( emitOperationsChanged ) );
 
 	try {
 		return await fn();
@@ -129,10 +148,10 @@ export async function withSiteOperation< T >(
 		// Releasing must never replace the operation's own failure: if the config
 		// lock times out here, `fn`'s error is the one worth seeing.
 		try {
-			await release( siteId, operation );
+			await release( siteIds, operation );
 		} catch ( error ) {
 			console.error( 'Failed to release the site operation:', error );
 		}
-		await emitOperationsChanged( siteId );
+		await Promise.all( siteIds.map( emitOperationsChanged ) );
 	}
 }

--- a/apps/cli/lib/tests/site-operations.test.ts
+++ b/apps/cli/lib/tests/site-operations.test.ts
@@ -10,7 +10,7 @@ import {
 } from 'cli/lib/cli-config/core';
 import { emitCliEvent } from 'cli/lib/daemon-client';
 import { LoggerError } from 'cli/logger';
-import { getLiveSiteOperation, withSiteOperation } from '../site-operations';
+import { getLiveSiteOperation, withSiteOperation, withSiteOperations } from '../site-operations';
 
 vi.mock( 'cli/lib/cli-config/core', () => ( {
 	lockCliConfig: vi.fn(),
@@ -35,6 +35,13 @@ const site: SiteData = {
 	port: 8888,
 	phpVersion: DEFAULT_PHP_VERSION,
 } as const;
+
+const secondSite: SiteData = {
+	...site,
+	id: 'site-2',
+	name: 'Second Site',
+	path: '/home/user/Studio/second-site',
+};
 
 let mockConfig: Awaited< ReturnType< typeof readCliConfig > >;
 
@@ -141,5 +148,61 @@ describe( 'withSiteOperation', () => {
 		await expect(
 			withSiteOperation( '/no/such/site', 'start', async () => undefined )
 		).rejects.toThrow( 'Site not found' );
+	} );
+} );
+
+describe( 'withSiteOperations', () => {
+	beforeEach( () => {
+		mockConfig.sites.push( structuredClone( secondSite ) );
+	} );
+
+	it( 'acquires and releases every site in one config transaction', async () => {
+		await withSiteOperations( [ site.id, secondSite.id ], 'delete', async () => {
+			expect( mockConfig.sites.map( ( item ) => item.operation ) ).toEqual( [
+				{ pid: process.pid, kind: 'delete' },
+				{ pid: process.pid, kind: 'delete' },
+			] );
+		} );
+
+		expect( mockConfig.sites.every( ( item ) => item.operation === undefined ) ).toBe( true );
+		expect( saveCliConfig ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'does not acquire any site when one is busy', async () => {
+		mockConfig.sites[ 1 ].operation = { pid: process.pid, kind: 'settings' };
+		const work = vi.fn();
+
+		await expect(
+			withSiteOperations( [ site.id, secondSite.id ], 'delete', work )
+		).rejects.toThrow( /already in progress/ );
+
+		expect( mockConfig.sites[ 0 ].operation ).toBeUndefined();
+		expect( mockConfig.sites[ 1 ].operation ).toEqual( {
+			pid: process.pid,
+			kind: 'settings',
+		} );
+		expect( saveCliConfig ).not.toHaveBeenCalled();
+		expect( work ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not acquire any site when one is missing', async () => {
+		const work = vi.fn();
+
+		await expect(
+			withSiteOperations( [ site.id, 'missing-site' ], 'delete', work )
+		).rejects.toThrow( 'Site not found' );
+
+		expect( mockConfig.sites[ 0 ].operation ).toBeUndefined();
+		expect( saveCliConfig ).not.toHaveBeenCalled();
+		expect( work ).not.toHaveBeenCalled();
+	} );
+
+	it( 'releases surviving sites after deleted records disappear', async () => {
+		await withSiteOperations( [ site.id, secondSite.id ], 'delete', async () => {
+			mockConfig.sites = mockConfig.sites.filter( ( item ) => item.id !== site.id );
+		} );
+
+		expect( mockConfig.sites ).toEqual( [ expect.objectContaining( { id: secondSite.id } ) ] );
+		expect( mockConfig.sites[ 0 ].operation ).toBeUndefined();
 	} );
 } );

--- a/skills/studio-cli/SKILL.md
+++ b/skills/studio-cli/SKILL.md
@@ -21,7 +21,7 @@ studio list      # List all sites (--format table|json)
 studio status    # Show site details (--format table|json)
 studio start     # Start a site
 studio stop      # Stop a site (--all to stop all)
-studio delete    # Delete a site (--files to trash site files)
+studio delete    # Delete one or more sites by path or ID (--files to trash, --dry-run to preview)
 studio config    # Get/set site settings (config get | config set)
 ```
 
@@ -86,14 +86,17 @@ studio stop --path ~/Studio/my-site                     # Stop current site
 studio stop --all                                       # Stop all sites
 ```
 
-### Deleting a site
+### Deleting sites
 
 ```bash
-studio delete --path ~/Studio/my-site          # Remove site record only
-studio delete --path ~/Studio/my-site --files   # Also trash site files
+studio delete --path ~/Studio/my-site                 # Trash files (default) and remove the site
+studio delete --path ~/Studio/my-site --no-files      # Remove the site record; keep files
+studio delete ~/Studio/site-a ~/Studio/site-b         # Delete multiple explicit paths in one session
+studio delete <site-id> <site-id> --format json       # Machine-readable per-site outcomes
+studio delete ~/Studio/site-a ~/Studio/site-b --dry-run
 ```
 
-Deleting a site also removes its associated preview sites if authenticated.
+Explicit paths or IDs authorize the deletion; there is no `--all`. Preview with `--dry-run`/`--preview` before mutating. Default is move-to-Trash. Partial failure returns a nonzero status and still reports completed items. Deleting a site also removes its associated preview sites if authenticated.
 
 ## Authentication
 


### PR DESCRIPTION
## Related issues

Closes #4728

## Proposed Changes

`studio delete` accepted only one `--path`, so cleaning up a known set of sites meant one process per site and a fresh daemon startup each time.

This PR adds a bounded batch delete:

- Accept multiple explicit site paths or IDs in one invocation (`studio delete <site...>`), keeping `--path` for single-site compatibility.
- Resolve and validate the full requested set before mutating files. Duplicates and unknown identities fail closed with skipped/failed outcomes and no daemon session.
- Acquire every site in one config transaction, then reuse one process-daemon session for the batch.
- Keep move-to-Trash as the default (`--no-files` still keeps files).
- Emit structured per-site outcomes (`deleted` / `skipped` / `failed`, plus `selected` for dry-run) with `--format json`.
- Return a nonzero status on partial failure while retaining completed-item evidence.
- Add `--dry-run` / `--preview` that reports the exact sites and file paths without connecting to the daemon or mutating anything.
- Explicit paths/IDs authorize the deletion. There is no `--all`.

## Testing Instructions

- `npx vitest run apps/cli/commands/site/tests/delete.test.ts apps/cli/lib/tests/site-operations.test.ts`
- `studio delete --help` shows `[sites..]`, `--dry-run`/`--preview`, and `--format`.
- `studio delete --path <one-site>` still deletes a single site and trashes files by default.
- `studio delete <site-a> <site-b> --dry-run --format json` prints selected sites and file paths without deleting.
- `studio delete <site-a> <site-b> --format json` deletes both in one daemon session and prints per-site outcomes.
- A mixed valid/invalid set must not mutate any site and must exit nonzero.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

## How AI was used in this PR

OpenAI gpt-5.6-sol via OpenCode general coding subagent implemented the batch delete CLI, the shared `withSiteOperations` lock, and the focused tests from issue #4728. Chris Huber directed the work and remains responsible for the change.