### PR TITLE
Studio Code: keep take_screenshot for text-only models and gate visual verification on vision

### DIFF
--- a/apps/cli/ai/runtimes/pi/index.ts
+++ b/apps/cli/ai/runtimes/pi/index.ts
@@ -54,7 +54,7 @@ import { createAskUserQuestionTool } from 'cli/ai/tools/ask-user-question';
 import { createSiteTool } from 'cli/ai/tools/create-site';
 import { pullSiteTool } from 'cli/ai/tools/pull-site';
 import { createSkillTool } from 'cli/ai/tools/skill';
-import { takeScreenshotTool } from 'cli/ai/tools/take-screenshot';
+import { createTakeScreenshotTool, takeScreenshotTool } from 'cli/ai/tools/take-screenshot';
 import { createWpcomRequestTool } from 'cli/ai/tools/wpcom-request';
 import { getSiteByFolder } from 'cli/lib/cli-config/sites';
 import { STUDIO_SITES_ROOT } from 'cli/lib/site-paths';
@@ -327,6 +327,7 @@ async function createStudioAgentSession(
 	const isRemoteSite = Boolean( config.activeSite?.remote && config.activeSite?.wpcomSiteId );
 	const remoteSession = config.env.STUDIO_REMOTE_SESSION === '1';
 	const chatArtifactsEnabled = typeof process.send === 'function';
+	const visionEnabled = aiModelSupportsImages( config.model );
 	const [ userInstructions, runtime, imageGenerationEnabled ] = await Promise.all( [
 		readGlobalInstructions(),
 		isRemoteSite ? undefined : resolveActiveSiteRuntime( config.activeSite ),
@@ -343,6 +344,7 @@ async function createStudioAgentSession(
 					},
 					remoteSession,
 					userInstructions,
+					visionEnabled,
 			  }
 			: {
 					chatArtifactsEnabled,
@@ -350,6 +352,7 @@ async function createStudioAgentSession(
 					runtime,
 					userInstructions,
 					imageGenerationEnabled,
+					visionEnabled,
 			  }
 	);
 
@@ -357,7 +360,8 @@ async function createStudioAgentSession(
 		config,
 		chatArtifactsEnabled,
 		remoteSession,
-		imageGenerationEnabled
+		imageGenerationEnabled,
+		visionEnabled
 	);
 	const toolDefinitions = tools.map( ( tool ) => toToolDefinition( tool, payloadGuardState ) );
 	const modelRuntime = await createModelRuntime( model, family, creds );
@@ -676,7 +680,8 @@ function buildAgentTools(
 	config: ResolvedStudioAgentTurnConfig,
 	chatArtifactsEnabled: boolean,
 	remoteSession: boolean,
-	imageGenerationEnabled: boolean
+	imageGenerationEnabled: boolean,
+	visionEnabled: boolean
 ): AgentToolAny[] {
 	const isRemoteSite = Boolean(
 		config.activeSite?.remote && config.activeSite?.wpcomSiteId && config.wpcomAccessToken
@@ -705,24 +710,19 @@ function buildAgentTools(
 		renameTool( createLsTool( STUDIO_WPCOM_BODY_FILES_ROOT ), 'Ls' ),
 	];
 
-	// A text-only model drops image blocks from tool results while still
-	// receiving their text, so it would report on a screenshot it never saw.
-	const withoutUnusableTools = ( tools: AgentToolAny[] ): AgentToolAny[] =>
-		aiModelSupportsImages( config.model )
-			? tools
-			: tools.filter( ( tool ) => tool.name !== takeScreenshotTool.name );
-
 	if ( isRemoteSite ) {
-		const remoteStudioTools = [ takeScreenshotTool, createSiteTool, pullSiteTool ].map( ( tool ) =>
-			withChatArtifactEmission( tool, chatArtifactsEnabled )
-		);
-		return withoutUnusableTools( [
+		const remoteStudioTools = [
+			visionEnabled ? takeScreenshotTool : createTakeScreenshotTool( { visionEnabled: false } ),
+			createSiteTool,
+			pullSiteTool,
+		].map( ( tool ) => withChatArtifactEmission( tool, chatArtifactsEnabled ) );
+		return [
 			createWpcomRequestTool( config.wpcomAccessToken!, config.activeSite!.wpcomSiteId! ),
 			...remoteStudioTools,
 			...remoteScratchTools,
 			...askUserTool,
 			...skillTool,
-		] );
+		];
 	}
 
 	const piTools: AgentToolAny[] = [
@@ -738,8 +738,9 @@ function buildAgentTools(
 		emitChatArtifacts: chatArtifactsEnabled,
 		remoteSession,
 		imageGeneration: imageGenerationEnabled,
+		visionEnabled,
 	} ) as unknown as AgentToolAny[];
-	return withoutUnusableTools( [ ...studioTools, ...askUserTool, ...skillTool, ...piTools ] );
+	return [ ...studioTools, ...askUserTool, ...skillTool, ...piTools ];
 }
 
 function parseJsonHeaderEnv(

--- a/apps/cli/ai/skills/visual-polish/SKILL.md
+++ b/apps/cli/ai/skills/visual-polish/SKILL.md
@@ -19,7 +19,7 @@ For a WooCommerce shop, polish each of these pages: Shop, single-product, Cart, 
 How much to iterate depends on the page:
 
 - **Home page** — run the full loop below, including Phase 3 (re-diagnose and fix again, up to the pass cap). The home page is the highest-traffic, highest-impact page and is worth iterating until it is right.
-- **Every other page** (other user pages AND WooCommerce pages) — run a **single pass**: diagnose (Phase 1), fix the batch (Phase 2), take one verification screenshot, then move on. Do not loop these pages; a single diagnose-and-fix pass is enough.
+- **Every other page** (other user pages AND WooCommerce pages) — run a **single pass**: diagnose (Phase 1), fix the batch (Phase 2), run one verification pass (Phase 3), then move on. Do not loop these pages; a single diagnose-and-fix pass is enough.
 
 ## Method: diagnose the whole page first, then fix in one batch
 
@@ -28,11 +28,13 @@ The most important rule: **do not fix issues one at a time as you find them.** F
 ### Phase 1 — Diagnose (read-only — make NO edits in this phase)
 
 1. Enumerate every section and component of the page (from the page markup you wrote, or by inspecting the top-level containers).
-2. Take one `take_screenshot` with `viewport: "all"` (desktop + mobile).
+2. If you can view images, take one `take_screenshot` with `viewport: "all"` (desktop + mobile). A model that cannot view images skips this step: `inspect_design` is then the whole diagnosis, so the sweep below must be complete rather than guided by what looks wrong.
 3. Go **section by section**. For each, call `inspect_design` on the relevant selectors and compare the rendered DOM and computed styles against your intent and the theme's `style.css` (read it). The screenshot is the symptom; `inspect_design` is the cause — never diagnose from the screenshot alone, because subtle issues like doubled button padding barely show in pixels. Inspect even sections that look roughly right, and always inspect:
+   - the header and footer template parts — for `padding-left`/`padding-right` on the bar; a part whose root group is not `layout: constrained` (and has no constrained inner group) gets no gutter, and its text touches the viewport edge,
    - every section wrapper — for width and centering,
    - every button — BOTH `.wp-block-button` and `.wp-block-button__link`, with `includeHover: true`.
    - every block that paints its own box (background, border, shadow — cards, panels, tinted sections) and every non-constrained full-width section — for `padding-left`/`padding-right`, which must not be `0px` when the box holds text.
+   - every inset box — a block that is rounded, bordered, or narrower than its container and paints its own background — for the edges it meets: compare its `boundingBox` with the neighbouring header, footer, or section, because an inset box must not sit directly against a hard edge such as the footer's border. Full-bleed bands are meant to sit flush; leave them alone.
 4. List the **complete** set of issues before fixing anything — a concise checklist, one short line per issue: the section, the root cause from the DOM, and the exact fix (file, selector, change). A list, not prose.
 
 Do not make a single edit until you have diagnosed every section and listed every issue. **A complete diagnosis is the gate into Phase 2.**
@@ -43,13 +45,13 @@ Work through the plan with targeted `Edit` calls (one `Write`/`Edit` per turn, p
 
 ### Phase 3 — Verify and loop
 
-After the whole batch, take one `viewport: "all"` screenshot. Check each plan item off and look for regressions the fixes introduced.
+After the whole batch, take one `viewport: "all"` screenshot — or, when you cannot view images, re-run `inspect_design` on the selectors you changed. Check each plan item off and look for regressions the fixes introduced.
 
-This looping phase applies to the **home page only** (see "Scope" above). For every other page — including WooCommerce pages — stop after this single verification screenshot; do not loop. For the home page, each pass is expensive, so cap the cycle at **5 passes**. If issues remain and you are within that budget, return to Phase 1 for what's left — re-diagnose the remaining issues with `inspect_design`, don't fix blind.
+This looping phase applies to the **home page only** (see "Scope" above). For every other page — including WooCommerce pages — stop after this single verification pass; do not loop. For the home page, each pass is expensive, so cap the cycle at **5 passes**. If issues remain and you are within that budget, return to Phase 1 for what's left — re-diagnose the remaining issues with `inspect_design`, don't fix blind.
 
 ## Recurring issues and what to inspect
 
-The issues below are common examples, **not an exhaustive list**. Treat them as a starting checklist, not the full scope of what to look for — fix every visual problem the screenshot reveals, including ones not listed here, and apply the same method (inspect the rendered DOM, find the real cause, then fix). For each, the cause lives in the DOM — inspect, don't guess.
+The issues below are common examples, **not an exhaustive list**. Treat them as a starting checklist, not the full scope of what to look for — fix every visual problem the screenshot or the inspection reveals, including ones not listed here, and apply the same method (inspect the rendered DOM, find the real cause, then fix). For each, the cause lives in the DOM — inspect, don't guess.
 
 ### Section width or centering is off
 
@@ -79,6 +81,14 @@ Inspect BOTH selectors with `includeHover: true` and compare their computed styl
 Symptom: copy sits flush against the edge of a card, a tinted panel, a bordered box, or the window — most visible on mobile.
 
 Inspect the box and read `padding-left`/`padding-right`. WordPress pads only full-width constrained groups (the root gutter via `.has-global-padding`) and zeroes it on constrained groups nested inside them; a group, column, or cover with its own background or border gets no padding, and neither does a full-width section with a `default`, `flex`, or `grid` layout. Fix it by giving the block's class horizontal padding in `style.css` (reuse `var(--wp--style--root--padding-left)` for a section gutter) or by moving the text into a constrained inner group — never with margins on the text blocks.
+
+The header is the usual victim: rewriting `parts/header.html` from scratch tends to drop the scaffold's outer `{"layout":{"type":"constrained"}}` group, leaving a flow or flex group that gets no gutter, so the site title sits at `x: 0`. Restore the constrained wrapper in the part's markup rather than padding the bar in CSS.
+
+### An inset box sits on a hard edge
+
+Symptom: a rounded or bordered card is the first or last section and its edge lands directly on the footer's top border or the header's bottom edge, with no breathing room.
+
+Inspect the box and its neighbour and compare their `boundingBox` values: equal edges with no gap is the fault. Scaffolded themes zero the gap between the template's top-level blocks and let sections own their rhythm, which is right for full-bleed bands but leaves an inset box touching whatever follows it. Give that section (not the text inside it) bottom or top spacing, or close the page on a full-bleed band instead. Do not add spacing to full-bleed sections — they are meant to sit flush.
 
 ### Spacing between blocks differs from intent
 

--- a/apps/cli/ai/skills/wpcom-remote-management/SKILL.md
+++ b/apps/cli/ai/skills/wpcom-remote-management/SKILL.md
@@ -99,7 +99,7 @@ Do not combine `bodyFile` with `body` or `bodyFiles`.
 1. Check the site plan first. This is already required by the remote system prompt and must happen before any change.
 2. Understand the site with lightweight reads, such as `GET /posts` and `GET /themes?status=active`.
 3. Make changes with POST requests to create or update content, manage templates, switch themes, or manage plugins.
-4. Verify visually with `take_screenshot` using `viewport: "all"` for desktop and mobile.
+4. Verify with `take_screenshot` using `viewport: "all"` for desktop and mobile; when you cannot view images, verify from the rendered DOM with `inspect_design` instead.
 5. If an operation fails, inspect the error and try a lightweight GET request to discover the available shape before retrying.
 
 Always confirm destructive operations, including deleting posts or deactivating plugins, before proceeding.

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -30,14 +30,18 @@ export interface BuildSystemPromptOptions {
 	// every imagery-related prompt section so unavailable sessions get exactly
 	// the pre-imagery prompt.
 	imageGenerationEnabled?: boolean;
+	// False for models that cannot view images. Defaults to true.
+	visionEnabled?: boolean;
 }
 
 export function buildSystemPrompt( options?: BuildSystemPromptOptions ): string {
 	const remoteSessionAddendum = options?.remoteSession ? `\n\n${ REMOTE_SESSION_GUIDANCE }` : '';
 	const userInstructionsSection = buildUserInstructionsSection( options?.userInstructions );
 
+	const visionEnabled = options?.visionEnabled ?? true;
+
 	if ( options?.remoteSite ) {
-		return `${ buildRemoteIntro( options.remoteSite ) }
+		return `${ buildRemoteIntro( options.remoteSite, visionEnabled ) }
 
 ${ REMOTE_CONTENT_GUIDELINES }
 
@@ -52,6 +56,7 @@ ${ REMOTE_DESIGN_GUIDELINES }${ remoteSessionAddendum }${ userInstructionsSectio
 		remoteSession: options?.remoteSession ?? false,
 		runtime: options?.runtime,
 		imageGenerationEnabled: options?.imageGenerationEnabled ?? false,
+		visionEnabled,
 	} ) }
 
 ${ LOCAL_SKILL_ROUTING }${ imageryRouting }${ remoteSessionAddendum }${ userInstructionsSection }
@@ -78,7 +83,10 @@ The user saved these standing instructions in Studio's settings. They apply to e
 ${ instructions }`;
 }
 
-function buildRemoteIntro( site: RemoteSiteContext ): string {
+function buildRemoteIntro( site: RemoteSiteContext, visionEnabled: boolean ): string {
+	const verifyStep = visionEnabled
+		? `Use take_screenshot with \`viewport: "all"\` to capture the site on desktop and mobile viewports in one call. Check spacing, alignment, colors, contrast, and layout. Fix any issues.`
+		: `You cannot view images, so verify from the rendered DOM with inspect_design instead. Fix any issues.`;
 	return `${ AGENT_IDENTITY } You manage WordPress.com sites using the WordPress.com REST API.
 
 IMPORTANT: The active site is a remote WordPress.com site: "${ site.name }" (ID: ${ site.id }) at ${ site.url }.
@@ -99,7 +107,7 @@ IMPORTANT: ${ PLAN_DATA_GUARDRAIL }
 1. **Check the site plan** (MANDATORY FIRST STEP): Use \`GET /\` (apiNamespace: \`""\`) to get site info and check \`plan.product_slug\`. Stop and inform the user if they request features unavailable on their plan.
 2. **Load remote guidance**: Load the \`wpcom-remote-management\` skill before selecting endpoints, creating or updating content, managing templates, switching themes, or managing plugins.
 3. **Understand and change the site**: Use wpcom_request according to the \`wpcom-remote-management\` skill.
-4. **Verify visually**: Use take_screenshot with \`viewport: "all"\` to capture the site on desktop and mobile viewports in one call. Check spacing, alignment, colors, contrast, and layout. Fix any issues.
+4. **Verify the result**: ${ verifyStep }
 
 ## General rules
 
@@ -132,8 +140,14 @@ function buildLocalIntro( options: {
 	remoteSession: boolean;
 	runtime?: SiteRuntime;
 	imageGenerationEnabled: boolean;
+	visionEnabled: boolean;
 } ): string {
 	const postContentGuidance = getPostContentGuidance( options.runtime );
+	const takeScreenshotToolBullet = options.visionEnabled
+		? `- take_screenshot: Take a full-page screenshot of a URL (supports desktop, mobile, or \`viewport: "all"\` for both). Use this to visually check the site after building it.
+- inspect_design: Inspect the rendered DOM and computed styles of a page by CSS selector to root-cause visual issues. Pair with take_screenshot when verifying or polishing a design.`
+		: `- take_screenshot: Save a full-page screenshot of a URL to a file (supports desktop, mobile, or \`viewport: "all"\` for both). You cannot view the image; the result reports the saved file path, which you need for the theme screenshot.
+- inspect_design: Inspect the rendered DOM and computed styles of a page by CSS selector. This is your verification tool: read widths, positions, and padding from it instead of looking at a capture.`;
 	const imageryWorkflowSection = options.imageGenerationEnabled
 		? `
 
@@ -211,7 +225,7 @@ Then continue with:
 4. **Provision the site**: Use wp_cli to activate the theme, install and activate any plugins the design needs, and set options. Do this before validating — the live editor only recognizes the active theme and registered plugin blocks. The site must be running.
 5. **Validate block content**: Any block content you generate MUST pass validate_blocks before it reaches the site — before \`wp post create/update\` and before \`wp_cli eval\` that imports a scratch file such as \`<site>/tmp/page-<slug>.html\`. Call validate_blocks with \`filePath\` for file content, or pass inline content. It runs a static core/html policy check first: if that reports invalid core/html blocks, editor validation is skipped — rewrite those as editable core or plugin blocks and call again. Once the policy passes it validates in the live editor. If an auto-fix was applied, the file already holds the fixed content; do not replace markup or re-validate unless you change the markup. Use the diff only to update CSS selectors for class/nesting changes. For inline content, use the returned fixed content exactly. Never apply unvalidated block content — a build that skips validate_blocks is incomplete.
 6. **Apply content**: Once it passes validation, create/update/import the posts and pages with the validated content. ${ postContentGuidance }
-7. **Check and polish the result**: Load the \`visual-polish\` skill and run it to polish the design. The design must match your original expectations.
+7. **Check and polish the result**: You MUST load the \`visual-polish\` skill and follow its instructions to do so. The design must match your original expectations. Do not inspect the design or take a screenshot before loading the skill.
 8. **Set the theme screenshot**: When the active theme was scaffolded by Studio Code, finish by copying your final desktop take_screenshot capture (each capture's saved file path is reported in the tool result) to \`screenshot.jpg\` in the theme's directory — it becomes the theme's thumbnail in Appearance → Themes. Copy the existing capture file; do not generate or hand-craft a screenshot image.${ imageryWorkflowSection }
 
 ## Working cadence
@@ -239,8 +253,7 @@ For long CSS or page-content files (>~200 lines), load the \`block-content\` ski
 - wp_cli: Run WP-CLI commands on a running site${ refreshBrowserToolBullet }
 - scaffold_theme: Scaffold a minimal block theme (style.css, theme.json, functions.php with frontend + editor enqueue, default templates and parts, empty assets/fonts and patterns dirs) into a site and activate it. Use as the first step when starting a new custom theme; the agent fills design-specific content afterwards. Pass parentTheme with an installed theme's slug to scaffold a child theme instead of editing that theme's files. Block themes only.
 - validate_blocks: Validate block content in two stages and return a combined report. First a static core/html policy check; if it finds invalid core/html blocks it returns only those (rewrite them as editable core or plugin blocks and call again) and skips the editor. Once it passes, validates in the running site's real block editor: with filePath, applies safe editor fixes directly to the file and returns a CSS-review diff; with inline content, returns exact fixed block content plus the diff. Requires a site name or path. Call after every file write/edit that contains block content.
-- take_screenshot: Take a full-page screenshot of a URL (supports desktop, mobile, or \`viewport: "all"\` for both). Use this to visually check the site after building it.
-- inspect_design: Inspect the rendered DOM and computed styles of a page by CSS selector to root-cause visual issues. Pair with take_screenshot when verifying or polishing a design.${ generateImagesToolBullet }
+${ takeScreenshotToolBullet }${ generateImagesToolBullet }
 - need_for_speed: Measure frontend performance metrics (TTFB, FCP, LCP, CLS, page weight, DOM size, JS/CSS/image/font asset breakdown) for a running site. Use this to identify performance bottlenecks and guide optimization.
 - rank_me_up: Run an on-page SEO audit (title/meta tags, headings, image alt text, OpenGraph/Twitter cards, JSON-LD structured data, robots.txt and sitemap.xml availability) for a running site. Use this to identify on-page SEO issues and guide fixes.
 - site_connected_remote_sites: List the durable WordPress.com remote sites (production/staging) already attached to a local site for syncing. These are distinct from temporary preview sites (preview_list). Call this before site_push to decide how to ask the user which remote site to target.

--- a/apps/cli/ai/tests/pi-runtime.test.ts
+++ b/apps/cli/ai/tests/pi-runtime.test.ts
@@ -336,9 +336,7 @@ describe( 'pi runtime', () => {
 		expect( mocks.createdSessions[ 1 ].options.model?.input ).toEqual( [ 'text' ] );
 	} );
 
-	// pi drops image blocks from tool results on a text-only model but still
-	// delivers the result text, so the model would describe a capture it never saw.
-	it( 'withholds take_screenshot from models that cannot see images', async () => {
+	it( 'keeps take_screenshot for models that cannot see images, without the image', async () => {
 		await runRuntime( {
 			prompt: 'hello',
 			env: HOSTED_ENV,
@@ -352,12 +350,16 @@ describe( 'pi runtime', () => {
 			session: newSession(),
 		} );
 
-		const toolNames = ( index: number ) =>
-			( ( mocks.createdSessions[ index ].options.customTools ?? [] ) as { name: string }[] ).map(
-				( tool ) => tool.name
-			);
-		expect( toolNames( 0 ) ).toContain( 'take_screenshot' );
-		expect( toolNames( 1 ) ).not.toContain( 'take_screenshot' );
+		const takeScreenshot = ( index: number ) =>
+			(
+				( mocks.createdSessions[ index ].options.customTools ?? [] ) as {
+					name: string;
+					description: string;
+				}[]
+			 ).find( ( tool ) => tool.name === 'take_screenshot' );
+		expect( takeScreenshot( 0 )?.description ).toContain( 'analyze visually' );
+		expect( takeScreenshot( 1 )?.description ).toContain( 'This model cannot view images' );
+		expect( takeScreenshot( 1 )?.description ).not.toContain( 'analyze visually' );
 	} );
 
 	it( 'rejects oversized direct Write, Edit, and Bash payloads', async () => {

--- a/apps/cli/ai/tests/system-prompt.test.ts
+++ b/apps/cli/ai/tests/system-prompt.test.ts
@@ -165,6 +165,32 @@ describe( 'buildSystemPrompt', () => {
 		expect( prompt ).toContain( 'Do not respond as though the user is looking at the capture' );
 	} );
 
+	it( 'describes the screenshot and inspect tools for models without vision', () => {
+		const polishStep = 'You MUST load the `visual-polish` skill and follow its instructions';
+		const withVision = buildSystemPrompt( {} );
+		expect( withVision ).toContain( polishStep );
+		expect( withVision ).toContain( 'Pair with take_screenshot' );
+		expect( withVision ).not.toContain( 'You cannot view' );
+
+		const textOnly = buildSystemPrompt( { visionEnabled: false } );
+		expect( textOnly ).toContain( polishStep );
+		expect( textOnly ).toContain( 'which you need for the theme screenshot' );
+		expect( textOnly ).toContain( 'copying your final desktop take_screenshot capture' );
+		expect( textOnly ).not.toContain( 'Pair with take_screenshot' );
+	} );
+
+	it( 'verifies remote sites from the rendered DOM without vision', () => {
+		expect( buildSystemPrompt( { remoteSite } ) ).toContain(
+			'**Verify the result**: Use take_screenshot with `viewport: "all"`'
+		);
+
+		const textOnly = buildSystemPrompt( { remoteSite, visionEnabled: false } );
+		expect( textOnly ).toContain(
+			'**Verify the result**: You cannot view images, so verify from the rendered DOM'
+		);
+		expect( textOnly ).not.toContain( 'Use take_screenshot with `viewport: "all"`' );
+	} );
+
 	it( 'omits the terminal screenshot caveat when chat artifacts are enabled', () => {
 		const prompt = buildSystemPrompt( { chatArtifactsEnabled: true } );
 

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -428,6 +428,26 @@ describe( 'Studio AI MCP tools', () => {
 		await cleanUpScreenshotArtifacts( artifacts );
 	} );
 
+	it( 'returns text only from take_screenshot when the model cannot view images', async () => {
+		const screenshotBuffer = Buffer.from( 'unseen-jpeg' );
+		mockScreenshotBrowser( createMockPage( { buffer: screenshotBuffer, documentHeight: 900 } ) );
+		const findTakeScreenshot = (
+			options?: Parameters< typeof resolveStudioToolDefinitions >[ 0 ]
+		) =>
+			resolveStudioToolDefinitions( options ).find( ( tool ) => tool.name === 'take_screenshot' );
+		expect( findTakeScreenshot()?.description ).toContain( 'analyze visually' );
+		const takeScreenshot = findTakeScreenshot( { visionEnabled: false } );
+		expect( takeScreenshot?.description ).toContain( 'This model cannot view images' );
+		expect( takeScreenshot?.description ).not.toContain( 'analyze visually' );
+
+		const result = await executeTool( takeScreenshot!, { url: 'http://localhost:8903/' } );
+
+		expect( result.content.map( ( block ) => block.type ) ).toEqual( [ 'text' ] );
+		expect( getTextContent( result ) ).toMatch( /Saved to .*screenshot-desktop-[0-9a-f]{8}\.jpg/ );
+		expect( getTextContent( result ) ).toContain( 'verify the rendered page with inspect_design' );
+		await cleanUpScreenshotArtifacts( getScreenshotArtifacts( result.details as never ) );
+	} );
+
 	it( 'returns no artifacts when take_screenshot is called with display: false', async () => {
 		const screenshotBuffer = Buffer.from( 'internal-jpeg' );
 		mockScreenshotBrowser( createMockPage( { buffer: screenshotBuffer, documentHeight: 900 } ) );

--- a/apps/cli/ai/tools/index.ts
+++ b/apps/cli/ai/tools/index.ts
@@ -24,7 +24,7 @@ import { getSiteInfoTool } from './site-info';
 import { startSiteTool } from './start-site';
 import { stopSiteTool } from './stop-site';
 import { studioPresentTool } from './studio-present';
-import { takeScreenshotTool } from './take-screenshot';
+import { createTakeScreenshotTool, takeScreenshotTool } from './take-screenshot';
 import { updatePreviewTool } from './update-preview';
 import { validateBlocksTool } from './validate-blocks';
 import { waitForAnnotationsTool } from './wait-for-annotations';
@@ -79,6 +79,8 @@ export interface CreateStudioToolsOptions {
 	// (async) and pass it; when off, sessions behave exactly as before the tool
 	// existed (no tool, no imagery prompt sections).
 	imageGeneration?: boolean;
+	// False for models that cannot view images. Defaults to true.
+	visionEnabled?: boolean;
 }
 
 export function resolveStudioToolDefinitions(
@@ -102,7 +104,11 @@ export function resolveStudioToolDefinitions(
 		if ( candidate.name === generateImagesTool.name && ! options.imageGeneration ) {
 			return [];
 		}
-		return [ withChatArtifactEmission( candidate, options.emitChatArtifacts === true ) ];
+		const tool =
+			candidate.name === takeScreenshotTool.name && options.visionEnabled === false
+				? createTakeScreenshotTool( { visionEnabled: false } )
+				: candidate;
+		return [ withChatArtifactEmission( tool, options.emitChatArtifacts === true ) ];
 	} );
 }
 

--- a/apps/cli/ai/tools/take-screenshot.ts
+++ b/apps/cli/ai/tools/take-screenshot.ts
@@ -52,135 +52,152 @@ function getCaptureListLabel(
 	return targets.map( getCaptureLabel ).join( ', ' );
 }
 
-export const takeScreenshotTool = defineTool(
-	'take_screenshot',
-	'Takes a full-page screenshot of a URL. Returns the screenshot as an image that you can analyze visually. ' +
-		'Supports desktop and mobile viewports; pass `viewport: "all"` when you need both for design verification. ' +
-		'Pass `colorScheme: "light"`, `colorScheme: "dark"`, or `colorScheme: "all"` to verify pages that respond to prefers-color-scheme. ' +
-		'Long pages are clipped at 8000 vertical pixels (a vision-model limit); the response reports the document height and whether more remains, and you can call again with `offset` to fetch the next slice. ' +
-		'Use this to verify the site looks correct after building it. ' +
-		'Captures are shown to the user in the chat by default; pass `display: false` for internal verification captures while iterating so the user only sees deliberate milestones. ' +
-		'Use `share_screenshot` instead only in remote sessions where you need to deliver the rendered page outside the Studio UI.',
-	{
-		url: Type.String( { description: 'The URL to screenshot' } ),
-		viewport: Type.Optional( screenshotViewportSchema ),
-		colorScheme: Type.Optional( screenshotColorSchemeSchema ),
-		display: Type.Optional(
-			Type.Boolean( {
-				description:
-					'Whether to show the capture to the user in the chat. Defaults to true; set false for internal verification captures the user does not need to see.',
-			} )
-		),
-		offset: Type.Optional(
-			Type.Number( {
-				minimum: 0,
-				description:
-					'Y-offset in CSS pixels for the capture region. Defaults to 0 (top of page). When a previous call reports the page was clipped, pass `offset` equal to where that capture ended to fetch the next slice.',
-			} )
-		),
-	},
-	async ( args, context ) => {
-		try {
-			const viewportTypes = resolveViewportTypes( args.viewport );
-			const colorSchemes = resolveColorSchemes( args.colorScheme );
-			const captureTargets = viewportTypes.flatMap( ( viewportType ) =>
-				colorSchemes.map( ( colorScheme ) => ( { viewportType, colorScheme } ) )
-			);
-			const captureLabel = getCaptureListLabel( captureTargets );
-			context.onProgress( `Taking ${ captureLabel } screenshot of ${ args.url }…` );
-			const captures = await Promise.all(
-				captureTargets.map( async ( { viewportType, colorScheme } ) => {
-					const capture = await captureScreenshotBuffer( args.url, VIEWPORTS[ viewportType ], {
-						fullPage: true,
-						format: 'jpeg',
-						offset: args.offset,
-						colorScheme,
-					} );
-					const screenshotFile = await saveScreenshotFile( capture.buffer, {
-						viewportType,
-						format: 'jpeg',
-						colorScheme,
-					} );
-					// Progress lines persist in the CLI transcript (but not in the
-					// desktop conversation history, where the inline artifact is the
-					// UI), so this is the terminal user's only handle on the file.
-					context.onProgress(
-						`Saved ${ getCaptureLabel( { viewportType, colorScheme } ) } screenshot to ${
-							screenshotFile.fileUrl
-						}`
-					);
-					return {
-						viewportType,
-						colorScheme,
-						path: screenshotFile.path,
-						buffer: capture.buffer,
-						documentHeight: capture.documentHeight,
-						capturedHeight: capture.capturedHeight,
-						offset: capture.offset,
-						clipped: capture.clipped,
-						mimeType: screenshotFile.mimeType,
-						mediaWidgetPayload: {
-							type: 'media',
-							widgetProps: {
-								url: screenshotFile.fileUrl,
-								mediaKind: 'image',
-								alt: `Screenshot of ${ args.url } (${ getCaptureLabel( {
-									viewportType,
-									colorScheme,
-								} ) })`,
-								mediaId: null,
-								source: {
-									type: 'local',
-									path: screenshotFile.path,
-									name: screenshotFile.name,
-									mimeType: screenshotFile.mimeType,
+const TEXT_ONLY_NOTE =
+	'This model cannot view images, so the capture is not shown to you: verify the rendered page with inspect_design, and use the saved file path when a screenshot file is needed (e.g. the theme screenshot).';
+
+// Text-only models still get the tool (the saved file is the theme screenshot)
+// but no image block, which they would otherwise describe without seeing.
+export function createTakeScreenshotTool( { visionEnabled }: { visionEnabled: boolean } ) {
+	return defineTool(
+		'take_screenshot',
+		'Takes a full-page screenshot of a URL. ' +
+			( visionEnabled
+				? 'Returns the screenshot as an image that you can analyze visually. '
+				: `${ TEXT_ONLY_NOTE } ` ) +
+			'Supports desktop and mobile viewports; pass `viewport: "all"` when you need both for design verification. ' +
+			'Pass `colorScheme: "light"`, `colorScheme: "dark"`, or `colorScheme: "all"` to verify pages that respond to prefers-color-scheme. ' +
+			'Long pages are clipped at 8000 vertical pixels (a vision-model limit); the response reports the document height and whether more remains, and you can call again with `offset` to fetch the next slice. ' +
+			'Use this to verify the site looks correct after building it. ' +
+			'Captures are shown to the user in the chat by default; pass `display: false` for internal verification captures while iterating so the user only sees deliberate milestones. ' +
+			'Use `share_screenshot` instead only in remote sessions where you need to deliver the rendered page outside the Studio UI.',
+		{
+			url: Type.String( { description: 'The URL to screenshot' } ),
+			viewport: Type.Optional( screenshotViewportSchema ),
+			colorScheme: Type.Optional( screenshotColorSchemeSchema ),
+			display: Type.Optional(
+				Type.Boolean( {
+					description:
+						'Whether to show the capture to the user in the chat. Defaults to true; set false for internal verification captures the user does not need to see.',
+				} )
+			),
+			offset: Type.Optional(
+				Type.Number( {
+					minimum: 0,
+					description:
+						'Y-offset in CSS pixels for the capture region. Defaults to 0 (top of page). When a previous call reports the page was clipped, pass `offset` equal to where that capture ended to fetch the next slice.',
+				} )
+			),
+		},
+		async ( args, context ) => {
+			try {
+				const viewportTypes = resolveViewportTypes( args.viewport );
+				const colorSchemes = resolveColorSchemes( args.colorScheme );
+				const captureTargets = viewportTypes.flatMap( ( viewportType ) =>
+					colorSchemes.map( ( colorScheme ) => ( { viewportType, colorScheme } ) )
+				);
+				const captureLabel = getCaptureListLabel( captureTargets );
+				context.onProgress( `Taking ${ captureLabel } screenshot of ${ args.url }…` );
+				const captures = await Promise.all(
+					captureTargets.map( async ( { viewportType, colorScheme } ) => {
+						const capture = await captureScreenshotBuffer( args.url, VIEWPORTS[ viewportType ], {
+							fullPage: true,
+							format: 'jpeg',
+							offset: args.offset,
+							colorScheme,
+						} );
+						const screenshotFile = await saveScreenshotFile( capture.buffer, {
+							viewportType,
+							format: 'jpeg',
+							colorScheme,
+						} );
+						// Progress lines persist in the CLI transcript (but not in the
+						// desktop conversation history, where the inline artifact is the
+						// UI), so this is the terminal user's only handle on the file.
+						context.onProgress(
+							`Saved ${ getCaptureLabel( { viewportType, colorScheme } ) } screenshot to ${
+								screenshotFile.fileUrl
+							}`
+						);
+						return {
+							viewportType,
+							colorScheme,
+							path: screenshotFile.path,
+							buffer: capture.buffer,
+							documentHeight: capture.documentHeight,
+							capturedHeight: capture.capturedHeight,
+							offset: capture.offset,
+							clipped: capture.clipped,
+							mimeType: screenshotFile.mimeType,
+							mediaWidgetPayload: {
+								type: 'media',
+								widgetProps: {
+									url: screenshotFile.fileUrl,
+									mediaKind: 'image',
+									alt: `Screenshot of ${ args.url } (${ getCaptureLabel( {
+										viewportType,
+										colorScheme,
+									} ) })`,
+									mediaId: null,
+									source: {
+										type: 'local',
+										path: screenshotFile.path,
+										name: screenshotFile.name,
+										mimeType: screenshotFile.mimeType,
+									},
 								},
 							},
+						};
+					} )
+				);
+				const describeCapture = ( capture: ( typeof captures )[ number ] ): string => {
+					const captureEnd = capture.offset + capture.capturedHeight;
+					const label = getCaptureLabel( capture );
+					if ( capture.clipped ) {
+						return `${ label }: captured rows ${ capture.offset }-${ captureEnd } of a ${ capture.documentHeight }px page. Page was clipped; call again with offset:${ captureEnd } to fetch the next slice.`;
+					}
+					if ( capture.offset > 0 ) {
+						return `${ label }: captured rows ${ capture.offset }-${ captureEnd } of a ${ capture.documentHeight }px page (end of page).`;
+					}
+					return `${ label }: captured full page (${ capture.documentHeight }px tall).`;
+				};
+				// The saved path lets the agent reuse a capture as a file — e.g. copying
+				// the final desktop capture to a scaffolded theme's screenshot.jpg.
+				const captureLines = captures.map(
+					( capture ) => `${ describeCapture( capture ) } Saved to ${ capture.path }`
+				);
+				const textLines =
+					captures.length === 1
+						? [ `Screenshot captured — ${ captureLines[ 0 ] }` ]
+						: [ 'Screenshots captured:', ...captureLines.map( ( line ) => `- ${ line }` ) ];
+				if ( ! visionEnabled ) {
+					textLines.push( TEXT_ONLY_NOTE );
+				}
+				context.onProgress( `Screenshot captured (${ captureLabel })` );
+				return {
+					content: [
+						{
+							type: 'text' as const,
+							text: textLines.join( '\n' ),
 						},
-					};
-				} )
-			);
-			const describeCapture = ( capture: ( typeof captures )[ number ] ): string => {
-				const captureEnd = capture.offset + capture.capturedHeight;
-				const label = getCaptureLabel( capture );
-				if ( capture.clipped ) {
-					return `${ label }: captured rows ${ capture.offset }-${ captureEnd } of a ${ capture.documentHeight }px page. Page was clipped; call again with offset:${ captureEnd } to fetch the next slice.`;
-				}
-				if ( capture.offset > 0 ) {
-					return `${ label }: captured rows ${ capture.offset }-${ captureEnd } of a ${ capture.documentHeight }px page (end of page).`;
-				}
-				return `${ label }: captured full page (${ capture.documentHeight }px tall).`;
-			};
-			// The saved path lets the agent reuse a capture as a file — e.g. copying
-			// the final desktop capture to a scaffolded theme's screenshot.jpg.
-			const captureLines = captures.map(
-				( capture ) => `${ describeCapture( capture ) } Saved to ${ capture.path }`
-			);
-			const textLines =
-				captures.length === 1
-					? [ `Screenshot captured — ${ captureLines[ 0 ] }` ]
-					: [ 'Screenshots captured:', ...captureLines.map( ( line ) => `- ${ line }` ) ];
-			context.onProgress( `Screenshot captured (${ captureLabel })` );
-			return {
-				content: [
-					{
-						type: 'text' as const,
-						text: textLines.join( '\n' ),
-					},
-					...captures.map( ( capture ) => ( {
-						type: 'image' as const,
-						data: capture.buffer.toString( 'base64' ),
-						mimeType: capture.mimeType,
-					} ) ),
-				],
-				...( args.display === false
-					? {}
-					: { studioArtifacts: captures.map( ( capture ) => capture.mediaWidgetPayload ) } ),
-			};
-		} catch ( error ) {
-			throw new Error(
-				`Screenshot failed: ${ error instanceof Error ? error.message : String( error ) }`
-			);
+						...( visionEnabled
+							? captures.map( ( capture ) => ( {
+									type: 'image' as const,
+									data: capture.buffer.toString( 'base64' ),
+									mimeType: capture.mimeType,
+							  } ) )
+							: [] ),
+					],
+					...( args.display === false
+						? {}
+						: { studioArtifacts: captures.map( ( capture ) => capture.mediaWidgetPayload ) } ),
+				};
+			} catch ( error ) {
+				throw new Error(
+					`Screenshot failed: ${ error instanceof Error ? error.message : String( error ) }`
+				);
+			}
 		}
-	}
-);
+	);
+}
+
+export const takeScreenshotTool = createTakeScreenshotTool( { visionEnabled: true } );


### PR DESCRIPTION
## Related issues

- Related to the Trattoria Lume batch review (header rendered without a gutter and an inset card sitting on the footer on a DeepSeek-built site); no Linear issue.

## How AI was used in this PR

Investigated with Claude Code: traced the two visual defects to the theme markup, compared them across 33 generated sites and the batch session logs, and found the systematic part was missed detection on text-only models. Claude implemented the change, the tests, and ran the evals; every design decision (no CSS safety nets in the scaffold, no tool-result nudges, the step 7 wording, the inset-box rule keyed on the box rather than its position) was reviewed and decided by me.

## Proposed Changes

Studio Code builds run on models that cannot view images (DeepSeek V4 Flash, GLM). For those models the runtime removed `take_screenshot`, but the system prompt kept telling the agent to verify with it and to copy its capture to the theme's `screenshot.jpg`. In practice every DeepSeek run in our batches spent turns discovering the tool was missing, improvised an ad-hoc DOM check instead of running the `visual-polish` skill, and shipped themes without a thumbnail. One such run produced a header touching the viewport edges and a rounded reservation card sitting on the footer border, and nothing in its verification could have caught either.

This PR makes the text-only path coherent:

- `take_screenshot` stays available to text-only models. It returns the capture lines plus a note that the model cannot view the image and should verify with `inspect_design`; the saved file still serves as the theme screenshot, so step 8 works again. Vision models are unaffected.
- The system prompt is told whether the model can see images, mirroring the existing image-generation gate. Only the tool descriptions and the remote flow's verify step change for text-only models.
- Step 7 now requires loading the `visual-polish` skill before any inspection or screenshot, for every model. On the same one-page brief with DeepSeek V4 Flash, the previous wording got the skill loaded in 2 of 4 runs; this wording got it in 4 of 4.
- The `visual-polish` skill makes its screenshot steps conditional on vision, and its always-inspect list gains two items that would have caught the reviewed site: the header and footer template parts (a part whose root group loses `layout: constrained` gets no gutter), and inset boxes (rounded, bordered, or narrower than their container) that sit directly on a hard edge such as the footer border. Full-bleed bands are explicitly left flush.

Deliberately not done: no CSS fallbacks in the scaffold for missing gutters or last-section spacing (they would silently alter layouts that are meant to be flush), and no positional "first/last section must have space" rule.

## Testing Instructions

- `npm test -- apps/cli/ai/tests/tools.test.ts apps/cli/ai/tests/pi-runtime.test.ts apps/cli/ai/tests/system-prompt.test.ts` — covers the text-only `take_screenshot` variant, the tool list for a text-only model, and both prompt variants.
- Evals run on this branch: `screenshot verification` (default vision model) passed; `single-page site build` with `STUDIO_EVAL_MODEL=deepseek-ai/DeepSeek-V4-Flash-0731` passed, with two clean `take_screenshot` calls, the theme screenshot copied, and no "tool not found" detours.
- Manual: `npm run cli:build`, then `node apps/cli/dist/cli/main.mjs code --model deepseek-ai/DeepSeek-V4-Flash-0731` and ask for a simple one-page site. Expect the agent to load `visual-polish` before its first `inspect_design`, to call `take_screenshot` without complaint, and the built theme to contain `screenshot.jpg`. Repeat with a vision model and confirm screenshots still return images.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
