### PR TITLE
Dim the preview around the element being annotated

### DIFF
--- a/apps/ui/src/components/site-preview/inspector-script.test.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.test.ts
@@ -207,6 +207,34 @@ describe( 'site preview inspector sessions', () => {
 		expect( root.querySelector( '.popup' ) ).toBeInTheDocument();
 		expect( root.querySelectorAll( '.marker' ) ).toHaveLength( 0 );
 	} );
+
+	it( 'dims the page around the selected element while a note is open', () => {
+		vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		document.body.innerHTML = '<h1 id="first">First</h1>';
+		const first = document.querySelector( '#first' ) as HTMLElement;
+		vi.spyOn( first, 'getBoundingClientRect' ).mockReturnValue( rect( 10, 20 ) );
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+		const root = ( document.querySelector( '#__studio-inspector-host' ) as HTMLElement )
+			.shadowRoot as ShadowRoot;
+		command( 'toggle-picking' );
+		expect( root.querySelectorAll( '.scrim' ) ).toHaveLength( 0 );
+
+		first.dispatchEvent( new MouseEvent( 'click', { bubbles: true, cancelable: true } ) );
+		const panels = Array.from( root.querySelectorAll( '.scrim' ) ) as HTMLElement[];
+		expect( panels ).toHaveLength( 4 );
+		// Top band ends where the element starts; the left band stops at its edge.
+		expect( panels[ 0 ] ).toHaveStyle( { height: '20px' } );
+		expect( panels[ 1 ] ).toHaveStyle( { top: '60px' } );
+		expect( panels[ 2 ] ).toHaveStyle( { width: '10px' } );
+		expect( panels[ 3 ] ).toHaveStyle( { left: '110px' } );
+
+		document.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true, cancelable: true } )
+		);
+		expect( root.querySelector( '.popup' ) ).toBeNull();
+		expect( root.querySelectorAll( '.scrim' ) ).toHaveLength( 0 );
+	} );
 } );
 
 function seedSavedNote() {

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -203,6 +203,15 @@ export const INSPECTOR_PAGE_SCRIPT =
 			border: 2px solid #7c3aed;
 			background: rgba(124,58,237,0.12);
 			border-radius: 2px;
+			z-index: 2;
+		}
+		/* Four viewport-fixed panels around the element being annotated,
+		   so the rest of the page dims and the selection reads as isolated.
+		   Sits above the markers, below the highlight and popup. */
+		.scrim {
+			position: fixed; pointer-events: none;
+			background: rgba(0,0,0,0.52);
+			z-index: 1;
 		}
 		.marker {
 			position: absolute; pointer-events: auto; cursor: pointer;
@@ -217,7 +226,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 		}
 		.marker.otherViewport { opacity: 0.55; border-style: dashed; }
 		.popup {
-			position: fixed; width: min(320px, calc(100vw - 16px));
+			position: fixed; width: min(320px, calc(100vw - 16px)); z-index: 3;
 			background: #1a1a1a; color: #fff;
 			border-radius: 12px;
 			box-shadow: 0 4px 24px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.08);
@@ -276,6 +285,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 		: [];
 
 	const markerNodes = new Map(); /* id -> marker element */
+	const scrimNodes = [];
 	let highlightNode = null;
 	let highlightEl = null;
 	let popupNode = null;
@@ -381,9 +391,13 @@ export const INSPECTOR_PAGE_SCRIPT =
 			if ( popupNode && activePopup ) {
 				positionPopup( popupNode, activePopup.target );
 			}
+			syncScrim();
 		} );
 	}
 	window.addEventListener( 'resize', relayout, { signal: teardown.signal } );
+	/* The scrim is viewport-fixed while its hole is a document rect, so it
+	 * has to be re-cut on every scroll, not just on reflow. */
+	window.addEventListener( 'scroll', syncScrim, { capture: true, signal: teardown.signal } );
 	const reflowObserver =
 		typeof ResizeObserver === 'function' ? new ResizeObserver( relayout ) : null;
 	if ( reflowObserver ) reflowObserver.observe( document.documentElement );
@@ -414,6 +428,47 @@ export const INSPECTOR_PAGE_SCRIPT =
 		root.appendChild( highlightNode );
 	}
 
+	function resolveTargetRect( target ) {
+		let el = null;
+		try {
+			el = target.selector ? document.querySelector( target.selector ) : null;
+		} catch {}
+		return el ? documentRect( el ) : target.documentRect || target.boundingBox || null;
+	}
+
+	function syncScrim() {
+		const rect = activePopup ? resolveTargetRect( activePopup.target ) : null;
+		if ( ! rect ) {
+			scrimNodes.splice( 0 ).forEach( ( node ) => node.remove() );
+			return;
+		}
+		while ( scrimNodes.length < 4 ) {
+			const node = document.createElement( 'div' );
+			node.className = 'scrim';
+			root.appendChild( node );
+			scrimNodes.push( node );
+		}
+		const vw = window.innerWidth;
+		const vh = window.innerHeight;
+		const left = Math.min( vw, Math.max( 0, rect.left - window.scrollX ) );
+		const top = Math.min( vh, Math.max( 0, rect.top - window.scrollY ) );
+		const right = Math.min( vw, Math.max( left, rect.left + rect.width - window.scrollX ) );
+		const bottom = Math.min( vh, Math.max( top, rect.top + rect.height - window.scrollY ) );
+		const panels = [
+			{ left: 0, top: 0, width: vw, height: top },
+			{ left: 0, top: bottom, width: vw, height: vh - bottom },
+			{ left: 0, top, width: left, height: bottom - top },
+			{ left: right, top, width: vw - right, height: bottom - top },
+		];
+		scrimNodes.forEach( ( node, index ) => {
+			const panel = panels[ index ];
+			node.style.left = panel.left + 'px';
+			node.style.top = panel.top + 'px';
+			node.style.width = panel.width + 'px';
+			node.style.height = panel.height + 'px';
+		} );
+	}
+
 	function showPopup() {
 		if ( popupNode ) {
 			popupNode.remove();
@@ -427,6 +482,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 
 	function render() {
 		syncMarkers();
+		syncScrim();
 		showHighlight( hoveredEl );
 		showPopup();
 		sendState();


### PR DESCRIPTION
## Related issues

- Related to [STU-2183](https://linear.app/a8c/issue/STU-2183/design-spec-focused-element-annotations-for-studio-preview-and-cli)
- Extracted from #4411

## How AI was used in this PR

Claude Code ported the scrim from #4411 onto trunk's inspector script and wrote the test. Reviewed and tested manually in the Desktop app.

## Proposed Changes

- While a preview annotation note is open, the rest of the page dims and only the selected element stays clear, so it is obvious what the note is about.
- The cut-out follows the element on scroll and reflow, and clears when the note is saved, cancelled, or escaped.
- Markers for other saved notes sit under the scrim; the highlight and note popup sit above it.

> ⚠️ Visual change: needs human review in light + dark mode.

## Screenshots

<img src="https://github.com/Automattic/studio/blob/16e2519f71c2aea9cdaf5b8bc03ce4f5a5856185/scrim.png?raw=true" width="700" alt="Site preview dimmed around a selected headline while its note is open" />

## Testing Instructions

- Open a site preview, click **Annotate**, click an element.
- Everything but that element dims. Scroll and resize the pane; the hole stays on the element.
- Esc, Save, or Cancel restores the page.
- `npm test -- apps/ui/src/components/site-preview/inspector-script.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

