### PR TITLE
CLI: Handle Reprint retry-later exits without advancing the pull

### DIFF
--- a/apps/cli/lib/pull/migration-client.test.ts
+++ b/apps/cli/lib/pull/migration-client.test.ts
@@ -1,0 +1,190 @@
+import { ChildProcess, fork } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { spawnPhpProcess } from 'cli/lib/native-php/php-process';
+import { runReprintCommandUntilComplete, type ReprintProcessResult } from './migration-client';
+
+vi.mock( 'node:child_process', () => {
+	const mocked = { fork: vi.fn() };
+	return { ...mocked, default: mocked };
+} );
+vi.mock( 'node:fs', () => ( {
+	default: { existsSync: vi.fn( () => true ), mkdirSync: vi.fn() },
+} ) );
+vi.mock( 'cli/lib/dependency-management/paths', () => ( {
+	getReprintPharPath: () => '/bundle/reprint.phar',
+} ) );
+vi.mock( 'cli/lib/dependency-management/php-binary', () => ( {
+	ensurePhpBinaryAvailable: vi.fn(),
+} ) );
+vi.mock( 'cli/lib/native-php/php-process', () => ( {
+	spawnPhpProcess: vi.fn(),
+	reapPhpTreeOnInterrupt: vi.fn( () => vi.fn() ),
+} ) );
+
+for ( const runtime of [ 'native-php', 'playground' ] as const ) {
+	describe( `Reprint retries (${ runtime })`, () => {
+		let results: ReprintProcessResult[];
+		let children: ChildProcess[];
+		const args = [ 'pull-db', 'https://example.com', '--state-dir=/state', '--fs-root=/files' ];
+
+		beforeEach( () => {
+			vi.useFakeTimers();
+			results = [];
+			children = [];
+			vi.mocked( spawnPhpProcess ).mockImplementation( () => createChild( false ) );
+			vi.mocked( fork ).mockImplementation( () => createChild( true ) );
+		} );
+
+		afterEach( () => {
+			vi.clearAllTimers();
+			vi.useRealTimers();
+		} );
+
+		it( 'keeps immediate exit-2 resumes for older Reprint versions without new JSON fields', async () => {
+			results.push( result( 2 ), result( 2 ), result( 0 ) );
+			const progress = vi.fn();
+			const completion = run( progress );
+			await vi.advanceTimersByTimeAsync( 0 );
+			expect( ( await completion ).exitCode ).toBe( 0 );
+			expect( children ).toHaveLength( 3 );
+			expect( progress ).not.toHaveBeenCalledWith( expect.stringContaining( 'Retrying' ) );
+			expect( vi.getTimerCount() ).toBe( 0 );
+		} );
+
+		it( 'waits 15 seconds then 45 seconds and resumes the same command and paths', async () => {
+			results.push( result( 3 ), result( 3 ), result( 0 ) );
+			const progress = vi.fn();
+			const completion = run( progress );
+			await vi.advanceTimersByTimeAsync( 0 );
+			expect( children ).toHaveLength( 1 );
+			expect( progress ).toHaveBeenLastCalledWith( expect.stringContaining( '15 seconds' ) );
+			await vi.advanceTimersByTimeAsync( 14_999 );
+			expect( children ).toHaveLength( 1 );
+			expect( progress ).toHaveBeenLastCalledWith( expect.stringContaining( '15 seconds' ) );
+			await vi.advanceTimersByTimeAsync( 1 );
+			expect( children ).toHaveLength( 2 );
+			expect( progress ).toHaveBeenLastCalledWith( expect.stringContaining( '45 seconds' ) );
+			await vi.advanceTimersByTimeAsync( 44_999 );
+			expect( children ).toHaveLength( 2 );
+			await vi.advanceTimersByTimeAsync( 1 );
+			expect( ( await completion ).exitCode ).toBe( 0 );
+			expect( children ).toHaveLength( 3 );
+			if ( runtime === 'native-php' ) {
+				for ( const [ command ] of vi.mocked( spawnPhpProcess ).mock.calls ) {
+					expect( command ).toEqual( [ '/bundle/reprint.phar', ...args ] );
+				}
+			} else {
+				for ( const child of children ) {
+					expect( child.send ).toHaveBeenCalledWith(
+						expect.objectContaining( {
+							args,
+							stateDir: '/state',
+							fsRoot: '/files',
+						} )
+					);
+				}
+			}
+			expect( vi.getTimerCount() ).toBe( 0 );
+		} );
+
+		it( 'stops after two delayed retries and preserves the final error details', async () => {
+			const error = JSON.stringify( {
+				status: 'error',
+				error: 'Upstream unavailable',
+				http_code: 520,
+				error_code: 'SERVER_ERROR',
+				exception: 'Reprint\\Importer\\TransientInterruptionException',
+				consecutive_failures_without_progress: 3,
+			} );
+			results.push( result( 3 ), result( 3 ), {
+				exitCode: 3,
+				stdout: error,
+				stderr: 'Final diagnostics',
+			} );
+			const failure = run().catch( ( caught: unknown ) => caught );
+			await vi.advanceTimersByTimeAsync( 60_000 );
+			expect( await failure ).toBeInstanceOf( Error );
+			expect( ( ( await failure ) as Error ).message ).toContain( error );
+			expect( ( ( await failure ) as Error ).message ).toContain( 'Final diagnostics' );
+			expect( children ).toHaveLength( 3 );
+			expect( vi.getTimerCount() ).toBe( 0 );
+		} );
+
+		it( 'does not reset the delayed retry limit after an exit-2 resume', async () => {
+			results.push( result( 3 ), result( 2 ), result( 3 ), result( 2 ), result( 3 ) );
+			const failure = run().catch( ( caught: unknown ) => caught );
+			await vi.advanceTimersByTimeAsync( 60_000 );
+			expect( await failure ).toBeInstanceOf( Error );
+			expect( children ).toHaveLength( 5 );
+			expect( vi.getTimerCount() ).toBe( 0 );
+		} );
+
+		it.each( [ 1, 64 ] )(
+			'stops on exit %i without retrying or reporting success',
+			async ( exitCode ) => {
+				results.push( { exitCode, stdout: '', stderr: '' } );
+				await expect( run() ).rejects.toThrow( `exited with code ${ exitCode }` );
+				expect( children ).toHaveLength( 1 );
+				expect( vi.getTimerCount() ).toBe( 0 );
+			}
+		);
+
+		it( 'stops immediately if a delayed retry returns a permanent error', async () => {
+			results.push( result( 3 ), { exitCode: 1, stdout: '', stderr: 'Authentication failed' } );
+			const failure = run().catch( ( caught: unknown ) => caught );
+			await vi.advanceTimersByTimeAsync( 15_000 );
+			expect( ( ( await failure ) as Error ).message ).toContain( 'Authentication failed' );
+			expect( children ).toHaveLength( 2 );
+			expect( vi.getTimerCount() ).toBe( 0 );
+		} );
+
+		function run( progress?: ( output: string ) => void ) {
+			return runReprintCommandUntilComplete( '/state', '/files', args, progress, { runtime } );
+		}
+
+		function result( exitCode: number ): ReprintProcessResult {
+			if ( exitCode === 3 ) {
+				return {
+					exitCode,
+					stdout: JSON.stringify( { status: 'error', error: 'Temporary remote failure' } ),
+					stderr: '',
+				};
+			}
+			return {
+				exitCode,
+				stdout: JSON.stringify( { status: exitCode === 0 ? 'complete' : 'partial' } ),
+				stderr: '',
+			};
+		}
+
+		function createChild( wasm: boolean ): ChildProcess {
+			const child = new EventEmitter() as ChildProcess;
+			child.stdout = new PassThrough();
+			child.stderr = new PassThrough();
+			children.push( child );
+			const respond = () =>
+				queueMicrotask( () => {
+					const next = results.shift();
+					if ( ! next ) {
+						throw new Error( 'Unexpected Reprint invocation' );
+					}
+					if ( wasm ) {
+						child.emit( 'message', { type: 'stdout', chunk: next.stdout + '\n' } );
+						child.emit( 'message', { type: 'result', ...next } );
+					} else {
+						( child.stdout as PassThrough ).write( next.stdout + '\n' );
+						( child.stderr as PassThrough ).write( next.stderr );
+						child.emit( 'close', next.exitCode );
+					}
+				} );
+			if ( wasm ) {
+				child.send = vi.fn().mockImplementation( respond );
+			} else {
+				respond();
+			}
+			return child;
+		}
+	} );
+}

