### PR TITLE
Pad main in scaffolded themes so WooCommerce default templates clear the header and footer

### DIFF
--- a/apps/cli/ai/skills/block-content/SKILL.md
+++ b/apps/cli/ai/skills/block-content/SKILL.md
@@ -65,8 +65,8 @@ This holds even when it looks harmless: inside a flex row an `inline-block` or `
 
 WordPress inserts `margin-block-start: var(--wp--style--block-gap)` between the top-level children of the rendered template — between the header template part, the main group, and the footer template part (`.wp-site-blocks > * + *`). Core supplies a default gap (24px) even when the theme's `theme.json` never declares `styles.spacing.blockGap`, so a gap appears there that no markup asked for.
 
-- Themes created with `scaffold_theme` already zero this in `style.css` (`.wp-site-blocks > * + * { margin-block-start: 0; }`) — sections butt edge-to-edge and own their vertical rhythm via their own padding. Keep that reset when editing the file.
-- When working in a theme without that reset, add the same rule to the theme's `style.css` instead of compensating with negative margins or guessing at the extra space.
+- Themes created with `scaffold_theme` already zero this in `style.css` (`.wp-site-blocks > * + * { margin-block-start: 0; }`) — sections butt edge-to-edge and own their vertical rhythm via their own padding, and `main` gets its padding back through the `.wp-site-blocks main` rule next to it so templates the theme does not author (plugin templates) still clear the header and footer. Keep both rules when editing the file.
+- When working in a theme without that reset, add the same rules to the theme's `style.css` instead of compensating with negative margins or guessing at the extra space.
 - Do not zero the gap by setting `styles.spacing.blockGap: "0"` in `theme.json` — that value cascades as the default gap inside every flow and constrained layout and collapses content rhythm site-wide.
 - When you want visible space between top-level sections, add it deliberately (padding on the sections) so the spacing is designed, not inherited.
 

--- a/apps/cli/ai/skills/plugin-recommendations/SKILL.md
+++ b/apps/cli/ai/skills/plugin-recommendations/SKILL.md
@@ -109,6 +109,8 @@ Use blocks such as `woocommerce/product-collection`, `woocommerce/featured-produ
 
 6. After installing WooCommerce, go back and edit the header template part (`parts/header.html`) to add a mini-cart, unless it already shows one. Add the `woocommerce/mini-cart` block alongside the navigation - it renders a cart icon with a live item count and opens the cart drawer - and add a "Shop" link to the primary navigation.
 
+7. Rely on WooCommerce's default block templates (shop, single product, cart, checkout, my account) whenever possible instead of writing `archive-product.html`, `single-product.html`, or similar into the theme. They already use the theme's header and footer parts and pick up its `theme.json` and `style.css`; the theme's `.wp-site-blocks main` padding (see the `block-content` skill's Root Block Gap section) is what keeps them clear of the header and footer, so style them through the theme rather than per-page body-class rules. Write a template override only when the design genuinely needs a different structure, and keep the header and footer template parts in it.
+
 ## Jetpack Forms
 
 When the user asks for a contact form, feedback form, survey, or any other interactive form that collects submissions, use Jetpack Forms - not raw HTML `<form>` elements.

--- a/apps/cli/ai/skills/visual-polish/SKILL.md
+++ b/apps/cli/ai/skills/visual-polish/SKILL.md
@@ -14,7 +14,7 @@ The core method is **diagnose from evidence, not from memory**. Do not guess why
 
 Polish **every page of the site**, not just the home page. This includes all user-created pages (Home, About, Contact, and similar) and any plugin-provided pages. A page the user never sees polished feels unfinished, and plugin pages ship with generic default styling that rarely matches the theme.
 
