### PR TITLE
Agentic UI: Fix sidebar footer spacing around the beta bubble and Settings row

### DIFF
--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -162,6 +162,13 @@
 	padding: var(--wpds-dimension-padding-sm) calc(var(--wpds-dimension-padding-lg) - var(--wpds-dimension-padding-sm)) 0;
 }
 
+/* The shelf root stays mounted as the aria-live region even with nothing to
+   show, so an empty shelf must add no space between the beta bubble and the
+   Settings row. */
+.sidebarToasts:empty {
+	padding: 0;
+}
+
 /* --app-main-composer-height is published on the document by the session
    view's chrome observer, so the shelf rides above the composer as it grows.
    Views without a composer leave it unset and the shelf sits on the panel's

--- a/apps/ui/src/components/user-menu/style.module.css
+++ b/apps/ui/src/components/user-menu/style.module.css
@@ -12,10 +12,13 @@
 	);
 
 	/* SidebarButton adds `sm` inline padding; this offset puts the avatar's
-	   inline edge on the same column as the site icons. Account for the button's
-	   internal border so the visible block-end gap matches the inline-start gap. */
+	   inline edge on the same column as the site icons. Block-end: the avatar
+	   sits 15px from the sidebar's start edge (this offset plus the trigger's
+	   inline padding and border) but only 2px inside the trigger's bottom, so
+	   the bottom padding makes up the difference and the avatar is inset the
+	   same distance from the window's bottom edge as from its side. */
 	padding-block: var(--wpds-dimension-padding-sm)
-		calc(var(--user-menu-leading-offset) + var(--wpds-border-width-xs));
+		calc(var(--wpds-dimension-padding-md) + var(--wpds-border-width-xs));
 	padding-inline: var(--user-menu-leading-offset) var(--user-menu-trailing-offset);
 }
 


### PR DESCRIPTION
## Related issues

- Related to #4777

## How AI was used in this PR

- Claude Code investigated the diff from #4777, measured the rendered gaps in a `studio ui` build, and wrote the CSS. Reviewed by hand in light and dark.

## Proposed Changes

- #4777 moved the BETA bubble above the toast shelf. The shelf's root stays mounted as the `aria-live` region even when empty, so its 8px top padding now landed between BETA and the App settings row: gap went from 12px to 20px. An empty shelf now adds no space.
- The avatar sat 15px from the sidebar's side edge but only 11px from the window's bottom edge. Bottom padding of the Settings row goes up 4px so the corner is symmetric.

| | Before | After |
|---|---|---|
| Light | ![Before, light](https://github.com/Automattic/studio/blob/540e1c29324c62bea71a1729d4efce84593c1987/before-light.png?raw=true) | ![After, light](https://github.com/Automattic/studio/blob/540e1c29324c62bea71a1729d4efce84593c1987/after-light.png?raw=true) |
| Dark | ![Before, dark](https://github.com/Automattic/studio/blob/540e1c29324c62bea71a1729d4efce84593c1987/before-dark.png?raw=true) | ![After, dark](https://github.com/Automattic/studio/blob/540e1c29324c62bea71a1729d4efce84593c1987/after-dark.png?raw=true) |

## Testing Instructions

- `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`, open http://localhost:8081
- Sidebar footer: BETA sits 12px above the App settings row; avatar is 15px from both the left and bottom edges
- Trigger a toast (e.g. start/stop a site) and confirm it still gets its padding above the Settings row
- Check light and dark

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
