### PR TITLE
Update SQLite database integration to v3.0.2

### DIFF
--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import { extractZip } from '../packages/common/lib/extract-zip.ts';
 import { fetch, sharedDispatcher, throwForHttpStatus, withRetry } from './lib/with-retry.ts';
 
-const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.0-rc.8';
+const SQLITE_DATABASE_INTEGRATION_VERSION = 'v3.0.2';
 const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/releases/download/${ SQLITE_DATABASE_INTEGRATION_VERSION }/plugin-sqlite-database-integration.zip`;
 
 async function fetchWithRetry( name: string, url: string ): Promise< Buffer > {


### PR DESCRIPTION
## Related issues

- Related to https://github.com/WordPress/sqlite-database-integration/releases/tag/v3.0.2

## How AI was used in this PR

Claude Code bumped the pinned version, checked the upstream 3.0.0 breaking-change list against our codebase, and ran the verification below. I reviewed the change myself.

## Proposed Changes

- Updates the bundled [WordPress SQLite database integration](https://github.com/WordPress/sqlite-database-integration/releases/tag/v3.0.2) from `v3.0.0-rc.8` to `v3.0.2`, moving Studio off a release candidate and onto the stable 3.0 line. This picks up 3.0.0 stable plus two patch releases: WordPress 7.1 compatibility, a fresh multisite setup fix, correct schema reconstruction with native numeric results, lexer and string-handling edge cases, preserved index prefix lengths in `SHOW CREATE TABLE`, and savepoint handling aligned with MySQL semantics.
- No user-visible behaviour change is expected — sites should boot and behave as before, with fewer driver-level query bugs.

### Note for reviewers

3.0.0 deprecated `WP_SQLite_Driver` in favour of `WP_MySQL_On_SQLite`, and our phpMyAdmin patch (`apps/cli/php/DbiMysqli.php`) constructs that class directly. The class still ships in 3.0.2 as a compatibility shim with an unchanged constructor, and every method the patch calls is still present, so nothing breaks here. Migrating that patch onto the new API is worth doing separately before the shim is dropped upstream.

None of the other 3.0.0 breaking changes apply — Studio doesn't use `DATABASE_ENGINE`, `FQDB`, `WP_SQLITE_AST_DRIVER` or `$GLOBALS['@pdo']`.

## Testing Instructions

- Run `npm install` (triggers the `postinstall` download of `wp-files/`) and confirm `wp-files/sqlite-database-integration/readme.txt` shows `Stable tag: 3.0.2`.
- Create and start a site, then confirm the front end, `wp-login.php` and a DB-heavy endpoint such as `/?rest_route=/wp/v2/posts` all respond correctly.
- Open phpMyAdmin for a site and confirm it still connects and lists tables — this is the one path that touches the deprecated driver class, and it can't be exercised headlessly.
- Worth a spot-check: WAL journal mode has been the default since 3.0.0 (`-wal`/`-shm` sidecar files). Import/export already resets this, but exercising site export and backup is prudent.

What I verified locally: lint and `npm run typecheck` clean; the 72 SQLite and mu-plugin unit tests pass; the download script fetches and extracts v3.0.2; a site created on the new driver booted, served HTTP 200, and returned real post data over the REST API. phpMyAdmin was not exercised — it launches from the desktop app.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
