### PR TITLE
Show each annotation as its own chat message with element context

### DIFF
--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -70,6 +70,7 @@ import type {
 	StudioCustomEntryType,
 } from '@studio/common/ai/sessions/entry-types';
 import type { LoadedAiSession, TurnStatus } from '@studio/common/ai/sessions/types';
+import type { StudioVisualAnnotationSummary } from '@studio/common/ai/visual-annotations';
 import type { TracksProps } from '@studio/common/lib/record-tracks-event';
 import type { AskUserQuestion } from 'cli/ai/types';
 
@@ -122,6 +123,7 @@ export async function runCommand( options: {
 	initialDisplayMessage?: string;
 	initialImages?: StudioChatImage[];
 	initialFiles?: StudioChatFileAttachment[];
+	initialVisualAnnotations?: StudioVisualAnnotationSummary[];
 	resumeSession?: LoadedAiSession;
 	resumeSessionId?: string;
 	showLegacyCommandNotice?: boolean;
@@ -511,7 +513,8 @@ export async function runCommand( options: {
 		prompt: string,
 		displayMessage = prompt,
 		images: StudioChatImage[] = [],
-		files: StudioChatFileAttachment[] = []
+		files: StudioChatFileAttachment[] = [],
+		visualAnnotations?: StudioVisualAnnotationSummary[]
 	): Promise< { status: TurnStatus; sessionId: string } > {
 		await maybeAutoSwitchProvider();
 		const sm = await ensureSession();
@@ -593,6 +596,7 @@ export async function runCommand( options: {
 				source: 'prompt',
 				sitePath: site?.path,
 				attachments: buildChatAttachmentSummaries( images, files ),
+				visualAnnotations,
 			} )
 		);
 
@@ -678,7 +682,8 @@ export async function runCommand( options: {
 				options.initialMessage,
 				displayMessage,
 				options.initialImages,
-				options.initialFiles
+				options.initialFiles,
+				options.initialVisualAnnotations
 			);
 			const jsonStatus = result.status === 'interrupted' ? 'error' : result.status;
 			( ui as JsonAdapter ).emitTurnCompleted( jsonStatus, result.sessionId );
@@ -703,7 +708,8 @@ export async function runCommand( options: {
 				options.initialMessage,
 				displayMessage,
 				options.initialImages,
-				options.initialFiles
+				options.initialFiles,
+				options.initialVisualAnnotations
 			);
 		} catch ( error ) {
 			handleAgentTurnError( error );

--- a/apps/cli/commands/ai/sessions/resume.ts
+++ b/apps/cli/commands/ai/sessions/resume.ts
@@ -3,6 +3,7 @@ import { validateStudioChatFiles } from '@studio/common/ai/chat-files';
 import { validateStudioChatImages } from '@studio/common/ai/chat-images';
 import { resolveActiveSiteFromEntries } from '@studio/common/ai/sessions/active-site';
 import { listAiSessions, loadAiSession } from '@studio/common/ai/sessions/store';
+import { validateStudioVisualAnnotations } from '@studio/common/ai/visual-annotations';
 import { getSessionsDirectory } from '@studio/common/lib/well-known-paths';
 import { __ } from '@wordpress/i18n';
 import { JsonAdapter } from 'cli/ai/output-adapter';
@@ -24,6 +25,7 @@ async function readInputPayload( path: string ): Promise< StudioAiSessionInputPa
 		displayMessage: parsed.displayMessage,
 		images: validateStudioChatImages( parsed.images ),
 		files: validateStudioChatFiles( parsed.files ),
+		visualAnnotations: validateStudioVisualAnnotations( parsed.visualAnnotations ),
 	};
 }
 
@@ -79,6 +81,7 @@ export async function runCommand(
 		initialDisplayMessage: inputPayload?.displayMessage ?? options.displayMessage,
 		initialImages: inputPayload?.images,
 		initialFiles: inputPayload?.files,
+		initialVisualAnnotations: inputPayload?.visualAnnotations,
 		activeSite: resolvedSite,
 	} );
 }

--- a/apps/cli/commands/ai/sessions/tests/resume.test.ts
+++ b/apps/cli/commands/ai/sessions/tests/resume.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { loadAiSession } from '@studio/common/ai/sessions/store';
 import { vi, type Mock } from 'vitest';
 import { runCommand as runAiCommand } from 'cli/commands/ai';
@@ -82,6 +85,43 @@ describe( 'sessions resume — active site hydration (JSON mode)', () => {
 
 		expect( runAiCommand ).toHaveBeenCalledWith(
 			expect.objectContaining( { activeSite: undefined } )
+		);
+	} );
+
+	it( 'passes validated visual annotations from an input payload', async () => {
+		( loadAiSession as Mock ).mockResolvedValue( { entries: [] } );
+		const directory = await fs.mkdtemp( path.join( os.tmpdir(), 'studio-annotations-' ) );
+		const inputPayloadPath = path.join( directory, 'input.json' );
+		await fs.writeFile(
+			inputPayloadPath,
+			JSON.stringify( {
+				prompt: 'Update the selected heading',
+				displayMessage: '1 annotation submitted',
+				visualAnnotations: [
+					{ comment: '  Make it smaller  ', tag: ' h1 ', nearbyText: 'Welcome' },
+				],
+			} )
+		);
+
+		try {
+			await runCommand( 'session-1', { json: true, inputPayloadPath } );
+		} finally {
+			await fs.rm( directory, { recursive: true, force: true } );
+		}
+
+		expect( runAiCommand ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				initialMessage: 'Update the selected heading',
+				initialDisplayMessage: '1 annotation submitted',
+				initialVisualAnnotations: [
+					{
+						comment: 'Make it smaller',
+						tag: 'h1',
+						elementLabel: undefined,
+						nearbyText: 'Welcome',
+					},
+				],
+			} )
 		);
 	} );
 } );