--- a/apps/cli/lib/pull/migration-client.ts
+++ b/apps/cli/lib/pull/migration-client.ts
@@ -4,8 +4,8 @@
  * reprint.phar is plain PHP, so any PHP runtime can execute it. The
  * `playground` runtime runs it inside a PHP WASM child process; the
  * `native-php` runtime spawns the bundled native `php` binary directly.
- * Either way the command is re-run while it exits with code 2 (partial)
- * until it exits with code 0 (success) or code 1 (error).
+ * Both runtimes resume exit 2 immediately and retry exit 3 after a bounded
+ * delay. Only exit 0 completes the command; other exit codes are errors.
  */
 import { ChildProcess, fork } from 'node:child_process';
 import fs from 'node:fs';
@@ -16,9 +16,12 @@ import {
 	type NativePhpSupportedVersion,
 } from '@studio/common/lib/php-binary-metadata';
 import { SITE_RUNTIME_NATIVE_PHP, SiteRuntime } from '@studio/common/lib/site-runtime';
+import { __, sprintf } from '@wordpress/i18n';
 import { getReprintPharPath } from 'cli/lib/dependency-management/paths';
 import { ensurePhpBinaryAvailable } from 'cli/lib/dependency-management/php-binary';
 import { reapPhpTreeOnInterrupt, spawnPhpProcess } from 'cli/lib/native-php/php-process';
