### PR TITLE
Studio Code: scaffold_theme treats an empty parentTheme as no parent

### DIFF
--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -1530,6 +1530,28 @@ describe( 'Studio AI MCP tools', () => {
 			).rejects.toThrow();
 		} );
 
+		it( 'treats an empty parentTheme as no parent and scaffolds a blank theme', async () => {
+			const result = await getTool( 'scaffold_theme' ).rawHandler( {
+				nameOrPath: scaffoldSite.name,
+				name: 'Acme Studio',
+				parentTheme: '',
+			} as never );
+
+			expect( getTextContent( result ) ).not.toMatch( /Child theme/ );
+			await expect(
+				stat(
+					path.join(
+						tempSiteRoot,
+						'wp-content',
+						'themes',
+						'acme-studio',
+						'templates',
+						'index.html'
+					)
+				)
+			).resolves.toBeDefined();
+		} );
+
 		it( 'fails when the target theme directory already exists', async () => {
 			await mkdir( path.join( tempSiteRoot, 'wp-content', 'themes', 'acme-studio' ), {
 				recursive: true,

--- a/apps/cli/ai/tools/scaffold-theme.ts
+++ b/apps/cli/ai/tools/scaffold-theme.ts
@@ -453,7 +453,10 @@ export const scaffoldThemeTool = defineTool(
 				throw new Error( `wp-content/themes directory not found in site: ${ themesDir }` );
 			}
 
-			const parentSlug = args.parentTheme?.trim();
+			// An empty parentTheme means "no parent" — models tend to send "" for
+			// optional fields, and rejecting it as a bad slug nudges them into naming
+			// the active theme as parent when they wanted a blank scaffold.
+			const parentSlug = args.parentTheme?.trim() || undefined;
 			if ( parentSlug !== undefined ) {
 				if ( ! parentSlug || ! /^[a-z0-9][a-z0-9-]*$/.test( parentSlug ) ) {
 					throw new Error(


### PR DESCRIPTION
## Related issues

- Related to #4780 (found while evaluating that branch; the fix is independent of it)

## How AI was used in this PR

Found by Claude Code while reviewing a GPT 5.6 Sol site build: the model passed `parentTheme: ""` to `scaffold_theme`, the tool rejected it as a malformed slug, and the model "fixed" the error by naming the active theme (Twenty Twenty-Five) as parent — producing a child theme the build never wanted. The one-line fix and its test were written with Claude Code and reviewed by hand.

## Proposed Changes

`scaffold_theme` now treats an empty or whitespace-only `parentTheme` as "no parent" and scaffolds a blank theme, instead of rejecting it with a slug-format error.

Why it matters for users: some models fill optional tool fields with empty strings. Today that error message steers them into scaffolding a child theme of whatever theme is active on a fresh site, so the site inherits Twenty Twenty-Five's templates, spacing, and type instead of the blank scaffold the workflow is built around, and the design ends up fighting the parent. With this change the intent ("no parent") is honored on the first call.

## Testing Instructions

- `npm test -- apps/cli/ai/tests/tools.test.ts` — includes a new case that scaffolds with `parentTheme: ""` and asserts a blank theme with its own `templates/index.html` is created (no "Child theme" result).
- Manual: in `studio code`, ask for a new site; if the model sends an empty `parentTheme`, the scaffold should succeed as a blank theme rather than error.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
