### PR TITLE
Use slim Static Site Importer 1.9.5

### DIFF
--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -108,7 +108,7 @@ const defaultLogger = new Logger< LoggerAction >();
 // `npm run build:dev-package -- --blocks-engine-path <path>` and pass it to
 // `--static-site-importer-path`.
 const DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL =
-	'https://github.com/Automattic/static-site-importer/releases/download/v1.9.1/static-site-importer.zip';
+	'https://github.com/Automattic/static-site-importer/releases/download/v1.9.2/static-site-importer.zip';
 const SSI_PLUGIN_SLUG = 'static-site-importer';
 const STATIC_SITE_IMPORT_DIR = '.studio-import';
 const STATIC_SITE_IMPORT_REQUEST_FILE = 'request.json';

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -102,13 +102,13 @@ import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
 const defaultLogger = new Logger< LoggerAction >();
-// The importer vendors its own transformer layers (blocks-engine php-transformer and
-// figma-transformer) inside this zip, so pinning the plugin pins the whole stack. To run
-// against an unreleased transformer, build a paired zip with the importer's
+// The HTML importer vendors blocks-engine php-transformer inside this zip, so pinning the
+// plugin pins the whole runtime. To run against an unreleased transformer, build a paired
+// zip with the importer's
 // `npm run build:dev-package -- --blocks-engine-path <path>` and pass it to
 // `--static-site-importer-path`.
 const DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL =
-	'https://github.com/Automattic/static-site-importer/releases/download/v1.9.2/static-site-importer.zip';
+	'https://github.com/Automattic/static-site-importer/releases/download/v1.9.3/static-site-importer-html-site-import.zip';
 const SSI_PLUGIN_SLUG = 'static-site-importer';
 const STATIC_SITE_IMPORT_DIR = '.studio-import';
 const STATIC_SITE_IMPORT_REQUEST_FILE = 'request.json';

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -108,7 +108,7 @@ const defaultLogger = new Logger< LoggerAction >();
 // `npm run build:dev-package -- --blocks-engine-path <path>` and pass it to
 // `--static-site-importer-path`.
 const DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL =
-	'https://github.com/Automattic/static-site-importer/releases/download/v1.8.5/static-site-importer.zip';
+	'https://github.com/Automattic/static-site-importer/releases/download/v1.9.1/static-site-importer.zip';
 const SSI_PLUGIN_SLUG = 'static-site-importer';
 const STATIC_SITE_IMPORT_DIR = '.studio-import';
 const STATIC_SITE_IMPORT_REQUEST_FILE = 'request.json';

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -108,7 +108,7 @@ const defaultLogger = new Logger< LoggerAction >();
 // `npm run build:dev-package -- --blocks-engine-path <path>` and pass it to
 // `--static-site-importer-path`.
 const DEFAULT_STATIC_SITE_IMPORTER_PLUGIN_URL =
-	'https://github.com/Automattic/static-site-importer/releases/download/v1.9.3/static-site-importer-html-site-import.zip';
+	'https://github.com/Automattic/static-site-importer/releases/download/v1.9.5/static-site-importer-html-site-import.zip';
 const SSI_PLUGIN_SLUG = 'static-site-importer';
 const STATIC_SITE_IMPORT_DIR = '.studio-import';
 const STATIC_SITE_IMPORT_REQUEST_FILE = 'request.json';


### PR DESCRIPTION
## Summary

Update the default Static Site Importer release used by `studio create --from` from the full `v1.8.5` package to the `v1.9.5` `html-site-import` package.

The slim package is self-contained for Studio's portable HTML import path: it includes Static Site Importer and PHP Transformer `0.9.3`, while excluding unused Figma, Markdown/MDX, and Composer runtime dependencies.

Release: https://github.com/Automattic/static-site-importer/releases/tag/v1.9.5

Published asset: `static-site-importer-html-site-import.zip`

- Size: `1303735` bytes
- SHA-256: `156e24b7e0805a32c3003d66d60b286a837c2048c63dfa9eb952dcf277d5b8c9`

### Why 1.9.5 rather than 1.9.3

This PR originally pinned `v1.9.3`, which vendors PHP Transformer `0.9.1`. That predates Automattic/blocks-engine#1545, so the pinned runtime did not contain the authored-input, documentation-navigation, breadcrumb-flow, syntax-token, or native code and grid conversion fixes. The pin was advanced through a full release chain so the Studio default carries them:

1. blocks-engine `php-transformer-v0.9.3`
2. Static Site Importer Automattic/static-site-importer#1520, then `v1.9.5`
3. This Studio pin

## Testing

- Built this branch's CLI and ran native `site create --from` against the Blocks Engine `83-startup-docs-hub` fixture using the default published URL, without a local package override.
- Source-of-truth manifest records SSI `1.9.5`, PHP Transformer `0.9.3`, and no Figma Transformer.
- Front page ID 5 is published with 70 native blocks and zero fallback, `core/html`, freeform, invalid, content-loss, or empty-conversion blocks.
- Import validation passed every quality gate, including asset materialization, runtime dependency parity, and semantic parity; the served front end returns HTTP 200 with the runtime search control and native navigation present.
- Verified the downloaded release asset hashes to the SHA-256 above and that its vendored transformer contains the blocks-engine#1545 navigation fix, so the pin demonstrably carries the intended code rather than only a newer version string.
- `89-static-site-importer-architecture` is covered by the solved-site promotion gate, which passed against PHP Transformer `0.9.3` on Automattic/static-site-importer#1520.
- Studio CI is green on this commit, including Lint, Unit Tests, E2E Tests, CLI E2E Tests, Performance Metrics, CodeQL, and Data Liberation.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed that the released pin predated blocks-engine#1545, orchestrated the blocks-engine and Static Site Importer releases through Homeboy, updated the Studio pin to the slim `v1.9.5` runtime, and verified the result through the built Studio CLI and published release artifact. Chris Huber directed and approved the work.