### PR TITLE
Agentic UI: stream assistant replies as they arrive and keep your place while they do

### DIFF
--- a/apps/ui/src/components/markdown/index.tsx
+++ b/apps/ui/src/components/markdown/index.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { clsx } from 'clsx';
-import { isValidElement, useMemo } from 'react';
+import { isValidElement, memo, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { CopyButton } from '@/components/copy-button';
@@ -84,7 +84,15 @@ const baseComponents: Components = {
 	pre: ( { children } ) => <CodeBlock>{ children }</CodeBlock>,
 };
 
-export function Markdown( { children, className }: { children: string; className?: string } ) {
+// Memoized: the transcript re-renders every frame while a reply streams, and
+// only the block still receiving text should pay for a Markdown parse.
+export const Markdown = memo( function Markdown( {
+	children,
+	className,
+}: {
+	children: string;
+	className?: string;
+} ) {
 	const connector = useConnector();
 
 	const components = useMemo< Components >( () => {
@@ -122,4 +130,4 @@ export function Markdown( { children, className }: { children: string; className
 			</ReactMarkdown>
 		</div>
 	);
-}
+} );

--- a/apps/ui/src/data/queries/streaming-entry.ts
+++ b/apps/ui/src/data/queries/streaming-entry.ts
@@ -1,0 +1,17 @@
+import type { SessionEntry } from '@/data/core';
+
+// Marks the optimistic entry holding an assistant reply that is still
+// streaming in. UI-only: the flag lives on the cached object and never reaches
+// the session file, so it disappears when the post-run refetch replaces the
+// entry with the disk-backed one.
+interface StreamingEntryMarker {
+	streaming?: true;
+}
+
+export function markStreamingEntry( entry: SessionEntry ): SessionEntry {
+	return { ...entry, streaming: true } as SessionEntry & StreamingEntryMarker;
+}
+
+export function isStreamingEntry( entry: SessionEntry ): boolean {
+	return ( entry as StreamingEntryMarker ).streaming === true;
+}

--- a/apps/ui/src/data/queries/use-agent-run.test.tsx
+++ b/apps/ui/src/data/queries/use-agent-run.test.tsx
@@ -251,3 +251,153 @@ describe( 'useAgentRun queued handoff', () => {
 		nowSpy.mockRestore();
 	} );
 } );
+
+describe( 'useAgentRun streamed assistant text', () => {
+	let agentListener: ( event: AgentRunEvent ) => void;
+
+	beforeEach( () => {
+		useConnectorMock.mockReturnValue( {
+			continueSession: vi.fn().mockResolvedValue( { runId: 'run-1' } ),
+			getActiveAgentRuns: vi.fn().mockResolvedValue( [] ),
+			onAgentEvent: vi.fn( ( listener: ( event: AgentRunEvent ) => void ) => {
+				agentListener = listener;
+				return vi.fn();
+			} ),
+		} as unknown as Connector );
+		outOfCreditsState.value = false;
+	} );
+
+	afterEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	function emitPiEvent( message: Record< string, unknown > ) {
+		act( () => {
+			agentListener( {
+				sessionId: 'session-1',
+				runId: 'run-1',
+				event: {
+					type: 'message',
+					timestamp: '2026-06-24T12:00:00.000Z',
+					message,
+				} as unknown as AgentRunEvent[ 'event' ],
+			} );
+		} );
+	}
+
+	function getAssistantEntries( queryClient: QueryClient ) {
+		const entries =
+			queryClient.getQueryData< LoadedAiSession >( [ ...SESSIONS_QUERY_KEY, 'session-1' ] )
+				?.entries ?? [];
+		return entries
+			.filter(
+				( entry ) =>
+					entry.type === 'message' &&
+					( entry as { message: { role: string } } ).message.role === 'assistant'
+			)
+			.map(
+				( entry ) => entry as { id: string; streaming?: true; message: { content: unknown[] } }
+			);
+	}
+
+	async function startRun( queryClient: QueryClient ) {
+		queryClient.setQueryData< LoadedAiSession >(
+			[ ...SESSIONS_QUERY_KEY, 'session-1' ],
+			createLoadedSession()
+		);
+		renderWithAgentRun( queryClient );
+		await waitFor( () => expect( agentListener ).toBeDefined() );
+		act( () => {
+			agentListener( {
+				sessionId: 'session-1',
+				runId: 'run-1',
+				event: { type: 'run.started', timestamp: '2026-06-24T12:00:00.000Z' },
+			} );
+		} );
+	}
+
+	it( 'grows one assistant entry from deltas and swaps in the final message in place', async () => {
+		const queryClient = createQueryClient();
+		await startRun( queryClient );
+
+		emitPiEvent( { type: 'message_start', message: { role: 'assistant', content: [] } } );
+		expect( getAssistantEntries( queryClient ) ).toHaveLength( 1 );
+		expect( getAssistantEntries( queryClient )[ 0 ].streaming ).toBe( true );
+		const entryId = getAssistantEntries( queryClient )[ 0 ].id;
+
+		emitPiEvent( {
+			type: 'message_update',
+			assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'Hel' },
+			message: { role: 'assistant', content: [ { type: 'text', text: 'Hel' } ] },
+		} );
+		emitPiEvent( {
+			type: 'message_update',
+			assistantMessageEvent: { type: 'toolcall_start', contentIndex: 1 },
+			message: {
+				role: 'assistant',
+				content: [
+					{ type: 'text', text: 'Hello' },
+					{ type: 'toolCall', id: 'call-1', name: 'read_file', arguments: {} },
+				],
+			},
+		} );
+
+		// Deltas coalesce into one write per frame; the half-built tool call is
+		// held back until the message ends.
+		await waitFor( () =>
+			expect( getAssistantEntries( queryClient )[ 0 ].message.content ).toEqual( [
+				{ type: 'text', text: 'Hello' },
+			] )
+		);
+		expect( getAssistantEntries( queryClient ) ).toHaveLength( 1 );
+
+		const finalMessage = {
+			role: 'assistant',
+			content: [
+				{ type: 'text', text: 'Hello world' },
+				{ type: 'toolCall', id: 'call-1', name: 'read_file', arguments: { path: 'a.php' } },
+			],
+		};
+		emitPiEvent( { type: 'message_end', message: finalMessage } );
+
+		const entries = getAssistantEntries( queryClient );
+		expect( entries ).toHaveLength( 1 );
+		expect( entries[ 0 ].id ).toBe( entryId );
+		expect( entries[ 0 ].streaming ).toBeUndefined();
+		expect( entries[ 0 ].message.content ).toEqual( finalMessage.content );
+	} );
+
+	it( 'starts the streamed entry from the first delta when message_start was missed', async () => {
+		const queryClient = createQueryClient();
+		await startRun( queryClient );
+
+		emitPiEvent( {
+			type: 'message_update',
+			assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'Hi' },
+			message: { role: 'assistant', content: [ { type: 'text', text: 'Hi' } ] },
+		} );
+		expect( getAssistantEntries( queryClient )[ 0 ].message.content ).toEqual( [
+			{ type: 'text', text: 'Hi' },
+		] );
+
+		emitPiEvent( {
+			type: 'message_end',
+			message: { role: 'assistant', content: [ { type: 'text', text: 'Hi there' } ] },
+		} );
+		const entries = getAssistantEntries( queryClient );
+		expect( entries ).toHaveLength( 1 );
+		expect( entries[ 0 ].message.content ).toEqual( [ { type: 'text', text: 'Hi there' } ] );
+	} );
+
+	it( 'ignores streamed user and tool-result messages', async () => {
+		const queryClient = createQueryClient();
+		await startRun( queryClient );
+
+		emitPiEvent( { type: 'message_start', message: { role: 'user', content: 'prompt' } } );
+		emitPiEvent( {
+			type: 'message_start',
+			message: { role: 'toolResult', toolCallId: 'call-1', content: [] },
+		} );
+		expect( getAssistantEntries( queryClient ) ).toHaveLength( 0 );
+	} );
+} );

