### PR TITLE
Show a link to debug.log in the agentic UI when the file exists

### DIFF
--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -34,7 +34,7 @@ import {
 } from '@studio/common/ai/settings-store';
 import { expandSkillCommandPrompt } from '@studio/common/ai/slash-commands';
 import { getAiTracksIdentity } from '@studio/common/ai/tracks-identity';
-import { DEFAULT_TOKEN_LIFETIME_MS } from '@studio/common/constants';
+import { DEBUG_LOG_RELATIVE_PATH, DEFAULT_TOKEN_LIFETIME_MS } from '@studio/common/constants';
 import { downloadAndExtractBlueprintBundle } from '@studio/common/lib/blueprint-bundle';
 import { createCliRunner } from '@studio/common/lib/cli-process';
 import {
@@ -726,6 +726,39 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 				}
 				throw error;
 			}
+		} )
+	);
+
+	// `readSitePath` for the reason above, and more so: the UI re-checks this on
+	// every window focus.
+	api.get(
+		'/sites/:id/debug-log',
+		asyncHandler( async ( req: Request, res: Response ) => {
+			const sitePath = await readSitePath( req.params.id );
+			if ( ! sitePath ) {
+				res.status( 404 ).json( { error: `Site ${ req.params.id } not found` } );
+				return;
+			}
+			res.json( { exists: existsSync( path.join( sitePath, DEBUG_LOG_RELATIVE_PATH ) ) } );
+		} )
+	);
+
+	api.post(
+		'/sites/:id/debug-log/open',
+		asyncHandler( async ( req: Request, res: Response ) => {
+			const sitePath = await readSitePath( req.params.id );
+			if ( ! sitePath ) {
+				res.status( 404 ).json( { error: `Site ${ req.params.id } not found` } );
+				return;
+			}
+			const logPath = path.join( sitePath, DEBUG_LOG_RELATIVE_PATH );
+			// `openPath` on a missing file is a silent no-op — report it instead.
+			if ( ! existsSync( logPath ) ) {
+				res.status( 404 ).json( { error: 'Debug log not found' } );
+				return;
+			}
+			await openPath( logPath );
+			res.status( 204 ).end();
 		} )
 	);
 

--- a/apps/local/src/tests/debug-log-routes.test.ts
+++ b/apps/local/src/tests/debug-log-routes.test.ts
@@ -1,0 +1,103 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { startLocalServer, type LocalServer } from '../index';
+import * as openInOs from '../open-in-os';
+
+// Driven over HTTP: a mismatch with the desktop's IPC path fails silently, so
+// the wire contract is what's worth pinning.
+
+let server: LocalServer;
+let configDir: string;
+let sitePath: string;
+
+const SITE_ID = 'site-1';
+
+function writeDebugLog(): void {
+	const wpContent = path.join( sitePath, 'wp-content' );
+	mkdirSync( wpContent, { recursive: true } );
+	writeFileSync( path.join( wpContent, 'debug.log' ), 'PHP Notice: something\n', 'utf-8' );
+}
+
+beforeEach( async () => {
+	configDir = mkdtempSync( path.join( os.tmpdir(), 'studio-debug-log-' ) );
+	sitePath = mkdtempSync( path.join( os.tmpdir(), 'studio-debug-log-site-' ) );
+	process.env.DEV_CONFIG_DIR = configDir;
+	writeFileSync(
+		path.join( configDir, 'cli.json' ),
+		JSON.stringify( { sites: [ { id: SITE_ID, path: sitePath } ] } ),
+		'utf-8'
+	);
+	server = await startLocalServer( {
+		cliBinary: path.join( os.tmpdir(), 'studio-test-cli.mjs' ),
+		sessionsRoot: path.join( os.tmpdir(), 'studio-test-sessions' ),
+		sitesRoot: path.join( os.tmpdir(), 'studio-test-sites' ),
+		port: 0,
+	} );
+} );
+
+afterEach( async () => {
+	await server.close();
+	vi.restoreAllMocks();
+	delete process.env.DEV_CONFIG_DIR;
+	rmSync( configDir, { recursive: true, force: true } );
+	rmSync( sitePath, { recursive: true, force: true } );
+} );
+
+describe( 'GET /api/sites/:id/debug-log', () => {
+	it( 'reports no log before WordPress writes one', async () => {
+		const response = await fetch( `${ server.url }/api/sites/${ SITE_ID }/debug-log` );
+
+		expect( response.status ).toBe( 200 );
+		await expect( response.json() ).resolves.toEqual( { exists: false } );
+	} );
+
+	it( 'reports the log once it exists', async () => {
+		writeDebugLog();
+
+		const response = await fetch( `${ server.url }/api/sites/${ SITE_ID }/debug-log` );
+
+		await expect( response.json() ).resolves.toEqual( { exists: true } );
+	} );
+
+	it( '404s for an unknown site', async () => {
+		const response = await fetch( `${ server.url }/api/sites/nope/debug-log` );
+
+		expect( response.status ).toBe( 404 );
+	} );
+} );
+
+describe( 'POST /api/sites/:id/debug-log/open', () => {
+	it( 'opens the log in the OS default app', async () => {
+		const openPath = vi.spyOn( openInOs, 'openPath' ).mockResolvedValue();
+		writeDebugLog();
+
+		const response = await fetch( `${ server.url }/api/sites/${ SITE_ID }/debug-log/open`, {
+			method: 'POST',
+		} );
+
+		expect( response.status ).toBe( 204 );
+		expect( openPath ).toHaveBeenCalledWith( path.join( sitePath, 'wp-content', 'debug.log' ) );
+	} );
+
+	// `openPath` on a missing file is a silent no-op; the guard is what surfaces it.
+	it( '404s when the log is gone, without asking the OS to open it', async () => {
+		const openPath = vi.spyOn( openInOs, 'openPath' ).mockResolvedValue();
+
+		const response = await fetch( `${ server.url }/api/sites/${ SITE_ID }/debug-log/open`, {
+			method: 'POST',
+		} );
+
+		expect( response.status ).toBe( 404 );
+		expect( openPath ).not.toHaveBeenCalled();
+	} );
+
+	it( '404s for an unknown site', async () => {
+		const response = await fetch( `${ server.url }/api/sites/nope/debug-log/open`, {
+			method: 'POST',
+		} );
+
+		expect( response.status ).toBe( 404 );
+	} );
+} );

