### PR TITLE
Accept --wp auto-update as the CLI name for the auto-update mode

### DIFF
--- a/apps/cli/commands/blueprint/use.ts
+++ b/apps/cli/commands/blueprint/use.ts
@@ -18,6 +18,11 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { runCommand as runCreateSiteCommand } from 'cli/commands/site/create';
 import { getDefaultSitePath } from 'cli/lib/site-paths';
 import { untildify } from 'cli/lib/utils';
+import {
+	CLI_AUTO_UPDATE_WP_VERSION,
+	coerceWpVersionOption,
+	getWpVersionOptionDescription,
+} from 'cli/lib/wp-version-option';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -162,8 +167,9 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				} )
 				.option( 'wp', {
 					type: 'string',
-					describe: __( 'WordPress version' ),
-					defaultDescription: DEFAULT_WORDPRESS_VERSION,
+					describe: getWpVersionOptionDescription(),
+					defaultDescription: CLI_AUTO_UPDATE_WP_VERSION,
+					coerce: coerceWpVersionOption,
 				} )
 				.option( 'php', {
 					type: 'string',

--- a/apps/cli/commands/config/set.ts
+++ b/apps/cli/commands/config/set.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_WORDPRESS_VERSION, MINIMUM_WORDPRESS_VERSION } from '@studio/common/constants';
+import { DEFAULT_WORDPRESS_VERSION } from '@studio/common/constants';
 import { SITE_EVENTS } from '@studio/common/lib/cli-events';
 import { getDomainNameValidationError } from '@studio/common/lib/domains';
 import { arePathsEqual } from '@studio/common/lib/fs-utils';
@@ -24,11 +24,7 @@ import {
 	siteRuntimeFromMode,
 	type SiteMode,
 } from '@studio/common/lib/site-runtime';
-import {
-	getWordPressVersionUrl,
-	isValidWordPressVersion,
-	isWordPressVersionAtLeast,
-} from '@studio/common/lib/wordpress-version-utils';
+import { getWordPressVersionUrl } from '@studio/common/lib/wordpress-version-utils';
 import { SiteCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
 import { SupportedPHPVersions } from '@studio/common/types/php-versions';
 import { __, sprintf } from '@wordpress/i18n';
@@ -46,12 +42,12 @@ import { validateSupportedPhpVersion } from 'cli/lib/php-versions';
 import { runWpCliCommand } from 'cli/lib/run-wp-cli-command';
 import { withSiteOperation } from 'cli/lib/site-operations';
 import { setupCustomDomain } from 'cli/lib/site-utils';
-import { ValidationError } from 'cli/lib/validation-error';
 import {
 	isServerRunning,
 	startWordPressServer,
 	stopWordPressServer,
 } from 'cli/lib/wordpress-server-manager';
+import { coerceWpVersionOption, getWpVersionOptionDescription } from 'cli/lib/wp-version-option';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -423,28 +419,8 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				} )
 				.option( 'wp', {
 					type: 'string',
-					description: __(
-						'WordPress version. Use "latest" to let the site auto-update, or pin a version (e.g., "6.4", "6.4.1")'
-					),
-					coerce: ( value: string ) => {
-						if ( ! isValidWordPressVersion( value ) ) {
-							throw new ValidationError(
-								'wp',
-								value,
-								__(
-									'Must be: "latest", "nightly", or a valid version number (e.g., "6.4", "6.4.1", "6.4-beta1")'
-								)
-							);
-						}
-						if ( ! isWordPressVersionAtLeast( value, MINIMUM_WORDPRESS_VERSION ) ) {
-							throw new ValidationError(
-								'wp',
-								value,
-								sprintf( __( 'Must be: at least %s' ), MINIMUM_WORDPRESS_VERSION )
-							);
-						}
-						return value;
-					},
+					description: getWpVersionOptionDescription(),
+					coerce: coerceWpVersionOption,
 				} )
 				.option( 'runtime', {
 					type: 'string',

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { confirm, input, password, select } from '@inquirer/prompts';
-import { DEFAULT_WORDPRESS_VERSION, MINIMUM_WORDPRESS_VERSION } from '@studio/common/constants';
+import { DEFAULT_WORDPRESS_VERSION } from '@studio/common/constants';
 import { installAiInstructionsToSite } from '@studio/common/lib/agent-skills';
 import {
 	createBlueprintTempDirSync,
@@ -53,10 +53,6 @@ import {
 } from '@studio/common/lib/site-runtime';
 import { sortSites } from '@studio/common/lib/sort-sites';
 import { getServerFilesPath } from '@studio/common/lib/well-known-paths';
-import {
-	isValidWordPressVersion,
-	isWordPressVersionAtLeast,
-} from '@studio/common/lib/wordpress-version-utils';
 import { fetchWordPressVersions } from '@studio/common/lib/wordpress-versions';
 import { SiteCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
 import {
@@ -98,6 +94,11 @@ import { StatsGroup } from 'cli/lib/types/bump-stats';
 import { untildify } from 'cli/lib/utils';
 import { ValidationError } from 'cli/lib/validation-error';
 import { runBlueprint, startWordPressServer } from 'cli/lib/wordpress-server-manager';
+import {
+	CLI_AUTO_UPDATE_WP_VERSION,
+	coerceWpVersionOption,
+	getWpVersionOptionDescription,
+} from 'cli/lib/wp-version-option';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -1110,28 +1111,6 @@ function coerceSiteId( value: string ) {
 	return value;
 }
 
-function coerceWpVersion( value: string ) {
-	if ( ! isValidWordPressVersion( value ) ) {
-		throw new ValidationError(
-			'wp',
-			value,
-			__(
-				'Must be: "latest", "nightly", or a valid version number (e.g., "6.4", "6.4.1", "6.4-beta1")'
-			)
-		);
-	}
-
-	if ( ! isWordPressVersionAtLeast( value, MINIMUM_WORDPRESS_VERSION ) ) {
-		throw new ValidationError(
-			'wp',
-			value,
-			sprintf( __( 'Must be: at least %s' ), MINIMUM_WORDPRESS_VERSION )
-		);
-	}
-
-	return value;
-}
-
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'create',
@@ -1150,11 +1129,9 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				} )
 				.option( 'wp', {
 					type: 'string',
-					describe: __(
-						'WordPress version. Use "latest" to let the site auto-update, or pin a version (e.g., "6.4", "6.4.1")'
-					),
-					defaultDescription: DEFAULT_WORDPRESS_VERSION,
-					coerce: coerceWpVersion,
+					describe: getWpVersionOptionDescription(),
+					defaultDescription: CLI_AUTO_UPDATE_WP_VERSION,
+					coerce: coerceWpVersionOption,
 				} )
 				.option( 'php', {
 					type: 'string',
@@ -1379,15 +1356,18 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 						try {
 							const versions = await fetchWordPressVersions();
 							wpChoices = versions.map( ( v ) => ( {
-								name: v.value === 'latest' ? `latest (${ v.label })` : v.label,
+								name:
+									v.value === DEFAULT_WORDPRESS_VERSION
+										? sprintf( __( 'Auto-update (%s)' ), v.label )
+										: v.label,
 								value: v.value,
 							} ) );
 						} catch {
-							// Offline or API failure — offer only "latest"
+							// Offline or API failure — offer only the auto-update mode
 							wpChoices = [
 								{
-									name: __( 'Latest (recommended)' ),
-									value: 'latest',
+									name: __( 'Auto-update (recommended)' ),
+									value: DEFAULT_WORDPRESS_VERSION,
 								},
 							];
 						}

--- a/apps/cli/lib/tests/wp-version-option.test.ts
+++ b/apps/cli/lib/tests/wp-version-option.test.ts
@@ -1,0 +1,46 @@
+import { DEFAULT_WORDPRESS_VERSION } from '@studio/common/constants';
+import { ValidationError } from 'cli/lib/validation-error';
+import {
+	CLI_AUTO_UPDATE_WP_VERSION,
+	coerceWpVersionOption,
+	normalizeCliWpVersion,
+} from 'cli/lib/wp-version-option';
+
+describe( 'normalizeCliWpVersion', () => {
+	it( 'resolves the auto-update alias to the internal mode value', () => {
+		expect( normalizeCliWpVersion( CLI_AUTO_UPDATE_WP_VERSION ) ).toBe( DEFAULT_WORDPRESS_VERSION );
+	} );
+
+	it( 'passes every other value through untouched', () => {
+		for ( const value of [ 'latest', 'nightly', '6.4', '6.4.1', '6.4-beta1' ] ) {
+			expect( normalizeCliWpVersion( value ) ).toBe( value );
+		}
+	} );
+} );
+
+describe( 'coerceWpVersionOption', () => {
+	it( 'accepts the auto-update value and returns the internal mode', () => {
+		expect( coerceWpVersionOption( CLI_AUTO_UPDATE_WP_VERSION ) ).toBe( DEFAULT_WORDPRESS_VERSION );
+	} );
+
+	it( 'still accepts `latest`, so existing scripts keep working', () => {
+		expect( coerceWpVersionOption( 'latest' ) ).toBe( DEFAULT_WORDPRESS_VERSION );
+	} );
+
+	it( 'accepts pinned versions and nightly', () => {
+		expect( coerceWpVersionOption( '6.4.1' ) ).toBe( '6.4.1' );
+		expect( coerceWpVersionOption( 'nightly' ) ).toBe( 'nightly' );
+	} );
+
+	it( 'rejects an unknown value', () => {
+		expect( () => coerceWpVersionOption( 'auto' ) ).toThrow( ValidationError );
+	} );
+
+	it( 'rejects a version below the supported minimum', () => {
+		expect( () => coerceWpVersionOption( '4.9' ) ).toThrow( ValidationError );
+	} );
+
+	it( 'reports the value the user typed, not the resolved one', () => {
+		expect( () => coerceWpVersionOption( 'auto-updates' ) ).toThrow( /auto-updates/ );
+	} );
+} );

--- a/apps/cli/lib/wp-version-option.ts
+++ b/apps/cli/lib/wp-version-option.ts
@@ -10,10 +10,10 @@ import { ValidationError } from 'cli/lib/validation-error';
  * CLI-facing name for the auto-update mode, matching the "Auto-update" option in
  * the apps.
  *
- * Internally the mode stays `latest`: it names a cache directory, a segment of
- * the wordpress.org download URL, and the persisted `wpVersion`. The alias is
- * resolved here so it never reaches storage, and `latest` keeps working for
- * existing scripts.
+ * `latest` is the legacy spelling. It stays the internal value — it names a cache
+ * directory, a segment of the wordpress.org download URL, and the persisted
+ * `wpVersion` — so `auto-update` is resolved to it here, at the boundary, and
+ * never reaches storage. Passing `latest` keeps working for existing scripts.
  */
 export const CLI_AUTO_UPDATE_WP_VERSION = 'auto-update';
 
@@ -24,11 +24,12 @@ export function normalizeCliWpVersion( value: string ): string {
 /** Description for the `--wp` option, shared so both commands read alike. */
 export function getWpVersionOptionDescription(): string {
 	return sprintf(
-		/* translators: %s: the literal CLI value "auto-update", do not translate. */
+		/* translators: 1: the CLI value "auto-update". 2: the legacy CLI value "latest". Do not translate either. */
 		__(
-			'WordPress version. Use "%s" to let the site auto-update, or pin a version (e.g., "6.4", "6.4.1"). "latest" is accepted as an alias.'
+			'WordPress version. Use "%1$s" to let the site auto-update, or pin a version (e.g., "6.4", "6.4.1"). Replaces the legacy "%2$s" option, which still works.'
 		),
-		CLI_AUTO_UPDATE_WP_VERSION
+		CLI_AUTO_UPDATE_WP_VERSION,
+		DEFAULT_WORDPRESS_VERSION
 	);
 }
 

--- a/apps/cli/lib/wp-version-option.ts
+++ b/apps/cli/lib/wp-version-option.ts
@@ -1,0 +1,62 @@
+import { DEFAULT_WORDPRESS_VERSION, MINIMUM_WORDPRESS_VERSION } from '@studio/common/constants';
+import {
+	isValidWordPressVersion,
+	isWordPressVersionAtLeast,
+} from '@studio/common/lib/wordpress-version-utils';
+import { __, sprintf } from '@wordpress/i18n';
+import { ValidationError } from 'cli/lib/validation-error';
+
+/**
+ * CLI-facing name for the auto-update mode, matching the "Auto-update" option in
+ * the apps.
+ *
+ * Internally the mode stays `latest`: it names a cache directory, a segment of
+ * the wordpress.org download URL, and the persisted `wpVersion`. The alias is
+ * resolved here so it never reaches storage, and `latest` keeps working for
+ * existing scripts.
+ */
+export const CLI_AUTO_UPDATE_WP_VERSION = 'auto-update';
+
+export function normalizeCliWpVersion( value: string ): string {
+	return value === CLI_AUTO_UPDATE_WP_VERSION ? DEFAULT_WORDPRESS_VERSION : value;
+}
+
+/** Description for the `--wp` option, shared so both commands read alike. */
+export function getWpVersionOptionDescription(): string {
+	return sprintf(
+		/* translators: %s: the literal CLI value "auto-update", do not translate. */
+		__(
+			'WordPress version. Use "%s" to let the site auto-update, or pin a version (e.g., "6.4", "6.4.1"). "latest" is accepted as an alias.'
+		),
+		CLI_AUTO_UPDATE_WP_VERSION
+	);
+}
+
+/** Resolves the auto-update alias, then validates. Returns the internal value. */
+export function coerceWpVersionOption( value: string ): string {
+	const version = normalizeCliWpVersion( value );
+
+	if ( ! isValidWordPressVersion( version ) ) {
+		throw new ValidationError(
+			'wp',
+			value,
+			sprintf(
+				/* translators: %s: the literal CLI value "auto-update", do not translate. */
+				__(
+					'Must be: "%s", "nightly", or a valid version number (e.g., "6.4", "6.4.1", "6.4-beta1")'
+				),
+				CLI_AUTO_UPDATE_WP_VERSION
+			)
+		);
+	}
+
+	if ( ! isWordPressVersionAtLeast( version, MINIMUM_WORDPRESS_VERSION ) ) {
+		throw new ValidationError(
+			'wp',
+			value,
+			sprintf( __( 'Must be: at least %s' ), MINIMUM_WORDPRESS_VERSION )
+		);
+	}
+
+	return version;
+}

--- a/skills/studio-cli/SKILL.md
+++ b/skills/studio-cli/SKILL.md
@@ -33,7 +33,7 @@ studio config    # Get/set site settings (config get | config set)
 studio create --name "My Site" --path ~/Studio/my-site
 ```
 
-**Options:** `--name`, `--wp` (default: "latest", min: 6.2.1), `--php` (default: 8.4, choices: 8.5/8.4/8.3/8.2/8.1/8.0/7.4), `--domain`, `--https`, `--blueprint` (local JSON file path), `--admin-username` (default: "admin"), `--admin-password` (auto-generated if omitted), `--admin-email` (default: "admin@localhost.com"), `--start` (default: true, use `--no-start` to skip), `--skip-browser`, `--skip-log-details`.
+**Options:** `--name`, `--wp` (default: "auto-update", which keeps WordPress core auto-updating; "latest" is accepted as an alias; pin with a version number, min: 6.2.1), `--php` (default: 8.4, choices: 8.5/8.4/8.3/8.2/8.1/8.0/7.4), `--domain`, `--https`, `--blueprint` (local JSON file path), `--admin-username` (default: "admin"), `--admin-password` (auto-generated if omitted), `--admin-email` (default: "admin@localhost.com"), `--start` (default: true, use `--no-start` to skip), `--skip-browser`, `--skip-log-details`.
 
 Without flags in a TTY, the CLI prompts interactively for name, path, WP/PHP versions, and domain.
 

--- a/skills/studio-cli/SKILL.md
+++ b/skills/studio-cli/SKILL.md
@@ -33,7 +33,7 @@ studio config    # Get/set site settings (config get | config set)
 studio create --name "My Site" --path ~/Studio/my-site
 ```
 
-**Options:** `--name`, `--wp` (default: "auto-update", which keeps WordPress core auto-updating; "latest" is accepted as an alias; pin with a version number, min: 6.2.1), `--php` (default: 8.4, choices: 8.5/8.4/8.3/8.2/8.1/8.0/7.4), `--domain`, `--https`, `--blueprint` (local JSON file path), `--admin-username` (default: "admin"), `--admin-password` (auto-generated if omitted), `--admin-email` (default: "admin@localhost.com"), `--start` (default: true, use `--no-start` to skip), `--skip-browser`, `--skip-log-details`.
+**Options:** `--name`, `--wp` (default: "auto-update", which keeps WordPress core auto-updating; replaces the legacy "latest" option, which still works; pin with a version number, min: 6.2.1), `--php` (default: 8.4, choices: 8.5/8.4/8.3/8.2/8.1/8.0/7.4), `--domain`, `--https`, `--blueprint` (local JSON file path), `--admin-username` (default: "admin"), `--admin-password` (auto-generated if omitted), `--admin-email` (default: "admin@localhost.com"), `--start` (default: true, use `--no-start` to skip), `--skip-browser`, `--skip-log-details`.
 
 Without flags in a TTY, the CLI prompts interactively for name, path, WP/PHP versions, and domain.
 


### PR DESCRIPTION
## Related issues

- Related to STU-2348
- Stacked on #4702

## How AI was used in this PR

I used Opus 5 for implementation and tests.

## Proposed Changes

#4702 renames the "latest" WordPress version option to "Auto-update" in both UIs. This PR updates the naming in the CLI to keep it consistent.

`--wp auto-update` now selects that mode, matching what the apps show. `--wp latest` keeps working as an alias too, so existing scripts and blueprints are unaffected.

`latest` is still the internal value, and it still names a cache directory, a segment of the wordpress.org download URL, and the persisted site setting. The alias is resolved where the CLI parses input and never reaches storage.

Two side effects:

- `blueprint use --wp` was not validated at all. It needed the alias mapping anyway, and the shared coercion brings validation with it, so a bad value now fails at parse time instead of throwing from inside the download helper.
- The interactive version picker in `site create` said `latest (7.1)`; it now says `Auto-update (7.1)`, matching the apps.

## Testing Instructions

- Build the CLI with `npm run cli:build`

**The new value works**

```
node apps/cli/dist/cli/main.mjs site create --path ~/Studio/wp-alias --name wp-alias --wp auto-update --no-start
```

- check `~/.studio/cli.json`: the site should have `"isWpAutoUpdating": true`.

<img width="1086" height="782" alt="CleanShot 2026-09-01 at 17 00 38@2x" src="https://github.com/user-attachments/assets/2bba17c2-1305-4d86-a412-da0d52cc4a09" />

**`latest` still works**

```
node apps/cli/dist/cli/main.mjs site start --path ~/Studio/wp-alias
node apps/cli/dist/cli/main.mjs config set --path ~/Studio/wp-alias --wp 6.9
node apps/cli/dist/cli/main.mjs config set --path ~/Studio/wp-alias --wp latest
```

| `--wp 6.9` | `--wp latest` |
|--------|--------|
| <img width="1020" height="836" alt="CleanShot 2026-09-01 at 17 14 59@2x" src="https://github.com/user-attachments/assets/06d1c691-7800-40e2-a4dc-c4bb6d9b62ca" /> | <img width="1022" height="838" alt="CleanShot 2026-09-01 at 17 16 21@2x" src="https://github.com/user-attachments/assets/5514426a-9c02-47d8-af07-a54cbacba71b" /> |  

`isWpAutoUpdating` should go `false`, then back to `true`. The site has to be running
for `config set --wp` to apply, so `studio start` it first.

**Help text**

`site create --help`, `config set --help` and `blueprint use --help` should all
describe `auto-update` and mention that `latest` is accepted.

<img width="1340" height="616" alt="CleanShot 2026-09-01 at 17 17 12@2x" src="https://github.com/user-attachments/assets/0cbe4b3c-bb60-4320-a262-406753637aca" />


## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
