### PR TITLE
Keep the annotation note in place: draggable popup and scroll lock

### DIFF
--- a/apps/ui/src/components/site-preview/inspector-script.test.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.test.ts
@@ -207,6 +207,68 @@ describe( 'site preview inspector sessions', () => {
 		expect( root.querySelector( '.popup' ) ).toBeInTheDocument();
 		expect( root.querySelectorAll( '.marker' ) ).toHaveLength( 0 );
 	} );
+
+	it( 'locks page scrolling while a note is open and restores it after', () => {
+		vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		document.body.innerHTML = '<h1 id="first">First</h1>';
+		document.body.style.overflow = 'auto';
+		const first = document.querySelector( '#first' ) as HTMLElement;
+		vi.spyOn( first, 'getBoundingClientRect' ).mockReturnValue( rect( 10, 10 ) );
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+		command( 'toggle-picking' );
+		first.dispatchEvent( new MouseEvent( 'click', { bubbles: true, cancelable: true } ) );
+		expect( document.body.style.getPropertyValue( 'overflow' ) ).toBe( 'hidden' );
+		expect( document.documentElement.style.getPropertyValue( 'overflow' ) ).toBe( 'hidden' );
+
+		document.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true, cancelable: true } )
+		);
+		expect( document.body.style.getPropertyValue( 'overflow' ) ).toBe( 'auto' );
+		expect( document.documentElement.style.getPropertyValue( 'overflow' ) ).toBe( '' );
+	} );
+
+	it( 'lets the note be dragged by its element row', () => {
+		vi.spyOn( console, 'log' ).mockImplementation( () => undefined );
+		document.body.innerHTML = '<h1 id="first">First</h1>';
+		const first = document.querySelector( '#first' ) as HTMLElement;
+		vi.spyOn( first, 'getBoundingClientRect' ).mockReturnValue( rect( 200, 100 ) );
+		vi.stubGlobal( 'requestAnimationFrame', ( cb: FrameRequestCallback ) => {
+			cb( 0 );
+			return 1;
+		} );
+
+		new Function( INSPECTOR_PAGE_SCRIPT )();
+		const root = ( document.querySelector( '#__studio-inspector-host' ) as HTMLElement )
+			.shadowRoot as ShadowRoot;
+		command( 'toggle-picking' );
+		first.dispatchEvent( new MouseEvent( 'click', { bubbles: true, cancelable: true } ) );
+
+		const popup = root.querySelector( '.popup' ) as HTMLElement;
+		const handle = root.querySelector( '.target' ) as HTMLElement;
+		const startLeft = parseFloat( popup.style.left );
+		const startTop = parseFloat( popup.style.top );
+
+		handle.dispatchEvent(
+			new MouseEvent( 'mousedown', { bubbles: true, button: 0, clientX: 300, clientY: 200 } )
+		);
+		window.dispatchEvent( new MouseEvent( 'mousemove', { clientX: 340, clientY: 230 } ) );
+		expect( popup.style.getPropertyValue( 'transform' ) ).toBe( 'translate(40px, 30px)' );
+		window.dispatchEvent( new MouseEvent( 'mouseup', { clientX: 340, clientY: 230 } ) );
+
+		expect( popup.style.getPropertyValue( 'transform' ) ).toBe( '' );
+		expect( parseFloat( popup.style.left ) ).toBe( startLeft + 40 );
+		expect( parseFloat( popup.style.top ) ).toBe( startTop + 30 );
+		// A re-render (e.g. typing) keeps the dragged position.
+		const ta = root.querySelector( 'textarea' ) as HTMLTextAreaElement;
+		ta.value = 'note';
+		ta.dispatchEvent( new InputEvent( 'input', { bubbles: true } ) );
+		window.dispatchEvent( new Event( 'resize' ) );
+		expect( parseFloat( ( root.querySelector( '.popup' ) as HTMLElement ).style.left ) ).toBe(
+			startLeft + 40
+		);
+		vi.unstubAllGlobals();
+	} );
 } );
 
 function seedSavedNote() {

--- a/apps/ui/src/components/site-preview/inspector-script.ts
+++ b/apps/ui/src/components/site-preview/inspector-script.ts
@@ -228,7 +228,9 @@ export const INSPECTOR_PAGE_SCRIPT =
 		.popup .target {
 			display: flex; align-items: baseline; justify-content: space-between; gap: 12px;
 			font-size: 11px; color: rgba(255,255,255,0.5);
+			cursor: grab; user-select: none;
 		}
+		.popup .target.dragging { cursor: grabbing; }
 		.popup .target .element {
 			min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 		}
@@ -279,6 +281,28 @@ export const INSPECTOR_PAGE_SCRIPT =
 	let highlightNode = null;
 	let highlightEl = null;
 	let popupNode = null;
+	let scrollLock = null;
+
+	/* Lock page scrolling while a note is open so the highlight and popup
+	 * stay put over the element being described. */
+	function syncScrollLock() {
+		if ( activePopup && ! scrollLock ) {
+			scrollLock = {
+				documentOverflow: document.documentElement.style.overflow,
+				bodyOverflow: document.body.style.overflow,
+			};
+			document.documentElement.style.overflow = 'hidden';
+			document.body.style.overflow = 'hidden';
+		} else if ( ! activePopup && scrollLock ) {
+			document.documentElement.style.overflow = scrollLock.documentOverflow;
+			document.body.style.overflow = scrollLock.bodyOverflow;
+			scrollLock = null;
+		}
+	}
+	teardown.signal.addEventListener( 'abort', () => {
+		activePopup = null;
+		syncScrollLock();
+	} );
 
 	/* Width of the viewport a note was made in vs. now. Beyond this the pin
 	 * is drawn muted so it reads as "from another viewport". */
@@ -379,7 +403,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 				placeHighlight( highlightEl );
 			}
 			if ( popupNode && activePopup ) {
-				positionPopup( popupNode, activePopup.target );
+				positionPopup( popupNode, activePopup );
 			}
 		} );
 	}
