### PR TITLE
Fix Vite config-loader warnings and async_hooks browser stub in the CLI build

### DIFF
--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -1,13 +1,20 @@
 import { execSync } from 'child_process';
 import { copyFileSync, cpSync, existsSync, mkdirSync, readdirSync, writeFileSync } from 'fs';
+import { createRequire } from 'module';
 import { resolve } from 'path';
 import semver from 'semver';
 import { defineConfig } from 'vite';
-import packageJson from './package.json';
+
+const __dirname = import.meta.dirname;
+const packageJson = createRequire( import.meta.url )( './package.json' ) as {
+	dependencies?: Record< string, string >;
+	engines?: { node?: string };
+	version: string;
+};
 
 const nodeBuiltinExternals: RegExp[] = [
 	/^node:/,
-	/^(path|fs|os|child_process|crypto|http|https|http2|url|querystring|stream|util|events|buffer|assert|net|tty|readline|zlib|constants|tls|domain|dns)$/,
+	/^(path|fs|os|child_process|crypto|http|https|http2|url|querystring|stream|util|events|buffer|assert|net|tty|readline|zlib|constants|tls|domain|dns|async_hooks)$/,
 	/^fs\/promises$/,
 	/^dns\/promises$/,
 ];

--- a/apps/cli/vite.config.dev.ts
+++ b/apps/cli/vite.config.dev.ts
@@ -1,6 +1,8 @@
 import { resolve } from 'path';
 import { defineConfig, mergeConfig } from 'vite';
