### PR TITLE
Let annotations pick between the elements stacked under the click

### DIFF
--- a/apps/ui/src/components/site-preview/inspector-script.test.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.test.ts
@@ -207,6 +207,34 @@ describe( 'site preview inspector sessions', () => {
 		expect( root.querySelector( '.popup' ) ).toBeInTheDocument();
 		expect( root.querySelectorAll( '.marker' ) ).toHaveLength( 0 );
 	} );
+
+	it( 'dims the page around the selected element while a note is open', () => {
+		vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		document.body.innerHTML = '<h1 id="first">First</h1>';
+		const first = document.querySelector( '#first' ) as HTMLElement;
+		vi.spyOn( first, 'getBoundingClientRect' ).mockReturnValue( rect( 10, 20 ) );
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+		const root = ( document.querySelector( '#__studio-inspector-host' ) as HTMLElement )
+			.shadowRoot as ShadowRoot;
+		command( 'toggle-picking' );
+		expect( root.querySelectorAll( '.scrim' ) ).toHaveLength( 0 );
+
+		first.dispatchEvent( new MouseEvent( 'click', { bubbles: true, cancelable: true } ) );
+		const panels = Array.from( root.querySelectorAll( '.scrim' ) ) as HTMLElement[];
+		expect( panels ).toHaveLength( 4 );
+		// Top band ends where the element starts; the left band stops at its edge.
+		expect( panels[ 0 ] ).toHaveStyle( { height: '20px' } );
+		expect( panels[ 1 ] ).toHaveStyle( { top: '60px' } );
+		expect( panels[ 2 ] ).toHaveStyle( { width: '10px' } );
+		expect( panels[ 3 ] ).toHaveStyle( { left: '110px' } );
+
+		document.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true, cancelable: true } )
+		);
+		expect( root.querySelector( '.popup' ) ).toBeNull();
+		expect( root.querySelectorAll( '.scrim' ) ).toHaveLength( 0 );
+	} );
 } );
 
 function seedSavedNote() {

--- a/apps/ui/src/components/site-preview/inspector-script.test.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.test.ts
@@ -235,6 +235,40 @@ describe( 'site preview inspector sessions', () => {
 		expect( root.querySelector( '.popup' ) ).toBeNull();
 		expect( root.querySelectorAll( '.scrim' ) ).toHaveLength( 0 );
 	} );
+
+	it( 'offers the elements stacked under the click as layers', () => {
+		vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		document.body.innerHTML = '<section id="wrap"><h1 id="title">Title</h1></section>';
+		const wrap = document.querySelector( '#wrap' ) as HTMLElement;
+		const title = document.querySelector( '#title' ) as HTMLElement;
+		vi.spyOn( wrap, 'getBoundingClientRect' ).mockReturnValue( rect( 0, 0, 400, 300 ) );
+		vi.spyOn( title, 'getBoundingClientRect' ).mockReturnValue( rect( 10, 10 ) );
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+		const root = ( document.querySelector( '#__studio-inspector-host' ) as HTMLElement )
+			.shadowRoot as ShadowRoot;
+		command( 'toggle-picking' );
+		title.dispatchEvent(
+			new MouseEvent( 'click', { bubbles: true, cancelable: true, clientX: 20, clientY: 20 } )
+		);
+
+		expect( root.querySelector( '.layers .count' )?.textContent ).toBe( '1/2' );
+		expect( root.querySelector( '.target code' )?.textContent ).toBe( '<h1>' );
+		expect(
+			( root.querySelector( '.highlight' ) as HTMLElement ).style.getPropertyValue( 'width' )
+		).toBe( '100px' );
+
+		( root.querySelector( '.layers button' ) as HTMLButtonElement ).click();
+		expect( root.querySelector( '.layers .count' )?.textContent ).toBe( '2/2' );
+		expect( root.querySelector( '.target code' )?.textContent ).toBe( '<section>' );
+		expect(
+			( root.querySelector( '.highlight' ) as HTMLElement ).style.getPropertyValue( 'width' )
+		).toBe( '400px' );
+		// The scrim hole follows the chosen layer too.
+		expect(
+			( root.querySelectorAll( '.scrim' )[ 0 ] as HTMLElement ).style.getPropertyValue( 'height' )
+		).toBe( '0px' );
+	} );
 } );
 
 function seedSavedNote() {
@@ -253,16 +287,16 @@ function command( type: string ) {
 	window.dispatchEvent( new CustomEvent( INSPECTOR_COMMAND_EVENT, { detail: { type } } ) );
 }
 
-function rect( left: number, top: number ): DOMRect {
+function rect( left: number, top: number, width = 100, height = 40 ): DOMRect {
 	return {
 		x: left,
 		y: top,
 		left,
 		top,
-		right: left + 100,
-		bottom: top + 40,
-		width: 100,
-		height: 40,
+		right: left + width,
+		bottom: top + height,
+		width,
+		height,
 		toJSON: () => ( {} ),
 	} as DOMRect;
 }

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -235,11 +235,28 @@ export const INSPECTOR_PAGE_SCRIPT =
 			display: flex; flex-direction: column; gap: 8px;
 		}
 		.popup .target {
-			display: flex; align-items: baseline; justify-content: space-between; gap: 12px;
+			display: flex; align-items: center; justify-content: space-between; gap: 8px;
 			font-size: 11px; color: rgba(255,255,255,0.5);
 		}
 		.popup .target .element {
-			min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+			flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+		}
+		.popup .layers {
+			display: inline-flex; align-items: center; flex: none; gap: 2px;
+			padding: 1px;
+			border: 1px solid rgba(255,255,255,0.14);
+			border-radius: 7px;
+		}
+		.popup .layers button {
+			width: 18px; height: 18px; padding: 0 0 2px; border-radius: 5px;
+			display: inline-flex; align-items: center; justify-content: center;
+			background: transparent; color: rgba(255,255,255,0.6);
+			font-size: 15px; line-height: 1;
+		}
+		.popup .layers button:hover { background: rgba(255,255,255,0.1); color: #fff; }
+		.popup .layers .count {
+			min-width: 24px; text-align: center; font-size: 10px;
+			color: rgba(255,255,255,0.5);
 		}
 		.popup .target .element code {
 			font: 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace; color: rgba(255,255,255,0.7);
@@ -385,8 +402,8 @@ export const INSPECTOR_PAGE_SCRIPT =
 				const marker = markerNodes.get( ann.id );
 				if ( marker ) positionMarker( marker, ann );
 			} );
-			if ( highlightNode && highlightEl ) {
-				placeHighlight( highlightEl );
+			if ( highlightNode ) {
+				placeHighlight( highlightRect() );
 			}
 			if ( popupNode && activePopup ) {
 				positionPopup( popupNode, activePopup.target );
@@ -406,12 +423,19 @@ export const INSPECTOR_PAGE_SCRIPT =
 		if ( relayoutFrame ) cancelAnimationFrame( relayoutFrame );
 	} );
 
-	function placeHighlight( el ) {
-		const r = documentRect( el );
+	function placeHighlight( r ) {
+		if ( ! r ) return;
 		highlightNode.style.left = r.left + 'px';
 		highlightNode.style.top = r.top + 'px';
 		highlightNode.style.width = r.width + 'px';
 		highlightNode.style.height = r.height + 'px';
+	}
+
+	/* While a note is open the outline tracks the popup's target (which the
+	 * layer picker can change); otherwise it follows the hovered element. */
+	function highlightRect() {
+		if ( activePopup ) return resolveTargetRect( activePopup.target );
+		return highlightEl ? documentRect( highlightEl ) : null;
 	}
 
 	function showHighlight( el ) {
@@ -420,11 +444,13 @@ export const INSPECTOR_PAGE_SCRIPT =
 			highlightNode = null;
 			highlightEl = null;
 		}
-		if ( ! el || ! isPicking ) return;
+		if ( ! isPicking ) return;
 		highlightEl = el;
+		const rect = highlightRect();
+		if ( ! rect ) return;
 		highlightNode = document.createElement( 'div' );
 		highlightNode.className = 'highlight';
-		placeHighlight( el );
+		placeHighlight( rect );
 		root.appendChild( highlightNode );
 	}
 
@@ -646,6 +672,9 @@ export const INSPECTOR_PAGE_SCRIPT =
 		viewportSpan.textContent = vp.width + '×' + vp.height;
 		viewportSpan.title = 'Viewport when annotated';
 		target.appendChild( viewportSpan );
+		if ( state.targets && state.targets.length > 1 ) {
+			target.appendChild( buildLayerControls( state ) );
+		}
 		popup.appendChild( target );
 
 		state.comment = state.comment || '';
@@ -737,6 +766,37 @@ export const INSPECTOR_PAGE_SCRIPT =
 		return popup;
 	}
 