-For a WooCommerce shop, polish each of these pages: Shop, single-product, Cart, Checkout, and My Account.
+For a WooCommerce shop, polish each of these pages: Shop, single-product, Cart, Checkout, and My Account, checking the space around `main` on each.
 
 How much to iterate depends on the page:
 

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -1490,6 +1490,14 @@ describe( 'Studio AI MCP tools', () => {
 			expect( styleCss ).not.toContain( 'Template:' );
 			expect( styleCss ).toContain( '.wp-site-blocks > * + * {' );
 			expect( styleCss ).toContain( 'margin-block-start: 0;' );
+			expect( styleCss ).toContain( '.wp-site-blocks main {' );
+			expect( styleCss ).toContain( '.wp-site-blocks main.is-flush {' );
+
+			const pageNoTitle = await readFile(
+				path.join( themeDir, 'templates', 'page-no-title.html' ),
+				'utf8'
+			);
+			expect( pageNoTitle ).toContain( '{"tagName":"main","className":"is-flush"}' );
 
 			const themeJson = JSON.parse(
 				await readFile( path.join( themeDir, 'theme.json' ), 'utf8' )

--- a/apps/cli/ai/tools/scaffold-theme.ts
+++ b/apps/cli/ai/tools/scaffold-theme.ts
@@ -87,6 +87,18 @@ Tags: full-site-editing, block-patterns, block-styles, wide-blocks, accessibilit
 .wp-site-blocks > * + * {
 	margin-block-start: 0;
 }
+
+/* With that gap gone, main carries its own vertical padding so templates this
+   theme does not author (WooCommerce shop, product, cart…) still clear the
+   header and footer. A descendant selector, not a child one: WooCommerce wraps
+   the single-product main in an extra group. Templates built from full-bleed
+   sections opt out with is-flush and let the sections own the rhythm. */
+.wp-site-blocks main {
+	padding-block: var(--wp--preset--spacing--60) var(--wp--preset--spacing--70);
+}
+.wp-site-blocks main.is-flush {
+	padding-block: 0;
+}
 `;
 }
 
@@ -290,8 +302,8 @@ const TEMPLATE_PAGE = `<!-- wp:template-part {"slug":"header"} /-->
 
 const TEMPLATE_PAGE_NO_TITLE = `<!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"tagName":"main"} -->
-<main class="wp-block-group">
+<!-- wp:group {"tagName":"main","className":"is-flush"} -->
+<main class="wp-block-group is-flush">
 	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 </main>
 <!-- /wp:group -->
@@ -383,7 +395,7 @@ const PART_FOOTER = `<!-- wp:group {"layout":{"type":"constrained"},"style":{"sp
 export const scaffoldThemeTool = defineTool(
 	'scaffold_theme',
 	'Scaffolds a minimal block theme into the given site at wp-content/themes/<slug>/ and activates it by default. ' +
-		'Drops in style.css (theme header plus a reset zeroing the default block gap between top-level template sections), ' +
+		'Drops in style.css (theme header, a reset zeroing the default block gap between top-level template sections, and default vertical padding on main that full-bleed templates opt out of with the is-flush class), ' +
 		'theme.json (appearanceTools, a content/wide layout width, and root-padding-aware horizontal padding so content never touches the viewport edge), ' +
 		'functions.php (frontend + editor style enqueue), default templates (index, single, page, archive, 404), ' +
 		'a registered page-no-title template to assign to designed pages whose content carries its own heading, ' +


### PR DESCRIPTION
## Related issues

- None

## How AI was used in this PR

Claude Code diagnosed the issue on two agent-built shop sites (measured the rendered gaps in a browser), proposed the fix, and applied it. The selector was corrected after live-testing against WooCommerce's single-product template. Reviewed by the author.

## Proposed Changes

Shops built by Studio Code render the WooCommerce pages (shop, product, cart, checkout, my account) with no vertical space between the header and the content, and between the content and the footer, while the site's own pages look right.

The cause is a contract the scaffolded theme sets up but only half honours. `scaffold_theme` zeroes WordPress's root block gap (`.wp-site-blocks > * + *`) so full-bleed sections can butt edge to edge, and agent-authored pages carry their own padding. WooCommerce's default block templates render a bare `main` and rely on that root gap for breathing room, so they collapse against the header and footer. The agent has been patching this per page with body-class rules during polish, and on one site it wrote its own `archive-product.html` without header or footer parts.

This PR keeps WooCommerce's default templates in play and fixes the theme side instead:

- The scaffolded `style.css` pairs the root-gap reset with vertical padding on `main`, using the theme's spacing presets. Any template the theme does not author (WooCommerce today, other plugins tomorrow) gets its space back with no plugin-specific rules. The `page-no-title` template opts out with an `is-flush` class, since its full-bleed sections own the rhythm.
- The `plugin-recommendations` skill tells the agent to rely on WooCommerce's default templates when possible and to keep header and footer parts if it ever does override one.
- The `block-content` and `visual-polish` skills get one-clause additions: keep both rules together, and check the space around `main` on Woo pages.

User impact: newly scaffolded shop sites get consistent spacing on every WooCommerce page without per-page hacks. Existing sites are unchanged.

## Testing Instructions

- `npm test -- apps/cli/ai/tests/tools.test.ts -t scaffold`
- Build a shop with Studio Code on a fresh site (custom theme via `scaffold_theme`, WooCommerce installed) and open Shop, a product, Cart and Checkout. The content should sit clear of the header and footer on each page. A page assigned the "Page (no title)" template should still start flush under the header.
- Agent evals were not run for this change; the theme and shop cases are the ones affected if someone wants to run them.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
