### PR TITLE
build(deps): bump @types/node to 26.x in dev tools (split from #4587)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30937,17 +30937,19 @@
 				"yargs": "^17.7.2"
 			},
 			"devDependencies": {
-				"@types/node": "^25.9.2",
+				"@types/node": "^26.2.0",
 				"@types/yargs": "^17.0.33",
 				"typescript": "^6.0.3"
 			}
 		},
 		"tools/benchmark-site-editor/node_modules/@types/node": {
-			"version": "25.9.3",
+			"version": "26.4.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+			"integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": ">=7.24.0 <7.24.7"
+				"undici-types": "~8.3.0"
 			}
 		},
 		"tools/benchmark-site-editor/node_modules/cliui": {
@@ -30973,7 +30975,9 @@
 			}
 		},
 		"tools/benchmark-site-editor/node_modules/undici-types": {
-			"version": "7.24.6",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -31011,16 +31015,18 @@
 				"ts-node": "^10.9.2"
 			},
 			"devDependencies": {
-				"@types/node": "^25.9.2",
+				"@types/node": "^26.2.0",
 				"typescript": "^6.0.3"
 			}
 		},
 		"tools/compare-perf/node_modules/@types/node": {
-			"version": "25.9.3",
+			"version": "26.4.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+			"integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": ">=7.24.0 <7.24.7"
+				"undici-types": "~8.3.0"
 			}
 		},
 		"tools/compare-perf/node_modules/chalk": {
@@ -31076,7 +31082,9 @@
 			}
 		},
 		"tools/compare-perf/node_modules/undici-types": {
-			"version": "7.24.6",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"devOptional": true,
 			"license": "MIT"
 		},

--- a/tools/benchmark-site-editor/package.json
+++ b/tools/benchmark-site-editor/package.json
@@ -16,7 +16,7 @@
 		"yargs": "^17.7.2"
 	},
 	"devDependencies": {
-		"@types/node": "^25.9.2",
+		"@types/node": "^26.2.0",
 		"@types/yargs": "^17.0.33",
 		"typescript": "^6.0.3"
 	}

--- a/tools/compare-perf/package.json
+++ b/tools/compare-perf/package.json
@@ -20,7 +20,7 @@
 		"ts-node": "^10.9.2"
 	},
 	"devDependencies": {
-		"@types/node": "^25.9.2",
+		"@types/node": "^26.2.0",
 		"typescript": "^6.0.3"
 	}
 }


### PR DESCRIPTION
## Related issues

- Related to #4587

## How AI was used in this PR

Claude Code investigated #4587, reproduced its CI failure locally, identified which half of the dependency group was safe to land, regenerated the lockfile, and ran the verification below. I reviewed the resulting diff.

## Proposed Changes

Dependabot's `typescript` group PR (#4587) bundled a TypeScript 6 → 7 major bump together with routine `@types/node` updates. TypeScript 7 can't land yet: `typescript-eslint` hard-errors when it loads against TS 7 (`Error: typescript-eslint does not support TS 7.0`), and `knip`'s peer range (`typescript >=5.0.4 <7`) makes `npm ci` fail outright — which is why every job on #4587 failed within two minutes. Upstream support is tracked in typescript-eslint/typescript-eslint#10940 and targets TS ≥ 7.1, with no timeline.

This PR takes only the part that is safe today: `@types/node` 25.9.3 → 26.4.0 in the two dev-only tool workspaces (`tools/benchmark-site-editor`, `tools/compare-perf`). Both are devDependencies of local tooling, so there is no runtime or user-visible impact. TypeScript stays on 6.0.3 and can be revisited once `typescript-eslint` supports 7.

The remaining bumps listed in #4587 (`@tsconfig/node10`, `@types/express-serve-static-core`, `@types/hast`) are transitive patch updates that need no manifest change and will ride along on a future Dependabot run.

## Testing Instructions

Run from a clean checkout of this branch:

- `npm ci` — completes with no ERESOLVE error (this is the step that fails on #4587)
- `npm run lint` — passes (0 errors; 2 pre-existing warnings in files this PR does not touch)
- `npm run typecheck` — passes across all 7 workspaces

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