+	/* ‹ 2/5 › — cycle through the elements stacked under the click point.
+	 * Changing the target re-renders the popup, which keeps its comment;
+	 * the outline, scrim hole and element line move to the chosen layer. */
+	function buildLayerControls( state ) {
+		const layers = document.createElement( 'span' );
+		layers.className = 'layers';
+		const change = ( offset ) => {
+			state.targetIndex =
+				( state.targetIndex + offset + state.targets.length ) % state.targets.length;
+			state.target = state.targets[ state.targetIndex ];
+			render();
+		};
+		const prev = document.createElement( 'button' );
+		prev.type = 'button';
+		prev.textContent = '‹';
+		prev.title = 'Select the element behind this one';
+		prev.setAttribute( 'aria-label', prev.title );
+		prev.addEventListener( 'click', () => change( 1 ) );
+		const count = document.createElement( 'span' );
+		count.className = 'count';
+		count.textContent = state.targetIndex + 1 + '/' + state.targets.length;
+		const next = document.createElement( 'button' );
+		next.type = 'button';
+		next.textContent = '›';
+		next.title = 'Select the element in front of this one';
+		next.setAttribute( 'aria-label', next.title );
+		next.addEventListener( 'click', () => change( -1 ) );
+		layers.append( prev, count, next );
+		return layers;
+	}
+
 	/* Editing an existing note leaves picking mode alone: markers stay
 	 * clickable when picking is off, and silently switching it on would
 	 * swallow every subsequent link click in the page. */