--- a/apps/local/src/tests/debug-log-routes.test.ts
+++ b/apps/local/src/tests/debug-log-routes.test.ts
@@ -60,12 +60,6 @@ describe( 'GET /api/sites/:id/debug-log', () => {
 
 		await expect( response.json() ).resolves.toEqual( { exists: true } );
 	} );
-
-	it( '404s for an unknown site', async () => {
-		const response = await fetch( `${ server.url }/api/sites/nope/debug-log` );
-
-		expect( response.status ).toBe( 404 );
-	} );
 } );
 
 describe( 'POST /api/sites/:id/debug-log/open', () => {

--- a/apps/studio/src/components/content-tab-settings.tsx
+++ b/apps/studio/src/components/content-tab-settings.tsx
@@ -1,3 +1,4 @@
+import { DEBUG_LOG_RELATIVE_PATH } from '@studio/common/constants';
 import { decodePassword } from '@studio/common/lib/passwords';
 import { getSiteFileAccess, SITE_FILE_ACCESS_ALL_FILES } from '@studio/common/lib/site-file-access';
 import { getSiteRuntime, SITE_RUNTIME_NATIVE_PHP } from '@studio/common/lib/site-runtime';
@@ -98,7 +99,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 		}
 		const path = await getIpcApi().getAbsolutePathFromSite(
 			selectedSite.id,
-			'wp-content/debug.log'
+			DEBUG_LOG_RELATIVE_PATH
 		);
 		setDebugLogPath( path );
 	}, [ selectedSite.id, selectedSite.enableDebugLog ] );

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -44,6 +44,7 @@ import {
 } from '@studio/common/ai/sessions/store';
 import { expandSkillCommandPrompt } from '@studio/common/ai/slash-commands';
 import { getAiTracksIdentity } from '@studio/common/ai/tracks-identity';
