### PR TITLE
Prioritise release jobs ahead of feature builds

### DIFF
--- a/.buildkite/release-build-and-distribute.yml
+++ b/.buildkite/release-build-and-distribute.yml
@@ -54,6 +54,7 @@ steps:
 
           echo "--- :package: Building standalone CLI bundle"
           npm run cli:bundle -- darwin {{matrix}}
+        priority: 1
         plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
         artifact_paths:
           - apps/studio/out/**/*.app.zip
@@ -85,6 +86,7 @@ steps:
           - apps\studio\out\**\*.appx
           - standalone-bundles\studio-cli-*.tgz
           - standalone-bundles\studio-cli-*.tgz.sha256
+        priority: 1
         plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
         matrix:
           - x64
@@ -127,6 +129,7 @@ steps:
           - apps/studio/out/make/deb/**/*.deb
           - standalone-bundles/studio-cli-*.tgz
           - standalone-bundles/studio-cli-*.tgz.sha256
+        priority: 1
         plugins:
           # Same Docker-on-default-queue pattern as the dev Linux build group
           # (see .buildkite/pipeline.yml): Amazon Linux on `default` lacks
@@ -177,6 +180,7 @@ steps:
       - step: release-mac
       - step: release-windows
       - step: release-linux
+    priority: 1
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     notify:
       - github_commit_status:

--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -4,6 +4,8 @@
 env:
   IMAGE_ID: $IMAGE_ID
 
+priority: 1
+
 steps:
   - label: ":snowflake: Code Freeze"
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -4,6 +4,8 @@
 env:
   IMAGE_ID: $IMAGE_ID
 
+priority: 1
+
 steps:
   - label: ":checkered_flag: Finalize Release"
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -4,6 +4,8 @@
 env:
   IMAGE_ID: $IMAGE_ID
 
+priority: 1
+
 steps:
   - label: ":package: New Beta Release"
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -4,6 +4,8 @@
 env:
   IMAGE_ID: $IMAGE_ID
 
+priority: 1
+
 steps:
   - label: ":fire: New Hotfix Release"
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -4,6 +4,8 @@
 env:
   IMAGE_ID: $IMAGE_ID
 
+priority: 1
+
 steps:
   - label: ":shipit: Publish Release"
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]


### PR DESCRIPTION
Adds `priority: 1` to the release pipelines so release jobs jump the queue ahead of feature builds, and the release train stalls less.

Closes [AINFRA-3047](https://linear.app/a8c/issue/AINFRA-3047).

<details>
<summary>AI-generated details.</summary>

## Description

The Releases V2 tasks run on the same pipeline and queue as every PR build, so a release manager waits behind queued feature work. The release build files already had `priority`; `release-pipelines/*` never did.

Set pipeline-wide rather than per step so that steps added later inherit it.

`release-build-and-distribute.yml` takes it per step instead: its build steps sit inside `group`s, and Buildkite does not document whether a pipeline-level value reaches those.

Part of [AINFRA-3038](https://linear.app/a8c/issue/AINFRA-3038); audit in [AINFRA-3032](https://linear.app/a8c/issue/AINFRA-3032).

## Testing instructions

CI here does not exercise these files — the upload step only uploads `pipeline.yml`. Locally, all 6 parse and every step resolves to priority `1`.

Real confirmation is the next release: the job should show **Priority** `1` in Buildkite, against `0` for a PR build.

</details>