@@ -760,20 +820,81 @@ export const INSPECTOR_PAGE_SCRIPT =
 		render();
 	}
 
-	function openPopupForElement( el ) {
+	function targetForElement( el ) {
 		const viewport = el.getBoundingClientRect();
+		return {
+			selector: buildSelector( el ),
+			tag: el.tagName.toLowerCase(),
+			classes: Array.from( el.classList || [] ).filter( ( c ) => ! c.startsWith( '__studio-' ) ),
+			nearbyText: nearbyText( el ),
+			boundingBox: { x: viewport.x, y: viewport.y, width: viewport.width, height: viewport.height },
+			documentRect: documentRect( el ),
+			computedStyles: pickComputedStyles( el ),
+		};
+	}
+
+	/* Everything stacked under the click point, front to back: the hit
+	 * element, then the rest of the hit-test stack, then (bounded) any other
+	 * element whose box contains the point — this catches things behind a
+	 * pointer-events:none overlay or a full-bleed wrapper. */
+	function elementsAtPoint( initial, clientX, clientY ) {
+		const MAX_CANDIDATES = 30;
+		const MAX_FALLBACK_ELEMENTS = 5000;
+		const MAX_FALLBACK_MS = 20;
+		const candidates = [];
+		const seen = new Set();
+		const add = ( el ) => {
+			if ( candidates.length >= MAX_CANDIDATES || ! el || seen.has( el ) || isOurElement( el ) )
+				return;
+			if ( el === document.documentElement || el === document.body ) return;
+			const rect = el.getBoundingClientRect();
+			if ( rect.width <= 0 || rect.height <= 0 ) return;
+			const style = window.getComputedStyle( el );
+			if ( style.display === 'none' || style.visibility === 'hidden' ) return;
+			seen.add( el );
+			candidates.push( el );
+		};
+		add( initial );
+		if ( typeof document.elementsFromPoint === 'function' ) {
+			document.elementsFromPoint( clientX, clientY ).forEach( add );
+		}
+		const behind = [];
+		const startedAt = performance.now();
+		let scanned = 0;
+		for ( const el of document.querySelectorAll( 'body *' ) ) {
+			scanned += 1;
+			if (
+				scanned > MAX_FALLBACK_ELEMENTS ||
+				( scanned % 50 === 0 && performance.now() - startedAt > MAX_FALLBACK_MS )
+			) {
+				break;
+			}
+			if ( seen.has( el ) || isOurElement( el ) ) continue;
+			const rect = el.getBoundingClientRect();
+			if (
+				rect.width > 0 &&
+				rect.height > 0 &&
+				clientX >= rect.left &&
+				clientX <= rect.right &&
+				clientY >= rect.top &&
+				clientY <= rect.bottom
+			) {
+				behind.push( { el, area: rect.width * rect.height } );
+			}
+		}
+		behind.sort( ( a, b ) => a.area - b.area ).forEach( ( item ) => add( item.el ) );
+		return candidates;
+	}
+
+	function openPopupForElement( el, clientX, clientY ) {
+		const elements = elementsAtPoint( el, clientX, clientY );
+		const targets = elements.length ? elements.map( targetForElement ) : [ targetForElement( el ) ];
 		activePopup = {
 			fromPicker: true,
 			comment: '',
-			target: {
-				selector: buildSelector( el ),
-				tag: el.tagName.toLowerCase(),
-				classes: Array.from( el.classList || [] ).filter( ( c ) => ! c.startsWith( '__studio-' ) ),
-				nearbyText: nearbyText( el ),
-				boundingBox: { x: viewport.x, y: viewport.y, width: viewport.width, height: viewport.height },
-				documentRect: documentRect( el ),
-				computedStyles: pickComputedStyles( el ),
-			},
+			target: targets[ 0 ],
+			targets,
+			targetIndex: 0,
 		};
 		persistAnnotations();
 		render();
@@ -815,7 +936,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 			if ( isOurElement( e.target ) ) return;
 			e.preventDefault();
 			e.stopPropagation();
-			openPopupForElement( e.target );
+			openPopupForElement( e.target, e.clientX, e.clientY );
 		},
 		{ capture: true, signal: teardown.signal }
 	);

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -203,6 +203,15 @@ export const INSPECTOR_PAGE_SCRIPT =
 			border: 2px solid #7c3aed;
 			background: rgba(124,58,237,0.12);
 			border-radius: 2px;
