### PR TITLE
Studio Code: answer pending questions from the prompt box instead of queueing

### DIFF
--- a/apps/studio/src/components/studio-code-session/composer/index.test.tsx
+++ b/apps/studio/src/components/studio-code-session/composer/index.test.tsx
@@ -76,6 +76,24 @@ describe( 'Composer', () => {
 		expect( screen.getByRole( 'combobox' ) ).toHaveValue( '' );
 	} );
 
+	it( 'answers a pending question with typed text, but still queues skill commands', async () => {
+		const onAnswer = vi.fn();
+		renderComposer( { busy: true, onAnswer } );
+
+		const textarea = screen.getByRole( 'combobox' );
+		fireEvent.change( textarea, { target: { value: 'Something warmer' } } );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Answer' } ) );
+
+		expect( onAnswer ).toHaveBeenCalledWith( 'Something warmer' );
+
+		fireEvent.change( textarea, { target: { value: '/annotate' } } );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Queue' } ) );
+
+		await waitFor( () => expect( defaultProps.onSend ).toHaveBeenCalledTimes( 1 ) );
+		expect( defaultProps.onSend.mock.calls[ 0 ][ 0 ] ).toBe( '/annotate' );
+		expect( onAnswer ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'clears the stored draft after sending', async () => {
 		const { unmount } = renderComposer();
 

--- a/apps/studio/src/components/studio-code-session/composer/index.tsx
+++ b/apps/studio/src/components/studio-code-session/composer/index.tsx
@@ -12,6 +12,7 @@ import {
 import { watchComposerFilePaste } from '@studio/common/ai/composer-attachments';
 import { getAiModelFamily, getAiModelLabel, getVisibleAiModels } from '@studio/common/ai/models';
 import { isStudioCustomEntryOfType } from '@studio/common/ai/sessions/entry-types';
+import { resolveSkillFromPrompt } from '@studio/common/ai/slash-commands';
 import { isAutomatticianEmail } from '@studio/common/lib/automattician';
 import { useQueryClient } from '@tanstack/react-query';
 import { createInterpolateElement } from '@wordpress/element';
@@ -73,6 +74,7 @@ interface ComposerProps {
 	usageCapMessage?: string | null;
 	model: AiModelId;
 	onSend: ( prompt: string, attachments: ComposerSendAttachments ) => Promise< void >;
+	onAnswer?: ( answer: string ) => void;
 	onInterrupt: () => Promise< void >;
 	sessionId?: string;
 	entries?: SessionEntry[];
@@ -233,6 +235,7 @@ export function Composer( {
 	usageCapMessage,
 	model,
 	onSend,
+	onAnswer,
 	onInterrupt,
 	sessionId,
 	entries,
@@ -316,6 +319,11 @@ export function Composer( {
 	const [ pendingFamilyChange, setPendingFamilyChange ] = useState< AiModelId | null >( null );
 	const [ familySwitchInFlight, setFamilySwitchInFlight ] = useState( false );
 
+	const answerQuestion =
+		onAnswer && attachments.length === 0 && ! resolveSkillFromPrompt( value )
+			? onAnswer
+			: undefined;
+
 	const send = useCallback( async () => {
 		const trimmed = value.trim();
 		// Allow sending attachments on their own; fall back to a minimal prompt so
@@ -327,6 +335,10 @@ export function Composer( {
 		const sentAttachments = attachments;
 		setDraftValue( '' );
 		clearAttachments();
+		if ( answerQuestion ) {
+			answerQuestion( trimmed );
+			return;
+		}
 		try {
 			await onSend( prompt, toComposerSendAttachments( sentAttachments ) );
 		} catch {
@@ -337,7 +349,15 @@ export function Composer( {
 			setDraftValue( trimmed );
 			restoreAttachments( sentAttachments );
 		}
-	}, [ value, attachments, clearAttachments, restoreAttachments, onSend, setDraftValue ] );
+	}, [
+		value,
+		attachments,
+		clearAttachments,
+		restoreAttachments,
+		onSend,
+		answerQuestion,
+		setDraftValue,
+	] );
 
 	const openFilePicker = useCallback( () => {
 		fileInputRef.current?.click();
@@ -450,10 +470,12 @@ export function Composer( {
 	}, [ onSwitchSession, ownerSiteId, pendingFamilyChange, queryClient ] );
 
 	const canSend = value.trim().length > 0 || attachments.length > 0;
-	const placeholder = busy
+	const placeholder = answerQuestion
+		? __( 'Or type your own answer…' )
+		: busy
 		? __( 'Queue a follow-up instruction…' )
 		: getSessionPlaceholder( sessionId );
-	const sendAriaLabel = busy ? __( 'Queue' ) : __( 'Send' );
+	const sendAriaLabel = answerQuestion ? __( 'Answer' ) : busy ? __( 'Queue' ) : __( 'Send' );
 	const modKey = isMacPlatform ? '⌘' : 'Ctrl';
 	const hoveredAttachment = hoverPreview
 		? attachments.find( ( attachment ) => attachment.id === hoverPreview.id )

--- a/apps/studio/src/components/studio-code-session/conversation/index.tsx
+++ b/apps/studio/src/components/studio-code-session/conversation/index.tsx
@@ -632,15 +632,19 @@ function AgentQuestion( {
 	onAnswer: ( label: string ) => void;
 } ) {
 	const hasImages = options.some( ( option ) => option.image );
-	const [ draft, setDraft ] = useState< string[] | null >( null );
-	const pickedLabels =
-		draft ?? ( multiSelect ? pickedLabel?.split( ', ' ) ?? [] : [ pickedLabel ] );
+	const [ draft, setDraft ] = useState< { pickedLabel?: string; labels: string[] } | null >( null );
+	const answeredLabels = multiSelect ? pickedLabel?.split( ', ' ) ?? [] : [ pickedLabel ];
+	const pickedLabels = draft && draft.pickedLabel === pickedLabel ? draft.labels : answeredLabels;
+	const typedAnswer = pickedLabels
+		.filter( ( label ) => label && ! options.some( ( option ) => option.label === label ) )
+		.join( ', ' );
 	const toggle = ( label: string ) =>
-		setDraft(
-			options
+		setDraft( {
+			pickedLabel,
+			labels: options
 				.map( ( option ) => option.label )
-				.filter( ( other ) => ( other === label ) !== pickedLabels.includes( other ) )
-		);
+				.filter( ( other ) => ( other === label ) !== pickedLabels.includes( other ) ),
+		} );
 	return (
 		<div className={ styles.question }>
 			<p className={ styles.questionText }>{ question }</p>
@@ -680,6 +684,17 @@ function AgentQuestion( {
 						);
 					} ) }
 				</ul>
+			) : null }
+			{ typedAnswer ? (
+				<span
+					className={ cx(
+						styles.questionOption,
+						styles.questionOptionPicked,
+						styles.questionTypedAnswer
+					) }
+				>
+					{ typedAnswer }
+				</span>
 			) : null }
 			{ multiSelect && isInteractive ? (
 				<div>

--- a/apps/studio/src/components/studio-code-session/conversation/style.module.css
+++ b/apps/studio/src/components/studio-code-session/conversation/style.module.css
@@ -355,6 +355,12 @@
 	cursor: default;
 }
 
+.questionTypedAnswer {
+	align-self: flex-start;
+	opacity: 0.6;
+	pointer-events: none;
+}
+
 .questionOptions[data-layout='grid'] {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));

--- a/apps/studio/src/components/studio-code-session/index.tsx
+++ b/apps/studio/src/components/studio-code-session/index.tsx
@@ -295,6 +295,9 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 		[ pendingQuestions ]
 	);
 	const composerBusy = hasActiveRun || pendingQuestions.length > 0;
+	const unansweredQuestion = pendingQuestions.find(
+		( question ) => typeof pendingAnswers[ question.question ] !== 'string'
+	);
 	const canEditLastUserMessage = useMemo(
 		() => ! composerBusy && ! isRunning && wasLastTurnInterrupted( data?.entries ?? [] ),
 		[ composerBusy, isRunning, data?.entries ]
@@ -433,6 +436,11 @@ function SessionContent( { selectedSite }: { selectedSite: SiteDetails } ) {
 								usageCapMessage={ usageCapReached ? runError : null }
 								model={ currentModel }
 								onSend={ sendMessage }
+								onAnswer={
+									unansweredQuestion
+										? ( answer ) => answerQuestion( unansweredQuestion.question, answer )
+										: undefined
+								}
 								onInterrupt={ interrupt }
 								sessionId={ sessionId }
 								entries={ data.entries }

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx
@@ -240,6 +240,26 @@ describe( 'Composer menu', () => {
 		).toBeInTheDocument();
 	} );
 
+	it( 'answers a pending question with typed text, but still queues skill commands', async () => {
+		const onSend = vi.fn< ( prompt: string ) => Promise< void > >();
+		const onAnswer = vi.fn();
+		renderComposer( { busy: true, onSend, onAnswer } );
+
+		const textarea = screen.getByPlaceholderText( 'Or type your own answer…' );
+		fireEvent.change( textarea, { target: { value: 'Something warmer' } } );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Answer' } ) );
+
+		expect( onAnswer ).toHaveBeenCalledWith( 'Something warmer' );
+		expect( textarea ).toHaveValue( '' );
+
+		fireEvent.change( textarea, { target: { value: '/annotate' } } );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Queue' } ) );
+
+		await waitFor( () => expect( onSend ).toHaveBeenCalledTimes( 1 ) );
+		expect( onSend.mock.calls[ 0 ][ 0 ] ).toBe( '/annotate' );
+		expect( onAnswer ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'keeps the placeholder suggestion steady while the composer sits idle', () => {
 		vi.useFakeTimers();
 		try {

--- a/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/composer/index.tsx
@@ -27,7 +27,7 @@ import {
 	type AiProviderId,
 } from '@studio/common/ai/providers';
 import { isStudioCustomEntryOfType } from '@studio/common/ai/sessions/entry-types';
-import { getAiSkillCommands } from '@studio/common/ai/slash-commands';
+import { getAiSkillCommands, resolveSkillFromPrompt } from '@studio/common/ai/slash-commands';
 import { isAutomatticianEmail } from '@studio/common/lib/automattician';
 import { useQueryClient } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
@@ -246,6 +246,7 @@ interface ComposerProps {
 	error: string | null;
 	model: AiModelId;
 	onSend: ( prompt: string, attachments?: ComposerSendAttachments ) => Promise< void >;
+	onAnswer?: ( answer: string ) => void;
 	onInterrupt: () => Promise< void >;
 	sessionId?: string;
 	entries?: SessionEntry[];
@@ -337,6 +338,7 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 		error,
 		model,
 		onSend,
+		onAnswer,
 		onInterrupt,
 		sessionId,
 		entries,
@@ -501,6 +503,9 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 		[ restoreAttachments, value, attachments, suggestionBaseline ]
 	);
 
+	const answerQuestion =
+		onAnswer && ! hasAttachments && ! resolveSkillFromPrompt( value ) ? onAnswer : undefined;
+
 	const send = useCallback( async () => {
 		// Guarded here as well as on the button: Enter reaches this directly, and
 		// while busy a send becomes a queued prompt that would dispatch later.
@@ -523,6 +528,10 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 		// A send is the only thing that swaps the suggestion; it is static
 		// otherwise, so the empty composer never changes under the user.
 		setPlaceholderIndex( ( current ) => current + 1 );
+		if ( answerQuestion ) {
+			answerQuestion( trimmed );
+			return;
+		}
 		try {
 			await onSend( prompt, toComposerSendAttachments( sentAttachments ) );
 		} catch {
@@ -549,6 +558,7 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 		clearAttachments,
 		restoreAttachments,
 		onSend,
+		answerQuestion,
 		sessionId,
 	] );
 
@@ -783,10 +793,12 @@ const ComposerContent = forwardRef< ComposerHandle, ComposerProps >( function Co
 				__( 'Drop the next idea here…' ),
 				__( 'What are we tuning now?' ),
 		  ];
-	const placeholder = placeholderOptions[ placeholderIndex % placeholderOptions.length ];
+	const placeholder = answerQuestion
+		? __( 'Or type your own answer…' )
+		: placeholderOptions[ placeholderIndex % placeholderOptions.length ];
 	const showPlaceholderText = value.length === 0;
 	const composerResizeMaxHeight = getComposerTextareaMaxHeight( true );
-	const sendAriaLabel = busy ? __( 'Queue' ) : __( 'Send' );
+	const sendAriaLabel = answerQuestion ? __( 'Answer' ) : busy ? __( 'Queue' ) : __( 'Send' );
 	const sendShortcutLabel = __( 'Return to send' );
 	const composerError = attachmentError ?? error;
 	const stopTooltipLabel = isInterrupting

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts
@@ -634,6 +634,28 @@ describe( 'Conversation Ask User questions', () => {
 			},
 		] );
 	} );
+
+	it( 'shows the typed part of an answer next to the picked options', () => {
+		const entry = agentQuestionEntry( 'Which pages?', [
+			'Blog',
+			'Contact',
+			'Shop',
+		] ) as SessionEntry & {
+			data: object;
+		};
+		renderConversation(
+			loadedSession( [
+				{ ...entry, data: { ...entry.data, multiSelect: true } } as SessionEntry,
+				askUserAnswerEntry( 'a1', 'Contact, Shop, A landing page' ),
+			] )
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Shop' } ) ).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+		expect( screen.getByText( 'A landing page' ) ).toBeInTheDocument();
+	} );
 } );
 
 describe( 'Conversation turn-closed markers', () => {

--- a/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/conversation/index.tsx
@@ -181,10 +181,8 @@ function usePrefersReducedMotion(): boolean {
 
 function resolveBatchedAnswerForQuestion(
 	entries: SessionEntry[],
-	entryIndex: number,
-	options: Array< { label: string } >
+	entryIndex: number
 ): string | undefined {
-	const optionLabels = new Set( options.map( ( option ) => option.label ) );
 	// Older transcripts store batched question answers as following
 	// `ask_user` prompts, in the same order as the question entries.
 	let batchPosition = 0;
@@ -227,11 +225,7 @@ function resolveBatchedAnswerForQuestion(
 	if ( answers.length !== batchSize ) {
 		return undefined;
 	}
-	const answer = answers[ batchPosition ];
-	const isOptionAnswer =
-		optionLabels.has( answer ) ||
-		answer.split( ', ' ).every( ( label ) => optionLabels.has( label ) );
-	return isOptionAnswer ? answer : undefined;
+	return answers[ batchPosition ];
 }
 
 export function entriesToRenderItems(
@@ -339,9 +333,7 @@ export function entriesToRenderItems(
 					question: data.question,
 					options: data.options,
 					multiSelect: data.multiSelect,
-					pickedLabel:
-						data.selectedLabel ??
-						resolveBatchedAnswerForQuestion( entries, entryIndex, data.options ),
+					pickedLabel: data.selectedLabel ?? resolveBatchedAnswerForQuestion( entries, entryIndex ),
 				} );
 			}
 			entryIndex -= 1;
@@ -867,6 +859,26 @@ function MediaArtifactImage( { widget }: { widget: StudioChatArtifactWidgetDraft
 	);
 }
 
+function PickedAnswer( { label, ariaHidden = false }: { label: string; ariaHidden?: boolean } ) {
+	return (
+		<span
+			className={ clsx(
+				styles.questionOption,
+				styles.questionOptionPicked,
+				styles.questionSummaryOption
+			) }
+			aria-hidden={ ariaHidden ? 'true' : undefined }
+		>
+			<span className={ styles.questionOptionNumber }>
+				<QuestionOptionCheckIcon />
+			</span>
+			<span className={ styles.questionOptionCopy }>
+				<span className={ styles.questionOptionLabel }>{ label }</span>
+			</span>
+		</span>
+	);
+}
+
 function AgentQuestion( {
 	question,
 	options,
@@ -887,15 +899,19 @@ function AgentQuestion( {
 	const optionsId = useId();
 	const isFolding = isCollapsing && Boolean( pickedLabel );
 	const hasImages = options.some( ( option ) => option.image );
-	const [ draft, setDraft ] = useState< string[] | null >( null );
-	const pickedLabels =
-		draft ?? ( multiSelect ? pickedLabel?.split( ', ' ) ?? [] : [ pickedLabel ] );
+	const [ draft, setDraft ] = useState< { pickedLabel?: string; labels: string[] } | null >( null );
+	const answeredLabels = multiSelect ? pickedLabel?.split( ', ' ) ?? [] : [ pickedLabel ];
+	const pickedLabels = draft && draft.pickedLabel === pickedLabel ? draft.labels : answeredLabels;
+	const typedAnswer = pickedLabels
+		.filter( ( label ) => label && ! options.some( ( option ) => option.label === label ) )
+		.join( ', ' );
 	const toggle = ( label: string ) =>
-		setDraft(
-			options
+		setDraft( {
+			pickedLabel,
+			labels: options
 				.map( ( option ) => option.label )
-				.filter( ( other ) => ( other === label ) !== pickedLabels.includes( other ) )
-		);
+				.filter( ( other ) => ( other === label ) !== pickedLabels.includes( other ) ),
+		} );
 
 	return (
 		<div className={ styles.question } data-state={ isFolding ? 'folding' : undefined }>
@@ -949,6 +965,7 @@ function AgentQuestion( {
 					} ) }
 				</ol>
 			) : null }
+			{ typedAnswer ? <PickedAnswer label={ typedAnswer } /> : null }
 			{ multiSelect && isInteractive ? (
 				<div>
 					<Button
@@ -1117,21 +1134,7 @@ function QuestionSummary( {
 	const content = (
 		<span className={ styles.questionSummaryBody }>
 			<span className={ styles.questionSummaryText }>{ question }</span>
-			<span
-				className={ clsx(
-					styles.questionOption,
-					styles.questionOptionPicked,
-					styles.questionSummaryOption
-				) }
-				aria-hidden={ canEdit ? 'true' : undefined }
-			>
-				<span className={ styles.questionOptionNumber }>
-					<QuestionOptionCheckIcon />
-				</span>
-				<span className={ styles.questionOptionCopy }>
-					<span className={ styles.questionOptionLabel }>{ pickedLabel }</span>
-				</span>
-			</span>
+			<PickedAnswer label={ pickedLabel } ariaHidden={ canEdit } />
 		</span>
 	);
 

--- a/apps/ui/src/ui-classic/components/session-view/index.tsx
+++ b/apps/ui/src/ui-classic/components/session-view/index.tsx
@@ -321,6 +321,9 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 		[ pendingQuestions ]
 	);
 	const composerBusy = hasActiveRun || pendingQuestions.length > 0;
+	const unansweredQuestion = pendingQuestions.find(
+		( question ) => typeof pendingAnswers[ question.question ] !== 'string'
+	);
 	const isEmpty = useMemo(
 		() =>
 			! ( data?.entries ?? [] ).some(
@@ -590,6 +593,11 @@ function SessionViewContent( { sessionId }: { sessionId: string } ) {
 							error={ runError }
 							model={ currentModel }
 							onSend={ sendMessage }
+							onAnswer={
+								unansweredQuestion
+									? ( answer ) => answerQuestion( unansweredQuestion.question, answer )
+									: undefined
+							}
 							onInterrupt={ interrupt }
 							sessionId={ sessionId }
 							entries={ data.entries }


### PR DESCRIPTION
## Related issues

- Related to #3146 (prompt queue) and #4830 (multi-select questions)

## How AI was used in this PR

Claude Code (Opus 5) traced why typed replies were queued while a question was open, implemented the change in both front ends, rebased it onto #4830 and resolved the overlap with multi-select questions, then pruned the tests down to three. It verified the agentic UI live with real Studio Code turns (a two-question batch, a multi-select question, and a page reload), in light and dark. The desktop app's Assistant tab is only covered by unit tests, so it needs a visual check.

## Proposed Changes

- When Studio Code asked a question, anything typed in the prompt box was queued as a follow-up. The queue only sends once the run ends, and the run was blocked waiting for that very answer, so the typed reply just sat there. The only ways out were picking one of the offered options or stopping the run, and after picking an option, the queued text went out as a new message that often contradicted the answer. The tool also tells the agent the user can type their own answer, which the app gave no way to do (the terminal already treats typing as the answer).
- While a question is waiting, text typed in the prompt box now answers it. The prompt box reads "Or type your own answer…" and the send button "Answer". When the agent asks several questions at once, it answers the one on screen, and the card moves on to the next. Attachments and skill commands (like `/annotate`) still queue, since an answer can only be text.
- The question card shows a typed answer as a checked chip under the options, and it stays after a reload. Before, an answer that matched no option disappeared from the card once the session reloaded.
- Multi-select questions: only the parts of an answer that aren't options show as a chip. If you toggle options and then answer from the prompt box instead of clicking Confirm, the unconfirmed picks are dropped rather than shown as if they were sent. This differs from the terminal, where a typed "Other" answer is added to the checked options; matching that would mean moving the picks out of the card, so it's left for a follow-up if wanted.
- Applies to both the agentic UI and the desktop app's Assistant tab. There are no agent-facing changes (tools, system prompt, result shapes), so no evals were run.

> ⚠️ Visual change: needs human review in light + dark mode (desktop app).

## Testing Instructions

- Agentic UI: run `npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui`, open a site's chat, and send:

  ```
  Call AskUserQuestion once with two questions in the same call: 'Which accent color should the site use?' with options Red and Blue, and 'Which font style?' with options Serif and Sans-serif. Don't touch the site. After I answer, reply with only the returned answers JSON.
  ```

  - The prompt box should read "Or type your own answer…" with an "Answer" button. Type "Forest green" and send: the first question should fold into a summary showing it, the second question should appear, and nothing should be queued.
  - Click an option for the second question. The agent should reply with both answers, including "Forest green". Reload the page, and the typed answer should still show.
- Multi-select: send #4830's prompt (`Call AskUserQuestion once with one question, multiSelect true: 'Which pages do you need?', options Blog, Contact, Shop. Don't touch the site. After I answer, reply with only the returned answer string.`). Toggle Blog, then type "A landing page" in the prompt box and send. The agent should reply "A landing page", Blog should show as not picked, and "A landing page" should show as a chip.
- While a question is waiting, a message with an attachment, or a skill command like `/annotate`, should still queue.
- Desktop app: run `npm start`, open the Assistant tab, and repeat the steps above in both light and dark appearance.
- Unit tests: `npm test -- apps/ui/src/ui-classic/components/session-view/composer/index.test.tsx apps/ui/src/ui-classic/components/session-view/conversation/index.test.ts apps/studio/src/components/studio-code-session/composer/index.test.tsx`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
