### PR TITLE
Agentic UI: Let menus follow the theme scope they open from

### DIFF
--- a/apps/ui/src/components/menu/index.tsx
+++ b/apps/ui/src/components/menu/index.tsx
@@ -1,5 +1,6 @@
 import { ContextMenu as BaseContextMenu } from '@base-ui/react/context-menu';
 import { Menu as BaseMenu } from '@base-ui/react/menu';
+import { ThemeProvider } from '@wordpress/theme';
 import { clsx } from 'clsx';
 import { forwardRef } from 'react';
 import motionStyles from '@/components/floating-surface-motion/style.module.css';
@@ -56,13 +57,20 @@ export function Popup( {
 				alignOffset={ alignOffset }
 				className={ styles.positioner }
 			>
-				<BaseMenu.Popup
-					className={ `${ styles.popup } ${ motionStyles.motion } ${ className ?? '' }` }
-					onClick={ onClick }
-					onPointerDown={ onPointerDown }
-				>
-					{ children }
-				</BaseMenu.Popup>
+				{ /* The portal mounts into document.body, outside the light/dark
+					ThemeProvider the trigger lives in. A bare ThemeProvider inherits
+					that scope through React context and re-emits it here, so the
+					menu matches its trigger (dark in the sidebar chrome, the app's
+					color scheme elsewhere). */ }
+				<ThemeProvider>
+					<BaseMenu.Popup
+						className={ `${ styles.popup } ${ motionStyles.motion } ${ className ?? '' }` }
+						onClick={ onClick }
+						onPointerDown={ onPointerDown }
+					>
+						{ children }
+					</BaseMenu.Popup>
+				</ThemeProvider>
 			</BaseMenu.Positioner>
 		</BaseMenu.Portal>
 	);
@@ -87,13 +95,16 @@ export function ContextPopup( {
 	return (
 		<BaseMenu.Portal>
 			<BaseMenu.Positioner className={ styles.positioner }>
-				<BaseMenu.Popup
-					className={ `${ styles.popup } ${ motionStyles.motion } ${ className ?? '' }` }
-					onClick={ onClick }
-					onPointerDown={ onPointerDown }
-				>
-					{ children }
-				</BaseMenu.Popup>
+				{ /* Re-establish the trigger's theme scope, same as `Popup` above. */ }
+				<ThemeProvider>
+					<BaseMenu.Popup
+						className={ `${ styles.popup } ${ motionStyles.motion } ${ className ?? '' }` }
+						onClick={ onClick }
+						onPointerDown={ onPointerDown }
+					>
+						{ children }
+					</BaseMenu.Popup>
+				</ThemeProvider>
 			</BaseMenu.Positioner>
 		</BaseMenu.Portal>
 	);

--- a/apps/ui/src/components/menu/style.module.css
+++ b/apps/ui/src/components/menu/style.module.css
@@ -10,35 +10,15 @@
 	outline: none;
 }
 
-/* Menus portal to document.body, escaping whatever light/dark scope they
-   opened from. Force the same dark, theme-independent surface everywhere
-   (matching the sidebar's fixed-dark chrome) instead of falling through to
-   the app's light/dark toggle — same technique as site-dropdown's `.popup`.
-   Literal colors, not the matching wpds tokens: this block remaps those same
-   tokens below, so seeding from them would make each definition depend on
-   itself. */
+/* Color comes from the ThemeProvider that `Popup` wraps the portal in, so the
+   tokens below resolve against the trigger's own light/dark scope. */
 .popup {
-	--menu-surface: #1e1e1e;
-	--menu-foreground: #f0f0f0;
-	--menu-surface-subtle: color-mix(in srgb, var(--menu-foreground) 7%, var(--menu-surface));
-	--menu-foreground-weak: color-mix(in srgb, var(--menu-foreground) 72%, transparent);
-	--menu-foreground-disabled: color-mix(in srgb, var(--menu-foreground) 38%, transparent);
-	--menu-border: color-mix(in srgb, var(--menu-foreground) 11%, transparent);
-	--menu-divider: color-mix(in srgb, var(--menu-foreground) 16%, transparent);
-	--wpds-color-background-surface-neutral-strong: var(--menu-surface);
-	--wpds-color-background-surface-neutral: var(--menu-surface-subtle);
-	--wpds-color-stroke-surface-neutral-weak: var(--menu-border);
-	--wpds-color-stroke-surface-neutral: var(--menu-divider);
-	--wpds-color-foreground-content-neutral: var(--menu-foreground);
-	--wpds-color-foreground-content-neutral-weak: var(--menu-foreground-weak);
-	--wpds-color-foreground-interactive-neutral-disabled: var(--menu-foreground-disabled);
-
 	min-width: 160px;
 	padding: var(--wpds-dimension-padding-xs);
 	background: var(--wpds-color-background-surface-neutral-strong);
 	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
 	border-radius: var(--wpds-border-radius-lg);
-	box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.05), 0 4px 5px 0 rgba(0, 0, 0, 0.04), 0 12px 12px 0 rgba(0, 0, 0, 0.03), 0 16px 16px 0 rgba(0, 0, 0, 0.02);
+	box-shadow: var(--wpds-elevation-md);
 	color: var(--wpds-color-foreground-content-neutral);
 	display: flex;
 	flex-direction: column;

--- a/apps/ui/src/components/menu/style.module.css
+++ b/apps/ui/src/components/menu/style.module.css
@@ -18,7 +18,7 @@
 	background: var(--wpds-color-background-surface-neutral-strong);
 	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
 	border-radius: var(--wpds-border-radius-lg);
-	box-shadow: var(--wpds-elevation-md);
+	box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.05), 0 4px 5px 0 rgba(0, 0, 0, 0.04), 0 12px 12px 0 rgba(0, 0, 0, 0.03), 0 16px 16px 0 rgba(0, 0, 0, 0.02);
 	color: var(--wpds-color-foreground-content-neutral);
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
## Related issues

- Follow-up to #4320

## How AI was used in this PR

Claude traced the regression through git history and wrote the fix. Reviewed by the author.

## Proposed Changes

- Since #4320, every menu in the agentic UI renders on a fixed dark surface, including menus opened from the light content area (composer, Open in, session actions, usage panel). Only the sidebar's menus are meant to be dark, because the sidebar chrome itself is fixed dark.
- Menus portal into `document.body`, outside the `ThemeProvider` their trigger lives in. Before #4320 a nested `ThemeProvider` inside the portal (kept for the old `compact` density) also re-emitted the trigger's color scope. The upgrade dropped that wrapper and compensated by hardcoding a dark surface in the menu CSS.
- This restores the nested `ThemeProvider` (now the public export) and removes the hardcoded colors, so a menu matches wherever it opens: dark in the sidebar, the app's light/dark scheme elsewhere. The drop shadow stays literal: theme 1.x ships no elevation tokens, and its build plugin rejects unknown `--wpds-*` names.

## Screenshots

Light color scheme, `studio ui` in the browser.

**Composer model menu (content area)** — should follow the app's light/dark scheme.

| Before (trunk) | After |
| --- | --- |
| <img src="https://github.com/Automattic/studio/blob/e8757f16b6af79333ccbdcea4218060f8d56458a/before-model-menu-light.png?raw=true" width="300" alt="Before: dark menu over the light composer" /> | <img src="https://github.com/Automattic/studio/blob/e8757f16b6af79333ccbdcea4218060f8d56458a/after-model-menu-light.png?raw=true" width="300" alt="After: light menu matching the light composer" /> |

**Site context menu (sidebar)** — stays dark, inherited from the sidebar's fixed-dark chrome.

| Before (trunk) | After |
| --- | --- |
| <img src="https://github.com/Automattic/studio/blob/e8757f16b6af79333ccbdcea4218060f8d56458a/before-site-menu-light.png?raw=true" width="300" alt="Before: dark sidebar menu" /> | <img src="https://github.com/Automattic/studio/blob/e8757f16b6af79333ccbdcea4218060f8d56458a/after-site-menu-light.png?raw=true" width="300" alt="After: still dark, now from the sidebar's theme scope" /> |

## Testing Instructions

- `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`, open http://localhost:8081.
- In light mode, open the composer's model/mode menu, the "Open in" menu, and a session's actions menu: they should be light.
- Right-click a site in the sidebar and open the beta menu in the footer: both should still be dark.
- Switch to dark mode and repeat; content-area menus should now be dark too.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