--- a/apps/ui/src/data/queries/use-agent-run.tsx
+++ b/apps/ui/src/data/queries/use-agent-run.tsx
@@ -14,6 +14,7 @@ import {
 	type PropsWithChildren,
 } from 'react';
 import { useConnector } from '@/data/core';
+import { markStreamingEntry } from '@/data/queries/streaming-entry';
 import { ASSISTANT_QUOTA_QUERY_KEY } from '@/data/queries/use-assistant-quota';
 import { SESSIONS_QUERY_KEY } from '@/data/queries/use-sessions';
 import { useIsOutOfAiCredits } from '@/hooks/use-is-out-of-ai-credits';
@@ -38,6 +39,50 @@ function newId(): string {
 // Optimistic entry id; the next refetch replaces it with the disk-backed one.
 function shortEntryId(): string {
 	return Math.random().toString( 36 ).slice( 2, 10 );
+}
+
+type AgentMessage = Extract< SessionEntry, { type: 'message' } >[ 'message' ];
+
+interface StreamingEntry {
+	entryId: string;
+	timestamp: string;
+}
+
+function isAssistantMessage( message: unknown ): boolean {
+	return ( message as { role?: string } | undefined )?.role === 'assistant';
+}
+
+function buildMessageEntry( entryId: string, timestamp: string, message: unknown ): SessionEntry {
+	return {
+		type: 'message',
+		id: entryId,
+		parentId: null,
+		timestamp,
+		message,
+	} as unknown as SessionEntry;
+}
+
+// Tool-call blocks stream in with their arguments as partial JSON; hold them
+// back until `message_end` so tool rows never render half-built input.
+function toStreamingMessage( message: AgentMessage ): AgentMessage {
+	const content = ( message as { content?: unknown } ).content;
+	if ( ! Array.isArray( content ) ) {
+		return message;
+	}
+	return {
+		...message,
+		content: content.filter( ( block ) => ( block as { type?: string } | null )?.type === 'text' ),
+	} as AgentMessage;
+}
+
+function upsertEntry( entries: SessionEntry[], entry: SessionEntry ): SessionEntry[] {
+	const index = entries.findIndex( ( candidate ) => candidate.id === entry.id );
+	if ( index === -1 ) {
+		return [ ...entries, entry ];
+	}
+	const next = entries.slice();
+	next[ index ] = entry;
+	return next;
 }
 
 export interface PendingQuestion {
@@ -296,6 +341,13 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 	const ignoredRunIdsRef = useRef< Set< string > >( new Set() );
 	const interruptRequestsBySessionRef = useRef< Map< string, Promise< void > > >( new Map() );
 	const interruptPendingStartSessionIdsRef = useRef< Set< string > >( new Set() );
+	// The in-flight assistant reply per session: an optimistic entry that
+	// `message_update` rewrites in place until `message_end` swaps in the final.
+	const streamingEntriesBySessionRef = useRef< Map< string, StreamingEntry > >( new Map() );
+	// Deltas arrive per token; coalesce them into one cache write per frame so a
+	// long reply doesn't re-render the transcript hundreds of times a second.
+	const pendingStreamUpdatesBySessionRef = useRef< Map< string, AgentMessage > >( new Map() );
+	const cancelStreamFlushRef = useRef< ( () => void ) | null >( null );
 
 	const dispatchSession = useCallback(
 		( sessionId: string, action: Action ) => {
@@ -320,6 +372,44 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 		},
 		[ queryClient ]
 	);
+
+	const flushStreamUpdates = useCallback( () => {
+		cancelStreamFlushRef.current = null;
+		const pending = Array.from( pendingStreamUpdatesBySessionRef.current );
+		pendingStreamUpdatesBySessionRef.current.clear();
+		for ( const [ sessionId, message ] of pending ) {
+			const streaming = streamingEntriesBySessionRef.current.get( sessionId );
+			if ( ! streaming ) {
+				continue;
+			}
+			updateCache( sessionId, ( entries ) =>
+				upsertEntry(
+					entries,
+					markStreamingEntry( buildMessageEntry( streaming.entryId, streaming.timestamp, message ) )
+				)
+			);
+		}
+	}, [ updateCache ] );
+
+	const scheduleStreamFlush = useCallback( () => {
+		if ( cancelStreamFlushRef.current ) {
+			return;
+		}
+		if ( typeof requestAnimationFrame === 'function' ) {
+			const handle = requestAnimationFrame( flushStreamUpdates );
+			cancelStreamFlushRef.current = () => cancelAnimationFrame( handle );
+			return;
+		}
+		const handle = setTimeout( flushStreamUpdates, 16 );
+		cancelStreamFlushRef.current = () => clearTimeout( handle );
+	}, [ flushStreamUpdates ] );
+
+	const clearStreamingState = useCallback( ( sessionId: string ) => {
+		streamingEntriesBySessionRef.current.delete( sessionId );
+		pendingStreamUpdatesBySessionRef.current.delete( sessionId );
+	}, [] );
+
+	useEffect( () => () => cancelStreamFlushRef.current?.(), [] );
 
 	useEffect( () => {
 		let cancelled = false;
@@ -405,6 +495,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					}
 					dispatchSession( payload.sessionId, { type: 'run_ended' } );
 					subscribedRunIdsBySessionRef.current.delete( payload.sessionId );
+					clearStreamingState( payload.sessionId );
 					// The finished run consumed AI credits; refresh the balance shown
 					// in the composer and in Settings → Usage.
 					void queryClient.invalidateQueries( { queryKey: ASSISTANT_QUOTA_QUERY_KEY } );
@@ -443,22 +534,58 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 						] );
 						return;
 					}