@@ -426,6 +450,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 	}
 
 	function render() {
+		syncScrollLock();
 		syncMarkers();
 		showHighlight( hoveredEl );
 		showPopup();
@@ -534,9 +559,13 @@ export const INSPECTOR_PAGE_SCRIPT =
 	/* Position the popup near the element using viewport coords (it's
 	 * \`position: fixed\` so it stays in the viewport). Falls back to
 	 * centre if the element can't be located. Re-run on relayout. */
-	function positionPopup( popup, target ) {
-		const el = resolveAnnotationElement( target );
-		if ( el ) {
+	function positionPopup( popup, state ) {
+		const el = state.popupPosition ? null : resolveAnnotationElement( state.target );
+		if ( state.popupPosition ) {
+			popup.style.left = state.popupPosition.left + 'px';
+			popup.style.top = state.popupPosition.top + 'px';
+			popup.style.transform = '';
+		} else if ( el ) {
 			const r = el.getBoundingClientRect();
 			const popupWidth = Math.min( 320, window.innerWidth - 16 );
 			const gap = 12;
@@ -548,6 +577,7 @@ export const INSPECTOR_PAGE_SCRIPT =
 			if ( top + 200 > window.innerHeight ) {
 				top = Math.max( 8, r.top - 200 - gap );
 			}
+			state.popupPosition = { left, top };
 			popup.style.left = left + 'px';
 			popup.style.top = top + 'px';
 			popup.style.transform = '';
@@ -562,10 +592,11 @@ export const INSPECTOR_PAGE_SCRIPT =
 		const popup = document.createElement( 'div' );
 		popup.className = 'popup';
 
-		positionPopup( popup, state.target );
+		positionPopup( popup, state );
 
 		const target = document.createElement( 'div' );
 		target.className = 'target';
+		makeDraggable( popup, target, state );
 		const element = document.createElement( 'span' );
 		element.className = 'element';
 		const tagCode = document.createElement( 'code' );
@@ -679,6 +710,81 @@ export const INSPECTOR_PAGE_SCRIPT =
 		popup.addEventListener( 'mousemove', ( e ) => e.stopPropagation() );
 
 		return popup;
+	}
+
+	/* Drag the popup by its target row. Movement is applied as a transform
+	 * during the drag and folded into the stored position on release, so a
+	 * re-render mid-drag can't snap it back. */
+	function makeDraggable( popup, handle, state ) {
+		handle.addEventListener( 'mousedown', ( event ) => {
+			if ( event.button !== 0 || event.target.closest( 'button' ) ) return;
+			if ( ! state.popupPosition ) {
+				const r = popup.getBoundingClientRect();
+				state.popupPosition = { left: r.left, top: r.top };
+				popup.style.left = r.left + 'px';
+				popup.style.top = r.top + 'px';
+				popup.style.transform = '';
+			}
+			event.preventDefault();
+			const startX = event.clientX;
+			const startY = event.clientY;
+			const startLeft = state.popupPosition.left;
+			const startTop = state.popupPosition.top;
+			let next = { left: startLeft, top: startTop };
+			let frame = null;
+			let didDrag = false;
+			handle.classList.add( 'dragging' );
+			const move = ( e ) => {
+				e.preventDefault();
+				e.stopPropagation();
+				if ( Math.abs( e.clientX - startX ) > 2 || Math.abs( e.clientY - startY ) > 2 ) {
+					didDrag = true;
+				}
+				const width = popup.offsetWidth || 320;
+				const height = popup.offsetHeight || 200;
+				next = {
+					left: Math.min(
+						Math.max( 8, startLeft + e.clientX - startX ),
+						Math.max( 8, window.innerWidth - width - 8 )
+					),
+					top: Math.min(
+						Math.max( 8, startTop + e.clientY - startY ),
+						Math.max( 8, window.innerHeight - height - 8 )
+					),
+				};
+				if ( frame !== null ) return;
+				frame = requestAnimationFrame( () => {
+					frame = null;
+					popup.style.transform =
+						'translate(' + ( next.left - startLeft ) + 'px, ' + ( next.top - startTop ) + 'px)';
+				} );
+			};
+			const stop = () => {
+				if ( frame !== null ) cancelAnimationFrame( frame );
+				frame = null;
+				state.popupPosition = next;
+				popup.style.left = next.left + 'px';
+				popup.style.top = next.top + 'px';
+				popup.style.transform = '';
+				handle.classList.remove( 'dragging' );
+				window.removeEventListener( 'mousemove', move, true );
+				window.removeEventListener( 'mouseup', stop, true );
+				window.removeEventListener( 'blur', stop, true );
+				if ( didDrag ) {
+					/* Swallow the click that ends the drag so the page (and our
+					 * own picker) doesn't treat it as a selection. */
+					const suppress = ( e ) => {
+						e.preventDefault();
+						e.stopPropagation();
+					};
+					window.addEventListener( 'click', suppress, { capture: true, once: true } );
+					setTimeout( () => window.removeEventListener( 'click', suppress, true ), 0 );
+				}
+			};
+			window.addEventListener( 'mousemove', move, true );
+			window.addEventListener( 'mouseup', stop, true );
+			window.addEventListener( 'blur', stop, true );
+		} );
 	}
 
 	/* Editing an existing note leaves picking mode alone: markers stay


### PR DESCRIPTION
## Related issues

- Related to [STU-2183](https://linear.app/a8c/issue/STU-2183/design-spec-focused-element-annotations-for-studio-preview-and-cli)
- Extracted from #4411. Independent of the other extractions; expect a small merge conflict with #4826 in the popup positioning code.

## How AI was used in this PR

Claude Code ported the draggable popup and scroll lock from #4411 onto trunk's inspector script and wrote the tests. Reviewed and tested manually in the Desktop app.

## Proposed Changes

- The annotation note can be dragged by its header, so it can be moved off whatever it happens to cover. It stays inside the viewport and keeps its position across re-renders (typing, resize).
- Page scrolling is locked while a note is open, so the outline and note stay over the element being described. Scrolling is restored on save, cancel, or Esc.

> ⚠️ Visual change: needs human review in light + dark mode.

## Screenshots

Note dragged away from its element; the page behind it stays put.

<img src="https://github.com/Automattic/studio/blob/33145425a8f5fd1cf7b75b12fdfbfa1339f0b270/drag.png?raw=true" width="700" alt="Annotation note dragged to the lower middle of the preview" />

## Testing Instructions

- Open a site preview, click **Annotate**, click an element.
- Drag the note by its top row; it clamps inside the pane. Type into it and resize the pane; it stays where you left it.
- Try to scroll the page; it shouldn't move. Esc the note; scrolling works again.
- `npm test -- apps/ui/src/components/site-preview/inspector-script.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

