### PR TITLE
Report update progress and version numbers while Studio updates

### DIFF
--- a/apps/studio/src/ipc-utils.ts
+++ b/apps/studio/src/ipc-utils.ts
@@ -83,7 +83,7 @@ export interface IpcEvents {
  * desktop app to report on (the browser UI's connectors), and `newVersion` is null until
  * the feed lookup resolves — Electron's autoUpdater only names the version on download.
  */
-export type AppUpdateStatus =
+export type AppUpdateStatus = (
 	| { state: 'idle' | 'checking'; currentVersion: string | null }
 	| { state: 'downloading'; currentVersion: string | null; newVersion: string | null }
 	| { state: 'ready'; currentVersion: string | null; newVersion: string | null }
@@ -92,7 +92,11 @@ export type AppUpdateStatus =
 			currentVersion: string | null;
 			reason: 'read-only-volume' | 'generic';
 			detail?: string;
-	  };
+	  }
+) & {
+	// Set when the user asked for this check, so the renderer can re-show a dismissed card.
+	requested?: boolean;
+};
 
 let isAppQuitting = false;
 

--- a/apps/studio/src/ipc-utils.ts
+++ b/apps/studio/src/ipc-utils.ts
@@ -75,12 +75,24 @@ export interface IpcEvents {
 	'ai-session-placement-updated': [ AiSessionPlacementUpdatedEvent ];
 	'remote-session-status': [ RemoteSessionStatus ];
 	'app-update-status': [ AppUpdateStatus ];
+	'app-update-not-available': [ { currentVersion: string } ];
 }
 
-export interface AppUpdateStatus {
-	readyToInstall: boolean;
-	version: string | null;
-}
+/**
+ * Updater lifecycle as the renderer sees it. `currentVersion` is null where there is no
+ * desktop app to report on (the browser UI's connectors), and `newVersion` is null until
+ * the feed lookup resolves — Electron's autoUpdater only names the version on download.
+ */
+export type AppUpdateStatus =
+	| { state: 'idle' | 'checking'; currentVersion: string | null }
+	| { state: 'downloading'; currentVersion: string | null; newVersion: string | null }
+	| { state: 'ready'; currentVersion: string | null; newVersion: string | null }
+	| {
+			state: 'error';
+			currentVersion: string | null;
+			reason: 'read-only-volume' | 'generic';
+			detail?: string;
+	  };
 
 let isAppQuitting = false;
 

--- a/apps/studio/src/tests/updates.test.ts
+++ b/apps/studio/src/tests/updates.test.ts
@@ -401,6 +401,26 @@ describe( 'update status emissions', () => {
 		expect( dialog.showMessageBox ).not.toHaveBeenCalled();
 	} );
 
+	it( 'flags manual re-emissions so a dismissed card comes back', async () => {
+		setAgenticUiEnabled( true );
+		setupDarwinUpdates();
+		await getHandler( 'update-downloaded' )?.( {}, 'notes', '1.9.0' );
+		vi.mocked( sendIpcEventToRenderer ).mockClear();
+
+		await manualCheckForUpdates();
+
+		expect( getLastEmittedStatus() ).toMatchObject( { state: 'ready', requested: true } );
+	} );
+
+	it( 'does not flag automatic emissions as requested', async () => {
+		setAgenticUiEnabled( true );
+		setupDarwinUpdates();
+
+		await getHandler( 'update-downloaded' )?.( {}, 'notes', '1.9.0' );
+
+		expect( getLastEmittedStatus()?.requested ).toBeUndefined();
+	} );
+
 	it( 'leaves the manual restart prompt to the sidebar card in the agentic UI', async () => {
 		setAgenticUiEnabled( true );
 		setupDarwinUpdates();

--- a/apps/studio/src/tests/updates.test.ts
+++ b/apps/studio/src/tests/updates.test.ts
@@ -4,6 +4,7 @@
 import { app, autoUpdater, clipboard, dialog, shell, type MessageBoxOptions } from 'electron';
 import * as Sentry from '@sentry/electron/main';
 import { vi } from 'vitest';
+import { sendIpcEventToRenderer, type AppUpdateStatus } from 'src/ipc-utils';
 import { setAgenticUiEnabled } from 'src/lib/studio-ui-mode';
 import { manualCheckForUpdates, setupUpdates } from 'src/updates';
 
@@ -25,6 +26,22 @@ vi.mock( 'src/main-window', () => ( {
 		webContents: { isDestroyed: () => false, send: vi.fn() },
 	} ),
 } ) );
+
+vi.mock( 'src/ipc-utils', async ( importOriginal ) => ( {
+	...( await importOriginal< typeof import('src/ipc-utils') >() ),
+	sendIpcEventToRenderer: vi.fn().mockResolvedValue( undefined ),
+} ) );
+
+function getEmittedStatuses(): AppUpdateStatus[] {
+	return vi
+		.mocked( sendIpcEventToRenderer )
+		.mock.calls.filter( ( [ channel ] ) => channel === 'app-update-status' )
+		.map( ( [ , status ] ) => status as AppUpdateStatus );
+}
+
+function getLastEmittedStatus(): AppUpdateStatus | undefined {
+	return getEmittedStatuses().at( -1 );
+}
 
 const originalFetch = global.fetch;
 const originalPlatform = process.platform;
