### PR TITLE
Detect connectivity with the system resolver instead of c-ares

### DIFF
--- a/packages/common/lib/network-utils.ts
+++ b/packages/common/lib/network-utils.ts
@@ -1,20 +1,66 @@
 import dns from 'dns/promises';
 
+const CONNECTIVITY_PROBE_HOST = 'public-api.wordpress.com';
+const CONNECTIVITY_TIMEOUT_MS = 5000;
+
 /**
- * Check if the system has internet connectivity by testing DNS resolution.
+ * Resolves with the first promise that fulfills and rejects only once every
+ * promise has rejected. Equivalent to `Promise.any()`, which the project's
+ * compilation target does not provide.
+ */
+function firstFulfilled< T >( promises: Promise< T >[] ): Promise< T > {
+	return new Promise< T >( ( resolve, reject ) => {
+		let rejections = 0;
+		for ( const promise of promises ) {
+			promise.then( resolve, ( error ) => {
+				rejections += 1;
+				if ( rejections === promises.length ) {
+					reject( error );
+				}
+			} );
+		}
+	} );
+}
+
+/**
+ * Check if the system has internet connectivity by resolving a WordPress.com host.
+ *
+ * The check goes through `dns.lookup()`, which uses the operating system's
+ * resolver (getaddrinfo), the same path the HTTP requests Studio makes next
+ * go through. `dns.resolve()` was used before; it bypasses the OS and talks
+ * to the name servers c-ares discovers on its own, which fails on Windows
+ * machines where Node reports the servers as 127.0.0.1 even though the system
+ * resolves fine (nodejs/node#62748). That produced a false "offline" while
+ * creating sites.
+ *
+ * IPv4 and IPv6 are resolved separately and the first answer wins. A single
+ * unspecified-family lookup waits for both records, and on networks that drop
+ * AAAA queries that wait alone can exceed the timeout.
  *
  * @returns Promise that resolves to true if online, false if offline
  */
 export async function isOnline(): Promise< boolean > {
-	try {
-		const timeoutPromise = new Promise( ( _, reject ) =>
-			setTimeout( () => reject( new Error( 'Timeout' ) ), 5000 )
+	let timer: ReturnType< typeof setTimeout > | undefined;
+	const timeout = new Promise< never >( ( _, reject ) => {
+		timer = setTimeout(
+			() => reject( new Error( 'Connectivity check timed out' ) ),
+			CONNECTIVITY_TIMEOUT_MS
 		);
+	} );
 
-		await Promise.race( [ dns.resolve( 'public-api.wordpress.com' ), timeoutPromise ] );
-
+	try {
+		await Promise.race( [
+			firstFulfilled( [
+				dns.lookup( CONNECTIVITY_PROBE_HOST, { family: 4 } ),
+				dns.lookup( CONNECTIVITY_PROBE_HOST, { family: 6 } ),
+			] ),
+			timeout,
+		] );
 		return true;
 	} catch {
 		return false;
+	} finally {
+		// Never keep the process alive for the remainder of the timeout.
+		clearTimeout( timer );
 	}
 }

--- a/packages/common/lib/tests/network-utils.test.ts
+++ b/packages/common/lib/tests/network-utils.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isOnline } from '@studio/common/lib/network-utils';
+
+const { lookup, resolve } = vi.hoisted( () => ( {
+	lookup: vi.fn(),
+	resolve: vi.fn(),
+} ) );
+
+vi.mock( 'dns/promises', () => ( {
+	default: { lookup, resolve },
+} ) );
+
+const HOST = 'public-api.wordpress.com';
+const IPV4 = { address: '192.0.78.9', family: 4 };
+const IPV6 = { address: '2a04:fa87:fffd::c000:4e09', family: 6 };
+const notFound = () =>
+	Object.assign( new Error( `getaddrinfo ENOTFOUND ${ HOST }` ), { code: 'ENOTFOUND' } );
+const pending = () => new Promise< never >( () => {} );
+
+function answer( v4: () => Promise< unknown >, v6: () => Promise< unknown > ) {
+	lookup.mockImplementation( ( _host: string, options: { family: number } ) =>
+		options.family === 6 ? v6() : v4()
+	);
+}
+
+describe( 'isOnline', () => {
+	beforeEach( () => {
+		vi.useFakeTimers();
+		lookup.mockReset();
+		resolve.mockReset();
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+	} );
+
+	it( 'returns true when the operating system resolver answers over IPv4', async () => {
+		answer(
+			() => Promise.resolve( IPV4 ),
+			() => Promise.reject( notFound() )
+		);
+
+		await expect( isOnline() ).resolves.toBe( true );
+
+		expect( lookup ).toHaveBeenCalledWith( HOST, { family: 4 } );
+		expect( lookup ).toHaveBeenCalledWith( HOST, { family: 6 } );
+	} );
+
+	it( 'returns true on an IPv6-only network', async () => {
+		answer(
+			() => Promise.reject( notFound() ),
+			() => Promise.resolve( IPV6 )
+		);
+
+		await expect( isOnline() ).resolves.toBe( true );
+	} );
+
+	it( 'returns false when neither family resolves', async () => {
+		answer(
+			() => Promise.reject( notFound() ),
+			() => Promise.reject( notFound() )
+		);
+
+		await expect( isOnline() ).resolves.toBe( false );
+	} );
+
+	it( 'does not wait for a slow IPv6 answer once IPv4 has resolved', async () => {
+		answer( () => Promise.resolve( IPV4 ), pending );
+
+		// No timers are advanced: the result must come from the IPv4 answer alone.
+		await expect( isOnline() ).resolves.toBe( true );
+	} );
+
+	it( 'returns false when the resolver hangs past the timeout', async () => {
+		answer( pending, pending );
+
+		const result = isOnline();
+		await vi.advanceTimersByTimeAsync( 5000 );
+
+		await expect( result ).resolves.toBe( false );
+	} );
+
+	it( 'uses the OS resolver, not the c-ares based dns.resolve()', async () => {
+		answer(
+			() => Promise.resolve( IPV4 ),
+			() => Promise.resolve( IPV6 )
+		);
+
+		await isOnline();
+
+		expect( resolve ).not.toHaveBeenCalled();
+	} );
+
+	it( 'clears its timeout so a quick answer does not keep the process alive', async () => {
+		answer(
+			() => Promise.resolve( IPV4 ),
+			() => Promise.resolve( IPV6 )
+		);
+
+		await isOnline();
+
+		expect( vi.getTimerCount() ).toBe( 0 );
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Fixes #3767

## How AI was used in this PR

I used an AI assistant to help confirm the root cause described in the issue, measure resolver behaviour and draft the tests. I reviewed the change, ran the affected suites locally and verified the resolver timings on a real machine.

## Proposed Changes

On Windows, creating a site with a specific WordPress version failed with "Cannot set up WordPress while offline" on machines that were online. `isOnline()` used `dns.resolve()`, which bypasses the operating system and queries the name servers that c-ares discovers on its own; the bundled Node reports those servers as `127.0.0.1` on affected Windows installs (nodejs/node#62748), so the probe failed while the system resolver worked.

The check now uses `dns.lookup()`, the getaddrinfo path that the HTTP requests Studio makes right after rely on. Two details matter for reliability:

- IPv4 and IPv6 are looked up separately and the first answer wins. A single unspecified-family lookup waits for the AAAA record; on networks that drop AAAA queries that wait alone was measured above 4 seconds and would have tripped the 5 second timeout, producing the very false "offline" this change removes.
- The timeout is cleared as soon as an answer arrives, so a quick check no longer keeps the CLI process alive for the remaining seconds.

## Testing Instructions

1. `npm test -- --project common network-utils`
   Covers IPv4-only, IPv6-only and fully offline answers, an IPv6 lookup that hangs after IPv4 resolved, the timeout, that `dns.resolve()` is no longer called, and that no timer is left behind.
2. Windows reproduction from the issue: with the bundled Node, `require('dns').getServers()` returns `['127.0.0.1']` and `dns.resolve('public-api.wordpress.com')` fails, while `dns.lookup()` succeeds. Create a site with WordPress 6.8: before, "Cannot set up WordPress while offline"; after, the site is created.
3. Offline check: disable the network and create a site with a specific version. The offline message still appears within 5 seconds.

Also passing locally: the full `common` suite (70 files, 754 tests) and the `site create` / `site status` CLI suites that mock `isOnline` (85 tests).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
- [x] Tests added and passing
