### PR TITLE
Point the Antigravity editor option at Antigravity IDE

### DIFF
--- a/packages/common/lib/user-settings/editor.ts
+++ b/packages/common/lib/user-settings/editor.ts
@@ -22,15 +22,15 @@ export type SupportedEditorConfig = {
 
 export const supportedEditorConfig: Record< SupportedEditor, SupportedEditorConfig > = {
 	antigravity: {
-		// translators: "Antigravity" is the brand name for an IDE and does not need to be translated
-		label: () => __( 'Antigravity' ),
-		url: ( path: string ) => `antigravity://file/${ path }?windowId=_blank`,
-		macOSBundleId: 'com.google.antigravity',
+		// translators: "Antigravity IDE" is the brand name for an IDE and does not need to be translated
+		label: () => __( 'Antigravity IDE' ),
+		url: ( path: string ) => `antigravity-ide://file/${ path }?windowId=_blank`,
+		macOSBundleId: 'com.google.antigravity-ide',
 		winPaths: [
-			'%LOCALAPPDATA%\\Programs\\Antigravity\\Antigravity.exe',
-			'%PROGRAMFILES%\\Google\\Antigravity\\Antigravity.exe',
+			'%LOCALAPPDATA%\\Programs\\Antigravity IDE\\Antigravity IDE.exe',
+			'%PROGRAMFILES%\\Google\\Antigravity IDE\\Antigravity IDE.exe',
 		],
-		linuxCommands: [ 'antigravity' ],
+		linuxCommands: [ 'antigravity-ide' ],
 	},
 	vscode: {
 		// translators: "Visual Studio Code" is the brand name for an IDE and does not need to be translated

--- a/packages/common/lib/user-settings/installed-apps.ts
+++ b/packages/common/lib/user-settings/installed-apps.ts
@@ -57,7 +57,7 @@ function getLocalProgramsPath(): string {
 // intentionally empty here.
 const installationPaths: Record< string, PlatformPaths > = {
 	darwin: {
-		antigravity: [ 'Antigravity.app' ],
+		antigravity: [ 'Antigravity IDE.app' ],
 		vscode: [ 'Visual Studio Code.app' ],
 		phpstorm: [ 'PhpStorm.app' ],
 		cursor: [ 'Cursor.app' ],
@@ -86,8 +86,8 @@ const installationPaths: Record< string, PlatformPaths > = {
 	},
 	win32: {
 		antigravity: [
-			path.win32.join( getLocalProgramsPath(), 'Antigravity' ),
-			path.win32.join( getProgramFilesPath(), 'Google\\Antigravity' ),
+			path.win32.join( getLocalProgramsPath(), 'Antigravity IDE' ),
+			path.win32.join( getProgramFilesPath(), 'Google\\Antigravity IDE' ),
 		],
 		vscode: [
 			path.win32.join( getProgramFilesPath(), 'Microsoft VS Code' ),


### PR DESCRIPTION
## Related issues

- Fixes #4585

## How AI was used in this PR

Claude Code investigated the report, verified the platform-specific details, and made the change. The two values the issue left unconfirmed were checked against a real Antigravity IDE 2.5.5 install rather than taken from the issue or from web sources:

- Bundle ID `com.google.antigravity-ide`, read from the installed app's `Info.plist`.
- `CFBundleURLSchemes` is `antigravity-ide` — the IDE does **not** claim `antigravity://`.

It also ran the exact command Studio uses on macOS (`open -b com.google.antigravity-ide <folder>`) and confirmed the IDE recorded the folder as a workspace. I've reviewed the diff.

## Proposed Changes

Since the Antigravity 2.0 release, Google split the product into a standalone agent app and a separately installed IDE. Studio's Antigravity option still targeted the pre-split identifiers, which now resolve to the agent app.

The practical effect was worse than a mislabeled entry: the option was non-functional on every platform. Picking Antigravity and clicking through from a site's Overview tab opened the agent surface instead of the site folder, and the configured `antigravity://` scheme is no longer claimed by any installed app. There was no way to open a site in Antigravity IDE at all.

This retargets the existing option at Antigravity IDE, so it detects the IDE, launches it, and is labelled "Antigravity IDE" in the editor picker.

The option keeps its internal key, so anyone who already selected Antigravity gets a working editor after updating with no action on their part and no stored-preference migration. The alternative — adding the IDE as a second entry and keeping the old one — would have left a picker option that cannot open a folder, since the 2.0 agent app registers no URL scheme.

One behaviour change worth naming: on Linux, detection now matches the `antigravity-ide` command only. A user who has just the 2.0 agent app installed will correctly see no Antigravity option, where previously they saw one that did not work.

## Testing Instructions

Requires Antigravity IDE (the 2.0-era separate install, not the agent app).

1. Open **Settings → Preferred editor**. The option should read **Antigravity IDE**, and should only appear if the IDE is installed.
2. Select it and save.
3. Open a site's **Overview** tab and use the button to open it in the editor.
4. The site root should open as a workspace in Antigravity IDE, the same way VS Code / Cursor / Zed behave.

Also worth confirming the option does *not* appear when only the standalone Antigravity agent app is installed.

**Windows reviewers, please check step 1.** The `%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe` path is the one detail here not verified on real hardware — it comes from a community report that the installer renamed the folder from `Programs\Antigravity\`. Note that the previous config pointed at the old name, so if that report is wrong this could regress Windows detection.

Verified locally: `npm run typecheck` passes across all six workspaces; 113 tests pass across the 10 editor-related test files; eslint clean on both modified files.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