-					// Only message-bearing pi event variants need optimistic entries.
-					if (
-						inner.type === 'message_end' &&
-						( inner.message as { role?: string } ).role === 'assistant'
-					) {
-						updateCache( payload.sessionId, ( entries ) => [
-							...entries,
-							{
-								type: 'message',
-								id: shortEntryId(),
-								parentId: null,
+					if ( inner.type === 'message_start' || inner.type === 'message_update' ) {
+						if ( ! isAssistantMessage( inner.message ) ) {
+							return;
+						}
+						const streaming = streamingEntriesBySessionRef.current.get( payload.sessionId );
+						if ( ! streaming || inner.type === 'message_start' ) {
+							// First sight of this reply — or a reload mid-run that missed
+							// `message_start` — so append the optimistic entry right away.
+							const started: StreamingEntry = {
+								entryId: shortEntryId(),
 								timestamp: event.timestamp,
-								message: inner.message,
-							} as unknown as SessionEntry,
-						] );
-					} else if ( inner.type === 'turn_end' ) {
+							};
+							streamingEntriesBySessionRef.current.set( payload.sessionId, started );
+							pendingStreamUpdatesBySessionRef.current.delete( payload.sessionId );
+							updateCache( payload.sessionId, ( entries ) => [
+								...entries,
+								markStreamingEntry(
+									buildMessageEntry(
+										started.entryId,
+										started.timestamp,
+										toStreamingMessage( inner.message )
+									)
+								),
+							] );
+							return;
+						}
+						pendingStreamUpdatesBySessionRef.current.set(
+							payload.sessionId,
+							toStreamingMessage( inner.message )
+						);
+						scheduleStreamFlush();
+						return;
+					}
+					if ( inner.type === 'message_end' ) {
+						if ( ! isAssistantMessage( inner.message ) ) {
+							return;
+						}
+						const streaming = streamingEntriesBySessionRef.current.get( payload.sessionId );
+						clearStreamingState( payload.sessionId );
+						updateCache( payload.sessionId, ( entries ) =>
+							upsertEntry(
+								entries,
+								buildMessageEntry(
+									streaming?.entryId ?? shortEntryId(),
+									streaming?.timestamp ?? event.timestamp,
+									inner.message
+								)
+							)
+						);
+						return;
+					}
+					if ( inner.type === 'turn_end' ) {
 						const toolResults = inner.toolResults;
 						if ( Array.isArray( toolResults ) && toolResults.length > 0 ) {
 							updateCache( payload.sessionId, ( entries ) => [
@@ -529,7 +656,15 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					return;
 			}
 		} );
-	}, [ connector, dispatchSession, queryClient, stateStore, updateCache ] );
+	}, [
+		clearStreamingState,
+		connector,
+		dispatchSession,
+		queryClient,
+		scheduleStreamFlush,
+		stateStore,
+		updateCache,
+	] );
 
 	const startRun = useCallback(
 		async ( sessionId: string, prompt: string, options: SendMessageOptions = {} ) => {
@@ -605,6 +740,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 				interruptPendingStartSessionIdsRef.current.add( sessionId );
 			}
 			subscribedRunIdsBySessionRef.current.delete( sessionId );
+			clearStreamingState( sessionId );
 			updateCache( sessionId, ( entries ) => [
 				...entries,
 				{
@@ -631,7 +767,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 			interruptRequestsBySessionRef.current.set( sessionId, interruptRequest );
 			await interruptRequest;
 		},
-		[ connector, dispatchSession, stateStore, updateCache ]
+		[ clearStreamingState, connector, dispatchSession, stateStore, updateCache ]
 	);
 
 	const answerQuestion = useCallback(

--- a/apps/ui/src/hooks/use-smooth-streaming-text.test.ts
+++ b/apps/ui/src/hooks/use-smooth-streaming-text.test.ts
@@ -1,0 +1,109 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { advanceReveal, useSmoothStreamingText } from './use-smooth-streaming-text';
+
+describe( 'advanceReveal', () => {
+	it( 'holds a half-typed word while the reply is live', () => {
+		const next = advanceReveal( { visible: 0, pending: 0 }, 'Hello world', 0.05, true );
+		expect( next.visible ).toBe( 0 );
+		expect( next.pending ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'cuts right before whitespace once the budget reaches past a word', () => {
+		const next = advanceReveal( { visible: 0, pending: 8 }, 'Hello brave world', 0, true );
+		expect( next.visible ).toBe( 5 );
+		expect( next.pending ).toBeCloseTo( 3 );
+	} );
+
+	it( 'never shows the trailing partial word while live', () => {
+		const next = advanceReveal( { visible: 0, pending: 100 }, 'Hello world', 0, true );
+		expect( next.visible ).toBe( 5 );
+	} );
+
+	it( 'reveals the whole text once the reply has ended', () => {
+		const next = advanceReveal( { visible: 5, pending: 100 }, 'Hello world', 0, false );
+		expect( next ).toEqual( { visible: 11, pending: 0 } );
+	} );
+
+	it( 'shows long unbroken tokens in slices instead of stalling', () => {
+		const url = 'https://example.com/a/very/long/path/without/spaces';
+		const next = advanceReveal( { visible: 0, pending: 30 }, `${ url } next`, 0, true );
+		expect( next.visible ).toBe( 30 );
+	} );
+
+	it( 'counts newlines as word boundaries', () => {
+		const next = advanceReveal( { visible: 0, pending: 12 }, 'One\n\nTwo three', 0, true );
+		expect( next.visible ).toBe( 8 );
+	} );
+
+	it( 'caps a single frame so a backgrounded tab does not dump its backlog', () => {
+		const target = 'a'.repeat( 400 ) + ' ' + 'b'.repeat( 400 );
+		const next = advanceReveal( { visible: 0, pending: 0 }, target, 5, false );
+		expect( next.visible ).toBeLessThan( target.length );
+	} );
+} );
+
+describe( 'useSmoothStreamingText', () => {
+	afterEach( () => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	} );
+
+	it( 'shows finished text immediately and never schedules a frame', () => {
+		const raf = vi.fn();
+		vi.stubGlobal( 'requestAnimationFrame', raf );
+		const { result } = renderHook( () => useSmoothStreamingText( 'Already done', false ) );
+		expect( result.current ).toBe( 'Already done' );
+		expect( raf ).not.toHaveBeenCalled();
+	} );
+
+	it( 'reveals live text word by word and drains the rest once the reply ends', () => {
+		const frames: FrameRequestCallback[] = [];
+		vi.stubGlobal( 'requestAnimationFrame', ( callback: FrameRequestCallback ) => {
+			frames.push( callback );
+			return frames.length;
+		} );
+		vi.stubGlobal( 'cancelAnimationFrame', vi.fn() );
+		vi.spyOn( performance, 'now' ).mockReturnValue( 0 );
+
+		const { result, rerender } = renderHook(
+			( { text, isLive }: { text: string; isLive: boolean } ) =>
+				useSmoothStreamingText( text, isLive ),
+			{ initialProps: { text: 'Hello brave new world', isLive: true } }
+		);
+		expect( result.current ).toBe( '' );
+
+		let now = 0;
+		const runFrame = () => {
+			now += 100;
+			const frame = frames.shift();
+			expect( frame ).toBeDefined();
+			act( () => frame?.( now ) );
+		};
+
+		runFrame();
+		expect( result.current ).toBe( 'Hello' );
+		runFrame();
+		expect( result.current ).toBe( 'Hello' );
+		runFrame();
+		// "world" is still the trailing partial word, so it waits.
+		expect( result.current ).toBe( 'Hello brave new' );
+
+		rerender( { text: 'Hello brave new world', isLive: false } );
+		for ( let guard = 0; frames.length > 0 && guard < 10; guard += 1 ) {
+			runFrame();
+		}
+		expect( result.current ).toBe( 'Hello brave new world' );
+		expect( frames ).toHaveLength( 0 );
+	} );
+
+	it( 'shows a re-keyed finished message whole instead of replaying it', () => {
+		const { result, rerender } = renderHook(
+			( { text, isLive }: { text: string; isLive: boolean } ) =>
+				useSmoothStreamingText( text, isLive ),
+			{ initialProps: { text: 'Short reply', isLive: false } }
+		);
+		rerender( { text: 'A completely different and much longer message', isLive: false } );
+		expect( result.current ).toBe( 'A completely different and much longer message' );
+	} );
+} );

--- a/apps/ui/src/hooks/use-smooth-streaming-text.ts
+++ b/apps/ui/src/hooks/use-smooth-streaming-text.ts
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useState } from 'react';
+
+// How far the shown text trails the received text. Deltas arrive in bursts
+// (token batching, proxy buffering); draining each burst over this window
+// turns it into an even flow without letting the display fall behind.
+const LIVE_LAG_SECONDS = 0.35;
+// Once the reply has ended there is nothing left to smooth against, so the
+// remainder empties quickly instead of trailing the finished message.
+const FINISHED_LAG_SECONDS = 0.12;
+const MIN_CHARS_PER_SECOND = 40;
+const MAX_CHARS_PER_SECOND = 4000;
+// A hidden tab pauses animation frames; cap one frame's catch-up so the first
+// frame back doesn't dump everything at once.
+const MAX_FRAME_SECONDS = 0.1;
+// Past this many characters without whitespace (a URL, a code identifier) the
+// reveal stops waiting for a word boundary rather than stalling.
+const LONG_TOKEN_CHARS = 24;
+
+export interface RevealState {
+	// Characters of the target currently shown.
+	visible: number;
+	// Fractional character budget carried between frames.
+	pending: number;
+}
+
+function isWhitespace( char: string ): boolean {
+	return char === ' ' || char === '\n' || char === '\t' || char === '\r';
+}
+
+// Largest index in (from, to] that sits right before a whitespace character,
+// or `from` when there is none.
+function lastWordBoundary( text: string, from: number, to: number ): number {
+	for ( let index = to; index > from; index -= 1 ) {
+		if ( index < text.length && isWhitespace( text[ index ] ) ) {
+			return index;
+		}
+	}
+	return from;
+}
+
+export function advanceReveal(
+	state: RevealState,
+	target: string,
+	dtSeconds: number,
+	isLive: boolean
+): RevealState {
+	const backlog = target.length - state.visible;
+	if ( backlog <= 0 ) {
+		return { visible: target.length, pending: 0 };
+	}
+	const lag = isLive ? LIVE_LAG_SECONDS : FINISHED_LAG_SECONDS;
+	const rate = Math.min( MAX_CHARS_PER_SECOND, Math.max( MIN_CHARS_PER_SECOND, backlog / lag ) );
+	const dt = Math.min( Math.max( dtSeconds, 0 ), MAX_FRAME_SECONDS );
+	const pending = state.pending + rate * dt;
+	const candidate = Math.min( target.length, state.visible + Math.floor( pending ) );
+
+	let cut = candidate;
+	// While live, stop before whitespace: a half-typed word can wrap onto the
+	// next line and jump back when the rest of it lands. A finished reply is
+	// final text, so its tail just drains.
+	if ( isLive ) {
+		const boundary = lastWordBoundary( target, state.visible, candidate );
+		if ( boundary > state.visible ) {
+			cut = boundary;
+		} else if ( candidate - state.visible < LONG_TOKEN_CHARS ) {
+			return { visible: state.visible, pending: Math.min( pending, LONG_TOKEN_CHARS ) };
+		}
+	}
+	return {
+		visible: cut,
+		pending: cut === target.length ? 0 : pending - ( cut - state.visible ),
+	};
+}
+
+function prefersReducedMotion(): boolean {
+	return window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches ?? false;
+}
+
+/**
+ * Meter a streaming text block onto the screen at an even pace. `text` is the
+ * latest received content; while `isLive` the visible portion chases it at
+ * word boundaries, and once the reply ends the remainder drains quickly.
+ * Text that mounts finished (history) shows whole and never animates.
+ */
+export function useSmoothStreamingText( text: string, isLive: boolean ): string {
+	const [ reduceMotion ] = useState( prefersReducedMotion );
+	const [ visible, setVisible ] = useState( () => ( isLive ? 0 : text.length ) );
+	const [ previousText, setPreviousText ] = useState( text );
+	if ( text !== previousText ) {
+		setPreviousText( text );
+		// The post-run refetch can re-key this row to a different message; show
+		// that one whole instead of replaying it.
+		if ( ! isLive && ! text.startsWith( previousText.slice( 0, visible ) ) ) {
+			setVisible( text.length );
+		}
+	}
+
+	const stateRef = useRef< RevealState >( { visible, pending: 0 } );
+	const targetRef = useRef( text );
+	const liveRef = useRef( isLive );
+	const frameRef = useRef( 0 );
+	const lastFrameRef = useRef( 0 );
+
+	useEffect( () => {
+		targetRef.current = text;
+		liveRef.current = isLive;
+		if ( stateRef.current.visible < visible ) {
+			stateRef.current = { visible, pending: 0 };
+		}
+		if ( reduceMotion || frameRef.current || stateRef.current.visible >= text.length ) {
+			return;
+		}
+		lastFrameRef.current = performance.now();
+		const tick = ( now: number ) => {
+			const next = advanceReveal(
+				stateRef.current,
+				targetRef.current,
+				( now - lastFrameRef.current ) / 1000,
+				liveRef.current
+			);
+			lastFrameRef.current = now;
+			stateRef.current = next;
+			setVisible( next.visible );
+			frameRef.current =
+				next.visible < targetRef.current.length ? requestAnimationFrame( tick ) : 0;
+		};
+		frameRef.current = requestAnimationFrame( tick );
+	}, [ isLive, reduceMotion, text, visible ] );
+
+	useEffect( () => () => cancelAnimationFrame( frameRef.current ), [] );
+
+	if ( reduceMotion || visible >= text.length ) {
+		return text;
+	}
+	return text.slice( 0, visible );
+}

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -84,8 +84,10 @@ import { AiAccessRequiredNotice, AiBlockedNotice } from '@/components/ai-access-
 import { CopyButton } from '@/components/copy-button';
 import { Markdown } from '@/components/markdown';
 import { useConnector, type LoadedAiSession } from '@/data/core';
+import { isStreamingEntry } from '@/data/queries/streaming-entry';
 import { useStudioAssistantQuota } from '@/data/queries/use-assistant-quota';
 import { useLocalMediaDataUrl } from '@/data/queries/use-local-media';
+import { useSmoothStreamingText } from '@/hooks/use-smooth-streaming-text';
 import { MESSAGE_TEXT_ATTRIBUTE, QUOTABLE_TEXT_ATTRIBUTE } from '@/hooks/use-text-context-menu';
 import { refreshIcon } from '@/lib/icons';
 import { ThinkingIndicator } from '../thinking-indicator';
@@ -106,7 +108,16 @@ type RenderItem =
 			text: string;
 			attachments?: StudioChatAttachmentSummary[];
 	  }
-	| { kind: 'assistant-text'; key: string; text: string; messageText: string; copyText?: string }
+	| {
+			kind: 'assistant-text';
+			key: string;
+			text: string;
+			messageText: string;
+			copyText?: string;
+			// The block still receiving tokens; only ever the last text block of
+			// the reply being streamed.
+			isStreaming?: boolean;
+	  }
 	| {
 			kind: 'tool-use';
 			key: string;
@@ -282,6 +293,7 @@ export function entriesToRenderItems(
 				.map( ( block ) => ( block.text as string ).trim() )
 				.join( '\n\n' );
 			const lastTextBlock = textBlocks[ textBlocks.length - 1 ];
+			const streaming = isStreamingEntry( entry );
 
 			message.content.forEach( ( block, blockIndex ) => {
 				if ( block.type === 'text' && typeof block.text === 'string' ) {
@@ -293,6 +305,7 @@ export function entriesToRenderItems(
 							text,
 							messageText: fullMessageText,
 							copyText: block === lastTextBlock ? fullMessageText : undefined,
+							isStreaming: streaming && block === lastTextBlock,
 						} );
 					}
 				} else if (
@@ -456,15 +469,18 @@ function AssistantText( {
 	text,
 	messageText,
 	copyText,
+	isStreaming = false,
 	showActions,
 	onToggleSelect,
 }: {
 	text: string;
 	messageText: string;
 	copyText?: string;
+	isStreaming?: boolean;
 	showActions: boolean;
 	onToggleSelect: () => void;
 } ) {
+	const visibleText = useSmoothStreamingText( text, isStreaming );
 	const handleClick = ( event: ReactMouseEvent< HTMLDivElement > ) => {
 		// Links and the buttons inside code blocks or the action row own their
 		// clicks; only bare message content toggles the actions.
@@ -493,7 +509,7 @@ function AssistantText( {
 			} }
 			onClick={ copyText ? handleClick : undefined }
 		>
-			<Markdown>{ text }</Markdown>
+			<Markdown>{ visibleText }</Markdown>
 			{ copyText ? (
 				<div className={ styles.messageActions }>
 					<div className={ styles.messageActionsClip }>
@@ -1335,6 +1351,7 @@ export function Conversation( {
 								text={ item.text }
 								messageText={ item.messageText }
 								copyText={ item.copyText }
+								isStreaming={ item.isStreaming }
 								showActions={ selectedKey === item.key || item.key === latestActionableKey }
 								onToggleSelect={ () =>
 									setSelectedKey( ( current ) => ( current === item.key ? null : item.key ) )

--- a/apps/ui/src/ui-classic/components/session-view/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.test.tsx
@@ -255,6 +255,50 @@ describe( 'SessionView', () => {
 		);
 	} );
 
+	it( 'stops following new content after an upward wheel and resumes at the bottom', () => {
+		const session = () => ( { data: makeLoadedSession(), isLoading: false as const, error: null } );
+		useSessionMock.mockReturnValue( session() );
+		const { container, rerender } = render( <SessionView sessionId="session-1" /> );
+		const scroller = container.querySelector( '[class*="classicScroll"]' ) as HTMLDivElement;
+
+		// Pinned to the bottom of a transcript taller than the viewport.
+		setScrollMetrics( scroller, { scrollTop: 600, scrollHeight: 1000, clientHeight: 400 } );
+		fireEvent.scroll( scroller );
+
+		// One upward wheel tick, still inside the "scrolled away" slack.
+		fireEvent.wheel( scroller, { deltaY: -10 } );
+		scroller.scrollTop = 590;
+		fireEvent.scroll( scroller );
+
+		// New content lands; the reading position must hold.
+		useSessionMock.mockReturnValue( session() );
+		rerender( <SessionView sessionId="session-1" /> );
+		expect( scroller.scrollTop ).toBe( 590 );
+
+		// Back at the bottom, following resumes.
+		scroller.scrollTop = 600;
+		fireEvent.scroll( scroller );
+		useSessionMock.mockReturnValue( session() );
+		rerender( <SessionView sessionId="session-1" /> );
+		expect( scroller.scrollTop ).toBe( 1000 );
+	} );
+
+	it( 'stops following after a scrollbar drag up, which has no wheel event', () => {
+		const session = () => ( { data: makeLoadedSession(), isLoading: false as const, error: null } );
+		useSessionMock.mockReturnValue( session() );
+		const { container, rerender } = render( <SessionView sessionId="session-1" /> );
+		const scroller = container.querySelector( '[class*="classicScroll"]' ) as HTMLDivElement;
+
+		setScrollMetrics( scroller, { scrollTop: 600, scrollHeight: 1000, clientHeight: 400 } );
+		fireEvent.scroll( scroller );
+		scroller.scrollTop = 100;
+		fireEvent.scroll( scroller );
+
+		useSessionMock.mockReturnValue( session() );
+		rerender( <SessionView sessionId="session-1" /> );
+		expect( scroller.scrollTop ).toBe( 100 );
+	} );
+
 	it( 'gates the chat behind the payment requirement when no payment method is saved', () => {
 		useSessionMock.mockReturnValue( {
 			data: makeLoadedSession(),

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -338,6 +338,11 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 		[]
 	);
 	const [ isScrolledAway, setIsScrolledAway ] = useState( false );
+	// Whether new content should pull the view to the bottom. A ref rather than
+	// state: while a reply streams the pin runs every frame, so the decision has
+	// to be current the instant the user scrolls, not one render later.
+	const followLatestRef = useRef( true );
+	const lastScrollTopRef = useRef( 0 );
 	const hasSession = !! data;
 
 	const updateIsScrolledAway = useCallback( () => {
@@ -352,9 +357,37 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 		if ( ! hasSession || ! node ) {
 			return;
 		}
+		lastScrollTopRef.current = node.scrollTop;
 		updateIsScrolledAway();
-		node.addEventListener( 'scroll', updateIsScrolledAway, { passive: true } );
-		return () => node.removeEventListener( 'scroll', updateIsScrolledAway );
+		// Any upward wheel is a request to read, even one that hasn't moved past
+		// the "scrolled away" slack yet — a trackpad starts in single pixels.
+		const handleWheel = ( event: WheelEvent ) => {
+			if ( event.deltaY < 0 ) {
+				followLatestRef.current = false;
+			}
+		};
+		const handleScroll = () => {
+			const away = isScrolledAwayFromLatest( node );
+			const movedUp = node.scrollTop < lastScrollTopRef.current - 1;
+			lastScrollTopRef.current = node.scrollTop;
+			if ( movedUp ) {
+				// Scrollbar drags and keyboard jumps have no wheel event, so a
+				// clear move up counts too. A nudge inside the slack doesn't: that
+				// is content reflow, not the user.
+				if ( away ) {
+					followLatestRef.current = false;
+				}
+			} else if ( ! away ) {
+				followLatestRef.current = true;
+			}
+			setIsScrolledAway( away );
+		};
+		node.addEventListener( 'wheel', handleWheel, { passive: true } );
+		node.addEventListener( 'scroll', handleScroll, { passive: true } );
+		return () => {
+			node.removeEventListener( 'wheel', handleWheel );
+			node.removeEventListener( 'scroll', handleScroll );
+		};
 	}, [ hasSession, updateIsScrolledAway ] );
 
 	// Content can grow without emitting scroll events (e.g. while the
@@ -365,6 +398,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 	}, [ data, pendingQuestions.length, queuedPrompts.length, updateIsScrolledAway ] );
 
 	useLayoutEffect( () => {
+		followLatestRef.current = true;
 		setIsScrolledAway( false );
 	}, [ sessionId ] );
 
@@ -440,14 +474,33 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 		}
 	}, [ createSession, isEmpty, ownerSite, switchSession ] );
 
+	// Between cache updates the reply's text is revealed at a metered pace, so
+	// the transcript grows without `data` changing. Follow that growth too.
+	useEffect( () => {
+		const node = scrollRef.current;
+		if ( ! node || typeof ResizeObserver === 'undefined' ) {
+			return;
+		}
+		const observer = new ResizeObserver( () => {
+			if ( ! followLatestRef.current || pendingQuestions.length > 0 ) {
+				return;
+			}
+			node.scrollTop = node.scrollHeight;
+		} );
+		Array.from( node.children ).forEach( ( child ) => observer.observe( child ) );
+		return () => observer.disconnect();
+	}, [ hasSession, pendingQuestions.length, sessionId ] );
+
 	useLayoutEffect( () => {
 		const node = scrollRef.current;
-		if ( ! node || isScrolledAway || pendingQuestions.length > 0 ) {
+		if ( ! node || ! followLatestRef.current || pendingQuestions.length > 0 ) {
 			return;
 		}
 		node.scrollTop = node.scrollHeight;
 		const id = requestAnimationFrame( () => {
-			node.scrollTop = node.scrollHeight;
+			if ( followLatestRef.current ) {
+				node.scrollTop = node.scrollHeight;
+			}
 		} );
 		return () => cancelAnimationFrame( id );
 	}, [


### PR DESCRIPTION
## Related issues

- Related to #3360 (the pi-coding-agent adoption, where the renderer stopped consuming token deltas) and #4575 (pause autoscroll while reading).

## How AI was used in this PR

- Investigated and built with Claude Code, tested live in `studio ui`.
- Worth a close look: the reveal pacing constants at the top of `use-smooth-streaming-text.ts`, and the follow/unfollow rules in the session view's scroll handler. Both were tuned by feel.

## Proposed Changes

- Since #3360 the agentic UI only showed an assistant reply once the whole message had finished. The CLI already forwarded pi's `message_update` deltas over IPC and SSE; the renderer dropped them. Replies now appear as they stream, in `studio ui` and in the Desktop app.
- Streamed text is revealed at a metered pace and only ever cut at word boundaries, so network bursts read as an even flow and a half-typed word can't wrap and jump when it completes. Once the reply ends the remainder drains quickly. Respects `prefers-reduced-motion`.
- Tool rows appear when their message completes, never with half-built arguments.
- Scrolling up while a reply streams holds your place. An upward wheel tick pauses following immediately, even before the "scrolled away" slack is crossed; scrollbar drags and keyboard jumps pause it once they clearly move up; returning to the bottom resumes it. The state-based check from #4575 lost the race once content grew every frame.
- Earlier messages no longer re-parse their Markdown on every frame while a reply streams.
- Trade-off: pi ships the full partial message with every delta, so a long reply moves quadratic bytes over the loopback transport. Fine locally; trimming `message_update` to its delta in the CLI adapter is a possible follow-up.

## Testing Instructions

- `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`, open http://localhost:8081.
- Send a text-only prompt, e.g. "Without using any tools, write four short paragraphs about why WordPress uses hooks." The reply should appear word by word under the thinking indicator, finish with the copy button, and not duplicate after the run ends.
- Wheel up while it streams: the view stays put and "Scroll to latest" appears. Scroll back to the bottom: following resumes.
- Send a prompt that uses tools: text before each tool call streams; the tool row appears when that message completes.
- Reload mid-reply: the partial text continues from the next delta.
- Unit: `npm test -- apps/ui/src/data/queries apps/ui/src/hooks/use-smooth-streaming-text.test.ts apps/ui/src/ui-classic/components/session-view apps/ui/src/components/markdown`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
