### PR TITLE
Agentic UI: Fix chat opening at the top after a cold start

### DIFF
--- a/apps/ui/src/ui-classic/components/session-view/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.test.tsx
@@ -255,6 +255,44 @@ describe( 'SessionView', () => {
 		);
 	} );
 
+	it( 'wires the scroller when the session loads before the quota check resolves', async () => {
+		// Cold start: the session is served from the persisted cache while the
+		// (never persisted) quota query is still loading, so the conversation
+		// scroller mounts in a later commit than the session data.
+		useSessionMock.mockReturnValue( {
+			data: makeLoadedSession(),
+			isLoading: false,
+			error: null,
+		} );
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: undefined,
+			isLoading: true,
+			isFetching: true,
+			refetch: vi.fn(),
+		} );
+
+		const { container, rerender } = render( <SessionView sessionId="session-1" /> );
+		const scroller = container.querySelector( '[class*="classicScroll"]' ) as HTMLDivElement;
+		setScrollMetrics( scroller, { scrollTop: 0, scrollHeight: 1000, clientHeight: 400 } );
+
+		useStudioAssistantQuotaMock.mockReturnValue( {
+			data: makeQuota( {} ),
+			isLoading: false,
+			isFetching: false,
+			refetch: vi.fn(),
+		} );
+		rerender( <SessionView sessionId="session-1" /> );
+
+		expect( container.querySelector( '[class*="classicScroll"]' ) ).toBe( scroller );
+		expect( scroller.scrollTop ).toBe( 1000 );
+
+		setScrollMetrics( scroller, { scrollTop: 100, scrollHeight: 1000, clientHeight: 400 } );
+		fireEvent.scroll( scroller );
+		expect(
+			await screen.findByRole( 'button', { name: SCROLL_TO_LATEST_LABEL } )
+		).toBeInTheDocument();
+	} );
+
 	it( 'gates the chat behind the payment requirement when no payment method is saved', () => {
 		useSessionMock.mockReturnValue( {
 			data: makeLoadedSession(),

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -65,6 +65,12 @@ export function isScrolledAwayFromLatest( node: {
 	);
 }
 
+// Kept outside the component: the React Compiler lint reads a direct
+// `scrollTop` store on a state-held node as a state mutation.
+function scrollToEnd( node: HTMLElement ) {
+	node.scrollTop = node.scrollHeight;
+}
+
 function SessionHeader( {
 	siteName,
 	site,
@@ -328,7 +334,11 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 			),
 		[ data?.entries ]
 	);
-	const scrollRef = useRef< HTMLDivElement >( null );
+	// The scroller only exists in the loaded frame, which can mount well after
+	// the session data arrives (a cold start serves the session from the
+	// persisted cache while the quota check is still pending). Keeping the node
+	// in state lets the scroll effects re-run when it appears; a ref can't.
+	const [ scrollNode, setScrollNode ] = useState< HTMLDivElement | null >( null );
 	const composerRef = useRef< ComposerHandle >( null );
 	useEffect(
 		() =>
@@ -338,24 +348,21 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 		[]
 	);
 	const [ isScrolledAway, setIsScrolledAway ] = useState( false );
-	const hasSession = !! data;
 
 	const updateIsScrolledAway = useCallback( () => {
-		const node = scrollRef.current;
-		if ( node ) {
-			setIsScrolledAway( isScrolledAwayFromLatest( node ) );
+		if ( scrollNode ) {
+			setIsScrolledAway( isScrolledAwayFromLatest( scrollNode ) );
 		}
-	}, [] );
+	}, [ scrollNode ] );
 
 	useEffect( () => {
-		const node = scrollRef.current;
-		if ( ! hasSession || ! node ) {
+		if ( ! scrollNode ) {
 			return;
 		}
 		updateIsScrolledAway();
-		node.addEventListener( 'scroll', updateIsScrolledAway, { passive: true } );
-		return () => node.removeEventListener( 'scroll', updateIsScrolledAway );
-	}, [ hasSession, updateIsScrolledAway ] );
+		scrollNode.addEventListener( 'scroll', updateIsScrolledAway, { passive: true } );
+		return () => scrollNode.removeEventListener( 'scroll', updateIsScrolledAway );
+	}, [ scrollNode, updateIsScrolledAway ] );
 
 	// Content can grow without emitting scroll events (e.g. while the
 	// auto-scroll below is suspended by pending questions), so re-check
@@ -369,13 +376,15 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 	}, [ sessionId ] );
 
 	const scrollToLatest = useCallback( () => {
-		const node = scrollRef.current;
-		if ( ! node ) {
+		if ( ! scrollNode ) {
 			return;
 		}
 		const prefersReducedMotion = window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches;
-		node.scrollTo( { top: node.scrollHeight, behavior: prefersReducedMotion ? 'auto' : 'smooth' } );
-	}, [] );
+		scrollNode.scrollTo( {
+			top: scrollNode.scrollHeight,
+			behavior: prefersReducedMotion ? 'auto' : 'smooth',
+		} );
+	}, [ scrollNode ] );
 	useSessionCommands( sessionId );
 	const canTogglePreview = !! ownerSite && effectiveEnvironment === 'local';
 	const siteSessionHistory = data
@@ -441,16 +450,14 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 	}, [ createSession, isEmpty, ownerSite, switchSession ] );
 
 	useLayoutEffect( () => {
-		const node = scrollRef.current;
-		if ( ! node || isScrolledAway || pendingQuestions.length > 0 ) {
+		if ( ! scrollNode || isScrolledAway || pendingQuestions.length > 0 ) {
 			return;
 		}
-		node.scrollTop = node.scrollHeight;
-		const id = requestAnimationFrame( () => {
-			node.scrollTop = node.scrollHeight;
-		} );
+		scrollToEnd( scrollNode );
+		const id = requestAnimationFrame( () => scrollToEnd( scrollNode ) );
 		return () => cancelAnimationFrame( id );
 	}, [
+		scrollNode,
 		sessionId,
 		data,
 		isRunning,
@@ -550,7 +557,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 
 	return (
 		<SessionFrame
-			scrollRef={ scrollRef }
+			scrollRef={ setScrollNode }
 			header={
 				<SessionHeader
 					siteName={ data.summary.ownerSiteName }


### PR DESCRIPTION
## Related issues

- None

## How AI was used in this PR

- Claude Code diagnosed the regression, wrote the fix and the regression test; diff reviewed by hand.

## Proposed Changes

- On a cold start, Studio opened the most recent chat scrolled to the top, and the scroll-to-latest button never appeared, even after scrolling up.
- Cause: the session is served from the persisted query cache before the AI-credits quota check resolves, so the conversation scroller mounts in a later render than the session data. The scroll effects ran once against a not-yet-mounted scroller and never re-ran. Regression from the quota gate in #4422 landing on top of the autoscroll pause in #4575.
- The scroll effects now key off the scroller itself, so the chat opens at the latest message and the button works regardless of which query resolves first. The same path covers the payment-method gate → chat transition.

## Testing Instructions

1. Quit Studio fully and relaunch so the quota query is cold.
2. The most recent chat opens scrolled to the latest message.
3. Scroll up: the scroll-to-latest button appears. Click it to return to the bottom.
4. Switch sessions and repeat.
5. `npm test -- apps/ui/src/ui-classic/components/session-view/index.test.tsx` — the new cold-start case fails on trunk and passes here.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