-import { baseConfig } from './vite.config.base';
+import { baseConfig } from './vite.config.base.ts';
+
+const __dirname = import.meta.dirname;
 
 export default mergeConfig(
 	baseConfig,

--- a/apps/cli/vite.config.npm.ts
+++ b/apps/cli/vite.config.npm.ts
@@ -1,5 +1,5 @@
 import { defineConfig, mergeConfig } from 'vite';
-import { baseConfig, buildLocalUiPlugin } from './vite.config.base';
+import { baseConfig, buildLocalUiPlugin } from './vite.config.base.ts';
 
 export default mergeConfig(
 	baseConfig,

--- a/apps/cli/vite.config.prod.ts
+++ b/apps/cli/vite.config.prod.ts
@@ -3,7 +3,9 @@ import { resolve } from 'path';
 import { globSync } from 'glob';
 import { defineConfig, mergeConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
-import { baseConfig, buildLocalUiPlugin } from './vite.config.base';
+import { baseConfig, buildLocalUiPlugin } from './vite.config.base.ts';
+
+const __dirname = import.meta.dirname;
 
 const cliNodeModulesPath = resolve( __dirname, 'node_modules' );
 const distCliNodeModulesPath = resolve( __dirname, 'dist/cli/node_modules' );

--- a/apps/cli/vite.config.standalone.ts
+++ b/apps/cli/vite.config.standalone.ts
@@ -1,5 +1,5 @@
 import { defineConfig, mergeConfig } from 'vite';
-import prodConfig from './vite.config.prod';
+import prodConfig from './vite.config.prod.ts';
 
 // Identical to the production build (the desktop-embedded CLI), but stamps
 // `__IS_PACKAGED_FOR_STANDALONE__` so the curl-installed bundle can identify itself at

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import { defineProject, mergeConfig } from 'vitest/config';
-import sharedConfig from '../../vitest.shared';
+import sharedConfig from '../../vitest.shared.ts';
+
+const __dirname = import.meta.dirname;
 
 export default mergeConfig(
 	sharedConfig,

--- a/apps/hosted/vite.config.ts
+++ b/apps/hosted/vite.config.ts
@@ -1,7 +1,12 @@
 import { mkdirSync, writeFileSync } from 'fs';
+import { createRequire } from 'module';
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
-import packageJson from './package.json';
+
+const __dirname = import.meta.dirname;
+const packageJson = createRequire( import.meta.url )( './package.json' ) as {
+	dependencies?: Record< string, string >;
+};
 
 // Node built-ins are always provided by the runtime, never bundled.
 const nodeBuiltinExternals: RegExp[] = [

--- a/apps/local/vitest.config.ts
+++ b/apps/local/vitest.config.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import { defineProject, mergeConfig } from 'vitest/config';
-import sharedConfig from '../../vitest.shared';
+import sharedConfig from '../../vitest.shared.ts';
+
+const __dirname = import.meta.dirname;
 
 export default mergeConfig(
 	sharedConfig,

--- a/apps/studio/vitest.config.ts
+++ b/apps/studio/vitest.config.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import { defineProject, mergeConfig } from 'vitest/config';
-import sharedConfig from '../../vitest.shared';
+import sharedConfig from '../../vitest.shared.ts';
+
+const __dirname = import.meta.dirname;
 
 export default mergeConfig(
 	sharedConfig,

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -5,10 +5,11 @@ import dsTokenFallbacksPostcss from '@wordpress/theme/postcss-plugins/postcss-ds
 import dsTokenFallbacks from '@wordpress/theme/vite-plugins/vite-ds-token-fallbacks';
 import { defineConfig, type Plugin } from 'vite';
 
-const require = createRequire( import.meta.url );
-const pkg = require( './package.json' ) as {
+const __dirname = import.meta.dirname;
+const pkg = createRequire( import.meta.url )( './package.json' ) as {
 	dependencies?: Record< string, string >;
 };
+
 // Dedupe + pre-bundle every direct dep so packages with module-scoped state
 // (React's hooks dispatcher, @wordpress/private-apis' lock/unlock registry,
 // etc.) can't accidentally resolve to two instances. Workspace packages

--- a/apps/ui/vitest.config.ts
+++ b/apps/ui/vitest.config.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import { defineProject, mergeConfig } from 'vitest/config';
-import sharedConfig from '../../vitest.shared';
+import sharedConfig from '../../vitest.shared.ts';
+
+const __dirname = import.meta.dirname;
 
 export default mergeConfig(
 	sharedConfig,

--- a/packages/common/vitest.config.ts
+++ b/packages/common/vitest.config.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import { defineProject, mergeConfig } from 'vitest/config';
-import sharedConfig from '../../vitest.shared';
+import sharedConfig from '../../vitest.shared.ts';
+
+const __dirname = import.meta.dirname;
 
 export default mergeConfig(
 	sharedConfig,

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import { defineConfig } from 'vitest/config';
 
+const __dirname = import.meta.dirname;
+
 export default defineConfig( {
 	test: {
 		pool: 'threads',


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code investigated the warnings, produced the changes, and verified them. All build output and the running server were inspected directly rather than trusting the absence of warnings.

## Proposed Changes

Two problems surfaced by the same build output on `npm start`.

**Vite 8 config-loader warnings.** Every build and test run printed warnings that our configs use features unsupported by `configLoader: 'native'`, which becomes the default in a future Vite major: `__dirname`, extensionless relative imports, and JSON imports without attributes. Fixing them now keeps the noise out of everyone's terminal and means the eventual loader switch is a non-event rather than a broken build.

Node >= 22 is already required, so `import.meta.dirname` is available. JSON imports use `createRequire` (the pattern `apps/ui` already used) rather than the `with { type: 'json' }` attribute the warning suggests — the pinned `wp-prettier@3.0.3` cannot parse import attributes, and `tsconfig` targets `es2022`, which doesn't permit them. Moving to the modern syntax is a separate change gated on those two upgrades.

**A real bug hiding behind one of those warnings.** The `async_hooks` externalization message was not cosmetic. The CLI is a Node program, but Vite builds it in the default `client` environment, so bundled Express dependencies were resolved with *browser* conditions. `require('async_hooks')` was rewritten to an empty-object stub:

```js
function tryRequireAsyncHooks() {
  try { return require___vite_browser_external(); }  // module.exports = {}
  catch (e) { return {}; }
}
```

That left `asyncHooks.AsyncResource` permanently `undefined`, so `on-finished` and `raw-body` silently fell back to unwrapped callbacks — losing async-context propagation in the `studio ui` server. It fails quietly, which is why it only ever showed up as a build warning. After the fix the same code emits `__require("async_hooks")`, resolving to the real module via the `createRequire` shim the config already installs per chunk.

No user-visible behaviour change is expected; the `studio ui` server regains correct async-context propagation.

## Testing Instructions

1. `npm start` — the config-loader and `async_hooks` externalization warnings should be gone.
2. `npm run cli:build && npm run cli:build:ui` — both clean.
3. Confirm the fix in the output: `grep -r "vite_browser_external" apps/cli/dist/cli/*.mjs` returns nothing, and `grep -r "async_hooks" apps/cli/dist/cli/*.mjs` shows `__require("async_hooks")`.
4. Confirm the CLI is still self-contained: `grep -rn 'from "express"' apps/cli/dist/cli/*.mjs` returns nothing (express stays bundled).
5. `node apps/cli/dist/cli/main.mjs ui --no-open --port 8099`, then check `/index.local.html` → 200, `/api/sites` → 200, and a POST with a JSON body → 400 (exercises the `raw-body` path).
6. `npm test -- --tagsFilter='!e2e'` and `npm run typecheck`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
