### PR TITLE
Design exploration: Clarify Agentic UI site settings

### DIFF
--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -67,6 +67,15 @@ import {
 	updateSharedConfig,
 	updateSharedSession,
 } from '@studio/common/lib/shared-config';
+import {
+	getSiteFileAccess,
+	SITE_FILE_ACCESS_SITE_DIRECTORY,
+} from '@studio/common/lib/site-file-access';
+import {
+	getSiteRuntime,
+	siteModeFromRuntime,
+	SITE_RUNTIME_PLAYGROUND,
+} from '@studio/common/lib/site-runtime';
 import { fetchStudioAssistantQuota } from '@studio/common/lib/studio-assistant-quota';
 import { fetchStudioAssistantTopUpPricing } from '@studio/common/lib/studio-assistant-top-up-pricing';
 import { isSyncCancelledError } from '@studio/common/lib/sync/cancel';
@@ -186,6 +195,8 @@ function toSiteDetails( site: SiteListItem, sortOrder?: number ) {
 		running: site.running,
 		url: site.url,
 		phpVersion: site.phpVersion,
+		runtime: site.runtime,
+		fileAccess: site.fileAccess,
 		customDomain: site.customDomain,
 		enableHttps: site.enableHttps,
 		adminUsername: site.adminUsername,
@@ -875,7 +886,7 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 
 	// Edit a site's settings — the same CLI `site set` the desktop uses, built
 	// from the shared arg builder. Mirrors the desktop's diff: only changed
-	// fields are forwarded (the agentic UI doesn't edit runtime/file-access).
+	// fields are forwarded.
 	api.post(
 		'/sites/:id/update',
 		asyncHandler( async ( req: Request, res: Response ) => {
@@ -905,6 +916,19 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 			}
 			if ( updated.phpVersion !== undefined && updated.phpVersion !== current.phpVersion ) {
 				options.php = updated.phpVersion;
+			}
+			const currentRuntime = getSiteRuntime( current );
+			const updatedRuntime = getSiteRuntime( updated );
+			if ( updated.runtime !== undefined && updatedRuntime !== currentRuntime ) {
+				options.runtime = siteModeFromRuntime( updatedRuntime );
+			}
+			const currentFileAccess = getSiteFileAccess( current );
+			const updatedFileAccess =
+				updatedRuntime === SITE_RUNTIME_PLAYGROUND
+					? SITE_FILE_ACCESS_SITE_DIRECTORY
+					: getSiteFileAccess( updated );
+			if ( updated.fileAccess !== undefined && updatedFileAccess !== currentFileAccess ) {
+				options.fileAccess = updatedFileAccess;
 			}
 			if ( wpVersion ) {
 				options.wp = isWordPressDevVersion( wpVersion ) ? 'nightly' : wpVersion;

--- a/apps/ui/src/components/site-fields/index.ts
+++ b/apps/ui/src/components/site-fields/index.ts
@@ -113,6 +113,7 @@ export function wpVersionField< T extends { wpVersion: string } >(
 				value: version.value,
 				label: version.label,
 				group: 'prerelease' as const,
+				current: version.value === currentVersion,
 			} ) );
 		let stable: WpVersionOption[] = offers
 			.filter(
@@ -123,6 +124,7 @@ export function wpVersionField< T extends { wpVersion: string } >(
 				value: version.value,
 				label: version.label,
 				group: 'stable' as const,
+				current: version.value === currentVersion,
 			} ) );
 		// The site's installed version may predate the fetched offers — keep it
 		// selectable, sorted into the right group, like the legacy selector's
@@ -132,6 +134,7 @@ export function wpVersionField< T extends { wpVersion: string } >(
 				value: currentVersion,
 				label: currentVersion,
 				group: 'stable',
+				current: true,
 			};
 			if ( isWordPressBetaVersion( currentVersion ) || isWordPressDevVersion( currentVersion ) ) {
 				prerelease = addVersionOption( { ...option, group: 'prerelease' }, prerelease );

--- a/apps/ui/src/components/site-fields/style.module.css
+++ b/apps/ui/src/components/site-fields/style.module.css
@@ -9,3 +9,27 @@
 	flex-shrink: 0;
 	fill: currentColor;
 }
+
+.updateModeControl {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-sm);
+	min-inline-size: 0;
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.updateModeControl :global(.components-radio-control) {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-lg);
+}
+
+.updateModeControl :global(.components-radio-control__option-description) {
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.pinnedVersionSelect {
+	width: min(180px, 100%);
+}

--- a/apps/ui/src/components/site-fields/wp-version-control.tsx
+++ b/apps/ui/src/components/site-fields/wp-version-control.tsx
@@ -1,5 +1,5 @@
-import { SelectControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { BaseControl, SelectControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import { Tooltip } from '@wordpress/ui';
 import { useState } from 'react';
@@ -21,6 +21,7 @@ const offlineIcon = (
 export type WpVersionOption = Option & {
 	group: 'latest' | 'prerelease' | 'stable';
 	hidden?: boolean;
+	current?: boolean;
 };
 
 /**
@@ -42,30 +43,51 @@ export function WpVersionControl< Item >( {
 	const value = field.getValue( { item: data } ) ?? '';
 	const disabled = field.isDisabled( { item: data, field } );
 	const options = ( field.elements ?? [] ) as WpVersionOption[];
+	const autoUpdateOption = options.find(
+		( option ) => option.group === 'latest' && ! option.hidden
+	);
+	const pinnedOptions = options.filter(
+		( option ) => option.group !== 'latest' && ! option.hidden
+	);
+	const currentVersion = pinnedOptions.find( ( option ) => option.current );
+	const usesUpdateModeControl = autoUpdateOption?.value === '';
+	const automaticUpdates = value === autoUpdateOption?.value;
+	const modeControlName = `${ String( field.id ) }-update-mode`;
 	const groups = [
 		{
+			key: 'latest',
 			label: __( 'Auto-updating' ),
 			options: options.filter( ( option ) => option.group === 'latest' ),
 		},
 		{
+			key: 'prerelease',
 			label: __( 'Beta & Nightly' ),
 			options: options.filter( ( option ) => option.group === 'prerelease' ),
 		},
 		{
+			key: 'stable',
 			label: __( 'Stable Versions' ),
 			options: options.filter( ( option ) => option.group === 'stable' ),
 		},
-	].filter( ( group ) => group.options.length > 0 );
+	].filter(
+		( group ) => group.options.length > 0 && ( ! usesUpdateModeControl || group.key !== 'latest' )
+	);
 
-	const select = (
+	const updateValue = ( newValue: string ) =>
+		onChange( field.setValue( { item: data, value: newValue } ) );
+	const selectedVersion =
+		usesUpdateModeControl && automaticUpdates
+			? currentVersion?.value ?? pinnedOptions[ 0 ]?.value ?? value
+			: value;
+	const versionSelect = (
 		<SelectControl
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
-			label={ field.label }
-			hideLabelFromVision={ hideLabelFromVision }
-			value={ value }
+			label={ usesUpdateModeControl ? __( 'Version' ) : field.label }
+			hideLabelFromVision={ usesUpdateModeControl ? true : hideLabelFromVision }
+			value={ selectedVersion }
 			disabled={ disabled }
-			onChange={ ( newValue ) => onChange( field.setValue( { item: data, value: newValue } ) ) }
+			onChange={ updateValue }
 		>
 			{ groups.map( ( group ) => (
 				<optgroup key={ group.label } label={ group.label }>
@@ -77,6 +99,74 @@ export function WpVersionControl< Item >( {
 				</optgroup>
 			) ) }
 		</SelectControl>
+	);
+	const control = usesUpdateModeControl ? (
+		<BaseControl
+			__nextHasNoMarginBottom
+			label={ field.label }
+			hideLabelFromVision={ hideLabelFromVision }
+		>
+			<fieldset className={ styles.updateModeControl } disabled={ disabled }>
+				<div className="components-radio-control">
+					<div className="components-radio-control__option">
+						<input
+							id={ `${ modeControlName }-automatic` }
+							className="components-radio-control__input"
+							type="radio"
+							name={ modeControlName }
+							value="automatic"
+							checked={ automaticUpdates }
+							onChange={ () => {
+								if ( autoUpdateOption ) updateValue( autoUpdateOption.value );
+							} }
+						/>
+						<label
+							htmlFor={ `${ modeControlName }-automatic` }
+							className="components-radio-control__label"
+						>
+							{ __( 'Automatic updates' ) }
+						</label>
+						<p className="components-radio-control__option-description">
+							{ currentVersion
+								? sprintf(
+										/* translators: %s: currently installed WordPress version. */
+										__(
+											'WordPress installs updates on its own schedule. Currently using version %s.'
+										),
+										currentVersion.label
+								  )
+								: __( 'WordPress installs updates on its own schedule.' ) }
+						</p>
+					</div>
+					<div className="components-radio-control__option">
+						<input
+							id={ `${ modeControlName }-pinned` }
+							className="components-radio-control__input"
+							type="radio"
+							name={ modeControlName }
+							value="pinned"
+							checked={ ! automaticUpdates }
+							onChange={ () =>
+								updateValue( currentVersion?.value ?? pinnedOptions[ 0 ]?.value ?? value )
+							}
+						/>
+						<label
+							htmlFor={ `${ modeControlName }-pinned` }
+							className="components-radio-control__label"
+						>
+							{ __( 'Select a version' ) }
+						</label>
+						<div
+							className={ `${ styles.pinnedVersionSelect } components-radio-control__option-description` }
+						>
+							{ versionSelect }
+						</div>
+					</div>
+				</div>
+			</fieldset>
+		</BaseControl>
+	) : (
+		versionSelect
 	);
 
 	if ( disabled && field.description ) {
@@ -96,7 +186,7 @@ export function WpVersionControl< Item >( {
 							onMouseEnter={ () => setShowTooltip( true ) }
 							onMouseLeave={ () => setShowTooltip( false ) }
 						>
-							<div style={ { pointerEvents: 'none' } }>{ select }</div>
+							<div style={ { pointerEvents: 'none' } }>{ control }</div>
 						</div>
 					}
 				/>
@@ -110,5 +200,5 @@ export function WpVersionControl< Item >( {
 			</Tooltip.Root>
 		);
 	}
-	return select;
+	return control;
 }

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -445,7 +445,7 @@ describe( 'SiteOverviewView', () => {
 	it( 'keeps the admin password visibility toggle', () => {
 		renderView( 'general' );
 
-		const password = screen.getByLabelText( 'Admin password' );
+		const password = screen.getByLabelText( 'Password' );
 		const showPassword = screen.getByRole( 'button', { name: 'Show password' } );
 		const copyPassword = screen.getByRole( 'button', { name: 'Copy admin password' } );
 		expect( password ).toHaveAttribute( 'type', 'password' );
@@ -463,33 +463,35 @@ describe( 'SiteOverviewView', () => {
 		renderView( 'general' );
 
 		expect( screen.getByLabelText( 'Site name' ) ).toBeRequired();
-		expect( screen.getByLabelText( 'Admin username' ) ).toBeRequired();
-		expect( screen.getByLabelText( 'Admin password' ) ).toBeRequired();
-		expect( screen.getByLabelText( 'Admin email' ) ).toBeRequired();
+		expect( screen.getByLabelText( 'Username' ) ).toBeRequired();
+		expect( screen.getByLabelText( 'Password' ) ).toBeRequired();
+		expect( screen.getByLabelText( 'Email' ) ).toBeRequired();
 		expect( screen.queryByText( /\(Required\)/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'marks the admin email control for RTL alignment', () => {
 		renderView( 'general' );
 
+		expect( screen.getByLabelText( 'Email' ).closest( '.components-input-control' ) ).toHaveClass(
+			settingsStyles.emailControl
+		);
 		expect(
-			screen.getByLabelText( 'Admin email' ).closest( '.components-input-control' )
-		).toHaveClass( settingsStyles.emailControl );
-		expect(
-			screen.getByLabelText( 'Admin username' ).closest( '.components-input-control' )
+			screen.getByLabelText( 'Username' ).closest( '.components-input-control' )
 		).not.toHaveClass( settingsStyles.emailControl );
 	} );
 
-	it( 'renders the WordPress version dropdown with latest preselected for auto-updating sites', () => {
+	it( 'shows automatic updates with the installed version and a separate version picker', () => {
 		useWordPressVersionsMock.mockReturnValue( { data: WP_VERSIONS } );
+		useWpVersionMock.mockReturnValue( { data: '6.8' } );
 
 		renderView( 'general' );
 
-		const select = screen.getByLabelText( 'WordPress version' );
+		const select = screen.getByLabelText( 'Version' );
 		expect( select.tagName ).toBe( 'SELECT' );
-		expect( select ).toHaveValue( '' );
+		expect( select ).toHaveValue( '6.8' );
+		expect( screen.getByRole( 'radio', { name: 'Automatic updates' } ) ).toBeChecked();
+		expect( screen.getByText( /Currently using version 6\.8\./ ) ).toBeVisible();
 		expect( screen.getByRole( 'option', { name: '6.7.2' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'group', { name: 'Auto-updating' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'group', { name: 'Stable Versions' } ) ).toBeInTheDocument();
 	} );
 
@@ -500,7 +502,7 @@ describe( 'SiteOverviewView', () => {
 
 		renderView( 'general' );
 
-		fireEvent.change( screen.getByLabelText( 'WordPress version' ), {
+		fireEvent.change( screen.getByLabelText( 'Version' ), {
 			target: { value: '6.7.2' },
 		} );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Save settings' } ) );
@@ -524,7 +526,7 @@ describe( 'SiteOverviewView', () => {
 
 		renderView( 'general' );
 
-		const select = screen.getByLabelText( 'WordPress version' );
+		const select = screen.getByLabelText( 'Version' );
 		expect( select ).toHaveValue( '6.5.2' );
 		expect( screen.getByRole( 'option', { name: '6.5.2' } ) ).toBeInTheDocument();
 	} );
@@ -569,7 +571,7 @@ describe( 'SiteOverviewView', () => {
 
 		const { showSite } = renderView( 'general' );
 
-		fireEvent.change( screen.getByLabelText( 'WordPress version' ), {
+		fireEvent.change( screen.getByLabelText( 'Version' ), {
 			target: { value: '6.7.2' },
 		} );
 
@@ -580,7 +582,7 @@ describe( 'SiteOverviewView', () => {
 		} );
 		showSite( 'site-1' );
 
-		expect( screen.getByLabelText( 'WordPress version' ) ).toHaveValue( '6.7.2' );
+		expect( screen.getByLabelText( 'Version' ) ).toHaveValue( '6.7.2' );
 	} );
 
 	it( 'keeps a pinned site pinned when saving other settings while offline', () => {
@@ -612,9 +614,9 @@ describe( 'SiteOverviewView', () => {
 	it( 'keeps the version field a dropdown when the version list is unavailable', () => {
 		renderView( 'general' );
 
-		const select = screen.getByLabelText( 'WordPress version' );
+		const select = screen.getByLabelText( 'Version' );
 		expect( select.tagName ).toBe( 'SELECT' );
-		expect( select ).toHaveValue( '' );
+		expect( screen.getByRole( 'radio', { name: 'Automatic updates' } ) ).toBeChecked();
 	} );
 
 	// Offline only blocks *changing* the version, so the field stays on the
@@ -629,7 +631,7 @@ describe( 'SiteOverviewView', () => {
 
 		renderView( 'general' );
 
-		const select = screen.getByLabelText( 'WordPress version' );
+		const select = screen.getByLabelText( 'Version' );
 		expect( select.tagName ).toBe( 'SELECT' );
 		expect( select ).toBeDisabled();
 		expect( select ).toHaveValue( '6.5.2' );
@@ -651,6 +653,7 @@ describe( 'SiteOverviewView', () => {
 		const updateSiteMutate = vi.fn();
 		useUpdateSiteMock.mockReturnValue( { isPending: false, mutate: updateSiteMutate } );
 		useWordPressVersionsMock.mockReturnValue( { data: WP_VERSIONS } );
+		useWpVersionMock.mockReturnValue( { data: '6.8' } );
 		useSitesMock.mockReturnValue( {
 			data: [ createSite( { running: true, isWpAutoUpdating: false } ) ],
 			isLoading: false,
@@ -658,10 +661,9 @@ describe( 'SiteOverviewView', () => {
 
 		renderView( 'general' );
 
-		const select = screen.getByLabelText( 'WordPress version' );
-		expect( select ).toHaveValue( 'latest' );
+		expect( screen.getByRole( 'radio', { name: 'Select a version' } ) ).toBeChecked();
 
-		fireEvent.change( select, { target: { value: '' } } );
+		fireEvent.click( screen.getByRole( 'radio', { name: 'Automatic updates' } ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Save settings' } ) );
 
 		// 'latest' has to reach the CLI so it actually installs the newest

--- a/apps/ui/src/components/site-overview-view/index.tsx
+++ b/apps/ui/src/components/site-overview-view/index.tsx
@@ -265,6 +265,9 @@ function SiteOverviewBody( {
 	const navigate = useNavigate();
 	const connector = useConnector();
 	const [ deleteOpen, setDeleteOpen ] = useState( false );
+	const [ footerActionsElement, setFooterActionsElement ] = useState< HTMLDivElement | null >(
+		null
+	);
 	const importInputRef = useRef< HTMLInputElement >( null );
 	const backupImport = useSiteBackupImport( site );
 	const managementActions = useSiteManagementActions( site, {
@@ -274,6 +277,7 @@ function SiteOverviewBody( {
 	const themeStatus = useThemeDetails( site );
 	const themeDetails = themeStatus.state === 'ready' ? themeStatus.details : undefined;
 	const busy = useIsSiteBusy( site );
+	const sidebarCollapsed = useSidebarCollapsed();
 	const isBlockTheme = themeDetails?.isBlockTheme === true;
 	const { data: wpVersion } = useWpVersion( site.id );
 
@@ -466,13 +470,25 @@ function SiteOverviewBody( {
 									</ButtonSection>
 								</div>
 							</Tabs.Panel>
-							<SiteSettingsForm site={ site } activeTab={ activeTab } />
+							<SiteSettingsForm
+								site={ site }
+								activeTab={ activeTab }
+								footerActionsElement={ footerActionsElement }
+							/>
 						</main>
 					</div>
 				</Tabs.Root>
 			</div>
-			<ProgressiveBlur direction="up" className={ styles.footerBlur } />
+			<ProgressiveBlur direction="up" className={ styles.footerBlur } fadeToSurface />
 			<div className={ styles.footerBar }>
+				<div
+					ref={ setFooterActionsElement }
+					className={
+						sidebarCollapsed
+							? `${ styles.footerActions } ${ styles.footerActionsSidebarCollapsed }`
+							: styles.footerActions
+					}
+				/>
 				<PreviewToggleButton />
 			</div>
 			<input

--- a/apps/ui/src/components/site-overview-view/style.module.css
+++ b/apps/ui/src/components/site-overview-view/style.module.css
@@ -1,6 +1,9 @@
 .root {
 	--overview-content-width: 1120px;
 	--overview-card-column-width: 320px;
+	--overview-footer-height: calc(
+		40px + var(--wpds-dimension-padding-sm) + var(--wpds-dimension-padding-lg)
+	);
 
 	/* Anchor for the footer toolbar + its progressive blur. */
 	position: relative;
@@ -104,14 +107,25 @@
 	display: flex;
 	align-items: center;
 	justify-content: flex-end;
-	min-height: 46px;
+	min-height: var(--overview-footer-height);
 	box-sizing: border-box;
-	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-xl);
+	padding-block: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-lg);
+	padding-inline: var(--wpds-dimension-padding-xl);
 	pointer-events: none;
 }
 
 .footerBar > * {
 	pointer-events: auto;
+}
+
+.footerActions {
+	display: flex;
+	align-items: center;
+	margin-inline-end: auto;
+}
+
+.footerActionsSidebarCollapsed {
+	margin-inline-start: calc(40px + var(--wpds-dimension-padding-md));
 }
 
 /* Shorter sibling of the chat panel's composer blur: just the toolbar strip
@@ -121,7 +135,7 @@
 	inset-inline-end: 14px;
 	bottom: 0;
 	z-index: 1;
-	height: calc(46px + var(--wpds-dimension-padding-lg));
+	height: calc(var(--overview-footer-height) + var(--wpds-dimension-padding-3xl));
 }
 
 .content {
@@ -134,7 +148,7 @@
 	/* Extra bottom padding keeps the last content clear of the overlaid
 	   footer toolbar. */
 	padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-xl)
-		calc(var(--wpds-dimension-padding-2xl) + 46px);
+		calc(var(--wpds-dimension-padding-2xl) + var(--overview-footer-height));
 }
 
 .columnHeading {

--- a/apps/ui/src/components/site-settings-view/index.tsx
+++ b/apps/ui/src/components/site-settings-view/index.tsx
@@ -1,12 +1,26 @@
 import { DEFAULT_WORDPRESS_VERSION } from '@studio/common/constants';
 import { generateCustomDomainFromSiteName } from '@studio/common/lib/domains';
 import { decodePassword, encodePassword } from '@studio/common/lib/passwords';
+import {
+	getSiteFileAccess,
+	SITE_FILE_ACCESS_ALL_FILES,
+	SITE_FILE_ACCESS_SITE_DIRECTORY,
+	type SiteFileAccess,
+} from '@studio/common/lib/site-file-access';
+import {
+	getSiteRuntime,
+	SITE_RUNTIME_NATIVE_PHP,
+	SITE_RUNTIME_PLAYGROUND,
+	type SiteRuntime,
+} from '@studio/common/lib/site-runtime';
 import { RecommendedPHPVersion } from '@studio/common/types/php-versions';
-import { CheckboxControl } from '@wordpress/components';
+import { BaseControl, CheckboxControl, RadioControl, SelectControl } from '@wordpress/components';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
+import { info } from '@wordpress/icons';
+import { Button, Notice, Tooltip } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { LearnHowLink } from '@/components/learn-more';
 import {
 	adminEmailField,
@@ -44,6 +58,8 @@ type TabId = 'overview' | 'general' | 'debugging';
 interface FormData {
 	name: string;
 	phpVersion: SupportedPHPVersion;
+	runtime: SiteRuntime;
+	fileAccess: SiteFileAccess;
 	// Empty string means "auto-update"; anything else pins the site to that
 	// version. Only forwarded on save when the user actually changed it.
 	wpVersion: string;
@@ -73,6 +89,8 @@ function initialFormData( site: SiteDetails, installedWpVersion?: string ): Form
 	return {
 		name: site.name,
 		phpVersion: ( site.phpVersion as SupportedPHPVersion ) ?? RecommendedPHPVersion,
+		runtime: getSiteRuntime( site ),
+		fileAccess: getSiteFileAccess( site ),
 		wpVersion: getEffectiveWpVersion( site, installedWpVersion ),
 		useCustomDomain: Boolean( site.customDomain ),
 		customDomain: site.customDomain ?? '',
@@ -105,12 +123,135 @@ function EnableHttpsControl( { data: item, field, onChange }: DataFormControlPro
 	);
 }
 
+function PhpVersionControl( {
+	data: item,
+	field,
+	onChange,
+	hideLabelFromVision,
+}: DataFormControlProps< FormData > ) {
+	const value = field.getValue( { item } ) ?? '';
+	return (
+		<SelectControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			className={ styles.phpVersionControl }
+			label={ field.label }
+			hideLabelFromVision={ hideLabelFromVision }
+			value={ value }
+			disabled={ field.isDisabled( { item, field } ) }
+			onChange={ ( nextValue ) => onChange( field.setValue( { item, value: nextValue } ) ) }
+		>
+			{ field.elements?.map( ( option ) => (
+				<option key={ option.value } value={ option.value }>
+					{ option.label }
+				</option>
+			) ) }
+		</SelectControl>
+	);
+}
+
+function PhpRuntimeControl( {
+	data: item,
+	field,
+	onChange,
+	hideLabelFromVision,
+}: DataFormControlProps< FormData > ) {
+	return (
+		<RadioControl
+			label={ field.label }
+			hideLabelFromVision={ hideLabelFromVision }
+			selected={ item.runtime }
+			disabled={ field.isDisabled( { item, field } ) }
+			options={ [
+				{
+					label: __( 'Native' ),
+					value: SITE_RUNTIME_NATIVE_PHP,
+					description: __( 'Runs the site with native PHP for the best performance.' ),
+				},
+				{
+					label: __( 'Sandbox' ),
+					value: SITE_RUNTIME_PLAYGROUND,
+					description: __( 'Runs the site in an isolated WordPress Playground sandbox.' ),
+				},
+			] }
+			onChange={ ( runtime ) => onChange( { runtime: runtime as SiteRuntime } ) }
+		/>
+	);
+}
+
+function FileAccessControl( {
+	data: item,
+	field,
+	onChange,
+	hideLabelFromVision,
+}: DataFormControlProps< FormData > ) {
+	const sandboxed = item.runtime === SITE_RUNTIME_PLAYGROUND;
+	const options = (
+		<RadioControl
+			label={ field.label }
+			hideLabelFromVision
+			selected={ item.fileAccess }
+			disabled={ field.isDisabled( { item, field } ) }
+			options={ [
+				{
+					label: __( 'Site directory' ),
+					value: SITE_FILE_ACCESS_SITE_DIRECTORY,
+					description: __( "Restricts PHP's file access to this site's directory." ),
+				},
+				{
+					label: __( 'All files' ),
+					value: SITE_FILE_ACCESS_ALL_FILES,
+					description: __( 'PHP can access any file on your system.' ),
+				},
+			] }
+			onChange={ ( fileAccess ) => onChange( { fileAccess: fileAccess as SiteFileAccess } ) }
+		/>
+	);
+	return (
+		<div className={ styles.fileAccessControl }>
+			{ ! hideLabelFromVision && (
+				<BaseControl.VisualLabel>{ field.label }</BaseControl.VisualLabel>
+			) }
+			{ sandboxed && (
+				<Notice.Root className={ styles.fileAccessNotice } icon={ info }>
+					<Notice.Description>
+						{ __( 'The sandbox can only access the site directory.' ) }
+					</Notice.Description>
+				</Notice.Root>
+			) }
+			{ sandboxed ? (
+				<Tooltip.Root>
+					<Tooltip.Trigger
+						render={ <div className={ styles.disabledFileAccess } tabIndex={ 0 } /> }
+					>
+						{ options }
+					</Tooltip.Trigger>
+					<Tooltip.Popup positioner={ <Tooltip.Positioner side="top" align="start" /> }>
+						{ __( 'Requires the Native PHP runtime' ) }
+					</Tooltip.Popup>
+				</Tooltip.Root>
+			) : (
+				options
+			) }
+		</div>
+	);
+}
+
 /**
  * The site settings form (General + Debugging), rendered as tab panels inside
  * a `Tabs.Root` owned by the caller — the site overview view. One instance
  * spans both panels so unsaved edits survive tab switches.
  */
-export function SiteSettingsForm( { site, activeTab }: { site: SiteDetails; activeTab: TabId } ) {
+export function SiteSettingsForm( {
+	site,
+	activeTab,
+	footerActionsElement,
+}: {
+	site: SiteDetails;
+	activeTab: TabId;
+	footerActionsElement: HTMLElement | null;
+} ) {
+	const formId = `site-settings-${ site.id }`;
 	const allDomains = useExistingCustomDomains();
 	const existingDomainNames = useMemo(
 		() => allDomains.filter( ( domain ) => domain !== site.customDomain ),
@@ -154,16 +295,37 @@ export function SiteSettingsForm( { site, activeTab }: { site: SiteDetails; acti
 	const fields = useMemo< Field< FormData >[] >(
 		() => [
 			{ ...siteNameField< FormData >(), Edit: SiteNameControl },
-			phpVersionField< FormData >(),
+			{ ...phpVersionField< FormData >(), Edit: PhpVersionControl },
+			{
+				id: 'runtime',
+				type: 'text',
+				label: __( 'PHP runtime' ),
+				Edit: PhpRuntimeControl,
+			},
+			{
+				id: 'fileAccess',
+				type: 'text',
+				label: __( 'File access' ),
+				isDisabled: data.runtime === SITE_RUNTIME_PLAYGROUND,
+				Edit: FileAccessControl,
+			},
 			wpVersionField< FormData >( DEFAULT_WORDPRESS_VERSION, wpVersions, {
 				latestValue: '',
 				currentVersion:
 					installedWpVersion && installedWpVersion !== '-' ? installedWpVersion : undefined,
 				offline: isOffline,
 			} ),
-			{ ...adminUsernameField< FormData >(), Edit: AdminUsernameControl },
-			{ ...adminPasswordField< FormData >(), Edit: AdminPasswordControl },
-			{ ...adminEmailField< FormData >(), Edit: AdminEmailControl },
+			{
+				...adminUsernameField< FormData >(),
+				label: __( 'Username' ),
+				Edit: AdminUsernameControl,
+			},
+			{
+				...adminPasswordField< FormData >(),
+				label: __( 'Password' ),
+				Edit: AdminPasswordControl,
+			},
+			{ ...adminEmailField< FormData >(), label: __( 'Email' ), Edit: AdminEmailControl },
 			customDomainToggleField< FormData >(),
 			customDomainField< FormData >( existingDomainNames ),
 			{
@@ -177,28 +339,44 @@ export function SiteSettingsForm( { site, activeTab }: { site: SiteDetails; acti
 			enableDebugLogField< FormData >(),
 			enableDebugDisplayField< FormData >(),
 		],
-		[ existingDomainNames, installedWpVersion, isOffline, wpVersions, xdebugConflictSiteName ]
+		[
+			data.runtime,
+			existingDomainNames,
+			installedWpVersion,
+			isOffline,
+			wpVersions,
+			xdebugConflictSiteName,
+		]
 	);
 
 	const generalForm = useMemo< Form >(
 		() => ( {
 			layout: { type: 'regular', labelPosition: 'top' },
 			fields: [
-				'name',
 				{
-					id: 'versions',
-					layout: { type: 'row', alignment: 'start' },
-					children: [ 'phpVersion', 'wpVersion' ],
+					id: 'siteDetails',
+					label: __( 'Site details' ),
+					layout: { type: 'regular', labelPosition: 'top' },
+					children: [ 'name', 'wpVersion' ],
 				},
 				{
-					id: 'adminCredentials',
-					layout: { type: 'row', alignment: 'start' },
-					children: [ 'adminUsername', 'adminPassword' ],
+					id: 'phpEnvironment',
+					label: __( 'PHP environment' ),
+					layout: { type: 'regular', labelPosition: 'top' },
+					children: [ 'phpVersion', 'runtime', 'fileAccess' ],
 				},
-				'adminEmail',
-				'useCustomDomain',
-				'customDomain',
-				'enableHttps',
+				{
+					id: 'administrator',
+					label: __( 'Administrator' ),
+					layout: { type: 'regular', labelPosition: 'top' },
+					children: [ 'adminUsername', 'adminPassword', 'adminEmail' ],
+				},
+				{
+					id: 'domain',
+					label: __( 'Domain' ),
+					layout: { type: 'regular', labelPosition: 'top' },
+					children: [ 'useCustomDomain', 'customDomain', 'enableHttps' ],
+				},
 			],
 		} ),
 		[]
@@ -227,6 +405,9 @@ export function SiteSettingsForm( { site, activeTab }: { site: SiteDetails; acti
 			// the input with a default derived from the current site name.
 			if ( ! prev.useCustomDomain && next.useCustomDomain && ! next.customDomain ) {
 				next.customDomain = generateCustomDomainFromSiteName( next.name );
+			}
+			if ( next.runtime === SITE_RUNTIME_PLAYGROUND ) {
+				next.fileAccess = SITE_FILE_ACCESS_SITE_DIRECTORY;
 			}
 			return next;
 		} );
@@ -263,6 +444,8 @@ export function SiteSettingsForm( { site, activeTab }: { site: SiteDetails; acti
 			...site,
 			name: data.name,
 			phpVersion: data.phpVersion,
+			runtime: data.runtime,
+			fileAccess: data.fileAccess,
 			isWpAutoUpdating: ! wpPinned,
 			customDomain: usedCustomDomain,
 			enableHttps: !! usedCustomDomain && data.enableHttps,
@@ -293,43 +476,49 @@ export function SiteSettingsForm( { site, activeTab }: { site: SiteDetails; acti
 	};
 
 	return (
-		<form onSubmit={ handleSubmit } className={ styles.form }>
+		<form id={ formId } onSubmit={ handleSubmit } className={ styles.form }>
 			<Tabs.Panel tabId="general">
-				<DataForm< FormData >
-					data={ data }
-					fields={ fields }
-					form={ generalForm }
-					onChange={ handleChange }
-					validity={ validity }
-				/>
+				<div className={ `${ styles.settingsColumn } ${ styles.generalSections }` }>
+					<DataForm< FormData >
+						data={ data }
+						fields={ fields }
+						form={ generalForm }
+						onChange={ handleChange }
+						validity={ validity }
+					/>
+				</div>
 			</Tabs.Panel>
 			<Tabs.Panel tabId="debugging">
-				<DataForm< FormData >
-					data={ data }
-					fields={ fields }
-					form={ debuggingForm }
-					onChange={ handleChange }
-					validity={ validity }
-				/>
+				<div className={ styles.settingsColumn }>
+					<DataForm< FormData >
+						data={ data }
+						fields={ fields }
+						form={ debuggingForm }
+						onChange={ handleChange }
+						validity={ validity }
+					/>
+				</div>
 			</Tabs.Panel>
 
 			{ submitError && <div className={ styles.submitError }>{ submitError }</div> }
 
-			{ /* The save actions apply to the form tabs only, not Overview. */ }
-			{ activeTab !== 'overview' && (
-				<div className={ styles.actions }>
-					<Button
-						type="submit"
-						variant="solid"
-						tone="brand"
-						disabled={ ! canSubmit }
-						loading={ updateSite.isPending }
-						loadingAnnouncement={ __( 'Saving settings' ) }
-					>
-						{ __( 'Save settings' ) }
-					</Button>
-				</div>
-			) }
+			{ /* The save action shares the fixed footer with the preview toggle. */ }
+			{ footerActionsElement && activeTab !== 'overview'
+				? createPortal(
+						<Button
+							form={ formId }
+							type="submit"
+							variant="solid"
+							tone="brand"
+							disabled={ ! canSubmit }
+							loading={ updateSite.isPending }
+							loadingAnnouncement={ __( 'Saving settings' ) }
+						>
+							{ __( 'Save settings' ) }
+						</Button>,
+						footerActionsElement
+				  )
+				: null }
 		</form>
 	);
 }

--- a/apps/ui/src/components/site-settings-view/style.module.css
+++ b/apps/ui/src/components/site-settings-view/style.module.css
@@ -13,10 +13,65 @@
 	font-size: 13px;
 }
 
-.actions {
+.settingsColumn {
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 560px;
+	margin-inline: auto;
+}
+
+.phpVersionControl {
+	width: min(120px, 100%);
+}
+
+.fileAccessControl {
 	display: flex;
-	justify-content: flex-end;
-	gap: var(--wpds-dimension-padding-sm);
+	flex-direction: column;
+}
+
+.fileAccessNotice {
+	margin-block: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-md);
+}
+
+.fileAccessNotice > svg {
+	align-self: center;
+}
+
+.disabledFileAccess {
+	cursor: not-allowed;
+}
+
+.disabledFileAccess :global(.components-radio-control) {
+	pointer-events: none;
+}
+
+.disabledFileAccess :global(*) {
+	cursor: inherit;
+}
+
+.generalSections :global(.dataforms-layouts-regular__header) {
+	padding-block-start: var(--wpds-dimension-padding-2xl);
+	border-block-start: var(--wpds-border-width-xs) solid
+		var(--wpds-color-stroke-surface-neutral-weak);
+}
+
+.generalSections :global(.dataforms-layouts-regular__header:not(:first-child)) {
+	margin-block-start: var(--wpds-dimension-padding-xl);
+}
+
+.generalSections :global(.dataforms-layouts-regular__header:first-child) {
+	padding-block-start: 0;
+	border-block-start: 0;
+}
+
+.generalSections :global(.dataforms-layouts__wrapper) {
+	gap: var(--wpds-dimension-padding-2xl) !important;
+}
+
+.generalSections :global(.components-radio-control) {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-lg);
 }
 
 .credentialActions {

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -94,6 +94,8 @@ export interface SiteDetails {
 	customDomain?: string;
 	enableHttps?: boolean;
 	phpVersion: string;
+	runtime?: import('@studio/common/lib/site-runtime').SiteRuntime;
+	fileAccess?: import('@studio/common/lib/site-file-access').SiteFileAccess;
 	isWpAutoUpdating?: boolean;
 	adminUsername?: string;
 	// Base64-encoded. Use encodePassword/decodePassword from

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -280,6 +280,7 @@ select option {
 
 [data-wpds-theme-provider-id] .components-radio-control__option-description {
 	color: var( --wpds-color-fg-content-neutral-weak );
+	unicode-bidi: plaintext;
 }
 
 /* @wordpress/components ships its RTL fixups in a separate style-rtl.css

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -267,9 +267,19 @@ input[type='checkbox']:focus:not( :focus-visible ) {
 	fill: var( --wpds-color-fg-content-neutral-weak );
 }
 
+select optgroup,
 select option {
 	background-color: var( --wpds-color-bg-surface-neutral );
 	color: var( --wpds-color-fg-content-neutral );
+}
+
+[data-wpds-theme-provider-id] .components-radio-control__input[type='radio']:not(:checked) {
+	border-color: var( --wpds-color-stroke-surface-neutral-strong );
+	background: transparent;
+}
+
+[data-wpds-theme-provider-id] .components-radio-control__option-description {
+	color: var( --wpds-color-fg-content-neutral-weak );
 }
 
 /* @wordpress/components ships its RTL fixups in a separate style-rtl.css


### PR DESCRIPTION
## Related issues

- Related to STU-2348
- Explores an alternative UX to #4702 without changing or superseding that PR

## How AI was used in this PR

Codex was used as an implementation and design-prototyping partner. The interaction model, hierarchy, wording, spacing, responsive behavior, dark-mode treatment, and disabled states were iterated through direct human review in the running Agentic UI. Codex also updated focused tests and prepared the review evidence; the design decisions came from that review loop.

## Executive summary

The existing `latest` WordPress version value mixes two concepts: the version currently installed and whether WordPress should update itself. This draft separates those decisions in the Agentic UI so users can choose **Automatic updates** or **Select a version**, while still seeing the installed version.

The exploration also uses the settings redesign to restore currently missing Agentic UI controls for PHP runtime and file access, improve grouping and scanability, and keep the save action reachable as the settings surface grows.

This is a draft design exploration. It is intentionally separate from #4702 so that PR can continue to represent Gergely's narrower wording approach.

## Proposed Changes

- Separate WordPress update behavior from pinned version selection with two radio choices. The compact version picker remains visible and selecting a version pins the site.
- Explain automatic updates in place and show the currently installed WordPress version without implying that it must already be the newest release.
- Group settings into Site details, PHP environment, Administrator, and Domain sections in one narrow, scannable column at every width.
- Expose PHP runtime and file access settings in the Agentic UI. Sandbox mode forces site-directory access and explains why through a WPDS notice and disabled-state tooltip.
- Use compact WordPress and PHP version pickers instead of stretching short values across the settings column.
- Move Save settings into the existing sticky footer, alongside the preview control, with spacing for the collapsed-sidebar control and a taller fade/blur over scrolling content.
- Improve native select and radio colors in dark mode and preserve the direction of untranslated fallback descriptions in RTL locales.

## Review guide

### 1. WordPress update model

Please focus first on whether **Automatic updates** and **Select a version** correctly express the two user intents. Automatic mode reports the installed version; pinned mode exposes the same compact picker at all times. This deliberately avoids hiding controls or encoding update mode in a version named `latest`.

### 2. Settings hierarchy and density

The form stays in a centered 560px column rather than expanding into multiple columns at wide widths. Section headings and separators establish hierarchy; related controls remain visible without accordions or secondary screens.

### 3. Runtime and file-access dependency

PHP runtime and file access now have parity with the underlying site settings. Selecting Sandbox forces Site directory access. The file-access choices remain visible but disabled, accompanied by a neutral WPDS notice and the tooltip “Requires the Native PHP runtime”.

### 4. Persistent actions and responsive behavior

Save settings is portaled into the existing footer toolbar. Review the footer with the preview open and closed, and with the sidebar expanded and collapsed. It should remain reachable without covering the final form content.

### 5. Data path

Runtime and file-access values travel through the shared `SiteDetails` shape and the local connector's existing `site set` argument builder. Sandbox normalization happens before the update is sent. There is no persistence migration.

## Okay to skim

- Theme-token color corrections for native select options and unselected radios.
- Mechanical test selector updates from the old WordPress version dropdown to the new radios and compact `Version` select.
- Spacing-only CSS once the overall hierarchy has been reviewed.

## Known tradeoffs and follow-ups

- This intentionally does **not** change WordPress download/cache behavior. It gives that work a clearer UI contract to integrate with later.
- Site-specific Skills/Instructions parity is outside this exploration; existing Linear/GitHub work already tracks it.
- The new strings are not translated yet. RTL verification uses Hebrew and confirms layout/control order plus mixed-direction fallback copy, but some labels therefore remain in English.
- The WPDS Notice is currently marked “use with caution” upstream when mixed with `@wordpress/components`; this draft uses it to evaluate the intended design-system direction.
- The change spans UI and the local connector, so this should remain a Proof of Concept until the interaction model and scope are agreed.

## Safety checklist

- [x] No config or data migration
- [x] No WordPress core or cache changes
- [x] Sandbox mode cannot submit unrestricted file access
- [x] Existing pinned/automatic update values remain compatible with the connector contract
- [x] Save action remains associated with the correct form through its HTML `form` attribute
- [x] Verified in light, dark, narrow, wide, preview-open, preview-closed, sidebar-expanded, sidebar-collapsed, and RTL states
- [ ] Product/design approval for the interaction model
- [ ] Final translation review

## Screenshots

### Wide layout with preview open

| Light | Dark |
| --- | --- |
| ![Wide settings layout in light mode](https://github.com/Automattic/studio/blob/4b3053a9ea45ccd2ea88a3e0dad3c5ce7a87d2da/settings-wide-light.jpg?raw=true) | ![Wide settings layout in dark mode](https://github.com/Automattic/studio/blob/4b3053a9ea45ccd2ea88a3e0dad3c5ce7a87d2da/settings-wide-dark.jpg?raw=true) |

The settings column keeps a stable readable width while the site preview uses the remaining space.

### Narrow layout and sticky footer

| Light | Dark |
| --- | --- |
| ![Narrow settings layout in light mode](https://github.com/Automattic/studio/blob/4b3053a9ea45ccd2ea88a3e0dad3c5ce7a87d2da/settings-narrow-light.jpg?raw=true) | ![Narrow settings layout in dark mode with Sandbox selected](https://github.com/Automattic/studio/blob/4b3053a9ea45ccd2ea88a3e0dad3c5ce7a87d2da/settings-narrow-dark.jpg?raw=true) |

The footer keeps Save settings visible at the bottom. With the sidebar collapsed, its toggle and the save action no longer overlap:

![Collapsed sidebar with unobstructed sticky footer](https://github.com/Automattic/studio/blob/4b3053a9ea45ccd2ea88a3e0dad3c5ce7a87d2da/settings-collapsed-sidebar-light.jpg?raw=true)

### WordPress update choices

| Automatic updates | Pinned version |
| --- | --- |
| ![Automatic updates selected with installed version copy](https://github.com/Automattic/studio/blob/4b3053a9ea45ccd2ea88a3e0dad3c5ce7a87d2da/wordpress-auto-light.jpg?raw=true) | ![Select a version selected with compact version picker](https://github.com/Automattic/studio/blob/4b3053a9ea45ccd2ea88a3e0dad3c5ce7a87d2da/wordpress-pinned-light.jpg?raw=true) |

### Sandbox and file access

| Light | Dark |
| --- | --- |
| ![Sandbox file-access restriction in light mode](https://github.com/Automattic/studio/blob/4b3053a9ea45ccd2ea88a3e0dad3c5ce7a87d2da/file-access-sandbox-light.jpg?raw=true) | ![Sandbox file-access restriction in dark mode](https://github.com/Automattic/studio/blob/4b3053a9ea45ccd2ea88a3e0dad3c5ce7a87d2da/file-access-sandbox-dark.jpg?raw=true) |

Disabled choices use a not-allowed cursor and explain the dependency on hover or keyboard focus:

![Disabled file-access tooltip explaining that Native PHP is required](https://github.com/Automattic/studio/blob/4b3053a9ea45ccd2ea88a3e0dad3c5ce7a87d2da/file-access-tooltip-light.jpg?raw=true)

### RTL and mixed-direction content

![Narrow Hebrew settings layout with English fallback descriptions](https://github.com/Automattic/studio/blob/4b3053a9ea45ccd2ea88a3e0dad3c5ce7a87d2da/settings-narrow-rtl.jpg?raw=true)

The Hebrew pass verifies mirrored layout, physical control order, compact select alignment, footer placement, and punctuation direction in untranslated English fallback copy.

## Testing Instructions

Automated checks run:

```sh
npm run typecheck
npm test -- apps/ui/src/components/site-settings-view/index.test.tsx apps/ui/src/components/site-overview-view/index.test.tsx
npm run cli:build:ui
```

Results:

- Workspace typecheck passed.
- 44 focused tests passed.
- Agentic UI and CLI build passed.
- Browser console had no errors during manual verification.

Manual verification:

1. Build and run `studio ui`, then open an existing site's Settings tab.
2. Confirm Automatic updates is selected for an auto-updating site and the installed version appears in its explanation.
3. Select **Select a version**, change the compact picker, and confirm Save settings becomes enabled.
4. Switch PHP runtime between Native and Sandbox. In Sandbox, confirm file access is forced to Site directory, both choices remain visible but disabled, the neutral notice appears, and hovering/focusing the group shows the tooltip.
5. Confirm the footer remains visible while scrolling and does not collide with the collapsed-sidebar or preview controls.
6. Repeat in light and dark appearances, at narrow and wide widths, and in an RTL locale such as Hebrew.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
