### PR TITLE
Fix unclickable Studio Code nudge by opting it out of the window drag region

### DIFF
--- a/apps/studio/src/components/agentic-ui-banner/index.tsx
+++ b/apps/studio/src/components/agentic-ui-banner/index.tsx
@@ -36,7 +36,7 @@ export function AgenticUiBanner( { onDismiss }: AgenticUiBannerProps ) {
 	return (
 		<div
 			className={ cx(
-				'absolute bottom-2 right-2 z-20 pointer-events-none',
+				'absolute bottom-2 right-2 z-20 pointer-events-none app-no-drag-region',
 				stage === 'entering' && styles.rise,
 				stage === 'exiting' && styles.sink
 			) }


### PR DESCRIPTION
## Related issues

- Fixes [STU-2416](https://linear.app/a8c/issue/STU-2416/agentic-ui-nudge-doesnt-work-on-windows)

## How AI was used in this PR

I used Claude to locate the root cause and write the one-line fix.

## Proposed Changes

The "There's a new way to build in Studio" nudge appeared correctly but was completely inert: neither "Try it" nor the dismiss button responded to clicks. Users had no way to accept or dismiss it from the banner itself, leaving the only route to the new UI in Settings.

Despite the issue title, this is not Windows-specific — it reproduces on macOS too, and nothing in the cause is platform-dependent.

## Testing Instructions

The nudge only exists in the Classic UI and the drag region only exists in Electron, so this needs the desktop app (it cannot be reproduced in a browser).

1. Run `npm start`.
2. Make sure the nudge is not already dismissed. It is gated by `isAgenticUiBannerDismissed`; reset `agenticUiBannerDismissed` in `~/.studio/app.json` if needed.
3. Select a site so the banner appears in the bottom-right of the site content area.
4. Click **Try it** — it should switch to the Agentic UI.
5. Reset the dismissal, bring the banner back, and click the **×** — it should play the exit animation and dismiss.
6. Confirm the banner can no longer be used to drag the window, and that dragging empty chrome elsewhere still moves it.
7. Check both light and dark appearance.

Before this change, steps 4 and 5 did nothing at all.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