--- a/apps/hosted/src/agent-runs.ts
+++ b/apps/hosted/src/agent-runs.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import { stubRuntime } from './stub-runtime';
 import type { AgentProcess, AgentRuntime } from './runtime';
 import type { ActiveAgentRun, AgentEvent, AgentRunEvent } from '@studio/common/ai/agent-events';
+import type { StudioVisualAnnotationSummary } from '@studio/common/ai/visual-annotations';
 
 /**
  * Headless analog of the desktop `run-manager` (apps/studio/src/modules/
@@ -53,10 +54,11 @@ export interface StartAgentRunOptions {
 	sessionId: string;
 	prompt: string;
 	displayMessage?: string;
+	visualAnnotations?: StudioVisualAnnotationSummary[];
 }
 
 export function startAgentRun( options: StartAgentRunOptions ): { runId: string } {
-	const { sessionId, prompt, displayMessage } = options;
+	const { sessionId, prompt, displayMessage, visualAnnotations } = options;
 
 	if ( runsBySessionId.has( sessionId ) ) {
 		throw new Error( `A run is already in progress for session ${ sessionId }` );
@@ -69,6 +71,7 @@ export function startAgentRun( options: StartAgentRunOptions ): { runId: string 
 		sessionId,
 		prompt,
 		displayMessage,
+		visualAnnotations,
 		onSpawn: () => emit( runId, sessionId, { type: 'run.started', timestamp: nowIso() } ),
 		onEvent: ( event ) => emit( runId, sessionId, event ),
 		onError: ( message ) =>

--- a/apps/hosted/src/index.ts
+++ b/apps/hosted/src/index.ts
@@ -9,6 +9,7 @@ import {
 	listAiSessions,
 	loadAiSession,
 } from '@studio/common/ai/sessions/store';
+import { validateStudioVisualAnnotations } from '@studio/common/ai/visual-annotations';
 import {
 	readAuthToken,
 	readSharedSessions,
@@ -298,12 +299,28 @@ api.post(
 );
 
 api.post( '/sessions/:id/messages', ( req: Request, res: Response ) => {
-	const { prompt, displayMessage } = req.body as { prompt?: string; displayMessage?: string };
+	const { prompt, displayMessage, visualAnnotations } = req.body as {
+		prompt?: string;
+		displayMessage?: string;
+		visualAnnotations?: unknown;
+	};
 	if ( ! prompt ) {
 		res.status( 400 ).json( { error: 'prompt is required' } );
 		return;
 	}
-	const { runId } = startAgentRun( { sessionId: req.params.id, prompt, displayMessage } );
+	let validatedVisualAnnotations;
+	try {
+		validatedVisualAnnotations = validateStudioVisualAnnotations( visualAnnotations );
+	} catch {
+		res.status( 400 ).json( { error: 'visualAnnotations is invalid' } );
+		return;
+	}
+	const { runId } = startAgentRun( {
+		sessionId: req.params.id,
+		prompt,
+		displayMessage,
+		visualAnnotations: validatedVisualAnnotations,
+	} );
 	res.json( { runId } );
 } );
 

--- a/apps/hosted/src/runtime.ts
+++ b/apps/hosted/src/runtime.ts
@@ -1,4 +1,5 @@
 import type { JsonEvent } from '@studio/common/ai/json-events';
+import type { StudioVisualAnnotationSummary } from '@studio/common/ai/visual-annotations';
 
 /**
  * Where the agent actually runs, behind a seam.
@@ -14,6 +15,7 @@ export interface AgentProcessOptions {
 	sessionId: string;
 	prompt: string;
 	displayMessage?: string;
+	visualAnnotations?: StudioVisualAnnotationSummary[];
 	// The process has started.
 	onSpawn: () => void;
 	// A JSON transport event the agent emitted.

--- a/apps/local/src/index.ts
+++ b/apps/local/src/index.ts
@@ -35,6 +35,7 @@ import {
 } from '@studio/common/ai/settings-store';
 import { expandSkillCommandPrompt } from '@studio/common/ai/slash-commands';
 import { getAiTracksIdentity } from '@studio/common/ai/tracks-identity';
+import { validateStudioVisualAnnotations } from '@studio/common/ai/visual-annotations';
 import { DEBUG_LOG_RELATIVE_PATH, DEFAULT_TOKEN_LIFETIME_MS } from '@studio/common/constants';
 import { downloadAndExtractBlueprintBundle } from '@studio/common/lib/blueprint-bundle';
 import { createCliRunner } from '@studio/common/lib/cli-process';
@@ -1746,15 +1747,27 @@ export async function startLocalServer( options: LocalServerOptions ): Promise< 
 	);
 
 	api.post( '/sessions/:id/messages', ( req: Request, res: Response ) => {
-		const { prompt, displayMessage } = req.body as { prompt?: string; displayMessage?: string };
+		const { prompt, displayMessage, visualAnnotations } = req.body as {
+			prompt?: string;
+			displayMessage?: string;
+			visualAnnotations?: unknown;
+		};
 		if ( ! prompt ) {
 			res.status( 400 ).json( { error: 'prompt is required' } );
+			return;
+		}
+		let validatedVisualAnnotations;
+		try {
+			validatedVisualAnnotations = validateStudioVisualAnnotations( visualAnnotations );
+		} catch {
+			res.status( 400 ).json( { error: 'visualAnnotations is invalid' } );
 			return;
 		}
 		const { runId } = runManager.startAgentRun( {
 			sessionId: req.params.id,
 			prompt: expandSkillCommandPrompt( prompt ),
 			displayMessage,
+			visualAnnotations: validatedVisualAnnotations,
 		} );
 		res.json( { runId } );
 	} );

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -44,6 +44,7 @@ import {
 } from '@studio/common/ai/sessions/store';
 import { expandSkillCommandPrompt } from '@studio/common/ai/slash-commands';
 import { getAiTracksIdentity } from '@studio/common/ai/tracks-identity';
+import { validateStudioVisualAnnotations } from '@studio/common/ai/visual-annotations';
 import { DEBUG_LOG_RELATIVE_PATH } from '@studio/common/constants';
 import {
 	installSkillToSite,
@@ -415,6 +416,7 @@ export async function continueAiSession(
 		displayMessage?: string;
 		images?: StudioChatImage[];
 		files?: StudioChatFileAttachment[];
+		visualAnnotations?: unknown;
 	} = {}
 ): Promise< { runId: string } > {
 	if ( ! ( await oauthClient.isAuthenticated() ) ) {
@@ -424,12 +426,14 @@ export async function continueAiSession(
 	await reconcileSessionEnvironmentBeforeRun( sessionId );
 	const images = validateStudioChatImages( options.images );
 	const files = validateStudioChatFiles( options.files );
+	const visualAnnotations = validateStudioVisualAnnotations( options.visualAnnotations );
 	return startAgentRun( {
 		sessionId,
 		prompt: expandSkillCommandPrompt( prompt ),
 		displayMessage: options.displayMessage,
 		images,
 		files,
+		visualAnnotations,
 		webContents: event.sender,
 	} );
 }

--- a/apps/studio/src/modules/ai-agent/run-manager.ts
+++ b/apps/studio/src/modules/ai-agent/run-manager.ts
@@ -4,6 +4,7 @@ import { getBundledNodeBinaryPath, getCliPath } from 'src/storage/paths';
 import type { ActiveAgentRun } from '@studio/common/ai/agent-events';
 import type { StudioChatFileAttachment } from '@studio/common/ai/chat-files';
 import type { StudioChatImage } from '@studio/common/ai/chat-images';
+import type { StudioVisualAnnotationSummary } from '@studio/common/ai/visual-annotations';
 import type { WebContents } from 'electron';
 
 /**
@@ -49,17 +50,26 @@ export interface StartAgentRunOptions {
 	displayMessage?: string;
 	images?: StudioChatImage[];
 	files?: StudioChatFileAttachment[];
+	visualAnnotations?: StudioVisualAnnotationSummary[];
 	webContents: WebContents;
 }
 
 export function startAgentRun( options: StartAgentRunOptions ): { runId: string } {
-	const { sessionId, prompt, displayMessage, images, files, webContents } = options;
+	const { sessionId, prompt, displayMessage, images, files, visualAnnotations, webContents } =
+		options;
 	// `startAgentRun` forks the child and returns its id synchronously; the
 	// child's first event arrives async (next tick), so registering the route
 	// after a successful start — keyed by the unique runId — is in time, and a
 	// rejected start (e.g. a concurrent run on the same session) never touches
 	// another run's routing.
-	const result = runManager.startAgentRun( { sessionId, prompt, displayMessage, images, files } );
+	const result = runManager.startAgentRun( {
+		sessionId,
+		prompt,
+		displayMessage,
+		images,
+		files,
+		visualAnnotations,
+	} );
 	runWebContents.set( result.runId, webContents );
 	// Abort the run if the window that started it goes away.
 	webContents.once( 'destroyed', () => runManager.interruptAgentRun( result.runId ) );

--- a/apps/ui/src/data/core/connectors/hosted/index.ts
+++ b/apps/ui/src/data/core/connectors/hosted/index.ts
@@ -333,7 +333,11 @@ export function createHostedConnector( { apiBaseUrl }: HostedConnectorOptions ):
 		async continueSession( sessionId, prompt, options ): Promise< { runId: string } > {
 			return api< { runId: string } >( `/sessions/${ encodeURIComponent( sessionId ) }/messages`, {
 				method: 'POST',
-				body: JSON.stringify( { prompt, displayMessage: options?.displayMessage } ),
+				body: JSON.stringify( {
+					prompt,
+					displayMessage: options?.displayMessage,
+					visualAnnotations: options?.visualAnnotations,
+				} ),
 			} );
 		},
 		async getActiveAgentRuns(): Promise< ActiveAgentRun[] > {

--- a/apps/ui/src/data/core/connectors/local/index.ts
+++ b/apps/ui/src/data/core/connectors/local/index.ts
@@ -722,7 +722,11 @@ export function createLocalConnector( { apiBaseUrl }: LocalConnectorOptions ): C
 		async continueSession( sessionId, prompt, options ): Promise< { runId: string } > {
 			return api< { runId: string } >( `/sessions/${ encodeURIComponent( sessionId ) }/messages`, {
 				method: 'POST',
-				body: JSON.stringify( { prompt, displayMessage: options?.displayMessage } ),
+				body: JSON.stringify( {
+					prompt,
+					displayMessage: options?.displayMessage,
+					visualAnnotations: options?.visualAnnotations,
+				} ),
 			} );
 		},
 		async getActiveAgentRuns(): Promise< ActiveAgentRun[] > {

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -40,6 +40,7 @@ export type {
 	StudioToolProgressData,
 	StudioTurnClosedData,
 	StudioUserPromptData,
+	StudioVisualAnnotationSummary,
 	SupportedEditor,
 	SupportedLocale,
 	SupportedTerminal,

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -4,6 +4,7 @@ import type { StudioChatImage } from '@studio/common/ai/chat-images';
 import type { AiModelId } from '@studio/common/ai/models';
 import type { AiProviderId, AiSettings } from '@studio/common/ai/providers';
 import type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessions/types';
+import type { StudioVisualAnnotationSummary } from '@studio/common/ai/visual-annotations';
 import type { SiteEvent } from '@studio/common/lib/cli-events';
 import type { ImportEventTuple } from '@studio/common/lib/import-export-events';
 import type { SupportedLocale } from '@studio/common/lib/locale';
@@ -38,6 +39,7 @@ export type { ActiveAgentRun, AgentRunEvent } from '@studio/common/ai/agent-even
 export type { StudioChatFileAttachment } from '@studio/common/ai/chat-files';
 export type { StudioChatImage, StudioChatImageAttachment } from '@studio/common/ai/chat-images';
 export type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessions/types';
+export type { StudioVisualAnnotationSummary } from '@studio/common/ai/visual-annotations';
 export type { SessionEntry } from '@earendil-works/pi-coding-agent';
 export type {
 	StudioCustomEntry,
@@ -408,6 +410,7 @@ export interface Connector {
 			displayMessage?: string;
 			images?: StudioChatImage[];
 			files?: StudioChatFileAttachment[];
+			visualAnnotations?: StudioVisualAnnotationSummary[];
 		}
 	): Promise< { runId: string } >;
 	getActiveAgentRuns(): Promise< ActiveAgentRun[] >;

--- a/apps/ui/src/data/queries/use-agent-run.tsx
+++ b/apps/ui/src/data/queries/use-agent-run.tsx
@@ -25,6 +25,7 @@ import type {
 	StudioChatFileAttachment,
 	StudioChatImage,
 	StudioCustomEntry,
+	StudioVisualAnnotationSummary,
 } from '@/data/core';
 
 function nowIso(): string {
@@ -51,12 +52,14 @@ export interface QueuedPrompt {
 	displayMessage?: string;
 	images?: StudioChatImage[];
 	files?: StudioChatFileAttachment[];
+	visualAnnotations?: StudioVisualAnnotationSummary[];
 }
 
 export interface SendMessageOptions {
 	displayMessage?: string;
 	images?: StudioChatImage[];
 	files?: StudioChatFileAttachment[];
+	visualAnnotations?: StudioVisualAnnotationSummary[];
 }
 
 export interface LiveAgentEvents {
@@ -536,6 +539,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 			const displayMessage = options.displayMessage ?? prompt;
 			const images = options.images ?? [];
 			const files = options.files ?? [];
+			const visualAnnotations = options.visualAnnotations;
 			dispatchSession( sessionId, { type: 'error_set', message: null } );
 			await queryClient.cancelQueries( { queryKey: [ ...SESSIONS_QUERY_KEY, sessionId ] } );
 
@@ -549,6 +553,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					text: displayMessage,
 					source: 'prompt',
 					attachments: buildChatAttachmentSummaries( images, files ),
+					visualAnnotations,
 				},
 			} as SessionEntry;
 			updateCache( sessionId, ( entries ) => [ ...entries, optimisticEntry ] );
@@ -560,6 +565,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 					displayMessage,
 					images,
 					files,
+					visualAnnotations,
 				} );
 				if ( interruptPendingStartSessionIdsRef.current.has( sessionId ) ) {
 					interruptPendingStartSessionIdsRef.current.delete( sessionId );
@@ -756,6 +762,7 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 					displayMessage: next.displayMessage,
 					images: next.images,
 					files: next.files,
+					visualAnnotations: next.visualAnnotations,
 				} );
 			} catch {
 				dispatchSession( sessionId, { type: 'queue_clear' } );
@@ -782,6 +789,7 @@ export function useAgentRun( sessionId: string | undefined ): LiveAgentEvents {
 						displayMessage: options.displayMessage,
 						images: options.images,
 						files: options.files,
+						visualAnnotations: options.visualAnnotations,
 					},
 				} );
 				return;

--- a/apps/ui/src/ui-classic/components/session-view/annotations.test.ts
+++ b/apps/ui/src/ui-classic/components/session-view/annotations.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { formatAnnotationsAsPrompt, formatAnnotationsSubmittedMessage } from './annotations';
+import {
+	formatAnnotationsAsPrompt,
+	formatAnnotationsSubmittedMessage,
+	toVisualAnnotationSummaries,
+} from './annotations';
 import type { Annotation } from '@/components/site-preview/types';
 
 describe( 'formatAnnotationsAsPrompt', () => {
@@ -71,5 +75,30 @@ describe( 'formatAnnotationsAsPrompt', () => {
 		expect( prompt ).toContain( 'The user submitted 2 visual annotations' );
 		expect( prompt ).toContain( '- Page: /pricing' );
 		expect( prompt ).toContain( '- Page: /about' );
+	} );
+
+	it( 'summarizes each note with a short element handle for the transcript', () => {
+		expect(
+			toVisualAnnotationSummaries( [
+				{
+					id: 'a1',
+					comment: 'Make this smaller',
+					tag: 'h1',
+					classes: [ 'hero-title', 'is-large', 'extra' ],
+					nearbyText: '  Welcome  ',
+				},
+				{ id: 'a2', comment: 'Swap the image', tag: 'img' },
+				{ id: 'a3', comment: 'No target info' },
+			] )
+		).toEqual( [
+			{
+				comment: 'Make this smaller',
+				tag: 'h1',
+				elementLabel: 'h1.hero-title.is-large',
+				nearbyText: 'Welcome',
+			},
+			{ comment: 'Swap the image', tag: 'img', elementLabel: '<img>', nearbyText: undefined },
+			{ comment: 'No target info', tag: undefined, elementLabel: undefined, nearbyText: undefined },
+		] );
 	} );
 } );

--- a/apps/ui/src/ui-classic/components/session-view/annotations.ts
+++ b/apps/ui/src/ui-classic/components/session-view/annotations.ts
@@ -1,5 +1,6 @@
 import { _n, sprintf } from '@wordpress/i18n';
 import type { Annotation } from '@/components/site-preview/types';
+import type { StudioVisualAnnotationSummary } from '@studio/common/ai/visual-annotations';
 
 function describeCount( count: number ): string {
 	return count === 1 ? '1 visual annotation' : `${ count } visual annotations`;
@@ -14,6 +15,27 @@ function truncateText( text: string, maxLength: number ): string {
 		return text;
 	}
 	return `${ text.slice( 0, maxLength - 1 ) }...`;
+}
+
+/* Short CSS-ish handle for the chip in the transcript: the tag plus up to two
+ * of the element's own classes, e.g. `h1.hero-title`. */
+function describeElement( annotation: Annotation ): string | undefined {
+	if ( ! annotation.tag ) return undefined;
+	const classes = ( annotation.classes ?? [] ).slice( 0, 2 );
+	return classes.length ? `${ annotation.tag }.${ classes.join( '.' ) }` : `<${ annotation.tag }>`;
+}
+
+export function toVisualAnnotationSummaries(
+	annotations: Annotation[]
+): StudioVisualAnnotationSummary[] {
+	return annotations.map( ( annotation ) => ( {
+		comment: annotation.comment,
+		tag: annotation.tag,
+		elementLabel: describeElement( annotation ),
+		nearbyText: annotation.nearbyText?.trim()
+			? truncateText( annotation.nearbyText.trim(), 120 )
+			: undefined,
+	} ) );
 }
 
 function stringifyAnnotation( annotation: Annotation ): string {

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
@@ -663,6 +663,52 @@ describe( 'getQuestionScrollDelta', () => {
 	} );
 } );
 