+
+const RETRY_DELAYS_MS = [ 15_000, 45_000 ];
 
 export interface ReprintProcessResult {
 	stdout: string;
@@ -37,13 +40,14 @@ function getBundledReprintPhar(): string {
 
 /**
  * Runs a reprint.phar command with the runtime selected by `STUDIO_RUNTIME`,
- * automatically retrying on partial completion.
+ * resuming partial work and retrying temporary failures.
  *
  * The `playground` runtime runs reprint inside a PHP WASM child process; the
  * `native-php` runtime spawns the bundled native `php` binary. Reprint
- * commands exit with code 2 when they've made progress but need another pass
- * (e.g., large file downloads that stream in chunks). This function loops
- * until the command exits with 0 (success) or throws on exit code 1 (error).
+ * commands exit with code 2 when work is unfinished and should resume
+ * immediately (e.g., a bounded download pass). Newer versions use
+ * exit 3 for temporary failures. Studio allows two delayed retries per
+ * command, even if partial work or a reset Reprint failure count follows.
  */
 export async function runReprintCommandUntilComplete(
 	stateDir: string,
@@ -77,9 +81,11 @@ export async function runReprintCommandUntilComplete(
 	const progress = createProgressReporter( label, startTime, onProgress );
 
 	let lastResult: ReprintProcessResult | undefined;
+	let retryAttempts = 0;
 
 	try {
 		do {
+			progress.setRetryMessage( null );
 			lastResult =
 				runtime === SITE_RUNTIME_NATIVE_PHP
 					? await runReprintCommandNative( pharPath, nativePhpVersion!, args, options, progress )
@@ -93,16 +99,27 @@ export async function runReprintCommandUntilComplete(
 							progress
 					  );
 
-			if ( lastResult.exitCode === 1 ) {
+			if ( lastResult.exitCode === 3 && retryAttempts < RETRY_DELAYS_MS.length ) {
+				const delay = RETRY_DELAYS_MS[ retryAttempts++ ];
+				progress.setRetryMessage(
+					sprintf(
+						__( 'The remote request failed. Retrying in %d seconds (%d/%d)…' ),
+						delay / 1000,
+						retryAttempts,
+						RETRY_DELAYS_MS.length
+					)
+				);
+				await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
+			} else if ( lastResult.exitCode !== 0 && lastResult.exitCode !== 2 ) {
 				const details = [ lastResult.stderr, lastResult.stdout ].filter( Boolean ).join( '\n' );
 				throw new Error(
 					details ||
-						`reprint.phar exited with code 1 (command: ${
+						`reprint.phar exited with code ${ lastResult.exitCode } (command: ${
 							args[ 0 ] ?? 'unknown'
 						}). No output was captured.`
 				);
 			}
-		} while ( lastResult.exitCode === 2 );
+		} while ( lastResult.exitCode === 2 || lastResult.exitCode === 3 );
 
 		return lastResult;
 	} finally {
@@ -343,6 +360,7 @@ interface ProgressSnapshot {
 }
 
 interface ProgressReporter {
+	setRetryMessage: ( message: string | null ) => void;
 	pushStdoutChunk: ( chunk: string ) => void;
 	flush: () => void;
 	cleanup: () => void;
@@ -366,6 +384,7 @@ function createProgressReporter(
 ): ProgressReporter {
 	let lineBuffer = '';
 	let snapshot: ProgressSnapshot = {};
+	let retryMessage: string | null = null;
 
 	const reportLines = ( lines: string[] ) => {
 		if ( ! onProgress ) {
@@ -389,13 +408,19 @@ function createProgressReporter(
 	const ticker =
 		onProgress &&
 		setInterval( () => {
-			const msg = formatSnapshot( snapshot, label, elapsedSeconds() );
+			const msg = retryMessage ?? formatSnapshot( snapshot, label, elapsedSeconds() );
 			if ( msg ) {
 				onProgress( msg );
 			}
 		}, 250 );
 
 	return {
+		setRetryMessage( message: string | null ) {
+			retryMessage = message;
+			if ( message ) {
+				onProgress?.( message );
+			}
+		},
 		pushStdoutChunk( chunk: string ) {
 			lineBuffer += chunk;
 			const lines = lineBuffer.split( '\n' );


### PR DESCRIPTION
Keeps Studio on the interrupted pull step when Reprint returns exit code `3`, instead of treating that step as complete.

## Related issues

Supports [WordPress/reprint#779](https://github.com/WordPress/reprint/pull/779).

## Proposed Changes

Exit `2` still resumes immediately, including with older Reprint versions. Exit `3` waits 15 seconds before retrying the same command, then 45 seconds before one final retry. The progress message explains the wait. Only exit `0` completes the step; other failures stop the pull and retain the captured error details.

For example, if `pull-db` returns `3`, `3`, then `0`, Studio waits 15 seconds, resumes `pull-db` from its saved state, waits 45 seconds, and resumes it again. Only after the `0` does Studio move to the next step. A third `3` stops the pull. An exit `2` between these failures does not reset the retry limit.

The bundled Reprint stays at **v0.10.4**. This change does not require the new JSON fields, so it can land before a separate Reprint version bump. Both native PHP and Playground use the same retry behavior.

## Testing Instructions

Pull a site with the bundled v0.10.4 and confirm it still completes. Then use a PHAR built from Reprint trunk against a disposable remote that returns HTTP 503 during `pull-db`. Confirm Studio shows the retry waits and stays on the database step. Restore the remote during a wait and confirm the pull resumes. Keep it unavailable through both retries and confirm Studio stops with the error details instead of proceeding.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? Type checking, changed-file lint, 73 related tests, and the CLI build passed. The full desktop pull above remains a manual check.
