### PR TITLE
Studio Code: support multi-select questions in AskUserQuestion

### DIFF
--- a/apps/cli/ai/option-picker.ts
+++ b/apps/cli/ai/option-picker.ts
@@ -1,30 +1,37 @@
 import { wrapTextWithAnsi, type SelectItem } from '@earendil-works/pi-tui';
 import { theme } from 'cli/ai/theme';
 
-const DESCRIPTION_INDENT = '     '; // aligns descriptions under the numbered labels ("→ 1. ")
+export const OTHER_VALUE = '__other__';
 const MIN_DESCRIPTION_WIDTH = 10;
 
 /**
  * Multi-line option rows for AskUserQuestion: full label with the wrapped
- * description indented below — no truncation, newlines preserved.
+ * description indented below — no truncation, newlines preserved. Passing
+ * `checked` renders multi-select checkboxes.
  */
 export function buildOptionPickerLines(
 	items: SelectItem[],
 	selectedValue: string | undefined,
-	width: number
+	width: number,
+	checked?: Set< string >
 ): string[] {
-	const descriptionWidth = Math.max( MIN_DESCRIPTION_WIDTH, width - DESCRIPTION_INDENT.length - 2 );
+	// Aligns descriptions under the numbered labels ("→ 1. " / "→ [x] 1. ").
+	const descriptionIndent = ' '.repeat( checked ? 9 : 5 );
+	const descriptionWidth = Math.max( MIN_DESCRIPTION_WIDTH, width - descriptionIndent.length - 2 );
 	const lines: string[] = [];
 
 	for ( const item of items ) {
 		const isSelected = item.value === selectedValue;
+		const checkbox =
+			! checked || item.value === OTHER_VALUE ? '' : checked.has( item.value ) ? '[x] ' : '[ ] ';
 		item.label.split( '\n' ).forEach( ( labelLine, index ) => {
 			const marker = index === 0 && isSelected ? '→ ' : '  ';
-			lines.push( isSelected ? theme.fg( 'accent', marker + labelLine ) : marker + labelLine );
+			const line = marker + ( index === 0 ? checkbox : ' '.repeat( checkbox.length ) ) + labelLine;
+			lines.push( isSelected ? theme.fg( 'accent', line ) : line );
 		} );
 		if ( item.description ) {
 			for ( const descriptionLine of wrapTextWithAnsi( item.description, descriptionWidth ) ) {
-				lines.push( theme.fg( 'muted', DESCRIPTION_INDENT + descriptionLine ) );
+				lines.push( theme.fg( 'muted', descriptionIndent + descriptionLine ) );
 			}
 		}
 	}

--- a/apps/cli/ai/output-adapter.ts
+++ b/apps/cli/ai/output-adapter.ts
@@ -174,6 +174,7 @@ export class JsonAdapter implements AiOutputAdapter {
 			questions: questions.map( ( q ) => ( {
 				question: q.question,
 				options: q.options,
+				multiSelect: q.multiSelect,
 			} ) ),
 		} );
 

--- a/apps/cli/ai/tests/option-picker.test.ts
+++ b/apps/cli/ai/tests/option-picker.test.ts
@@ -68,6 +68,20 @@ describe( 'buildOptionPickerLines', () => {
 		] );
 	} );
 
