### PR TITLE
Always send an admin password so a renamed admin user can't block site startup

### DIFF
--- a/apps/cli/lib/admin-credentials.ts
+++ b/apps/cli/lib/admin-credentials.ts
@@ -1,4 +1,4 @@
-import { decodePassword } from '@studio/common/lib/passwords';
+import { decodeAdminPassword } from '@studio/common/lib/passwords';
 import { ServerConfig } from 'cli/lib/types/wordpress-server-ipc';
 
 type AdminCredentialsConfig = Pick<
@@ -28,9 +28,11 @@ export function shouldSetAdminCredentials( config: AdminCredentialsConfig ): boo
 export function getSetAdminCredentialsRequestBody(
 	config: AdminCredentialsConfig
 ): SetAdminCredentialsRequestBody {
+	// The password is always sent: creating a user requires one, so omitting it fails the
+	// request outright when adminUsername names a user that does not exist yet.
 	return {
 		action: 'set_admin_password',
-		...( config.adminPassword && { password: decodePassword( config.adminPassword ) } ),
+		password: decodeAdminPassword( config.adminPassword ),
 		...( config.adminUsername && { username: config.adminUsername } ),
 		...( config.adminEmail && { email: config.adminEmail } ),
 	};

--- a/apps/cli/lib/native-php/site-setup.ts
+++ b/apps/cli/lib/native-php/site-setup.ts
@@ -2,7 +2,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { DEFAULT_LOCALE } from '@studio/common/lib/locale';
 import { escapePhpSingleQuotedString } from '@studio/common/lib/mu-plugins';
-import { decodePassword } from '@studio/common/lib/passwords';
+import {
+	DEFAULT_ADMIN_EMAIL,
+	DEFAULT_ADMIN_USERNAME,
+	decodeAdminPassword,
+} from '@studio/common/lib/passwords';
 import { type NativePhpSupportedVersion } from '@studio/common/lib/php-binary-metadata';
 import { getWpCliPharPath } from 'cli/lib/dependency-management/paths';
 import { ensurePhpBinaryAvailable } from '../dependency-management/php-binary';
@@ -167,9 +171,9 @@ export async function installWordPress(
 	}
 
 	const siteTitle = config.siteTitle ?? 'My WordPress Website';
-	const username = config.adminUsername ?? 'admin';
-	const password = config.adminPassword ? decodePassword( config.adminPassword ) : 'password';
-	const email = config.adminEmail ?? 'admin@localhost.com';
+	const username = config.adminUsername ?? DEFAULT_ADMIN_USERNAME;
+	const password = decodeAdminPassword( config.adminPassword );
+	const email = config.adminEmail ?? DEFAULT_ADMIN_EMAIL;
 	const siteUrl = config.absoluteUrl ?? `http://localhost:${ config.port }`;
 	// WP-CLI defaults to en_US; Studio's DEFAULT_LOCALE of "en" is not a WP locale code.
 	const locale =

--- a/apps/cli/lib/tests/admin-credentials.test.ts
+++ b/apps/cli/lib/tests/admin-credentials.test.ts
@@ -1,4 +1,4 @@
-import { encodePassword } from '@studio/common/lib/passwords';
+import { DEFAULT_ADMIN_PASSWORD, encodePassword } from '@studio/common/lib/passwords';
 import {
 	getSetAdminCredentialsRequestBody,
 	requestSetAdminCredentials,
@@ -24,6 +24,16 @@ describe( 'admin credentials', () => {
 			username: 'site-owner',
 			password: 'secret',
 			email: 'owner@example.com',
+		} );
+	} );
+
+	it( 'falls back to the default password when the site has none stored', () => {
+		// A site configured with only a username must still send a password: creating the
+		// user fails without one, which previously left the site unable to start.
+		expect( getSetAdminCredentialsRequestBody( { adminUsername: 'admine' } ) ).toEqual( {
+			action: 'set_admin_password',
+			username: 'admine',
+			password: DEFAULT_ADMIN_PASSWORD,
 		} );
 	} );
 

--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -55,7 +55,11 @@ import { getWordPressVersion } from '@studio/common/lib/get-wordpress-version';
 import { importIpcEventSchema } from '@studio/common/lib/import-export-events';
 import { isErrnoException } from '@studio/common/lib/is-errno-exception';
 import { getAuthenticationUrl, getSignUpUrl } from '@studio/common/lib/oauth';
