### PR TITLE
Studio Code: shorten the Pick design tool row and stop revealing the agent's picks

### DIFF
--- a/packages/common/ai/tests/tools.test.ts
+++ b/packages/common/ai/tests/tools.test.ts
@@ -102,6 +102,15 @@ describe( 'tool display helpers', () => {
 		expect( getToolDisplayName( 'open_annotation_browser' ) ).toBe( 'Open annotation browser' );
 	} );
 
+	it( 'does not reveal which design options the agent chose', () => {
+		expect(
+			getToolDetail( 'pick_design', {
+				options: 4,
+				chosen: [ { layout: 'Stacked bands', direction: 'Art Deco', reason: 'Bold and festive.' } ],
+			} )
+		).toBe( '' );
+	} );
+
 	it( 'summarizes Ask User questions without exposing the raw tool name', () => {
 		expect(
 			getToolDetail( 'AskUserQuestion', {

--- a/packages/common/ai/tools.ts
+++ b/packages/common/ai/tools.ts
@@ -311,7 +311,7 @@ export function getToolDisplayName( name: string, input?: Record< string, unknow
 		refresh_browser: __( 'Refresh preview' ),
 		site_connected_remote_sites: __( 'List connected remote sites' ),
 		scaffold_theme: __( 'Scaffold theme' ),
-		pick_design: __( 'Pick concept and direction' ),
+		pick_design: __( 'Pick design' ),
 		present_design_options: __( 'Present design options' ),
 		inspect_design: __( 'Inspect design' ),
 		validate_blocks: __( 'Validate blocks' ),
@@ -433,24 +433,6 @@ export function getToolDetail( name: string, input?: Record< string, unknown > )
 			return typeof input.command === 'string' ? `wp ${ input.command }` : '';
 		case 'scaffold_theme':
 			return typeof input.name === 'string' ? input.name : '';
-		case 'pick_design': {
-			const named = [ input.layoutNamedInBrief, input.directionNamedInBrief ].filter(
-				( name ): name is string => typeof name === 'string'
-			);
-			const chosen = ( Array.isArray( input.chosen ) ? input.chosen : [] )
-				.map( ( pair ) =>
-					pair &&
-					typeof pair === 'object' &&
-					typeof ( pair as { layout?: unknown } ).layout === 'string' &&
-					typeof ( pair as { direction?: unknown } ).direction === 'string'
-						? `${ ( pair as { layout: string } ).layout } × ${
-								( pair as { direction: string } ).direction
-						  }`
-						: ''
-				)
-				.filter( Boolean );
-			return [ ...named, ...chosen ].join( ' · ' );
-		}
 		case 'present_design_options':
 			return ( Array.isArray( input.options ) ? input.options : [] )
 				.map( ( option ) =>


### PR DESCRIPTION
## Related issues

- Follow-up to https://github.com/Automattic/studio/pull/4813

## How AI was used in this PR

Claude Code (Opus 5) traced the row to the shared tool display helpers, made the change and added a test. It then checked the result in `studio ui` on a real session with two `pick_design` calls. The diff is small: one label string, one removed detail case, one test.

## Proposed Changes

- When the agent picks the site design, its tool row read like `Pick concept and dir…  Stacked bands × Art Deco · Sticky split × Eart…`. The label and the list of pairs were both cut off, and the `×` / `·` separators made the list hard to read.
- That list showed the two pairs the agent itself chose. The user could tell which two of the four options came from the agent, which the shuffle in `pick_design` is meant to hide.
- The row now reads just **Pick design**. The design picker that follows already shows every option in full, and expanding the row still shows the full tool input.

Before: `🔀 Pick concept and dir…  Stacked bands × Art Deco · Sticky split × Eart…`
After: `🔀 Pick design`

## Testing Instructions

- Start a site build that lets you pick a design (e.g. "Build a one-page site for a boutique hotel"), or open an existing session with a design pick.
- Check that the tool row reads `Pick design` in full, with nothing after it, in `studio ui` (`npm run cli:build:ui && node apps/cli/dist/cli/main.mjs ui --no-open`) and in the Desktop app.
- Click the row: the full input, including the agent's chosen pairs, is still there.
- `npm test -- packages/common/ai/tests/tools.test.ts`

Checked in `studio ui` (light theme) only. The change is text only, with no CSS or color changes.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)