+	it( 'renders checkboxes for multi-select, except on the Other row', () => {
+		const checked = new Set( [ 'Blocks + products' ] );
+		const lines = buildOptionPickerLines( ITEMS, 'Theme replication', 100, checked ).map(
+			stripAnsi
+		);
+		expect( lines ).toEqual( [
+			'  [x] 1. Blocks + products (Recommended)',
+			'         Native, fully editable WordPress blocks. Best launchpad for a redesign.',
+			'→ [ ] 2. Theme replication',
+			'         Pixel-accurate replica of the source.',
+			'  Other (type my own)',
+		] );
+	} );
+
 	it( 'keeps the descriptionless last item on the final line for the Other inline input', () => {
 		const lines = buildOptionPickerLines( ITEMS, '__other__', 100 ).map( stripAnsi );
 		expect( lines[ lines.length - 1 ] ).toBe( '→ Other (type my own)' );

--- a/apps/cli/ai/tools/ask-user-question.ts
+++ b/apps/cli/ai/tools/ask-user-question.ts
@@ -11,7 +11,7 @@ export function createAskUserQuestionTool(
 ): AgentTool< TSchema > {
 	return defineTool(
 		'AskUserQuestion',
-		'Ask the user 1–4 multiple-choice questions and wait for their answers. Use this whenever you need a clarification, preference, or selection from the user — instead of asking inline in prose. Each question must include 2–4 short option labels with a one-sentence description for each. The system automatically appends a free-form "Other" option, so do NOT add one yourself. Returns a map of question text → selected option label (or the user\'s typed answer if they chose "Other").',
+		'Ask the user 1–4 multiple-choice questions and wait for their answers. Use this whenever you need a clarification, preference, or selection from the user — instead of asking inline in prose. Each question must include 2–4 short option labels with a one-sentence description for each. The system automatically appends a free-form "Other" option, so do NOT add one yourself. Returns a map of question text → selected option label (or the user\'s typed answer if they chose "Other"). Set `multiSelect: true` when several options can apply; the answer is then the picked labels joined with ", ".',
 		{
 			questions: Type.Array(
 				Type.Object( {
@@ -25,6 +25,9 @@ export function createAskUserQuestionTool(
 						} ),
 						{ description: '2-4 predefined options for the user to choose from.' }
 					),
+					multiSelect: Type.Optional(
+						Type.Boolean( { description: 'Let the user pick several options.' } )
+					),
 				} ),
 				{ description: '1-4 questions to ask in a single batch.' }
 			),
@@ -33,6 +36,7 @@ export function createAskUserQuestionTool(
 			const questions: AskUserQuestion[] = args.questions.map( ( q ) => ( {
 				question: q.question,
 				options: q.options,
+				multiSelect: q.multiSelect,
 				allowFreeForm: true,
 			} ) );
 			const answers = await onAskUser( questions );

--- a/apps/cli/ai/types.ts
+++ b/apps/cli/ai/types.ts
@@ -1,6 +1,7 @@
 export interface AskUserQuestion {
 	question: string;
 	options: { label: string; description: string; image?: string }[];
+	multiSelect?: boolean;
 	allowFreeForm?: boolean;
 }
 

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -44,7 +44,7 @@ import {
 	DescriptionAwareAutocompleteProvider,
 	dimUnhighlighted,
 } from 'cli/ai/description-autocomplete';
-import { buildOptionPickerLines } from 'cli/ai/option-picker';
+import { buildOptionPickerLines, OTHER_VALUE } from 'cli/ai/option-picker';
 import { type AiOutputAdapter } from 'cli/ai/output-adapter';
 import { AI_PROVIDERS, DEFAULT_AI_PROVIDER, type AiProviderId } from 'cli/ai/providers';
 import { getActiveSlashCommands } from 'cli/ai/slash-commands';
@@ -282,7 +282,7 @@ export class AiChatUI implements AiOutputAdapter {
 	private optionPickerInput: Input | null = null;
 	private optionPickerItems: SelectItem[] = [];
 	private optionPickerQuestion = '';
-	private static readonly OTHER_VALUE = '__other__';
+	private optionPickerChecked: Set< string > | null = null;
 	private static readonly OPTION_PICKER_THEME: SelectListTheme = {
 		selectedPrefix: ( text: string ) => theme.fg( 'accent', text ),
 		selectedText: ( text: string ) => theme.fg( 'accent', text ),
@@ -482,6 +482,17 @@ export class AiChatUI implements AiOutputAdapter {
 					return { consume: true };
 				}
 
+				if ( this.optionPickerChecked && data === ' ' ) {
+					const value = this.optionPickerSelectList.getSelectedItem()?.value;
+					if ( value && value !== OTHER_VALUE ) {
+						if ( ! this.optionPickerChecked.delete( value ) ) {
+							this.optionPickerChecked.add( value );
+						}
+						this.renderOptionPicker();
+					}
+					return { consume: true };
+				}
+
 				// If user starts typing while on a regular option, jump to "Other" (only if free-form is enabled)
 				if (
 					this.optionPickerHasFreeForm &&
@@ -508,7 +519,7 @@ export class AiChatUI implements AiOutputAdapter {
 				// Check if we landed on "Other" after navigation
 				if ( this.optionPickerHasFreeForm ) {
 					const selected = this.optionPickerSelectList.getSelectedItem();
-					if ( selected?.value === AiChatUI.OTHER_VALUE ) {
+					if ( selected?.value === OTHER_VALUE ) {
 						this.activateOptionPickerOther();
 					}
 				}
@@ -1009,7 +1020,8 @@ export class AiChatUI implements AiOutputAdapter {
 		const lines = buildOptionPickerLines(
 			this.optionPickerItems,
 			this.optionPickerSelectList.getSelectedItem()?.value,
-			width
+			width,
+			this.optionPickerChecked ?? undefined
 		);
 
 		// When "Other" is active, replace the last line with the inline input
@@ -1023,6 +1035,9 @@ export class AiChatUI implements AiOutputAdapter {
 			lines[ lines.length - 1 ] = `${ theme.fg( 'accent', '→' ) } ${ display }`;
 		}
 
+		if ( this.optionPickerChecked ) {
+			lines.push( '', theme.fg( 'muted', __( 'space to toggle · enter to confirm' ) ) );
+		}
 		const question = this.optionPickerQuestion
 			? '\n' + theme.bold( this.optionPickerQuestion ) + '\n'
 			: '';
@@ -1051,11 +1066,19 @@ export class AiChatUI implements AiOutputAdapter {
 			const trimmed = value.trim();
 			if ( trimmed && this.optionPickerResolve ) {
 				const resolve = this.optionPickerResolve;
+				const answer = this.checkedAnswer( trimmed );
 				this.optionPickerResolve = null;
 				this.closeOptionPicker();
-				resolve( trimmed );
+				resolve( answer );
 			}
 		};
+	}
+
+	private checkedAnswer( ...extra: string[] ): string {
+		const checked = this.optionPickerItems
+			.map( ( item ) => item.value )
+			.filter( ( value ) => this.optionPickerChecked?.has( value ) );
+		return [ ...checked, ...extra ].join( ', ' );
 	}
 
 	private deactivateOptionPickerOther(): void {
@@ -1074,6 +1097,7 @@ export class AiChatUI implements AiOutputAdapter {
 		this.optionPickerItemCount = 0;
 		this.optionPickerItems = [];
 		this.optionPickerQuestion = '';
+		this.optionPickerChecked = null;
 		this.deactivateOptionPickerOther();
 		this.tui.requestRender();
 	}
@@ -1722,9 +1746,10 @@ export class AiChatUI implements AiOutputAdapter {
 					description: opt.description,
 				} ) );
 				this.optionPickerHasFreeForm = q.allowFreeForm === true;
+				this.optionPickerChecked = q.multiSelect ? new Set() : null;
 				if ( this.optionPickerHasFreeForm ) {
 					selectItems.push( {
-						value: AiChatUI.OTHER_VALUE,
+						value: OTHER_VALUE,
 						label: __( 'Other (type my own)' ),
 					} );
 				}
@@ -1746,15 +1771,16 @@ export class AiChatUI implements AiOutputAdapter {
 				const selected = await new Promise< string >( ( resolve ) => {
 					this.optionPickerResolve = resolve;
 					selectList.onSelect = ( item: SelectItem ) => {
-						if ( item.value === AiChatUI.OTHER_VALUE ) {
+						if ( item.value === OTHER_VALUE ) {
 							// "Other" selected via enter without typing — activate input
 							this.activateOptionPickerOther();
 							this.renderOptionPicker();
 							return;
 						}
+						const answer = this.checkedAnswer() || item.value;
 						this.optionPickerResolve = null;
 						this.closeOptionPicker();
-						resolve( item.value );
+						resolve( answer );
 					};
 					selectList.onCancel = () => {
 						this.cancelOptionPicker();

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -485,6 +485,7 @@ export async function runCommand( options: {
 						description: option.description,
 						...( option.image ? { image: option.image } : {} ),
 					} ) ),
+					multiSelect: question.multiSelect,
 				} )
 			);
 		}

--- a/apps/studio/src/components/studio-code-session/conversation/index.tsx
+++ b/apps/studio/src/components/studio-code-session/conversation/index.tsx
@@ -31,6 +31,7 @@ import { image, page } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { AiAccessRequiredNotice, AiBlockedNotice } from 'src/components/ai-access-required-notice';
+import Button from 'src/components/button';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useGetStudioAssistantQuota } from 'src/stores/wpcom-api';
@@ -62,6 +63,7 @@ type RenderItem =
 			key: string;
 			question: string;
 			options: Array< { label: string; description: string; image?: string } >;
+			multiSelect?: boolean;
 			answer?: string;
 	  }
 	| {
@@ -234,6 +236,7 @@ export function entriesToRenderItems( entries: SessionEntry[] ): RenderItem[] {
 				key: `${ entryIndex }:question`,
 				question: data.question,
 				options: data.options,
+				multiSelect: data.multiSelect,
 				answer: askUserAnswers[ questionOrdinal ],
 			} );
 			questionOrdinal += 1;
@@ -616,31 +619,49 @@ function MediaArtifactImage( { widget }: { widget: StudioChatArtifactWidgetDraft
 function AgentQuestion( {
 	question,
 	options,
+	multiSelect = false,
 	isInteractive,
 	pickedLabel,
 	onAnswer,
 }: {
 	question: string;
 	options: Array< { label: string; description: string; image?: string } >;
+	multiSelect?: boolean;
 	isInteractive: boolean;
 	pickedLabel: string | undefined;
 	onAnswer: ( label: string ) => void;
 } ) {
 	const hasImages = options.some( ( option ) => option.image );
+	const [ draft, setDraft ] = useState< string[] | null >( null );
+	const pickedLabels =
+		draft ?? ( multiSelect ? pickedLabel?.split( ', ' ) ?? [] : [ pickedLabel ] );
+	const toggle = ( label: string ) =>
+		setDraft(
+			options
+				.map( ( option ) => option.label )
+				.filter( ( other ) => ( other === label ) !== pickedLabels.includes( other ) )
+		);
 	return (
 		<div className={ styles.question }>
 			<p className={ styles.questionText }>{ question }</p>
+			{ multiSelect ? (
+				<span className={ styles.questionOptionDescription }>
+					{ __( 'Select all that apply.' ) }
+				</span>
+			) : null }
 			{ options.length > 0 ? (
 				<ul className={ styles.questionOptions } data-layout={ hasImages ? 'grid' : undefined }>
 					{ options.map( ( option, index ) => {
-						const picked = option.label === pickedLabel;
+						const picked = pickedLabels.includes( option.label );
 						return (
 							<li key={ index }>
 								<button
 									type="button"
 									className={ cx( styles.questionOption, picked && styles.questionOptionPicked ) }
 									disabled={ ! isInteractive }
-									onClick={ () => onAnswer( option.label ) }
+									onClick={ () =>
+										multiSelect ? toggle( option.label ) : onAnswer( option.label )
+									}
 									title={ option.description }
 									aria-pressed={ picked }
 									data-has-image={ hasImages ? 'true' : undefined }
@@ -659,6 +680,17 @@ function AgentQuestion( {
 						);
 					} ) }
 				</ul>
+			) : null }
+			{ multiSelect && isInteractive ? (
+				<div>
+					<Button
+						variant="primary"
+						disabled={ pickedLabels.length === 0 }
+						onClick={ () => onAnswer( pickedLabels.join( ', ' ) ) }
+					>
+						{ __( 'Confirm' ) }
+					</Button>
+				</div>
 			) : null }
 		</div>
 	);
@@ -838,6 +870,7 @@ export function Conversation( {
 								key={ item.key }
 								question={ item.question }
 								options={ item.options }
+								multiSelect={ item.multiSelect }
 								isInteractive={ pendingQuestions.has( item.question ) }
 								pickedLabel={
 									pendingAnswers[ item.question ] ??

--- a/apps/studio/src/components/studio-code-session/use-agent-run.tsx
+++ b/apps/studio/src/components/studio-code-session/use-agent-run.tsx
@@ -517,7 +517,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 									parentId: null,
 									timestamp: event.timestamp,
 									customType: 'studio.agent_question',
-									data: { question: q.question, options: q.options },
+									data: q,
 								} ) as SessionEntry
 						),
 					] );

--- a/apps/ui/src/data/queries/use-agent-run.tsx
+++ b/apps/ui/src/data/queries/use-agent-run.tsx
@@ -518,7 +518,7 @@ export function AgentRunProvider( { children }: PropsWithChildren ) {
 									parentId: null,
 									timestamp: event.timestamp,
 									customType: 'studio.agent_question',
-									data: { question: q.question, options: q.options },
+									data: q,
 								} ) as SessionEntry
 						),
 					] );

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
@@ -21,6 +21,7 @@ vi.mock( '@/data/core', () => ( {
 } ) );
 
 vi.mock( '@wordpress/ui', () => ( {
+	Button: ( props: Record< string, unknown > ) => createElement( 'button', props ),
 	Icon: () => null,
 	Tooltip: {
 		Root: ( { children }: { children?: unknown } ) => children,
@@ -366,6 +367,27 @@ describe( 'Conversation Ask User questions', () => {
 		const pickedOption = screen.getByRole( 'button', { name: 'Bold & Editorial' } );
 		expect( pickedOption ).toHaveAttribute( 'aria-pressed', 'true' );
 		expect( pickedOption ).toBeDisabled();
+	} );
+
+	it( 'submits multi-select picks together on confirm', () => {
+		const onAnswerQuestion = vi.fn();
+		const entry = agentQuestionEntry( 'Which pages?', [
+			'Blog',
+			'Contact',
+			'Shop',
+		] ) as SessionEntry & {
+			data: object;
+		};
+		renderConversation(
+			loadedSession( [ { ...entry, data: { ...entry.data, multiSelect: true } } as SessionEntry ] ),
+			{ pendingQuestions: new Set( [ 'Which pages?' ] ), onAnswerQuestion }
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Shop' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Blog' } ) );
+		expect( onAnswerQuestion ).not.toHaveBeenCalled();
+		fireEvent.click( screen.getByRole( 'button', { name: 'Confirm' } ) );
+		expect( onAnswerQuestion ).toHaveBeenCalledWith( 'Which pages?', 'Blog, Shop' );
 	} );
 
 	it( 'folds answered live questions into summaries before showing the next question', async () => {

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -69,7 +69,7 @@ import {
 	update,
 	upload,
 } from '@wordpress/icons';
-import { Icon } from '@wordpress/ui';
+import { Button, Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import {
 	useEffect,
@@ -96,6 +96,7 @@ interface AgentQuestionRenderItem {
 	key: string;
 	question: string;
 	options: Array< { label: string; description: string; image?: string } >;
+	multiSelect?: boolean;
 	pickedLabel?: string;
 }
 
@@ -227,7 +228,10 @@ function resolveBatchedAnswerForQuestion(
 		return undefined;
 	}
 	const answer = answers[ batchPosition ];
-	return optionLabels.has( answer ) ? answer : undefined;
+	const isOptionAnswer =
+		optionLabels.has( answer ) ||
+		answer.split( ', ' ).every( ( label ) => optionLabels.has( label ) );
+	return isOptionAnswer ? answer : undefined;
 }
 
 export function entriesToRenderItems(
@@ -334,6 +338,7 @@ export function entriesToRenderItems(
 					key: `${ entryIndex }:question`,
 					question: data.question,
 					options: data.options,
+					multiSelect: data.multiSelect,
 					pickedLabel:
 						data.selectedLabel ??
 						resolveBatchedAnswerForQuestion( entries, entryIndex, data.options ),
@@ -865,6 +870,7 @@ function MediaArtifactImage( { widget }: { widget: StudioChatArtifactWidgetDraft
 function AgentQuestion( {
 	question,
 	options,
+	multiSelect = false,
 	isInteractive,
 	pickedLabel,
 	isCollapsing = false,
@@ -872,6 +878,7 @@ function AgentQuestion( {
 }: {
 	question: string;
 	options: Array< { label: string; description: string; image?: string } >;
+	multiSelect?: boolean;
 	isInteractive: boolean;
 	pickedLabel: string | undefined;
 	isCollapsing?: boolean;
@@ -880,14 +887,28 @@ function AgentQuestion( {
 	const optionsId = useId();
 	const isFolding = isCollapsing && Boolean( pickedLabel );
 	const hasImages = options.some( ( option ) => option.image );
+	const [ draft, setDraft ] = useState< string[] | null >( null );
+	const pickedLabels =
+		draft ?? ( multiSelect ? pickedLabel?.split( ', ' ) ?? [] : [ pickedLabel ] );
+	const toggle = ( label: string ) =>
+		setDraft(
+			options
+				.map( ( option ) => option.label )
+				.filter( ( other ) => ( other === label ) !== pickedLabels.includes( other ) )
+		);
 
 	return (
 		<div className={ styles.question } data-state={ isFolding ? 'folding' : undefined }>
 			<p className={ styles.questionText }>{ question }</p>
+			{ multiSelect ? (
+				<span className={ styles.questionOptionDescription }>
+					{ __( 'Select all that apply.' ) }
+				</span>
+			) : null }
 			{ options.length > 0 ? (
 				<ol className={ styles.questionOptions } data-layout={ hasImages ? 'grid' : undefined }>
 					{ options.map( ( option, index ) => {
-						const picked = option.label === pickedLabel;
+						const picked = pickedLabels.includes( option.label );
 						const descriptionId =
 							option.description && ! isFolding
 								? `${ optionsId }-option-${ index }-description`
@@ -902,7 +923,9 @@ function AgentQuestion( {
 									type="button"
 									className={ clsx( styles.questionOption, picked && styles.questionOptionPicked ) }
 									disabled={ ! isInteractive }
-									onClick={ () => onAnswer( option.label ) }
+									onClick={ () =>
+										multiSelect ? toggle( option.label ) : onAnswer( option.label )
+									}
 									aria-label={ option.label }
 									aria-describedby={ descriptionId }
 									aria-pressed={ picked }
@@ -925,6 +948,17 @@ function AgentQuestion( {
 						);
 					} ) }
 				</ol>
+			) : null }
+			{ multiSelect && isInteractive ? (
+				<div>
+					<Button
+						size="compact"
+						disabled={ pickedLabels.length === 0 }
+						onClick={ () => onAnswer( pickedLabels.join( ', ' ) ) }
+					>
+						{ __( 'Confirm' ) }
+					</Button>
+				</div>
 			) : null }
 		</div>
 	);
@@ -1201,6 +1235,7 @@ function AgentQuestionBatch( {
 			<AgentQuestion
 				question={ question.question }
 				options={ question.options }
+				multiSelect={ question.multiSelect }
 				isInteractive={ pendingQuestions.has( question.question ) }
 				pickedLabel={ getQuestionPickedLabel( question, pendingAnswers ) }
 				onAnswer={ ( label ) => onAnswer( question.question, label ) }
@@ -1254,6 +1289,7 @@ function AgentQuestionBatch( {
 						<AgentQuestion
 							question={ question.question }
 							options={ question.options }
+							multiSelect={ question.multiSelect }
 							isInteractive={ pendingQuestions.has( question.question ) && settlingIndex !== index }
 							pickedLabel={ pickedLabel }
 							isCollapsing={ settlingIndex === index }

--- a/packages/common/ai/json-events.ts
+++ b/packages/common/ai/json-events.ts
@@ -21,6 +21,7 @@ export type JsonEvent =
 			questions: Array< {
 				question: string;
 				options: Array< { label: string; description: string; image?: string } >;
+				multiSelect?: boolean;
 			} >;
 	  }
 	| { type: 'turn.started'; timestamp: string }

--- a/packages/common/ai/sessions/entry-types.ts
+++ b/packages/common/ai/sessions/entry-types.ts
@@ -35,6 +35,7 @@ export interface StudioToolProgressData {
 export interface StudioAgentQuestionData {
 	question: string;
 	options: Array< { label: string; description: string; image?: string } >;
+	multiSelect?: boolean;
 	selectedLabel?: string;
 }
 


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude Code implemented the change across the CLI, the agentic UI, and the desktop app, then pruned it down to the smallest version. It verified the agentic UI live: a real Studio Code turn asked a multi-select question, and the confirmed picks came back to the agent. That was checked in light and dark. I reviewed the diff.

## Proposed Changes

- Studio Code's `AskUserQuestion` could only ask for one answer per question. Questions like "Which pages do you need?" forced the user to pick one option or type the rest into "Other".
- The agent can now mark a question as multi-select. The user can then pick any number of options and confirm them together. The agent receives the picked labels in option order, joined with ", ".
- **Agentic UI and desktop app**: options toggle on click under a "Select all that apply." hint. A Confirm button sends the answer and stays disabled until something is picked. Picks stay highlighted after a reload.
- **Terminal**: options show checkboxes. Space toggles an option, and Enter confirms the checked set. With nothing checked, Enter picks the highlighted option, as before. A typed "Other" answer is appended to the checked options.
- Single-choice questions behave exactly as before.

> ⚠️ Visual change: needs human review in light + dark mode (desktop app).

## Testing Instructions

Paste this prompt in Studio Code to get a multi-select question reliably:

```
Call AskUserQuestion once with one question, multiSelect true: 'Which pages do you need?', options Blog, Contact, Shop. Don't touch the site. After I answer, reply with only the returned answer string.
```

- **Agentic UI**: run `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui`. Pick two options, check that nothing is sent until you click Confirm, and check that the agent replies with something like "Contact, Shop". Reload, and the picks should still be checked.
- **Desktop app**: run `npm start` and repeat the steps in both light and dark appearance.
- **Terminal**: run `npm run cli:build && node apps/cli/dist/cli/main.mjs code`. Use arrows, space, and Enter as described above.
- Confirm that a regular single-choice question still sends on the first click.

The tool description changed, but no promptfoo eval asserts on `AskUserQuestion`, so no eval was run.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