-import { decodePassword } from '@studio/common/lib/passwords';
+import {
+	DEFAULT_ADMIN_USERNAME,
+	decodeAdminPassword,
+	decodePassword,
+} from '@studio/common/lib/passwords';
 import {
 	getInstructionsLengthBucket,
 	isTracksEventName,
@@ -961,12 +965,18 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 			if ( ( updated.enableXdebug ?? false ) !== ( current.enableXdebug ?? false ) ) {
 				options.xdebug = updated.enableXdebug ?? false;
 			}
-			if ( ( updated.adminUsername ?? 'admin' ) !== ( current.adminUsername ?? 'admin' ) ) {
+			if (
+				( updated.adminUsername ?? DEFAULT_ADMIN_USERNAME ) !==
+				( current.adminUsername ?? DEFAULT_ADMIN_USERNAME )
+			) {
 				options.adminUsername = updated.adminUsername;
 			}
-			if ( ( updated.adminPassword ?? '' ) !== ( current.adminPassword ?? '' ) ) {
+			if (
+				decodeAdminPassword( updated.adminPassword ) !==
+				decodeAdminPassword( current.adminPassword )
+			) {
 				// The CLI expects a plaintext password (it encodes before saving).
-				options.adminPassword = decodePassword( updated.adminPassword ?? '' );
+				options.adminPassword = decodeAdminPassword( updated.adminPassword );
 			}
 			if ( ( updated.adminEmail ?? '' ) !== ( current.adminEmail ?? '' ) ) {
 				options.adminEmail = updated.adminEmail;

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -76,7 +76,11 @@ import { isMultisite } from '@studio/common/lib/is-multisite';
 import { checkMaintenanceFile } from '@studio/common/lib/maintenance-file';
 import { getLocalMediaMimeType } from '@studio/common/lib/media-mime';
 import { getAuthenticationUrl } from '@studio/common/lib/oauth';
-import { decodePassword, encodePassword } from '@studio/common/lib/passwords';
+import {
+	DEFAULT_ADMIN_PASSWORD,
+	decodePassword,
+	encodePassword,
+} from '@studio/common/lib/passwords';
 import { isTracksEventName } from '@studio/common/lib/record-tracks-event';
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
 import {
@@ -717,7 +721,7 @@ export async function removeWordPressSkillFromAllSites(
 
 const DEBUG_LOG_MAX_LINES = 50;
 const PROCESS_MANAGER_HOME = nodePath.join( os.homedir(), '.studio', 'daemon' );
-const DEFAULT_ENCODED_PASSWORD = encodePassword( 'password' );
+const DEFAULT_ENCODED_PASSWORD = encodePassword( DEFAULT_ADMIN_PASSWORD );
 
 function readWordPressDebugLog( sitePath: string ): string[] | undefined {
 	const debugLogPath = nodePath.join( sitePath, DEBUG_LOG_RELATIVE_PATH );

--- a/apps/ui/src/components/create-site-form/index.tsx
+++ b/apps/ui/src/components/create-site-form/index.tsx
@@ -1,6 +1,10 @@
 import { DEFAULT_WORDPRESS_VERSION } from '@studio/common/constants';
 import { generateCustomDomainFromSiteName } from '@studio/common/lib/domains';
-import { generatePassword } from '@studio/common/lib/passwords';
+import {
+	DEFAULT_ADMIN_EMAIL,
+	DEFAULT_ADMIN_USERNAME,
+	generatePassword,
+} from '@studio/common/lib/passwords';
 import { getLatestVersionLabel } from '@studio/common/lib/wordpress-versions';
 import { RecommendedPHPVersion } from '@studio/common/types/php-versions';
 import { BaseControl, CheckboxControl, TextControl } from '@wordpress/components';
@@ -113,9 +117,9 @@ function createDefaultFormData(): FormData {
 		useCustomDomain: false,
 		customDomain: '',
 		enableHttps: false,
-		adminUsername: 'admin',
+		adminUsername: DEFAULT_ADMIN_USERNAME,
 		adminPassword: generatePassword(),
-		adminEmail: 'admin@localhost.com',
+		adminEmail: DEFAULT_ADMIN_EMAIL,
 	};
 }
 

--- a/apps/ui/src/components/site-overview-view/admin-section.tsx
+++ b/apps/ui/src/components/site-overview-view/admin-section.tsx
@@ -1,4 +1,8 @@
-import { decodePassword } from '@studio/common/lib/passwords';
+import {
+	DEFAULT_ADMIN_EMAIL,
+	DEFAULT_ADMIN_USERNAME,
+	decodeAdminPassword,
+} from '@studio/common/lib/passwords';
 import { __ } from '@wordpress/i18n';
 import { CopyButton } from '@/components/copy-button';
 import styles from './cards.module.css';
@@ -28,9 +32,9 @@ function CredentialRow( {
 }
 
 export function AdminSection( { site }: { site: SiteDetails } ) {
-	const username = site.adminUsername ?? 'admin';
-	const password = site.adminPassword ? decodePassword( site.adminPassword ) : '';
-	const email = site.adminEmail ?? 'admin@localhost.com';
+	const username = site.adminUsername ?? DEFAULT_ADMIN_USERNAME;
+	const password = decodeAdminPassword( site.adminPassword );
+	const email = site.adminEmail ?? DEFAULT_ADMIN_EMAIL;
 
 	return (
 		<CardSection>

--- a/apps/ui/src/components/site-settings-view/index.tsx
+++ b/apps/ui/src/components/site-settings-view/index.tsx
@@ -1,6 +1,11 @@
 import { DEFAULT_WORDPRESS_VERSION } from '@studio/common/constants';
 import { generateCustomDomainFromSiteName } from '@studio/common/lib/domains';
-import { decodePassword, encodePassword } from '@studio/common/lib/passwords';
+import {
+	DEFAULT_ADMIN_EMAIL,
+	DEFAULT_ADMIN_USERNAME,
+	decodeAdminPassword,
+	encodePassword,
+} from '@studio/common/lib/passwords';
 import { RecommendedPHPVersion } from '@studio/common/types/php-versions';
 import { CheckboxControl } from '@wordpress/components';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
@@ -79,9 +84,9 @@ function initialFormData( site: SiteDetails, installedWpVersion?: string ): Form
 		useCustomDomain: Boolean( site.customDomain ),
 		customDomain: site.customDomain ?? '',
 		enableHttps: site.enableHttps ?? false,
-		adminUsername: site.adminUsername ?? 'admin',
-		adminPassword: decodePassword( site.adminPassword ?? '' ) || 'password',
-		adminEmail: site.adminEmail || 'admin@localhost.com',
+		adminUsername: site.adminUsername ?? DEFAULT_ADMIN_USERNAME,
+		adminPassword: decodeAdminPassword( site.adminPassword ),
+		adminEmail: site.adminEmail || DEFAULT_ADMIN_EMAIL,
 		enableXdebug: site.enableXdebug ?? false,
 		enableDebugLog: site.enableDebugLog ?? false,
 		enableDebugDisplay: site.enableDebugDisplay ?? false,

--- a/packages/common/lib/passwords.ts
+++ b/packages/common/lib/passwords.ts
@@ -4,6 +4,25 @@ import { __, sprintf } from '@wordpress/i18n';
 export { generatePassword };
 
 /**
+ * Defaults for a site's admin credentials, shared by both front ends and the CLI so an
+ * unset value resolves to the same thing everywhere. A site whose config predates these
+ * fields — or that only ever had one of them set — falls back to these on start.
+ */
+export const DEFAULT_ADMIN_USERNAME = 'admin';
+export const DEFAULT_ADMIN_PASSWORD = 'password';
+export const DEFAULT_ADMIN_EMAIL = 'admin@localhost.com';
+
+/**
+ * Resolves a site's stored (encoded) admin password to plain text, falling back to the
+ * default when nothing is stored. Callers that send credentials to WordPress must use
+ * this rather than skipping the field: omitting the password fails the admin API when
+ * the username names a user that does not exist yet.
+ */
+export function decodeAdminPassword( encodedPassword?: string ): string {
+	return encodedPassword ? decodePassword( encodedPassword ) : DEFAULT_ADMIN_PASSWORD;
+}
+
+/**
  * Generates a random, Base64-encoded password.
  *
  * @returns The Base64-encoded password.


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code investigated the failure from a real broken site, traced it to the admin-credentials request builder, wrote the fix and the regression test, and verified it end-to-end by rebuilding the CLI and starting the affected site.

## Proposed Changes

Changing a site's admin username in Settings — without also setting a password — left the site unable to start. Every start attempt failed with `Failed to set admin credentials: Password is required to create a new admin user`, and the server process was killed.

The cause was an inconsistent treatment of "no stored password" across the codebase. The settings screen displayed `password` as a default in the field, but that value was never persisted, and the startup path omitted the password from its request entirely when none was stored. WordPress can update an existing user without a password, but it cannot *create* one — so as soon as the username named a user that didn't exist yet, startup failed outright.

This makes the default a real value rather than field decoration: it now lives in `@studio/common` as a single source of truth and is actually sent to the CLI. A site in this state starts normally again and the renamed admin user is created, with the original user left intact (existing behavior). No action is needed from users whose sites already work.

Two related inconsistencies are fixed along the way:

- The site overview showed an empty password for sites with none stored, rather than the one the site actually uses.
- `apps/local` compared an unset password against `''` while the desktop compared against the encoded default, so a settings save could behave differently in the browser UI than in the desktop app.

**Known gap, not addressed here:** when startup fails this way, Studio misreports it as a PHP error — `isPhpUserError()` treats any non-infrastructure error as user PHP, and `parsePhpError()` finds nothing quotable in a Node stack trace, so the user sees a bare "PHP error during startup" page and a file watcher waiting for a `.php` edit that can never fix it. That misclassification is what made this bug hard to diagnose, and is worth a follow-up.

## Testing Instructions

Reproducing on trunk:

1. Create a site, then in Settings change the admin username to something that doesn't exist yet (e.g. `admine`) and save without touching the password field.
2. Stop and start the site — it fails to start, showing a "PHP Error Detected / PHP error during startup" page.
3. Confirm the real error in `~/.studio/daemon/logs/studio-site-<siteId>-error-*.log`: `Password is required to create a new admin user`.

With this branch, step 2 starts normally and the new admin user is created.

Also worth checking:

- Settings → admin password field still shows and saves correctly; changing the password still applies.
- Site overview shows admin credentials for a site that has never had a password saved.
- Creating a new site still gets a randomly generated password (not the shared default).
- Verify in both the Desktop app and the browser UI (`npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`), since both front ends are touched.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
