### PR TITLE
Agentic UI: flatten notices to one neutral card, retitle the history dialog

### DIFF
--- a/apps/ui/src/components/app-message-cards/index.tsx
+++ b/apps/ui/src/components/app-message-cards/index.tsx
@@ -5,15 +5,8 @@ import { AddAiCreditsButton } from '@/components/add-ai-credits-button';
 import toastStyles from '@/components/app-toasts/style.module.css';
 import { useActivePersistentMessages } from '@/data/queries/use-app-messages';
 import styles from './style.module.css';
-import type { NoticeAppearance } from '@/components/app-toasts';
 
-export function AppMessageCards( {
-	className,
-	appearance = 'neutral',
-}: {
-	className?: string;
-	appearance?: NoticeAppearance;
-} ) {
+export function AppMessageCards( { className }: { className?: string } ) {
 	const { messages, dismiss } = useActivePersistentMessages();
 
 	if ( ! messages.length ) {
@@ -27,11 +20,7 @@ export function AppMessageCards( {
 					<Notice.Root
 						intent={ message.intent }
 						icon={ null }
-						className={ clsx(
-							toastStyles.notice,
-							appearance === 'neutral' && toastStyles.neutral,
-							styles.card
-						) }
+						className={ clsx( toastStyles.notice, toastStyles.neutral, styles.card ) }
 					>
 						<Notice.Title>{ message.title }</Notice.Title>
 						{ message.description ? (

--- a/apps/ui/src/components/app-message-cards/index.tsx
+++ b/apps/ui/src/components/app-message-cards/index.tsx
@@ -5,8 +5,15 @@ import { AddAiCreditsButton } from '@/components/add-ai-credits-button';
 import toastStyles from '@/components/app-toasts/style.module.css';
 import { useActivePersistentMessages } from '@/data/queries/use-app-messages';
 import styles from './style.module.css';
+import type { NoticeAppearance } from '@/components/app-toasts';
 
-export function AppMessageCards( { className }: { className?: string } ) {
+export function AppMessageCards( {
+	className,
+	appearance = 'neutral',
+}: {
+	className?: string;
+	appearance?: NoticeAppearance;
+} ) {
 	const { messages, dismiss } = useActivePersistentMessages();
 
 	if ( ! messages.length ) {
@@ -20,7 +27,11 @@ export function AppMessageCards( { className }: { className?: string } ) {
 					<Notice.Root
 						intent={ message.intent }
 						icon={ null }
-						className={ clsx( toastStyles.notice, styles.card ) }
+						className={ clsx(
+							toastStyles.notice,
+							appearance === 'neutral' && toastStyles.neutral,
+							styles.card
+						) }
 					>
 						<Notice.Title>{ message.title }</Notice.Title>
 						{ message.description ? (

--- a/apps/ui/src/components/app-toasts/index.test.tsx
+++ b/apps/ui/src/components/app-toasts/index.test.tsx
@@ -1,8 +1,13 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NoticeHistoryDialog } from '@/components/notice-history';
 import { showToast, resetAppMessagesForTests } from '@/data/app-messages';
 import { AppToasts } from './index';
+
+vi.mock( '@/hooks/use-color-scheme', () => ( {
+	useColorScheme: () => 'light',
+} ) );
 
 describe( 'AppToasts', () => {
 	afterEach( () => {
@@ -56,5 +61,24 @@ describe( 'AppToasts', () => {
 		} );
 
 		expect( screen.getByText( 'Pulling from live' ) ).toBeVisible();
+	} );
+
+	it( 'offers Copy and More only on error toasts with details', () => {
+		render(
+			<>
+				<AppToasts />
+				<NoticeHistoryDialog />
+			</>
+		);
+
+		act( () => {
+			showToast( { intent: 'success', title: 'Saved', description: 'All good.' } );
+			showToast( { intent: 'error', title: 'Failed', description: 'Stack trace…' } );
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Copy' } ) ).toBeVisible();
+		fireEvent.click( screen.getByRole( 'button', { name: 'More' } ) );
+		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+		expect( screen.getAllByText( 'Stack trace…' ) ).toHaveLength( 2 );
 	} );
 } );

--- a/apps/ui/src/components/app-toasts/index.tsx
+++ b/apps/ui/src/components/app-toasts/index.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useEffect } from 'react';
+import { CopyNoticeButton, openNoticeHistory } from '@/components/notice-history';
 import {
 	dismissToast,
 	notifyRendererMounted,
@@ -10,18 +11,31 @@ import {
 	resumeToastExpiry,
 	useQueuedToastCount,
 	useVisibleToasts,
+	type ToastMessage,
 } from '@/data/app-messages';
 import styles from './style.module.css';
+
+export type NoticeAppearance = 'neutral' | 'intent';
+
+// Error text is clamped in the toast; these get Copy (the full text) and More
+// (the recent-notifications dialog, where it runs in full).
+function hasErrorDetails( item: ToastMessage ) {
+	return item.intent === 'error' && Boolean( item.description );
+}
 
 export function AppToasts( {
 	className,
 	fit = 'row',
+	appearance = 'neutral',
 }: {
 	className?: string;
 	// 'row' stretches toasts to the shelf width (sidebar footer, matching the
 	// site rows); 'content' lets each toast hug its text up to the shelf's
 	// max-width (the floating collapsed shelf).
 	fit?: 'row' | 'content';
+	// 'neutral' flattens every toast to one quiet card; 'intent' keeps
+	// Notice's tinted surface so an error reads red at a glance.
+	appearance?: NoticeAppearance;
 } ) {
 	const toasts = useVisibleToasts();
 	const queuedCount = useQueuedToastCount();
@@ -57,23 +71,39 @@ export function AppToasts( {
 								<Notice.Root
 									key={ `${ item.intent }:${ !! item.description }:${ !! item.action }` }
 									intent={ item.intent }
-									className={ styles.notice }
+									className={ clsx( styles.notice, appearance === 'neutral' && styles.neutral ) }
 								>
 									<Notice.Title>{ item.title }</Notice.Title>
 									{ item.description ? (
 										<Notice.Description>{ item.description }</Notice.Description>
 									) : null }
-									{ item.action ? (
+									{ item.action || hasErrorDetails( item ) ? (
 										<Notice.Actions>
-											<Button
-												size="small"
-												variant="solid"
-												tone="neutral"
-												className={ styles.actionButton }
-												onClick={ item.action.onClick }
-											>
-												{ item.action.label }
-											</Button>
+											{ item.action ? (
+												<Button
+													size="small"
+													variant="solid"
+													tone="neutral"
+													className={ styles.actionButton }
+													onClick={ item.action.onClick }
+												>
+													{ item.action.label }
+												</Button>
+											) : null }
+											{ hasErrorDetails( item ) ? (
+												<>
+													<CopyNoticeButton notice={ item } className={ styles.actionButton } />
+													<Button
+														size="small"
+														variant="solid"
+														tone="neutral"
+														className={ styles.actionButton }
+														onClick={ openNoticeHistory }
+													>
+														{ __( 'More' ) }
+													</Button>
+												</>
+											) : null }
 										</Notice.Actions>
 									) : null }
 									<Notice.CloseIcon

--- a/apps/ui/src/components/app-toasts/index.tsx
+++ b/apps/ui/src/components/app-toasts/index.tsx
@@ -15,8 +15,6 @@ import {
 } from '@/data/app-messages';
 import styles from './style.module.css';
 
-export type NoticeAppearance = 'neutral' | 'intent';
-
 // Error text is clamped in the toast; these get Copy (the full text) and More
 // (the recent-notifications dialog, where it runs in full).
 function hasErrorDetails( item: ToastMessage ) {
@@ -26,16 +24,12 @@ function hasErrorDetails( item: ToastMessage ) {
 export function AppToasts( {
 	className,
 	fit = 'row',
-	appearance = 'neutral',
 }: {
 	className?: string;
 	// 'row' stretches toasts to the shelf width (sidebar footer, matching the
 	// site rows); 'content' lets each toast hug its text up to the shelf's
 	// max-width (the floating collapsed shelf).
 	fit?: 'row' | 'content';
-	// 'neutral' flattens every toast to one quiet card; 'intent' keeps
-	// Notice's tinted surface so an error reads red at a glance.
-	appearance?: NoticeAppearance;
 } ) {
 	const toasts = useVisibleToasts();
 	const queuedCount = useQueuedToastCount();
@@ -71,7 +65,7 @@ export function AppToasts( {
 								<Notice.Root
 									key={ `${ item.intent }:${ !! item.description }:${ !! item.action }` }
 									intent={ item.intent }
-									className={ clsx( styles.notice, appearance === 'neutral' && styles.neutral ) }
+									className={ clsx( styles.notice, styles.neutral ) }
 								>
 									<Notice.Title>{ item.title }</Notice.Title>
 									{ item.description ? (

--- a/apps/ui/src/components/app-toasts/style.module.css
+++ b/apps/ui/src/components/app-toasts/style.module.css
@@ -61,25 +61,42 @@
 	   percentage — and this font's digits are not equal width, so a counter
 	   would shift the text by a few pixels on nearly every update. */
 	font-variant-numeric: tabular-nums;
-	--wp-ui-notice-background-color: var(--wpds-color-background-surface-neutral-strong);
-	--wp-ui-notice-border-color: transparent;
-	--wp-ui-notice-text-color: var(--wpds-color-foreground-content-neutral);
 	box-shadow:
-		0 0 0 1px color-mix(in srgb, var(--wpds-color-foreground-content-neutral) 14%, transparent),
 		0 2px 3px 0 rgba(0, 0, 0, 0.05), 0 4px 5px 0 rgba(0, 0, 0, 0.04), 0 12px 12px 0 rgba(0, 0, 0, 0.03), 0 16px 16px 0 rgba(0, 0, 0, 0.02);
 	padding-block: 6px;
 	padding-inline: var(--wpds-dimension-padding-sm);
 	border-radius: 6px;
 }
 
+/* Default appearance: one quiet neutral card whatever the intent, with a
+   hairline ring in place of Notice's tinted border. `appearance="intent"`
+   skips this and keeps Notice's own tinted surface, border, and text. */
+.neutral {
+	--wp-ui-notice-background-color: var(--wpds-color-background-surface-neutral-strong);
+	--wp-ui-notice-border-color: transparent;
+	--wp-ui-notice-text-color: var(--wpds-color-foreground-content-neutral);
+	box-shadow:
+		0 0 0 1px color-mix(in srgb, var(--wpds-color-foreground-content-neutral) 14%, transparent),
+		0 2px 3px 0 rgba(0, 0, 0, 0.05), 0 4px 5px 0 rgba(0, 0, 0, 0.04), 0 12px 12px 0 rgba(0, 0, 0, 0.03), 0 16px 16px 0 rgba(0, 0, 0, 0.02);
+}
+
+.neutral [class*='__description'] {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
 .notice [class*='heading'] {
 	line-height: 16px;
 }
 
+/* Error text can run to paragraphs; the toast shows the first few lines and
+   the notifications panel (notice-history) keeps the full message. */
 .notice [class*='__description'] {
 	font-size: var(--wpds-typography-font-size-xs);
 	line-height: 16px;
-	color: var(--wpds-color-foreground-content-neutral-weak);
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 3;
+	overflow: hidden;
 }
 
 /* Button's solid-variant sets these properties on the element itself, so
@@ -101,8 +118,18 @@
 	--wp-ui-button-border-color-active: transparent;
 }
 
+/* Row one is as tall as the close button; center the icon and the title on
+   it so a one-line toast doesn't ride high. */
 .notice > svg {
-	margin-top: 2px;
+	align-self: center;
+}
+
+.notice [class*='__title'] {
+	align-self: center;
+}
+
+.notice [class*='__actions'] {
+	gap: var(--wpds-dimension-gap-sm);
 }
 
 .queuePeek {

--- a/apps/ui/src/components/app-toasts/style.module.css
+++ b/apps/ui/src/components/app-toasts/style.module.css
@@ -68,11 +68,17 @@
 	border-radius: 6px;
 }
 
-/* Default appearance: one quiet neutral card whatever the intent, with a
-   hairline ring in place of Notice's tinted border. `appearance="intent"`
-   skips this and keeps Notice's own tinted surface, border, and text. */
+/* One quiet neutral card whatever the intent, with a hairline ring in place
+   of Notice's tinted border. The intent icon carries the severity. */
 .neutral {
-	--wp-ui-notice-background-color: var(--wpds-color-background-surface-neutral-strong);
+	/* Lifted off the chrome so the card reads clearly against it. The sidebar
+	   is dark in both color schemes, so this stays a mid grey either way
+	   rather than going near-white in light mode. */
+	--wp-ui-notice-background-color: color-mix(
+		in srgb,
+		var(--wpds-color-foreground-content-neutral) 14%,
+		var(--wpds-color-background-surface-neutral-strong)
+	);
 	--wp-ui-notice-border-color: transparent;
 	--wp-ui-notice-text-color: var(--wpds-color-foreground-content-neutral);
 	box-shadow:

--- a/apps/ui/src/components/notice-history/index.test.tsx
+++ b/apps/ui/src/components/notice-history/index.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetAppMessagesForTests, toast } from '@/data/app-messages';
+import { closeNoticeHistory, NoticeHistoryButton, NoticeHistoryDialog } from './index';
+
+vi.mock( '@/hooks/use-color-scheme', () => ( {
+	useColorScheme: () => 'light',
+} ) );
+
+const writeText = vi.fn( () => Promise.resolve() );
+
+describe( 'NoticeHistory', () => {
+	beforeEach( () => {
+		Object.assign( navigator, { clipboard: { writeText } } );
+	} );
+
+	afterEach( () => {
+		closeNoticeHistory();
+		resetAppMessagesForTests();
+		writeText.mockClear();
+	} );
+
+	it( 'shows an empty state before anything has been shown', () => {
+		render(
+			<>
+				<NoticeHistoryButton />
+				<NoticeHistoryDialog />
+			</>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Recent notifications' } ) );
+		expect( screen.getByText( 'No notifications yet' ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Clear all' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'lists past notices in full, copies one, and clears them all', async () => {
+		render(
+			<>
+				<NoticeHistoryButton />
+				<NoticeHistoryDialog />
+			</>
+		);
+		act( () => {
+			toast.error( 'Could not open the terminal.', { description: 'iTerm is not installed.' } );
+		} );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Recent notifications' } ) );
+		expect( screen.getByText( 'Could not open the terminal.' ) ).toBeVisible();
+		expect( screen.getByText( 'iTerm is not installed.' ) ).toBeVisible();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Copy' } ) );
+		expect( writeText ).toHaveBeenCalledWith(
+			'Could not open the terminal.\niTerm is not installed.'
+		);
+		expect( await screen.findByRole( 'button', { name: 'Copied' } ) ).toBeVisible();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Clear all' } ) );
+		expect( screen.getByText( 'No notifications yet' ) ).toBeVisible();
+	} );
+} );

--- a/apps/ui/src/components/notice-history/index.test.tsx
+++ b/apps/ui/src/components/notice-history/index.test.tsx
@@ -28,7 +28,7 @@ describe( 'NoticeHistory', () => {
 				<NoticeHistoryDialog />
 			</>
 		);
-		fireEvent.click( screen.getByRole( 'button', { name: 'Recent notifications' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Notification history' } ) );
 		expect( screen.getByText( 'No notifications yet' ) ).toBeVisible();
 		expect( screen.queryByRole( 'button', { name: 'Clear all' } ) ).not.toBeInTheDocument();
 	} );
@@ -44,7 +44,7 @@ describe( 'NoticeHistory', () => {
 			toast.error( 'Could not open the terminal.', { description: 'iTerm is not installed.' } );
 		} );
 
-		fireEvent.click( screen.getByRole( 'button', { name: 'Recent notifications' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Notification history' } ) );
 		expect( screen.getByText( 'Could not open the terminal.' ) ).toBeVisible();
 		expect( screen.getByText( 'iTerm is not installed.' ) ).toBeVisible();
 

--- a/apps/ui/src/components/notice-history/index.tsx
+++ b/apps/ui/src/components/notice-history/index.tsx
@@ -1,0 +1,191 @@
+import { __ } from '@wordpress/i18n';
+import { bell } from '@wordpress/icons';
+import { Button, Dialog, EmptyState, IconButton, Notice } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { AppThemeScope } from '@/components/app-theme-scope';
+import {
+	clearNoticeHistory,
+	noticeToText,
+	useNoticeHistory,
+	type NoticeRecord,
+} from '@/data/app-messages';
+import styles from './style.module.css';
+
+// The dialog mounts once at the layout level; the bell and a toast's "More"
+// both open it through this, so it works with the sidebar collapsed too.
+let isOpen = false;
+const listeners = new Set< () => void >();
+
+function subscribe( listener: () => void ) {
+	listeners.add( listener );
+	return () => {
+		listeners.delete( listener );
+	};
+}
+
+function setOpen( next: boolean ) {
+	if ( isOpen === next ) {
+		return;
+	}
+	isOpen = next;
+	for ( const listener of listeners ) {
+		listener();
+	}
+}
+
+export function openNoticeHistory(): void {
+	setOpen( true );
+}
+
+export function closeNoticeHistory(): void {
+	setOpen( false );
+}
+
+function useNoticeHistoryOpen(): boolean {
+	return useSyncExternalStore(
+		subscribe,
+		() => isOpen,
+		() => false
+	);
+}
+
+export function NoticeHistoryButton( { className }: { className?: string } ) {
+	return (
+		<IconButton
+			variant="minimal"
+			tone="neutral"
+			size="small"
+			className={ clsx( styles.bell, className ) }
+			icon={ bell }
+			label={ __( 'Recent notifications' ) }
+			onClick={ openNoticeHistory }
+		/>
+	);
+}
+
+// Flips to "Copied" briefly; a toast would be the obvious feedback, but a
+// toast about copying a notice would itself land in the list.
+export function CopyNoticeButton( {
+	notice,
+	className,
+	variant = 'solid',
+}: {
+	notice: Pick< NoticeRecord, 'title' | 'description' >;
+	className?: string;
+	variant?: 'solid' | 'outline';
+} ) {
+	const [ copied, setCopied ] = useState( false );
+	const timer = useRef< ReturnType< typeof setTimeout > | undefined >( undefined );
+
+	useEffect( () => () => clearTimeout( timer.current ), [] );
+
+	const copy = async () => {
+		await navigator.clipboard.writeText( noticeToText( notice ) );
+		setCopied( true );
+		clearTimeout( timer.current );
+		timer.current = setTimeout( () => setCopied( false ), 1500 );
+	};
+
+	return (
+		<Button
+			size="small"
+			variant={ variant }
+			tone="neutral"
+			className={ className }
+			onClick={ () => void copy() }
+		>
+			{ copied ? __( 'Copied' ) : __( 'Copy' ) }
+		</Button>
+	);
+}
+
+function formatTime( timestamp: number ) {
+	return new Intl.DateTimeFormat( undefined, { hour: 'numeric', minute: '2-digit' } ).format(
+		timestamp
+	);
+}
+
+export function NoticeHistoryDialog() {
+	const open = useNoticeHistoryOpen();
+	const notices = useNoticeHistory();
+
+	return (
+		// Opened from the sidebar's dark chrome scope; without this the dialog
+		// inherits that palette and renders dark on top of the light app.
+		<AppThemeScope>
+			<Dialog.Root open={ open } onOpenChange={ setOpen }>
+				<Dialog.Popup size="medium">
+					<Dialog.Header className={ styles.header }>
+						<Dialog.Title>{ __( 'Recent notifications' ) }</Dialog.Title>
+					</Dialog.Header>
+					<Dialog.Content>
+						{ notices.length === 0 ? (
+							<EmptyState.Root className={ styles.empty }>
+								<EmptyState.Icon icon={ bell } />
+								<EmptyState.Title>{ __( 'No notifications yet' ) }</EmptyState.Title>
+								<EmptyState.Description>
+									{ __(
+										'Notices Studio shows you during this session collect here, until Studio\u00a0restarts.'
+									) }
+								</EmptyState.Description>
+							</EmptyState.Root>
+						) : (
+							<>
+								{ /* Description drops a passed className, so the spacing lives on
+							     a wrapper. The NBSP keeps the last word from wrapping alone. */ }
+								<div className={ styles.intro }>
+									<Dialog.Description>
+										{ __(
+											'Notices from this session, newest first. They clear when Studio\u00a0restarts.'
+										) }
+									</Dialog.Description>
+								</div>
+								<ul className={ styles.list }>
+									{ notices.map( ( notice ) => (
+										<li key={ `${ notice.id }:${ notice.shownAt }` }>
+											<Notice.Root intent={ notice.intent } className={ styles.notice }>
+												<Notice.Title>{ notice.title }</Notice.Title>
+												{ notice.description ? (
+													<Notice.Description className={ styles.description }>
+														{ notice.description }
+													</Notice.Description>
+												) : null }
+												<time
+													className={ styles.time }
+													dateTime={ new Date( notice.shownAt ).toISOString() }
+												>
+													{ formatTime( notice.shownAt ) }
+												</time>
+												{ notice.description ? (
+													<Notice.Actions>
+														<CopyNoticeButton notice={ notice } variant="outline" />
+													</Notice.Actions>
+												) : null }
+											</Notice.Root>
+										</li>
+									) ) }
+								</ul>
+							</>
+						) }
+					</Dialog.Content>
+					<Dialog.Footer>
+						{ notices.length > 0 ? (
+							<Button
+								variant="minimal"
+								tone="neutral"
+								className={ styles.clearAll }
+								onClick={ clearNoticeHistory }
+							>
+								{ __( 'Clear all' ) }
+							</Button>
+						) : null }
+						<Dialog.Action variant="minimal" tone="neutral">
+							{ __( 'Close' ) }
+						</Dialog.Action>
+					</Dialog.Footer>
+				</Dialog.Popup>
+			</Dialog.Root>
+		</AppThemeScope>
+	);
+}

--- a/apps/ui/src/components/notice-history/index.tsx
+++ b/apps/ui/src/components/notice-history/index.tsx
@@ -58,7 +58,7 @@ export function NoticeHistoryButton( { className }: { className?: string } ) {
 			size="small"
 			className={ clsx( styles.bell, className ) }
 			icon={ bell }
-			label={ __( 'Recent notifications' ) }
+			label={ __( 'Notification history' ) }
 			onClick={ openNoticeHistory }
 		/>
 	);
@@ -117,7 +117,7 @@ export function NoticeHistoryDialog() {
 			<Dialog.Root open={ open } onOpenChange={ setOpen }>
 				<Dialog.Popup size="medium">
 					<Dialog.Header className={ styles.header }>
-						<Dialog.Title>{ __( 'Recent notifications' ) }</Dialog.Title>
+						<Dialog.Title>{ __( 'Notification history' ) }</Dialog.Title>
 					</Dialog.Header>
 					<Dialog.Content>
 						{ notices.length === 0 ? (
@@ -125,9 +125,7 @@ export function NoticeHistoryDialog() {
 								<EmptyState.Icon icon={ bell } />
 								<EmptyState.Title>{ __( 'No notifications yet' ) }</EmptyState.Title>
 								<EmptyState.Description>
-									{ __(
-										'Notices Studio shows you during this session collect here, until Studio\u00a0restarts.'
-									) }
+									{ __( 'Notices Studio shows you collect here, until Studio\u00a0restarts.' ) }
 								</EmptyState.Description>
 							</EmptyState.Root>
 						) : (
@@ -136,9 +134,7 @@ export function NoticeHistoryDialog() {
 							     a wrapper. The NBSP keeps the last word from wrapping alone. */ }
 								<div className={ styles.intro }>
 									<Dialog.Description>
-										{ __(
-											'Notices from this session, newest first. They clear when Studio\u00a0restarts.'
-										) }
+										{ __( 'Cleared when Studio\u00a0restarts.' ) }
 									</Dialog.Description>
 								</div>
 								<ul className={ styles.list }>

--- a/apps/ui/src/components/notice-history/index.tsx
+++ b/apps/ui/src/components/notice-history/index.tsx
@@ -116,7 +116,7 @@ export function NoticeHistoryDialog() {
 		<AppThemeScope>
 			<Dialog.Root open={ open } onOpenChange={ setOpen }>
 				<Dialog.Popup size="medium">
-					<Dialog.Header className={ styles.header }>
+					<Dialog.Header>
 						<Dialog.Title>{ __( 'Notification history' ) }</Dialog.Title>
 					</Dialog.Header>
 					<Dialog.Content>
@@ -130,13 +130,6 @@ export function NoticeHistoryDialog() {
 							</EmptyState.Root>
 						) : (
 							<>
-								{ /* Description drops a passed className, so the spacing lives on
-							     a wrapper. The NBSP keeps the last word from wrapping alone. */ }
-								<div className={ styles.intro }>
-									<Dialog.Description>
-										{ __( 'Cleared when Studio\u00a0restarts.' ) }
-									</Dialog.Description>
-								</div>
 								<ul className={ styles.list }>
 									{ notices.map( ( notice ) => (
 										<li key={ `${ notice.id }:${ notice.shownAt }` }>
@@ -162,6 +155,13 @@ export function NoticeHistoryDialog() {
 										</li>
 									) ) }
 								</ul>
+								{ /* Description drops a passed className, so the note lives on a
+								     wrapper. */ }
+								<div className={ styles.outro }>
+									<Dialog.Description>
+										{ __( 'Notifications are cleared automatically when Studio restarts.' ) }
+									</Dialog.Description>
+								</div>
 							</>
 						) }
 					</Dialog.Content>

--- a/apps/ui/src/components/notice-history/style.module.css
+++ b/apps/ui/src/components/notice-history/style.module.css
@@ -1,0 +1,79 @@
+/* Same weight as the sidebar toggle beside it (user-menu's `.sidebarToggle`);
+   the button paints its own foreground, so the color has to land on it. */
+.bell {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+/* The chrome's header padding puts a full gap between the title and the
+   intro paragraph; tighten it so the two read as one block, and put the
+   space below the paragraph instead. Text zeroes the paragraph's own margin,
+   so it has to be set here. */
+.header {
+	padding-block-end: var(--wpds-dimension-gap-xs);
+}
+
+.intro {
+	margin-block-end: var(--wpds-dimension-gap-lg);
+}
+
+.list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-sm);
+}
+
+.notice {
+	width: 100%;
+	box-sizing: border-box;
+}
+
+/* Notice sizes its title row for a 24px icon, but at this density the glyph
+   renders smaller and sits high; center it on the title row instead. */
+.notice > svg {
+	align-self: center;
+}
+
+/* The toast clamps this; here it runs in full, but a stack trace can be
+   hundreds of lines, so past ~a dozen the entry scrolls on its own rather
+   than pushing every other notice off screen. Error text can be a long,
+   unbroken path or JSON, so let it wrap anywhere. */
+.description {
+	/* Run under the timestamp's column too; it only occupies the title row. */
+	grid-column: 2 / -1;
+	max-height: 240px;
+	overflow: auto;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+}
+
+/* Notice lays out as `auto 1fr auto`; the timestamp takes the trailing cell
+   on the title row, aligned to the title's own text padding. */
+.time {
+	grid-column: 3;
+	grid-row: 1;
+	padding-block: var(--text-vertical-padding);
+	margin-inline-start: var(--wpds-dimension-gap-sm);
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	white-space: nowrap;
+	font-variant-numeric: tabular-nums;
+}
+
+/* EmptyState.Root is a max-width block, so it sits at the content box's
+   start until it is centered. The min-height gives it enough room to read as
+   a state rather than a stub, with the stack centered in it. */
+.empty {
+	margin-inline: auto;
+	justify-content: center;
+	min-height: 200px;
+	padding-block: var(--wpds-dimension-padding-2xl);
+}
+
+/* Footer actions sit at the end; push the destructive-ish one to the start. */
+.clearAll {
+	margin-inline-end: auto;
+}

--- a/apps/ui/src/components/notice-history/style.module.css
+++ b/apps/ui/src/components/notice-history/style.module.css
@@ -28,6 +28,22 @@
 .notice {
 	width: 100%;
 	box-sizing: border-box;
+
+	/* Flat grey entries, matching the sidebar notices: the intent icon carries
+	   the severity rather than a tinted surface. Unlike the sidebar this sits on
+	   the app canvas, so the lift follows the color scheme — mixing toward the
+	   content foreground darkens it in light mode and lightens it in dark. */
+	--wp-ui-notice-background-color: color-mix(
+		in srgb,
+		var(--wpds-color-foreground-content-neutral) 6%,
+		var(--wpds-color-background-surface-neutral-strong)
+	);
+	--wp-ui-notice-border-color: transparent;
+	--wp-ui-notice-text-color: var(--wpds-color-foreground-content-neutral);
+}
+
+.notice [class*='__description'] {
+	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
 /* Notice sizes its title row for a 24px icon, but at this density the glyph

--- a/apps/ui/src/components/notice-history/style.module.css
+++ b/apps/ui/src/components/notice-history/style.module.css
@@ -4,16 +4,17 @@
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
-/* The chrome's header padding puts a full gap between the title and the
-   intro paragraph; tighten it so the two read as one block, and put the
-   space below the paragraph instead. Text zeroes the paragraph's own margin,
-   so it has to be set here. */
-.header {
-	padding-block-end: var(--wpds-dimension-gap-xs);
-}
-
-.intro {
-	margin-block-end: var(--wpds-dimension-gap-lg);
+/* A quiet footnote under the list rather than a subtitle above it: it
+   explains the log's lifetime, which the reader only wants once. */
+.outro {
+	margin-block-start: var(--wpds-dimension-gap-lg);
+	font-size: var(--wpds-typography-font-size-xs);
+	/* A step below the notice body text, which is already `-weak`. */
+	color: color-mix(
+		in srgb,
+		var(--wpds-color-foreground-content-neutral-weak) 75%,
+		transparent
+	);
 }
 
 .list {

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -4,8 +4,10 @@ import { Button, Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AppMessageCards, AppMessageCardsDot } from '@/components/app-message-cards';
+import { appThemeColor } from '@/components/app-theme-scope';
 import { AppToasts } from '@/components/app-toasts';
 import { CollapsedSiteSwitcher } from '@/components/collapsed-site-switcher';
+import { NoticeHistoryDialog } from '@/components/notice-history';
 import { ResizeHandle, ResizeOverlay } from '@/components/resize-handle';
 import { SidebarHeader } from '@/components/sidebar-header';
 import { SeenSessionTimestampsProvider, SiteList } from '@/components/site-list';
@@ -154,15 +156,21 @@ export function SidebarLayout( {
 								<SidebarHeader />
 								<SiteList />
 								<div className={ styles.sidebarFooter }>
+									{ ! effectiveCollapsed ? (
+										<StudioBetaMenu className={ styles.sidebarBeta } />
+									) : null }
 									{ /* Toasts sit above the persistent cards: the footer is
 								     bottom-anchored, so a transient toast arriving below a card
 								     would shove it up and drop it back on expiry. */ }
-									{ ! effectiveCollapsed ? <AppToasts className={ styles.sidebarToasts } /> : null }
 									{ ! effectiveCollapsed ? (
-										<AppMessageCards className={ styles.sidebarCards } />
-									) : null }
-									{ ! effectiveCollapsed ? (
-										<StudioBetaMenu className={ styles.sidebarBeta } />
+										// Notices sit on the dark chrome, so they take the app's
+										// own theme (a step up from the chrome in both schemes) and
+										// keep their intent tints instead of flattening to a
+										// chrome-on-chrome neutral card.
+										<ThemeProvider color={ appThemeColor( colorScheme ) }>
+											<AppToasts className={ styles.sidebarToasts } appearance="intent" />
+											<AppMessageCards className={ styles.sidebarCards } appearance="intent" />
+										</ThemeProvider>
 									) : null }
 									<UserMenu onToggleSidebar={ toggleSidebar } />
 								</div>
@@ -236,6 +244,7 @@ export function SidebarLayout( {
 						) : null }
 					</main>
 					{ sidebarResize.isResizing ? <ResizeOverlay /> : null }
+					<NoticeHistoryDialog />
 				</div>
 			</SeenSessionTimestampsProvider>
 		</SidebarCollapsedContext.Provider>

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -4,7 +4,6 @@ import { Button, Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AppMessageCards, AppMessageCardsDot } from '@/components/app-message-cards';
-import { appThemeColor } from '@/components/app-theme-scope';
 import { AppToasts } from '@/components/app-toasts';
 import { CollapsedSiteSwitcher } from '@/components/collapsed-site-switcher';
 import { NoticeHistoryDialog } from '@/components/notice-history';
@@ -162,15 +161,9 @@ export function SidebarLayout( {
 									{ /* Toasts sit above the persistent cards: the footer is
 								     bottom-anchored, so a transient toast arriving below a card
 								     would shove it up and drop it back on expiry. */ }
+									{ ! effectiveCollapsed ? <AppToasts className={ styles.sidebarToasts } /> : null }
 									{ ! effectiveCollapsed ? (
-										// Notices sit on the dark chrome, so they take the app's
-										// own theme (a step up from the chrome in both schemes) and
-										// keep their intent tints instead of flattening to a
-										// chrome-on-chrome neutral card.
-										<ThemeProvider color={ appThemeColor( colorScheme ) }>
-											<AppToasts className={ styles.sidebarToasts } appearance="intent" />
-											<AppMessageCards className={ styles.sidebarCards } appearance="intent" />
-										</ThemeProvider>
+										<AppMessageCards className={ styles.sidebarCards } />
 									) : null }
 									<UserMenu onToggleSidebar={ toggleSidebar } />
 								</div>

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -82,8 +82,8 @@
 	padding: var(--wpds-dimension-padding-sm) calc(var(--wpds-dimension-padding-lg) - var(--wpds-dimension-padding-sm)) 0;
 }
 
-/* The beta affordance stays in normal footer flow, below transient/persistent
-   messages and above Settings, so it never overlays a toast or checklist.
+/* The beta affordance stays in normal footer flow, at the top of the footer
+   so notices sit directly above the Settings row and its bell.
    Margin, not padding: this class lands on the bubble itself, which owns its
    own padding. */
 .sidebarBeta {

--- a/apps/ui/src/components/user-menu/index.tsx
+++ b/apps/ui/src/components/user-menu/index.tsx
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, settings } from '@wordpress/icons';
 import { IconButton } from '@wordpress/ui';
 import { Gravatar } from '@/components/gravatar';
+import { NoticeHistoryButton } from '@/components/notice-history';
 import { SidebarButton } from '@/components/sidebar-button';
 import { useAuthUser } from '@/data/queries/use-auth-user';
 import { useColorScheme } from '@/hooks/use-color-scheme';
@@ -34,6 +35,7 @@ export function UserMenu( { onToggleSidebar }: Props ) {
 					) }
 					<span className={ styles.userName }>{ __( 'App settings' ) }</span>
 				</SidebarButton>
+				<NoticeHistoryButton />
 				<IconButton
 					variant="minimal"
 					tone="neutral"

--- a/apps/ui/src/data/app-messages.test.ts
+++ b/apps/ui/src/data/app-messages.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+	clearNoticeHistory,
 	dismissToast,
+	getNoticeHistory,
 	getQueuedToastCount,
 	getVisibleToasts,
 	notifyRendererMounted,
@@ -223,5 +225,43 @@ describe( 'app-messages', () => {
 
 		vi.advanceTimersByTime( 4_500 );
 		expect( getQueuedToastCount() ).toBe( 0 );
+	} );
+
+	describe( 'notice history', () => {
+		const historyTitles = () => getNoticeHistory().map( ( item ) => item.title );
+
+		it( 'records every toast newest first, with the full description', () => {
+			toast.success( 'Saved' );
+			toast.error( 'Failed', { description: 'Long error text' } );
+			expect( historyTitles() ).toEqual( [ 'Failed', 'Saved' ] );
+			expect( getNoticeHistory()[ 0 ].description ).toBe( 'Long error text' );
+		} );
+
+		it( 'folds an in-place replacement into the original record', () => {
+			showToast( { id: 'sync', intent: 'info', title: 'Pushing to live' } );
+			showToast( { id: 'sync', intent: 'success', title: 'Push complete' } );
+			expect( historyTitles() ).toEqual( [ 'Push complete' ] );
+		} );
+
+		it( 'keeps a notice after its toast expires', () => {
+			toast.success( 'Saved' );
+			vi.advanceTimersByTime( 4_500 );
+			settleExit();
+			expect( titles() ).toEqual( [] );
+			expect( historyTitles() ).toEqual( [ 'Saved' ] );
+		} );
+
+		it( 'clears the list and dismisses the toasts still showing or queued', () => {
+			for ( let i = 0; i < 5; i++ ) {
+				toast.success( `Saved ${ i }` );
+			}
+			expect( getQueuedToastCount() ).toBe( 2 );
+
+			clearNoticeHistory();
+			expect( historyTitles() ).toEqual( [] );
+			expect( getQueuedToastCount() ).toBe( 0 );
+			settleExit();
+			expect( titles() ).toEqual( [] );
+		} );
 	} );
 } );

--- a/apps/ui/src/data/app-messages.ts
+++ b/apps/ui/src/data/app-messages.ts
@@ -36,6 +36,15 @@ export type ToastMessage = {
 	leaving?: boolean;
 };
 
+export type NoticeRecord = {
+	id: string;
+	intent: ToastIntent;
+	title: string;
+	description?: string;
+	// Epoch ms of the first showing; an in-place replacement keeps it.
+	shownAt: number;
+};
+
 const DEFAULT_TOAST_TTL_MS = 4_500;
 // Failures linger so a glance away doesn't miss them.
 const ERROR_TOAST_TTL_MS = 10_000;
@@ -48,6 +57,12 @@ let visible: ToastMessage[] = [];
 let queued: ToastMessage[] = [];
 let nextId = 1;
 let rendererMounted = false;
+
+// Session-only log of everything shown, newest first. A toast clamps long
+// error text and then expires; the history panel is where the full message
+// can still be read. Bounded so a noisy session can't grow it forever.
+const HISTORY_LIMIT = 50;
+let noticeHistory: NoticeRecord[] = [];
 
 const timers = new Map< string, ReturnType< typeof setTimeout > >();
 const listeners = new Set< () => void >();
@@ -82,6 +97,28 @@ function scheduleExpiry( toast: ToastMessage ) {
 		beginToastExit( toast.id );
 	}, toast.durationMs );
 	timers.set( toast.id, timer );
+}
+
+function recordNotice( toastMessage: ToastMessage, isReplacement: boolean ) {
+	const record: NoticeRecord = {
+		id: toastMessage.id,
+		intent: toastMessage.intent,
+		title: toastMessage.title,
+		description: toastMessage.description,
+		shownAt: Date.now(),
+	};
+	if ( isReplacement ) {
+		const index = noticeHistory.findIndex( ( item ) => item.id === toastMessage.id );
+		if ( index >= 0 ) {
+			// A sync ticking from "Pushing… 62%" to "Push complete" is one event,
+			// not two entries.
+			noticeHistory = noticeHistory.map( ( item, i ) =>
+				i === index ? { ...record, shownAt: item.shownAt } : item
+			);
+			return;
+		}
+	}
+	noticeHistory = [ record, ...noticeHistory ].slice( 0, HISTORY_LIMIT );
 }
 
 function promoteQueued() {
@@ -136,13 +173,17 @@ export function showToast( input: ToastInput ): string {
 		// leaving flag, and scheduleExpiry clears the pending removal timer.
 		visible = visible.map( ( toast ) => ( toast.id === toastMessage.id ? toastMessage : toast ) );
 		scheduleExpiry( toastMessage );
+		recordNotice( toastMessage, true );
 	} else if ( queued.some( ( toast ) => toast.id === toastMessage.id ) ) {
 		queued = queued.map( ( toast ) => ( toast.id === toastMessage.id ? toastMessage : toast ) );
+		recordNotice( toastMessage, true );
 	} else if ( visible.length < MAX_VISIBLE_TOASTS ) {
 		visible = [ ...visible, toastMessage ];
 		scheduleExpiry( toastMessage );
+		recordNotice( toastMessage, false );
 	} else {
 		queued = [ ...queued, toastMessage ];
+		recordNotice( toastMessage, false );
 	}
 
 	emit();
@@ -230,6 +271,36 @@ export function useQueuedToastCount(): number {
 }
 
 const EMPTY_TOASTS: readonly ToastMessage[] = [];
+const EMPTY_HISTORY: readonly NoticeRecord[] = [];
+
+export function getNoticeHistory(): readonly NoticeRecord[] {
+	return noticeHistory;
+}
+
+export function useNoticeHistory(): readonly NoticeRecord[] {
+	return useSyncExternalStore(
+		subscribe,
+		() => noticeHistory,
+		() => EMPTY_HISTORY
+	);
+}
+
+// "Clear all" in the recent-notifications dialog: the list, plus whatever is
+// still showing or waiting in the sidebar — a cleared list with toasts left
+// behind reads as if nothing happened.
+export function clearNoticeHistory(): void {
+	queued = [];
+	for ( const toastMessage of visible ) {
+		beginToastExit( toastMessage.id );
+	}
+	noticeHistory = [];
+	emit();
+}
+
+// Title plus the full description, for the clipboard.
+export function noticeToText( notice: Pick< NoticeRecord, 'title' | 'description' > ): string {
+	return notice.description ? `${ notice.title }\n${ notice.description }` : notice.title;
+}
 
 export function resetAppMessagesForTests(): void {
 	for ( const timer of timers.values() ) {
@@ -241,4 +312,5 @@ export function resetAppMessagesForTests(): void {
 	nextId = 1;
 	rendererMounted = false;
 	snapshot = visible;
+	noticeHistory = [];
 }


### PR DESCRIPTION
## Related issues

- Targets #4777 — a proposal on top of it, not a replacement
- Related to STU-2415

## How AI was used in this PR

Built with Claude Code against a running `studio ui`, using a temporary `window.__toasts` hook to fire notices of each intent (not part of this PR). Colors below were read back with `getComputedStyle`, not eyeballed.

## Proposed Changes

### Flatten notices to one neutral card

I propose using a neutral card color and using an icon to mark severity. Also, as the sidebar has the same color in light and dark mode, I propose using the same color for notifications.

The dialog follows the light/dark mode scheme, so colors are adjusted there.

### Retitle the dialog, demote the retention note

"Recent notifications" + "Notices from this session, newest first…" said the same thing twice. I retitled it to **Notification history** (bell tooltip follows).

The session-scoped fact is real but secondary, and as a subtitle it sat between the title and the notices. I move below the list as a footnote above the buttons: **"Notifications are cleared automatically when Studio restarts."**

|**Light**|**Dark**|**Copy**|
|---|---|---|
|<img width="2470" height="1580" alt="CleanShot 2026-09-09 at 09 54 47@2x" src="https://github.com/user-attachments/assets/940f0952-8554-4fa5-8403-9a1700c58c9d" />|<img width="2470" height="1580" alt="CleanShot 2026-09-09 at 09 54 57@2x" src="https://github.com/user-attachments/assets/7f91135f-19c5-4f77-a6a8-6883ff2431fb" />|<img width="1235" height="790" alt="CleanShot 2026-09-09 at 10 04 33" src="https://github.com/user-attachments/assets/6f4847a8-21f9-4f6b-a31e-ccc3b55c78ca" />|

## Testing Instructions

Run the agentic UI (`npm start`), in **both light and dark**.

1. Trigger each intent — copy a site URL (success), start a site (info), open an uninstalled terminal (error). Each should be legible, with the icon still reading as its intent.
2. Confirm the sidebar card is the same grey in light and dark, not near-white in light.
3. Open the dialog (bell, or **More** on an error toast): flat grey entries, colored icons, dialog surface following light/dark.
4. Title reads "Notification history"; retention note is a footnote above the buttons.
5. Everything else from #4777 — clamping, Copy, More, Clear all, empty state — unchanged.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
- [x] `npm run typecheck` passes
- [x] 24 tests pass across `notice-history`, `app-toasts`, `app-messages`
- [x] Verified in light and dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)