### PR TITLE
Keep standalone CLI bundles out of the release Slack message

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -655,7 +655,7 @@ def release_download_links(builds)
   RELEASE_ATTACHED_BUILD_KEYS
     .filter_map { |key| builds[key] }
     .select { |build| build[:cdn_url] }
-    .map { |build| "[#{build[:name]}](#{build[:cdn_url]})" }
+    .map { |build| "[#{build[:display_name] || build[:name]}](#{build[:cdn_url]})" }
 end
 
 def slack_release_links(builds)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -635,11 +635,12 @@ def linux_deb_path(arch:)
   clean_path
 end
 
-# The builds announced in the release Slack message, in display order: the desktop
-# installers users actually download. Excludes the Mac/Windows "Update" payloads (consumed
-# by the in-app updater), the unsigned Appx builds (Buildkite artifacts for the Microsoft
-# Store publish), and the standalone CLI bundles that {distribute_builds} merges in.
-SLACK_ANNOUNCED_BUILD_KEYS = %i[
+# The builds offered to users as downloads, in display order: the desktop installers, shared
+# by the GitHub release notes and the release Slack message. Excludes the Mac/Windows "Update"
+# payloads (consumed by the in-app updater), the unsigned Appx builds (Buildkite artifacts for
+# the Microsoft Store publish), and the standalone CLI bundles that {distribute_builds} merges
+# in — none of which a person reading a release announcement should be handed.
+RELEASE_ATTACHED_BUILD_KEYS = %i[
   x64_dmg
   arm64_dmg
   windows
@@ -648,14 +649,20 @@ SLACK_ANNOUNCED_BUILD_KEYS = %i[
   linux_arm64_deb
 ].freeze
 
+# Markdown download links for the release installers, in RELEASE_ATTACHED_BUILD_KEYS order.
+# Builds that were never uploaded (no CDN URL) are skipped and reported by the caller.
+def release_download_links(builds)
+  RELEASE_ATTACHED_BUILD_KEYS
+    .filter_map { |key| builds[key] }
+    .select { |build| build[:cdn_url] }
+    .map { |build| "[#{build[:name]}](#{build[:cdn_url]})" }
+end
+
 def slack_release_links(builds)
-  missing = SLACK_ANNOUNCED_BUILD_KEYS.reject { |key| builds[key] }
+  missing = RELEASE_ATTACHED_BUILD_KEYS.reject { |key| builds[key]&.dig(:cdn_url) }
   UI.important("Slack release message is missing builds: #{missing.join(', ')}") unless missing.empty?
 
-  SLACK_ANNOUNCED_BUILD_KEYS
-    .filter_map { |key| builds[key] }
-    .map { |b| "[#{b[:name]}](#{b[:cdn_url]})" }
-    .join(', ')
+  release_download_links(builds).join(', ')
 end
 
 def distribute_builds(
@@ -1380,14 +1387,7 @@ end
 def create_draft_github_release(version:, release_tag:, builds:)
   notes = extract_release_notes(version: version)
 
-  # Format download links from CDN URLs
-  download_link_keys = %i[x64_dmg arm64_dmg windows windows_arm64 linux_x64_deb linux_arm64_deb]
-  links = download_link_keys.filter_map do |key|
-    build = builds[key]
-    next unless build&.dig(:cdn_url)
-
-    "[#{build[:name]}](#{build[:cdn_url]})"
-  end
+  links = release_download_links(builds)
 
   body = notes
   unless links.empty?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -171,13 +171,7 @@ lane :distribute_release_build do |version: read_package_json_version|
     success: true,
     slack_url: get_required_env('SLACK_WEBHOOK'),
     payload: {
-      # Link only the installers users download: "Full Install" builds plus the Linux .debs
-      # (tagged "Update" but the sole Linux installer). Skip the Mac/Windows "Update" payloads,
-      # and the unsigned Appx builds (grabbed from Buildkite for the Microsoft Store publish).
-      ':studio-app-icon-mac: Release available for': builds.each_value
-        .reject { |b| b[:install_type] == 'Update' && !b[:platform].to_s.start_with?('Linux') }
-        .reject { |b| b[:platform].to_s.start_with?('Microsoft Store') }
-        .map { |b| "[#{b[:name]}](#{b[:cdn_url]})" }.join(', ')
+      ':studio-app-icon-mac: Release available for': slack_release_links(builds)
     },
     default_payloads: []
   )
@@ -641,6 +635,29 @@ def linux_deb_path(arch:)
   clean_path
 end
 
+# The builds announced in the release Slack message, in display order: the desktop
+# installers users actually download. Excludes the Mac/Windows "Update" payloads (consumed
+# by the in-app updater), the unsigned Appx builds (Buildkite artifacts for the Microsoft
+# Store publish), and the standalone CLI bundles that {distribute_builds} merges in.
+SLACK_ANNOUNCED_BUILD_KEYS = %i[
+  x64_dmg
+  arm64_dmg
+  windows
+  windows_arm64
+  linux_x64_deb
+  linux_arm64_deb
+].freeze
+
+def slack_release_links(builds)
+  missing = SLACK_ANNOUNCED_BUILD_KEYS.reject { |key| builds[key] }
+  UI.important("Slack release message is missing builds: #{missing.join(', ')}") unless missing.empty?
+
+  SLACK_ANNOUNCED_BUILD_KEYS
+    .filter_map { |key| builds[key] }
+    .map { |b| "[#{b[:name]}](#{b[:cdn_url]})" }
+    .join(', ')
+end
+
 def distribute_builds(
   commit_hash: last_git_commit[:abbreviated_commit_hash],
   build_number: get_required_env('BUILDKITE_BUILD_NUMBER'),
@@ -811,7 +828,7 @@ def distribute_builds(
     buildkite_annotate(
       context: 'cdn-link',
       style: 'info',
-      message: "🔗 Build available for #{builds_to_upload.each_value.map { |build| "[#{build[:name]}](#{build[:cdn_url]})" }.join(', ')}"
+      message: "🔗 Build available for #{builds_to_upload.each_value.map { |build| "[#{build[:display_name] || build[:name]}](#{build[:cdn_url]})" }.join(', ')}"
     )
   end
 
@@ -1031,7 +1048,7 @@ def studio_cli_cdn_builds
     { key: :cli_windows_arm64, file_name: 'studio-cli-win32-arm64.tgz',  name: 'Windows arm64', platform: 'Windows - ARM64' },
     { key: :cli_linux_x64,     file_name: 'studio-cli-linux-x64.tgz',    name: 'Linux x64',     platform: 'Linux - x64' },
     { key: :cli_linux_arm64,   file_name: 'studio-cli-linux-arm64.tgz',  name: 'Linux arm64',   platform: 'Linux - ARM64' }
-  ]
+  ].map { |build| build.merge(display_name: "CLI #{build[:name]}") }
 end
 
 # Upload (or update) the standalone Studio CLI bundles on the Apps CDN.
@@ -1105,6 +1122,7 @@ def upload_studio_cli_binaries_to_apps_cdn(version:, artifacts_dir:, build_type:
 
     builds[build[:key]] = {
       name: build[:name],
+      display_name: build[:display_name],
       platform: build[:platform],
       cdn_url: media_url,
       post_id: post_id,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1402,7 +1402,7 @@ def create_draft_github_release(version:, release_tag:, builds:)
 
   # Every build must have a post ID: builds missing from the embedded list would
   # silently stay Internal after publish_release and never reach users.
-  missing = builds.values.reject { |b| b[:post_id]&.to_i&.positive? }.map { |b| b[:name] }
+  missing = builds.values.reject { |b| b[:post_id]&.to_i&.positive? }.map { |b| b[:display_name] || b[:name] }
   UI.user_error!("Missing CDN post IDs for: #{missing.join(', ')}. publish_release needs every build's post ID to flip its visibility to External.") unless missing.empty?
 
   body += "\n<!-- CDN_POST_IDS:#{cdn_post_ids.join(',')} -->"


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code traced the regression to the interaction between two previously merged PRs, wrote the fix, and simulated both the Slack and Buildkite messages against the real build definitions to confirm the output. I reviewed the diff and the reasoning.

## Proposed Changes

The release announcement in `#studio` has been listing twelve download links instead of six since the 1.15.0-era releases, and reads as though the Windows entries are duplicated or corrupted:

> Release available for Linux - x64 (DEB), Linux - ARM64 (DEB), Mac Intel (DMG), Mac Apple Silicon (DMG), **Windows - x64**, **Windows - ARM64**, macOS arm64, macOS x64, **Windows x64**, **Windows arm64**, Linux x64, Linux arm64

The desktop installers are all present — but each is shadowed by a near-identically named entry that is actually a standalone Studio CLI tarball, which is not something a person reading the release announcement is meant to download.

The cause is an ordering accident between two merged PRs. #3835 merged the CLI bundles into the uploaded-builds hash; #4071 later added the filter that trims the message to installers, but only accounted for the desktop builds. The CLI entries carry no `install_type` key at all, so they satisfied neither `reject` clause and passed straight through.

The filter is now an explicit allowlist of the six installer keys rather than a chain of exclusions. A denylist silently admits anything new added to the uploads hash — precisely how this broke — whereas an allowlist fails closed, and it also gives the message a stable Mac → Windows → Linux order instead of the incidental one. If an expected installer is missing from a run, the lane now logs a warning rather than quietly dropping it from the announcement.

The Buildkite `cdn-link` annotation had the same label collision. That one intentionally lists every upload, which is useful in CI, so instead of filtering it the CLI bundles now carry a distinct display name (`CLI Windows x64`), leaving them unambiguous alongside the `Windows - x64` installer.

No change to how builds are uploaded, named on the CDN, or published — this only affects the two human-facing messages.

## Testing Instructions

There is no practical local test for this one, and I'd rather say so than suggest a command that doesn't exercise the change.

The change is confined to how two message strings are assembled, so review of the diff is the main check. It then verifies on the next release build:

- **Slack** (`#studio`): six links instead of twelve — Mac Intel (DMG), Mac Apple Silicon (DMG), Windows - x64, Windows - ARM64, Linux - x64 (DEB), Linux - ARM64 (DEB). In particular no `Windows x64` / `Windows arm64` entries shadowing the installers.
- **Buildkite** (`cdn-link` annotation): still all uploads, with the six CLI bundles now prefixed `CLI `.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


