### PR TITLE
Agentic UI: Make sidebar notices legible and add a recent notifications dialog

### DIFF
--- a/apps/ui/src/components/app-message-cards/index.tsx
+++ b/apps/ui/src/components/app-message-cards/index.tsx
@@ -5,8 +5,15 @@ import { AddAiCreditsButton } from '@/components/add-ai-credits-button';
 import toastStyles from '@/components/app-toasts/style.module.css';
 import { useActivePersistentMessages } from '@/data/queries/use-app-messages';
 import styles from './style.module.css';
+import type { NoticeAppearance } from '@/components/app-toasts';
 
-export function AppMessageCards( { className }: { className?: string } ) {
+export function AppMessageCards( {
+	className,
+	appearance = 'neutral',
+}: {
+	className?: string;
+	appearance?: NoticeAppearance;
+} ) {
 	const { messages, dismiss } = useActivePersistentMessages();
 
 	if ( ! messages.length ) {
@@ -20,7 +27,11 @@ export function AppMessageCards( { className }: { className?: string } ) {
 					<Notice.Root
 						intent={ message.intent }
 						icon={ null }
-						className={ clsx( toastStyles.notice, styles.card ) }
+						className={ clsx(
+							toastStyles.notice,
+							appearance === 'neutral' && toastStyles.neutral,
+							styles.card
+						) }
 					>
 						<Notice.Title>{ message.title }</Notice.Title>
 						{ message.description ? (

--- a/apps/ui/src/components/app-toasts/index.test.tsx
+++ b/apps/ui/src/components/app-toasts/index.test.tsx
@@ -1,8 +1,13 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NoticeHistoryDialog } from '@/components/notice-history';
 import { showToast, resetAppMessagesForTests } from '@/data/app-messages';
 import { AppToasts } from './index';
+
+vi.mock( '@/hooks/use-color-scheme', () => ( {
+	useColorScheme: () => 'light',
+} ) );
 
 describe( 'AppToasts', () => {
 	afterEach( () => {
@@ -56,5 +61,24 @@ describe( 'AppToasts', () => {
 		} );
 
 		expect( screen.getByText( 'Pulling from live' ) ).toBeVisible();
+	} );
+
+	it( 'offers Copy and More only on error toasts with details', () => {
+		render(
+			<>
+				<AppToasts />
+				<NoticeHistoryDialog />
+			</>
+		);
+
+		act( () => {
+			showToast( { intent: 'success', title: 'Saved', description: 'All good.' } );
+			showToast( { intent: 'error', title: 'Failed', description: 'Stack trace…' } );
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Copy' } ) ).toBeVisible();
+		fireEvent.click( screen.getByRole( 'button', { name: 'More' } ) );
+		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+		expect( screen.getAllByText( 'Stack trace…' ) ).toHaveLength( 2 );
 	} );
 } );

--- a/apps/ui/src/components/app-toasts/index.tsx
+++ b/apps/ui/src/components/app-toasts/index.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useEffect } from 'react';
+import { CopyNoticeButton, openNoticeHistory } from '@/components/notice-history';
 import {
 	dismissToast,
 	notifyRendererMounted,
@@ -10,18 +11,31 @@ import {
 	resumeToastExpiry,
 	useQueuedToastCount,
 	useVisibleToasts,
+	type ToastMessage,
 } from '@/data/app-messages';
 import styles from './style.module.css';
+
+export type NoticeAppearance = 'neutral' | 'intent';
+
+// Error text is clamped in the toast; these get Copy (the full text) and More
+// (the recent-notifications dialog, where it runs in full).
+function hasErrorDetails( item: ToastMessage ) {
+	return item.intent === 'error' && Boolean( item.description );
+}
 
 export function AppToasts( {
 	className,
 	fit = 'row',
+	appearance = 'neutral',
 }: {
 	className?: string;
 	// 'row' stretches toasts to the shelf width (sidebar footer, matching the
 	// site rows); 'content' lets each toast hug its text up to the shelf's
 	// max-width (the floating collapsed shelf).
 	fit?: 'row' | 'content';
+	// 'neutral' flattens every toast to one quiet card; 'intent' keeps
+	// Notice's tinted surface so an error reads red at a glance.
+	appearance?: NoticeAppearance;
 } ) {
 	const toasts = useVisibleToasts();
 	const queuedCount = useQueuedToastCount();
@@ -57,23 +71,39 @@ export function AppToasts( {
 								<Notice.Root
 									key={ `${ item.intent }:${ !! item.description }:${ !! item.action }` }
 									intent={ item.intent }
-									className={ styles.notice }
+									className={ clsx( styles.notice, appearance === 'neutral' && styles.neutral ) }
 								>
 									<Notice.Title>{ item.title }</Notice.Title>
 									{ item.description ? (
 										<Notice.Description>{ item.description }</Notice.Description>
 									) : null }
-									{ item.action ? (
+									{ item.action || hasErrorDetails( item ) ? (
 										<Notice.Actions>
-											<Button
-												size="small"
-												variant="solid"
-												tone="neutral"
-												className={ styles.actionButton }
-												onClick={ item.action.onClick }
-											>
-												{ item.action.label }
-											</Button>
+											{ item.action ? (
+												<Button
+													size="small"
+													variant="solid"
+													tone="neutral"
+													className={ styles.actionButton }
+													onClick={ item.action.onClick }
+												>
+													{ item.action.label }
+												</Button>
+											) : null }
+											{ hasErrorDetails( item ) ? (
+												<>
+													<CopyNoticeButton notice={ item } className={ styles.actionButton } />
+													<Button
+														size="small"
+														variant="solid"
+														tone="neutral"
+														className={ styles.actionButton }
+														onClick={ openNoticeHistory }
+													>
+														{ __( 'More' ) }
+													</Button>
+												</>
+											) : null }
 										</Notice.Actions>
 									) : null }
 									<Notice.CloseIcon

--- a/apps/ui/src/components/app-toasts/index.tsx
+++ b/apps/ui/src/components/app-toasts/index.tsx
@@ -9,7 +9,7 @@ import {
 	notifyRendererUnmounted,
 	pauseToastExpiry,
 	resumeToastExpiry,
-	useQueuedToastCount,
+	useQueuedToasts,
 	useVisibleToasts,
 	type ToastMessage,
 } from '@/data/app-messages';
@@ -38,7 +38,7 @@ export function AppToasts( {
 	appearance?: NoticeAppearance;
 } ) {
 	const toasts = useVisibleToasts();
-	const queuedCount = useQueuedToastCount();
+	const queued = useQueuedToasts();
 
 	useEffect( () => {
 		notifyRendererMounted();
@@ -114,13 +114,14 @@ export function AppToasts( {
 							</div>
 						</div>
 					) ) }
-					{ queuedCount > 0 ? <div className={ styles.queuePeek } aria-hidden="true" /> : null }
-					{ queuedCount > 1 ? (
+					{ queued.slice( 0, 2 ).map( ( item, index ) => (
 						<div
-							className={ clsx( styles.queuePeek, styles.queuePeekDeeper ) }
+							key={ item.id }
+							className={ clsx( styles.queuePeek, index === 1 && styles.queuePeekDeeper ) }
+							data-intent={ appearance === 'intent' ? item.intent : undefined }
 							aria-hidden="true"
 						/>
-					) : null }
+					) ) }
 				</div>
 			) : null }
 		</div>

--- a/apps/ui/src/components/app-toasts/style.module.css
+++ b/apps/ui/src/components/app-toasts/style.module.css
@@ -61,25 +61,42 @@
 	   percentage — and this font's digits are not equal width, so a counter
 	   would shift the text by a few pixels on nearly every update. */
 	font-variant-numeric: tabular-nums;
-	--wp-ui-notice-background-color: var(--wpds-color-background-surface-neutral-strong);
-	--wp-ui-notice-border-color: transparent;
-	--wp-ui-notice-text-color: var(--wpds-color-foreground-content-neutral);
 	box-shadow:
-		0 0 0 1px color-mix(in srgb, var(--wpds-color-foreground-content-neutral) 14%, transparent),
 		0 2px 3px 0 rgba(0, 0, 0, 0.05), 0 4px 5px 0 rgba(0, 0, 0, 0.04), 0 12px 12px 0 rgba(0, 0, 0, 0.03), 0 16px 16px 0 rgba(0, 0, 0, 0.02);
 	padding-block: 6px;
 	padding-inline: var(--wpds-dimension-padding-sm);
 	border-radius: 6px;
 }
 
+/* Default appearance: one quiet neutral card whatever the intent, with a
+   hairline ring in place of Notice's tinted border. `appearance="intent"`
+   skips this and keeps Notice's own tinted surface, border, and text. */
+.neutral {
+	--wp-ui-notice-background-color: var(--wpds-color-background-surface-neutral-strong);
+	--wp-ui-notice-border-color: transparent;
+	--wp-ui-notice-text-color: var(--wpds-color-foreground-content-neutral);
+	box-shadow:
+		0 0 0 1px color-mix(in srgb, var(--wpds-color-foreground-content-neutral) 14%, transparent),
+		0 2px 3px 0 rgba(0, 0, 0, 0.05), 0 4px 5px 0 rgba(0, 0, 0, 0.04), 0 12px 12px 0 rgba(0, 0, 0, 0.03), 0 16px 16px 0 rgba(0, 0, 0, 0.02);
+}
+
+.neutral [class*='__description'] {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
 .notice [class*='heading'] {
 	line-height: 16px;
 }
 
+/* Error text can run to paragraphs; the toast shows the first few lines and
+   the notifications panel (notice-history) keeps the full message. */
 .notice [class*='__description'] {
 	font-size: var(--wpds-typography-font-size-xs);
 	line-height: 16px;
-	color: var(--wpds-color-foreground-content-neutral-weak);
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 3;
+	overflow: hidden;
 }
 
 /* Button's solid-variant sets these properties on the element itself, so
@@ -101,8 +118,18 @@
 	--wp-ui-button-border-color-active: transparent;
 }
 
+/* Row one is as tall as the close button; center the icon and the title on
+   it so a one-line toast doesn't ride high. */
 .notice > svg {
-	margin-top: 2px;
+	align-self: center;
+}
+
+.notice [class*='__title'] {
+	align-self: center;
+}
+
+.notice [class*='__actions'] {
+	gap: var(--wpds-dimension-gap-sm);
 }
 
 .queuePeek {

--- a/apps/ui/src/components/app-toasts/style.module.css
+++ b/apps/ui/src/components/app-toasts/style.module.css
@@ -62,7 +62,7 @@
 	   would shift the text by a few pixels on nearly every update. */
 	font-variant-numeric: tabular-nums;
 	box-shadow:
-		0 2px 3px 0 rgba(0, 0, 0, 0.05), 0 4px 5px 0 rgba(0, 0, 0, 0.04), 0 12px 12px 0 rgba(0, 0, 0, 0.03), 0 16px 16px 0 rgba(0, 0, 0, 0.02);
+		0 1px 2px 0 rgba(0, 0, 0, 0.06), 0 3px 6px 0 rgba(0, 0, 0, 0.05), 0 6px 8px 0 rgba(0, 0, 0, 0.03);
 	padding-block: 6px;
 	padding-inline: var(--wpds-dimension-padding-sm);
 	border-radius: 6px;
@@ -77,7 +77,7 @@
 	--wp-ui-notice-text-color: var(--wpds-color-foreground-content-neutral);
 	box-shadow:
 		0 0 0 1px color-mix(in srgb, var(--wpds-color-foreground-content-neutral) 14%, transparent),
-		0 2px 3px 0 rgba(0, 0, 0, 0.05), 0 4px 5px 0 rgba(0, 0, 0, 0.04), 0 12px 12px 0 rgba(0, 0, 0, 0.03), 0 16px 16px 0 rgba(0, 0, 0, 0.02);
+		0 1px 2px 0 rgba(0, 0, 0, 0.06), 0 3px 6px 0 rgba(0, 0, 0, 0.05), 0 6px 8px 0 rgba(0, 0, 0, 0.03);
 }
 
 .neutral [class*='__description'] {
@@ -147,12 +147,36 @@
 	opacity: 0.5;
 }
 
+/* With `appearance="intent"` the peek strips borrow the queued toast's tint,
+   so a pending error is visible before it surfaces. */
+.queuePeek[data-intent='info'] {
+	background-color: var(--wpds-color-background-surface-info-weak);
+	box-shadow: 0 0 0 1px var(--wpds-color-stroke-surface-info);
+}
+
+.queuePeek[data-intent='success'] {
+	background-color: var(--wpds-color-background-surface-success-weak);
+	box-shadow: 0 0 0 1px var(--wpds-color-stroke-surface-success);
+}
+
+.queuePeek[data-intent='error'] {
+	background-color: var(--wpds-color-background-surface-error-weak);
+	box-shadow: 0 0 0 1px var(--wpds-color-stroke-surface-error);
+}
+
+/* The hugging shelf's toasts vary in width, so the peeks take a fixed one
+   and the toast above gets a floor so they never poke out. */
 .shelfHug .queuePeek {
-	margin-inline: 0 16px;
+	width: 144px;
+	margin-inline: 0;
 }
 
 .shelfHug .queuePeekDeeper {
-	margin-inline: 0 32px;
+	width: 128px;
+}
+
+.shelfHug .notice {
+	min-width: 160px;
 }
 
 @keyframes toast-enter {

--- a/apps/ui/src/components/notice-history/index.test.tsx
+++ b/apps/ui/src/components/notice-history/index.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetAppMessagesForTests, toast } from '@/data/app-messages';
+import { closeNoticeHistory, NoticeHistoryButton, NoticeHistoryDialog } from './index';
+
+vi.mock( '@/hooks/use-color-scheme', () => ( {
+	useColorScheme: () => 'light',
+} ) );
+
+const writeText = vi.fn( () => Promise.resolve() );
+
+describe( 'NoticeHistory', () => {
+	beforeEach( () => {
+		Object.assign( navigator, { clipboard: { writeText } } );
+	} );
+
+	afterEach( () => {
+		closeNoticeHistory();
+		resetAppMessagesForTests();
+		writeText.mockClear();
+	} );
+
+	it( 'shows an empty state before anything has been shown', () => {
+		render(
+			<>
+				<NoticeHistoryButton />
+				<NoticeHistoryDialog />
+			</>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Recent notifications' } ) );
+		expect( screen.getByText( 'No notifications yet' ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Clear all' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'lists past notices in full, copies one, and clears them all', async () => {
+		render(
+			<>
+				<NoticeHistoryButton />
+				<NoticeHistoryDialog />
+			</>
+		);
+		act( () => {
+			toast.error( 'Could not open the terminal.', { description: 'iTerm is not installed.' } );
+		} );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Recent notifications' } ) );
+		expect( screen.getByText( 'Could not open the terminal.' ) ).toBeVisible();
+		expect( screen.getByText( 'iTerm is not installed.' ) ).toBeVisible();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Copy' } ) );
+		expect( writeText ).toHaveBeenCalledWith(
+			'Could not open the terminal.\niTerm is not installed.'
+		);
+		expect( await screen.findByRole( 'button', { name: 'Copied' } ) ).toBeVisible();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Clear all' } ) );
+		expect( screen.getByText( 'No notifications yet' ) ).toBeVisible();
+	} );
+} );

--- a/apps/ui/src/components/notice-history/index.test.tsx
+++ b/apps/ui/src/components/notice-history/index.test.tsx
@@ -28,7 +28,7 @@ describe( 'NoticeHistory', () => {
 				<NoticeHistoryDialog />
 			</>
 		);
-		fireEvent.click( screen.getByRole( 'button', { name: 'Recent notifications' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Notification history' } ) );
 		expect( screen.getByText( 'No notifications yet' ) ).toBeVisible();
 		expect( screen.queryByRole( 'button', { name: 'Clear all' } ) ).not.toBeInTheDocument();
 	} );
@@ -44,7 +44,7 @@ describe( 'NoticeHistory', () => {
 			toast.error( 'Could not open the terminal.', { description: 'iTerm is not installed.' } );
 		} );
 
-		fireEvent.click( screen.getByRole( 'button', { name: 'Recent notifications' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Notification history' } ) );
 		expect( screen.getByText( 'Could not open the terminal.' ) ).toBeVisible();
 		expect( screen.getByText( 'iTerm is not installed.' ) ).toBeVisible();
 

--- a/apps/ui/src/components/notice-history/index.tsx
+++ b/apps/ui/src/components/notice-history/index.tsx
@@ -1,0 +1,191 @@
+import { __ } from '@wordpress/i18n';
+import { bell } from '@wordpress/icons';
+import { Button, Dialog, EmptyState, IconButton, Notice } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { AppThemeScope } from '@/components/app-theme-scope';
+import {
+	clearNoticeHistory,
+	noticeToText,
+	useNoticeHistory,
+	type NoticeRecord,
+} from '@/data/app-messages';
+import styles from './style.module.css';
+
+// The dialog mounts once at the layout level; the bell and a toast's "More"
+// both open it through this, so it works with the sidebar collapsed too.
+let isOpen = false;
+const listeners = new Set< () => void >();
+
+function subscribe( listener: () => void ) {
+	listeners.add( listener );
+	return () => {
+		listeners.delete( listener );
+	};
+}
+
+function setOpen( next: boolean ) {
+	if ( isOpen === next ) {
+		return;
+	}
+	isOpen = next;
+	for ( const listener of listeners ) {
+		listener();
+	}
+}
+
+export function openNoticeHistory(): void {
+	setOpen( true );
+}
+
+export function closeNoticeHistory(): void {
+	setOpen( false );
+}
+
+function useNoticeHistoryOpen(): boolean {
+	return useSyncExternalStore(
+		subscribe,
+		() => isOpen,
+		() => false
+	);
+}
+
+export function NoticeHistoryButton( { className }: { className?: string } ) {
+	return (
+		<IconButton
+			variant="minimal"
+			tone="neutral"
+			size="small"
+			className={ clsx( styles.bell, className ) }
+			icon={ bell }
+			label={ __( 'Recent notifications' ) }
+			onClick={ openNoticeHistory }
+		/>
+	);
+}
+
+// Flips to "Copied" briefly; a toast would be the obvious feedback, but a
+// toast about copying a notice would itself land in the list.
+export function CopyNoticeButton( {
+	notice,
+	className,
+	variant = 'solid',
+}: {
+	notice: Pick< NoticeRecord, 'title' | 'description' >;
+	className?: string;
+	variant?: 'solid' | 'outline';
+} ) {
+	const [ copied, setCopied ] = useState( false );
+	const timer = useRef< ReturnType< typeof setTimeout > | undefined >( undefined );
+
+	useEffect( () => () => clearTimeout( timer.current ), [] );
+
+	const copy = async () => {
+		await navigator.clipboard.writeText( noticeToText( notice ) );
+		setCopied( true );
+		clearTimeout( timer.current );
+		timer.current = setTimeout( () => setCopied( false ), 1500 );
+	};
+
+	return (
+		<Button
+			size="small"
+			variant={ variant }
+			tone="neutral"
+			className={ className }
+			onClick={ () => void copy() }
+		>
+			{ copied ? __( 'Copied' ) : __( 'Copy' ) }
+		</Button>
+	);
+}
+
+function formatTime( timestamp: number ) {
+	return new Intl.DateTimeFormat( undefined, { hour: 'numeric', minute: '2-digit' } ).format(
+		timestamp
+	);
+}
+
+export function NoticeHistoryDialog() {
+	const open = useNoticeHistoryOpen();
+	const notices = useNoticeHistory();
+
+	return (
+		// Opened from the sidebar's dark chrome scope; without this the dialog
+		// inherits that palette and renders dark on top of the light app.
+		<AppThemeScope>
+			<Dialog.Root open={ open } onOpenChange={ setOpen }>
+				<Dialog.Popup size="medium">
+					<Dialog.Header className={ styles.header }>
+						<Dialog.Title>{ __( 'Recent notifications' ) }</Dialog.Title>
+					</Dialog.Header>
+					<Dialog.Content>
+						{ notices.length === 0 ? (
+							<EmptyState.Root className={ styles.empty }>
+								<EmptyState.Icon icon={ bell } />
+								<EmptyState.Title>{ __( 'No notifications yet' ) }</EmptyState.Title>
+								<EmptyState.Description>
+									{ __(
+										'Notices Studio shows you during this session collect here, until Studio\u00a0restarts.'
+									) }
+								</EmptyState.Description>
+							</EmptyState.Root>
+						) : (
+							<>
+								{ /* Description drops a passed className, so the spacing lives on
+							     a wrapper. The NBSP keeps the last word from wrapping alone. */ }
+								<div className={ styles.intro }>
+									<Dialog.Description>
+										{ __(
+											'Notices from this session, newest first. They clear when Studio\u00a0restarts.'
+										) }
+									</Dialog.Description>
+								</div>
+								<ul className={ styles.list }>
+									{ notices.map( ( notice ) => (
+										<li key={ `${ notice.id }:${ notice.shownAt }` }>
+											<Notice.Root intent={ notice.intent } className={ styles.notice }>
+												<Notice.Title>{ notice.title }</Notice.Title>
+												{ notice.description ? (
+													<Notice.Description className={ styles.description }>
+														{ notice.description }
+													</Notice.Description>
+												) : null }
+												<time
+													className={ styles.time }
+													dateTime={ new Date( notice.shownAt ).toISOString() }
+												>
+													{ formatTime( notice.shownAt ) }
+												</time>
+												{ notice.description ? (
+													<Notice.Actions>
+														<CopyNoticeButton notice={ notice } variant="outline" />
+													</Notice.Actions>
+												) : null }
+											</Notice.Root>
+										</li>
+									) ) }
+								</ul>
+							</>
+						) }
+					</Dialog.Content>
+					<Dialog.Footer>
+						{ notices.length > 0 ? (
+							<Button
+								variant="minimal"
+								tone="neutral"
+								className={ styles.clearAll }
+								onClick={ clearNoticeHistory }
+							>
+								{ __( 'Clear all' ) }
+							</Button>
+						) : null }
+						<Dialog.Action variant="minimal" tone="neutral">
+							{ __( 'Close' ) }
+						</Dialog.Action>
+					</Dialog.Footer>
+				</Dialog.Popup>
+			</Dialog.Root>
+		</AppThemeScope>
+	);
+}

--- a/apps/ui/src/components/notice-history/index.tsx
+++ b/apps/ui/src/components/notice-history/index.tsx
@@ -58,7 +58,7 @@ export function NoticeHistoryButton( { className }: { className?: string } ) {
 			size="small"
 			className={ clsx( styles.bell, className ) }
 			icon={ bell }
-			label={ __( 'Recent notifications' ) }
+			label={ __( 'Notification history' ) }
 			onClick={ openNoticeHistory }
 		/>
 	);
@@ -116,8 +116,8 @@ export function NoticeHistoryDialog() {
 		<AppThemeScope>
 			<Dialog.Root open={ open } onOpenChange={ setOpen }>
 				<Dialog.Popup size="medium">
-					<Dialog.Header className={ styles.header }>
-						<Dialog.Title>{ __( 'Recent notifications' ) }</Dialog.Title>
+					<Dialog.Header>
+						<Dialog.Title>{ __( 'Notification history' ) }</Dialog.Title>
 					</Dialog.Header>
 					<Dialog.Content>
 						{ notices.length === 0 ? (
@@ -125,22 +125,11 @@ export function NoticeHistoryDialog() {
 								<EmptyState.Icon icon={ bell } />
 								<EmptyState.Title>{ __( 'No notifications yet' ) }</EmptyState.Title>
 								<EmptyState.Description>
-									{ __(
-										'Notices Studio shows you during this session collect here, until Studio\u00a0restarts.'
-									) }
+									{ __( 'Notices Studio shows you collect here, until Studio\u00a0restarts.' ) }
 								</EmptyState.Description>
 							</EmptyState.Root>
 						) : (
 							<>
-								{ /* Description drops a passed className, so the spacing lives on
-							     a wrapper. The NBSP keeps the last word from wrapping alone. */ }
-								<div className={ styles.intro }>
-									<Dialog.Description>
-										{ __(
-											'Notices from this session, newest first. They clear when Studio\u00a0restarts.'
-										) }
-									</Dialog.Description>
-								</div>
 								<ul className={ styles.list }>
 									{ notices.map( ( notice ) => (
 										<li key={ `${ notice.id }:${ notice.shownAt }` }>
@@ -166,6 +155,13 @@ export function NoticeHistoryDialog() {
 										</li>
 									) ) }
 								</ul>
+								{ /* Description drops a passed className, so the note lives on a
+								     wrapper. */ }
+								<div className={ styles.outro }>
+									<Dialog.Description>
+										{ __( 'Notifications are cleared automatically when Studio restarts.' ) }
+									</Dialog.Description>
+								</div>
 							</>
 						) }
 					</Dialog.Content>

--- a/apps/ui/src/components/notice-history/style.module.css
+++ b/apps/ui/src/components/notice-history/style.module.css
@@ -1,0 +1,79 @@
+/* Same weight as the sidebar toggle beside it (user-menu's `.sidebarToggle`);
+   the button paints its own foreground, so the color has to land on it. */
+.bell {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+/* The chrome's header padding puts a full gap between the title and the
+   intro paragraph; tighten it so the two read as one block, and put the
+   space below the paragraph instead. Text zeroes the paragraph's own margin,
+   so it has to be set here. */
+.header {
+	padding-block-end: var(--wpds-dimension-gap-xs);
+}
+
+.intro {
+	margin-block-end: var(--wpds-dimension-gap-lg);
+}
+
+.list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-sm);
+}
+
+.notice {
+	width: 100%;
+	box-sizing: border-box;
+}
+
+/* Notice sizes its title row for a 24px icon, but at this density the glyph
+   renders smaller and sits high; center it on the title row instead. */
+.notice > svg {
+	align-self: center;
+}
+
+/* The toast clamps this; here it runs in full, but a stack trace can be
+   hundreds of lines, so past ~a dozen the entry scrolls on its own rather
+   than pushing every other notice off screen. Error text can be a long,
+   unbroken path or JSON, so let it wrap anywhere. */
+.description {
+	/* Run under the timestamp's column too; it only occupies the title row. */
+	grid-column: 2 / -1;
+	max-height: 240px;
+	overflow: auto;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+}
+
+/* Notice lays out as `auto 1fr auto`; the timestamp takes the trailing cell
+   on the title row, aligned to the title's own text padding. */
+.time {
+	grid-column: 3;
+	grid-row: 1;
+	padding-block: var(--text-vertical-padding);
+	margin-inline-start: var(--wpds-dimension-gap-sm);
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	white-space: nowrap;
+	font-variant-numeric: tabular-nums;
+}
+
+/* EmptyState.Root is a max-width block, so it sits at the content box's
+   start until it is centered. The min-height gives it enough room to read as
+   a state rather than a stub, with the stack centered in it. */
+.empty {
+	margin-inline: auto;
+	justify-content: center;
+	min-height: 200px;
+	padding-block: var(--wpds-dimension-padding-2xl);
+}
+
+/* Footer actions sit at the end; push the destructive-ish one to the start. */
+.clearAll {
+	margin-inline-end: auto;
+}

--- a/apps/ui/src/components/notice-history/style.module.css
+++ b/apps/ui/src/components/notice-history/style.module.css
@@ -4,16 +4,17 @@
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
-/* The chrome's header padding puts a full gap between the title and the
-   intro paragraph; tighten it so the two read as one block, and put the
-   space below the paragraph instead. Text zeroes the paragraph's own margin,
-   so it has to be set here. */
-.header {
-	padding-block-end: var(--wpds-dimension-gap-xs);
-}
-
-.intro {
-	margin-block-end: var(--wpds-dimension-gap-lg);
+/* A quiet footnote under the list rather than a subtitle above it: it
+   explains the log's lifetime, which the reader only wants once. */
+.outro {
+	margin-block-start: var(--wpds-dimension-gap-lg);
+	font-size: var(--wpds-typography-font-size-xs);
+	/* A step below the notice body text, which is already `-weak`. */
+	color: color-mix(
+		in srgb,
+		var(--wpds-color-foreground-content-neutral-weak) 75%,
+		transparent
+	);
 }
 
 .list {

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -4,8 +4,10 @@ import { Button, Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AppMessageCards, AppMessageCardsDot } from '@/components/app-message-cards';
+import { appThemeColor } from '@/components/app-theme-scope';
 import { AppToasts } from '@/components/app-toasts';
 import { CollapsedSiteSwitcher } from '@/components/collapsed-site-switcher';
+import { NoticeHistoryDialog } from '@/components/notice-history';
 import { ResizeHandle, ResizeOverlay } from '@/components/resize-handle';
 import { SidebarHeader } from '@/components/sidebar-header';
 import { SeenSessionTimestampsProvider, SiteList } from '@/components/site-list';
@@ -154,15 +156,21 @@ export function SidebarLayout( {
 								<SidebarHeader />
 								<SiteList />
 								<div className={ styles.sidebarFooter }>
+									{ ! effectiveCollapsed ? (
+										<StudioBetaMenu className={ styles.sidebarBeta } />
+									) : null }
 									{ /* Toasts sit above the persistent cards: the footer is
 								     bottom-anchored, so a transient toast arriving below a card
 								     would shove it up and drop it back on expiry. */ }
-									{ ! effectiveCollapsed ? <AppToasts className={ styles.sidebarToasts } /> : null }
 									{ ! effectiveCollapsed ? (
-										<AppMessageCards className={ styles.sidebarCards } />
-									) : null }
-									{ ! effectiveCollapsed ? (
-										<StudioBetaMenu className={ styles.sidebarBeta } />
+										// Notices sit on the dark chrome, so they take the app's
+										// own theme (a step up from the chrome in both schemes) and
+										// keep their intent tints instead of flattening to a
+										// chrome-on-chrome neutral card.
+										<ThemeProvider color={ appThemeColor( colorScheme ) }>
+											<AppToasts className={ styles.sidebarToasts } appearance="intent" />
+											<AppMessageCards className={ styles.sidebarCards } appearance="intent" />
+										</ThemeProvider>
 									) : null }
 									<UserMenu onToggleSidebar={ toggleSidebar } />
 								</div>
@@ -236,6 +244,7 @@ export function SidebarLayout( {
 						) : null }
 					</main>
 					{ sidebarResize.isResizing ? <ResizeOverlay /> : null }
+					<NoticeHistoryDialog />
 				</div>
 			</SeenSessionTimestampsProvider>
 		</SidebarCollapsedContext.Provider>

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -4,7 +4,6 @@ import { Button, Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AppMessageCards, AppMessageCardsDot } from '@/components/app-message-cards';
-import { appThemeColor } from '@/components/app-theme-scope';
 import { AppToasts } from '@/components/app-toasts';
 import { CollapsedSiteSwitcher } from '@/components/collapsed-site-switcher';
 import { NoticeHistoryDialog } from '@/components/notice-history';
@@ -163,14 +162,13 @@ export function SidebarLayout( {
 								     bottom-anchored, so a transient toast arriving below a card
 								     would shove it up and drop it back on expiry. */ }
 									{ ! effectiveCollapsed ? (
-										// Notices sit on the dark chrome, so they take the app's
-										// own theme (a step up from the chrome in both schemes) and
-										// keep their intent tints instead of flattening to a
-										// chrome-on-chrome neutral card.
-										<ThemeProvider color={ appThemeColor( colorScheme ) }>
+										// Notices inherit the sidebar's chrome theme scope, so they
+										// sit on the dark chrome in both schemes and keep their
+										// intent tints against it.
+										<>
 											<AppToasts className={ styles.sidebarToasts } appearance="intent" />
 											<AppMessageCards className={ styles.sidebarCards } appearance="intent" />
-										</ThemeProvider>
+										</>
 									) : null }
 									<UserMenu onToggleSidebar={ toggleSidebar } />
 								</div>
@@ -240,6 +238,7 @@ export function SidebarLayout( {
 									forceCollapsed && styles.floatingToastsOverPreview
 								) }
 								fit="content"
+								appearance="intent"
 							/>
 						) : null }
 					</main>

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -82,8 +82,8 @@
 	padding: var(--wpds-dimension-padding-sm) calc(var(--wpds-dimension-padding-lg) - var(--wpds-dimension-padding-sm)) 0;
 }
 
-/* The beta affordance stays in normal footer flow, below transient/persistent
-   messages and above Settings, so it never overlays a toast or checklist.
+/* The beta affordance stays in normal footer flow, at the top of the footer
+   so notices sit directly above the Settings row and its bell.
    Margin, not padding: this class lands on the bubble itself, which owns its
    own padding. */
 .sidebarBeta {

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -169,8 +169,12 @@
 .floatingToasts {
 	position: absolute;
 	bottom: calc(52px + var(--app-main-composer-height, 0px));
-	inset-inline-start: var(--wpds-dimension-padding-xl);
-	width: min(320px, calc(100% - 2 * var(--wpds-dimension-padding-xl)));
+	/* --app-main-composer-left is the composer box's start edge, published
+	   by the session view like the height. Views without a composer fall
+	   back to the panel's own control inset. */
+	--shelf-start: var(--app-main-composer-left, var(--wpds-dimension-padding-xl));
+	inset-inline-start: var(--shelf-start);
+	width: min(320px, calc(100% - 2 * var(--shelf-start)));
 	z-index: 110;
 	pointer-events: auto;
 	-webkit-app-region: no-drag;

--- a/apps/ui/src/components/user-menu/index.tsx
+++ b/apps/ui/src/components/user-menu/index.tsx
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, settings } from '@wordpress/icons';
 import { IconButton } from '@wordpress/ui';
 import { Gravatar } from '@/components/gravatar';
+import { NoticeHistoryButton } from '@/components/notice-history';
 import { SidebarButton } from '@/components/sidebar-button';
 import { useAuthUser } from '@/data/queries/use-auth-user';
 import { useColorScheme } from '@/hooks/use-color-scheme';
@@ -34,6 +35,7 @@ export function UserMenu( { onToggleSidebar }: Props ) {
 					) }
 					<span className={ styles.userName }>{ __( 'App settings' ) }</span>
 				</SidebarButton>
+				<NoticeHistoryButton />
 				<IconButton
 					variant="minimal"
 					tone="neutral"

--- a/apps/ui/src/data/app-messages.test.ts
+++ b/apps/ui/src/data/app-messages.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+	clearNoticeHistory,
 	dismissToast,
+	getNoticeHistory,
 	getQueuedToastCount,
 	getVisibleToasts,
 	notifyRendererMounted,
@@ -223,5 +225,43 @@ describe( 'app-messages', () => {
 
 		vi.advanceTimersByTime( 4_500 );
 		expect( getQueuedToastCount() ).toBe( 0 );
+	} );
+
+	describe( 'notice history', () => {
+		const historyTitles = () => getNoticeHistory().map( ( item ) => item.title );
+
+		it( 'records every toast newest first, with the full description', () => {
+			toast.success( 'Saved' );
+			toast.error( 'Failed', { description: 'Long error text' } );
+			expect( historyTitles() ).toEqual( [ 'Failed', 'Saved' ] );
+			expect( getNoticeHistory()[ 0 ].description ).toBe( 'Long error text' );
+		} );
+
+		it( 'folds an in-place replacement into the original record', () => {
+			showToast( { id: 'sync', intent: 'info', title: 'Pushing to live' } );
+			showToast( { id: 'sync', intent: 'success', title: 'Push complete' } );
+			expect( historyTitles() ).toEqual( [ 'Push complete' ] );
+		} );
+
+		it( 'keeps a notice after its toast expires', () => {
+			toast.success( 'Saved' );
+			vi.advanceTimersByTime( 4_500 );
+			settleExit();
+			expect( titles() ).toEqual( [] );
+			expect( historyTitles() ).toEqual( [ 'Saved' ] );
+		} );
+
+		it( 'clears the list and dismisses the toasts still showing or queued', () => {
+			for ( let i = 0; i < 5; i++ ) {
+				toast.success( `Saved ${ i }` );
+			}
+			expect( getQueuedToastCount() ).toBe( 2 );
+
+			clearNoticeHistory();
+			expect( historyTitles() ).toEqual( [] );
+			expect( getQueuedToastCount() ).toBe( 0 );
+			settleExit();
+			expect( titles() ).toEqual( [] );
+		} );
 	} );
 } );

--- a/apps/ui/src/data/app-messages.ts
+++ b/apps/ui/src/data/app-messages.ts
@@ -36,6 +36,15 @@ export type ToastMessage = {
 	leaving?: boolean;
 };
 
+export type NoticeRecord = {
+	id: string;
+	intent: ToastIntent;
+	title: string;
+	description?: string;
+	// Epoch ms of the first showing; an in-place replacement keeps it.
+	shownAt: number;
+};
+
 const DEFAULT_TOAST_TTL_MS = 4_500;
 // Failures linger so a glance away doesn't miss them.
 const ERROR_TOAST_TTL_MS = 10_000;
@@ -48,6 +57,12 @@ let visible: ToastMessage[] = [];
 let queued: ToastMessage[] = [];
 let nextId = 1;
 let rendererMounted = false;
+
+// Session-only log of everything shown, newest first. A toast clamps long
+// error text and then expires; the history panel is where the full message
+// can still be read. Bounded so a noisy session can't grow it forever.
+const HISTORY_LIMIT = 50;
+let noticeHistory: NoticeRecord[] = [];
 
 const timers = new Map< string, ReturnType< typeof setTimeout > >();
 const listeners = new Set< () => void >();
@@ -82,6 +97,28 @@ function scheduleExpiry( toast: ToastMessage ) {
 		beginToastExit( toast.id );
 	}, toast.durationMs );
 	timers.set( toast.id, timer );
+}
+
+function recordNotice( toastMessage: ToastMessage, isReplacement: boolean ) {
+	const record: NoticeRecord = {
+		id: toastMessage.id,
+		intent: toastMessage.intent,
+		title: toastMessage.title,
+		description: toastMessage.description,
+		shownAt: Date.now(),
+	};
+	if ( isReplacement ) {
+		const index = noticeHistory.findIndex( ( item ) => item.id === toastMessage.id );
+		if ( index >= 0 ) {
+			// A sync ticking from "Pushing… 62%" to "Push complete" is one event,
+			// not two entries.
+			noticeHistory = noticeHistory.map( ( item, i ) =>
+				i === index ? { ...record, shownAt: item.shownAt } : item
+			);
+			return;
+		}
+	}
+	noticeHistory = [ record, ...noticeHistory ].slice( 0, HISTORY_LIMIT );
 }
 
 function promoteQueued() {
@@ -136,13 +173,17 @@ export function showToast( input: ToastInput ): string {
 		// leaving flag, and scheduleExpiry clears the pending removal timer.
 		visible = visible.map( ( toast ) => ( toast.id === toastMessage.id ? toastMessage : toast ) );
 		scheduleExpiry( toastMessage );
+		recordNotice( toastMessage, true );
 	} else if ( queued.some( ( toast ) => toast.id === toastMessage.id ) ) {
 		queued = queued.map( ( toast ) => ( toast.id === toastMessage.id ? toastMessage : toast ) );
+		recordNotice( toastMessage, true );
 	} else if ( visible.length < MAX_VISIBLE_TOASTS ) {
 		visible = [ ...visible, toastMessage ];
 		scheduleExpiry( toastMessage );
+		recordNotice( toastMessage, false );
 	} else {
 		queued = [ ...queued, toastMessage ];
+		recordNotice( toastMessage, false );
 	}
 
 	emit();
@@ -230,6 +271,36 @@ export function useQueuedToastCount(): number {
 }
 
 const EMPTY_TOASTS: readonly ToastMessage[] = [];
+const EMPTY_HISTORY: readonly NoticeRecord[] = [];
+
+export function getNoticeHistory(): readonly NoticeRecord[] {
+	return noticeHistory;
+}
+
+export function useNoticeHistory(): readonly NoticeRecord[] {
+	return useSyncExternalStore(
+		subscribe,
+		() => noticeHistory,
+		() => EMPTY_HISTORY
+	);
+}
+
+// "Clear all" in the recent-notifications dialog: the list, plus whatever is
+// still showing or waiting in the sidebar — a cleared list with toasts left
+// behind reads as if nothing happened.
+export function clearNoticeHistory(): void {
+	queued = [];
+	for ( const toastMessage of visible ) {
+		beginToastExit( toastMessage.id );
+	}
+	noticeHistory = [];
+	emit();
+}
+
+// Title plus the full description, for the clipboard.
+export function noticeToText( notice: Pick< NoticeRecord, 'title' | 'description' > ): string {
+	return notice.description ? `${ notice.title }\n${ notice.description }` : notice.title;
+}
 
 export function resetAppMessagesForTests(): void {
 	for ( const timer of timers.values() ) {
@@ -241,4 +312,5 @@ export function resetAppMessagesForTests(): void {
 	nextId = 1;
 	rendererMounted = false;
 	snapshot = visible;
+	noticeHistory = [];
 }

--- a/apps/ui/src/data/app-messages.ts
+++ b/apps/ui/src/data/app-messages.ts
@@ -68,9 +68,11 @@ const timers = new Map< string, ReturnType< typeof setTimeout > >();
 const listeners = new Set< () => void >();
 
 let snapshot: readonly ToastMessage[] = visible;
+let queuedSnapshot: readonly ToastMessage[] = queued;
 
 function emit() {
 	snapshot = [ ...visible ];
+	queuedSnapshot = [ ...queued ];
 	for ( const listener of listeners ) {
 		listener();
 	}
@@ -262,11 +264,13 @@ export function getQueuedToastCount(): number {
 	return queued.length;
 }
 
-export function useQueuedToastCount(): number {
+// The toasts waiting behind the visible ones, in the order they will
+// surface — the stack's peek strips tint themselves to match.
+export function useQueuedToasts(): readonly ToastMessage[] {
 	return useSyncExternalStore(
 		subscribe,
-		() => queued.length,
-		() => 0
+		() => queuedSnapshot,
+		() => EMPTY_TOASTS
 	);
 }
 

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -160,13 +160,22 @@ function SessionFrame( {
 				'--app-main-composer-height',
 				`${ composerHeight }px`
 			);
+			// The shelf's start edge lines up with the composer box, wherever
+			// the reading column puts it.
+			const composerBox = composerRef.current?.firstElementChild;
+			if ( composerBox && root ) {
+				const left = composerBox.getBoundingClientRect().left - root.getBoundingClientRect().left;
+				document.documentElement.style.setProperty( '--app-main-composer-left', `${ left }px` );
+			}
 		};
 
 		updateChromeSize();
 
 		// Views without a composer must fall back to the shelf's 0px default.
-		const clearComposerHeight = () =>
+		const clearComposerHeight = () => {
 			document.documentElement.style.removeProperty( '--app-main-composer-height' );
+			document.documentElement.style.removeProperty( '--app-main-composer-left' );
+		};
 
 		if ( typeof ResizeObserver === 'undefined' ) {
 			window.addEventListener( 'resize', updateChromeSize );


### PR DESCRIPTION
## Related issues

- Related to STU-2415

## How AI was used in this PR

Built with Claude Code against a running `studio ui`, using a temporary tweaks panel to fire notices of every intent, length, and count (not part of this PR). Every state below was reviewed in light and dark; the diff, copy, and tests were reviewed by hand.

## Proposed Changes

Problems this addresses:
- Sidebar notices were hard to read: neutral cards with muted text on the dark chrome, and no way to tell an error from a confirmation at a glance.
- Long notice content, typically errors, broke the layout.
- Once a notice expired there was no way to find it again.
- With the sidebar collapsed, floating notices didn't line up with anything and looked like a different component.

What changes:

**Notices carry their intent.** Success, info, and error notices use the design system's tinted surface and border. In the sidebar they sit directly on the chrome theme scope, so they read the same on the dark sidebar in both color schemes.

| Light | Dark |
|---|---|
| ![Sidebar notices, light](https://github.com/Automattic/studio/blob/ad27adae8904cfecea342f950ab8f5b5a49a9188/sidebar-light.png?raw=true) | ![Sidebar notices, dark](https://github.com/Automattic/studio/blob/ad27adae8904cfecea342f950ab8f5b5a49a9188/sidebar-dark.png?raw=true) |

**Queued notices show their color.** When more than three notices are waiting, the peek strips under the stack take the tint of the next notices in line, so a pending error is visible before it surfaces.

![Queue peeks tinted by the next notices](https://github.com/Automattic/studio/blob/ad27adae8904cfecea342f950ab8f5b5a49a9188/sidebar-peeks-light.png?raw=true)

**Collapsed sidebar notices match.** With the sidebar hidden, notices float above the composer with the same intent styling, hug their content width, and line up with the composer's left edge. Peeks there take a fixed width so a short notice above them still reads as the top of a stack.

| Light | Dark |
|---|---|
| ![Collapsed sidebar notices, light](https://github.com/Automattic/studio/blob/ad27adae8904cfecea342f950ab8f5b5a49a9188/collapsed-light.png?raw=true) | ![Collapsed sidebar notices, dark](https://github.com/Automattic/studio/blob/ad27adae8904cfecea342f950ab8f5b5a49a9188/collapsed-dark.png?raw=true) |

**Long errors no longer swallow the UI.** A notice description clamps to three lines. Error notices with details gain **Copy** (title plus full text, for pasting to the agent or a bug report) and **More**, which opens the new **Notification history** dialog, also reachable from the bell beside App settings.

The dialog is a session log, not a persisted inbox: everything Studio has shown, newest first, with full text, a timestamp, and a per-entry Copy. A single entry scrolls internally past roughly a dozen lines, so one enormous stack trace can't push the rest off screen. **Clear all** empties the list and dismisses notices still showing or queued. A footnote under the list notes that the history clears when Studio restarts. With nothing to show it presents an empty state, and Clear all is not offered.

| Light | Dark |
|---|---|
| ![Notification history, light](https://github.com/Automattic/studio/blob/df3fc4325759f41d5a20e26bcf156e772564ba66/modal-light.png?raw=true) | ![Notification history, dark](https://github.com/Automattic/studio/blob/df3fc4325759f41d5a20e26bcf156e772564ba66/modal-dark.png?raw=true) |

| Huge error | Empty state (light) | Empty state (dark) |
|---|---|---|
| ![A 300-line error scrolling inside its entry](https://github.com/Automattic/studio/blob/df3fc4325759f41d5a20e26bcf156e772564ba66/modal-huge.png?raw=true) | ![Empty state, light](https://github.com/Automattic/studio/blob/df3fc4325759f41d5a20e26bcf156e772564ba66/modal-empty-light.png?raw=true) | ![Empty state, dark](https://github.com/Automattic/studio/blob/df3fc4325759f41d5a20e26bcf156e772564ba66/modal-empty-dark.png?raw=true) |

Also: notice shadows are tighter (max 8px blur instead of 16px) so they sit closer to the surface.

## Testing Instructions

Run the agentic UI (`npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`) or the Desktop app, in **both light and dark**.

1. Trigger notices of each kind: copy a site URL (success), start a site (info), and provoke a failure such as opening a terminal that isn't installed (error). Confirm each is readable on the sidebar and carries its intent color, identically in light and dark.
2. Trigger more than three notices in quick succession and confirm the peek strips under the stack take the color of the waiting notices.
3. On an error notice with details, confirm **Copy** and **More** appear and that Copy puts title plus full text on the clipboard.
4. Click **More**, or the bell beside App settings, and confirm the dialog lists notices newest first with full text and timestamps.
5. Provoke or simulate a very long error and confirm the notice clamps to three lines while the dialog entry scrolls inside itself.
6. Press **Clear all** and confirm both the dialog and the sidebar empty, and the empty state appears with no Clear all button.
7. Collapse the sidebar and confirm notices float above the composer, left-aligned with it, hugging their content, with the same colors as in the sidebar. Confirm **More** still opens the dialog.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

