### PR TITLE
Studio Code: clear tool progress after the call ends and rotate the thinking label per step

### DIFF
--- a/apps/studio/src/components/studio-code-session/conversation/index.tsx
+++ b/apps/studio/src/components/studio-code-session/conversation/index.tsx
@@ -293,23 +293,24 @@ export function wasLastTurnInterrupted( entries: SessionEntry[] ): boolean {
 	return false;
 }
 
-// Progress from earlier turns must not leak into the current indicator, so
-// the scan stops at the nearest turn boundary.
-function findLatestProgressMessage( entries: SessionEntry[] ): string | null {
+export interface ActiveStep {
+	key: string | null;
+	progressMessage: string | null;
+}
+
+export function getActiveStep( entries: SessionEntry[] ): ActiveStep {
+	let progressMessage: string | null = null;
 	for ( let i = entries.length - 1; i >= 0; i -= 1 ) {
 		const entry = entries[ i ];
-		if (
-			isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ||
-			isStudioCustomEntryOfType( entry, 'studio.turn_closed' )
-		) {
-			return null;
+		if ( ! isStudioCustomEntryOfType( entry, 'studio.tool_progress' ) ) {
+			return { key: entry.id, progressMessage };
 		}
-		if ( isStudioCustomEntryOfType( entry, 'studio.tool_progress' ) ) {
-			const data = ( entry as StudioCustomEntry< 'studio.tool_progress' > ).data;
-			if ( data ) return data.message;
+		const data = ( entry as StudioCustomEntry< 'studio.tool_progress' > ).data;
+		if ( progressMessage === null && data ) {
+			progressMessage = data.message;
 		}
 	}
-	return null;
+	return { key: null, progressMessage };
 }
 
 function UserTurn( {
@@ -709,10 +710,7 @@ export function Conversation( {
 } ) {
 	const entries = data.entries;
 	const items = useMemo( () => entriesToRenderItems( entries ), [ entries ] );
-	const progressMessage = useMemo(
-		() => ( isRunning ? findLatestProgressMessage( entries ) : null ),
-		[ entries, isRunning ]
-	);
+	const activeStep = useMemo( () => getActiveStep( entries ), [ entries ] );
 	// Only the most recent user prompt is offered for editing, and only once
 	// the run behind it has been stopped.
 	const lastUserTextKey = useMemo( () => {
@@ -815,7 +813,8 @@ export function Conversation( {
 			<ThinkingIndicator
 				active={ isRunning && pendingQuestions.size === 0 }
 				startedAt={ startedAt }
-				progressMessage={ progressMessage }
+				stepKey={ activeStep.key }
+				progressMessage={ isRunning ? activeStep.progressMessage : null }
 			/>
 		</div>
 	);

--- a/apps/studio/src/components/studio-code-session/thinking-indicator/index.tsx
+++ b/apps/studio/src/components/studio-code-session/thinking-indicator/index.tsx
@@ -6,31 +6,33 @@ import styles from './style.module.css';
 export function ThinkingIndicator( {
 	active,
 	startedAt,
+	stepKey,
 	progressMessage,
 }: {
 	active: boolean;
 	startedAt: number | null;
+	stepKey: string | null;
 	progressMessage: string | null;
 } ) {
 	const [ message, setMessage ] = useState( () => randomThinkingMessage() );
 	const [ elapsedSeconds, setElapsedSeconds ] = useState( 0 );
 
 	useEffect( () => {
-		if ( ! active || startedAt === null ) {
+		if ( ! active ) {
 			return;
 		}
 		setMessage( randomThinkingMessage() );
+	}, [ active, stepKey ] );
+
+	useEffect( () => {
+		if ( ! active || startedAt === null ) {
+			return;
+		}
 		setElapsedSeconds( Math.floor( ( Date.now() - startedAt ) / 1000 ) );
-		const labelInterval = window.setInterval( () => {
-			setMessage( randomThinkingMessage() );
-		}, 4000 );
 		const tickInterval = window.setInterval( () => {
 			setElapsedSeconds( Math.floor( ( Date.now() - startedAt ) / 1000 ) );
 		}, 1000 );
-		return () => {
-			window.clearInterval( labelInterval );
-			window.clearInterval( tickInterval );
-		};
+		return () => window.clearInterval( tickInterval );
 	}, [ active, startedAt ] );
 
 	return (

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -392,23 +392,24 @@ export function entriesToRenderItems(
 	return items;
 }
 
-// Progress from earlier turns must not leak into the current indicator, so
-// the scan stops at the nearest turn boundary.
-function findLatestProgressMessage( entries: SessionEntry[] ): string | null {
+export interface ActiveStep {
+	key: string | null;
+	progressMessage: string | null;
+}
+
+export function getActiveStep( entries: SessionEntry[] ): ActiveStep {
+	let progressMessage: string | null = null;
 	for ( let i = entries.length - 1; i >= 0; i -= 1 ) {
 		const entry = entries[ i ];
-		if (
-			isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ||
-			isStudioCustomEntryOfType( entry, 'studio.turn_closed' )
-		) {
-			return null;
+		if ( ! isStudioCustomEntryOfType( entry, 'studio.tool_progress' ) ) {
+			return { key: entry.id, progressMessage };
 		}
-		if ( isStudioCustomEntryOfType( entry, 'studio.tool_progress' ) ) {
-			const data = ( entry as StudioCustomEntry< 'studio.tool_progress' > ).data;
-			if ( data ) return data.message;
+		const data = ( entry as StudioCustomEntry< 'studio.tool_progress' > ).data;
+		if ( progressMessage === null && data ) {
+			progressMessage = data.message;
 		}
 	}
-	return null;
+	return { key: null, progressMessage };
 }
 
 function UserTurn( {
@@ -1293,10 +1294,7 @@ export function Conversation( {
 		() => entriesToRenderItems( entries, { canReadLocalMedia } ),
 		[ entries, canReadLocalMedia ]
 	);
-	const progressMessage = useMemo(
-		() => ( isRunning ? findLatestProgressMessage( entries ) : null ),
-		[ entries, isRunning ]
-	);
+	const activeStep = useMemo( () => getActiveStep( entries ), [ entries ] );
 
 	// One selected message at a time, so picking a new one closes the last.
 	const [ selectedKey, setSelectedKey ] = useState< string | null >( null );
@@ -1379,7 +1377,8 @@ export function Conversation( {
 			<ThinkingIndicator
 				active={ isRunning && pendingQuestions.size === 0 }
 				startedAt={ startedAt }
-				progressMessage={ progressMessage }
+				stepKey={ activeStep.key }
+				progressMessage={ isRunning ? activeStep.progressMessage : null }
 			/>
 		</div>
 	);

--- a/apps/ui/src/ui-classic/components/session-view/thinking-indicator/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/thinking-indicator/index.test.tsx
@@ -5,7 +5,12 @@ import { formatElapsedTime, ThinkingIndicator } from './index';
 describe( 'ThinkingIndicator', () => {
 	it( 'uses the shared working mark without adding a nested status', () => {
 		const { container } = render(
-			<ThinkingIndicator active startedAt={ Date.now() } progressMessage={ null } />
+			<ThinkingIndicator
+				active
+				startedAt={ Date.now() }
+				stepKey={ null }
+				progressMessage={ null }
+			/>
 		);
 
 		expect( screen.getAllByRole( 'status' ) ).toHaveLength( 1 );

--- a/apps/ui/src/ui-classic/components/session-view/thinking-indicator/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/thinking-indicator/index.tsx
@@ -86,10 +86,12 @@ function AnimatedElapsedTime( { elapsedSeconds }: { elapsedSeconds: number } ) {
 export function ThinkingIndicator( {
 	active,
 	startedAt,
+	stepKey,
 	progressMessage,
 }: {
 	active: boolean;
 	startedAt: number | null;
+	stepKey: string | null;
 	progressMessage: string | null;
 } ) {
 	const [ message, setMessage ] = useState( () => randomThinkingMessage() );
@@ -100,11 +102,7 @@ export function ThinkingIndicator( {
 			return;
 		}
 		setMessage( randomThinkingMessage() );
-		const labelInterval = window.setInterval( () => {
-			setMessage( randomThinkingMessage() );
-		}, 4000 );
-		return () => window.clearInterval( labelInterval );
-	}, [ active ] );
+	}, [ active, stepKey ] );
 
 	useEffect( () => {
 		if ( ! active || startedAt === null ) {


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code diagnosed how the thinking indicator's label and progress line are driven from session entries, then made the change in both the agentic UI and the classic Studio renderer. I reviewed the resulting diff and ran lint, typecheck and the affected test suites.

## Proposed Changes

While the agent runs, the thinking indicator shows a random label ("Paragraphing…") and, below it, the progress message reported by the running tool ("Generated 7/7 images"). Two things felt off:

- The progress line stayed visible after the tool call had returned, so it could describe a tool that was no longer running while the model was already composing its next step.
- The random label rotated every 4 seconds on a timer, unrelated to what the agent was actually doing.

Now the progress line clears as soon as any later entry lands (the tool's result, the next assistant message, or a turn boundary), and the label only changes when the agent moves on to a new step. The change is mirrored in `apps/ui` and `apps/studio`, which have duplicated versions of this indicator.

## Testing Instructions

- Start a Studio Code session and ask for something that runs a long tool with progress updates (e.g. generating several images, or pulling a site).
- While the tool runs, the label under the loader should stay fixed and the second line should update with the tool's progress.
- Once the tool returns, the second line should disappear and the label should pick a new word.
- Verify in the Desktop app and in `studio ui` (`npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