+describe( 'Conversation visual annotations', () => {
+	it( 'renders each submitted annotation as its own user turn', () => {
+		const items = entriesToRenderItems( [
+			visualAnnotationsEntry( [
+				{ comment: 'Make this smaller', tag: 'h1', nearbyText: 'Welcome' },
+				{ comment: 'Use a different image', elementLabel: 'img#hero' },
+			] ),
+		] );
+
+		expect( items ).toMatchObject( [
+			{
+				kind: 'user-text',
+				text: 'Make this smaller',
+				annotation: { tag: 'h1', nearbyText: 'Welcome' },
+			},
+			{
+				kind: 'user-text',
+				text: 'Use a different image',
+				annotation: { elementLabel: 'img#hero' },
+			},
+		] );
+	} );
+} );
+
+function visualAnnotationsEntry(
+	visualAnnotations: Array< {
+		comment: string;
+		tag?: string;
+		elementLabel?: string;
+		nearbyText?: string;
+	} >
+): SessionEntry {
+	return {
+		type: 'custom',
+		id: 'visual-annotations',
+		parentId: null,
+		timestamp: '2026-06-05T12:00:03.000Z',
+		customType: 'studio.user_prompt',
+		data: {
+			text: `${ visualAnnotations.length } annotations submitted`,
+			source: 'prompt',
+			visualAnnotations,
+		},
+	} as SessionEntry;
+}
+
 function turnClosedEntry( status: string, errorMessage?: string ): SessionEntry {
 	return {
 		type: 'custom',

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -91,6 +91,7 @@ import { refreshIcon } from '@/lib/icons';
 import { ThinkingIndicator } from '../thinking-indicator';
 import styles from './style.module.css';
 import type { SessionEntry } from '@earendil-works/pi-coding-agent';
+import type { StudioVisualAnnotationSummary } from '@studio/common/ai/visual-annotations';
 
 interface AgentQuestionRenderItem {
 	key: string;
@@ -105,6 +106,7 @@ type RenderItem =
 			key: string;
 			text: string;
 			attachments?: StudioChatAttachmentSummary[];
+			annotation?: StudioVisualAnnotationSummary;
 	  }
 	| { kind: 'assistant-text'; key: string; text: string; messageText: string; copyText?: string }
 	| {
@@ -260,6 +262,17 @@ export function entriesToRenderItems(
 		if ( isStudioCustomEntryOfType( entry, 'studio.user_prompt' ) ) {
 			const data = ( entry as StudioCustomEntry< 'studio.user_prompt' > ).data;
 			if ( ! data || data.source !== 'prompt' ) continue;
+			if ( data.visualAnnotations?.length ) {
+				data.visualAnnotations.forEach( ( annotation, annotationIndex ) => {
+					items.push( {
+						kind: 'user-text',
+						key: `${ entryIndex }:annotation:${ annotationIndex }`,
+						text: annotation.comment,
+						annotation,
+					} );
+				} );
+				continue;
+			}
 			items.push( {
 				kind: 'user-text',
 				key: `${ entryIndex }:user`,
@@ -419,13 +432,26 @@ export function getActiveStep( entries: SessionEntry[] ): ActiveStep {
 function UserTurn( {
 	text,
 	attachments,
+	annotation,
 }: {
 	text: string;
 	attachments?: StudioChatAttachmentSummary[];
+	annotation?: StudioVisualAnnotationSummary;
 } ) {
 	return (
 		<div className={ styles.userTurn } { ...{ [ MESSAGE_TEXT_ATTRIBUTE ]: text } }>
 			<div className={ styles.userText }>{ text }</div>
+			{ annotation ? (
+				<div className={ styles.annotationAttachment }>
+					<span className={ styles.annotationElementTag }>
+						{ annotation.elementLabel ??
+							( annotation.tag ? `<${ annotation.tag }>` : __( 'Element' ) ) }
+					</span>
+					{ annotation.nearbyText ? (
+						<span className={ styles.annotationElementText }>{ annotation.nearbyText }</span>
+					) : null }
+				</div>
+			) : null }
 			{ attachments && attachments.length > 0 ? (
 				<ul className={ styles.userAttachments }>
 					{ attachments.map( ( attachment, index ) =>
@@ -1351,7 +1377,12 @@ export function Conversation( {
 				switch ( item.kind ) {
 					case 'user-text':
 						return (
-							<UserTurn key={ item.key } text={ item.text } attachments={ item.attachments } />
+							<UserTurn
+								key={ item.key }
+								text={ item.text }
+								attachments={ item.attachments }
+								annotation={ item.annotation }
+							/>
 						);
 					case 'assistant-text':
 						return (

--- a/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/style.module.css
@@ -60,6 +60,33 @@
 	object-fit: cover;
 }
 
+.annotationAttachment {
+	align-self: flex-end;
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-xs);
+	max-width: 80%;
+	margin-top: var(--wpds-dimension-padding-xs);
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-md, 8px);
+	background-color: var(--wpds-color-background-surface-neutral);
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-sm);
+}
+
+.annotationElementTag {
+	flex: none;
+	font-family: var(--wpds-typography-font-family-mono);
+	color: var(--wpds-color-foreground-content-neutral);
+}
+
+.annotationElementText {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .userText {
 	align-self: flex-end;
 	padding: var(--wpds-dimension-padding-md) calc(var(--wpds-dimension-padding-lg) + 8px);

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -41,7 +41,11 @@ import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
 import { useTrafficLightSpace } from '@/hooks/use-traffic-light-space';
 import { formatComposerTextQuote, watchComposerTextQuote } from '@/lib/composer-text-quote';
 import { AccessRequirements } from './access-requirements';
-import { formatAnnotationsAsPrompt, formatAnnotationsSubmittedMessage } from './annotations';
+import {
+	formatAnnotationsAsPrompt,
+	formatAnnotationsSubmittedMessage,
+	toVisualAnnotationSummaries,
+} from './annotations';
 import { Composer, ComposerSkeleton, type ComposerHandle } from './composer';
 import { Conversation } from './conversation';
 import { EmptyBackground } from './empty-background';
@@ -399,6 +403,7 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 			if ( annotations.length === 0 ) return;
 			void sendMessage( formatAnnotationsAsPrompt( annotations ), {
 				displayMessage: formatAnnotationsSubmittedMessage( annotations.length ),
+				visualAnnotations: toVisualAnnotationSummaries( annotations ),
 			} );
 		},
 		[ sendMessage ]

--- a/packages/common/ai/chat-images.ts
+++ b/packages/common/ai/chat-images.ts
@@ -1,4 +1,5 @@
 import type { StudioChatFileAttachment } from './chat-files';
+import type { StudioVisualAnnotationSummary } from './visual-annotations';
 
 // Image types the model accepts as multimodal content blocks (matches the
 // Anthropic vision-supported set). Anything else is sent as a file path instead.
@@ -29,6 +30,7 @@ export interface StudioAiSessionInputPayload {
 	displayMessage?: string;
 	images?: StudioChatImage[];
 	files?: StudioChatFileAttachment[];
+	visualAnnotations?: StudioVisualAnnotationSummary[];
 }
 
 export const STUDIO_CHAT_MAX_IMAGES = 4;

--- a/packages/common/ai/run-manager.ts
+++ b/packages/common/ai/run-manager.ts
@@ -15,6 +15,7 @@ import type { ActiveAgentRun, AgentRunEvent } from '@studio/common/ai/agent-even
 import type { StudioChatFileAttachment } from '@studio/common/ai/chat-files';
 import type { StudioAiSessionInputPayload, StudioChatImage } from '@studio/common/ai/chat-images';
 import type { JsonEvent } from '@studio/common/ai/json-events';
+import type { StudioVisualAnnotationSummary } from '@studio/common/ai/visual-annotations';
 
 /**
  * Runs the Studio Code agent as a CLI child process: forks the CLI
@@ -67,6 +68,7 @@ export interface StartAgentRunOptions {
 	displayMessage?: string;
 	images?: StudioChatImage[];
 	files?: StudioChatFileAttachment[];
+	visualAnnotations?: StudioVisualAnnotationSummary[];
 }
 
 export interface AgentRunManager {
@@ -161,7 +163,14 @@ export function createAgentRunManager( config: AgentRunManagerConfig ): AgentRun
 	}
 
 	function startAgentRun( options: StartAgentRunOptions ): { runId: string } {
-		const { sessionId, prompt, displayMessage, images = [], files = [] } = options;
+		const {
+			sessionId,
+			prompt,
+			displayMessage,
+			images = [],
+			files = [],
+			visualAnnotations,
+		} = options;
 
 		if ( runsBySessionId.has( sessionId ) ) {
 			throw new Error( `A run is already in progress for session ${ sessionId }` );
@@ -170,8 +179,8 @@ export function createAgentRunManager( config: AgentRunManagerConfig ): AgentRun
 		const runId = crypto.randomUUID();
 		const startedAt = Date.now();
 		const inputPayload =
-			images.length > 0 || files.length > 0
-				? writeInputPayloadFile( { prompt, displayMessage, images, files } )
+			images.length > 0 || files.length > 0 || ( visualAnnotations?.length ?? 0 ) > 0
+				? writeInputPayloadFile( { prompt, displayMessage, images, files, visualAnnotations } )
 				: undefined;
 		const args = [ 'code', 'sessions', 'resume', sessionId ];
 		if ( inputPayload ) {

--- a/packages/common/ai/sessions/entry-types.ts
+++ b/packages/common/ai/sessions/entry-types.ts
@@ -4,6 +4,7 @@
 
 import type { StudioChatArtifactData } from '../chat-artifacts';
 import type { StudioChatImageAttachment } from '../chat-images';
+import type { StudioVisualAnnotationSummary } from '../visual-annotations';
 import type { CustomEntry, SessionEntry } from '@earendil-works/pi-coding-agent';
 
 export type StudioCustomEntryType =
@@ -82,6 +83,7 @@ export interface StudioUserPromptData {
 	source: 'prompt' | 'ask_user';
 	sitePath?: string;
 	attachments?: StudioChatAttachmentSummary[];
+	visualAnnotations?: StudioVisualAnnotationSummary[];
 }
 
 export interface StudioMessageEditedData {

--- a/packages/common/ai/visual-annotations.test.ts
+++ b/packages/common/ai/visual-annotations.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { validateStudioVisualAnnotations } from './visual-annotations';
+
+describe( 'validateStudioVisualAnnotations', () => {
+	it( 'accepts and normalizes annotation summaries', () => {
+		expect(
+			validateStudioVisualAnnotations( [
+				{
+					comment: '  Make this larger  ',
+					tag: ' h1 ',
+					elementLabel: '',
+				},
+			] )
+		).toEqual( [
+			{
+				comment: 'Make this larger',
+				tag: 'h1',
+				elementLabel: undefined,
+				nearbyText: undefined,
+			},
+		] );
+	} );
+
+	it( 'allows an omitted payload', () => {
+		expect( validateStudioVisualAnnotations( undefined ) ).toBeUndefined();
+	} );
+
+	it.each( [ [], [ { comment: '' } ], [ { comment: 'Valid', tag: 42 } ], 'invalid' ] )(
+		'rejects an invalid payload',
+		( value ) => {
+			expect( () => validateStudioVisualAnnotations( value ) ).toThrow();
+		}
+	);
+
+	it( 'rejects unexpected and oversized fields', () => {
+		expect( () =>
+			validateStudioVisualAnnotations( [ { comment: 'Valid', selector: '#private' } ] )
+		).toThrow( 'Invalid visual annotation' );
+		expect( () =>
+			validateStudioVisualAnnotations( [ { comment: 'x'.repeat( 1_000_001 ) } ] )
+		).toThrow( 'too much data' );
+	} );
+} );

--- a/packages/common/ai/visual-annotations.ts
+++ b/packages/common/ai/visual-annotations.ts
@@ -1,0 +1,65 @@
+export interface StudioVisualAnnotationSummary {
+	comment: string;
+	tag?: string;
+	elementLabel?: string;
+	nearbyText?: string;
+}
+
+const MAX_VISUAL_ANNOTATIONS = 100;
+const MAX_COMMENT_LENGTH = 10_000;
+const MAX_SERIALIZED_LENGTH = 1_000_000;
+const ALLOWED_FIELDS = new Set( [ 'comment', 'tag', 'elementLabel', 'nearbyText' ] );
+const FIELD_LIMITS = {
+	tag: 100,
+	elementLabel: 500,
+	nearbyText: 1_000,
+} as const;
+
+export function validateStudioVisualAnnotations(
+	value: unknown
+): StudioVisualAnnotationSummary[] | undefined {
+	if ( value === undefined ) {
+		return undefined;
+	}
+	if ( ! Array.isArray( value ) || value.length === 0 || value.length > MAX_VISUAL_ANNOTATIONS ) {
+		throw new Error( 'Invalid visual annotations.' );
+	}
+	let serializedLength: number;
+	try {
+		serializedLength = JSON.stringify( value ).length;
+	} catch {
+		throw new Error( 'Invalid visual annotations.' );
+	}
+	if ( serializedLength > MAX_SERIALIZED_LENGTH ) {
+		throw new Error( 'Visual annotations contain too much data.' );
+	}
+	return value.map( ( annotation ) => {
+		if (
+			typeof annotation !== 'object' ||
+			annotation === null ||
+			typeof ( annotation as StudioVisualAnnotationSummary ).comment !== 'string' ||
+			! ( annotation as StudioVisualAnnotationSummary ).comment.trim() ||
+			( annotation as StudioVisualAnnotationSummary ).comment.length > MAX_COMMENT_LENGTH
+		) {
+			throw new Error( 'Invalid visual annotation.' );
+		}
+		if ( Object.keys( annotation ).some( ( field ) => ! ALLOWED_FIELDS.has( field ) ) ) {
+			throw new Error( 'Invalid visual annotation.' );
+		}
+		const typed = annotation as StudioVisualAnnotationSummary;
+		for ( const field of [ 'tag', 'elementLabel', 'nearbyText' ] as const ) {
+			if (
+				typed[ field ] !== undefined &&
+				( typeof typed[ field ] !== 'string' || typed[ field ].length > FIELD_LIMITS[ field ] )
+			) {
+				throw new Error( 'Invalid visual annotation.' );
+			}
+		}
+		return {
+			comment: typed.comment.trim(),
+			tag: typed.tag?.trim() || undefined,
+			elementLabel: typed.elementLabel?.trim() || undefined,
+			nearbyText: typed.nearbyText?.trim() || undefined,
+		};
+	} );
+}


### PR DESCRIPTION
## Related issues

- Related to [STU-2183](https://linear.app/a8c/issue/STU-2183/design-spec-focused-element-annotations-for-studio-preview-and-cli)
- Extracted from #4411. Independent of the other extractions.

## How AI was used in this PR

Claude Code ported the transcript changes from #4411 onto trunk and adapted the element summary to trunk's annotation shape. Reviewed and tested manually in the Desktop app.

## Proposed Changes

- Submitting preview annotations used to show a single "2 annotations submitted" bubble in the chat. Each note now appears as its own user message, with a chip underneath naming the element (`h1.hero-title`) and its nearby text.
- The agent prompt is unchanged; only the transcript display gains the per-note summaries, which are persisted on the user-prompt entry so they survive reload.
- The summary travels through every backend that starts a run (Desktop IPC, `studio ui` server, hosted) and is validated on the way in.

> ⚠️ Visual change: needs human review in light + dark mode.

## Screenshots

| Light | Dark |
| --- | --- |
| <img src="https://github.com/Automattic/studio/blob/bccab735f3a857a0fa4ec96951cec4cf9e0e506a/chat-light-crop.png?raw=true" width="440" alt="Two annotation notes as separate chat messages with element chips, light" /> | <img src="https://github.com/Automattic/studio/blob/bccab735f3a857a0fa4ec96951cec4cf9e0e506a/chat-dark-crop.png?raw=true" width="440" alt="Two annotation notes as separate chat messages with element chips, dark" /> |

## Testing Instructions

- Open a site preview, click **Annotate**, save two notes on different elements, click **Submit**.
- The chat shows two user messages, each with an element chip under it. Reload the session; they persist.
- Check the chip in light and dark.
- `npm test -- apps/ui/src/ui-classic/components/session-view apps/ui/src/data/queries/use-agent-run.test.tsx apps/cli/commands/ai/sessions/tests/resume.test.ts packages/common/ai/visual-annotations.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