+			z-index: 2;
+		}
+		/* Four viewport-fixed panels around the element being annotated,
+		   so the rest of the page dims and the selection reads as isolated.
+		   Sits above the markers, below the highlight and popup. */
+		.scrim {
+			position: fixed; pointer-events: none;
+			background: rgba(0,0,0,0.52);
+			z-index: 1;
 		}
 		.marker {
 			position: absolute; pointer-events: auto; cursor: pointer;
@@ -217,7 +226,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 		}
 		.marker.otherViewport { opacity: 0.55; border-style: dashed; }
 		.popup {
-			position: fixed; width: min(320px, calc(100vw - 16px));
+			position: fixed; width: min(320px, calc(100vw - 16px)); z-index: 3;
 			background: #1a1a1a; color: #fff;
 			border-radius: 12px;
 			box-shadow: 0 4px 24px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.08);
@@ -276,6 +285,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 		: [];
 
 	const markerNodes = new Map(); /* id -> marker element */
+	const scrimNodes = [];
 	let highlightNode = null;
 	let highlightEl = null;
 	let popupNode = null;
@@ -381,9 +391,13 @@ export const INSPECTOR_PAGE_SCRIPT =
 			if ( popupNode && activePopup ) {
 				positionPopup( popupNode, activePopup.target );
 			}
+			syncScrim();
 		} );
 	}
 	window.addEventListener( 'resize', relayout, { signal: teardown.signal } );
+	/* The scrim is viewport-fixed while its hole is a document rect, so it
+	 * has to be re-cut on every scroll, not just on reflow. */
+	window.addEventListener( 'scroll', syncScrim, { capture: true, signal: teardown.signal } );
 	const reflowObserver =
 		typeof ResizeObserver === 'function' ? new ResizeObserver( relayout ) : null;
 	if ( reflowObserver ) reflowObserver.observe( document.documentElement );
