### PR TITLE
Fix broken build in AI credits notice by using public ThemeProvider API

### DIFF
--- a/apps/studio/src/components/ai-credits-purchased-notice.tsx
+++ b/apps/studio/src/components/ai-credits-purchased-notice.tsx
@@ -1,13 +1,10 @@
 import { formatAiCreditsAddedTitle } from '@studio/common/lib/studio-assistant-quota';
-import { privateApis } from '@wordpress/theme';
+import { ThemeProvider } from '@wordpress/theme';
 import { Notice } from '@wordpress/ui';
 import { useFrameBackgroundColor } from 'src/hooks/use-frame-background-color';
 import { useAppDispatch, useI18nLocale, useRootSelector } from 'src/stores';
 import { selectAiCreditsAdded, setAiCreditsAdded } from 'src/stores/ui-slice';
-import { unlock } from './studio-code-session/lock-unlock';
 import buttonDefense from './studio-code-session/wp-ui-button-defense.module.css';
-
-const { ThemeProvider } = unlock( privateApis );
 
 /**
  * Confirms a top-up above the Classic composer once the balance has grown.
@@ -31,7 +28,7 @@ export function AiCreditsPurchasedNotice() {
 	}
 
 	return (
-		<ThemeProvider color={ { bg: frameBackgroundColor } }>
+		<ThemeProvider color={ { background: frameBackgroundColor } }>
 			<Notice.Root intent="success" className="mb-2">
 				<Notice.Title>{ formatAiCreditsAddedTitle( creditsAdded, locale ) }</Notice.Title>
 				<Notice.CloseIcon

--- a/apps/studio/src/hooks/use-frame-background-color.ts
+++ b/apps/studio/src/hooks/use-frame-background-color.ts
@@ -14,7 +14,8 @@ function readFrameBackgroundColor(): string {
  * Studio's current frame background, read from `--color-frame-bg` so the two
  * never drift.
  *
- * Feed this to `@wordpress/ui`'s `ThemeProvider` as its `color.bg` seed: WPDS
+ * Feed this to `@wordpress/theme`'s `ThemeProvider` as its `color.background`
+ * seed: WPDS
  * derives its whole ramp from that seed, and without one it falls back to the
  * light-only values built into `@wordpress/theme` — which is why a WPDS
  * component renders a light card on Studio's dark chrome.


### PR DESCRIPTION
## Related issues

- Related to #4745
- Related to #4320

## How AI was used in this PR

Claude Code diagnosed the build failure, applied the fix, and ran lint, typecheck, and the affected tests. I reviewed the change.

## Proposed Changes

Trunk currently fails to build. `apps/studio` errors with `Failed to resolve import "./studio-code-session/lock-unlock"`, which takes down the Classic renderer and the AI credits top-up notice with it.

The notice was written against `@wordpress/theme` v1, while #4320 had already moved `apps/studio` to v2. Two separate v1 assumptions were baked in:

1. It reached `ThemeProvider` through `unlock( privateApis )`, importing an `unlock` helper from a path that doesn't exist in `apps/studio` (the only `lock-unlock.ts` in the repo belongs to `apps/ui`). In v2 `ThemeProvider` is a plain public export, so the indirection is unnecessary — and would have failed anyway: v2's `privateApis` is an empty deprecated object, so the destructure yields `undefined` and crashes at render even with the missing file restored.
2. The `ThemeProvider` color seed prop was renamed `bg` to `background`. This one only surfaced in typecheck once the import resolution was unblocked.

The notice now imports `ThemeProvider` directly, matching how `studio-code-session/index.tsx` already does it.

## Testing Instructions

Confirm the build goes through

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