@@ -189,6 +206,151 @@ describe( 'update ready to install', () => {
 		setAgenticUiEnabled( true );
 
 		await emitUpdateDownloaded();
+
+		expect( dialog.showMessageBox ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'update status emissions', () => {
+	function setupDarwinUpdates() {
+		Object.defineProperty( process, 'platform', { value: 'darwin', configurable: true } );
+		setupUpdates();
+	}
+
+	function getHandler( event: string ) {
+		const calls = vi.mocked( autoUpdater.on ).mock.calls as unknown as [
+			string,
+			( ...args: unknown[] ) => Promise< void > | void,
+		][];
+		return calls.find( ( [ name ] ) => name === event )?.[ 1 ];
+	}
+
+	beforeEach( () => {
+		// setupUpdates registers listeners on the shared autoUpdater mock; without clearing,
+		// getHandler would find the previous test's handler and its stale module state.
+		vi.mocked( autoUpdater.on ).mockClear();
+		vi.mocked( sendIpcEventToRenderer ).mockClear();
+		vi.mocked( dialog.showMessageBox ).mockClear();
+	} );
+
+	afterEach( () => {
+		setAgenticUiEnabled( false );
+	} );
+
+	it( 'emits a checking state with the current version', async () => {
+		setupDarwinUpdates();
+
+		await getHandler( 'checking-for-update' )?.();
+
+		expect( getLastEmittedStatus() ).toEqual( { state: 'checking', currentVersion: '1.8.2' } );
+	} );
+
+	it( 'emits downloading, then re-emits with the version the feed reports', async () => {
+		global.fetch = vi.fn().mockResolvedValue( {
+			status: 200,
+			ok: true,
+			json: async () => ( { version: '1.9.0' } ),
+		} as Response );
+		setupDarwinUpdates();
+
+		await getHandler( 'update-available' )?.();
+
+		const statuses = getEmittedStatuses();
+		expect( statuses ).toContainEqual( {
+			state: 'downloading',
+			currentVersion: '1.8.2',
+			newVersion: null,
+		} );
+		expect( getLastEmittedStatus() ).toEqual( {
+			state: 'downloading',
+			currentVersion: '1.8.2',
+			newVersion: '1.9.0',
+		} );
+	} );
+
+	it( 'reads the version out of the Squirrel feed URL on macOS and Windows', async () => {
+		// macOS/Windows get `{ url }` only; the version lives in the path.
+		global.fetch = vi.fn().mockResolvedValue( {
+			status: 200,
+			ok: true,
+			json: async () => ( {
+				url: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/mac-silicon/v1.9.0/21476/update/studio-arm64-v1.9.0.zip',
+			} ),
+		} as Response );
+		setupDarwinUpdates();
+
+		await getHandler( 'update-available' )?.();
+
+		expect( getLastEmittedStatus() ).toEqual( {
+			state: 'downloading',
+			currentVersion: '1.8.2',
+			newVersion: '1.9.0',
+		} );
+	} );
+
+	it( 'leaves the new version unnamed when the feed lookup fails', async () => {
+		global.fetch = vi.fn().mockRejectedValue( new Error( 'offline' ) );
+		setupDarwinUpdates();
+
+		await getHandler( 'update-available' )?.();
+
+		expect( getLastEmittedStatus() ).toEqual( {
+			state: 'downloading',
+			currentVersion: '1.8.2',
+			newVersion: null,
+		} );
+	} );
+
+	it( 'emits a ready state naming both versions once the download completes', async () => {
+		setupDarwinUpdates();
+
+		await getHandler( 'update-downloaded' )?.( {}, 'notes', '1.9.0' );
+
+		expect( getLastEmittedStatus() ).toEqual( {
+			state: 'ready',
+			currentVersion: '1.8.2',
+			newVersion: '1.9.0',
+		} );
+	} );
+
+	it( 'emits an error state when the updater fails', async () => {
+		setupDarwinUpdates();
+
+		await getHandler( 'error' )?.( new Error( 'boom' ) );
+
+		expect( getLastEmittedStatus() ).toEqual( {
+			state: 'error',
+			currentVersion: '1.8.2',
+			reason: 'generic',
+		} );
+	} );
+
+	it( 'reports a read-only volume error to the sidebar instead of a dialog in the agentic UI', async () => {
+		// Not part of the shared electron mock; only this path calls it.
+		( app as unknown as { isInApplicationsFolder: () => boolean } ).isInApplicationsFolder = () =>
+			true;
+		setAgenticUiEnabled( true );
+		setupDarwinUpdates();
+
+		const err = Object.assign( new Error( 'read-only' ), { code: 8 } );
+		await getHandler( 'error' )?.( err );
+
+		await vi.waitFor( () => {
+			expect( getLastEmittedStatus() ).toMatchObject( {
+				state: 'error',
+				reason: 'read-only-volume',
+			} );
+		} );
+		expect( dialog.showMessageBox ).not.toHaveBeenCalled();
+	} );
+
+	it( 'leaves the manual restart prompt to the sidebar card in the agentic UI', async () => {
+		setAgenticUiEnabled( true );
+		setupDarwinUpdates();
+		await getHandler( 'update-downloaded' )?.( {}, 'notes', '1.9.0' );
+		vi.mocked( dialog.showMessageBox ).mockClear();
+
+		await manualCheckForUpdates();
 
 		expect( dialog.showMessageBox ).not.toHaveBeenCalled();
 	} );

--- a/apps/studio/src/tests/updates.test.ts
+++ b/apps/studio/src/tests/updates.test.ts
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/electron/main';
 import { vi } from 'vitest';
 import { sendIpcEventToRenderer, type AppUpdateStatus } from 'src/ipc-utils';
 import { setAgenticUiEnabled } from 'src/lib/studio-ui-mode';
-import { manualCheckForUpdates, setupUpdates } from 'src/updates';
+import { manualCheckForUpdates, setupUpdates, switchToNightlyAndUpdate } from 'src/updates';
 
 function getLastDialogOptions(): MessageBoxOptions {
 	const lastCall = vi.mocked( dialog.showMessageBox ).mock.lastCall as unknown as [
@@ -217,6 +217,11 @@ describe( 'update status emissions', () => {
 		setupUpdates();
 	}
 
+	// The flag that tells the event handlers a user asked for this check.
+	function showManualCheck() {
+		void manualCheckForUpdates();
+	}
+
 	function getHandler( event: string ) {
 		const calls = vi.mocked( autoUpdater.on ).mock.calls as unknown as [
 			string,
@@ -340,6 +345,59 @@ describe( 'update status emissions', () => {
 				reason: 'read-only-volume',
 			} );
 		} );
+		expect( dialog.showMessageBox ).not.toHaveBeenCalled();
+	} );
+
+	it( 'names both versions in the manual-check dialog', async () => {
+		global.fetch = vi.fn().mockResolvedValue( {
+			status: 200,
+			ok: true,
+			json: async () => ( { version: '1.9.0' } ),
+		} as Response );
+		setupDarwinUpdates();
+		showManualCheck();
+
+		await getHandler( 'update-available' )?.();
+
+		expect( getLastDialogOptions().message ).toBe( 'Updating Studio from 1.8.2 to 1.9.0' );
+	} );
+
+	it( 'queries the nightly feed for the version after switching channels', async () => {
+		const fetchMock = vi.fn().mockResolvedValue( {
+			status: 200,
+			ok: true,
+			json: async () => ( { version: '1.9.0-dev.1' } ),
+		} as Response );
+		global.fetch = fetchMock;
+		setupDarwinUpdates();
+		switchToNightlyAndUpdate();
+
+		await getHandler( 'update-available' )?.();
+
+		expect( String( fetchMock.mock.calls.at( -1 )?.[ 0 ] ) ).toContain( 'channel=nightly' );
+	} );
+
+	it( 'still reports status when a manual check runs mid-download in the agentic UI', async () => {
+		setAgenticUiEnabled( true );
+		setupDarwinUpdates();
+		await getHandler( 'update-available' )?.();
+		vi.mocked( sendIpcEventToRenderer ).mockClear();
+
+		await manualCheckForUpdates();
+
+		expect( getLastEmittedStatus() ).toMatchObject( { state: 'downloading' } );
+		expect( dialog.showMessageBox ).not.toHaveBeenCalled();
+	} );
+
+	it( 'still reports status when a manual check runs while ready to restart in the agentic UI', async () => {
+		setAgenticUiEnabled( true );
+		setupDarwinUpdates();
+		await getHandler( 'update-downloaded' )?.( {}, 'notes', '1.9.0' );
+		vi.mocked( sendIpcEventToRenderer ).mockClear();
+
+		await manualCheckForUpdates();
+
+		expect( getLastEmittedStatus() ).toMatchObject( { state: 'ready', newVersion: '1.9.0' } );
 		expect( dialog.showMessageBox ).not.toHaveBeenCalled();
 	} );
 

--- a/apps/studio/src/tests/updates.test.ts
+++ b/apps/studio/src/tests/updates.test.ts
@@ -269,7 +269,6 @@ describe( 'update status emissions', () => {
 	} );
 
 	it( 'reads the version out of the Squirrel feed URL on macOS and Windows', async () => {
-		// macOS/Windows get `{ url }` only; the version lives in the path.
 		global.fetch = vi.fn().mockResolvedValue( {
 			status: 200,
 			ok: true,

--- a/apps/studio/src/updates.ts
+++ b/apps/studio/src/updates.ts
@@ -20,6 +20,10 @@ type UpdpaterState =
 
 let updaterState: UpdpaterState = 'init';
 let downloadedVersion: string | null = null;
+// Target version for an in-flight download. Electron's autoUpdater doesn't name it until
+// `update-downloaded`, so it's fetched from the feed separately and may stay null.
+let availableVersion: string | null = null;
+let lastError: { reason: 'read-only-volume' | 'generic'; detail?: string } | null = null;
 
 let timeout: NodeJS.Timeout | null = null;
 
@@ -79,11 +83,17 @@ export function setupUpdates() {
 
 	autoUpdater.on( 'checking-for-update', () => {
 		updaterState = 'checking-for-update';
+		lastError = null;
+		emitAppUpdateStatus();
 	} );
 
 	autoUpdater.on( 'update-available', async () => {
 		console.log( 'Update available' );
 		updaterState = 'downloading';
+		lastError = null;
+		// Clear any version left from a previous check so a failed lookup can't show a stale one.
+		availableVersion = null;
+		emitAppUpdateStatus();
 
 		if ( isDevRelease( app.getVersion() ) ) {
 			await updateAppdata( { lastNightlyUpdateCheck: Date.now() } );
@@ -92,6 +102,13 @@ export function setupUpdates() {
 		if ( showManualCheckDialogs ) {
 			await showUpdateAvailableNotice();
 		}
+
+		// Re-emit once the feed names the version. Ordered after the notice so the dialog
+		// isn't held up by a network round trip.
+		availableVersion = await fetchAvailableVersion();
+		if ( availableVersion && updaterState === 'downloading' ) {
+			emitAppUpdateStatus();
+		}
 	} );
 
 	autoUpdater.on( 'update-not-available', async () => {
@@ -99,8 +116,12 @@ export function setupUpdates() {
 			await showUpdateUnavailableNotice();
 		}
 
+		availableVersion = null;
+		lastError = null;
+
 		if ( ! shouldPoll ) {
 			updaterState = 'done';
+			emitAppUpdateStatus();
 			return;
 		}
 
@@ -109,6 +130,7 @@ export function setupUpdates() {
 		}
 
 		queueUpdateCheck();
+		emitAppUpdateStatus();
 	} );
 
 	autoUpdater.on( 'error', ( err ) => {
@@ -128,24 +150,20 @@ export function setupUpdates() {
 			return;
 		}
 
+		lastError = { reason: 'generic' };
+		emitAppUpdateStatus();
+
 		console.error( err );
 		Sentry.captureException( err );
 	} );
 
-	autoUpdater.on( 'update-available', () => {
-		console.log( 'Update available' );
-	} );
-
 	autoUpdater.on( 'update-downloaded', async ( _event, releaseNotes, releaseName ) => {
 		updaterState = 'waiting-for-restart';
+		lastError = null;
 		downloadedVersion = typeof releaseName === 'string' ? releaseName : null;
 		console.log( 'Update has been downloaded', { version: downloadedVersion } );
-		void sendIpcEventToRenderer( 'app-update-status', buildAppUpdateStatus() );
-		// The agentic UI surfaces this as a dismissable card in the sidebar, so a modal on top of
-		// it would be a duplicate interruption. Classic has no such affordance and still needs it.
-		if ( getPreferredStudioUiMode() !== 'agentic' ) {
-			await showUpdateReadyToInstallNotice();
-		}
+		emitAppUpdateStatus();
+		await showUpdateReadyToInstallNotice();
 	} );
 
 	if ( ! shouldPoll ) {
@@ -243,12 +261,28 @@ function queueUpdateCheck() {
 
 async function showUpdateAvailableNotice() {
 	showManualCheckDialogs = false;
+	// The agentic UI reports the whole update lifecycle in the sidebar, so a modal would be a
+	// duplicate interruption. Classic has no such affordance and still needs it.
+	if ( getPreferredStudioUiMode() === 'agentic' ) {
+		return;
+	}
 	const mainWindow = await getMainWindow();
 	await dialog.showMessageBox( mainWindow, {
 		type: 'info',
 		buttons: [ __( 'OK' ) ],
 		title: __( 'New Version Available' ),
-		message: __( 'Downloading update in the background' ),
+		message: availableVersion
+			? sprintf(
+					/* translators: 1: current version, e.g. "1.20.0". 2: new version, e.g. "1.21.0". */
+					__( 'Updating Studio from %1$s to %2$s' ),
+					app.getVersion(),
+					availableVersion
+			  )
+			: sprintf(
+					/* translators: %s is the current version number, e.g. "1.20.0". */
+					__( 'Updating Studio from %s' ),
+					app.getVersion()
+			  ),
 		detail: __(
 			'Studio will notify you when the update is ready to install. You can continue working normally.'
 		),
@@ -257,19 +291,34 @@ async function showUpdateAvailableNotice() {
 
 async function showUpdateUnavailableNotice() {
 	showManualCheckDialogs = false;
+	// The agentic UI answers a manual check with a sidebar toast: there's nothing to act on,
+	// so a modal the user has to dismiss is heavier than the result warrants.
+	if ( getPreferredStudioUiMode() === 'agentic' ) {
+		void sendIpcEventToRenderer( 'app-update-not-available', { currentVersion: app.getVersion() } );
+		return;
+	}
 	const mainWindow = await getMainWindow();
 	await dialog.showMessageBox( mainWindow, {
 		type: 'info',
 		buttons: [ __( 'OK' ) ],
 		title: __( 'Application Update' ),
 		message: __( 'No updates available' ),
-		detail: __(
-			"You're already running the latest version of Studio. No update is needed at this time."
+		detail: sprintf(
+			/* translators: %s is the current version number, e.g. "1.20.0". */
+			__(
+				"You're already running the latest version of Studio (%s). No update is needed at this time."
+			),
+			app.getVersion()
 		),
 	} );
 }
 
 async function showUpdateReadyToInstallNotice() {
+	// The agentic UI surfaces this as a dismissable sidebar card; a modal on top would be a
+	// duplicate interruption. Gated here so the manual check behaves like the automatic one.
+	if ( getPreferredStudioUiMode() === 'agentic' ) {
+		return;
+	}
 	// Only show the restart dialog if a window is already open. If the user
 	// closed the window while an update was downloading, don't recreate it —
 	// the update will be applied on the next launch or when the user reopens
@@ -455,6 +504,13 @@ async function showReadOnlyVolumeError( err: Error ) {
 		console.error( err );
 	}
 
+	lastError = { reason: 'read-only-volume', detail: `${ detailMessage }\n\n${ detailPath }` };
+
+	if ( getPreferredStudioUiMode() === 'agentic' ) {
+		emitAppUpdateStatus();
+		return;
+	}
+
 	const existingWindow = getExistingMainWindow();
 	if ( ! existingWindow ) {
 		return;
@@ -468,10 +524,55 @@ async function showReadOnlyVolumeError( err: Error ) {
 }
 
 function buildAppUpdateStatus(): AppUpdateStatus {
-	return {
-		readyToInstall: updaterState === 'waiting-for-restart',
-		version: downloadedVersion,
-	};
+	const currentVersion = app.getVersion();
+
+	if ( lastError ) {
+		return { state: 'error', currentVersion, ...lastError };
+	}
+
+	switch ( updaterState ) {
+		case 'checking-for-update':
+			return { state: 'checking', currentVersion };
+		case 'downloading':
+			return { state: 'downloading', currentVersion, newVersion: availableVersion };
+		case 'waiting-for-restart':
+			return { state: 'ready', currentVersion, newVersion: downloadedVersion ?? availableVersion };
+		default:
+			return { state: 'idle', currentVersion };
+	}
+}
+
+function emitAppUpdateStatus(): void {
+	void sendIpcEventToRenderer( 'app-update-status', buildAppUpdateStatus() );
+}
+
+/**
+ * Looks up the version the feed is offering. Electron's autoUpdater withholds it until the
+ * download finishes, so the renderer would otherwise have nothing to show while downloading.
+ * Best-effort: any failure just leaves the version unnamed.
+ */
+async function fetchAvailableVersion( { channel }: { channel?: 'nightly' } = {} ): Promise<
+	string | null
+> {
+	try {
+		const response = await fetch( buildUpdateFeedUrl( { channel } ) );
+		if ( ! response.ok ) {
+			return null;
+		}
+		// Shapes differ by platform: Linux gets `{ version, downloadUrl }`, while macOS and
+		// Windows get Squirrel's `{ url }`, whose path carries the version as a `v1.2.3` segment.
+		const data = ( await response.json() ) as { version?: string; url?: string };
+		return data?.version ?? versionFromUpdateUrl( data?.url ) ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function versionFromUpdateUrl( url: string | undefined ): string | null {
+	if ( ! url ) {
+		return null;
+	}
+	return /\/v(\d+\.\d+\.\d+[^/]*)\//.exec( url )?.[ 1 ] ?? null;
 }
 
 export async function getAppUpdateStatus( _event: IpcMainInvokeEvent ): Promise< AppUpdateStatus > {

--- a/apps/studio/src/updates.ts
+++ b/apps/studio/src/updates.ts
@@ -91,7 +91,6 @@ export function setupUpdates() {
 		console.log( 'Update available' );
 		updaterState = 'downloading';
 		lastError = null;
-		// Clear any version left from a previous check so a failed lookup can't show a stale one.
 		availableVersion = null;
 		emitAppUpdateStatus();
 
@@ -103,8 +102,7 @@ export function setupUpdates() {
 			await showUpdateAvailableNotice();
 		}
 
-		// Re-emit once the feed names the version. Ordered after the notice so the dialog
-		// isn't held up by a network round trip.
+		// After the notice, so the dialog isn't held up by a network round trip.
 		availableVersion = await fetchAvailableVersion();
 		if ( availableVersion && updaterState === 'downloading' ) {
 			emitAppUpdateStatus();
@@ -261,8 +259,7 @@ function queueUpdateCheck() {
 
 async function showUpdateAvailableNotice() {
 	showManualCheckDialogs = false;
-	// The agentic UI reports the whole update lifecycle in the sidebar, so a modal would be a
-	// duplicate interruption. Classic has no such affordance and still needs it.
+	// The agentic UI reports this in the sidebar; classic has no such affordance.
 	if ( getPreferredStudioUiMode() === 'agentic' ) {
 		return;
 	}
@@ -291,8 +288,7 @@ async function showUpdateAvailableNotice() {
 
 async function showUpdateUnavailableNotice() {
 	showManualCheckDialogs = false;
-	// The agentic UI answers a manual check with a sidebar toast: there's nothing to act on,
-	// so a modal the user has to dismiss is heavier than the result warrants.
+	// The agentic UI answers with a toast: there's nothing to act on.
 	if ( getPreferredStudioUiMode() === 'agentic' ) {
 		void sendIpcEventToRenderer( 'app-update-not-available', { currentVersion: app.getVersion() } );
 		return;
@@ -314,8 +310,8 @@ async function showUpdateUnavailableNotice() {
 }
 
 async function showUpdateReadyToInstallNotice() {
-	// The agentic UI surfaces this as a dismissable sidebar card; a modal on top would be a
-	// duplicate interruption. Gated here so the manual check behaves like the automatic one.
+	// The agentic UI surfaces this as a sidebar card. Gated here so the manual check and the
+	// automatic one behave alike.
 	if ( getPreferredStudioUiMode() === 'agentic' ) {
 		return;
 	}

--- a/apps/studio/src/updates.ts
+++ b/apps/studio/src/updates.ts
@@ -223,7 +223,7 @@ export async function manualCheckForUpdates() {
 		// Re-emitting re-surfaces the sidebar card if the user dismissed it, so the menu item
 		// still does something in the agentic UI.
 		if ( agentic ) {
-			emitAppUpdateStatus();
+			emitAppUpdateStatus( { requested: true } );
 		} else {
 			await showUpdateReadyToInstallNotice();
 		}
@@ -233,7 +233,7 @@ export async function manualCheckForUpdates() {
 	if ( updaterState === 'downloading' ) {
 		console.log( 'Manually checking for update, but discovered a download is already in progress' );
 		if ( agentic ) {
-			emitAppUpdateStatus();
+			emitAppUpdateStatus( { requested: true } );
 		} else {
 			await showUpdateAvailableNotice();
 		}
@@ -552,8 +552,12 @@ function buildAppUpdateStatus(): AppUpdateStatus {
 	}
 }
 
-function emitAppUpdateStatus(): void {
-	void sendIpcEventToRenderer( 'app-update-status', buildAppUpdateStatus() );
+function emitAppUpdateStatus( { requested }: { requested?: boolean } = {} ): void {
+	const status = buildAppUpdateStatus();
+	void sendIpcEventToRenderer(
+		'app-update-status',
+		requested ? { ...status, requested: true } : status
+	);
 }
 
 /**

--- a/apps/studio/src/updates.ts
+++ b/apps/studio/src/updates.ts
@@ -24,6 +24,8 @@ let downloadedVersion: string | null = null;
 // `update-downloaded`, so it's fetched from the feed separately and may stay null.
 let availableVersion: string | null = null;
 let lastError: { reason: 'read-only-volume' | 'generic'; detail?: string } | null = null;
+// Which feed the updater is pointed at, so follow-up lookups query the same channel.
+let activeChannel: 'nightly' | undefined;
 
 let timeout: NodeJS.Timeout | null = null;
 
@@ -60,6 +62,7 @@ export function switchToNightlyAndUpdate(): void {
 	}
 	const feedUrl = buildUpdateFeedUrl( { channel: 'nightly' } );
 	console.log( `Switching to nightly channel and checking for update: ${ feedUrl }` );
+	activeChannel = 'nightly';
 	autoUpdater.setFeedURL( { url: feedUrl } );
 	autoUpdater.checkForUpdates();
 }
@@ -98,14 +101,19 @@ export function setupUpdates() {
 			await updateAppdata( { lastNightlyUpdateCheck: Date.now() } );
 		}
 
-		if ( showManualCheckDialogs ) {
-			await showUpdateAvailableNotice();
+		// Before the notice, so the dialog can name the version it's downloading.
+		availableVersion = await fetchAvailableVersion( { channel: activeChannel } );
+		if ( availableVersion ) {
+			emitAppUpdateStatus();
 		}
 
-		// After the notice, so the dialog isn't held up by a network round trip.
-		availableVersion = await fetchAvailableVersion();
-		if ( availableVersion && updaterState === 'downloading' ) {
-			emitAppUpdateStatus();
+		// The agentic UI reports this in the sidebar; classic has no such affordance.
+		if ( showManualCheckDialogs ) {
+			if ( getPreferredStudioUiMode() === 'agentic' ) {
+				showManualCheckDialogs = false;
+			} else {
+				await showUpdateAvailableNotice();
+			}
 		}
 	} );
 
@@ -161,7 +169,10 @@ export function setupUpdates() {
 		downloadedVersion = typeof releaseName === 'string' ? releaseName : null;
 		console.log( 'Update has been downloaded', { version: downloadedVersion } );
 		emitAppUpdateStatus();
-		await showUpdateReadyToInstallNotice();
+		// The agentic UI surfaces this as a sidebar card; a modal on top would duplicate it.
+		if ( getPreferredStudioUiMode() !== 'agentic' ) {
+			await showUpdateReadyToInstallNotice();
+		}
 	} );
 
 	if ( ! shouldPoll ) {
@@ -203,17 +214,29 @@ export function setupUpdates() {
 }
 
 export async function manualCheckForUpdates() {
+	const agentic = getPreferredStudioUiMode() === 'agentic';
+
 	if ( updaterState === 'waiting-for-restart' ) {
 		// Not a valid state to check for updatees, user should be manually restarting instead
 		// However, let's open the dialog to let them easily restart
 		console.log( 'Update has been already downloaded, proposing to restart again' );
-		await showUpdateReadyToInstallNotice();
+		// Re-emitting re-surfaces the sidebar card if the user dismissed it, so the menu item
+		// still does something in the agentic UI.
+		if ( agentic ) {
+			emitAppUpdateStatus();
+		} else {
+			await showUpdateReadyToInstallNotice();
+		}
 		return;
 	}
 
 	if ( updaterState === 'downloading' ) {
 		console.log( 'Manually checking for update, but discovered a download is already in progress' );
-		await showUpdateAvailableNotice();
+		if ( agentic ) {
+			emitAppUpdateStatus();
+		} else {
+			await showUpdateAvailableNotice();
+		}
 		return;
 	}
 
@@ -259,10 +282,6 @@ function queueUpdateCheck() {
 
 async function showUpdateAvailableNotice() {
 	showManualCheckDialogs = false;
-	// The agentic UI reports this in the sidebar; classic has no such affordance.
-	if ( getPreferredStudioUiMode() === 'agentic' ) {
-		return;
-	}
 	const mainWindow = await getMainWindow();
 	await dialog.showMessageBox( mainWindow, {
 		type: 'info',
@@ -310,11 +329,6 @@ async function showUpdateUnavailableNotice() {
 }
 
 async function showUpdateReadyToInstallNotice() {
-	// The agentic UI surfaces this as a sidebar card. Gated here so the manual check and the
-	// automatic one behave alike.
-	if ( getPreferredStudioUiMode() === 'agentic' ) {
-		return;
-	}
 	// Only show the restart dialog if a window is already open. If the user
 	// closed the window while an update was downloading, don't recreate it —
 	// the update will be applied on the next launch or when the user reopens

--- a/apps/ui/src/data/app-messages.ts
+++ b/apps/ui/src/data/app-messages.ts
@@ -1,5 +1,9 @@
 import { useSyncExternalStore } from 'react';
 
+// Session-only dismissals for persistent sidebar cards. Lives here rather than in
+// use-app-messages so the update hooks can reset it without an import cycle.
+export const DISMISSED_MESSAGES_QUERY_KEY = [ 'dismissed-messages' ] as const;
+
 export type ToastIntent = 'success' | 'info' | 'error';
 
 export type ToastAction = {

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -554,12 +554,17 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 			writeLastSeenVersion( version );
 		},
 		async getAppUpdateStatus() {
-			return { readyToInstall: false, version: null };
+			// The browser UI updates through the CLI's own notifier, not Electron's autoUpdater.
+			return { state: 'idle', currentVersion: null };
 		},
 		async installAppUpdate() {
 			// No-op.
 		},
 		onAppUpdateStatusChanged() {
+			return () => {};
+		},
+
+		onAppUpdateNotAvailable() {
 			return () => {};
 		},
 	};

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -554,7 +554,7 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 			writeLastSeenVersion( version );
 		},
 		async getAppUpdateStatus() {
-			// The browser UI updates through the CLI's own notifier, not Electron's autoUpdater.
+			// This front end updates through the CLI's own notifier, not Electron's autoUpdater.
 			return { state: 'idle', currentVersion: null };
 		},
 		async installAppUpdate() {

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -1148,5 +1148,12 @@ export function createIpcConnector(): Connector {
 				listener( status as AppUpdateStatus )
 			);
 		},
+
+		onAppUpdateNotAvailable( listener ) {
+			return ipcListener.subscribe(
+				'app-update-not-available',
+				( _event: unknown, info: unknown ) => listener( info as { currentVersion: string } )
+			);
+		},
 	};
 }

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -957,7 +957,7 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			writeLastSeenVersion( version );
 		},
 		async getAppUpdateStatus() {
-			// The browser UI updates through the CLI's own notifier, not Electron's autoUpdater.
+			// This front end updates through the CLI's own notifier, not Electron's autoUpdater.
 			return { state: 'idle', currentVersion: null };
 		},
 		async installAppUpdate() {

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -957,12 +957,17 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 			writeLastSeenVersion( version );
 		},
 		async getAppUpdateStatus() {
-			return { readyToInstall: false, version: null };
+			// The browser UI updates through the CLI's own notifier, not Electron's autoUpdater.
+			return { state: 'idle', currentVersion: null };
 		},
 		async installAppUpdate() {
 			// No-op.
 		},
 		onAppUpdateStatusChanged() {
+			return () => {};
+		},
+
+		onAppUpdateNotAvailable() {
 			return () => {};
 		},
 	};

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -619,12 +619,24 @@ export interface Connector {
 	getAppUpdateStatus(): Promise< AppUpdateStatus >;
 	installAppUpdate(): Promise< void >;
 	onAppUpdateStatusChanged( listener: ( status: AppUpdateStatus ) => void ): () => void;
+
+	// Fires when a user-initiated check finds nothing. Distinct from the status above because
+	// "already up to date" is a transient answer to an action, not a lasting state.
+	onAppUpdateNotAvailable( listener: ( info: { currentVersion: string } ) => void ): () => void;
 }
 
-export interface AppUpdateStatus {
-	readyToInstall: boolean;
-	version: string | null;
-}
+// Mirrors `AppUpdateStatus` in apps/studio/src/ipc-utils.ts. `currentVersion` is null
+// where there is no desktop app to report on (the local and hosted connectors).
+export type AppUpdateStatus =
+	| { state: 'idle' | 'checking'; currentVersion: string | null }
+	| { state: 'downloading'; currentVersion: string | null; newVersion: string | null }
+	| { state: 'ready'; currentVersion: string | null; newVersion: string | null }
+	| {
+			state: 'error';
+			currentVersion: string | null;
+			reason: 'read-only-volume' | 'generic';
+			detail?: string;
+	  };
 
 // Persisted first-run onboarding state for the workbench. Separate from the
 // pre-workbench welcome flag (getOnboardingCompleted).

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -626,7 +626,7 @@ export interface Connector {
 }
 
 // Mirrors `AppUpdateStatus` in apps/studio/src/ipc-utils.ts.
-export type AppUpdateStatus =
+export type AppUpdateStatus = (
 	| { state: 'idle' | 'checking'; currentVersion: string | null }
 	| { state: 'downloading'; currentVersion: string | null; newVersion: string | null }
 	| { state: 'ready'; currentVersion: string | null; newVersion: string | null }
@@ -635,7 +635,11 @@ export type AppUpdateStatus =
 			currentVersion: string | null;
 			reason: 'read-only-volume' | 'generic';
 			detail?: string;
-	  };
+	  }
+) & {
+	// Set when the user asked for this check, so a dismissed card is shown again.
+	requested?: boolean;
+};
 
 // Persisted first-run onboarding state for the workbench. Separate from the
 // pre-workbench welcome flag (getOnboardingCompleted).

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -620,13 +620,12 @@ export interface Connector {
 	installAppUpdate(): Promise< void >;
 	onAppUpdateStatusChanged( listener: ( status: AppUpdateStatus ) => void ): () => void;
 
-	// Fires when a user-initiated check finds nothing. Distinct from the status above because
-	// "already up to date" is a transient answer to an action, not a lasting state.
+	// Separate from the status above: "already up to date" is a transient answer to a user
+	// action, not a lasting state.
 	onAppUpdateNotAvailable( listener: ( info: { currentVersion: string } ) => void ): () => void;
 }
 
-// Mirrors `AppUpdateStatus` in apps/studio/src/ipc-utils.ts. `currentVersion` is null
-// where there is no desktop app to report on (the local and hosted connectors).
+// Mirrors `AppUpdateStatus` in apps/studio/src/ipc-utils.ts.
 export type AppUpdateStatus =
 	| { state: 'idle' | 'checking'; currentVersion: string | null }
 	| { state: 'downloading'; currentVersion: string | null; newVersion: string | null }

--- a/apps/ui/src/data/queries/use-app-messages.test.ts
+++ b/apps/ui/src/data/queries/use-app-messages.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+import { deriveUpdateMessages } from './use-app-messages';
+import type { AppUpdateStatus } from '@/data/core';
+
+const noop = () => {};
+
+describe( 'deriveUpdateMessages', () => {
+	it( 'shows nothing while idle, checking, or before the first status arrives', () => {
+		expect( deriveUpdateMessages( undefined, noop ) ).toEqual( [] );
+		expect( deriveUpdateMessages( { state: 'idle', currentVersion: '1.20.0' }, noop ) ).toEqual(
+			[]
+		);
+		expect( deriveUpdateMessages( { state: 'checking', currentVersion: '1.20.0' }, noop ) ).toEqual(
+			[]
+		);
+	} );
+
+	it( 'names both versions while downloading', () => {
+		const [ message ] = deriveUpdateMessages(
+			{ state: 'downloading', currentVersion: '1.20.0', newVersion: '1.21.0' },
+			noop
+		);
+
+		expect( message.title ).toBe( 'Downloading update' );
+		expect( message.description ).toBe( 'Updating from 1.20.0 to 1.21.0.' );
+		expect( message.cta ).toBeUndefined();
+	} );
+
+	it( 'falls back to the current version when the target is not yet known', () => {
+		const [ message ] = deriveUpdateMessages(
+			{ state: 'downloading', currentVersion: '1.20.0', newVersion: null },
+			noop
+		);
+
+		expect( message.description ).toBe( 'Updating from 1.20.0.' );
+	} );
+
+	it( 'offers a restart once the update is ready', () => {
+		const onInstall = vi.fn();
+		const [ message ] = deriveUpdateMessages(
+			{ state: 'ready', currentVersion: '1.20.0', newVersion: '1.21.0' },
+			onInstall
+		);
+
+		expect( message.title ).toBe( 'Studio 1.21.0 is ready to install' );
+		expect( message.description ).toBe( 'Updating from 1.20.0 to 1.21.0.' );
+		expect( message.id ).toBe( 'app-update:1.21.0' );
+
+		message.cta?.onClick();
+		expect( onInstall ).toHaveBeenCalled();
+	} );
+
+	it( 'still offers a restart when the updater never named the version', () => {
+		const [ message ] = deriveUpdateMessages(
+			{ state: 'ready', currentVersion: null, newVersion: null },
+			noop
+		);
+
+		expect( message.title ).toBe( 'A Studio update is ready to install' );
+		expect( message.description ).toBe( 'Restart to finish updating.' );
+		expect( message.id ).toBe( 'app-update' );
+	} );
+
+	it( 'surfaces updater errors with the reason detail when there is one', () => {
+		const status: AppUpdateStatus = {
+			state: 'error',
+			currentVersion: '1.20.0',
+			reason: 'read-only-volume',
+			detail: 'Studio is running from a disk image.',
+		};
+
+		const [ message ] = deriveUpdateMessages( status, noop );
+
+		expect( message.intent ).toBe( 'error' );
+		expect( message.title ).toBe( "Couldn't update Studio" );
+		expect( message.description ).toBe( 'Studio is running from a disk image.' );
+	} );
+
+	it( 'falls back to generic guidance for an error with no detail', () => {
+		const [ message ] = deriveUpdateMessages(
+			{ state: 'error', currentVersion: '1.20.0', reason: 'generic' },
+			noop
+		);
+
+		expect( message.description ).toBe(
+			'Studio will try again the next time it checks for updates.'
+		);
+	} );
+} );

--- a/apps/ui/src/data/queries/use-app-messages.ts
+++ b/apps/ui/src/data/queries/use-app-messages.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import { DISMISSED_MESSAGES_QUERY_KEY } from '@/data/app-messages';
 import { useConnector } from '@/data/core';
 import { useAppUpdateStatus } from '@/data/queries/use-app-update';
 import type { AppUpdateStatus } from '@/data/core';
@@ -15,10 +16,8 @@ export interface PersistentMessage {
 
 // Dismissals are session-only by design: the cache entry isn't persisted and
 // never refetches, so it lives until the app restarts — and restarting installs
-// the pending update, which removes the card's reason to exist. If a future
-// message must outlive restarts (e.g. server announcements), that's the point
-// to add persisted dismissal storage.
-const DISMISSED_MESSAGES_QUERY_KEY = [ 'dismissed-messages' ] as const;
+// the pending update, which removes the card's reason to exist. An explicit
+// "Check for Updates" also clears them, so a dismissed card can come back.
 
 /**
  * The target version is often unknown mid-download: Electron's updater doesn't name it

--- a/apps/ui/src/data/queries/use-app-messages.ts
+++ b/apps/ui/src/data/queries/use-app-messages.ts
@@ -3,6 +3,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { useConnector } from '@/data/core';
 import { useAppUpdateStatus } from '@/data/queries/use-app-update';
+import type { AppUpdateStatus } from '@/data/core';
 
 export interface PersistentMessage {
 	id: string;
@@ -19,6 +20,87 @@ export interface PersistentMessage {
 // to add persisted dismissal storage.
 const DISMISSED_MESSAGES_QUERY_KEY = [ 'dismissed-messages' ] as const;
 
+/**
+ * "1.20.0 → 1.21.0" when both versions are known, degrading to whichever one is. The target
+ * is often unknown mid-download: Electron's updater doesn't name it until the download ends.
+ */
+function describeVersionChange(
+	currentVersion: string | null,
+	newVersion: string | null,
+	{ fallback }: { fallback?: string } = {}
+): string | undefined {
+	if ( currentVersion && newVersion ) {
+		return sprintf(
+			/* translators: 1: current version, e.g. "1.20.0". 2: new version, e.g. "1.21.0". */
+			__( 'Updating from %1$s to %2$s.' ),
+			currentVersion,
+			newVersion
+		);
+	}
+	if ( currentVersion ) {
+		return sprintf(
+			/* translators: %s: current version number, e.g. "1.20.0". */
+			__( 'Updating from %s.' ),
+			currentVersion
+		);
+	}
+	return fallback;
+}
+
+export function deriveUpdateMessages(
+	status: AppUpdateStatus | undefined,
+	onInstall: () => void
+): PersistentMessage[] {
+	if ( status?.state === 'downloading' ) {
+		return [
+			{
+				id: status.newVersion
+					? `app-update-downloading:${ status.newVersion }`
+					: 'app-update-downloading',
+				intent: 'info',
+				title: __( 'Downloading update' ),
+				description: describeVersionChange( status.currentVersion, status.newVersion ),
+			},
+		];
+	}
+
+	if ( status?.state === 'ready' ) {
+		const version = status.newVersion;
+		return [
+			{
+				// Version-scoped id so a dismissal re-arms for the next release.
+				id: version ? `app-update:${ version }` : 'app-update',
+				intent: 'info',
+				title: version
+					? sprintf(
+							/* translators: %s: app version number. */
+							__( 'Studio %s is ready to install' ),
+							version
+					  )
+					: __( 'A Studio update is ready to install' ),
+				description: describeVersionChange( status.currentVersion, version, {
+					fallback: __( 'Restart to finish updating.' ),
+				} ),
+				cta: { label: __( 'Restart now' ), onClick: onInstall },
+			},
+		];
+	}
+
+	if ( status?.state === 'error' ) {
+		return [
+			{
+				id: 'app-update-error',
+				intent: 'error',
+				title: __( "Couldn't update Studio" ),
+				description:
+					status.detail ?? __( 'Studio will try again the next time it checks for updates.' ),
+			},
+		];
+	}
+
+	return [];
+}
+
 export function useActivePersistentMessages(): {
 	messages: PersistentMessage[];
 	dismiss: ( message: PersistentMessage ) => void;
@@ -33,29 +115,10 @@ export function useActivePersistentMessages(): {
 		meta: { persist: false },
 	} );
 
-	const sources = useMemo( () => {
-		const messages: PersistentMessage[] = [];
-
-		if ( updateStatus.data?.readyToInstall ) {
-			const version = updateStatus.data.version;
-			messages.push( {
-				// Version-scoped id so a dismissal re-arms for the next release.
-				id: version ? `app-update:${ version }` : 'app-update',
-				intent: 'info',
-				title: version
-					? sprintf(
-							/* translators: %s: app version number. */
-							__( 'Studio %s is ready to install' ),
-							version
-					  )
-					: __( 'A Studio update is ready to install' ),
-				description: __( 'Restart to finish updating.' ),
-				cta: { label: __( 'Restart now' ), onClick: () => void connector.installAppUpdate() },
-			} );
-		}
-
-		return messages;
-	}, [ updateStatus.data, connector ] );
+	const sources = useMemo(
+		() => deriveUpdateMessages( updateStatus.data, () => void connector.installAppUpdate() ),
+		[ updateStatus.data, connector ]
+	);
 
 	const messages = useMemo(
 		() => sources.filter( ( message ) => ! dismissedIds.includes( message.id ) ),

--- a/apps/ui/src/data/queries/use-app-messages.ts
+++ b/apps/ui/src/data/queries/use-app-messages.ts
@@ -54,9 +54,9 @@ export function deriveUpdateMessages(
 	if ( status?.state === 'downloading' ) {
 		return [
 			{
-				id: status.newVersion
-					? `app-update-downloading:${ status.newVersion }`
-					: 'app-update-downloading',
+				// Stable across the feed lookup resolving: a version-scoped id would change
+				// mid-download and resurrect a card the user had dismissed.
+				id: 'app-update-downloading',
 				intent: 'info',
 				title: __( 'Downloading update' ),
 				description: describeVersionChange( status.currentVersion, status.newVersion ),

--- a/apps/ui/src/data/queries/use-app-messages.ts
+++ b/apps/ui/src/data/queries/use-app-messages.ts
@@ -21,8 +21,8 @@ export interface PersistentMessage {
 const DISMISSED_MESSAGES_QUERY_KEY = [ 'dismissed-messages' ] as const;
 
 /**
- * "1.20.0 → 1.21.0" when both versions are known, degrading to whichever one is. The target
- * is often unknown mid-download: Electron's updater doesn't name it until the download ends.
+ * The target version is often unknown mid-download: Electron's updater doesn't name it
+ * until the download ends.
  */
 function describeVersionChange(
 	currentVersion: string | null,

--- a/apps/ui/src/data/queries/use-app-update.ts
+++ b/apps/ui/src/data/queries/use-app-update.ts
@@ -1,5 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEffect } from 'react';
+import { toast } from '@/data/app-messages';
 import { useConnector } from '@/data/core';
 import type { AppUpdateStatus } from '@/data/core';
 
@@ -28,4 +30,19 @@ export function useSyncAppUpdateStatus(): void {
 			queryClient.setQueryData( APP_UPDATE_STATUS_QUERY_KEY, status );
 		} );
 	}, [ connector, queryClient ] );
+
+	// A manual check that finds nothing gets a toast rather than a card: there's nothing to
+	// act on, so it shouldn't linger until dismissed.
+	useEffect( () => {
+		return connector.onAppUpdateNotAvailable( ( { currentVersion } ) => {
+			toast.info(
+				sprintf(
+					/* translators: %s: current version number, e.g. "1.20.0". */
+					__( "You're on the latest version (%s)" ),
+					currentVersion
+				),
+				{ id: 'app-update-not-available' }
+			);
+		} );
+	}, [ connector ] );
 }

--- a/apps/ui/src/data/queries/use-app-update.ts
+++ b/apps/ui/src/data/queries/use-app-update.ts
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
 import { useEffect } from 'react';
-import { toast } from '@/data/app-messages';
+import { DISMISSED_MESSAGES_QUERY_KEY, toast } from '@/data/app-messages';
 import { useConnector } from '@/data/core';
 import type { AppUpdateStatus } from '@/data/core';
 
@@ -28,6 +28,10 @@ export function useSyncAppUpdateStatus(): void {
 	useEffect( () => {
 		return connector.onAppUpdateStatusChanged( ( status: AppUpdateStatus ) => {
 			queryClient.setQueryData( APP_UPDATE_STATUS_QUERY_KEY, status );
+			// The user explicitly asked, so an earlier dismissal shouldn't keep the card hidden.
+			if ( status.requested ) {
+				queryClient.setQueryData( DISMISSED_MESSAGES_QUERY_KEY, [] as string[] );
+			}
 		} );
 	}, [ connector, queryClient ] );
 

--- a/apps/ui/src/data/queries/use-app-update.ts
+++ b/apps/ui/src/data/queries/use-app-update.ts
@@ -31,8 +31,7 @@ export function useSyncAppUpdateStatus(): void {
 		} );
 	}, [ connector, queryClient ] );
 
-	// A manual check that finds nothing gets a toast rather than a card: there's nothing to
-	// act on, so it shouldn't linger until dismissed.
+	// A toast rather than a card: there's nothing to act on, so it shouldn't linger.
 	useEffect( () => {
 		return connector.onAppUpdateNotAvailable( ( { currentVersion } ) => {
 			toast.info(


### PR DESCRIPTION
## Related issues

- Fixes STU-2368

## How AI was used in this PR

Written with Claude Code: codebase exploration, implementation, and tests. I reviewed the whole diff and manually verified the update dialogs in the Electron app.

## Proposed Changes

Studio's update pop-ups didn't say which version you were on or which one was arriving — the report on STU-2368 was "would like to know current version, new version, progress, really anything", and, on the second dialog, "Which version?".

Now every update message names the versions involved. The classic dialogs read "Updating Studio from 1.20.0 to 1.21.0" instead of a bare "Downloading update in the background", and "No updates available" says which version you're already on.

The agentic UI previously only learned about an update once it had finished downloading, so a background update was invisible until it was suddenly ready to install. It now follows the whole lifecycle in the sidebar: a card while downloading, the existing ready-to-install card, and an error card if the update fails (for example when Studio is running from a disk image and can't update itself). A manual check that finds nothing answers with an auto-expiring toast rather than a card, since there's nothing to act on.

This also fixes an inconsistency where the restart prompt was suppressed in the agentic UI when it appeared on its own, but still showed as a native modal when reached through **Check for Updates**.

`studio ui` in the browser is unaffected — it updates through the CLI's own notifier, which already prints both versions in its terminal banner.

<img width="1230" height="783" alt="CleanShot 2026-09-07 at 11 58 24" src="https://github.com/user-attachments/assets/d456c253-8493-4e06-96cb-7f5054a07242" />

## Testing Instructions

Manual, for the real dialogs — the updater only runs in a packaged build:

1. Set `version` in `apps/studio/package.json` to `1.19.0` and run `npm run make`.
2. Launch the packaged app and choose **Check for Updates**.
3. The dialog should read "Updating Studio from 1.19.0 to 1.20.0".
4. Confirm that it shows the error when the download completes - it's expected, as auto-update won't update to a new version if the current one is not signed.

Repeat with agentic UI to see the sidebar cards instead of dialogs. To exercise card states without a real update, seed the query cache from the browser console:

```js
const el = document.querySelector('#root').firstElementChild; const key = Object.keys(el).find(k => k.startsWith('__reactFiber$')); let f = el[key], qc = null; while (f && !qc) { const v = f.memoizedProps?.client; if (v?.setQueryData) qc = v; f = f.return; } window.qc = qc; qc ? 'found' : 'not found';

qc.setQueryData( [ 'app-update-status' ], { state: 'downloading', currentVersion: '1.20.0', newVersion: '1.21.0' } );
```

Also worth checking `state: 'ready'` and `state: 'error'`, in both light and dark.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
