### PR TITLE
Import .wpress archives with entries larger than 2 GiB

### DIFF
--- a/apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts
+++ b/apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts
@@ -52,14 +52,38 @@ function readFromBuffer( buffer: Buffer, start: number, end: number ): string {
 }
 
 /**
- * Reads the header of a .wpress file.
+ * Reads the header located at `position` in a .wpress file.
+ *
+ * Reads always use an explicit position instead of the file handle's implicit
+ * cursor, so skipping an entry is a matter of arithmetic and never requires
+ * reading (or allocating) its content. This is what keeps entries larger than
+ * 2 GiB from crashing the process: `FileHandle.read()` rejects lengths that do
+ * not fit in a signed 32-bit integer.
  *
  * @param {fs.promises.FileHandle} fd - The file handle to read from.
- * @returns {Promise<Header | null>} - A promise that resolves to the header or null if the end of the file is reached.
+ * @param {number} position - The byte offset of the header in the archive.
+ * @returns {Promise<Header | null>} - A promise that resolves to the header, or null when the end of the archive is reached.
  */
-async function readHeader( fd: fs.promises.FileHandle ): Promise< Header | null > {
+async function readHeader(
+	fd: fs.promises.FileHandle,
+	position: number
+): Promise< Header | null > {
 	const headerChunk = Buffer.alloc( HEADER_SIZE );
-	await fd.read( headerChunk, 0, HEADER_SIZE );
+	const { bytesRead } = await fd.read( headerChunk, 0, HEADER_SIZE, position );
+
+	// A clean end of file without the EOF marker, or with only part of it, is
+	// treated like the marker itself: every entry before it is complete.
+	if ( bytesRead === 0 || headerChunk.subarray( 0, bytesRead ).every( ( byte ) => byte === 0 ) ) {
+		return null;
+	}
+
+	if ( bytesRead < HEADER_SIZE ) {
+		throw new LoggerError(
+			__( 'The backup archive is truncated: it ends in the middle of a file header.' ),
+			undefined,
+			'wpress_truncated'
+		);
+	}
 
 	if ( Buffer.compare( headerChunk, HEADER_CHUNK_EOF ) === 0 ) {
 		return null;
@@ -69,6 +93,14 @@ async function readHeader( fd: fs.promises.FileHandle ): Promise< Header | null 
 	const size = parseInt( readFromBuffer( headerChunk, 255, 269 ), 10 );
 	const mTime = readFromBuffer( headerChunk, 269, 281 );
 	const prefix = readFromBuffer( headerChunk, 281, HEADER_SIZE );
+
+	if ( ! Number.isSafeInteger( size ) || size < 0 ) {
+		throw new LoggerError(
+			sprintf( __( 'The backup archive is corrupted: invalid size for "%s".' ), name ),
+			undefined,
+			'wpress_corrupted'
+		);
+	}
 
 	return {
 		name,
@@ -85,17 +117,28 @@ function isPathWithinDirectory( filePath: string, directory: string ): boolean {
 }
 
 /**
- * Reads a block of data from a .wpress file and writes it to a file.
+ * Copies the content of one archive entry, starting at `position`, into the
+ * extraction directory.
+ *
+ * Entries that would land outside the extraction directory are not extracted.
+ * Nothing is read for them: the caller advances past them using the size
+ * recorded in the header.
  *
  * @param {fs.promises.FileHandle} fd - The file handle to read from.
- * @param {Header} header - The header of the file to read.
- * @param {string} outputPath - The path to write the file to.
+ * @param {Header} header - The header of the entry to extract.
+ * @param {string} outputPath - The extraction directory.
+ * @param {number} position - The byte offset of the entry content in the archive.
+ * @returns {Promise<void>} - Resolves once the extracted file is fully written and closed.
  */
-async function readBlockToFile( fd: fs.promises.FileHandle, header: Header, outputPath: string ) {
+async function readBlockToFile(
+	fd: fs.promises.FileHandle,
+	header: Header,
+	outputPath: string,
+	position: number
+): Promise< void > {
 	const outputFilePath = path.join( outputPath, header.prefix, header.name );
 
 	if ( ! isPathWithinDirectory( outputFilePath, outputPath ) ) {
-		await fd.read( Buffer.alloc( header.size ), 0, header.size, null );
 		return;
 	}
 
@@ -104,22 +147,15 @@ async function readBlockToFile( fd: fs.promises.FileHandle, header: Header, outp
 
 	// Resolve once the underlying fd is closed — either after end() flushes or
 	// after an error destroys the stream. Awaiting this before returning prevents
-	// the writeStream's lazy open + flush from racing with synchronous existence
-	// checks in the caller (manifested as a Windows-only test flake; libuv's
-	// worker happens to flush fast enough on Linux/macOS to mask it).
+	// the caller from touching the file while it is still open.
 	const closed = new Promise< void >( ( resolve ) => {
 		outputStream.once( 'close', () => resolve() );
 	} );
 
 	let totalBytesToRead = header.size;
-	let errored = false;
+	let readPosition = position;
+	let failure: Error | undefined;
 	let streamEnded = false;
-
-	const errorHandler = () => {
-		if ( ! errored ) {
-			errored = true;
-		}
-	};
 
 	const endStream = () => {
 		if ( ! streamEnded && ! outputStream.destroyed ) {
@@ -128,28 +164,46 @@ async function readBlockToFile( fd: fs.promises.FileHandle, header: Header, outp
 		}
 	};
 
-	outputStream.once( 'error', errorHandler );
+	outputStream.once( 'error', ( error: Error ) => {
+		failure ??= error;
+	} );
 
 	try {
-		while ( totalBytesToRead > 0 ) {
-			let bytesToRead = CHUNK_SIZE_TO_READ;
-			if ( bytesToRead > totalBytesToRead ) {
-				bytesToRead = totalBytesToRead;
-			}
-			if ( bytesToRead === 0 ) break;
+		while ( totalBytesToRead > 0 && ! failure && ! outputStream.destroyed ) {
+			const bytesToRead = Math.min( CHUNK_SIZE_TO_READ, totalBytesToRead );
 			const buffer = Buffer.alloc( bytesToRead );
-			const data = await fd.read( buffer, 0, bytesToRead );
-			if ( errored || outputStream.destroyed ) {
-				return;
+			const { bytesRead } = await fd.read( buffer, 0, bytesToRead, readPosition );
+			if ( bytesRead === 0 ) {
+				throw new LoggerError(
+					sprintf(
+						__( 'The backup archive is truncated: "%s" is shorter than its header declares.' ),
+						header.name
+					),
+					undefined,
+					'wpress_truncated'
+				);
 			}
-			outputStream.write( buffer );
-			totalBytesToRead -= data.bytesRead;
+			// A read may return fewer bytes than requested; only forward what was read.
+			outputStream.write( buffer.subarray( 0, bytesRead ) );
+			totalBytesToRead -= bytesRead;
+			readPosition += bytesRead;
 		}
-	} catch ( err ) {
-		errorHandler();
+	} catch ( error ) {
+		failure ??= error as Error;
 	} finally {
 		endStream();
 		await closed;
+	}
+
+	if ( failure ) {
+		if ( failure instanceof LoggerError ) {
+			throw failure;
+		}
+		throw new LoggerError(
+			sprintf( __( 'Failed to extract "%s" from the backup archive.' ), header.name ),
+			failure,
+			'wpress_extract_failed'
+		);
 	}
 }
 
@@ -193,19 +247,19 @@ export class BackupHandlerWpress extends ImportExportEventEmitter implements Bac
 
 		const inputFile = await fs.promises.open( file.path, 'r' );
 
-		// Read all of the headers and file data into memory.
+		// Walk the headers only. Entry content is skipped by position, so the
+		// size of an entry (which can exceed 2 GiB) never has to fit in memory.
 		try {
+			let position = 0;
 			let header;
-			do {
-				header = await readHeader( inputFile );
-				if ( header ) {
-					const filePath = path.join( header.prefix, header.name );
-					if ( ! filePath.split( path.sep ).includes( '..' ) ) {
-						fileNames.push( filePath );
-					}
-					await inputFile.read( Buffer.alloc( header.size ), 0, header.size, null );
+			while ( ( header = await readHeader( inputFile, position ) ) !== null ) {
+				position += HEADER_SIZE;
+				const filePath = path.join( header.prefix, header.name );
+				if ( ! filePath.split( path.sep ).includes( '..' ) ) {
+					fileNames.push( filePath );
 				}
-			} while ( header );
+				position += header.size;
+			}
 		} finally {
 			await inputFile.close();
 		}
@@ -242,12 +296,11 @@ export class BackupHandlerWpress extends ImportExportEventEmitter implements Bac
 
 		const inputFile = await fs.promises.open( file.path, 'r' );
 
+		let position = 0;
 		let header;
 		try {
-			while ( ( header = await readHeader( inputFile ) ) !== null ) {
-				if ( ! header ) {
-					break;
-				}
+			while ( ( header = await readHeader( inputFile, position ) ) !== null ) {
+				position += HEADER_SIZE;
 
 				// Emit progress before processing file
 				const currentFile = path.join( header.prefix, header.name );
@@ -259,7 +312,8 @@ export class BackupHandlerWpress extends ImportExportEventEmitter implements Bac
 					currentFile,
 				} );
 
-				await readBlockToFile( inputFile, header, extractionDirectory );
+				await readBlockToFile( inputFile, header, extractionDirectory, position );
+				position += header.size;
 				this.processedFiles++;
 
 				// Emit progress after processing file

--- a/apps/cli/lib/import-export/import/handlers/tests/backup-handler-wpress.test.ts
+++ b/apps/cli/lib/import-export/import/handlers/tests/backup-handler-wpress.test.ts
@@ -149,3 +149,268 @@ describe( 'BackupHandlerWpress — listFiles traversal filtering', () => {
 		expect( files ).toContain( 'database.sql' );
 	} );
 } );
+
+// ── Large archives and damaged archives ─────────────────────────────────────
+
+const TWO_GIB = 2 ** 31;
+
+/**
+ * Writes a .wpress archive whose entries can be much larger than the bytes
+ * actually stored on disk. Entry content that is not provided is left as a
+ * hole (a sparse region), so a multi-gigabyte entry costs a few kilobytes.
+ * The archive is finished with `ftruncate`, which never writes data, so it
+ * stays sparse on every platform; the reader treats a clean end of file like
+ * the EOF marker.
+ */
+function writeSparseWpress(
+	archivePath: string,
+	entries: { name: string; prefix: string; size: number; content?: Buffer }[],
+	options: { withEofMarker?: boolean } = {}
+): void {
+	const fd = fs.openSync( archivePath, 'w' );
+	try {
+		let position = 0;
+		for ( const entry of entries ) {
+			fs.writeSync(
+				fd,
+				makeHeader( entry.name, entry.size, entry.prefix ),
+				0,
+				HEADER_SIZE,
+				position
+			);
+			position += HEADER_SIZE;
+			if ( entry.content ) {
+				fs.writeSync( fd, entry.content, 0, entry.content.length, position );
+			}
+			position += entry.size;
+		}
+		if ( options.withEofMarker ) {
+			fs.writeSync( fd, Buffer.alloc( HEADER_SIZE ), 0, HEADER_SIZE, position );
+			position += HEADER_SIZE;
+		}
+		fs.ftruncateSync( fd, position );
+	} finally {
+		fs.closeSync( fd );
+	}
+}
+
+/** Deterministic pseudo-random bytes, so content corruption is detectable. */
+function pseudoRandomBytes( length: number, seed = 1 ): Buffer {
+	const buffer = Buffer.alloc( length );
+	let state = seed >>> 0;
+	for ( let i = 0; i < length; i++ ) {
+		// xorshift32
+		state ^= state << 13;
+		state ^= state >>> 17;
+		state ^= state << 5;
+		buffer[ i ] = state & 0xff;
+	}
+	return buffer;
+}
+
+describe( 'BackupHandlerWpress — entries larger than 2 GiB', () => {
+	let tmpDir: string;
+	let extractDir: string;
+	let archivePath: string;
+	let handler: BackupHandlerWpress;
+
+	beforeEach( () => {
+		tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-wpress-large-test-' ) );
+		extractDir = path.join( tmpDir, 'extract' );
+		archivePath = path.join( tmpDir, 'large.wpress' );
+		fs.mkdirSync( extractDir );
+		handler = new BackupHandlerWpress();
+	} );
+
+	afterEach( () => {
+		fs.rmSync( tmpDir, { recursive: true, force: true } );
+	} );
+
+	it( 'lists every entry of an archive containing an entry larger than 2 GiB', async () => {
+		writeSparseWpress( archivePath, [
+			{ name: 'database.sql', prefix: '', size: 6, content: Buffer.from( '-- ok\n' ) },
+			{ name: 'package.json', prefix: '', size: 2, content: Buffer.from( '{}' ) },
+			{ name: 'backup.mp4', prefix: 'uploads', size: TWO_GIB + 4096 },
+		] );
+		expect( fs.statSync( archivePath ).size ).toBeGreaterThan( TWO_GIB );
+
+		const files = await handler.listFiles( { path: archivePath, type: 'wpress' } );
+
+		expect( files ).toEqual( [
+			'database.sql',
+			'package.json',
+			path.join( 'uploads', 'backup.mp4' ),
+		] );
+	} );
+
+	it( 'skips a blocked traversal entry larger than 2 GiB without reading it', async () => {
+		writeSparseWpress( archivePath, [
+			{ name: 'safe.txt', prefix: '', size: 5, content: Buffer.from( 'good\n' ) },
+			{ name: 'huge-evil.bin', prefix: '..', size: TWO_GIB + 512 },
+		] );
+
+		const started = Date.now();
+		await handler.extractFiles( { path: archivePath, type: 'wpress' }, extractDir );
+
+		expect( fs.readFileSync( path.join( extractDir, 'safe.txt' ), 'utf8' ) ).toBe( 'good\n' );
+		expect( fs.existsSync( path.join( tmpDir, 'huge-evil.bin' ) ) ).toBe( false );
+		// Skipping by position is O(1); reading 2 GiB of holes would take seconds.
+		expect( Date.now() - started ).toBeLessThan( 2000 );
+	} );
+
+	it.skipIf( process.platform === 'win32' )(
+		'keeps the test archive sparse (documents that the fixture really is > 2 GiB)',
+		() => {
+			writeSparseWpress( archivePath, [
+				{ name: 'backup.mp4', prefix: 'uploads', size: TWO_GIB + 4096 },
+			] );
+			const stat = fs.statSync( archivePath );
+			expect( stat.size ).toBeGreaterThan( TWO_GIB );
+			// Allocated blocks are 512 bytes each; the header plus metadata is well under 1 MiB.
+			expect( stat.blocks * 512 ).toBeLessThan( 1024 * 1024 );
+		}
+	);
+} );
+
+describe( 'BackupHandlerWpress — content integrity across chunk boundaries', () => {
+	let tmpDir: string;
+	let extractDir: string;
+	let archivePath: string;
+	let handler: BackupHandlerWpress;
+
+	beforeEach( () => {
+		tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-wpress-content-test-' ) );
+		extractDir = path.join( tmpDir, 'extract' );
+		archivePath = path.join( tmpDir, 'content.wpress' );
+		fs.mkdirSync( extractDir );
+		handler = new BackupHandlerWpress();
+	} );
+
+	afterEach( () => {
+		fs.rmSync( tmpDir, { recursive: true, force: true } );
+	} );
+
+	it( 'extracts multi-chunk entries byte for byte and keeps following entries aligned', async () => {
+		// 3 MiB plus a remainder that is not a multiple of the read chunk size.
+		const big = pseudoRandomBytes( 3 * 1024 * 1024 + 777, 42 );
+		const after = Buffer.from( 'after the big one\n' );
+		writeSparseWpress(
+			archivePath,
+			[
+				{ name: 'video.mp4', prefix: 'uploads/2026/09', size: big.length, content: big },
+				{ name: 'notes.txt', prefix: '', size: after.length, content: after },
+			],
+			{ withEofMarker: true }
+		);
+
+		await handler.extractFiles( { path: archivePath, type: 'wpress' }, extractDir );
+
+		const extracted = fs.readFileSync(
+			path.join( extractDir, 'uploads', '2026', '09', 'video.mp4' )
+		);
+		expect( extracted.length ).toBe( big.length );
+		expect( extracted.equals( big ) ).toBe( true );
+		expect( fs.readFileSync( path.join( extractDir, 'notes.txt' ), 'utf8' ) ).toBe(
+			'after the big one\n'
+		);
+	} );
+
+	it( 'extracts an empty entry as an empty file', async () => {
+		writeSparseWpress( archivePath, [ { name: 'empty.txt', prefix: '', size: 0 } ], {
+			withEofMarker: true,
+		} );
+
+		await handler.extractFiles( { path: archivePath, type: 'wpress' }, extractDir );
+
+		expect( fs.statSync( path.join( extractDir, 'empty.txt' ) ).size ).toBe( 0 );
+	} );
+} );
+
+describe( 'BackupHandlerWpress — damaged archives', () => {
+	let tmpDir: string;
+	let extractDir: string;
+	let archivePath: string;
+	let handler: BackupHandlerWpress;
+
+	beforeEach( () => {
+		tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-wpress-damaged-test-' ) );
+		extractDir = path.join( tmpDir, 'extract' );
+		archivePath = path.join( tmpDir, 'damaged.wpress' );
+		fs.mkdirSync( extractDir );
+		handler = new BackupHandlerWpress();
+	} );
+
+	afterEach( () => {
+		fs.rmSync( tmpDir, { recursive: true, force: true } );
+	} );
+
+	it( 'rejects an archive cut in the middle of an entry instead of hanging', async () => {
+		const content = pseudoRandomBytes( 10 * 1024 );
+		writeSparseWpress( archivePath, [
+			{ name: 'cut.bin', prefix: '', size: content.length, content },
+		] );
+		// Drop the last 4 KiB of the entry.
+		fs.truncateSync( archivePath, HEADER_SIZE + content.length - 4096 );
+
+		await expect(
+			handler.extractFiles( { path: archivePath, type: 'wpress' }, extractDir )
+		).rejects.toMatchObject( { message: expect.stringContaining( 'truncated' ) } );
+	}, 10_000 );
+
+	it( 'rejects an archive cut in the middle of a header', async () => {
+		writeSparseWpress( archivePath, [
+			{ name: 'ok.txt', prefix: '', size: 3, content: Buffer.from( 'abc' ) },
+			{ name: 'next.txt', prefix: '', size: 3, content: Buffer.from( 'def' ) },
+		] );
+		// Keep the first entry whole and half of the second header.
+		fs.truncateSync( archivePath, HEADER_SIZE + 3 + Math.floor( HEADER_SIZE / 2 ) );
+
+		await expect(
+			handler.listFiles( { path: archivePath, type: 'wpress' } )
+		).rejects.toMatchObject( { message: expect.stringContaining( 'truncated' ) } );
+	} );
+
+	it( 'accepts an archive whose EOF marker is cut short, since every entry is complete', async () => {
+		writeSparseWpress(
+			archivePath,
+			[ { name: 'whole.txt', prefix: '', size: 5, content: Buffer.from( 'whole' ) } ],
+			{ withEofMarker: true }
+		);
+		// Keep the entry and only a third of the trailing EOF marker.
+		fs.truncateSync( archivePath, HEADER_SIZE + 5 + Math.floor( HEADER_SIZE / 3 ) );
+
+		await expect( handler.listFiles( { path: archivePath, type: 'wpress' } ) ).resolves.toEqual( [
+			'whole.txt',
+		] );
+		await handler.extractFiles( { path: archivePath, type: 'wpress' }, extractDir );
+		expect( fs.readFileSync( path.join( extractDir, 'whole.txt' ), 'utf8' ) ).toBe( 'whole' );
+	} );
+
+	it( 'rejects a header whose size field is not a number', async () => {
+		const header = Buffer.alloc( HEADER_SIZE );
+		header.write( 'weird.txt', 0, 'utf8' );
+		header.write( 'not-a-size', 255, 'utf8' );
+		fs.writeFileSync( archivePath, Buffer.concat( [ header, Buffer.alloc( HEADER_SIZE ) ] ) );
+
+		await expect(
+			handler.listFiles( { path: archivePath, type: 'wpress' } )
+		).rejects.toMatchObject( { message: expect.stringContaining( 'invalid size' ) } );
+	} );
+
+	it( 'surfaces write failures instead of silently skipping the entry', async () => {
+		// The first entry creates a directory named "clash"; the second wants to
+		// write a file at that same path, which fails with EISDIR.
+		writeSparseWpress(
+			archivePath,
+			[
+				{ name: 'inner.txt', prefix: 'clash', size: 2, content: Buffer.from( 'hi' ) },
+				{ name: 'clash', prefix: '', size: 2, content: Buffer.from( 'no' ) },
+			],
+			{ withEofMarker: true }
+		);
+
+		await expect(
+			handler.extractFiles( { path: archivePath, type: 'wpress' }, extractDir )
+		).rejects.toMatchObject( { message: expect.stringContaining( 'Failed to extract "clash"' ) } );
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Fixes #4387

## How AI was used in this PR

I used an AI assistant to help trace the crash, draft the position-based reader and the sparse-file test fixtures. I reviewed every line of the change, ran the full CLI unit suite locally, and reproduced the original native assertion against trunk with the new tests before applying the fix. Reviewers may want to focus on the position arithmetic in `readHeader`/`readBlockToFile` and on the new error paths for damaged archives.

## Proposed Changes

Importing a `.wpress` backup that contains an entry of 2 GiB or more crashed Studio with `Assertion failed: args[3]->IsInt32()`. Listing the archive skipped every entry by reading its whole content into a buffer sized from the entry header, and `FileHandle.read()` only accepts a length that fits in a signed 32-bit integer. The same read happened when a blocked traversal entry was skipped during extraction.

- Entry content is never read or allocated just to be skipped anymore, whatever its size, so backups holding large media files or database dumps import again.
- Damaged archives now fail clearly instead of silently or forever: an archive that ends before the size declared in a header raises a "truncated" error rather than looping on zero-byte reads, a read that returns fewer bytes than requested only forwards the bytes read, and read or write failures are reported instead of being swallowed, so a partial import is no longer presented as a success.
- An archive whose trailing EOF marker is cut short is still accepted, as before, since every entry in it is complete.

## Testing Instructions

1. Run `npm test -- --project cli backup-handler-wpress`. The suite builds sparse archives, so an entry above 2 GiB costs a few kilobytes on disk. It covers listing and extraction with such an entry, byte-for-byte integrity across chunk boundaries, empty entries, archives cut inside an entry or a header, an EOF marker cut short, a non-numeric size field and a write failure.
2. To see the original failure, restore trunk's `apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts` and run the same tests: the vitest worker dies with `Assertion failed: args[3]->IsInt32()` in `node::fs::Read` (Node 24.18).
3. Manual check: create a `.wpress` export with All-in-One WP Migration from a site holding a file larger than 2 GiB under `wp-content/uploads`, then import it with `studio site import` or from the app. Before: the import crashes. After: the import completes and the large file is extracted intact.

Also passing locally: the full CLI unit suite (`npm test -- --project cli --tagsFilter='!e2e'`, 101 files, 1192 tests), `npm run typecheck` and `npm run lint` for `apps/cli`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
