### PR TITLE
Teach Studio Code to pad cards and non-constrained full-width sections

### DIFF
--- a/apps/cli/ai/skills/block-content/SKILL.md
+++ b/apps/cli/ai/skills/block-content/SKILL.md
@@ -38,6 +38,13 @@ Use these patterns:
 
 The common failure is a hero or banner that was intended to be full-width but still renders in the narrow content column. Fix that in markup by adding `align: "full"` on the outer group or correcting the inner `layout` type, not by trying to force width in CSS.
 
+### Horizontal Padding
+
+WordPress supplies horizontal padding in exactly one place: the root gutter (`styles.spacing.padding`) lands on full-width constrained groups via `.has-global-padding`, and core zeroes it again on constrained groups nested inside them. Every other box gets none — a full-width section with a `default`, `flex`, or `grid` layout, and any group, column, or cover that paints its own background, border, or shadow (a card, a callout, a tinted panel). Block themes do not load core's default `.has-background` padding either. Text sitting flush against its own background, border, or the viewport edge is the most common tell of an unfinished section, so:
+
+- Whenever a block paints its own box, give its class horizontal padding in `style.css` — `.is-style-card { padding: 1.5rem; }`.
+- Give a non-constrained full-width section the same gutter as the rest of the page — `padding-inline: var(--wp--style--root--padding-left);` — or place its text inside a constrained inner group, which keeps the gutter when it sits directly in a full-width `default` group.
+
 ### Shrink-Wrapped Labels (Eyebrows, Badges, Pills)
 
 Constrained layouts keep children in the content column with `max-width` plus `margin-left/right: auto !important`. Auto margins only work on block-level boxes, so setting `display: inline-block` (or any `inline-*` value) on a block's wrapper class detaches it from the content column — it aligns to the edge of the full-width section instead. `width: fit-content` fails differently: the auto margins always center it, so it cannot sit left or right within the column.

--- a/apps/cli/ai/skills/visual-polish/SKILL.md
+++ b/apps/cli/ai/skills/visual-polish/SKILL.md
@@ -32,6 +32,7 @@ The most important rule: **do not fix issues one at a time as you find them.** F
 3. Go **section by section**. For each, call `inspect_design` on the relevant selectors and compare the rendered DOM and computed styles against your intent and the theme's `style.css` (read it). The screenshot is the symptom; `inspect_design` is the cause — never diagnose from the screenshot alone, because subtle issues like doubled button padding barely show in pixels. Inspect even sections that look roughly right, and always inspect:
    - every section wrapper — for width and centering,
    - every button — BOTH `.wp-block-button` and `.wp-block-button__link`, with `includeHover: true`.
+   - every block that paints its own box (background, border, shadow — cards, panels, tinted sections) and every non-constrained full-width section — for `padding-left`/`padding-right`, which must not be `0px` when the box holds text.
 4. List the **complete** set of issues before fixing anything — a concise checklist, one short line per issue: the section, the root cause from the DOM, and the exact fix (file, selector, change). A list, not prose.
 
 Do not make a single edit until you have diagnosed every section and listed every issue. **A complete diagnosis is the gate into Phase 2.**
@@ -72,6 +73,12 @@ Inspect BOTH selectors with `includeHover: true` and compare their computed styl
 
 - If padding/background/border is set on BOTH the wrapper and the link, the button renders with **doubled padding and looks too big** — remove that styling from the wrapper (or its custom class) and put it on `.wp-element-button` / `.wp-block-button__link`.
 - There must be exactly ONE hover rule, on the inner element (`.wp-element-button:hover` or `.wp-block-button__link:hover`), never the `.wp-block-button` wrapper. If both have hover styles you get **two conflicting hover effects** — delete the wrapper hover. Use the `hover` block in the inspect output to confirm only the inner element changes.
+
+### Text touches a background, border, or the viewport edge
+
+Symptom: copy sits flush against the edge of a card, a tinted panel, a bordered box, or the window — most visible on mobile.
+
+Inspect the box and read `padding-left`/`padding-right`. WordPress pads only full-width constrained groups (the root gutter via `.has-global-padding`) and zeroes it on constrained groups nested inside them; a group, column, or cover with its own background or border gets no padding, and neither does a full-width section with a `default`, `flex`, or `grid` layout. Fix it by giving the block's class horizontal padding in `style.css` (reuse `var(--wp--style--root--padding-left)` for a section gutter) or by moving the text into a constrained inner group — never with margins on the text blocks.
 
 ### Spacing between blocks differs from intent
 


### PR DESCRIPTION
## Related issues

- None

## How AI was used in this PR

Claude Code investigated the cause (scanned 33 locally agent-built sites, checked the WordPress core layout CSS that governs horizontal padding), wrote the skill wording, and ran three DeepSeek V4 Flash builds with the change in place. The wording was reviewed by hand.

## Proposed Changes

Studio Code regularly produces sections and cards whose text sits flush against the edge of their own background, border, or the viewport, which makes an otherwise good build feel unfinished. This is not model randomness: WordPress block themes supply horizontal padding in exactly one place (the root gutter on full-width constrained groups) and explicitly zero it on constrained groups nested inside them. Cards, tinted panels, columns with a background, and full-width sections using a `default`/`flex`/`grid` layout get nothing, and block themes never load core's fallback `.has-background` padding. None of the agent's skills mentioned this. In a scan of 33 agent-built pages on one machine, half of the card-like boxes and a third of the non-constrained full-width sections had no horizontal padding at all.

This PR adds a short "Horizontal Padding" note to the `block-content` skill, telling the agent which boxes must own their padding and how (class padding in `style.css`, the root-padding token for non-constrained full-width sections, or a constrained inner group), and adds a matching checklist item plus a recurring-issue entry to the `visual-polish` skill so the verification pass inspects `padding-left`/`padding-right` on those boxes. No prompt, tool, or eval changes; 14 lines of skill text.

## Testing Instructions

- Build a one-page site that naturally produces cards and a full-width hero, e.g. "Build a farm one page site, known for its animals visits and its local products. Use elegant colors and design."
- Check that cards/panels with a background or border and any full-width section have visible horizontal padding, on desktop and mobile.
- Existing evals don't cover this (the card eval explicitly asks for padding). Three DeepSeek V4 Flash builds with this change produced padded cards and sections.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