@@ -414,6 +428,47 @@ export const INSPECTOR_PAGE_SCRIPT =
 		root.appendChild( highlightNode );
 	}
 
+	function resolveTargetRect( target ) {
+		let el = null;
+		try {
+			el = target.selector ? document.querySelector( target.selector ) : null;
+		} catch {}
+		return el ? documentRect( el ) : target.documentRect || target.boundingBox || null;
+	}
+
+	function syncScrim() {
+		const rect = activePopup ? resolveTargetRect( activePopup.target ) : null;
+		if ( ! rect ) {
+			scrimNodes.splice( 0 ).forEach( ( node ) => node.remove() );
+			return;
+		}
+		while ( scrimNodes.length < 4 ) {
+			const node = document.createElement( 'div' );
+			node.className = 'scrim';
+			root.appendChild( node );
+			scrimNodes.push( node );
+		}
+		const vw = window.innerWidth;
+		const vh = window.innerHeight;
+		const left = Math.min( vw, Math.max( 0, rect.left - window.scrollX ) );
+		const top = Math.min( vh, Math.max( 0, rect.top - window.scrollY ) );
+		const right = Math.min( vw, Math.max( left, rect.left + rect.width - window.scrollX ) );
+		const bottom = Math.min( vh, Math.max( top, rect.top + rect.height - window.scrollY ) );
+		const panels = [
+			{ left: 0, top: 0, width: vw, height: top },
+			{ left: 0, top: bottom, width: vw, height: vh - bottom },
+			{ left: 0, top, width: left, height: bottom - top },
+			{ left: right, top, width: vw - right, height: bottom - top },
+		];
+		scrimNodes.forEach( ( node, index ) => {
+			const panel = panels[ index ];
+			node.style.left = panel.left + 'px';
+			node.style.top = panel.top + 'px';
+			node.style.width = panel.width + 'px';
+			node.style.height = panel.height + 'px';
+		} );
+	}
+
 	function showPopup() {
 		if ( popupNode ) {
 			popupNode.remove();
@@ -427,6 +482,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 
 	function render() {
 		syncMarkers();
+		syncScrim();
 		showHighlight( hoveredEl );
 		showPopup();
 		sendState();


### PR DESCRIPTION
## Related issues

- Related to [STU-2183](https://linear.app/a8c/issue/STU-2183/design-spec-focused-element-annotations-for-studio-preview-and-cli)
- Extracted from #4411. Stacked on #4825 (needs the scrim's target-rect helper); merge that first.

## How AI was used in this PR

Claude Code ported the layer picker from #4411 onto trunk's inspector script and wrote the test. Reviewed and tested manually in the Desktop app.

## Proposed Changes

- Clicking an element during annotation often hits a wrapper, a link, or an overlay rather than the thing you meant. The note now collects every element stacked under the click point and shows `‹ 1/N ›` in its header.
- Stepping through the layers moves the outline, the scrim cut-out, and the element line in the note; the typed comment is kept.
- Candidates come from the hit-test stack plus a bounded scan for elements behind pointer-events:none overlays, capped at 30 and ~20ms.
- The note header now keeps the viewport size and layer controls tucked to the right regardless of selector length.

> ⚠️ Visual change: needs human review in light + dark mode.

## Screenshots

After stepping ‹ once: the wrapping `<h3>` behind the link is selected, showing `2/8`.

<img src="https://github.com/Automattic/studio/blob/8ed9738bf1b5adc16cd87e50310b5163852fa7f3/layers.png?raw=true" width="700" alt="Annotation note with layer controls showing 2/8 and the wrapping heading outlined" />

## Testing Instructions

- Open a site preview, click **Annotate**, click a headline inside a section or a link inside a card.
- The note header shows `‹ 1/N ›`. Click ‹ to select the element behind; the outline and dimmed area move to it, and the `<tag>` line updates.
- Type a note, switch layers, confirm the text stays.
- `npm test -- apps/ui/src/components/site-preview/inspector-script.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