+import { DEBUG_LOG_RELATIVE_PATH } from '@studio/common/constants';
 import {
 	installSkillToSite,
 	removeSkillFromSite,
@@ -734,7 +735,7 @@ const PROCESS_MANAGER_HOME = nodePath.join( os.homedir(), '.studio', 'daemon' );
 const DEFAULT_ENCODED_PASSWORD = encodePassword( 'password' );
 
 function readWordPressDebugLog( sitePath: string ): string[] | undefined {
-	const debugLogPath = nodePath.join( sitePath, 'wp-content', 'debug.log' );
+	const debugLogPath = nodePath.join( sitePath, DEBUG_LOG_RELATIVE_PATH );
 	return readLastLines( debugLogPath, DEBUG_LOG_MAX_LINES );
 }
 

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -1043,6 +1043,17 @@ describe( 'SiteOverviewView', () => {
 			expect( openSiteDebugLog ).toHaveBeenCalledWith( 'site-1' );
 		} );
 
+		// Turning logging off stops WordPress writing, but leaves the file behind.
+		it( 'still offers the log after logging is turned off', () => {
+			useSitesMock.mockReturnValue( {
+				data: [ createSite( { running: true, enableDebugLog: false } ) ],
+			} );
+			useDebugLogExistsMock.mockReturnValue( { data: true } );
+			renderView( 'debugging' );
+
+			expect( screen.getByRole( 'button', { name: 'Open log file' } ) ).toBeVisible();
+		} );
+
 		// The custom control replaces DataForm's rendering of the description.
 		it( 'keeps the field description', () => {
 			useDebugLogExistsMock.mockReturnValue( { data: true } );

--- a/apps/ui/src/components/site-overview-view/index.test.tsx
+++ b/apps/ui/src/components/site-overview-view/index.test.tsx
@@ -8,6 +8,7 @@ import { useConnector } from '@/data/core';
 import { useAgenticFeatures } from '@/data/queries/use-agentic-features';
 import { useLogin } from '@/data/queries/use-auth-user';
 import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
+import { useDebugLogExists } from '@/data/queries/use-debug-log';
 import { useSiteStorageUsage } from '@/data/queries/use-site-storage-usage';
 import { useSiteThumbnail } from '@/data/queries/use-site-thumbnail';
 import {
@@ -110,6 +111,11 @@ vi.mock( '@/data/queries/use-sites', () => ( {
 	useXdebugEnabledSite: vi.fn(),
 } ) );
 
+vi.mock( '@/data/queries/use-debug-log', () => ( {
+	debugLogExistsQueryKey: ( siteId: string ) => [ 'debug-log-exists', siteId ],
+	useDebugLogExists: vi.fn(),
+} ) );
+
 vi.mock( '@/data/queries/use-site-thumbnail', () => ( {
 	siteThumbnailQueryKey: ( siteId: string ) => [ 'site-thumbnail', siteId ],
 	useSiteThumbnail: vi.fn(),
@@ -161,6 +167,7 @@ const useExportFullSiteMock = vi.mocked( useExportFullSite, { partial: true } );
 const useIsSiteBusyMock = vi.mocked( useIsSiteBusy );
 const useIsSiteStartingMock = vi.mocked( useIsSiteStarting );
 const useIsSiteStoppingMock = vi.mocked( useIsSiteStopping );
+const useDebugLogExistsMock = vi.mocked( useDebugLogExists, { partial: true } );
 const useSiteThumbnailMock = vi.mocked( useSiteThumbnail, { partial: true } );
 const useSiteStorageUsageMock = vi.mocked( useSiteStorageUsage, { partial: true } );
 const useSitesMock = vi.mocked( useSites, { partial: true } );
@@ -178,6 +185,7 @@ describe( 'SiteOverviewView', () => {
 	const openSiteFolder = vi.fn().mockResolvedValue( undefined );
 	const openSiteInEditor = vi.fn().mockResolvedValue( undefined );
 	const openSiteInTerminal = vi.fn().mockResolvedValue( undefined );
+	const openSiteDebugLog = vi.fn().mockResolvedValue( undefined );
 	const trackEvent = vi.fn().mockResolvedValue( undefined );
 	const copyText = vi.fn().mockResolvedValue( undefined );
 	const startSite = vi.fn().mockResolvedValue( undefined );
@@ -193,6 +201,7 @@ describe( 'SiteOverviewView', () => {
 		openSiteFolder,
 		openSiteInEditor,
 		openSiteInTerminal,
+		openSiteDebugLog,
 		trackEvent,
 		copyText,
 		getFilePath,
@@ -274,6 +283,7 @@ describe( 'SiteOverviewView', () => {
 		useWordPressVersionsMock.mockReturnValue( { data: undefined } );
 		useWpVersionMock.mockReturnValue( { data: undefined } );
 		useXdebugEnabledSiteMock.mockReturnValue( null );
+		useDebugLogExistsMock.mockReturnValue( { data: false } );
 	} );
 
 	function renderView(
@@ -991,6 +1001,44 @@ describe( 'SiteOverviewView', () => {
 		expect(
 			screen.queryByRole( 'heading', { name: 'Sign in to do more with Studio' } )
 		).not.toBeInTheDocument();
+	} );
+
+	// Driven by a lookup rather than the setting: the log may not exist yet.
+	describe( 'debug log shortcut', () => {
+		it( 'offers to open the log once one exists', () => {
+			useDebugLogExistsMock.mockReturnValue( { data: true } );
+			renderView( 'debugging' );
+
+			expect( screen.getByRole( 'button', { name: 'Open log file' } ) ).toBeVisible();
+		} );
+
+		it( 'stays hidden while the site has no log yet', () => {
+			useDebugLogExistsMock.mockReturnValue( { data: false } );
+			renderView( 'debugging' );
+
+			expect( screen.queryByRole( 'button', { name: 'Open log file' } ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'asks the host to open the log', () => {
+			useDebugLogExistsMock.mockReturnValue( { data: true } );
+			renderView( 'debugging' );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Open log file' } ) );
+
+			expect( openSiteDebugLog ).toHaveBeenCalledWith( 'site-1' );
+		} );
+
+		// The custom control replaces DataForm's rendering of the description.
+		it( 'keeps the field description', () => {
+			useDebugLogExistsMock.mockReturnValue( { data: true } );
+			renderView( 'debugging' );
+
+			expect(
+				screen.getByText(
+					"Log PHP errors and warnings to a debug.log file in your site's wp-content directory."
+				)
+			).toBeVisible();
+		} );
 	} );
 
 	it( 'shows a not-found state for unknown sites', () => {

--- a/apps/ui/src/components/site-settings-view/index.tsx
+++ b/apps/ui/src/components/site-settings-view/index.tsx
@@ -164,7 +164,7 @@ export function SiteSettingsForm( { site, activeTab }: { site: SiteDetails; acti
 
 	const connector = useConnector();
 	const updateSite = useUpdateSite();
-	const { data: logExists } = useDebugLogExists( site.id, site.enableDebugLog ?? false );
+	const { data: logExists } = useDebugLogExists( site.id );
 	const handleOpenLog = useCallback( () => {
 		void connector.openSiteDebugLog( site.id ).catch( ( error ) => {
 			// The file can vanish between the check and the click.

--- a/apps/ui/src/components/site-settings-view/index.tsx
+++ b/apps/ui/src/components/site-settings-view/index.tsx
@@ -22,7 +22,9 @@ import {
 	wpVersionField,
 } from '@/components/site-fields';
 import * as Tabs from '@/components/tabs';
+import { useConnector } from '@/data/core';
 import { useExistingCustomDomains } from '@/data/queries/use-create-site-helpers';
+import { useDebugLogExists } from '@/data/queries/use-debug-log';
 import { useIsSiteBusy, useUpdateSite, useXdebugEnabledSite } from '@/data/queries/use-sites';
 import { useWordPressVersions, useWpVersion } from '@/data/queries/use-wordpress-versions';
 import { useOffline } from '@/hooks/use-offline';
@@ -106,6 +108,46 @@ function EnableHttpsControl( { data: item, field, onChange }: DataFormControlPro
 }
 
 /**
+ * The debug log checkbox, plus a shortcut to the log once one exists. A custom
+ * `Edit` replaces DataForm's rendering, so the description is re-emitted here.
+ */
+function EnableDebugLogControl( {
+	data: item,
+	field,
+	onChange,
+	logExists,
+	onOpenLog,
+}: DataFormControlProps< FormData > & { logExists: boolean; onOpenLog: () => void } ) {
+	return (
+		<CheckboxControl
+			__nextHasNoMarginBottom
+			label={ field.label }
+			checked={ item.enableDebugLog }
+			onChange={ ( checked ) => onChange( { enableDebugLog: checked } ) }
+			help={
+				<>
+					{ field.description }
+					{ /* A span, not a div: `help` renders inside a paragraph. */ }
+					{ logExists && (
+						<span className={ styles.debugLogAction }>
+							<Button
+								type="button"
+								variant="outline"
+								tone="neutral"
+								size="compact"
+								onClick={ onOpenLog }
+							>
+								{ __( 'Open log file' ) }
+							</Button>
+						</span>
+					) }
+				</>
+			}
+		/>
+	);
+}
+
+/**
  * The site settings form (General + Debugging), rendered as tab panels inside
  * a `Tabs.Root` owned by the caller — the site overview view. One instance
  * spans both panels so unsaved edits survive tab switches.
@@ -120,7 +162,15 @@ export function SiteSettingsForm( { site, activeTab }: { site: SiteDetails; acti
 	const xdebugConflictSiteName =
 		xdebugEnabledSite && xdebugEnabledSite.id !== site.id ? xdebugEnabledSite.name : undefined;
 
+	const connector = useConnector();
 	const updateSite = useUpdateSite();
+	const { data: logExists } = useDebugLogExists( site.id, site.enableDebugLog ?? false );
+	const handleOpenLog = useCallback( () => {
+		void connector.openSiteDebugLog( site.id ).catch( ( error ) => {
+			// The file can vanish between the check and the click.
+			console.error( 'Failed to open debug log:', error );
+		} );
+	}, [ connector, site.id ] );
 	const { data: wpVersions } = useWordPressVersions();
 	const { data: installedWpVersion } = useWpVersion( site.id );
 	const isOffline = useOffline();
@@ -174,10 +224,27 @@ export function SiteSettingsForm( { site, activeTab }: { site: SiteDetails; acti
 				Edit: EnableHttpsControl,
 			},
 			enableXdebugField< FormData >( { conflictingSiteName: xdebugConflictSiteName } ),
-			enableDebugLogField< FormData >(),
+			{
+				...enableDebugLogField< FormData >(),
+				Edit: ( props: DataFormControlProps< FormData > ) => (
+					<EnableDebugLogControl
+						{ ...props }
+						logExists={ !! logExists }
+						onOpenLog={ handleOpenLog }
+					/>
+				),
+			},
 			enableDebugDisplayField< FormData >(),
 		],
-		[ existingDomainNames, installedWpVersion, isOffline, wpVersions, xdebugConflictSiteName ]
+		[
+			existingDomainNames,
+			handleOpenLog,
+			installedWpVersion,
+			isOffline,
+			logExists,
+			wpVersions,
+			xdebugConflictSiteName,
+		]
 	);
 
 	const generalForm = useMemo< Form >(

--- a/apps/ui/src/components/site-settings-view/style.module.css
+++ b/apps/ui/src/components/site-settings-view/style.module.css
@@ -34,3 +34,8 @@
 		flex-direction: column !important;
 	}
 }
+
+.debugLogAction {
+	display: flex;
+	margin-block-start: var(--wpds-dimension-gap-xs);
+}

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -440,6 +440,14 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		async openSiteInTerminal() {
 			throw new UnsupportedError( 'openSiteInTerminal' );
 		},
+		// Queried on mount, so answer rather than throw. There is no local file
+		// to open here anyway.
+		async siteDebugLogExists() {
+			return false;
+		},
+		async openSiteDebugLog() {
+			throw new UnsupportedError( 'openSiteDebugLog' );
+		},
 		async openStudioLogs() {
 			throw new UnsupportedError( 'openStudioLogs' );
 		},

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -440,10 +440,8 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		async openSiteInTerminal() {
 			throw new UnsupportedError( 'openSiteInTerminal' );
 		},
-		// Queried on mount, so answer rather than throw. There is no local file
-		// to open here anyway.
 		async siteDebugLogExists() {
-			return false;
+			throw new UnsupportedError( 'siteDebugLogExists' );
 		},
 		async openSiteDebugLog() {
 			throw new UnsupportedError( 'openSiteDebugLog' );

--- a/apps/ui/src/data/core/connectors/ipc/index.test.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.test.ts
@@ -305,3 +305,48 @@ describe( 'createIpcConnector Connect contracts', () => {
 		} );
 	} );
 } );
+
+// Guards the IPC call shape: drifting from the shared relative path would hide
+// the "Open log file" button on this front end only.
+describe( 'createIpcConnector debug log', () => {
+	const getAbsolutePathFromSite = vi.fn();
+	const openLocalPath = vi.fn();
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.stubGlobal( 'ipcApi', { getAbsolutePathFromSite, openLocalPath } );
+		vi.stubGlobal( 'ipcListener', { subscribe: vi.fn() } );
+	} );
+
+	afterEach( () => {
+		vi.unstubAllGlobals();
+	} );
+
+	it( 'reports the log exists when main resolves a path', async () => {
+		getAbsolutePathFromSite.mockResolvedValue( '/sites/demo/wp-content/debug.log' );
+
+		await expect( createIpcConnector().siteDebugLogExists( 'site-1' ) ).resolves.toBe( true );
+		expect( getAbsolutePathFromSite ).toHaveBeenCalledWith( 'site-1', 'wp-content/debug.log' );
+	} );
+
+	it( 'reports no log when main resolves null', async () => {
+		getAbsolutePathFromSite.mockResolvedValue( null );
+
+		await expect( createIpcConnector().siteDebugLogExists( 'site-1' ) ).resolves.toBe( false );
+	} );
+
+	it( 'opens the resolved log path', async () => {
+		getAbsolutePathFromSite.mockResolvedValue( '/sites/demo/wp-content/debug.log' );
+
+		await createIpcConnector().openSiteDebugLog( 'site-1' );
+
+		expect( openLocalPath ).toHaveBeenCalledWith( '/sites/demo/wp-content/debug.log' );
+	} );
+
+	it( 'rejects without opening anything when the log is gone', async () => {
+		getAbsolutePathFromSite.mockResolvedValue( null );
+
+		await expect( createIpcConnector().openSiteDebugLog( 'site-1' ) ).rejects.toThrow();
+		expect( openLocalPath ).not.toHaveBeenCalled();
+	} );
+} );

--- a/apps/ui/src/data/core/connectors/ipc/index.test.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.test.ts
@@ -306,8 +306,8 @@ describe( 'createIpcConnector Connect contracts', () => {
 	} );
 } );
 
-// Guards the IPC call shape: drifting from the shared relative path would hide
-// the "Open log file" button on this front end only.
+// `window.ipcApi` is untyped, so only a test catches a drifting method name or
+// argument order here. The relative path is shared with the local server.
 describe( 'createIpcConnector debug log', () => {
 	const getAbsolutePathFromSite = vi.fn();
 	const openLocalPath = vi.fn();
@@ -322,30 +322,20 @@ describe( 'createIpcConnector debug log', () => {
 		vi.unstubAllGlobals();
 	} );
 
-	it( 'reports the log exists when main resolves a path', async () => {
+	it( 'resolves the log through main, then opens what it resolved', async () => {
 		getAbsolutePathFromSite.mockResolvedValue( '/sites/demo/wp-content/debug.log' );
 
 		await expect( createIpcConnector().siteDebugLogExists( 'site-1' ) ).resolves.toBe( true );
 		expect( getAbsolutePathFromSite ).toHaveBeenCalledWith( 'site-1', 'wp-content/debug.log' );
-	} );
-
-	it( 'reports no log when main resolves null', async () => {
-		getAbsolutePathFromSite.mockResolvedValue( null );
-
-		await expect( createIpcConnector().siteDebugLogExists( 'site-1' ) ).resolves.toBe( false );
-	} );
-
-	it( 'opens the resolved log path', async () => {
-		getAbsolutePathFromSite.mockResolvedValue( '/sites/demo/wp-content/debug.log' );
 
 		await createIpcConnector().openSiteDebugLog( 'site-1' );
-
 		expect( openLocalPath ).toHaveBeenCalledWith( '/sites/demo/wp-content/debug.log' );
 	} );
 
-	it( 'rejects without opening anything when the log is gone', async () => {
+	it( 'reports no log, and opens nothing, when main resolves null', async () => {
 		getAbsolutePathFromSite.mockResolvedValue( null );
 
+		await expect( createIpcConnector().siteDebugLogExists( 'site-1' ) ).resolves.toBe( false );
 		await expect( createIpcConnector().openSiteDebugLog( 'site-1' ) ).rejects.toThrow();
 		expect( openLocalPath ).not.toHaveBeenCalled();
 	} );

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -1,3 +1,4 @@
+import { DEBUG_LOG_RELATIVE_PATH } from '@studio/common/constants';
 import { getErrorMessage, stripIpcErrorPrefix } from '@studio/common/lib/error-formatting';
 import { TRACKS_EVENTS } from '@studio/common/lib/record-tracks-event';
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
@@ -952,6 +953,18 @@ export function createIpcConnector(): Connector {
 		async openSiteInTerminal( siteId ): Promise< void > {
 			const sitePath = await resolveSiteFolder( siteId );
 			await ipcApi.openTerminalAtPath( sitePath );
+		},
+
+		async siteDebugLogExists( siteId ): Promise< boolean > {
+			return Boolean( await ipcApi.getAbsolutePathFromSite( siteId, DEBUG_LOG_RELATIVE_PATH ) );
+		},
+
+		async openSiteDebugLog( siteId ): Promise< void > {
+			const logPath = await ipcApi.getAbsolutePathFromSite( siteId, DEBUG_LOG_RELATIVE_PATH );
+			if ( ! logPath ) {
+				throw new Error( 'Debug log not found.' );
+			}
+			ipcApi.openLocalPath( logPath );
 		},
 
 		async openStudioLogs(): Promise< void > {

--- a/apps/ui/src/data/core/connectors/local/index.test.ts
+++ b/apps/ui/src/data/core/connectors/local/index.test.ts
@@ -162,3 +162,42 @@ describe( 'createLocalConnector Connect contracts', () => {
 		} );
 	} );
 } );
+
+// Missing routes make `api()` throw and the button silently never appear, so
+// pin the exact URLs.
+describe( 'createLocalConnector debug log', () => {
+	const fetchMock = vi.fn();
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.stubGlobal( 'fetch', fetchMock );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	} );
+
+	it( 'unwraps the existence check', async () => {
+		fetchMock.mockResolvedValue( new Response( JSON.stringify( { exists: true } ) ) );
+		const connector = createLocalConnector( { apiBaseUrl: 'http://localhost:8081' } );
+
+		await expect( connector.siteDebugLogExists( 'site-1' ) ).resolves.toBe( true );
+		expect( fetchMock ).toHaveBeenCalledWith(
+			'http://localhost:8081/api/sites/site-1/debug-log',
+			expect.any( Object )
+		);
+	} );
+
+	it( 'asks the server to open the log', async () => {
+		fetchMock.mockResolvedValue( new Response( null, { status: 204 } ) );
+		const connector = createLocalConnector( { apiBaseUrl: 'http://localhost:8081' } );
+
+		await connector.openSiteDebugLog( 'site-1' );
+
+		expect( fetchMock ).toHaveBeenCalledWith(
+			'http://localhost:8081/api/sites/site-1/debug-log/open',
+			expect.objectContaining( { method: 'POST' } )
+		);
+	} );
+} );

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -832,6 +832,17 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			await api( `/sites/${ encodeURIComponent( siteId ) }/open-in-terminal`, { method: 'POST' } );
 		},
 
+		// Resolved server-side, so no host path crosses into the browser.
+		async siteDebugLogExists( siteId ) {
+			const { exists } = await api< { exists: boolean } >(
+				`/sites/${ encodeURIComponent( siteId ) }/debug-log`
+			);
+			return exists;
+		},
+		async openSiteDebugLog( siteId ) {
+			await api( `/sites/${ encodeURIComponent( siteId ) }/debug-log/open`, { method: 'POST' } );
+		},
+
 		// The CLI has no equivalent of the desktop's log file — site server output
 		// goes to `~/.studio/daemon/logs` and the rest to the terminal that ran
 		// `studio ui` — so there is nothing to open here.

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -494,6 +494,12 @@ export interface Connector {
 	openSiteInEditor( siteId: string ): Promise< void >;
 	openSiteInTerminal( siteId: string ): Promise< void >;
 
+	// The site's WordPress debug log, resolved host-side from the site id. Its
+	// existence is a query, not a `SiteDetails` field: the file comes and goes
+	// while the UI is open. False where the host can't reach the filesystem.
+	siteDebugLogExists( siteId: string ): Promise< boolean >;
+	openSiteDebugLog( siteId: string ): Promise< void >;
+
 	// Open Studio's own log file. Gated by `capabilities.studioLogs`.
 	openStudioLogs(): Promise< void >;
 

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -496,7 +496,7 @@ export interface Connector {
 
 	// The site's WordPress debug log, resolved host-side from the site id. Its
 	// existence is a query, not a `SiteDetails` field: the file comes and goes
-	// while the UI is open. False where the host can't reach the filesystem.
+	// while the UI is open. Both are gated on `capabilities.openInOS`.
 	siteDebugLogExists( siteId: string ): Promise< boolean >;
 	openSiteDebugLog( siteId: string ): Promise< void >;
 

--- a/apps/ui/src/data/queries/use-debug-log.test.tsx
+++ b/apps/ui/src/data/queries/use-debug-log.test.tsx
@@ -1,0 +1,48 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConnectorProvider } from '@/data/core';
+import { useDebugLogExists } from './use-debug-log';
+import type { Connector } from '@/data/core';
+import type { ReactNode } from 'react';
+
+function createWrapper( connector: Connector ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+	return function Wrapper( { children }: { children: ReactNode } ) {
+		return (
+			<QueryClientProvider client={ queryClient }>
+				<ConnectorProvider connector={ connector }>{ children }</ConnectorProvider>
+			</QueryClientProvider>
+		);
+	};
+}
+
+function createConnector( openInOS: boolean, siteDebugLogExists: () => Promise< boolean > ) {
+	return { capabilities: { openInOS }, siteDebugLogExists } as unknown as Connector;
+}
+
+describe( 'useDebugLogExists', () => {
+	it( 'checks for the log where the host can open files', async () => {
+		const siteDebugLogExists = vi.fn().mockResolvedValue( true );
+		const { result } = renderHook( () => useDebugLogExists( 'site-1' ), {
+			wrapper: createWrapper( createConnector( true, siteDebugLogExists ) ),
+		} );
+
+		await waitFor( () => expect( result.current.data ).toBe( true ) );
+		expect( siteDebugLogExists ).toHaveBeenCalledWith( 'site-1' );
+	} );
+
+	// Hosted rejects this call, so the capability gate is what keeps it unasked.
+	it( 'never asks a host that cannot open files', async () => {
+		const siteDebugLogExists = vi.fn().mockRejectedValue( new Error( 'Unsupported' ) );
+		const { result } = renderHook( () => useDebugLogExists( 'site-1' ), {
+			wrapper: createWrapper( createConnector( false, siteDebugLogExists ) ),
+		} );
+
+		expect( siteDebugLogExists ).not.toHaveBeenCalled();
+		expect( result.current.data ).toBeUndefined();
+		expect( result.current.isError ).toBe( false );
+	} );
+} );

--- a/apps/ui/src/data/queries/use-debug-log.ts
+++ b/apps/ui/src/data/queries/use-debug-log.ts
@@ -4,20 +4,18 @@ import { useConnector } from '@/data/core';
 export const debugLogExistsQueryKey = ( siteId: string ) => [ 'debug-log-exists', siteId ] as const;
 
 /**
- * Whether the site has a `wp-content/debug.log` yet. WordPress writes it lazily,
- * so it can't be derived from the site's settings. `persist: false` keeps a
- * stale answer from rehydrating out of localStorage.
- *
- * Pass the site's saved `enableDebugLog` as `enabled`, not the form's unsaved
- * value: ticking the checkbox doesn't write the file, the restart on save does.
+ * Whether the site has a `wp-content/debug.log` yet. WordPress writes it lazily
+ * and leaves it behind when logging is turned off, so this tracks the file
+ * itself rather than the site's setting. `persist: false` keeps a stale answer
+ * from rehydrating out of localStorage.
  */
-export function useDebugLogExists( siteId: string, enabled: boolean ) {
+export function useDebugLogExists( siteId: string ) {
 	const connector = useConnector();
 
 	return useQuery( {
 		queryKey: debugLogExistsQueryKey( siteId ),
 		queryFn: () => connector.siteDebugLogExists( siteId ),
-		enabled: enabled && connector.capabilities.openInOS,
+		enabled: connector.capabilities.openInOS,
 		// An unresolvable site means "no log", not a transient failure.
 		retry: false,
 		meta: { persist: false },

--- a/apps/ui/src/data/queries/use-debug-log.ts
+++ b/apps/ui/src/data/queries/use-debug-log.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+
+export const debugLogExistsQueryKey = ( siteId: string ) => [ 'debug-log-exists', siteId ] as const;
+
+/**
+ * Whether the site has a `wp-content/debug.log` yet. WordPress writes it lazily,
+ * so it can't be derived from the site's settings. `persist: false` keeps a
+ * stale answer from rehydrating out of localStorage.
+ *
+ * Pass the site's saved `enableDebugLog` as `enabled`, not the form's unsaved
+ * value: ticking the checkbox doesn't write the file, the restart on save does.
+ */
+export function useDebugLogExists( siteId: string, enabled: boolean ) {
+	const connector = useConnector();
+
+	return useQuery( {
+		queryKey: debugLogExistsQueryKey( siteId ),
+		queryFn: () => connector.siteDebugLogExists( siteId ),
+		enabled: enabled && connector.capabilities.openInOS,
+		// An unresolvable site means "no log", not a transient failure.
+		retry: false,
+		meta: { persist: false },
+	} );
+}

--- a/packages/common/constants.ts
+++ b/packages/common/constants.ts
@@ -66,3 +66,6 @@ export const ARCHIVER_OPTIONS = {
 		gzipOptions: { level: 9 },
 	},
 };
+
+// Shared so the desktop and the local server can't drift on the path.
+export const DEBUG_LOG_RELATIVE_PATH = 'wp-content/debug.log';


### PR DESCRIPTION
## Related issues

- Fixes [STU-2404](https://linear.app/a8c/issue/STU-2404/show-link-to-debuglog-when-it-exists-in-the-agentic-ui)

## How AI was used in this PR

Claude Code wrote the implementation and tests, and drove the browser verification below. I reviewed the diff, directed the button styling and other improvements.

## Proposed Changes

Studio Classic offers an **Open log file** link in site Settings once a site has actually written a `wp-content/debug.log`. The agentic UI had the *Enable debug log* toggle but no way to get to the file it produces, so you had to go find it in the site folder yourself. This ports that shortcut, as a button under the toggle, matching the mockup on the issue.

<img width="2084" height="1424" alt="CleanShot 2026-09-03 at 12 16 04@2x" src="https://github.com/user-attachments/assets/737d94f0-f8b2-4ecc-a100-595d4a7a6c91" />

## Testing Instructions

Browser UI:

```bash
npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open
```

Then at http://localhost:8081 → a site → Settings → Debugging. Repeat the same steps on the desktop app (`npm start`) — both front ends are in scope.

1. On a site with no `wp-content/debug.log`, there's no button.
2. On a site that has one, **Open log file** appears below the toggle's description; the description itself is still there.
3. Click it — the log opens in the OS default app (TextEdit/Notepad), *not* your configured editor.
4. `rm wp-content/debug.log`, then navigate to another site and back — the button is gone. Restore the file and it returns.
5. Check both light and dark mode.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
