### PR TITLE
Agentic UI: Realign sidebar add/toggle buttons with the site status dots

### DIFF
--- a/apps/ui/src/components/sidebar-header/style.module.css
+++ b/apps/ui/src/components/sidebar-header/style.module.css
@@ -1,6 +1,10 @@
 .root {
+	/* The action buttons pull back by `sm` (see .actions), so this lands their
+	   trailing edge on `lg` — the same column the site rows' status buttons end
+	   on (row outer inset + row inline-end padding in site-list). Keep the two
+	   in sync. */
 	--sidebar-header-inline-end: calc(
-		var(--wpds-dimension-padding-2xl) - var(--wpds-dimension-padding-xs)
+		var(--wpds-dimension-padding-lg) + var(--wpds-dimension-padding-sm)
 	);
 
 	display: flex;

--- a/apps/ui/src/components/user-menu/style.module.css
+++ b/apps/ui/src/components/user-menu/style.module.css
@@ -4,8 +4,11 @@
 	--user-menu-leading-offset: calc(
 		var(--wpds-dimension-padding-lg) - var(--wpds-dimension-padding-sm)
 	);
+	/* The sidebar toggle pulls back by `sm`, so this lands its trailing edge on
+	   `lg` — the same column the site rows' status buttons and the header's
+	   add button end on. Keep in sync with sidebar-header. */
 	--user-menu-trailing-offset: calc(
-		var(--wpds-dimension-padding-2xl) - var(--wpds-dimension-padding-xs)
+		var(--wpds-dimension-padding-lg) + var(--wpds-dimension-padding-sm)
 	);
 
 	/* SidebarButton adds `sm` inline padding; this offset puts the avatar's


### PR DESCRIPTION
## Related issues

- Follow-up to #4320

## How AI was used in this PR

Claude traced the regression through git history and wrote the fix. Reviewed by the author.

## Proposed Changes

- In the agentic sidebar, the "Add site" button (top) and the sidebar toggle (bottom) sat 4px to the right of the site rows' status dots.
- #4320 upgraded `@wordpress/theme` to 1.0, which dropped the `compact` density the app used. The header and footer trailing insets were expressed as `2xl − xs`, the site rows' as `lg`; those were equal (12px) under compact and only coincidentally so. On the default scale they diverge (12px vs 16px).
- The header and footer insets are now derived from the same `lg` column the rows end on, so all three line up again in both densities and in light/dark.

## Screenshots

Red line runs through the center of the `+` button. Dark chrome, `studio ui` in the browser.

| Before (trunk) | After |
| --- | --- |
| <img src="https://github.com/Automattic/studio/blob/7f2727de0e2c931fbfa29522fe65e9777963579a/before-dark.png?raw=true" width="320" alt="Before: status dots sit 4px left of the + button" /> | <img src="https://github.com/Automattic/studio/blob/7f2727de0e2c931fbfa29522fe65e9777963579a/after-dark.png?raw=true" width="320" alt="After: + button, status dots and footer toggle share one center line" /> |

## Testing Instructions

- `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`, open http://localhost:8081.
- With several running sites, check that the `+` button, each row's green status dot (or Xdebug bug icon), and the sidebar toggle in the footer share one vertical center line.
- Repeat with the sidebar in light and dark theme, and on a non-macOS/browser window (flush header variant).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

