### PR TITLE
AI credits: add top-up confirmation toast

### DIFF
--- a/apps/studio/src/components/ai-credits-purchased-notice.tsx
+++ b/apps/studio/src/components/ai-credits-purchased-notice.tsx
@@ -2,32 +2,19 @@ import { formatAiCreditsAddedTitle } from '@studio/common/lib/studio-assistant-q
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
-import { useEffect } from 'react';
 import { useAppDispatch, useI18nLocale, useRootSelector } from 'src/stores';
 import { selectAiCreditsAdded, setAiCreditsAdded } from 'src/stores/ui-slice';
-
-// The confirmation reads like a toast, so it leaves like one. Classic has no
-// toast host, and a purchase note that outstays its welcome above the composer
-// is worse than one the user misses.
-const PURCHASE_NOTICE_TTL_MS = 8000;
 
 /**
  * Confirms a top-up above the Classic composer once the balance has grown.
  * The agentic UI says the same thing in a toast; Classic has no toast surface,
- * so it borrows the card treatment of the out-of-credits notice beside it.
+ * so it borrows the card treatment of the out-of-credits notice beside it. It
+ * leaves like a toast too, on a clock the listener starts at confirmation.
  */
 export function AiCreditsPurchasedNotice() {
 	const dispatch = useAppDispatch();
 	const locale = useI18nLocale();
 	const creditsAdded = useRootSelector( selectAiCreditsAdded );
-
-	useEffect( () => {
-		if ( creditsAdded === null ) {
-			return;
-		}
-		const timer = setTimeout( () => dispatch( setAiCreditsAdded( null ) ), PURCHASE_NOTICE_TTL_MS );
-		return () => clearTimeout( timer );
-	}, [ creditsAdded, dispatch ] );
 
 	if ( creditsAdded === null ) {
 		return null;

--- a/apps/studio/src/components/ai-credits-purchased-notice.tsx
+++ b/apps/studio/src/components/ai-credits-purchased-notice.tsx
@@ -1,0 +1,51 @@
+import { formatAiCreditsAddedTitle } from '@studio/common/lib/studio-assistant-quota';
+import { __ } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
+import { Icon } from '@wordpress/ui';
+import { useEffect } from 'react';
+import { useAppDispatch, useI18nLocale, useRootSelector } from 'src/stores';
+import { selectAiCreditsAdded, setAiCreditsAdded } from 'src/stores/ui-slice';
+
+// The confirmation reads like a toast, so it leaves like one. Classic has no
+// toast host, and a purchase note that outstays its welcome above the composer
+// is worse than one the user misses.
+const PURCHASE_NOTICE_TTL_MS = 8000;
+
+/**
+ * Confirms a top-up above the Classic composer once the balance has grown.
+ * The agentic UI says the same thing in a toast; Classic has no toast surface,
+ * so it borrows the card treatment of the out-of-credits notice beside it.
+ */
+export function AiCreditsPurchasedNotice() {
+	const dispatch = useAppDispatch();
+	const locale = useI18nLocale();
+	const creditsAdded = useRootSelector( selectAiCreditsAdded );
+
+	useEffect( () => {
+		if ( creditsAdded === null ) {
+			return;
+		}
+		const timer = setTimeout( () => dispatch( setAiCreditsAdded( null ) ), PURCHASE_NOTICE_TTL_MS );
+		return () => clearTimeout( timer );
+	}, [ creditsAdded, dispatch ] );
+
+	if ( creditsAdded === null ) {
+		return null;
+	}
+
+	return (
+		<div className="border-frame-border bg-frame-surface relative mb-2 flex flex-col items-start gap-1 rounded-lg border p-3 text-left">
+			<span className="text-frame-text pe-6 text-sm font-semibold">
+				{ formatAiCreditsAddedTitle( creditsAdded, locale ) }
+			</span>
+			<button
+				type="button"
+				aria-label={ __( 'Dismiss' ) }
+				onClick={ () => dispatch( setAiCreditsAdded( null ) ) }
+				className="text-frame-text-secondary hover:text-frame-text absolute end-2 top-2"
+			>
+				<Icon icon={ close } size={ 16 } />
+			</button>
+		</div>
+	);
+}

--- a/apps/studio/src/components/ai-credits-purchased-notice.tsx
+++ b/apps/studio/src/components/ai-credits-purchased-notice.tsx
@@ -1,38 +1,44 @@
 import { formatAiCreditsAddedTitle } from '@studio/common/lib/studio-assistant-quota';
-import { __ } from '@wordpress/i18n';
-import { close } from '@wordpress/icons';
-import { Icon } from '@wordpress/ui';
+import { privateApis } from '@wordpress/theme';
+import { Notice } from '@wordpress/ui';
+import { useFrameBackgroundColor } from 'src/hooks/use-frame-background-color';
 import { useAppDispatch, useI18nLocale, useRootSelector } from 'src/stores';
 import { selectAiCreditsAdded, setAiCreditsAdded } from 'src/stores/ui-slice';
+import { unlock } from './studio-code-session/lock-unlock';
+import buttonDefense from './studio-code-session/wp-ui-button-defense.module.css';
+
+const { ThemeProvider } = unlock( privateApis );
 
 /**
  * Confirms a top-up above the Classic composer once the balance has grown.
  * The agentic UI says the same thing in a toast; Classic has no toast surface,
- * so it borrows the card treatment of the out-of-credits notice beside it. It
- * leaves like a toast too, on a clock the listener starts at confirmation.
+ * so it uses the design system's Notice. It leaves like a toast too, on a
+ * clock the listener starts at confirmation.
+ *
+ * The nested `ThemeProvider` is what makes the Notice follow dark mode: its
+ * colors come from `--wpds-color-*`, which are light-only until the theme gets
+ * a background seed. Scoped to this notice rather than to all of Studio Code,
+ * because seeding higher up restyles every WPDS component under it.
  */
 export function AiCreditsPurchasedNotice() {
 	const dispatch = useAppDispatch();
 	const locale = useI18nLocale();
 	const creditsAdded = useRootSelector( selectAiCreditsAdded );
+	const frameBackgroundColor = useFrameBackgroundColor();
 
 	if ( creditsAdded === null ) {
 		return null;
 	}
 
 	return (
-		<div className="border-frame-border bg-frame-surface relative mb-2 flex flex-col items-start gap-1 rounded-lg border p-3 text-left">
-			<span className="text-frame-text pe-6 text-sm font-semibold">
-				{ formatAiCreditsAddedTitle( creditsAdded, locale ) }
-			</span>
-			<button
-				type="button"
-				aria-label={ __( 'Dismiss' ) }
-				onClick={ () => dispatch( setAiCreditsAdded( null ) ) }
-				className="text-frame-text-secondary hover:text-frame-text absolute end-2 top-2"
-			>
-				<Icon icon={ close } size={ 16 } />
-			</button>
-		</div>
+		<ThemeProvider color={ { bg: frameBackgroundColor } }>
+			<Notice.Root intent="success" className="mb-2">
+				<Notice.Title>{ formatAiCreditsAddedTitle( creditsAdded, locale ) }</Notice.Title>
+				<Notice.CloseIcon
+					className={ buttonDefense.button }
+					onClick={ () => dispatch( setAiCreditsAdded( null ) ) }
+				/>
+			</Notice.Root>
+		</ThemeProvider>
 	);
 }

--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -21,6 +21,7 @@ import {
 	type UIEvent,
 } from 'react';
 import { OutOfCreditsNotice } from 'src/components/ai-access-required-notice';
+import { AiCreditsPurchasedNotice } from 'src/components/ai-credits-purchased-notice';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import { IllustrationGrid } from 'src/components/illustration-grid';
@@ -422,6 +423,7 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 				composer={
 					<div className={ styles.classicColumn }>
 						<QueuedPrompts prompts={ queuedPrompts } onRemove={ removeQueuedPrompt } />
+						<AiCreditsPurchasedNotice />
 						{ isOutOfCredits ? (
 							<OutOfCreditsNotice />
 						) : (

--- a/apps/studio/src/components/studio-code-session/tests/access-requirements.test.tsx
+++ b/apps/studio/src/components/studio-code-session/tests/access-requirements.test.tsx
@@ -31,6 +31,9 @@ vi.mock( 'src/hooks/use-auth', () => ( {
 
 vi.mock( 'src/stores', () => ( {
 	useI18nLocale: () => 'en',
+	useAppDispatch: () => vi.fn(),
+	// Neutral for every ui-slice selector the session tree reads.
+	useRootSelector: () => null,
 } ) );
 
 vi.mock( 'src/stores/wpcom-api', () => ( {

--- a/apps/studio/src/components/studio-code-session/tests/session-not-found.test.tsx
+++ b/apps/studio/src/components/studio-code-session/tests/session-not-found.test.tsx
@@ -25,6 +25,9 @@ vi.mock( 'src/hooks/use-auth', () => ( {
 
 vi.mock( 'src/stores', () => ( {
 	useI18nLocale: () => 'en',
+	useAppDispatch: () => vi.fn(),
+	// Neutral for every ui-slice selector the session tree reads.
+	useRootSelector: () => null,
 } ) );
 
 vi.mock( 'src/stores/wpcom-api', () => ( {

--- a/apps/studio/src/components/tests/ai-credits-purchased-notice.test.tsx
+++ b/apps/studio/src/components/tests/ai-credits-purchased-notice.test.tsx
@@ -1,0 +1,65 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AiCreditsPurchasedNotice } from 'src/components/ai-credits-purchased-notice';
+import { useAppDispatch, useRootSelector } from 'src/stores';
+import { setAiCreditsAdded } from 'src/stores/ui-slice';
+
+vi.mock( 'src/stores', () => ( {
+	useAppDispatch: vi.fn(),
+	useRootSelector: vi.fn(),
+	useI18nLocale: () => 'en',
+} ) );
+
+const dispatch = vi.fn();
+
+function mockState( creditsAdded: number | null ) {
+	vi.mocked( useRootSelector ).mockImplementation( ( selector ) =>
+		selector( { ui: { aiCreditsAdded: creditsAdded } } as never )
+	);
+}
+
+describe( 'AiCreditsPurchasedNotice', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.mocked( useAppDispatch, { partial: true } ).mockReturnValue( dispatch );
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+	} );
+
+	it( 'shows nothing until a purchase is confirmed', () => {
+		mockState( null );
+		render( <AiCreditsPurchasedNotice /> );
+
+		expect( screen.queryByText( /AI credits added/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'reports the credits the purchase added', () => {
+		mockState( 500000 );
+		render( <AiCreditsPurchasedNotice /> );
+
+		expect( screen.getByText( '500,000 AI credits added' ) ).toBeInTheDocument();
+	} );
+
+	it( 'clears itself on dismiss', async () => {
+		mockState( 500000 );
+		render( <AiCreditsPurchasedNotice /> );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Dismiss' } ) );
+
+		expect( dispatch ).toHaveBeenCalledWith( setAiCreditsAdded( null ) );
+	} );
+
+	it( 'clears itself once it has been read', () => {
+		vi.useFakeTimers();
+		mockState( 500000 );
+		render( <AiCreditsPurchasedNotice /> );
+
+		expect( dispatch ).not.toHaveBeenCalled();
+		act( () => {
+			vi.advanceTimersByTime( 8000 );
+		} );
+		expect( dispatch ).toHaveBeenCalledWith( setAiCreditsAdded( null ) );
+	} );
+} );

--- a/apps/studio/src/components/tests/ai-credits-purchased-notice.test.tsx
+++ b/apps/studio/src/components/tests/ai-credits-purchased-notice.test.tsx
@@ -1,6 +1,6 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AiCreditsPurchasedNotice } from 'src/components/ai-credits-purchased-notice';
 import { useAppDispatch, useRootSelector } from 'src/stores';
 import { setAiCreditsAdded } from 'src/stores/ui-slice';
@@ -25,10 +25,6 @@ describe( 'AiCreditsPurchasedNotice', () => {
 		vi.mocked( useAppDispatch, { partial: true } ).mockReturnValue( dispatch );
 	} );
 
-	afterEach( () => {
-		vi.useRealTimers();
-	} );
-
 	it( 'shows nothing until a purchase is confirmed', () => {
 		mockState( null );
 		render( <AiCreditsPurchasedNotice /> );
@@ -48,18 +44,6 @@ describe( 'AiCreditsPurchasedNotice', () => {
 		render( <AiCreditsPurchasedNotice /> );
 		await userEvent.click( screen.getByRole( 'button', { name: 'Dismiss' } ) );
 
-		expect( dispatch ).toHaveBeenCalledWith( setAiCreditsAdded( null ) );
-	} );
-
-	it( 'clears itself once it has been read', () => {
-		vi.useFakeTimers();
-		mockState( 500000 );
-		render( <AiCreditsPurchasedNotice /> );
-
-		expect( dispatch ).not.toHaveBeenCalled();
-		act( () => {
-			vi.advanceTimersByTime( 8000 );
-		} );
 		expect( dispatch ).toHaveBeenCalledWith( setAiCreditsAdded( null ) );
 	} );
 } );

--- a/apps/studio/src/hooks/tests/use-ai-credits-purchased-listener.test.ts
+++ b/apps/studio/src/hooks/tests/use-ai-credits-purchased-listener.test.ts
@@ -68,6 +68,18 @@ describe( 'useAiCreditsPurchasedListener', () => {
 		expect( dispatched ).toEqual( [] );
 	} );
 
+	it( 'expires the confirmation from when it lands, not from when it is drawn', async () => {
+		refetchResults = [ 0, 500000 ];
+		renderHook( () => useAiCreditsPurchasedListener() );
+
+		act( () => eventHandler() );
+		await vi.advanceTimersByTimeAsync( 0 );
+		expect( dispatched ).toEqual( [ setAiCreditsAdded( 500000 ) ] );
+
+		await vi.advanceTimersByTimeAsync( 8000 );
+		expect( dispatched ).toEqual( [ setAiCreditsAdded( 500000 ), setAiCreditsAdded( null ) ] );
+	} );
+
 	it( 'no longer drags the user into the settings', async () => {
 		refetchResults = [ 0, 500000 ];
 		renderHook( () => useAiCreditsPurchasedListener() );

--- a/apps/studio/src/hooks/tests/use-ai-credits-purchased-listener.test.ts
+++ b/apps/studio/src/hooks/tests/use-ai-credits-purchased-listener.test.ts
@@ -1,45 +1,80 @@
 import { renderHook } from '@testing-library/react';
 import { act } from 'react';
-import { vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAiCreditsPurchasedListener } from 'src/hooks/use-ai-credits-purchased-listener';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useAppDispatch } from 'src/stores';
-import { wpcomApi } from 'src/stores/wpcom-api';
+import { setAiCreditsAdded } from 'src/stores/ui-slice';
 
 vi.mock( 'src/lib/get-ipc-api' );
 vi.mock( 'src/hooks/use-ipc-listener' );
-vi.mock( 'src/stores', () => ( {
-	useAppDispatch: vi.fn(),
-} ) );
+vi.mock( 'src/stores', () => ( { useAppDispatch: vi.fn() } ) );
 
 const showUserSettings = vi.fn();
-const dispatch = vi.fn();
 
 describe( 'useAiCreditsPurchasedListener', () => {
-	let channel: string | undefined;
 	let eventHandler: () => void = () => undefined;
+	let refetchResults: ( number | undefined )[] = [];
+	let purchasedRemaining: number | undefined;
+	const dispatched: unknown[] = [];
+
+	// The listener reads the quota by dispatching an RTK Query thunk; each
+	// dispatched thunk resolves the next server answer.
+	const dispatch = vi.fn( ( action: unknown ) => {
+		if ( typeof action === 'function' ) {
+			if ( refetchResults.length > 0 ) {
+				purchasedRemaining = refetchResults.shift();
+			}
+			const request = Promise.resolve( { data: { purchasedRemaining } } );
+			return Object.assign( request, { unsubscribe: vi.fn() } );
+		}
+		dispatched.push( action );
+		return action;
+	} );
 
 	beforeEach( () => {
+		vi.useFakeTimers();
 		vi.clearAllMocks();
+		dispatched.length = 0;
+		refetchResults = [];
+		purchasedRemaining = 0;
 		vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( { showUserSettings } );
 		vi.mocked( useAppDispatch, { partial: true } ).mockReturnValue( dispatch );
-		vi.mocked( useIpcListener, { partial: true } ).mockImplementation( ( name, handler ) => {
-			channel = name;
+		vi.mocked( useIpcListener, { partial: true } ).mockImplementation( ( _name, handler ) => {
 			eventHandler = handler as unknown as typeof eventHandler;
 		} );
 	} );
 
-	it( 'refreshes the quota and opens the account settings on the checkout return', () => {
+	afterEach( () => vi.useRealTimers() );
+
+	it( 'records the added credits once the balance grows', async () => {
+		refetchResults = [ 0, 0, 500000 ];
 		renderHook( () => useAiCreditsPurchasedListener() );
 
-		expect( channel ).toBe( 'ai-credits-purchased' );
+		act( () => eventHandler() );
+		await vi.advanceTimersByTimeAsync( 20000 );
+
+		expect( dispatched ).toContainEqual( setAiCreditsAdded( 500000 ) );
+	} );
+
+	it( 'records nothing when the balance never grows', async () => {
+		refetchResults = [ 0, 0, 0, 0, 0, 0 ];
+		renderHook( () => useAiCreditsPurchasedListener() );
 
 		act( () => eventHandler() );
+		await vi.advanceTimersByTimeAsync( 20000 );
 
-		expect( dispatch ).toHaveBeenCalledWith(
-			wpcomApi.util.invalidateTags( [ 'StudioAssistantQuota' ] )
-		);
-		expect( showUserSettings ).toHaveBeenCalledWith( 'account' );
+		expect( dispatched ).toEqual( [] );
+	} );
+
+	it( 'no longer drags the user into the settings', async () => {
+		refetchResults = [ 0, 500000 ];
+		renderHook( () => useAiCreditsPurchasedListener() );
+
+		act( () => eventHandler() );
+		await vi.advanceTimersByTimeAsync( 20000 );
+
+		expect( showUserSettings ).not.toHaveBeenCalled();
 	} );
 } );

--- a/apps/studio/src/hooks/use-ai-credits-purchased-listener.ts
+++ b/apps/studio/src/hooks/use-ai-credits-purchased-listener.ts
@@ -2,11 +2,15 @@ import {
 	AI_CREDITS_CONFIRM_ATTEMPTS,
 	AI_CREDITS_CONFIRM_INTERVAL_MS,
 } from '@studio/common/lib/studio-assistant-quota';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useAppDispatch } from 'src/stores';
 import { setAiCreditsAdded } from 'src/stores/ui-slice';
 import { wpcomApi } from 'src/stores/wpcom-api';
+
+// How long the confirmation stays on screen. A purchase note that outstays its
+// welcome above the composer is worse than one the user misses.
+const PURCHASE_NOTICE_TTL_MS = 8000;
 
 /**
  * Confirms an AI credits top-up after WordPress.com checkout sends the user
@@ -17,9 +21,15 @@ import { wpcomApi } from 'src/stores/wpcom-api';
  * silent, and the user is left where they were rather than pushed into the
  * settings — someone who bought from Settings → Usage is already looking at
  * the refreshed meter.
+ *
+ * The confirmation reads like a toast, so it leaves like one — and its clock
+ * starts here, when the purchase lands, not when the composer that draws it
+ * happens to mount. A top-up confirmed while Classic sits on Settings would
+ * otherwise wait, and greet a session opened hours later as fresh news.
  */
 export function useAiCreditsPurchasedListener() {
 	const dispatch = useAppDispatch();
+	const expiryTimer = useRef< ReturnType< typeof setTimeout > | undefined >( undefined );
 
 	useIpcListener(
 		'ai-credits-purchased',
@@ -48,6 +58,11 @@ export function useAiCreditsPurchasedListener() {
 					const after = await readPurchased( true );
 					if ( before !== undefined && after !== undefined && after > before ) {
 						dispatch( setAiCreditsAdded( after - before ) );
+						clearTimeout( expiryTimer.current );
+						expiryTimer.current = setTimeout(
+							() => dispatch( setAiCreditsAdded( null ) ),
+							PURCHASE_NOTICE_TTL_MS
+						);
 						return;
 					}
 				}

--- a/apps/studio/src/hooks/use-ai-credits-purchased-listener.ts
+++ b/apps/studio/src/hooks/use-ai-credits-purchased-listener.ts
@@ -1,14 +1,22 @@
+import {
+	AI_CREDITS_CONFIRM_ATTEMPTS,
+	AI_CREDITS_CONFIRM_INTERVAL_MS,
+} from '@studio/common/lib/studio-assistant-quota';
 import { useCallback } from 'react';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
-import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useAppDispatch } from 'src/stores';
+import { setAiCreditsAdded } from 'src/stores/ui-slice';
 import { wpcomApi } from 'src/stores/wpcom-api';
 
 /**
- * Returns the user to their AI credits after a WordPress.com checkout sends
- * them back via wp-studio://ai-credits-purchased. The balance lives in the
- * Account tab, and the quota is cached for an hour with nothing refetching it
- * while Studio sits behind the browser, so it has to be invalidated explicitly.
+ * Confirms an AI credits top-up after WordPress.com checkout sends the user
+ * back via wp-studio://ai-credits-purchased.
+ *
+ * Only a balance that grew counts: a cancelled checkout returns exactly like a
+ * completed one, so the return itself proves nothing. Every other outcome is
+ * silent, and the user is left where they were rather than pushed into the
+ * settings — someone who bought from Settings → Usage is already looking at
+ * the refreshed meter.
  */
 export function useAiCreditsPurchasedListener() {
 	const dispatch = useAppDispatch();
@@ -16,8 +24,34 @@ export function useAiCreditsPurchasedListener() {
 	useIpcListener(
 		'ai-credits-purchased',
 		useCallback( () => {
-			dispatch( wpcomApi.util.invalidateTags( [ 'StudioAssistantQuota' ] ) );
-			void getIpcApi().showUserSettings( 'account' );
+			const readPurchased = async ( forceRefetch: boolean ) => {
+				const request = dispatch(
+					wpcomApi.endpoints.getStudioAssistantQuota.initiate( undefined, { forceRefetch } )
+				);
+				try {
+					return ( await request ).data?.purchasedRemaining;
+				} finally {
+					request.unsubscribe();
+				}
+			};
+
+			void ( async () => {
+				// Nothing from before the trip means nothing to prove an increase
+				// against; the balance still refreshes, but no claim is made.
+				const before = await readPurchased( false );
+				for ( let attempt = 0; attempt < AI_CREDITS_CONFIRM_ATTEMPTS; attempt++ ) {
+					if ( attempt > 0 ) {
+						await new Promise( ( resolve ) =>
+							setTimeout( resolve, AI_CREDITS_CONFIRM_INTERVAL_MS )
+						);
+					}
+					const after = await readPurchased( true );
+					if ( before !== undefined && after !== undefined && after > before ) {
+						dispatch( setAiCreditsAdded( after - before ) );
+						return;
+					}
+				}
+			} )();
 		}, [ dispatch ] )
 	);
 }

--- a/apps/studio/src/hooks/use-frame-background-color.ts
+++ b/apps/studio/src/hooks/use-frame-background-color.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+
+function readFrameBackgroundColor(): string {
+	const value = getComputedStyle( document.documentElement )
+		.getPropertyValue( '--color-frame-bg' )
+		.trim();
+	// jsdom resolves no custom properties; the light value keeps tests honest.
+	return value || '#fff';
+}
+
+/**
+ * Studio's current frame background, read from `--color-frame-bg` so the two
+ * never drift.
+ *
+ * Feed this to `@wordpress/ui`'s `ThemeProvider` as its `color.bg` seed: WPDS
+ * derives its whole ramp from that seed, and without one it falls back to the
+ * light-only values built into `@wordpress/theme` — which is why a WPDS
+ * component renders a light card on Studio's dark chrome.
+ */
+export function useFrameBackgroundColor(): string {
+	const [ backgroundColor, setBackgroundColor ] = useState( readFrameBackgroundColor );
+
+	useEffect( () => {
+		const query = window.matchMedia( DARK_SCHEME_QUERY );
+		const update = () => setBackgroundColor( readFrameBackgroundColor() );
+		query.addEventListener( 'change', update );
+		return () => query.removeEventListener( 'change', update );
+	}, [] );
+
+	return backgroundColor;
+}

--- a/apps/studio/src/stores/ui-slice.ts
+++ b/apps/studio/src/stores/ui-slice.ts
@@ -1,14 +1,18 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from 'src/stores';
 
 type UiState = {
 	isAddSiteModalOpen: boolean;
 	isWapuuWorldOpen: boolean;
+	// Credits confirmed to have landed since the app opened. Session-only on
+	// purpose: this reports one purchase, not a standing preference.
+	aiCreditsAdded: number | null;
 };
 
 const initialState: UiState = {
 	isAddSiteModalOpen: false,
 	isWapuuWorldOpen: false,
+	aiCreditsAdded: null,
 };
 
 const uiSlice = createSlice( {
@@ -30,13 +34,22 @@ const uiSlice = createSlice( {
 		closeWapuuWorld: ( state ) => {
 			state.isWapuuWorldOpen = false;
 		},
+		setAiCreditsAdded: ( state, action: PayloadAction< number | null > ) => {
+			state.aiCreditsAdded = action.payload;
+		},
 	},
 } );
 
-export const { openAddSiteModal, closeAddSiteModal, openWapuuWorld, closeWapuuWorld } =
-	uiSlice.actions;
+export const {
+	openAddSiteModal,
+	closeAddSiteModal,
+	openWapuuWorld,
+	closeWapuuWorld,
+	setAiCreditsAdded,
+} = uiSlice.actions;
 
 export const selectIsAddSiteModalOpen = ( state: RootState ) => state.ui.isAddSiteModalOpen;
 export const selectIsWapuuWorldOpen = ( state: RootState ) => state.ui.isWapuuWorldOpen;
+export const selectAiCreditsAdded = ( state: RootState ) => state.ui.aiCreditsAdded;
 
 export default uiSlice.reducer;

--- a/apps/ui/src/components/add-ai-credits-button/index.tsx
+++ b/apps/ui/src/components/add-ai-credits-button/index.tsx
@@ -2,9 +2,8 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import { useState } from 'react';
 import { AiCreditsPurchaseDialog } from '@/components/ai-credits-purchase-dialog';
-import { useConnector } from '@/data/core';
 import { useStudioAssistantTopUpPricing } from '@/data/queries/use-top-up-pricing';
-import { useAddAiCreditsUrlBuilder } from '@/hooks/use-add-ai-credits-url';
+import { useOpenAiCreditsCheckout } from '@/hooks/use-open-ai-credits-checkout';
 import type { ComponentProps } from 'react';
 
 /**
@@ -22,8 +21,7 @@ export function AddAiCreditsButton( {
 	variant?: ComponentProps< typeof Button >[ 'variant' ];
 	tone?: ComponentProps< typeof Button >[ 'tone' ];
 } ) {
-	const connector = useConnector();
-	const buildAddAiCreditsUrl = useAddAiCreditsUrlBuilder();
+	const openCheckout = useOpenAiCreditsCheckout();
 	const { data: pricing } = useStudioAssistantTopUpPricing();
 	const [ dialogOpen, setDialogOpen ] = useState( false );
 	const hasOptions = ( pricing?.options.length ?? 0 ) > 0;
@@ -40,7 +38,7 @@ export function AddAiCreditsButton( {
 						setDialogOpen( true );
 						return;
 					}
-					void connector.openExternalUrl( buildAddAiCreditsUrl() );
+					openCheckout();
 				} }
 			>
 				{ __( 'Add AI credits' ) }

--- a/apps/ui/src/components/ai-credits-details-dialog/index.test.tsx
+++ b/apps/ui/src/components/ai-credits-details-dialog/index.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	clearAiCreditsCheckoutPending,
+	isAiCreditsCheckoutPending,
+} from '@/data/ai-credits-checkout';
+import { useConnector } from '@/data/core';
+import { useAppGlobals } from '@/data/queries/use-app-globals';
+import { AiCreditsDetailsDialog } from './index';
+
+vi.mock( '@/data/core', () => ( { useConnector: vi.fn() } ) );
+vi.mock( '@/data/queries/use-app-globals', () => ( { useAppGlobals: vi.fn() } ) );
+
+describe( 'AiCreditsDetailsDialog', () => {
+	const openExternalUrl = vi.fn();
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		clearAiCreditsCheckoutPending();
+		vi.mocked( useConnector ).mockReturnValue( { openExternalUrl } as never );
+		// A browser tab, where the return is a window focus rather than a
+		// deeplink — so the trip has to be recorded for it to be noticed.
+		vi.mocked( useAppGlobals ).mockReturnValue( { data: { platform: 'browser' } } as never );
+	} );
+
+	it( 'records the trip when the user leaves to buy credits', () => {
+		render( <AiCreditsDetailsDialog open onOpenChange={ vi.fn() } /> );
+
+		fireEvent.click( screen.getByRole( 'link', { name: 'buy more credits' } ) );
+
+		expect( openExternalUrl ).toHaveBeenCalledWith(
+			expect.stringContaining( 'studio-code-ai-credits' )
+		);
+		expect( isAiCreditsCheckoutPending() ).toBe( true );
+	} );
+} );

--- a/apps/ui/src/components/ai-credits-details-dialog/index.tsx
+++ b/apps/ui/src/components/ai-credits-details-dialog/index.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { Dialog } from '@wordpress/ui';
 import { useConnector } from '@/data/core';
 import { useAddAiCreditsUrl } from '@/hooks/use-add-ai-credits-url';
+import { useOpenAiCreditsCheckout } from '@/hooks/use-open-ai-credits-checkout';
 import styles from './style.module.css';
 import type { MouseEvent } from 'react';
 
@@ -13,7 +14,11 @@ export function AiCreditsDetailsDialog( {
 	onOpenChange: ( open: boolean ) => void;
 } ) {
 	const connector = useConnector();
+	// The href is only for the browser's own affordances (middle click, copy
+	// link); the click itself goes through the shared entry point so the trip
+	// to checkout is recorded.
 	const addAiCreditsUrl = useAddAiCreditsUrl();
+	const openCheckout = useOpenAiCreditsCheckout();
 
 	const handleLearnMoreClick = ( event: MouseEvent< HTMLAnchorElement > ) => {
 		event.preventDefault();
@@ -23,7 +28,7 @@ export function AiCreditsDetailsDialog( {
 	};
 	const handleBuyCreditsClick = ( event: MouseEvent< HTMLAnchorElement > ) => {
 		event.preventDefault();
-		void connector.openExternalUrl( addAiCreditsUrl );
+		openCheckout();
 	};
 
 	return (

--- a/apps/ui/src/components/ai-credits-purchase-dialog/index.tsx
+++ b/apps/ui/src/components/ai-credits-purchase-dialog/index.tsx
@@ -6,10 +6,9 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Dialog } from '@wordpress/ui';
 import { useRef, useState, type KeyboardEvent } from 'react';
-import { useConnector } from '@/data/core';
 import { useStudioAssistantTopUpPricing } from '@/data/queries/use-top-up-pricing';
 import { useUserLocale } from '@/data/queries/use-user-locale';
-import { useAddAiCreditsUrlBuilder } from '@/hooks/use-add-ai-credits-url';
+import { useOpenAiCreditsCheckout } from '@/hooks/use-open-ai-credits-checkout';
 import styles from './style.module.css';
 
 /**
@@ -28,9 +27,8 @@ export function AiCreditsPurchaseDialog( {
 	open: boolean;
 	onOpenChange: ( open: boolean ) => void;
 } ) {
-	const connector = useConnector();
 	const locale = useUserLocale();
-	const buildAddAiCreditsUrl = useAddAiCreditsUrlBuilder();
+	const openCheckout = useOpenAiCreditsCheckout();
 	const { data: pricing } = useStudioAssistantTopUpPricing();
 	const options = pricing?.options ?? [];
 	const [ selectedCredits, setSelectedCredits ] = useState< number | null >( null );
@@ -125,7 +123,7 @@ export function AiCreditsPurchaseDialog( {
 							if ( ! selected ) {
 								return;
 							}
-							void connector.openExternalUrl( buildAddAiCreditsUrl( selected.credits ) );
+							openCheckout( selected.credits );
 							onOpenChange( false );
 						} }
 					>

--- a/apps/ui/src/data/ai-credits-checkout.ts
+++ b/apps/ui/src/data/ai-credits-checkout.ts
@@ -1,0 +1,16 @@
+// Raised while the user is away at WordPress.com checkout. This flag is what
+// keeps a window focus honest: without it, credits bought in some other session
+// would surface here as a purchase that never happened in this window.
+let checkoutPending = false;
+
+export function markAiCreditsCheckoutPending(): void {
+	checkoutPending = true;
+}
+
+export function isAiCreditsCheckoutPending(): boolean {
+	return checkoutPending;
+}
+
+export function clearAiCreditsCheckoutPending(): void {
+	checkoutPending = false;
+}

--- a/apps/ui/src/hooks/use-ai-credits-purchase-result.test.tsx
+++ b/apps/ui/src/hooks/use-ai-credits-purchase-result.test.tsx
@@ -1,0 +1,121 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	clearAiCreditsCheckoutPending,
+	markAiCreditsCheckoutPending,
+} from '@/data/ai-credits-checkout';
+import { getVisibleToasts, resetAppMessagesForTests } from '@/data/app-messages';
+import { useAiCreditsPurchaseResult } from './use-ai-credits-purchase-result';
+
+const navigate = vi.fn();
+let onPurchased: () => void = () => undefined;
+const connector = {
+	onAiCreditsPurchased: ( listener: () => void ) => {
+		onPurchased = listener;
+		return () => undefined;
+	},
+};
+
+// The cache the hook reads; each refetch shifts in the next server answer.
+let purchasedRemaining: number | undefined;
+let refetchResults: ( number | undefined )[] = [];
+const refetchQueries = vi.fn( async () => {
+	if ( refetchResults.length > 0 ) {
+		purchasedRemaining = refetchResults.shift();
+	}
+} );
+
+vi.mock( '@tanstack/react-query', () => ( {
+	useQueryClient: () => ( {
+		getQueryData: () => ( { purchasedRemaining } ),
+		refetchQueries,
+	} ),
+} ) );
+vi.mock( '@tanstack/react-router', () => ( { useNavigate: () => navigate } ) );
+vi.mock( '@/data/core', () => ( { useConnector: () => connector } ) );
+vi.mock( '@/data/queries/use-auth-user', () => ( { useAuthUser: () => ( { data: { id: 7 } } ) } ) );
+vi.mock( '@/data/queries/use-user-locale', () => ( { useUserLocale: () => 'en' } ) );
+
+async function flushPoll() {
+	// Long enough to run every attempt and its wait.
+	await vi.advanceTimersByTimeAsync( 20000 );
+}
+
+describe( 'useAiCreditsPurchaseResult', () => {
+	beforeEach( () => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		resetAppMessagesForTests();
+		clearAiCreditsCheckoutPending();
+		purchasedRemaining = 0;
+		refetchResults = [];
+	} );
+
+	afterEach( () => vi.useRealTimers() );
+
+	it( 'confirms a purchase only once the balance grows', async () => {
+		refetchResults = [ 0, 500000 ];
+		renderHook( () => useAiCreditsPurchaseResult() );
+
+		onPurchased();
+		await flushPoll();
+
+		expect( getVisibleToasts() ).toEqual( [
+			expect.objectContaining( {
+				id: 'ai-credits-purchased',
+				intent: 'success',
+				title: '500,000 AI credits added',
+			} ),
+		] );
+	} );
+
+	it( 'stays silent when the balance never grows', async () => {
+		refetchResults = [ 0, 0, 0, 0, 0 ];
+		renderHook( () => useAiCreditsPurchaseResult() );
+
+		onPurchased();
+		await flushPoll();
+
+		expect( getVisibleToasts() ).toEqual( [] );
+		expect( refetchQueries ).toHaveBeenCalledTimes( 5 );
+	} );
+
+	it( 'stays silent without a baseline to prove an increase against', async () => {
+		purchasedRemaining = undefined;
+		refetchResults = [ 500000 ];
+		renderHook( () => useAiCreditsPurchaseResult() );
+
+		onPurchased();
+		await flushPoll();
+
+		expect( getVisibleToasts() ).toEqual( [] );
+	} );
+
+	it( 'ignores a repeated deeplink while a check is already running', async () => {
+		refetchResults = [ 0, 0, 0, 0, 0 ];
+		renderHook( () => useAiCreditsPurchaseResult() );
+
+		onPurchased();
+		onPurchased();
+		await flushPoll();
+
+		expect( refetchQueries ).toHaveBeenCalledTimes( 5 );
+	} );
+
+	it( 'checks on focus only while a checkout is pending', async () => {
+		renderHook( () => useAiCreditsPurchaseResult() );
+
+		window.dispatchEvent( new Event( 'focus' ) );
+		await flushPoll();
+		expect( refetchQueries ).not.toHaveBeenCalled();
+
+		markAiCreditsCheckoutPending();
+		refetchResults = [ 500000 ];
+		window.dispatchEvent( new Event( 'focus' ) );
+		await flushPoll();
+
+		expect( getVisibleToasts() ).toEqual( [
+			expect.objectContaining( { title: '500,000 AI credits added' } ),
+		] );
+	} );
+} );

--- a/apps/ui/src/hooks/use-ai-credits-purchase-result.ts
+++ b/apps/ui/src/hooks/use-ai-credits-purchase-result.ts
@@ -1,0 +1,97 @@
+import {
+	AI_CREDITS_CONFIRM_ATTEMPTS,
+	AI_CREDITS_CONFIRM_INTERVAL_MS,
+	formatAiCreditsAddedTitle,
+} from '@studio/common/lib/studio-assistant-quota';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useEffect, useRef } from 'react';
+import {
+	clearAiCreditsCheckoutPending,
+	isAiCreditsCheckoutPending,
+} from '@/data/ai-credits-checkout';
+import { toast } from '@/data/app-messages';
+import { useConnector } from '@/data/core';
+import { ASSISTANT_QUOTA_QUERY_KEY } from '@/data/queries/use-assistant-quota';
+import { useAuthUser } from '@/data/queries/use-auth-user';
+import { useUserLocale } from '@/data/queries/use-user-locale';
+import type { StudioAssistantQuota } from '@studio/common/lib/studio-assistant-quota';
+
+// One id for every outcome, so a repeated deeplink replaces the toast in place
+// rather than stacking a second copy of the same news.
+const PURCHASE_TOAST_ID = 'ai-credits-purchased';
+
+/**
+ * Confirms an AI credits top-up after the user comes back from WordPress.com.
+ *
+ * Only a balance that actually grew counts as a purchase — returning is not
+ * evidence of one, and a cancelled checkout returns exactly like a completed
+ * one. Every other outcome (cancelled, still pending past the poll, failed
+ * purchase, failed refresh) is silent: a "didn't work" message after a
+ * deliberate cancel is noise, and the balance on screen stays whatever the
+ * last good fetch reported.
+ */
+export function useAiCreditsPurchaseResult(): void {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	const navigate = useNavigate();
+	const locale = useUserLocale();
+	const { data: authUser } = useAuthUser();
+	const userId = authUser?.id;
+	const runningRef = useRef( false );
+
+	const confirmPurchase = useCallback( async () => {
+		if ( runningRef.current ) {
+			return;
+		}
+		runningRef.current = true;
+		const queryKey = [ ...ASSISTANT_QUOTA_QUERY_KEY, userId ];
+		const readPurchased = () =>
+			queryClient.getQueryData< StudioAssistantQuota >( queryKey )?.purchasedRemaining;
+		// Without a figure from before the trip there is nothing to prove an
+		// increase against, so the balance still refreshes but no claim is made.
+		const before = readPurchased();
+		try {
+			for ( let attempt = 0; attempt < AI_CREDITS_CONFIRM_ATTEMPTS; attempt++ ) {
+				if ( attempt > 0 ) {
+					await new Promise( ( resolve ) => setTimeout( resolve, AI_CREDITS_CONFIRM_INTERVAL_MS ) );
+				}
+				await queryClient.refetchQueries( { queryKey } );
+				const after = readPurchased();
+				if ( before === undefined || after === undefined || after <= before ) {
+					continue;
+				}
+				toast.success( formatAiCreditsAddedTitle( after - before, locale ), {
+					id: PURCHASE_TOAST_ID,
+					action: {
+						label: __( 'View usage' ),
+						onClick: () => void navigate( { to: '/settings', search: { tab: 'usage' } } ),
+					},
+				} );
+				return;
+			}
+		} finally {
+			clearAiCreditsCheckoutPending();
+			runningRef.current = false;
+		}
+	}, [ locale, navigate, queryClient, userId ] );
+
+	useEffect(
+		() => connector.onAiCreditsPurchased( () => void confirmPurchase() ),
+		[ connector, confirmPurchase ]
+	);
+
+	// The other end of the same trip: a browser tab can't receive the
+	// wp-studio:// return at all, and on desktop the user may close the checkout
+	// tab by hand instead of clicking through.
+	useEffect( () => {
+		const handleFocus = () => {
+			if ( isAiCreditsCheckoutPending() ) {
+				void confirmPurchase();
+			}
+		};
+		window.addEventListener( 'focus', handleFocus );
+		return () => window.removeEventListener( 'focus', handleFocus );
+	}, [ confirmPurchase ] );
+}

--- a/apps/ui/src/hooks/use-app-menu-navigation.test.tsx
+++ b/apps/ui/src/hooks/use-app-menu-navigation.test.tsx
@@ -2,7 +2,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConnector } from '@/data/core';
-import { ASSISTANT_QUOTA_QUERY_KEY } from '@/data/queries/use-assistant-quota';
 import { pendingBlueprintSlot } from '@/lib/pending-blueprint';
 import { useAppMenuNavigation } from './use-app-menu-navigation';
 import type { ReactNode } from 'react';
@@ -11,7 +10,6 @@ const navigate = vi.fn( async () => undefined );
 const showErrorMessageBox = vi.fn();
 let addSiteListener: () => void = () => undefined;
 let blueprintListener: ( payload: { blueprintPath: string } ) => void = () => undefined;
-let aiCreditsPurchasedListener: () => void = () => undefined;
 
 let queryClient: QueryClient;
 
@@ -55,10 +53,6 @@ describe( 'useAppMenuNavigation', () => {
 				return () => undefined;
 			} ),
 			onOpenSettings: vi.fn( () => () => undefined ),
-			onAiCreditsPurchased: vi.fn( ( listener ) => {
-				aiCreditsPurchasedListener = listener;
-				return () => undefined;
-			} ),
 			readBlueprintFile,
 		} );
 	} );
@@ -85,16 +79,6 @@ describe( 'useAppMenuNavigation', () => {
 			title: 'Deep-linked Blueprint',
 			file: { name: 'deep-link.json' },
 		} );
-	} );
-
-	it( 'opens the usage settings and refreshes the balance after a credits purchase', () => {
-		renderAppMenuNavigation();
-		const invalidateQueries = vi.spyOn( queryClient, 'invalidateQueries' );
-
-		act( () => aiCreditsPurchasedListener() );
-
-		expect( invalidateQueries ).toHaveBeenCalledWith( { queryKey: ASSISTANT_QUOTA_QUERY_KEY } );
-		expect( navigate ).toHaveBeenCalledWith( { to: '/settings', search: { tab: 'usage' } } );
 	} );
 
 	it( 'shows an error when a Blueprint deep link cannot be read', async () => {

--- a/apps/ui/src/hooks/use-app-menu-navigation.ts
+++ b/apps/ui/src/hooks/use-app-menu-navigation.ts
@@ -1,16 +1,13 @@
-import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { useConnector } from '@/data/core';
-import { ASSISTANT_QUOTA_QUERY_KEY } from '@/data/queries/use-assistant-quota';
 import { createSelectedBlueprint } from '@/lib/blueprint-selection';
 import { pendingBlueprintSlot } from '@/lib/pending-blueprint';
 
 export function useAppMenuNavigation() {
 	const connector = useConnector();
 	const navigate = useNavigate();
-	const queryClient = useQueryClient();
 
 	useEffect(
 		() => connector.onAddSite( () => void navigate( { to: '/onboarding' } ) ),
@@ -58,16 +55,5 @@ export function useAppMenuNavigation() {
 	useEffect(
 		() => connector.onOpenSettings( () => void navigate( { to: '/settings' } ) ),
 		[ connector, navigate ]
-	);
-	// Returning from the AI credits checkout. The quota is cached for five
-	// minutes and an Electron window behind the browser never fires the focus
-	// refetch, so show the new balance by invalidating it explicitly.
-	useEffect(
-		() =>
-			connector.onAiCreditsPurchased( () => {
-				void queryClient.invalidateQueries( { queryKey: ASSISTANT_QUOTA_QUERY_KEY } );
-				void navigate( { to: '/settings', search: { tab: 'usage' } } );
-			} ),
-		[ connector, navigate, queryClient ]
 	);
 }

--- a/apps/ui/src/hooks/use-open-ai-credits-checkout.test.tsx
+++ b/apps/ui/src/hooks/use-open-ai-credits-checkout.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	clearAiCreditsCheckoutPending,
+	isAiCreditsCheckoutPending,
+} from '@/data/ai-credits-checkout';
+import { useOpenAiCreditsCheckout } from './use-open-ai-credits-checkout';
+
+const openExternalUrl = vi.fn();
+
+vi.mock( '@/data/core', () => ( { useConnector: () => ( { openExternalUrl } ) } ) );
+vi.mock( '@/hooks/use-add-ai-credits-url', () => ( {
+	useAddAiCreditsUrlBuilder: () => ( credits?: number ) =>
+		`https://checkout.test/${ credits ?? 'default' }`,
+} ) );
+
+describe( 'useOpenAiCreditsCheckout', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		clearAiCreditsCheckoutPending();
+	} );
+
+	it( 'opens checkout for the chosen amount', () => {
+		const { result } = renderHook( () => useOpenAiCreditsCheckout() );
+
+		result.current( 500000 );
+
+		expect( openExternalUrl ).toHaveBeenCalledWith( 'https://checkout.test/500000' );
+	} );
+
+	it( 'records the trip so the return has something to check against', () => {
+		const { result } = renderHook( () => useOpenAiCreditsCheckout() );
+		expect( isAiCreditsCheckoutPending() ).toBe( false );
+
+		result.current();
+
+		expect( isAiCreditsCheckoutPending() ).toBe( true );
+	} );
+} );

--- a/apps/ui/src/hooks/use-open-ai-credits-checkout.ts
+++ b/apps/ui/src/hooks/use-open-ai-credits-checkout.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+import { markAiCreditsCheckoutPending } from '@/data/ai-credits-checkout';
+import { useConnector } from '@/data/core';
+import { useAddAiCreditsUrlBuilder } from '@/hooks/use-add-ai-credits-url';
+
+/**
+ * Opens WordPress.com checkout for a credits top-up and records that the user
+ * has gone there. Every purchase entry point goes through here, so whichever
+ * way the user comes back — the deeplink on desktop, a window focus in a
+ * browser tab — the return has a trip to reconcile against.
+ */
+export function useOpenAiCreditsCheckout(): ( credits?: number ) => void {
+	const connector = useConnector();
+	const buildAddAiCreditsUrl = useAddAiCreditsUrlBuilder();
+	return useCallback(
+		( credits?: number ) => {
+			markAiCreditsCheckoutPending();
+			void connector.openExternalUrl( buildAddAiCreditsUrl( credits ) );
+		},
+		[ connector, buildAddAiCreditsUrl ]
+	);
+}

--- a/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/ai-credits-control.tsx
@@ -8,19 +8,17 @@ import { useState } from 'react';
 import { AiCreditsDetailsDialog } from '@/components/ai-credits-details-dialog';
 import { AiCreditsPurchaseDialog } from '@/components/ai-credits-purchase-dialog';
 import * as Menu from '@/components/menu';
-import { useConnector } from '@/data/core';
 import {
 	ASSISTANT_QUOTA_QUERY_KEY,
 	useStudioAssistantQuota,
 } from '@/data/queries/use-assistant-quota';
 import { useStudioAssistantTopUpPricing } from '@/data/queries/use-top-up-pricing';
 import { useUserLocale } from '@/data/queries/use-user-locale';
-import { useAddAiCreditsUrl } from '@/hooks/use-add-ai-credits-url';
+import { useOpenAiCreditsCheckout } from '@/hooks/use-open-ai-credits-checkout';
 import styles from './style.module.css';
 
 export function AiCreditsControl() {
-	const connector = useConnector();
-	const addAiCreditsUrl = useAddAiCreditsUrl();
+	const openCheckout = useOpenAiCreditsCheckout();
 	const locale = useUserLocale();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
@@ -106,7 +104,7 @@ export function AiCreditsControl() {
 								setPurchaseOpen( true );
 								return;
 							}
-							void connector.openExternalUrl( addAiCreditsUrl );
+							openCheckout();
 						} }
 					>
 						{ __( 'Add AI credits' ) }

--- a/apps/ui/src/ui-classic/router/layout-root/index.tsx
+++ b/apps/ui/src/ui-classic/router/layout-root/index.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef } from 'react';
 import { useConnector } from '@/data/core';
 import { SESSIONS_QUERY_KEY } from '@/data/queries/use-sessions';
 import { SITES_QUERY_KEY } from '@/data/queries/use-sites';
+import { useAiCreditsPurchaseResult } from '@/hooks/use-ai-credits-purchase-result';
 import { useAppMenuNavigation } from '@/hooks/use-app-menu-navigation';
 import { WapuuWorldMount } from '@/ui-classic/components/wapuu-world';
 import type { AiSessionSummary, Connector, SiteDetails } from '@/data/core';
@@ -18,6 +19,11 @@ export interface RouterContext {
 
 function AppMenuNavigation() {
 	useAppMenuNavigation();
+	return null;
+}
+
+function AiCreditsPurchaseResult() {
+	useAiCreditsPurchaseResult();
 	return null;
 }
 
@@ -83,6 +89,7 @@ export const rootRoute = createRootRouteWithContext< RouterContext >()( {
 	component: () => (
 		<>
 			<AppMenuNavigation />
+			<AiCreditsPurchaseResult />
 			<DeletedSiteRedirect />
 			<WapuuWorldMount />
 			<Outlet />

--- a/packages/common/lib/studio-assistant-quota.ts
+++ b/packages/common/lib/studio-assistant-quota.ts
@@ -415,3 +415,17 @@ export function formatOutOfCreditsTitle(): string {
 export function formatOutOfCreditsDescription(): string {
 	return __( 'You’ve used your available AI credits. Add more to keep chatting.' );
 }
+
+// Crediting can trail the checkout redirect by a second or two, so a single
+// refetch would report "nothing bought" for a purchase about to land.
+export const AI_CREDITS_CONFIRM_ATTEMPTS = 5;
+export const AI_CREDITS_CONFIRM_INTERVAL_MS = 2000;
+
+/** Confirmation shown once a top-up is proven to have reached the balance. */
+export function formatAiCreditsAddedTitle( credits: number, locale?: string ): string {
+	return sprintf(
+		/* translators: %s: number of AI credits the purchase added (e.g. 500,000). */
+		__( '%s AI credits added' ),
+		new Intl.NumberFormat( locale ).format( credits )
+	);
+}

--- a/packages/common/lib/tests/studio-assistant-quota.test.ts
+++ b/packages/common/lib/tests/studio-assistant-quota.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	formatAiAccessRequiredNotice,
+	formatAiCreditsAddedTitle,
 	formatAiCreditsAvailableLabel,
 	formatAiCreditsCallout,
 	formatAiCreditsUsedLabel,
@@ -322,5 +323,12 @@ describe( 'formatAiCreditsCallout', () => {
 		expect( formatAiCreditsCallout( neverBought, { fraction: 1 } ) ).toBe(
 			'Your next idea is ready when you are. Top up to bring it to life.'
 		);
+	} );
+} );
+
+describe( 'formatAiCreditsAddedTitle', () => {
+	it( 'formats the added credits for the locale', () => {
+		expect( formatAiCreditsAddedTitle( 500000, 'en' ) ).toBe( '500,000 AI credits added' );
+		expect( formatAiCreditsAddedTitle( 500000, 'de' ) ).toBe( '500.000 AI credits added' );
 	} );
 } );


### PR DESCRIPTION
## Related issues

- Related to STU-2338 — this is the purchase-result half. The usage notices are in #4722.
- Design exploration: #4446

## How AI was used in this PR

I used Opus 5 for implementation and tests.

## Proposed Changes

Returning from WordPress.com checkout currently just shows the Settings page, which might throw the user out of the conversation flow. Also, a canceled checkout does the same.

This PR waits for the balance to actually grow, then shows a toast in the Agentic UI, or a card above the composer in Classic, acknowleding the top-up. It also updates cancelling to be silent.

The copy is the wording from the exploration in #4446. One thing it did not have: a `View usage` action on the toast. @shaunandrews — worth a look, along with staying silent after a cancel.

## Testing Instructions

Use the balance setup steps in 236947-ghe-Automattic/wpcom.

- Buy the smallest top-up from **Add AI credits**. Confirm you stay where you were, and one toast reads `N AI credits added`. `View usage` opens Settings → Usage.
- Start checkout and cancel it. Confirm no message appears, and that you are not moved to Settings.
- Repeat the purchase in Classic. The confirmation is a card above the composer, and it clears itself after 8 seconds.

| State | Light | Dark |
|--------|--------|---|
| Agentic UI success | <img width="276" height="158" alt="image" src="https://github.com/user-attachments/assets/7e1e579d-0b25-4d2c-8e19-23e8d81c24dd" /> | same as light |
| Classic UI success | <img width="1570" height="416" alt="CleanShot 2026-09-02 at 16 20 18@2x" src="https://github.com/user-attachments/assets/3f9dca7a-ef6a-46c4-9119-b89282602098" /> | <img width="1570" height="416" alt="CleanShot 2026-09-02 at 16 20 25@2x" src="https://github.com/user-attachments/assets/327c354c-3965-4a5a-a0ac-9aff8b4b6cec" /> |

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

> ⚠️ Visual change: the Classic card needs a human review in light + dark mode.
